### PR TITLE
feat(channels): add validateWebSocketOrigin helper for WS upgrade hooks

### DIFF
--- a/.changeset/validate-websocket-origin.md
+++ b/.changeset/validate-websocket-origin.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `validateWebSocketOrigin`, an opt-in helper for `WS()` `upgrade` hooks that enforces an `Origin` allowlist to defend against cross-site WebSocket hijacking and DNS rebinding. It returns a `403` to reject a missing or non-allowlisted `Origin` and `undefined` to proceed; no default behavior changes.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -78,6 +78,33 @@ export default defineChannel({
 
 `WS()` handlers receive the same helpers as HTTP route handlers: `send`, `getSession`, `receive`, `params`, `waitUntil`, and `requestIp`. The returned hooks are eve-owned structural types compatible with Nitro/H3 websocket routing, including `upgrade`, `open`, `message`, `close`, and `error`.
 
+### Validating the Origin
+
+The production server binds `0.0.0.0` and accepts a WebSocket handshake on any matched `WS()` route. Because a browser cannot suppress or forge the `Origin` header, validating it in the `upgrade` hook is the standard defense against cross-site WebSocket hijacking and DNS rebinding: a malicious page in a victim's browser otherwise completes a same-credentials handshake to your agent and drives it. eve does not enforce this for you — your channel decides which origins may connect.
+
+`validateWebSocketOrigin()` enforces an allowlist from inside the `upgrade` hook. It returns a `403` `Response` to reject a missing or non-allowlisted `Origin` and `undefined` to let an allowed handshake through, matching the hook's `Response | void` contract:
+
+```ts
+import { defineChannel, WS, validateWebSocketOrigin } from "eve/channels";
+
+export default defineChannel({
+  routes: [
+    WS("/voice/ws", async (_req, { send }) => ({
+      upgrade(request) {
+        return validateWebSocketOrigin(request, {
+          allowedOrigins: ["https://app.example.com"],
+        });
+      },
+      async message(_peer, message) {
+        await send(message.text(), { auth: null, continuationToken: "voice-demo" });
+      },
+    })),
+  ],
+});
+```
+
+Allowlist entries are compared by normalized origin, so port, trailing slash, and case differences don't matter. A missing `Origin` header is rejected by default; pass `allowNoOrigin: true` when the route also serves non-browser clients (which never send one). An origin check bounds the browser threat only — a non-browser client can send any value — so keep authenticating the session as well.
+
 ### Node upgrade server escape hatch
 
 Prefer the `WS()` lifecycle hooks above when you own the websocket behavior. eve also exposes `createWebSocketUpgradeServer()` for the narrower case where a third-party SDK or framework expects to bind directly to a Node `http.Server` with `server.on("upgrade", ...)`.

--- a/packages/eve/src/channel/websocket-origin.test.ts
+++ b/packages/eve/src/channel/websocket-origin.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { validateWebSocketOrigin } from "#public/channels/index.js";
+import type { WebSocketUpgradeRequest } from "#public/channels/index.js";
+
+function upgradeRequest(origin?: string): WebSocketUpgradeRequest {
+  const headers = new Headers();
+
+  if (origin !== undefined) {
+    headers.set("origin", origin);
+  }
+
+  return new Request("https://eve.test/ws", { headers }) as WebSocketUpgradeRequest;
+}
+
+describe("validateWebSocketOrigin", () => {
+  it("allows an allowlisted origin", () => {
+    const result = validateWebSocketOrigin(upgradeRequest("https://app.example.com"), {
+      allowedOrigins: ["https://app.example.com"],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("normalizes default port, trailing slash, and case when matching", () => {
+    const result = validateWebSocketOrigin(upgradeRequest("https://App.Example.com:443"), {
+      allowedOrigins: ["https://app.example.com/"],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("rejects a non-allowlisted origin with 403", async () => {
+    const result = validateWebSocketOrigin(upgradeRequest("https://evil.example"), {
+      allowedOrigins: ["https://app.example.com"],
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(403);
+    await expect((result as Response).json()).resolves.toEqual({
+      error: "WebSocket upgrade rejected: Origin is not allowed.",
+      ok: false,
+    });
+  });
+
+  it("rejects a missing Origin header by default", () => {
+    const result = validateWebSocketOrigin(upgradeRequest(undefined), {
+      allowedOrigins: ["https://app.example.com"],
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(403);
+  });
+
+  it("allows a missing Origin header when allowNoOrigin is set", () => {
+    const result = validateWebSocketOrigin(upgradeRequest(undefined), {
+      allowedOrigins: ["https://app.example.com"],
+      allowNoOrigin: true,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("rejects the opaque `null` origin even when allowNoOrigin is set", () => {
+    const result = validateWebSocketOrigin(upgradeRequest("null"), {
+      allowedOrigins: ["https://app.example.com"],
+      allowNoOrigin: true,
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(403);
+  });
+
+  it("rejects every origin when the allowlist is empty", () => {
+    const result = validateWebSocketOrigin(upgradeRequest("https://app.example.com"), {
+      allowedOrigins: [],
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(403);
+  });
+});

--- a/packages/eve/src/channel/websocket-origin.ts
+++ b/packages/eve/src/channel/websocket-origin.ts
@@ -1,0 +1,92 @@
+import type { WebSocketUpgradeRequest } from "#channel/routes.js";
+
+/**
+ * Options for {@link validateWebSocketOrigin}.
+ */
+export interface ValidateWebSocketOriginOptions {
+  /**
+   * Origins permitted to open the WebSocket. Each entry is compared by its
+   * normalized {@link URL.origin} (scheme + host + non-default port), so
+   * `"https://app.example.com"`, `"https://app.example.com:443/"`, and
+   * `"https://App.Example.com"` are equivalent. An empty list rejects every
+   * origin.
+   */
+  readonly allowedOrigins: readonly string[];
+  /**
+   * Whether to allow handshakes that send no `Origin` header. A browser always
+   * sends `Origin` on a WebSocket handshake, so a missing header marks a
+   * non-browser client (native app, server-to-server) that cannot be the
+   * target of cross-site WebSocket hijacking. Defaults to `false` (reject) —
+   * the strict posture; set `true` when the route also serves non-browser
+   * clients. The opaque `Origin: null` value is always rejected.
+   */
+  readonly allowNoOrigin?: boolean;
+}
+
+/**
+ * Enforces an `Origin` allowlist on a WebSocket upgrade to defend against
+ * cross-site WebSocket hijacking (CWE-1385) and DNS rebinding (CWE-346).
+ *
+ * Call it from a {@link WS} route's `upgrade` hook: it returns a `403`
+ * `Response` to reject a handshake whose `Origin` is missing, opaque, or not
+ * allowlisted, and `undefined` to let an allowed handshake proceed — matching
+ * the hook's `Response | void` contract.
+ *
+ * An `Origin` check bounds the *browser* threat only: a browser cannot suppress
+ * or forge the `Origin` header, but a non-browser client can send any value, so
+ * this is one layer of defense, not authentication. Keep authenticating the
+ * session as well.
+ *
+ * @example
+ * ```ts
+ * WS("/ws", () => ({
+ *   upgrade(request) {
+ *     return validateWebSocketOrigin(request, {
+ *       allowedOrigins: ["https://app.example.com"],
+ *     });
+ *   },
+ *   message(peer, message) {
+ *     // ...
+ *   },
+ * }));
+ * ```
+ */
+export function validateWebSocketOrigin(
+  request: WebSocketUpgradeRequest,
+  options: ValidateWebSocketOriginOptions,
+): Response | undefined {
+  const header = request.headers.get("origin");
+
+  if (header === null || header === "") {
+    return options.allowNoOrigin === true ? undefined : rejectUpgrade();
+  }
+
+  const origin = normalizeOrigin(header);
+
+  if (origin === null) {
+    return rejectUpgrade();
+  }
+
+  for (const candidate of options.allowedOrigins) {
+    if (normalizeOrigin(candidate) === origin) {
+      return undefined;
+    }
+  }
+
+  return rejectUpgrade();
+}
+
+function rejectUpgrade(): Response {
+  return Response.json(
+    { error: "WebSocket upgrade rejected: Origin is not allowed.", ok: false },
+    { status: 403 },
+  );
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}

--- a/packages/eve/src/public/channels/index.ts
+++ b/packages/eve/src/public/channels/index.ts
@@ -32,6 +32,10 @@ export {
   createWebSocketUpgradeServer,
   type WebSocketUpgradeServerBridge,
 } from "#channel/websocket-upgrade-server.js";
+export {
+  validateWebSocketOrigin,
+  type ValidateWebSocketOriginOptions,
+} from "#channel/websocket-origin.js";
 
 import { getChannelInstrumentationKind } from "#channel/compiled-channel.js";
 import type { Channel } from "#public/definitions/defineChannel.js";


### PR DESCRIPTION
## Summary

eve's `WS()` `upgrade` hook can already reject a handshake by returning a `Response`, but the framework ships no helper to validate the `Origin` — so cross-site WebSocket hijacking (CWE-1385) / DNS-rebinding (CWE-346) defense is left to each channel author to hand-roll, and the safe default is easy to miss. The production server binds `0.0.0.0` and accepts a WS handshake on any matched route, so a malicious page in a victim's browser can complete a same-credentials handshake and drive the agent unless the author wrote an `Origin` check.

This adds a small, **opt-in, additive** helper — no default behavior changes.

## API

```ts
import { defineChannel, WS, validateWebSocketOrigin } from "eve/channels";

WS("/ws", () => ({
  upgrade(request) {
    return validateWebSocketOrigin(request, {
      allowedOrigins: ["https://app.example.com"],
    });
  },
  message(peer, message) { /* ... */ },
}));
```

- Returns a `403` `Response` to reject a missing, opaque (`Origin: null`), or non-allowlisted `Origin`; returns `undefined` to proceed — matching the hook's `Response | void` contract.
- Origins are compared by normalized `URL.origin` (scheme + host + non-default port), so port / trailing-slash / case differences don't matter.
- A missing `Origin` is rejected by default (strict posture); `allowNoOrigin: true` permits non-browser clients (which never send one). An `Origin` check bounds the *browser* threat only — documented as one layer of defense, not authentication.

## Changes
- `packages/eve/src/channel/websocket-origin.ts` — helper + `ValidateWebSocketOriginOptions`
- exported from `eve/channels` (`public/channels/index.ts`)
- `docs/channels/custom.mdx` — "Validating the Origin" section
- 7 colocated unit tests + a `patch` changeset

## Verification
`pnpm typecheck`, `pnpm lint`, `pnpm fmt`, `pnpm guard:invariants`, and the full `pnpm --filter eve test:unit` (3637 tests) all pass locally. I did not run the e2e/scenario suites — they require model-provider credentials — and this change is pure request-header logic covered at the unit tier.

Happy to adjust the API (e.g. a predicate form for subdomain matching) if you'd prefer a different surface.