### PR TITLE
fix(skills): qualify single-entry dynamic skill maps as slug__key

### DIFF
--- a/.changeset/dynamic-skill-single-entry-map-naming.md
+++ b/.changeset/dynamic-skill-single-entry-map-naming.md
@@ -3,3 +3,5 @@
 ---
 
 Dynamic skill resolvers that return a map now name every entry `<slug>__<key>` even when the map holds a single entry, matching dynamic tools and the documented contract. Previously a one-entry map was advertised and materialized under the bare resolver slug, so `load_skill` failed to find it and adding a second skill silently renamed the first. `load_skill` failures now also list the available skill names so the model can correct a wrong id.
+
+Adds a `t.loadedSkill(skill, opts?)` eval assertion — sugar for `t.calledTool("load_skill", { input: { skill }, ... })`.

--- a/.changeset/dynamic-skill-single-entry-map-naming.md
+++ b/.changeset/dynamic-skill-single-entry-map-naming.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Dynamic skill resolvers that return a map now name every entry `<slug>__<key>` even when the map holds a single entry, matching dynamic tools and the documented contract. Previously a one-entry map was advertised and materialized under the bare resolver slug, so `load_skill` failed to find it and adding a second skill silently renamed the first. `load_skill` failures now also list the available skill names so the model can correct a wrong id.

--- a/docs/evals/assertions.mdx
+++ b/docs/evals/assertions.mdx
@@ -17,6 +17,7 @@ Run-level assertions read the whole run, so they take no value. They are methods
 | `t.messageIncludes(token)`                          | Joined assistant text contains `token` (string or RegExp)                               |
 | `t.outputEquals(value)` / `t.outputMatches(schema)` | Deep equality or Standard Schema (e.g. Zod) validation of the agent's structured output |
 | `t.calledTool(name, opts?)`                         | A matching tool call happened (`input`, `output`, `isError`, `times` constraints)       |
+| `t.loadedSkill(skill, opts?)`                       | Sugar for `t.calledTool("load_skill", { input: { skill }, ...opts })`                   |
 | `t.notCalledTool(name)`                             | No call to `name`                                                                       |
 | `t.toolOrder([...names])`                           | Tool names appear in order (other calls may interleave)                                 |
 | `t.usedNoTools()`                                   | No tool calls at all                                                                    |

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -116,6 +116,8 @@ export default defineDynamic({
 
 The caller's team gets its own playbook advertised as a loadable skill; everyone else gets nothing.
 
+Skills follow the same naming rule as tools: a single `defineSkill(...)` is named after the file slug, while a map return names each entry `slug__key` — even when the map holds one entry, so adding a second skill later never renames the first.
+
 ## Dynamic instructions
 
 A dynamic instructions file resolves the per-session system prompt the same way, returning `defineInstructions(...)` built from the principal, tenant, or external data:

--- a/e2e/fixtures/agent-skills/agent/skills/dynamic-single-map.ts
+++ b/e2e/fixtures/agent-skills/agent/skills/dynamic-single-map.ts
@@ -1,0 +1,26 @@
+import { defineDynamic, defineSkill } from "eve/skills";
+
+export const DYNAMIC_SINGLE_MAP_TOKEN = "dynamic-single-map-solo-X3R8";
+
+// A map with exactly one entry: its id must still qualify as
+// `dynamic-single-map__solo`, never collapse to the bare resolver slug.
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      return {
+        solo: defineSkill({
+          description:
+            "Smoke-test fixture: the sole skill from a single-entry map resolver. " +
+            'Only load when the user explicitly asks for "dynamic single map solo".',
+          markdown: [
+            "# Solo Skill",
+            "",
+            "When this skill is loaded, reply with exactly:",
+            "",
+            DYNAMIC_SINGLE_MAP_TOKEN,
+          ].join("\n"),
+        }),
+      };
+    },
+  },
+});

--- a/e2e/fixtures/agent-skills/evals/skills/dynamic-single-map.eval.ts
+++ b/e2e/fixtures/agent-skills/evals/skills/dynamic-single-map.eval.ts
@@ -19,8 +19,7 @@ export default defineEval({
 
     t.didNotFail();
     t.completed();
-    t.calledTool("load_skill", {
-      input: { skill: "dynamic-single-map__solo" },
+    t.loadedSkill("dynamic-single-map__solo", {
       output: new RegExp(DYNAMIC_SINGLE_MAP_TOKEN, "u"),
     });
     t.messageIncludes(DYNAMIC_SINGLE_MAP_TOKEN);

--- a/e2e/fixtures/agent-skills/evals/skills/dynamic-single-map.eval.ts
+++ b/e2e/fixtures/agent-skills/evals/skills/dynamic-single-map.eval.ts
@@ -1,0 +1,28 @@
+import { defineEval } from "eve/evals";
+
+const DYNAMIC_SINGLE_MAP_TOKEN = "dynamic-single-map-solo-X3R8";
+
+/**
+ * Skill smoke eval (regression):
+ * a `defineDynamic` resolver returning a single-entry map
+ * (skills/dynamic-single-map.ts) must expose that entry under its qualified id
+ * `dynamic-single-map__solo` — not the bare resolver slug. Asserting the loaded
+ * skill id is exactly the qualified name guards the single-entry-map naming fix.
+ */
+export default defineEval({
+  description: "Skills smoke: single-entry dynamic skill-map qualifies as slug__key.",
+  async test(t) {
+    const turn = await t.send(
+      "Please use the dynamic single map solo skill and follow its instructions exactly.",
+    );
+    turn.expectOk();
+
+    t.didNotFail();
+    t.completed();
+    t.calledTool("load_skill", {
+      input: { skill: "dynamic-single-map__solo" },
+      output: new RegExp(DYNAMIC_SINGLE_MAP_TOKEN, "u"),
+    });
+    t.messageIncludes(DYNAMIC_SINGLE_MAP_TOKEN);
+  },
+});

--- a/e2e/fixtures/agent-skills/evals/skills/dynamic-skill-map.eval.ts
+++ b/e2e/fixtures/agent-skills/evals/skills/dynamic-skill-map.eval.ts
@@ -18,8 +18,7 @@ export default defineEval({
 
     t.didNotFail();
     t.completed();
-    t.calledTool("load_skill", {
-      input: { skill: "dynamic-multi__alpha" },
+    t.loadedSkill("dynamic-multi__alpha", {
       output: new RegExp(DYNAMIC_MULTI_ALPHA_TOKEN, "u"),
     });
     t.messageIncludes(DYNAMIC_MULTI_ALPHA_TOKEN);

--- a/e2e/fixtures/agent-skills/evals/skills/dynamic-skill.eval.ts
+++ b/e2e/fixtures/agent-skills/evals/skills/dynamic-skill.eval.ts
@@ -18,8 +18,7 @@ export default defineEval({
 
     t.didNotFail();
     t.completed();
-    t.calledTool("load_skill", {
-      input: { skill: "dynamic-tenant-policy" },
+    t.loadedSkill("dynamic-tenant-policy", {
       output: new RegExp(DYNAMIC_SKILL_TOKEN, "u"),
     });
     t.messageIncludes(DYNAMIC_SKILL_TOKEN);

--- a/packages/eve/src/context/dynamic-skill-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-skill-lifecycle.test.ts
@@ -132,6 +132,47 @@ describe("dispatchDynamicSkillEvent", () => {
     expect(announcement).toContain("support: Support policy");
   });
 
+  it("qualifies a single-entry map as slug__key (never collapses to the bare slug)", async () => {
+    const { ctx, sandbox } = createCtx();
+    const resolver = createResolver("custom", () => ({
+      "talk-like-a-dog": makeSkill("Talk like a dog", "Woof."),
+    }));
+
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: makeEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(ctx.get(DynamicSkillManifestKey)).toEqual({
+      custom: [{ description: "Talk like a dog", name: "custom__talk-like-a-dog" }],
+    });
+    expect(ctx.get(PendingSkillAnnouncementKey)).toContain(
+      "custom__talk-like-a-dog: Talk like a dog",
+    );
+    expect(sandbox.writes.some((w) => w.path.includes("/skills/custom__talk-like-a-dog/"))).toBe(
+      true,
+    );
+  });
+
+  it("collapses a directly-returned single defineSkill to the bare slug", async () => {
+    const { ctx, sandbox } = createCtx();
+    const resolver = createResolver("tenant", () => makeSkill("Tenant policy"));
+
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: makeEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(ctx.get(DynamicSkillManifestKey)).toEqual({
+      tenant: [{ description: "Tenant policy", name: "tenant" }],
+    });
+    expect(sandbox.writes.some((w) => w.path.includes("/skills/tenant/"))).toBe(true);
+  });
+
   it("rejects duplicate names produced by dynamic skill resolvers before writing", async () => {
     const { ctx, sandbox } = createCtx();
     const single = createResolver("foo__bar", () => makeSkill("Single"));

--- a/packages/eve/src/context/dynamic-skill-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-skill-lifecycle.ts
@@ -40,9 +40,7 @@ function qualifyDynamicSkillNames(
 
   if (keys.length === 0) return result;
 
-  // Only a directly-returned single `defineSkill` collapses to the bare slug. A
-  // map is always `slug__key`, even with one entry, so adding a second entry
-  // never renames the first. Mirrors `qualifyDynamicToolNames`.
+  // A single-entry map still qualifies as `slug__key`; only isSingle collapses.
   if (isSingle) {
     result.push({ name: slug, entryKey: keys[0]!, entry: entries[keys[0]!]! });
     return result;

--- a/packages/eve/src/context/dynamic-skill-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-skill-lifecycle.ts
@@ -40,7 +40,10 @@ function qualifyDynamicSkillNames(
 
   if (keys.length === 0) return result;
 
-  if (isSingle || keys.length === 1) {
+  // Only a directly-returned single `defineSkill` collapses to the bare slug. A
+  // map is always `slug__key`, even with one entry, so adding a second entry
+  // never renames the first. Mirrors `qualifyDynamicToolNames`.
+  if (isSingle) {
     result.push({ name: slug, entryKey: keys[0]!, entry: entries[keys[0]!]! });
     return result;
   }

--- a/packages/eve/src/evals/assertions/run.test.ts
+++ b/packages/eve/src/evals/assertions/run.test.ts
@@ -60,6 +60,20 @@ describe("run assertions", () => {
     expect((await Run.calledTool("missing").evaluate(result)).score).toBe(0);
   });
 
+  it("loadedSkill matches a load_skill call by skill id", async () => {
+    const result = makeResult({
+      derived: {
+        toolCalls: [toolCall("load_skill", { skill: "custom__talk-like-a-dog" })],
+        toolCallCount: 1,
+      },
+    });
+    expect((await Run.loadedSkill("custom__talk-like-a-dog").evaluate(result)).score).toBe(1);
+    expect((await Run.loadedSkill("talk-like-a-dog").evaluate(result)).score).toBe(0);
+    expect(Run.loadedSkill("custom__talk-like-a-dog").name).toBe(
+      "loadedSkill(custom__talk-like-a-dog)",
+    );
+  });
+
   it("usedNoTools passes only with zero tool calls", async () => {
     expect((await Run.usedNoTools().evaluate(makeResult({}))).score).toBe(1);
     expect(

--- a/packages/eve/src/evals/assertions/run.ts
+++ b/packages/eve/src/evals/assertions/run.ts
@@ -5,9 +5,11 @@ import {
   subagentCallMatches,
   testRegExp,
   toolCallMatches,
+  type EveEvalSkillLoadMatchOptions,
   type EveEvalSubagentCallMatchOptions,
   type EveEvalToolCallMatchOptions,
 } from "#evals/match.js";
+import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
 import type { AssertionOutcome, RunAssertion } from "#evals/assertions/collector.js";
 
 const PASS: AssertionOutcome = { score: 1 };
@@ -122,6 +124,19 @@ export function calledTool(name: string, options: EveEvalToolCallMatchOptions = 
       return fail(`${expectation}; ${observed}`);
     },
   };
+}
+
+/**
+ * Sugar over {@link calledTool} for the framework `load_skill` tool: asserts a
+ * skill with id `skill` was loaded. `output`/`isError`/`times` constrain the
+ * matching call exactly as for `calledTool`.
+ */
+export function loadedSkill(
+  skill: string,
+  options: EveEvalSkillLoadMatchOptions = {},
+): RunAssertion {
+  const base = calledTool(LOAD_SKILL_TOOL_NAME, { ...options, input: { skill } });
+  return { ...base, name: `loadedSkill(${skill})` };
 }
 
 /**

--- a/packages/eve/src/evals/context.ts
+++ b/packages/eve/src/evals/context.ts
@@ -79,6 +79,7 @@ export function createEvalContext(deps: {
     waiting: () => collector.recordRun(RunAssertions.waiting()),
     messageIncludes: (token) => collector.recordRun(RunAssertions.messageIncludes(token)),
     calledTool: (name, options) => collector.recordRun(RunAssertions.calledTool(name, options)),
+    loadedSkill: (skill, options) => collector.recordRun(RunAssertions.loadedSkill(skill, options)),
     notCalledTool: (name) => collector.recordRun(RunAssertions.notCalledTool(name)),
     toolOrder: (names) => collector.recordRun(RunAssertions.toolOrder(names)),
     usedNoTools: () => collector.recordRun(RunAssertions.usedNoTools()),

--- a/packages/eve/src/evals/index.ts
+++ b/packages/eve/src/evals/index.ts
@@ -16,6 +16,7 @@ export type { InputRequest } from "#runtime/input/types.js";
 export type {
   EveEvalValueMatcher,
   EveEvalToolCallMatchOptions,
+  EveEvalSkillLoadMatchOptions,
   EveEvalSubagentCallMatchOptions,
 } from "#evals/match.js";
 

--- a/packages/eve/src/evals/match.ts
+++ b/packages/eve/src/evals/match.ts
@@ -34,6 +34,13 @@ export interface EveEvalToolCallMatchOptions {
 }
 
 /**
+ * Constraints applied to a `load_skill` call by `t.loadedSkill`. Identical to
+ * {@link EveEvalToolCallMatchOptions} without `input`, which the helper fixes to
+ * the loaded skill id.
+ */
+export type EveEvalSkillLoadMatchOptions = Omit<EveEvalToolCallMatchOptions, "input">;
+
+/**
  * Constraints applied to subagent calls by `t.calledSubagent`.
  */
 export interface EveEvalSubagentCallMatchOptions {

--- a/packages/eve/src/evals/types.ts
+++ b/packages/eve/src/evals/types.ts
@@ -7,7 +7,11 @@ import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { JsonObject } from "#shared/json.js";
 import type { AgentModelOptionsDefinition } from "#shared/agent-definition.js";
 import type { EvalReporter } from "#evals/runner/reporters/types.js";
-import type { EveEvalSubagentCallMatchOptions, EveEvalToolCallMatchOptions } from "#evals/match.js";
+import type {
+  EveEvalSkillLoadMatchOptions,
+  EveEvalSubagentCallMatchOptions,
+  EveEvalToolCallMatchOptions,
+} from "#evals/match.js";
 
 /**
  * One tool call extracted from the captured stream, pairing the
@@ -285,6 +289,8 @@ export interface EveEvalContext extends EveEvalSession {
   waiting(): AssertionHandle;
   messageIncludes(token: string | RegExp): AssertionHandle;
   calledTool(name: string, options?: EveEvalToolCallMatchOptions): AssertionHandle;
+  /** Sugar for `calledTool("load_skill", { input: { skill }, ... })`. */
+  loadedSkill(skill: string, options?: EveEvalSkillLoadMatchOptions): AssertionHandle;
   notCalledTool(name: string): AssertionHandle;
   toolOrder(names: readonly string[]): AssertionHandle;
   usedNoTools(): AssertionHandle;

--- a/packages/eve/src/runtime/framework-tools/skill.test.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.test.ts
@@ -6,6 +6,27 @@ import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
 import { SKILL_TOOL_DEFINITION } from "#runtime/framework-tools/skill.js";
 import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 
+// Mirrors the helper in dynamic-skill-lifecycle.test.ts: a CompiledBundle is
+// large and mostly irrelevant here, so unused fields are stubbed `as never`
+// (the established guard-clean pattern) and only resolvedAgent.skills is real.
+function mockBundleWithSkills(skillNames: readonly string[]): CompiledBundle {
+  return {
+    adapterRegistry: undefined as never,
+    compiledArtifactsSource: undefined as never,
+    graph: undefined as never,
+    hookRegistry: undefined as never,
+    moduleMap: undefined as never,
+    nodeId: undefined,
+    resolvedAgent: {
+      config: { name: "test-agent" },
+      skills: skillNames.map((name) => ({ name })),
+    } as never,
+    subagentRegistry: undefined as never,
+    toolRegistry: undefined as never,
+    turnAgent: undefined as never,
+  };
+}
+
 describe("SKILL_TOOL_DEFINITION", () => {
   it("describes when skill loading should be used", () => {
     expect(SKILL_TOOL_DEFINITION.description).toContain(
@@ -22,9 +43,7 @@ describe("load_skill executor", () => {
   it("surfaces authored and dynamic skill names when the requested id is missing", async () => {
     const ctx = new ContextContainer();
     ctx.set(SandboxKey, mockSandbox().access);
-    ctx.set(BundleKey, {
-      resolvedAgent: { config: { name: "test-agent" }, skills: [{ name: "research" }] },
-    } as unknown as CompiledBundle);
+    ctx.set(BundleKey, mockBundleWithSkills(["research"]));
     ctx.set(DynamicSkillManifestKey, {
       custom: [{ description: "Talk like a dog", name: "custom__talk-like-a-dog" }],
     });

--- a/packages/eve/src/runtime/framework-tools/skill.test.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.test.ts
@@ -4,28 +4,6 @@ import { ContextContainer, contextStorage } from "#context/container.js";
 import { DynamicSkillManifestKey, SandboxKey } from "#context/keys.js";
 import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
 import { SKILL_TOOL_DEFINITION } from "#runtime/framework-tools/skill.js";
-import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
-
-// Mirrors the helper in dynamic-skill-lifecycle.test.ts: a CompiledBundle is
-// large and mostly irrelevant here, so unused fields are stubbed `as never`
-// (the established guard-clean pattern) and only resolvedAgent.skills is real.
-function mockBundleWithSkills(skillNames: readonly string[]): CompiledBundle {
-  return {
-    adapterRegistry: undefined as never,
-    compiledArtifactsSource: undefined as never,
-    graph: undefined as never,
-    hookRegistry: undefined as never,
-    moduleMap: undefined as never,
-    nodeId: undefined,
-    resolvedAgent: {
-      config: { name: "test-agent" },
-      skills: skillNames.map((name) => ({ name })),
-    } as never,
-    subagentRegistry: undefined as never,
-    toolRegistry: undefined as never,
-    turnAgent: undefined as never,
-  };
-}
 
 describe("SKILL_TOOL_DEFINITION", () => {
   it("describes when skill loading should be used", () => {
@@ -40,12 +18,14 @@ describe("SKILL_TOOL_DEFINITION", () => {
 });
 
 describe("load_skill executor", () => {
-  it("surfaces authored and dynamic skill names when the requested id is missing", async () => {
+  it("surfaces dynamic skill names when the requested id is missing", async () => {
     const ctx = new ContextContainer();
     ctx.set(SandboxKey, mockSandbox().access);
-    ctx.set(BundleKey, mockBundleWithSkills(["research"]));
     ctx.set(DynamicSkillManifestKey, {
-      custom: [{ description: "Talk like a dog", name: "custom__talk-like-a-dog" }],
+      custom: [
+        { description: "Talk like a dog", name: "custom__talk-like-a-dog" },
+        { description: "Bark", name: "custom__bark" },
+      ],
     });
 
     const execute = SKILL_TOOL_DEFINITION.execute;
@@ -53,6 +33,6 @@ describe("load_skill executor", () => {
 
     await expect(
       contextStorage.run(ctx, () => execute({ skill: "talk-like-a-dog" })),
-    ).rejects.toThrow("Available skills: custom__talk-like-a-dog, research.");
+    ).rejects.toThrow("Available skills: custom__bark, custom__talk-like-a-dog.");
   });
 });

--- a/packages/eve/src/runtime/framework-tools/skill.test.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { DynamicSkillManifestKey, SandboxKey } from "#context/keys.js";
+import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
 import { SKILL_TOOL_DEFINITION } from "#runtime/framework-tools/skill.js";
+import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 
 describe("SKILL_TOOL_DEFINITION", () => {
   it("describes when skill loading should be used", () => {
@@ -11,5 +15,25 @@ describe("SKILL_TOOL_DEFINITION", () => {
       "Loading adds the skill instructions to the current turn.",
     );
     expect(SKILL_TOOL_DEFINITION.description).toContain("Available skills block");
+  });
+});
+
+describe("load_skill executor", () => {
+  it("surfaces authored and dynamic skill names when the requested id is missing", async () => {
+    const ctx = new ContextContainer();
+    ctx.set(SandboxKey, mockSandbox().access);
+    ctx.set(BundleKey, {
+      resolvedAgent: { config: { name: "test-agent" }, skills: [{ name: "research" }] },
+    } as unknown as CompiledBundle);
+    ctx.set(DynamicSkillManifestKey, {
+      custom: [{ description: "Talk like a dog", name: "custom__talk-like-a-dog" }],
+    });
+
+    const execute = SKILL_TOOL_DEFINITION.execute;
+    if (execute === undefined) throw new Error("load_skill tool is missing an execute function");
+
+    await expect(
+      contextStorage.run(ctx, () => execute({ skill: "talk-like-a-dog" })),
+    ).rejects.toThrow("Available skills: custom__talk-like-a-dog, research.");
   });
 });

--- a/packages/eve/src/runtime/framework-tools/skill.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.ts
@@ -1,6 +1,7 @@
 import { loadContext } from "#context/container.js";
-import { SandboxKey } from "#context/keys.js";
+import { DynamicSkillManifestKey, SandboxKey } from "#context/keys.js";
 import { loadSkillFromSandbox } from "#runtime/skills/sandbox-access.js";
+import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
 import type { ResolvedToolDefinition } from "#runtime/types.js";
 import type { JsonObject } from "#shared/json.js";
 
@@ -29,7 +30,21 @@ async function executeLoadSkillTool(args: LoadSkillInput): Promise<unknown> {
   }
 
   const { skill } = args;
-  return await loadSkillFromSandbox(sandbox, skill);
+  return await loadSkillFromSandbox(sandbox, skill, availableSkillNames(ctx));
+}
+
+/**
+ * The skill names the model was shown in the "Available skills" section:
+ * authored skills plus every entry the dynamic skill manifest last produced.
+ * Best-effort — a missing bundle or manifest yields fewer names rather than
+ * masking the underlying "skill not found" error.
+ */
+function availableSkillNames(ctx: ReturnType<typeof loadContext>): string[] {
+  const authored = ctx.get(BundleKey)?.resolvedAgent.skills.map((s) => s.name) ?? [];
+  const dynamic = Object.values(ctx.get(DynamicSkillManifestKey) ?? {})
+    .flat()
+    .map((s) => s.name);
+  return [...new Set([...authored, ...dynamic])].sort();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/runtime/framework-tools/skill.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.ts
@@ -1,7 +1,6 @@
 import { loadContext } from "#context/container.js";
 import { DynamicSkillManifestKey, SandboxKey } from "#context/keys.js";
 import { loadSkillFromSandbox } from "#runtime/skills/sandbox-access.js";
-import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
 import type { ResolvedToolDefinition } from "#runtime/types.js";
 import type { JsonObject } from "#shared/json.js";
 
@@ -34,17 +33,22 @@ async function executeLoadSkillTool(args: LoadSkillInput): Promise<unknown> {
 }
 
 /**
- * The skill names the model was shown in the "Available skills" section:
- * authored skills plus every entry the dynamic skill manifest last produced.
- * Best-effort — a missing bundle or manifest yields fewer names rather than
- * masking the underlying "skill not found" error.
+ * The runtime-contributed (dynamic) skill names the model was shown, used to
+ * help it correct a wrong id — e.g. calling `talk-like-a-dog` when the loadable
+ * id is `custom__talk-like-a-dog`. Dynamic skills are the ones whose names are
+ * qualified at runtime (`slug__key`); authored skills already appear verbatim in
+ * the static "Available skills" prompt section, so they are not repeated here.
+ *
+ * Reads only `#context/keys.js`: a framework tool must not import heavy session
+ * modules (e.g. for the bundle), which would create an import cycle through the
+ * framework-tools barrel. Best-effort — an absent manifest yields no hint rather
+ * than masking the underlying "skill not found" error.
  */
 function availableSkillNames(ctx: ReturnType<typeof loadContext>): string[] {
-  const authored = ctx.get(BundleKey)?.resolvedAgent.skills.map((s) => s.name) ?? [];
   const dynamic = Object.values(ctx.get(DynamicSkillManifestKey) ?? {})
     .flat()
     .map((s) => s.name);
-  return [...new Set([...authored, ...dynamic])].sort();
+  return [...new Set(dynamic)].sort();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/runtime/framework-tools/skill.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.ts
@@ -32,18 +32,9 @@ async function executeLoadSkillTool(args: LoadSkillInput): Promise<unknown> {
   return await loadSkillFromSandbox(sandbox, skill, availableSkillNames(ctx));
 }
 
-/**
- * The runtime-contributed (dynamic) skill names the model was shown, used to
- * help it correct a wrong id — e.g. calling `talk-like-a-dog` when the loadable
- * id is `custom__talk-like-a-dog`. Dynamic skills are the ones whose names are
- * qualified at runtime (`slug__key`); authored skills already appear verbatim in
- * the static "Available skills" prompt section, so they are not repeated here.
- *
- * Reads only `#context/keys.js`: a framework tool must not import heavy session
- * modules (e.g. for the bundle), which would create an import cycle through the
- * framework-tools barrel. Best-effort — an absent manifest yields no hint rather
- * than masking the underlying "skill not found" error.
- */
+// Dynamic skill names for load_skill's not-found hint. Dynamic-only on purpose:
+// importing the bundle (for authored skills) would cycle through the
+// framework-tools barrel.
 function availableSkillNames(ctx: ReturnType<typeof loadContext>): string[] {
   const dynamic = Object.values(ctx.get(DynamicSkillManifestKey) ?? {})
     .flat()

--- a/packages/eve/src/runtime/skills/sandbox-access.test.ts
+++ b/packages/eve/src/runtime/skills/sandbox-access.test.ts
@@ -39,6 +39,17 @@ describe("loadSkillFromSandbox", () => {
       'No skill named "missing"',
     );
   });
+
+  it("lists available skill names when the requested id is missing", async () => {
+    const sandbox = mockSandbox();
+
+    await expect(
+      loadSkillFromSandbox(sandbox.access, "talk-like-a-dog", [
+        "custom__talk-like-a-dog",
+        "research",
+      ]),
+    ).rejects.toThrow("Available skills: custom__talk-like-a-dog, research.");
+  });
 });
 
 describe("createSandboxSkillHandle", () => {

--- a/packages/eve/src/runtime/skills/sandbox-access.ts
+++ b/packages/eve/src/runtime/skills/sandbox-access.ts
@@ -31,12 +31,8 @@ export function assertSafeSkillId(id: string): asserts id is string {
  * Returns the SKILL.md body with any YAML frontmatter stripped, so the
  * model receives plain markdown as the tool result. Throws when the id
  * is unsafe or the file does not exist; the AI SDK forwards the error
- * to the model as a tool-error result.
- *
- * When the skill is missing, `availableNames` (the names the model was
- * shown in the "Available skills" section) is appended to the error so the
- * model can correct a wrong id on its next turn — e.g. calling
- * `talk-like-a-dog` when the loadable id is `custom__talk-like-a-dog`.
+ * to the model as a tool-error result. `availableNames`, when given, is
+ * listed in the not-found error so the model can correct a wrong id.
  */
 export async function loadSkillFromSandbox(
   access: SandboxAccess,

--- a/packages/eve/src/runtime/skills/sandbox-access.ts
+++ b/packages/eve/src/runtime/skills/sandbox-access.ts
@@ -32,15 +32,26 @@ export function assertSafeSkillId(id: string): asserts id is string {
  * model receives plain markdown as the tool result. Throws when the id
  * is unsafe or the file does not exist; the AI SDK forwards the error
  * to the model as a tool-error result.
+ *
+ * When the skill is missing, `availableNames` (the names the model was
+ * shown in the "Available skills" section) is appended to the error so the
+ * model can correct a wrong id on its next turn — e.g. calling
+ * `talk-like-a-dog` when the loadable id is `custom__talk-like-a-dog`.
  */
-export async function loadSkillFromSandbox(access: SandboxAccess, id: string): Promise<string> {
+export async function loadSkillFromSandbox(
+  access: SandboxAccess,
+  id: string,
+  availableNames: readonly string[] = [],
+): Promise<string> {
   assertSafeSkillId(id);
   const sandbox = await requireSandboxSession(access);
   const path = skillFilePath(id, "SKILL.md");
   const instructions = await sandbox.readTextFile({ path });
 
   if (instructions === null) {
-    throw new Error(`No skill named "${id}" at ${path}.`);
+    const hint =
+      availableNames.length > 0 ? ` Available skills: ${availableNames.join(", ")}.` : "";
+    throw new Error(`No skill named "${id}" at ${path}.${hint}`);
   }
 
   return instructions.replace(FRONTMATTER_PATTERN, "");


### PR DESCRIPTION
A map-returning dynamic skill resolver collapsed a **single-entry** map to the bare resolver slug, so one saved skill was named `custom` instead of `custom__<key>`. `load_skill` then couldn't find it, and adding a second skill silently renamed the first.

**Fix:** drop the `|| keys.length === 1` clause in `qualifyDynamicSkillNames` so a map is always `slug__key` — matching `qualifyDynamicToolNames` and the documented contract. `load_skill` failures now also list the available skill names so the model can correct a wrong id.

Tests added; `patch` changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)