### PR TITLE
Improve default sandbox microsandbox fallback

### DIFF
--- a/.changeset/default-backend-microsandbox-fallback.md
+++ b/.changeset/default-backend-microsandbox-fallback.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`defaultBackend()` now verifies microsandbox package and VM runtime setup before using microsandbox. If setup or auto-install fails, it falls back to just-bash so local sandbox startup can continue with the dependency-free backend.

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -114,13 +114,13 @@ export default defineSandbox({
 
 The backend decides where the sandbox runs. eve ships four pinned factories from nested `eve/sandbox/*` imports plus an availability-aware default from `eve/sandbox`:
 
-| Backend            | Runs the sandbox                                                                               |
-| ------------------ | ---------------------------------------------------------------------------------------------- |
-| `vercel()`         | on [Vercel Sandbox](https://vercel.com/docs/sandbox).                                          |
-| `docker()`         | locally in a Docker container, driven through the `docker` CLI.                                |
-| `microsandbox()`   | locally in a lightweight [microsandbox](https://www.npmjs.com/package/microsandbox) VM.        |
-| `justbash()`       | locally in the pure-JS `just-bash` interpreter (no daemon or VM, but no real binaries either). |
-| `defaultBackend()` | picks the best available: Vercel Sandbox on hosted Vercel → Docker → microsandbox → just-bash. |
+| Backend            | Runs the sandbox                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `vercel()`         | on [Vercel Sandbox](https://vercel.com/docs/sandbox).                                                              |
+| `docker()`         | locally in a Docker container, driven through the `docker` CLI.                                                    |
+| `microsandbox()`   | locally in a lightweight [microsandbox](https://www.npmjs.com/package/microsandbox) VM.                            |
+| `justbash()`       | locally in the pure-JS `just-bash` interpreter (no daemon or VM, but no real binaries either).                     |
+| `defaultBackend()` | picks the best available: Vercel Sandbox on hosted Vercel → Docker → microsandbox when setup succeeds → just-bash. |
 
 Configuring a pinned factory uses that backend unconditionally. `docker()` always requires a reachable Docker daemon, and `vercel()` always creates hosted sandboxes (including from local dev, with Vercel credentials).
 
@@ -128,8 +128,8 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 
 1. **Vercel Sandbox** when deploying on Vercel (`process.env.VERCEL` is set), since local container/VM runtimes can't run there.
 2. **Docker** when a daemon is reachable through a Docker-compatible `docker` CLI (Docker Desktop, OrbStack, Colima, Podman via its docker-compatible CLI; override the binary with `EVE_DOCKER_PATH`).
-3. **microsandbox** when the host supports it: macOS on Apple Silicon, or glibc Linux with KVM enabled.
-4. **just-bash** as the dependency-free fallback.
+3. **microsandbox** when the host supports it and its package plus VM runtime are ready. In `eve dev`, eve tries to install both automatically before using the backend.
+4. **just-bash** as the dependency-free fallback, including when microsandbox setup or auto-install fails.
 
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 

--- a/packages/eve/src/execution/sandbox/bindings/local.ts
+++ b/packages/eve/src/execution/sandbox/bindings/local.ts
@@ -15,6 +15,9 @@ import {
 import { pruneDockerSandboxTemplates } from "#execution/sandbox/bindings/docker.js";
 import { pruneJustBashSandboxTemplates } from "#execution/sandbox/bindings/just-bash.js";
 import { pruneMicrosandboxTemplates } from "#execution/sandbox/bindings/microsandbox.js";
+import { resolveMicrosandboxOptions } from "#execution/sandbox/bindings/microsandbox-options.js";
+import { loadMicrosandboxModule } from "#execution/sandbox/bindings/microsandbox-runtime.js";
+import type { MicrosandboxCreateOptions } from "#public/sandbox/microsandbox-sandbox.js";
 
 export {
   createDockerSandboxBackend,
@@ -34,6 +37,23 @@ export {
 } from "#execution/sandbox/bindings/microsandbox.js";
 export { isMicrosandboxPlatformSupported } from "#execution/sandbox/bindings/microsandbox-platform.js";
 export { stopDevelopmentSandboxResources } from "#execution/sandbox/development-cleanup.js";
+
+/**
+ * Verifies the optional microsandbox package and VM runtime are ready,
+ * auto-installing them when enabled. Kept behind the local binding facade so
+ * hosted bundles can stub every local sandbox engine through one module.
+ */
+export async function prepareMicrosandboxSandboxBackend(input: {
+  readonly appRoot: string;
+  readonly log?: (message: string) => void;
+  readonly options?: MicrosandboxCreateOptions;
+}): Promise<void> {
+  await loadMicrosandboxModule({
+    appRoot: input.appRoot,
+    log: input.log,
+    options: resolveMicrosandboxOptions(input.options),
+  });
+}
 
 /**
  * Removes stale local sandbox template state for one application

--- a/packages/eve/src/internal/nitro/host/compiled-sandbox-backend-prune-plugin.test.ts
+++ b/packages/eve/src/internal/nitro/host/compiled-sandbox-backend-prune-plugin.test.ts
@@ -17,5 +17,6 @@ describe("createCompiledSandboxBackendPrunePlugin", () => {
     const source = plugin.load?.(id);
 
     expect(source).toContain("export const stopDevelopmentSandboxResources = pruned;");
+    expect(source).toContain("export const prepareMicrosandboxSandboxBackend = pruned;");
   });
 });

--- a/packages/eve/src/internal/nitro/host/compiled-sandbox-backend-prune-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/compiled-sandbox-backend-prune-plugin.ts
@@ -37,6 +37,7 @@ export function createCompiledSandboxBackendPrunePlugin(): BundlerPluginShape {
         'export const MICROSANDBOX_BACKEND_NAME = "microsandbox";',
         "export const isDockerDaemonAvailableSync = () => false;",
         "export const isMicrosandboxPlatformSupported = () => false;",
+        "export const prepareMicrosandboxSandboxBackend = pruned;",
         "export const pruneDockerSandboxTemplates = pruned;",
         "export const pruneJustBashSandboxTemplates = pruned;",
         "export const pruneMicrosandboxTemplates = pruned;",

--- a/packages/eve/src/public/sandbox/backends/default.ts
+++ b/packages/eve/src/public/sandbox/backends/default.ts
@@ -121,16 +121,17 @@ export function createMicrosandboxWithJustBashFallback(input: {
   readonly prepareMicrosandbox: DefaultSandboxProbes["prepareMicrosandbox"];
   readonly primary: SandboxBackend;
 }): SandboxBackend {
-  let choice: DefaultLocalBackendChoice | undefined;
+  let availabilityChoice: DefaultLocalBackendChoice | undefined;
+  const templateChoices = new Map<string, DefaultLocalBackendChoice>();
 
-  async function select(inputContext: {
+  async function selectAvailableBackend(inputContext: {
     readonly appRoot: string;
     readonly log?: (message: string) => void;
   }): Promise<SandboxBackend> {
-    if (choice === "microsandbox") {
+    if (availabilityChoice === "microsandbox") {
       return input.primary;
     }
-    if (choice === "just-bash") {
+    if (availabilityChoice === "just-bash") {
       return input.fallback;
     }
 
@@ -140,10 +141,10 @@ export function createMicrosandboxWithJustBashFallback(input: {
         log: inputContext.log,
         options: input.options,
       });
-      choice = "microsandbox";
+      availabilityChoice = "microsandbox";
       return input.primary;
     } catch (error) {
-      choice = "just-bash";
+      availabilityChoice = "just-bash";
       inputContext.log?.(
         `microsandbox setup failed; falling back to just-bash: ${toErrorMessage(error)}`,
       );
@@ -157,27 +158,46 @@ export function createMicrosandboxWithJustBashFallback(input: {
     // handles rewrite captured state below so reconnect checks keep working.
     name: input.primary.name,
     async prewarm(prewarmInput) {
-      const backend = await select({
-        appRoot: prewarmInput.runtimeContext.appRoot,
-        log: prewarmInput.log,
-      });
+      const templateChoice = templateChoices.get(prewarmInput.templateKey);
+      const backend =
+        templateChoice === "microsandbox"
+          ? input.primary
+          : templateChoice === "just-bash"
+            ? input.fallback
+            : await selectAvailableBackend({
+                appRoot: prewarmInput.runtimeContext.appRoot,
+                log: prewarmInput.log,
+              });
       try {
-        return await backend.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+        const result = await backend.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+        templateChoices.set(
+          prewarmInput.templateKey,
+          backend === input.primary ? "microsandbox" : "just-bash",
+        );
+        return result;
       } catch (error) {
         if (backend !== input.primary) {
           throw error;
         }
-        choice = "just-bash";
         prewarmInput.log?.(
           `microsandbox prewarm failed; falling back to just-bash: ${toErrorMessage(error)}`,
         );
-        return await input.fallback.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+        const result = await input.fallback.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+        templateChoices.set(prewarmInput.templateKey, "just-bash");
+        return result;
       }
     },
     async create(createInput) {
-      const backend = await select({
-        appRoot: createInput.runtimeContext.appRoot,
-      });
+      const templateChoice =
+        createInput.templateKey === null ? undefined : templateChoices.get(createInput.templateKey);
+      const backend =
+        templateChoice === "microsandbox"
+          ? input.primary
+          : templateChoice === "just-bash"
+            ? input.fallback
+            : await selectAvailableBackend({
+                appRoot: createInput.runtimeContext.appRoot,
+              });
       const handle = await backend.create(createInput as SandboxBackendCreateInput);
       return backend === input.primary ? handle : wrapFallbackHandle(handle, input.primary.name);
     },

--- a/packages/eve/src/public/sandbox/backends/default.ts
+++ b/packages/eve/src/public/sandbox/backends/default.ts
@@ -161,7 +161,18 @@ export function createMicrosandboxWithJustBashFallback(input: {
         appRoot: prewarmInput.runtimeContext.appRoot,
         log: prewarmInput.log,
       });
-      return await backend.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+      try {
+        return await backend.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+      } catch (error) {
+        if (backend !== input.primary) {
+          throw error;
+        }
+        choice = "just-bash";
+        prewarmInput.log?.(
+          `microsandbox prewarm failed; falling back to just-bash: ${toErrorMessage(error)}`,
+        );
+        return await input.fallback.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+      }
     },
     async create(createInput) {
       const backend = await select({

--- a/packages/eve/src/public/sandbox/backends/default.ts
+++ b/packages/eve/src/public/sandbox/backends/default.ts
@@ -1,9 +1,8 @@
 import {
   isDockerDaemonAvailableSync,
   isMicrosandboxPlatformSupported,
+  prepareMicrosandboxSandboxBackend,
 } from "#execution/sandbox/bindings/local.js";
-import { resolveMicrosandboxOptions } from "#execution/sandbox/bindings/microsandbox-options.js";
-import { loadMicrosandboxModule } from "#execution/sandbox/bindings/microsandbox-runtime.js";
 import { lazyBackend } from "#execution/sandbox/lazy-backend.js";
 import type {
   SandboxBackend,
@@ -56,13 +55,7 @@ const PRODUCTION_PROBES: DefaultSandboxProbes = {
   isDeployedOnVercel: () => Boolean(process.env.VERCEL),
   isDockerAvailable: () => isDockerDaemonAvailableSync(),
   isMicrosandboxSupported: () => isMicrosandboxPlatformSupported(),
-  prepareMicrosandbox: async (input) => {
-    await loadMicrosandboxModule({
-      appRoot: input.appRoot,
-      log: input.log,
-      options: resolveMicrosandboxOptions(input.options),
-    });
-  },
+  prepareMicrosandbox: (input) => prepareMicrosandboxSandboxBackend(input),
 };
 
 /**

--- a/packages/eve/src/public/sandbox/backends/default.ts
+++ b/packages/eve/src/public/sandbox/backends/default.ts
@@ -2,8 +2,15 @@ import {
   isDockerDaemonAvailableSync,
   isMicrosandboxPlatformSupported,
 } from "#execution/sandbox/bindings/local.js";
+import { resolveMicrosandboxOptions } from "#execution/sandbox/bindings/microsandbox-options.js";
+import { loadMicrosandboxModule } from "#execution/sandbox/bindings/microsandbox-runtime.js";
 import { lazyBackend } from "#execution/sandbox/lazy-backend.js";
-import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
+import type {
+  SandboxBackend,
+  SandboxBackendCreateInput,
+  SandboxBackendHandle,
+  SandboxBackendPrewarmInput,
+} from "#public/definitions/sandbox-backend.js";
 import { docker } from "#public/sandbox/backends/docker.js";
 import type { DockerSandboxCreateOptions } from "#public/sandbox/docker-sandbox.js";
 import { justbash } from "#public/sandbox/backends/just-bash.js";
@@ -12,6 +19,7 @@ import { microsandbox } from "#public/sandbox/backends/microsandbox.js";
 import type { MicrosandboxCreateOptions } from "#public/sandbox/microsandbox-sandbox.js";
 import { vercel } from "#public/sandbox/backends/vercel.js";
 import type { VercelSandboxCreateOptions } from "#public/sandbox/vercel-sandbox.js";
+import { toErrorMessage } from "#shared/errors.js";
 
 /**
  * Input to {@link defaultSandbox}: a separate options bag per inner
@@ -33,6 +41,11 @@ export interface DefaultSandboxProbes {
   readonly isDeployedOnVercel: () => boolean;
   readonly isDockerAvailable: () => boolean;
   readonly isMicrosandboxSupported: () => boolean;
+  readonly prepareMicrosandbox: (input: {
+    readonly appRoot: string;
+    readonly log?: (message: string) => void;
+    readonly options?: MicrosandboxCreateOptions;
+  }) => Promise<void>;
 }
 
 // Wrapped in arrows (not captured by reference) deliberately: this
@@ -43,6 +56,13 @@ const PRODUCTION_PROBES: DefaultSandboxProbes = {
   isDeployedOnVercel: () => Boolean(process.env.VERCEL),
   isDockerAvailable: () => isDockerDaemonAvailableSync(),
   isMicrosandboxSupported: () => isMicrosandboxPlatformSupported(),
+  prepareMicrosandbox: async (input) => {
+    await loadMicrosandboxModule({
+      appRoot: input.appRoot,
+      log: input.log,
+      options: resolveMicrosandboxOptions(input.options),
+    });
+  },
 };
 
 /**
@@ -53,10 +73,12 @@ const PRODUCTION_PROBES: DefaultSandboxProbes = {
  *    is set) — local container/VM runtimes cannot run there.
  * 2. **Docker** when a Docker daemon is reachable.
  * 3. **microsandbox** when the host supports it (macOS on Apple
- *    Silicon, or glibc Linux with KVM); `eve dev` auto-installs the
- *    package into the project.
+ *    Silicon, or glibc Linux with KVM) and its package plus VM runtime
+ *    are ready; `eve dev` auto-installs them into the project before
+ *    using the backend.
  * 4. **just-bash** as the dependency-free fallback; `eve dev`
- *    auto-installs the package into the project.
+ *    auto-installs the package into the project. When microsandbox
+ *    setup fails, defaultSandbox falls through to this backend.
  *
  * The selection is cached for the process lifetime. To pin a backend
  * unconditionally, configure its factory directly (`docker()`,
@@ -82,7 +104,94 @@ export function selectDefaultSandbox(
     return docker(opts?.docker);
   }
   if (probes.isMicrosandboxSupported()) {
-    return microsandbox(opts?.microsandbox);
+    return createMicrosandboxWithJustBashFallback({
+      fallback: justbash(opts?.justBash),
+      options: opts?.microsandbox,
+      prepareMicrosandbox: probes.prepareMicrosandbox,
+      primary: microsandbox(opts?.microsandbox),
+    });
   }
   return justbash(opts?.justBash);
+}
+
+type DefaultLocalBackendChoice = "microsandbox" | "just-bash";
+
+/**
+ * A microsandbox-supported host can still fail later because the npm package
+ * or VM runtime is missing or cannot install. defaultSandbox treats that as an
+ * availability miss and falls back to just-bash before running authored
+ * bootstrap/session code.
+ */
+export function createMicrosandboxWithJustBashFallback(input: {
+  readonly fallback: SandboxBackend;
+  readonly options?: MicrosandboxCreateOptions;
+  readonly prepareMicrosandbox: DefaultSandboxProbes["prepareMicrosandbox"];
+  readonly primary: SandboxBackend;
+}): SandboxBackend {
+  let choice: DefaultLocalBackendChoice | undefined;
+
+  async function select(inputContext: {
+    readonly appRoot: string;
+    readonly log?: (message: string) => void;
+  }): Promise<SandboxBackend> {
+    if (choice === "microsandbox") {
+      return input.primary;
+    }
+    if (choice === "just-bash") {
+      return input.fallback;
+    }
+
+    try {
+      await input.prepareMicrosandbox({
+        appRoot: inputContext.appRoot,
+        log: inputContext.log,
+        options: input.options,
+      });
+      choice = "microsandbox";
+      return input.primary;
+    } catch (error) {
+      choice = "just-bash";
+      inputContext.log?.(
+        `microsandbox setup failed; falling back to just-bash: ${toErrorMessage(error)}`,
+      );
+      return input.fallback;
+    }
+  }
+
+  return {
+    // Keep the existing stable name so defaultBackend keeps the same public
+    // identity and key namespace on microsandbox-capable hosts. Fallback
+    // handles rewrite captured state below so reconnect checks keep working.
+    name: input.primary.name,
+    async prewarm(prewarmInput) {
+      const backend = await select({
+        appRoot: prewarmInput.runtimeContext.appRoot,
+        log: prewarmInput.log,
+      });
+      return await backend.prewarm(prewarmInput as SandboxBackendPrewarmInput);
+    },
+    async create(createInput) {
+      const backend = await select({
+        appRoot: createInput.runtimeContext.appRoot,
+      });
+      const handle = await backend.create(createInput as SandboxBackendCreateInput);
+      return backend === input.primary ? handle : wrapFallbackHandle(handle, input.primary.name);
+    },
+  };
+}
+
+function wrapFallbackHandle(
+  handle: SandboxBackendHandle,
+  backendName: string,
+): SandboxBackendHandle {
+  return {
+    ...handle,
+    async captureState() {
+      const state = await handle.captureState();
+      return {
+        ...state,
+        backendName,
+      };
+    },
+  };
 }

--- a/packages/eve/test/default-backend.test.ts
+++ b/packages/eve/test/default-backend.test.ts
@@ -155,4 +155,44 @@ describe("createMicrosandboxWithJustBashFallback", () => {
       "microsandbox setup failed; falling back to just-bash: install rejected",
     );
   });
+
+  it("prewarms just-bash when microsandbox prewarm fails", async () => {
+    const calls: string[] = [];
+    const logs: string[] = [];
+    const backend = createMicrosandboxWithJustBashFallback({
+      fallback: createRecordingBackend("just-bash", calls),
+      prepareMicrosandbox: async () => {
+        calls.push("prepare");
+      },
+      primary: {
+        ...createRecordingBackend("microsandbox", calls),
+        async prewarm(input) {
+          calls.push(`microsandbox:prewarm:${input.templateKey}`);
+          throw new Error("template rejected");
+        },
+      },
+    });
+
+    await backend.prewarm({
+      log: (message) => logs.push(message),
+      runtimeContext: { appRoot: "/tmp/app" },
+      seedFiles: [],
+      templateKey: "tpl",
+    });
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/app" },
+      seedFiles: [],
+      templateKey: "tpl-2",
+    });
+
+    expect(calls).toEqual([
+      "prepare",
+      "microsandbox:prewarm:tpl",
+      "just-bash:prewarm:tpl",
+      "just-bash:prewarm:tpl-2",
+    ]);
+    expect(logs.join("\n")).toContain(
+      "microsandbox prewarm failed; falling back to just-bash: template rejected",
+    );
+  });
 });

--- a/packages/eve/test/default-backend.test.ts
+++ b/packages/eve/test/default-backend.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
+import type {
+  SandboxBackend,
+  SandboxBackendCreateInput,
+  SandboxBackendHandle,
+  SandboxBackendPrewarmInput,
+} from "../src/public/definitions/sandbox-backend.js";
 import {
+  createMicrosandboxWithJustBashFallback,
   defaultSandbox,
   selectDefaultSandbox,
   type DefaultSandboxProbes,
@@ -10,7 +17,39 @@ function probes(overrides: Partial<DefaultSandboxProbes>): DefaultSandboxProbes 
     isDeployedOnVercel: () => false,
     isDockerAvailable: () => false,
     isMicrosandboxSupported: () => false,
+    prepareMicrosandbox: async () => {},
     ...overrides,
+  };
+}
+
+function createRecordingBackend(name: string, calls: string[]): SandboxBackend {
+  return {
+    name,
+    async prewarm(input: SandboxBackendPrewarmInput) {
+      calls.push(`${name}:prewarm:${input.templateKey}`);
+      return { reused: false };
+    },
+    async create(input: SandboxBackendCreateInput) {
+      calls.push(`${name}:create:${input.sessionKey}`);
+      return createHandle(name, input.sessionKey);
+    },
+  };
+}
+
+function createHandle(backendName: string, sessionKey: string): SandboxBackendHandle {
+  return {
+    async captureState() {
+      return {
+        backendName,
+        metadata: { backendName },
+        sessionKey,
+      };
+    },
+    async dispose() {},
+    session: {} as SandboxBackendHandle["session"],
+    useSessionFn: (() => {
+      throw new Error("not used");
+    }) as SandboxBackendHandle["useSessionFn"],
   };
 }
 
@@ -60,5 +99,60 @@ describe("defaultSandbox", () => {
     const backend = defaultSandbox({ docker: { image: "alpine:3" } });
     expect(typeof backend.create).toBe("function");
     expect(typeof backend.prewarm).toBe("function");
+  });
+});
+
+describe("createMicrosandboxWithJustBashFallback", () => {
+  it("preflights microsandbox before using it", async () => {
+    const calls: string[] = [];
+    const backend = createMicrosandboxWithJustBashFallback({
+      fallback: createRecordingBackend("just-bash", calls),
+      prepareMicrosandbox: async ({ appRoot }) => {
+        calls.push(`prepare:${appRoot}`);
+      },
+      primary: createRecordingBackend("microsandbox", calls),
+    });
+
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/app" },
+      seedFiles: [],
+      templateKey: "tpl",
+    });
+
+    expect(calls).toEqual(["prepare:/tmp/app", "microsandbox:prewarm:tpl"]);
+  });
+
+  it("falls back to just-bash when microsandbox setup fails", async () => {
+    const calls: string[] = [];
+    const logs: string[] = [];
+    const backend = createMicrosandboxWithJustBashFallback({
+      fallback: createRecordingBackend("just-bash", calls),
+      prepareMicrosandbox: async () => {
+        calls.push("prepare");
+        throw new Error("install rejected");
+      },
+      primary: createRecordingBackend("microsandbox", calls),
+    });
+
+    await backend.prewarm({
+      log: (message) => logs.push(message),
+      runtimeContext: { appRoot: "/tmp/app" },
+      seedFiles: [],
+      templateKey: "tpl",
+    });
+    const handle = await backend.create({
+      runtimeContext: { appRoot: "/tmp/app" },
+      sessionKey: "ses",
+      templateKey: "tpl",
+    });
+
+    await expect(handle.captureState()).resolves.toMatchObject({
+      backendName: "microsandbox",
+      sessionKey: "ses",
+    });
+    expect(calls).toEqual(["prepare", "just-bash:prewarm:tpl", "just-bash:create:ses"]);
+    expect(logs.join("\n")).toContain(
+      "microsandbox setup failed; falling back to just-bash: install rejected",
+    );
   });
 });

--- a/packages/eve/test/default-backend.test.ts
+++ b/packages/eve/test/default-backend.test.ts
@@ -182,17 +182,75 @@ describe("createMicrosandboxWithJustBashFallback", () => {
     await backend.prewarm({
       runtimeContext: { appRoot: "/tmp/app" },
       seedFiles: [],
-      templateKey: "tpl-2",
+      templateKey: "tpl",
     });
 
     expect(calls).toEqual([
       "prepare",
       "microsandbox:prewarm:tpl",
       "just-bash:prewarm:tpl",
-      "just-bash:prewarm:tpl-2",
+      "just-bash:prewarm:tpl",
     ]);
     expect(logs.join("\n")).toContain(
       "microsandbox prewarm failed; falling back to just-bash: template rejected",
     );
+  });
+
+  it("keeps backend choices isolated per template", async () => {
+    const calls: string[] = [];
+    const backend = createMicrosandboxWithJustBashFallback({
+      fallback: createRecordingBackend("just-bash", calls),
+      prepareMicrosandbox: async () => {
+        calls.push("prepare");
+      },
+      primary: {
+        ...createRecordingBackend("microsandbox", calls),
+        async prewarm(input) {
+          calls.push(`microsandbox:prewarm:${input.templateKey}`);
+          if (input.templateKey === "fallback-tpl") {
+            throw new Error("template rejected");
+          }
+          return { reused: false };
+        },
+      },
+    });
+
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/app" },
+      seedFiles: [],
+      templateKey: "primary-tpl",
+    });
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/app" },
+      seedFiles: [],
+      templateKey: "fallback-tpl",
+    });
+    const primaryHandle = await backend.create({
+      runtimeContext: { appRoot: "/tmp/app" },
+      sessionKey: "primary-ses",
+      templateKey: "primary-tpl",
+    });
+    const fallbackHandle = await backend.create({
+      runtimeContext: { appRoot: "/tmp/app" },
+      sessionKey: "fallback-ses",
+      templateKey: "fallback-tpl",
+    });
+
+    await expect(primaryHandle.captureState()).resolves.toMatchObject({
+      backendName: "microsandbox",
+      sessionKey: "primary-ses",
+    });
+    await expect(fallbackHandle.captureState()).resolves.toMatchObject({
+      backendName: "microsandbox",
+      sessionKey: "fallback-ses",
+    });
+    expect(calls).toEqual([
+      "prepare",
+      "microsandbox:prewarm:primary-tpl",
+      "microsandbox:prewarm:fallback-tpl",
+      "just-bash:prewarm:fallback-tpl",
+      "microsandbox:create:primary-ses",
+      "just-bash:create:fallback-ses",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Make `defaultSandbox()` verify microsandbox setup before selecting it on Docker-less local hosts, so missing or partially installed microsandbox dependencies are treated as unavailable.
- Fall back to `just-bash` when microsandbox setup or template prewarm fails, and surface the failure reason through the sandbox prewarm log.
- Ensure the just-bash fallback runs its own `prewarm()` path so its package auto-install can happen before session creation.
- Keep hosted Vercel bundles from pulling in local microsandbox setup code by routing the setup probe through the existing local sandbox facade.
- Track fallback decisions per sandbox template, so one template falling back to just-bash does not misroute another template already provisioned under microsandbox.
- Preserve the default backend identity/captured state namespace when using the just-bash fallback on a microsandbox-capable host.

## Verification

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts test/default-backend.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/app-runtime-dependencies.scenario.test.ts`
- `pnpm fmt`
- `pnpm lint`
- CI is green as of commit `a8edefe` after rerunning transient HITL e2e flakes.