### PR TITLE
feat(eve): add AgentPhone channel for SMS, iMessage, and voice

### DIFF
--- a/.changeset/add-agentphone-channel.md
+++ b/.changeset/add-agentphone-channel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add AgentPhone as a built-in channel for SMS, MMS, iMessage, and voice calls. Import `agentphoneChannel` from `eve/channels/agentphone` and point your AgentPhone webhook at `/eve/v1/agentphone/webhooks`.

--- a/docs/channels/agentphone.mdx
+++ b/docs/channels/agentphone.mdx
@@ -1,0 +1,122 @@
+---
+title: "AgentPhone"
+description: "Reach your agent over SMS, iMessage, and voice calls with AgentPhone."
+type: integration
+---
+
+The AgentPhone channel connects your agent to phone numbers that support SMS, MMS, iMessage, and voice calls. Inbound text messages and voice transcriptions arrive as webhooks. Voice webhooks deliver real-time speech transcripts so your agent can participate in live phone calls. Every request is verified with HMAC-SHA256 and a 5-minute replay window before anything else runs. The raw continuation token is `From:To`. See [Channels](./overview) for the contract this builds on.
+
+## Add the channel
+
+```ts title="agent/channels/agentphone.ts"
+import { agentphoneChannel } from "eve/channels/agentphone";
+
+export default agentphoneChannel({
+  allowFrom: "+15551234567",
+  messaging: { from: "+15557654321" },
+});
+```
+
+```bash
+AGENTPHONE_API_KEY=...            # required for outbound messages and calls
+AGENTPHONE_WEBHOOK_SECRET=...     # required for inbound signature verification
+```
+
+To skip env vars, pass the same values via `credentials: { apiKey, webhookSecret }`. The channel mounts one route:
+
+- `POST /eve/v1/agentphone/webhooks`: all inbound webhook events
+
+Point your AgentPhone agent's webhook URL at `/eve/v1/agentphone/webhooks`.
+
+## How the channel handles messages
+
+### Dispatch
+
+`allowFrom` is required. It gates who can reach the inbound hooks. Pass a single number, a list, an async resolver, or `"*"`. The wildcard is dangerous; only use it with an explicit check inside `onText`/`onVoice`.
+
+```ts
+export default agentphoneChannel({ allowFrom: ["+15551234567", "+15557654321"] });
+```
+
+`onText` decides dispatch and `auth` for SMS, MMS, and iMessage messages. Return `{ auth }` to proceed, or `null` to drop the message. `onVoice` fires for real-time voice transcripts during a call. `onCallEnded` fires when a call completes and delivers the full transcript and summary.
+
+```ts
+export default agentphoneChannel({
+  allowFrom: ["+15551234567"],
+  onText: (ctx, message) => ({
+    auth: {
+      principalId: message.from,
+      principalType: "user",
+      authenticator: "agentphone",
+      attributes: { channel: message.channel },
+    },
+  }),
+});
+```
+
+### Delivery
+
+The default `message.completed` handler sends the reply as SMS through AgentPhone's Messages API. A reply to an inbound message can reuse the webhook's `to` as the sender, but a proactive send has nothing to reuse, so it needs `messaging.from` or `messaging.numberId`. AgentPhone automatically routes via iMessage when available and falls back to SMS.
+
+### Channels supported
+
+| Channel  | Inbound | Outbound |
+| -------- | ------- | -------- |
+| SMS      | Yes     | Yes      |
+| MMS      | Yes     | Yes      |
+| iMessage | Yes     | Yes      |
+| Voice    | Yes     | Yes      |
+
+### Human-in-the-loop (HITL)
+
+SMS and voice have no native button or card affordance, so HITL prompts do not render as interactive controls. The agent's `input.requested` event reaches your `events["input.requested"]` handler if you declare one. Handle it by sending the prompt as text and mapping the caller's reply back to the input request yourself.
+
+### Proactive sessions
+
+Start a session without an inbound message through `receive(agentphone, { message, target, auth })` from a schedule `run` handler, or `args.receive(agentphone, ...)` from another channel. `target.phoneNumber` is required, and the channel needs `messaging.from` or `messaging.numberId` for the outbound sender.
+
+### Making outbound calls
+
+Use the `agentphone` handle to initiate calls programmatically:
+
+```ts
+export default agentphoneChannel({
+  allowFrom: "*",
+  events: {
+    async "message.completed"(event, channel) {
+      // Example: make a call from a tool result
+      if (event.finishReason === "tool-calls") {
+        await channel.agentphone.makeCall({
+          agentId: "agt_abc123",
+          initialGreeting: "Hello, this is your AI assistant calling.",
+        });
+      }
+    },
+  },
+});
+```
+
+### Voice webhook responses
+
+When a voice transcript arrives (`agent.message` with `channel: "voice"`), AgentPhone expects a JSON response telling the agent what to say next. The `onVoice` hook can return `{ text, hangup }` to control the response. The transcript is also dispatched to the eve session so your agent can process it like any other message.
+
+### Attachments
+
+Inbound MMS and iMessage media URLs are available via `message.mediaUrl`. Outbound media is supported through `sendMessage` options:
+
+```ts
+await channel.agentphone.sendMessage("Check out this image", {
+  mediaUrls: ["https://example.com/photo.jpg"],
+});
+```
+
+## Disclaimer
+
+As the deployer, it is your responsibility to ensure your agent complies with applicable laws.
+
+For outbound SMS or calls you initiate, you may be required to get prior express consent, honor STOP/opt-out and quiet-hour rules, and complete required carrier registration. For voice calls, you may be required to inform callers that calls are processed by an automated AI system and obtain consent where required.
+
+## What to read next
+
+- [Channels overview](./overview): the channel contract and every built-in channel
+- [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/channels/meta.json
+++ b/docs/channels/meta.json
@@ -8,6 +8,7 @@
     "teams",
     "telegram",
     "twilio",
+    "agentphone",
     "github",
     "linear",
     "custom"

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -123,6 +123,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "agentphone",
+    name: "AgentPhone",
+    kind: "channel",
+    tagline: "Reach users over SMS, iMessage, and voice calls through AgentPhone.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "github",
     name: "GitHub",
     kind: "channel",

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -231,6 +231,11 @@
       "import": "./dist/src/public/channels/twilio/index.js",
       "default": "./dist/src/public/channels/twilio/index.js"
     },
+    "./channels/agentphone": {
+      "types": "./dist/src/public/channels/agentphone/index.d.ts",
+      "import": "./dist/src/public/channels/agentphone/index.js",
+      "default": "./dist/src/public/channels/agentphone/index.js"
+    },
     "./channels/telegram": {
       "types": "./dist/src/public/channels/telegram/index.d.ts",
       "import": "./dist/src/public/channels/telegram/index.js",

--- a/packages/eve/src/public/channels/agentphone/agentphoneChannel.ts
+++ b/packages/eve/src/public/channels/agentphone/agentphoneChannel.ts
@@ -297,7 +297,7 @@ export function agentphoneChannel(config: AgentPhoneChannelConfig): AgentPhoneCh
           });
           if (voiceResult === null) return new Response("forbidden", { status: 403 });
 
-          waitUntil(dispatchVoice({ config, message: voice, onVoice, send }));
+          waitUntil(dispatchVoice({ config, message: voice, send }));
           return jsonResponse(voiceResult ?? {});
         }
 
@@ -522,31 +522,9 @@ async function acceptVoiceWebhook(input: {
 async function dispatchVoice(input: {
   readonly config: AgentPhoneChannelConfig;
   readonly message: AgentPhoneVoiceMessage;
-  readonly onVoice: NonNullable<AgentPhoneChannelConfig["onVoice"]>;
   readonly send: SendFn<AgentPhoneChannelState>;
 }): Promise<void> {
   const { message } = input;
-  const agentphone: AgentPhoneContext = {
-    agentphone: buildAgentPhoneHandle({
-      callId: message.callId,
-      config: input.config,
-      from: message.from,
-      to: message.to,
-    }),
-  };
-
-  let result: AgentPhoneInboundResult;
-  try {
-    const voiceResult = await input.onVoice(agentphone, message);
-    if (voiceResult === null || voiceResult === undefined) return;
-    result = {
-      auth: defaultAgentPhoneAuthFromVoice(message),
-    };
-  } catch (error) {
-    log.error("voice dispatch failed", { error });
-    return;
-  }
-  if (result === null || result === undefined) return;
 
   const contextBlock = formatAgentPhoneContextBlock({
     callId: message.callId,
@@ -562,7 +540,7 @@ async function dispatchVoice(input: {
         context: [contextBlock],
       },
       {
-        auth: result.auth,
+        auth: defaultAgentPhoneAuthFromVoice(message),
         continuationToken: agentphoneContinuationToken(message.from, message.to),
         state: {
           from: message.from,

--- a/packages/eve/src/public/channels/agentphone/agentphoneChannel.ts
+++ b/packages/eve/src/public/channels/agentphone/agentphoneChannel.ts
@@ -1,0 +1,668 @@
+import type { SessionHandle } from "#channel/session.js";
+import type { SessionAuthContext } from "#channel/types.js";
+import type { SessionContext } from "#public/definitions/callback-context.js";
+import type { ChannelSessionOps } from "#public/definitions/defineChannel.js";
+
+import { createLogger } from "#internal/logging.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import {
+  agentphoneContinuationToken,
+  callAgentPhoneApi,
+  makeAgentPhoneCall,
+  sendAgentPhoneMessage,
+  type AgentPhoneApiOptions,
+  type AgentPhoneApiResponse,
+  type AgentPhoneCredentials,
+} from "#public/channels/agentphone/api.js";
+import {
+  defaultEvents,
+  defaultOnCallEnded,
+  defaultOnText,
+  defaultOnVoice,
+} from "#public/channels/agentphone/defaults.js";
+import {
+  formatAgentPhoneContextBlock,
+  parseAgentPhoneCallEnded,
+  parseAgentPhoneTextMessage,
+  parseAgentPhoneVoiceMessage,
+  type AgentPhoneCallEnded,
+  type AgentPhoneTextMessage,
+  type AgentPhoneVoiceMessage,
+} from "#public/channels/agentphone/inbound.js";
+import {
+  verifyAgentPhoneRequest,
+  type AgentPhoneWebhookSecret,
+} from "#public/channels/agentphone/verify.js";
+import {
+  defineChannel,
+  POST,
+  type Channel,
+  type SendFn,
+} from "#public/definitions/defineChannel.js";
+
+const log = createLogger("agentphone.channel");
+
+type EventData<T extends HandleMessageStreamEvent["type"]> =
+  Extract<HandleMessageStreamEvent, { type: T }> extends { data: infer D } ? D : undefined;
+
+/** Pre-dispatch AgentPhone context passed to inbound hooks. */
+export interface AgentPhoneContext {
+  readonly agentphone: AgentPhoneHandle;
+}
+
+/** Channel-owned AgentPhone context returned by `context()`. */
+export interface AgentPhoneChannelContext extends AgentPhoneContext {
+  state: AgentPhoneChannelState;
+}
+
+/** Event-handler AgentPhone context, including session operations. */
+export interface AgentPhoneEventContext extends AgentPhoneChannelContext, ChannelSessionOps {}
+
+/** JSON-serializable state for the phone-number conversation. */
+export interface AgentPhoneChannelState {
+  /** Caller / sender phone number. */
+  from: string | null;
+  /** AgentPhone number that received the latest session-starting webhook. */
+  to: string | null;
+  /** Most recent conversation ID when this session was started by text. */
+  lastConversationId?: string | null;
+  /** Most recent call ID when this session was started by voice. */
+  lastCallId?: string | null;
+}
+
+/** Per-session instrumentation snapshot for AgentPhone runtime telemetry. */
+export interface AgentPhoneInstrumentationMetadata extends Record<string, unknown> {
+  readonly from: string | null;
+  readonly lastCallId: string | null;
+  readonly lastConversationId: string | null;
+  readonly to: string | null;
+}
+
+/** AgentPhone channel credentials. */
+export interface AgentPhoneChannelCredentials extends AgentPhoneCredentials {
+  readonly webhookSecret?: AgentPhoneWebhookSecret;
+}
+
+/** Target accepted by `receive(agentphone, { target })` for proactive sessions. */
+export interface AgentPhoneReceiveTarget {
+  readonly phoneNumber: string;
+  /** AgentPhone sender number included in the continuation token. */
+  readonly from?: string;
+}
+
+/** Result of an inbound AgentPhone text or call-ended hook. Return `null` to drop the webhook. */
+export type AgentPhoneInboundResult = {
+  auth: SessionAuthContext | null;
+} | null;
+
+/** Sync or async {@link AgentPhoneInboundResult}. */
+export type AgentPhoneInboundResultOrPromise =
+  | AgentPhoneInboundResult
+  | Promise<AgentPhoneInboundResult>;
+
+/** Phone-number allow list for inbound AgentPhone webhooks. `"*"` allows every sender. */
+export type AgentPhoneAllowFrom =
+  | string
+  | readonly string[]
+  | (() => string | readonly string[] | Promise<string | readonly string[]>);
+
+/**
+ * Result of an inbound AgentPhone voice hook. Return `null` to reject.
+ * Any non-null result accepts the voice webhook and can supply a text
+ * response for the agent to speak.
+ */
+export interface AgentPhoneVoiceResult {
+  /** Text for the agent to speak in response. */
+  readonly text?: string;
+  /** Whether to hang up after speaking. */
+  readonly hangup?: boolean;
+}
+
+/** Sync or async {@link AgentPhoneVoiceResult}. */
+export type AgentPhoneVoiceResultOrPromise =
+  | AgentPhoneVoiceResult
+  | null
+  | undefined
+  | Promise<AgentPhoneVoiceResult | null | undefined>;
+
+type AgentPhoneEventHandler<T extends HandleMessageStreamEvent["type"]> = (
+  data: EventData<T>,
+  channel: AgentPhoneEventContext,
+  ctx: SessionContext,
+) => void | Promise<void>;
+
+type AgentPhoneSessionFailedHandler = (
+  data: EventData<"session.failed">,
+  channel: AgentPhoneEventContext,
+) => void | Promise<void>;
+
+/** Event handlers supported by `agentphoneChannel({ events })`. */
+export interface AgentPhoneChannelEvents {
+  readonly "turn.started"?: AgentPhoneEventHandler<"turn.started">;
+  readonly "actions.requested"?: AgentPhoneEventHandler<"actions.requested">;
+  readonly "action.result"?: AgentPhoneEventHandler<"action.result">;
+  readonly "message.completed"?: AgentPhoneEventHandler<"message.completed">;
+  readonly "message.appended"?: AgentPhoneEventHandler<"message.appended">;
+  readonly "input.requested"?: AgentPhoneEventHandler<"input.requested">;
+  readonly "turn.failed"?: AgentPhoneEventHandler<"turn.failed">;
+  readonly "turn.completed"?: AgentPhoneEventHandler<"turn.completed">;
+  readonly "session.failed"?: AgentPhoneSessionFailedHandler;
+  readonly "session.completed"?: AgentPhoneEventHandler<"session.completed">;
+  readonly "session.waiting"?: AgentPhoneEventHandler<"session.waiting">;
+  readonly "authorization.required"?: AgentPhoneEventHandler<"authorization.required">;
+  readonly "authorization.completed"?: AgentPhoneEventHandler<"authorization.completed">;
+}
+
+/** SMS/Messaging defaults for AgentPhone outbound replies. */
+export interface AgentPhoneMessagingConfig {
+  /** Sender phone number. Defaults to the inbound `to` number when available. */
+  readonly from?: string;
+  /** Send from a specific AgentPhone number ID. */
+  readonly numberId?: string;
+  /** AgentPhone agent ID used for outbound messages. */
+  readonly agentId?: string;
+}
+
+/** Configuration for {@link agentphoneChannel}. */
+export interface AgentPhoneChannelConfig {
+  readonly credentials?: AgentPhoneChannelCredentials;
+  /**
+   * Base route for AgentPhone webhooks. Defaults to `/eve/v1/agentphone`
+   * and mounts `/webhooks` below it.
+   */
+  readonly route?: string;
+  /**
+   * Exact caller/sender numbers allowed to reach inbound hooks, or `"*"` to
+   * allow every verified AgentPhone sender. Resolvers run on each inbound webhook.
+   */
+  readonly allowFrom: AgentPhoneAllowFrom;
+  readonly messaging?: AgentPhoneMessagingConfig;
+  readonly api?: Omit<AgentPhoneApiOptions, "credentials">;
+
+  /** Inbound text hook. Defaults to phone-number auth and dispatch. */
+  onText?(ctx: AgentPhoneContext, message: AgentPhoneTextMessage): AgentPhoneInboundResultOrPromise;
+  /** Inbound voice hook. Return `null` to reject. */
+  onVoice?(ctx: AgentPhoneContext, message: AgentPhoneVoiceMessage): AgentPhoneVoiceResultOrPromise;
+  /** Inbound call-ended hook. Defaults to phone-number auth and dispatch. */
+  onCallEnded?(
+    ctx: AgentPhoneContext,
+    callEnded: AgentPhoneCallEnded,
+  ): AgentPhoneInboundResultOrPromise;
+
+  readonly events?: AgentPhoneChannelEvents;
+}
+
+/** Low-level AgentPhone handle exposed to hooks and event handlers. */
+export interface AgentPhoneHandle {
+  /** Caller / sender phone number bound to this conversation. */
+  readonly from: string;
+  /** AgentPhone receiver / sender number for replies, when known. */
+  readonly to: string | undefined;
+  /** Most recent call ID, when the session started from a voice webhook. */
+  readonly callId: string | undefined;
+  /** Raw AgentPhone REST API escape hatch. */
+  request(path: string, body: Record<string, unknown>): Promise<AgentPhoneApiResponse>;
+  /** Sends a text message to this conversation's phone number by default. */
+  sendMessage(
+    message: string,
+    options?: AgentPhoneSendMessageOptions,
+  ): Promise<AgentPhoneApiResponse>;
+  /** Initiates an outbound call. */
+  makeCall(options: AgentPhoneMakeCallOptions): Promise<AgentPhoneApiResponse>;
+}
+
+/** Per-call overrides for {@link AgentPhoneHandle.sendMessage}. */
+export interface AgentPhoneSendMessageOptions {
+  /** Recipient phone number. Defaults to the conversation's `from` number. */
+  readonly to?: string;
+  /** Sender phone number. Defaults to `messaging.from`. */
+  readonly from?: string;
+  /** AgentPhone number ID. Defaults to `messaging.numberId`. */
+  readonly numberId?: string;
+  /** Media attachment URLs. */
+  readonly mediaUrls?: readonly string[];
+}
+
+/** Options for {@link AgentPhoneHandle.makeCall}. */
+export interface AgentPhoneMakeCallOptions {
+  /** AgentPhone agent ID. Required. */
+  readonly agentId: string;
+  /** Recipient phone number. Defaults to the conversation's `from` number. */
+  readonly to?: string;
+  /** What to say when the recipient answers. */
+  readonly initialGreeting?: string;
+}
+
+/** Concrete return type of {@link agentphoneChannel}. */
+export interface AgentPhoneChannel extends Channel<
+  AgentPhoneChannelState,
+  AgentPhoneReceiveTarget,
+  AgentPhoneInstrumentationMetadata
+> {}
+
+/** AgentPhone channel factory for SMS, MMS, iMessage, and voice. */
+export function agentphoneChannel(config: AgentPhoneChannelConfig): AgentPhoneChannel {
+  assertAllowFromConfigured(config);
+  const routes = buildRoutes(config.route ?? "/eve/v1/agentphone");
+  const onText = config.onText ?? defaultOnText;
+  const onVoice = config.onVoice ?? defaultOnVoice;
+  const onCallEnded = config.onCallEnded ?? defaultOnCallEnded;
+  const mergedEvents: AgentPhoneChannelEvents = { ...defaultEvents, ...config.events };
+
+  return defineChannel<
+    AgentPhoneChannelState,
+    AgentPhoneChannelContext,
+    AgentPhoneReceiveTarget,
+    AgentPhoneInstrumentationMetadata
+  >({
+    kindHint: "agentphone",
+    state: {
+      from: null as string | null,
+      to: null as string | null,
+      lastCallId: null,
+      lastConversationId: null,
+    },
+    metadata(state): AgentPhoneInstrumentationMetadata {
+      return {
+        from: state.from,
+        lastCallId: state.lastCallId ?? null,
+        lastConversationId: state.lastConversationId ?? null,
+        to: state.to,
+      };
+    },
+
+    context(state, session) {
+      return rebuildAgentPhoneContext(state, session, config);
+    },
+
+    routes: [
+      POST<AgentPhoneChannelState>(routes.webhooks, async (req, { send, waitUntil }) => {
+        const verified = await verifyInbound(req, config);
+        if (verified === null) return new Response("unauthorized", { status: 401 });
+
+        const payload = verified.payload as Record<string, unknown>;
+        const event = payload.event as string | undefined;
+        const channel = payload.channel as string | undefined;
+
+        if (event === "agent.message" && channel === "voice") {
+          const voice = parseAgentPhoneVoiceMessage(payload);
+          if (!voice) return jsonResponse({});
+          if (!(await isAllowed(voice.from, config.allowFrom)))
+            return new Response("forbidden", { status: 403 });
+
+          const voiceResult = await acceptVoiceWebhook({
+            config,
+            message: voice,
+            onVoice,
+          });
+          if (voiceResult === null) return new Response("forbidden", { status: 403 });
+
+          waitUntil(dispatchVoice({ config, message: voice, onVoice, send }));
+          return jsonResponse(voiceResult ?? {});
+        }
+
+        if (event === "agent.message") {
+          const message = parseAgentPhoneTextMessage(payload);
+          if (!message) return jsonResponse({ status: "ok" });
+          if (!(await isAllowed(message.from, config.allowFrom)))
+            return new Response("forbidden", { status: 403 });
+
+          waitUntil(dispatchText({ config, message, onText, send }));
+          return jsonResponse({ status: "ok" });
+        }
+
+        if (event === "agent.call_ended") {
+          const callEnded = parseAgentPhoneCallEnded(payload);
+          if (!callEnded) return jsonResponse({ status: "ok" });
+          if (!(await isAllowed(callEnded.from, config.allowFrom)))
+            return new Response("forbidden", { status: 403 });
+
+          waitUntil(dispatchCallEnded({ callEnded, config, onCallEnded, send }));
+          return jsonResponse({ status: "ok" });
+        }
+
+        return jsonResponse({ status: "ok" });
+      }),
+    ],
+
+    async receive(input, { send }) {
+      const phoneNumber = readString(input.target.phoneNumber);
+      if (!phoneNumber) {
+        throw new Error("agentphoneChannel().receive requires target.phoneNumber.");
+      }
+      const from = readString(input.target.from) ?? config.messaging?.from ?? null;
+      return send(input.message, {
+        auth: input.auth,
+        continuationToken: agentphoneContinuationToken(phoneNumber, from ?? undefined),
+        state: {
+          from: phoneNumber,
+          lastCallId: null,
+          lastConversationId: null,
+          to: from,
+        },
+      });
+    },
+
+    events: mergedEvents,
+  });
+}
+
+function rebuildAgentPhoneContext(
+  state: AgentPhoneChannelState,
+  _session: SessionHandle,
+  config: AgentPhoneChannelConfig,
+): AgentPhoneChannelContext {
+  return {
+    state,
+    agentphone: buildAgentPhoneHandle({
+      callId: state.lastCallId ?? undefined,
+      config,
+      from: state.from ?? "",
+      to: state.to ?? undefined,
+    }),
+  };
+}
+
+function buildAgentPhoneHandle(input: {
+  readonly callId: string | undefined;
+  readonly config: AgentPhoneChannelConfig;
+  readonly from: string;
+  readonly to: string | undefined;
+}): AgentPhoneHandle {
+  const api = input.config.api;
+  const credentials = input.config.credentials;
+  const defaultFrom = input.config.messaging?.from ?? input.to;
+  const defaultNumberId = input.config.messaging?.numberId;
+  const defaultAgentId = input.config.messaging?.agentId;
+
+  return {
+    callId: input.callId,
+    from: input.from,
+    to: input.to,
+    request(path, body) {
+      return callAgentPhoneApi({
+        apiBaseUrl: api?.apiBaseUrl,
+        body,
+        credentials,
+        fetch: api?.fetch,
+        path,
+      });
+    },
+    sendMessage(message, options) {
+      return sendAgentPhoneMessage({
+        agentId: defaultAgentId,
+        apiBaseUrl: api?.apiBaseUrl,
+        body: message,
+        credentials,
+        fetch: api?.fetch,
+        fromNumber: options?.from ?? defaultFrom,
+        mediaUrls: options?.mediaUrls,
+        numberId: options?.numberId ?? defaultNumberId,
+        toNumber: options?.to ?? input.from,
+      });
+    },
+    makeCall(options) {
+      return makeAgentPhoneCall({
+        agentId: options.agentId,
+        apiBaseUrl: api?.apiBaseUrl,
+        credentials,
+        fetch: api?.fetch,
+        initialGreeting: options.initialGreeting,
+        toNumber: options.to ?? input.from,
+      });
+    },
+  };
+}
+
+function buildRoutes(baseRoute: string): { webhooks: string } {
+  const base = baseRoute.endsWith("/") ? baseRoute.slice(0, -1) : baseRoute;
+  return { webhooks: `${base}/webhooks` };
+}
+
+function assertAllowFromConfigured(
+  config: AgentPhoneChannelConfig | undefined,
+): asserts config is AgentPhoneChannelConfig {
+  if (config?.allowFrom === undefined) {
+    throw new Error(
+      'agentphoneChannel requires allowFrom. Use allowFrom: "*" to allow all numbers.',
+    );
+  }
+}
+
+async function verifyInbound(
+  req: Request,
+  config: AgentPhoneChannelConfig,
+): Promise<{ body: string; payload: unknown } | null> {
+  try {
+    return await verifyAgentPhoneRequest(req, {
+      webhookSecret: config.credentials?.webhookSecret,
+    });
+  } catch (error) {
+    log.warn("agentphone inbound verification failed", { error });
+    return null;
+  }
+}
+
+async function dispatchText(input: {
+  readonly config: AgentPhoneChannelConfig;
+  readonly message: AgentPhoneTextMessage;
+  readonly onText: NonNullable<AgentPhoneChannelConfig["onText"]>;
+  readonly send: SendFn<AgentPhoneChannelState>;
+}): Promise<void> {
+  const { message } = input;
+  const agentphone: AgentPhoneContext = {
+    agentphone: buildAgentPhoneHandle({
+      callId: undefined,
+      config: input.config,
+      from: message.from,
+      to: message.to,
+    }),
+  };
+
+  let result: AgentPhoneInboundResult;
+  try {
+    result = await input.onText(agentphone, message);
+  } catch (error) {
+    log.error("text handler failed", { error });
+    return;
+  }
+  if (result === null || result === undefined) return;
+
+  const contextBlock = formatAgentPhoneContextBlock({
+    channel: message.channel,
+    conversationId: message.conversationId,
+    from: message.from,
+    to: message.to,
+  });
+
+  try {
+    await input.send(
+      {
+        message: message.body,
+        context: [contextBlock],
+      },
+      {
+        auth: result.auth,
+        continuationToken: agentphoneContinuationToken(message.from, message.to),
+        state: {
+          from: message.from,
+          lastCallId: null,
+          lastConversationId: message.conversationId ?? null,
+          to: message.to ?? null,
+        },
+      },
+    );
+  } catch (error) {
+    log.error("text delivery failed", { error });
+  }
+}
+
+async function acceptVoiceWebhook(input: {
+  readonly config: AgentPhoneChannelConfig;
+  readonly message: AgentPhoneVoiceMessage;
+  readonly onVoice: NonNullable<AgentPhoneChannelConfig["onVoice"]>;
+}): Promise<AgentPhoneVoiceResult | null | undefined> {
+  const agentphone: AgentPhoneContext = {
+    agentphone: buildAgentPhoneHandle({
+      callId: input.message.callId,
+      config: input.config,
+      from: input.message.from,
+      to: input.message.to,
+    }),
+  };
+
+  try {
+    return await input.onVoice(agentphone, input.message);
+  } catch (error) {
+    log.error("voice handler failed", { error });
+    return null;
+  }
+}
+
+async function dispatchVoice(input: {
+  readonly config: AgentPhoneChannelConfig;
+  readonly message: AgentPhoneVoiceMessage;
+  readonly onVoice: NonNullable<AgentPhoneChannelConfig["onVoice"]>;
+  readonly send: SendFn<AgentPhoneChannelState>;
+}): Promise<void> {
+  const { message } = input;
+  const agentphone: AgentPhoneContext = {
+    agentphone: buildAgentPhoneHandle({
+      callId: message.callId,
+      config: input.config,
+      from: message.from,
+      to: message.to,
+    }),
+  };
+
+  let result: AgentPhoneInboundResult;
+  try {
+    const voiceResult = await input.onVoice(agentphone, message);
+    if (voiceResult === null || voiceResult === undefined) return;
+    result = {
+      auth: defaultAgentPhoneAuthFromVoice(message),
+    };
+  } catch (error) {
+    log.error("voice dispatch failed", { error });
+    return;
+  }
+  if (result === null || result === undefined) return;
+
+  const contextBlock = formatAgentPhoneContextBlock({
+    callId: message.callId,
+    channel: "voice",
+    from: message.from,
+    to: message.to,
+  });
+
+  try {
+    await input.send(
+      {
+        message: message.transcript,
+        context: [contextBlock],
+      },
+      {
+        auth: result.auth,
+        continuationToken: agentphoneContinuationToken(message.from, message.to),
+        state: {
+          from: message.from,
+          lastCallId: message.callId ?? null,
+          lastConversationId: null,
+          to: message.to ?? null,
+        },
+      },
+    );
+  } catch (error) {
+    log.error("voice delivery failed", { error });
+  }
+}
+
+async function dispatchCallEnded(input: {
+  readonly callEnded: AgentPhoneCallEnded;
+  readonly config: AgentPhoneChannelConfig;
+  readonly onCallEnded: NonNullable<AgentPhoneChannelConfig["onCallEnded"]>;
+  readonly send: SendFn<AgentPhoneChannelState>;
+}): Promise<void> {
+  const { callEnded } = input;
+  const agentphone: AgentPhoneContext = {
+    agentphone: buildAgentPhoneHandle({
+      callId: callEnded.callId,
+      config: input.config,
+      from: callEnded.from,
+      to: callEnded.to,
+    }),
+  };
+
+  let result: AgentPhoneInboundResult;
+  try {
+    result = await input.onCallEnded(agentphone, callEnded);
+  } catch (error) {
+    log.error("call-ended handler failed", { error });
+    return;
+  }
+  if (result === null || result === undefined) return;
+
+  const summaryText = callEnded.summary
+    ? `Call ended. Summary: ${callEnded.summary}`
+    : "Call ended.";
+
+  const contextBlock = formatAgentPhoneContextBlock({
+    callId: callEnded.callId,
+    channel: "voice",
+    from: callEnded.from,
+    to: callEnded.to,
+  });
+
+  try {
+    await input.send(
+      {
+        message: summaryText,
+        context: [contextBlock],
+      },
+      {
+        auth: result.auth,
+        continuationToken: agentphoneContinuationToken(callEnded.from, callEnded.to),
+        state: {
+          from: callEnded.from,
+          lastCallId: callEnded.callId ?? null,
+          lastConversationId: null,
+          to: callEnded.to ?? null,
+        },
+      },
+    );
+  } catch (error) {
+    log.error("call-ended delivery failed", { error });
+  }
+}
+
+function defaultAgentPhoneAuthFromVoice(message: AgentPhoneVoiceMessage) {
+  const attributes: Record<string, string> = {
+    channel: "voice",
+    from: message.from,
+  };
+  if (message.to) attributes.to = message.to;
+
+  return {
+    attributes,
+    authenticator: "agentphone-webhook",
+    issuer: "agentphone",
+    principalId: `agentphone:${message.from}`,
+    principalType: "user" as const,
+  };
+}
+
+async function isAllowed(from: string, allowFrom: AgentPhoneAllowFrom): Promise<boolean> {
+  const resolved = typeof allowFrom === "function" ? await allowFrom() : allowFrom;
+  if (resolved === "*") return true;
+  return typeof resolved === "string" ? resolved === from : resolved.includes(from);
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/eve/src/public/channels/agentphone/api.test.ts
+++ b/packages/eve/src/public/channels/agentphone/api.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  agentphoneContinuationToken,
+  callAgentPhoneApi,
+  resolveAgentPhoneApiKey,
+  sendAgentPhoneMessage,
+  makeAgentPhoneCall,
+} from "./api.js";
+
+describe("agentphoneContinuationToken", () => {
+  it("joins from and to", () => {
+    expect(agentphoneContinuationToken("+15551234567", "+15557654321")).toBe(
+      "+15551234567:+15557654321",
+    );
+  });
+
+  it("handles missing to", () => {
+    expect(agentphoneContinuationToken("+15551234567", undefined)).toBe("+15551234567:");
+  });
+});
+
+describe("resolveAgentPhoneApiKey", () => {
+  afterEach(() => {
+    delete process.env.AGENTPHONE_API_KEY;
+  });
+
+  it("uses a provided string", async () => {
+    expect(await resolveAgentPhoneApiKey("key_direct")).toBe("key_direct");
+  });
+
+  it("calls a function provider", async () => {
+    const provider = vi.fn().mockResolvedValue("key_async");
+    expect(await resolveAgentPhoneApiKey(provider)).toBe("key_async");
+  });
+
+  it("falls back to AGENTPHONE_API_KEY env", async () => {
+    process.env.AGENTPHONE_API_KEY = "key_env";
+    expect(await resolveAgentPhoneApiKey()).toBe("key_env");
+  });
+
+  it("throws when no key is available", async () => {
+    await expect(resolveAgentPhoneApiKey()).rejects.toThrow("AGENTPHONE_API_KEY is required.");
+  });
+});
+
+describe("callAgentPhoneApi", () => {
+  it("sends a Bearer-authed JSON request", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg_123" }), { status: 200 }));
+
+    const result = await callAgentPhoneApi({
+      credentials: { apiKey: "key_test" },
+      fetch: mockFetch,
+      path: "/v1/messages",
+      body: { to_number: "+15551234567", body: "Hello" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.agentphone.ai/v1/messages");
+    expect(options.method).toBe("POST");
+    expect(options.headers).toMatchObject({
+      authorization: "Bearer key_test",
+      "content-type": "application/json",
+    });
+    expect(JSON.parse(options.body as string)).toEqual({
+      to_number: "+15551234567",
+      body: "Hello",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.body).toEqual({ id: "msg_123" });
+  });
+
+  it("respects apiBaseUrl override", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await callAgentPhoneApi({
+      apiBaseUrl: "https://custom.api.test",
+      credentials: { apiKey: "key_test" },
+      fetch: mockFetch,
+      path: "/v1/messages",
+      body: {},
+    });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe("https://custom.api.test/v1/messages");
+  });
+});
+
+describe("sendAgentPhoneMessage", () => {
+  it("posts to /v1/messages with required fields", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "msg_456", status: "sent" }), { status: 200 }),
+      );
+
+    const result = await sendAgentPhoneMessage({
+      body: "Hello from eve",
+      credentials: { apiKey: "key_test" },
+      fetch: mockFetch,
+      toNumber: "+15551234567",
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string);
+    expect(body.to_number).toBe("+15551234567");
+    expect(body.body).toBe("Hello from eve");
+    expect(result.ok).toBe(true);
+  });
+
+  it("includes optional fields when provided", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await sendAgentPhoneMessage({
+      agentId: "agt_123",
+      body: "With media",
+      credentials: { apiKey: "key_test" },
+      fetch: mockFetch,
+      fromNumber: "+15557654321",
+      mediaUrls: ["https://example.com/photo.jpg"],
+      numberId: "num_789",
+      toNumber: "+15551234567",
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(options.body as string);
+    expect(body.from_number).toBe("+15557654321");
+    expect(body.number_id).toBe("num_789");
+    expect(body.agent_id).toBe("agt_123");
+    expect(body.media_urls).toEqual(["https://example.com/photo.jpg"]);
+  });
+});
+
+describe("makeAgentPhoneCall", () => {
+  it("posts to /v1/calls", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "call_123" }), { status: 200 }));
+
+    const result = await makeAgentPhoneCall({
+      agentId: "agt_abc",
+      credentials: { apiKey: "key_test" },
+      fetch: mockFetch,
+      initialGreeting: "Hello!",
+      toNumber: "+15551234567",
+    });
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.agentphone.ai/v1/calls");
+    const body = JSON.parse(options.body as string);
+    expect(body.agentId).toBe("agt_abc");
+    expect(body.toNumber).toBe("+15551234567");
+    expect(body.initialGreeting).toBe("Hello!");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/eve/src/public/channels/agentphone/api.ts
+++ b/packages/eve/src/public/channels/agentphone/api.ts
@@ -1,0 +1,146 @@
+/**
+ * Minimal AgentPhone REST API wrapper used by the AgentPhone channel.
+ *
+ * Requests use JSON encoding and Bearer-token auth. No AgentPhone SDK
+ * dependency is required or exposed through eve public APIs.
+ */
+
+/** API key, materialized directly or from an async secret provider. */
+export type AgentPhoneApiKey = string | (() => string | Promise<string>);
+
+/** Fetch implementation override. Defaults to the runtime global. */
+export type AgentPhoneFetch = typeof fetch;
+
+/** Credentials required for AgentPhone REST API calls. */
+export interface AgentPhoneCredentials {
+  readonly apiKey?: AgentPhoneApiKey;
+}
+
+/** Shared AgentPhone REST API options. */
+export interface AgentPhoneApiOptions {
+  readonly credentials?: AgentPhoneCredentials;
+  readonly apiBaseUrl?: string;
+  readonly fetch?: AgentPhoneFetch;
+}
+
+/** Result of an AgentPhone REST call. */
+export interface AgentPhoneApiResponse {
+  readonly status: number;
+  readonly ok: boolean;
+  readonly body: unknown;
+}
+
+/** Parameters for creating an outbound AgentPhone message. */
+export interface AgentPhoneSendMessageInput extends AgentPhoneApiOptions {
+  readonly toNumber: string;
+  readonly body: string;
+  readonly fromNumber?: string;
+  readonly numberId?: string;
+  readonly agentId?: string;
+  readonly mediaUrls?: readonly string[];
+}
+
+/** Parameters for creating an outbound AgentPhone call. */
+export interface AgentPhoneMakeCallInput extends AgentPhoneApiOptions {
+  readonly agentId: string;
+  readonly toNumber: string;
+  readonly fromNumberId?: string;
+  readonly initialGreeting?: string;
+  readonly voice?: string;
+  readonly systemPrompt?: string;
+}
+
+/**
+ * Builds the AgentPhone channel-local continuation token (`<from>:<to>`).
+ * Route `send()` namespaces this with the channel name before passing it
+ * to the runtime.
+ */
+export function agentphoneContinuationToken(from: string, to: string | undefined): string {
+  return `${from}:${to ?? ""}`;
+}
+
+/** Resolves an AgentPhone API key, falling back to `AGENTPHONE_API_KEY`. */
+export async function resolveAgentPhoneApiKey(apiKey?: AgentPhoneApiKey): Promise<string> {
+  const source = apiKey ?? process.env.AGENTPHONE_API_KEY;
+  if (!source) throw new Error("AGENTPHONE_API_KEY is required.");
+  return typeof source === "function" ? await source() : source;
+}
+
+/** Calls AgentPhone's REST API with Bearer auth and a JSON body. */
+export async function callAgentPhoneApi(input: {
+  readonly credentials?: AgentPhoneCredentials;
+  readonly apiBaseUrl?: string;
+  readonly fetch?: AgentPhoneFetch;
+  readonly method?: string;
+  readonly path: string;
+  readonly body?: Record<string, unknown>;
+}): Promise<AgentPhoneApiResponse> {
+  const apiKey = await resolveAgentPhoneApiKey(input.credentials?.apiKey);
+  const apiFetch = input.fetch ?? fetch;
+  const url = `${input.apiBaseUrl ?? "https://api.agentphone.ai"}${input.path}`;
+  const response = await apiFetch(url, {
+    method: input.method ?? "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: input.body ? JSON.stringify(input.body) : undefined,
+  });
+  return {
+    status: response.status,
+    ok: response.ok,
+    body: await parseResponseBody(response),
+  };
+}
+
+/** Sends an outbound message via AgentPhone's Messages resource. */
+export async function sendAgentPhoneMessage(
+  input: AgentPhoneSendMessageInput,
+): Promise<AgentPhoneApiResponse> {
+  const body: Record<string, unknown> = {
+    to_number: input.toNumber,
+    body: input.body,
+  };
+  if (input.fromNumber) body.from_number = input.fromNumber;
+  if (input.numberId) body.number_id = input.numberId;
+  if (input.agentId) body.agent_id = input.agentId;
+  if (input.mediaUrls?.length) body.media_urls = input.mediaUrls;
+  return callAgentPhoneApi({
+    apiBaseUrl: input.apiBaseUrl,
+    credentials: input.credentials,
+    fetch: input.fetch,
+    path: "/v1/messages",
+    body,
+  });
+}
+
+/** Initiates an outbound call via AgentPhone's Calls resource. */
+export async function makeAgentPhoneCall(
+  input: AgentPhoneMakeCallInput,
+): Promise<AgentPhoneApiResponse> {
+  const body: Record<string, unknown> = {
+    agentId: input.agentId,
+    toNumber: input.toNumber,
+  };
+  if (input.fromNumberId) body.fromNumberId = input.fromNumberId;
+  if (input.initialGreeting) body.initialGreeting = input.initialGreeting;
+  if (input.voice) body.voice = input.voice;
+  if (input.systemPrompt) body.systemPrompt = input.systemPrompt;
+  return callAgentPhoneApi({
+    apiBaseUrl: input.apiBaseUrl,
+    credentials: input.credentials,
+    fetch: input.fetch,
+    path: "/v1/calls",
+    body,
+  });
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/packages/eve/src/public/channels/agentphone/defaults.ts
+++ b/packages/eve/src/public/channels/agentphone/defaults.ts
@@ -1,0 +1,105 @@
+import type { SessionAuthContext } from "#channel/types.js";
+
+import { extractErrorId, formatErrorHint } from "#internal/logging.js";
+import type {
+  AgentPhoneCallEnded,
+  AgentPhoneTextMessage,
+  AgentPhoneVoiceMessage,
+} from "#public/channels/agentphone/inbound.js";
+import type {
+  AgentPhoneChannelEvents,
+  AgentPhoneContext,
+  AgentPhoneInboundResult,
+  AgentPhoneVoiceResult,
+} from "#public/channels/agentphone/agentphoneChannel.js";
+
+/** Default phone-number auth projection for AgentPhone webhook actors. */
+export function defaultAgentPhoneAuth(input: {
+  readonly from: string;
+  readonly to?: string;
+  readonly channel: "sms" | "mms" | "imessage" | "voice";
+}): SessionAuthContext {
+  const attributes: Record<string, string> = {
+    channel: input.channel,
+    from: input.from,
+  };
+  if (input.to !== undefined) attributes.to = input.to;
+
+  return {
+    attributes,
+    authenticator: "agentphone-webhook",
+    issuer: "agentphone",
+    principalId: `agentphone:${input.from}`,
+    principalType: "user",
+  };
+}
+
+/** Default inbound text hook: dispatch with AgentPhone phone-number auth. */
+export function defaultOnText(
+  _ctx: AgentPhoneContext,
+  message: AgentPhoneTextMessage,
+): AgentPhoneInboundResult {
+  return {
+    auth: defaultAgentPhoneAuth({
+      channel: message.channel,
+      from: message.from,
+      to: message.to,
+    }),
+  };
+}
+
+/** Default inbound voice hook: accept the webhook with no overrides. */
+export function defaultOnVoice(
+  _ctx: AgentPhoneContext,
+  _message: AgentPhoneVoiceMessage,
+): AgentPhoneVoiceResult {
+  return {};
+}
+
+/** Default inbound call-ended hook: dispatch with phone-number auth. */
+export function defaultOnCallEnded(
+  _ctx: AgentPhoneContext,
+  callEnded: AgentPhoneCallEnded,
+): AgentPhoneInboundResult {
+  return {
+    auth: defaultAgentPhoneAuth({
+      channel: "voice",
+      from: callEnded.from,
+      to: callEnded.to,
+    }),
+  };
+}
+
+/** Built-in AgentPhone event handlers for text delivery and terminal errors. */
+export const defaultEvents: AgentPhoneChannelEvents = {
+  async "message.completed"(event, channel, _ctx) {
+    if (event.finishReason === "tool-calls" || !event.message) return;
+    await channel.agentphone.sendMessage(event.message);
+  },
+
+  async "turn.failed"(event, channel, _ctx) {
+    const hint = formatErrorHint(event);
+    const errorId = extractErrorId(event.details);
+    await channel.agentphone.sendMessage(
+      [
+        `I hit an error while handling your request${hint}.`,
+        "",
+        "Please try again, rephrase, or reach out if it keeps failing.",
+        ...(errorId ? ["", `Error id: ${errorId}`] : []),
+      ].join("\n"),
+    );
+  },
+
+  async "session.failed"(event, channel) {
+    const hint = formatErrorHint(event);
+    const errorId = extractErrorId(event.details);
+    await channel.agentphone.sendMessage(
+      [
+        `This session could not recover from an error${hint}.`,
+        "",
+        "Start a new message to continue.",
+        ...(errorId ? ["", `Error id: ${errorId}`] : []),
+      ].join("\n"),
+    );
+  },
+};

--- a/packages/eve/src/public/channels/agentphone/inbound.ts
+++ b/packages/eve/src/public/channels/agentphone/inbound.ts
@@ -1,0 +1,181 @@
+/**
+ * AgentPhone inbound webhook parsing and prompt shaping.
+ *
+ * The channel owns these small data shapes instead of exposing raw
+ * AgentPhone webhook payloads as the public API surface.
+ */
+
+/** Channel-owned representation of an inbound AgentPhone text message. */
+export interface AgentPhoneTextMessage {
+  readonly from: string;
+  readonly to: string | undefined;
+  readonly body: string;
+  readonly channel: "sms" | "mms" | "imessage";
+  readonly conversationId: string | undefined;
+  readonly numberId: string | undefined;
+  readonly agentId: string | undefined;
+  readonly mediaUrl: string | undefined;
+  readonly raw: Record<string, unknown>;
+}
+
+/** Channel-owned representation of an inbound AgentPhone voice webhook. */
+export interface AgentPhoneVoiceMessage {
+  readonly from: string;
+  readonly to: string | undefined;
+  readonly transcript: string;
+  readonly callId: string | undefined;
+  readonly numberId: string | undefined;
+  readonly agentId: string | undefined;
+  readonly confidence: number | undefined;
+  readonly raw: Record<string, unknown>;
+}
+
+/** Channel-owned representation of an AgentPhone call-ended event. */
+export interface AgentPhoneCallEnded {
+  readonly from: string;
+  readonly to: string | undefined;
+  readonly callId: string | undefined;
+  readonly numberId: string | undefined;
+  readonly agentId: string | undefined;
+  readonly durationSeconds: number | undefined;
+  readonly summary: string | undefined;
+  readonly transcript: readonly { role: string; content: string }[] | undefined;
+  readonly raw: Record<string, unknown>;
+}
+
+/** Channel-owned representation of an AgentPhone iMessage reaction. */
+export interface AgentPhoneReaction {
+  readonly fromNumber: string;
+  readonly conversationId: string | undefined;
+  readonly reactionType: string;
+  readonly messageId: string | undefined;
+  readonly messageBody: string | undefined;
+  readonly raw: Record<string, unknown>;
+}
+
+const AGENTPHONE_SMS_RESPONSE_INSTRUCTIONS =
+  "Reply for SMS in plain text. Keep the response concise and avoid Markdown formatting, " +
+  "tables, headings, code fences, and long lists. Ask at most one short follow-up question " +
+  "when more information is needed.";
+
+/** Inbound identity fields for the model-visible `<agentphone_context>` block. */
+export interface AgentPhoneInboundContext {
+  readonly from: string;
+  readonly to?: string;
+  readonly conversationId?: string;
+  readonly callId?: string;
+  readonly channel: "sms" | "mms" | "imessage" | "voice";
+}
+
+/** Parses an `agent.message` webhook with a text channel. */
+export function parseAgentPhoneTextMessage(
+  payload: Record<string, unknown>,
+): AgentPhoneTextMessage | null {
+  const data = payload.data as Record<string, unknown> | undefined;
+  if (!data) return null;
+
+  const from = readString(data.from);
+  const body = readString(data.message);
+  if (!from || !body) return null;
+
+  return {
+    agentId: readString(payload.agentId),
+    body,
+    channel: (readString(payload.channel) as "sms" | "mms" | "imessage") ?? "sms",
+    conversationId: readString(data.conversationId),
+    from,
+    mediaUrl: readString(data.mediaUrl),
+    numberId: readString(data.numberId),
+    raw: payload,
+    to: readString(data.to),
+  };
+}
+
+/** Parses an `agent.message` webhook with a voice channel. */
+export function parseAgentPhoneVoiceMessage(
+  payload: Record<string, unknown>,
+): AgentPhoneVoiceMessage | null {
+  const data = payload.data as Record<string, unknown> | undefined;
+  if (!data) return null;
+
+  const from = readString(data.from);
+  const transcript = readString(data.transcript);
+  if (!from || !transcript) return null;
+
+  return {
+    agentId: readString(payload.agentId),
+    callId: readString(data.callId),
+    confidence: typeof data.confidence === "number" ? data.confidence : undefined,
+    from,
+    numberId: readString(data.numberId),
+    raw: payload,
+    to: readString(data.to),
+    transcript,
+  };
+}
+
+/** Parses an `agent.call_ended` webhook. */
+export function parseAgentPhoneCallEnded(
+  payload: Record<string, unknown>,
+): AgentPhoneCallEnded | null {
+  const data = payload.data as Record<string, unknown> | undefined;
+  if (!data) return null;
+
+  const from = readString(data.from);
+  if (!from) return null;
+
+  return {
+    agentId: readString(payload.agentId),
+    callId: readString(data.callId),
+    durationSeconds: typeof data.durationSeconds === "number" ? data.durationSeconds : undefined,
+    from,
+    numberId: readString(data.numberId),
+    raw: payload,
+    summary: readString(data.summary),
+    to: readString(data.to),
+    transcript: Array.isArray(data.transcript)
+      ? (data.transcript as { role: string; content: string }[])
+      : undefined,
+  };
+}
+
+/** Parses an `agent.reaction` webhook. */
+export function parseAgentPhoneReaction(
+  payload: Record<string, unknown>,
+): AgentPhoneReaction | null {
+  const data = payload.data as Record<string, unknown> | undefined;
+  if (!data) return null;
+
+  const fromNumber = readString(data.fromNumber);
+  const reactionType = readString(data.reactionType);
+  if (!fromNumber || !reactionType) return null;
+
+  return {
+    conversationId: readString(data.conversationId),
+    fromNumber,
+    messageBody: readString(data.messageBody),
+    messageId: readString(data.messageId),
+    raw: payload,
+    reactionType,
+  };
+}
+
+/** Renders a deterministic `<agentphone_context>` block for the model. */
+export function formatAgentPhoneContextBlock(context: AgentPhoneInboundContext): string {
+  const lines = [
+    "<agentphone_context>",
+    `channel: ${context.channel}`,
+    "response_medium: sms",
+    `response_instructions: ${AGENTPHONE_SMS_RESPONSE_INSTRUCTIONS}`,
+    `from: ${context.from}`,
+    ...(context.to ? [`to: ${context.to}`] : []),
+    ...(context.conversationId ? [`conversation_id: ${context.conversationId}`] : []),
+    ...(context.callId ? [`call_id: ${context.callId}`] : []),
+    "</agentphone_context>",
+  ];
+  return lines.join("\n");
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/eve/src/public/channels/agentphone/index.ts
+++ b/packages/eve/src/public/channels/agentphone/index.ts
@@ -1,0 +1,52 @@
+export {
+  agentphoneChannel,
+  type AgentPhoneAllowFrom,
+  type AgentPhoneChannel,
+  type AgentPhoneChannelConfig,
+  type AgentPhoneChannelCredentials,
+  type AgentPhoneChannelEvents,
+  type AgentPhoneChannelState,
+  type AgentPhoneContext,
+  type AgentPhoneEventContext,
+  type AgentPhoneHandle,
+  type AgentPhoneInboundResult,
+  type AgentPhoneInboundResultOrPromise,
+  type AgentPhoneInstrumentationMetadata,
+  type AgentPhoneMakeCallOptions,
+  type AgentPhoneMessagingConfig,
+  type AgentPhoneReceiveTarget,
+  type AgentPhoneSendMessageOptions,
+  type AgentPhoneVoiceResult,
+  type AgentPhoneVoiceResultOrPromise,
+} from "#public/channels/agentphone/agentphoneChannel.js";
+
+export {
+  agentphoneContinuationToken,
+  callAgentPhoneApi,
+  makeAgentPhoneCall,
+  sendAgentPhoneMessage,
+  type AgentPhoneApiKey,
+  type AgentPhoneApiOptions,
+  type AgentPhoneApiResponse,
+  type AgentPhoneCredentials,
+  type AgentPhoneFetch,
+  type AgentPhoneMakeCallInput,
+  type AgentPhoneSendMessageInput,
+} from "#public/channels/agentphone/api.js";
+
+export type {
+  AgentPhoneCallEnded,
+  AgentPhoneInboundContext,
+  AgentPhoneReaction,
+  AgentPhoneTextMessage,
+  AgentPhoneVoiceMessage,
+} from "#public/channels/agentphone/inbound.js";
+
+export {
+  resolveAgentPhoneWebhookSecret,
+  signAgentPhoneRequest,
+  verifyAgentPhoneRequest,
+  type AgentPhoneVerifiedRequest,
+  type AgentPhoneVerifyOptions,
+  type AgentPhoneWebhookSecret,
+} from "#public/channels/agentphone/verify.js";

--- a/packages/eve/src/public/channels/agentphone/verify.test.ts
+++ b/packages/eve/src/public/channels/agentphone/verify.test.ts
@@ -1,0 +1,137 @@
+import { createHmac } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveAgentPhoneWebhookSecret,
+  signAgentPhoneRequest,
+  verifyAgentPhoneRequest,
+} from "./verify.js";
+
+function sign(secret: string, timestamp: string, body: string): string {
+  const digest = createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex");
+  return `sha256=${digest}`;
+}
+
+function makeRequest(body: string, headers: Record<string, string>): Request {
+  return new Request("https://example.com/eve/v1/agentphone/webhooks", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("signAgentPhoneRequest", () => {
+  it("produces sha256=<hex> format", () => {
+    const result = signAgentPhoneRequest({
+      body: '{"event":"agent.message"}',
+      secret: "whsec_test",
+      timestamp: "1700000000",
+    });
+    expect(result).toMatch(/^sha256=[0-9a-f]{64}$/);
+  });
+
+  it("matches manual HMAC-SHA256", () => {
+    const secret = "whsec_test";
+    const timestamp = "1700000000";
+    const body = '{"event":"agent.message"}';
+    const expected = sign(secret, timestamp, body);
+    const actual = signAgentPhoneRequest({ body, secret, timestamp });
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("resolveAgentPhoneWebhookSecret", () => {
+  afterEach(() => {
+    delete process.env.AGENTPHONE_WEBHOOK_SECRET;
+  });
+
+  it("uses the provided string", async () => {
+    expect(await resolveAgentPhoneWebhookSecret("whsec_direct")).toBe("whsec_direct");
+  });
+
+  it("calls a function provider", async () => {
+    const provider = vi.fn().mockResolvedValue("whsec_async");
+    expect(await resolveAgentPhoneWebhookSecret(provider)).toBe("whsec_async");
+    expect(provider).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to AGENTPHONE_WEBHOOK_SECRET env", async () => {
+    process.env.AGENTPHONE_WEBHOOK_SECRET = "whsec_env";
+    expect(await resolveAgentPhoneWebhookSecret()).toBe("whsec_env");
+  });
+
+  it("throws when no secret is available", async () => {
+    await expect(resolveAgentPhoneWebhookSecret()).rejects.toThrow(
+      "AGENTPHONE_WEBHOOK_SECRET is required.",
+    );
+  });
+});
+
+describe("verifyAgentPhoneRequest", () => {
+  const secret = "whsec_test_secret";
+
+  it("verifies a valid request", async () => {
+    const body = '{"event":"agent.message","data":{"from":"+15551234567"}}';
+    const now = Math.floor(Date.now() / 1000);
+    const timestamp = String(now);
+    const signature = sign(secret, timestamp, body);
+
+    const request = makeRequest(body, {
+      "x-webhook-signature": signature,
+      "x-webhook-timestamp": timestamp,
+    });
+
+    const result = await verifyAgentPhoneRequest(request, { webhookSecret: secret });
+    expect(result.body).toBe(body);
+    expect(result.payload).toEqual(JSON.parse(body));
+  });
+
+  it("rejects missing signature header", async () => {
+    const request = makeRequest("{}", {
+      "x-webhook-timestamp": String(Math.floor(Date.now() / 1000)),
+    });
+
+    await expect(verifyAgentPhoneRequest(request, { webhookSecret: secret })).rejects.toThrow(
+      "missing X-Webhook-Signature",
+    );
+  });
+
+  it("rejects missing timestamp header", async () => {
+    const request = makeRequest("{}", {
+      "x-webhook-signature": "sha256=abc",
+    });
+
+    await expect(verifyAgentPhoneRequest(request, { webhookSecret: secret })).rejects.toThrow(
+      "missing X-Webhook-Timestamp",
+    );
+  });
+
+  it("rejects a timestamp outside the replay window", async () => {
+    const body = "{}";
+    const oldTimestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const signature = sign(secret, oldTimestamp, body);
+
+    const request = makeRequest(body, {
+      "x-webhook-signature": signature,
+      "x-webhook-timestamp": oldTimestamp,
+    });
+
+    await expect(verifyAgentPhoneRequest(request, { webhookSecret: secret })).rejects.toThrow(
+      "outside replay window",
+    );
+  });
+
+  it("rejects an invalid signature", async () => {
+    const body = "{}";
+    const timestamp = String(Math.floor(Date.now() / 1000));
+
+    const request = makeRequest(body, {
+      "x-webhook-signature":
+        "sha256=0000000000000000000000000000000000000000000000000000000000000000",
+      "x-webhook-timestamp": timestamp,
+    });
+
+    await expect(verifyAgentPhoneRequest(request, { webhookSecret: secret })).rejects.toThrow(
+      "signature mismatch",
+    );
+  });
+});

--- a/packages/eve/src/public/channels/agentphone/verify.ts
+++ b/packages/eve/src/public/channels/agentphone/verify.ts
@@ -1,0 +1,97 @@
+/**
+ * AgentPhone inbound-webhook verification.
+ *
+ * AgentPhone signs webhook requests with HMAC-SHA256. The signed payload
+ * is `{timestamp}.{raw_body}` and the signature is delivered in
+ * `X-Webhook-Signature` as `sha256=<hex_digest>`. Requests older than 5
+ * minutes are rejected to prevent replay attacks.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { createLogger } from "#internal/logging.js";
+
+const log = createLogger("agentphone.verify");
+
+const REPLAY_WINDOW_SECONDS = 300;
+
+/** Webhook secret, materialized directly or from an async secret provider. */
+export type AgentPhoneWebhookSecret = string | (() => string | Promise<string>);
+
+/** Parsed and verified AgentPhone webhook body. */
+export interface AgentPhoneVerifiedRequest {
+  readonly body: string;
+  readonly payload: unknown;
+}
+
+/** Options for {@link verifyAgentPhoneRequest}. */
+export interface AgentPhoneVerifyOptions {
+  readonly webhookSecret: AgentPhoneWebhookSecret | undefined;
+}
+
+/** Resolves the webhook secret, falling back to `AGENTPHONE_WEBHOOK_SECRET`. */
+export async function resolveAgentPhoneWebhookSecret(
+  webhookSecret?: AgentPhoneWebhookSecret,
+): Promise<string> {
+  const source = webhookSecret ?? process.env.AGENTPHONE_WEBHOOK_SECRET;
+  if (!source) throw new Error("AGENTPHONE_WEBHOOK_SECRET is required.");
+  return typeof source === "function" ? await source() : source;
+}
+
+/**
+ * Verifies an inbound AgentPhone webhook and returns the raw body plus parsed JSON.
+ *
+ * Consumes the request body. Throws when the webhook secret is missing,
+ * required headers are absent, the signature does not match, or the
+ * timestamp is outside the replay window.
+ */
+export async function verifyAgentPhoneRequest(
+  request: Request,
+  options: AgentPhoneVerifyOptions,
+): Promise<AgentPhoneVerifiedRequest> {
+  const body = await request.text();
+  const secret = await resolveAgentPhoneWebhookSecret(options.webhookSecret);
+
+  const signature = request.headers.get("x-webhook-signature") ?? "";
+  if (!signature) {
+    throw new Error("agentphoneChannel: inbound request missing X-Webhook-Signature.");
+  }
+
+  const timestamp = request.headers.get("x-webhook-timestamp") ?? "";
+  if (!timestamp) {
+    throw new Error("agentphoneChannel: inbound request missing X-Webhook-Timestamp.");
+  }
+
+  const ts = parseInt(timestamp, 10);
+  if (Number.isNaN(ts) || Math.abs(Date.now() / 1000 - ts) > REPLAY_WINDOW_SECONDS) {
+    throw new Error("agentphoneChannel: inbound request outside replay window.");
+  }
+
+  const expected = signAgentPhoneRequest({ body, secret, timestamp });
+  if (!constantTimeCompare(expected, signature)) {
+    throw new Error("agentphoneChannel: inbound request signature mismatch.");
+  }
+
+  return { body, payload: JSON.parse(body) };
+}
+
+/** Computes AgentPhone's HMAC-SHA256 request signature. */
+export function signAgentPhoneRequest(input: {
+  readonly secret: string;
+  readonly timestamp: string;
+  readonly body: string;
+}): string {
+  const signedString = `${input.timestamp}.${input.body}`;
+  const digest = createHmac("sha256", input.secret).update(signedString).digest("hex");
+  return `sha256=${digest}`;
+}
+
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch (error) {
+    log.debug("timingSafeEqual threw", { error });
+    return false;
+  }
+}

--- a/packages/eve/src/public/channels/index.ts
+++ b/packages/eve/src/public/channels/index.ts
@@ -60,6 +60,7 @@ export interface ChannelMetadataMap {
   readonly "channel:slack": import("#public/channels/slack/slackChannel.js").SlackInstrumentationMetadata;
   readonly "channel:discord": import("#public/channels/discord/index.js").DiscordInstrumentationMetadata;
   readonly "channel:twilio": import("#public/channels/twilio/twilioChannel.js").TwilioInstrumentationMetadata;
+  readonly "channel:agentphone": import("#public/channels/agentphone/agentphoneChannel.js").AgentPhoneInstrumentationMetadata;
   readonly "channel:teams": import("#public/channels/teams/index.js").TeamsInstrumentationMetadata;
   readonly "channel:telegram": import("#public/channels/telegram/index.js").TelegramInstrumentationMetadata;
   readonly "channel:linear": import("#public/channels/linear/index.js").LinearInstrumentationMetadata;
@@ -84,6 +85,7 @@ export interface ChannelReferenceMap {
   readonly "channel:slack": import("#public/channels/slack/slackChannel.js").SlackChannel;
   readonly "channel:discord": import("#public/channels/discord/discordChannel.js").DiscordChannel;
   readonly "channel:twilio": import("#public/channels/twilio/twilioChannel.js").TwilioChannel;
+  readonly "channel:agentphone": import("#public/channels/agentphone/agentphoneChannel.js").AgentPhoneChannel;
   readonly "channel:teams": import("#public/channels/teams/teamsChannel.js").TeamsChannel;
   readonly "channel:telegram": import("#public/channels/telegram/telegramChannel.js").TelegramChannel;
   readonly "channel:linear": import("#public/channels/linear/linearChannel.js").LinearChannel;


### PR DESCRIPTION
## Summary

- Adds AgentPhone as a built-in channel alongside Twilio, Slack, Discord, Teams, Telegram, GitHub, and Linear
- Handles inbound SMS/MMS/iMessage messages, real-time voice transcripts, and call-ended events via HMAC-SHA256 verified webhooks
- Outbound messaging and call initiation use AgentPhone's JSON REST API with Bearer auth
- Single webhook endpoint at `POST /eve/v1/agentphone/webhooks` handles all event types (`agent.message`, `agent.call_ended`, `agent.reaction`)
- Includes catalog registration, package export (`eve/channels/agentphone`), channel metadata/reference maps, documentation, and unit tests (22 tests)

### Files changed

| Area | Files |
|------|-------|
| Channel implementation | `packages/eve/src/public/channels/agentphone/` (6 source files) |
| Tests | `api.test.ts`, `verify.test.ts` (22 tests) |
| Catalog | `packages/eve-catalog/src/index.ts` |
| Package export | `packages/eve/package.json` |
| Channel registry | `packages/eve/src/public/channels/index.ts` |
| Documentation | `docs/channels/agentphone.mdx`, `docs/channels/meta.json` |
| Changeset | `.changeset/add-agentphone-channel.md` |

### Usage

```ts
// agent/channels/agentphone.ts
import { agentphoneChannel } from "eve/channels/agentphone";

export default agentphoneChannel({
  allowFrom: "+15551234567",
  messaging: { from: "+15557654321" },
});
```

```bash
AGENTPHONE_API_KEY=...            # required for outbound messages and calls
AGENTPHONE_WEBHOOK_SECRET=...     # required for inbound signature verification
```

## Test plan

- [x] `pnpm typecheck` passes (all 20 tasks)
- [x] `pnpm test:unit` passes (3640 tests across 365 files)
- [x] `pnpm lint` passes
- [x] `pnpm docs:check` passes (68 files, 163 import paths, 68 MDX files)
- [x] `pnpm guard:invariants` passes
- [x] `pnpm build` succeeds
- [ ] CI passes