### PR TITLE
feat(eve): dev - add local runtime debugging

### DIFF
--- a/.changeset/local-runtime-debugging.md
+++ b/.changeset/local-runtime-debugging.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add local Node inspector support to `eve dev` with `--inspect`, `--inspect-wait`, and `--inspect-brk`, plus source-map remapping so breakpoints in authored runtime files bind to the live workspace paths.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -99,6 +99,9 @@ Pass a bare URL as the only argument and the UI connects to that server instead 
 | `--port <port>`                     | number | `$PORT`, then 3000 | Port to listen on                                                                         |
 | `-u, --url <url>`                   | string | none               | Connect to an existing server URL instead of starting one                                 |
 | `--no-ui`                           | flag   | UI on              | Start the server without an interactive UI                                                |
+| `--inspect [target]`                | string | `127.0.0.1:9229`   | Open the Node inspector for local runtime debugging                                       |
+| `--inspect-wait [target]`           | string | `127.0.0.1:9229`   | Open the Node inspector and wait for a debugger before startup                            |
+| `--inspect-brk [target]`            | string | `127.0.0.1:9229`   | Open the Node inspector, wait for a debugger, then pause before startup                   |
 | `--name <name>`                     | string | app folder name    | Title shown in the terminal UI                                                            |
 | `--input <text>`                    | string | none               | Pre-fill the prompt input after launching the UI (editable, not auto-submitted)           |
 | `--tools <mode>`                    | enum   | `auto-collapsed`   | Tool-call rendering: `full` \| `collapsed` \| `auto-collapsed` \| `hidden`                |
@@ -112,6 +115,35 @@ Pass a bare URL as the only argument and the UI connects to that server instead 
 Local dev writes the active server process ID to `.eve/dev-process.pid`. If another `eve dev` starts for the same agent while that process is still running, eve exits with a message that includes the command to stop the existing server.
 
 Local dev keeps immutable runtime source snapshots under `.eve/dev-runtime/snapshots/` so in-flight sessions hold a consistent code revision while new prompts pick up rebuilds. On startup, `eve dev` prunes stale runtime snapshots and old local sandbox templates in the background. For manual cleanup, stop `eve dev` and delete `.eve/dev-runtime/snapshots/` or `.eve/sandbox-cache/local/templates/`.
+
+### Local runtime debugging
+
+Use `eve dev --inspect` to attach VS Code or Chrome DevTools to the local Eve runtime process. The default target is `127.0.0.1:9229`; pass a port (`--inspect=9230`), host and port (`--inspect=127.0.0.1:9230`), or `--inspect=0` to ask Node for an available port. Inspector flags are local-only and cannot be combined with `--url`.
+
+`--inspect-wait` prints the WebSocket URL and waits for a debugger before the server starts. `--inspect-brk` does the same, then triggers one early `debugger` pause before startup.
+
+VS Code attach configuration:
+
+```json
+{
+  "type": "node",
+  "request": "attach",
+  "name": "Attach to eve dev",
+  "address": "127.0.0.1",
+  "port": 9229,
+  "sourceMaps": true,
+  "resolveSourceMapLocations": [
+    "${workspaceFolder}/.eve/nitro/**/*.mjs",
+    "${workspaceFolder}/node_modules/.cache/eve/authored-modules/**/*.mjs",
+    "${workspaceFolder}/.eve/dev-runtime/snapshots/**/node_modules/.cache/eve/authored-modules/**/*.mjs"
+  ],
+  "skipFiles": ["<node_internals>/**"]
+}
+```
+
+Eve stores runtime-authored bundles under `node_modules/.cache`, which VS Code excludes from source-map resolution by default. The scoped `resolveSourceMapLocations` entries allow those bundles and immutable dev snapshots without enabling source maps for every dependency.
+
+Chrome DevTools can attach through `chrome://inspect`. Breakpoints in authored TypeScript files such as `agent/tools/get_weather.ts` resolve through source maps rewritten from the immutable dev snapshot back to the live workspace file. A breakpoint pauses the whole local Eve process, including the active turn, HTTP handling, rebuild work, and TUI streaming until you resume execution. If you edit a tool while a turn is in flight, that turn may continue on its old snapshot; start a new prompt after rebuild to debug the newest code.
 
 ## `eve link`
 

--- a/packages/eve/src/cli/dev/inspector.test.ts
+++ b/packages/eve/src/cli/dev/inspector.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  openDevInspector,
+  resolveDevInspectorRequest,
+  type DevInspectorRequest,
+} from "./inspector.js";
+
+describe("resolveDevInspectorRequest", () => {
+  it("resolves the default inspector target", () => {
+    expect(resolveDevInspectorRequest({ inspect: true })).toEqual({
+      host: "127.0.0.1",
+      mode: "inspect",
+      port: 9229,
+    });
+  });
+
+  it("resolves port-only and host-port targets", () => {
+    expect(resolveDevInspectorRequest({ inspect: "9230" })).toMatchObject({
+      host: "127.0.0.1",
+      port: 9230,
+    });
+    expect(resolveDevInspectorRequest({ inspectWait: "localhost:0" })).toMatchObject({
+      host: "localhost",
+      mode: "inspect-wait",
+      port: 0,
+    });
+  });
+
+  it("resolves non-loopback hosts", () => {
+    expect(resolveDevInspectorRequest({ inspect: "0.0.0.0:9229" })).toMatchObject({
+      host: "0.0.0.0",
+      mode: "inspect",
+      port: 9229,
+    });
+  });
+
+  it("rejects multiple modes and malformed targets", () => {
+    expect(() => resolveDevInspectorRequest({ inspect: true, inspectBrk: true })).toThrow(
+      "Use only one",
+    );
+    expect(() => resolveDevInspectorRequest({ inspect: "host" })).toThrow("host:port");
+    expect(() => resolveDevInspectorRequest({ inspect: "127.0.0.1:65536" })).toThrow(
+      "between 0 and 65535",
+    );
+    expect(() => resolveDevInspectorRequest({ inspect: "[::1]:9229" })).toThrow(
+      "IPv6 inspector targets",
+    );
+  });
+});
+
+describe("openDevInspector", () => {
+  it("opens with wait disabled and returns the inspector URL", async () => {
+    const api = createInspectorApi();
+    const request: DevInspectorRequest = {
+      host: "127.0.0.1",
+      mode: "inspect",
+      port: 9229,
+    };
+
+    const handle = await openDevInspector(request, api);
+
+    expect(api.open).toHaveBeenCalledWith(9229, "127.0.0.1", false);
+    expect(handle.url).toBe("ws://127.0.0.1:9229/session");
+  });
+
+  it("waits and closes through the inspector API fallback", async () => {
+    const api = createInspectorApi({ openReturn: undefined });
+    const handle = await openDevInspector(
+      {
+        host: "127.0.0.1",
+        mode: "inspect-wait",
+        port: 0,
+      },
+      api,
+    );
+
+    handle.waitForDebugger();
+    handle.close();
+    handle.close();
+
+    expect(api.waitForDebugger).toHaveBeenCalledTimes(1);
+    expect(api.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createInspectorApi(options: { readonly openReturn?: unknown } = {}) {
+  return {
+    close: vi.fn(),
+    open: vi.fn(() => options.openReturn),
+    url: vi.fn(() => "ws://127.0.0.1:9229/session"),
+    waitForDebugger: vi.fn(),
+  };
+}

--- a/packages/eve/src/cli/dev/inspector.ts
+++ b/packages/eve/src/cli/dev/inspector.ts
@@ -1,0 +1,167 @@
+import * as inspector from "node:inspector";
+
+import { InvalidArgumentError } from "#compiled/commander/index.js";
+
+const DEFAULT_INSPECTOR_HOST = "127.0.0.1";
+const DEFAULT_INSPECTOR_PORT = 9229;
+
+export type DevInspectorMode = "inspect" | "inspect-wait" | "inspect-brk";
+
+export interface DevInspectorRequest {
+  readonly host: string;
+  readonly mode: DevInspectorMode;
+  readonly port: number;
+}
+
+export interface DevInspectorHandle {
+  readonly mode: DevInspectorMode;
+  readonly url: string;
+  close(): void;
+  waitForDebugger(): void;
+}
+
+export interface DevInspectorApi {
+  close(): void;
+  open(port?: number, host?: string, wait?: boolean): unknown;
+  url(): string | undefined;
+  waitForDebugger(): void;
+}
+
+export function resolveDevInspectorRequest(input: {
+  readonly inspect?: string | boolean;
+  readonly inspectBrk?: string | boolean;
+  readonly inspectWait?: string | boolean;
+}): DevInspectorRequest | undefined {
+  const candidates: ReadonlyArray<{
+    readonly mode: DevInspectorMode;
+    readonly value: string | boolean | undefined;
+  }> = [
+    { mode: "inspect", value: input.inspect },
+    { mode: "inspect-brk", value: input.inspectBrk },
+    { mode: "inspect-wait", value: input.inspectWait },
+  ];
+  const entries = candidates.filter((entry) => entry.value !== undefined);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  if (entries.length > 1) {
+    throw new InvalidArgumentError("Use only one of --inspect, --inspect-wait, or --inspect-brk.");
+  }
+
+  const [entry] = entries;
+  const target = parseDevInspectorTarget(entry!.value);
+  return {
+    ...target,
+    mode: entry!.mode,
+  };
+}
+
+export async function openDevInspector(
+  request: DevInspectorRequest,
+  api: DevInspectorApi = inspector,
+): Promise<DevInspectorHandle> {
+  const disposable = api.open(request.port, request.host, false);
+  const url = api.url();
+
+  if (url === undefined) {
+    throw new Error("Node inspector opened without reporting an attach URL.");
+  }
+
+  let closed = false;
+  return {
+    mode: request.mode,
+    url,
+    close() {
+      if (closed) {
+        return;
+      }
+
+      closed = true;
+      disposeInspectorHandle(disposable, api);
+    },
+    waitForDebugger() {
+      api.waitForDebugger();
+    },
+  };
+}
+
+function parseDevInspectorTarget(value: string | boolean | undefined): {
+  readonly host: string;
+  readonly port: number;
+} {
+  if (value === undefined || value === true) {
+    return { host: DEFAULT_INSPECTOR_HOST, port: DEFAULT_INSPECTOR_PORT };
+  }
+
+  if (value === false) {
+    throw new InvalidArgumentError("Inspector target cannot be false.");
+  }
+
+  const target = value.trim();
+  if (target.length === 0) {
+    throw new InvalidArgumentError("Inspector target cannot be empty.");
+  }
+
+  if (/^\d+$/u.test(target)) {
+    return { host: DEFAULT_INSPECTOR_HOST, port: parseDevInspectorPort(target) };
+  }
+
+  if (target.startsWith("[") || target.includes("]:")) {
+    throw new InvalidArgumentError(
+      "Bracketed IPv6 inspector targets are not supported; use a hostname, IPv4 address, or port.",
+    );
+  }
+
+  const separator = target.indexOf(":");
+  if (separator === -1 || separator !== target.lastIndexOf(":")) {
+    throw new InvalidArgumentError(
+      `Expected inspector target to be a port or host:port, received "${value}".`,
+    );
+  }
+
+  const host = target.slice(0, separator);
+  const port = target.slice(separator + 1);
+
+  if (host.length === 0 || port.length === 0) {
+    throw new InvalidArgumentError(
+      `Expected inspector target to be a port or host:port, received "${value}".`,
+    );
+  }
+
+  return {
+    host,
+    port: parseDevInspectorPort(port),
+  };
+}
+
+function parseDevInspectorPort(value: string): number {
+  if (!/^\d+$/u.test(value)) {
+    throw new InvalidArgumentError(`Expected inspector port to be numeric, received "${value}".`);
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new InvalidArgumentError(
+      `Expected inspector port between 0 and 65535, received "${value}".`,
+    );
+  }
+
+  return port;
+}
+
+function disposeInspectorHandle(disposable: unknown, api: DevInspectorApi): void {
+  if (disposable !== undefined && disposable !== null && typeof disposable === "object") {
+    const symbolDispose = (Symbol as { readonly dispose?: symbol }).dispose;
+    if (symbolDispose !== undefined) {
+      const dispose = (disposable as Record<symbol, unknown>)[symbolDispose];
+      if (typeof dispose === "function") {
+        dispose.call(disposable);
+        return;
+      }
+    }
+  }
+
+  api.close();
+}

--- a/packages/eve/src/cli/dev/options.ts
+++ b/packages/eve/src/cli/dev/options.ts
@@ -1,0 +1,195 @@
+import { basename } from "node:path";
+
+import { InvalidArgumentError } from "#compiled/commander/index.js";
+import { LOG_DISPLAY_MODES, parseLogDisplayMode } from "#cli/dev/tui/log-display-mode.js";
+import type {
+  AssistantResponseStatsMode,
+  LogDisplayMode,
+  TerminalPartDisplayMode,
+  TuiDisplayOptions,
+} from "#cli/dev/tui/types.js";
+
+export interface DevelopmentCliOptions {
+  assistantResponseStats?: AssistantResponseStatsMode;
+  connectionAuth?: TerminalPartDisplayMode;
+  contextSize?: number;
+  host?: string;
+  input?: string;
+  inspect?: string | boolean;
+  inspectBrk?: string | boolean;
+  inspectWait?: string | boolean;
+  logs?: LogDisplayMode;
+  name?: string;
+  port?: number;
+  reasoning?: TerminalPartDisplayMode;
+  subagents?: TerminalPartDisplayMode;
+  tools?: TerminalPartDisplayMode;
+  ui?: boolean;
+  url?: string;
+}
+
+const DISPLAY_MODES = new Set(["full", "collapsed", "auto-collapsed", "hidden"]);
+const STATS_MODES = new Set(["tokens", "tokensPerSecond"]);
+
+export function parseDisplayMode(value: string): TerminalPartDisplayMode {
+  if (!DISPLAY_MODES.has(value)) {
+    throw new InvalidArgumentError(
+      `Expected one of ${[...DISPLAY_MODES].join(", ")}, received "${value}".`,
+    );
+  }
+
+  return value as TerminalPartDisplayMode;
+}
+
+export function parseStatsMode(value: string): AssistantResponseStatsMode {
+  if (!STATS_MODES.has(value)) {
+    throw new InvalidArgumentError(
+      `Expected one of ${[...STATS_MODES].join(", ")}, received "${value}".`,
+    );
+  }
+
+  return value as AssistantResponseStatsMode;
+}
+
+export function parseLogsMode(value: string): LogDisplayMode {
+  const mode = parseLogDisplayMode(value);
+  if (mode === undefined) {
+    throw new InvalidArgumentError(
+      `Expected one of ${LOG_DISPLAY_MODES.join(", ")}, received "${value}".`,
+    );
+  }
+
+  return mode;
+}
+
+export function parseContextSizeOption(value: string): number {
+  const size = Number(value);
+
+  if (!Number.isFinite(size) || size <= 0) {
+    throw new InvalidArgumentError(`Expected a positive number, received "${value}".`);
+  }
+
+  return size;
+}
+
+/**
+ * The interactive UI `eve dev` runs against a server.
+ *
+ * - `tui` — the default terminal UI.
+ * - `headless` — no UI: just keep the server running (`--no-ui`, or a
+ *   non-interactive terminal).
+ *
+ * Exported for unit coverage of the flag-routing contract.
+ */
+export type DevUiMode = "tui" | "headless";
+
+/**
+ * Resolves which UI `eve dev` should run from the parsed flags and whether
+ * the terminal is interactive. `--no-ui` and non-TTY terminals force
+ * `headless`; otherwise the terminal UI runs.
+ */
+export function resolveDevUiMode(input: {
+  options: Pick<DevelopmentCliOptions, "ui">;
+  interactive: boolean;
+}): DevUiMode {
+  if (input.options.ui === false || !input.interactive) {
+    return "headless";
+  }
+
+  return "tui";
+}
+
+/**
+ * Resolves the terminal UI's header title: an explicit `--name`, else the
+ * remote server's host (for `--url`), else the humanized app-folder name
+ * (e.g. `apps/fixtures/weather-agent` → "Weather Agent"). Returns `undefined` when
+ * nothing meaningful can be derived, so the runner falls back to its own
+ * default.
+ */
+export function resolveTuiTitle(input: {
+  name: string | undefined;
+  remoteServerUrl: string | undefined;
+  appRoot: string;
+}): string | undefined {
+  if (input.name !== undefined && input.name.length > 0) {
+    return input.name;
+  }
+
+  if (input.remoteServerUrl !== undefined) {
+    try {
+      return new URL(input.remoteServerUrl).host;
+    } catch {
+      return undefined;
+    }
+  }
+
+  const humanized = humanizeProjectName(basename(input.appRoot));
+  return humanized.length > 0 ? humanized : undefined;
+}
+
+/**
+ * Builds the terminal-UI display options for `eve dev`. Tools default to
+ * `auto-collapsed`, reasoning to `full`, and stderr logs are visible so
+ * long-running local sandbox work can report progress.
+ */
+export function resolveTuiDisplayOptions(options: DevelopmentCliOptions): TuiDisplayOptions {
+  const display: TuiDisplayOptions = {
+    logs: options.logs ?? "stderr",
+    reasoning: options.reasoning ?? "full",
+    tools: options.tools ?? "auto-collapsed",
+  };
+
+  if (options.subagents !== undefined) display.subagents = options.subagents;
+  if (options.connectionAuth !== undefined) display.connectionAuth = options.connectionAuth;
+  if (options.assistantResponseStats !== undefined) {
+    display.assistantResponseStats = options.assistantResponseStats;
+  }
+  if (options.contextSize !== undefined) display.contextSize = options.contextSize;
+  return display;
+}
+
+export function resolveRemoteDevelopmentServerUrl(
+  options: DevelopmentCliOptions,
+): string | undefined {
+  if (!options.url) {
+    return undefined;
+  }
+
+  if (hasDevInspectorOption(options)) {
+    throw new InvalidArgumentError("The --inspect options cannot be used with --url.");
+  }
+
+  if (options.host !== undefined) {
+    throw new InvalidArgumentError("The --host option cannot be used with --url.");
+  }
+
+  if (options.port !== undefined) {
+    throw new InvalidArgumentError("The --port option cannot be used with --url.");
+  }
+
+  if (options.ui === false) {
+    throw new InvalidArgumentError("The --no-ui option cannot be used with --url.");
+  }
+
+  return options.url;
+}
+
+function humanizeProjectName(name: string): string {
+  return name
+    .replace(/[-_.]+/gu, " ")
+    .trim()
+    .split(/\s+/u)
+    .filter((word) => word.length > 0)
+    .map((word) => word[0]!.toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function hasDevInspectorOption(
+  options: Pick<DevelopmentCliOptions, "inspect" | "inspectBrk" | "inspectWait">,
+): boolean {
+  return (
+    options.inspect !== undefined ||
+    options.inspectBrk !== undefined ||
+    options.inspectWait !== undefined
+  );
+}

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { resolveDevUiMode, resolveTuiDisplayOptions, resolveTuiTitle, runCli } from "#cli/run.js";
+import type { DevInspectorHandle, DevInspectorRequest } from "#cli/dev/inspector.js";
+import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
 
 async function withInteractiveTerminal<T>(fn: () => Promise<T>): Promise<T> {
   const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -98,6 +100,126 @@ describe("eve dev --logs", () => {
         serverUrl: "https://example.com/",
       }),
     );
+  });
+});
+
+describe("eve dev --inspect", () => {
+  it("rejects inspector flags with remote URLs", async () => {
+    await expect(
+      runCli(["dev", "--inspect", "--url", "https://example.com"], {
+        error: () => {},
+        log: () => {},
+      }),
+    ).rejects.toThrow("cannot be used with --url");
+  });
+
+  it("opens the inspector before starting the local server", async () => {
+    const output: string[] = [];
+    const order: string[] = [];
+    const inspectorClose = vi.fn(() => order.push("inspector-close"));
+    const serverClose = vi.fn(async () => {
+      order.push("server-close");
+    });
+    const openDevInspector = vi.fn(
+      async (request: DevInspectorRequest): Promise<DevInspectorHandle> => {
+        order.push("inspector-open");
+        return {
+          mode: request.mode,
+          url: "ws://127.0.0.1:9230/session",
+          close: inspectorClose,
+          waitForDebugger: vi.fn(() => order.push("inspector-wait")),
+        };
+      },
+    );
+    const startHost = vi.fn(async () => {
+      order.push("server-start");
+      return {
+        close: serverClose,
+        url: "http://127.0.0.1:2000",
+      };
+    });
+    const runDevelopmentTui = vi.fn(async (_input: RunDevelopmentTuiInput) => {
+      order.push("tui");
+    });
+
+    await withInteractiveTerminal(() =>
+      runCli(
+        ["dev", "--inspect=9230"],
+        { error: (message) => output.push(message), log: (message) => output.push(message) },
+        { openDevInspector, runDevelopmentTui, startHost },
+      ),
+    );
+
+    expect(openDevInspector).toHaveBeenCalledWith({
+      host: "127.0.0.1",
+      mode: "inspect",
+      port: 9230,
+    });
+    expect(startHost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ runtimeDebugging: true }),
+    );
+    expect(order).toEqual([
+      "inspector-open",
+      "server-start",
+      "tui",
+      "server-close",
+      "inspector-close",
+    ]);
+    expect(output.join("\n")).not.toContain("inspector listening");
+    expect(output.join("\n")).not.toContain("chrome://inspect");
+    const tuiInput = runDevelopmentTui.mock.calls[0]?.[0];
+    expect(tuiInput).toEqual(expect.objectContaining({ serverUrl: "http://127.0.0.1:2000" }));
+    expect(tuiInput).not.toHaveProperty("inspector");
+  });
+
+  it("waits before startup for a non-loopback inspect-wait target", async () => {
+    const order: string[] = [];
+    const openDevInspector = vi.fn(
+      async (request: DevInspectorRequest): Promise<DevInspectorHandle> => {
+        order.push("open");
+        return {
+          mode: request.mode,
+          url: "ws://0.0.0.0:9231/session",
+          close: vi.fn(() => order.push("close-inspector")),
+          waitForDebugger: vi.fn(() => order.push("wait")),
+        };
+      },
+    );
+    const startHost = vi.fn(async () => {
+      order.push("start");
+      return {
+        close: vi.fn(async () => {
+          order.push("close-server");
+        }),
+        url: "http://127.0.0.1:2000",
+      };
+    });
+
+    await withInteractiveTerminal(() =>
+      runCli(
+        ["dev", "--inspect-wait=0.0.0.0:9231"],
+        { error: () => {}, log: () => {} },
+        {
+          openDevInspector,
+          runDevelopmentTui: vi.fn(async () => {
+            order.push("tui");
+          }),
+          startHost,
+        },
+      ),
+    );
+
+    expect(openDevInspector).toHaveBeenCalledWith({
+      host: "0.0.0.0",
+      mode: "inspect-wait",
+      port: 9231,
+    });
+    expect(startHost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ runtimeDebugging: true }),
+    );
+    expect(order).toEqual(["open", "wait", "start", "tui", "close-server", "close-inspector"]);
   });
 });
 

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -1,39 +1,34 @@
-import { basename } from "node:path";
-
 import { Command, CommanderError, InvalidArgumentError } from "#compiled/commander/index.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerProjectCommands } from "#cli/commands/register-project-commands.js";
-import { LOG_DISPLAY_MODES, parseLogDisplayMode } from "#cli/dev/tui/log-display-mode.js";
+import {
+  openDevInspector,
+  resolveDevInspectorRequest,
+  type DevInspectorHandle,
+  type DevInspectorRequest,
+} from "#cli/dev/inspector.js";
+import {
+  parseContextSizeOption,
+  parseDisplayMode,
+  parseLogsMode,
+  parseStatsMode,
+  resolveDevUiMode,
+  resolveRemoteDevelopmentServerUrl,
+  resolveTuiDisplayOptions,
+  resolveTuiTitle,
+  type DevelopmentCliOptions,
+} from "#cli/dev/options.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";
-import type {
-  AssistantResponseStatsMode,
-  LogDisplayMode,
-  TerminalPartDisplayMode,
-  TuiDisplayOptions,
-} from "#cli/dev/tui/types.js";
+import type { TuiDisplayOptions } from "#cli/dev/tui/types.js";
+
+export { resolveDevUiMode, resolveTuiDisplayOptions, resolveTuiTitle } from "#cli/dev/options.js";
 
 interface CliLogger {
   error(message: string): void;
   log(message: string): void;
-}
-
-interface DevelopmentCliOptions {
-  assistantResponseStats?: AssistantResponseStatsMode;
-  connectionAuth?: TerminalPartDisplayMode;
-  contextSize?: number;
-  host?: string;
-  input?: string;
-  logs?: LogDisplayMode;
-  name?: string;
-  port?: number;
-  reasoning?: TerminalPartDisplayMode;
-  subagents?: TerminalPartDisplayMode;
-  tools?: TerminalPartDisplayMode;
-  ui?: boolean;
-  url?: string;
 }
 
 interface ProductionCliOptions {
@@ -54,6 +49,7 @@ interface ProductionServerHandle {
 
 interface CliRuntimeDependencies {
   buildHost(appRoot: string): Promise<string>;
+  openDevInspector(request: DevInspectorRequest): Promise<DevInspectorHandle>;
   printApplicationInfo(
     logger: CliLogger,
     appRoot: string,
@@ -72,6 +68,7 @@ interface CliRuntimeDependencies {
     options?: {
       host?: string;
       port?: number;
+      runtimeDebugging?: boolean;
     },
   ): Promise<DevelopmentServerHandle>;
   startProductionHost(
@@ -177,136 +174,6 @@ function parsePortOption(value: string): number {
   return port;
 }
 
-const DISPLAY_MODES = new Set(["full", "collapsed", "auto-collapsed", "hidden"]);
-const STATS_MODES = new Set(["tokens", "tokensPerSecond"]);
-
-function parseDisplayMode(value: string): TerminalPartDisplayMode {
-  if (!DISPLAY_MODES.has(value)) {
-    throw new InvalidArgumentError(
-      `Expected one of ${[...DISPLAY_MODES].join(", ")}, received "${value}".`,
-    );
-  }
-
-  return value as TerminalPartDisplayMode;
-}
-
-function parseStatsMode(value: string): AssistantResponseStatsMode {
-  if (!STATS_MODES.has(value)) {
-    throw new InvalidArgumentError(
-      `Expected one of ${[...STATS_MODES].join(", ")}, received "${value}".`,
-    );
-  }
-
-  return value as AssistantResponseStatsMode;
-}
-
-function parseLogsMode(value: string): LogDisplayMode {
-  const mode = parseLogDisplayMode(value);
-  if (mode === undefined) {
-    throw new InvalidArgumentError(
-      `Expected one of ${LOG_DISPLAY_MODES.join(", ")}, received "${value}".`,
-    );
-  }
-
-  return mode;
-}
-
-function parseContextSizeOption(value: string): number {
-  const size = Number(value);
-
-  if (!Number.isFinite(size) || size <= 0) {
-    throw new InvalidArgumentError(`Expected a positive number, received "${value}".`);
-  }
-
-  return size;
-}
-
-/**
- * The interactive UI `eve dev` runs against a server.
- *
- * - `tui` — the default terminal UI.
- * - `headless` — no UI: just keep the server running (`--no-ui`, or a
- *   non-interactive terminal).
- *
- * Exported for unit coverage of the flag-routing contract.
- */
-export type DevUiMode = "tui" | "headless";
-
-/**
- * Resolves which UI `eve dev` should run from the parsed flags and whether
- * the terminal is interactive. `--no-ui` and non-TTY terminals force
- * `headless`; otherwise the terminal UI runs.
- */
-export function resolveDevUiMode(input: {
-  options: Pick<DevelopmentCliOptions, "ui">;
-  interactive: boolean;
-}): DevUiMode {
-  if (input.options.ui === false || !input.interactive) {
-    return "headless";
-  }
-
-  return "tui";
-}
-
-/**
- * Resolves the terminal UI's header title: an explicit `--name`, else the
- * remote server's host (for `--url`), else the humanized app-folder name
- * (e.g. `apps/fixtures/weather-agent` → "Weather Agent"). Returns `undefined` when
- * nothing meaningful can be derived, so the runner falls back to its own
- * default.
- */
-export function resolveTuiTitle(input: {
-  name: string | undefined;
-  remoteServerUrl: string | undefined;
-  appRoot: string;
-}): string | undefined {
-  if (input.name !== undefined && input.name.length > 0) {
-    return input.name;
-  }
-
-  if (input.remoteServerUrl !== undefined) {
-    try {
-      return new URL(input.remoteServerUrl).host;
-    } catch {
-      return undefined;
-    }
-  }
-
-  const humanized = humanizeProjectName(basename(input.appRoot));
-  return humanized.length > 0 ? humanized : undefined;
-}
-
-function humanizeProjectName(name: string): string {
-  return name
-    .replace(/[-_.]+/gu, " ")
-    .trim()
-    .split(/\s+/u)
-    .filter((word) => word.length > 0)
-    .map((word) => word[0]!.toUpperCase() + word.slice(1))
-    .join(" ");
-}
-
-/**
- * Builds the terminal-UI display options for `eve dev`. Tools default to
- * `auto-collapsed`, reasoning to `full`, and stderr logs are visible so
- * long-running local sandbox work can report progress.
- */
-export function resolveTuiDisplayOptions(options: DevelopmentCliOptions): TuiDisplayOptions {
-  const display: TuiDisplayOptions = {
-    logs: options.logs ?? "stderr",
-    reasoning: options.reasoning ?? "full",
-    tools: options.tools ?? "auto-collapsed",
-  };
-
-  if (options.subagents !== undefined) display.subagents = options.subagents;
-  if (options.connectionAuth !== undefined) display.connectionAuth = options.connectionAuth;
-  if (options.assistantResponseStats !== undefined) {
-    display.assistantResponseStats = options.assistantResponseStats;
-  }
-  if (options.contextSize !== undefined) display.contextSize = options.contextSize;
-  return display;
-}
-
 function hasInteractiveTerminal(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
@@ -324,26 +191,6 @@ function rewriteDevelopmentUrlShorthand(argv: readonly string[]): string[] {
   }
 
   return ["dev", "--url", shorthandUrl];
-}
-
-function resolveRemoteDevelopmentServerUrl(options: DevelopmentCliOptions): string | undefined {
-  if (!options.url) {
-    return undefined;
-  }
-
-  if (options.host !== undefined) {
-    throw new InvalidArgumentError("The --host option cannot be used with --url.");
-  }
-
-  if (options.port !== undefined) {
-    throw new InvalidArgumentError("The --port option cannot be used with --url.");
-  }
-
-  if (options.ui === false) {
-    throw new InvalidArgumentError("The --no-ui option cannot be used with --url.");
-  }
-
-  return options.url;
 }
 
 function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Command {
@@ -461,6 +308,9 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
     .option("--port <port>", "Port to listen on (defaults to $PORT, then 2000)", parsePortOption)
     .option("-u, --url <url>", "Connect to an existing server URL", parseDevelopmentServerUrl)
     .option("--no-ui", "Start the server without an interactive UI")
+    .option("--inspect [target]", "Open the Node inspector for local runtime debugging")
+    .option("--inspect-brk [target]", "Open the Node inspector and pause before startup")
+    .option("--inspect-wait [target]", "Open the Node inspector and wait for attach before startup")
     .option("--name <name>", "Title shown in the terminal UI (defaults to the app folder name)")
     .option("--input <text>", "Pre-fill the prompt input after launching the UI")
     .option(
@@ -512,6 +362,8 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
 
       loadDevelopmentEnvironmentFiles(appRoot);
+      const inspectorRequest = resolveDevInspectorRequest(options);
+      let inspectorHandle: DevInspectorHandle | undefined;
 
       const runInteractiveUi = async (serverUrl: string): Promise<void> => {
         logger.log("");
@@ -557,14 +409,26 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
         return;
       }
 
-      const startHost = runtime.startHost ?? (await loadStartHost());
-      const server = await startHost(appRoot, {
-        host: options.host,
-        port: options.port,
-      });
+      if (inspectorRequest !== undefined) {
+        const inspect = runtime.openDevInspector ?? openDevInspector;
+        inspectorHandle = await inspect(inspectorRequest);
+        if (inspectorHandle.mode === "inspect-wait" || inspectorHandle.mode === "inspect-brk") {
+          inspectorHandle.waitForDebugger();
+        }
+        if (inspectorHandle.mode === "inspect-brk") {
+          // oxlint-disable-next-line no-debugger
+          debugger;
+        }
+      }
+
+      let server: DevelopmentServerHandle | undefined;
       let closed = false;
 
       const closeServer = async () => {
+        if (server === undefined) {
+          return;
+        }
+
         if (closed) {
           return;
         }
@@ -574,6 +438,13 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       };
 
       try {
+        const startHost = runtime.startHost ?? (await loadStartHost());
+        server = await startHost(appRoot, {
+          host: options.host,
+          port: options.port,
+          runtimeDebugging: inspectorRequest !== undefined,
+        });
+
         // The terminal UI's header already shows the server URL, and startup
         // no longer clears the screen, so the line would linger as noise.
         // Headless consumers (scripts, scenario tests) still parse it.
@@ -609,6 +480,7 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
         await runInteractiveUi(server.url);
       } finally {
         await closeServer();
+        inspectorHandle?.close();
       }
     });
 

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -8,11 +8,15 @@ import { createAuthoredModuleBundleError } from "#internal/authored-module-bundl
 import { createAuthoredPackageTsConfigPathsPlugin } from "#internal/authored-package-tsconfig-paths.js";
 import { expectObjectRecord } from "#internal/authored-module.js";
 import {
+  externalizeInlineSourceMap,
+  prependNodeEsmCompatBannerToInlineSourceMap,
+  rewriteDevSnapshotSourceMap,
+} from "#internal/authored-module-source-map.js";
+import {
   buildWithNitroRolldown,
   getSingleRolldownChunk,
 } from "#internal/bundler/nitro-rolldown.js";
 import { SERVER_EXTERNAL_PACKAGES } from "#internal/nitro/host/server-external-packages.js";
-import { createNodeEsmCompatBannerPlugin } from "#internal/node-esm-compat-banner.js";
 
 const AUTHORED_BUNDLED_MODULE_EXTENSION = /\.[cm]?[jt]sx?$/;
 const AUTHORED_MODULE_BUNDLE_DIRECTORY_PATH = join(
@@ -32,7 +36,6 @@ const RESOLVE_EXTENSIONS = [
   ".cjs",
   ".json",
 ] as const;
-
 const CHANNEL_MODULE_CACHE_KEY = "__eveChannelModuleCache__";
 const CACHED_CHANNEL_PREFIX = "eve-cached-channel:";
 
@@ -200,7 +203,6 @@ async function loadBundledAuthoredModule(
       appPackageRoot: packageRoot,
       extensions: RESOLVE_EXTENSIONS,
     }),
-    createNodeEsmCompatBannerPlugin({ includeRequire: true }),
     createPackageBoundaryPlugin(packageRoot, externalDependencies),
     channelIdentityPlugin,
   ].filter((plugin) => plugin !== null);
@@ -228,19 +230,43 @@ async function loadBundledAuthoredModule(
     throw createAuthoredModuleBundleError(modulePath, error);
   }
 
+  // The banner is added after bundling so it can skip bindings that the
+  // finished chunk already declares, but that means this pass owns keeping the
+  // source-map line offsets aligned with the authored code.
+  const banneredCode = prependNodeEsmCompatBannerToInlineSourceMap({
+    code: outputFile.code,
+    includeRequire: true,
+  });
+  const bundleCode = rewriteDevSnapshotSourceMap({
+    code: banneredCode,
+    modulePath,
+    packageRoot,
+  });
   const bundleHash = createHash("sha1")
     .update(modulePath)
     .update("\0")
     .update(externalDependencies.join("\0"))
     .update("\0")
-    .update(outputFile.code)
+    .update("external-source-map-v1")
+    .update("\0")
+    .update(bundleCode)
     .digest("hex");
   const bundleDirectoryPath = join(packageRoot, AUTHORED_MODULE_BUNDLE_DIRECTORY_PATH);
   const bundlePath = join(bundleDirectoryPath, `${bundleHash}.mjs`);
+  const sourceMapPath = `${bundlePath}.map`;
+  const externalizedBundle = externalizeInlineSourceMap({
+    code: bundleCode,
+    sourceMapFileName: `${bundleHash}.mjs.map`,
+  });
 
   if (!existsSync(bundlePath)) {
     mkdirSync(bundleDirectoryPath, { recursive: true });
-    writeFileSync(bundlePath, outputFile.code);
+    writeFileSync(bundlePath, externalizedBundle.code);
+  }
+
+  if (externalizedBundle.sourceMap !== undefined && !existsSync(sourceMapPath)) {
+    mkdirSync(bundleDirectoryPath, { recursive: true });
+    writeFileSync(sourceMapPath, `${JSON.stringify(externalizedBundle.sourceMap)}\n`);
   }
 
   return await import(`${createFileImportSpecifier(bundlePath)}?v=${bundleHash}`);

--- a/packages/eve/src/internal/authored-module-source-map.ts
+++ b/packages/eve/src/internal/authored-module-source-map.ts
@@ -1,0 +1,310 @@
+import { existsSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  readDevelopmentRuntimeSnapshotMetadataForPath,
+  type DevelopmentRuntimeArtifactsSnapshotMetadata,
+} from "#internal/nitro/dev-runtime-snapshot-metadata.js";
+import { buildNodeEsmCompatBanner } from "#internal/node-esm-compat-banner.js";
+import { isSourceMapUrl } from "#internal/source-map-path.js";
+
+const INLINE_SOURCE_MAP_PATTERN =
+  /(\/\/# sourceMappingURL=data:application\/json(?:;charset=[^;,]+)?;base64,)([A-Za-z0-9+/=]+)(\s*)$/u;
+
+export function prependNodeEsmCompatBannerToInlineSourceMap(input: {
+  readonly code: string;
+  readonly includeRequire: boolean;
+}): string {
+  const banner = buildNodeEsmCompatBanner(input.code, { includeRequire: input.includeRequire });
+  if (banner === "") {
+    return input.code;
+  }
+
+  const decoded = decodeInlineSourceMap(input.code);
+  if (decoded === undefined) {
+    return `${banner}\n${input.code}`;
+  }
+
+  // The compatibility banner adds generated lines before the authored bundle.
+  // Pad the map with empty generated lines so existing original-line mappings
+  // still point at the same authored statements after the banner is prepended.
+  const insertedLineCount = banner.split("\n").length;
+  const sourceMap = {
+    ...decoded.sourceMap,
+    mappings: `${";".repeat(insertedLineCount)}${String(decoded.sourceMap.mappings ?? "")}`,
+  };
+  const encoded = Buffer.from(JSON.stringify(sourceMap), "utf8").toString("base64");
+
+  return (
+    `${banner}\n` +
+    input.code.slice(0, decoded.matchStart) +
+    decoded.prefix +
+    encoded +
+    decoded.trailingWhitespace
+  );
+}
+
+export function rewriteDevSnapshotSourceMap(input: {
+  readonly code: string;
+  readonly modulePath: string;
+  readonly packageRoot?: string;
+}): string {
+  // Authored modules are imported from content-addressed cache files, and in
+  // dev they may originate from immutable runtime snapshots. Rewriting sources
+  // to live file URLs keeps DevTools breakpoints attached to editable files
+  // instead of cache or snapshot copies.
+  const metadata = readDevelopmentRuntimeSnapshotMetadataForPath(input.modulePath);
+  const snapshotMetadata =
+    metadata !== undefined && isPathInsideOrEqual(input.modulePath, metadata.snapshotSourceRoot)
+      ? metadata
+      : undefined;
+
+  if (snapshotMetadata === undefined && input.packageRoot === undefined) {
+    return input.code;
+  }
+
+  const decoded = decodeInlineSourceMap(input.code);
+  if (decoded === undefined) {
+    return input.code;
+  }
+
+  const sources = decoded.sourceMap.sources;
+  if (!Array.isArray(sources)) {
+    return input.code;
+  }
+
+  let changed = false;
+  const rewrittenSources = sources.map((source) => {
+    if (typeof source !== "string") {
+      return source;
+    }
+
+    const rewritten =
+      snapshotMetadata !== undefined
+        ? rewriteDevSnapshotSource({
+            metadata: snapshotMetadata,
+            modulePath: input.modulePath,
+            source,
+          })
+        : rewriteLiveAuthoredSource({
+            modulePath: input.modulePath,
+            packageRoot: input.packageRoot!,
+            source,
+          });
+    if (rewritten !== source) {
+      changed = true;
+    }
+    return rewritten;
+  });
+
+  if (!changed) {
+    return input.code;
+  }
+
+  const nextSourceMap = {
+    ...decoded.sourceMap,
+    sources: rewrittenSources,
+  };
+  const encoded = Buffer.from(JSON.stringify(nextSourceMap), "utf8").toString("base64");
+
+  return (
+    input.code.slice(0, decoded.matchStart) + decoded.prefix + encoded + decoded.trailingWhitespace
+  );
+}
+
+export function externalizeInlineSourceMap(input: {
+  readonly code: string;
+  readonly sourceMapFileName: string;
+}): { readonly code: string; readonly sourceMap?: Record<string, unknown> } {
+  const decoded = decodeInlineSourceMap(input.code);
+  if (decoded === undefined) {
+    return { code: input.code };
+  }
+
+  // These cache modules are imported through `file://...mjs?v=<hash>`. Chrome
+  // associates source maps with those URLs more reliably when the map is a
+  // sibling file instead of an inline data URL.
+  return {
+    code:
+      input.code.slice(0, decoded.matchStart) +
+      `//# sourceMappingURL=${input.sourceMapFileName}` +
+      decoded.trailingWhitespace,
+    sourceMap: decoded.sourceMap,
+  };
+}
+
+function decodeInlineSourceMap(code: string):
+  | {
+      readonly matchStart: number;
+      readonly prefix: string;
+      readonly sourceMap: Record<string, unknown>;
+      readonly trailingWhitespace: string;
+    }
+  | undefined {
+  const match = INLINE_SOURCE_MAP_PATTERN.exec(code);
+  if (match === null || match.index === undefined) {
+    return undefined;
+  }
+
+  try {
+    const sourceMap = JSON.parse(Buffer.from(match[2]!, "base64").toString("utf8")) as unknown;
+    if (sourceMap === null || typeof sourceMap !== "object" || Array.isArray(sourceMap)) {
+      return undefined;
+    }
+
+    return {
+      matchStart: match.index,
+      prefix: match[1]!,
+      sourceMap: sourceMap as Record<string, unknown>,
+      trailingWhitespace: match[3]!,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewriteDevSnapshotSource(input: {
+  readonly metadata: DevelopmentRuntimeArtifactsSnapshotMetadata;
+  readonly modulePath: string;
+  readonly source: string;
+}): string {
+  const sourcePath = normalizeSourceMapPath(input.source);
+  if (sourcePath === undefined) {
+    return input.source;
+  }
+
+  const candidates = createDevSnapshotSourceCandidates({
+    metadata: input.metadata,
+    modulePath: input.modulePath,
+    sourcePath,
+  });
+
+  const snapshotCandidates = candidates.filter((candidate) =>
+    isPathInsideOrEqual(candidate, input.metadata.snapshotSourceRoot),
+  );
+  const candidate =
+    snapshotCandidates.find((snapshotCandidate) => existsSync(snapshotCandidate)) ??
+    snapshotCandidates[0];
+
+  if (candidate !== undefined) {
+    return pathToFileURL(
+      join(input.metadata.sourceRoot, relative(input.metadata.snapshotSourceRoot, candidate)),
+    ).href;
+  }
+
+  return input.source;
+}
+
+function rewriteLiveAuthoredSource(input: {
+  readonly modulePath: string;
+  readonly packageRoot: string;
+  readonly source: string;
+}): string {
+  const sourcePath = normalizeSourceMapPath(input.source);
+  if (sourcePath === undefined) {
+    return input.source;
+  }
+
+  const candidates = createLiveAuthoredSourceCandidates({
+    modulePath: input.modulePath,
+    packageRoot: input.packageRoot,
+    sourcePath,
+  });
+  const candidate =
+    candidates.find((sourceCandidate) => existsSync(sourceCandidate)) ?? candidates[0];
+
+  return candidate === undefined ? input.source : pathToFileURL(candidate).href;
+}
+
+function createLiveAuthoredSourceCandidates(input: {
+  readonly modulePath: string;
+  readonly packageRoot: string;
+  readonly sourcePath: string;
+}): readonly string[] {
+  if (isAbsolute(input.sourcePath)) {
+    return [input.sourcePath];
+  }
+
+  const packageRelativeSource = resolve(
+    input.packageRoot,
+    stripLeadingRelativeSourceSegments(input.sourcePath),
+  );
+  const moduleRelativeSource = resolve(dirname(input.modulePath), input.sourcePath);
+  const packageRelativeOriginalSource = resolve(input.packageRoot, input.sourcePath);
+
+  return [packageRelativeSource, moduleRelativeSource, packageRelativeOriginalSource];
+}
+
+function createDevSnapshotSourceCandidates(input: {
+  readonly metadata: DevelopmentRuntimeArtifactsSnapshotMetadata;
+  readonly modulePath: string;
+  readonly sourcePath: string;
+}): readonly string[] {
+  if (isAbsolute(input.sourcePath)) {
+    return [input.sourcePath];
+  }
+
+  const appSourcePath = stripLeadingRelativeSourceSegments(input.sourcePath);
+  const moduleRelativeSource = resolve(dirname(input.modulePath), input.sourcePath);
+  const appRelativeSource = resolve(input.metadata.runtimeAppRoot, appSourcePath);
+  const sourceRootRelativeSource = resolve(input.metadata.snapshotSourceRoot, appSourcePath);
+  const appRelativeOriginalSource = resolve(input.metadata.runtimeAppRoot, input.sourcePath);
+  const sourceRootRelativeOriginalSource = resolve(
+    input.metadata.snapshotSourceRoot,
+    input.sourcePath,
+  );
+
+  if (input.sourcePath.startsWith("./") || input.sourcePath.startsWith("../")) {
+    return [
+      moduleRelativeSource,
+      appRelativeSource,
+      sourceRootRelativeSource,
+      appRelativeOriginalSource,
+      sourceRootRelativeOriginalSource,
+    ];
+  }
+
+  return [
+    appRelativeSource,
+    sourceRootRelativeSource,
+    moduleRelativeSource,
+    appRelativeOriginalSource,
+    sourceRootRelativeOriginalSource,
+  ];
+}
+
+function stripLeadingRelativeSourceSegments(sourcePath: string): string {
+  let stripped = sourcePath;
+
+  while (stripped.startsWith("./") || stripped.startsWith("../")) {
+    stripped = stripped.startsWith("./") ? stripped.slice(2) : stripped.slice(3);
+  }
+
+  return stripped;
+}
+
+function normalizeSourceMapPath(source: string): string | undefined {
+  if (source.startsWith("file://")) {
+    try {
+      return fileURLToPath(source);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (isSourceMapUrl(source)) {
+    return undefined;
+  }
+
+  return source;
+}
+
+function isPathInsideOrEqual(path: string, directory: string): boolean {
+  const resolvedPath = resolve(path);
+  const resolvedDirectory = resolve(directory);
+
+  return (
+    resolvedPath === resolvedDirectory || resolvedPath.startsWith(`${resolvedDirectory}${sep}`)
+  );
+}

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -1,11 +1,13 @@
 import { existsSync } from "node:fs";
 import { lstat, mkdir, readdir, readFile, symlink, utimes, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { loadAuthoredModuleNamespace } from "#internal/authored-module-loader.js";
+import { rewriteDevSnapshotSourceMap } from "#internal/authored-module-source-map.js";
 import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
 import {
   activateDevelopmentRuntimeArtifactsSnapshot,
@@ -16,6 +18,11 @@ import {
   resolveDevelopmentRuntimeArtifactsPointerPath,
   stageDevelopmentRuntimeArtifactsSnapshot,
 } from "#internal/nitro/dev-runtime-artifacts.js";
+import {
+  DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME,
+  DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+  DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
+} from "#internal/nitro/dev-runtime-snapshot-metadata.js";
 import { resolveNitroCompiledArtifactsSource } from "#internal/nitro/routes/runtime-artifacts.js";
 
 const createScratchDirectory = useTemporaryDirectories();
@@ -85,6 +92,7 @@ describe("development runtime artifact snapshots", () => {
         runtimeAppRoot: join(activeSnapshotRoot, "source", "app"),
         snapshotRoot: activeSnapshotRoot,
         snapshotSourceRoot: join(activeSnapshotRoot, "source"),
+        sourceRoot: appRoot,
       },
     });
 
@@ -178,6 +186,19 @@ describe("development runtime artifact snapshots", () => {
       runtimeAppRoot: snapshot.runtimeAppRoot,
       snapshotRoot: snapshot.snapshotRoot,
       version: 2,
+    });
+    await expect(
+      readFile(join(snapshot.snapshotRoot, DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME), "utf8").then(
+        (source) => JSON.parse(source) as Record<string, unknown>,
+      ),
+    ).resolves.toMatchObject({
+      appRoot,
+      kind: DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+      runtimeAppRoot: snapshot.runtimeAppRoot,
+      snapshotRoot: snapshot.snapshotRoot,
+      snapshotSourceRoot: snapshot.snapshotSourceRoot,
+      sourceRoot: appRoot,
+      version: DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
     });
     expect(
       resolveNitroCompiledArtifactsSource({
@@ -384,4 +405,123 @@ describe("development runtime artifact snapshots", () => {
 
     expect(moduleNamespace.result).toBe("snapshotted:external");
   });
+
+  it("leaves inline source maps unchanged outside dev runtime snapshots", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-sourcemap-normal-");
+    const sourceMap = createInlineSourceMap({
+      sources: [join(appRoot, "agent", "tool.ts")],
+      sourcesContent: ["export const answer = 42;\n"],
+    });
+    const code = `export const answer = 42;\n${sourceMap}\n`;
+
+    expect(
+      rewriteDevSnapshotSourceMap({
+        code,
+        modulePath: join(appRoot, "agent", "tool.ts"),
+      }),
+    ).toBe(code);
+  });
+
+  it("rewrites dev snapshot inline source maps back to live source paths", async () => {
+    const sourceRoot = await createScratchDirectory("eve-dev-runtime-sourcemap-");
+    const appRoot = join(sourceRoot, "apps", "weather");
+    const snapshotRoot = join(appRoot, ".eve", "dev-runtime", "snapshots", "revision-a");
+    const snapshotSourceRoot = join(snapshotRoot, "source");
+    const runtimeAppRoot = join(snapshotSourceRoot, "apps", "weather");
+    const modulePath = join(runtimeAppRoot, "agent", "tools", "get_weather.ts");
+
+    await mkdir(dirname(modulePath), { recursive: true });
+    await mkdir(join(snapshotSourceRoot, "packages", "shared", "src"), { recursive: true });
+    await writeFile(modulePath, "export const weather = 72;\n");
+    await writeFile(
+      join(runtimeAppRoot, "agent", "tools", "helper.ts"),
+      "export const helper = true;\n",
+    );
+    await mkdir(join(runtimeAppRoot, "agent", "tools", "agent", "tools"), { recursive: true });
+    await writeFile(
+      join(runtimeAppRoot, "agent", "tools", "agent", "tools", "helper.ts"),
+      "export const doubled = true;\n",
+    );
+    await writeFile(
+      join(snapshotSourceRoot, "packages", "shared", "src", "message.ts"),
+      "export const message = 'hi';\n",
+    );
+    await writeFile(
+      join(snapshotRoot, DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME),
+      `${JSON.stringify(
+        {
+          appRoot,
+          kind: DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+          runtimeAppRoot,
+          snapshotRoot,
+          snapshotSourceRoot,
+          sourceRoot,
+          version: DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await mkdir(join(appRoot, ".eve", "dev-runtime"), { recursive: true });
+    await writeFile(
+      join(appRoot, ".eve", "dev-runtime", "current.json"),
+      `${JSON.stringify({ sourceRoot: "/must/not/be/used" })}\n`,
+    );
+
+    const sourceMap = createInlineSourceMap({
+      sources: [modulePath, "agent/tools/helper.ts", "packages/shared/src/message.ts", "node:fs"],
+      sourcesContent: [
+        "export const weather = 72;\n",
+        "export const helper = true;\n",
+        "export const message = 'hi';\n",
+        null,
+      ],
+    });
+    const code = `export const weather = 72;\n${sourceMap}\n`;
+
+    const rewritten = rewriteDevSnapshotSourceMap({ code, modulePath });
+    const rewrittenSourceMap = readInlineSourceMap(rewritten);
+
+    expect(rewrittenSourceMap.sources).toEqual([
+      pathToFileURL(join(sourceRoot, "apps", "weather", "agent", "tools", "get_weather.ts")).href,
+      pathToFileURL(join(sourceRoot, "apps", "weather", "agent", "tools", "helper.ts")).href,
+      pathToFileURL(join(sourceRoot, "packages", "shared", "src", "message.ts")).href,
+      "node:fs",
+    ]);
+    expect(rewrittenSourceMap.sourcesContent).toEqual([
+      "export const weather = 72;\n",
+      "export const helper = true;\n",
+      "export const message = 'hi';\n",
+      null,
+    ]);
+  });
 });
+
+function createInlineSourceMap(input: {
+  readonly sources: readonly string[];
+  readonly sourcesContent: readonly (string | null)[];
+}): string {
+  const sourceMap = {
+    mappings: "",
+    sources: input.sources,
+    sourcesContent: input.sourcesContent,
+    version: 3,
+  };
+  const encoded = Buffer.from(JSON.stringify(sourceMap), "utf8").toString("base64");
+  return `//# sourceMappingURL=data:application/json;base64,${encoded}`;
+}
+
+function readInlineSourceMap(code: string): {
+  readonly sources: readonly string[];
+  readonly sourcesContent: readonly (string | null)[];
+} {
+  const match = /sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/u.exec(code);
+  if (match === null) {
+    throw new Error("Missing inline source map.");
+  }
+
+  return JSON.parse(Buffer.from(match[1]!, "base64").toString("utf8")) as {
+    readonly sources: readonly string[];
+    readonly sourcesContent: readonly (string | null)[];
+  };
+}

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -6,6 +6,7 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { copyDevelopmentSourceSnapshot } from "#internal/nitro/dev-runtime-source-snapshot-copy.js";
 import { createDevelopmentSourceSnapshotPlan } from "#internal/nitro/dev-runtime-source-snapshot.js";
+import { writeDevelopmentRuntimeSnapshotMetadata } from "#internal/nitro/dev-runtime-snapshot-metadata.js";
 
 const DEV_RUNTIME_ARTIFACTS_DIRECTORY = "dev-runtime";
 const DEV_RUNTIME_ARTIFACTS_POINTER_VERSION = 2;
@@ -34,6 +35,7 @@ export interface DevelopmentRuntimeArtifactsSnapshot {
   readonly runtimeAppRoot: string;
   readonly snapshotRoot: string;
   readonly snapshotSourceRoot: string;
+  readonly sourceRoot: string;
 }
 
 /**
@@ -105,6 +107,15 @@ export async function stageDevelopmentRuntimeArtifactsSnapshot(
       ),
       runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
     });
+    // The runtime uses frozen snapshot files, but source maps need this
+    // provenance to point DevTools back at live authored workspace files.
+    await writeDevelopmentRuntimeSnapshotMetadata({
+      appRoot: sourceSnapshotPlan.appRoot,
+      runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
+      snapshotRoot,
+      snapshotSourceRoot: sourceSnapshotPlan.snapshotSourceRoot,
+      sourceRoot: sourceSnapshotPlan.sourceRoot,
+    });
   } catch (error) {
     await rm(snapshotRoot, { force: true, recursive: true }).catch(() => {});
     throw error;
@@ -114,6 +125,7 @@ export async function stageDevelopmentRuntimeArtifactsSnapshot(
     runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
     snapshotRoot,
     snapshotSourceRoot: sourceSnapshotPlan.snapshotSourceRoot,
+    sourceRoot: sourceSnapshotPlan.sourceRoot,
   };
 }
 

--- a/packages/eve/src/internal/nitro/dev-runtime-snapshot-metadata.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-snapshot-metadata.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+export const DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME = "snapshot-metadata.json";
+export const DEV_RUNTIME_SNAPSHOT_METADATA_KIND = "eve-dev-runtime-snapshot-metadata";
+export const DEV_RUNTIME_SNAPSHOT_METADATA_VERSION = 1;
+
+export interface DevelopmentRuntimeArtifactsSnapshotMetadata {
+  readonly appRoot: string;
+  readonly kind: typeof DEV_RUNTIME_SNAPSHOT_METADATA_KIND;
+  readonly runtimeAppRoot: string;
+  readonly snapshotRoot: string;
+  readonly snapshotSourceRoot: string;
+  readonly sourceRoot: string;
+  readonly version: typeof DEV_RUNTIME_SNAPSHOT_METADATA_VERSION;
+}
+
+/**
+ * Dev runtime snapshots execute immutable copied files, but debugger surfaces
+ * need enough provenance to map those snapshot paths back to live workspace
+ * files that users can edit and set breakpoints in.
+ */
+export async function writeDevelopmentRuntimeSnapshotMetadata(input: {
+  readonly appRoot: string;
+  readonly runtimeAppRoot: string;
+  readonly snapshotRoot: string;
+  readonly snapshotSourceRoot: string;
+  readonly sourceRoot: string;
+}): Promise<void> {
+  const metadata: DevelopmentRuntimeArtifactsSnapshotMetadata = {
+    appRoot: input.appRoot,
+    kind: DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+    runtimeAppRoot: input.runtimeAppRoot,
+    snapshotRoot: input.snapshotRoot,
+    snapshotSourceRoot: input.snapshotSourceRoot,
+    sourceRoot: input.sourceRoot,
+    version: DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
+  };
+
+  await writeFile(
+    join(input.snapshotRoot, DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+}
+
+export function readDevelopmentRuntimeSnapshotMetadataForPath(
+  path: string,
+): DevelopmentRuntimeArtifactsSnapshotMetadata | undefined {
+  let currentDirectory = dirname(resolve(path));
+
+  while (true) {
+    const metadataPath = join(currentDirectory, DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME);
+    if (existsSync(metadataPath)) {
+      return readDevelopmentRuntimeSnapshotMetadata(metadataPath);
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return undefined;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+}
+
+export function readDevelopmentRuntimeSnapshotMetadata(
+  path: string,
+): DevelopmentRuntimeArtifactsSnapshotMetadata | undefined {
+  try {
+    const metadata = JSON.parse(
+      readFileSync(path, "utf8"),
+    ) as Partial<DevelopmentRuntimeArtifactsSnapshotMetadata>;
+    if (
+      metadata.kind !== DEV_RUNTIME_SNAPSHOT_METADATA_KIND ||
+      metadata.version !== DEV_RUNTIME_SNAPSHOT_METADATA_VERSION ||
+      typeof metadata.appRoot !== "string" ||
+      typeof metadata.runtimeAppRoot !== "string" ||
+      typeof metadata.snapshotRoot !== "string" ||
+      typeof metadata.snapshotSourceRoot !== "string" ||
+      typeof metadata.sourceRoot !== "string"
+    ) {
+      return undefined;
+    }
+
+    return {
+      appRoot: metadata.appRoot,
+      kind: DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+      runtimeAppRoot: metadata.runtimeAppRoot,
+      snapshotRoot: metadata.snapshotRoot,
+      snapshotSourceRoot: metadata.snapshotSourceRoot,
+      sourceRoot: metadata.sourceRoot,
+      version: DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -24,6 +24,7 @@ import { configureNitroRoutes } from "#internal/nitro/host/configure-nitro-route
 import { applyEveCronHandlerRoute } from "#internal/nitro/host/cron-handler-route.js";
 import { createNitroBundlerConfig } from "#internal/nitro/host/nitro-bundler-config.js";
 import { captureDevLiveVirtualModules } from "#internal/nitro/host/dev-live-virtual-modules.js";
+import { addDevelopmentSourceMapNormalizePlugin } from "#internal/nitro/host/dev-source-map-normalize-plugin.js";
 import {
   createOptionalEngineDependencyPlugin,
   OPTIONAL_ENGINE_PACKAGES_BY_BACKEND_NAME,
@@ -742,6 +743,10 @@ export async function createApplicationNitro(
   addNitroRoutingImportSpecifierPlugin(nitro);
   if (dev) {
     captureDevLiveVirtualModules(nitro);
+    // The final Nitro dev map mixes virtual route ids, immutable snapshot
+    // files, and generated `.eve` artifacts. Normalize those source URLs so
+    // DevTools shows live authored files and Eve-owned virtual namespaces.
+    addDevelopmentSourceMapNormalizePlugin(nitro);
   }
 
   // Resolve bare `workflow/*` specifiers during Nitro's Rollup bundling so

--- a/packages/eve/src/internal/nitro/host/dev-source-map-normalize-plugin.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-source-map-normalize-plugin.integration.test.ts
@@ -1,0 +1,110 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME,
+  DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+  DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
+} from "#internal/nitro/dev-runtime-snapshot-metadata.js";
+import { normalizeDevelopmentSourceMapForDevTools } from "#internal/nitro/host/dev-source-map-normalize-plugin.js";
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+const createScratchDirectory = useTemporaryDirectories();
+
+describe("normalizeDevelopmentSourceMapForDevTools", () => {
+  it("folds sourceRoot into relative sources before dropping sourceRoot", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-sourcemap-source-root-");
+    const sourcePath = join(appRoot, "agent", "tools", "source-root-breakpoint.ts");
+    const sourceMapPath = join(appRoot, ".eve", "nitro", "server", "index.mjs.map");
+
+    await mkdir(dirname(sourcePath), { recursive: true });
+    await mkdir(dirname(sourceMapPath), { recursive: true });
+    await writeFile(sourcePath, "export const sourceRootBreakpoint = true;\n");
+    await writeFile(
+      sourceMapPath,
+      `${JSON.stringify({
+        mappings: "",
+        sourceRoot: appRoot,
+        sources: ["agent/tools/source-root-breakpoint.ts", "node:fs"],
+        version: 3,
+      })}\n`,
+    );
+
+    expect(normalizeDevelopmentSourceMapForDevTools(sourceMapPath, { appRoot })).toBe(true);
+
+    const normalized = JSON.parse(await readFile(sourceMapPath, "utf8")) as {
+      readonly ignoreList: readonly number[];
+      readonly sourceRoot?: unknown;
+      readonly sources: readonly string[];
+    };
+    expect(normalized.sources).toEqual([pathToFileURL(sourcePath).href, "node:fs"]);
+    expect(normalized.sourceRoot).toBeUndefined();
+    expect(normalized.ignoreList).toEqual([1]);
+  });
+
+  it("rewrites file URL dev snapshot sources away from the .eve snapshot tree", async () => {
+    const sourceRoot = await createScratchDirectory("eve-dev-sourcemap-normalize-");
+    const appRoot = join(sourceRoot, "apps", "agent-tools");
+    const snapshotRoot = join(appRoot, ".eve", "dev-runtime", "snapshots", "revision-a");
+    const snapshotSourceRoot = join(snapshotRoot, "source");
+    const runtimeAppRoot = join(snapshotSourceRoot, "apps", "agent-tools");
+    const authoredSnapshotPath = join(runtimeAppRoot, "agent", "tools", "dynamic-echo.ts");
+    const runtimeArtifactPath = join(
+      runtimeAppRoot,
+      ".eve",
+      "compile",
+      "compiled-agent-manifest.json",
+    );
+    const sourceMapPath = join(snapshotRoot, "server", "index.mjs.map");
+
+    await mkdir(dirname(authoredSnapshotPath), { recursive: true });
+    await mkdir(dirname(runtimeArtifactPath), { recursive: true });
+    await mkdir(dirname(sourceMapPath), { recursive: true });
+    await writeFile(authoredSnapshotPath, "export const dynamicEcho = true;\n");
+    await writeFile(runtimeArtifactPath, "{}\n");
+    await writeFile(
+      join(snapshotRoot, DEV_RUNTIME_SNAPSHOT_METADATA_FILE_NAME),
+      `${JSON.stringify(
+        {
+          appRoot,
+          kind: DEV_RUNTIME_SNAPSHOT_METADATA_KIND,
+          runtimeAppRoot,
+          snapshotRoot,
+          snapshotSourceRoot,
+          sourceRoot,
+          version: DEV_RUNTIME_SNAPSHOT_METADATA_VERSION,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      sourceMapPath,
+      `${JSON.stringify({
+        mappings: "",
+        sources: [
+          pathToFileURL(authoredSnapshotPath).href,
+          pathToFileURL(runtimeArtifactPath).href,
+          "node:fs",
+        ],
+        version: 3,
+      })}\n`,
+    );
+
+    expect(normalizeDevelopmentSourceMapForDevTools(sourceMapPath, { appRoot })).toBe(true);
+
+    const normalized = JSON.parse(await readFile(sourceMapPath, "utf8")) as {
+      readonly ignoreList: readonly number[];
+      readonly sources: readonly string[];
+    };
+    expect(normalized.sources).toEqual([
+      pathToFileURL(join(appRoot, "agent", "tools", "dynamic-echo.ts")).href,
+      "eve://runtime/.eve/compile/compiled-agent-manifest.json",
+      "node:fs",
+    ]);
+    expect(normalized.ignoreList).toEqual([1, 2]);
+  });
+});

--- a/packages/eve/src/internal/nitro/host/dev-source-map-normalize-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/dev-source-map-normalize-plugin.ts
@@ -1,0 +1,318 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import type { Nitro } from "nitro/types";
+
+import { readDevelopmentRuntimeSnapshotMetadataForPath } from "#internal/nitro/dev-runtime-snapshot-metadata.js";
+import { isSourceMapUrl } from "#internal/source-map-path.js";
+
+interface MutableSourceMap {
+  ignoreList?: unknown;
+  sources?: unknown;
+  sourceRoot?: unknown;
+  version: number;
+}
+
+interface NormalizedSourceMapSource {
+  readonly authored: boolean;
+  readonly source: string;
+}
+
+interface NormalizeDevelopmentSourceMapOptions {
+  readonly appRoot?: string;
+}
+
+/**
+ * Cleans up Nitro's final dev bundle sourcemap for Chrome DevTools.
+ *
+ * Nitro virtual ids are `#...` specifiers. If they stay relative in the final
+ * map, Chrome resolves them as `file:///app/#...` and renders many duplicate
+ * entries named after the app directory. Dev snapshots are also real runtime
+ * files, but users want breakpoints in their live workspace files. This pass
+ * moves virtual/generated runtime sources to Eve-owned URL schemes and rewrites
+ * snapshot-authored sources back to live `file://` URLs.
+ */
+export function addDevelopmentSourceMapNormalizePlugin(nitro: Nitro): void {
+  nitro.hooks.hook("rollup:before", (_nitro, config) => {
+    if (!Array.isArray(config.plugins)) {
+      return;
+    }
+
+    config.plugins.push({
+      name: "eve:dev-source-map-normalize",
+      writeBundle(options, bundle) {
+        if (options.dir === undefined) {
+          return;
+        }
+
+        for (const item of Object.values(bundle)) {
+          if (item.type !== "chunk") {
+            continue;
+          }
+
+          const sourceMapPath = join(options.dir, `${item.fileName}.map`);
+          if (!existsSync(sourceMapPath)) {
+            continue;
+          }
+
+          normalizeDevelopmentSourceMapForDevTools(sourceMapPath, {
+            appRoot: nitro.options.rootDir,
+          });
+        }
+      },
+    });
+  });
+}
+
+export function normalizeDevelopmentSourceMapForDevTools(
+  sourceMapPath: string,
+  options: NormalizeDevelopmentSourceMapOptions = {},
+): boolean {
+  const map = JSON.parse(readFileSync(sourceMapPath, "utf8")) as MutableSourceMap;
+  if (!Array.isArray(map.sources)) {
+    return false;
+  }
+
+  const sourceMapDirectory = dirname(sourceMapPath);
+  const appRoot = options.appRoot === undefined ? undefined : resolve(options.appRoot);
+  const sourceRoot =
+    typeof map.sourceRoot === "string" && map.sourceRoot.length > 0 ? map.sourceRoot : undefined;
+  let changed = false;
+  const normalizedSources = map.sources.map((source) => {
+    if (typeof source !== "string") {
+      return { authored: false, source: String(source) };
+    }
+
+    const normalized = normalizeDevSourceMapSource(sourceMapDirectory, source, appRoot, sourceRoot);
+    if (normalized.source !== source) {
+      changed = true;
+    }
+    return normalized;
+  });
+  const sources = normalizedSources.map((source) => source.source);
+  // Only live authored files should stay prominent in DevTools; virtual ids,
+  // framework/runtime files, and generated artifacts are useful but noisy.
+  const ignoreList = appRoot === undefined ? [] : createDevToolsIgnoreList(normalizedSources);
+  if (!numberArraysEqual(ignoreList, map.ignoreList)) {
+    changed = true;
+  }
+
+  if (map.sourceRoot !== undefined) {
+    changed = true;
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  writeFileSync(
+    sourceMapPath,
+    `${JSON.stringify({
+      ...map,
+      ignoreList,
+      sources,
+      sourceRoot: undefined,
+    })}\n`,
+  );
+  return true;
+}
+
+function normalizeDevSourceMapSource(
+  sourceMapDirectory: string,
+  source: string,
+  appRoot: string | undefined,
+  sourceRoot: string | undefined,
+): NormalizedSourceMapSource {
+  const virtualSource = normalizeVirtualSource(source);
+  if (virtualSource !== undefined) {
+    return { authored: false, source: virtualSource };
+  }
+
+  const resolvedSource = resolveSourceMapSource({
+    source,
+    sourceMapDirectory,
+    sourceRoot,
+  });
+  if (resolvedSource.path === undefined) {
+    return { authored: false, source: resolvedSource.source };
+  }
+
+  const sourcePath = resolvedSource.path;
+  const metadata = readDevelopmentRuntimeSnapshotMetadataForPath(sourcePath);
+  if (metadata === undefined) {
+    return {
+      authored: isAuthoredApplicationSourcePath(sourcePath, appRoot),
+      source: resolvedSource.source,
+    };
+  }
+
+  if (!isPathInsideOrEqual(sourcePath, metadata.snapshotSourceRoot)) {
+    return {
+      authored: isAuthoredApplicationSourcePath(sourcePath, appRoot),
+      source: resolvedSource.source,
+    };
+  }
+
+  // Generated runtime artifacts are useful context, but mapping them back into
+  // the app's real `.eve` directory makes DevTools look like user source.
+  if (isPathInsideOrEqual(sourcePath, join(metadata.runtimeAppRoot, ".eve"))) {
+    return {
+      authored: false,
+      source: toEveRuntimeSourceUrl(relative(metadata.runtimeAppRoot, sourcePath)),
+    };
+  }
+
+  const liveSourcePath = join(
+    metadata.sourceRoot,
+    relative(metadata.snapshotSourceRoot, sourcePath),
+  );
+  const authored = isAuthoredApplicationSourcePath(liveSourcePath, appRoot);
+
+  if (!authored && appRoot !== undefined) {
+    return {
+      authored: false,
+      source: toEveRuntimeSourceUrl(relative(metadata.snapshotSourceRoot, sourcePath)),
+    };
+  }
+
+  return {
+    authored,
+    source: pathToFileURL(liveSourcePath).href,
+  };
+}
+
+function resolveSourceMapSource(input: {
+  readonly source: string;
+  readonly sourceMapDirectory: string;
+  readonly sourceRoot: string | undefined;
+}): { readonly path?: string; readonly source: string } {
+  const fileUrlSourcePath = parseFileUrlSourcePath(input.source);
+  if (fileUrlSourcePath !== undefined) {
+    return { path: fileUrlSourcePath, source: input.source };
+  }
+
+  if (isSourceMapUrl(input.source)) {
+    return { source: input.source };
+  }
+
+  if (isAbsolute(input.source)) {
+    return { path: input.source, source: input.source };
+  }
+
+  if (input.sourceRoot === undefined) {
+    return {
+      path: resolve(input.sourceMapDirectory, input.source),
+      source: input.source,
+    };
+  }
+
+  const sourceRootPath = parseFileUrlSourcePath(input.sourceRoot);
+  if (sourceRootPath !== undefined) {
+    const sourcePath = resolve(sourceRootPath, input.source);
+    return { path: sourcePath, source: pathToFileURL(sourcePath).href };
+  }
+
+  if (isSourceMapUrl(input.sourceRoot)) {
+    try {
+      const baseUrl = input.sourceRoot.endsWith("/") ? input.sourceRoot : `${input.sourceRoot}/`;
+      return { source: new URL(input.source, baseUrl).href };
+    } catch {
+      return { source: input.source };
+    }
+  }
+
+  const sourcePath = resolve(
+    isAbsolute(input.sourceRoot)
+      ? input.sourceRoot
+      : resolve(input.sourceMapDirectory, input.sourceRoot),
+    input.source,
+  );
+  return { path: sourcePath, source: pathToFileURL(sourcePath).href };
+}
+
+function normalizeVirtualSource(source: string): string | undefined {
+  const stripped = stripLeadingRelativeSourceSegments(source.replaceAll("\\", "/"));
+  if (!stripped.startsWith("#")) {
+    return undefined;
+  }
+
+  // Chrome resolves relative `#...` sources as app files; an Eve-owned scheme
+  // keeps Nitro virtual modules out of the authored source tree.
+  return toEveNitroSourceUrl(stripped.slice(1).trim());
+}
+
+function stripLeadingRelativeSourceSegments(source: string): string {
+  let stripped = source;
+  while (stripped.startsWith("./") || stripped.startsWith("../")) {
+    stripped = stripped.startsWith("./") ? stripped.slice(2) : stripped.slice(3);
+  }
+  return stripped;
+}
+
+function toEveNitroSourceUrl(source: string): string {
+  return `eve://nitro/${encodeSourcePath(source)}`;
+}
+
+function toEveRuntimeSourceUrl(source: string): string {
+  return `eve://runtime/${encodeSourcePath(source)}`;
+}
+
+function encodeSourcePath(source: string): string {
+  return source
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function parseFileUrlSourcePath(source: string): string | undefined {
+  if (!source.startsWith("file://")) {
+    return undefined;
+  }
+
+  try {
+    return fileURLToPath(source);
+  } catch {
+    return undefined;
+  }
+}
+
+function isAuthoredApplicationSourcePath(path: string, appRoot: string | undefined): boolean {
+  if (appRoot === undefined || !isPathInsideOrEqual(path, appRoot)) {
+    return false;
+  }
+
+  const relativePath = relative(appRoot, path);
+  if (relativePath === "") {
+    return false;
+  }
+
+  const parts = relativePath.split(/[\\/]/);
+  return !parts.includes(".eve") && !parts.includes("node_modules");
+}
+
+function createDevToolsIgnoreList(sources: readonly NormalizedSourceMapSource[]): number[] {
+  const ignoreList: number[] = [];
+  for (const [sourceIndex, source] of sources.entries()) {
+    if (!source.authored) {
+      ignoreList.push(sourceIndex);
+    }
+  }
+  return ignoreList;
+}
+
+function numberArraysEqual(left: readonly number[], right: unknown): boolean {
+  if (!Array.isArray(right) || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => right[index] === value);
+}
+
+function isPathInsideOrEqual(path: string, directory: string): boolean {
+  const relativePath = relative(directory, path);
+  return (
+    relativePath === "" || (!relativePath.startsWith("..") && !relativePath.includes(`..${sep}`))
+  );
+}

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -215,6 +215,7 @@ describe("startDevelopmentServer", () => {
     Object.assign(mocks.nitro.options.devServer, {
       hostname: "127.0.0.1",
       port: undefined,
+      runner: undefined,
     });
     Object.assign(mocks.listenerServer, {
       url: "http://localhost:2000/",
@@ -262,6 +263,16 @@ describe("startDevelopmentServer", () => {
     expect(process.env.WORKFLOW_LOCAL_BASE_URL).toBeUndefined();
     expect(process.env.PORT).toBeUndefined();
     expect(process.env.EVE_DEVELOPMENT_SANDBOX_RUN_ID).toBeUndefined();
+  });
+
+  it("uses Nitro's self runner when runtime debugging is enabled", async () => {
+    const { startDevelopmentServer } = await import("./start-development-server.js");
+
+    const server = await startDevelopmentServer("/tmp/eve-test", { runtimeDebugging: true });
+
+    expect(mocks.nitro.options.devServer).toMatchObject({ runner: "self" });
+
+    await server.close();
   });
 
   it("uses eve's default port when no port is requested", async () => {

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -467,6 +467,7 @@ export async function startDevelopmentServer(
   options: {
     host?: string;
     port?: number;
+    runtimeDebugging?: boolean;
   } = {},
 ): Promise<DevelopmentServerHandle> {
   // Marks this process tree as an `eve dev` session so runtime features
@@ -499,6 +500,13 @@ export async function startDevelopmentServer(
     });
     pruneLocalSandboxTemplatesInBackground(preparedHost.appRoot);
     nitro = await createApplicationNitro(preparedHost, true);
+    if (options.runtimeDebugging === true) {
+      // Nitro's default dev runner handles requests in a worker. The Node
+      // inspector opened by `eve dev --inspect*` attaches to this parent
+      // process, so debug sessions must execute runtime code in-process for
+      // authored tool breakpoints to pause reliably.
+      nitro.options.devServer.runner = "self";
+    }
     devServer = createDevServer(nitro);
     guardDevelopmentServerWebSocketUpgrades(nitro, devServer);
     const hostname =

--- a/packages/eve/src/internal/source-map-path.test.ts
+++ b/packages/eve/src/internal/source-map-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { isSourceMapUrl } from "./source-map-path.js";
+
+describe("isSourceMapUrl", () => {
+  it("distinguishes Windows absolute paths from URL schemes", () => {
+    expect(isSourceMapUrl("C:\\repo\\app\\agent\\tool.ts")).toBe(false);
+    expect(isSourceMapUrl("C:/repo/app/agent/tool.ts")).toBe(false);
+    expect(isSourceMapUrl("/C:/repo/app/agent/tool.ts")).toBe(false);
+    expect(isSourceMapUrl("\\\\server\\share\\agent\\tool.ts")).toBe(false);
+
+    expect(isSourceMapUrl("file:///C:/repo/app/agent/tool.ts")).toBe(true);
+    expect(isSourceMapUrl("node:fs")).toBe(true);
+    expect(isSourceMapUrl("webpack://app/agent/tool.ts")).toBe(true);
+  });
+});

--- a/packages/eve/src/internal/source-map-path.ts
+++ b/packages/eve/src/internal/source-map-path.ts
@@ -1,0 +1,11 @@
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^(?:\/?[A-Za-z]:[\\/]|\\\\[^\\])/u;
+const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/u;
+
+/**
+ * Returns whether a source-map reference is a URL rather than a filesystem path.
+ * Windows drive-letter paths resemble URL schemes, so they must be excluded
+ * before applying the generic scheme check.
+ */
+export function isSourceMapUrl(source: string): boolean {
+  return !WINDOWS_ABSOLUTE_PATH_PATTERN.test(source) && URL_SCHEME_PATTERN.test(source);
+}


### PR DESCRIPTION
### Description

Adds local runtime debugging support to `eve dev` through `--inspect`, `--inspect-wait`, and `--inspect-brk`. When inspector mode is enabled, Nitro dev runs runtime code in-process so breakpoints in authored tools and runtime files pause the same Node process the debugger is attached to.

This also adds source-map remapping for dev runtime snapshots and cached authored-module bundles. Runtime sessions still execute immutable `.eve/dev-runtime/snapshots/` files, but source maps now point debugger surfaces back to the live workspace files. Nitro virtual/generated sources are moved under Eve-owned URL schemes and non-authored sources are added to DevTools ignore lists.

The implementation keeps the larger dev-runtime pieces split into focused modules: dev CLI option parsing/display helpers live under `src/cli/dev/options.ts`, and authored-module source-map rewriting lives under `src/internal/authored-module-source-map.ts`. (needed for passing the lint check, also)

**Note:** Chrome DevTools ignores `node_modules/` by default. For now, when debugging with Chrome DevTools, remove the `node_modules/` ignore list entry by right clicking to it in the Sources list, and clicking "Remove from Ignore List". Longer term, Eve should move generated authored-module bundles out of node_modules/.cache so this manual DevTools configuration is unnecessary.

### How did you test your changes?

I ran `pnpm dev --inspect` in the `agent-tools` fixture and verified in Chrome DevTools and VS Code that the attached debugger shows console logs and can pause on breakpoints in tool calls, hooks, and channels.

I also ran the relevant checks from `CONTRIBUTING.md`, including formatting, lint/invariant checks, typecheck, build, unit tests, integration tests, and scenario tests. After the refactor, I re-ran the targeted unit/integration tests, `turbo run typecheck --filter=eve`, and the full unit suite.

### PR Checklist

- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)