### PR TITLE
Configure apt sandbox user in Eve image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV LC_ALL=C.UTF-8
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN set -eux; \
+  printf 'APT::Sandbox::User "root";\n' >/etc/apt/apt.conf.d/99eve-sandbox-user; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
## Summary
- Configure apt to use root as its sandbox user in the Eve base image.
- This helps alleviate gpgv issues seen when running apt-get update inside Vercel Sandbox.

## Testing
- Not run; Docker image build not requested.