### PR TITLE
fix(eve): resolve code-defined model imported from a sibling module in dev

### DIFF
--- a/.changeset/fix-dev-source-backed-model-resolution.md
+++ b/.changeset/fix-dev-source-backed-model-resolution.md
@@ -1,0 +1,12 @@
+---
+"eve": patch
+---
+
+Fix `eve dev` and `eve eval` failing with `LoadCompiledModuleMapError` when an
+agent's `model` is a code-defined provider object (e.g. `anthropic("claude-opus-4-8")`)
+imported into the agent config from a sibling module. Source-backed model
+resolution now loads the compiled module map through the same authored-source
+loader the rest of the dev runtime uses, so NodeNext `.js` import specifiers
+between authored source files resolve to their `.ts` sources. Previously this
+path imported the compiled module map directly and skipped that mapping, which
+only surfaced in the dev runtime (`eve build` + `eve start` were unaffected).

--- a/packages/eve/src/runtime/agent/resolve-model.test.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The module-map loader is mocked so we can assert *which* loader source-backed
+// model resolution uses without standing up a compiled app on disk.
+const { loadRuntimeCompiledModuleMap, loadCompiledModuleMap } = vi.hoisted(() => ({
+  loadCompiledModuleMap: vi.fn(),
+  loadRuntimeCompiledModuleMap: vi.fn(),
+}));
+
+vi.mock("#runtime/loaders/module-map.js", () => ({
+  loadCompiledModuleMap,
+  loadRuntimeCompiledModuleMap,
+}));
+
+import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
+import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { resolveRuntimeModelReference } from "#runtime/agent/resolve-model.js";
+
+describe("resolveRuntimeModelReference", () => {
+  beforeEach(() => {
+    // The deterministic authored-model mock activates under NODE_ENV=test and
+    // would short-circuit before the source-backed path; bypass it here.
+    vi.stubEnv("NODE_ENV", "production");
+    loadRuntimeCompiledModuleMap.mockReset();
+    loadCompiledModuleMap.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves a source-backed model through the authored-source-aware module-map loader", async () => {
+    // Regression (vercel/eve#92): a code-defined model imported into the agent
+    // config from a sibling module is a source-backed reference, re-imported at
+    // turn time. That re-import must go through loadRuntimeCompiledModuleMap —
+    // which uses the authored-source loader in dev and so resolves NodeNext
+    // `.js` specifiers between authored source files — not loadCompiledModuleMap,
+    // which imports the compiled module-map directly and fails to resolve them
+    // in the dev runtime.
+    const model = {
+      doGenerate() {
+        throw new Error("model should not be invoked");
+      },
+      doStream() {
+        throw new Error("model should not be invoked");
+      },
+      modelId: "claude-opus-4-8",
+      provider: "anthropic",
+      specificationVersion: "v2",
+    };
+
+    loadRuntimeCompiledModuleMap.mockResolvedValue({
+      nodes: {
+        [ROOT_COMPILED_AGENT_NODE_ID]: {
+          modules: {
+            "agent.ts": { default: { model } },
+          },
+        },
+      },
+    });
+
+    const reference = {
+      id: "anthropic/claude-opus-4.8",
+      source: {
+        exportName: "default",
+        logicalPath: "agent.ts",
+        sourceId: "agent.ts",
+        sourceKind: "module",
+      },
+    } as unknown as RuntimeModelReference;
+
+    const compiledArtifactsSource = {
+      appRoot: "/app",
+      kind: "disk",
+      moduleMapLoaderPath: "/eve/authored-module-map-loader.js",
+    } as unknown as RuntimeCompiledArtifactsSource;
+
+    const resolved = await resolveRuntimeModelReference(reference, { compiledArtifactsSource });
+
+    expect(loadRuntimeCompiledModuleMap).toHaveBeenCalledWith(compiledArtifactsSource);
+    expect(loadCompiledModuleMap).not.toHaveBeenCalled();
+    expect(resolved).toBe(model);
+  });
+});

--- a/packages/eve/src/runtime/agent/resolve-model.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.ts
@@ -8,7 +8,7 @@ import {
 } from "#internal/authored-module.js";
 import type { ModuleDefinitionExport } from "#public/definitions/source.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
-import { loadCompiledModuleMap } from "#runtime/loaders/module-map.js";
+import { loadRuntimeCompiledModuleMap } from "#runtime/loaders/module-map.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import { resolveBootstrapRuntimeModel } from "#runtime/agent/bootstrap-model.js";
 import {
@@ -60,9 +60,7 @@ async function loadSourceBackedRuntimeModelReference(
     );
   }
 
-  const moduleMap = await loadCompiledModuleMap({
-    compiledArtifactsSource: input.compiledArtifactsSource,
-  });
+  const moduleMap = await loadRuntimeCompiledModuleMap(input.compiledArtifactsSource);
   const moduleNamespace =
     moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules[reference.source.sourceId];
 

--- a/packages/eve/src/runtime/loaders/module-map.ts
+++ b/packages/eve/src/runtime/loaders/module-map.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from "node:url";
+
 import { type CompiledModuleMap, compiledModuleMapSchema } from "#compiler/module-map.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { formatValidationError } from "#runtime/validation.js";
@@ -69,6 +71,38 @@ export async function loadCompiledModuleMap(
     "Compiled module map is unavailable without an app root or bundled compiled artifacts.",
     BUNDLED_MODULE_MAP_SOURCE,
   );
+}
+
+/**
+ * Loads the compiled module map the way the runtime does. When the source is a
+ * disk build that ships an authored-source module-map loader (dev and build
+ * flows), authored modules are hydrated through it so tsconfig path aliases and
+ * NodeNext `.js` import specifiers resolve to their `.ts` sources. Otherwise it
+ * falls back to the bundled/compiled module map.
+ *
+ * Every runtime consumer that re-reads authored config (the compiled-agent
+ * cache and source-backed model resolution) must go through this single entry
+ * point so they resolve modules identically; importing the compiled
+ * `module-map.mjs` directly skips the authored-source loader and fails to
+ * resolve `.js` specifiers between authored source files in dev.
+ */
+export async function loadRuntimeCompiledModuleMap(
+  compiledArtifactsSource: RuntimeCompiledArtifactsSource,
+): Promise<CompiledModuleMap> {
+  if (
+    compiledArtifactsSource.kind === "disk" &&
+    compiledArtifactsSource.moduleMapLoaderPath !== undefined
+  ) {
+    const loader = (await import(
+      pathToFileURL(compiledArtifactsSource.moduleMapLoaderPath).href
+    )) as typeof import("#internal/authored-module-map-loader.js");
+
+    return await loader.loadCompiledModuleMapFromAuthoredSource({
+      compiledArtifactsSource,
+    });
+  }
+
+  return await loadCompiledModuleMap({ compiledArtifactsSource });
 }
 
 function parseCompiledModuleMap(value: unknown, moduleMapPath: string): CompiledModuleMap {

--- a/packages/eve/src/runtime/sessions/compiled-agent-cache.ts
+++ b/packages/eve/src/runtime/sessions/compiled-agent-cache.ts
@@ -1,5 +1,3 @@
-import { pathToFileURL } from "node:url";
-
 import type { CompiledModuleMap } from "#compiler/module-map.js";
 import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
 import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
@@ -7,13 +5,12 @@ import type { RuntimeAdapterRegistry } from "#runtime/channels/registry.js";
 import { createRuntimeAdapterRegistry } from "#runtime/channels/registry.js";
 import {
   getRuntimeCompiledArtifactsCacheKey,
-  type RuntimeDiskCompiledArtifactsSource,
   type RuntimeCompiledArtifactsSource,
 } from "#runtime/compiled-artifacts-source.js";
 import { getResolvedRuntimeAgentNode, type ResolvedAgentGraphBundle } from "#runtime/graph.js";
 import type { RuntimeHookRegistry } from "#runtime/hooks/registry.js";
 import { loadCompiledManifest } from "#runtime/loaders/manifest.js";
-import { loadCompiledModuleMap } from "#runtime/loaders/module-map.js";
+import { loadRuntimeCompiledModuleMap } from "#runtime/loaders/module-map.js";
 import { resolveRuntimeAgentGraph } from "#runtime/resolve-agent-graph.js";
 import type { RuntimeSubagentRegistry } from "#runtime/subagents/registry.js";
 import type { RuntimeToolRegistry } from "#runtime/tools/registry.js";
@@ -63,37 +60,6 @@ async function loadFullBundle(
     toolRegistry: rootNode.toolRegistry,
     turnAgent: rootNode.turnAgent,
   };
-}
-
-async function loadRuntimeCompiledModuleMap(
-  compiledArtifactsSource: RuntimeCompiledArtifactsSource,
-): Promise<CompiledModuleMap> {
-  if (
-    compiledArtifactsSource.kind === "disk" &&
-    compiledArtifactsSource.moduleMapLoaderPath !== undefined
-  ) {
-    return await loadAuthoredSourceCompiledModuleMap(compiledArtifactsSource);
-  }
-
-  return await loadCompiledModuleMap({ compiledArtifactsSource });
-}
-
-async function loadAuthoredSourceCompiledModuleMap(
-  compiledArtifactsSource: RuntimeDiskCompiledArtifactsSource,
-): Promise<CompiledModuleMap> {
-  if (compiledArtifactsSource.moduleMapLoaderPath === undefined) {
-    throw new Error(
-      'Authored-source module map loading requires "moduleMapLoaderPath" in the compiled artifacts source.',
-    );
-  }
-
-  const loader = (await import(
-    pathToFileURL(compiledArtifactsSource.moduleMapLoaderPath).href
-  )) as typeof import("#internal/authored-module-map-loader.js");
-
-  return await loader.loadCompiledModuleMapFromAuthoredSource({
-    compiledArtifactsSource,
-  });
 }
 
 async function getOrLoadFullBundle(


### PR DESCRIPTION
Fixes #92.

## Problem

`eve dev` (and therefore `eve eval`, which runs through the dev runtime) fails at turn
time with `LoadCompiledModuleMapError` when an agent's `model` is a **code-defined provider
object** (e.g. `anthropic("claude-opus-4-8")`) imported into the agent config from a
**sibling module**:

```
LoadCompiledModuleMapError: Cannot find module '.../source/agent/lib/models.js'
  imported from '.../source/agent/agent.ts'
```

`eve build` + `eve start` resolve the same agent fine; only the dev runtime is affected.

## Root cause

A non-string `model` can't be serialised into durable state, so it becomes a _source-backed
model reference_ that is re-imported at turn time to read `.model` back out
(`resolve-model.ts` → `loadSourceBackedRuntimeModelReference`). That path called the basic
`loadCompiledModuleMap` **directly**, which imports `module-map.mjs` and re-imports the
authored config from raw `.ts` source — without the NodeNext `.js`→`.ts` specifier mapping.

Meanwhile the normal agent-loading path (`compiled-agent-cache.ts`) already branches on
`moduleMapLoaderPath` and uses the **authored-source loader** (`loadAuthoredModuleNamespace`)
in dev, which resolves those specifiers correctly. The two paths diverged; the model
resolver used the wrong one.

## Fix

Extract that branching logic into a single shared `loadRuntimeCompiledModuleMap` in
`runtime/loaders/module-map.ts`, and route **both** the compiled-agent cache and source-backed
model resolution through it. So a code-defined model imported from a sibling module now
resolves identically in dev and production. Net change is a small consolidation
(+49/−39) that removes the duplicated loader.

## Verification

- **Repro fixed end-to-end.** A fresh `eve init` app with `export const model =
anthropic("claude-opus-4-8")` in `agent/lib/models.ts`, imported by `agent/agent.ts`, fails
  on `eve eval` before this change. After it, model resolution succeeds and the run proceeds to
  the actual model call (no more `LoadCompiledModuleMapError`).
- **Regression test added** (`runtime/agent/resolve-model.test.ts`): asserts source-backed
  model resolution loads the module map through `loadRuntimeCompiledModuleMap` (the
  authored-source-aware loader), not `loadCompiledModuleMap`. It fails on the previous code and
  passes on the fix. (A note on why it's a unit test: the runtime failure only reproduces under
  real Node — vitest's loader transparently remaps `.js`→`.ts`, so an end-to-end scenario test
  passes either way and can't guard this regression. The unit test pins the loader the resolver
  must use.)
- **No regressions.** `typecheck`, `build`, and the existing scenario + integration tests for
  the authored-source loading path (`authored-module-loader.scenario`, `cache-key.scenario`,
  `dev-runtime-artifacts.integration`) all pass.
- Changeset included (`patch`).
