### PR TITLE
fix(eve): slack - stream reasoning status progressively

### DIFF
--- a/.changeset/smart-slack-reasoning.md
+++ b/.changeset/smart-slack-reasoning.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Slack reasoning typing indicators now keep the generic working status until streamed reasoning contains a meaningful snippet, preventing partial opening words from remaining visible during short reasoning steps.
+Slack reasoning typing indicators now update progressively when the cumulative status grows by at least four characters, preventing opening fragments from remaining stale without issuing one Slack request per token.

--- a/.changeset/smart-slack-reasoning.md
+++ b/.changeset/smart-slack-reasoning.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack reasoning typing indicators now keep the generic working status until streamed reasoning contains a meaningful snippet, preventing partial opening words from remaining visible during short reasoning steps.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -78,7 +78,7 @@ export default slackChannel({
 
 ### Delivery
 
-The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets replace `Working…` once the streamed first line is complete or long enough to be meaningful, so partial opening words never become the status. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
+The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets build progressively: extensions of at least four characters appear immediately, while smaller streamed deltas use the five-second refresh interval to avoid one Slack request per token. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
 
 When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), it anchors on the first agent post, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -78,7 +78,7 @@ export default slackChannel({
 
 ### Delivery
 
-The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets are visible in Slack status while the model is thinking; override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
+The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets replace `Working…` once the streamed first line is complete or long enough to be meaningful, so partial opening words never become the status. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
 
 When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), it anchors on the first agent post, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -21,7 +21,7 @@ import type {
 
 const log = createLogger("slack.defaults");
 const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
-const REASONING_TYPING_MIN_FRAGMENT_LENGTH = 32;
+const REASONING_TYPING_MIN_PROGRESS_CHARS = 4;
 
 /**
  * Workspace-scoped projection of the Slack actor that produced
@@ -88,32 +88,6 @@ function firstNonEmptyLine(text: string): string | undefined {
 }
 
 /**
- * Returns the first reasoning line once it contains enough context for a
- * useful status. Providers may stream initial deltas as single words, so a
- * short line waits for punctuation or a newline while `Working...` remains
- * visible. Longer fragments are useful even before the sentence completes.
- */
-function firstMeaningfulReasoningLine(text: string): string | undefined {
-  const lines = text.split(/\r?\n/u);
-  for (const [index, line] of lines.entries()) {
-    const trimmed = line.trim();
-    if (trimmed.length === 0) continue;
-
-    const isCompleteLine = index < lines.length - 1;
-    const hasTerminalPunctuation = /[.!?…]["')\]}]*$/u.test(trimmed);
-    if (
-      isCompleteLine ||
-      hasTerminalPunctuation ||
-      trimmed.length >= REASONING_TYPING_MIN_FRAGMENT_LENGTH
-    ) {
-      return trimmed;
-    }
-    return undefined;
-  }
-  return undefined;
-}
-
-/**
  * Default `input.requested` handler — renders each pending HITL
  * request as Slack `block_actions`. Buttons by default; radio for
  * ≤6-option select requests; static_select for >6-option select
@@ -147,17 +121,23 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "reasoning.appended"(event, channel, _ctx) {
-    const line = firstMeaningfulReasoningLine(event.reasoningSoFar);
+    const line = firstNonEmptyLine(event.reasoningSoFar);
     if (line === undefined) return;
 
+    const status = truncateTypingStatus(line);
+    const lastStatus = channel.state.lastReasoningTypingStatus;
+    const isProgressiveExtension =
+      lastStatus !== null &&
+      lastStatus !== undefined &&
+      status.startsWith(lastStatus) &&
+      status.length >= lastStatus.length + REASONING_TYPING_MIN_PROGRESS_CHARS;
     const now = Date.now();
     const lastAt = channel.state.lastReasoningTypingAtMs;
-    if (lastAt !== null && lastAt !== undefined) {
+    if (!isProgressiveExtension && lastAt !== null && lastAt !== undefined) {
       const elapsed = now - lastAt;
       if (elapsed >= 0 && elapsed < REASONING_TYPING_REFRESH_INTERVAL_MS) return;
     }
 
-    const status = truncateTypingStatus(line);
     await channel.thread.startTyping(status);
     channel.state.lastReasoningTypingAtMs = now;
     channel.state.lastReasoningTypingStatus = status;

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -21,6 +21,7 @@ import type {
 
 const log = createLogger("slack.defaults");
 const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
+const REASONING_TYPING_MIN_FRAGMENT_LENGTH = 32;
 
 /**
  * Workspace-scoped projection of the Slack actor that produced
@@ -87,6 +88,32 @@ function firstNonEmptyLine(text: string): string | undefined {
 }
 
 /**
+ * Returns the first reasoning line once it contains enough context for a
+ * useful status. Providers may stream initial deltas as single words, so a
+ * short line waits for punctuation or a newline while `Working...` remains
+ * visible. Longer fragments are useful even before the sentence completes.
+ */
+function firstMeaningfulReasoningLine(text: string): string | undefined {
+  const lines = text.split(/\r?\n/u);
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+
+    const isCompleteLine = index < lines.length - 1;
+    const hasTerminalPunctuation = /[.!?…]["')\]}]*$/u.test(trimmed);
+    if (
+      isCompleteLine ||
+      hasTerminalPunctuation ||
+      trimmed.length >= REASONING_TYPING_MIN_FRAGMENT_LENGTH
+    ) {
+      return trimmed;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
  * Default `input.requested` handler — renders each pending HITL
  * request as Slack `block_actions`. Buttons by default; radio for
  * ≤6-option select requests; static_select for >6-option select
@@ -120,7 +147,7 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "reasoning.appended"(event, channel, _ctx) {
-    const line = firstNonEmptyLine(event.reasoningSoFar);
+    const line = firstMeaningfulReasoningLine(event.reasoningSoFar);
     if (line === undefined) return;
 
     const now = Date.now();

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -255,10 +255,12 @@ async function firePost(
 describe("slackChannel() default event handlers", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   beforeEach(() => {
-    fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
-        headers: { "content-type": "application/json" },
-      }),
+    fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
+          headers: { "content-type": "application/json" },
+        }),
+      ),
     );
     vi.stubGlobal("fetch", fetchMock);
   });
@@ -479,7 +481,9 @@ describe("slackChannel() default event handlers", () => {
     expect(ctx.state.lastReasoningTypingStatus).toBe(body.status);
   });
 
-  it("reasoning.appended does not replace the fallback with streamed opening words", async () => {
+  it("reasoning.appended immediately publishes progressive extensions of four characters", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-18T12:00:00Z"));
     const adapter = withState(
       getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
       THREAD_STATE,
@@ -495,45 +499,16 @@ describe("slackChannel() default event handlers", () => {
       });
 
     await callEvent(adapter, reasoningEvent("I", "I"), ctx);
-    await callEvent(adapter, reasoningEvent(" need", "I need"), ctx);
-    expect(fetchMock).not.toHaveBeenCalled();
+    await callEvent(adapter, reasoningEvent(" ca", "I ca"), ctx);
+    await callEvent(adapter, reasoningEvent("n", "I can"), ctx);
 
-    await callEvent(
-      adapter,
-      reasoningEvent(" to inspect the implementation", "I need to inspect the implementation"),
-      ctx,
+    const statuses = fetchMock.mock.calls.map(
+      ([, init]) => parseSlackRequestBody(init as RequestInit).status,
     );
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
-    expect(body.status).toBe("I need to inspect the implementation");
+    expect(statuses).toEqual(["I", "I can"]);
   });
 
-  it("reasoning.appended accepts a completed short line", async () => {
-    const adapter = withState(
-      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
-      THREAD_STATE,
-    );
-    const ctx = buildAdapterContext(adapter, stubAccessor());
-
-    await callEvent(
-      adapter,
-      makeEvent("reasoning.appended", {
-        reasoningDelta: "Check logs.",
-        reasoningSoFar: "Check logs.",
-        sequence: 0,
-        stepIndex: 0,
-        turnId: "t1",
-      }),
-      ctx,
-    );
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
-    expect(body.status).toBe("Check logs.");
-  });
-
-  it("reasoning.appended throttles repeated status refreshes", async () => {
+  it("reasoning.appended requires a matching prefix and four new characters", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-18T12:00:00Z"));
     const adapter = withState(
@@ -550,20 +525,18 @@ describe("slackChannel() default event handlers", () => {
         turnId: "t1",
       });
 
-    await callEvent(adapter, reasoningEvent("Need to inspect the repo."), ctx);
+    await callEvent(adapter, reasoningEvent("Need"), ctx);
     vi.setSystemTime(new Date("2026-06-18T12:00:01Z"));
-    await callEvent(adapter, reasoningEvent("Need to inspect the repo. Then test."), ctx);
+    await callEvent(adapter, reasoningEvent("Need to"), ctx);
+    await callEvent(adapter, reasoningEvent("Check something else"), ctx);
     vi.setSystemTime(new Date("2026-06-18T12:00:05Z"));
-    await callEvent(adapter, reasoningEvent("Need to inspect the repo. Then test again."), ctx);
+    await callEvent(adapter, reasoningEvent("Need to"), ctx);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const statuses = fetchMock.mock.calls.map(
       ([, init]) => parseSlackRequestBody(init as RequestInit).status,
     );
-    expect(statuses).toEqual([
-      "Need to inspect the repo.",
-      "Need to inspect the repo. Then test again.",
-    ]);
+    expect(statuses).toEqual(["Need", "Need to"]);
   });
 
   it("turn.started resets reasoning status throttling", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -479,6 +479,60 @@ describe("slackChannel() default event handlers", () => {
     expect(ctx.state.lastReasoningTypingStatus).toBe(body.status);
   });
 
+  it("reasoning.appended does not replace the fallback with streamed opening words", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+    const reasoningEvent = (reasoningDelta: string, reasoningSoFar: string) =>
+      makeEvent("reasoning.appended", {
+        reasoningDelta,
+        reasoningSoFar,
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      });
+
+    await callEvent(adapter, reasoningEvent("I", "I"), ctx);
+    await callEvent(adapter, reasoningEvent(" need", "I need"), ctx);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await callEvent(
+      adapter,
+      reasoningEvent(" to inspect the implementation", "I need to inspect the implementation"),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
+    expect(body.status).toBe("I need to inspect the implementation");
+  });
+
+  it("reasoning.appended accepts a completed short line", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("reasoning.appended", {
+        reasoningDelta: "Check logs.",
+        reasoningSoFar: "Check logs.",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
+    expect(body.status).toBe("Check logs.");
+  });
+
   it("reasoning.appended throttles repeated status refreshes", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-18T12:00:00Z"));

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -172,8 +172,8 @@ export interface SlackChannelState {
   pendingToolCallMessage?: string | null;
   /**
    * Last reasoning-derived typing indicator sent by the default
-   * `reasoning.appended` handler. Used to refresh Slack's status during
-   * long reasoning streams without sending one API call per delta.
+   * `reasoning.appended` handler. Used to surface substantial progressive
+   * extensions immediately while throttling smaller streamed deltas.
    */
   lastReasoningTypingAtMs?: number | null;
   lastReasoningTypingStatus?: string | null;


### PR DESCRIPTION
## Summary

- publish the first streamed reasoning fragment immediately
- publish a cumulative status immediately when it extends the last displayed prefix by at least four characters
- preserve the existing five-second refresh throttle for smaller or non-prefix updates
- document the behavior and include a patch changeset

## Root cause

The `reasoning.appended` handler published the first provider delta immediately and then throttled every subsequent update for five seconds. Providers can emit token-sized opening deltas such as `I` or `The`, so short reasoning steps could finish before Slack received a useful replacement.

The handler now remembers the last displayed reasoning status. A cumulative update that preserves that prefix and adds at least four characters bypasses the timer, creating a progressive typing effect. Smaller deltas remain throttled so token-sized provider chunks do not each issue a Slack request.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm build`
- `pnpm test:unit` — 3,630 passed
- `pnpm test:integration` — 318 passed
- `pnpm test:scenario` — 251 passed, 15 platform-dependent skips; two temporary tarball-copy failures passed on isolated rerun (37 tests)
