### PR TITLE
fix(harness): keep compacted prompt ending on a user turn

### DIFF
--- a/.changeset/compaction-trailing-assistant.md
+++ b/.changeset/compaction-trailing-assistant.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix compaction emitting a prompt that ends on an assistant turn, which providers without assistant-prefill support (e.g. Anthropic) reject with "the conversation must end with a user message". The trailing-assistant guard now runs against the fully-assembled compacted prompt instead of only the recent window, so it also covers the case where the recent window is empty (a single oversized turn, or `keep` decaying to 0) and the summary block itself is the final message.

--- a/packages/eve/src/harness/compaction.test.ts
+++ b/packages/eve/src/harness/compaction.test.ts
@@ -251,6 +251,37 @@ describe("compactMessages", () => {
     expect(result[4]).toEqual({ content: "Continue.", role: "user" });
   });
 
+  it("ends on a user turn when no recent messages are kept", async () => {
+    const { generateText } = await import("ai");
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: "Summary of prior context",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    const messages: ModelMessage[] = [
+      { content: "old message 1", role: "user" },
+      { content: "old message 2", role: "assistant" },
+    ];
+
+    const model = {} as Parameters<typeof compactMessages>[1];
+    // recentWindowSize 0 forces an empty recent window, so the summary's
+    // assistant block would be the final message without the trailing guard.
+    const result = await compactMessages(messages, model, {
+      ...config,
+      recentWindowSize: 0,
+    });
+
+    expect(result.at(-1)).toEqual({ content: "Continue.", role: "user" });
+    expect(result[0]).toEqual({
+      content: "Summary of our conversation so far:",
+      role: "user",
+    });
+    expect(result[1]).toEqual({
+      content: "Summary of prior context",
+      role: "assistant",
+    });
+  });
+
   it("forwards provider options to the compaction model call", async () => {
     const { generateText } = await import("ai");
 
@@ -339,6 +370,10 @@ describe("compactMessages", () => {
       {
         content: "Summary of the large SQL result",
         role: "assistant",
+      },
+      {
+        content: "Continue.",
+        role: "user",
       },
     ]);
     expect(vi.mocked(generateText)).toHaveBeenCalledTimes(1);

--- a/packages/eve/src/harness/compaction.ts
+++ b/packages/eve/src/harness/compaction.ts
@@ -136,21 +136,22 @@ export async function compactMessages(
       temperature: 0,
     });
 
-    // The recent window may trail with an assistant message (e.g.
-    // deferred-input continuations where no user message was appended).
-    // Providers that don't support assistant prefill reject the request.
-    // Append a synthetic user message so the model resumes from a user turn.
-    const trailingAssistantGuard: ModelMessage[] =
-      recent.length > 0 && recent.at(-1)?.role === "assistant"
-        ? [{ role: "user", content: "Continue." }]
-        : [];
-
     const compacted: ModelMessage[] = [
       { content: "Summary of our conversation so far:", role: "user" },
       { content: result.text, role: "assistant" },
       ...recent,
-      ...trailingAssistantGuard,
     ];
+
+    // The compacted prompt may end on an assistant message — either because the
+    // recent window trails with one (deferred-input continuations) or because
+    // `recent` is empty and the summary block itself is the final message (a
+    // single oversized turn, or `keep` reaching 0). Providers that don't support
+    // assistant prefill (e.g. Anthropic) reject a prompt that doesn't end on a
+    // user turn, so append a synthetic user message whenever the assembled tail
+    // is still an assistant message.
+    if (compacted.at(-1)?.role === "assistant") {
+      compacted.push({ role: "user", content: "Continue." });
+    }
 
     if (estimateTokens(compacted) <= config.threshold || keep === 0) {
       return compacted;


### PR DESCRIPTION
Fixes #80.

### Problem

After compaction, the next model call can fail terminally on Anthropic models with *"This model does not support assistant message prefill. The conversation must end with a user message."*

The existing trailing-assistant guard only fires when the **kept recent window** trails with an assistant message (`recent.length > 0 && recent.at(-1)?.role === "assistant"`). It never covers the case where `recent` is empty — a single oversized tool-result turn, or `keep` decaying to 0 — so the summary's own assistant block becomes the final message, the guard is skipped, and Anthropic rejects the prompt. The turn cannot recover, since each retry re-compacts to the same assistant-terminal shape.

### Fix

Move the guard off `recent` and onto the fully-assembled `compacted` array: append the synthetic `"Continue."` user message whenever the final message is an assistant turn, however it got there.

```ts
const compacted: ModelMessage[] = [
  { content: "Summary of our conversation so far:", role: "user" },
  { content: result.text, role: "assistant" },
  ...recent,
];

if (compacted.at(-1)?.role === "assistant") {
  compacted.push({ role: "user", content: "Continue." });
}
```

### Tests

- Adds a regression test: `recentWindowSize: 0` forces an empty recent window, and the compacted result must still end on a user turn.
- Updates the existing `folds oversized recent tool results into the summary...` test, which had asserted the buggy assistant-terminal output; it now expects the trailing `"Continue."` user turn.

`pnpm run test:unit -- compaction` → all green (26 passing).
