### PR TITLE
fix(eve): resolve dev model module map from authored source

### DIFF
--- a/.changeset/dev-schedule-channel-model-resolution.md
+++ b/.changeset/dev-schedule-channel-model-resolution.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `eve dev` failing with `LoadCompiledModuleMapError` when resolving an agent's model for an app that has a `run`-handler schedule (or any module-map entry) which statically imports an authored channel. Runtime model resolution now loads the dev module map through the authored-source hydrator, matching the rest of the dev runtime, so authored `.js` import specifiers resolve to their `.ts` sources. Production builds are unaffected.

--- a/packages/eve/src/runtime/agent/resolve-model.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.ts
@@ -8,7 +8,7 @@ import {
 } from "#internal/authored-module.js";
 import type { ModuleDefinitionExport } from "#public/definitions/source.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
-import { loadCompiledModuleMap } from "#runtime/loaders/module-map.js";
+import { loadRuntimeCompiledModuleMap } from "#runtime/sessions/compiled-agent-cache.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import { resolveBootstrapRuntimeModel } from "#runtime/agent/bootstrap-model.js";
 import {
@@ -60,9 +60,7 @@ async function loadSourceBackedRuntimeModelReference(
     );
   }
 
-  const moduleMap = await loadCompiledModuleMap({
-    compiledArtifactsSource: input.compiledArtifactsSource,
-  });
+  const moduleMap = await loadRuntimeCompiledModuleMap(input.compiledArtifactsSource);
   const moduleNamespace =
     moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules[reference.source.sourceId];
 

--- a/packages/eve/src/runtime/sessions/compiled-agent-cache.ts
+++ b/packages/eve/src/runtime/sessions/compiled-agent-cache.ts
@@ -65,7 +65,7 @@ async function loadFullBundle(
   };
 }
 
-async function loadRuntimeCompiledModuleMap(
+export async function loadRuntimeCompiledModuleMap(
   compiledArtifactsSource: RuntimeCompiledArtifactsSource,
 ): Promise<CompiledModuleMap> {
   if (

--- a/packages/eve/test/scenarios/schedule-channel-model-resolution.scenario.test.ts
+++ b/packages/eve/test/scenarios/schedule-channel-model-resolution.scenario.test.ts
@@ -1,0 +1,219 @@
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+
+import type { HandleMessageStreamEvent } from "eve/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  type ScenarioAppDescriptor,
+  useScenarioApp,
+} from "../../src/internal/testing/scenario-app.js";
+import { sendDevelopmentMessage } from "../dev-client-harness/send-message.js";
+import { createDevelopmentSessionState } from "../dev-client-harness/session.js";
+
+const scenarioApp = useScenarioApp();
+const SCENARIO_TIMEOUT_MS = 360_000;
+
+const TSCONFIG_SOURCE = `${JSON.stringify(
+  {
+    compilerOptions: {
+      allowJs: true,
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      noEmit: true,
+      strict: true,
+      target: "ES2024",
+    },
+    include: ["agent/**/*"],
+  },
+  null,
+  2,
+)}\n`;
+
+const SCHEDULE_CHANNEL_AGENT: ScenarioAppDescriptor = {
+  files: {
+    "agent/agent.ts": [
+      'import { defineAgent } from "eve";',
+      'import { gateway } from "ai";',
+      "",
+      "export default defineAgent({",
+      '  model: gateway("openai/gpt-5.5"),',
+      "  // Pin context-window metadata so compile stays credential-free.",
+      "  modelContextWindowTokens: 200_000,",
+      "});",
+      "",
+    ].join("\n"),
+    "agent/channels/probe.ts": [
+      'import { defineChannel, POST } from "eve/channels";',
+      "",
+      "export default defineChannel({",
+      '  routes: [POST("/probe", async () => Response.json({ ok: true }))],',
+      "  async receive(input, { send }) {",
+      '    return send(input.message, { auth: input.auth, continuationToken: "probe" });',
+      "  },",
+      "});",
+      "",
+    ].join("\n"),
+    "agent/instructions.md": "Probe agent.\n",
+    "agent/schedules/digest.ts": [
+      'import { defineSchedule } from "eve/schedules";',
+      'import probe from "../channels/probe.js";',
+      "",
+      "export default defineSchedule({",
+      '  cron: "0 0 * * *",',
+      "  async run({ receive, waitUntil, appAuth }) {",
+      "    waitUntil(",
+      "      receive(probe, {",
+      '        message: "scheduled ping",',
+      '        target: { sessionRef: "probe" },',
+      "        auth: appAuth,",
+      "      }),",
+      "    );",
+      "  },",
+      "});",
+      "",
+    ].join("\n"),
+    "tsconfig.json": TSCONFIG_SOURCE,
+  },
+  installDependencies: true,
+  name: "schedule-channel-model-resolution",
+};
+
+interface RunningEveDev {
+  readonly output: () => string;
+  readonly url: string;
+  stop(): Promise<void>;
+}
+
+function stripAnsi(text: string): string {
+  return text
+    .split("[")
+    .map((segment, index) => (index === 0 ? segment : segment.replace(/^[0-9;]*m/, "")))
+    .join("");
+}
+
+function parseServerUrl(output: string): string | undefined {
+  return /server listening at (https?:\/\/\S+)/.exec(stripAnsi(output))?.[1];
+}
+
+async function startEveDev(appRoot: string): Promise<RunningEveDev> {
+  const eveBinPath = join(appRoot, "node_modules", "eve", "bin", "eve.js");
+  const child = spawn(
+    process.execPath,
+    [eveBinPath, "dev", "--no-ui", "--host", "127.0.0.1", "--port", "0"],
+    {
+      cwd: appRoot,
+      env: {
+        ...process.env,
+        // NODE_ENV=test would mock the model and skip the resolution path
+        // under test, so run with real resolution.
+        NODE_ENV: "development",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let combined = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    combined += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    combined += chunk;
+  });
+
+  const url = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for eve dev to start.\noutput:\n${combined}`));
+    }, 120_000);
+
+    const settle = () => {
+      const candidate = parseServerUrl(combined);
+      if (candidate !== undefined) {
+        clearTimeout(timeout);
+        child.stdout.off("data", settle);
+        child.stderr.off("data", settle);
+        resolve(candidate);
+      }
+    };
+
+    child.stdout.on("data", settle);
+    child.stderr.on("data", settle);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(
+        new Error(
+          `eve dev exited before listening (code ${String(code)}, signal ${String(signal)}).\noutput:\n${combined}`,
+        ),
+      );
+    });
+    settle();
+  });
+
+  return {
+    output: () => combined,
+    async stop() {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          child.kill("SIGKILL");
+          resolve();
+        }, 10_000);
+        child.once("exit", () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+        child.kill("SIGTERM");
+      });
+    },
+    url,
+  };
+}
+
+describe("dev model resolution with a run-handler schedule importing a channel", () => {
+  it(
+    "resolves the source-backed model without a module-map load error",
+    async () => {
+      const app = await scenarioApp(SCHEDULE_CHANNEL_AGENT);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        // No model credentials, so the turn is expected to fail; assert only
+        // that it started (not a vacuous pass) and failed past model resolution
+        // rather than on the module-map regression.
+        const events: HandleMessageStreamEvent[] = [];
+        let thrown = "";
+        try {
+          await sendDevelopmentMessage({
+            message: "hello",
+            session: createDevelopmentSessionState(),
+            serverUrl: server.url,
+            onEvent: (event) => events.push(event),
+          });
+        } catch (error) {
+          thrown = String(error);
+        }
+
+        expect(
+          events.length > 0,
+          [
+            "Expected the dev message route to stream at least one session event.",
+            `thrown: ${thrown}`,
+            `output:\n${server.output()}`,
+          ].join("\n\n"),
+        ).toBe(true);
+
+        const combined = `${JSON.stringify(events)}\n${thrown}\n${server.output()}`;
+        expect(
+          combined.includes("LoadCompiledModuleMapError"),
+          `Model resolution hit the dev module-map regression.\n${combined}`,
+        ).toBe(false);
+      } finally {
+        await server.stop();
+      }
+    },
+    SCENARIO_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
### Description

Fixes #104.

Under `eve dev`, model resolution loaded the compiled module map with the raw loader (`loadCompiledModuleMap`). That loader statically re-imports authored entry modules, so a `run`-handler schedule importing a channel via a `.js` specifier crashed the turn with `LoadCompiledModuleMapError` (native ESM can't map the `.js` specifier to the dev snapshot's `.ts` source). Builds and production were unaffected.

The fix routes model resolution through the runtime's existing `loadRuntimeCompiledModuleMap` (now exported from `compiled-agent-cache.ts`), which already hydrates source-backed/dev runs through the authored-source loader and falls back to the raw loader for bundled/production. One call swapped; production path unchanged.

### How did you test your changes?

- Added `packages/eve/test/scenarios/schedule-channel-model-resolution.scenario.test.ts`: spawns a real `eve dev` subprocess (with real, unmocked model resolution) for an agent whose `run`-handler schedule imports a channel, then asserts a turn starts and resolution does not raise `LoadCompiledModuleMapError`. It fails before the fix with the exact error and passes after. (In-process tests can't catch this: vitest's resolver maps `.js`→`.ts`, and the model mock seam skips the load.)
- Manually verified against a real agent running this branch's build: a `run`-handler schedule that delivers to a Telegram channel failed with `LoadCompiledModuleMapError` under `eve dev` before the fix, and after it the session resolved the model, ran the turn, and delivered the message.
- `pnpm typecheck`, `pnpm lint`, `pnpm guard:invariants`, `pnpm test:unit`, `pnpm test:integration`, `pnpm test:scenario` all pass.

### PR Checklist

- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
