### PR TITLE
feat(eve): cancel active turns server-side

### DIFF
--- a/.changeset/native-turn-cancellation.md
+++ b/.changeset/native-turn-cancellation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add authenticated per-turn server cancellation and propagate its AbortSignal through model and authored tool execution while preserving durable parent sessions.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -18,20 +18,21 @@ export default eveChannel({
 
 ## Routes
 
-The channel exposes routes that create sessions, send follow-ups, and stream events:
+The channel exposes routes that create sessions, send follow-ups, cancel active turns, and stream events:
 
 - `GET /eve/v1/health`
 - `POST /eve/v1/session` (start a session)
 - `POST /eve/v1/session/:sessionId` (send a follow-up)
+- `POST /eve/v1/session/:sessionId/cancel` (cancel the active turn)
 - `GET /eve/v1/session/:sessionId/stream` (stream events, NDJSON)
 
-Start a session with a minimal body. The response returns `sessionId` and the `continuationToken` you reuse for follow-ups:
+Start a session with a minimal body. The response returns `sessionId`, the `continuationToken` you reuse for follow-ups, and a one-turn `cancelToken`:
 
 ```bash
 curl -X POST https://<deployment>/eve/v1/session \
   -H "Content-Type: application/json" \
   -d '{"message":"What is the weather in Paris?"}'
-# {"continuationToken":"eve:7f3c...","ok":true,"sessionId":"ses_01h..."}
+# {"cancelToken":"eve:cancel:9a2d...","continuationToken":"eve:7f3c...","ok":true,"sessionId":"ses_01h..."}
 ```
 
 Stream that session's events as newline-delimited JSON (`application/x-ndjson; charset=utf-8`), one event object per line:
@@ -41,6 +42,14 @@ curl -N https://<deployment>/eve/v1/session/ses_01h.../stream
 # {"type":"turn.started",...}
 # {"type":"text.delta","delta":"It is "}
 # {"type":"message.completed",...}
+```
+
+Cancel only that active turn by posting its `cancelToken`. The child turn stops cooperatively and emits a recoverable failure boundary ending in `session.waiting`; the parent session remains available for follow-ups:
+
+```bash
+curl -X POST https://<deployment>/eve/v1/session/ses_01h.../cancel \
+  -H "Content-Type: application/json" \
+  -d '{"cancelToken":"eve:cancel:9a2d..."}'
 ```
 
 See [Sessions, runs & streaming](../concepts/sessions-runs-and-streaming) for the full request and stream flow, including the complete event set.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -24,7 +24,7 @@ curl -X POST http://127.0.0.1:3000/eve/v1/session \
   -d '{"message":"Summarize the latest forecast."}'
 ```
 
-eve responds right away. The JSON body carries a `sessionId` and a `continuationToken`, and the `x-eve-session-id` header names the durable session to stream.
+eve responds right away. The JSON body carries a `sessionId`, a `continuationToken`, and a one-turn `cancelToken`. The `x-eve-session-id` header names the durable session to stream.
 
 ## Stream a session
 
@@ -83,6 +83,18 @@ curl -X POST http://127.0.0.1:3000/eve/v1/session/<sessionId> \
 ```
 
 The follow-up reuses the same durable session: same history, same state.
+
+## Cancel the active turn
+
+Post the active turn's `cancelToken` to stop its child workflow without terminating the parent session:
+
+```bash
+curl -X POST http://127.0.0.1:3000/eve/v1/session/<sessionId>/cancel \
+  -H 'content-type: application/json' \
+  -d '{"cancelToken":"<cancelToken>"}'
+```
+
+The turn receives a durable `AbortSignal` and stops cooperatively. Its stream ends with `step.failed` and `turn.failed` using `code: "TURN_CANCELLED"`, followed by `session.waiting`. You can then send another follow-up with the same continuation token.
 
 For deterministic ordering, send one follow-up at a time and wait for the next `session.waiting` event before sending another message to the same session. See [message delivery and queueing](./execution-model-and-durability#message-delivery-and-queueing) for the current runtime contract.
 

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -16,6 +16,7 @@ The route-auth policy lives on the HTTP channel factory (`agent/channels/eve.ts`
 
 - `POST /eve/v1/session`
 - `POST /eve/v1/session/:sessionId`
+- `POST /eve/v1/session/:sessionId/cancel`
 - `GET /eve/v1/session/:sessionId/stream`
 
 These routes are protected by the channel's auth policy. eve fails closed by default: production browser traffic is rejected unless you configure an authenticator that accepts it, and anonymous access requires an explicit `none()`.

--- a/packages/eve/src/channel/cross-channel-receive.test.ts
+++ b/packages/eve/src/channel/cross-channel-receive.test.ts
@@ -10,6 +10,7 @@ import type { Runtime } from "#channel/types.js";
 
 function makeRuntime(): Runtime {
   return {
+    cancelTurn: vi.fn().mockResolvedValue(false),
     deliver: vi.fn(),
     getEventStream: vi.fn(),
     run: vi.fn(),
@@ -18,6 +19,9 @@ function makeRuntime(): Runtime {
 
 function makeSession(): Session {
   return {
+    async cancelTurn() {
+      return false;
+    },
     id: "sess_1",
     continuationToken: "tok",
     async getEventStream() {

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -64,6 +64,7 @@ export type SendFn<TState = undefined> = (
 type BaseSendOptions = {
   auth: SessionAuthContext | null;
   callback?: SessionCallback;
+  cancelToken?: string;
   continuationToken: string;
   mode?: RunMode;
 };

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -23,6 +23,7 @@ function createMockRunHandle(): RunHandle {
 
 function createMockRuntime(): Runtime {
   return {
+    cancelTurn: vi.fn().mockResolvedValue(false),
     deliver: vi.fn().mockRejectedValue(new Error("no parked session")),
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -16,6 +16,7 @@ function createMockRunHandle(): RunHandle {
 
 function createRuntime(deliverError: unknown): Runtime {
   return {
+    cancelTurn: vi.fn().mockResolvedValue(false),
     deliver: vi.fn().mockRejectedValue(deliverError),
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
@@ -84,6 +85,7 @@ describe("createSendFn", () => {
   it("forwards context through deliver and run payloads", async () => {
     const context = ["thread background"];
     const deliverRuntime: Runtime = {
+      cancelTurn: vi.fn().mockResolvedValue(false),
       deliver: vi.fn().mockResolvedValue({ sessionId: "existing-session-id" }),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
@@ -120,6 +122,7 @@ describe("createSendFn", () => {
       type: "object",
     } as const;
     const deliverRuntime: Runtime = {
+      cancelTurn: vi.fn().mockResolvedValue(false),
       deliver: vi.fn().mockResolvedValue({ sessionId: "existing-session-id" }),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -21,10 +21,12 @@ export function createSendFn<TState = undefined>(
   ): Promise<Session> => {
     const auth = (options as { auth: SessionAuthContext | null }).auth;
     const callback = (options as { callback?: SendOptions<TState>["callback"] }).callback;
+    const cancelToken = (options as { cancelToken?: string }).cancelToken;
     const mode = (options as { mode?: SendOptions<TState>["mode"] }).mode ?? "conversation";
     const state = (options as { state?: TState }).state;
     const rawToken = (options as { continuationToken: string }).continuationToken;
     const continuationToken = `${channelName}:${rawToken}`;
+    const cancelOptions = cancelToken === undefined ? {} : { cancelToken };
 
     const {
       message: rawMessage,
@@ -37,6 +39,7 @@ export function createSendFn<TState = undefined>(
     try {
       const { sessionId } = await runtime.deliver({
         auth,
+        ...cancelOptions,
         continuationToken,
         payload: { inputResponses, message, context, outputSchema },
       });
@@ -65,6 +68,7 @@ export function createSendFn<TState = undefined>(
     const handle = await runtime.run({
       adapter: sessionAdapter,
       auth,
+      ...cancelOptions,
       capabilities: mode === "conversation" ? { requestInput: true } : undefined,
       channelName,
       callback,

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -16,6 +16,8 @@ import { AuthKey, ContinuationTokenKey, InitiatorAuthKey, SessionIdKey } from "#
 export interface Session {
   readonly id: string;
   readonly continuationToken: string;
+  /** Cancels the active turn while preserving this session. */
+  cancelTurn(cancelToken: string): Promise<boolean>;
   getEventStream(options?: {
     startIndex?: number;
   }): Promise<ReadableStream<HandleMessageStreamEvent>>;
@@ -39,6 +41,9 @@ export function createSession(id: string, continuationToken: string, runtime: Ru
   return {
     id,
     continuationToken,
+    async cancelTurn(cancelToken: string) {
+      return await runtime.cancelTurn(id, cancelToken);
+    },
     async getEventStream(options?: { startIndex?: number }) {
       return runtime.getEventStream(id, options);
     },

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -112,6 +112,7 @@ export interface DeliverPayload {
  */
 export interface DeliverHookPayload {
   readonly auth?: SessionAuthContext | null;
+  readonly cancelToken?: string;
   readonly kind: "deliver";
   readonly payloads: readonly DeliverPayload[];
 }
@@ -241,6 +242,8 @@ export interface RunInput {
    * callback when the session completes or fails.
    */
   readonly callback?: SessionCallback;
+  /** Opaque token that authorizes cancellation of this active turn. */
+  readonly cancelToken?: string;
   /**
    * Session continuation token for delivery and hook creation. Channels can
    * re-key the session during the first turn via
@@ -273,6 +276,8 @@ export interface DeliverInput {
    * this field before calling the adapter's hooks.
    */
   readonly auth?: SessionAuthContext | null;
+  /** Opaque token that authorizes cancellation of this active turn. */
+  readonly cancelToken?: string;
   readonly continuationToken: string;
   readonly payload: DeliverPayload;
 }
@@ -307,6 +312,12 @@ export interface RunHandle {
  * Runtime interface consumed by routes and the subagent tool wrapper.
  */
 export interface Runtime {
+  /**
+   * Requests cooperative cancellation of one active turn without terminating
+   * its parent session.
+   */
+  cancelTurn(sessionId: string, cancelToken: string): Promise<boolean>;
+
   /**
    * Starts a new run from a flat platform-shape input.
    *

--- a/packages/eve/src/execution/dispatch-turn.ts
+++ b/packages/eve/src/execution/dispatch-turn.ts
@@ -1,0 +1,51 @@
+import { createHook } from "#compiled/@workflow/core/index.js";
+
+import type { HookPayload, SessionCapabilities } from "#channel/types.js";
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+import type { NextDriverAction } from "#execution/next-driver-action.js";
+import type { TurnCompletionPayload } from "#execution/turn-workflow.js";
+import { rebuildSerializableError } from "#execution/workflow-errors.js";
+import { dispatchTurnStep } from "#execution/workflow-steps.js";
+import type { RunMode } from "#shared/run-mode.js";
+
+/** Dispatches one child turn workflow and resolves its durable completion hook. */
+export async function dispatchAndAwaitTurn(input: {
+  readonly cancelToken?: string;
+  readonly capabilities?: SessionCapabilities;
+  readonly completionToken: string;
+  readonly delivery: HookPayload;
+  readonly mode: RunMode;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<NextDriverAction> {
+  const completion = createHook<TurnCompletionPayload>({ token: input.completionToken });
+
+  try {
+    await dispatchTurnStep({
+      cancelToken: input.cancelToken,
+      capabilities: input.capabilities,
+      completionToken: completion.token,
+      delivery: input.delivery,
+      mode: input.mode,
+      parentWritable: input.parentWritable,
+      serializedContext: input.serializedContext,
+      sessionState: input.sessionState,
+    });
+
+    const payload = await awaitHookPayload(completion);
+    if (payload.kind === "turn-error") {
+      throw rebuildSerializableError(payload.error);
+    }
+    return payload.action;
+  } finally {
+    completion.dispose();
+  }
+}
+
+async function awaitHookPayload<T>(hook: AsyncIterable<T>): Promise<T> {
+  for await (const value of hook) {
+    return value;
+  }
+  throw new Error("Turn completion hook closed before delivering a result.");
+}

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -20,6 +20,7 @@ import { turnWorkflowInputV0ToV1 } from "./turn-workflow-v0-to-v1.js";
 export const TURN_WORKFLOW_INPUT_VERSION = 1;
 
 export interface TurnStepInput {
+  readonly abortSignal?: AbortSignal;
   readonly input: HookPayload | undefined;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
@@ -28,6 +29,7 @@ export interface TurnStepInput {
 
 export interface TurnWorkflowInput {
   readonly version: typeof TURN_WORKFLOW_INPUT_VERSION;
+  readonly cancelToken?: string;
   readonly capabilities: SessionCapabilities | undefined;
   readonly completionToken: string;
   readonly mode: RunMode;
@@ -35,6 +37,7 @@ export interface TurnWorkflowInput {
 }
 
 export interface TurnWorkflowDispatchInput {
+  readonly cancelToken?: string;
   readonly capabilities: SessionCapabilities | undefined;
   readonly completionToken: string;
   readonly delivery: HookPayload;
@@ -47,8 +50,10 @@ export interface TurnWorkflowDispatchInput {
 const turnWorkflowInputMigrations: readonly VersionMigration[] = [turnWorkflowInputV0ToV1];
 
 export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnWorkflowInput {
+  const cancelOptions = input.cancelToken === undefined ? {} : { cancelToken: input.cancelToken };
   return {
     capabilities: input.capabilities,
+    ...cancelOptions,
     completionToken: input.completionToken,
     mode: input.mode,
     stepInput: {

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -47,6 +47,15 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+interface MockAgentCallOptions {
+  readonly abortSignal?: AbortSignal;
+  readonly messages: unknown[];
+}
+
+interface MockExecutableTool {
+  execute(input: unknown, options: { readonly abortSignal?: AbortSignal }): Promise<unknown>;
+}
+
 function setupMockAgentForToolExecution(toolName: string, args: unknown): void {
   vi.mocked(ToolLoopAgent).mockImplementation(function (
     this: Record<string, unknown>,
@@ -59,7 +68,7 @@ function setupMockAgentForToolExecution(toolName: string, args: unknown): void {
       | ((...args: unknown[]) => Promise<unknown>)
       | undefined;
 
-    this.generate = vi.fn().mockImplementation(async (options: { messages: unknown[] }) => {
+    this.generate = vi.fn().mockImplementation(async (options: MockAgentCallOptions) => {
       if (prepareStep) {
         await prepareStep({
           messages: options.messages,
@@ -70,18 +79,14 @@ function setupMockAgentForToolExecution(toolName: string, args: unknown): void {
         });
       }
 
-      const tools = (
-        settings as {
-          readonly tools: Record<string, { execute: (input: unknown) => Promise<unknown> }>;
-        }
-      ).tools;
+      const tools = (settings as { readonly tools: Record<string, MockExecutableTool> }).tools;
       const tool = tools[toolName];
 
       if (tool === undefined) {
         throw new Error(`Missing test tool "${toolName}".`);
       }
 
-      const output = await tool.execute(args);
+      const output = await tool.execute(args, { abortSignal: options.abortSignal });
 
       const result = {
         finishReason: "stop",
@@ -217,6 +222,7 @@ function createTestNode(
 
 function createNoopRuntime(): Runtime {
   return {
+    cancelTurn: vi.fn().mockResolvedValue(false),
     deliver: vi.fn(),
     run: vi.fn().mockRejectedValue(new Error("runtime.run should not be called in this test")),
     getEventStream: vi
@@ -273,6 +279,58 @@ describe("createExecutionNodeStep", () => {
     );
 
     expect(result.next).toEqual({ done: true, output: "tool-output" });
+  });
+
+  it("passes the active turn signal to authored tool contexts", async () => {
+    setupMockAgentForToolExecution("regular-tool", {});
+    const controller = new AbortController();
+    let receivedContext: unknown;
+    const toolRegistry = await createRuntimeToolRegistry({
+      tools: [
+        {
+          description: "A cancellable tool.",
+          execute: async (_input, ctx) => {
+            receivedContext = ctx;
+            return "tool-output";
+          },
+          inputSchema: { type: "object" },
+          logicalPath: "tools/regular-tool.ts",
+          name: "regular-tool",
+          sourceId: "tools/regular-tool.ts",
+          sourceKind: "module",
+        },
+      ],
+    });
+    const rootNode = createTestNode(createTestTurnAgent({ tools: toolRegistry.preparedTools }), {
+      toolRegistry,
+    });
+    const step = createExecutionNodeStep({
+      abortSignal: controller.signal,
+      compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
+      createRuntime: () => createNoopRuntime(),
+      mode: "task",
+      node: rootNode,
+    });
+
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "sess-root",
+      turn: { id: "turn-1", sequence: 0 },
+    });
+
+    await contextStorage.run(ctx, async () =>
+      step(
+        createSession({
+          continuationToken: "test-root",
+          sessionId: "sess-root",
+          turnAgent: rootNode.turnAgent,
+        }),
+        { message: "Run the tool." },
+      ),
+    );
+
+    expect(receivedContext).toMatchObject({ abortSignal: controller.signal });
   });
 
   it("records visible subagent tools as pending runtime actions", async () => {

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -281,6 +281,8 @@ describe("createExecutionNodeStep", () => {
     expect(result.next).toEqual({ done: true, output: "tool-output" });
   });
 
+  // Authored tools can outlive the model call, so they need the same signal or
+  // client cancellation would leave tool work running.
   it("passes the active turn signal to authored tool contexts", async () => {
     setupMockAgentForToolExecution("regular-tool", {});
     const controller = new AbortController();

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -37,6 +37,8 @@ export type CreateRuntime = (config: {
  * Input for building a harness step for one resolved runtime node.
  */
 export interface CreateExecutionNodeStepInput {
+  /** Durable signal that cancels model work for the active turn. */
+  readonly abortSignal?: AbortSignal;
   /**
    * Session-level capabilities propagated from the runtime. The
    * harness passes this through to `buildToolSet` so `ask_question`
@@ -63,6 +65,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
   const resolveModel = createRuntimeModelResolver(input.compiledArtifactsSource);
   const tools = createNodeHarnessTools({ node: input.node });
   return createToolLoopHarness({
+    abortSignal: input.abortSignal,
     capabilities: input.capabilities,
     codeMode: resolveCodeModeEnabled(input.node.agent.config?.experimental?.codeMode),
     workflow: input.node.agent.workflowEnabled === true,
@@ -253,7 +256,8 @@ function resolveAuthoredExecute(input: {
   if (auth !== undefined) {
     return createAuthorizedToolExecute({ auth, execute: authored, scope });
   }
-  return (toolInput: unknown) => authored(toolInput, buildUnauthorizedToolContext(scope));
+  return (toolInput, options) =>
+    authored(toolInput, buildUnauthorizedToolContext({ abortSignal: options?.abortSignal, scope }));
 }
 
 function maybeJsonSchema(

--- a/packages/eve/src/execution/tool-auth.ts
+++ b/packages/eve/src/execution/tool-auth.ts
@@ -31,6 +31,7 @@ import {
   startScopedAuthorization,
   type ScopedAuthorization,
 } from "#runtime/connections/scoped-authorization.js";
+import type { ToolExecuteOptions } from "#shared/tool-definition.js";
 
 /**
  * Wraps one authored tool's `execute` with the tool-hosted
@@ -56,7 +57,7 @@ export function createAuthorizedToolExecute(input: {
   readonly scope: string;
   readonly auth: AuthorizationDefinition;
   readonly execute: (toolInput: unknown, ctx: unknown) => unknown;
-}): (toolInput: unknown) => Promise<unknown> {
+}): (toolInput: unknown, options?: ToolExecuteOptions) => Promise<unknown> {
   const { scope, auth, execute } = input;
   const scoped: ScopedAuthorization = {
     authorization: auth,
@@ -64,11 +65,14 @@ export function createAuthorizedToolExecute(input: {
     scope,
   };
 
-  return async (toolInput: unknown): Promise<unknown> => {
+  return async (toolInput: unknown, options?: ToolExecuteOptions): Promise<unknown> => {
     const justAuthorized = await completeScopedAuthorization(scoped);
 
     try {
-      return await execute(toolInput, buildToolContext(scoped));
+      return await execute(
+        toolInput,
+        buildToolContext({ abortSignal: options?.abortSignal, scoped }),
+      );
     } catch (err) {
       if (!isConnectionAuthorizationRequiredError(err)) throw err;
 
@@ -122,15 +126,19 @@ export function createAuthorizedToolExecute(input: {
  * declare `auth`. The token accessors are present (the type promises
  * them) but throw, since there is no strategy to resolve a token from.
  */
-export function buildUnauthorizedToolContext(scope: string): ToolContext {
+export function buildUnauthorizedToolContext(input: {
+  readonly abortSignal?: AbortSignal;
+  readonly scope: string;
+}): ToolContext {
   const base = buildCallbackContext();
   return {
     ...base,
+    abortSignal: input.abortSignal,
     getToken(): Promise<TokenResult> {
-      throw noAuthError(scope);
+      throw noAuthError(input.scope);
     },
     requireAuth(): never {
-      throw noAuthError(scope);
+      throw noAuthError(input.scope);
     },
   };
 }
@@ -140,15 +148,19 @@ export function buildUnauthorizedToolContext(scope: string): ToolContext {
  * `execute`: the base session context plus token accessors bound to the
  * tool's scope.
  */
-function buildToolContext(scoped: ScopedAuthorization): ToolContext {
+function buildToolContext(input: {
+  readonly abortSignal?: AbortSignal;
+  readonly scoped: ScopedAuthorization;
+}): ToolContext {
   const base = buildCallbackContext();
   return {
     ...base,
+    abortSignal: input.abortSignal,
     getToken(): Promise<TokenResult> {
-      return resolveScopedToken(scoped);
+      return resolveScopedToken(input.scoped);
     },
     requireAuth(): never {
-      throw new ConnectionAuthorizationRequiredError(scoped.scope);
+      throw new ConnectionAuthorizationRequiredError(input.scoped.scope);
     },
   };
 }

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHook } from "#compiled/@workflow/core/index.js";
 
 import type { HookPayload } from "#channel/types.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
@@ -10,6 +11,10 @@ import {
 import { turnStep } from "#execution/workflow-steps.js";
 
 const resumeHookMock = vi.fn();
+
+vi.mock("#compiled/@workflow/core/index.js", () => ({
+  createHook: vi.fn(),
+}));
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   resumeHook: (...args: unknown[]) => resumeHookMock(...args),
@@ -23,6 +28,57 @@ describe("turnWorkflow", () => {
   afterEach(() => {
     vi.clearAllMocks();
     resumeHookMock.mockReset();
+  });
+
+  it("aborts the active turn step when the cancellation hook resumes", async () => {
+    const sessionState = createSessionState();
+    let resolveCancellation!: (payload: { readonly kind: "cancel-turn" }) => void;
+    const cancellation = new Promise<{ readonly kind: "cancel-turn" }>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const dispose = vi.fn();
+    vi.mocked(createHook).mockReturnValue(
+      Object.assign(cancellation, { dispose, token: "cancel_1" }) as never,
+    );
+    let stepSignal: AbortSignal | undefined;
+    vi.mocked(turnStep).mockImplementationOnce(
+      async (input) =>
+        await new Promise((resolve) => {
+          stepSignal = input.abortSignal;
+          input.abortSignal?.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                action: "park",
+                hasPendingAuthorization: false,
+                hasPendingInputBatch: false,
+                serializedContext: { state: "cancelled" },
+                sessionState,
+              }),
+            { once: true },
+          );
+        }),
+    );
+
+    const { input } = createInput({ cancelToken: "cancel_1", sessionState });
+    const running = turnWorkflow(input);
+    await vi.waitFor(() => expect(stepSignal).toBeInstanceOf(AbortSignal));
+    resolveCancellation({ kind: "cancel-turn" });
+    await running;
+
+    expect(stepSignal?.aborted).toBe(true);
+    expect(createHook).toHaveBeenCalledWith({
+      metadata: { sessionId: "wrun_test_123" },
+      token: "cancel_1",
+    });
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({
+        action: expect.objectContaining({ kind: "park" }),
+        kind: "turn-result",
+      }),
+    );
   });
 
   it("notifies the driver when a turn completes", async () => {

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -30,6 +30,8 @@ describe("turnWorkflow", () => {
     resumeHookMock.mockReset();
   });
 
+  // The hook is the durable bridge from the cancel route to a running step;
+  // this proves that bridge also settles the step and closes its hook.
   it("aborts the active turn step when the cancellation hook resumes", async () => {
     const sessionState = createSessionState();
     let resolveCancellation!: (payload: { readonly kind: "cancel-turn" }) => void;

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -1,4 +1,5 @@
 import type { NextDriverAction } from "#execution/next-driver-action.js";
+import { createHook } from "#compiled/@workflow/core/index.js";
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
 import {
   migrateTurnWorkflowInput,
@@ -33,11 +34,37 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
   "use workflow";
 
   const input = migrateTurnWorkflowInput(rawInput);
-  let currentStepInput: TurnStepInput = input.stepInput;
+  const cancellation =
+    input.cancelToken === undefined
+      ? undefined
+      : createHook<{ readonly kind: "cancel-turn" }>({
+          metadata: { sessionId: input.stepInput.sessionState.sessionId },
+          token: input.cancelToken,
+        });
+  const controller = cancellation === undefined ? undefined : new AbortController();
+  const cancellationPromise = cancellation?.then(() => ({ kind: "cancelled" as const }));
+  let currentStepInput: TurnStepInput =
+    controller === undefined
+      ? input.stepInput
+      : { ...input.stepInput, abortSignal: controller.signal };
 
   try {
     while (true) {
-      const result = await turnStep(currentStepInput);
+      const stepPromise = turnStep(currentStepInput);
+      const outcome =
+        cancellationPromise === undefined || controller === undefined
+          ? { kind: "completed" as const, result: await stepPromise }
+          : await Promise.race([
+              stepPromise.then((result) => ({ kind: "completed" as const, result })),
+              cancellationPromise,
+            ]);
+      let result;
+      if (outcome.kind === "completed") {
+        result = outcome.result;
+      } else {
+        controller?.abort();
+        result = await stepPromise;
+      }
 
       if (result.action === "done") {
         await notifyDriverStep({
@@ -106,7 +133,12 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
         return;
       }
 
+      const abortOptions =
+        currentStepInput.abortSignal === undefined
+          ? {}
+          : { abortSignal: currentStepInput.abortSignal };
       currentStepInput = {
+        ...abortOptions,
         input: undefined,
         parentWritable: currentStepInput.parentWritable,
         serializedContext: result.serializedContext,
@@ -122,6 +154,8 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
       },
     });
     throw error;
+  } finally {
+    cancellation?.dispose();
   }
 }
 

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -26,17 +26,13 @@ import {
 } from "#execution/delegated-parent-result.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
-import type { TurnCompletionPayload } from "#execution/turn-workflow.js";
-import {
-  normalizeSerializableError,
-  rebuildSerializableError,
-} from "#execution/workflow-errors.js";
+import { normalizeSerializableError } from "#execution/workflow-errors.js";
 import { resolveVercelProductionCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import { createSessionStep } from "#execution/create-session-step.js";
 import { dispatchCodeModeRuntimeActionsStep } from "#execution/dispatch-code-mode-runtime-actions-step.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
+import { dispatchAndAwaitTurn } from "#execution/dispatch-turn.js";
 import {
-  dispatchTurnStep,
   emitTerminalSessionFailureStep,
   routeProxiedDeliverStep,
   runProxyInputRequestStep,
@@ -53,6 +49,7 @@ import { fireSessionCallbackStep } from "#execution/session-callback-step.js";
  * and deserialized at each `"use step"` boundary.
  */
 export interface WorkflowEntryInput {
+  readonly cancelToken?: string;
   readonly input: RunInput["input"];
   readonly serializedContext: Record<string, unknown>;
 }
@@ -112,10 +109,12 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       sessionId,
     });
 
+    const cancelOptions = input.cancelToken === undefined ? {} : { cancelToken: input.cancelToken };
     return await runDriverLoop({
       capabilities,
       driverWritable,
       initialInput: {
+        ...cancelOptions,
         kind: "deliver",
         payloads: [
           {
@@ -181,6 +180,8 @@ async function runDriverLoop(input: {
   let iterator: AsyncIterator<HookPayload> | undefined;
   let pendingNext: Promise<IteratorResult<HookPayload>> | null = null;
   const bufferedDeliveries: DeliverHookPayload[] = [];
+  let activeCancelToken =
+    input.initialInput.kind === "deliver" ? input.initialInput.cancelToken : undefined;
 
   const createParkHook = (nextToken: string): void => {
     parkToken = nextToken;
@@ -231,6 +232,7 @@ async function runDriverLoop(input: {
   };
 
   let action: NextDriverAction = await dispatchAndAwaitTurn({
+    cancelToken: activeCancelToken,
     capabilities: input.capabilities,
     completionToken: nextTurnCompletionToken(),
     delivery: input.initialInput,
@@ -305,6 +307,7 @@ async function runDriverLoop(input: {
           }
 
           action = await dispatchAndAwaitTurn({
+            cancelToken: activeCancelToken,
             capabilities: input.capabilities,
             completionToken: nextTurnCompletionToken(),
             delivery: {
@@ -335,6 +338,7 @@ async function runDriverLoop(input: {
             }
 
             action = await dispatchAndAwaitTurn({
+              cancelToken: undefined,
               capabilities: input.capabilities,
               completionToken: nextTurnCompletionToken(),
               delivery: {
@@ -373,7 +377,10 @@ async function runDriverLoop(input: {
             continue;
           }
 
+          activeCancelToken = nextDeliver.cancelToken;
+
           action = await dispatchAndAwaitTurn({
+            cancelToken: activeCancelToken,
             capabilities: input.capabilities,
             completionToken: nextTurnCompletionToken(),
             delivery: {
@@ -419,48 +426,6 @@ async function finalizeDone(input: {
     serializedContext,
   });
   return { output };
-}
-
-async function dispatchAndAwaitTurn(input: {
-  readonly capabilities?: SessionCapabilities;
-  readonly completionToken: string;
-  readonly delivery: HookPayload;
-  readonly mode: RunMode;
-  readonly parentWritable: WritableStream<Uint8Array>;
-  readonly serializedContext: Record<string, unknown>;
-  readonly sessionState: DurableSessionState;
-}): Promise<NextDriverAction> {
-  const completion = createHook<TurnCompletionPayload>({ token: input.completionToken });
-  const completionToken = completion.token;
-
-  try {
-    await dispatchTurnStep({
-      capabilities: input.capabilities,
-      completionToken,
-      delivery: input.delivery,
-      mode: input.mode,
-      parentWritable: input.parentWritable,
-      serializedContext: input.serializedContext,
-      sessionState: input.sessionState,
-    });
-
-    const payload = await awaitHookPayload(completion);
-
-    if (payload.kind === "turn-error") {
-      throw rebuildSerializableError(payload.error);
-    }
-
-    return payload.action;
-  } finally {
-    await disposeHook(completion);
-  }
-}
-
-async function awaitHookPayload<T>(hook: Hook<T>): Promise<T> {
-  for await (const value of hook) {
-    return value;
-  }
-  throw new Error("Turn completion hook closed before delivering a result.");
 }
 
 interface PendingRuntimeActionResultsOutcome {

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -101,6 +101,7 @@ describe("createWorkflowRuntime#cancelTurn", () => {
     });
   }
 
+  // A valid session-scoped token must resume exactly the active turn hook.
   it("resumes the active turn cancellation hook", async () => {
     getHookByTokenMock.mockResolvedValue({
       metadata: { sessionId: "session_1" },
@@ -112,6 +113,8 @@ describe("createWorkflowRuntime#cancelTurn", () => {
     expect(resumeHookMock).toHaveBeenCalledWith("cancel_1", { kind: "cancel-turn" });
   });
 
+  // The API can expose a cancel token before the child workflow registers its
+  // hook, so an immediate stop must bridge that registration race.
   it("waits for the child hook to register before returning", async () => {
     vi.useFakeTimers();
     const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
@@ -127,6 +130,7 @@ describe("createWorkflowRuntime#cancelTurn", () => {
     expect(resumeHookMock).toHaveBeenCalledWith("cancel_1", { kind: "cancel-turn" });
   });
 
+  // A leaked or stale token must not let one session cancel another session's turn.
   it("does not cancel a token owned by another session", async () => {
     getHookByTokenMock.mockResolvedValue({
       metadata: { sessionId: "session_2" },
@@ -137,6 +141,7 @@ describe("createWorkflowRuntime#cancelTurn", () => {
     expect(resumeHookMock).not.toHaveBeenCalled();
   });
 
+  // Missing hooks are an expected stale-turn outcome, not a server error.
   it("returns false when the active turn hook is not registered", async () => {
     const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
     getHookByTokenMock.mockRejectedValue(new HookNotFoundError("cancel_1"));

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -35,6 +35,7 @@ afterEach(() => {
   startMock.mockReset();
   vi.mocked(getCompiledRuntimeAgentBundle).mockReset();
   vi.unstubAllEnvs();
+  vi.useRealTimers();
 });
 
 describe("workflowEntryReference", () => {
@@ -90,6 +91,57 @@ describe("createWorkflowRuntime#deliver", () => {
         payload: {},
       }),
     ).rejects.toBe(failure);
+  });
+});
+
+describe("createWorkflowRuntime#cancelTurn", () => {
+  function buildRuntime() {
+    return createWorkflowRuntime({
+      compiledArtifactsSource: {} as RuntimeCompiledArtifactsSource,
+    });
+  }
+
+  it("resumes the active turn cancellation hook", async () => {
+    getHookByTokenMock.mockResolvedValue({
+      metadata: { sessionId: "session_1" },
+      runId: "turn_1",
+    });
+
+    await expect(buildRuntime().cancelTurn("session_1", "cancel_1")).resolves.toBe(true);
+    expect(getHookByTokenMock).toHaveBeenCalledWith("cancel_1");
+    expect(resumeHookMock).toHaveBeenCalledWith("cancel_1", { kind: "cancel-turn" });
+  });
+
+  it("waits for the child hook to register before returning", async () => {
+    vi.useFakeTimers();
+    const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
+    getHookByTokenMock
+      .mockRejectedValueOnce(new HookNotFoundError("cancel_1"))
+      .mockResolvedValueOnce({ metadata: { sessionId: "session_1" }, runId: "turn_1" });
+
+    const cancelling = buildRuntime().cancelTurn("session_1", "cancel_1");
+    await vi.runAllTimersAsync();
+
+    await expect(cancelling).resolves.toBe(true);
+    expect(getHookByTokenMock).toHaveBeenCalledTimes(2);
+    expect(resumeHookMock).toHaveBeenCalledWith("cancel_1", { kind: "cancel-turn" });
+  });
+
+  it("does not cancel a token owned by another session", async () => {
+    getHookByTokenMock.mockResolvedValue({
+      metadata: { sessionId: "session_2" },
+      runId: "turn_2",
+    });
+
+    await expect(buildRuntime().cancelTurn("session_1", "cancel_1")).resolves.toBe(false);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the active turn hook is not registered", async () => {
+    const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
+    getHookByTokenMock.mockRejectedValue(new HookNotFoundError("cancel_1"));
+
+    await expect(buildRuntime().cancelTurn("session_1", "cancel_1")).resolves.toBe(false);
   });
 });
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -20,9 +20,10 @@ import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { buildRunContext } from "#execution/runtime-context.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
-
 const WORKFLOW_ENTRY_NAME = "workflowEntry";
 const TURN_WORKFLOW_NAME = "turnWorkflow";
+const CANCEL_HOOK_REGISTRATION_ATTEMPTS = 80;
+const CANCEL_HOOK_REGISTRATION_RETRY_MS = 25;
 const EVE_PACKAGE_INFO = resolveInstalledPackageInfo();
 export const LATEST_DEPLOYMENT_UNSUPPORTED_MESSAGE =
   "deploymentId 'latest' requires a World that implements resolveLatestDeploymentId()";
@@ -47,6 +48,7 @@ const STABLE_ID_BASE = EVE_PACKAGE_INFO.name;
 const log = createLogger("execution.workflow-runtime");
 
 interface WorkflowHookRecord {
+  readonly metadata?: unknown;
   readonly runId: string;
 }
 
@@ -80,6 +82,30 @@ export function createWorkflowRuntime(config: {
   readonly nodeId?: string;
 }): Runtime {
   return {
+    async cancelTurn(sessionId: string, cancelToken: string): Promise<boolean> {
+      applyEveWorkflowQueueNamespace();
+      for (let attempt = 0; attempt < CANCEL_HOOK_REGISTRATION_ATTEMPTS; attempt += 1) {
+        try {
+          const hook = normalizeWorkflowHook(await getHookByToken(cancelToken));
+          if (!isTurnCancellationHookForSession(hook, sessionId)) return false;
+          await resumeHook(cancelToken, { kind: "cancel-turn" });
+          return true;
+        } catch (error) {
+          if (!HookNotFoundError.is(error)) {
+            logError(log, "failed to cancel active turn", error, {
+              cancelToken,
+              sessionId,
+            });
+            throw error;
+          }
+          if (attempt < CANCEL_HOOK_REGISTRATION_ATTEMPTS - 1) {
+            await new Promise((resolve) => setTimeout(resolve, CANCEL_HOOK_REGISTRATION_RETRY_MS));
+          }
+        }
+      }
+      return false;
+    },
+
     async run(input: RunInput): Promise<RunHandle> {
       const bundle = await getCompiledRuntimeAgentBundle({
         compiledArtifactsSource: config.compiledArtifactsSource,
@@ -87,11 +113,14 @@ export function createWorkflowRuntime(config: {
       });
       const ctx = buildRunContext({ bundle, run: input });
       const serializedContext = serializeContext(ctx);
+      const cancelOptions =
+        input.cancelToken === undefined ? {} : { cancelToken: input.cancelToken };
 
       let run: Awaited<ReturnType<typeof startWorkflowPreferLatest>>;
       try {
         run = await startWorkflowPreferLatest(workflowEntryReference, [
           {
+            ...cancelOptions,
             input: input.input,
             serializedContext,
           },
@@ -120,8 +149,11 @@ export function createWorkflowRuntime(config: {
 
     async deliver(input: DeliverInput): Promise<{ sessionId: string }> {
       applyEveWorkflowQueueNamespace();
+      const cancelOptions =
+        input.cancelToken === undefined ? {} : { cancelToken: input.cancelToken };
       const hookPayload: HookPayload = {
         auth: input.auth,
+        ...cancelOptions,
         kind: "deliver",
         payloads: [input.payload],
       };
@@ -204,8 +236,18 @@ function normalizeWorkflowHook(value: unknown): WorkflowHookRecord {
   }
 
   return {
+    metadata: (value as { metadata?: unknown }).metadata,
     runId,
   };
+}
+
+function isTurnCancellationHookForSession(hook: WorkflowHookRecord, sessionId: string): boolean {
+  return (
+    hook.metadata !== null &&
+    typeof hook.metadata === "object" &&
+    "sessionId" in hook.metadata &&
+    hook.metadata.sessionId === sessionId
+  );
 }
 
 function parseNdjsonStream(

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -321,6 +321,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       });
 
       const step = createExecutionNodeStep({
+        abortSignal: input.abortSignal,
         capabilities,
         compiledArtifactsSource: bundle.compiledArtifactsSource,
         createRuntime: createWorkflowRuntime,

--- a/packages/eve/src/harness/compaction.ts
+++ b/packages/eve/src/harness/compaction.ts
@@ -112,6 +112,7 @@ export async function compactMessages(
   providerOptions?: Parameters<typeof generateText>[0]["providerOptions"],
   telemetry?: TelemetryOptions,
   headers?: Record<string, string>,
+  abortSignal?: AbortSignal,
 ): Promise<ModelMessage[]> {
   let keep = selectRecentWindowSize(messages, config);
 
@@ -127,6 +128,7 @@ export async function compactMessages(
     }));
 
     const result = await generateText({
+      abortSignal,
       headers,
       model,
       prompt: formatCompactionPrompt(prunedOlder),

--- a/packages/eve/src/harness/execute-tool.ts
+++ b/packages/eve/src/harness/execute-tool.ts
@@ -1,6 +1,7 @@
 import type { FlexibleSchema } from "ai";
 
 import type { NeedsApprovalContext } from "#public/definitions/tool.js";
+import type { ToolExecuteOptions } from "#shared/tool-definition.js";
 
 /**
  * Runtime-owned action metadata attached to one harness-visible tool.
@@ -21,7 +22,7 @@ export type HarnessRuntimeActionDefinition = {
 export interface HarnessToolDefinition {
   readonly approvalKey?: (toolInput: Readonly<Record<string, unknown>>) => string;
   readonly description: string;
-  readonly execute?: (input: any) => any;
+  readonly execute?: (input: any, options?: ToolExecuteOptions) => any;
   readonly inputSchema: FlexibleSchema;
   readonly name: string;
   readonly needsApproval?: (ctx: NeedsApprovalContext) => boolean;

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -180,6 +180,7 @@ function toUserContentArray(value: string | UserContent): UserContentArray {
  */
 interface DeliverLike {
   readonly auth?: SessionAuthContext | null;
+  readonly cancelToken?: string;
   readonly kind: "deliver";
   readonly payloads: readonly DeliverPayload[];
 }
@@ -201,14 +202,18 @@ export function coalesceDeliveries<T extends DeliverLike>(items: readonly T[]): 
   }
 
   let auth = first.auth;
+  let cancelToken = first.cancelToken;
   const payloads = [...first.payloads];
 
   for (const item of rest) {
     if (item.auth !== undefined) {
       auth = item.auth;
     }
+    if (item.cancelToken !== undefined) {
+      cancelToken = item.cancelToken;
+    }
     payloads.push(...item.payloads);
   }
 
-  return { ...first, auth, payloads };
+  return { ...first, auth, cancelToken, payloads };
 }

--- a/packages/eve/src/harness/tool-interrupts.test.ts
+++ b/packages/eve/src/harness/tool-interrupts.test.ts
@@ -94,7 +94,9 @@ describe("wrapToolExecute", () => {
     const signal = signalWithVerifier();
     const wrapped = wrapToolExecute({ ...baseDef, execute: async () => signal })!;
     const ctx = new ContextContainer();
-    const output = await contextStorage.run(ctx, () => wrapped({}, { toolCallId: "call_1" }));
+    const output = await contextStorage.run(ctx, () =>
+      wrapped({}, { messages: [], toolCallId: "call_1" }),
+    );
 
     expect(isAuthorizationPendingModelOutput(output)).toBe(true);
     expect(output).toEqual(modelFacingAuthorizationOutput(signal));
@@ -107,7 +109,8 @@ describe("wrapToolExecute", () => {
     const signal = signalWithVerifier();
     const wrapped = wrapToolExecute({ ...baseDef, execute: async () => signal })!;
     const ctx = new ContextContainer();
-    const options = markCodeModeToolExecutionOptions({ toolCallId: "call_2" }) as {
+    const options = markCodeModeToolExecutionOptions({ messages: [], toolCallId: "call_2" }) as {
+      messages: [];
       toolCallId: string;
     };
     const output = await contextStorage.run(ctx, () => wrapped({}, options));
@@ -119,7 +122,9 @@ describe("wrapToolExecute", () => {
   it("passes non-interrupt outputs through unchanged", async () => {
     const wrapped = wrapToolExecute({ ...baseDef, execute: async () => ({ ok: true }) })!;
     const ctx = new ContextContainer();
-    const output = await contextStorage.run(ctx, () => wrapped({}, { toolCallId: "call_3" }));
+    const output = await contextStorage.run(ctx, () =>
+      wrapped({}, { messages: [], toolCallId: "call_3" }),
+    );
 
     expect(output).toEqual({ ok: true });
     expect(readToolInterrupt(ctx, "call_3")).toBeUndefined();

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -2014,6 +2014,56 @@ describe("createToolLoopHarness", () => {
     expect((stepFailed!.data as { details?: { errorId?: string } }).details?.errorId).toBeDefined();
   });
 
+  it("emits a recoverable cancellation boundary for an aborted turn", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, { abortSignal: controller.signal }),
+    );
+
+    const result = await runStep(createTestSession(), { message: "Hi" });
+
+    expect(result.next).toBeNull();
+    expect(events.map((event) => event.type)).toEqual([
+      "session.started",
+      "turn.started",
+      "message.received",
+      "step.failed",
+      "turn.failed",
+      "session.waiting",
+    ]);
+    expect(events.find((event) => event.type === "step.failed")?.data).toMatchObject({
+      code: "TURN_CANCELLED",
+      message: "Turn cancelled by the client.",
+    });
+    expect(ToolLoopAgent).not.toHaveBeenCalled();
+  });
+
+  it("passes the durable turn signal to the AI SDK model call", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "done", role: "assistant" }] },
+      text: "done",
+      toolCalls: [],
+      toolResults: [],
+    });
+    const controller = new AbortController();
+    const { emit } = createEventCollector();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, { abortSignal: controller.signal }),
+    );
+
+    await runStep(createTestSession(), { message: "Hi" });
+
+    const instance = vi.mocked(ToolLoopAgent).mock.results[0]?.value as {
+      stream: ReturnType<typeof vi.fn>;
+    };
+    expect(instance.stream).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: controller.signal }),
+    );
+  });
+
   it("parks the session on an ambiguous GatewayInternalServerError 400 model-call error", async () => {
     setupMockAgentError(
       createGatewayModelCallError({

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -2014,6 +2014,8 @@ describe("createToolLoopHarness", () => {
     expect((stepFailed!.data as { details?: { errorId?: string } }).details?.errorId).toBeDefined();
   });
 
+  // Cancellation must park at a recoverable boundary so the next message can
+  // continue the same durable conversation.
   it("emits a recoverable cancellation boundary for an aborted turn", async () => {
     const controller = new AbortController();
     controller.abort();
@@ -2040,6 +2042,8 @@ describe("createToolLoopHarness", () => {
     expect(ToolLoopAgent).not.toHaveBeenCalled();
   });
 
+  // Reaching the model call is what stops provider generation and billing,
+  // rather than merely hiding the response on the client.
   it("passes the durable turn signal to the AI SDK model call", async () => {
     setupMockAgent({
       finishReason: "stop",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -497,6 +497,38 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = pending.session;
     let messages: ModelMessage[] = pending.messages;
 
+    const finishCancelledTurn = async (): Promise<StepResult | undefined> => {
+      if (config.abortSignal?.aborted !== true) return undefined;
+      if (!emit) {
+        config.abortSignal.throwIfAborted();
+        throw new Error("Turn cancelled.");
+      }
+
+      const failure = {
+        code: "TURN_CANCELLED",
+        message: "Turn cancelled by the client.",
+      };
+      if (config.mode === "task") {
+        await emitFailedStep(emit, emissionState, {
+          ...failure,
+          sessionId: session.sessionId,
+        });
+        return {
+          next: { done: true, isError: true, output: failure.message },
+          session,
+        };
+      }
+
+      emissionState = await emitRecoverableFailedTurn(emit, emissionState, failure);
+      return {
+        next: null,
+        session: setHarnessEmissionState(session, emissionState),
+      };
+    };
+
+    const alreadyCancelled = await finishCancelledTurn();
+    if (alreadyCancelled !== undefined) return alreadyCancelled;
+
     if (stepInput.input?.context !== undefined) {
       for (const entry of stepInput.input.context) {
         messages.push({ content: entry, role: "user" });
@@ -525,17 +557,24 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // `messages` (which the harness uses to rebuild session history).
     const attributionHeaders = buildGatewayAttributionHeaders(model, config.runtimeIdentity);
 
-    ({ messages, session } = await maybeCompact({
-      emit,
-      emissionState,
-      headers: attributionHeaders,
-      messages,
-      model,
-      onCompaction: config.onCompaction,
-      resolveModel: config.resolveModel,
-      session,
-      telemetry: enrichTelemetry(telemetryConfig, agentName) ?? undefined,
-    }));
+    try {
+      ({ messages, session } = await maybeCompact({
+        abortSignal: config.abortSignal,
+        emit,
+        emissionState,
+        headers: attributionHeaders,
+        messages,
+        model,
+        onCompaction: config.onCompaction,
+        resolveModel: config.resolveModel,
+        session,
+        telemetry: enrichTelemetry(telemetryConfig, agentName) ?? undefined,
+      }));
+    } catch (error) {
+      const cancelled = await finishCancelledTurn();
+      if (cancelled !== undefined) return cancelled;
+      throw error;
+    }
 
     const approvedTools = getApprovedTools(session);
 
@@ -737,7 +776,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       const executeModelCall = async (): Promise<HarnessStepResult> => {
         if (emit) {
-          const streamResult = await agent.stream({ messages: callMessages });
+          const streamResult = await agent.stream({
+            abortSignal: config.abortSignal,
+            messages: callMessages,
+          });
           const {
             handledInlineToolResultCallIds,
             inlineAuthorizationResults,
@@ -795,7 +837,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           }
           return stepResult;
         }
-        await agent.generate({ messages: callMessages });
+        await agent.generate({ abortSignal: config.abortSignal, messages: callMessages });
         const stepResult = await hooks.stepResult;
         if (isEmptyModelResponse(stepResult)) {
           throw new EmptyModelResponseError();
@@ -809,6 +851,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           sessionId: session.sessionId,
           turnId: emissionState.turnId,
         },
+        config.abortSignal,
       );
     };
 
@@ -846,6 +889,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         suppressStepStartedEmission: true,
       });
     } catch (error) {
+      const cancelled = await finishCancelledTurn();
+      if (cancelled !== undefined) return cancelled;
+
       // Stage order: drop a gateway-rejected provider tool first, then
       // reissue an empty response; see runModelCallRecoveryPipeline for
       // the skip/act semantics.
@@ -2088,6 +2134,7 @@ function createNextCompactionConfig(
  * harness uses to rebuild `session.history` after the step.
  */
 async function maybeCompact(input: {
+  readonly abortSignal?: AbortSignal;
   readonly emit?: ToolLoopHarnessConfig["handleEvent"];
   readonly emissionState: ReturnType<typeof getHarnessEmissionState>;
   readonly headers?: Record<string, string>;
@@ -2132,6 +2179,7 @@ async function maybeCompact(input: {
     compaction.providerOptions,
     input.telemetry,
     input.headers,
+    input.abortSignal,
   );
 
   if (input.onCompaction) {
@@ -2180,11 +2228,16 @@ function resolveApprovalKeyFromTools(
 async function runModelCallWithRetries<T>(
   fn: () => Promise<T>,
   diag: { readonly sessionId: string; readonly turnId: string },
+  abortSignal?: AbortSignal,
 ): Promise<T> {
   for (let attempt = 1; ; attempt++) {
+    abortSignal?.throwIfAborted();
     try {
       return await fn();
     } catch (error) {
+      if (abortSignal?.aborted === true) {
+        throw error;
+      }
       if (attempt === MODEL_CALL_MAX_ATTEMPTS || classifyModelCallError(error) !== "retry") {
         throw error;
       }
@@ -2197,9 +2250,29 @@ async function runModelCallWithRetries<T>(
         turnId: diag.turnId,
         error,
       });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await sleepWithAbortSignal(delayMs, abortSignal);
     }
   }
+}
+
+async function sleepWithAbortSignal(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal === undefined) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+    return;
+  }
+
+  signal.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function findAuthorizationSignalFromToolResults(

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -17,6 +17,7 @@ import {
 } from "#harness/authorization.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { isCodeModeToolExecutionOptions } from "#runtime/framework-tools/code-mode-connection-auth.js";
+import type { ToolExecuteOptions } from "#shared/tool-definition.js";
 
 /**
  * Builds an AI SDK `ToolSet` from unified harness tool definitions.
@@ -133,11 +134,11 @@ export function buildToolSetFromDefinitions(input: {
  */
 export function wrapToolExecute(
   definition: HarnessToolDefinition,
-): ((input: any, options: { readonly toolCallId: string }) => Promise<any>) | undefined {
+): ((input: any, options: ToolExecuteOptions) => Promise<any>) | undefined {
   const execute = definition.execute;
   if (execute === undefined) return undefined;
   return async (input, options) => {
-    const output = await execute(input);
+    const output = await execute(input, options);
     if (!isAuthorizationSignal(output)) return output;
     if (isCodeModeToolExecutionOptions(options)) return output;
     stashToolInterrupt(loadContext(), options.toolCallId, output);

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -180,6 +180,8 @@ export type HandleEventFn = (
  * Dependencies injected into the tool-loop harness at construction time.
  */
 export interface ToolLoopHarnessConfig {
+  /** Signal used to cancel model work for the active durable turn. */
+  readonly abortSignal?: AbortSignal;
   /**
    * Session-level capabilities. The harness reads
    * {@link SessionCapabilities.requestInput} when assembling the

--- a/packages/eve/src/protocol/routes.ts
+++ b/packages/eve/src/protocol/routes.ts
@@ -30,6 +30,11 @@ export const EVE_CREATE_SESSION_ROUTE_PATH = `${EVE_ROUTE_PREFIX}/session`;
 export const EVE_CONTINUE_SESSION_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/session/:sessionId`;
 
 /**
+ * Stable framework-owned route pattern for cancelling a session's active turn.
+ */
+export const EVE_CANCEL_TURN_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/session/:sessionId/cancel`;
+
+/**
  * Stable framework-owned message stream route pattern.
  */
 export const EVE_MESSAGE_STREAM_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/session/:sessionId/stream`;
@@ -110,6 +115,13 @@ export function createEveMessageStreamRoutePath(sessionId: string): string {
  */
 export function createEveContinueSessionRoutePath(sessionId: string): string {
   return `${EVE_ROUTE_PREFIX}/session/${encodeURIComponent(sessionId)}`;
+}
+
+/**
+ * Creates the stable framework-owned active-turn cancellation route path.
+ */
+export function createEveCancelTurnRoutePath(sessionId: string): string {
+  return `${EVE_ROUTE_PREFIX}/session/${encodeURIComponent(sessionId)}/cancel`;
 }
 
 /**

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -201,6 +201,8 @@ function contextAccessorFor(ctx: ContextContainer): ContextAccessor {
 }
 
 describe("eveChannel cancel route", () => {
+  // The public endpoint must cancel the addressed turn without terminating
+  // the durable session that owns it.
   it("cancels only the active turn for the requested session", async () => {
     const handler = createEveCancelHandler({ auth: none() });
 
@@ -428,6 +430,8 @@ describe("eveChannel — onMessage", () => {
 });
 
 describe("eveChannel — create session (text)", () => {
+  // The create response is where the client learns how to address this turn,
+  // so it must return the exact token passed into the runtime.
   it("accepts a plain-string message and opens a new session", async () => {
     const handler = createEveCreateHandler({ auth: none() });
 
@@ -957,6 +961,8 @@ describe("eveChannel — uploadPolicy enforcement", () => {
 });
 
 describe("eveChannel — continue session HITL (inputResponses)", () => {
+  // Every continuation turn needs a fresh cancellation handle, including
+  // turns that carry HITL responses alongside a message.
   it("forwards inputResponses alongside a message", async () => {
     const handler = createEveContinueHandler({ auth: none() });
 

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -58,6 +58,9 @@ function createEveCreateHandler(input: EveChannelInput) {
   if (!createRoute) throw new Error("No create POST route found");
 
   const mockSend = vi.fn<SendFn>().mockResolvedValue({
+    async cancelTurn() {
+      return false;
+    },
     id: "test-session-id",
     continuationToken: "eve:test",
     async getEventStream() {
@@ -93,6 +96,9 @@ function createEveContinueHandler(input: EveChannelInput) {
   if (!continueRoute) throw new Error("No continue POST route found");
 
   const mockSession: ChannelSession = {
+    async cancelTurn() {
+      return false;
+    },
     id: "test-session-id",
     continuationToken: "eve:test",
     async getEventStream() {
@@ -115,6 +121,39 @@ function createEveContinueHandler(input: EveChannelInput) {
         requestIp: "127.0.0.1",
       };
       return (continueRoute as any).handler(req, args);
+    },
+  };
+}
+
+function createEveCancelHandler(input: EveChannelInput) {
+  const channel = eveChannel(input);
+  const cancelRoute = channel.routes.find(
+    (route) => route.method === "POST" && route.path === "/eve/v1/session/:sessionId/cancel",
+  );
+  if (!cancelRoute) throw new Error("No cancel POST route found");
+
+  const cancelTurn = vi.fn().mockResolvedValue(true);
+  const mockSession: ChannelSession = {
+    cancelTurn,
+    continuationToken: "",
+    async getEventStream() {
+      return new ReadableStream();
+    },
+    id: "test-session-id",
+  };
+
+  return {
+    cancelTurn,
+    async fetch(req: Request) {
+      const args: RouteHandlerArgs = {
+        getSession: vi.fn().mockReturnValue(mockSession),
+        params: { sessionId: "test-session-id" },
+        receive: vi.fn() as any,
+        requestIp: "127.0.0.1",
+        send: vi.fn() as any,
+        waitUntil: () => undefined,
+      };
+      return (cancelRoute as any).handler(req, args);
     },
   };
 }
@@ -160,6 +199,24 @@ function contextAccessorFor(ctx: ContextContainer): ContextAccessor {
     ensure: (key, create) => ctx.ensure(key as any, create),
   };
 }
+
+describe("eveChannel cancel route", () => {
+  it("cancels only the active turn for the requested session", async () => {
+    const handler = createEveCancelHandler({ auth: none() });
+
+    const response = await handler.fetch(
+      new Request("https://example.com/eve/v1/session/test-session-id/cancel", {
+        body: JSON.stringify({ cancelToken: "cancel_1" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ cancelled: true, ok: true });
+    expect(handler.cancelTurn).toHaveBeenCalledWith("cancel_1");
+  });
+});
 
 describe("eveChannel — events", () => {
   it("passes configured event handlers through with session context", async () => {
@@ -379,6 +436,10 @@ describe("eveChannel — create session (text)", () => {
     expect(response.status).toBe(202);
     expect(handler.send).toHaveBeenCalledTimes(1);
     expect(handler.send.mock.calls[0]?.[0]).toBe("hi");
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    const body = (await response.json()) as { cancelToken: string };
+    expect(options.cancelToken).toMatch(/^eve:cancel:/);
+    expect(body.cancelToken).toBe(options.cancelToken);
   });
 
   it("accepts task mode for callback-driven session creation", async () => {
@@ -912,6 +973,10 @@ describe("eveChannel — continue session HITL (inputResponses)", () => {
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
     expect(payload.message).toBe("yes please");
     expect(payload.inputResponses).toEqual([{ requestId: "req-1", optionId: "approve" }]);
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    const body = (await response.json()) as { cancelToken: string };
+    expect(options.cancelToken).toMatch(/^eve:cancel:/);
+    expect(body.cancelToken).toBe(options.cancelToken);
   });
 
   it("converts clientContext on continue-session requests", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -117,8 +117,8 @@ export interface EveChannel extends Channel {}
 
 /**
  * Builds the default eve HTTP channel: a {@link defineChannel} instance serving the
- * built-in `/eve/v1` routes (POST creates a session, POST delivers a follow-up, GET
- * streams a session's NDJSON event feed). Every route runs {@link EveChannelInput.auth}
+ * built-in `/eve/v1` routes (POST creates a session, delivers a follow-up, or cancels
+ * an active turn; GET streams a session's NDJSON event feed). Every route runs {@link EveChannelInput.auth}
  * via {@link routeAuth} before dispatching. Default-export the result as your
  * `agent/channels/eve.ts` channel; reach for {@link defineChannel} directly only for a custom transport.
  */
@@ -159,17 +159,20 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         if (!messageResult.dispatch) return droppedMessageResponse();
 
         const token = `eve:${crypto.randomUUID()}`;
+        const cancelToken = `eve:cancel:${crypto.randomUUID()}`;
         const context = mergeContext(body.context, messageResult.context);
 
         const session = await send(createSendPayload(body, context), {
           auth: messageResult.auth,
           callback: body.callback,
+          cancelToken,
           continuationToken: token,
           mode: body.mode,
         });
 
         return Response.json(
           {
+            cancelToken,
             continuationToken: session.continuationToken,
             ok: true,
             sessionId: session.id,
@@ -233,6 +236,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           dispatchAuth = messageResult.auth;
         }
 
+        const cancelToken = `eve:cancel:${crypto.randomUUID()}`;
         const session = await send(
           {
             inputResponses: body.inputResponses,
@@ -242,12 +246,14 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           },
           {
             auth: dispatchAuth,
+            cancelToken,
             continuationToken: body.continuationToken,
           },
         );
 
         return Response.json(
           {
+            cancelToken,
             ok: true,
             sessionId: session.id,
           },
@@ -258,6 +264,47 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             },
             status: 200,
           },
+        );
+      }),
+
+      POST("/eve/v1/session/:sessionId/cancel", async (req, { getSession, params }) => {
+        const authResult = await routeAuth(req, input.auth);
+        if (authResult instanceof Response) return authResult;
+
+        const sessionId = params.sessionId;
+        if (!sessionId) {
+          return Response.json({ error: "Missing session id.", ok: false }, { status: 400 });
+        }
+
+        let payload: unknown;
+        try {
+          payload = await req.json();
+        } catch {
+          return Response.json({ error: "Invalid JSON body.", ok: false }, { status: 400 });
+        }
+
+        const cancelToken =
+          payload !== null &&
+          typeof payload === "object" &&
+          "cancelToken" in payload &&
+          typeof payload.cancelToken === "string"
+            ? payload.cancelToken.trim()
+            : "";
+        if (!cancelToken) {
+          return Response.json({ error: "Missing cancel token.", ok: false }, { status: 400 });
+        }
+
+        const cancelled = await getSession(sessionId).cancelTurn(cancelToken);
+        if (!cancelled) {
+          return Response.json(
+            { cancelled: false, error: "Active turn not found.", ok: false },
+            { status: 409 },
+          );
+        }
+
+        return Response.json(
+          { cancelled: true, ok: true },
+          { headers: { "cache-control": "no-store" }, status: 202 },
         );
       }),
 

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -26,6 +26,7 @@ async function firePost(
   }
 
   const send = vi.fn(async (_input: unknown, _options: unknown) => ({
+    cancelTurn: async () => false,
     continuationToken: "TOKEN",
     getEventStream: async () => new ReadableStream(),
     id: "SESSION",
@@ -148,6 +149,7 @@ describe("teamsChannel", () => {
       credentials: { tokenProvider: () => "token" },
     });
     const send = vi.fn(async (_input: unknown, _options: unknown) => ({
+      cancelTurn: async () => false,
       continuationToken: "TOKEN",
       getEventStream: async () => new ReadableStream(),
       id: "SESSION",

--- a/packages/eve/src/public/definitions/defineChannel.test.ts
+++ b/packages/eve/src/public/definitions/defineChannel.test.ts
@@ -511,6 +511,9 @@ describe("defineChannel", () => {
         void threadTs;
 
         return {
+          async cancelTurn() {
+            return false;
+          },
           id: channelId,
           continuationToken: channelId,
           async getEventStream() {

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -60,6 +60,11 @@ export type ToolAuthDefinition =
  */
 export type ToolContext = SessionContext & {
   /**
+   * Signals that the active turn was cancelled. Long-running tools should
+   * pass this signal to cancellable APIs such as `fetch` and sandbox commands.
+   */
+  readonly abortSignal?: AbortSignal;
+  /**
    * Resolves the bearer token for this tool's declared `auth`,
    * consulting the per-step token cache before invoking the authored
    * `getToken`. For interactive strategies a cache miss throws

--- a/packages/eve/src/runtime/agent/mock-model-adapter.ts
+++ b/packages/eve/src/runtime/agent/mock-model-adapter.ts
@@ -35,6 +35,7 @@ import { FINAL_OUTPUT_TOOL_NAME } from "#runtime/framework-tools/final-output.js
 import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
 
 const MOCK_RUNTIME_MODEL_PROVIDER = "eve-runtime-mock";
+const MOCK_CANCELLATION_PROMPT = "[wait-for-cancel]";
 const LOAD_SKILL_TOOL_CALL_ID = "call_load_skill";
 type BootstrapGenerateOptions = Parameters<MockLanguageModelV3["doGenerate"]>[0];
 
@@ -79,13 +80,27 @@ export function createMockAuthoredRuntimeModel(reference: RuntimeModelReference)
     modelId: reference.id,
     provider: MOCK_RUNTIME_MODEL_PROVIDER,
     doGenerate: async (options) => createMockModelResult(options, reference.id),
-    doStream: async (options) =>
-      createBootstrapStreamResult(createMockModelResult(options, reference.id)),
+    doStream: async (options) => {
+      if (getLastUserPromptText(options.prompt)?.includes(MOCK_CANCELLATION_PROMPT) === true) {
+        return await waitForMockModelCancellation(options.abortSignal);
+      }
+      return createBootstrapStreamResult(createMockModelResult(options, reference.id));
+    },
   });
 
   authoredRuntimeModelMocks.set(reference.id, model);
 
   return model;
+}
+
+async function waitForMockModelCancellation(signal: AbortSignal | undefined): Promise<never> {
+  if (signal === undefined) {
+    throw new Error("The cancellable mock model requires an AbortSignal.");
+  }
+  signal.throwIfAborted();
+  return await new Promise((_, reject) => {
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
 }
 
 function createMockModelResult(

--- a/packages/eve/test/eve-run-stream-channel.test.ts
+++ b/packages/eve/test/eve-run-stream-channel.test.ts
@@ -166,6 +166,9 @@ function createEvents(
 
 function createMockGetSession(events: ReadableStream<HandleMessageStreamEvent>) {
   return vi.fn<GetSessionFn>().mockReturnValue({
+    async cancelTurn() {
+      return false;
+    },
     id: "session_xyz",
     continuationToken: "",
     async getEventStream() {

--- a/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
+++ b/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
@@ -79,6 +79,9 @@ interface CapturedRun {
 
 function createCapturingRuntime(captured: CapturedRun[]): Runtime {
   return {
+    async cancelTurn() {
+      return false;
+    },
     async run(input) {
       captured.push({
         adapter: input.adapter,

--- a/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
+++ b/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
@@ -57,6 +57,9 @@ interface CapturedRun {
 
 function createCapturingRuntime(captured: CapturedRun[]): Runtime {
   return {
+    async cancelTurn() {
+      return false;
+    },
     async run(input) {
       captured.push({
         adapter: input.adapter,


### PR DESCRIPTION
## Summary

- add authenticated per-turn cancellation tokens and a server cancellation route
- propagate the active turn `AbortSignal` through model generation and authored tool execution
- retry server-side workflow-hook registration without client polling
- keep the durable parent session waiting and ready for the next turn after cancellation

## Stack

1. #118 — core server cancellation
2. #127 — client, framework, and TUI controls
3. #128 — delegated local and remote runtime-action cancellation

This PR was reduced to the core server primitive so each layer can be reviewed and landed independently.

## Validation

- `pnpm --filter eve typecheck`
- `pnpm test:unit` (3,639 tests)
- `pnpm test:integration` (318 tests)
- `pnpm build`