### PR TITLE
prevent cache poisoning in container workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
 
       - name: Validate VCR configuration
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
### Description

Scanning our actions with [zizmor](https://github.com/zizmorcore/zizmor) warned about be open to [cache poisoning](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/). This PR just turns it off for the affected step,  as [recommended in setup-node](https://github.com/actions/setup-node). 

The build times are [super fast (4s with 33% caching)](https://github.com/vercel/eve/actions/runs/27785007333) so it should be fine to not use the cache.


### How did you test your changes?
Merging would test this - since it's a workflow I can't really test it locally.

### PR Checklist

- [Not applicable] I ran the relevant checks from `CONTRIBUTING.md`
- [Not applicable] I added tests and documentation where relevant
- [Not applicable] I added a changeset if this touches the published `eve` package
- [X] DCO sign-off passes for every commit (`git commit --signoff`)
