### PR TITLE
Add Docker image size analysis workflow

### DIFF
--- a/.github/workflows/docker-image-size-analysis.yml
+++ b/.github/workflows/docker-image-size-analysis.yml
@@ -1,0 +1,158 @@
+name: Docker Image Size Analysis
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-image-size-analysis.yml
+      - scripts/docker-image-size-budget.mjs
+      - scripts/docker-image-size-report.mjs
+
+concurrency:
+  group: docker-image-size-analysis-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Prepare main baseline worktree
+        id: baseline
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          BASELINE_ROOT="$RUNNER_TEMP/eve-docker-image-baseline"
+          rm -rf "$BASELINE_ROOT"
+          git worktree add --detach "$BASELINE_ROOT" "$BASE_SHA"
+          echo "root=$BASELINE_ROOT" >> "$GITHUB_OUTPUT"
+          echo "label=main (${BASE_SHA:0:7})" >> "$GITHUB_OUTPUT"
+
+      - name: Build main baseline Docker image
+        id: baseline_image
+        working-directory: ${{ steps.baseline.outputs.root }}
+        run: |
+          docker buildx build \
+            --cache-from type=gha,scope=eve-docker-image-size \
+            --load \
+            --platform linux/amd64 \
+            --tag eve-docker-size:baseline \
+            .
+
+          size_bytes="$(docker image inspect eve-docker-size:baseline --format '{{.Size}}')"
+          echo "size_bytes=$size_bytes" >> "$GITHUB_OUTPUT"
+
+      - name: Build current Docker image
+        id: current_image
+        run: |
+          docker buildx build \
+            --cache-from type=gha,scope=eve-docker-image-size \
+            --cache-to type=gha,mode=max,scope=eve-docker-image-size \
+            --load \
+            --platform linux/amd64 \
+            --tag eve-docker-size:current \
+            .
+
+          size_bytes="$(docker image inspect eve-docker-size:current --format '{{.Size}}')"
+          echo "size_bytes=$size_bytes" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Docker image size report
+        env:
+          BASELINE_LABEL: ${{ steps.baseline.outputs.label }}
+          BASELINE_SIZE_BYTES: ${{ steps.baseline_image.outputs.size_bytes }}
+          CURRENT_SIZE_BYTES: ${{ steps.current_image.outputs.size_bytes }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPORT_JSON: ${{ runner.temp }}/docker-image-size-report.json
+          REPORT_MARKDOWN: ${{ runner.temp }}/docker-image-size-report.md
+        run: |
+          node ./scripts/docker-image-size-report.mjs \
+            --baseline-label "$BASELINE_LABEL" \
+            --baseline-size-bytes "$BASELINE_SIZE_BYTES" \
+            --current-label "pull request (${HEAD_SHA:0:7})" \
+            --current-size-bytes "$CURRENT_SIZE_BYTES" \
+            --image-label Dockerfile \
+            --output-json "$REPORT_JSON" \
+            --output-markdown "$REPORT_MARKDOWN"
+
+      - name: Publish job summary
+        env:
+          REPORT_MARKDOWN: ${{ runner.temp }}/docker-image-size-report.md
+        run: cat "$REPORT_MARKDOWN" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Docker image size report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: docker-image-size-report
+          path: |
+            ${{ runner.temp }}/docker-image-size-report.json
+            ${{ runner.temp }}/docker-image-size-report.md
+
+      - name: Update pull request comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          REPORT_MARKDOWN: ${{ runner.temp }}/docker-image-size-report.md
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const marker = "<!-- eve-docker-image-size-analysis -->";
+            const reportBody = fs.readFileSync(process.env.REPORT_MARKDOWN, "utf8").trim();
+            const body = `${marker}\n${reportBody}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              per_page: 100,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find(
+              (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                body,
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              body,
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+      - name: Enforce Docker image size budget
+        env:
+          REPORT_JSON: ${{ runner.temp }}/docker-image-size-report.json
+        run: node ./scripts/docker-image-size-budget.mjs --report-json "$REPORT_JSON"

--- a/scripts/docker-image-size-budget.mjs
+++ b/scripts/docker-image-size-budget.mjs
@@ -1,0 +1,111 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function formatBytes(bytes) {
+  if (bytes < 1_000) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < 1_000_000) {
+    return `${(bytes / 1_000).toFixed(1)} kB`;
+  }
+
+  return `${(bytes / 1_000_000).toFixed(2)} MB`;
+}
+
+function formatRatioPercent(ratio) {
+  if (!Number.isFinite(ratio)) {
+    return "new";
+  }
+
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+function printUsage() {
+  process.stdout.write(
+    [
+      "Usage: node ./scripts/docker-image-size-budget.mjs --report-json <path>",
+      "",
+      "Options:",
+      "  --report-json <path>  Docker image size report JSON",
+      "  --help                Show this help text",
+      "",
+    ].join("\n"),
+  );
+}
+
+function parseArguments(argv) {
+  const parsedArguments = {
+    reportJsonPath: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--help") {
+      printUsage();
+      process.exit(0);
+    }
+
+    const value = argv[index + 1];
+
+    if (value === undefined) {
+      throw new Error(`Missing value for "${argument}".`);
+    }
+
+    if (argument === "--report-json") {
+      parsedArguments.reportJsonPath = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument "${argument}".`);
+  }
+
+  if (parsedArguments.reportJsonPath === null) {
+    throw new Error('The "--report-json" option is required.');
+  }
+
+  return parsedArguments;
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const report = JSON.parse(await readFile(resolve(args.reportJsonPath), "utf8"));
+  const comparison = report.comparison;
+  const sizeBudget = comparison?.sizeBudget;
+
+  if (!comparison || !sizeBudget) {
+    process.stderr.write("Docker image size report does not contain a baseline comparison.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!sizeBudget.failed) {
+    process.stdout.write("Docker image size budget passed.\n");
+    return;
+  }
+
+  process.stderr.write(
+    [
+      "Docker image size budget exceeded:",
+      `- Image size grew ${formatRatioPercent(sizeBudget.increaseRatio)} (${formatBytes(comparison.sizeBytes.baseline)} -> ${formatBytes(comparison.sizeBytes.current)}), above the ${formatRatioPercent(sizeBudget.thresholdRatio)} limit.`,
+      "",
+      "The pull request comment contains the same failure details.",
+      "",
+    ].join("\n"),
+  );
+  process.exitCode = 1;
+}
+
+const executedScriptPath = process.argv[1] ? resolve(process.argv[1]) : null;
+const moduleScriptPath = resolve(fileURLToPath(import.meta.url));
+
+if (
+  executedScriptPath !== null &&
+  moduleScriptPath !== null &&
+  executedScriptPath === moduleScriptPath
+) {
+  await main();
+}

--- a/scripts/docker-image-size-report.mjs
+++ b/scripts/docker-image-size-report.mjs
@@ -1,0 +1,278 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SIZE_BUDGET_THRESHOLD = 0.1;
+
+function formatBytes(bytes) {
+  if (bytes < 1_000) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < 1_000_000) {
+    return `${(bytes / 1_000).toFixed(1)} kB`;
+  }
+
+  return `${(bytes / 1_000_000).toFixed(2)} MB`;
+}
+
+function formatSignedBytes(bytes) {
+  if (bytes === 0) {
+    return "0 B";
+  }
+
+  return `${bytes > 0 ? "+" : "-"}${formatBytes(Math.abs(bytes))}`;
+}
+
+function formatRatioPercent(ratio) {
+  if (!Number.isFinite(ratio)) {
+    return "new";
+  }
+
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+function parseSizeBytes(value, label) {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer byte count.`);
+  }
+
+  return parsed;
+}
+
+function calculateIncreaseRatio(baselineBytes, currentBytes) {
+  const deltaBytes = currentBytes - baselineBytes;
+
+  if (deltaBytes <= 0) {
+    return 0;
+  }
+
+  if (baselineBytes <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return deltaBytes / baselineBytes;
+}
+
+function createComparison(input) {
+  const deltaBytes = input.currentSizeBytes - input.baselineSizeBytes;
+  const increaseRatio = calculateIncreaseRatio(input.baselineSizeBytes, input.currentSizeBytes);
+
+  return {
+    baselineLabel: input.baselineLabel,
+    sizeBudget: {
+      failed: increaseRatio >= SIZE_BUDGET_THRESHOLD,
+      increaseRatio,
+      thresholdRatio: SIZE_BUDGET_THRESHOLD,
+    },
+    sizeBytes: {
+      baseline: input.baselineSizeBytes,
+      current: input.currentSizeBytes,
+      delta: deltaBytes,
+    },
+  };
+}
+
+function summarizeComparison(comparison) {
+  const sizeMetric = comparison.sizeBytes;
+
+  if (sizeMetric.delta === 0) {
+    return [`- Image size is unchanged vs \`${comparison.baselineLabel}\`.`];
+  }
+
+  const direction = sizeMetric.delta > 0 ? "increased" : "decreased";
+  const ratioText =
+    sizeMetric.delta > 0 ? ` (${formatRatioPercent(comparison.sizeBudget.increaseRatio)})` : "";
+
+  return [
+    `- Image size ${direction} ${formatSignedBytes(sizeMetric.delta)}${ratioText}: ${formatBytes(sizeMetric.baseline)} -> ${formatBytes(sizeMetric.current)}.`,
+    `- Size budget fails at ${formatRatioPercent(comparison.sizeBudget.thresholdRatio)} or more growth.`,
+  ];
+}
+
+function renderBudgetSection(report) {
+  const sizeBudget = report.comparison.sizeBudget;
+
+  if (!sizeBudget.failed) {
+    return [];
+  }
+
+  const sizeMetric = report.comparison.sizeBytes;
+
+  return [
+    "### Docker Image Size Budget: Action Will Fail",
+    "",
+    "This action will fail because the Docker image grew by 10.0% or more.",
+    "",
+    "| Metric | Details |",
+    "| --- | --- |",
+    `| Image size | ${formatBytes(sizeMetric.baseline)} -> ${formatBytes(sizeMetric.current)}; ${formatSignedBytes(sizeMetric.delta)} (${formatRatioPercent(sizeBudget.increaseRatio)}) over limit ${formatRatioPercent(sizeBudget.thresholdRatio)} |`,
+    "",
+  ];
+}
+
+export function renderDockerImageSizeReportMarkdown(report) {
+  const comparison = report.comparison;
+  const lines = [
+    `## Docker Image Size Summary: \`${report.imageLabel}\``,
+    "",
+    "**Key takeaways**",
+    "",
+    ...summarizeComparison(comparison),
+    "",
+    ...renderBudgetSection(report),
+    `### Delta vs \`${comparison.baselineLabel}\``,
+    "",
+    "| Metric | Baseline | Current | Delta |",
+    "| --- | --- | --- | --- |",
+    `| Image size | ${formatBytes(comparison.sizeBytes.baseline)} | ${formatBytes(comparison.sizeBytes.current)} | ${formatSignedBytes(comparison.sizeBytes.delta)} |`,
+    "",
+    "### Metadata",
+    "",
+    `- Current: \`${report.currentLabel}\``,
+    `- Generated at: \`${report.generatedAt}\``,
+  ];
+
+  return lines.join("\n");
+}
+
+function printUsage() {
+  process.stdout.write(
+    [
+      "Usage: node ./scripts/docker-image-size-report.mjs --baseline-size-bytes <bytes> --current-size-bytes <bytes> [options]",
+      "",
+      "Options:",
+      "  --baseline-size-bytes <bytes>  Docker image size for the baseline image",
+      "  --current-size-bytes <bytes>   Docker image size for the current image",
+      "  --baseline-label <label>       Display label used for the baseline comparison",
+      "  --current-label <label>        Display label used for the current image",
+      "  --image-label <label>          Display label for the analyzed image",
+      "  --output-json <path>           Write the JSON report to this file",
+      "  --output-markdown <path>       Write the Markdown report to this file",
+      "  --help                         Show this help text",
+      "",
+    ].join("\n"),
+  );
+}
+
+function parseArguments(argv) {
+  const parsedArguments = {
+    baselineLabel: "baseline",
+    baselineSizeBytes: null,
+    currentLabel: "current",
+    currentSizeBytes: null,
+    imageLabel: "Dockerfile",
+    outputJsonPath: null,
+    outputMarkdownPath: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--help") {
+      printUsage();
+      process.exit(0);
+    }
+
+    const value = argv[index + 1];
+
+    if (value === undefined) {
+      throw new Error(`Missing value for "${argument}".`);
+    }
+
+    if (argument === "--baseline-size-bytes") {
+      parsedArguments.baselineSizeBytes = parseSizeBytes(value, "--baseline-size-bytes");
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--current-size-bytes") {
+      parsedArguments.currentSizeBytes = parseSizeBytes(value, "--current-size-bytes");
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--baseline-label") {
+      parsedArguments.baselineLabel = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--current-label") {
+      parsedArguments.currentLabel = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--image-label") {
+      parsedArguments.imageLabel = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--output-json") {
+      parsedArguments.outputJsonPath = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--output-markdown") {
+      parsedArguments.outputMarkdownPath = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument "${argument}".`);
+  }
+
+  if (parsedArguments.baselineSizeBytes === null) {
+    throw new Error('The "--baseline-size-bytes" option is required.');
+  }
+
+  if (parsedArguments.currentSizeBytes === null) {
+    throw new Error('The "--current-size-bytes" option is required.');
+  }
+
+  return parsedArguments;
+}
+
+async function writeOutputFile(path, content) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const report = {
+    comparison: createComparison(args),
+    currentLabel: args.currentLabel,
+    generatedAt: new Date().toISOString(),
+    imageLabel: args.imageLabel,
+  };
+  const markdown = renderDockerImageSizeReportMarkdown(report);
+
+  if (args.outputJsonPath) {
+    await writeOutputFile(args.outputJsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  if (args.outputMarkdownPath) {
+    await writeOutputFile(args.outputMarkdownPath, `${markdown}\n`);
+  }
+
+  if (!args.outputMarkdownPath) {
+    process.stdout.write(`${markdown}\n`);
+  }
+}
+
+const executedScriptPath = process.argv[1] ? resolve(process.argv[1]) : null;
+const moduleScriptPath = resolve(fileURLToPath(import.meta.url));
+
+if (
+  executedScriptPath !== null &&
+  moduleScriptPath !== null &&
+  executedScriptPath === moduleScriptPath
+) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- add a PR workflow that compares Docker image size against the base commit
- post a sticky PR comment with before/after image size details
- fail when the image grows by 10% or more

## Verification
- pnpm exec oxfmt --check .github/workflows/docker-image-size-analysis.yml scripts/docker-image-size-report.mjs scripts/docker-image-size-budget.mjs
- pnpm exec oxlint .github/workflows/docker-image-size-analysis.yml scripts/docker-image-size-report.mjs scripts/docker-image-size-budget.mjs
- node ./scripts/docker-image-size-budget.mjs --report-json /tmp/docker-size-pass.json
- node ./scripts/docker-image-size-budget.mjs --report-json /tmp/docker-size-fail.json (expected failure at 10.0%)