### PR TITLE
fix(eve): harness - preserve approval gates on dynamic tools

### DIFF
--- a/.changeset/fuzzy-tfl-approvals.md
+++ b/.changeset/fuzzy-tfl-approvals.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix dynamic connection tools so approval gates from OpenAPI and other connection-backed tools are preserved when the tools are exposed to the model. Calls to connections with `approval: always()` now correctly park for HITL approval before execution.

--- a/apps/docs/components/geistdocs/footer.tsx
+++ b/apps/docs/components/geistdocs/footer.tsx
@@ -34,9 +34,7 @@ export const Footer = ({
           </Link>
         </div>
         <div className="flex items-center gap-2">
-          <p className="text-center sm:text-left text-gray-800 text-sm">
-            {copyright}
-          </p>
+          <p className="text-center sm:text-left text-gray-800 text-sm">{copyright}</p>
           {hasMultipleLanguages ? <LanguageSelector /> : null}
           <Button asChild size="icon-sm" type="button" variant="ghost">
             <a href="/rss.xml" rel="noopener" target="_blank">

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -6,7 +6,9 @@ description: "Install Eve, scaffold your first agent, give it a tool, and run it
 Eve is a filesystem-first framework for durable agents. You write capabilities under `agent/`, and Eve runs the model loop, persists every session, and serves the agent over HTTP and platform channels. You'll scaffold an app, add a tool, run it locally, then create, stream, and continue a session over HTTP.
 
 <Callout>
-  Eve is currently in beta and subject to the [Vercel beta terms](https://vercel.com/docs/release-phases/public-beta-agreement); the framework, APIs, documentation, and behavior may change before general availability.
+  Eve is currently in beta and subject to the [Vercel beta
+  terms](https://vercel.com/docs/release-phases/public-beta-agreement); the framework, APIs,
+  documentation, and behavior may change before general availability.
 </Callout>
 
 ## Prerequisites

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -8,7 +8,9 @@ Eve is a framework for building durable agents as ordinary files in a TypeScript
 Instead of one large configuration object, each part of your agent gets a clear home. Instructions go in one file, tools in one folder, channels in another. Eve discovers that structure and turns it into an agent that runs locally, serves HTTP, connects to other platforms, and keeps working across many turns.
 
 <Callout>
-  Eve is currently in beta and subject to the [Vercel beta terms](https://vercel.com/docs/release-phases/public-beta-agreement); the framework, APIs, documentation, and behavior may change before general availability.
+  Eve is currently in beta and subject to the [Vercel beta
+  terms](https://vercel.com/docs/release-phases/public-beta-agreement); the framework, APIs,
+  documentation, and behavior may change before general availability.
 </Callout>
 
 ## An Eve project at a glance

--- a/e2e/fixtures/agent-openapi-swagger/agent/connections/tfl-approval.ts
+++ b/e2e/fixtures/agent-openapi-swagger/agent/connections/tfl-approval.ts
@@ -1,0 +1,11 @@
+import { defineOpenAPIConnection } from "eve/connections";
+import { always } from "eve/tools/approval";
+
+export default defineOpenAPIConnection({
+  approval: always(),
+  baseUrl: "https://api.tfl.gov.uk",
+  spec: "https://api.tfl.gov.uk/swagger/docs/v1",
+  description:
+    "Approval-gated Transport for London Unified API from its public Swagger 2.0 document.",
+  operations: { allow: ["Journey_Meta"] },
+});

--- a/e2e/fixtures/agent-openapi-swagger/evals/tfl-swagger-approval.eval.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/tfl-swagger-approval.eval.ts
@@ -1,4 +1,4 @@
-import type { EveEvalTurn } from "eve/evals";
+import type { HandleMessageStreamEvent } from "eve/client";
 import { defineEval } from "eve/evals";
 
 const SEARCH_TOOL = "connection__search";
@@ -31,14 +31,20 @@ export default defineEval({
     if (!optionIds.includes("approve") || !optionIds.includes("deny")) {
       throw new Error(`Expected approve/deny options, got [${optionIds.join(", ")}].`);
     }
-    if (parked.toolCalls.some((call) => call.name === TFL_APPROVAL_JOURNEY_MODES_TOOL)) {
+    if (toolResultOutputs(parked.events, TFL_APPROVAL_JOURNEY_MODES_TOOL).length > 0) {
       throw new Error("Approval-gated OpenAPI tool executed before approval.");
     }
 
     const approved = await t.respondAll("approve");
     approved.expectOk();
 
-    const output = requireToolOutput(approved, TFL_APPROVAL_JOURNEY_MODES_TOOL);
+    const outputs = toolResultOutputs(t.events, TFL_APPROVAL_JOURNEY_MODES_TOOL);
+    if (outputs.length !== 1) {
+      throw new Error(
+        `Expected "${TFL_APPROVAL_JOURNEY_MODES_TOOL}" to execute exactly once after approval; saw ${outputs.length}.`,
+      );
+    }
+    const [output] = outputs;
     const modes = extractModeNames(output.body);
     if (!modes.has("bus") || !modes.has("tube")) {
       throw new Error(
@@ -48,26 +54,33 @@ export default defineEval({
 
     t.didNotFail();
     t.completed();
-    t.toolOrder([SEARCH_TOOL, TFL_APPROVAL_JOURNEY_MODES_TOOL]);
     t.calledTool(SEARCH_TOOL, { isError: false });
-    t.calledTool(TFL_APPROVAL_JOURNEY_MODES_TOOL, { isError: false, times: 1 });
     t.messageIncludes(/\bbus\b/iu);
     t.messageIncludes(/\btube\b/iu);
   },
 });
 
-function requireToolOutput(turn: EveEvalTurn, toolName: string): Record<string, unknown> {
-  const call = turn.toolCalls.find((candidate) => candidate.name === toolName);
-  if (call === undefined) {
-    const seen = turn.toolCalls.map((candidate) => candidate.name).join(", ");
-    throw new Error(`Expected a "${toolName}" call in this turn; saw [${seen}].`);
+function toolResultOutputs(
+  events: readonly HandleMessageStreamEvent[],
+  toolName: string,
+): Record<string, unknown>[] {
+  const outputs: Record<string, unknown>[] = [];
+  for (const event of events) {
+    if (event.type !== "action.result" || event.data.status === "rejected") {
+      continue;
+    }
+    const result = event.data.result;
+    if (result.kind !== "tool-result" || result.toolName !== toolName) {
+      continue;
+    }
+    if (typeof result.output !== "object" || result.output === null) {
+      throw new Error(
+        `Expected object output from "${toolName}"; got ${JSON.stringify(result.output)}.`,
+      );
+    }
+    outputs.push(result.output as Record<string, unknown>);
   }
-  if (typeof call.output !== "object" || call.output === null) {
-    throw new Error(
-      `Expected object output from "${toolName}"; got ${JSON.stringify(call.output)}.`,
-    );
-  }
-  return call.output as Record<string, unknown>;
+  return outputs;
 }
 
 function extractModeNames(body: unknown): Set<string> {

--- a/e2e/fixtures/agent-openapi-swagger/evals/tfl-swagger-approval.eval.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/tfl-swagger-approval.eval.ts
@@ -1,0 +1,88 @@
+import type { EveEvalTurn } from "eve/evals";
+import { defineEval } from "eve/evals";
+
+const SEARCH_TOOL = "connection__search";
+const TFL_APPROVAL_JOURNEY_MODES_TOOL = "connection__tfl-approval__Journey_Meta";
+
+export default defineEval({
+  description:
+    "OpenAPI connection HITL: an approval-gated TfL Swagger operation parks before execution.",
+
+  async test(t) {
+    const parked = await t.send(
+      [
+        "Use the `connection__search` tool with connection `tfl-approval` to find the TfL journey modes operation.",
+        "Then call `connection__tfl-approval__Journey_Meta` exactly once with an empty object.",
+        "Wait for approval if requested.",
+        "After the tool runs, reply with the exact words `bus` and `tube` if both mode names are present in the tool result.",
+      ].join("\n"),
+    );
+    parked.expectOk();
+
+    const [request] = t.expectInputRequests({
+      display: "confirmation",
+      toolName: TFL_APPROVAL_JOURNEY_MODES_TOOL,
+    });
+    if (request === undefined) {
+      throw new Error("Expected the OpenAPI connection tool to request approval.");
+    }
+
+    const optionIds = (request.options ?? []).map((option) => option.id);
+    if (!optionIds.includes("approve") || !optionIds.includes("deny")) {
+      throw new Error(`Expected approve/deny options, got [${optionIds.join(", ")}].`);
+    }
+    if (parked.toolCalls.some((call) => call.name === TFL_APPROVAL_JOURNEY_MODES_TOOL)) {
+      throw new Error("Approval-gated OpenAPI tool executed before approval.");
+    }
+
+    const approved = await t.respondAll("approve");
+    approved.expectOk();
+
+    const output = requireToolOutput(approved, TFL_APPROVAL_JOURNEY_MODES_TOOL);
+    const modes = extractModeNames(output.body);
+    if (!modes.has("bus") || !modes.has("tube")) {
+      throw new Error(
+        `Expected TfL modes to include bus and tube after approval, got ${JSON.stringify([...modes])}`,
+      );
+    }
+
+    t.didNotFail();
+    t.completed();
+    t.toolOrder([SEARCH_TOOL, TFL_APPROVAL_JOURNEY_MODES_TOOL]);
+    t.calledTool(SEARCH_TOOL, { isError: false });
+    t.calledTool(TFL_APPROVAL_JOURNEY_MODES_TOOL, { isError: false, times: 1 });
+    t.messageIncludes(/\bbus\b/iu);
+    t.messageIncludes(/\btube\b/iu);
+  },
+});
+
+function requireToolOutput(turn: EveEvalTurn, toolName: string): Record<string, unknown> {
+  const call = turn.toolCalls.find((candidate) => candidate.name === toolName);
+  if (call === undefined) {
+    const seen = turn.toolCalls.map((candidate) => candidate.name).join(", ");
+    throw new Error(`Expected a "${toolName}" call in this turn; saw [${seen}].`);
+  }
+  if (typeof call.output !== "object" || call.output === null) {
+    throw new Error(
+      `Expected object output from "${toolName}"; got ${JSON.stringify(call.output)}.`,
+    );
+  }
+  return call.output as Record<string, unknown>;
+}
+
+function extractModeNames(body: unknown): Set<string> {
+  const modes = new Set<string>();
+  if (!Array.isArray(body)) {
+    return modes;
+  }
+  for (const item of body) {
+    if (typeof item !== "object" || item === null) {
+      continue;
+    }
+    const modeName = (item as { modeName?: unknown }).modeName;
+    if (typeof modeName === "string") {
+      modes.add(modeName);
+    }
+  }
+  return modes;
+}

--- a/packages/eve/src/harness/code-mode.test.ts
+++ b/packages/eve/src/harness/code-mode.test.ts
@@ -1,10 +1,11 @@
 import { jsonSchema, tool } from "ai";
 import { describe, expect, it } from "vitest";
 
-import { applySandboxToolSet } from "#harness/code-mode.js";
+import { applySandboxToolSet, buildSandboxHostTools } from "#harness/code-mode.js";
 import { CODE_MODE_SURFACE, WORKFLOW_SURFACE } from "#harness/sandbox-surface.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { ContextKey } from "#context/key.js";
+import { LiveStepToolsKey } from "#context/keys.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { buildToolSet } from "#harness/tools.js";
 import type { HarnessToolMap } from "#harness/types.js";
@@ -276,6 +277,29 @@ describe("applySandboxToolSet", () => {
 
     expect(observedSession).toBe("call-session");
     expect(result).toBe(true);
+  });
+
+  it("preserves dynamic tool approval gates in sandbox host tools", async () => {
+    const needsApproval = () => true;
+    const ctx = new ContextContainer();
+    ctx.setVirtualContext(LiveStepToolsKey, [
+      {
+        description: "Requires approval.",
+        execute: async () => "ok",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "connection__tfl__getLineStatus",
+        needsApproval,
+      },
+    ]);
+
+    const hostTools = await contextStorage.run(ctx, () =>
+      buildSandboxHostTools({ tools: new Map() }),
+    );
+    const guardedTool = hostTools.connection__tfl__getLineStatus as {
+      needsApproval?: (input: unknown) => Promise<boolean> | boolean;
+    };
+
+    await expect(guardedTool.needsApproval?.({ line: "victoria" })).resolves.toBe(true);
   });
 
   it("dual-routes runtime action tools to both modelTools and hostTools", async () => {

--- a/packages/eve/src/harness/code-mode.ts
+++ b/packages/eve/src/harness/code-mode.ts
@@ -15,7 +15,7 @@ import {
 import { loadCodeModeModule, type CodeModeOptions } from "#shared/code-mode.js";
 import { ALL_SANDBOX_SURFACES, type SandboxSurface } from "#harness/sandbox-surface.js";
 import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
-import { buildToolSet } from "#harness/tools.js";
+import { buildToolSet, buildToolSetFromDefinitions } from "#harness/tools.js";
 
 /**
  * Framework tools that must never enter a sandbox — they stay directly callable
@@ -163,13 +163,13 @@ export async function buildSandboxHostTools(input: {
   const ctx = contextStorage.getStore();
   if (ctx !== undefined) {
     const dynamicTools = buildDynamicTools(ctx);
-    for (const def of dynamicTools) {
-      flatTools[def.name] ??= {
-        description: def.description,
-        inputSchema: def.inputSchema,
-        execute: def.execute,
-        outputSchema: def.outputSchema,
-      };
+    const dynamicToolSet = buildToolSetFromDefinitions({
+      approvedTools: input.approvedTools,
+      capabilities: input.capabilities,
+      tools: dynamicTools,
+    });
+    for (const [name, toolDefinition] of Object.entries(dynamicToolSet)) {
+      flatTools[name] ??= toolDefinition;
     }
   }
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3,7 +3,7 @@ import { type FilePart, jsonSchema, type LanguageModel, ToolLoopAgent, type User
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
-import { SessionDynamicInstructionsKey } from "#context/keys.js";
+import { LiveStepToolsKey, SessionDynamicInstructionsKey } from "#context/keys.js";
 import { ChannelInstrumentationKey, SandboxKey } from "#context/keys.js";
 import { decodeSandboxRef, isSandboxRefUrl } from "#internal/attachments/sandbox-refs.js";
 import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
@@ -550,6 +550,45 @@ describe("createToolLoopHarness", () => {
     expect(agentCall).toBeDefined();
     expect(agentCall!.tools).toHaveProperty("add");
     expect(agentCall!.tools).not.toHaveProperty("code_mode");
+  });
+
+  it("preserves approval gates on step-scoped dynamic tools", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Hello!", role: "assistant" }] },
+      text: "Hello!",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const needsApproval = vi.fn(() => true);
+    const ctx = new ContextContainer();
+    ctx.setVirtualContext(LiveStepToolsKey, [
+      {
+        description: "Get TfL line status.",
+        execute: vi.fn().mockResolvedValue({ ok: true }),
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "connection__tfl__getLineStatus",
+        needsApproval,
+      },
+    ]);
+
+    const config = createTestConfig("conversation", undefined, { codeMode: false });
+    const runStep = createToolLoopHarness(config);
+    await contextStorage.run(ctx, () => runStep(createTestSession(), { message: "Hi" }));
+
+    const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as
+      | { tools: Record<string, { needsApproval?: (toolInput: unknown) => Promise<boolean> }> }
+      | undefined;
+    expect(agentCall).toBeDefined();
+    const dynamicTool = agentCall!.tools.connection__tfl__getLineStatus!;
+
+    await expect(dynamicTool.needsApproval?.({ line: "victoria" })).resolves.toBe(true);
+    expect(needsApproval).toHaveBeenCalledExactlyOnceWith({
+      approvedTools: new Set(),
+      toolInput: { line: "victoria" },
+      toolName: "connection__tfl__getLineStatus",
+    });
   });
 
   it("preserves a user-authored web_search tool instead of replacing it with the provider tool", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -142,7 +142,7 @@ import {
   isInvalidToolCall,
 } from "#harness/step-hooks.js";
 import { pruneToolResults } from "#harness/tool-result-pruning.js";
-import { buildToolSetWithProviderTools } from "#harness/tools.js";
+import { buildToolSetFromDefinitions, buildToolSetWithProviderTools } from "#harness/tools.js";
 import {
   CODE_MODE_TOOL_NAME,
   loadCodeModeModule,
@@ -652,13 +652,14 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       if (ctx !== undefined) {
         const dynamicTools = buildDynamicTools(ctx);
-        for (const def of dynamicTools) {
-          flatTools[def.name] ??= {
-            description: def.description,
-            inputSchema: def.inputSchema,
-            execute: def.execute,
-            outputSchema: def.outputSchema,
-          };
+        const dynamicToolSet = buildToolSetFromDefinitions({
+          approvedTools,
+          capabilities: config.capabilities,
+          disabledProviderTools: opts.disabledProviderTools,
+          tools: dynamicTools,
+        });
+        for (const [name, toolDefinition] of Object.entries(dynamicToolSet)) {
+          flatTools[name] ??= toolDefinition;
         }
       }
 

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -95,6 +95,32 @@ export function buildToolSet(input: {
 }
 
 /**
+ * Builds a ToolSet from an ordered list of harness definitions.
+ *
+ * The first definition for a name wins, matching the dynamic-tool scope
+ * ordering where step tools override turn/session tools.
+ */
+export function buildToolSetFromDefinitions(input: {
+  readonly approvedTools?: ReadonlySet<string>;
+  readonly capabilities?: SessionCapabilities;
+  readonly disabledProviderTools?: ReadonlySet<string>;
+  readonly tools: readonly HarnessToolDefinition[];
+}): ToolSet {
+  const tools = new Map<string, HarnessToolDefinition>();
+  for (const definition of input.tools) {
+    if (!tools.has(definition.name)) {
+      tools.set(definition.name, definition);
+    }
+  }
+  return buildToolSet({
+    approvedTools: input.approvedTools,
+    capabilities: input.capabilities,
+    disabledProviderTools: input.disabledProviderTools,
+    tools,
+  });
+}
+
+/**
  * Wraps a tool's `execute` so a returned {@link AuthorizationSignal} is
  * stashed out-of-band ({@link stashToolInterrupt}) for the park detector while
  * the AI SDK records an opaque {@link AuthorizationPendingModelOutput} that


### PR DESCRIPTION
## Summary
- Preserve dynamic tool metadata by routing step-scoped dynamic tools through the normal tool-set builder before merging them into the regular tool loop and code-mode host tool surfaces.
- Fix OpenAPI and other connection-backed dynamic tools so connection `approval` callbacks reach AI SDK `needsApproval`, which lets `approval: always()` park for HITL approval before execution.
- Add regression coverage for both the regular tool-loop path and the sandbox host-tool path, plus a patch changeset for `eve`.
- Includes minor formatting-only docs/footer cleanup already present on the branch.

## Testing
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/tools.test.ts src/harness/tool-loop.test.ts src/harness/code-mode.test.ts`
- `pnpm fmt`
- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm test:integration`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm build`
- `pnpm test:scenario`

## Notes
- Model-backed e2e evals were not run locally because provider credentials were not available.
