### PR TITLE
fix(setup): link Vercel project non-interactively in the dev TUI

### DIFF
--- a/.changeset/vercel-link-non-interactive.md
+++ b/.changeset/vercel-link-non-interactive.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Run `vercel link` non-interactively when connecting a project via the dev TUI `/model` menu (and `eve link`). The link is already fully specified by the team and project picked in the TUI, so the CLI no longer inherits a TTY and can no longer surface its interactive prompts (such as the agent/MCP setup question), which previously corrupted the TUI.

--- a/packages/eve/src/setup/vercel-project.test.ts
+++ b/packages/eve/src/setup/vercel-project.test.ts
@@ -455,7 +455,7 @@ describe("linkProject", () => {
     expect(mockedRunVercel).toHaveBeenNthCalledWith(
       1,
       ["link", "--project", "prj_new", "--scope", "team-a", "--yes"],
-      { cwd: "/tmp/eve-agent", onOutput: expect.any(Function) },
+      { cwd: "/tmp/eve-agent", onOutput: expect.any(Function), nonInteractive: true },
     );
   });
 });

--- a/packages/eve/src/setup/vercel-project.ts
+++ b/packages/eve/src/setup/vercel-project.ts
@@ -624,6 +624,14 @@ export async function linkProject(
       runVercel(["link", "--project", project.id, ...scope, "--yes"], {
         cwd: projectRoot,
         onOutput,
+        // The plan already names the team and project, so the link needs no
+        // input. eve strips the coding-agent env markers (so the CLI does not
+        // mis-react to the agent driving it), which also stops the CLI from
+        // auto-enabling its agent non-interactive default — left with an
+        // inherited TTY it would prompt (e.g. the MCP/plugin setup question)
+        // and read stdin, wedging the dev TUI. Force non-interactive: it both
+        // passes `--non-interactive` and closes the child's stdin.
+        nonInteractive: true,
         signal: options.signal,
       }),
   );


### PR DESCRIPTION
The `/model` → Vercel AI Gateway → **Connect via a project** flow shelled out to an *interactive* `vercel link`. Inside the dev TUI that took over stdin and let the CLI raise its own prompts — including CLI 54's MCP/plugin setup question — which corrupted the TUI rendering.

## What

- `linkProject` now passes `nonInteractive: true` to the `vercel link` spawn.
- Updated the spawn-args assertion in `vercel-project.test.ts`.
- Changeset (`patch`).

## Why it prompted

The link is already fully specified by the team and project picked in the TUI: `link --project <id> --scope <team> --yes`. Nothing is left to ask. But two things lined up to make the CLI prompt anyway:

- Every other Vercel call in `vercel-project.ts` goes through `captureVercel`, which closes stdin. Only `linkProject`'s `runVercel` call omitted `nonInteractive`, so `stdioForRun` handed the child an inherited TTY.
- eve strips the coding-agent env markers (`coding-agent-env.ts`) so the CLI never mis-reacts to the agent driving it. That also disables the CLI's own "non-interactive when an agent is detected" default. With a live stdin and no agent signal, CLI 54 treats the session as a human terminal and prompts.

`nonInteractive: true` both appends `--non-interactive` and closes the child's stdin. The sibling `deploy` spawn already does this; the link call was the lone omission.

## Scope

One spawn option, plus the test and changeset. No change to team/project selection — that already runs through eve's own TUI pickers. Scenario/e2e suites not run here (need a build + model credentials); the change is covered by the unit test pinning the spawn args.