### PR TITLE
fix(eve): init - isolate npm installs from workspaces

### DIFF
--- a/.changeset/isolate-npm-init-workspaces.md
+++ b/.changeset/isolate-npm-init-workspaces.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve init` now isolates npm installs and dev handoff commands from ancestor workspaces, preventing npm from walking Bun-owned parent dependency trees during fresh scaffolds.

--- a/packages/eve/src/cli/commands/agent-instructions.test.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.test.ts
@@ -23,7 +23,7 @@ describe("initAgentDevHandoff", () => {
   it("points at the bundled docs, applies the purpose, and hands the dev command to the user", () => {
     const handoff = initAgentDevHandoff({
       projectPath: "/tmp/triage-bot",
-      devCommand: "npm exec -- eve dev",
+      devCommand: "npm exec --workspaces=false -- eve dev",
     });
 
     expect(handoff).toContain("/tmp/triage-bot/node_modules/eve/docs/");
@@ -31,6 +31,6 @@ describe("initAgentDevHandoff", () => {
     expect(handoff).toContain("purpose you collected");
     expect(handoff).toContain("Do not start `eve dev` because it is interactive");
     expect(handoff).toContain("cd /tmp/triage-bot");
-    expect(handoff).toContain("npm exec -- eve dev");
+    expect(handoff).toContain("npm exec --workspaces=false -- eve dev");
   });
 });

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -194,7 +194,7 @@ describe("runInitCommand", () => {
   );
 
   it.each([
-    ["npm", ["exec", "--", "eve", "dev", "--input", "/model"]],
+    ["npm", ["exec", "--workspaces=false", "--", "eve", "dev", "--input", "/model"]],
     ["yarn", ["eve", "dev", "--input", "/model"]],
     ["bun", ["x", "eve", "dev", "--input", "/model"]],
   ] as const)(
@@ -217,7 +217,9 @@ describe("runInitCommand", () => {
       expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
         kind,
         projectPath,
-        expect.anything(),
+        expect.objectContaining({
+          ignoreWorkspace: kind === "npm",
+        }),
       );
       expect(deps.spawnPackageManager).toHaveBeenCalledWith(kind, projectPath, [...devArguments]);
     },
@@ -237,10 +239,11 @@ describe("runInitCommand", () => {
     expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
       "npm",
       projectPath,
-      expect.anything(),
+      expect.objectContaining({ ignoreWorkspace: true }),
     );
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("npm", projectPath, [
       "exec",
+      "--workspaces=false",
       "--",
       "eve",
       "dev",
@@ -426,7 +429,7 @@ describe("runInitCommand", () => {
   });
 
   it.each([
-    ["npm", "package-lock.json", ["exec", "--", "eve", "dev"]],
+    ["npm", "package-lock.json", ["exec", "--workspaces=false", "--", "eve", "dev"]],
     ["yarn", "yarn.lock", ["eve", "dev"]],
     ["bun", "bun.lock", ["x", "eve", "dev"]],
   ] as const)(
@@ -454,7 +457,9 @@ describe("runInitCommand", () => {
       expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
         kind,
         projectRoot,
-        expect.anything(),
+        expect.objectContaining({
+          ignoreWorkspace: false,
+        }),
       );
       expect(deps.spawnPackageManager).toHaveBeenCalledWith(kind, projectRoot, [...devArguments]);
     },
@@ -549,7 +554,7 @@ describe("runInitCommand", () => {
     await runInitCommand(output, parentDirectory, "host-app", {}, deps);
 
     expect(deps.spawnPackageManager).not.toHaveBeenCalled();
-    expect(output.messages.join("\n")).toContain("npm exec -- eve dev");
+    expect(output.messages.join("\n")).toContain("npm exec --workspaces=false -- eve dev");
   });
 
   it("stops before Git and dev when dependency installation fails, replaying its output", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -277,6 +277,9 @@ export async function runInitCommand(
       // The scaffold pins versions younger than typical release-age cooldown
       // windows; gating them would fail every fresh bootstrap.
       bypassMinimumReleaseAge: true,
+      // A freshly scaffolded app is standalone even when created under an
+      // ancestor workspace; npm in particular can crash on Bun-owned trees.
+      ignoreWorkspace: freshScaffold && packageManager === "npm",
       onOutput: (line) => installLog.push(line.text),
     });
   } finally {

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -380,7 +380,7 @@ describe("startDevelopmentServer", () => {
     await expect(startDevelopmentServer("/tmp/eve-test")).rejects.toThrow(
       [
         `A dev server is already running for this eve agent (pid ${process.pid}).`,
-        "To connect to the existing instance, run: npm exec -- eve dev http://127.0.0.1:4321/",
+        "To connect to the existing instance, run: npm exec --workspaces=false -- eve dev http://127.0.0.1:4321/",
         `To stop it, run: ${
           process.platform === "win32" ? "taskkill /PID" : "kill"
         } ${process.pid}`,

--- a/packages/eve/src/setup/primitives/pm/npm.ts
+++ b/packages/eve/src/setup/primitives/pm/npm.ts
@@ -5,9 +5,10 @@ export const npmPackageManager = {
   kind: "npm",
   scaffoldFiles: {},
   applyProjectConfiguration: applyNoProjectConfiguration,
-  devArguments: () => ["exec", "--", "eve", "dev"],
+  devArguments: () => ["exec", "--workspaces=false", "--", "eve", "dev"],
   installArguments: (options) => [
     "install",
+    ...(options.ignoreWorkspace === true ? ["--workspaces=false"] : []),
     ...(options.bypassMinimumReleaseAge === true ? ["--min-release-age=0"] : []),
   ],
   prepareArguments: (_projectRoot, args) => args,

--- a/packages/eve/src/setup/primitives/run-pnpm.test.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.test.ts
@@ -146,11 +146,23 @@ describe("runPackageManagerInstall", () => {
       expect.objectContaining({ cwd: "/tmp/app" }),
     );
   });
+
+  test("can isolate npm installs from ancestor workspaces", async () => {
+    await expect(
+      runPackageManagerInstall("npm", "/tmp/app", { ignoreWorkspace: true }),
+    ).resolves.toBe(true);
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      "npm",
+      ["install", "--workspaces=false"],
+      expect.objectContaining({ cwd: "/tmp/app" }),
+    );
+  });
 });
 
 describe("eveDevArguments", () => {
   test.each([
-    ["npm", ["exec", "--", "eve", "dev"]],
+    ["npm", ["exec", "--workspaces=false", "--", "eve", "dev"]],
     ["pnpm", ["exec", "eve", "dev"]],
     ["yarn", ["eve", "dev"]],
     ["bun", ["x", "eve", "dev"]],

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -253,11 +253,11 @@ describe("eve init smoke", () => {
     await expect(pathExists(join(projectDir, "package-lock.json"))).resolves.toBe(true);
     expect(await fakeNpm.readCalls()).toEqual([
       {
-        args: ["install", "--min-release-age=0"],
+        args: ["install", "--workspaces=false", "--min-release-age=0"],
         cwd: canonicalProjectDir,
       },
       {
-        args: ["exec", "--", "eve", "dev", "--input", "/model"],
+        args: ["exec", "--workspaces=false", "--", "eve", "dev", "--input", "/model"],
         cwd: canonicalProjectDir,
       },
     ]);


### PR DESCRIPTION
## Summary

- Isolate fresh npm-owned `eve init` installs with `--workspaces=false` so npm does not walk ancestor workspaces.
- Use the same npm workspace guard for the generated `eve dev` handoff command.
- Add coverage for the npm init path and a patch changeset for the published `eve` package.

## Why

A fresh scaffold should be standalone even when it is created under an existing monorepo. When `eve init` is launched through `npx`, npm can discover an ancestor workspace and traverse a dependency tree produced by another package manager such as Bun. In affected npm versions this can surface as an internal Arborist crash like `Cannot read properties of null (reading 'matches')` during install.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/primitives/run-pnpm.test.ts src/cli/commands/agent-instructions.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/init.integration.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/eve-init.scenario.test.ts`
