### PR TITLE
feat(eve): make dev TUI preview URL clickable

### DIFF
--- a/.changeset/clickable-preview-url.md
+++ b/.changeset/clickable-preview-url.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The `eve dev` header now shows the beta-terms link inline (`eve is currently in preview: <url>`), clickable via the terminal's own URL matcher. The verbose preview notice is dropped from the boot banner and from `eve init` output.

--- a/packages/eve/src/cli/banner.ts
+++ b/packages/eve/src/cli/banner.ts
@@ -4,8 +4,6 @@ import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 
 export const EVE_WORDMARK = "eve";
 export const EVE_BETA_TERMS_URL = "https://vercel.com/docs/release-phases/public-beta-agreement";
-export const EVE_PREVIEW_NOTICE =
-  "eve is currently a preview and subject to the Vercel beta terms; the framework, APIs, documentation, and behavior may change before general availability.";
 
 /**
  * The boot banner shared by every CLI command that announces itself: the eve
@@ -15,7 +13,5 @@ export const EVE_PREVIEW_NOTICE =
  */
 export function eveCliBanner(): string {
   const { version } = resolveInstalledPackageInfo();
-  return `${pc.bgBlack(pc.white(` ${EVE_WORDMARK} `))} ${pc.dim(`v${version}`)}\n${pc.dim(
-    EVE_PREVIEW_NOTICE,
-  )}`;
+  return `${pc.bgBlack(pc.white(` ${EVE_WORDMARK} `))} ${pc.dim(`v${version}`)}`;
 }

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -4,7 +4,7 @@ import { basename, join, resolve } from "node:path";
 import pc from "picocolors";
 
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
-import { EVE_PREVIEW_NOTICE, EVE_WORDMARK } from "#cli/banner.js";
+import { EVE_WORDMARK } from "#cli/banner.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import { SPINNER_FRAME_MS, SPINNER_FRAMES } from "#setup/cli/rail-log.js";
 import { formatNodeEngineOverrideWarning, type NodeEngineOverride } from "#setup/node-engine.js";
@@ -62,9 +62,6 @@ const defaultDependencies: InitCommandDependencies = {
 
 const CURRENT_DIRECTORY_PROJECT_NAME = ".";
 const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([".DS_Store", ".git", ".gitkeep", ".hg"]);
-function withPublicBetaNotice(message: string): string {
-  return `${message}\n${pc.dim(EVE_PREVIEW_NOTICE)}`;
-}
 
 /** Resolves `target` to an existing directory, or undefined for name mode. */
 async function resolveTargetDirectory(
@@ -257,21 +254,13 @@ export async function runInitCommand(
       dependencies,
     );
     freshScaffold = true;
-    logger.log(
-      withPublicBetaNotice(
-        `${pc.green("✓")} Created an ${EVE_WORDMARK} agent in ${pc.bold(projectPath)}`,
-      ),
-    );
+    logger.log(`${pc.green("✓")} Created an ${EVE_WORDMARK} agent in ${pc.bold(projectPath)}`);
   } else {
     const addition = await addToExistingProject(existingDirectory, options, dependencies);
     packageManager = addition.packageManager;
     projectPath = existingDirectory;
     freshScaffold = false;
-    logger.log(
-      withPublicBetaNotice(
-        `${pc.green("✓")} Added an ${EVE_WORDMARK} agent to ${pc.bold(projectPath)}`,
-      ),
-    );
+    logger.log(`${pc.green("✓")} Added an ${EVE_WORDMARK} agent to ${pc.bold(projectPath)}`);
     if (addition.nodeEngineOverride !== undefined) {
       logger.log(pc.yellow(`⚠ ${formatNodeEngineOverrideWarning(addition.nodeEngineOverride)}`));
     }

--- a/packages/eve/src/cli/dev/tui/agent-header.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.test.ts
@@ -112,7 +112,7 @@ const INFO: AgentInfoResult = {
 
 describe("buildAgentHeader", () => {
   const theme = createTheme({ color: false, unicode: false });
-  const previewLine = ` Public preview: ${EVE_BETA_TERMS_URL}`;
+  const previewLine = ` eve is currently in preview: ${EVE_BETA_TERMS_URL}`;
 
   it("renders the brand line with the agent name and preview label", () => {
     const lines = buildAgentHeader({ name: "agent-subagents", info: INFO, theme, width: 120 });
@@ -134,6 +134,23 @@ describe("buildAgentHeader", () => {
 
     const remote = buildAgentHeader({ name: "weather-agent", info: INFO, theme, width: 120 });
     expect(remote.join("\n")).not.toContain("/channels");
+  });
+
+  it("keeps the preview URL visible and plain on a color terminal (no OSC 8 escape)", () => {
+    const colorTheme = createTheme({ color: true, unicode: false });
+    const lines = buildAgentHeader({
+      name: "weather-agent",
+      info: INFO,
+      theme: colorTheme,
+      width: 120,
+    });
+    const preview = lines.find((line) => line.includes("eve is currently in preview"))!;
+
+    // The bare URL stays visible so the terminal's own URL matcher makes it
+    // ⌘/ctrl-clickable. OSC 8 explicit hyperlinks are deliberately avoided —
+    // their click handling is unreliable (e.g. Ghostty bug #11907).
+    expect(preview).toContain(EVE_BETA_TERMS_URL);
+    expect(preview).not.toContain("\x1b]8;;");
   });
 
   it("keeps the discovery-diagnostics line when the compiler reported problems", () => {

--- a/packages/eve/src/cli/dev/tui/agent-header.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.ts
@@ -54,7 +54,9 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
   const brand = c.bold("eve");
   lines.push(` ${brand} ${c.dim(truncate(name, Math.max(8, width - 8)))}`);
   lines.push(
-    ` ${c.dim(truncate(`Public preview: ${EVE_BETA_TERMS_URL}`, Math.max(8, width - 2)))}`,
+    ` ${c.dim(
+      truncate(`eve is currently in preview: ${EVE_BETA_TERMS_URL}`, Math.max(8, width - 2)),
+    )}`,
   );
 
   if (info && (info.diagnostics.discoveryErrors > 0 || info.diagnostics.discoveryWarnings > 0)) {


### PR DESCRIPTION
## What

- The dev TUI header prints the beta-terms URL in full, so the terminal auto-links it — ⌘/ctrl-click opens it.
- The verbose preview notice ("…subject to the Vercel beta terms…") is gone from the CLI: it no longer prints in the boot banner or after `eve init`. `EVE_PREVIEW_NOTICE` is removed.

The beta terms still reach users — as the clickable URL in the dev header. The README disclaimers are left in place.

## Why a plain URL, not a hyperlink

The obvious move is an OSC 8 hyperlink behind a short label. I skipped it. OSC 8 click handling is unreliable — Ghostty 1.3.1 renders the link on hover but won't open it on ⌘-click ([ghostty#11907](https://github.com/ghostty-org/ghostty/issues/11907)). A plain visible URL leans on the terminal's own URL matcher, which works across terminals, and stays copyable where even that doesn't.

## Scope

`eve init` success lines no longer carry the notice paragraph (just the `✓ Created…` line). The banner still prints for `info`/`dev`/`init` — only the notice paragraph is dropped.