### PR TITLE
fix(eve): finish cancellation through delegated agents

### DIFF
--- a/.changeset/cancel-delegated-turn-parents.md
+++ b/.changeset/cancel-delegated-turn-parents.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Finish a cancelled logical turn after its delegated local, nested, or remote agent work stops, instead of resuming the parent model with child cancellation errors.

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -121,6 +121,8 @@ export interface DeliverHookPayload {
  * Runtime-action results resumed back into a parked parent workflow.
  */
 export interface RuntimeActionResultHookPayload {
+  /** Stops the resumed logical turn after consuming these child results. */
+  readonly cancelled?: boolean;
   readonly kind: "runtime-action-result";
   readonly results: readonly RuntimeActionResult[];
 }

--- a/packages/eve/src/execution/runtime-action-cancellation.test.ts
+++ b/packages/eve/src/execution/runtime-action-cancellation.test.ts
@@ -40,6 +40,7 @@ describe("runRuntimeActionCancellationScope", () => {
     dispatch.resolve({ cancellationTargets: [TARGET] });
 
     await expect(running).resolves.toEqual({
+      cancelled: true,
       dispatchResult: { cancellationTargets: [TARGET] },
       result: "complete",
     });

--- a/packages/eve/src/execution/runtime-action-cancellation.ts
+++ b/packages/eve/src/execution/runtime-action-cancellation.ts
@@ -37,7 +37,11 @@ export async function runRuntimeActionCancellationScope<
   readonly dispatch: () => Promise<TDispatch>;
   readonly sessionId: string;
   readonly wait: (dispatchResult: TDispatch) => Promise<TResult>;
-}): Promise<{ readonly dispatchResult: TDispatch; readonly result: TResult }> {
+}): Promise<{
+  readonly cancelled: boolean;
+  readonly dispatchResult: TDispatch;
+  readonly result: TResult;
+}> {
   const cancellation =
     input.cancelToken === undefined
       ? undefined
@@ -58,16 +62,16 @@ export async function runRuntimeActionCancellationScope<
 
     const waitOperation = input.wait(dispatchResult);
     if (dispatchOutcome.kind === "cancelled") {
-      return { dispatchResult, result: await waitOperation };
+      return { cancelled: true, dispatchResult, result: await waitOperation };
     }
 
     const waitOutcome = await raceCancellation(waitOperation, cancelled);
     if (waitOutcome.kind === "cancelled") {
       await input.cancel(dispatchResult.cancellationTargets);
-      return { dispatchResult, result: await waitOperation };
+      return { cancelled: true, dispatchResult, result: await waitOperation };
     }
 
-    return { dispatchResult, result: waitOutcome.value };
+    return { cancelled: false, dispatchResult, result: waitOutcome.value };
   } finally {
     cancellation?.dispose();
   }

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -81,6 +81,52 @@ describe("turnWorkflow", () => {
     );
   });
 
+  // Runtime-action cancellation settles child workflows before the parent can
+  // resume. The resumed turn must start cancelled instead of asking the model
+  // to interpret the children's cancellation errors as ordinary tool results.
+  it("starts the resumed turn cancelled after delegated work settles", async () => {
+    const sessionState = createSessionState();
+    let stepSignal: AbortSignal | undefined;
+    vi.mocked(turnStep).mockImplementationOnce(
+      async (input) =>
+        await new Promise((resolve) => {
+          stepSignal = input.abortSignal;
+          input.abortSignal?.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                action: "park",
+                hasPendingAuthorization: false,
+                hasPendingInputBatch: false,
+                serializedContext: { state: "cancelled" },
+                sessionState,
+              }),
+            { once: true },
+          );
+        }),
+    );
+
+    const { input } = createInput({ sessionState });
+    const cancelledInput: TurnWorkflowInput = {
+      ...input,
+      stepInput: {
+        ...input.stepInput,
+        input: { cancelled: true, kind: "runtime-action-result", results: [] },
+      },
+    };
+    await turnWorkflow(cancelledInput);
+
+    expect(stepSignal?.aborted).toBe(true);
+    expect(createHook).not.toHaveBeenCalled();
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({
+        action: expect.objectContaining({ kind: "park" }),
+        kind: "turn-result",
+      }),
+    );
+  });
+
   it("notifies the driver when a turn completes", async () => {
     const sessionState = createSessionState();
     vi.mocked(turnStep).mockResolvedValueOnce({

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -34,6 +34,9 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
   "use workflow";
 
   const input = migrateTurnWorkflowInput(rawInput);
+  const cancelledBeforeStep =
+    input.stepInput.input?.kind === "runtime-action-result" &&
+    input.stepInput.input.cancelled === true;
   const cancellation =
     input.cancelToken === undefined
       ? undefined
@@ -41,8 +44,11 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
           metadata: { sessionId: input.stepInput.sessionState.sessionId },
           token: input.cancelToken,
         });
-  const controller = cancellation === undefined ? undefined : new AbortController();
-  const cancellationPromise = cancellation?.then(() => ({ kind: "cancelled" as const }));
+  const controller =
+    cancellation === undefined && !cancelledBeforeStep ? undefined : new AbortController();
+  const cancellationPromise = cancelledBeforeStep
+    ? Promise.resolve({ kind: "cancelled" as const })
+    : cancellation?.then(() => ({ kind: "cancelled" as const }));
   let currentStepInput: TurnStepInput =
     controller === undefined
       ? input.stepInput

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -286,7 +286,7 @@ async function runDriverLoop(input: {
               ? dispatchCodeModeRuntimeActionsStep
               : dispatchRuntimeActionsStep;
 
-          const { result: runtimeResults } = await runRuntimeActionCancellationScope({
+          const { cancelled, result: runtimeResults } = await runRuntimeActionCancellationScope({
             cancel: (targets) =>
               cancelRuntimeActionsStep({
                 serializedContext: runtimeAction.serializedContext,
@@ -321,11 +321,15 @@ async function runDriverLoop(input: {
             return { output: "" };
           }
 
+          const cancelTokenOptions =
+            activeCancelToken === undefined ? {} : { cancelToken: activeCancelToken };
+          const cancellationResultOptions = cancelled ? { cancelled: true } : {};
           action = await dispatchAndAwaitTurn({
-            cancelToken: activeCancelToken,
+            ...cancelTokenOptions,
             capabilities: input.capabilities,
             completionToken: nextTurnCompletionToken(),
             delivery: {
+              ...cancellationResultOptions,
               kind: "runtime-action-result",
               results: runtimeResults.results,
             },

--- a/packages/eve/test/scenarios/dev-server.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server.scenario.test.ts
@@ -4,6 +4,10 @@ import type { Readable } from "node:stream";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  type HandleMessageStreamEvent,
+  isCurrentTurnBoundaryEvent,
+} from "../../src/protocol/message.js";
 import { EVE_HEALTH_ROUTE_PATH } from "../../src/protocol/routes.js";
 import { Client } from "../../src/client/client.js";
 import { WEATHER_AGENT_DESCRIPTOR } from "../../src/internal/testing/scenario-apps/weather-agent.js";
@@ -32,12 +36,193 @@ const CANCELLATION_AGENT_DESCRIPTOR: ScenarioAppDescriptor = {
   ...DEV_SERVER_AGENT_DESCRIPTOR,
   name: "cancellation-agent",
 };
+const LOCAL_SUBAGENT_CANCELLATION_DESCRIPTOR: ScenarioAppDescriptor = {
+  ...DEV_SERVER_AGENT_DESCRIPTOR,
+  files: {
+    ...DEV_SERVER_AGENT_DESCRIPTOR.files,
+    "agent/subagents/coordinator/agent.ts": `
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description: "Delegates cancellation probes to the sleeper subagent.",
+  model: "openai/gpt-5.5",
+});
+`,
+    "agent/subagents/coordinator/subagents/sleeper/agent.ts": `
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description: "Waits for cancellation. [wait-for-cancel]",
+  model: "openai/gpt-5.5",
+});
+`,
+  },
+  name: "local-subagent-cancellation-agent",
+};
+
+function createRemoteSubagentCancellationDescriptor(remoteUrl: string): ScenarioAppDescriptor {
+  return {
+    ...DEV_SERVER_AGENT_DESCRIPTOR,
+    files: {
+      ...DEV_SERVER_AGENT_DESCRIPTOR.files,
+      "agent/subagents/remote-sleeper.ts": `
+import { defineRemoteAgent } from "eve";
+
+export default defineRemoteAgent({
+  description: "Waits for cancellation. [wait-for-cancel]",
+  url: ${JSON.stringify(remoteUrl)},
+});
+`,
+    },
+    name: "remote-subagent-cancellation-parent",
+  };
+}
 
 interface RunningEveDev {
   readonly stderr: () => string;
   readonly stdout: () => string;
   readonly url: string;
   stop(): Promise<void>;
+}
+
+interface EventRead {
+  readonly event: HandleMessageStreamEvent;
+  readonly events: readonly HandleMessageStreamEvent[];
+}
+
+interface ObservedSubagent {
+  readonly event: Extract<HandleMessageStreamEvent, { type: "subagent.called" }>;
+  readonly iterator: AsyncIterator<HandleMessageStreamEvent>;
+}
+
+const EVENT_TIMEOUT_MS = 20_000;
+
+async function readUntil(input: {
+  readonly iterator: AsyncIterator<HandleMessageStreamEvent>;
+  readonly label: string;
+  readonly matches: (event: HandleMessageStreamEvent) => boolean;
+}): Promise<EventRead> {
+  const events: HandleMessageStreamEvent[] = [];
+  return await withTimeout(
+    (async () => {
+      while (true) {
+        const next = await input.iterator.next();
+        if (next.done) {
+          throw new Error(
+            `Stream ended before ${input.label}. Events: ${JSON.stringify(events, null, 2)}`,
+          );
+        }
+
+        events.push(next.value);
+        if (input.matches(next.value)) {
+          return { event: next.value, events };
+        }
+      }
+    })(),
+    input.label,
+    () => `Events: ${JSON.stringify(events, null, 2)}`,
+  );
+}
+
+async function readThroughBoundary(input: {
+  readonly iterator: AsyncIterator<HandleMessageStreamEvent>;
+  readonly label: string;
+}): Promise<readonly HandleMessageStreamEvent[]> {
+  const read = await readUntil({
+    iterator: input.iterator,
+    label: input.label,
+    matches: isCurrentTurnBoundaryEvent,
+  });
+  const end = await withTimeout(input.iterator.next(), `${input.label} stream completion`);
+  if (!end.done) {
+    throw new Error(`Stream emitted ${end.value.type} after ${input.label}.`);
+  }
+  return read.events;
+}
+
+async function observeSubagent(input: {
+  readonly childClient: Client;
+  readonly expectedToolName: string;
+  readonly label: string;
+  readonly parentIterator: AsyncIterator<HandleMessageStreamEvent>;
+}): Promise<ObservedSubagent> {
+  const read = await readUntil({
+    iterator: input.parentIterator,
+    label: input.label,
+    matches: (event) => event.type === "subagent.called",
+  });
+  if (read.event.type !== "subagent.called") {
+    throw new Error(`Expected ${input.label}.`);
+  }
+  expect(read.event.data.toolName).toBe(input.expectedToolName);
+
+  return {
+    event: read.event,
+    iterator: input.childClient
+      .session({ sessionId: read.event.data.childSessionId, streamIndex: 0 })
+      .stream()
+      [Symbol.asyncIterator](),
+  };
+}
+
+async function waitForStepStarted(
+  iterator: AsyncIterator<HandleMessageStreamEvent>,
+  label: string,
+): Promise<void> {
+  await readUntil({
+    iterator,
+    label,
+    matches: (event) => event.type === "step.started",
+  });
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  label: string,
+  diagnostics?: () => string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      const detail = diagnostics?.();
+      reject(new Error(`Timed out waiting for ${label}.${detail ? ` ${detail}` : ""}`));
+    }, EVENT_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([operation, expired]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function expectCancellationCascade(
+  events: readonly HandleMessageStreamEvent[],
+  boundary: "session.failed" | "session.waiting",
+): void {
+  const diagnostic = `Events: ${JSON.stringify(events, null, 2)}`;
+  expect(events.find((event) => event.type === "step.failed")?.data, diagnostic).toMatchObject({
+    code: "TURN_CANCELLED",
+    message: "Turn cancelled by the client.",
+  });
+  expect(events.find((event) => event.type === "turn.failed")?.data, diagnostic).toMatchObject({
+    code: "TURN_CANCELLED",
+    message: "Turn cancelled by the client.",
+  });
+  expect(events.at(-1)?.type).toBe(boundary);
+}
+
+async function expectSessionContinuation(input: {
+  readonly session: ReturnType<Client["session"]>;
+  readonly sessionId: string;
+}): Promise<void> {
+  const followUp = await (
+    await input.session.send("Reply with the exact string `still-alive` and nothing else.")
+  ).result();
+
+  expect(followUp.sessionId).toBe(input.sessionId);
+  expect(followUp.message).toBe("still-alive");
+  expect(followUp.status).toBe("waiting");
 }
 
 function stripAnsi(text: string): string {
@@ -238,6 +423,130 @@ async function startEveDev(appRoot: string): Promise<RunningEveDev> {
 }
 
 describe("eve dev server", () => {
+  // A root-only cancellation check cannot catch a token lost while a delegated
+  // child waits on its own child. Observe every session so recursive shutdown
+  // and the surviving parent conversation are proven in one real dev run.
+  it(
+    "cancels a nested local subagent chain and continues the root session",
+    async () => {
+      const app = await scenarioApp(LOCAL_SUBAGENT_CANCELLATION_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        const client = new Client({ host: server.url });
+        const session = client.session();
+        const response = await session.send(
+          "Use the coordinator subagent with message 'Use the sleeper subagent with message wait.'.",
+        );
+        const parentIterator = response[Symbol.asyncIterator]();
+        const coordinator = await observeSubagent({
+          childClient: client,
+          expectedToolName: "coordinator",
+          label: "the coordinator subagent call",
+          parentIterator,
+        });
+        const sleeper = await observeSubagent({
+          childClient: client,
+          expectedToolName: "sleeper",
+          label: "the sleeper subagent call",
+          parentIterator: coordinator.iterator,
+        });
+        await waitForStepStarted(sleeper.iterator, "the sleeper model step");
+
+        await expect(response.cancel()).resolves.toBe(true);
+        const sleeperEvents = await readThroughBoundary({
+          iterator: sleeper.iterator,
+          label: "the sleeper cancellation boundary",
+        });
+        const coordinatorEvents = await readThroughBoundary({
+          iterator: coordinator.iterator,
+          label: "the coordinator cancellation boundary",
+        });
+        const parentEvents = await readThroughBoundary({
+          iterator: parentIterator,
+          label: "the root cancellation boundary",
+        });
+
+        expectCancellationCascade(sleeperEvents, "session.failed");
+        expectCancellationCascade(coordinatorEvents, "session.failed");
+        expectCancellationCascade(parentEvents, "session.waiting");
+        expect(parentEvents.some((event) => event.type === "subagent.completed")).toBe(false);
+        expect(parentEvents.some((event) => event.type === "message.appended")).toBe(false);
+        await expectSessionContinuation({ session, sessionId: response.sessionId });
+      } catch (error) {
+        throw new Error(
+          [`stdout:\n${server.stdout()}`, `stderr:\n${server.stderr()}`].join("\n\n"),
+          { cause: error },
+        );
+      } finally {
+        await server.stop();
+      }
+    },
+    DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  );
+
+  // Remote delegation uses a second Eve server and an authenticated HTTP
+  // cancellation hop. Reading the remote child stream prevents a mocked fetch
+  // or an accepted parent request from masquerading as stopped remote work.
+  it(
+    "cancels a running remote subagent and continues the root session",
+    async () => {
+      const remoteApp = await scenarioApp({
+        ...CANCELLATION_AGENT_DESCRIPTOR,
+        name: "remote-subagent-cancellation-child",
+      });
+      const remoteServer = await startEveDev(remoteApp.appRoot);
+
+      try {
+        const parentApp = await scenarioApp(
+          createRemoteSubagentCancellationDescriptor(remoteServer.url),
+        );
+        const parentServer = await startEveDev(parentApp.appRoot);
+
+        try {
+          const parentClient = new Client({ host: parentServer.url });
+          const parentSession = parentClient.session();
+          const response = await parentSession.send(
+            "Use the remote-sleeper subagent with message wait.",
+          );
+          const parentIterator = response[Symbol.asyncIterator]();
+          const remote = await observeSubagent({
+            childClient: new Client({ host: remoteServer.url }),
+            expectedToolName: "remote-sleeper",
+            label: "the remote sleeper subagent call",
+            parentIterator,
+          });
+          expect(remote.event.data.remote?.url).toBe(remoteServer.url);
+          await waitForStepStarted(remote.iterator, "the remote sleeper model step");
+
+          await expect(response.cancel()).resolves.toBe(true);
+          const remoteEvents = await readThroughBoundary({
+            iterator: remote.iterator,
+            label: "the remote child cancellation boundary",
+          });
+          const parentEvents = await readThroughBoundary({
+            iterator: parentIterator,
+            label: "the remote parent cancellation boundary",
+          });
+
+          expectCancellationCascade(remoteEvents, "session.failed");
+          expectCancellationCascade(parentEvents, "session.waiting");
+          expect(parentEvents.some((event) => event.type === "subagent.completed")).toBe(false);
+          expect(parentEvents.some((event) => event.type === "message.appended")).toBe(false);
+          await expectSessionContinuation({
+            session: parentSession,
+            sessionId: response.sessionId,
+          });
+        } finally {
+          await parentServer.stop();
+        }
+      } finally {
+        await remoteServer.stop();
+      }
+    },
+    DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  );
+
   it(
     "cancels one child turn and continues the parent session",
     async () => {


### PR DESCRIPTION
## Summary

Stacked on #128 (with #127 and #118 beneath it).

Cancellation already reached delegated children, but after those children settled the parked parent turn resumed the model with cancellation errors. That could append an unexpected assistant message and complete the turn normally.

This PR preserves the cancelled outcome across the runtime-action callback. The resumed parent consumes the child results, starts with a live distributed signal, and is immediately cancelled instead of invoking the model again.

It also adds deterministic real-dev-server coverage for:

- root -> local coordinator -> local sleeper
- root -> coordinator -> remote sleeper on a second `eve` server
- same-session follow-up after cancellation

Both scenarios assert the full failure cascade, absence of `subagent.completed` and `message.appended`, and successful continuation on the original root session.

## Before / after evidence

Before #128, the tests showed that local children did not receive an `AbortSignal` and remote `response.cancel()` returned `false`.

On #128 before this fix, delegated children stopped, but their parents resumed and emitted an assistant response describing the cancellation.

With this change, local nested and remote delegated work stop, every active logical parent turn finishes as `TURN_CANCELLED`, the root session returns to `session.waiting`, and the next message continues that same session.

## Review guide

1. Start with the two tests in `dev-server.scenario.test.ts`; they are the executable end-to-end proof.
2. Follow the `cancelled` marker from `runtime-action-cancellation.ts` through `workflow-entry.ts`.
3. `turn-workflow.ts` consumes that marker by starting the resumed step with a live signal and immediately aborting it.
4. The unit test covers the workflow-resumption edge directly.
