### PR TITLE
fix(eve): cancel delegated runtime actions

### DIFF
--- a/.changeset/native-turn-cancellation-runtime-actions.md
+++ b/.changeset/native-turn-cancellation-runtime-actions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Cancel delegated local and remote agent work when a parent turn is cancelled, including cancellations that arrive during dispatch.

--- a/packages/eve/src/execution/cancel-runtime-actions-step.test.ts
+++ b/packages/eve/src/execution/cancel-runtime-actions-step.test.ts
@@ -35,6 +35,8 @@ afterEach(() => {
 });
 
 describe("cancelRuntimeActionsStep", () => {
+  // Local children run in node-specific runtimes, so cancellation must rebuild
+  // the matching runtime before it addresses the child session.
   it("cancels local delegated sessions through their runtime", async () => {
     const cancelTurn = vi.fn().mockResolvedValue(true);
     vi.mocked(createWorkflowRuntime).mockReturnValue({ cancelTurn } as never);
@@ -58,6 +60,8 @@ describe("cancelRuntimeActionsStep", () => {
     expect(cancelTurn).toHaveBeenCalledWith("child_session_1", "child_cancel_1");
   });
 
+  // Remote children may live in another Workflow world, so their authenticated
+  // Eve endpoint is the only reliable cancellation path.
   it("cancels remote delegated sessions through the eve protocol", async () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({ cancelled: true }));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/eve/src/execution/cancel-runtime-actions-step.test.ts
+++ b/packages/eve/src/execution/cancel-runtime-actions-step.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { cancelRuntimeActionsStep } from "#execution/cancel-runtime-actions-step.js";
+import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
+
+vi.mock("#context/serialize.js", () => ({
+  deserializeContext: vi.fn().mockResolvedValue({
+    require: () => ({
+      compiledArtifactsSource: { kind: "test" },
+      subagentRegistry: {
+        subagentsByNodeId: new Map([
+          [
+            "remote/research",
+            {
+              definition: {
+                headers: { authorization: "Bearer token" },
+                kind: "remote",
+                url: "https://remote.example.com",
+              },
+            },
+          ],
+        ]),
+      },
+    }),
+  }),
+}));
+
+vi.mock("#execution/workflow-runtime.js", () => ({
+  createWorkflowRuntime: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("cancelRuntimeActionsStep", () => {
+  it("cancels local delegated sessions through their runtime", async () => {
+    const cancelTurn = vi.fn().mockResolvedValue(true);
+    vi.mocked(createWorkflowRuntime).mockReturnValue({ cancelTurn } as never);
+
+    await cancelRuntimeActionsStep({
+      serializedContext: {},
+      targets: [
+        {
+          cancelToken: "child_cancel_1",
+          kind: "local",
+          nodeId: "subagents/research",
+          sessionId: "child_session_1",
+        },
+      ],
+    });
+
+    expect(createWorkflowRuntime).toHaveBeenCalledWith({
+      compiledArtifactsSource: { kind: "test" },
+      nodeId: "subagents/research",
+    });
+    expect(cancelTurn).toHaveBeenCalledWith("child_session_1", "child_cancel_1");
+  });
+
+  it("cancels remote delegated sessions through the eve protocol", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ cancelled: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await cancelRuntimeActionsStep({
+      serializedContext: {},
+      targets: [
+        {
+          cancelToken: "remote_cancel_1",
+          kind: "remote",
+          nodeId: "remote/research",
+          sessionId: "remote_session_1",
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("https://remote.example.com/eve/v1/session/remote_session_1/cancel"),
+      {
+        body: JSON.stringify({ cancelToken: "remote_cancel_1" }),
+        headers: { authorization: "Bearer token", "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+  });
+});

--- a/packages/eve/src/execution/cancel-runtime-actions-step.ts
+++ b/packages/eve/src/execution/cancel-runtime-actions-step.ts
@@ -1,0 +1,48 @@
+import { deserializeContext } from "#context/serialize.js";
+import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
+import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
+import type { RuntimeActionCancellationTarget } from "#execution/runtime-action-cancellation.js";
+import { createEveCancelTurnRoutePath } from "#protocol/routes.js";
+import { resolveRemoteAgentRequestHeaders } from "#execution/remote-agent-dispatch.js";
+
+/** Cancels delegated child sessions owned by the active logical turn. */
+export async function cancelRuntimeActionsStep(input: {
+  readonly serializedContext: Record<string, unknown>;
+  readonly targets: readonly RuntimeActionCancellationTarget[];
+}): Promise<void> {
+  "use step";
+
+  if (input.targets.length === 0) return;
+  const ctx = await deserializeContext(input.serializedContext);
+  const bundle = ctx.require(BundleKey);
+
+  await Promise.all(
+    input.targets.map(async (target) => {
+      if (target.kind === "remote") {
+        const definition = bundle.subagentRegistry.subagentsByNodeId.get(target.nodeId)?.definition;
+        if (definition?.kind !== "remote") {
+          throw new Error(`Missing remote agent cancellation target "${target.nodeId}".`);
+        }
+        const headers = await resolveRemoteAgentRequestHeaders(definition);
+        const response = await fetch(
+          new URL(createEveCancelTurnRoutePath(target.sessionId), `${definition.url}/`),
+          {
+            body: JSON.stringify({ cancelToken: target.cancelToken }),
+            headers: { "content-type": "application/json", ...headers },
+            method: "POST",
+          },
+        );
+        if (!response.ok && response.status !== 409) {
+          throw new Error(`Remote turn cancellation failed with HTTP ${response.status}.`);
+        }
+        return;
+      }
+
+      const runtime = createWorkflowRuntime({
+        compiledArtifactsSource: bundle.compiledArtifactsSource,
+        nodeId: target.nodeId,
+      });
+      await runtime.cancelTurn(target.sessionId, target.cancelToken);
+    }),
+  );
+}

--- a/packages/eve/src/execution/dispatch-code-mode-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-code-mode-runtime-actions-step.ts
@@ -22,13 +22,16 @@ import { hydrateDurableSession } from "#execution/session.js";
 import { deserializeContext } from "#context/serialize.js";
 import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
+import type { RuntimeActionCancellationTarget } from "#execution/runtime-action-cancellation.js";
 
 export async function dispatchCodeModeRuntimeActionsStep(input: {
   readonly callbackBaseUrl?: string;
+  readonly cancelToken?: string;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<{
+  readonly cancellationTargets: readonly RuntimeActionCancellationTarget[];
   readonly results: readonly RuntimeSubagentResultActionResult[];
   readonly sessionState: DurableSessionState;
 }> {
@@ -38,7 +41,7 @@ export async function dispatchCodeModeRuntimeActionsStep(input: {
   const codeModeAction = getPendingCodeModeInterrupt(durableSession.state);
 
   if (codeModeAction === undefined) {
-    return { results: [], sessionState: input.sessionState };
+    return { cancellationTargets: [], results: [], sessionState: input.sessionState };
   }
 
   const action = buildRuntimeActionFromInterrupt(codeModeAction.interrupt);
@@ -64,6 +67,7 @@ export async function dispatchCodeModeRuntimeActionsStep(input: {
 
   return dispatchRuntimeActionsStep({
     callbackBaseUrl: input.callbackBaseUrl,
+    cancelToken: input.cancelToken,
     parentWritable: input.parentWritable,
     serializedContext: input.serializedContext,
     sessionState: batchState,

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -44,15 +44,18 @@ import { buildSubagentRunInput } from "#execution/subagent-tool.js";
 import { createWorkflowRuntime, workflowEntryReference } from "#execution/workflow-runtime.js";
 import { createLogger, logError } from "#internal/logging.js";
 import { toErrorMessage } from "#shared/errors.js";
+import type { RuntimeActionCancellationTarget } from "#execution/runtime-action-cancellation.js";
 
 const log = createLogger("execution.dispatch-runtime-actions");
 
 export async function dispatchRuntimeActionsStep(input: {
   readonly callbackBaseUrl?: string;
+  readonly cancelToken?: string;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<{
+  readonly cancellationTargets: readonly RuntimeActionCancellationTarget[];
   readonly results: readonly RuntimeSubagentResultActionResult[];
   readonly sessionState: DurableSessionState;
 }> {
@@ -62,7 +65,7 @@ export async function dispatchRuntimeActionsStep(input: {
   const batch = getPendingRuntimeActionBatch(durableSession.state);
 
   if (batch === undefined || batch.actions.length === 0) {
-    return { results: [], sessionState: input.sessionState };
+    return { cancellationTargets: [], results: [], sessionState: input.sessionState };
   }
 
   const ctx = await deserializeContext(input.serializedContext);
@@ -84,6 +87,7 @@ export async function dispatchRuntimeActionsStep(input: {
   const adapterCtx = buildAdapterContext(adapter, ctx);
 
   let nextSession = session;
+  const cancellationTargets: RuntimeActionCancellationTarget[] = [];
   const results: RuntimeSubagentResultActionResult[] = [];
 
   try {
@@ -95,6 +99,8 @@ export async function dispatchRuntimeActionsStep(input: {
 
       switch (action.kind) {
         case "subagent-call": {
+          const cancelToken =
+            input.cancelToken === undefined ? undefined : `eve:cancel:${crypto.randomUUID()}`;
           const childRuntime = createWorkflowRuntime({
             compiledArtifactsSource: bundle.compiledArtifactsSource,
             nodeId: action.nodeId,
@@ -104,6 +110,7 @@ export async function dispatchRuntimeActionsStep(input: {
             auth,
             batchEvent: batch.event,
             capabilities,
+            cancelToken,
             channelMetadata,
             initiatorAuth,
             session,
@@ -116,6 +123,14 @@ export async function dispatchRuntimeActionsStep(input: {
             session: nextSession,
           });
           childSessionId = handle.sessionId;
+          if (cancelToken !== undefined) {
+            cancellationTargets.push({
+              cancelToken,
+              kind: "local",
+              nodeId: action.nodeId,
+              sessionId: childSessionId,
+            });
+          }
           name = action.name;
           toolName = action.subagentName;
           break;
@@ -128,12 +143,21 @@ export async function dispatchRuntimeActionsStep(input: {
               remoteAgentName: action.remoteAgentName,
               registry: bundle.subagentRegistry.subagentsByNodeId,
             });
-            childSessionId = await startRemoteAgentSession({
+            const remoteSession = await startRemoteAgentSession({
               action,
               callbackBaseUrl: input.callbackBaseUrl,
               remote: resolvedRemote,
               session,
             });
+            childSessionId = remoteSession.sessionId;
+            if (remoteSession.cancelToken !== undefined) {
+              cancellationTargets.push({
+                cancelToken: remoteSession.cancelToken,
+                kind: "remote",
+                nodeId: action.nodeId,
+                sessionId: childSessionId,
+              });
+            }
           } catch (error) {
             logError(log, "remote agent start failed", error, {
               remoteAgentName: action.remoteAgentName,
@@ -178,7 +202,7 @@ export async function dispatchRuntimeActionsStep(input: {
       ? input.sessionState
       : createDurableSessionState({ session: nextSession });
 
-  return { results, sessionState: nextState };
+  return { cancellationTargets, results, sessionState: nextState };
 }
 
 function createRemoteAgentStartFailureResult(input: {

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -12,14 +12,17 @@ describe("startRemoteAgentSession", () => {
 
   it("posts the formatted subagent message and callback metadata", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, sessionId: "remote-session" }), {
-        headers: { "x-eve-session-id": "remote-session-header" },
-        status: 202,
-      }),
+      new Response(
+        JSON.stringify({ cancelToken: "remote-cancel", ok: true, sessionId: "remote-session" }),
+        {
+          headers: { "x-eve-session-id": "remote-session-header" },
+          status: 202,
+        },
+      ),
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const childSessionId = await startRemoteAgentSession({
+    const childSession = await startRemoteAgentSession({
       action: createAction(),
       callbackBaseUrl: "https://caller.example.com",
       remote: createRemoteAgent(),
@@ -40,7 +43,10 @@ describe("startRemoteAgentSession", () => {
       },
     });
 
-    expect(childSessionId).toBe("remote-session-header");
+    expect(childSession).toEqual({
+      cancelToken: "remote-cancel",
+      sessionId: "remote-session-header",
+    });
     expect(fetchMock).toHaveBeenCalledWith("https://remote.example.com/eve/v1/session", {
       body: expect.any(String),
       headers: {

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -10,6 +10,8 @@ describe("startRemoteAgentSession", () => {
     vi.unstubAllEnvs();
   });
 
+  // The parent needs both identifiers from session creation so it can route
+  // results by session and later cancel that exact remote turn.
   it("posts the formatted subagent message and callback metadata", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -7,12 +7,17 @@ import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types
 import type { RuntimeSubagentRegistry } from "#runtime/subagents/registry.js";
 import type { ResolvedRuntimeRemoteAgentNode } from "#runtime/types.js";
 
+export interface RemoteAgentSessionStart {
+  readonly cancelToken?: string;
+  readonly sessionId: string;
+}
+
 export async function startRemoteAgentSession(input: {
   readonly action: RuntimeRemoteAgentCallActionRequest;
   readonly callbackBaseUrl: string | undefined;
   readonly remote: ResolvedRuntimeRemoteAgentNode;
   readonly session: HarnessSession;
-}): Promise<string> {
+}): Promise<RemoteAgentSessionStart> {
   const callbackToken = input.session.continuationToken;
   if (!callbackToken) {
     throw new Error("Cannot dispatch remote agent without a parent continuation token.");
@@ -51,18 +56,28 @@ export async function startRemoteAgentSession(input: {
     );
   }
 
-  const sessionIdFromHeader = response.headers.get(EVE_SESSION_ID_HEADER);
-  if (sessionIdFromHeader !== null && sessionIdFromHeader.length > 0) {
-    return sessionIdFromHeader;
-  }
+  const sessionIdFromHeader = response.headers.get(EVE_SESSION_ID_HEADER) ?? undefined;
 
   try {
-    const body = (await response.json()) as { readonly sessionId?: unknown };
-    if (typeof body.sessionId === "string" && body.sessionId.length > 0) {
-      return body.sessionId;
+    const body = (await response.json()) as {
+      readonly cancelToken?: unknown;
+      readonly sessionId?: unknown;
+    };
+    const sessionId =
+      sessionIdFromHeader ??
+      (typeof body.sessionId === "string" && body.sessionId.length > 0
+        ? body.sessionId
+        : undefined);
+    if (sessionId !== undefined) {
+      return {
+        cancelToken: typeof body.cancelToken === "string" ? body.cancelToken : undefined,
+        sessionId,
+      };
     }
   } catch {
-    // Fall through to the generic error below.
+    if (sessionIdFromHeader !== undefined) {
+      return { sessionId: sessionIdFromHeader };
+    }
   }
 
   throw new Error(
@@ -87,7 +102,7 @@ function createRemoteAgentSessionUrl(remote: ResolvedRuntimeRemoteAgentNode): st
   return new URL(remote.path, `${trimTrailingSlash(remote.url)}/`).toString();
 }
 
-async function resolveRemoteAgentRequestHeaders(
+export async function resolveRemoteAgentRequestHeaders(
   remote: ResolvedRuntimeRemoteAgentNode,
 ): Promise<Record<string, string>> {
   const headers: Record<string, string> = {};

--- a/packages/eve/src/execution/runtime-action-cancellation.test.ts
+++ b/packages/eve/src/execution/runtime-action-cancellation.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHook } from "#compiled/@workflow/core/index.js";
+
+import {
+  runRuntimeActionCancellationScope,
+  type RuntimeActionCancellationTarget,
+} from "#execution/runtime-action-cancellation.js";
+
+vi.mock("#compiled/@workflow/core/index.js", () => ({
+  createHook: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runRuntimeActionCancellationScope", () => {
+  it("cancels children started after cancellation arrives during dispatch", async () => {
+    const cancellation = deferred<{ readonly kind: "cancel-turn" }>();
+    const dispatch = deferred<DispatchResult>();
+    const dispose = vi.fn();
+    vi.mocked(createHook).mockReturnValue(
+      Object.assign(cancellation.promise, { dispose, token: "cancel_1:runtime-actions" }) as never,
+    );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const wait = vi.fn().mockResolvedValue("complete");
+    const running = runRuntimeActionCancellationScope({
+      cancel,
+      cancelToken: "cancel_1",
+      dispatch: () => dispatch.promise,
+      sessionId: "session_1",
+      wait,
+    });
+
+    cancellation.resolve({ kind: "cancel-turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+    dispatch.resolve({ cancellationTargets: [TARGET] });
+
+    await expect(running).resolves.toEqual({
+      dispatchResult: { cancellationTargets: [TARGET] },
+      result: "complete",
+    });
+    expect(cancel).toHaveBeenCalledWith([TARGET]);
+    expect(wait).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+interface DispatchResult {
+  readonly cancellationTargets: readonly RuntimeActionCancellationTarget[];
+}
+
+const TARGET: RuntimeActionCancellationTarget = {
+  cancelToken: "child_cancel_1",
+  kind: "local",
+  nodeId: "child",
+  sessionId: "child_session_1",
+};
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/eve/src/execution/runtime-action-cancellation.test.ts
+++ b/packages/eve/src/execution/runtime-action-cancellation.test.ts
@@ -15,6 +15,8 @@ afterEach(() => {
 });
 
 describe("runRuntimeActionCancellationScope", () => {
+  // Cancellation can beat target discovery; the scope must wait for dispatch
+  // and cancel every child that appeared during that race.
   it("cancels children started after cancellation arrives during dispatch", async () => {
     const cancellation = deferred<{ readonly kind: "cancel-turn" }>();
     const dispatch = deferred<DispatchResult>();

--- a/packages/eve/src/execution/runtime-action-cancellation.ts
+++ b/packages/eve/src/execution/runtime-action-cancellation.ts
@@ -1,0 +1,86 @@
+import { createHook } from "#compiled/@workflow/core/index.js";
+
+export interface LocalRuntimeActionCancellationTarget {
+  readonly cancelToken: string;
+  readonly kind: "local";
+  readonly nodeId: string;
+  readonly sessionId: string;
+}
+
+export interface RemoteRuntimeActionCancellationTarget {
+  readonly cancelToken: string;
+  readonly kind: "remote";
+  readonly nodeId: string;
+  readonly sessionId: string;
+}
+
+export type RuntimeActionCancellationTarget =
+  | LocalRuntimeActionCancellationTarget
+  | RemoteRuntimeActionCancellationTarget;
+
+export interface RuntimeActionDispatchResult {
+  readonly cancellationTargets: readonly RuntimeActionCancellationTarget[];
+}
+
+/** Derives the driver-owned hook token used while runtime actions are active. */
+export function createRuntimeActionCancellationHookToken(cancelToken: string): string {
+  return `${cancelToken}:runtime-actions`;
+}
+
+/** Keeps cancellation active across runtime-action dispatch and callback waiting. */
+export async function runRuntimeActionCancellationScope<
+  TDispatch extends RuntimeActionDispatchResult,
+  TResult,
+>(input: {
+  readonly cancel: (targets: readonly RuntimeActionCancellationTarget[]) => Promise<void>;
+  readonly cancelToken?: string;
+  readonly dispatch: () => Promise<TDispatch>;
+  readonly sessionId: string;
+  readonly wait: (dispatchResult: TDispatch) => Promise<TResult>;
+}): Promise<{ readonly dispatchResult: TDispatch; readonly result: TResult }> {
+  const cancellation =
+    input.cancelToken === undefined
+      ? undefined
+      : createHook<{ readonly kind: "cancel-turn" }>({
+          metadata: { sessionId: input.sessionId },
+          token: createRuntimeActionCancellationHookToken(input.cancelToken),
+        });
+  const cancelled = cancellation?.then(() => true as const);
+
+  try {
+    const dispatchOperation = input.dispatch();
+    const dispatchOutcome = await raceCancellation(dispatchOperation, cancelled);
+    const dispatchResult =
+      dispatchOutcome.kind === "completed" ? dispatchOutcome.value : await dispatchOperation;
+    if (dispatchOutcome.kind === "cancelled") {
+      await input.cancel(dispatchResult.cancellationTargets);
+    }
+
+    const waitOperation = input.wait(dispatchResult);
+    if (dispatchOutcome.kind === "cancelled") {
+      return { dispatchResult, result: await waitOperation };
+    }
+
+    const waitOutcome = await raceCancellation(waitOperation, cancelled);
+    if (waitOutcome.kind === "cancelled") {
+      await input.cancel(dispatchResult.cancellationTargets);
+      return { dispatchResult, result: await waitOperation };
+    }
+
+    return { dispatchResult, result: waitOutcome.value };
+  } finally {
+    cancellation?.dispose();
+  }
+}
+
+async function raceCancellation<T>(
+  operation: Promise<T>,
+  cancelled: Promise<true> | undefined,
+): Promise<{ readonly kind: "cancelled" } | { readonly kind: "completed"; readonly value: T }> {
+  if (cancelled === undefined) return { kind: "completed", value: await operation };
+
+  return await Promise.race([
+    operation.then((value) => ({ kind: "completed" as const, value })),
+    cancelled.then(() => ({ kind: "cancelled" as const })),
+  ]);
+}

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -32,6 +32,8 @@ function makeAction(): RuntimeSubagentCallActionRequest {
 }
 
 describe("buildSubagentRunInput", () => {
+  // A delegated child can register its cancellation hook only if the parent's
+  // freshly minted token survives run-input construction.
   it("forwards the child cancellation token", () => {
     const { runInput } = buildSubagentRunInput({
       action: makeAction(),

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -32,6 +32,19 @@ function makeAction(): RuntimeSubagentCallActionRequest {
 }
 
 describe("buildSubagentRunInput", () => {
+  it("forwards the child cancellation token", () => {
+    const { runInput } = buildSubagentRunInput({
+      action: makeAction(),
+      auth: null,
+      batchEvent: { sequence: 0, turnId: "turn-0" },
+      cancelToken: "child_cancel_1",
+      initiatorAuth: null,
+      session: makeSession(),
+    });
+
+    expect(runInput.cancelToken).toBe("child_cancel_1");
+  });
+
   it("forwards parent capabilities to the child run input", () => {
     const { runInput } = buildSubagentRunInput({
       action: makeAction(),

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -45,6 +45,7 @@ export function buildSubagentRunInput(input: {
    */
   readonly capabilities?: SessionCapabilities;
   readonly channelMetadata?: ChannelInstrumentationProjection;
+  readonly cancelToken?: string;
   readonly initiatorAuth: SessionAuthContext | null;
   readonly session: HarnessSession;
 }): SubagentRunInputBuild {
@@ -78,6 +79,7 @@ export function buildSubagentRunInput(input: {
     },
     auth,
     capabilities,
+    cancelToken: input.cancelToken,
     channelMetadata,
     continuationToken: childContinuationToken,
     initiatorAuth,

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -48,6 +48,7 @@ vi.mock("./dispatch-runtime-actions-step.js", () => ({
   dispatchRuntimeActionsStep: vi
     .fn()
     .mockImplementation(async ({ sessionState }: { sessionState: DurableSessionState }) => ({
+      cancellationTargets: [],
       results: [],
       sessionState,
     })),
@@ -219,6 +220,7 @@ describe("workflowEntry", () => {
     const parentWritable = vi.mocked(dispatchTurnStep).mock.calls[0]?.[0].parentWritable;
     expect(dispatchRuntimeActionsStep).toHaveBeenCalledWith({
       callbackBaseUrl: "https://eve.example.com",
+      cancelToken: undefined,
       parentWritable,
       serializedContext: expect.objectContaining({
         "eve.sessionId": "wrun_test_123",
@@ -263,6 +265,7 @@ describe("workflowEntry", () => {
       createSessionStepResultForMock(baseSessionState),
     );
     vi.mocked(dispatchRuntimeActionsStep).mockResolvedValueOnce({
+      cancellationTargets: [],
       results: [failedResult],
       sessionState: pendingSessionState,
     });

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -32,6 +32,8 @@ import { createSessionStep } from "#execution/create-session-step.js";
 import { dispatchCodeModeRuntimeActionsStep } from "#execution/dispatch-code-mode-runtime-actions-step.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { dispatchAndAwaitTurn } from "#execution/dispatch-turn.js";
+import { cancelRuntimeActionsStep } from "#execution/cancel-runtime-actions-step.js";
+import { runRuntimeActionCancellationScope } from "#execution/runtime-action-cancellation.js";
 import {
   emitTerminalSessionFailureStep,
   routeProxiedDeliverStep,
@@ -278,28 +280,41 @@ async function runDriverLoop(input: {
 
         case "dispatch-code-mode-runtime-actions":
         case "dispatch-runtime-actions": {
+          const runtimeAction = action;
           const dispatchStep =
-            action.kind === "dispatch-code-mode-runtime-actions"
+            runtimeAction.kind === "dispatch-code-mode-runtime-actions"
               ? dispatchCodeModeRuntimeActionsStep
               : dispatchRuntimeActionsStep;
 
-          const dispatchResult = await dispatchStep({
-            callbackBaseUrl: resolveVercelProductionCallbackBaseUrl() ?? getWorkflowMetadata().url,
-            parentWritable: input.driverWritable,
-            serializedContext: action.serializedContext,
-            sessionState: action.sessionState,
-          });
-
-          const runtimeResults = await waitForPendingRuntimeActionResults({
-            bufferedDeliveries,
-            consumeNext,
-            getNextPromise,
-            initialResults: dispatchResult.results,
-            parentWritable: input.driverWritable,
-            pendingActionKeys: action.pendingActionKeys,
-            rekeyHook,
-            serializedContext: action.serializedContext,
-            sessionState: dispatchResult.sessionState,
+          const { result: runtimeResults } = await runRuntimeActionCancellationScope({
+            cancel: (targets) =>
+              cancelRuntimeActionsStep({
+                serializedContext: runtimeAction.serializedContext,
+                targets,
+              }),
+            cancelToken: activeCancelToken,
+            dispatch: () =>
+              dispatchStep({
+                callbackBaseUrl:
+                  resolveVercelProductionCallbackBaseUrl() ?? getWorkflowMetadata().url,
+                cancelToken: activeCancelToken,
+                parentWritable: input.driverWritable,
+                serializedContext: runtimeAction.serializedContext,
+                sessionState: runtimeAction.sessionState,
+              }),
+            sessionId: input.sessionState.sessionId,
+            wait: (result) =>
+              waitForPendingRuntimeActionResults({
+                bufferedDeliveries,
+                consumeNext,
+                getNextPromise,
+                initialResults: result.results,
+                parentWritable: input.driverWritable,
+                pendingActionKeys: runtimeAction.pendingActionKeys,
+                rekeyHook,
+                serializedContext: runtimeAction.serializedContext,
+                sessionState: result.sessionState,
+              }),
           });
 
           if (runtimeResults === null) {

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -117,13 +117,14 @@ describe("createWorkflowRuntime#cancelTurn", () => {
     const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
     getHookByTokenMock
       .mockRejectedValueOnce(new HookNotFoundError("cancel_1"))
+      .mockRejectedValueOnce(new HookNotFoundError("cancel_1:runtime-actions"))
       .mockResolvedValueOnce({ metadata: { sessionId: "session_1" }, runId: "turn_1" });
 
     const cancelling = buildRuntime().cancelTurn("session_1", "cancel_1");
     await vi.runAllTimersAsync();
 
     await expect(cancelling).resolves.toBe(true);
-    expect(getHookByTokenMock).toHaveBeenCalledTimes(2);
+    expect(getHookByTokenMock).toHaveBeenCalledTimes(3);
     expect(resumeHookMock).toHaveBeenCalledWith("cancel_1", { kind: "cancel-turn" });
   });
 
@@ -138,10 +139,13 @@ describe("createWorkflowRuntime#cancelTurn", () => {
   });
 
   it("returns false when the active turn hook is not registered", async () => {
+    vi.useFakeTimers();
     const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
     getHookByTokenMock.mockRejectedValue(new HookNotFoundError("cancel_1"));
 
-    await expect(buildRuntime().cancelTurn("session_1", "cancel_1")).resolves.toBe(false);
+    const cancelling = buildRuntime().cancelTurn("session_1", "cancel_1");
+    await vi.runAllTimersAsync();
+    await expect(cancelling).resolves.toBe(false);
   });
 });
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -20,6 +20,8 @@ import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { buildRunContext } from "#execution/runtime-context.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
+import { createRuntimeActionCancellationHookToken } from "#execution/runtime-action-cancellation.js";
+
 const WORKFLOW_ENTRY_NAME = "workflowEntry";
 const TURN_WORKFLOW_NAME = "turnWorkflow";
 const CANCEL_HOOK_REGISTRATION_ATTEMPTS = 80;
@@ -84,23 +86,26 @@ export function createWorkflowRuntime(config: {
   return {
     async cancelTurn(sessionId: string, cancelToken: string): Promise<boolean> {
       applyEveWorkflowQueueNamespace();
+      const hookTokens = [cancelToken, createRuntimeActionCancellationHookToken(cancelToken)];
       for (let attempt = 0; attempt < CANCEL_HOOK_REGISTRATION_ATTEMPTS; attempt += 1) {
-        try {
-          const hook = normalizeWorkflowHook(await getHookByToken(cancelToken));
-          if (!isTurnCancellationHookForSession(hook, sessionId)) return false;
-          await resumeHook(cancelToken, { kind: "cancel-turn" });
-          return true;
-        } catch (error) {
-          if (!HookNotFoundError.is(error)) {
-            logError(log, "failed to cancel active turn", error, {
-              cancelToken,
-              sessionId,
-            });
-            throw error;
+        for (const hookToken of hookTokens) {
+          try {
+            const hook = normalizeWorkflowHook(await getHookByToken(hookToken));
+            if (!isTurnCancellationHookForSession(hook, sessionId)) return false;
+            await resumeHook(hookToken, { kind: "cancel-turn" });
+            return true;
+          } catch (error) {
+            if (!HookNotFoundError.is(error)) {
+              logError(log, "failed to cancel active turn", error, {
+                cancelToken,
+                sessionId,
+              });
+              throw error;
+            }
           }
-          if (attempt < CANCEL_HOOK_REGISTRATION_ATTEMPTS - 1) {
-            await new Promise((resolve) => setTimeout(resolve, CANCEL_HOOK_REGISTRATION_RETRY_MS));
-          }
+        }
+        if (attempt < CANCEL_HOOK_REGISTRATION_ATTEMPTS - 1) {
+          await new Promise((resolve) => setTimeout(resolve, CANCEL_HOOK_REGISTRATION_RETRY_MS));
         }
       }
       return false;

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -299,16 +299,29 @@ describe("dispatchRuntimeActionsStep", () => {
     });
 
     const result = await dispatchRuntimeActionsStep({
+      cancelToken: "parent_cancel_1",
       parentWritable: createTestWritable(),
       serializedContext: createSerializedContext(),
       sessionState,
     });
 
-    expect(result).toEqual({ results: [], sessionState: expect.any(Object) });
+    expect(result).toEqual({
+      cancellationTargets: [
+        {
+          cancelToken: expect.stringMatching(/^eve:cancel:/),
+          kind: "local",
+          nodeId: "subagents/delegate",
+          sessionId: "child-run",
+        },
+      ],
+      results: [],
+      sessionState: expect.any(Object),
+    });
     expect(startMock).toHaveBeenCalledWith(
       workflowEntryReference,
       [
         expect.objectContaining({
+          cancelToken: result.cancellationTargets[0]?.cancelToken,
           input: {
             message: expect.stringContaining("investigate latest routing"),
           },
@@ -388,6 +401,7 @@ describe("dispatchRuntimeActionsStep", () => {
         sessionState,
       }),
     ).resolves.toEqual({
+      cancellationTargets: [],
       results: [
         {
           callId: "call-1",

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -240,6 +240,8 @@ describe("dispatchTurnStep", () => {
 });
 
 describe("dispatchRuntimeActionsStep", () => {
+  // Cancellation fan-out depends on recording the same token sent to the child
+  // together with the child session and node that own it.
   it("starts subagent child drivers on the latest deployment", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as never;


### PR DESCRIPTION
## Summary

- cancel delegated local child-agent work when its parent turn is cancelled
- cancel remote runtime actions with phase-owned tokens and re-resolved authorization
- close dispatch races so cancellation cannot orphan work started concurrently
- add focused coverage for local, remote, and cancellation-during-dispatch behavior

## Stack

- depends on #127
- followed by #135 
- completes the native turn-cancellation stack

## Validation

- workspace typecheck
- `pnpm test:unit` (3,645 tests)
- `pnpm test:integration` (318 tests)
- build, lint, format, invariant, and docs checks
- full scenario suite passed on the equivalent original implementation