### PR TITLE
Remove stale withEve config field

### DIFF
--- a/.changeset/remove-next-vercel-output-option.md
+++ b/.changeset/remove-next-vercel-output-option.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Remove the `withEve` Vercel output opt-out option. Next.js projects now skip generated Vercel Build Output writes when no linked Vercel project or existing output context is detected.

--- a/apps/frameworks/next/README.md
+++ b/apps/frameworks/next/README.md
@@ -13,10 +13,11 @@ Eve endpoints like `/eve/v1/session` to that server.
 Set `EVE_BASE_URL` before starting Next.js to reuse an already-running Eve
 server instead of letting `withEve()` start one.
 
-On Vercel, `withEve()` writes generated `experimentalServices` to
-`.vercel/output/config.json` for Next.js at `/` and Eve behind the private
-`/_eve_internal/eve` service prefix. Next.js rewrites the public Eve endpoints
-to that private service so the Eve index route is not exposed at the site root.
+When a linked Vercel project is detected, `withEve()` writes generated
+`experimentalServices` to `.vercel/output/config.json` for Next.js at `/` and
+Eve behind the private `/_eve_internal/eve` service prefix. Next.js rewrites
+the public Eve endpoints to that private service so the Eve index route is not
+exposed at the site root.
 
 For non-Vercel production hosts, set `EVE_NEXT_PRODUCTION_ORIGIN` to the public
 origin that serves the Eve service namespace before building the Next.js app.

--- a/apps/templates/web-chat-next/README.md
+++ b/apps/templates/web-chat-next/README.md
@@ -22,10 +22,11 @@ server instead of letting `withEve()` start one:
 EVE_BASE_URL=http://localhost:3000 pnpm --filter web-chat-next-template dev
 ```
 
-On Vercel, `withEve()` writes generated `experimentalServices` to
-`.vercel/output/config.json` so Next.js deploys at `/` and the app-local Eve
-agent runs behind the private `/_eve_internal/eve` service prefix, then rewrites
-public Eve endpoints to that private service.
+When a linked Vercel project is detected, `withEve()` writes generated
+`experimentalServices` to `.vercel/output/config.json` so Next.js deploys at
+`/` and the app-local Eve agent runs behind the private
+`/_eve_internal/eve` service prefix, then rewrites public Eve endpoints to that
+private service.
 
 ## Scaffold Source
 

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -34,13 +34,12 @@ export default withEve(nextConfig, {
 
 All fields are optional.
 
-| Option                  | Type      | Default                | Purpose                                                                                                                                             |
-| ----------------------- | --------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eveRoot`               | `string`  | Next.js app root       | Path to the Eve app root, relative to `process.cwd()` unless absolute. Set it when the agent lives outside the Next.js project.                     |
-| `eveBuildCommand`       | `string`  | `"eve build"`          | Build command for the generated Eve Vercel service. Use it when the Eve service needs project-specific prework, without changing the Next.js build. |
-| `configureVercelOutput` | `boolean` | `true`                 | When `true`, `withEve` writes the `experimentalServices` entries for both apps to `.vercel/output/config.json`. Set to `false` to skip that step.   |
-| `servicePrefix`         | `string`  | `"/_eve_internal/eve"` | Private Vercel route namespace for the Eve service. Must match the Eve service's mount in your Vercel Build Output config when you set it manually. |
-| `devServerTimeoutMs`    | `number`  | `180000`               | Maximum time to wait for the Eve development server to become available.                                                                            |
+| Option               | Type     | Default                | Purpose                                                                                                                                             |
+| -------------------- | -------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eveRoot`            | `string` | Next.js app root       | Path to the Eve app root, relative to `process.cwd()` unless absolute. Set it when the agent lives outside the Next.js project.                     |
+| `eveBuildCommand`    | `string` | `"eve build"`          | Build command for the generated Eve Vercel service. Use it when the Eve service needs project-specific prework, without changing the Next.js build. |
+| `servicePrefix`      | `string` | `"/_eve_internal/eve"` | Private Vercel route namespace for the Eve service. Must match the Eve service's mount in your Vercel Build Output config when you set it manually. |
+| `devServerTimeoutMs` | `number` | `180000`               | Maximum time to wait for the Eve development server to become available.                                                                            |
 
 For slow cold starts, increase the development timeout:
 

--- a/packages/eve/src/cli/commands/channels.integration.test.ts
+++ b/packages/eve/src/cli/commands/channels.integration.test.ts
@@ -314,10 +314,9 @@ describe("runChannelsAddCommand", () => {
       "AgentChat",
     );
     const nextConfig = await readFile(join(projectRoot, "next.config.ts"), "utf8");
-    expect(nextConfig).toContain("withEve");
+    expect(nextConfig).toContain("export default withEve(nextConfig);");
     // configureVercelServices stays pinned on for this command (R5): the
     // scaffold writes the services config even in an unlinked directory.
-    expect(nextConfig).not.toContain("configureVercelOutput");
     await expect(readFile(join(projectRoot, "vercel.json"), "utf8")).resolves.toContain(
       "experimentalServices",
     );

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -275,7 +275,7 @@ describe("runInitCommand", () => {
     await expect(pathExists(join(projectPath, "app/page.tsx"))).resolves.toBe(true);
     await expect(pathExists(join(projectPath, "vercel.json"))).resolves.toBe(false);
     expect(await readFile(join(projectPath, "next.config.ts"), "utf8")).toContain(
-      "configureVercelOutput: false",
+      "export default withEve(nextConfig);",
     );
     expect(await readFile(join(projectPath, "package.json"), "utf8")).toContain('"eve": "^0.6.0"');
     // The compatibility extension stays limited to releases with the incomplete manifest.

--- a/packages/eve/src/public/next/index.integration.test.ts
+++ b/packages/eve/src/public/next/index.integration.test.ts
@@ -38,7 +38,7 @@ describe("withEve Vercel config", () => {
     vi.unstubAllGlobals();
   });
 
-  it("creates Build Output experimentalServices when missing", async () => {
+  it("does not create Build Output config when no Vercel project is detected", async () => {
     const appRoot = await createTempAppRoot();
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
@@ -47,26 +47,10 @@ describe("withEve Vercel config", () => {
 
     const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
-    const outputConfig = await readJsonFile(join(appRoot, ".vercel", "output", "config.json"));
 
-    expect(outputConfig).toEqual({
-      version: 3,
-      experimentalServices: {
-        eve: {
-          buildCommand: "eve build",
-          entrypoint: ".",
-          framework: "eve",
-          mount: EVE_NEXT_SERVICE_PREFIX,
-          type: "web",
-        },
-        web: {
-          entrypoint: ".",
-          framework: "nextjs",
-          mount: "/",
-          type: "web",
-        },
-      },
-    });
+    await expect(
+      readFile(join(appRoot, ".vercel", "output", "config.json"), "utf8"),
+    ).rejects.toThrow();
     expect(getBeforeFiles(rewrites)).toContainEqual({
       destination: `${EVE_NEXT_SERVICE_PREFIX}/eve/v1/:path+`,
       source: "/eve/v1/:path+",
@@ -214,6 +198,8 @@ describe("withEve Vercel config", () => {
   it("accepts a custom Eve service build command", async () => {
     const appRoot = await createTempAppRoot();
     process.chdir(appRoot);
+    await mkdir(join(appRoot, ".vercel"), { recursive: true });
+    await writeFile(join(appRoot, ".vercel", "project.json"), "{}\n");
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_URL", "preview.example.com");
@@ -246,12 +232,9 @@ describe("withEve Vercel config", () => {
     });
     await writeFile(join(appRoot, ".output", "server", "index.mjs"), "process.exit(1);\n");
 
-    const config = await withEve<TestConfig>({}, { configureVercelOutput: false })(
-      "phase-production-build",
-      {
-        defaultConfig: {},
-      },
-    );
+    const config = await withEve<TestConfig>({})("phase-production-build", {
+      defaultConfig: {},
+    });
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -286,7 +269,7 @@ describe("withEve Vercel config", () => {
       )}\n`,
     );
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:49152/eve/v1/health", {

--- a/packages/eve/src/public/next/index.test.ts
+++ b/packages/eve/src/public/next/index.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("./vercel-output-config.js", () => ({
+  ensureEveVercelOutputConfig: vi.fn(async (input: { readonly servicePrefix: string }) => ({
+    servicePrefix: input.servicePrefix,
+  })),
+}));
+
 import {
   EVE_NEXT_SERVICE_PREFIX,
   withEve,
@@ -27,7 +33,7 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(isRewriteSections(rewrites)).toBe(true);
@@ -49,12 +55,9 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
     const config = await resolveConfig(
-      withEve<TestConfig>(
-        {
-          basePath: "/web",
-        },
-        { configureVercelOutput: false },
-      ),
+      withEve<TestConfig>({
+        basePath: "/web",
+      }),
     );
     const rewrites = await config.rewrites?.();
     const [eveRewrite] = getBeforeFiles(rewrites);
@@ -71,7 +74,7 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -85,7 +88,7 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
     const beforeFiles = getBeforeFiles(rewrites);
 
@@ -99,7 +102,7 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -112,7 +115,7 @@ describe("withEve", () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("EVE_BASE_URL", " http://127.0.0.1:49152/ ");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -126,7 +129,7 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_URL", "http://preview.example.com");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -140,7 +143,7 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("EVE_NEXT_PRODUCTION_ORIGIN", "https://agent.example.com/root");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -155,20 +158,17 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
     const config = await resolveConfig(
-      withEve<TestConfig>(
-        {
-          basePath: "/web",
-          async rewrites() {
-            return [
-              {
-                destination: "/legacy",
-                source: "/legacy",
-              },
-            ];
-          },
+      withEve<TestConfig>({
+        basePath: "/web",
+        async rewrites() {
+          return [
+            {
+              destination: "/legacy",
+              source: "/legacy",
+            },
+          ];
         },
-        { configureVercelOutput: false },
-      ),
+      }),
     );
     const rewrites = await config.rewrites?.();
 
@@ -194,27 +194,24 @@ describe("withEve", () => {
     vi.stubEnv("VERCEL_URL", "preview.example.com");
 
     const config = await resolveConfig(
-      withEve<TestConfig>(
-        {
-          async rewrites() {
-            return {
-              afterFiles: [
-                {
-                  destination: "/after",
-                  source: "/after",
-                },
-              ],
-              beforeFiles: [
-                {
-                  destination: "/before",
-                  source: "/before",
-                },
-              ],
-            };
-          },
+      withEve<TestConfig>({
+        async rewrites() {
+          return {
+            afterFiles: [
+              {
+                destination: "/after",
+                source: "/after",
+              },
+            ],
+            beforeFiles: [
+              {
+                destination: "/before",
+                source: "/before",
+              },
+            ],
+          };
         },
-        { configureVercelOutput: false },
-      ),
+      }),
     );
     const rewrites = await config.rewrites?.();
 
@@ -248,7 +245,6 @@ describe("withEve", () => {
       withEve<TestConfig>(
         {},
         {
-          configureVercelOutput: false,
           servicePrefix: "internal/eve",
         },
       ),
@@ -265,7 +261,7 @@ describe("withEve", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("EVE_NEXT_PRODUCTION_ORIGIN", "https://agent.example.com/root");
 
-    const config = await resolveConfig(withEve<TestConfig>({}, { configureVercelOutput: false }));
+    const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -277,12 +273,9 @@ describe("withEve", () => {
   it("uses a stable local production port while Next.js is building outside Vercel", async () => {
     vi.stubEnv("NODE_ENV", "production");
 
-    const config = await withEve<TestConfig>({}, { configureVercelOutput: false })(
-      "phase-production-build",
-      {
-        defaultConfig: {},
-      },
-    );
+    const config = await withEve<TestConfig>({})("phase-production-build", {
+      defaultConfig: {},
+    });
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
@@ -295,12 +288,9 @@ describe("withEve", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("EVE_NEXT_PRODUCTION_PORT", "51234");
 
-    const config = await withEve<TestConfig>({}, { configureVercelOutput: false })(
-      "phase-production-build",
-      {
-        defaultConfig: {},
-      },
-    );
+    const config = await withEve<TestConfig>({})("phase-production-build", {
+      defaultConfig: {},
+    });
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -92,12 +92,6 @@ export interface WithEveOptions {
    */
   readonly eveBuildCommand?: string;
   /**
-   * Set to `false` to skip creating or updating Vercel Build Output config.
-   * When unset, `withEve` ensures `.vercel/output/config.json` contains
-   * `experimentalServices` for the Next.js app and Eve app.
-   */
-  readonly configureVercelOutput?: boolean;
-  /**
    * Private Vercel service prefix for the Eve deployment. Defaults to
    * {@link EVE_NEXT_SERVICE_PREFIX} (`/_eve_internal/eve`). `withEve` normalizes
    * the prefix (adds a leading slash, strips trailing slashes) and rejects a
@@ -249,7 +243,7 @@ async function resolveNextConfig<TConfig extends EveNextConfig>(
  *
  * In development, starts `eve dev --no-ui --port 0` for the Eve app and
  * rewrites Eve protocol endpoints to that local URL. In Vercel production,
- * rewrites to the private Eve service prefix from `.vercel/output/config.json`.
+ * rewrites to the resolved private Eve service prefix.
  * Outside Vercel production, serves an existing `.output/server/index.mjs` build
  * on a stable local port when present; otherwise set `EVE_NEXT_PRODUCTION_ORIGIN`
  * to the origin serving the Eve service namespace.
@@ -262,21 +256,16 @@ export function withEve<TConfig extends EveNextConfig>(
   const appRoot = resolveApplicationRoot(options.eveRoot);
   const devServerTimeoutMs = resolveDevServerTimeout(options.devServerTimeoutMs);
   const servicePrefixInput = normalizeRoutePrefix(options.servicePrefix ?? EVE_NEXT_SERVICE_PREFIX);
-  const shouldConfigureVercelOutput = options.configureVercelOutput !== false;
 
   return async function eveNextConfig(phase, context) {
     const nextConfig = await resolveNextConfig(configOrFunction, phase, context);
     const existingRewrites = nextConfig.rewrites;
-    const configuredVercel = shouldConfigureVercelOutput
-      ? await ensureEveVercelOutputConfig({
-          appRoot,
-          eveBuildCommand: options.eveBuildCommand ?? DEFAULT_EVE_BUILD_COMMAND,
-          nextRoot,
-          servicePrefix: servicePrefixInput,
-        })
-      : {
-          servicePrefix: servicePrefixInput,
-        };
+    const configuredVercel = await ensureEveVercelOutputConfig({
+      appRoot,
+      eveBuildCommand: options.eveBuildCommand ?? DEFAULT_EVE_BUILD_COMMAND,
+      nextRoot,
+      servicePrefix: servicePrefixInput,
+    });
     const productionDestination = resolveProductionDestination(configuredVercel.servicePrefix);
 
     return {

--- a/packages/eve/src/public/next/vercel-output-config.ts
+++ b/packages/eve/src/public/next/vercel-output-config.ts
@@ -58,6 +58,7 @@ function resolveRelativeEntrypoint(fromRoot: string, toRoot: string): string {
 }
 
 async function resolveVercelOutputConfigLocation(nextRoot: string): Promise<{
+  readonly canWriteGeneratedOutput: boolean;
   readonly outputConfigPath: string;
   readonly projectRoot: string;
 }> {
@@ -67,6 +68,7 @@ async function resolveVercelOutputConfigLocation(nextRoot: string): Promise<{
 
   if (outputDirectory !== undefined) {
     return {
+      canWriteGeneratedOutput: true,
       outputConfigPath: join(outputDirectory, "config.json"),
       projectRoot,
     };
@@ -74,12 +76,14 @@ async function resolveVercelOutputConfigLocation(nextRoot: string): Promise<{
 
   if (vercelDirectory !== undefined) {
     return {
+      canWriteGeneratedOutput: true,
       outputConfigPath: join(vercelDirectory, "output", "config.json"),
       projectRoot,
     };
   }
 
   return {
+    canWriteGeneratedOutput: false,
     outputConfigPath: join(nextRoot, VERCEL_OUTPUT_CONFIG_FILE_NAME),
     projectRoot,
   };
@@ -178,7 +182,8 @@ export async function ensureEveVercelOutputConfig(input: {
   readonly nextRoot: string;
   readonly servicePrefix: string;
 }): Promise<EnsureVercelOutputConfigResult> {
-  const { outputConfigPath, projectRoot } = await resolveVercelOutputConfigLocation(input.nextRoot);
+  const { canWriteGeneratedOutput, outputConfigPath, projectRoot } =
+    await resolveVercelOutputConfigLocation(input.nextRoot);
   const rootVercelConfig = await readVercelServicesConfig(
     join(projectRoot, VERCEL_JSON_FILE_NAME),
     VERCEL_JSON_FILE_NAME,
@@ -207,6 +212,13 @@ export async function ensureEveVercelOutputConfig(input: {
     services: existingServices,
     servicePrefix: input.servicePrefix,
   });
+
+  if (!canWriteGeneratedOutput) {
+    return {
+      servicePrefix,
+    };
+  }
+
   const experimentalServices: Record<string, VercelServiceConfig> = {
     ...existingServices,
   };

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -374,7 +374,7 @@ describe("ensureChannel", () => {
       code: "ENOENT",
     });
     await expect(readFile(join(projectRoot, "next.config.ts"), "utf8")).resolves.toContain(
-      "withEve(nextConfig, { configureVercelOutput: false })",
+      "withEve(nextConfig)",
     );
     await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
       '"dev": "next dev"',
@@ -403,7 +403,7 @@ describe("ensureChannel", () => {
     expect(result.filesWritten).toContain(join(projectRoot, "next.config.ts"));
     expect(result.competingNextConfigFiles).toEqual([join(projectRoot, "next.config.mjs")]);
     await expect(readFile(join(projectRoot, "next.config.ts"), "utf8")).resolves.toContain(
-      "withEve(nextConfig, { configureVercelOutput: false })",
+      "withEve(nextConfig)",
     );
     await expect(readFile(join(projectRoot, "next.config.mjs"), "utf8")).resolves.toBe(
       "export default {};\n",

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -337,15 +337,10 @@ export default slackChannel({
 `;
 }
 
-function renderWebAppTemplate(
-  content: string,
-  appName: string,
-  configureVercelServices: boolean,
-): string {
-  const withEveOptions = configureVercelServices ? "" : ", { configureVercelOutput: false }";
+function renderWebAppTemplate(content: string, appName: string): string {
   return content
     .replaceAll("__EVE_INIT_APP_NAME__", appName)
-    .replaceAll("__EVE_INIT_WITH_EVE_OPTIONS__", withEveOptions);
+    .replaceAll("__EVE_INIT_WITH_EVE_OPTIONS__", "");
 }
 
 function withWebVercelServices(source: string): string {
@@ -500,7 +495,7 @@ async function ensureWebChannel(
     }
 
     const existed = await pathExists(filePath);
-    await writeTextFile(filePath, renderWebAppTemplate(content, appName, configureVercelServices), {
+    await writeTextFile(filePath, renderWebAppTemplate(content, appName), {
       force: true,
     });
     filesWritten.push(filePath);

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -224,7 +224,7 @@ describe("eve init smoke", () => {
     await expect(pathExists(join(projectDir, "app/page.tsx"))).resolves.toBe(true);
     await expect(pathExists(join(projectDir, "vercel.json"))).resolves.toBe(false);
     expect(await readFile(join(projectDir, "next.config.ts"), "utf8")).toContain(
-      "configureVercelOutput: false",
+      "export default withEve(nextConfig);",
     );
     const [installCall, devCall] = await fakePnpm.readCalls();
     expect(installCall?.args.slice(-3)).toEqual([

--- a/scripts/check-doc-mdx.mjs
+++ b/scripts/check-doc-mdx.mjs
@@ -23,7 +23,7 @@ function findMdxPackage() {
   const store = `${repoRoot}/node_modules/.pnpm`;
   let match;
   try {
-    match = readdirSync(store).find((d) => /^@mdx-js\+mdx@/.test(d));
+    match = readdirSync(store).find((d) => d.startsWith("@mdx-js+mdx@"));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Remove the public withEve Vercel output opt-out option and all call sites/docs for it.
- Skip generated Build Output writes when no linked Vercel project or existing output context is detected, while still reading existing service config for routing.
- Update Web Chat scaffolding to emit plain withEve(nextConfig) and add a changeset.

## Verification
- pnpm fmt
- pnpm lint
- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/next/index.test.ts
- pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/public/next/index.integration.test.ts src/setup/scaffold/index.integration.test.ts src/cli/commands/init.integration.test.ts src/cli/commands/channels.integration.test.ts
- pnpm --filter eve typecheck
- pnpm --filter eve build
- pnpm test:unit (rerun with elevated permissions after sandbox EPERM on 127.0.0.1 bind)
- pnpm test:integration
- pnpm docs:check
- pnpm build
- pnpm guard:invariants

Note: top-level pnpm typecheck is blocked by the existing agent-skills fixture error: primary compaction trigger model openai/gpt-5.5 lacks known AI Gateway context window metadata.