### PR TITLE
Docs: add resources page

### DIFF
--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -7,11 +7,11 @@ const title = "Resources";
 const description = "Guides, templates, and examples to help you build with eve.";
 
 const kindClassName: Record<ResourceKind, string> = {
-  Community: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
-  Example: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
-  Guide: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
-  Reference: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
-  Template: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
+  Community: "border-transparent bg-gray-300 text-gray-1000",
+  Example: "border-transparent bg-gray-300 text-gray-1000",
+  Guide: "border-transparent bg-gray-300 text-gray-1000",
+  Reference: "border-transparent bg-gray-300 text-gray-1000",
+  Template: "border-transparent bg-gray-300 text-gray-1000",
 };
 
 export const metadata: Metadata = {
@@ -24,22 +24,18 @@ export const generateStaticParams = () => Object.keys(translations).map((lang) =
 const ResourceCard = ({ resource }: { resource: Resource }) => {
   const isExternal = resource.href.startsWith("https://");
   const className =
-    "group flex min-h-[172px] flex-col rounded-xl border border-gray-alpha-400 bg-background-100 p-6 transition-colors hover:border-gray-alpha-500 hover:bg-gray-100 dark:bg-gray-100 dark:hover:bg-gray-200";
+    "flex h-full flex-col gap-3 rounded-xl border border-gray-alpha-400 bg-background-100 p-6 no-underline shadow-none transition-colors hover:bg-gray-100 dark:bg-gray-100 dark:hover:bg-gray-200";
   const content = (
     <>
       <span
-        className={`w-fit rounded-full px-3 py-1 font-medium text-xs xl:text-sm ${kindClassName[resource.kind]}`}
+        className={`inline-flex w-fit shrink-0 items-center justify-center rounded-full border px-2 py-0.5 font-medium text-xs ${kindClassName[resource.kind]}`}
       >
         {resource.kind}
       </span>
-      <div className="mt-6 flex flex-col gap-4 xl:mt-7 xl:gap-5">
-        <h2 className="line-clamp-2 font-medium text-gray-1000 text-xl leading-tight tracking-tight xl:text-2xl">
-          {resource.title}
-        </h2>
-        <p className="line-clamp-2 text-base text-gray-900 leading-relaxed xl:text-lg">
-          {resource.description}
-        </p>
-      </div>
+      <h2 className="line-clamp-2 text-balance font-medium text-base text-gray-1000 leading-snug">
+        {resource.title}
+      </h2>
+      <p className="line-clamp-2 text-gray-900 text-sm">{resource.description}</p>
     </>
   );
 
@@ -59,12 +55,14 @@ const ResourceCard = ({ resource }: { resource: Resource }) => {
 };
 
 const ResourcesPage = () => (
-  <main className="mx-auto w-full max-w-[1908px] px-4 pt-12 pb-24 sm:px-8 lg:px-16">
-    <header className="mb-16">
-      <h1 className="font-semibold text-4xl text-gray-1000 tracking-tight">{title}</h1>
-      <p className="mt-3 max-w-2xl text-gray-900 text-lg">{description}</p>
+  <main className="mx-auto w-full max-w-5xl px-4 pt-16 pb-16 sm:pt-24">
+    <header className="space-y-4 pb-8">
+      <h1 className="text-balance font-semibold text-[40px] text-gray-1000 leading-[1.1] tracking-tight sm:text-5xl">
+        {title}
+      </h1>
+      <p className="max-w-2xl text-gray-900 text-lg leading-relaxed">{description}</p>
     </header>
-    <div className="grid gap-5 sm:grid-cols-2 md:grid-cols-3">
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {resources.map((resource) => (
         <ResourceCard key={resource.title} resource={resource} />
       ))}

--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -25,15 +25,15 @@ const iconByKind: Record<ResourceKind, LucideIcon> = {
 
 const kindClassName: Record<ResourceKind, string> = {
   Community:
-    "border-gray-200 bg-gray-100 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400",
+    "border-gray-200 bg-gray-100 text-gray-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
   Example:
-    "border-amber-200 bg-amber-100 text-amber-900 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-300",
+    "border-amber-200 bg-amber-100 text-amber-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
   Guide:
-    "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-500/25 dark:bg-blue-500/10 dark:text-blue-300",
+    "border-blue-200 bg-blue-100 text-blue-800 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
   Reference:
-    "border-teal-200 bg-teal-100 text-teal-900 dark:border-teal-500/25 dark:bg-teal-500/10 dark:text-teal-300",
+    "border-teal-200 bg-teal-100 text-teal-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
   Template:
-    "border-violet-200 bg-violet-100 text-violet-900 dark:border-violet-500/25 dark:bg-violet-500/10 dark:text-violet-300",
+    "border-violet-200 bg-violet-100 text-violet-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
 };
 
 export const metadata: Metadata = {

--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -1,0 +1,118 @@
+import {
+  ArrowUpRight,
+  Blocks,
+  BookOpenText,
+  Library,
+  MessageSquareText,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { DocsLayout } from "@/components/geistdocs/docs-layout";
+import { translations } from "@/geistdocs";
+import { source } from "@/lib/geistdocs/source";
+import { type Resource, resources, type ResourceKind } from "@/lib/resources/data";
+
+const title = "Resources";
+const description = "Guides, templates, and examples to help you build with eve.";
+
+const iconByKind: Record<ResourceKind, LucideIcon> = {
+  Community: MessageSquareText,
+  Example: Workflow,
+  Guide: BookOpenText,
+  Reference: Library,
+  Template: Blocks,
+};
+
+const kindClassName: Record<ResourceKind, string> = {
+  Community: "bg-gray-100 text-gray-900",
+  Example: "bg-amber-100 text-amber-900",
+  Guide: "bg-blue-100 text-blue-800",
+  Reference: "bg-teal-100 text-teal-900",
+  Template: "bg-violet-100 text-violet-900",
+};
+
+export const metadata: Metadata = {
+  title,
+  description,
+};
+
+export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
+
+interface ResourcesPageProps {
+  params: Promise<{
+    lang: keyof typeof translations;
+  }>;
+}
+
+const ResourceCard = ({ resource }: { resource: Resource }) => {
+  const Icon = iconByKind[resource.kind];
+  const isExternal = resource.href.startsWith("https://");
+  const className =
+    "group flex min-h-48 flex-col justify-between rounded-lg border bg-background-100 p-5 transition-colors hover:border-gray-400 hover:bg-gray-100";
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-background text-gray-1000">
+          <Icon aria-hidden className="size-5" />
+        </span>
+        <span
+          className={`rounded-full px-2.5 py-0.5 font-medium text-xs ${kindClassName[resource.kind]}`}
+        >
+          {resource.kind}
+        </span>
+      </div>
+      <div className="mt-8 flex flex-col gap-2">
+        <h2 className="flex items-center gap-1.5 font-medium text-base text-gray-1000 tracking-tight">
+          {resource.title}
+          {isExternal ? (
+            <ArrowUpRight
+              aria-hidden
+              className="size-4 text-gray-700 opacity-0 transition-opacity group-hover:opacity-100"
+            />
+          ) : null}
+        </h2>
+        <p className="text-gray-900 text-sm leading-relaxed">{resource.description}</p>
+      </div>
+    </>
+  );
+
+  if (isExternal) {
+    return (
+      <a className={className} href={resource.href} rel="noopener noreferrer" target="_blank">
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link className={className} href={resource.href}>
+      {content}
+    </Link>
+  );
+};
+
+const ResourcesPage = async ({ params }: ResourcesPageProps) => {
+  const { lang } = await params;
+
+  return (
+    <div className="bg-background-100">
+      <DocsLayout tree={source.pageTree[lang]}>
+        <main className="mx-auto w-full max-w-[920px] px-4 pt-12 pb-24 sm:px-6 lg:px-8">
+          <header className="mb-10">
+            <h1 className="font-semibold text-4xl text-gray-1000 tracking-tight">{title}</h1>
+            <p className="mt-3 max-w-2xl text-gray-900 text-lg">{description}</p>
+          </header>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {resources.map((resource) => (
+              <ResourceCard key={resource.title} resource={resource} />
+            ))}
+          </div>
+        </main>
+      </DocsLayout>
+    </div>
+  );
+};
+
+export default ResourcesPage;

--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -1,12 +1,3 @@
-import {
-  ArrowUpRight,
-  Blocks,
-  BookOpenText,
-  Library,
-  MessageSquareText,
-  Workflow,
-  type LucideIcon,
-} from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { translations } from "@/geistdocs";
@@ -15,25 +6,12 @@ import { type Resource, resources, type ResourceKind } from "@/lib/resources/dat
 const title = "Resources";
 const description = "Guides, templates, and examples to help you build with eve.";
 
-const iconByKind: Record<ResourceKind, LucideIcon> = {
-  Community: MessageSquareText,
-  Example: Workflow,
-  Guide: BookOpenText,
-  Reference: Library,
-  Template: Blocks,
-};
-
 const kindClassName: Record<ResourceKind, string> = {
-  Community:
-    "border-gray-200 bg-gray-100 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400",
-  Example:
-    "border-amber-200 bg-amber-100 text-amber-900 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-300",
-  Guide:
-    "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-500/25 dark:bg-blue-500/10 dark:text-blue-300",
-  Reference:
-    "border-teal-200 bg-teal-100 text-teal-900 dark:border-teal-500/25 dark:bg-teal-500/10 dark:text-teal-300",
-  Template:
-    "border-violet-200 bg-violet-100 text-violet-900 dark:border-violet-500/25 dark:bg-violet-500/10 dark:text-violet-300",
+  Community: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
+  Example: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
+  Guide: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
+  Reference: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
+  Template: "bg-gray-200 text-gray-900 dark:bg-gray-300 dark:text-gray-1000",
 };
 
 export const metadata: Metadata = {
@@ -44,33 +22,21 @@ export const metadata: Metadata = {
 export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
 
 const ResourceCard = ({ resource }: { resource: Resource }) => {
-  const Icon = iconByKind[resource.kind];
   const isExternal = resource.href.startsWith("https://");
   const className =
-    "group flex min-h-48 flex-col justify-between rounded-lg border bg-background-100 p-5 transition-colors hover:border-gray-400 hover:bg-gray-100";
+    "group flex min-h-[172px] flex-col rounded-xl border border-gray-alpha-400 bg-background-100 p-6 transition-colors hover:border-gray-alpha-500 hover:bg-gray-100 dark:bg-gray-100 dark:hover:bg-gray-200";
   const content = (
     <>
-      <div className="flex items-start justify-between gap-4">
-        <span className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-background text-gray-1000">
-          <Icon aria-hidden className="size-5" />
-        </span>
-        <span
-          className={`rounded-full border px-2.5 py-0.5 font-medium text-xs ${kindClassName[resource.kind]}`}
-        >
-          {resource.kind}
-        </span>
-      </div>
-      <div className="mt-8 flex flex-col gap-2">
-        <h2 className="flex items-center gap-1.5 font-medium text-base text-gray-1000 tracking-tight">
+      <span
+        className={`w-fit rounded-full px-3 py-1 font-medium text-sm ${kindClassName[resource.kind]}`}
+      >
+        {resource.kind}
+      </span>
+      <div className="mt-7 flex flex-col gap-5">
+        <h2 className="line-clamp-2 font-medium text-2xl text-gray-1000 leading-tight tracking-tight">
           {resource.title}
-          {isExternal ? (
-            <ArrowUpRight
-              aria-hidden
-              className="size-4 text-gray-700 opacity-0 transition-opacity group-hover:opacity-100"
-            />
-          ) : null}
         </h2>
-        <p className="text-gray-900 text-sm leading-relaxed">{resource.description}</p>
+        <p className="line-clamp-2 text-gray-900 text-lg leading-relaxed">{resource.description}</p>
       </div>
     </>
   );
@@ -91,12 +57,12 @@ const ResourceCard = ({ resource }: { resource: Resource }) => {
 };
 
 const ResourcesPage = () => (
-  <main className="mx-auto w-full max-w-[1080px] px-4 pt-12 pb-24 sm:px-6 lg:px-8">
-    <header className="mb-10">
+  <main className="mx-auto w-full max-w-[1908px] px-4 pt-12 pb-24 sm:px-8 lg:px-16">
+    <header className="mb-16">
       <h1 className="font-semibold text-4xl text-gray-1000 tracking-tight">{title}</h1>
       <p className="mt-3 max-w-2xl text-gray-900 text-lg">{description}</p>
     </header>
-    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-5 sm:grid-cols-2 md:grid-cols-3">
       {resources.map((resource) => (
         <ResourceCard key={resource.title} resource={resource} />
       ))}

--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -25,15 +25,15 @@ const iconByKind: Record<ResourceKind, LucideIcon> = {
 
 const kindClassName: Record<ResourceKind, string> = {
   Community:
-    "border-gray-200 bg-gray-100 text-gray-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
+    "border-gray-200 bg-gray-100 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400",
   Example:
-    "border-amber-200 bg-amber-100 text-amber-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
+    "border-amber-200 bg-amber-100 text-amber-900 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-300",
   Guide:
-    "border-blue-200 bg-blue-100 text-blue-800 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
+    "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-500/25 dark:bg-blue-500/10 dark:text-blue-300",
   Reference:
-    "border-teal-200 bg-teal-100 text-teal-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
+    "border-teal-200 bg-teal-100 text-teal-900 dark:border-teal-500/25 dark:bg-teal-500/10 dark:text-teal-300",
   Template:
-    "border-violet-200 bg-violet-100 text-violet-900 dark:border-gray-700 dark:bg-transparent dark:text-gray-900",
+    "border-violet-200 bg-violet-100 text-violet-900 dark:border-violet-500/25 dark:bg-violet-500/10 dark:text-violet-300",
 };
 
 export const metadata: Metadata = {

--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -28,15 +28,17 @@ const ResourceCard = ({ resource }: { resource: Resource }) => {
   const content = (
     <>
       <span
-        className={`w-fit rounded-full px-3 py-1 font-medium text-sm ${kindClassName[resource.kind]}`}
+        className={`w-fit rounded-full px-3 py-1 font-medium text-xs xl:text-sm ${kindClassName[resource.kind]}`}
       >
         {resource.kind}
       </span>
-      <div className="mt-7 flex flex-col gap-5">
-        <h2 className="line-clamp-2 font-medium text-2xl text-gray-1000 leading-tight tracking-tight">
+      <div className="mt-6 flex flex-col gap-4 xl:mt-7 xl:gap-5">
+        <h2 className="line-clamp-2 font-medium text-gray-1000 text-xl leading-tight tracking-tight xl:text-2xl">
           {resource.title}
         </h2>
-        <p className="line-clamp-2 text-gray-900 text-lg leading-relaxed">{resource.description}</p>
+        <p className="line-clamp-2 text-base text-gray-900 leading-relaxed xl:text-lg">
+          {resource.description}
+        </p>
       </div>
     </>
   );

--- a/apps/docs/app/[lang]/resources/page.tsx
+++ b/apps/docs/app/[lang]/resources/page.tsx
@@ -9,9 +9,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { DocsLayout } from "@/components/geistdocs/docs-layout";
 import { translations } from "@/geistdocs";
-import { source } from "@/lib/geistdocs/source";
 import { type Resource, resources, type ResourceKind } from "@/lib/resources/data";
 
 const title = "Resources";
@@ -26,11 +24,16 @@ const iconByKind: Record<ResourceKind, LucideIcon> = {
 };
 
 const kindClassName: Record<ResourceKind, string> = {
-  Community: "bg-gray-100 text-gray-900",
-  Example: "bg-amber-100 text-amber-900",
-  Guide: "bg-blue-100 text-blue-800",
-  Reference: "bg-teal-100 text-teal-900",
-  Template: "bg-violet-100 text-violet-900",
+  Community:
+    "border-gray-200 bg-gray-100 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400",
+  Example:
+    "border-amber-200 bg-amber-100 text-amber-900 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-300",
+  Guide:
+    "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-500/25 dark:bg-blue-500/10 dark:text-blue-300",
+  Reference:
+    "border-teal-200 bg-teal-100 text-teal-900 dark:border-teal-500/25 dark:bg-teal-500/10 dark:text-teal-300",
+  Template:
+    "border-violet-200 bg-violet-100 text-violet-900 dark:border-violet-500/25 dark:bg-violet-500/10 dark:text-violet-300",
 };
 
 export const metadata: Metadata = {
@@ -39,12 +42,6 @@ export const metadata: Metadata = {
 };
 
 export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
-
-interface ResourcesPageProps {
-  params: Promise<{
-    lang: keyof typeof translations;
-  }>;
-}
 
 const ResourceCard = ({ resource }: { resource: Resource }) => {
   const Icon = iconByKind[resource.kind];
@@ -58,7 +55,7 @@ const ResourceCard = ({ resource }: { resource: Resource }) => {
           <Icon aria-hidden className="size-5" />
         </span>
         <span
-          className={`rounded-full px-2.5 py-0.5 font-medium text-xs ${kindClassName[resource.kind]}`}
+          className={`rounded-full border px-2.5 py-0.5 font-medium text-xs ${kindClassName[resource.kind]}`}
         >
           {resource.kind}
         </span>
@@ -93,26 +90,18 @@ const ResourceCard = ({ resource }: { resource: Resource }) => {
   );
 };
 
-const ResourcesPage = async ({ params }: ResourcesPageProps) => {
-  const { lang } = await params;
-
-  return (
-    <div className="bg-background-100">
-      <DocsLayout tree={source.pageTree[lang]}>
-        <main className="mx-auto w-full max-w-[920px] px-4 pt-12 pb-24 sm:px-6 lg:px-8">
-          <header className="mb-10">
-            <h1 className="font-semibold text-4xl text-gray-1000 tracking-tight">{title}</h1>
-            <p className="mt-3 max-w-2xl text-gray-900 text-lg">{description}</p>
-          </header>
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {resources.map((resource) => (
-              <ResourceCard key={resource.title} resource={resource} />
-            ))}
-          </div>
-        </main>
-      </DocsLayout>
+const ResourcesPage = () => (
+  <main className="mx-auto w-full max-w-[1080px] px-4 pt-12 pb-24 sm:px-6 lg:px-8">
+    <header className="mb-10">
+      <h1 className="font-semibold text-4xl text-gray-1000 tracking-tight">{title}</h1>
+      <p className="mt-3 max-w-2xl text-gray-900 text-lg">{description}</p>
+    </header>
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {resources.map((resource) => (
+        <ResourceCard key={resource.title} resource={resource} />
+      ))}
     </div>
-  );
-};
+  </main>
+);
 
 export default ResourcesPage;

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -32,6 +32,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
       url: url("/"),
     },
+    {
+      changeFrequency: "weekly",
+      priority: 0.5,
+      url: url("/resources"),
+    },
     ...pages,
   ];
 }

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -22,6 +22,10 @@ export const nav = [
     href: "/integrations",
   },
   {
+    label: "Resources",
+    href: "/resources",
+  },
+  {
     label: "GitHub",
     href: `https://github.com/${github.owner}/${github.repo}/`,
   },

--- a/apps/docs/lib/resources/data.ts
+++ b/apps/docs/lib/resources/data.ts
@@ -1,0 +1,74 @@
+export type ResourceKind = "Community" | "Example" | "Guide" | "Reference" | "Template";
+
+export interface Resource {
+  description: string;
+  href: string;
+  kind: ResourceKind;
+  title: string;
+}
+
+export const resources: Resource[] = [
+  {
+    kind: "Guide",
+    title: "Build your first agent",
+    description:
+      "Follow the tutorial from a first agent through warehouse tools, spend approval, and a deployable chat UI.",
+    href: "/docs/tutorial/first-agent",
+  },
+  {
+    kind: "Guide",
+    title: "Frontend guides",
+    description:
+      "Use React, Vue, Svelte, Next.js, Nuxt, or SvelteKit helpers to put a durable eve session behind your own UI.",
+    href: "/docs/guides/frontend/overview",
+  },
+  {
+    kind: "Guide",
+    title: "TypeScript client",
+    description:
+      "Drive the default HTTP channel from scripts, tests, backend jobs, or custom server-side integrations.",
+    href: "/docs/guides/client/overview",
+  },
+  {
+    kind: "Template",
+    title: "eve Chat Template",
+    description:
+      "A persisted Next.js chat app with Better Auth, Neon, Upstash Redis, Notion MCP, and durable eve session state.",
+    href: "https://github.com/vercel-labs/eve-chat-template",
+  },
+  {
+    kind: "Guide",
+    title: "eve Slack Agent Starter",
+    description:
+      "Provision a Slack connector on Vercel and deploy an eve agent that can answer DMs and mentions.",
+    href: "https://vercel.com/kb/guide/eve-slack-agent-starter",
+  },
+  {
+    kind: "Template",
+    title: "eve Slack Agent Template",
+    description:
+      "A minimal Slack channel project with an eve agent, deploy button, and Vercel Connect-backed credentials.",
+    href: "https://github.com/vercel-labs/eve-slack-agent-template",
+  },
+  {
+    kind: "Example",
+    title: "Weather Agent Fixture",
+    description:
+      "A small representative eve app with agent config, instructions, a typed weather tool, and a markdown skill.",
+    href: "https://github.com/vercel/eve/tree/main/apps/fixtures/weather-agent",
+  },
+  {
+    kind: "Reference",
+    title: "Integrations gallery",
+    description:
+      "Browse built-in channels and connections, including setup steps for Slack, Linear, GitHub, Notion, and more.",
+    href: "/integrations",
+  },
+  {
+    kind: "Community",
+    title: "GitHub Discussions",
+    description:
+      "Ask questions, share what you're building, and follow framework conversations with the eve community.",
+    href: "https://github.com/vercel/eve/discussions",
+  },
+];

--- a/apps/docs/lib/resources/data.ts
+++ b/apps/docs/lib/resources/data.ts
@@ -9,13 +9,6 @@ export interface Resource {
 
 export const resources: Resource[] = [
   {
-    kind: "Reference",
-    title: "Eve Knowledge Base",
-    description:
-      "Vercel's Eve hub with getting-started guides, build guides, templates, docs, integrations, and community links.",
-    href: "https://vercel.com/kb/eve",
-  },
-  {
     kind: "Guide",
     title: "Build your first agent",
     description:
@@ -59,16 +52,9 @@ export const resources: Resource[] = [
   },
   {
     kind: "Reference",
-    title: "Integrations gallery",
+    title: "Eve Knowledge Base",
     description:
-      "Browse built-in channels and connections, including setup steps for Slack, Linear, GitHub, Notion, and more.",
-    href: "/integrations",
-  },
-  {
-    kind: "Community",
-    title: "GitHub Discussions",
-    description:
-      "Ask questions, share what you're building, and follow framework conversations with the eve community.",
-    href: "https://github.com/vercel/eve/discussions",
+      "Vercel's Eve hub with getting-started guides, build guides, templates, docs, integrations, and community links.",
+    href: "https://vercel.com/kb/eve",
   },
 ];

--- a/apps/docs/lib/resources/data.ts
+++ b/apps/docs/lib/resources/data.ts
@@ -9,6 +9,13 @@ export interface Resource {
 
 export const resources: Resource[] = [
   {
+    kind: "Reference",
+    title: "Eve Knowledge Base",
+    description:
+      "Vercel's Eve hub with getting-started guides, build guides, templates, docs, integrations, and community links.",
+    href: "https://vercel.com/kb/eve",
+  },
+  {
     kind: "Guide",
     title: "Build your first agent",
     description:
@@ -31,24 +38,17 @@ export const resources: Resource[] = [
   },
   {
     kind: "Template",
-    title: "eve Chat Template",
+    title: "Eve Chat Template",
     description:
-      "A persisted Next.js chat app with Better Auth, Neon, Upstash Redis, Notion MCP, and durable eve session state.",
-    href: "https://github.com/vercel-labs/eve-chat-template",
-  },
-  {
-    kind: "Guide",
-    title: "eve Slack Agent Starter",
-    description:
-      "Provision a Slack connector on Vercel and deploy an eve agent that can answer DMs and mentions.",
-    href: "https://vercel.com/kb/guide/eve-slack-agent-starter",
+      "A persisted Next.js chat template for Eve, built with shadcn/ui, Tailwind CSS, Streamdown, Better Auth, Drizzle, Neon, and Upstash Redis.",
+    href: "https://vercel.com/templates/eve/eve-chat-template",
   },
   {
     kind: "Template",
-    title: "eve Slack Agent Template",
+    title: "Eve Slack Agent",
     description:
-      "A minimal Slack channel project with an eve agent, deploy button, and Vercel Connect-backed credentials.",
-    href: "https://github.com/vercel-labs/eve-slack-agent-template",
+      "A Slack agent template with webhook handling, Vercel Connect, a starter agent, and an example tool ready to deploy on Vercel.",
+    href: "https://vercel.com/templates/eve/eve-slack-agent",
   },
   {
     kind: "Example",


### PR DESCRIPTION
## Summary
- add a top-level Resources nav item and /resources page using a standalone top-level layout
- add a reusable resources catalog for Eve guides, templates, examples, references, and community links
- pull in the canonical Vercel Eve KB, Eve Slack Agent template, and Eve Chat Template pages
- remove the docs sidebar from /resources and use muted dark-mode badge colors
- include /resources in the docs sitemap

## Verification
- pnpm docs:check
- pnpm --filter eve-docs build
- local smoke: http://localhost:3000/resources returned 200, rendered the Resources cards, had no docs sidebar markup, and included dark-mode badge classes
- checked external resource links return 200