### PR TITLE
feat(eve): aggregate inline tool auth providers

### DIFF
--- a/.changeset/inline-tool-auth-aggregation.md
+++ b/.changeset/inline-tool-auth-aggregation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `ctx.getTokens(...)` so tools can resolve multiple inline auth providers together and aggregate missing authorization prompts into one consent step.

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -276,11 +276,12 @@ export default defineTool({
   description: "Sync GitHub context into Linear.",
   inputSchema: z.object({ issueId: z.string() }),
   async execute({ issueId }, ctx) {
-    const { token: githubToken } = await ctx.getToken(githubAuth, {
-      displayName: "GitHub",
-    });
-    const { token: linearToken } = await ctx.getToken(linearAuth, {
-      displayName: "Linear",
+    const {
+      github: { token: githubToken },
+      linear: { token: linearToken },
+    } = await ctx.getTokens({
+      github: [githubAuth, { displayName: "GitHub" }],
+      linear: [linearAuth, { displayName: "Linear" }],
     });
 
     const repo = await fetch("https://api.github.com/user/repos", {
@@ -297,12 +298,15 @@ The tool's `ctx` exposes two auth accessors:
 
 - `ctx.getToken()` resolves the bearer for the declared strategy, checking the per-step token cache first. With an interactive strategy, a cache miss suspends the turn on a framework-owned callback URL, shows a "Sign in" affordance, and re-runs the tool once the OAuth callback completes.
 - `ctx.getToken(provider, options?)` resolves an inline provider such as `connect("github")`. It uses the same cache, callback, and sign-in machinery, but scopes the flow to that provider instead of the tool's top-level `auth`.
+- `ctx.getTokens({ key: provider })` resolves several inline providers concurrently. If more than one provider needs interactive authorization, eve surfaces one consent step containing every missing provider instead of prompting one at a time.
 - `ctx.requireAuth()` throws `ConnectionAuthorizationRequiredError` to gate the tool on authorization before any token resolves. The runtime turns that into the same consent prompt.
 - `ctx.requireAuth(provider, options?)` does the same for an inline provider. Use it after a downstream `401` rejects a token returned by `ctx.getToken(provider)`.
 
 Throw `ConnectionAuthorizationRequiredError` anywhere in `execute` (directly, via `requireAuth()`, or implicitly from `getToken()`) and you trigger the consent flow, keyed by the tool's name. Calling a no-arg accessor on a tool that does not declare `auth` throws; pass a provider to use inline auth from a plain tool.
 
 By default the sign-in affordance title-cases the tool's path-derived name, so a tool file named `sfdc_lookup.ts` renders "Sign in with Sfdc_lookup". Set `displayName` on the `auth` definition to control what users see instead, for example `auth: { ...connect("sfdc"), displayName: "Salesforce" }`. It is presentation-only. The tool's name still keys the authorization scope, token cache, and callback URL, and a definition-level `displayName` wins over one the strategy stamps on the challenge.
+
+`Promise.all([ctx.getToken(a), ctx.getToken(b)])` is fine when both tokens resolve. When both providers might be missing authorization, prefer `ctx.getTokens(...)`: JavaScript rejects `Promise.all` on the first rejection, so the runtime only sees one missing auth request and may prompt for the providers sequentially.
 
 Inline providers derive a stable tool-qualified scope from Vercel Connect metadata when available. If you pass multiple custom providers that do not carry provider metadata, give each one an explicit `scope`, for example `ctx.getToken(auth, { scope: "github" })`.
 

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -63,6 +63,7 @@ A few non-`define*` helpers round out the set: `disableTool` and `ExperimentalWo
 | `ctx.getSkill(identifier)`  | Handle for a named skill visible to the current agent                         |
 | `ctx.getToken()`            | Resolve the bearer token for a tool's declared `auth` (throws without `auth`) |
 | `ctx.getToken(provider)`    | Resolve a bearer token for an inline auth provider such as `connect("...")`   |
+| `ctx.getTokens({ ... })`    | Resolve several inline providers and aggregate missing authorization prompts  |
 | `ctx.requireAuth()`         | Force the tool's declared authorization flow before proceeding                |
 | `ctx.requireAuth(provider)` | Re-challenge an inline provider, commonly after a downstream `401`            |
 

--- a/e2e/fixtures/agent-tool-auth/.gitignore
+++ b/e2e/fixtures/agent-tool-auth/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env*
+.eve
+.vercel
+.workflow-data
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-tool-auth/.vercelignore
+++ b/e2e/fixtures/agent-tool-auth/.vercelignore
@@ -1,0 +1,6 @@
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-tool-auth/agent/agent.ts
+++ b/e2e/fixtures/agent-tool-auth/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "openai/gpt-5.5",
+});

--- a/e2e/fixtures/agent-tool-auth/agent/channels/eve.ts
+++ b/e2e/fixtures/agent-tool-auth/agent/channels/eve.ts
@@ -1,0 +1,14 @@
+import { eveChannel } from "eve/channels/eve";
+import type { AuthFn } from "eve/channels/auth";
+
+const evalUserAuth: AuthFn<Request> = () => ({
+  attributes: {},
+  authenticator: "e2e-eval",
+  issuer: "e2e-eval",
+  principalId: "eval-user",
+  principalType: "user",
+});
+
+export default eveChannel({
+  auth: evalUserAuth,
+});

--- a/e2e/fixtures/agent-tool-auth/agent/instructions.md
+++ b/e2e/fixtures/agent-tool-auth/agent/instructions.md
@@ -1,0 +1,3 @@
+# Identity
+
+You are a helpful assistant. When a user asks you to call a named tool, call that tool exactly as requested and report the relevant returned values.

--- a/e2e/fixtures/agent-tool-auth/agent/tools/inline-auth-multi-ticket.ts
+++ b/e2e/fixtures/agent-tool-auth/agent/tools/inline-auth-multi-ticket.ts
@@ -1,0 +1,63 @@
+import {
+  ConnectionAuthorizationRequiredError,
+  type AuthorizationDefinition,
+  type TokenResult,
+} from "eve/connections";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+const INLINE_AUTH_MARKER = "inline-auth-e2e-ok-Q7M2";
+
+const githubAuth = buildAuthProvider({
+  connector: "oauth/github-e2e",
+  provider: "github",
+  url: "https://auth.example.test/github",
+});
+
+const linearAuth = buildAuthProvider({
+  connector: "oauth/linear-e2e",
+  provider: "linear",
+  url: "https://auth.example.test/linear",
+});
+
+export default defineTool({
+  description: "Return a deterministic marker after resolving GitHub and Linear inline auth.",
+  inputSchema: z.object({}),
+  async execute(_input, ctx) {
+    const tokens = await ctx.getTokens({
+      github: [githubAuth, { displayName: "GitHub E2E" }],
+      linear: [linearAuth, { displayName: "Linear E2E" }],
+    });
+
+    return {
+      marker: INLINE_AUTH_MARKER,
+      github: tokens.github.token,
+      linear: tokens.linear.token,
+    };
+  },
+});
+
+function buildAuthProvider(input: {
+  readonly connector: string;
+  readonly provider: string;
+  readonly url: string;
+}): AuthorizationDefinition {
+  return {
+    principalType: "user",
+    vercelConnect: { connector: input.connector },
+    async getToken(): Promise<TokenResult> {
+      throw new ConnectionAuthorizationRequiredError(input.connector);
+    },
+    async startAuthorization() {
+      return {
+        challenge: {
+          instructions: `Authorize ${input.provider}`,
+          url: input.url,
+        },
+      };
+    },
+    async completeAuthorization({ callback }): Promise<TokenResult> {
+      return { token: `${input.provider}-${callback.params.code ?? "missing-code"}` };
+    },
+  };
+}

--- a/e2e/fixtures/agent-tool-auth/agent/tools/inline-auth-ticket.ts
+++ b/e2e/fixtures/agent-tool-auth/agent/tools/inline-auth-ticket.ts
@@ -1,0 +1,53 @@
+import {
+  ConnectionAuthorizationRequiredError,
+  type AuthorizationDefinition,
+  type TokenResult,
+} from "eve/connections";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+const INLINE_AUTH_MARKER = "inline-auth-e2e-ok-Q7M2";
+
+const githubAuth = buildAuthProvider({
+  connector: "oauth/github-e2e",
+  provider: "github",
+  url: "https://auth.example.test/github",
+});
+
+export default defineTool({
+  description: "Return a deterministic marker after resolving GitHub inline auth.",
+  inputSchema: z.object({}),
+  async execute(_input, ctx) {
+    const github = await ctx.getToken(githubAuth, { displayName: "GitHub E2E" });
+
+    return {
+      marker: INLINE_AUTH_MARKER,
+      github: github.token,
+    };
+  },
+});
+
+function buildAuthProvider(input: {
+  readonly connector: string;
+  readonly provider: string;
+  readonly url: string;
+}): AuthorizationDefinition {
+  return {
+    principalType: "user",
+    vercelConnect: { connector: input.connector },
+    async getToken(): Promise<TokenResult> {
+      throw new ConnectionAuthorizationRequiredError(input.connector);
+    },
+    async startAuthorization() {
+      return {
+        challenge: {
+          instructions: `Authorize ${input.provider}`,
+          url: input.url,
+        },
+      };
+    },
+    async completeAuthorization({ callback }): Promise<TokenResult> {
+      return { token: `${input.provider}-${callback.params.code ?? "missing-code"}` };
+    },
+  };
+}

--- a/e2e/fixtures/agent-tool-auth/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tool-auth/evals/evals.config.ts
@@ -1,0 +1,6 @@
+import { defineEvalConfig } from "eve/evals";
+
+/** Default judge model for any `t.judge.*` assertion in this fixture. */
+export default defineEvalConfig({
+  judge: { model: "openai/gpt-5.5" },
+});

--- a/e2e/fixtures/agent-tool-auth/evals/inline-auth/multiple-providers.eval.ts
+++ b/e2e/fixtures/agent-tool-auth/evals/inline-auth/multiple-providers.eval.ts
@@ -1,0 +1,153 @@
+import type {
+  ActionResultStreamEvent,
+  AuthorizationCompletedStreamEvent,
+  AuthorizationRequiredStreamEvent,
+  HandleMessageStreamEvent,
+} from "eve/client";
+import { defineEval } from "eve/evals";
+
+const TOOL_NAME = "inline-auth-multi-ticket";
+const GITHUB_SCOPE = "inline-auth-multi-ticket__oauth_github-e2e";
+const LINEAR_SCOPE = "inline-auth-multi-ticket__oauth_linear-e2e";
+const MARKER = "inline-auth-e2e-ok-Q7M2";
+
+export default defineEval({
+  description:
+    "Inline tool auth e2e: multiple provider prompts complete through real callback routes.",
+
+  async test(t) {
+    const turn = await t.authorize(
+      [
+        `Call the \`${TOOL_NAME}\` tool exactly once with an empty object.`,
+        `After it returns, reply with ${MARKER}, github-github-code, and linear-linear-code.`,
+      ].join("\n"),
+      [
+        { name: GITHUB_SCOPE, params: { code: "github-code" } },
+        { name: LINEAR_SCOPE, params: { code: "linear-code" } },
+      ],
+    );
+    turn.expectOk();
+
+    const authRequired = authorizationRequiredEvents(t.events);
+    if (authRequired.length !== 2) {
+      throw new Error(`Expected 2 authorization.required events, got ${authRequired.length}.`);
+    }
+    assertAuthRequired(
+      authRequired,
+      GITHUB_SCOPE,
+      "GitHub E2E",
+      "https://auth.example.test/github",
+    );
+    assertAuthRequired(
+      authRequired,
+      LINEAR_SCOPE,
+      "Linear E2E",
+      "https://auth.example.test/linear",
+    );
+
+    const completed = authorizationCompletedEvents(t.events);
+    if (completed.length !== 2) {
+      throw new Error(`Expected 2 authorization.completed events, got ${completed.length}.`);
+    }
+    assertAuthorized(completed, GITHUB_SCOPE);
+    assertAuthorized(completed, LINEAR_SCOPE);
+
+    const output = inlineAuthOutput(t.events);
+    if (
+      output.marker !== MARKER ||
+      output.github !== "github-github-code" ||
+      output.linear !== "linear-linear-code"
+    ) {
+      throw new Error(`Unexpected inline auth output: ${JSON.stringify(output)}.`);
+    }
+
+    t.didNotFail();
+    t.completed();
+    t.calledTool(TOOL_NAME, {
+      isError: false,
+      output: {
+        github: "github-github-code",
+        linear: "linear-linear-code",
+        marker: MARKER,
+      },
+      times: 1,
+    });
+    t.messageIncludes(MARKER);
+    t.messageIncludes("github-github-code");
+    t.messageIncludes("linear-linear-code");
+  },
+});
+
+function authorizationRequiredEvents(
+  events: readonly HandleMessageStreamEvent[],
+): AuthorizationRequiredStreamEvent[] {
+  return events.filter(
+    (event): event is AuthorizationRequiredStreamEvent => event.type === "authorization.required",
+  );
+}
+
+function authorizationCompletedEvents(
+  events: readonly HandleMessageStreamEvent[],
+): AuthorizationCompletedStreamEvent[] {
+  return events.filter(
+    (event): event is AuthorizationCompletedStreamEvent => event.type === "authorization.completed",
+  );
+}
+
+function assertAuthRequired(
+  events: readonly AuthorizationRequiredStreamEvent[],
+  name: string,
+  displayName: string,
+  url: string,
+): void {
+  const event = events.find((candidate) => candidate.data.name === name);
+  if (event === undefined) {
+    throw new Error(`Missing authorization.required for ${name}.`);
+  }
+  if (event.data.authorization?.displayName !== displayName) {
+    throw new Error(
+      `Expected ${name} displayName ${JSON.stringify(displayName)}, got ${JSON.stringify(
+        event.data.authorization?.displayName,
+      )}.`,
+    );
+  }
+  if (event.data.authorization?.url !== url) {
+    throw new Error(
+      `Expected ${name} auth URL ${JSON.stringify(url)}, got ${JSON.stringify(
+        event.data.authorization?.url,
+      )}.`,
+    );
+  }
+  if (!event.data.webhookUrl?.includes(`/eve/v1/connections/${name}/callback/`)) {
+    throw new Error(`Expected ${name} webhookUrl to include its provider-scoped callback route.`);
+  }
+}
+
+function assertAuthorized(
+  events: readonly AuthorizationCompletedStreamEvent[],
+  name: string,
+): void {
+  const event = events.find((candidate) => candidate.data.name === name);
+  if (event === undefined) {
+    throw new Error(`Missing authorization.completed for ${name}.`);
+  }
+  if (event.data.outcome !== "authorized") {
+    throw new Error(`Expected ${name} to authorize, got ${event.data.outcome}.`);
+  }
+}
+
+function inlineAuthOutput(events: readonly HandleMessageStreamEvent[]): Record<string, unknown> {
+  const result = events.find(
+    (event): event is ActionResultStreamEvent =>
+      event.type === "action.result" &&
+      event.data.result.kind === "tool-result" &&
+      event.data.result.toolName === TOOL_NAME,
+  );
+  if (result === undefined || typeof result.data.result.output !== "object") {
+    throw new Error(`Missing ${TOOL_NAME} action.result output.`);
+  }
+  if (result.data.result.output === null || Array.isArray(result.data.result.output)) {
+    throw new Error(`Expected object output from ${TOOL_NAME}.`);
+  }
+  return result.data.result.output as Record<string, unknown>;
+}

--- a/e2e/fixtures/agent-tool-auth/evals/inline-auth/single-provider.eval.ts
+++ b/e2e/fixtures/agent-tool-auth/evals/inline-auth/single-provider.eval.ts
@@ -1,0 +1,135 @@
+import type {
+  ActionResultStreamEvent,
+  AuthorizationCompletedStreamEvent,
+  AuthorizationRequiredStreamEvent,
+  HandleMessageStreamEvent,
+} from "eve/client";
+import { defineEval } from "eve/evals";
+
+const TOOL_NAME = "inline-auth-ticket";
+const GITHUB_SCOPE = "inline-auth-ticket__oauth_github-e2e";
+const MARKER = "inline-auth-e2e-ok-Q7M2";
+
+export default defineEval({
+  description: "Inline tool auth e2e: provider prompts complete through real callback routes.",
+
+  async test(t) {
+    const turn = await t.authorize(
+      [
+        `Call the \`${TOOL_NAME}\` tool exactly once with an empty object.`,
+        `After it returns, reply with ${MARKER} and github-github-code.`,
+      ].join("\n"),
+      [{ name: GITHUB_SCOPE, params: { code: "github-code" } }],
+    );
+    turn.expectOk();
+
+    const authRequired = authorizationRequiredEvents(t.events);
+    if (authRequired.length !== 1) {
+      throw new Error(`Expected 1 authorization.required event, got ${authRequired.length}.`);
+    }
+    assertAuthRequired(
+      authRequired,
+      GITHUB_SCOPE,
+      "GitHub E2E",
+      "https://auth.example.test/github",
+    );
+
+    const completed = authorizationCompletedEvents(t.events);
+    if (completed.length !== 1) {
+      throw new Error(`Expected 1 authorization.completed event, got ${completed.length}.`);
+    }
+    assertAuthorized(completed, GITHUB_SCOPE);
+
+    const output = inlineAuthOutput(t.events);
+    if (output.marker !== MARKER || output.github !== "github-github-code") {
+      throw new Error(`Unexpected inline auth output: ${JSON.stringify(output)}.`);
+    }
+
+    t.didNotFail();
+    t.completed();
+    t.calledTool(TOOL_NAME, {
+      isError: false,
+      output: {
+        github: "github-github-code",
+        marker: MARKER,
+      },
+      times: 1,
+    });
+    t.messageIncludes(MARKER);
+    t.messageIncludes("github-github-code");
+  },
+});
+
+function authorizationRequiredEvents(
+  events: readonly HandleMessageStreamEvent[],
+): AuthorizationRequiredStreamEvent[] {
+  return events.filter(
+    (event): event is AuthorizationRequiredStreamEvent => event.type === "authorization.required",
+  );
+}
+
+function authorizationCompletedEvents(
+  events: readonly HandleMessageStreamEvent[],
+): AuthorizationCompletedStreamEvent[] {
+  return events.filter(
+    (event): event is AuthorizationCompletedStreamEvent => event.type === "authorization.completed",
+  );
+}
+
+function assertAuthRequired(
+  events: readonly AuthorizationRequiredStreamEvent[],
+  name: string,
+  displayName: string,
+  url: string,
+): void {
+  const event = events.find((candidate) => candidate.data.name === name);
+  if (event === undefined) {
+    throw new Error(`Missing authorization.required for ${name}.`);
+  }
+  if (event.data.authorization?.displayName !== displayName) {
+    throw new Error(
+      `Expected ${name} displayName ${JSON.stringify(displayName)}, got ${JSON.stringify(
+        event.data.authorization?.displayName,
+      )}.`,
+    );
+  }
+  if (event.data.authorization?.url !== url) {
+    throw new Error(
+      `Expected ${name} auth URL ${JSON.stringify(url)}, got ${JSON.stringify(
+        event.data.authorization?.url,
+      )}.`,
+    );
+  }
+  if (!event.data.webhookUrl?.includes(`/eve/v1/connections/${name}/callback/`)) {
+    throw new Error(`Expected ${name} webhookUrl to include its provider-scoped callback route.`);
+  }
+}
+
+function assertAuthorized(
+  events: readonly AuthorizationCompletedStreamEvent[],
+  name: string,
+): void {
+  const event = events.find((candidate) => candidate.data.name === name);
+  if (event === undefined) {
+    throw new Error(`Missing authorization.completed for ${name}.`);
+  }
+  if (event.data.outcome !== "authorized") {
+    throw new Error(`Expected ${name} to authorize, got ${event.data.outcome}.`);
+  }
+}
+
+function inlineAuthOutput(events: readonly HandleMessageStreamEvent[]): Record<string, unknown> {
+  const result = events.find(
+    (event): event is ActionResultStreamEvent =>
+      event.type === "action.result" &&
+      event.data.result.kind === "tool-result" &&
+      event.data.result.toolName === TOOL_NAME,
+  );
+  if (result === undefined || typeof result.data.result.output !== "object") {
+    throw new Error(`Missing ${TOOL_NAME} action.result output.`);
+  }
+  if (result.data.result.output === null || Array.isArray(result.data.result.output)) {
+    throw new Error(`Expected object output from ${TOOL_NAME}.`);
+  }
+  return result.data.result.output as Record<string, unknown>;
+}

--- a/e2e/fixtures/agent-tool-auth/package.json
+++ b/e2e/fixtures/agent-tool-auth/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agent-tool-auth",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsgo",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "2.6.1",
+    "@opentelemetry/sdk-trace-base": "2.6.1",
+    "@vercel/otel": "2.1.2",
+    "eve": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-tool-auth/tsconfig.json
+++ b/e2e/fixtures/agent-tool-auth/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts", ".eve/**/*.d.ts"]
+}

--- a/packages/eve/src/client/url.test.ts
+++ b/packages/eve/src/client/url.test.ts
@@ -24,4 +24,13 @@ describe("createClientUrl", () => {
       "/api/eve/v1/session/123/stream?startIndex=4",
     );
   });
+
+  it("preserves query strings already present in route paths", () => {
+    expect(createClientUrl("https://agent.example.com", "/eve/v1/callback/tok?code=abc")).toBe(
+      "https://agent.example.com/eve/v1/callback/tok?code=abc",
+    );
+    expect(createClientUrl("/api", "/eve/v1/callback/tok?code=abc", { state: "xyz" })).toBe(
+      "/api/eve/v1/callback/tok?code=abc&state=xyz",
+    );
+  });
 });

--- a/packages/eve/src/client/url.ts
+++ b/packages/eve/src/client/url.ts
@@ -10,8 +10,9 @@ export function createClientUrl(
   routePath: string,
   searchParams?: Readonly<Record<string, string>>,
 ): string {
-  const normalizedRoute = routePath.startsWith("/") ? routePath : `/${routePath}`;
-  const search = formatSearch(searchParams);
+  const route = splitRoutePath(routePath);
+  const normalizedRoute = route.pathname.startsWith("/") ? route.pathname : `/${route.pathname}`;
+  const search = formatSearch(route.search, searchParams);
 
   if (isAbsoluteUrl(host)) {
     const url = new URL(host);
@@ -34,10 +35,31 @@ function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
-function formatSearch(searchParams: Readonly<Record<string, string>> | undefined): string {
-  if (!searchParams || Object.keys(searchParams).length === 0) {
-    return "";
+function splitRoutePath(routePath: string): { readonly pathname: string; readonly search: string } {
+  const hashIndex = routePath.indexOf("#");
+  const withoutHash = hashIndex === -1 ? routePath : routePath.slice(0, hashIndex);
+  const searchIndex = withoutHash.indexOf("?");
+  if (searchIndex === -1) {
+    return { pathname: withoutHash, search: "" };
+  }
+  return {
+    pathname: withoutHash.slice(0, searchIndex),
+    search: withoutHash.slice(searchIndex),
+  };
+}
+
+function formatSearch(
+  routeSearch: string,
+  searchParams: Readonly<Record<string, string>> | undefined,
+): string {
+  const params = new URLSearchParams(routeSearch);
+
+  if (searchParams !== undefined) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      params.set(key, value);
+    }
   }
 
-  return `?${new URLSearchParams(searchParams).toString()}`;
+  const formatted = params.toString();
+  return formatted.length > 0 ? `?${formatted}` : "";
 }

--- a/packages/eve/src/evals/context.ts
+++ b/packages/eve/src/evals/context.ts
@@ -54,6 +54,10 @@ export function createEvalContext(deps: {
     expectInputRequests: (filter) => primary().expectInputRequests(filter),
     respond: (...responses) => primary().respond(...responses),
     respondAll: (optionId) => primary().respondAll(optionId),
+    authorize: (input, authorizations) => {
+      lastPrompt = promptText(input);
+      return primary().authorize(input, authorizations, deps.target);
+    },
     send: (input) => {
       lastPrompt = promptText(input);
       return primary().send(input);

--- a/packages/eve/src/evals/index.ts
+++ b/packages/eve/src/evals/index.ts
@@ -25,6 +25,7 @@ export type {
   AssertionResult,
   AssertionSeverity,
   AutoevalsJudges,
+  EveEvalAuthorizationInput,
   EveEvalContext,
   EveEvalDerivedFacts,
   EveEvalJudgeConfig,

--- a/packages/eve/src/evals/session.ts
+++ b/packages/eve/src/evals/session.ts
@@ -1,11 +1,16 @@
 import { readFile } from "node:fs/promises";
 import { basename, extname } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 
 import { createTextWithFileContent } from "#client/file-parts.js";
 import type { Client } from "#client/client.js";
 import type { ClientSession } from "#client/session.js";
 import type { SendTurnInput, SendTurnPayload, SessionState } from "#client/types.js";
-import type { HandleMessageStreamEvent, TurnFailureStreamEvent } from "#protocol/message.js";
+import type {
+  AuthorizationRequiredStreamEvent,
+  HandleMessageStreamEvent,
+  TurnFailureStreamEvent,
+} from "#protocol/message.js";
 import { isCurrentTurnBoundaryEvent, isTurnFailureEvent } from "#protocol/message.js";
 import {
   deriveResultStatus,
@@ -16,11 +21,16 @@ import { extractCompletedResult } from "#client/output-schema.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import { deriveRunFacts } from "#evals/runner/derive-run-facts.js";
 import type {
+  EveEvalAuthorizationInput,
   EveEvalSession,
   EveEvalSessionResult,
+  EveEvalTargetHandle,
   EveEvalToolCall,
   EveEvalTurn,
 } from "#evals/types.js";
+
+const AUTH_CALLBACK_RETRY_INTERVAL_MS = 100;
+const AUTH_CALLBACK_TIMEOUT_MS = 10_000;
 
 /**
  * Error thrown by {@link EveEvalTurn.expectOk} when a turn failed.
@@ -112,6 +122,85 @@ export class EvalSessionDriver implements EveEvalSession {
         requestId: request.requestId,
       })),
     );
+  }
+
+  async authorize(
+    input: SendTurnInput,
+    authorizations: readonly EveEvalAuthorizationInput[],
+    target: Pick<EveEvalTargetHandle, "fetch" | "url">,
+  ): Promise<EveEvalTurn> {
+    if (authorizations.length === 0) {
+      throw new Error("authorize() requires at least one expected authorization.");
+    }
+
+    const pending = buildExpectedAuthorizationMap(authorizations);
+    const response = await this.#session.send(attachSignal(input, this.#signal));
+    const events: HandleMessageStreamEvent[] = [];
+    let callbacksStarted = false;
+    let callbacksDone = false;
+    let callbacksPromise: Promise<void> | undefined;
+    const iterator = response[Symbol.asyncIterator]();
+    let nextEvent = iterator.next();
+
+    const recordTurn = (): EveEvalTurn =>
+      this.#recordTurn({
+        data: extractCompletedResult(events),
+        events,
+        inputRequests: extractInputRequests(events),
+        message: extractCompletedMessage(events),
+        sessionId: response.sessionId,
+        status: deriveResultStatus(events),
+      });
+
+    try {
+      while (true) {
+        const result = await raceEventAndCallbacks(nextEvent, callbacksPromise, callbacksDone);
+
+        if (result.kind === "callbacks") {
+          callbacksDone = true;
+          continue;
+        }
+
+        const { value, done } = result.next;
+        if (done === true) break;
+        nextEvent = iterator.next();
+        events.push(value);
+
+        if (!callbacksStarted && value.type === "authorization.required") {
+          recordAuthorizationEvent(pending, value);
+          if (allExpectedAuthorizationsReady(pending)) {
+            callbacksStarted = true;
+            callbacksPromise = completeExpectedAuthorizations(pending, target);
+          }
+        }
+      }
+    } catch (error) {
+      if (events.length > 0) {
+        recordTurn();
+      }
+      throw error;
+    }
+
+    if (!callbacksStarted) {
+      recordTurn();
+      const failure = events.find(isTurnFailureEvent);
+      if (failure !== undefined) {
+        throw new Error(
+          `Expected authorization.required events for ${authorizationNames(
+            authorizations,
+          )}, but the turn failed before they were all observed: ${failure.type}: ${failure.data.code} ${failure.data.message}`,
+        );
+      }
+      throw new Error(
+        `Expected authorization.required events for ${authorizationNames(
+          authorizations,
+        )}, but the turn ended before they were all observed.`,
+      );
+    }
+
+    await callbacksPromise;
+
+    return recordTurn();
   }
 
   async send(input: SendTurnInput): Promise<EveEvalTurn> {
@@ -206,6 +295,139 @@ export class EvalSessionDriver implements EveEvalSession {
     this.#lastTurn = turn;
     return turn;
   }
+}
+
+interface PendingAuthorizationExpectation {
+  readonly input: EveEvalAuthorizationInput;
+  event?: AuthorizationRequiredStreamEvent;
+}
+
+function buildExpectedAuthorizationMap(
+  authorizations: readonly EveEvalAuthorizationInput[],
+): Map<string, PendingAuthorizationExpectation> {
+  const pending = new Map<string, PendingAuthorizationExpectation>();
+  for (const input of authorizations) {
+    if (pending.has(input.name)) {
+      throw new Error(`authorize() received duplicate authorization name "${input.name}".`);
+    }
+    pending.set(input.name, { input });
+  }
+  return pending;
+}
+
+function recordAuthorizationEvent(
+  pending: Map<string, PendingAuthorizationExpectation>,
+  event: AuthorizationRequiredStreamEvent,
+): void {
+  const entry = pending.get(event.data.name);
+  if (entry === undefined) return;
+  entry.event = event;
+}
+
+function allExpectedAuthorizationsReady(
+  pending: Map<string, PendingAuthorizationExpectation>,
+): boolean {
+  return [...pending.values()].every((entry) => entry.event !== undefined);
+}
+
+async function raceEventAndCallbacks(
+  nextEvent: Promise<IteratorResult<HandleMessageStreamEvent>>,
+  callbacksPromise: Promise<void> | undefined,
+  callbacksDone: boolean,
+): Promise<
+  | { readonly kind: "event"; readonly next: IteratorResult<HandleMessageStreamEvent> }
+  | { readonly kind: "callbacks" }
+> {
+  if (callbacksPromise === undefined || callbacksDone) {
+    return { kind: "event", next: await nextEvent };
+  }
+
+  return await Promise.race([
+    nextEvent.then((next) => ({ kind: "event", next }) as const),
+    callbacksPromise.then(() => ({ kind: "callbacks" }) as const),
+  ]);
+}
+
+async function completeExpectedAuthorizations(
+  pending: Map<string, PendingAuthorizationExpectation>,
+  target: Pick<EveEvalTargetHandle, "fetch" | "url">,
+): Promise<void> {
+  await Promise.all(
+    [...pending.values()].map((entry) => completeExpectedAuthorizationEvent(entry, target)),
+  );
+}
+
+async function completeExpectedAuthorizationEvent(
+  entry: PendingAuthorizationExpectation,
+  target: Pick<EveEvalTargetHandle, "fetch" | "url">,
+): Promise<void> {
+  const event = entry.event;
+  if (event === undefined) {
+    throw new Error(`Missing authorization.required event for "${entry.input.name}".`);
+  }
+
+  const webhookUrl = event.data.webhookUrl;
+  if (webhookUrl === undefined) {
+    throw new Error(`authorization.required for "${entry.input.name}" did not include webhookUrl.`);
+  }
+
+  await completeExpectedAuthorization(entry, target, webhookUrl);
+}
+
+async function completeExpectedAuthorization(
+  entry: PendingAuthorizationExpectation,
+  target: Pick<EveEvalTargetHandle, "fetch" | "url">,
+  webhookUrl: string,
+): Promise<void> {
+  const callbackPath = callbackPathFromWebhookUrl(webhookUrl, target.url, entry.input.params);
+  const deadline = Date.now() + AUTH_CALLBACK_TIMEOUT_MS;
+
+  while (true) {
+    const response = await target.fetch(callbackPath, { method: "GET" });
+    if (response.ok) return;
+
+    const body = await response.text().catch(() => "");
+    if (!shouldRetryAuthorizationCallback(response, body) || Date.now() >= deadline) {
+      throw new Error(
+        `Authorization callback for "${entry.input.name}" failed: ${response.status} ${response.statusText}` +
+          (body.trim().length > 0 ? `, ${body.trim()}` : ""),
+      );
+    }
+
+    await sleep(AUTH_CALLBACK_RETRY_INTERVAL_MS);
+  }
+}
+
+function shouldRetryAuthorizationCallback(response: Response, body: string): boolean {
+  return response.status === 404 && body.includes("Connection callback not pending");
+}
+
+function authorizationNames(authorizations: readonly EveEvalAuthorizationInput[]): string {
+  return authorizations.map((entry) => JSON.stringify(entry.name)).join(", ");
+}
+
+function callbackPathFromWebhookUrl(
+  webhookUrl: string,
+  targetUrl: string,
+  params: Readonly<Record<string, string>> | undefined,
+): string {
+  const callback = new URL(webhookUrl);
+  for (const [key, value] of Object.entries(params ?? { code: "authorized" })) {
+    callback.searchParams.set(key, value);
+  }
+
+  const base = new URL(targetUrl);
+  const basePath = trimTrailingSlash(base.pathname);
+  let pathname = callback.pathname;
+  if (basePath.length > 0 && pathname.startsWith(`${basePath}/`)) {
+    pathname = pathname.slice(basePath.length);
+  }
+
+  return `${pathname}${callback.search}`;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value === "/" || !value.endsWith("/") ? (value === "/" ? "" : value) : value.slice(0, -1);
 }
 
 class EvalTurn implements EveEvalTurn {

--- a/packages/eve/src/evals/types.ts
+++ b/packages/eve/src/evals/types.ts
@@ -196,6 +196,16 @@ export interface EveEvalSession {
 }
 
 /**
+ * One expected connection authorization callback for {@link EveEvalContext.authorize}.
+ */
+export interface EveEvalAuthorizationInput {
+  /** Provider-scoped authorization name from the `authorization.required` stream event. */
+  readonly name: string;
+  /** Query params to deliver to the framework callback route. Defaults to `{ code: "authorized" }`. */
+  readonly params?: Readonly<Record<string, string>>;
+}
+
+/**
  * One completed eval-driver turn.
  */
 export interface EveEvalTurn {
@@ -278,6 +288,15 @@ export interface EveEvalContext extends EveEvalSession {
   sleep(ms?: number): Promise<void>;
   /** Create an additional independent session against the same target. */
   newSession(): EveEvalSession;
+  /**
+   * Send one turn that is expected to emit connection authorization requests,
+   * complete those callbacks through their real `webhookUrl`s, and then read
+   * the resumed turn to a normal boundary.
+   */
+  authorize(
+    input: SendTurnInput,
+    authorizations: readonly EveEvalAuthorizationInput[],
+  ): Promise<EveEvalTurn>;
 
   // Run-level assertions (lazy: evaluated against the final run; default gate).
   completed(): AssertionHandle;

--- a/packages/eve/src/execution/tool-auth.integration.test.ts
+++ b/packages/eve/src/execution/tool-auth.integration.test.ts
@@ -163,6 +163,48 @@ describe("tool-hosted authorization", () => {
     expect(result).toEqual({ github: "github-token", linear: "linear-token" });
   });
 
+  it("resolves and caches multiple inline providers with ctx.getTokens()", async () => {
+    let githubCalls = 0;
+    let linearCalls = 0;
+    const githubAuth: AuthorizationDefinition = {
+      principalType: "app",
+      vercelConnect: { connector: "oauth/github" },
+      async getToken(): Promise<TokenResult> {
+        githubCalls += 1;
+        return { token: `github-${githubCalls}` };
+      },
+    };
+    const linearAuth: AuthorizationDefinition = {
+      principalType: "app",
+      vercelConnect: { connector: "oauth/linear" },
+      async getToken(): Promise<TokenResult> {
+        linearCalls += 1;
+        return { token: `linear-${linearCalls}` };
+      },
+    };
+    const tool = authoredTool({
+      name: "sync_ticket",
+      async execute(_input, ctx) {
+        const first = await ctx.getTokens({ github: githubAuth, linear: linearAuth });
+        const second = await ctx.getTokens({ github: githubAuth, linear: linearAuth });
+        return {
+          first: { github: first.github.token, linear: first.linear.token },
+          second: { github: second.github.token, linear: second.linear.token },
+        };
+      },
+    });
+    const runtime = createTestRuntime({ tools: [tool] });
+
+    const result = await runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {}));
+
+    expect(result).toEqual({
+      first: { github: "github-1", linear: "linear-1" },
+      second: { github: "github-1", linear: "linear-1" },
+    });
+    expect(githubCalls).toBe(1);
+    expect(linearCalls).toBe(1);
+  });
+
   it("rejects multiple anonymous inline providers without explicit scopes", async () => {
     const githubAuth: AuthorizationDefinition = {
       principalType: "app",
@@ -242,6 +284,74 @@ describe("tool-hosted authorization", () => {
       name: "sync_ticket__oauth_linear",
       challenge: { displayName: "Linear", url: "https://idp.example/auth" },
     });
+  });
+
+  it("aggregates inline provider challenges with ctx.getTokens()", async () => {
+    const githubAuth: AuthorizationDefinition = {
+      principalType: "user",
+      vercelConnect: { connector: "oauth/github" },
+      async getToken(): Promise<TokenResult> {
+        throw requiredError();
+      },
+      async startAuthorization() {
+        return {
+          challenge: { url: "https://idp.example/github" },
+          resume: { provider: "github" },
+        };
+      },
+      async completeAuthorization(): Promise<TokenResult> {
+        return { token: "github-minted" };
+      },
+    };
+    const linearAuth: AuthorizationDefinition = {
+      principalType: "user",
+      vercelConnect: { connector: "oauth/linear" },
+      async getToken(): Promise<TokenResult> {
+        throw requiredError();
+      },
+      async startAuthorization() {
+        return {
+          challenge: { url: "https://idp.example/linear" },
+          resume: { provider: "linear" },
+        };
+      },
+      async completeAuthorization(): Promise<TokenResult> {
+        return { token: "linear-minted" };
+      },
+    };
+    const tool = authoredTool({
+      name: "sync_ticket",
+      async execute(_input, ctx) {
+        return await ctx.getTokens({
+          github: [githubAuth, { displayName: "GitHub" }],
+          linear: [linearAuth, { displayName: "Linear" }],
+        });
+      },
+    });
+    const runtime = createTestRuntime({ tools: [tool] });
+
+    const result = await runtime.runAsSession(
+      { sessionId: "session_inline_auth_many" },
+      async () => {
+        seedUserPrincipal();
+        loadContext().set(CallbackBaseUrlKey, "https://app.example");
+        return runtime.executeTool(tool, {});
+      },
+    );
+
+    expect(isAuthorizationSignal(result)).toBe(true);
+    if (!isAuthorizationSignal(result)) throw new Error("expected signal");
+    expect(result.challenges).toHaveLength(2);
+    expect(result.challenges).toMatchObject([
+      {
+        name: "sync_ticket__oauth_github",
+        challenge: { displayName: "GitHub", url: "https://idp.example/github" },
+      },
+      {
+        name: "sync_ticket__oauth_linear",
+        challenge: { displayName: "Linear", url: "https://idp.example/linear" },
+      },
+    ]);
   });
 
   it("parks the turn with a challenge when getToken throws Required", async () => {

--- a/packages/eve/src/execution/tool-auth.ts
+++ b/packages/eve/src/execution/tool-auth.ts
@@ -20,8 +20,11 @@ import {
 } from "#public/connections/errors.js";
 import type {
   ToolAuthProvider,
+  ToolAuthProviderEntry,
+  ToolAuthProviderMap,
   ToolAuthScopeOptions,
   ToolContext,
+  ToolTokenResults,
 } from "#public/definitions/tool.js";
 import { type AuthorizationChallenge, requestAuthorization } from "#harness/authorization.js";
 import {
@@ -166,6 +169,16 @@ function buildToolContext(input: {
         toolScope: scope,
       });
     },
+    async getTokens<TProviders extends ToolAuthProviderMap>(
+      providers: TProviders,
+    ): Promise<ToolTokenResults<TProviders>> {
+      return await resolveInlineTokens({
+        inlineAuthState,
+        justAuthorizedScopes,
+        providers,
+        toolScope: scope,
+      });
+    },
     requireAuth(provider?: ToolAuthProvider, options?: ToolAuthScopeOptions): never {
       if (provider === undefined) {
         if (topLevelScoped === undefined) throw noAuthError(scope);
@@ -186,6 +199,70 @@ function buildToolContext(input: {
       ]);
     },
   };
+}
+
+async function resolveInlineTokens<TProviders extends ToolAuthProviderMap>(input: {
+  readonly toolScope: string;
+  readonly providers: TProviders;
+  readonly justAuthorizedScopes: Set<string>;
+  readonly inlineAuthState: InlineAuthState;
+}): Promise<ToolTokenResults<TProviders>> {
+  const entries = Object.entries(input.providers) as Array<
+    [keyof TProviders & string, ToolAuthProviderEntry]
+  >;
+  const settled = await Promise.allSettled(
+    entries.map(async ([key, entry]) => {
+      const { options, provider } = parseProviderEntry(entry);
+      const token = await resolveInlineToken({
+        inlineAuthState: input.inlineAuthState,
+        justAuthorizedScopes: input.justAuthorizedScopes,
+        options,
+        provider,
+        toolScope: input.toolScope,
+      });
+      return [key, token] as const;
+    }),
+  );
+
+  const results: Partial<Record<keyof TProviders, TokenResult>> = {};
+  const requests: ToolAuthorizationRequiredRequest[] = [];
+  let firstError: unknown;
+
+  settled.forEach((entry) => {
+    if (entry.status === "fulfilled") {
+      const [key, token] = entry.value;
+      results[key] = token;
+      return;
+    }
+
+    if (isToolAuthorizationRequiredError(entry.reason)) {
+      requests.push(...entry.reason.requests);
+      return;
+    }
+
+    firstError ??= entry.reason;
+  });
+
+  if (firstError !== undefined) {
+    throw firstError;
+  }
+
+  if (requests.length > 0) {
+    throw new ToolAuthorizationRequiredError(requests);
+  }
+
+  return results as ToolTokenResults<TProviders>;
+}
+
+function parseProviderEntry(input: ToolAuthProviderEntry): {
+  readonly provider: ToolAuthProvider;
+  readonly options?: ToolAuthScopeOptions;
+} {
+  if (Array.isArray(input)) {
+    const [provider, options] = input as readonly [ToolAuthProvider, ToolAuthScopeOptions?];
+    return { options, provider };
+  }
+  return { provider: input as ToolAuthProvider };
 }
 
 async function resolveInlineToken(input: {

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { getWorld, resumeHook, start } from "#compiled/@workflow/core/runtime.js";
 
+import type { SessionAuthContext } from "#channel/types.js";
 import { captureTurnEvents, filterEventsByType } from "#internal/testing/events.js";
-import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { createTestRuntime, type TestRuntime } from "#internal/testing/app-harness.js";
 import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
+import { authHookToken } from "#harness/authorization.js";
+import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
+import type { ToolContext } from "#public/definitions/tool.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import type { AuthorizationDefinition, TokenResult } from "#runtime/connections/types.js";
+import type { ResolvedToolDefinition } from "#runtime/types.js";
 import { workflowEntry } from "#execution/workflow-entry.js";
 
 function buildSerializedContext(overrides: {
@@ -32,6 +39,163 @@ function buildSerializedContext(overrides: {
     context["eve.parentSession"] = overrides.parent;
   }
   return context;
+}
+
+const TEST_USER_AUTH: SessionAuthContext = {
+  attributes: {},
+  authenticator: "test-idp",
+  issuer: "test-idp",
+  principalId: "user-1",
+  principalType: "user",
+};
+
+function buildInlineAuthWorkflowTool(): ResolvedToolDefinition {
+  const githubAuth = buildInteractiveAuth({
+    connector: "oauth/github",
+    provider: "github",
+    url: "https://idp.example/github",
+  });
+  const linearAuth = buildInteractiveAuth({
+    connector: "oauth/linear",
+    provider: "linear",
+    url: "https://idp.example/linear",
+  });
+  const execute = async (_input: unknown, ctx: ToolContext) => {
+    const tokens = await ctx.getTokens({
+      github: [githubAuth, { displayName: "GitHub" }],
+      linear: [linearAuth, { displayName: "Linear" }],
+    });
+
+    return {
+      github: tokens.github.token,
+      linear: tokens.linear.token,
+    };
+  };
+
+  return {
+    description: "Sync ticket data with GitHub and Linear credentials.",
+    execute: execute as unknown as ResolvedToolDefinition["execute"],
+    inputSchema: null,
+    logicalPath: "tools/sync_ticket.ts",
+    name: "sync_ticket",
+    sourceId: "tools/sync_ticket.ts",
+    sourceKind: "module",
+  };
+}
+
+function attachInMemoryToolModule(runtime: TestRuntime, tool: ResolvedToolDefinition): void {
+  const compiledTool = runtime.manifest.tools.find((entry) => entry.name === tool.name);
+  if (compiledTool === undefined) {
+    throw new Error(`Missing compiled manifest entry for tool "${tool.name}".`);
+  }
+
+  const nodeScope = Object.values(runtime.moduleMap.nodes).find(
+    (scope) => scope.modules[compiledTool.sourceId] !== undefined,
+  );
+  if (nodeScope === undefined) {
+    throw new Error(`Missing compiled module map entry for tool "${tool.name}".`);
+  }
+
+  nodeScope.modules[compiledTool.sourceId] = {
+    default: {
+      execute: tool.execute,
+    },
+  };
+}
+
+function buildInteractiveAuth(input: {
+  readonly connector: string;
+  readonly provider: string;
+  readonly url: string;
+}): AuthorizationDefinition {
+  let token: TokenResult | undefined;
+
+  return {
+    principalType: "user",
+    vercelConnect: { connector: input.connector },
+    async getToken(): Promise<TokenResult> {
+      if (token !== undefined) {
+        return token;
+      }
+
+      throw new ConnectionAuthorizationRequiredError(input.connector);
+    },
+    async startAuthorization() {
+      return {
+        challenge: { url: input.url },
+        resume: { provider: input.provider },
+      };
+    },
+    async completeAuthorization({ callback, resume }): Promise<TokenResult> {
+      const code = callback.params.code ?? "authorized";
+      token = { token: `${readResumeProvider(resume) ?? input.provider}-${code}` };
+      return token;
+    },
+  };
+}
+
+function readResumeProvider(resume: unknown): string | undefined {
+  if (typeof resume !== "object" || resume === null || Array.isArray(resume)) {
+    return undefined;
+  }
+
+  const provider = (resume as { readonly provider?: unknown }).provider;
+  return typeof provider === "string" ? provider : undefined;
+}
+
+interface CapturedWorkflowEventStream {
+  nextUntil(
+    predicate: (events: readonly HandleMessageStreamEvent[]) => boolean,
+  ): Promise<HandleMessageStreamEvent[]>;
+  dispose(): void;
+}
+
+function captureWorkflowEventStream(run: {
+  readonly readable: ReadableStream<Uint8Array>;
+}): CapturedWorkflowEventStream {
+  const reader = run.readable.getReader();
+  const decoder = new TextDecoder();
+  const state: { buffer: string } = { buffer: "" };
+  let disposed = false;
+
+  return {
+    async nextUntil(predicate) {
+      if (disposed) {
+        throw new Error("CapturedWorkflowEventStream: stream already disposed.");
+      }
+
+      const events: HandleMessageStreamEvent[] = [];
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          throw new Error("Workflow stream closed before expected events were observed.");
+        }
+
+        state.buffer += decoder.decode(value);
+
+        for (
+          let newlineIndex = state.buffer.indexOf("\n");
+          newlineIndex !== -1;
+          newlineIndex = state.buffer.indexOf("\n")
+        ) {
+          const line = state.buffer.slice(0, newlineIndex).trim();
+          state.buffer = state.buffer.slice(newlineIndex + 1);
+          if (line.length === 0) continue;
+
+          events.push(JSON.parse(line) as HandleMessageStreamEvent);
+          if (predicate(events)) {
+            return events;
+          }
+        }
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      reader.releaseLock();
+    },
+  };
 }
 
 describe("workflowEntry integration", () => {
@@ -87,6 +251,152 @@ describe("workflowEntry integration", () => {
             (event) =>
               event.type === "message.completed" &&
               event.data.message?.includes("follow up") === true,
+          ),
+        ).toBe(true);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  });
+
+  it("surfaces multiple inline provider authorizations through the workflow stream", async () => {
+    const tool = buildInlineAuthWorkflowTool();
+    const runtime = createTestRuntime({
+      agent: { name: "workflow-entry-inline-auth" },
+      tools: [tool],
+    });
+    attachInMemoryToolModule(runtime, tool);
+    const continuationToken = "http:workflow-entry-inline-auth";
+
+    await runtime.run(async () => {
+      const serializedContext = buildSerializedContext({
+        channelKind: "http",
+        continuationToken,
+        mode: "conversation",
+      });
+      serializedContext["eve.auth"] = TEST_USER_AUTH;
+
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "Please call sync_ticket now." },
+          serializedContext,
+        },
+      ]);
+
+      const stream = captureWorkflowEventStream(run);
+
+      try {
+        const firstEvents = await stream.nextUntil(
+          (events) => filterEventsByType(events, "authorization.required").length === 2,
+        );
+        const firstAuthRequired = filterEventsByType(firstEvents, "authorization.required");
+        const authHook = await waitForHook(
+          { runId: run.runId },
+          {
+            token: authHookToken(run.runId),
+          },
+        );
+
+        expect(authHook.token).toBe(authHookToken(run.runId));
+        expect(firstAuthRequired).toHaveLength(2);
+        expect(firstAuthRequired).toMatchObject([
+          {
+            data: {
+              authorization: {
+                displayName: "GitHub",
+                url: "https://idp.example/github",
+              },
+              name: "sync_ticket__oauth_github",
+              webhookUrl: expect.stringContaining(
+                "/eve/v1/connections/sync_ticket__oauth_github/callback/",
+              ),
+            },
+          },
+          {
+            data: {
+              authorization: {
+                displayName: "Linear",
+                url: "https://idp.example/linear",
+              },
+              name: "sync_ticket__oauth_linear",
+              webhookUrl: expect.stringContaining(
+                "/eve/v1/connections/sync_ticket__oauth_linear/callback/",
+              ),
+            },
+          },
+        ]);
+
+        await resumeHook(authHook.token, {
+          kind: "deliver",
+          payloads: [
+            {
+              authorizationCallback: {
+                callback: { method: "GET", params: { code: "github-code" } },
+                connectionName: "sync_ticket__oauth_github",
+              },
+            },
+            {
+              authorizationCallback: {
+                callback: { method: "GET", params: { code: "linear-code" } },
+                connectionName: "sync_ticket__oauth_linear",
+              },
+            },
+          ],
+        });
+
+        const secondEvents = await stream.nextUntil((events) =>
+          events.some(
+            (event) =>
+              event.type === "session.waiting" ||
+              event.type === "session.completed" ||
+              event.type === "session.failed",
+          ),
+        );
+        const completedAuth = filterEventsByType(secondEvents, "authorization.completed");
+        const secondAuthRequired = filterEventsByType(secondEvents, "authorization.required");
+        const actionResults = filterEventsByType(secondEvents, "action.result");
+
+        expect(completedAuth).toHaveLength(2);
+        expect(completedAuth).toMatchObject([
+          {
+            data: {
+              name: "sync_ticket__oauth_github",
+              outcome: "authorized",
+            },
+          },
+          {
+            data: {
+              name: "sync_ticket__oauth_linear",
+              outcome: "authorized",
+            },
+          },
+        ]);
+        expect(secondEvents.at(-1)?.type).toBe("session.waiting");
+        expect(secondAuthRequired).toHaveLength(0);
+        expect(actionResults).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              data: expect.objectContaining({
+                result: expect.objectContaining({
+                  kind: "tool-result",
+                  output: {
+                    github: "github-github-code",
+                    linear: "linear-linear-code",
+                  },
+                  toolName: "sync_ticket",
+                }),
+                status: "completed",
+              }),
+            }),
+          ]),
+        );
+        expect(
+          secondEvents.some(
+            (event) =>
+              event.type === "message.completed" &&
+              event.data.message?.includes("github-github-code") === true &&
+              event.data.message.includes("linear-linear-code"),
           ),
         ).toBe(true);
       } finally {

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -195,6 +195,7 @@ describe("startDevelopmentServer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.WORKFLOW_LOCAL_BASE_URL;
+    delete process.env.WORKFLOW_LOCAL_DATA_DIR;
     delete process.env.PORT;
     delete process.env.EVE_DEVELOPMENT_SANDBOX_RUN_ID;
     mocks.files.clear();
@@ -216,6 +217,7 @@ describe("startDevelopmentServer", () => {
 
   afterEach(() => {
     delete process.env.WORKFLOW_LOCAL_BASE_URL;
+    delete process.env.WORKFLOW_LOCAL_DATA_DIR;
     delete process.env.PORT;
     delete process.env.EVE_DEVELOPMENT_SANDBOX_RUN_ID;
     mocks.files.clear();
@@ -243,6 +245,7 @@ describe("startDevelopmentServer", () => {
     });
     expect(mocks.pruneLocalSandboxTemplatesInBackground).toHaveBeenCalledWith("/tmp/eve-test");
     expect(process.env.WORKFLOW_LOCAL_BASE_URL).toBe("http://127.0.0.1:42123");
+    expect(process.env.WORKFLOW_LOCAL_DATA_DIR).toBe("/tmp/eve-test/.workflow-data");
     expect(process.env.PORT).toBe("42123");
 
     await server.close();
@@ -253,6 +256,7 @@ describe("startDevelopmentServer", () => {
       log: expect.any(Function),
     });
     expect(process.env.WORKFLOW_LOCAL_BASE_URL).toBeUndefined();
+    expect(process.env.WORKFLOW_LOCAL_DATA_DIR).toBeUndefined();
     expect(process.env.PORT).toBeUndefined();
     expect(process.env.EVE_DEVELOPMENT_SANDBOX_RUN_ID).toBeUndefined();
   });

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -34,6 +34,7 @@ import {
 
 const MAX_ALLOWED_DEVELOPMENT_SERVER_PORT = 65_535;
 const WORKFLOW_LOCAL_BASE_URL_ENV = "WORKFLOW_LOCAL_BASE_URL";
+const WORKFLOW_LOCAL_DATA_DIR_ENV = "WORKFLOW_LOCAL_DATA_DIR";
 const PORT_ENV = "PORT";
 const DEVELOPMENT_PROCESS_ID_FILE = "dev-process.pid";
 const DEFAULT_DEVELOPMENT_SERVER_HOST = "127.0.0.1";
@@ -213,12 +214,14 @@ function resolveDevelopmentServerPorts(input: {
   return ports as [number, ...number[]];
 }
 
-function installWorkflowLocalQueueEnvironment(serverUrl: string): () => void {
+function installWorkflowLocalQueueEnvironment(appRoot: string, serverUrl: string): () => void {
   const previousWorkflowLocalBaseUrl = process.env[WORKFLOW_LOCAL_BASE_URL_ENV];
+  const previousWorkflowLocalDataDir = process.env[WORKFLOW_LOCAL_DATA_DIR_ENV];
   const previousPort = process.env[PORT_ENV];
   const url = new URL(normalizeDevelopmentServerClientUrl(serverUrl));
 
   process.env[WORKFLOW_LOCAL_BASE_URL_ENV] = url.origin;
+  process.env[WORKFLOW_LOCAL_DATA_DIR_ENV] = join(appRoot, ".workflow-data");
   if (url.port) {
     process.env[PORT_ENV] = url.port;
   }
@@ -228,6 +231,12 @@ function installWorkflowLocalQueueEnvironment(serverUrl: string): () => void {
       delete process.env[WORKFLOW_LOCAL_BASE_URL_ENV];
     } else {
       process.env[WORKFLOW_LOCAL_BASE_URL_ENV] = previousWorkflowLocalBaseUrl;
+    }
+
+    if (previousWorkflowLocalDataDir === undefined) {
+      delete process.env[WORKFLOW_LOCAL_DATA_DIR_ENV];
+    } else {
+      process.env[WORKFLOW_LOCAL_DATA_DIR_ENV] = previousWorkflowLocalDataDir;
     }
 
     if (previousPort === undefined) {
@@ -395,7 +404,10 @@ export async function startDevelopmentServer(
       throw new Error("Nitro dev server did not expose a URL.");
     }
 
-    restoreWorkflowLocalQueueEnvironment = installWorkflowLocalQueueEnvironment(server.url);
+    restoreWorkflowLocalQueueEnvironment = installWorkflowLocalQueueEnvironment(
+      preparedHost.appRoot,
+      server.url,
+    );
     await prepare(nitro);
     await buildNitro(nitro);
 

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -53,6 +53,16 @@ export type ToolAuthDefinition =
 
 export type ToolAuthProvider = ToolAuthDefinition;
 
+export type ToolAuthProviderEntry =
+  | ToolAuthProvider
+  | readonly [provider: ToolAuthProvider, options?: ToolAuthScopeOptions];
+
+export type ToolAuthProviderMap = Readonly<Record<string, ToolAuthProviderEntry>>;
+
+export type ToolTokenResults<TProviders extends ToolAuthProviderMap> = {
+  readonly [K in keyof TProviders]: TokenResult;
+};
+
 /**
  * Controls how an inline tool auth provider is scoped and presented.
  *
@@ -94,6 +104,16 @@ export type ToolContext = SessionContext & {
    * `connect("...")` from `@vercel/connect/eve`.
    */
   getToken(provider: ToolAuthProvider, options?: ToolAuthScopeOptions): Promise<TokenResult>;
+  /**
+   * Resolves several inline providers concurrently and aggregates any missing
+   * interactive authorizations into one consent step.
+   *
+   * Each provider value can be either a provider directly or a
+   * `[provider, options]` tuple.
+   */
+  getTokens<TProviders extends ToolAuthProviderMap>(
+    providers: TProviders,
+  ): Promise<ToolTokenResults<TProviders>>;
   /**
    * Signals that the caller must complete this tool's authorization flow
    * before proceeding. Throws `ConnectionAuthorizationRequiredError`, which

--- a/packages/eve/src/public/tools/index.ts
+++ b/packages/eve/src/public/tools/index.ts
@@ -11,11 +11,14 @@ export {
   isDisabledToolSentinel,
   isEnableWorkflowToolSentinel,
   type NeedsApprovalContext,
+  type ToolAuthProviderEntry,
+  type ToolAuthProviderMap,
   type ToolAuthProvider,
   type ToolAuthScopeOptions,
   type ToolDefinition,
   type ToolContext,
   type ToolModelOutput,
+  type ToolTokenResults,
   ExperimentalWorkflow,
 } from "#public/definitions/tool.js";
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,6 +661,31 @@ importers:
         specifier: 'catalog:'
         version: 7.0.0-dev.20260523.1
 
+  e2e/fixtures/agent-tool-auth:
+    dependencies:
+      '@opentelemetry/core':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@vercel/otel':
+        specifier: 2.1.2
+        version: 2.1.2(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260523.1
+
   e2e/fixtures/agent-tools:
     dependencies:
       '@opentelemetry/core':


### PR DESCRIPTION
## Summary
- add `ctx.getTokens({ ... })` for resolving multiple inline auth providers together
- aggregate multiple missing provider auth requests into one authorization signal using `Promise.allSettled`
- document when `getTokens` is preferable to `Promise.all` and update the implementation plan

## Verification
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/definitions/tool-auth.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/tool-auth.integration.test.ts`
- `pnpm docs:check`
- `pnpm --filter eve run typecheck`