### PR TITLE
fix(eve): fix TUI setup sequencing

### DIFF
--- a/.changeset/model-flow-exit-to-prompt.md
+++ b/.changeset/model-flow-exit-to-prompt.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Completing a model change or provider setup in `/model` now closes the menu and returns you to the prompt, surfacing the result as the command's reply line (for example "Model changed to openai/gpt-5.5. Live on your next prompt." or a rejection message). Previously the menu stayed open and repainted with an in-menu success/warning notice. A cancelled picker or the "use my own key" branch still repaints the menu as before.

--- a/.changeset/model-flow-exit-to-prompt.md
+++ b/.changeset/model-flow-exit-to-prompt.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Completing a model change or provider setup in `/model` now closes the menu and returns you to the prompt, surfacing the result as the command's reply line (for example "Model changed to openai/gpt-5.5. Live on your next prompt." or a rejection message). Previously the menu stayed open and repainted with an in-menu success/warning notice. A cancelled picker or the "use my own key" branch still repaints the menu as before.
+Changing a model or configuring its provider in `/model` now returns to the prompt and prints the result there. Cancelling or choosing an external provider still returns to the menu.

--- a/.changeset/tui-setup-attention-order.md
+++ b/.changeset/tui-setup-attention-order.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The dev TUI startup attention line now lists an unmet Vercel auth prerequisite (`/vc` to install the CLI, `/login` to sign in) ahead of the `/model` hint it gates. Linking a project to fix the `/model` hint needs a working CLI and a logged-in session, so the line points you at the step you can actually complete first.

--- a/.changeset/tui-setup-attention-order.md
+++ b/.changeset/tui-setup-attention-order.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-The dev TUI startup attention line now lists an unmet Vercel auth prerequisite (`/vc` to install the CLI, `/login` to sign in) ahead of the `/model` hint it gates. Linking a project to fix the `/model` hint needs a working CLI and a logged-in session, so the line points you at the step you can actually complete first.
+The dev TUI now shows `/vc` or `/login` before `/model` when Vercel authentication is blocking model setup.

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -51,6 +51,7 @@ import {
   detectSetupIssues,
   formatSetupIssuesLine,
   LOGIN_SETUP_ISSUE,
+  orderedSetupIssues,
   type BootDetection,
   type BootDetectionContext,
   type SetupIssue,
@@ -909,9 +910,13 @@ export class EveTUIRunner {
     this.#probeAuthIssue();
   }
 
-  /** Repaints the attention line from the cached detection + auth issues, or clears it. */
+  /**
+   * Repaints the attention line from the cached auth + detection issues, or
+   * clears it. {@link orderedSetupIssues} puts an unmet auth prerequisite
+   * (`/vc` or `/login`) ahead of the boot `/model` hint it gates.
+   */
   #paintSetupAttention(): void {
-    const issues = [...this.#bootIssues, ...(this.#authIssue ? [this.#authIssue] : [])];
+    const issues = orderedSetupIssues(this.#bootIssues, this.#authIssue);
     if (issues.length > 0) {
       this.#renderer.renderSetupWarning?.(formatSetupIssuesLine(issues));
     } else {

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -910,11 +910,7 @@ export class EveTUIRunner {
     this.#probeAuthIssue();
   }
 
-  /**
-   * Repaints the attention line from the cached auth + detection issues, or
-   * clears it. {@link orderedSetupIssues} puts an unmet auth prerequisite
-   * (`/vc` or `/login`) ahead of the boot `/model` hint it gates.
-   */
+  /** Repaints the attention line from the cached detection + auth issues, or clears it. */
   #paintSetupAttention(): void {
     const issues = orderedSetupIssues(this.#bootIssues, this.#authIssue);
     if (issues.length > 0) {

--- a/packages/eve/src/cli/dev/tui/setup-issues.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.test.ts
@@ -6,6 +6,7 @@ import {
   detectSetupIssues,
   formatSetupIssuesLine,
   LOGIN_SETUP_ISSUE,
+  orderedSetupIssues,
   type BootDetectionContext,
 } from "./setup-issues.js";
 
@@ -105,5 +106,24 @@ describe("formatSetupIssuesLine", () => {
     expect(formatSetupIssuesLine([CLI_MISSING_SETUP_ISSUE])).toBe(
       "1 setup issue: Vercel CLI not found · /vc",
     );
+  });
+});
+
+describe("orderedSetupIssues", () => {
+  it("puts the auth prerequisite before the boot detections", () => {
+    const modelIssue = { label: "model provider not linked", command: "/model" };
+    expect(orderedSetupIssues([modelIssue], CLI_MISSING_SETUP_ISSUE)).toEqual([
+      CLI_MISSING_SETUP_ISSUE,
+      modelIssue,
+    ]);
+    expect(orderedSetupIssues([modelIssue], LOGIN_SETUP_ISSUE)).toEqual([
+      LOGIN_SETUP_ISSUE,
+      modelIssue,
+    ]);
+  });
+
+  it("returns the boot issues unchanged when no auth prerequisite is unmet", () => {
+    const boot = [{ label: "AI Gateway credentials missing", command: "/model" }];
+    expect(orderedSetupIssues(boot, undefined)).toEqual(boot);
   });
 });

--- a/packages/eve/src/cli/dev/tui/setup-issues.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.ts
@@ -105,6 +105,21 @@ export async function detectSetupIssues(
 }
 
 /**
+ * Orders the attention line so the Vercel auth prerequisite (install the CLI
+ * via `/vc`, or log in via `/login`) precedes the boot detections. The boot
+ * `/model` hint is fixed by linking a project, which needs a working CLI and a
+ * logged-in session — so an unmet auth prerequisite has to clear first.
+ * Listing `/model` ahead of `/vc` would point the user at a step they can't
+ * complete yet.
+ */
+export function orderedSetupIssues(
+  bootIssues: readonly SetupIssue[],
+  authIssue: SetupIssue | undefined,
+): SetupIssue[] {
+  return [...(authIssue === undefined ? [] : [authIssue]), ...bootIssues];
+}
+
+/**
  * The attention line's body, mirroring Claude Code's
  * `1 setup issue: MCP · /doctor` shape; the renderer prefixes the warning
  * glyph and paints the command blue.

--- a/packages/eve/src/cli/dev/tui/setup-issues.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.ts
@@ -104,19 +104,12 @@ export async function detectSetupIssues(
   return results.flat();
 }
 
-/**
- * Orders the attention line so the Vercel auth prerequisite (install the CLI
- * via `/vc`, or log in via `/login`) precedes the boot detections. The boot
- * `/model` hint is fixed by linking a project, which needs a working CLI and a
- * logged-in session — so an unmet auth prerequisite has to clear first.
- * Listing `/model` ahead of `/vc` would point the user at a step they can't
- * complete yet.
- */
+/** Places the auth issue before boot-time setup issues. */
 export function orderedSetupIssues(
   bootIssues: readonly SetupIssue[],
   authIssue: SetupIssue | undefined,
 ): SetupIssue[] {
-  return [...(authIssue === undefined ? [] : [authIssue]), ...bootIssues];
+  return authIssue === undefined ? [...bootIssues] : [authIssue, ...bootIssues];
 }
 
 /**

--- a/packages/eve/src/setup/flows/model.test.ts
+++ b/packages/eve/src/setup/flows/model.test.ts
@@ -255,9 +255,9 @@ describe("runModelFlow", () => {
     });
   });
 
-  it("applies the pick, then repaints with the new hint and a success notice", async () => {
+  it("applies the pick and returns to the prompt without repainting the menu", async () => {
     const { prompter, menuPaints, selectMessages } = scriptedPrompter({
-      menu: ["model", "esc"],
+      menu: ["model"],
       picker: ["openai/gpt-5.5"],
     });
     const deps = flowDeps();
@@ -267,45 +267,17 @@ describe("runModelFlow", () => {
       modelMessage: `Model changed to ${pc.bold("openai/gpt-5.5")}. Live on your next prompt.`,
     });
 
-    expect(selectMessages).toEqual([
-      MODEL_MENU_MESSAGE,
-      "Which model should your agent use?",
-      MODEL_MENU_MESSAGE,
-    ]);
+    // The completed change exits straight to the main prompt: one menu paint,
+    // then the catalog picker, with no repaint to land on Done.
+    expect(selectMessages).toEqual([MODEL_MENU_MESSAGE, "Which model should your agent use?"]);
+    expect(menuPaints).toHaveLength(1);
     expect(deps.applyModel).toHaveBeenCalledWith({ appRoot: APP_ROOT, slug: "openai/gpt-5.5" });
-    // The applied slug is authoritative for the hint — no compiled-state
-    // re-read (which would race the HMR recompile).
     expect(deps.readCurrentModel).toHaveBeenCalledTimes(1);
-    expect(menuPaints[1]?.options[0]).toEqual({
-      value: "model",
-      label: "Change model",
-      hint: "openai/gpt-5.5",
-    });
-    expect(menuPaints[1]?.notices).toEqual([
-      { tone: "success", text: "Model changed to openai/gpt-5.5" },
-    ]);
   });
 
-  it("keeps only the latest model-change notice", async () => {
+  it("exits with the rejection message when the applied slug is rejected", async () => {
     const { prompter, menuPaints } = scriptedPrompter({
-      menu: ["model", "model", "esc"],
-      picker: ["openai/gpt-5.5", "anthropic/claude-sonnet-4.6"],
-    });
-    const deps = flowDeps();
-
-    await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps })).resolves.toEqual({
-      kind: "done",
-      modelMessage: `Model changed to ${pc.bold("anthropic/claude-sonnet-4.6")}. Live on your next prompt.`,
-    });
-
-    expect(menuPaints[2]?.notices).toEqual([
-      { tone: "success", text: "Model changed to anthropic/claude-sonnet-4.6" },
-    ]);
-  });
-
-  it("paints a warning notice for a rejected slug and keeps the old hint", async () => {
-    const { prompter, menuPaints } = scriptedPrompter({
-      menu: ["model", "esc"],
+      menu: ["model"],
       picker: ["openai/gpt-5.5"],
     });
     const deps = flowDeps({
@@ -314,17 +286,18 @@ describe("runModelFlow", () => {
       ),
     });
 
+    // A rejected apply still completes the action: the menu exits and the
+    // rejection surfaces as the command's reply line, not an in-menu notice.
     await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps })).resolves.toEqual({
       kind: "done",
       modelMessage: "Couldn't confirm the id.",
     });
 
-    expect(menuPaints[1]?.options[0]?.hint).toBe("anthropic/claude-sonnet-4.6");
-    expect(menuPaints[1]?.notices).toEqual([{ tone: "warning", text: "Couldn't confirm the id." }]);
+    expect(menuPaints).toHaveLength(1);
   });
 
-  it("runs the provider sub-flow, re-detects the status, and posts its notice", async () => {
-    const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider", "esc"] });
+  it("runs the provider sub-flow, re-detects the status, and returns to the prompt", async () => {
+    const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider"] });
     const detectProviderStatus = vi
       .fn<ModelFlowDeps["detectProviderStatus"]>()
       .mockResolvedValueOnce({ kind: "unset" })
@@ -343,13 +316,10 @@ describe("runModelFlow", () => {
     });
 
     expect(runVercelFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
+    // Status is re-read once after the sub-flow (plus the initial menu read),
+    // then the completed setup exits without repainting the menu.
     expect(detectProviderStatus).toHaveBeenCalledTimes(2);
-    expect(menuPaints[1]?.options[1]).toEqual({
-      value: "provider",
-      label: "Change provider",
-      hint: `AI Gateway (Linked to ${pc.bold("my-agent")})`,
-    });
-    expect(menuPaints[1]?.notices).toEqual([{ tone: "success", text: "Connected to AI Gateway" }]);
+    expect(menuPaints).toHaveLength(1);
   });
 
   it("treats the external-provider branch as informational — no notice, no outcome", async () => {
@@ -412,31 +382,6 @@ describe("runModelFlow", () => {
       await runModelFlow({ appRoot: APP_ROOT, prompter, deps });
 
       expect(menuPaints[0]?.initialValue).toBe("model");
-    });
-
-    it("lands on Done after a model change", async () => {
-      const { prompter, menuPaints } = scriptedPrompter({
-        menu: ["model", "esc"],
-        picker: ["openai/gpt-5.5"],
-      });
-
-      await runModelFlow({ appRoot: APP_ROOT, prompter, deps: flowDeps() });
-
-      expect(menuPaints[0]?.initialValue).toBe("provider");
-      expect(menuPaints[1]?.initialValue).toBe("done");
-    });
-
-    it("lands on Done after a completed provider sub-flow", async () => {
-      const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider", "esc"] });
-      const deps = flowDeps({
-        runVercelFlow: vi.fn(
-          async () => ({ kind: "done", credential: "AI_GATEWAY_API_KEY" }) as const,
-        ),
-      });
-
-      await runModelFlow({ appRoot: APP_ROOT, prompter, deps });
-
-      expect(menuPaints[1]?.initialValue).toBe("done");
     });
 
     it("lands on Done after the external-provider branch", async () => {

--- a/packages/eve/src/setup/flows/model.test.ts
+++ b/packages/eve/src/setup/flows/model.test.ts
@@ -255,7 +255,7 @@ describe("runModelFlow", () => {
     });
   });
 
-  it("applies the pick and returns to the prompt without repainting the menu", async () => {
+  it("applies the model and returns to the prompt", async () => {
     const { prompter, menuPaints, selectMessages } = scriptedPrompter({
       menu: ["model"],
       picker: ["openai/gpt-5.5"],
@@ -267,15 +267,13 @@ describe("runModelFlow", () => {
       modelMessage: `Model changed to ${pc.bold("openai/gpt-5.5")}. Live on your next prompt.`,
     });
 
-    // The completed change exits straight to the main prompt: one menu paint,
-    // then the catalog picker, with no repaint to land on Done.
     expect(selectMessages).toEqual([MODEL_MENU_MESSAGE, "Which model should your agent use?"]);
     expect(menuPaints).toHaveLength(1);
     expect(deps.applyModel).toHaveBeenCalledWith({ appRoot: APP_ROOT, slug: "openai/gpt-5.5" });
     expect(deps.readCurrentModel).toHaveBeenCalledTimes(1);
   });
 
-  it("exits with the rejection message when the applied slug is rejected", async () => {
+  it("returns a rejection without repainting the menu", async () => {
     const { prompter, menuPaints } = scriptedPrompter({
       menu: ["model"],
       picker: ["openai/gpt-5.5"],
@@ -286,8 +284,6 @@ describe("runModelFlow", () => {
       ),
     });
 
-    // A rejected apply still completes the action: the menu exits and the
-    // rejection surfaces as the command's reply line, not an in-menu notice.
     await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps })).resolves.toEqual({
       kind: "done",
       modelMessage: "Couldn't confirm the id.",
@@ -296,7 +292,7 @@ describe("runModelFlow", () => {
     expect(menuPaints).toHaveLength(1);
   });
 
-  it("runs the provider sub-flow, re-detects the status, and returns to the prompt", async () => {
+  it("returns to the prompt after provider setup", async () => {
     const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider"] });
     const detectProviderStatus = vi
       .fn<ModelFlowDeps["detectProviderStatus"]>()
@@ -316,8 +312,6 @@ describe("runModelFlow", () => {
     });
 
     expect(runVercelFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
-    // Status is re-read once after the sub-flow (plus the initial menu read),
-    // then the completed setup exits without repainting the menu.
     expect(detectProviderStatus).toHaveBeenCalledTimes(2);
     expect(menuPaints).toHaveLength(1);
   });

--- a/packages/eve/src/setup/flows/model.ts
+++ b/packages/eve/src/setup/flows/model.ts
@@ -179,26 +179,6 @@ function modelMenuRows(
   return [modelRow, providerRow, { value: "done", label: "Done" }];
 }
 
-/** The menu's per-action outcome notices; each lap keeps only the latest. */
-function applyModelNotice(outcome: ApplyModelOutcome): SelectNotice {
-  switch (outcome.kind) {
-    case "changed":
-      return { tone: "success", text: `Model changed to ${outcome.to}` };
-    case "unchanged":
-      return { tone: "info", text: `Model is already ${outcome.model}` };
-    case "rejected":
-      return { tone: "warning", text: outcome.message };
-  }
-}
-
-function providerNotice(provider: ModelProviderStatus): SelectNotice {
-  // Short on purpose: the menu's provider row already names the project and
-  // team, and the full status hint overflows the panel width.
-  return provider.kind === "unset"
-    ? { tone: "warning", text: "Provider updated — no gateway credential detected yet." }
-    : { tone: "success", text: "Connected to AI Gateway" };
-}
-
 /**
  * Reads the provider status the menu shows. Detection order matters: a linked
  * project subsumes any pulled credential (the link is what the user manages),
@@ -240,10 +220,11 @@ export async function detectModelProviderStatus(
  * choice into `agent.ts` (activation is the dev server's HMR watcher).
  * The provider row runs {@link runVercelFlow} — the provider gate (AI
  * Gateway or your own), then link-or-paste-a-key.
- * Each sub-flow lands back on the repainted menu; Done or Esc leaves. A
- * cancelled sub-flow also returns to the menu. Esc after something completed
- * reports it exactly like the channels flow (the effects already happened);
- * only an empty exit folds to cancelled.
+ * A completed model change or provider setup leaves the menu for the main
+ * prompt, carrying its outcome as the command's reply line (the effects already
+ * happened, exactly like the channels flow). A cancelled sub-flow — or the
+ * own-key branch, which only shows instructions — repaints the menu instead;
+ * Done or Esc there folds to cancelled.
  */
 export async function runModelFlow(input: {
   appRoot: string;
@@ -281,10 +262,6 @@ export async function runModelFlow(input: {
 
   let lastApply: ApplyModelOutcome | undefined;
   let providerOutcome: ModelProviderOutcome | undefined;
-  // One notice per action kind, each overwritten by its latest outcome — two
-  // model changes in a row leave a single "Model changed to …" line.
-  let modelNotice: SelectNotice | undefined;
-  let provNotice: SelectNotice | undefined;
   // Explains, once, why every row is inert for an external-provider model.
   const externalNotice: SelectNotice | undefined =
     routing?.kind === "external"
@@ -296,9 +273,10 @@ export async function runModelFlow(input: {
 
   // The menu opens on the most useful selectable row: an unconfigured provider
   // (the agent can't run without it) leads on the first lap; otherwise the model
-  // row when it can be edited, else the provider row, else Done. Completing a
-  // sub-flow lands the cursor on Done; a cancelled sub-flow leaves it where it
-  // came from.
+  // row when it can be edited, else the provider row, else Done. A completed
+  // change or provider setup exits the menu, so the cursor only matters on a
+  // repaint: a cancelled sub-flow stays on its row, the own-key branch lands on
+  // Done.
   let nextSelection: ModelMenuRow =
     provider.kind === "unset" && routing?.kind !== "external"
       ? "provider"
@@ -316,7 +294,7 @@ export async function runModelFlow(input: {
         options: modelMenuRows(current, provider, routing, editable),
         hintLayout: "stacked",
         initialValue: nextSelection,
-        notices: [externalNotice, modelNotice, provNotice].filter((notice) => notice !== undefined),
+        notices: externalNotice === undefined ? [] : [externalNotice],
       });
     } catch (error) {
       if (!(error instanceof WizardCancelledError)) throw error;
@@ -333,21 +311,18 @@ export async function runModelFlow(input: {
         signal,
         deps: deps.selectModel,
       });
-      if (slug !== undefined) {
-        signal?.throwIfAborted();
-        lastApply = await deps.applyModel({ appRoot, slug });
-        signal?.throwIfAborted();
-        // The notice distinguishes success from a rejected slug; the menu
-        // hint alone would show an unchanged model with no explanation.
-        modelNotice = applyModelNotice(lastApply);
-        // The applied slug is authoritative for the hint — the compiled
-        // state the read reports lags behind the HMR recompile.
-        if (lastApply.kind === "changed") current = lastApply.to;
-        nextSelection = "done";
-      } else {
+      // A cancelled picker changed nothing; repaint the menu on the model row.
+      if (slug === undefined) {
         nextSelection = "model";
+        continue;
       }
-      continue;
+      signal?.throwIfAborted();
+      lastApply = await deps.applyModel({ appRoot, slug });
+      signal?.throwIfAborted();
+      // The action completed: leave the menu for the main prompt. The apply
+      // outcome (changed, unchanged, or a rejected slug) surfaces there as the
+      // command's reply line.
+      break;
     }
 
     const result = await deps.runVercelFlow({ appRoot, prompter, signal });
@@ -359,8 +334,8 @@ export async function runModelFlow(input: {
       continue;
     }
     // The external-provider branch only showed instructions (any gateway link
-    // is untouched), so it earns no outcome, notice, or status re-read — but
-    // the user did make a provider choice, so the menu lands on Done.
+    // is untouched), so nothing changed on disk: it earns no outcome or status
+    // re-read, and the menu stays open on Done rather than exiting.
     if ("outcome" in result) {
       nextSelection = "done";
       continue;
@@ -371,8 +346,8 @@ export async function runModelFlow(input: {
     signal?.throwIfAborted();
     providerOutcome = { status: provider };
     if (result.credential !== undefined) providerOutcome.credential = result.credential;
-    provNotice = providerNotice(provider);
-    nextSelection = "done";
+    // The action completed: leave the menu for the main prompt.
+    break;
   }
 
   if (lastApply === undefined && providerOutcome === undefined) {

--- a/packages/eve/src/setup/flows/model.ts
+++ b/packages/eve/src/setup/flows/model.ts
@@ -220,11 +220,8 @@ export async function detectModelProviderStatus(
  * choice into `agent.ts` (activation is the dev server's HMR watcher).
  * The provider row runs {@link runVercelFlow} — the provider gate (AI
  * Gateway or your own), then link-or-paste-a-key.
- * A completed model change or provider setup leaves the menu for the main
- * prompt, carrying its outcome as the command's reply line (the effects already
- * happened, exactly like the channels flow). A cancelled sub-flow — or the
- * own-key branch, which only shows instructions — repaints the menu instead;
- * Done or Esc there folds to cancelled.
+ * Completed model and provider changes return to the prompt with their result.
+ * Cancelled flows and external-provider instructions return to the menu.
  */
 export async function runModelFlow(input: {
   appRoot: string;
@@ -271,12 +268,7 @@ export async function runModelFlow(input: {
         }
       : undefined;
 
-  // The menu opens on the most useful selectable row: an unconfigured provider
-  // (the agent can't run without it) leads on the first lap; otherwise the model
-  // row when it can be edited, else the provider row, else Done. A completed
-  // change or provider setup exits the menu, so the cursor only matters on a
-  // repaint: a cancelled sub-flow stays on its row, the own-key branch lands on
-  // Done.
+  // Start at the first useful row. Cancellation keeps the current row.
   let nextSelection: ModelMenuRow =
     provider.kind === "unset" && routing?.kind !== "external"
       ? "provider"
@@ -311,7 +303,6 @@ export async function runModelFlow(input: {
         signal,
         deps: deps.selectModel,
       });
-      // A cancelled picker changed nothing; repaint the menu on the model row.
       if (slug === undefined) {
         nextSelection = "model";
         continue;
@@ -319,9 +310,6 @@ export async function runModelFlow(input: {
       signal?.throwIfAborted();
       lastApply = await deps.applyModel({ appRoot, slug });
       signal?.throwIfAborted();
-      // The action completed: leave the menu for the main prompt. The apply
-      // outcome (changed, unchanged, or a rejected slug) surfaces there as the
-      // command's reply line.
       break;
     }
 
@@ -333,9 +321,7 @@ export async function runModelFlow(input: {
       nextSelection = "provider";
       continue;
     }
-    // The external-provider branch only showed instructions (any gateway link
-    // is untouched), so nothing changed on disk: it earns no outcome or status
-    // re-read, and the menu stays open on Done rather than exiting.
+    // External-provider setup only shows instructions, so keep the menu open.
     if ("outcome" in result) {
       nextSelection = "done";
       continue;
@@ -346,7 +332,6 @@ export async function runModelFlow(input: {
     signal?.throwIfAborted();
     providerOutcome = { status: provider };
     if (result.credential !== undefined) providerOutcome.credential = result.credential;
-    // The action completed: leave the menu for the main prompt.
     break;
   }
 


### PR DESCRIPTION
## What

- Show `/vc` or `/login` before `/model` when Vercel auth blocks model setup.
- Close `/model` after a model or provider change and print the result in the transcript.

The TUI built its setup line from boot checks first, then appended the async auth check. That could tell someone to run `/model` before the Vercel CLI was installed or before they had logged in. The auth fix now comes first because `/model` depends on it.

`/model` also reopened its menu after a completed change, forcing one more Done or Esc. It now returns to the prompt as soon as the change finishes. Cancellations and the external-provider info path stay in the menu because they did not change anything.

Unit, integration, scenario, typecheck, build, lint, formatting, and invariant checks pass. The packaged `/model` TUI check passes too. I could not finish the model-backed TUI checks without AI Gateway credentials.
