### PR TITLE
[codex] expose sandbox ports

### DIFF
--- a/.changeset/friendly-sandboxes-connect.md
+++ b/.changeset/friendly-sandboxes-connect.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose declared sandbox ports through backend-neutral URLs.

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -52,6 +52,7 @@ The handle does more than `run` and `writeTextFile`. In every method, relative p
 | `readBinaryFile` / `writeBinaryFile`     | read/write raw bytes (images, archives, anything non-text)                                      |
 | `readFile` / `writeFile`                 | stream a file in/out as bytes                                                                   |
 | `removePath({ path, force, recursive })` | delete one file or directory; `force` ignores missing paths, `recursive` removes non-empty dirs |
+| `getPortUrl(port)`                       | resolve a port declared in the backend options                                                  |
 | `resolvePath(path)`                      | anchor a relative path to its absolute `/workspace/...` form                                    |
 | `setNetworkPolicy(policy)`               | change egress policy mid-turn (backend-dependent; see [Network policy](#network-policy))        |
 
@@ -69,6 +70,30 @@ A `SandboxProcess` exposes `stdout`/`stderr` byte streams, `wait()` (resolves wi
 `sandbox.id` is a stable per-session identifier that persists across reconnects to the same logical session. Use it as the cache key for per-session state that must outlive individual step executions.
 
 The option types (`SandboxSpawnOptions`, `SandboxReadBinaryFileOptions`, `SandboxWriteBinaryFileOptions`, and so on) are named exports from `eve/sandbox`, alongside `SandboxProcess`.
+
+### Exposing ports
+
+To run a server, declare the port when configuring the backend, bind the process to `0.0.0.0` inside the sandbox, then ask the session for its URL:
+
+```ts title="agent/sandbox.ts"
+import { defineSandbox } from "eve/sandbox";
+import { docker } from "eve/sandbox/docker";
+
+export default defineSandbox({
+  backend: docker({
+    ports: [{ sandboxPort: 3000, hostPort: 43000 }],
+  }),
+});
+```
+
+```ts
+const server = await sandbox.spawn({
+  command: "python -m http.server 3000 --bind 0.0.0.0",
+});
+const url = await sandbox.getPortUrl(3000); // http://127.0.0.1:43000
+```
+
+Docker and microsandbox use `{ sandboxPort, hostPort }` mappings and expose only the loopback host address. Vercel Sandbox uses its existing `ports: number[]` option and returns the hosted URL for that declared port. `justbash()` rejects `getPortUrl()` because it cannot run listening processes. Docker and microsandbox port mappings cannot be combined with `"deny-all"` networking.
 
 ## Seeding `/workspace`
 
@@ -147,7 +172,7 @@ export default defineSandbox({
 
 ### Docker
 
-`docker()` drives the Docker CLI directly. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. eve creates `/workspace` and verifies Bash during framework setup, before authored bootstrap code runs. Configure it through `docker({ image, env, pullPolicy, networkPolicy })`, and install authored runtime tools in sandbox bootstrap or provide them through a custom image. Templates are committed as local Docker images and reused across sessions when the sandbox source, seed files, `revalidationKey`, and Docker backend options still match. Sessions run as long-lived containers whose filesystems persist `/workspace` changes across turns for the same durable session. `eve dev` prunes stale template images in the background.
+`docker()` drives the Docker CLI directly. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. eve creates `/workspace` and verifies Bash during framework setup, before authored bootstrap code runs. Configure it through `docker({ image, env, pullPolicy, networkPolicy, ports })`, and install authored runtime tools in sandbox bootstrap or provide them through a custom image. Templates are committed as local Docker images and reused across sessions when the sandbox source, seed files, `revalidationKey`, and Docker backend options still match. Sessions run as long-lived containers whose filesystems persist `/workspace` changes across turns for the same durable session. `eve dev` prunes stale template images in the background.
 
 ### microsandbox
 

--- a/packages/eve/src/execution/sandbox/bash-tool.test.ts
+++ b/packages/eve/src/execution/sandbox/bash-tool.test.ts
@@ -41,6 +41,7 @@ describe("executeBashOnSandbox", () => {
 
 function createTestSandboxSession(result: SandboxCommandResult): SandboxSession {
   return {
+    getPortUrl: async () => "http://127.0.0.1:3000",
     id: "test-sandbox",
     readBinaryFile: async () => null,
     readFile: async () => null,

--- a/packages/eve/src/execution/sandbox/bindings/docker-container.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker-container.ts
@@ -40,6 +40,14 @@ export async function startDockerContainer(input: {
   for (const [key, value] of Object.entries(input.options.env)) {
     args.push("-e", `${key}=${value}`);
   }
+  if (input.role === "session") {
+    for (const mapping of input.options.ports) {
+      args.push(
+        "--publish",
+        `127.0.0.1:${String(mapping.hostPort)}:${String(mapping.sandboxPort)}/tcp`,
+      );
+    }
+  }
   if (input.initialNetworkPolicy === "deny-all") {
     args.push("--network", "none");
   }

--- a/packages/eve/src/execution/sandbox/bindings/docker-options.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker-options.test.ts
@@ -12,6 +12,7 @@ describe("resolveDockerSandboxOptions", () => {
       env: {},
       image: DEFAULT_DOCKER_SANDBOX_IMAGE,
       networkPolicy: "allow-all",
+      ports: [],
       pullPolicy: "if-not-present",
     });
   });
@@ -21,15 +22,26 @@ describe("resolveDockerSandboxOptions", () => {
       resolveDockerSandboxOptions({
         env: { FOO: "bar" },
         image: "ubuntu:26.04",
-        networkPolicy: "deny-all",
+        networkPolicy: "allow-all",
+        ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
         pullPolicy: "never",
       }),
     ).toEqual({
       env: { FOO: "bar" },
       image: "ubuntu:26.04",
-      networkPolicy: "deny-all",
+      networkPolicy: "allow-all",
+      ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
       pullPolicy: "never",
     });
+  });
+
+  it("rejects published ports with deny-all networking", () => {
+    expect(() =>
+      resolveDockerSandboxOptions({
+        networkPolicy: "deny-all",
+        ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+      }),
+    ).toThrow('Docker sandbox ports require networkPolicy: "allow-all"');
   });
 
   it("hashes template-affecting options stably", () => {
@@ -57,5 +69,15 @@ describe("resolveDockerSandboxOptions", () => {
 
     expect(first).toBe(second);
     expect(changed).not.toBe(first);
+    expect(
+      createDockerSandboxOptionsHash(
+        resolveDockerSandboxOptions({
+          env: { A: "1", B: "2" },
+          image: "ubuntu:26.04",
+          networkPolicy: "allow-all",
+          ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+        }),
+      ),
+    ).not.toBe(first);
   });
 });

--- a/packages/eve/src/execution/sandbox/bindings/docker-options.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker-options.ts
@@ -5,6 +5,8 @@ import type {
   DockerSandboxNetworkPolicy,
   DockerSandboxPullPolicy,
 } from "#public/sandbox/docker-sandbox.js";
+import { normalizeSandboxPortMappings } from "#execution/sandbox/port-mappings.js";
+import type { SandboxPortMapping } from "#shared/sandbox-session.js";
 
 /**
  * Default base image for the Docker backend: eve's published sandbox
@@ -20,6 +22,7 @@ export interface ResolvedDockerSandboxOptions {
   readonly env: Readonly<Record<string, string>>;
   readonly image: string;
   readonly networkPolicy: DockerSandboxNetworkPolicy;
+  readonly ports: ReadonlyArray<SandboxPortMapping>;
   readonly pullPolicy: DockerSandboxPullPolicy;
 }
 
@@ -29,10 +32,16 @@ export interface ResolvedDockerSandboxOptions {
 export function resolveDockerSandboxOptions(
   options: DockerSandboxCreateOptions = {},
 ): ResolvedDockerSandboxOptions {
+  const networkPolicy = options.networkPolicy ?? "allow-all";
+  const ports = normalizeSandboxPortMappings(options.ports);
+  if (networkPolicy === "deny-all" && ports.length > 0) {
+    throw new Error('Docker sandbox ports require networkPolicy: "allow-all".');
+  }
   return {
     env: options.env ?? {},
     image: options.image ?? DEFAULT_DOCKER_SANDBOX_IMAGE,
-    networkPolicy: options.networkPolicy ?? "allow-all",
+    networkPolicy,
+    ports,
     pullPolicy: options.pullPolicy ?? "if-not-present",
   };
 }
@@ -49,6 +58,7 @@ function dockerOptionsForHash(options: ResolvedDockerSandboxOptions): Record<str
     env: sortStringRecord(options.env),
     image: options.image,
     networkPolicy: options.networkPolicy,
+    ports: options.ports,
     pullPolicy: options.pullPolicy,
   };
 }

--- a/packages/eve/src/execution/sandbox/bindings/docker-session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker-session.ts
@@ -3,6 +3,7 @@ import { dirname as posixDirname } from "node:path/posix";
 
 import type { DockerCli } from "#execution/sandbox/bindings/docker-cli.js";
 import { expectDockerSuccess } from "#execution/sandbox/bindings/docker-utils.js";
+import { getLoopbackPortUrl } from "#execution/sandbox/port-mappings.js";
 import { resolveWorkspacePath } from "#execution/sandbox/bindings/local-backend-utils.js";
 import { shellQuote } from "#execution/sandbox/shell-quote.js";
 import { bufferToStream, streamToBuffer } from "#execution/sandbox/stream-utils.js";
@@ -11,6 +12,7 @@ import type {
   InternalSandboxSession,
   SandboxReadFileOptions,
   SandboxRemovePathOptions,
+  SandboxPortMapping,
   SandboxSpawnOptions,
   SandboxWriteFileOptions,
 } from "#shared/sandbox-session.js";
@@ -52,6 +54,7 @@ export function createDockerInternalSession(input: {
   readonly cli: DockerCli;
   readonly containerName: string;
   readonly id: string;
+  readonly ports?: ReadonlyArray<SandboxPortMapping>;
 }): InternalSandboxSession {
   const { cli, containerName } = input;
 
@@ -73,6 +76,9 @@ export function createDockerInternalSession(input: {
 
   return {
     id: input.id,
+    getPortUrl(port: number) {
+      return getLoopbackPortUrl(input.ports ?? [], port);
+    },
     resolvePath: resolveWorkspacePath,
     async spawn(options: SandboxSpawnOptions) {
       const args = ["exec", "-w", resolveWorkspacePath(options.workingDirectory ?? WORKSPACE_ROOT)];

--- a/packages/eve/src/execution/sandbox/bindings/docker.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker.integration.test.ts
@@ -288,6 +288,11 @@ describe("createDockerSandboxBackend create", () => {
 
   it("creates a session container from the template image with labels and tags", async () => {
     const appRoot = await createScratchDirectory("eve-docker-sandbox-");
+    const options = { ports: [{ hostPort: 43_000, sandboxPort: 3000 }] } as const;
+    const templateImage = dockerTemplateImageReference({
+      optionsHash: createDockerSandboxOptionsHash(resolveDockerSandboxOptions(options)),
+      templateKey: TEMPLATE_KEY,
+    });
     const previousRunId = process.env[EVE_DEVELOPMENT_SANDBOX_RUN_ID_ENV];
     process.env[EVE_DEVELOPMENT_SANDBOX_RUN_ID_ENV] = "dev-run-test";
     const { calls, cli } = createFakeDockerCli((args) => {
@@ -298,7 +303,10 @@ describe("createDockerSandboxBackend create", () => {
     });
 
     try {
-      const handle = await createEngine({ cli }).create({
+      const handle = await createEngine({
+        cli,
+        options,
+      }).create({
         runtimeContext: { appRoot },
         sessionKey: SESSION_KEY,
         tags: { agent: "weather" },
@@ -310,7 +318,14 @@ describe("createDockerSandboxBackend create", () => {
       expect(run?.args).toContain("eve.sandbox.role=session");
       expect(run?.args).toContain("eve.sandbox.tag.agent=weather");
       expect(run?.args).toContain("eve.sandbox.tag.devRunId=dev-run-test");
-      expect(run?.args.at(-3)).toBe(TEMPLATE_IMAGE);
+      expect(run?.args).toContain("--publish");
+      expect(run?.args).toContain("127.0.0.1:43000:3000/tcp");
+      expect(run?.args.at(-3)).toBe(templateImage);
+
+      await expect(handle.session.getPortUrl(3000)).resolves.toBe("http://127.0.0.1:43000");
+      await expect(handle.session.getPortUrl(3001)).rejects.toThrow(
+        "Sandbox port 3001 is not published",
+      );
 
       // No base setup against template-backed sessions — the template
       // image already carries it.

--- a/packages/eve/src/execution/sandbox/bindings/docker.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker.ts
@@ -263,8 +263,18 @@ export function createDockerSandboxBackend(
       }
 
       const session = buildSandboxSession(
-        createDockerInternalSession({ cli, containerName, id: createInput.sessionKey }),
-        (policy) => setDockerNetworkPolicy(cli, containerName, policy),
+        createDockerInternalSession({
+          cli,
+          containerName,
+          id: createInput.sessionKey,
+          ports: options.ports,
+        }),
+        async (policy) => {
+          if (policy === "deny-all" && options.ports.length > 0) {
+            throw new Error('Docker sandbox ports require networkPolicy: "allow-all".');
+          }
+          await setDockerNetworkPolicy(cli, containerName, policy);
+        },
       );
 
       return {

--- a/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
@@ -249,12 +249,23 @@ export async function justBashSetNetworkPolicyUnsupported(): Promise<never> {
   );
 }
 
+export async function justBashGetPortUrlUnsupported(): Promise<never> {
+  throw new Error(
+    "getPortUrl() is not supported on the just-bash sandbox backend because just-bash " +
+      "cannot run listening processes. Use docker(), microsandbox(), or vercel().",
+  );
+}
+
 export function createJustBashHandle(
   sandbox: BashSandbox,
   backendName: string,
 ): SandboxBackendHandle {
   const session = buildSandboxSession(
-    createFileBackedInternalSandboxSession({ id: sandbox.sessionKey, sandbox }),
+    createFileBackedInternalSandboxSession({
+      getPortUrl: justBashGetPortUrlUnsupported,
+      id: sandbox.sessionKey,
+      sandbox,
+    }),
     justBashSetNetworkPolicyUnsupported,
   );
   return {

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
@@ -78,6 +78,19 @@ describe("just-bash sandbox file API", () => {
     expect(content).toBe("hello world");
   });
 
+  it("explains that just-bash cannot expose listening ports", async () => {
+    const appRoot = await createTemporaryCacheDirectory("port-url");
+    const handle = await createPrewarmedLocalHandle({
+      appRoot,
+      sessionKey: "session-port",
+      templateKey: "tpl-port",
+    });
+
+    await expect(handle.session.getPortUrl(3000)).rejects.toThrow(
+      "just-bash cannot run listening processes",
+    );
+  });
+
   it("passes env vars to a command run via the public session", async () => {
     const cacheDirectory = await createTemporaryCacheDirectory("run-env");
     const handle = await createPrewarmedLocalHandle({

--- a/packages/eve/src/execution/sandbox/bindings/local-backend-utils.ts
+++ b/packages/eve/src/execution/sandbox/bindings/local-backend-utils.ts
@@ -23,10 +23,12 @@ export interface FileBackedSandbox {
 }
 
 export function createFileBackedInternalSandboxSession(input: {
+  readonly getPortUrl?: (port: number) => Promise<string> | string;
   readonly id: string;
   readonly sandbox: FileBackedSandbox;
 }): InternalSandboxSession {
   return {
+    getPortUrl: input.getPortUrl,
     id: input.id,
     resolvePath: resolveWorkspacePath,
     async spawn(options: SandboxSpawnOptions) {

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-create-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-create-runtime.ts
@@ -1,0 +1,67 @@
+import { createMicrosandboxWithProgress } from "#execution/sandbox/bindings/microsandbox-create.js";
+import { applyMicrosandboxNetwork } from "#execution/sandbox/bindings/microsandbox-network.js";
+import type { ResolvedMicrosandboxOptions } from "#execution/sandbox/bindings/microsandbox-options.js";
+import { withDevelopmentSandboxTags } from "#execution/sandbox/development-run.js";
+import type { SandboxBackendTags } from "#public/definitions/sandbox-backend.js";
+import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
+import type { Sandbox as MicrosandboxSandbox } from "microsandbox";
+
+export type MicrosandboxModule = typeof import("microsandbox");
+
+export async function createMicrosandbox(input: {
+  readonly fromSnapshot?: string;
+  readonly log?: (message: string) => void;
+  readonly module: MicrosandboxModule;
+  readonly name: string;
+  readonly networkPolicy?: SandboxNetworkPolicy;
+  readonly options: ResolvedMicrosandboxOptions;
+  readonly ports: ResolvedMicrosandboxOptions["ports"];
+  readonly tags?: SandboxBackendTags;
+  readonly user?: string;
+  readonly workdir: string;
+}): Promise<MicrosandboxSandbox> {
+  let builder = input.module.Sandbox.builder(input.name)
+    .cpus(input.options.cpus)
+    .detached(true)
+    .envs(input.options.env)
+    .labels(resolveMicrosandboxLabels(input.tags))
+    .memory(input.options.memoryMiB)
+    .pullPolicy(input.options.pullPolicy)
+    .replace()
+    .workdir(input.workdir);
+
+  builder =
+    input.fromSnapshot === undefined
+      ? builder.image(input.options.image)
+      : builder.fromSnapshot(input.fromSnapshot);
+
+  if (input.user !== undefined) {
+    builder = builder.user(input.user);
+  }
+
+  builder = applyMicrosandboxNetwork(
+    builder,
+    input.networkPolicy,
+    input.ports.map((mapping) => mapping.sandboxPort),
+  );
+  for (const mapping of input.ports) {
+    builder = builder.portBind("127.0.0.1", mapping.hostPort, mapping.sandboxPort);
+  }
+
+  return await createMicrosandboxWithProgress({
+    builder,
+    errorType: input.module.MicrosandboxError,
+    log: input.log,
+    source:
+      input.fromSnapshot === undefined
+        ? `image "${input.options.image}"`
+        : `snapshot "${input.fromSnapshot}"`,
+  });
+}
+
+function resolveMicrosandboxLabels(tags: SandboxBackendTags | undefined): Record<string, string> {
+  return {
+    "eve.backend": "microsandbox",
+    ...withDevelopmentSandboxTags(tags),
+  };
+}

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.ts
@@ -106,6 +106,7 @@ export async function prewarmMicrosandboxTemplate(input: {
     name: temporarySandboxName,
     networkPolicy: input.options.networkPolicy,
     options: input.options,
+    publishPorts: false,
     sessionKey: input.prewarmInput.templateKey,
     setupBaseRuntime: true,
     tags: undefined,
@@ -316,7 +317,11 @@ function createHandle(
 }
 
 function createMicrosandboxInternalSession(sandbox: MicrosandboxVm): InternalSandboxSession {
-  return createFileBackedInternalSandboxSession({ id: sandbox.id, sandbox });
+  return createFileBackedInternalSandboxSession({
+    getPortUrl: (port) => sandbox.getPortUrl(port),
+    id: sandbox.id,
+    sandbox,
+  });
 }
 
 function createActiveMicrosandboxSessionKey(sessionRootPath: string, optionsHash: string): string {

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts
@@ -72,8 +72,9 @@ export interface MicrosandboxNetworkPlan {
 export function applyMicrosandboxNetwork(
   builder: MicrosandboxSandboxBuilder,
   networkPolicy: SandboxNetworkPolicy | undefined,
+  publishedPorts: ReadonlyArray<number> = [],
 ): MicrosandboxSandboxBuilder {
-  const networkPlan = createMicrosandboxNetworkPlan(networkPolicy);
+  const networkPlan = createMicrosandboxNetworkPlan(networkPolicy, publishedPorts);
   if (networkPlan.disabled) {
     return builder.disableNetwork();
   }
@@ -143,6 +144,7 @@ export function serializeMicrosandboxNetworkPolicyJson(policy: MicrosandboxNetwo
 
 export function createMicrosandboxNetworkPlan(
   policy: SandboxNetworkPolicy | undefined,
+  publishedPorts: ReadonlyArray<number> = [],
 ): MicrosandboxNetworkPlan {
   if (policy === undefined || policy === "allow-all") {
     return {
@@ -150,7 +152,7 @@ export function createMicrosandboxNetworkPlan(
       policy: {
         defaultEgress: "allow",
         defaultIngress: "deny",
-        rules: [],
+        rules: createPublishedPortRules(publishedPorts),
       },
       transformHeaderRules: [],
     };
@@ -228,6 +230,8 @@ export function createMicrosandboxNetworkPlan(
     }
   }
 
+  rules.push(...createPublishedPortRules(publishedPorts));
+
   return {
     disabled: false,
     policy: {
@@ -237,6 +241,16 @@ export function createMicrosandboxNetworkPlan(
     },
     transformHeaderRules,
   };
+}
+
+function createPublishedPortRules(ports: ReadonlyArray<number>): MicrosandboxRule[] {
+  return ports.map((port) => ({
+    action: "allow",
+    destination: { kind: "any" },
+    direction: "ingress",
+    ports: [{ end: port, start: port }],
+    protocols: ["tcp"],
+  }));
 }
 
 export function createTransformBrokerEnvironment(

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-options.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-options.ts
@@ -1,5 +1,7 @@
 import type { MicrosandboxCreateOptions } from "#public/sandbox/microsandbox-sandbox.js";
+import { normalizeSandboxPortMappings } from "#execution/sandbox/port-mappings.js";
 import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
+import type { SandboxPortMapping } from "#shared/sandbox-session.js";
 
 export const MICROSANDBOX_DEFAULT_IMAGE = "ghcr.io/vercel/eve:latest";
 export const MICROSANDBOX_DEFAULT_CPUS = 1;
@@ -18,6 +20,7 @@ export interface ResolvedMicrosandboxOptions {
   readonly image: string;
   readonly memoryMiB: number;
   readonly networkPolicy?: SandboxNetworkPolicy;
+  readonly ports: ReadonlyArray<SandboxPortMapping>;
   readonly pullPolicy: "always" | "if-missing" | "never";
   readonly setup: {
     readonly autoInstall: boolean;
@@ -31,12 +34,18 @@ export interface ResolvedMicrosandboxOptions {
 export function resolveMicrosandboxOptions(
   options: MicrosandboxCreateOptions | undefined,
 ): ResolvedMicrosandboxOptions {
+  const networkPolicy = options?.networkPolicy;
+  const ports = normalizeSandboxPortMappings(options?.ports);
+  if (networkPolicy === "deny-all" && ports.length > 0) {
+    throw new Error('Microsandbox ports require a network policy other than "deny-all".');
+  }
   return {
     cpus: options?.cpus ?? MICROSANDBOX_DEFAULT_CPUS,
     env: options?.env ?? {},
     image: options?.image ?? MICROSANDBOX_DEFAULT_IMAGE,
     memoryMiB: options?.memoryMiB ?? MICROSANDBOX_DEFAULT_MEMORY_MIB,
-    networkPolicy: options?.networkPolicy,
+    networkPolicy,
+    ports,
     pullPolicy: options?.pullPolicy ?? MICROSANDBOX_DEFAULT_PULL_POLICY,
     setup: {
       autoInstall: options?.setup?.autoInstall ?? true,
@@ -58,6 +67,7 @@ export function microsandboxOptionsForHash(
     env: options.env,
     image: options.image,
     memoryMiB: options.memoryMiB,
+    ports: options.ports,
     pullPolicy: options.pullPolicy,
   };
 }

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.test.ts
@@ -193,6 +193,25 @@ describe.skipIf(process.platform === "win32")("connectMicrosandbox", () => {
 });
 
 describe.skipIf(process.platform === "win32")("MicrosandboxVm", () => {
+  it("resolves configured sandbox ports to loopback host ports", () => {
+    const vm = new MicrosandboxVm(
+      {
+        module: {} as never,
+        options: resolveMicrosandboxOptions({
+          ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+        }),
+        ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+        sessionKey: "session-key",
+      },
+      {} as never,
+      "sandbox-name",
+      undefined,
+    );
+
+    expect(vm.getPortUrl(3000)).toBe("http://127.0.0.1:43000");
+    expect(() => vm.getPortUrl(3001)).toThrow("Sandbox port 3001 is not published");
+  });
+
   it("finishes streamed commands when the exec handle emits an exit event", async () => {
     const sandbox = {
       async execStreamWith() {
@@ -206,6 +225,7 @@ describe.skipIf(process.platform === "win32")("MicrosandboxVm", () => {
       {
         module: {} as never,
         options: resolveMicrosandboxOptions({ image: MICROSANDBOX_DEFAULT_IMAGE }),
+        ports: [],
         sessionKey: "session-key",
       },
       sandbox as never,
@@ -236,6 +256,7 @@ describe.skipIf(process.platform === "win32")("MicrosandboxVm", () => {
       {
         module: {} as never,
         options: resolveMicrosandboxOptions({ image: MICROSANDBOX_DEFAULT_IMAGE }),
+        ports: [],
         sessionKey: "session-key",
       },
       sandbox as never,
@@ -255,6 +276,27 @@ describe.skipIf(process.platform === "win32")("MicrosandboxVm", () => {
 });
 
 describe.skipIf(process.platform === "win32")("createPreparedMicrosandbox", () => {
+  it("binds configured ports to loopback", async () => {
+    const module = createCreationModule({
+      create: async () => createMockMicrosandbox(),
+      progress: [],
+    });
+
+    await createPreparedMicrosandbox({
+      module: module as never,
+      name: "session-vm",
+      options: resolveMicrosandboxOptions({
+        ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+      }),
+      sessionKey: "session-key",
+      setupBaseRuntime: false,
+    });
+
+    expect(module.portBindings).toEqual([
+      { host: "127.0.0.1", hostPort: 43_000, sandboxPort: 3000 },
+    ]);
+  });
+
   it("reports the current creation phase while the VM is still starting", async () => {
     vi.useFakeTimers();
     const sandbox = createMockMicrosandbox();
@@ -377,6 +419,7 @@ function createCreationModule(input: {
   readonly create: () => Promise<ReturnType<typeof createMockMicrosandbox>>;
   readonly progress: readonly Record<string, unknown>[];
 }) {
+  const portBindings: Array<{ host: string; hostPort: number; sandboxPort: number }> = [];
   const builder = {
     cpus: returnBuilder,
     async create() {
@@ -396,6 +439,14 @@ function createCreationModule(input: {
     image: returnBuilder,
     labels: returnBuilder,
     memory: returnBuilder,
+    network(configure: (network: unknown) => unknown) {
+      configure(createMockNetworkBuilder());
+      return builder;
+    },
+    portBind(host: string, hostPort: number, sandboxPort: number) {
+      portBindings.push({ host, hostPort, sandboxPort });
+      return builder;
+    },
     pullPolicy: returnBuilder,
     replace: returnBuilder,
     user: returnBuilder,
@@ -407,6 +458,7 @@ function createCreationModule(input: {
   }
 
   return {
+    portBindings,
     Sandbox: {
       builder() {
         return builder;
@@ -535,6 +587,9 @@ function createMockSandboxBuilder(create: (fromSnapshot: string) => unknown) {
       return builder;
     },
     memory() {
+      return builder;
+    },
+    portBind() {
       return builder;
     },
     network(configure: (network: unknown) => unknown) {

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.ts
@@ -3,12 +3,15 @@ import { access } from "node:fs/promises";
 import { posix } from "node:path";
 
 import { shellQuote } from "#execution/sandbox/shell-quote.js";
-import { createMicrosandboxWithProgress } from "#execution/sandbox/bindings/microsandbox-create.js";
+import { getLoopbackPortUrl } from "#execution/sandbox/port-mappings.js";
 import {
-  applyMicrosandboxNetwork,
   createMicrosandboxNetworkPlan,
   createTransformBrokerEnvironment,
 } from "#execution/sandbox/bindings/microsandbox-network.js";
+import {
+  createMicrosandbox,
+  type MicrosandboxModule,
+} from "#execution/sandbox/bindings/microsandbox-create-runtime.js";
 import {
   MICROSANDBOX_USER,
   type ResolvedMicrosandboxOptions,
@@ -27,7 +30,6 @@ import {
   isEveDevEnvironment,
   loadOptionalEnginePackage,
 } from "#internal/application/optional-package-install.js";
-import { withDevelopmentSandboxTags } from "#execution/sandbox/development-run.js";
 import type { SandboxBackendTags } from "#public/definitions/sandbox-backend.js";
 import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
 import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
@@ -38,7 +40,7 @@ import type {
 } from "#shared/sandbox-session.js";
 import type { Sandbox as MicrosandboxSandbox } from "microsandbox";
 
-export type MicrosandboxModule = typeof import("microsandbox");
+export type { MicrosandboxModule } from "#execution/sandbox/bindings/microsandbox-create-runtime.js";
 
 const MICROSANDBOX_PACKAGE_NAME = "microsandbox";
 const MICROSANDBOX_CONNECT_TIMEOUT_MS = 10_000;
@@ -48,6 +50,7 @@ export class MicrosandboxVm {
   readonly #input: {
     readonly module: MicrosandboxModule;
     readonly options: ResolvedMicrosandboxOptions;
+    readonly ports: ResolvedMicrosandboxOptions["ports"];
     readonly sessionKey: string;
     readonly tags?: SandboxBackendTags;
   };
@@ -62,6 +65,7 @@ export class MicrosandboxVm {
     input: {
       readonly module: MicrosandboxModule;
       readonly options: ResolvedMicrosandboxOptions;
+      readonly ports: ResolvedMicrosandboxOptions["ports"];
       readonly sessionKey: string;
       readonly tags?: SandboxBackendTags;
     },
@@ -83,6 +87,10 @@ export class MicrosandboxVm {
 
   get id(): string {
     return this.#input.sessionKey;
+  }
+
+  getPortUrl(port: number): string {
+    return getLoopbackPortUrl(this.#input.ports, port);
   }
 
   async captureState(optionsHash: string): Promise<MicrosandboxSessionMetadata> {
@@ -157,6 +165,9 @@ export class MicrosandboxVm {
   }
 
   async setNetworkPolicy(policy: SandboxNetworkPolicy): Promise<void> {
+    if (policy === "deny-all" && this.#input.ports.length > 0) {
+      throw new Error('Microsandbox ports require a network policy other than "deny-all".');
+    }
     const previousStateSnapshotName = this.#stateSnapshotName;
     const stateSnapshotName = createProviderName(
       "eve-sbx-state",
@@ -177,6 +188,7 @@ export class MicrosandboxVm {
       name: nextSandboxName,
       networkPolicy: policy,
       options: this.#input.options,
+      ports: this.#input.ports,
       tags: this.#input.tags,
       user: MICROSANDBOX_USER,
       workdir: WORKSPACE_ROOT,
@@ -286,11 +298,13 @@ export async function createPreparedMicrosandbox(input: {
   readonly name: string;
   readonly networkPolicy?: SandboxNetworkPolicy;
   readonly options: ResolvedMicrosandboxOptions;
+  readonly publishPorts?: boolean;
   readonly sessionKey: string;
   readonly setupBaseRuntime: boolean;
   readonly tags?: SandboxBackendTags;
 }): Promise<MicrosandboxVm> {
   const initialNetworkPolicy = input.setupBaseRuntime ? "allow-all" : input.networkPolicy;
+  const ports = input.publishPorts === false ? [] : input.options.ports;
   const sandbox = await createMicrosandbox({
     fromSnapshot: input.fromSnapshot,
     log: input.log,
@@ -298,6 +312,7 @@ export async function createPreparedMicrosandbox(input: {
     name: input.name,
     networkPolicy: initialNetworkPolicy,
     options: input.options,
+    ports,
     tags: input.tags,
     user: input.setupBaseRuntime ? undefined : MICROSANDBOX_USER,
     workdir: input.setupBaseRuntime ? "/" : WORKSPACE_ROOT,
@@ -307,6 +322,7 @@ export async function createPreparedMicrosandbox(input: {
     {
       module: input.module,
       options: input.options,
+      ports,
       sessionKey: input.sessionKey,
       tags: input.tags,
     },
@@ -366,6 +382,7 @@ export async function connectMicrosandbox(input: {
     {
       module: input.module,
       options: input.options,
+      ports: input.options.ports,
       sessionKey: input.sessionKey,
       tags: input.tags,
     },
@@ -400,6 +417,7 @@ async function restoreMicrosandboxSessionSnapshot(input: {
     name: sandboxName,
     networkPolicy: input.metadata.networkPolicy,
     options: input.options,
+    ports: input.metadata.networkPolicy === "deny-all" ? [] : input.options.ports,
     tags: input.tags,
     user: MICROSANDBOX_USER,
     workdir: WORKSPACE_ROOT,
@@ -410,6 +428,7 @@ async function restoreMicrosandboxSessionSnapshot(input: {
     {
       module: input.module,
       options: input.options,
+      ports: input.options.ports,
       sessionKey: input.sessionKey,
       tags: input.tags,
     },
@@ -590,49 +609,6 @@ export async function doesPathExist(path: string): Promise<boolean> {
   }
 }
 
-async function createMicrosandbox(input: {
-  readonly fromSnapshot?: string;
-  readonly log?: (message: string) => void;
-  readonly module: MicrosandboxModule;
-  readonly name: string;
-  readonly networkPolicy?: SandboxNetworkPolicy;
-  readonly options: ResolvedMicrosandboxOptions;
-  readonly tags?: SandboxBackendTags;
-  readonly user?: string;
-  readonly workdir: string;
-}): Promise<MicrosandboxSandbox> {
-  let builder = input.module.Sandbox.builder(input.name)
-    .cpus(input.options.cpus)
-    .detached(true)
-    .envs(input.options.env)
-    .labels(resolveMicrosandboxLabels(input.tags))
-    .memory(input.options.memoryMiB)
-    .pullPolicy(input.options.pullPolicy)
-    .replace()
-    .workdir(input.workdir);
-
-  if (input.fromSnapshot !== undefined) {
-    builder = builder.fromSnapshot(input.fromSnapshot);
-  } else {
-    builder = builder.image(input.options.image);
-  }
-
-  if (input.user !== undefined) {
-    builder = builder.user(input.user);
-  }
-
-  const source =
-    input.fromSnapshot === undefined
-      ? `image "${input.options.image}"`
-      : `snapshot "${input.fromSnapshot}"`;
-  return await createMicrosandboxWithProgress({
-    builder: applyMicrosandboxNetwork(builder, input.networkPolicy),
-    errorType: input.module.MicrosandboxError,
-    log: input.log,
-    source,
-  });
-}
-
 async function removeSandboxIfExists(
   module: MicrosandboxModule,
   sandboxName: string,
@@ -681,11 +657,4 @@ function isMicrosandboxSnapshotSourceRunningError(error: unknown): boolean {
     return false;
   }
   return /snapshot source sandbox .*not stopped|SnapshotSandboxRunning/i.test(error.message);
-}
-
-function resolveMicrosandboxLabels(tags: SandboxBackendTags | undefined): Record<string, string> {
-  return {
-    "eve.backend": "microsandbox",
-    ...withDevelopmentSandboxTags(tags),
-  };
 }

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#execution/sandbox/bindings/microsandbox-network.js";
 import {
   MICROSANDBOX_DEFAULT_IMAGE,
+  microsandboxOptionsForHash,
   resolveMicrosandboxOptions,
 } from "#execution/sandbox/bindings/microsandbox-options.js";
 
@@ -33,6 +34,26 @@ describe.skipIf(onWindows)("createMicrosandboxSandboxBackend", () => {
   it("defaults to eve's published sandbox runtime image", () => {
     expect(MICROSANDBOX_DEFAULT_IMAGE).toBe("ghcr.io/vercel/eve:latest");
     expect(resolveMicrosandboxOptions(undefined).image).toBe(MICROSANDBOX_DEFAULT_IMAGE);
+    expect(resolveMicrosandboxOptions(undefined).ports).toEqual([]);
+  });
+
+  it("normalizes ports and includes them in template compatibility", () => {
+    const base = resolveMicrosandboxOptions(undefined);
+    const withPort = resolveMicrosandboxOptions({
+      ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+    });
+
+    expect(withPort.ports).toEqual([{ hostPort: 43_000, sandboxPort: 3000 }]);
+    expect(microsandboxOptionsForHash(withPort)).not.toEqual(microsandboxOptionsForHash(base));
+  });
+
+  it("rejects published ports with deny-all networking", () => {
+    expect(() =>
+      resolveMicrosandboxOptions({
+        networkPolicy: "deny-all",
+        ports: [{ hostPort: 43_000, sandboxPort: 3000 }],
+      }),
+    ).toThrow('Microsandbox ports require a network policy other than "deny-all"');
   });
 
   it("excludes setup behavior from the template compatibility hash", () => {
@@ -79,6 +100,31 @@ describe.skipIf(onWindows)("createMicrosandboxNetworkPlan", () => {
         rules: [],
       },
       transformHeaderRules: [],
+    });
+  });
+
+  it("allows ingress only to published sandbox TCP ports", () => {
+    const plan = createMicrosandboxNetworkPlan("allow-all", [3000, 8080]);
+
+    expect(plan.policy).toEqual({
+      defaultEgress: "allow",
+      defaultIngress: "deny",
+      rules: [
+        {
+          action: "allow",
+          destination: { kind: "any" },
+          direction: "ingress",
+          ports: [{ end: 3000, start: 3000 }],
+          protocols: ["tcp"],
+        },
+        {
+          action: "allow",
+          destination: { kind: "any" },
+          direction: "ingress",
+          ports: [{ end: 8080, start: 8080 }],
+          protocols: ["tcp"],
+        },
+      ],
     });
   });
 

--- a/packages/eve/src/execution/sandbox/bindings/vercel-session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-session.ts
@@ -17,9 +17,16 @@ import type {
 export function createVercelInternalSandboxSession(
   sandbox: SdkSandbox,
   id: string,
+  ports: ReadonlyArray<number> | undefined,
 ): InternalSandboxSession {
   return {
     id,
+    getPortUrl(port: number) {
+      if (ports?.includes(port) !== true) {
+        throw new Error(`Sandbox port ${String(port)} is not published.`);
+      }
+      return sandbox.domain(port);
+    },
     resolvePath: resolveVercelSandboxPath,
     async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
       const command = await sandbox.runCommand({

--- a/packages/eve/src/execution/sandbox/bindings/vercel-session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-session.ts
@@ -1,0 +1,116 @@
+import type {
+  Sandbox as SdkSandbox,
+  SandboxCommand as SdkSandboxCommand,
+} from "#compiled/@vercel/sandbox/index.js";
+
+import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
+import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
+import type {
+  InternalSandboxSession,
+  SandboxProcess,
+  SandboxReadFileOptions,
+  SandboxRemovePathOptions,
+  SandboxSpawnOptions,
+  SandboxWriteFileOptions,
+} from "#shared/sandbox-session.js";
+
+export function createVercelInternalSandboxSession(
+  sandbox: SdkSandbox,
+  id: string,
+): InternalSandboxSession {
+  return {
+    id,
+    resolvePath: resolveVercelSandboxPath,
+    async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
+      const command = await sandbox.runCommand({
+        args: ["-lc", options.command],
+        cmd: "bash",
+        cwd: options.workingDirectory ?? WORKSPACE_ROOT,
+        detached: true,
+        env: options.env,
+        signal: options.abortSignal,
+      });
+      return adaptVercelCommandToSandboxProcess(command);
+    },
+    async readFile(options: SandboxReadFileOptions) {
+      const stream = await sandbox.readFile({ path: options.path });
+      return stream ?? null;
+    },
+    async writeFile(options: SandboxWriteFileOptions) {
+      const bytes = await streamToBuffer(options.content);
+      await sandbox.writeFiles([{ content: bytes, path: options.path }]);
+    },
+    async removePath(options: SandboxRemovePathOptions) {
+      await sandbox.fs.rm(options.path, {
+        force: options.force,
+        recursive: options.recursive,
+        signal: options.abortSignal,
+      });
+    },
+  };
+}
+
+/** Adapts one detached Vercel command to Eve's streamed process contract. */
+function adaptVercelCommandToSandboxProcess(command: SdkSandboxCommand): SandboxProcess {
+  const encoder = new TextEncoder();
+  let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let stderrController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let streamingDone = false;
+  let streamingError: unknown;
+
+  const stdout = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stdoutController = controller;
+    },
+  });
+  const stderr = new ReadableStream<Uint8Array>({
+    start(controller) {
+      stderrController = controller;
+    },
+  });
+
+  void (async () => {
+    try {
+      for await (const message of command.logs()) {
+        const chunk = encoder.encode(message.data);
+        if (message.stream === "stdout") {
+          stdoutController?.enqueue(chunk);
+        } else {
+          stderrController?.enqueue(chunk);
+        }
+      }
+    } catch (error) {
+      streamingError = error;
+      stdoutController?.error(error);
+      stderrController?.error(error);
+    } finally {
+      streamingDone = true;
+      if (streamingError === undefined) {
+        stdoutController?.close();
+        stderrController?.close();
+      }
+    }
+  })();
+
+  return {
+    stdout,
+    stderr,
+    async wait() {
+      const finished = await command.wait();
+      while (!streamingDone) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      if (streamingError !== undefined) {
+        throw streamingError;
+      }
+      return { exitCode: finished.exitCode };
+    },
+    async kill() {
+      await command.kill();
+    },
+  };
+}
+
+function resolveVercelSandboxPath(path: string): string {
+  return path.startsWith("/") ? path : `${WORKSPACE_ROOT}/${path}`;
+}

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -40,6 +40,7 @@ function createMockSandbox(input: {
   return {
     currentSnapshotId: input.snapshotId ?? "",
     delete: vi.fn().mockResolvedValue(undefined),
+    domain: vi.fn((port: number) => `https://port-${String(port)}.sandbox.example.com`),
     fs: {
       rm: vi.fn().mockResolvedValue(undefined),
       unlink: vi.fn().mockResolvedValue(undefined),
@@ -411,6 +412,43 @@ describe("createVercelSandbox", () => {
       signal: undefined,
     });
     expect(sessionSandbox.runCommand).not.toHaveBeenCalled();
+  });
+
+  it("resolves declared port URLs through the Vercel Sandbox SDK", async () => {
+    const templateSandbox = createMockSandbox({ name: "template" });
+    const sessionSandbox = createMockSandbox({ name: "session" });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi
+          .fn()
+          .mockResolvedValueOnce(templateSandbox)
+          .mockResolvedValueOnce(sessionSandbox),
+        get: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const backend = createTestVercelSandbox({
+      createOptions: { ports: [3000] } as never,
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      seedFiles: [],
+      templateKey: "template-key",
+    });
+    const handle = await backend.create({
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      sessionKey: "session-key",
+      templateKey: "template-key",
+    });
+
+    await expect(handle.session.getPortUrl(3000)).resolves.toBe(
+      "https://port-3000.sandbox.example.com",
+    );
+    expect(sessionSandbox.domain).toHaveBeenCalledWith(3000);
+    await expect(handle.session.getPortUrl(3001)).rejects.toThrow(
+      "Sandbox port 3001 is not published",
+    );
   });
 
   it("applies a 30-minute default timeout to Sandbox.create", async () => {

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -122,7 +122,7 @@ export function createVercelSandbox(
         await applyInitialVercelNetworkPolicy(session.sandbox, createOptions.networkPolicy);
       }
 
-      return createHandle(session.sandbox, createInput.sessionKey);
+      return createHandle(session.sandbox, createInput.sessionKey, createOptions.ports);
     },
     async prewarm(
       prewarmInput: SandboxBackendPrewarmInput<VercelSandboxBootstrapUseOptions>,
@@ -305,7 +305,7 @@ async function ensureTemplate(input: EnsureTemplateInput): Promise<EnsureTemplat
   await applyInitialVercelNetworkPolicy(sandbox, input.createOptions.networkPolicy);
 
   const templateSession = buildSandboxSession(
-    createVercelInternalSandboxSession(sandbox, input.templateKey),
+    createVercelInternalSandboxSession(sandbox, input.templateKey, input.createOptions.ports),
     createVercelNetworkPolicySetter(sandbox),
   );
 
@@ -424,10 +424,11 @@ function withBaseSetupNetworkPolicy(
 function createHandle(
   sandbox: SdkSandbox,
   sessionKey: string,
+  ports: ReadonlyArray<number> | undefined,
 ): SandboxBackendHandle<VercelSandboxSessionUseOptions> {
   return {
     session: buildSandboxSession(
-      createVercelInternalSandboxSession(sandbox, sessionKey),
+      createVercelInternalSandboxSession(sandbox, sessionKey, ports),
       createVercelNetworkPolicySetter(sandbox),
     ),
     useSessionFn: async (options?: VercelSandboxSessionUseOptions) => {
@@ -435,7 +436,7 @@ function createHandle(
         await sandbox.update(options);
       }
       return buildSandboxSession(
-        createVercelInternalSandboxSession(sandbox, sessionKey),
+        createVercelInternalSandboxSession(sandbox, sessionKey, ports),
         createVercelNetworkPolicySetter(sandbox),
       );
     },

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -1,7 +1,6 @@
 import type {
   SandboxCreateOptions,
   Sandbox as SdkSandbox,
-  SandboxCommand as SdkSandboxCommand,
 } from "#compiled/@vercel/sandbox/index.js";
 
 import {
@@ -10,14 +9,6 @@ import {
 } from "#execution/sandbox/bindings/vercel-base-runtime.js";
 import type { SandboxBootstrapContext } from "#public/definitions/sandbox.js";
 import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
-import type {
-  InternalSandboxSession,
-  SandboxProcess,
-  SandboxReadFileOptions,
-  SandboxRemovePathOptions,
-  SandboxSpawnOptions,
-  SandboxWriteFileOptions,
-} from "#shared/sandbox-session.js";
 import type {
   SandboxBackend,
   SandboxBackendCreateInput,
@@ -32,10 +23,9 @@ import type {
   VercelSandboxBootstrapUseOptions,
   VercelSandboxSessionUseOptions,
 } from "#public/sandbox/vercel-sandbox.js";
-import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
 import { createLoggingSandboxSession } from "#execution/sandbox/logging-session.js";
 import { buildSandboxSession } from "#execution/sandbox/session.js";
-import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
+import { createVercelInternalSandboxSession } from "#execution/sandbox/bindings/vercel-session.js";
 import {
   createVercelEveImageSandbox,
   type CreateVercelSandbox,
@@ -466,115 +456,6 @@ function createVercelNetworkPolicySetter(
   return async (policy) => {
     await sandbox.update({ networkPolicy: policy });
   };
-}
-
-function createVercelInternalSandboxSession(
-  sandbox: SdkSandbox,
-  id: string,
-): InternalSandboxSession {
-  return {
-    id,
-    resolvePath: resolveVercelSandboxPath,
-    async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
-      const command = await sandbox.runCommand({
-        args: ["-lc", options.command],
-        cmd: "bash",
-        cwd: options.workingDirectory ?? WORKSPACE_ROOT,
-        detached: true,
-        env: options.env,
-        signal: options.abortSignal,
-      });
-      return adaptVercelCommandToSandboxProcess(command);
-    },
-    async readFile(options: SandboxReadFileOptions) {
-      const stream = await sandbox.readFile({ path: options.path });
-      return stream ?? null;
-    },
-    async writeFile(options: SandboxWriteFileOptions) {
-      const bytes = await streamToBuffer(options.content);
-      await sandbox.writeFiles([{ content: bytes, path: options.path }]);
-    },
-    async removePath(options: SandboxRemovePathOptions) {
-      await sandbox.fs.rm(options.path, {
-        force: options.force,
-        recursive: options.recursive,
-        signal: options.abortSignal,
-      });
-    },
-  };
-}
-
-/**
- * Wraps a Vercel `Command` (returned from `runCommand({ detached: true })`)
- * in the AI SDK `Experimental_SandboxProcess` shape. Splits the single
- * `logs()` iterator into two byte streams, exposes a `wait()` that
- * resolves with the exit code, and forwards `kill()` to the SDK.
- */
-function adaptVercelCommandToSandboxProcess(command: SdkSandboxCommand): SandboxProcess {
-  const encoder = new TextEncoder();
-  let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
-  let stderrController: ReadableStreamDefaultController<Uint8Array> | undefined;
-  let streamingDone = false;
-  let streamingError: unknown;
-
-  const stdout = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stdoutController = controller;
-    },
-  });
-  const stderr = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stderrController = controller;
-    },
-  });
-
-  void (async () => {
-    try {
-      for await (const message of command.logs()) {
-        const chunk = encoder.encode(message.data);
-        if (message.stream === "stdout") {
-          stdoutController?.enqueue(chunk);
-        } else {
-          stderrController?.enqueue(chunk);
-        }
-      }
-    } catch (error) {
-      streamingError = error;
-      stdoutController?.error(error);
-      stderrController?.error(error);
-    } finally {
-      streamingDone = true;
-      if (streamingError === undefined) {
-        stdoutController?.close();
-        stderrController?.close();
-      }
-    }
-  })();
-
-  return {
-    stdout,
-    stderr,
-    async wait() {
-      const finished = await command.wait();
-      while (!streamingDone) {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      }
-      if (streamingError !== undefined) {
-        throw streamingError;
-      }
-      return { exitCode: finished.exitCode };
-    },
-    async kill() {
-      await command.kill();
-    },
-  };
-}
-
-function resolveVercelSandboxPath(path: string): string {
-  if (path.startsWith("/")) {
-    return path;
-  }
-  return `${WORKSPACE_ROOT}/${path}`;
 }
 
 function isUnprovisionedTerminalTemplateSandbox(

--- a/packages/eve/src/execution/sandbox/logging-session.test.ts
+++ b/packages/eve/src/execution/sandbox/logging-session.test.ts
@@ -89,6 +89,7 @@ describe("createLoggingSandboxSession", () => {
 
 function createTestSession(runResult = { exitCode: 0, stderr: "", stdout: "" }): SandboxSession {
   return {
+    getPortUrl: vi.fn(async () => "http://127.0.0.1:3000"),
     id: "test-session",
     resolvePath: (path) => (path.startsWith("/") ? path : `/workspace/${path}`),
     run: vi.fn(async () => runResult),

--- a/packages/eve/src/execution/sandbox/port-mappings.test.ts
+++ b/packages/eve/src/execution/sandbox/port-mappings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getLoopbackPortUrl,
+  normalizeSandboxPortMappings,
+} from "#execution/sandbox/port-mappings.js";
+
+describe("sandbox port mappings", () => {
+  it("copies and resolves valid loopback mappings", () => {
+    const input = [{ hostPort: 43_000, sandboxPort: 3000 }];
+    const mappings = normalizeSandboxPortMappings(input);
+
+    expect(mappings).toEqual(input);
+    expect(mappings).not.toBe(input);
+    expect(getLoopbackPortUrl(mappings, 3000)).toBe("http://127.0.0.1:43000");
+  });
+
+  it.each([
+    [{ hostPort: 0, sandboxPort: 3000 }, "hostPort"],
+    [{ hostPort: 43_000, sandboxPort: 65_536 }, "sandboxPort"],
+    [{ hostPort: 43_000.5, sandboxPort: 3000 }, "hostPort"],
+  ] as const)("rejects invalid mappings %#", (mapping, field) => {
+    expect(() => normalizeSandboxPortMappings([mapping])).toThrow(
+      `${field} must be an integer between 1 and 65535`,
+    );
+  });
+
+  it("rejects duplicate host and sandbox ports", () => {
+    expect(() =>
+      normalizeSandboxPortMappings([
+        { hostPort: 43_000, sandboxPort: 3000 },
+        { hostPort: 43_000, sandboxPort: 3001 },
+      ]),
+    ).toThrow("Duplicate sandbox hostPort: 43000");
+    expect(() =>
+      normalizeSandboxPortMappings([
+        { hostPort: 43_000, sandboxPort: 3000 },
+        { hostPort: 43_001, sandboxPort: 3000 },
+      ]),
+    ).toThrow("Duplicate sandboxPort: 3000");
+  });
+
+  it("rejects ports that were not published", () => {
+    expect(() => getLoopbackPortUrl([], 3000)).toThrow("Sandbox port 3000 is not published");
+  });
+});

--- a/packages/eve/src/execution/sandbox/port-mappings.ts
+++ b/packages/eve/src/execution/sandbox/port-mappings.ts
@@ -1,0 +1,44 @@
+import type { SandboxPortMapping } from "#shared/sandbox-session.js";
+
+const MIN_PORT = 1;
+const MAX_PORT = 65_535;
+
+export function normalizeSandboxPortMappings(
+  mappings: ReadonlyArray<SandboxPortMapping> | undefined,
+): ReadonlyArray<SandboxPortMapping> {
+  const resolved = mappings?.map((mapping) => ({ ...mapping })) ?? [];
+  const hostPorts = new Set<number>();
+  const sandboxPorts = new Set<number>();
+
+  for (const mapping of resolved) {
+    validatePort(mapping.hostPort, "hostPort");
+    validatePort(mapping.sandboxPort, "sandboxPort");
+    if (hostPorts.has(mapping.hostPort)) {
+      throw new Error(`Duplicate sandbox hostPort: ${String(mapping.hostPort)}.`);
+    }
+    if (sandboxPorts.has(mapping.sandboxPort)) {
+      throw new Error(`Duplicate sandboxPort: ${String(mapping.sandboxPort)}.`);
+    }
+    hostPorts.add(mapping.hostPort);
+    sandboxPorts.add(mapping.sandboxPort);
+  }
+
+  return resolved;
+}
+
+export function getLoopbackPortUrl(
+  mappings: ReadonlyArray<SandboxPortMapping>,
+  sandboxPort: number,
+): string {
+  const mapping = mappings.find((entry) => entry.sandboxPort === sandboxPort);
+  if (mapping === undefined) {
+    throw new Error(`Sandbox port ${String(sandboxPort)} is not published.`);
+  }
+  return `http://127.0.0.1:${String(mapping.hostPort)}`;
+}
+
+function validatePort(port: number, name: string): void {
+  if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) {
+    throw new Error(`${name} must be an integer between 1 and 65535.`);
+  }
+}

--- a/packages/eve/src/execution/sandbox/prewarm.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/prewarm.scenario.test.ts
@@ -800,6 +800,9 @@ function createRecordingDispatch(
     if (input.bootstrap !== undefined) {
       await input.bootstrap({
         use: async () => ({
+          async getPortUrl() {
+            return "http://127.0.0.1:3000";
+          },
           id: "test-prewarm-session",
           async readFile() {
             return null;

--- a/packages/eve/src/execution/sandbox/session.test.ts
+++ b/packages/eve/src/execution/sandbox/session.test.ts
@@ -28,6 +28,7 @@ function createTestPrimitives(
   overrides: Partial<InternalSandboxSession> = {},
 ): InternalSandboxSession {
   return {
+    getPortUrl: overrides.getPortUrl,
     id: overrides.id ?? "test-session-id",
     readFile: overrides.readFile ?? vi.fn(async () => null),
     removePath: overrides.removePath ?? vi.fn(async () => {}),
@@ -106,6 +107,34 @@ describe("buildSandboxSession", () => {
       path: "/workspace/skills/tenant",
       recursive: true,
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPortUrl
+  // ---------------------------------------------------------------------------
+
+  it("delegates valid ports to the backend primitive", async () => {
+    const getPortUrl = vi.fn((port: number) => `https://port-${String(port)}.example.com`);
+    const session = buildSandboxSession(createTestPrimitives({ getPortUrl }));
+
+    await expect(session.getPortUrl(3000)).resolves.toBe("https://port-3000.example.com");
+    expect(getPortUrl).toHaveBeenCalledWith(3000);
+  });
+
+  it.each([0, 65_536, 1.5, Number.NaN])("rejects invalid port %s", async (port) => {
+    const session = buildSandboxSession(createTestPrimitives({ getPortUrl: vi.fn() }));
+
+    await expect(session.getPortUrl(port)).rejects.toThrow(
+      "port must be an integer between 1 and 65535",
+    );
+  });
+
+  it("rejects port access when the backend does not support listening processes", async () => {
+    const session = buildSandboxSession(createTestPrimitives());
+
+    await expect(session.getPortUrl(3000)).rejects.toThrow(
+      "Port URLs are not supported by this sandbox backend",
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/eve/src/execution/sandbox/session.ts
+++ b/packages/eve/src/execution/sandbox/session.ts
@@ -111,8 +111,21 @@ export function buildSandboxSession(
         recursive: options.recursive,
       });
     },
+    async getPortUrl(port: number) {
+      validatePort(port);
+      if (primitives.getPortUrl === undefined) {
+        throw new Error("Port URLs are not supported by this sandbox backend.");
+      }
+      return await primitives.getPortUrl(port);
+    },
     setNetworkPolicy,
   };
+}
+
+function validatePort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("port must be an integer between 1 and 65535.");
+  }
 }
 
 /**

--- a/packages/eve/src/internal/testing/mocks/mock-sandbox.ts
+++ b/packages/eve/src/internal/testing/mocks/mock-sandbox.ts
@@ -44,6 +44,8 @@ export interface MockSandboxInput {
    * fall through to {@link MockSandboxInput.run}.
    */
   readonly commands?: Readonly<Record<string, SandboxCommandResult>>;
+  /** Published port URLs returned by `session.getPortUrl()`. */
+  readonly portUrls?: Readonly<Record<number, string>>;
   /**
    * Fallback command handler. Invoked when the request does not match a
    * {@link MockSandboxInput.commands} entry. Defaults to a no-op exit code 0
@@ -175,6 +177,13 @@ export function mockSandbox(input: MockSandboxInput = {}): MockSandbox {
   }
 
   const session: SandboxSession = {
+    async getPortUrl(port: number): Promise<string> {
+      const url = input.portUrls?.[port];
+      if (url === undefined) {
+        throw new Error(`Sandbox port ${String(port)} is not published.`);
+      }
+      return url;
+    },
     id: sandboxId,
     resolvePath(path: string): string {
       return resolveWorkspacePath(path);

--- a/packages/eve/src/public/definitions/sandbox.ts
+++ b/packages/eve/src/public/definitions/sandbox.ts
@@ -6,6 +6,7 @@ import type {
 
 export type {
   SandboxCommandResult,
+  SandboxPortMapping,
   SandboxProcess,
   SandboxReadBinaryFileOptions,
   SandboxReadFileOptions,

--- a/packages/eve/src/public/sandbox/docker-sandbox.ts
+++ b/packages/eve/src/public/sandbox/docker-sandbox.ts
@@ -1,3 +1,5 @@
+import type { SandboxPortMapping } from "#shared/sandbox-session.js";
+
 /**
  * Image pull behavior for the Docker sandbox backend.
  *
@@ -44,4 +46,6 @@ export interface DockerSandboxCreateOptions {
    * `"allow-all"`.
    */
   readonly networkPolicy?: DockerSandboxNetworkPolicy;
+  /** TCP ports published on loopback for live session containers. */
+  readonly ports?: ReadonlyArray<SandboxPortMapping>;
 }

--- a/packages/eve/src/public/sandbox/index.ts
+++ b/packages/eve/src/public/sandbox/index.ts
@@ -8,6 +8,7 @@ export {
   type SandboxBootstrapUseFn,
   type SandboxCommandResult,
   type SandboxDefinition,
+  type SandboxPortMapping,
   type SandboxProcess,
   type SandboxReadBinaryFileOptions,
   type SandboxReadFileOptions,

--- a/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
+++ b/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
@@ -1,4 +1,5 @@
 import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
+import type { SandboxPortMapping } from "#shared/sandbox-session.js";
 
 /**
  * Options accepted by `microsandbox(opts)`.
@@ -40,6 +41,8 @@ export interface MicrosandboxCreateOptions {
   };
   /** Initial network policy applied to sandboxes after framework setup. */
   readonly networkPolicy?: SandboxNetworkPolicy;
+  /** TCP ports published on loopback for live session VMs. */
+  readonly ports?: ReadonlyArray<SandboxPortMapping>;
 }
 
 /**

--- a/packages/eve/src/shared/sandbox-session.ts
+++ b/packages/eve/src/shared/sandbox-session.ts
@@ -76,6 +76,12 @@ export interface SandboxRemovePathOptions {
   readonly recursive?: boolean;
 }
 
+/** One loopback TCP port published by a local sandbox backend. */
+export interface SandboxPortMapping {
+  readonly hostPort: number;
+  readonly sandboxPort: number;
+}
+
 /**
  * Public eve-owned sandbox session exposed to authored lifecycle hooks.
  *
@@ -83,8 +89,8 @@ export interface SandboxRemovePathOptions {
  * `readTextFile`, `writeFile`, `writeBinaryFile`, `writeTextFile`) are
  * pulled directly from the AI SDK {@link AiSdkSandbox} type, so authored
  * code that targets either surface uses identical signatures. `id` and
- * `resolvePath` are eve-specific extensions that the runtime relies on
- * for caching and `/workspace` path anchoring.
+ * `resolvePath`, `removePath`, and `getPortUrl` are eve-specific extensions
+ * for lifecycle, path management, and port access.
  *
  * Relative paths resolve from `/workspace`, the live working directory
  * for every backend. Absolute paths pass through unchanged.
@@ -141,6 +147,13 @@ export interface SandboxSession extends Pick<
    * Relative paths resolve from `/workspace`; absolute paths pass through.
    */
   removePath(options: SandboxRemovePathOptions): Promise<void>;
+  /**
+   * Returns the URL for a port declared in the selected backend's create
+   * options. Vercel URLs are public; Docker and microsandbox URLs use the
+   * configured loopback host port. Throws when the port is not published or
+   * the backend cannot run listening processes.
+   */
+  getPortUrl(port: number): Promise<string>;
 }
 
 /**
@@ -165,6 +178,8 @@ export interface InternalSandboxSession extends Pick<
    * Stable identifier surfaced on the public {@link SandboxSession}.
    */
   readonly id: string;
+  /** Resolves a published sandbox port when the backend supports it. */
+  getPortUrl?(port: number): Promise<string> | string;
   /** Removes an already-resolved path from the backend filesystem. */
   removePath(options: SandboxRemovePathOptions): Promise<void>;
   /** Translates a user-facing path to the backend's native path. */

--- a/packages/eve/test/define-bash-tool.test.ts
+++ b/packages/eve/test/define-bash-tool.test.ts
@@ -45,6 +45,9 @@ describe("defineBashTool", () => {
 
       async get() {
         return {
+          async getPortUrl() {
+            return "http://127.0.0.1:3000";
+          },
           id: "test-bash-sandbox",
           async readFile() {
             return null;
@@ -137,6 +140,9 @@ describe("defineBashTool", () => {
 
       async get() {
         return {
+          async getPortUrl() {
+            return "http://127.0.0.1:3000";
+          },
           id: "test-bash-sandbox-large",
           async readFile() {
             return null;

--- a/packages/eve/test/define-glob-tool.test.ts
+++ b/packages/eve/test/define-glob-tool.test.ts
@@ -20,6 +20,9 @@ function createFakeAccess(
       const callHandler = handler;
       if (callHandler === null) return null;
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         id: `test-glob-sandbox-${crypto.randomUUID()}`,
         async readFile() {
           return null;

--- a/packages/eve/test/define-grep-tool.test.ts
+++ b/packages/eve/test/define-grep-tool.test.ts
@@ -20,6 +20,9 @@ function createFakeAccess(
       const callHandler = handler;
       if (callHandler === null) return null;
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         id: `test-grep-sandbox-${crypto.randomUUID()}`,
         async readFile() {
           return null;

--- a/packages/eve/test/define-read-file-tool.test.ts
+++ b/packages/eve/test/define-read-file-tool.test.ts
@@ -17,6 +17,9 @@ function createFakeAccess(files: Record<string, string>): SandboxAccess {
 
     async get() {
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         id: "test-read-file-sandbox",
         async readFile() {
           return null;

--- a/packages/eve/test/define-write-file-tool.test.ts
+++ b/packages/eve/test/define-write-file-tool.test.ts
@@ -20,6 +20,9 @@ function createFakeAccess(files: Record<string, string>): SandboxAccess {
 
     async get() {
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         id: "test-write-file-sandbox",
         async readFile() {
           return null;

--- a/packages/eve/test/file-tool-compaction.test.ts
+++ b/packages/eve/test/file-tool-compaction.test.ts
@@ -21,6 +21,9 @@ function createFakeAccess(files: Record<string, string>): {
   session: SandboxSession;
 } {
   const session = {
+    async getPortUrl() {
+      return "http://127.0.0.1:3000";
+    },
     id: "test-file-compaction-sandbox",
     async readFile() {
       return null;

--- a/packages/eve/test/glob-tool.test.ts
+++ b/packages/eve/test/glob-tool.test.ts
@@ -38,6 +38,9 @@ function createFakeAccess(
 
     async get() {
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         // Use a fresh id per fake session so the ripgrep-probe cache
         // (keyed by `session.id`) does not leak across tests.
         id: `test-glob-sandbox-${crypto.randomUUID()}`,

--- a/packages/eve/test/grep-tool.test.ts
+++ b/packages/eve/test/grep-tool.test.ts
@@ -38,6 +38,9 @@ function createFakeAccess(
 
     async get() {
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         // Use a fresh id per fake session so the ripgrep-probe cache
         // (keyed by `session.id`) does not leak across tests.
         id: `test-grep-sandbox-${crypto.randomUUID()}`,

--- a/packages/eve/test/read-file-tool.test.ts
+++ b/packages/eve/test/read-file-tool.test.ts
@@ -23,6 +23,9 @@ function createFakeAccess(files: Record<string, string | null>): SandboxAccess {
 
     async get() {
       return {
+        async getPortUrl() {
+          return "http://127.0.0.1:3000";
+        },
         id: "test-read-file-sandbox",
         async readFile() {
           return null;

--- a/packages/eve/test/scenarios/vercel-build-prewarm.scenario.test.ts
+++ b/packages/eve/test/scenarios/vercel-build-prewarm.scenario.test.ts
@@ -230,6 +230,9 @@ function createRecordingDispatch(events: ReturnType<typeof createPrewarmEvents>)
     if (input.bootstrap !== undefined) {
       await input.bootstrap({
         use: async () => ({
+          async getPortUrl() {
+            return "http://127.0.0.1:3000";
+          },
           id: input.templateKey,
           async readFile() {
             return null;
@@ -276,6 +279,9 @@ function createFailingBootstrapDispatch() {
     if (input.bootstrap !== undefined) {
       await input.bootstrap({
         use: async () => ({
+          async getPortUrl() {
+            return "http://127.0.0.1:3000";
+          },
           id: input.templateKey,
           async readFile() {
             return null;

--- a/packages/eve/test/write-file-tool.test.ts
+++ b/packages/eve/test/write-file-tool.test.ts
@@ -24,6 +24,9 @@ function createFakeAccess(files: Record<string, string>): {
   session: SandboxSession;
 } {
   const session = {
+    async getPortUrl() {
+      return "http://127.0.0.1:3000";
+    },
     id: "test-write-file-sandbox",
     async readFile() {
       return null;


### PR DESCRIPTION
## Summary

- add `SandboxSession.getPortUrl()` for ports declared by a sandbox backend
- publish Docker and Microsandbox TCP ports through validated loopback-only `{ sandboxPort, hostPort }` mappings
- resolve declared Vercel Sandbox ports through their hosted domains
- return an actionable unsupported error for Just Bash, which cannot run listening processes
- allow ingress only to declared Microsandbox TCP ports while retaining default-deny ingress

## API

```ts
export default defineSandbox({
  backend: docker({
    ports: [{ sandboxPort: 3000, hostPort: 43000 }],
  }),
});

const url = await sandbox.getPortUrl(3000);
```

Docker and Microsandbox URLs use `127.0.0.1`; Vercel returns the provider-hosted URL. Undeclared and invalid ports are rejected.

## Security

- local backends bind published ports to loopback only
- duplicate, invalid, and conflicting mappings are rejected
- Docker and Microsandbox reject port mappings with `deny-all` networking because that combination cannot work
- Microsandbox keeps default ingress denied and adds TCP ingress rules only for declared guest ports

## Review notes

The first commit mechanically moves the existing Vercel session adapter out of `vercel.ts`. That file is already at the repository's 700-line production limit on `main`; the extraction is behavior-preserving and gives the port implementation a focused home.

## Verification

- 3,649 unit tests passed
- 318 integration tests passed
- 254 scenario tests passed; 15 skipped
- typecheck, build, docs checks, invariant guards, lint, and formatting passed
