### PR TITLE
Add pip to sandbox Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN set -eux; \
     jq \
     python-is-python3 \
     python3 \
+    python3-pip \
     ripgrep \
     sudo \
     unzip \
@@ -57,6 +58,8 @@ RUN set -eux; \
   pnpm --version; \
   python --version; \
   python3 --version; \
+  pip --version; \
+  pip3 --version; \
   dig -v; \
   gpgv --version | head -1; \
   git --version; \


### PR DESCRIPTION
## Summary
- install python3-pip in the sandbox Docker image
- verify pip and pip3 during the image build alongside the existing Python checks

## Why pip instead of uv?
The image already includes Python, so python3-pip is the smallest standard package-installer addition.

Local arm64 image-size measurement:
- python3-pip: about +11.4 MiB
- optimized uv/uvx: about +48.0 MiB

## Verification
- docker build -t eve-add-pip-check -f Dockerfile .
- docker run --rm eve-add-pip-check bash -lc 'python --version; python3 --version; pip --version; pip3 --version'