### PR TITLE
docs: add beta notice to getting started

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -5,6 +5,10 @@ description: "Install Eve, scaffold your first agent, give it a tool, and run it
 
 Eve is a filesystem-first framework for durable agents. You write capabilities under `agent/`, and Eve runs the model loop, persists every session, and serves the agent over HTTP and platform channels. You'll scaffold an app, add a tool, run it locally, then create, stream, and continue a session over HTTP.
 
+<Callout>
+  Eve is currently in beta and subject to the [Vercel beta terms](https://vercel.com/docs/release-phases/public-beta-agreement); the framework, APIs, documentation, and behavior may change before general availability.
+</Callout>
+
 ## Prerequisites
 
 - Node 24 or newer


### PR DESCRIPTION
## Summary
- Add the legal beta notice callout to the Getting Started page.
- Confirm the Introduction page already has the exact same notice.

## Testing
- `node ./scripts/check-docs.mjs`
- `node ./scripts/check-doc-snippets.mjs`
- `node ./scripts/check-doc-mdx.mjs`

Note: `pnpm exec prettier --check docs/getting-started.mdx` attempted a local dependency repair and failed on the existing esbuild binary mismatch (expected 0.28.0, got 0.25.12).