### PR TITLE
fix(eve): cli - detect parent workspace package manager during init

### DIFF
--- a/.changeset/init-monorepo-package-manager.md
+++ b/.changeset/init-monorepo-package-manager.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Detect parent workspace package managers when running `eve init <name>` so fresh agents created inside monorepos install with the workspace manager instead of always following the launcher.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -36,7 +36,7 @@ npx eve@latest init my-agent
 
 The command:
 
-- Creates an npm-managed child directory and uses eve's default model
+- Creates a child directory using the current workspace or launcher package manager, and uses eve's default model
 - Installs dependencies and initializes Git
 - Starts the development server and opens the interactive [terminal UI](./guides/dev-tui)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,7 +35,7 @@ The optional `target` decides the mode:
 - An existing directory, including `.` for the current one (`eve init .`), adds an agent to that project. The project needs a `package.json`, the `agent/` files must not exist yet, and the missing `eve`, `ai`, and `zod` dependencies are added without touching anything else.
 - Omitting the target scaffolds or updates the current directory, the same as `eve init .`.
 
-Either mode installs dependencies, initializes Git, and runs `eve dev` through the project's package manager.
+Either mode installs dependencies, initializes Git, and runs `eve dev` through the detected project package manager. Fresh projects inherit a parent workspace manager when one is present; otherwise they use the manager that launched `eve init`.
 
 | Flag                   | Type | Default | Description                                                                                                                            |
 | ---------------------- | ---- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -223,6 +223,76 @@ describe("runInitCommand", () => {
     },
   );
 
+  it("scaffolds a fresh named project with the ancestor packageManager before npx", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-bun-workspace-"));
+    const appsDirectory = join(workspaceRoot, "apps");
+    await mkdir(appsDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, packageManager: "bun@1.2.0" }, null, 2)}\n`,
+      "utf8",
+    );
+    const output = logger();
+    const deps = dependencies();
+    deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+    await runInitCommand(output, appsDirectory, "amelie", {}, deps);
+
+    const projectPath = join(appsDirectory, "amelie");
+    expect(await readFile(join(projectPath, "agent/agent.ts"), "utf8")).toContain(
+      DEFAULT_AGENT_MODEL_ID,
+    );
+    await expect(pathExists(join(projectPath, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "bun",
+      projectPath,
+      expect.anything(),
+    );
+    expect(deps.spawnPackageManager).toHaveBeenCalledWith("bun", projectPath, [
+      "x",
+      "eve",
+      "dev",
+      "--input",
+      "/model",
+    ]);
+  });
+
+  it.each([
+    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--input", "/model"]],
+    ["yarn", "yarn.lock", "npm", ["eve", "dev", "--input", "/model"]],
+    ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--input", "/model"]],
+    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--input", "/model"]],
+  ] as const)(
+    "scaffolds a fresh named project with the ancestor %s lockfile before the launcher",
+    async (kind, lockfile, invokingManager, devArguments) => {
+      const workspaceRoot = await mkdtemp(join(tmpdir(), `eve-init-${kind}-workspace-`));
+      const appsDirectory = join(workspaceRoot, "apps");
+      await mkdir(appsDirectory, { recursive: true });
+      await writeFile(
+        join(workspaceRoot, "package.json"),
+        `${JSON.stringify({ private: true }, null, 2)}\n`,
+        "utf8",
+      );
+      await writeFile(join(workspaceRoot, lockfile), "", "utf8");
+      const output = logger();
+      const deps = dependencies();
+      deps.detectInvokingPackageManager.mockReturnValue(invokingManager);
+
+      await runInitCommand(output, appsDirectory, "my-agent", {}, deps);
+
+      const projectPath = join(appsDirectory, "my-agent");
+      expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+        kind,
+        projectPath,
+        expect.anything(),
+      );
+      expect(deps.spawnPackageManager).toHaveBeenCalledWith(kind, projectPath, [...devArguments]);
+      await expect(pathExists(join(projectPath, "pnpm-workspace.yaml"))).resolves.toBe(
+        kind === "pnpm",
+      );
+    },
+  );
+
   it("adds Web Chat to an npm-owned fresh scaffold without pnpm configuration", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-agent-web-npm-"));
     const output = logger();
@@ -459,6 +529,36 @@ describe("runInitCommand", () => {
       expect(deps.spawnPackageManager).toHaveBeenCalledWith(kind, projectRoot, [...devArguments]);
     },
   );
+
+  it("adds an agent to an existing project with the ancestor package manager", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-existing-workspace-"));
+    const appsDirectory = join(workspaceRoot, "apps");
+    const projectRoot = join(appsDirectory, "host-app");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, packageManager: "bun@1.2.0" }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(projectRoot, "package.json"), '{ "name": "host-app" }\n', "utf8");
+    const output = logger();
+    const deps = dependencies();
+    deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+    await runInitCommand(output, appsDirectory, "host-app", {}, deps);
+
+    expect(await readFile(join(projectRoot, "agent/agent.ts"), "utf8")).toContain(
+      DEFAULT_AGENT_MODEL_ID,
+    );
+    await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "bun",
+      projectRoot,
+      expect.anything(),
+    );
+    expect(deps.tryInitializeGit).not.toHaveBeenCalled();
+    expect(deps.spawnPackageManager).toHaveBeenCalledWith("bun", projectRoot, ["x", "eve", "dev"]);
+  });
 
   it("reports agent file conflicts before writing anything", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-dir-conflict-"));

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -126,11 +126,17 @@ async function addToExistingProject(
 }
 
 /**
- * The manager a fresh scaffold will be owned by: the one whose package runner
- * launched the CLI, or pnpm when the binary ran directly and no preference
- * is visible.
+ * The manager a fresh scaffold will be owned by: an existing ancestor project
+ * manager first, then the package runner that launched the CLI, then pnpm.
  */
-function resolveScaffoldPackageManager(dependencies: InitCommandDependencies): PackageManagerKind {
+async function resolveScaffoldPackageManager(
+  projectPath: string,
+  dependencies: InitCommandDependencies,
+): Promise<PackageManagerKind> {
+  const detected = await dependencies.detectPackageManager(projectPath);
+  if (detected.source !== "default") {
+    return detected.kind;
+  }
   return dependencies.detectInvokingPackageManager() ?? "pnpm";
 }
 
@@ -235,17 +241,20 @@ export async function runInitCommand(
       : undefined
     : await resolveTargetDirectory(parentDirectory, rawTarget);
 
-  // A fresh project is owned by the manager that launched the CLI (`npx`,
-  // `pnpm dlx`, `yarn dlx`), defaulting to pnpm for a direct binary run; an
-  // existing project keeps whatever manager it already uses.
+  // A fresh project inside a workspace inherits that workspace's manager before
+  // considering the launcher (`npx`, `pnpm dlx`, `yarn dlx`); an existing
+  // project keeps whatever manager it already uses.
   let packageManager: PackageManagerKind;
   let projectPath: string;
   let freshScaffold: boolean;
   if (existingDirectory === undefined) {
-    packageManager = resolveScaffoldPackageManager(dependencies);
     const projectName = currentDirectoryTarget
       ? CURRENT_DIRECTORY_PROJECT_NAME
       : parseProjectName(rawTarget);
+    const parentPath = resolve(parentDirectory);
+    const plannedProjectPath =
+      projectName === CURRENT_DIRECTORY_PROJECT_NAME ? parentPath : join(parentPath, projectName);
+    packageManager = await resolveScaffoldPackageManager(plannedProjectPath, dependencies);
     projectPath = await scaffoldProject(
       parentDirectory,
       projectName,

--- a/packages/eve/src/setup/package-manager.ts
+++ b/packages/eve/src/setup/package-manager.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { pathExists } from "./path-exists.js";
 
@@ -67,11 +67,12 @@ export function detectInvokingPackageManager(): PackageManagerKind | undefined {
   return packageManagerFromUserAgent(process.env.npm_config_user_agent);
 }
 
-/** Reads the detection facts for {@link resolvePackageManager} from `projectRoot`. */
-export async function detectPackageManager(projectRoot: string): Promise<DetectedPackageManager> {
+async function detectPackageManagerInDirectory(
+  directory: string,
+): Promise<DetectedPackageManager | undefined> {
   let packageManagerField: string | undefined;
   try {
-    const parsed: unknown = JSON.parse(await readFile(join(projectRoot, "package.json"), "utf8"));
+    const parsed: unknown = JSON.parse(await readFile(join(directory, "package.json"), "utf8"));
     if (
       typeof parsed === "object" &&
       parsed !== null &&
@@ -86,10 +87,33 @@ export async function detectPackageManager(projectRoot: string): Promise<Detecte
 
   const lockfiles: string[] = [];
   for (const [lockfile] of LOCKFILE_MANAGERS) {
-    if (await pathExists(join(projectRoot, lockfile))) {
+    if (await pathExists(join(directory, lockfile))) {
       lockfiles.push(lockfile);
     }
   }
 
-  return resolvePackageManager({ packageManagerField, lockfiles });
+  const resolved = resolvePackageManager({ packageManagerField, lockfiles });
+  return resolved.source === "default" ? undefined : resolved;
+}
+
+async function detectAncestorPackageManager(
+  projectRoot: string,
+): Promise<DetectedPackageManager | undefined> {
+  let directory = dirname(resolve(projectRoot));
+  while (true) {
+    const detected = await detectPackageManagerInDirectory(directory);
+    if (detected !== undefined) return detected;
+
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+/** Reads package-manager facts from `projectRoot`, then walks ancestors. */
+export async function detectPackageManager(projectRoot: string): Promise<DetectedPackageManager> {
+  return (
+    (await detectPackageManagerInDirectory(resolve(projectRoot))) ??
+    (await detectAncestorPackageManager(projectRoot)) ?? { kind: "pnpm", source: "default" }
+  );
 }


### PR DESCRIPTION
## Summary

Fixes `eve init <name>` when run from inside a monorepo subdirectory with a different package manager than the launcher.

Previously, `npx eve@latest init my-agent` always treated the fresh scaffold as npm-owned because `npx` was the invoking package manager. Now fresh named scaffolds first detect package-manager facts from the planned project path and ancestor directories, so a Bun, pnpm, yarn, or npm workspace keeps using its own manager.

## Changes

- Make package-manager detection walk ancestor directories for `packageManager` fields and lockfiles.
- Use ancestor workspace detection before falling back to the invoking package manager for fresh `eve init <name>` scaffolds.
- Add regression coverage for Bun, npm, yarn, and pnpm monorepo roots.
- Update docs to avoid implying `npx eve init` always creates an npm-managed project.
- Add a patch changeset.

## Testing

- `pnpm exec oxlint`
- `pnpm --filter eve run typecheck`
- `pnpm docs:check`
- `pnpm --filter eve run test:unit`
- `pnpm --filter eve run test:integration`
- `pnpm --filter eve run build`
- `pnpm guard:invariants`