### PR TITLE
fix(docs): hide breadcrumb on mobile to stop sub-navbar overlap

### DIFF
--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -13,6 +13,16 @@ html {
   @apply max-md:px-6;
 }
 
+/*
+ * On mobile the sticky MobileDocsBar abuts the navbar via a negative top
+ * margin, which would otherwise overlap and clip the page breadcrumb rendered
+ * above it. Hide the breadcrumb on mobile so the bar sits flush under the
+ * navbar; it stays visible on desktop, where the bar is hidden.
+ */
+#nd-page > .text-fd-muted-foreground:first-child {
+  @apply max-md:hidden;
+}
+
 /* TOC and footer links use gray-1000. */
 #nd-toc {
   @apply text-gray-1000 md:pl-6;


### PR DESCRIPTION
## Problem

On mobile, the docs page's second navbar (the geistdocs `MobileDocsBar` with **Menu** + the TOC icon) appeared misaligned with the main navbar — the page breadcrumb ("Channels") was clipped into a thin sliver wedged between the two bars.

| Before | After |
| --- | --- |
| breadcrumb clipped between bars | sub-navbar flush under navbar |

## Root cause

The horizontal insets were actually fine (both bars sit at 24px from each edge). The real issue was vertical: fumadocs renders a breadcrumb at the top of the article, and the `MobileDocsBar` from `@vercel/geistdocs` is a sticky mobile sub-navbar that abuts the main navbar via a negative top margin (`-mt-6`). With the breadcrumb above it, that negative margin pulled the bar up over the breadcrumb and clipped it.

On desktop the bar is `md:hidden`, so there's no collision and the breadcrumb displays normally.

## Fix

Hide the breadcrumb on mobile only (in the existing local geistdocs override stylesheet), so the sub-navbar sits flush under the main navbar:

```css
#nd-page > .text-fd-muted-foreground:first-child {
  @apply max-md:hidden;
}
```
