### PR TITLE
[eve/nitro] Add vc link hint to non-local deployments

### DIFF
--- a/packages/eve/src/internal/nitro/routes/index.test.ts
+++ b/packages/eve/src/internal/nitro/routes/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { buildHomePageResponse } from "#internal/nitro/routes/index.js";
 
@@ -7,6 +7,10 @@ function buildResponseForRequest(url: string, headers?: Record<string, string>):
 }
 
 describe("buildHomePageResponse", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("returns a barebones HTML response", () => {
     const response = buildResponseForRequest("https://my-agent.example.com/");
 
@@ -48,6 +52,28 @@ describe("buildHomePageResponse", () => {
 
     expect(body).toContain("eve dev https://public.example");
     expect(body).not.toContain("internal-edge");
+  });
+
+  it("hints at `vercel link` on Vercel preview and production deployments", async () => {
+    for (const environment of ["preview", "production"]) {
+      vi.stubEnv("VERCEL_ENV", environment);
+      const body = await buildResponseForRequest("https://my-agent.example.com/").text();
+
+      expect(body, environment).toContain("vercel link");
+      expect(body, environment).toContain("VERCEL_OIDC_TOKEN");
+      expect(body, environment).not.toContain("{{REMOTE_HINT}}");
+    }
+  });
+
+  it("omits the `vercel link` hint when not a Vercel deployment", async () => {
+    // `eve dev` leaves VERCEL_ENV unset; `vercel dev` reports "development".
+    for (const environment of [undefined, "development"] as const) {
+      vi.stubEnv("VERCEL_ENV", environment);
+      const body = await buildResponseForRequest("https://my-agent.example.com/").text();
+
+      expect(body, String(environment)).not.toContain("vercel link");
+      expect(body, String(environment)).not.toContain("{{REMOTE_HINT}}");
+    }
   });
 
   it("escapes HTML metacharacters from the host", async () => {

--- a/packages/eve/src/internal/nitro/routes/index.ts
+++ b/packages/eve/src/internal/nitro/routes/index.ts
@@ -9,6 +9,23 @@ const EVE_DOCS_URL = "https://beta.eve.dev/docs";
 
 const DEPLOYMENT_URL_PLACEHOLDER = "{{DEPLOYMENT_URL}}";
 
+const REMOTE_HINT_PLACEHOLDER = "{{REMOTE_HINT}}";
+
+/**
+ * Note shown only when the visitor reached a deployed (non-local) URL.
+ *
+ * Connecting the TUI to a remote eve goes through the Vercel OIDC auth
+ * chain: without it the connection fails with "Authorization is required
+ * for this route." `eve dev` reads that token from a linked project (the
+ * `.vercel` directory written by `vercel link`) or from `VERCEL_OIDC_TOKEN`,
+ * so a fresh clone — or any directory that was never linked — has to link
+ * first.
+ */
+const REMOTE_HINT_HTML =
+  '<p class="hint">Connecting to a deployed agent? Run ' +
+  '<span class="hint-cmd mono">vercel link</span> in your project first to ' +
+  'authenticate (or set <span class="hint-cmd mono">VERCEL_OIDC_TOKEN</span>).</p>';
+
 /**
  * Barebones HTML served at `GET /`.
  *
@@ -162,6 +179,14 @@ const HOME_PAGE_HTML_TEMPLATE = `<!doctype html>
     flex-shrink: 0;
   }
   .terminal-cmd { color: var(--fg); }
+  .hint {
+    margin: 1rem auto 0;
+    max-width: 28rem;
+    color: var(--faint);
+    font-size: 0.75rem;
+    text-align: center;
+  }
+  .hint-cmd { color: var(--muted); }
 </style>
 </head>
 <body>
@@ -176,6 +201,7 @@ const HOME_PAGE_HTML_TEMPLATE = `<!doctype html>
     <span class="terminal-prompt" aria-hidden="true">$</span>
     <span class="terminal-cmd">eve dev ${DEPLOYMENT_URL_PLACEHOLDER}</span>
   </div>
+  ${REMOTE_HINT_PLACEHOLDER}
 </main>
 </body>
 </html>
@@ -223,16 +249,26 @@ function resolveDeploymentUrl(request: Request): string {
 }
 
 /**
+ * Reports whether the page is being served from a Vercel preview or
+ * production deployment.
+ */
+function isVercelHostedDeployment(): boolean {
+  const environment = process.env.VERCEL_ENV;
+  return environment === "preview" || environment === "production";
+}
+
+/**
  * Builds the barebones home page response for one request. Exposed
  * for tests so callers can supply a real {@link Request}; production
  * traffic flows through the Nitro {@link H3Event} default export.
  */
 export function buildHomePageResponse(request: Request): Response {
   const deploymentUrl = resolveDeploymentUrl(request);
+  const remoteHint = isVercelHostedDeployment() ? REMOTE_HINT_HTML : "";
   const html = HOME_PAGE_HTML_TEMPLATE.replace(
     DEPLOYMENT_URL_PLACEHOLDER,
     escapeHtml(deploymentUrl),
-  );
+  ).replace(REMOTE_HINT_PLACEHOLDER, remoteHint);
 
   return new Response(html, {
     headers: {


### PR DESCRIPTION
Adds a small hint to `vc link` project in order to run `eve dev [remote-url]`.