### PR TITLE
fix(eve): validate resolved OIDC token

### DIFF
--- a/.changeset/sharp-dolphins-check.md
+++ b/.changeset/sharp-dolphins-check.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Treat empty Vercel OIDC resolver results as unavailable credentials instead of reporting AI Gateway as connected.

--- a/packages/eve/src/internal/nitro/routes/info.test.ts
+++ b/packages/eve/src/internal/nitro/routes/info.test.ts
@@ -113,6 +113,19 @@ describe("handleAgentInfoRequest", () => {
     expect(mocks.getVercelOidcToken).toHaveBeenCalledOnce();
   });
 
+  it("does not report OIDC when the Vercel SDK returns an empty token", async () => {
+    mocks.getVercelOidcToken.mockResolvedValue("");
+
+    const response = await requestAgentInfo();
+
+    expect(response.status).toBe(200);
+    expect(mocks.buildAgentInfoResponseFromManifest).toHaveBeenCalledWith(GATEWAY_MANIFEST_DATA, {
+      mode: "development",
+      gatewayCredentials: { apiKey: false, oidc: false },
+    });
+    expect(mocks.getVercelOidcToken).toHaveBeenCalledOnce();
+  });
+
   it("does not resolve OIDC when an AI Gateway API key is present", async () => {
     vi.stubEnv("AI_GATEWAY_API_KEY", "gateway-key");
 

--- a/packages/eve/src/internal/nitro/routes/info.ts
+++ b/packages/eve/src/internal/nitro/routes/info.ts
@@ -45,8 +45,8 @@ async function resolveGatewayCredentialPresence(
   }
 
   try {
-    await getVercelOidcToken();
-    return { apiKey: false, oidc: true };
+    const token = await getVercelOidcToken();
+    return { apiKey: false, oidc: token.trim() !== "" };
   } catch {
     return { apiKey: false, oidc: false };
   }


### PR DESCRIPTION
## What

- Derive OIDC credential presence from the token returned by `getVercelOidcToken()`.
- Keep empty and whitespace-only resolver results disconnected.
- Add the regression test and patch changeset.

PR #40 merged while this edge case was being corrected. Its `/eve/v1/info` path currently turns any resolved SDK call into `oidc: true`, even though the SDK returns a string.

The follow-up keeps `GatewayCredentialPresence` boolean and validates the returned token at that boundary. An empty resolver result now produces `{ apiKey: false, oidc: false }`.
