### PR TITLE
docs: document sandbox file exports

### DIFF
--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -76,6 +76,61 @@ Most chat UIs only need `data.messages` and `status`. Drop down to `events` to r
 
 `data.messages` are `EveMessage[]` following the AI SDK `UIMessage` convention, so they drop straight into any AI SDK UI primitive that accepts a `UIMessage[]`. Parts include user text, assistant text, reasoning, tool calls, tool results, and input requests.
 
+## Render generated images and file downloads
+
+An authored tool can use [`sandbox.readFile()`](../../sandbox#export-files-from-the-sandbox) to export a generated file, then return a JSON-safe artifact descriptor. Use an HTTPS URL for a file uploaded to storage. For an explicitly size-limited file, the tool can return a base64 `data:` URL instead.
+
+The default reducer exposes a completed tool result as a `dynamic-tool` part with `state: "output-available"`. Each tool owns its output shape, so validate `part.output` before using it in the DOM:
+
+```tsx
+import type { EveDynamicToolPart } from "eve/react";
+
+interface FileArtifact {
+  readonly filename: string;
+  readonly mediaType: string;
+  readonly url: string;
+}
+
+const INLINE_IMAGE_MEDIA_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+function isFileArtifact(output: unknown): output is FileArtifact {
+  if (typeof output !== "object" || output === null) return false;
+  if (!("filename" in output) || typeof output.filename !== "string") return false;
+  if (!("mediaType" in output) || typeof output.mediaType !== "string") return false;
+  if (!("url" in output) || typeof output.url !== "string") return false;
+
+  return (
+    output.url.startsWith("https://") || output.url.startsWith(`data:${output.mediaType};base64,`)
+  );
+}
+
+export function ToolArtifact({ part }: { readonly part: EveDynamicToolPart }) {
+  if (part.state !== "output-available" || !isFileArtifact(part.output)) return null;
+
+  const artifact = part.output;
+  if (INLINE_IMAGE_MEDIA_TYPES.has(artifact.mediaType)) {
+    return (
+      <figure>
+        <img alt={artifact.filename} src={artifact.url} />
+        <a download={artifact.filename} href={artifact.url}>
+          Download image
+        </a>
+      </figure>
+    );
+  }
+
+  return (
+    <a download={artifact.filename} href={artifact.url}>
+      Download {artifact.filename}
+    </a>
+  );
+}
+```
+
+Render `ToolArtifact` from the `dynamic-tool` branch of your message-part component. The `download` attribute supplies a filename for same-origin and `data:` URLs. For a cross-origin storage URL, set `Content-Disposition: attachment` on the file response.
+
+Tool outputs are part of the durable event stream. Keep inline artifacts bounded, and prefer an expiring or authenticated storage URL for larger or sensitive files. A tool's [`toModelOutput`](../../tools) can send a small summary to the model while the full artifact descriptor remains available to the frontend.
+
 ## Sending and streaming
 
 Pass an object to `send()` for text, multi-part messages, attachments, HITL responses, and per-turn context:

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -55,6 +55,39 @@ The handle does more than `run` and `writeTextFile`. In every method, relative p
 | `resolvePath(path)`                      | anchor a relative path to its absolute `/workspace/...` form                                    |
 | `setNetworkPolicy(policy)`               | change egress policy mid-turn (backend-dependent; see [Network policy](#network-policy))        |
 
+### Export files from the sandbox
+
+`sandbox.readFile()` returns `Promise<ReadableStream<Uint8Array> | null>`. Use this byte stream to copy a generated file out of `/workspace` without buffering the complete file in memory. A missing file returns `null`.
+
+The following helper streams a sandbox file into the app runtime filesystem:
+
+```ts
+import { createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { SandboxSession } from "eve/sandbox";
+
+export async function copySandboxFile(
+  sandbox: SandboxSession,
+  sandboxPath: string,
+  destinationPath: string,
+): Promise<boolean> {
+  const stream = await sandbox.readFile({ path: sandboxPath });
+  if (stream === null) return false;
+
+  await pipeline(Readable.fromWeb(stream), createWriteStream(destinationPath));
+  return true;
+}
+```
+
+Choose the reader based on how the application uses the file:
+
+- Use `readTextFile()` to decode text and optionally select a range of lines.
+- Use `readBinaryFile()` when the complete file is small enough to buffer as a `Uint8Array`.
+- Use `readFile()` when the file size is unknown or the destination accepts a byte stream.
+
+The app runtime filesystem does not create a browser-accessible URL. To expose an artifact in a frontend, upload the stream to storage and return its HTTPS URL, or return an explicitly size-limited file as a JSON-safe data URL in a tool result. A `ReadableStream` cannot cross the durable event stream as a tool output. See [Render generated images and file downloads](./guides/frontend/overview#render-generated-images-and-file-downloads) for the browser side.
+
 Since `run` blocks until the command exits, use `spawn` when the process should keep running while the agent does other work:
 
 ```ts

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -57,13 +57,12 @@ The handle does more than `run` and `writeTextFile`. In every method, relative p
 
 ### Export files from the sandbox
 
-`sandbox.readFile()` returns `Promise<ReadableStream<Uint8Array> | null>`. Use this byte stream to copy a generated file out of `/workspace` without buffering the complete file in memory. A missing file returns `null`.
+`sandbox.readFile()` resolves to `ReadableStream<Uint8Array> | null`. Use this byte stream to copy a generated file out of `/workspace` without buffering the complete file in memory. A missing file returns `null`.
 
 The following helper streams a sandbox file into the app runtime filesystem:
 
 ```ts
 import { createWriteStream } from "node:fs";
-import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { SandboxSession } from "eve/sandbox";
 
@@ -75,7 +74,7 @@ export async function copySandboxFile(
   const stream = await sandbox.readFile({ path: sandboxPath });
   if (stream === null) return false;
 
-  await pipeline(Readable.fromWeb(stream), createWriteStream(destinationPath));
+  await pipeline(stream, createWriteStream(destinationPath));
   return true;
 }
 ```


### PR DESCRIPTION
## Summary

- document `SandboxSession.readFile()` as the streaming primitive for exporting sandbox files
- compare `readFile()`, `readBinaryFile()`, and `readTextFile()` by buffering and decoding behavior
- show how to stream a sandbox file into the app runtime without buffering it
- show how frontend message parts can render validated tool outputs as inline images or download links
- distinguish bounded data URLs from storage URLs for larger or sensitive artifacts

## Why

The sandbox guide listed `readFile()` in a method table but did not state its return type or connect it to file-export workflows. This made an existing capability difficult to discover and obscured the boundary between reading sandbox bytes and creating a browser download.

This PR documents the existing public `ReadableStream<Uint8Array> | null` contract. It does not add or change an API type.

## Relationship to the Vercel fix

Issue #120 tracks the Vercel backend returning a Node stream instead of Eve's advertised Web stream. PR #117 fixes that implementation. This documentation PR targets `main` independently but should merge after #117 so the example works consistently across every backend.

## Verification

- `pnpm fmt`
- `pnpm docs:check` (67 docs, 164 Eve import paths, and 224 code blocks validated; all MDX compiled)

No changeset is included because this PR changes documentation only.
