### PR TITLE
feat(docs): add static OG image for home and docs

### DIFF
--- a/apps/docs/app/[lang]/(home)/page.tsx
+++ b/apps/docs/app/[lang]/(home)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Installer } from "@/components/geistdocs/installer";
+import { staticOgImage } from "@/lib/geistdocs/og";
 import { ArchitectureDiagram } from "./components/architecture";
 import { CTA } from "./components/cta";
 import { FeatureGrid } from "./components/feature-grid";
@@ -15,6 +16,17 @@ const betaAgreementHref = "https://vercel.com/docs/release-phases/public-beta-ag
 export const metadata: Metadata = {
   title,
   description: `${tagline} ${description}`,
+  openGraph: {
+    title,
+    description: `${tagline} ${description}`,
+    images: [staticOgImage],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description: `${tagline} ${description}`,
+    images: [staticOgImage],
+  },
 };
 
 const HomePage = () => (

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import { createDocsPage } from "@vercel/geistdocs/pages/docs";
 import type { MDXComponents } from "mdx/types";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { config } from "@/lib/geistdocs/config";
+import { staticOgImage } from "@/lib/geistdocs/og";
 import { geistdocsSource } from "@/lib/geistdocs/source";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
 
@@ -12,12 +13,15 @@ const docsPage = createDocsPage({
     const components: MDXComponents = link ? { a: link } : {};
     return getMDXComponents(components);
   },
-  metadata: ({ metadata, page }) => ({
+  metadata: ({ metadata }) => ({
     ...metadata,
     metadataBase: new URL(getSiteOrigin()),
     openGraph: {
       ...metadata.openGraph,
-      images: geistdocsSource.getPageImage(page).url,
+      // Override with the static OG image for now. To restore dynamic per-page
+      // OG generation, add `page` back to the destructure above and swap the
+      // line below back to: images: geistdocsSource.getPageImage(page).url,
+      images: [staticOgImage],
     },
   }),
   source: geistdocsSource,

--- a/apps/docs/lib/geistdocs/og.ts
+++ b/apps/docs/lib/geistdocs/og.ts
@@ -1,0 +1,4 @@
+// Shared static OG image used across the site for now.
+// TODO: restore the dynamic per-page OG generation in
+// app/[lang]/docs/[[...slug]]/page.tsx when ready.
+export const staticOgImage = "https://ztwjwi3ssdvgx15d.public.blob.vercel-storage.com/og-image.jpg";


### PR DESCRIPTION
## Summary
- Adds a shared static OG image (Vercel Blob URL) used for both the home page (`/`) and docs pages (`/docs/*`) for now.
- Wires up `openGraph` + `twitter` (summary_large_image) metadata on the home page, which previously had no OG image.
- Overrides the docs pages' dynamic OG to the same static image. Design update for dynamic OG images is more complex, we will ITG later

| **Before**  | **After** |
| ------------- | ------------- |
| <img width="1222" height="653" alt="image" src="https://github.com/user-attachments/assets/2fe4d7e2-26ec-4c56-ac04-b851dd0deb08" /> | <img width="1882" height="996" alt="CleanShot 2026-06-17 at 16 22 49@2x" src="https://github.com/user-attachments/assets/81ca6dd6-54fc-4de3-ade5-5708cbca67c1" /> |

## Notes
- To restore dynamic per-page docs OGs later, follow the comment in `app/[lang]/docs/[[...slug]]/page.tsx`.