### PR TITLE
fix(setup): add Eve scripts to web template

### DIFF
--- a/.changeset/web-template-eve-scripts.md
+++ b/.changeset/web-template-eve-scripts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add Eve CLI package scripts to the generated Web Chat template.

--- a/apps/templates/web-chat-next/package.json
+++ b/apps/templates/web-chat-next/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "build": "next build",
+    "build:eve": "eve build",
     "dev": "next dev",
+    "dev:eve": "eve dev",
     "start": "next start",
     "typecheck": "tsgo --noEmit -p tsconfig.json"
   },

--- a/packages/eve/src/setup/scaffold/create/web-template.ts
+++ b/packages/eve/src/setup/scaffold/create/web-template.ts
@@ -78,7 +78,9 @@ export const WEB_APP_TEMPLATE_FILES = {
 export const WEB_APP_TEMPLATE_PACKAGE_JSON = {
   scripts: {
     build: "next build",
+    "build:eve": "eve build",
     dev: "next dev",
+    "dev:eve": "eve dev",
     start: "next start",
     typecheck: "tsgo --noEmit -p tsconfig.json",
   },

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -156,7 +156,14 @@ describe("ensureChannel", () => {
         path: join(projectRoot, "package.json"),
         dependencies: expect.arrayContaining(["eve", "next", "react", "react-dom"]),
         devDependencies: expect.arrayContaining(["@typescript/native-preview", "@types/react"]),
-        scripts: expect.arrayContaining(["build", "dev", "start", "typecheck"]),
+        scripts: expect.arrayContaining([
+          "build",
+          "build:eve",
+          "dev",
+          "dev:eve",
+          "start",
+          "typecheck",
+        ]),
       }),
     ]);
     await expect(readFile(join(projectRoot, "agent/channels/eve.ts"), "utf8")).resolves.toBe(
@@ -184,6 +191,8 @@ describe("ensureChannel", () => {
     const packageJson = await readFile(join(projectRoot, "package.json"), "utf8");
     expect(packageJson).toContain('"next": "16.2.6"');
     expect(packageJson).toContain('"dev": "next dev"');
+    expect(packageJson).toContain('"dev:eve": "eve dev"');
+    expect(packageJson).toContain('"build:eve": "eve build"');
     expect(JSON.parse(packageJson)).toMatchObject({ engines: { node: "24.x" } });
     await expect(readFile(join(projectRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
       PNPM_WORKSPACE_CONTENT,
@@ -378,6 +387,9 @@ describe("ensureChannel", () => {
     );
     await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
       '"dev": "next dev"',
+    );
+    await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
+      '"dev:eve": "eve dev"',
     );
   });
 


### PR DESCRIPTION
Closes #29

## Summary
- Add explicit `dev:eve` and `build:eve` scripts to the Web Chat template
- Regenerate the scaffold template
- Assert the generated package scripts in scaffold integration tests

## Test plan
- `pnpm install`
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm fmt`
- `pnpm check:deps`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `git diff --check`