### PR TITLE
feat(eve): warn when Vercel build skips sandbox prewarm

### DIFF
--- a/.changeset/warn-unprewarmed-prebuilt.md
+++ b/.changeset/warn-unprewarmed-prebuilt.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Warn when a Vercel build skips sandbox template prewarming because `VERCEL_DEPLOYMENT_ID` is missing, and direct users away from deploying that output with `vercel deploy --prebuilt`.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -94,6 +94,8 @@ During hosted builds, eve prewarms reusable Vercel sandbox templates so the firs
 - Prewarming only covers template construction. `onSession()` still runs at runtime, once per session.
 - **If build-time prewarm fails, the build fails.**
 
+If `VERCEL` is set but `VERCEL_DEPLOYMENT_ID` is missing, eve warns that it skipped prewarming. Do not deploy that build with `vercel deploy --prebuilt`; its output may reference sandbox templates that were never provisioned. Run `vercel deploy` instead so Vercel builds the source in its hosted build environment.
+
 ## 6. Auth
 
 Swap any scaffolded `placeholderAuth()` for your real policy before the first production browser request hits the app. Both the framework default and the placeholder reject production browser traffic, so an unconfigured app fails closed rather than serving open routes. The production policy can be a shipped helper (`httpBasic()`, `jwtHmac()`, `jwtEcdsa()`, `oidc()`, `vercelOidc()`) or a custom `AuthFn` that validates your own sessions, API keys, or identity provider. See [Auth and route protection](./auth-and-route-protection) for the ordered auth walk and the fail-closed guarantee.

--- a/packages/eve/src/internal/nitro/host/vercel-build-prewarm.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-prewarm.ts
@@ -2,6 +2,11 @@ import { prewarmAppSandboxes } from "#execution/sandbox/prewarm.js";
 
 type PrewarmAppSandboxesInput = Parameters<typeof prewarmAppSandboxes>[0];
 
+const VERCEL_BUILD_PREWARM_SKIPPED_WARNING =
+  "[eve] WARNING: Skipped Vercel sandbox template prewarm because VERCEL_DEPLOYMENT_ID is missing. " +
+  "The generated .vercel/output may reference sandbox templates that were not provisioned. " +
+  'Do not deploy it with "vercel deploy --prebuilt"; use "vercel deploy" so Vercel builds from source.';
+
 /**
  * Detects whether the current build is running inside Vercel with a
  * stable deployment identifier. Build-time sandbox prewarm runs only
@@ -30,6 +35,9 @@ export function shouldPrewarmVercelBuild(): boolean {
  */
 export async function runVercelBuildPrewarm(input: PrewarmAppSandboxesInput): Promise<boolean> {
   if (!shouldPrewarmVercelBuild()) {
+    if (process.env.VERCEL?.trim() && !process.env.VERCEL_DEPLOYMENT_ID?.trim()) {
+      console.warn(VERCEL_BUILD_PREWARM_SKIPPED_WARNING);
+    }
     return false;
   }
   await prewarmAppSandboxes(input);

--- a/packages/eve/test/scenarios/vercel-build-prewarm.scenario.test.ts
+++ b/packages/eve/test/scenarios/vercel-build-prewarm.scenario.test.ts
@@ -80,6 +80,21 @@ describe("Vercel build-time sandbox prewarm", () => {
     expect(shouldPrewarmVercelBuild()).toBe(true);
   });
 
+  it("warns when a Vercel build cannot prewarm sandbox templates", async () => {
+    vi.stubEnv("VERCEL", "1");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      runVercelBuildPrewarm({
+        appRoot: "/unused",
+      }),
+    ).resolves.toBe(false);
+
+    expect(warn).toHaveBeenCalledWith(
+      '[eve] WARNING: Skipped Vercel sandbox template prewarm because VERCEL_DEPLOYMENT_ID is missing. The generated .vercel/output may reference sandbox templates that were not provisioned. Do not deploy it with "vercel deploy --prebuilt"; use "vercel deploy" so Vercel builds from source.',
+    );
+  });
+
   it("prewarms sandbox templates with per-agent skill seed files", async () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_test_build_prewarm");


### PR DESCRIPTION
An agent ran `vercel deploy --prebuilt` on an eve app and shipped a build that broke at runtime — the deployment referenced sandbox templates that were never provisioned.

Why: sandbox template prewarming only runs when `VERCEL_DEPLOYMENT_ID` is set. A prebuilt build (`VERCEL` set, no deployment id) skips prewarming but still writes `.vercel/output` pointing at those templates, with no signal the output is unsafe to deploy.

Fix: `runVercelBuildPrewarm` now warns when it skips inside a Vercel build, pointing to `vercel deploy` (hosted source build, which sets the deployment id) instead of `--prebuilt`.

**What's here**
- Warning in the build-time prewarm hook.
- Note in the deployment guide.
- Scenario test for the skip-and-warn path.

**Warn, not fail** — the skip is correct for dev and one-off builds, so blocking the build would be wrong. Prewarm running and then failing still fails the build; this only covers prewarm being skipped. The remaining hazard is deploying that output with `--prebuilt`, which the build can't detect, so it flags the risk instead.