### PR TITLE
feat(eve): slack - show reasoning typing indicators

### DIFF
--- a/.changeset/slack-reasoning-typing.md
+++ b/.changeset/slack-reasoning-typing.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack channels now refresh assistant thread typing status during streamed reasoning, using a truncated reasoning snippet so long reasoning steps keep visible progress before tool calls or final replies.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -78,7 +78,7 @@ export default slackChannel({
 
 ### Delivery
 
-The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, tool status on `actions.requested`. Override `onAppMention` or the `events` handlers to customize.
+The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets are visible in Slack status while the model is thinking; override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
 
 When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), it anchors on the first agent post, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -20,6 +20,7 @@ import type {
 } from "#public/channels/slack/slackChannel.js";
 
 const log = createLogger("slack.defaults");
+const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
 
 /**
  * Workspace-scoped projection of the Slack actor that produced
@@ -113,7 +114,26 @@ export function defaultInputRequestedHandler(): NonNullable<SlackChannelEvents["
 export const defaultEvents: SlackChannelInternalEvents = {
   async "turn.started"(_event, channel, _ctx) {
     channel.state.pendingToolCallMessage = null;
+    channel.state.lastReasoningTypingAtMs = null;
+    channel.state.lastReasoningTypingStatus = null;
     await channel.thread.startTyping("Working...");
+  },
+
+  async "reasoning.appended"(event, channel, _ctx) {
+    const line = firstNonEmptyLine(event.reasoningSoFar);
+    if (line === undefined) return;
+
+    const now = Date.now();
+    const lastAt = channel.state.lastReasoningTypingAtMs;
+    if (lastAt !== null && lastAt !== undefined) {
+      const elapsed = now - lastAt;
+      if (elapsed >= 0 && elapsed < REASONING_TYPING_REFRESH_INTERVAL_MS) return;
+    }
+
+    const status = truncateTypingStatus(line);
+    await channel.thread.startTyping(status);
+    channel.state.lastReasoningTypingAtMs = now;
+    channel.state.lastReasoningTypingStatus = status;
   },
 
   async "actions.requested"(event, channel, _ctx) {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "node:crypto";
 
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildAdapterContext } from "#channel/adapter-context.js";
 import { callAdapterEventHandler, type ChannelAdapter } from "#channel/adapter.js";
@@ -262,6 +262,9 @@ describe("slackChannel() default event handlers", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
   });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("message.completed posts the agent message via Slack API", async () => {
     const adapter = withState(
@@ -439,6 +442,119 @@ describe("slackChannel() default event handlers", () => {
       status: "Working...",
       loading_messages: ["Working..."],
     });
+  });
+
+  it("reasoning.appended calls assistant.threads.setStatus with a truncated snippet", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+    const longReasoning =
+      "Need to inspect the implementation and verify the Slack typing status behavior before editing.";
+
+    await callEvent(
+      adapter,
+      makeEvent("reasoning.appended", {
+        reasoningDelta: longReasoning,
+        reasoningSoFar: `${longReasoning}\nThen continue.`,
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://slack.com/api/assistant.threads.setStatus");
+    const body = parseSlackRequestBody(init as RequestInit);
+    expect(body).toMatchObject({
+      channel_id: "C01",
+      thread_ts: "1700000000.000001",
+    });
+    expect((body.status as string).length).toBeLessThanOrEqual(50);
+    expect((body.status as string).endsWith("...")).toBe(true);
+    expect(body.loading_messages).toEqual([body.status]);
+    expect(ctx.state.lastReasoningTypingStatus).toBe(body.status);
+  });
+
+  it("reasoning.appended throttles repeated status refreshes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-18T12:00:00Z"));
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+    const reasoningEvent = (reasoningSoFar: string) =>
+      makeEvent("reasoning.appended", {
+        reasoningDelta: reasoningSoFar,
+        reasoningSoFar,
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      });
+
+    await callEvent(adapter, reasoningEvent("Need to inspect the repo."), ctx);
+    vi.setSystemTime(new Date("2026-06-18T12:00:01Z"));
+    await callEvent(adapter, reasoningEvent("Need to inspect the repo. Then test."), ctx);
+    vi.setSystemTime(new Date("2026-06-18T12:00:05Z"));
+    await callEvent(adapter, reasoningEvent("Need to inspect the repo. Then test again."), ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const statuses = fetchMock.mock.calls.map(
+      ([, init]) => parseSlackRequestBody(init as RequestInit).status,
+    );
+    expect(statuses).toEqual([
+      "Need to inspect the repo.",
+      "Need to inspect the repo. Then test again.",
+    ]);
+  });
+
+  it("turn.started resets reasoning status throttling", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-18T12:00:00Z"));
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("reasoning.appended", {
+        reasoningDelta: "Need to inspect the repo.",
+        reasoningSoFar: "Need to inspect the repo.",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+    vi.setSystemTime(new Date("2026-06-18T12:00:01Z"));
+    await callEvent(
+      adapter,
+      makeEvent("turn.started", { sequence: 0, stepIndex: 0, turnId: "t2" }),
+      ctx,
+    );
+    await callEvent(
+      adapter,
+      makeEvent("reasoning.appended", {
+        reasoningDelta: "Fresh turn reasoning.",
+        reasoningSoFar: "Fresh turn reasoning.",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "t2",
+      }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const statuses = fetchMock.mock.calls.map(
+      ([, init]) => parseSlackRequestBody(init as RequestInit).status,
+    );
+    expect(statuses).toEqual(["Need to inspect the repo.", "Working...", "Fresh turn reasoning."]);
   });
 
   it("session.failed posts a terminal markdown message with error hint and id", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -171,6 +171,13 @@ export interface SlackChannelState {
    */
   pendingToolCallMessage?: string | null;
   /**
+   * Last reasoning-derived typing indicator sent by the default
+   * `reasoning.appended` handler. Used to refresh Slack's status during
+   * long reasoning streams without sending one API call per delta.
+   */
+  lastReasoningTypingAtMs?: number | null;
+  lastReasoningTypingStatus?: string | null;
+  /**
    * Connection name to Slack message ts. Each entry is the public
    * link-free fallback status post created by the default
    * `authorization.required` handler when the challenge could not be
@@ -318,6 +325,8 @@ export interface SlackChannelEvents {
   readonly "action.result"?: SlackEventHandler<"action.result">;
   readonly "message.completed"?: SlackEventHandler<"message.completed">;
   readonly "message.appended"?: SlackEventHandler<"message.appended">;
+  readonly "reasoning.appended"?: SlackEventHandler<"reasoning.appended">;
+  readonly "reasoning.completed"?: SlackEventHandler<"reasoning.completed">;
   readonly "input.requested"?: SlackEventHandler<"input.requested">;
   readonly "turn.failed"?: SlackEventHandler<"turn.failed">;
   readonly "turn.completed"?: SlackEventHandler<"turn.completed">;
@@ -495,6 +504,8 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       teamId: null as string | null,
       triggeringUserId: null,
       pendingToolCallMessage: null,
+      lastReasoningTypingAtMs: null,
+      lastReasoningTypingStatus: null,
       pendingAuthMessageTs: {},
     },
     fetchFile: slackFetchFile,

--- a/packages/eve/src/public/definitions/defineChannel.test.ts
+++ b/packages/eve/src/public/definitions/defineChannel.test.ts
@@ -374,6 +374,86 @@ describe("defineChannel", () => {
     expect(typeof capturedChannel.setContinuationToken).toBe("function");
   });
 
+  it("registers reasoning event handlers with channel and session context", async () => {
+    let appendedData: unknown;
+    let completedData: unknown;
+    let capturedChannel: any;
+    let capturedCtx: any;
+    const channel = defineChannel({
+      routes: [POST("/x", async () => new Response("ok"))],
+      events: {
+        "reasoning.appended": (data, ch, ctx) => {
+          appendedData = data;
+          capturedChannel = ch;
+          capturedCtx = ctx;
+        },
+        "reasoning.completed": (data) => {
+          completedData = data;
+        },
+      },
+    });
+
+    const adapter = getAdapter(channel);
+    const session: Session = {
+      auth: { current: null, initiator: null },
+      sessionId: "sess-channel-test",
+      turn: { id: "turn-1", sequence: 0 },
+    };
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, session);
+
+    const accessor: ContextAccessor = {
+      get: (key) => ctx.get(key as any),
+      has: (key) => ctx.has(key as any),
+      require: (key) => ctx.require(key as any),
+      set: (key, value) => ctx.set(key as any, value),
+      ensure: (key, create) => ctx.ensure(key as any, create),
+    };
+    const adapterCtx = buildAdapterContext(adapter, accessor);
+
+    await contextStorage.run(ctx, async () => {
+      await callAdapterEventHandler(
+        adapter,
+        {
+          type: "reasoning.appended",
+          data: {
+            reasoningDelta: "Need",
+            reasoningSoFar: "Need",
+            sequence: 0,
+            stepIndex: 0,
+            turnId: "turn-1",
+          },
+        },
+        adapterCtx,
+      );
+      await callAdapterEventHandler(
+        adapter,
+        {
+          type: "reasoning.completed",
+          data: {
+            reasoning: "Need to inspect the repo.",
+            sequence: 0,
+            stepIndex: 0,
+            turnId: "turn-1",
+          },
+        },
+        adapterCtx,
+      );
+    });
+
+    expect(appendedData).toMatchObject({
+      reasoningDelta: "Need",
+      reasoningSoFar: "Need",
+      turnId: "turn-1",
+    });
+    expect(completedData).toMatchObject({
+      reasoning: "Need to inspect the repo.",
+      turnId: "turn-1",
+    });
+    expect(typeof capturedChannel.continuationToken).toBe("string");
+    expect(capturedCtx.session.id).toBe("sess-channel-test");
+  });
+
   it("session.failed handler receives no ctx parameter", async () => {
     let called = false;
     let argCount = 0;

--- a/packages/eve/src/public/definitions/defineChannel.ts
+++ b/packages/eve/src/public/definitions/defineChannel.ts
@@ -75,6 +75,8 @@ export interface ChannelEvents<TCtx = void> {
   readonly "action.result"?: ChannelEventHandler<"action.result", TCtx>;
   readonly "message.completed"?: ChannelEventHandler<"message.completed", TCtx>;
   readonly "message.appended"?: ChannelEventHandler<"message.appended", TCtx>;
+  readonly "reasoning.appended"?: ChannelEventHandler<"reasoning.appended", TCtx>;
+  readonly "reasoning.completed"?: ChannelEventHandler<"reasoning.completed", TCtx>;
   readonly "input.requested"?: ChannelEventHandler<"input.requested", TCtx>;
   readonly "turn.failed"?: ChannelEventHandler<"turn.failed", TCtx>;
   readonly "turn.completed"?: ChannelEventHandler<"turn.completed", TCtx>;
@@ -234,6 +236,8 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
     "action.result",
     "message.completed",
     "message.appended",
+    "reasoning.appended",
+    "reasoning.completed",
     "input.requested",
     "turn.failed",
     "turn.completed",


### PR DESCRIPTION
## Summary

- expose reasoning stream events through the public channel event surface
- refresh Slack assistant thread status from reasoning snippets during long reasoning streams
- document the visible reasoning-status behavior and add a patch changeset

## Why

Slack only refreshed typing/status indicators on inbound handling, turn start, and tool requests. Long model reasoning steps could therefore go quiet before a tool call or final message. This keeps progress visible by updating the Slack status from the first non-empty reasoning line, throttled to avoid one API call per stream delta.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/definitions/defineChannel.test.ts src/public/channels/slack/slackChannel.test.ts`
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:scenario`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm build`
