### PR TITLE
Fix docs Open Graph card images

### DIFF
--- a/.changeset/canonical-eve-docs-url.md
+++ b/.changeset/canonical-eve-docs-url.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Update public package links to point at the canonical eve.dev documentation URL.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ my-agent/
         └── weekly_recap.ts
 ```
 
-Read the [documentation](https://beta.eve.dev/docs) for the full project layout and guides.
+Read the [documentation](https://eve.dev/docs) for the full project layout and guides.
 
 ## Quick start
 
@@ -98,7 +98,7 @@ npm run dev
 ```
 
 That's a working agent. Add human-in-the-loop prompts, subagents, and schedules as needed.
-Follow the [first-agent tutorial](https://beta.eve.dev/docs/tutorial/first-agent) for a complete
+Follow the [first-agent tutorial](https://eve.dev/docs/tutorial/first-agent) for a complete
 walkthrough.
 
 ## Community

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -3,7 +3,6 @@ import { createDocsPage } from "@vercel/geistdocs/pages/docs";
 import type { MDXComponents } from "mdx/types";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { config } from "@/lib/geistdocs/config";
-import { staticOgImage } from "@/lib/geistdocs/og";
 import { geistdocsSource } from "@/lib/geistdocs/source";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
 
@@ -13,17 +12,27 @@ const docsPage = createDocsPage({
     const components: MDXComponents = link ? { a: link } : {};
     return getMDXComponents(components);
   },
-  metadata: ({ metadata }) => ({
-    ...metadata,
-    metadataBase: new URL(getSiteOrigin()),
-    openGraph: {
-      ...metadata.openGraph,
-      // Override with the static OG image for now. To restore dynamic per-page
-      // OG generation, add `page` back to the destructure above and swap the
-      // line below back to: images: geistdocsSource.getPageImage(page).url,
-      images: [staticOgImage],
-    },
-  }),
+  metadata: ({ metadata, page }) => {
+    const image = geistdocsSource.getPageImage(page).url;
+
+    return {
+      ...metadata,
+      metadataBase: new URL(getSiteOrigin()),
+      openGraph: {
+        ...metadata.openGraph,
+        description: page.data.description,
+        images: [image],
+        title: page.data.title,
+        url: page.url,
+      },
+      twitter: {
+        card: "summary_large_image",
+        description: page.data.description,
+        images: [image],
+        title: page.data.title,
+      },
+    };
+  },
   source: geistdocsSource,
   tableOfContentPopover: {
     enabled: false,

--- a/packages/eve/src/internal/nitro/routes/index.test.ts
+++ b/packages/eve/src/internal/nitro/routes/index.test.ts
@@ -18,7 +18,7 @@ describe("buildHomePageResponse", () => {
   it("links out to the public docs site", async () => {
     const body = await buildResponseForRequest("https://my-agent.example.com/").text();
 
-    expect(body).toContain("https://beta.eve.dev/docs");
+    expect(body).toContain("https://eve.dev/docs");
   });
 
   it("echoes the deployment origin into the `eve dev` hint", async () => {

--- a/packages/eve/src/internal/nitro/routes/index.ts
+++ b/packages/eve/src/internal/nitro/routes/index.ts
@@ -5,7 +5,7 @@ import type { H3Event } from "nitro";
  * so the deployment output is a fully static, build-time-baked HTML
  * response that performs no runtime resolution.
  */
-const EVE_DOCS_URL = "https://beta.eve.dev/docs";
+const EVE_DOCS_URL = "https://eve.dev/docs";
 
 const DEPLOYMENT_URL_PLACEHOLDER = "{{DEPLOYMENT_URL}}";
 

--- a/packages/eve/src/setup/flows/vercel.ts
+++ b/packages/eve/src/setup/flows/vercel.ts
@@ -23,7 +23,7 @@ export const EXTERNAL_PROVIDER_INSTRUCTIONS_TITLE = "Using another model provide
 export const EXTERNAL_PROVIDER_INSTRUCTIONS: readonly string[] = [
   `Set your provider's API key in ${ENV_FILE_NAME} — e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY.`,
   'In agent/agent.ts, set `model` to a provider-authored model — e.g. `anthropic("claude-opus-4.8")` from `@ai-sdk/anthropic`.',
-  "See https://beta.eve.dev/docs/agent-config for details.",
+  "See https://eve.dev/docs/agent-config for details.",
   "A running `eve dev` reloads env files automatically — no restart needed.",
 ];
 


### PR DESCRIPTION
## Summary

- wire docs pages back to their existing per-page dynamic OG image route
- emit matching `twitter:*` image metadata for docs pages
- update package-facing docs links from `beta.eve.dev` to the canonical `eve.dev` URL

## Verification

- `pnpm --filter eve-docs build`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/nitro/routes/index.test.ts`