### PR TITLE
docs(eve): links - use canonical documentation URLs

### DIFF
--- a/.changeset/fix-npm-readme-links.md
+++ b/.changeset/fix-npm-readme-links.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Fix the documentation links in the npm package README so they point to the published eve documentation.
+Point the npm README, runtime landing page, and setup guidance at the canonical eve documentation domain.

--- a/.changeset/fix-npm-readme-links.md
+++ b/.changeset/fix-npm-readme-links.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix the documentation links in the npm package README so they point to the published eve documentation.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ my-agent/
         └── weekly_recap.ts
 ```
 
-Read the [documentation](https://beta.eve.dev/docs) for the full project layout and guides.
+Read the [documentation](https://eve.dev/docs) for the full project layout and guides.
 
 ## Quick start
 
@@ -98,7 +98,7 @@ npm run dev
 ```
 
 That's a working agent. Add human-in-the-loop prompts, subagents, and schedules as needed.
-Follow the [first-agent tutorial](https://beta.eve.dev/docs/tutorial/first-agent) for a complete
+Follow the [first-agent tutorial](https://eve.dev/docs/tutorial/first-agent) for a complete
 walkthrough.
 
 ## Community

--- a/packages/eve/README.md
+++ b/packages/eve/README.md
@@ -75,7 +75,7 @@ Runtime accessors live on the subpath that owns the concern:
 - `getSkill(identifier)` — handle for a named skill visible to the current agent (`eve/skills`)
 - `getContext(key)`, `requireContext(key)`, `hasContext(key)`, `setContext(key)`, `ensureContext(key, factory)` — unified context helpers (`eve/context`)
 
-The complete API reference, including types and lower-level runtime primitives, is in [`./docs/reference/typescript-api.md`](./docs/reference/typescript-api.md).
+The complete API reference, including types and lower-level runtime primitives, is in the [TypeScript API documentation](https://eve.dev/docs/reference/typescript-api).
 
 ## Tiny Example
 
@@ -138,22 +138,22 @@ CLI commands:
 
 ## Deploying
 
-eve is built to be durable. The runtime is Nitro + Workflows. Read [`./docs/guides/deployment.md`](./docs/guides/deployment.md) for the deployment path, environment variables, and configuration.
+eve is built to be durable. The runtime is Nitro + Workflows. Read the [deployment guide](https://eve.dev/docs/guides/deployment) for the deployment path, environment variables, and configuration.
 
 ## Read Next
 
 These files ship inside the installed package at `node_modules/eve/docs/`:
 
-- [Full docs index](./docs/README.md) — recommended entry point
-- [Getting Started](./docs/getting-started.mdx) — install, scaffold, and run locally
-- [Project Layout](./docs/reference/project-layout.md) — every authored directory in depth
-- [`agent.ts`](./docs/agent-config.md) — agent config reference
-- [TypeScript API](./docs/reference/typescript-api.md) — complete `define*` and runtime helper reference
-- [Vercel Deployment](./docs/guides/deployment.md) — deploy to production
+- [Full docs index](https://eve.dev/docs) — recommended entry point
+- [Getting Started](https://eve.dev/docs/getting-started) — install, scaffold, and run locally
+- [Project Layout](https://eve.dev/docs/reference/project-layout) — every authored directory in depth
+- [`agent.ts`](https://eve.dev/docs/agent-config) — agent config reference
+- [TypeScript API](https://eve.dev/docs/reference/typescript-api) — complete `define*` and runtime helper reference
+- [Vercel Deployment](https://eve.dev/docs/guides/deployment) — deploy to production
 
-By authoring concern: [Tools](./docs/tools.mdx) · [Channels](./docs/channels/overview.mdx) · [Hooks](./docs/guides/hooks.md) · [Skills](./docs/skills.mdx) · [Sandbox](./docs/sandbox.mdx) · [Connections](./docs/connections.mdx) · [Subagents](./docs/subagents.mdx) · [Schedules](./docs/schedules.mdx) · [Evals](./docs/evals/overview.mdx)
+By authoring concern: [Tools](https://eve.dev/docs/tools) · [Channels](https://eve.dev/docs/channels/overview) · [Hooks](https://eve.dev/docs/guides/hooks) · [Skills](https://eve.dev/docs/skills) · [Sandbox](https://eve.dev/docs/sandbox) · [Connections](https://eve.dev/docs/connections) · [Subagents](https://eve.dev/docs/subagents) · [Schedules](https://eve.dev/docs/schedules) · [Evals](https://eve.dev/docs/evals/overview)
 
-By runtime concern: [Sessions and Streaming](./docs/concepts/sessions-runs-and-streaming.md) · [Session Context](./docs/guides/session-context.md) · [Context Control](./docs/concepts/context-control.md) · [Auth and Route Protection](./docs/guides/auth-and-route-protection.md) · [CLI, Build, and Debugging](./docs/reference/cli.md) · [Instrumentation](./docs/guides/instrumentation.md)
+By runtime concern: [Sessions and Streaming](https://eve.dev/docs/concepts/sessions-runs-and-streaming) · [Session Context](https://eve.dev/docs/guides/session-context) · [Context Control](https://eve.dev/docs/concepts/context-control) · [Auth and Route Protection](https://eve.dev/docs/guides/auth-and-route-protection) · [CLI, Build, and Debugging](https://eve.dev/docs/reference/cli) · [Instrumentation](https://eve.dev/docs/guides/instrumentation)
 
 ## Architecture (Internals)
 

--- a/packages/eve/scripts/copy-docs.mjs
+++ b/packages/eve/scripts/copy-docs.mjs
@@ -5,10 +5,9 @@ import { fileURLToPath } from "node:url";
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 const monorepoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 
-// The npm package README points at `./docs/...`, and scaffolded
-// apps tell agents to read `node_modules/eve/docs/`. The
-// package-local README is already listed in package.json#files; do not
-// overwrite it with the monorepo root README.
+// Scaffolded apps tell agents to read `node_modules/eve/docs/`. The package-local
+// README is already listed in package.json#files; do not overwrite it with the
+// monorepo root README.
 const packageDocsDir = join(packageRoot, "docs");
 const oldDistDocsDir = join(packageRoot, "dist", "docs");
 

--- a/packages/eve/src/internal/nitro/routes/index.test.ts
+++ b/packages/eve/src/internal/nitro/routes/index.test.ts
@@ -18,7 +18,7 @@ describe("buildHomePageResponse", () => {
   it("links out to the public docs site", async () => {
     const body = await buildResponseForRequest("https://my-agent.example.com/").text();
 
-    expect(body).toContain("https://beta.eve.dev/docs");
+    expect(body).toContain("https://eve.dev/docs");
   });
 
   it("echoes the deployment origin into the `eve dev` hint", async () => {

--- a/packages/eve/src/internal/nitro/routes/index.ts
+++ b/packages/eve/src/internal/nitro/routes/index.ts
@@ -5,7 +5,7 @@ import type { H3Event } from "nitro";
  * so the deployment output is a fully static, build-time-baked HTML
  * response that performs no runtime resolution.
  */
-const EVE_DOCS_URL = "https://beta.eve.dev/docs";
+const EVE_DOCS_URL = "https://eve.dev/docs";
 
 const DEPLOYMENT_URL_PLACEHOLDER = "{{DEPLOYMENT_URL}}";
 

--- a/packages/eve/src/setup/flows/vercel.ts
+++ b/packages/eve/src/setup/flows/vercel.ts
@@ -23,7 +23,7 @@ export const EXTERNAL_PROVIDER_INSTRUCTIONS_TITLE = "Using another model provide
 export const EXTERNAL_PROVIDER_INSTRUCTIONS: readonly string[] = [
   `Set your provider's API key in ${ENV_FILE_NAME} — e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY.`,
   'In agent/agent.ts, set `model` to a provider-authored model — e.g. `anthropic("claude-opus-4.8")` from `@ai-sdk/anthropic`.',
-  "See https://beta.eve.dev/docs/agent-config for details.",
+  "See https://eve.dev/docs/agent-config for details.",
   "A running `eve dev` reloads env files automatically — no restart needed.",
 ];
 


### PR DESCRIPTION
## Summary

- replace package README-relative documentation links with canonical `eve.dev` URLs
- replace every remaining `beta.eve.dev` reference across documentation, runtime output, and setup guidance
- correct the Tools landing-page route
- add a patch changeset so npm receives the updated README in the next release

## Root cause

npm resolved the relative `./docs/...` links using the package repository directory, `packages/eve`, while the documentation source lives at the repository root. Those generated GitHub URLs therefore returned 404 responses. Several other surfaces still referenced the retired `beta.eve.dev` hostname instead of the canonical `eve.dev` domain.

## Impact

Documentation links rendered on the `eve` npm package page, runtime landing page, repository README, and setup guidance now open the canonical published eve documentation.

## Validation

- confirmed all 21 linked documentation URLs return HTTP 200
- confirmed the repository contains no `beta.eve.dev` references
- confirmed the root docs, first-agent tutorial, and agent-config URLs return HTTP 200
- `pnpm docs:check`
- `pnpm test:unit` — 3,630 tests passed
- `pnpm test:integration` — 318 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `pnpm guard:invariants`
- `pnpm build`
- `pnpm test:scenario` — 253 tests passed, 15 skipped
- `pnpm exec changeset status`
- `git diff --check`
