### PR TITLE
feat(eve): multi-line input in the dev TUI prompt (bracketed paste + Shift+Enter)

### DIFF
--- a/.changeset/tui-multiline-paste.md
+++ b/.changeset/tui-multiline-paste.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Multi-line input in the dev TUI prompt: pasting multi-line text now inserts it intact via bracketed paste (instead of truncating at the first line), and Shift+Enter / Alt+Enter insert a newline without sending. Embedded newlines show inline as `⏎` and are preserved on submit.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -63,12 +63,15 @@ The prompt input behaves like a shell line editor.
 | Key                                            | Action                                                                                                            |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `Enter`                                        | Send the message.                                                                                                 |
+| `Shift+Enter` / `Alt+Enter`                    | Insert a newline without sending (needs a terminal that reports modified keys).                                   |
 | `Ctrl+C`                                       | Interrupt a running turn, or quit at the prompt.                                                                  |
 | `↑` / `↓`                                      | Cycle through the messages you have sent this session.                                                            |
 | `←` / `→`, `Home` / `End`, `Ctrl+A` / `Ctrl+E` | Move the caret.                                                                                                   |
 | `Ctrl+U` / `Ctrl+K` / `Ctrl+W`                 | Kill the whole line, the rest of the line, or the previous word.                                                  |
 | `Ctrl+L`                                       | Cycle the log display mode (`none → all → stderr → sandbox → none`) and briefly show the mode in the status line. |
 | `Ctrl+R`                                       | Redraw the screen.                                                                                                |
+
+Pasting multi-line text inserts it intact: the prompt enables bracketed paste, so embedded newlines stay in the message (shown inline as `⏎`) rather than submitting at the first line. `Enter` still sends.
 
 If a turn fails terminally (the server session dies or the connection drops), the TUI starts a fresh session and notes it inline so you can keep going. Server-side context resets with the old session.
 

--- a/packages/eve/src/cli/dev/tui/line-editor.test.ts
+++ b/packages/eve/src/cli/dev/tui/line-editor.test.ts
@@ -25,6 +25,20 @@ describe("line editing", () => {
     expect(line).toEqual({ text: "hello", cursor: 4 });
   });
 
+  it("inserts a paste, newlines and all, at the caret", () => {
+    expect(applyLineEditorKey(lineOf(""), { type: "paste", value: "one\ntwo" })).toEqual({
+      text: "one\ntwo",
+      cursor: 7,
+    });
+  });
+
+  it("inserts a newline keystroke (Shift+Enter) at the caret", () => {
+    expect(applyLineEditorKey(lineOf("a"), { type: "newline" })).toEqual({
+      text: "a\n",
+      cursor: 2,
+    });
+  });
+
   it("backspaces the character before the caret", () => {
     const line = backspace({ text: "abc", cursor: 2 });
     expect(line).toEqual({ text: "ac", cursor: 1 });

--- a/packages/eve/src/cli/dev/tui/line-editor.ts
+++ b/packages/eve/src/cli/dev/tui/line-editor.ts
@@ -96,7 +96,10 @@ export function deleteWord(state: LineState): LineState {
 export function applyLineEditorKey(state: LineState, key: TerminalKey): LineState | undefined {
   switch (key.type) {
     case "character":
+    case "paste":
       return insert(state, key.value);
+    case "newline":
+      return insert(state, "\n");
     case "backspace":
       return backspace(state);
     case "delete":

--- a/packages/eve/src/cli/dev/tui/live-region.test.ts
+++ b/packages/eve/src/cli/dev/tui/live-region.test.ts
@@ -38,4 +38,12 @@ describe("LiveRegion", () => {
     live.clear();
     expect(screen.snapshot()).toBe("");
   });
+
+  it("toggles bracketed paste mode through the bound write", () => {
+    const { screen, live } = setup();
+    live.enableBracketedPaste();
+    expect(screen.rawOutput()).toContain("\x1b[?2004h");
+    live.disableBracketedPaste();
+    expect(screen.rawOutput()).toContain("\x1b[?2004l");
+  });
 });

--- a/packages/eve/src/cli/dev/tui/live-region.ts
+++ b/packages/eve/src/cli/dev/tui/live-region.ts
@@ -29,6 +29,8 @@ const CLEAR_SCROLLBACK = `${ESC}[3J`;
 const CURSOR_HOME = `${ESC}[H`;
 const SYNC_START = `${ESC}[?2026h`;
 const SYNC_END = `${ESC}[?2026l`;
+const BRACKETED_PASTE_ON = `${ESC}[?2004h`;
+const BRACKETED_PASTE_OFF = `${ESC}[?2004l`;
 
 export interface LiveRegionOutput {
   write(chunk: string): boolean;
@@ -57,6 +59,21 @@ export class LiveRegion {
 
   showCursor(): void {
     this.#write(SHOW_CURSOR);
+  }
+
+  /**
+   * Enables the terminal's bracketed-paste mode (DEC private mode 2004) through
+   * the bound original `write`, so the sequence reaches the terminal instead of
+   * being swallowed by the renderer's foreign-output capture (which monkeypatches
+   * `process.stdout.write`).
+   */
+  enableBracketedPaste(): void {
+    this.#write(BRACKETED_PASTE_ON);
+  }
+
+  /** Disables bracketed-paste mode, restoring the terminal default. */
+  disableBracketedPaste(): void {
+    this.#write(BRACKETED_PASTE_OFF);
   }
 
   /** Writes a newline through the bound (original) write. */

--- a/packages/eve/src/cli/dev/tui/stream-format.test.ts
+++ b/packages/eve/src/cli/dev/tui/stream-format.test.ts
@@ -5,11 +5,23 @@ import {
   formatTokenFlow,
   nextKey,
   parseKey,
+  sanitizePastedText,
   stripPromptControlCharacters,
   takeUntil,
 } from "./stream-format.js";
 
 const FLOW_GLYPHS = { arrowUp: "↑", arrowDown: "↓" };
+
+describe("sanitizePastedText", () => {
+  it("keeps newlines and tabs but drops other control characters and ESC", () => {
+    expect(sanitizePastedText("a\tb\nc")).toBe("a\tb\nc");
+    expect(sanitizePastedText("a\x1b[31mb\x07c")).toBe("a[31mbc");
+  });
+
+  it("normalizes CRLF and lone CR to LF", () => {
+    expect(sanitizePastedText("a\r\nb\rc")).toBe("a\nb\nc");
+  });
+});
 
 describe("formatCompactTokenCount", () => {
   it("keeps small counts plain and abbreviates with one trimmed decimal", () => {
@@ -58,6 +70,35 @@ describe("nextKey", () => {
 
   it("takes a printable run as a single character token", () => {
     expect(nextKey("hello")).toEqual({ key: { type: "character", value: "hello" }, consumed: 5 });
+  });
+
+  it("decodes a bracketed paste as one token, preserving newlines", () => {
+    const buffer = "\x1b[200~first\nsecond\x1b[201~";
+    expect(nextKey(buffer)).toEqual({
+      key: { type: "paste", value: "first\nsecond" },
+      consumed: buffer.length,
+    });
+  });
+
+  it("waits for the bracketed-paste end marker before decoding", () => {
+    expect(nextKey("\x1b[200~still arriving")).toEqual({ consumed: 0, incomplete: true });
+  });
+
+  it("re-tokenizes input that follows a bracketed paste", () => {
+    const buffer = "\x1b[200~hi\x1b[201~\r";
+    const token = nextKey(buffer);
+    expect(token).toEqual({ key: { type: "paste", value: "hi" }, consumed: buffer.length - 1 });
+    expect(nextKey(buffer.slice(token.consumed))).toEqual({ key: { type: "enter" }, consumed: 1 });
+  });
+
+  it("decodes Shift+Enter as a newline (insert, not submit)", () => {
+    expect(nextKey("\x1b[27;2;13~")).toEqual({ key: { type: "newline" }, consumed: 10 });
+    expect(nextKey("\x1b[13;2u")).toEqual({ key: { type: "newline" }, consumed: 7 });
+  });
+
+  it("decodes Alt+Enter as a newline while a bare Enter still submits", () => {
+    expect(nextKey("\x1b\r")).toEqual({ key: { type: "newline" }, consumed: 2 });
+    expect(nextKey("\r")).toEqual({ key: { type: "enter" }, consumed: 1 });
   });
 
   it("stops a printable run at a control byte", () => {

--- a/packages/eve/src/cli/dev/tui/stream-format.ts
+++ b/packages/eve/src/cli/dev/tui/stream-format.ts
@@ -8,6 +8,8 @@ import type { AssistantResponseStatsMode } from "./types.js";
 
 export type TerminalKey =
   | { type: "character"; value: string }
+  | { type: "paste"; value: string }
+  | { type: "newline" }
   | { type: "backspace" }
   | { type: "delete" }
   | { type: "enter" }
@@ -41,6 +43,27 @@ export interface KeyToken {
 // Final byte of a CSI escape sequence (`ESC [ … <final>`), range 0x40–0x7e.
 const CSI_FINAL = /[\u0040-\u007e]/u;
 
+// Bracketed paste markers (DEC private mode 2004). The terminal wraps pasted
+// text in these so an embedded newline inserts literally instead of submitting.
+const PASTE_START = "\x1B[200~";
+const PASTE_END = "\x1B[201~";
+
+/**
+ * Sanitizes bracketed-paste content for the prompt: preserves newlines and tabs
+ * (the whole point of multi-line paste), normalizes CR/CRLF to LF, and drops
+ * other C0 controls, DEL, and any embedded ESC so a paste cannot smuggle escape
+ * sequences into the line.
+ */
+export function sanitizePastedText(text: string): string {
+  let printable = "";
+  for (const character of text.replace(/\r\n?/gu, "\n")) {
+    if (character === "\n" || character === "\t" || (character >= " " && character !== "\x7f")) {
+      printable += character;
+    }
+  }
+  return printable;
+}
+
 /** Removes C0 control characters and DEL from text intended for the prompt. */
 export function stripPromptControlCharacters(text: string): string {
   let printable = "";
@@ -72,12 +95,27 @@ export function nextKey(buffer: string): KeyToken {
       return { key: parseKey(Buffer.from(buffer.slice(0, 3))), consumed: 3 };
     }
     if (second === "[") {
+      // Bracketed paste: capture everything between the start and end markers as
+      // one chunk so embedded newlines insert literally instead of each one
+      // submitting the line. Wait for the closing marker if it hasn't arrived.
+      if (buffer.startsWith(PASTE_START)) {
+        const end = buffer.indexOf(PASTE_END, PASTE_START.length);
+        if (end === -1) return { consumed: 0, incomplete: true };
+        return {
+          key: { type: "paste", value: sanitizePastedText(buffer.slice(PASTE_START.length, end)) },
+          consumed: end + PASTE_END.length,
+        };
+      }
       for (let i = 2; i < buffer.length; i += 1) {
         if (CSI_FINAL.test(buffer[i]!)) {
           return { key: parseKey(Buffer.from(buffer.slice(0, i + 1))), consumed: i + 1 };
         }
       }
       return { consumed: 0, incomplete: true };
+    }
+    // Alt/Option+Enter (ESC + CR/LF) inserts a newline instead of submitting.
+    if (second === "\r" || second === "\n") {
+      return { key: { type: "newline" }, consumed: 2 };
     }
     // `ESC` + another byte (e.g. Alt+key): surface the Escape and re-tokenize.
     return { key: { type: "escape" }, consumed: 1 };
@@ -124,6 +162,11 @@ export function parseKey(chunk: Buffer): TerminalKey {
     case "\r":
     case "\n":
       return { type: "enter" };
+    // Shift+Enter: insert a newline instead of submitting. Terminals report it
+    // as xterm modifyOtherKeys (`CSI 27 ; 2 ; 13 ~`) or the kitty/CSI-u form.
+    case "\x1b[27;2;13~":
+    case "\x1b[13;2u":
+      return { type: "newline" };
     case "\u007f":
     case "\b":
       return { type: "backspace" };

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -245,6 +245,30 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(input.rawModes).toEqual([true, false]);
   });
 
+  it("inserts a bracketed paste intact and submits it with its newlines", async () => {
+    const { input, renderer } = makeRenderer();
+
+    const prompt = renderer.readPrompt();
+    input.send("\x1b[200~first line\nsecond line\x1b[201~");
+    input.enter();
+
+    expect(await prompt).toBe("first line\nsecond line");
+    renderer.shutdown();
+  });
+
+  it("inserts a newline on Shift+Enter and submits the whole multi-line buffer", async () => {
+    const { input, renderer } = makeRenderer();
+
+    const prompt = renderer.readPrompt();
+    input.type("line one");
+    input.send("\x1b[27;2;13~"); // Shift+Enter (xterm modifyOtherKeys)
+    input.type("line two");
+    input.enter();
+
+    expect(await prompt).toBe("line one\nline two");
+    renderer.shutdown();
+  });
+
   it("renders reused stream block ids across separate prompt turns", async () => {
     const { screen, renderer } = makeRenderer();
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -1658,6 +1658,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
     if (this.#input.isTTY) {
       this.#input.setRawMode?.(true);
       this.#input.resume();
+      // Enable bracketed paste (DEC private mode 2004) so the terminal wraps
+      // pasted text in \x1b[200~ … \x1b[201~; the decoder then inserts a
+      // multi-line paste intact instead of each newline submitting the prompt.
+      // Routed through the live region's original `write` so the foreign-output
+      // capture installed just above can't swallow the control sequence.
+      this.#live.enableBracketedPaste();
     }
 
     this.#onResize = () => this.#paint();
@@ -1691,6 +1697,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#live.newline();
 
     if (this.#input.isTTY) {
+      // Disable bracketed paste, restoring the terminal to how we found it.
+      this.#live.disableBracketedPaste();
       this.#input.setRawMode?.(false);
       this.#input.pause();
     }
@@ -2359,7 +2367,14 @@ export class TerminalRenderer implements AgentTUIRenderer {
         isCommand && segment.length > 0 ? c.blue(segment) : segment;
       const caret = this.#caretVisible ? c.cyan(this.#theme.glyph.caret) : " ";
       const ghost = inlineHint ? c.dim(` ${inlineHint}`) : "";
-      const body = `${style(before)}${caret}${style(after)}${ghost}`;
+      // A pasted multi-line prompt keeps its real newlines in the buffer (and on
+      // submit); show each as a dim glyph so this single input row never emits a
+      // literal newline into the live region.
+      const showNewlines = (segment: string): string =>
+        segment.includes("\n")
+          ? segment.replaceAll("\n", c.dim(this.#theme.glyph.newline))
+          : segment;
+      const body = `${style(showNewlines(before))}${caret}${style(showNewlines(after))}${ghost}`;
       rows.push(...promptInputRows(body, width, this.#theme, true));
       this.#pushStatusLine(rows, width);
       return rows;

--- a/packages/eve/src/cli/dev/tui/theme.ts
+++ b/packages/eve/src/cli/dev/tui/theme.ts
@@ -91,6 +91,8 @@ export interface ThemeGlyphs {
   hrule: string;
   /** `▏` — the synthetic input caret. */
   caret: string;
+  /** `⏎` — marks a newline inside a pasted multi-line prompt. */
+  newline: string;
   /** `·` — inline separator for header / status segments. */
   dot: string;
   /** `…` — truncation marker. */
@@ -119,6 +121,7 @@ const UNICODE_GLYPHS: ThemeGlyphs = {
   elbow: "⎿",
   hrule: "▔",
   caret: "▏",
+  newline: "⏎",
   dot: "·",
   ellipsis: "…",
   arrowUp: "↑",
@@ -143,6 +146,7 @@ const ASCII_GLYPHS: ThemeGlyphs = {
   elbow: "`-",
   hrule: "=",
   caret: "_",
+  newline: "\\n",
   dot: "-",
   ellipsis: "...",
   arrowUp: "^",


### PR DESCRIPTION
## Problem

The dev TUI prompt is a single-line editor where `Enter` submits. A pasted newline was decoded as `Enter`, so pasting a multi-line message (a brief, a code block, logs) submitted only the first line and dropped the rest. There was also no way to compose a multi-line message by hand.

## What this does

- **Bracketed paste (DEC private mode 2004).** The prompt enables bracketed paste while it's active and decodes the `\x1b[200~ … \x1b[201~` wrapper in `nextKey` as a single `paste` token, reassembling it across reads (it returns `incomplete` until the end marker arrives). Content is sanitized: newlines and tabs preserved, CRLF/CR normalized to LF, embedded ESC and other C0/DEL dropped so a paste can't inject escape sequences. The paste inserts intact and `Enter` submits the whole buffer.
- **Shift+Enter / Alt+Enter insert a newline** instead of submitting, so you can compose multi-line input by hand. Decoded from the xterm modifyOtherKeys form (`\x1b[27;2;13~`), the kitty/CSI-u form (`\x1b[13;2u`), and `ESC`+CR/LF. A bare `Enter` still submits.
- Embedded newlines render inline as a dim `⏎` glyph so the single input row never writes a literal newline into the live region; the buffer and the submitted message keep their real newlines.
