### PR TITLE
feat(eve): add client turn cancellation controls

### DIFF
--- a/.changeset/native-turn-cancellation-client.md
+++ b/.changeset/native-turn-cancellation-client.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose server-side turn cancellation through MessageResponse.cancel(), frontend stop(), and TUI Ctrl-C controls.

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -115,9 +115,26 @@ for await (const event of session.stream({ startIndex: 0 })) {
 
 `stream()` throws if the session has no `sessionId`, because there's no stream to attach to before the first send.
 
+## Cancel a turn
+
+Call `response.cancel()` to stop the current server-side turn while keeping its durable parent session alive. Keep consuming the response through its `session.waiting` boundary so the client can advance the stream cursor:
+
+```ts
+const response = await session.send("Run a long analysis.");
+
+setTimeout(() => {
+  void response.cancel();
+}, 10_000);
+
+const result = await response.result();
+console.log(result.status); // "waiting"
+```
+
+Cancellation is cooperative. eve passes a durable `AbortSignal` into the turn's model and compaction calls, then emits `step.failed` and `turn.failed` with `code: "TURN_CANCELLED"` before parking the session.
+
 ## Abort a request
 
-Pass an `AbortSignal` to cancel the POST or stream. Arm the timeout before awaiting `send()` so it covers the POST as well as the stream:
+Pass an `AbortSignal` to detach the local POST or stream without cancelling server work. Arm the timeout before awaiting `send()` so it covers the POST as well as the stream:
 
 ```ts
 const controller = new AbortController();
@@ -135,7 +152,7 @@ for await (const event of response) {
 clearTimeout(timeout);
 ```
 
-Once a response is aborted, create a new send for the next turn. Don't reuse the same `MessageResponse`.
+Once a response is aborted, create a new send for the next turn. Don't reuse the same `MessageResponse`. Prefer `response.cancel()` when the server should stop the turn too.
 
 ## What to read next
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -96,7 +96,7 @@ await agent.send({
 });
 ```
 
-Assistant text, reasoning, tool calls, and tool results stream into `data` as they arrive, and `status` moves from `ready` to `submitted` to `streaming` and back. Call `stop()` to abort the active request, and `reset()` to clear local state so the next send starts a fresh durable session.
+Assistant text, reasoning, tool calls, and tool results stream into `data` as they arrive, and `status` moves from `ready` to `submitted` to `streaming` and back. Call `stop()` to cancel the active server turn while preserving the session, and `reset()` to clear local state so the next send starts a fresh durable session.
 
 ## Human-in-the-loop prompts
 

--- a/docs/guides/frontend/use-eve-agent-svelte.mdx
+++ b/docs/guides/frontend/use-eve-agent-svelte.mdx
@@ -103,7 +103,7 @@ The find-and-answer flow is identical across frameworks. The [React hook referen
 
 ## Stop, reset, and resume
 
-`stop()` aborts the in-flight stream. `reset()` wipes state and starts a fresh session. To resume across reloads, hand `initialSession` the state you saved earlier and use `onSessionChange` to persist the cursor as it advances:
+`stop()` cancels the active server turn and keeps the session available for follow-ups. `reset()` wipes state and starts a fresh session. To resume across reloads, hand `initialSession` the state you saved earlier and use `onSessionChange` to persist the cursor as it advances:
 
 ```ts
 const agent = useEveAgent({

--- a/docs/guides/frontend/use-eve-agent-vue.mdx
+++ b/docs/guides/frontend/use-eve-agent-vue.mdx
@@ -116,7 +116,7 @@ The find-and-answer flow is the same across every framework. The [React hook ref
 
 ## Stop, reset, and resume
 
-`stop()` aborts the in-flight stream. `reset()` wipes state and starts a fresh session. To survive a reload, pass `initialSession` to restore a saved session and `onSessionChange` to persist the cursor as it moves:
+`stop()` cancels the active server turn and keeps the session available for follow-ups. `reset()` wipes state and starts a fresh session. To survive a reload, pass `initialSession` to restore a saved session and `onSessionChange` to persist the cursor as it moves:
 
 ```ts
 const agent = useEveAgent({

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -81,7 +81,8 @@ const idleRuntimeArtifactPollMs = 500;
 
 export type AgentTUIStreamResult = {
   events: AsyncIterable<AgentTUIStreamEvent> | ReadableStream<AgentTUIStreamEvent>;
-  abort?: () => void;
+  abort?: () => void | Promise<void>;
+  forceAbort?: () => void;
   turnState?: AgentTUITurnState;
 };
 
@@ -871,7 +872,14 @@ export class EveTUIRunner {
     const turnState = createTurnState();
 
     return {
-      abort: () => abortController.abort(),
+      abort: async () => {
+        try {
+          if (await response.cancel()) return;
+        } catch {
+          // Fall back to detaching locally when server cancellation fails.
+        }
+        abortController.abort();
+      },
       events: eveEventsToTUIStream({
         events: response,
         pendingInputRequests: this.#pendingInputRequests,
@@ -890,6 +898,7 @@ export class EveTUIRunner {
             : (event) =>
                 isGatewayAuthFailure(event) ? formatGatewayAuthFailureNotice(event) : undefined,
       }),
+      forceAbort: () => abortController.abort(),
       turnState,
     };
   }

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -200,6 +200,8 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  // The first Ctrl+C is a turn-level action, so the TUI must preserve the
+  // session cursor while returning control to the prompt instead of exiting.
   it("interrupts a running response and returns to the prompt without exiting", async () => {
     const { screen, input, renderer } = makeRenderer();
     let streamController: ReadableStreamDefaultController<AgentTUIStreamEvent> | undefined;

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -225,13 +225,20 @@ describe("TerminalRenderer (inline scrollback)", () => {
       expect(screen.snapshot()).toContain("partial response");
     });
 
-    // The first Ctrl+C aborts the in-flight turn and unblocks the render
-    // loop even though the server stream never closes on its own. Draining
-    // instead would wait forever for an event that never arrives.
+    // The first Ctrl+C requests server cancellation but keeps draining until
+    // the server closes the turn stream, preserving the session cursor.
     input.ctrlC();
+    await vi.waitFor(() => expect(abort).toHaveBeenCalledTimes(1));
+    let settled = false;
+    void rendering.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    streamController?.close();
     await expect(rendering).resolves.toBeUndefined();
 
-    expect(abort).toHaveBeenCalledTimes(1);
     expect(screen.snapshot()).toContain("Interrupted");
     expect(input.rawModes).toEqual([true]);
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -312,6 +312,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #keyFlushTimer?: ReturnType<typeof setTimeout>;
   #onResize?: () => void;
   #resolveStreamInterrupt?: () => void;
+  #cancelActiveStream?: () => void | Promise<void>;
+  #forceAbortActiveStream?: () => void;
   #painting = false;
   #paintAgain = false;
 
@@ -587,6 +589,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
       this.#resolveStreamInterrupt = resolve;
     });
     this.#consumeKey = (key) => this.#handleStreamingKey(key);
+    this.#cancelActiveStream = result.abort;
+    this.#forceAbortActiveStream = result.forceAbort;
     this.#attachInput();
     const turnState: RenderTurnState = {
       text: new Map(),
@@ -597,14 +601,15 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
     try {
       for await (const event of takeUntil(iterateTUIStream(result.events), streamInterrupted)) {
-        if (this.#interrupted) break;
+        if (this.#interrupted) continue;
         this.#applyStreamEvent(event, displayModes, turnState);
       }
     } catch (error) {
       this.#addErrorBlock("Error", toErrorMessage(error));
     } finally {
       this.#resolveStreamInterrupt = undefined;
-      if (this.#interrupted) result.abort?.();
+      this.#cancelActiveStream = undefined;
+      this.#forceAbortActiveStream = undefined;
       this.#detachInput();
       this.#stopTicker();
       this.#working = false;
@@ -1763,8 +1768,11 @@ export class TerminalRenderer implements AgentTUIRenderer {
         if (!this.#interrupted) {
           this.#interrupted = true;
           this.#status = "Interrupted";
-          this.#resolveStreamInterrupt?.();
+          void this.#cancelActiveStream?.();
           this.#paint();
+        } else {
+          this.#forceAbortActiveStream?.();
+          this.#resolveStreamInterrupt?.();
         }
         break;
       default:

--- a/packages/eve/src/client/active-turn-control.ts
+++ b/packages/eve/src/client/active-turn-control.ts
@@ -1,0 +1,57 @@
+type ActiveTurnPhase =
+  | { readonly kind: "preparing" }
+  | { readonly kind: "dispatching" }
+  | { readonly cancel: () => Promise<boolean>; readonly kind: "running" };
+
+/** Coordinates local aborts with a server cancellation handle that arrives after dispatch. */
+export class ActiveTurnControl {
+  readonly #abortController = new AbortController();
+  #cancellationRequested = false;
+  #phase: ActiveTurnPhase = { kind: "preparing" };
+  #stopRequested = false;
+
+  get signal(): AbortSignal {
+    return this.#abortController.signal;
+  }
+
+  beginDispatch(): boolean {
+    if (this.#phase.kind !== "preparing") {
+      throw new Error("Turn dispatch has already started.");
+    }
+    if (this.#stopRequested) {
+      this.#abortController.abort();
+      return false;
+    }
+    this.#phase = { kind: "dispatching" };
+    return true;
+  }
+
+  attachCancellation(cancel: () => Promise<boolean>): void {
+    if (this.#phase.kind !== "dispatching") {
+      throw new Error("Cannot attach cancellation before dispatch starts.");
+    }
+    this.#phase = { cancel, kind: "running" };
+    if (this.#stopRequested) {
+      this.#requestCancellation(cancel);
+    }
+  }
+
+  stop(): void {
+    this.#stopRequested = true;
+    if (this.#phase.kind === "preparing") {
+      this.#abortController.abort();
+    } else if (this.#phase.kind === "running") {
+      this.#requestCancellation(this.#phase.cancel);
+    }
+  }
+
+  #requestCancellation(cancel: () => Promise<boolean>): void {
+    if (this.#cancellationRequested) return;
+    this.#cancellationRequested = true;
+    void cancel()
+      .then((cancelled) => {
+        if (!cancelled) this.#abortController.abort();
+      })
+      .catch(() => this.#abortController.abort());
+  }
+}

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -165,13 +165,14 @@ export class EveAgentStore<TData> {
         return;
       }
 
+      if (!activeTurn.beginDispatch()) {
+        this.#status = "ready";
+        return;
+      }
+
       this.#projectOptimisticMessage(preparedInput);
       this.#projectInputResponses(preparedInput);
       this.#publish();
-
-      if (!activeTurn.beginDispatch()) {
-        return;
-      }
 
       const response = await this.#session.send({
         ...preparedInput,

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -2,6 +2,7 @@ import { Client } from "#client/client.js";
 import type { EveAgentReducer, EveAgentReducerEvent } from "#client/reducer.js";
 import type { ClientSession } from "#client/session.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { ActiveTurnControl } from "#client/active-turn-control.js";
 import { toError } from "#shared/errors.js";
 import type { ClientAuth, HeadersValue, SendTurnPayload, SessionState } from "#client/types.js";
 import type { UserContent } from "ai";
@@ -90,7 +91,7 @@ interface PendingMessageSubmission {
  * Drives one turn at a time: `send` rejects if a turn is already submitted or
  * streaming. Read the latest projection via the `snapshot` getter, observe
  * changes with `subscribe`, register lifecycle hooks with `setCallbacks`,
- * abort the in-flight turn with `stop`, and discard all state with `reset`.
+ * cancel the active server turn with `stop`, and discard all state with `reset`.
  */
 export class EveAgentStore<TData> {
   readonly #createSession: (() => ClientSession) | undefined;
@@ -98,7 +99,7 @@ export class EveAgentStore<TData> {
   readonly #reducer: EveAgentReducer<TData>;
   readonly #subscribers = new Set<() => void>();
 
-  #abortController: AbortController | undefined;
+  #activeTurn: ActiveTurnControl | undefined;
   #callbacks: EveAgentStoreCallbacks<TData> = {};
   #data: TData;
   #error: Error | undefined;
@@ -151,8 +152,8 @@ export class EveAgentStore<TData> {
     }
 
     const operationId = this.#startOperation();
-    const abortController = new AbortController();
-    this.#abortController = abortController;
+    const activeTurn = new ActiveTurnControl();
+    this.#activeTurn = activeTurn;
     this.#error = undefined;
     this.#status = "submitted";
     this.#publish();
@@ -168,10 +169,15 @@ export class EveAgentStore<TData> {
       this.#projectInputResponses(preparedInput);
       this.#publish();
 
+      if (!activeTurn.beginDispatch()) {
+        return;
+      }
+
       const response = await this.#session.send({
         ...preparedInput,
-        signal: createAbortSignal(preparedInput.signal, abortController.signal),
+        signal: createAbortSignal(preparedInput.signal, activeTurn.signal),
       });
+      activeTurn.attachCancellation(() => response.cancel());
 
       let sawEvent = false;
       for await (const event of response) {
@@ -212,7 +218,9 @@ export class EveAgentStore<TData> {
       }
     } finally {
       if (this.#isCurrentOperation(operationId)) {
-        this.#abortController = undefined;
+        if (this.#activeTurn === activeTurn) {
+          this.#activeTurn = undefined;
+        }
         this.#callbacks.onSessionChange?.(this.#session.state);
         this.#publish();
         this.#callbacks.onFinish?.(this.#snapshot);
@@ -221,13 +229,13 @@ export class EveAgentStore<TData> {
   }
 
   stop(): void {
-    this.#abortController?.abort();
+    this.#activeTurn?.stop();
   }
 
   reset(): void {
     this.#invalidateOperation();
     this.stop();
-    this.#abortController = undefined;
+    this.#activeTurn = undefined;
     this.#session = this.#createSession?.() ?? this.#session;
     this.#events = [];
     this.#pendingMessageSubmission = undefined;

--- a/packages/eve/src/client/message-response.ts
+++ b/packages/eve/src/client/message-response.ts
@@ -11,6 +11,7 @@ import type { MessageResult } from "#client/types.js";
  * Internal configuration passed to construct a {@link MessageResponse}.
  */
 interface MessageResponseInput {
+  readonly cancel?: () => Promise<boolean>;
   readonly continuationToken?: string;
   readonly createStream: () => AsyncGenerator<HandleMessageStreamEvent>;
   readonly sessionId: string;
@@ -34,14 +35,26 @@ export class MessageResponse<TOutput = unknown> implements AsyncIterable<HandleM
    */
   readonly sessionId: string;
 
+  readonly #cancel: () => Promise<boolean>;
+  #cancelPromise: Promise<boolean> | undefined;
   #consumed = false;
   readonly #createStream: () => AsyncGenerator<HandleMessageStreamEvent>;
 
   /** @internal */
   constructor(input: MessageResponseInput) {
+    this.#cancel = input.cancel ?? (() => Promise.resolve(false));
     this.continuationToken = input.continuationToken;
     this.sessionId = input.sessionId;
     this.#createStream = input.createStream;
+  }
+
+  /**
+   * Cooperatively cancels this active turn on the server. The parent session
+   * remains available for follow-up messages. Repeated calls share one request.
+   */
+  cancel(): Promise<boolean> {
+    this.#cancelPromise ??= this.#cancel();
+    return this.#cancelPromise;
   }
 
   /**

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -26,6 +26,7 @@ function createSession(
 function createAcceptedResponse() {
   return Response.json(
     {
+      cancelToken: "cancel_1",
       continuationToken: "eve:test",
       ok: true,
       sessionId: "session_1",
@@ -49,6 +50,24 @@ function createStreamResponse(events: readonly unknown[]) {
 }
 
 describe("ClientSession", () => {
+  it("cancels the active server turn without aborting the session", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(createAcceptedResponse())
+      .mockResolvedValueOnce(Response.json({ cancelled: true }, { status: 202 }));
+    const session = createSession();
+
+    const response = await session.send("hello");
+    await expect(response.cancel()).resolves.toBe(true);
+    await expect(response.cancel()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(new URL(String(url)).pathname).toBe("/eve/v1/session/session_1/cancel");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ cancelToken: "cancel_1" });
+  });
+
   it("serializes clientContext when sending a create-session message", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(createAcceptedResponse());
     const session = createSession();

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -50,6 +50,8 @@ function createStreamResponse(events: readonly unknown[]) {
 }
 
 describe("ClientSession", () => {
+  // Repeated stop actions must share one server request so rapid clicks cannot
+  // race multiple cancellations for the same turn.
   it("cancels the active server turn without aborting the session", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -2,6 +2,7 @@ import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import { EVE_SESSION_ID_HEADER, isCurrentTurnBoundaryEvent } from "#protocol/message.js";
 import {
   EVE_CREATE_SESSION_ROUTE_PATH,
+  createEveCancelTurnRoutePath,
   createEveContinueSessionRoutePath,
 } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
@@ -63,9 +64,10 @@ export class ClientSession {
     const payload = normalizeSendTurnInput(input);
     const state = this.#state;
     const postResult = await this.#postTurn(payload, state);
-    const { continuationToken, sessionId } = postResult;
+    const { cancelToken, continuationToken, sessionId } = postResult;
 
     return new MessageResponse<TOutput>({
+      cancel: () => this.#cancelTurn(sessionId, cancelToken, payload.headers),
       continuationToken,
       createStream: () => this.#createEventStream(sessionId, continuationToken, state, payload),
       sessionId,
@@ -99,7 +101,7 @@ export class ClientSession {
   async #postTurn(
     input: SendTurnPayload,
     session: SessionState,
-  ): Promise<{ continuationToken?: string; sessionId: string }> {
+  ): Promise<{ cancelToken?: string; continuationToken?: string; sessionId: string }> {
     const routePath = session.sessionId
       ? createEveContinueSessionRoutePath(session.sessionId)
       : EVE_CREATE_SESSION_ROUTE_PATH;
@@ -138,8 +140,30 @@ export class ClientSession {
 
     const continuationToken =
       typeof payload.continuationToken === "string" ? payload.continuationToken : undefined;
+    const cancelToken = typeof payload.cancelToken === "string" ? payload.cancelToken : undefined;
 
-    return { continuationToken, sessionId };
+    return { cancelToken, continuationToken, sessionId };
+  }
+
+  async #cancelTurn(
+    sessionId: string,
+    cancelToken: string | undefined,
+    perRequestHeaders?: Readonly<Record<string, string>>,
+  ): Promise<boolean> {
+    if (!cancelToken) return false;
+
+    const url = createClientUrl(this.#context.host, createEveCancelTurnRoutePath(sessionId));
+    const headers = await this.#context.resolveHeaders(perRequestHeaders);
+    headers.set("content-type", "application/json");
+
+    const response = await fetch(url, {
+      body: JSON.stringify({ cancelToken }),
+      headers,
+      method: "POST",
+    });
+    if (response.ok) return true;
+    if (response.status === 409) return false;
+    throw new ClientError(response.status, await response.text());
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -117,7 +117,8 @@ export interface SendTurnPayload<TOutput = unknown> {
   readonly outputSchema?: StandardJSONSchemaV1<unknown, TOutput> | JsonObject;
 
   /**
-   * Abort signal for cancelling the request.
+   * Abort signal for detaching the local request or stream. Use
+   * `MessageResponse.cancel()` to cancel server-side turn work.
    */
   readonly signal?: AbortSignal;
 

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -225,6 +225,8 @@ describe("useEveAgent", () => {
     );
   });
 
+  // Stop can arrive before the POST returns its cancel token, so the client
+  // must replay that intent as soon as the server handle becomes available.
   it("remembers a stop requested while the turn POST is pending", async () => {
     const startResponse = createDeferred<Response>();
     const streamResponse = createEagerStreamResponse([createSessionWaitingEvent()]);

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -17,13 +17,16 @@ import {
 import type { SessionState } from "#client/types.js";
 
 function createStartedMessageResponse(sessionId: string, continuationToken: string): Response {
-  return new Response(JSON.stringify({ continuationToken, ok: true, sessionId }), {
-    headers: {
-      "content-type": "application/json",
-      [EVE_SESSION_ID_HEADER]: sessionId,
+  return new Response(
+    JSON.stringify({ cancelToken: `cancel:${sessionId}`, continuationToken, ok: true, sessionId }),
+    {
+      headers: {
+        "content-type": "application/json",
+        [EVE_SESSION_ID_HEADER]: sessionId,
+      },
+      status: 202,
     },
-    status: 202,
-  });
+  );
 }
 
 function createEagerStreamResponse(events: readonly HandleMessageStreamEvent[]): Response {
@@ -220,6 +223,44 @@ describe("useEveAgent", () => {
         userMessage: "Hello",
       }),
     );
+  });
+
+  it("remembers a stop requested while the turn POST is pending", async () => {
+    const startResponse = createDeferred<Response>();
+    const streamResponse = createEagerStreamResponse([createSessionWaitingEvent()]);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (request) => {
+      const url = new URL(String(request), "https://eve.test");
+      if (url.pathname.endsWith("/cancel")) {
+        return Response.json({ cancelled: true, ok: true }, { status: 202 });
+      }
+      if (url.pathname.endsWith("/stream")) return streamResponse;
+      return await startResponse.promise;
+    });
+    let helpers: UseEveAgentHelpers<EveMessageData> | undefined;
+
+    function TestComponent() {
+      helpers = useEveAgent();
+      return null;
+    }
+
+    await act(async () => {
+      create(createElement(TestComponent));
+    });
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = helpers?.send({ message: "Stop after dispatch" });
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      helpers?.stop();
+      startResponse.resolve(createStartedMessageResponse("session_1", "http:session_1"));
+      await sendPromise;
+    });
+
+    expect(
+      fetchMock.mock.calls.some(([request]) =>
+        new URL(String(request), "https://eve.test").pathname.endsWith("/cancel"),
+      ),
+    ).toBe(true);
   });
 
   it("prepares fresh clientContext before sending without projecting it optimistically", async () => {

--- a/packages/eve/src/react/use-eve-agent.ts
+++ b/packages/eve/src/react/use-eve-agent.ts
@@ -36,11 +36,11 @@ export type UseEveAgentSnapshot<TData> = EveAgentStoreSnapshot<TData>;
  * Snapshot plus commands returned by `useEveAgent`.
  */
 export interface UseEveAgentHelpers<TData> extends UseEveAgentSnapshot<TData> {
-  /** Resets the session: aborts any in-flight turn, recreates the owned session, and clears events and projected data. */
+  /** Resets the session: cancels any active turn, recreates the owned session, and clears events and projected data. */
   readonly reset: () => void;
   /** Sends a turn (message, HITL responses, and/or client context). Rejects if a turn is already in flight. */
   readonly send: <TOutput = unknown>(input: SendTurnPayload<TOutput>) => Promise<void>;
-  /** Aborts the in-flight turn's stream, if any. */
+  /** Cancels the active server turn while preserving its session. */
   readonly stop: () => void;
 }
 

--- a/packages/eve/src/svelte/use-eve-agent.ts
+++ b/packages/eve/src/svelte/use-eve-agent.ts
@@ -51,7 +51,7 @@ export interface UseEveAgentReturn<TData> {
   readonly session: SessionState;
   /** Lifecycle phase: `"ready"` (idle), `"submitted"` (request sent, awaiting first event), `"streaming"` (events arriving), or `"error"`. */
   readonly status: UseEveAgentStatus;
-  /** Abort the in-flight request. */
+  /** Cancel the active server turn while preserving its session. */
   readonly stop: () => void;
 }
 

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -197,6 +197,8 @@ describe("EveAgentStore (Vue composable backing store)", () => {
     ]);
   });
 
+  // Async preparation is still pre-dispatch: stopping here must leave no
+  // optimistic message or submitted state behind when preparation resolves.
   it("returns to ready when stopped while prepareSend is pending", async () => {
     const preparedInput = createDeferred<SendTurnPayload>();
     const fetchMock = vi

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -13,7 +13,7 @@ import {
   type HandleMessageStreamEvent,
 } from "#protocol/message.js";
 import { defaultMessageReducer } from "#client/message-reducer.js";
-import type { SessionState } from "#client/types.js";
+import type { SendTurnPayload, SessionState } from "#client/types.js";
 
 function createStartedMessageResponse(sessionId: string, continuationToken: string): Response {
   return new Response(JSON.stringify({ continuationToken, ok: true, sessionId }), {
@@ -195,6 +195,33 @@ describe("EveAgentStore (Vue composable backing store)", () => {
         streamIndex: 3,
       },
     ]);
+  });
+
+  it("returns to ready when stopped while prepareSend is pending", async () => {
+    const preparedInput = createDeferred<SendTurnPayload>();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("fetch should not run"));
+    const store = new EveAgentStore({
+      reducer: defaultMessageReducer(),
+    });
+    store.setCallbacks({
+      prepareSend() {
+        return preparedInput.promise;
+      },
+    });
+
+    const sendPromise = store.send({ message: "Stop before dispatch" });
+    await Promise.resolve();
+    expect(store.snapshot.status).toBe("submitted");
+
+    store.stop();
+    preparedInput.resolve({ message: "Stop before dispatch" });
+    await sendPromise;
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(store.snapshot.status).toBe("ready");
+    expect(store.snapshot.data.messages).toEqual([]);
   });
 
   it("surfaces transport errors", async () => {

--- a/packages/eve/src/vue/use-eve-agent.ts
+++ b/packages/eve/src/vue/use-eve-agent.ts
@@ -49,7 +49,7 @@ export interface UseEveAgentReturn<TData> {
   readonly session: ComputedRef<SessionState>;
   /** Lifecycle phase: `"ready"` (idle), `"submitted"` (request sent, awaiting first event), `"streaming"` (events arriving), or `"error"`. */
   readonly status: ComputedRef<UseEveAgentStatus>;
-  /** Abort the in-flight request. */
+  /** Cancel the active server turn while preserving its session. */
   readonly stop: () => void;
 }
 

--- a/packages/eve/test/scenarios/dev-server.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server.scenario.test.ts
@@ -5,6 +5,7 @@ import type { Readable } from "node:stream";
 import { describe, expect, it } from "vitest";
 
 import { EVE_HEALTH_ROUTE_PATH } from "../../src/protocol/routes.js";
+import { Client } from "../../src/client/client.js";
 import { WEATHER_AGENT_DESCRIPTOR } from "../../src/internal/testing/scenario-apps/weather-agent.js";
 import {
   type ScenarioAppDescriptor,
@@ -26,6 +27,10 @@ const DEV_SERVER_AGENT_DESCRIPTOR: ScenarioAppDescriptor = {
       ([path]) => !path.startsWith("agent/channels/"),
     ),
   ),
+};
+const CANCELLATION_AGENT_DESCRIPTOR: ScenarioAppDescriptor = {
+  ...DEV_SERVER_AGENT_DESCRIPTOR,
+  name: "cancellation-agent",
 };
 
 interface RunningEveDev {
@@ -233,6 +238,40 @@ async function startEveDev(appRoot: string): Promise<RunningEveDev> {
 }
 
 describe("eve dev server", () => {
+  it(
+    "cancels one child turn and continues the parent session",
+    async () => {
+      const app = await scenarioApp(CANCELLATION_AGENT_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        const session = new Client({ host: server.url }).session();
+        const response = await session.send("[wait-for-cancel]");
+        const resultPromise = response.result();
+
+        await expect(response.cancel()).resolves.toBe(true);
+        const cancelled = await resultPromise;
+
+        expect(cancelled.status).toBe("waiting");
+        expect(cancelled.events.find((event) => event.type === "step.failed")?.data).toMatchObject({
+          code: "TURN_CANCELLED",
+          message: "Turn cancelled by the client.",
+        });
+        expect(cancelled.events.at(-1)?.type).toBe("session.waiting");
+
+        const followUp = await (
+          await session.send("Reply with the exact string `still-alive` and nothing else.")
+        ).result();
+        expect(followUp.sessionId).toBe(cancelled.sessionId);
+        expect(followUp.message).toBe("still-alive");
+        expect(followUp.status).toBe("waiting");
+      } finally {
+        await server.stop();
+      }
+    },
+    DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  );
+
   it(
     "boots the packaged development server and completes a streamed turn",
     async () => {


### PR DESCRIPTION
## Summary

- expose `MessageResponse.cancel()` for authenticated server-side turn cancellation
- wire stop controls through the React, Vue, and Svelte clients and the development TUI
- retain stop intent when cancellation is requested before the turn POST returns
- make the client send cancellation once while the server handles hook-readiness retries

## Stack

- depends on #118
- followed by #128

## Validation

- `pnpm --filter eve typecheck`
- `pnpm test:unit` (3,641 tests)
- `pnpm build`
- focused dev-server cancellation scenario