### PR TITLE
Alternative: bind Slack HITL from current auth

### DIFF
--- a/.changeset/quiet-pandas-answer.md
+++ b/.changeset/quiet-pandas-answer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Bind Slack human-in-the-loop prompts to the current Slack-authenticated caller, including when another user continues a shared thread. Answered cards hide the responder's identity; other users receive a private rejection, while stale or unauthenticated prompts explain how to recover.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -103,7 +103,7 @@ export default slackChannel({
 
 ### Human-in-the-loop (HITL)
 
-HITL renders as Slack buttons and selects. When the user responds, the parked session (paused awaiting input) resumes.
+HITL renders as Slack buttons and selects. Each prompt is bound to the current Slack-authenticated caller in `ctx.session.auth`. A click from another user is rejected privately and does not resume the parked session. Custom `onAppMention` and `onDirectMessage` handlers must preserve the Slack auth context returned by `defaultSlackAuth` for this binding to work. Prompts posted before responder binding was enabled cannot be answered after upgrading; start a new request to render a bound prompt.
 
 Authorization prompts are private. A sign-in challenge (OAuth URL, device code) is a credential. Anyone who completes it binds their identity to the session's connection. The default `authorization.required` handler delivers the challenge ephemerally to the triggering user, device code included, and posts a public link-free status only when it has no user to target. The handler receives a private-delivery context with `postEphemeral`, `postDirectMessage` (needs the `im:write` scope), and `state`. There is, intentionally, no public `post` and no raw API access.
 

--- a/packages/eve/src/internal/testing/scenario-apps/slack-hitl-authorization.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/slack-hitl-authorization.ts
@@ -1,0 +1,57 @@
+import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
+
+export const SLACK_HITL_AUTHORIZATION_DESCRIPTOR: ScenarioAppDescriptor = {
+  dependencies: {
+    zod: "^4.3.6",
+  },
+  files: {
+    "agent/agent.ts": `export default { model: "openai/gpt-5.4-mini" };
+`,
+    "agent/channels/slack.ts": `import { slackChannel } from "eve/channels/slack";
+
+export default slackChannel({
+  credentials: { botToken: "xoxb-scenario", signingSecret: "scenario-signing-secret" },
+});
+`,
+    "agent/instructions.md": "Call guarded-echo when the user requests it.\n",
+    "agent/tools/guarded-echo.ts": `import { defineTool } from "eve/tools";
+import { always } from "eve/tools/approval";
+import { z } from "zod";
+
+export default defineTool({
+  description: "Record a marker after the caller approves this operation.",
+  inputSchema: z.object({ note: z.string() }),
+  needsApproval: always(),
+  async execute(input) {
+    return { recorded: input.note };
+  },
+});
+`,
+    "slack-fetch-preload.mjs": `import { appendFile } from "node:fs/promises";
+
+const callsPath = process.env.EVE_SLACK_CALLS_PATH;
+if (!callsPath) throw new Error("EVE_SLACK_CALLS_PATH is required.");
+const originalFetch = globalThis.fetch.bind(globalThis);
+
+globalThis.fetch = async (input, init) => {
+  const url = input instanceof Request ? input.url : String(input);
+  if (!url.startsWith("https://slack.com/api/")) return originalFetch(input, init);
+
+  const body = typeof init?.body === "string" ? init.body : "";
+  const params = new URLSearchParams(body);
+  const blocks = JSON.parse(params.get("blocks") ?? "[]");
+  const actions = blocks.find((block) => block.block_id?.startsWith("eve_input_responder:"));
+  const element = actions?.elements?.find((item) => item.action_id?.startsWith("eve_input:"));
+  const card = element && {
+    actionId: element.action_id, blockId: actions.block_id, value: element.value,
+  };
+  await appendFile(callsPath, JSON.stringify({
+    api: new URL(url).pathname.slice("/api/".length), card, user: params.get("user"),
+  }) + "\\n");
+  return Response.json({ ok: true, message_ts: "1", ts: "1" });
+};
+`,
+  },
+  installDependencies: true,
+  name: "slack-hitl-authorization",
+};

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { SessionAuthContext } from "#channel/types.js";
 import type { SessionContext } from "#public/definitions/callback-context.js";
-import { defaultEvents } from "#public/channels/slack/defaults.js";
+import { buildSlackAuthContext } from "#public/channels/slack/auth.js";
+import { defaultEvents, defaultInputRequestedHandler } from "#public/channels/slack/defaults.js";
+import { buildHitlResponderBlockId } from "#public/channels/slack/hitl.js";
 import type { SlackChannelState, SlackEventContext } from "#public/channels/slack/slackChannel.js";
 
-const sessionCtx = {} as SessionContext;
+function buildSessionContext(current: SessionAuthContext | null): SessionContext {
+  return {
+    getSandbox: async () => {
+      throw new Error("not available in this test");
+    },
+    getSkill: () => {
+      throw new Error("not available in this test");
+    },
+    session: {
+      auth: { current, initiator: current },
+      id: "test-session",
+      turn: { id: "test-turn", sequence: 0 },
+    },
+  };
+}
+
+const sessionCtx = buildSessionContext(null);
 
 function buildChannelStub(state: Partial<SlackChannelState> = {}) {
   const postEphemeral = vi.fn().mockResolvedValue({ id: "eph1" });
@@ -35,6 +54,73 @@ function authRequiredEvent(
     turnId: "turn_0",
   };
 }
+
+function inputRequestedEvent() {
+  return {
+    requests: [
+      {
+        action: {
+          callId: "call-1",
+          input: {},
+          kind: "tool-call" as const,
+          toolName: "ask",
+        },
+        prompt: "Question?",
+        requestId: "request-1",
+      },
+    ],
+    sequence: 0,
+    stepIndex: 0,
+    turnId: "turn-1",
+  };
+}
+
+describe("defaultInputRequestedHandler", () => {
+  it("binds each prompt to the current Slack auth instead of channel state", async () => {
+    const { channel, post } = buildChannelStub({ triggeringUserId: "U_STALE" });
+    const handler = defaultInputRequestedHandler();
+    const slackAuth = (userId: string) =>
+      buildSlackAuthContext({
+        channelId: "C123",
+        teamId: "T123",
+        threadTs: "111.222",
+        userId,
+      });
+
+    await handler(inputRequestedEvent(), channel, buildSessionContext(slackAuth("U_FIRST")));
+    await handler(inputRequestedEvent(), channel, buildSessionContext(slackAuth("U_SECOND")));
+
+    const blockIds = post.mock.calls.map(([message]) => {
+      const blocks = (message as { blocks: Array<{ block_id?: string }> }).blocks;
+      return blocks.find((block) => block.block_id !== undefined)?.block_id;
+    });
+    expect(blockIds).toEqual(
+      ["U_FIRST", "U_SECOND"].map((responderUserId) =>
+        buildHitlResponderBlockId({ requestId: "request-1", responderUserId }),
+      ),
+    );
+  });
+
+  it("posts a visible diagnostic when the current caller is not Slack-authenticated", async () => {
+    const { channel, post } = buildChannelStub({ triggeringUserId: "U_STALE" });
+    const current: SessionAuthContext = {
+      attributes: { user_id: "U_UNTRUSTED" },
+      authenticator: "custom",
+      principalId: "app-user-1",
+      principalType: "user",
+    };
+
+    await defaultInputRequestedHandler()(
+      inputRequestedEvent(),
+      channel,
+      buildSessionContext(current),
+    );
+
+    expect(post).toHaveBeenCalledWith(
+      "I can't collect this response because the current caller is not authenticated by Slack. Start a new request from Slack to continue.",
+    );
+  });
+});
 
 describe("defaultEvents authorization.required", () => {
   it("delivers the challenge ephemerally to the triggering user and posts nothing publicly", async () => {

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -22,6 +22,8 @@ import type {
 const log = createLogger("slack.defaults");
 const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
 const REASONING_TYPING_MIN_PROGRESS_CHARS = 4;
+const UNBOUND_HITL_RESPONSE =
+  "I can't collect this response because the current caller is not authenticated by Slack. Start a new request from Slack to continue.";
 
 /**
  * Workspace-scoped projection of the Slack actor that produced
@@ -87,6 +89,12 @@ function firstNonEmptyLine(text: string): string | undefined {
   return undefined;
 }
 
+function slackResponderUserId(auth: SessionAuthContext | null): string | undefined {
+  if (auth?.authenticator !== "slack-webhook") return undefined;
+  const userId = auth.attributes["user_id"];
+  return typeof userId === "string" && userId.length > 0 ? userId : undefined;
+}
+
 /**
  * Default `input.requested` handler — renders each pending HITL
  * request as Slack `block_actions`. Buttons by default; radio for
@@ -94,11 +102,18 @@ function firstNonEmptyLine(text: string): string | undefined {
  * requests. Override by declaring `events["input.requested"]`.
  */
 export function defaultInputRequestedHandler(): NonNullable<SlackChannelEvents["input.requested"]> {
-  return async (data, channel, _ctx) => {
+  return async (data, channel, ctx) => {
     if (data.requests.length === 0) return;
+    const responderUserId = slackResponderUserId(ctx.session.auth.current);
+    if (responderUserId === undefined) {
+      await channel.thread.post(UNBOUND_HITL_RESPONSE);
+      return;
+    }
     const promptText = truncateMessageText(data.requests.map((r) => r.prompt).join("\n"));
     await channel.thread.post({
-      blocks: data.requests.flatMap(renderInputRequestBlocks),
+      blocks: data.requests.flatMap((request) =>
+        renderInputRequestBlocks(request, responderUserId),
+      ),
       text: promptText,
     });
   };

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -4,6 +4,7 @@ import type { InputRequest } from "#runtime/input/types.js";
 import {
   buildAnsweredBlocks,
   buildFreeformModalView,
+  buildHitlResponderBlockId,
   deriveHitlResponse,
   freeformRequestIdFromActionId,
   HITL_ACTION_PREFIX,
@@ -24,6 +25,10 @@ function makeRequest(overrides: Partial<InputRequest>): InputRequest {
     requestId: "call_abc123",
     ...overrides,
   };
+}
+
+function makeResponderBlockId(responderUserId: string, requestId: string): string {
+  return buildHitlResponderBlockId({ requestId, responderUserId });
 }
 
 describe("deriveHitlResponse", () => {
@@ -80,6 +85,13 @@ describe("isHitlAction", () => {
 });
 
 describe("renderInputRequestBlocks", () => {
+  it("keeps responder block ids bounded and unique for long request ids", () => {
+    const firstBlockId = makeResponderBlockId("U0123456789", "a".repeat(230));
+    const secondBlockId = makeResponderBlockId("U0123456789", `${"a".repeat(229)}b`);
+    expect(firstBlockId.length).toBeLessThanOrEqual(255);
+    expect(secondBlockId).not.toBe(firstBlockId);
+  });
+
   it("emits a section + buttons block for an option list with no display hint", () => {
     const blocks = renderInputRequestBlocks(
       makeRequest({
@@ -88,6 +100,7 @@ describe("renderInputRequestBlocks", () => {
           { id: "deny", label: "Deny", style: "danger" },
         ],
       }),
+      "U01",
     );
 
     expect(blocks).toHaveLength(2);
@@ -98,6 +111,12 @@ describe("renderInputRequestBlocks", () => {
       elements: Array<Record<string, unknown>>;
     };
     expect(actions.type).toBe("actions");
+    expect(actions).toMatchObject({
+      block_id: buildHitlResponderBlockId({
+        requestId: "call_abc123",
+        responderUserId: "U01",
+      }),
+    });
     expect(actions.elements).toHaveLength(2);
     const actionIds = actions.elements.map((element) => element.action_id);
     expect(new Set(actionIds).size).toBe(actionIds.length);
@@ -124,6 +143,7 @@ describe("renderInputRequestBlocks", () => {
           { id: "weekly", label: "Weekly", description: "Best for low-volume reports" },
         ],
       }),
+      "U01",
     );
 
     const actions = blocks[1] as {
@@ -156,6 +176,7 @@ describe("renderInputRequestBlocks", () => {
         display: "select",
         options,
       }),
+      "U01",
     );
 
     const actions = blocks[1] as {
@@ -172,7 +193,10 @@ describe("renderInputRequestBlocks", () => {
   });
 
   it("renders a 'Type your answer' freeform button when the request has no options", () => {
-    const blocks = renderInputRequestBlocks(makeRequest({ prompt: "What's the date range?" }));
+    const blocks = renderInputRequestBlocks(
+      makeRequest({ prompt: "What's the date range?" }),
+      "U01",
+    );
 
     expect(blocks).toHaveLength(2);
     const actions = blocks[1] as { type: string; elements: Array<Record<string, unknown>> };
@@ -194,6 +218,7 @@ describe("renderInputRequestBlocks", () => {
         allowFreeform: true,
         options: [{ id: "yes", label: "Yes" }],
       }),
+      "U01",
     );
     // current behavior: options take precedence; freeform button is the
     // fallback when no options are supplied. This documents the
@@ -212,7 +237,7 @@ describe("renderInputRequestBlocks", () => {
       options: [{ id: "yes_please", label: "Yes please" }],
     });
 
-    const blocks = renderInputRequestBlocks(request);
+    const blocks = renderInputRequestBlocks(request, "U01");
     const button = (blocks[1] as { elements: Array<{ action_id: string; value: string }> })
       .elements[0]!;
 
@@ -238,7 +263,7 @@ describe("renderInputRequestBlocks", () => {
 
   it("truncates section-block prompts past the Slack 3000-char cap", () => {
     const longPrompt = "x".repeat(SLACK_SECTION_TEXT_MAX_LENGTH + 500);
-    const blocks = renderInputRequestBlocks(makeRequest({ prompt: longPrompt }));
+    const blocks = renderInputRequestBlocks(makeRequest({ prompt: longPrompt }), "U01");
     const promptBlock = blocks[0] as { text: { text: string } };
     expect(promptBlock.text.text.length).toBeLessThanOrEqual(SLACK_SECTION_TEXT_MAX_LENGTH);
     expect(promptBlock.text.text.endsWith("...")).toBe(true);
@@ -251,7 +276,7 @@ describe("renderInputRequestBlocks", () => {
       options: [{ id: "weekly_report", label: "Weekly report" }],
     });
 
-    const blocks = renderInputRequestBlocks(request);
+    const blocks = renderInputRequestBlocks(request, "U01");
     const widget = (
       blocks[1] as { elements: Array<{ action_id: string; options: Array<{ value: string }> }> }
     ).elements[0]!;
@@ -276,6 +301,7 @@ describe("buildFreeformModalView", () => {
         threadTs: "1.0",
         messageTs: "1.1",
         requestId: "call_abc",
+        responderBlockId: makeResponderBlockId("U01", "call_abc"),
       },
       prompt: "What's the date range?",
     });
@@ -303,6 +329,7 @@ describe("buildFreeformModalView", () => {
         threadTs: "1.0",
         messageTs: "1.1",
         requestId: "call_abc",
+        responderBlockId: makeResponderBlockId("U01", "call_abc"),
       },
       prompt: longPrompt,
     });
@@ -320,6 +347,7 @@ describe("buildFreeformModalView", () => {
         threadTs: "1.0",
         messageTs: "1.1",
         requestId: "call_abc",
+        responderBlockId: makeResponderBlockId("U01", "call_abc"),
       },
     });
     const blocks = view.blocks as Array<Record<string, unknown>>;
@@ -328,7 +356,7 @@ describe("buildFreeformModalView", () => {
 });
 
 describe("buildAnsweredBlocks", () => {
-  it("preserves the prompt block, appends a confirmation, and attributes the click", () => {
+  it("preserves the prompt and appends the answer confirmation", () => {
     const promptBlock = {
       type: "section",
       text: { type: "mrkdwn", text: "Approve deploy?" },
@@ -336,21 +364,17 @@ describe("buildAnsweredBlocks", () => {
     const blocks = buildAnsweredBlocks({
       promptBlock,
       answerLabel: "Approve",
-      userId: "U01",
     });
-    expect(blocks).toHaveLength(3);
+
+    expect(blocks).toHaveLength(2);
     expect(blocks[0]).toBe(promptBlock);
     expect(blocks[1]).toMatchObject({
       type: "section",
       text: { text: ":white_check_mark: *Approve*", type: "mrkdwn" },
     });
-    expect(blocks[2]).toMatchObject({
-      type: "context",
-      elements: [{ type: "mrkdwn", text: "Answered by <@U01>" }],
-    });
   });
 
-  it("omits the attribution block when no userId is supplied", () => {
+  it("renders the confirmation without a prompt block", () => {
     const blocks = buildAnsweredBlocks({ promptBlock: undefined, answerLabel: "Deny" });
     expect(blocks).toHaveLength(1);
     expect(blocks[0]).toMatchObject({

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -12,6 +12,8 @@
  * UX grounds without changing the read path.
  */
 
+import { createHash } from "node:crypto";
+
 import {
   truncateModalTitle,
   truncatePlainText,
@@ -25,6 +27,15 @@ import type { InputRequest } from "#runtime/input/types.js";
  * interactive widgets can avoid collisions.
  */
 export const HITL_ACTION_PREFIX = "eve_input:";
+
+/**
+ * `block_id` prefix that binds a rendered HITL request to the Slack user
+ * allowed to answer it. Slack returns the block id unchanged in its signed
+ * interaction payload, so the inbound handler can reject cross-user clicks
+ * before resuming the parked turn. The request digest also keeps every actions
+ * block unique when one message contains multiple requests.
+ */
+export const HITL_RESPONDER_BLOCK_PREFIX = "eve_input_responder:";
 
 /**
  * `action_id` prefix for the "Type your answer" button that opens a
@@ -83,6 +94,21 @@ interface DerivedHitlResponse {
 }
 
 /**
+ * Builds the bounded Slack block id that binds one request to one responder.
+ * Hashing the pair keeps the wire value below Slack's 255-character limit
+ * regardless of request-id length.
+ */
+export function buildHitlResponderBlockId(input: {
+  readonly requestId: string;
+  readonly responderUserId: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify([input.responderUserId, input.requestId]))
+    .digest("base64url");
+  return `${HITL_RESPONDER_BLOCK_PREFIX}${digest}`;
+}
+
+/**
  * Decodes one Slack interactivity action into an HITL response, or
  * returns `null` when the action does not match an HITL widget the
  * framework rendered.
@@ -132,12 +158,19 @@ export function isHitlAction(actionId: string): boolean {
  *
  * Always emits at least the prompt section.
  */
-export function renderInputRequestBlocks(request: InputRequest): unknown[] {
+export function renderInputRequestBlocks(
+  request: InputRequest,
+  responderUserId: string,
+): unknown[] {
   const prompt = {
     text: { text: truncateSectionText(request.prompt), type: "mrkdwn" },
     type: "section",
   };
   const actionId = `${HITL_ACTION_PREFIX}${request.requestId}`;
+  const blockId = buildHitlResponderBlockId({
+    requestId: request.requestId,
+    responderUserId,
+  });
 
   const options = request.options;
   const acceptsFreeform = request.allowFreeform === true || !options || options.length === 0;
@@ -152,7 +185,7 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
             options: options.map(buildOption),
             placeholder: { type: "plain_text", text: "Choose an option" },
           };
-    return [prompt, { type: "actions", elements: [widget] }];
+    return [prompt, { type: "actions", block_id: blockId, elements: [widget] }];
   }
 
   if (options && options.length > 0) {
@@ -160,6 +193,7 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
       prompt,
       {
         type: "actions",
+        block_id: blockId,
         elements: options.map((opt, index) => buildButton(opt, actionId, index)),
       },
     ];
@@ -170,6 +204,7 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
       prompt,
       {
         type: "actions",
+        block_id: blockId,
         elements: [
           {
             type: "button",
@@ -198,6 +233,7 @@ export interface HitlFreeformModalMetadata {
   readonly threadTs: string;
   readonly messageTs: string;
   readonly requestId: string;
+  readonly responderBlockId: string;
 }
 
 /**
@@ -288,8 +324,7 @@ function buildOption(opt: NonNullable<InputRequest["options"]>[number]): Record<
 /**
  * Renders the "answered" replacement blocks for a previously-posted
  * HITL card. Preserves the original prompt block (so context stays
- * visible), appends a confirmation line naming the chosen answer, and
- * attributes the click to the user when their id is known.
+ * visible) and appends a confirmation line naming the chosen answer.
  *
  * Slack's `chat.update` replaces every block in one shot, so the caller
  * passes the full list to `blocks` and the rendered fallback text to
@@ -298,7 +333,6 @@ function buildOption(opt: NonNullable<InputRequest["options"]>[number]): Record<
 export function buildAnsweredBlocks(input: {
   readonly promptBlock: unknown;
   readonly answerLabel: string;
-  readonly userId?: string;
 }): unknown[] {
   const blocks: unknown[] = [];
   if (input.promptBlock !== undefined && input.promptBlock !== null) {
@@ -308,11 +342,5 @@ export function buildAnsweredBlocks(input: {
     type: "section",
     text: { type: "mrkdwn", text: `:white_check_mark: *${input.answerLabel}*` },
   });
-  if (input.userId && input.userId.length > 0) {
-    blocks.push({
-      type: "context",
-      elements: [{ type: "mrkdwn", text: `Answered by <@${input.userId}>` }],
-    });
-  }
   return blocks;
 }

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -25,6 +25,7 @@ import {
 } from "#public/channels/slack/api.js";
 import { buildSlackAuthContext } from "#public/channels/slack/auth.js";
 import {
+  buildHitlResponderBlockId,
   buildAnsweredBlocks,
   buildFreeformModalView,
   deriveHitlResponse,
@@ -32,6 +33,7 @@ import {
   HITL_FREEFORM_MODAL_ACTION_ID,
   HITL_FREEFORM_MODAL_BLOCK_ID,
   HITL_FREEFORM_MODAL_CALLBACK_ID,
+  HITL_RESPONDER_BLOCK_PREFIX,
   isFreeformAction,
   isHitlAction,
   type HitlFreeformModalMetadata,
@@ -46,6 +48,9 @@ import type {
 import type { SendFn } from "#public/definitions/defineChannel.js";
 
 const log = createLogger("slack.interactions");
+const UNAUTHORIZED_HITL_RESPONSE = "Only the person who requested this action can respond to it.";
+const UNBOUND_HITL_RESPONSE =
+  "This prompt is no longer valid. Start a new request so it can be bound to your Slack identity.";
 
 /**
  * Decoded view of a Slack `block_actions` payload. Returned by
@@ -63,6 +68,8 @@ interface ParsedBlockActionsPayload {
    */
   readonly messageBlocks: readonly unknown[];
 }
+
+type HitlRejectionReason = "unauthorized" | "unbound";
 
 /**
  * Decodes a Slack `block_actions` payload into a {@link ParsedBlockActionsPayload}.
@@ -198,10 +205,43 @@ export async function handleInteractionPost(
   const interaction = parseBlockActionsPayload(payload);
   if (!interaction) return ack;
 
-  const freeformAction = interaction.actions.find((a) => isFreeformAction(a.actionId));
-  if (freeformAction) {
-    await openFreeformModal({ payload, interaction, freeformAction, deps });
-    return ack;
+  const hitlAction = interaction.actions.find(
+    (action) => isFreeformAction(action.actionId) || isHitlAction(action.actionId),
+  );
+  if (hitlAction) {
+    const freeform = isFreeformAction(hitlAction.actionId);
+    const requestId = freeform
+      ? freeformRequestIdFromActionId(hitlAction.actionId)
+      : deriveHitlResponse(hitlAction)?.requestId;
+    if (
+      !requestId ||
+      hitlAction.blockId !==
+        buildHitlResponderBlockId({ requestId, responderUserId: hitlAction.user.id })
+    ) {
+      queueHitlRejectionNotice({
+        channelId: interaction.channelId,
+        ctx,
+        deps,
+        reason: hitlAction.blockId?.startsWith(HITL_RESPONDER_BLOCK_PREFIX)
+          ? "unauthorized"
+          : "unbound",
+        teamId: interaction.teamId,
+        threadTs: interaction.threadTs,
+        userId: hitlAction.user.id,
+      });
+      return ack;
+    }
+    if (freeform) {
+      await openFreeformModal({
+        payload,
+        interaction,
+        freeformAction: hitlAction,
+        requestId,
+        responderBlockId: hitlAction.blockId,
+        deps,
+      });
+      return ack;
+    }
   }
 
   const continuationToken = slackContinuationToken(interaction.channelId, interaction.threadTs);
@@ -274,18 +314,13 @@ async function openFreeformModal(input: {
   readonly payload: Record<string, unknown>;
   readonly interaction: ParsedBlockActionsPayload;
   readonly freeformAction: SlackInteractionAction;
+  readonly requestId: string;
+  readonly responderBlockId: string;
   readonly deps: InteractionHandlerDeps;
 }): Promise<void> {
   const triggerId = (input.payload as { trigger_id?: unknown }).trigger_id;
   if (typeof triggerId !== "string" || triggerId.length === 0) {
     log.warn("freeform button click missing trigger_id — cannot open modal");
-    return;
-  }
-
-  const requestId =
-    freeformRequestIdFromActionId(input.freeformAction.actionId) ?? input.freeformAction.value;
-  if (!requestId) {
-    log.warn("freeform button click missing requestId");
     return;
   }
 
@@ -303,7 +338,8 @@ async function openFreeformModal(input: {
     channelId: input.interaction.channelId,
     threadTs: input.interaction.threadTs,
     messageTs,
-    requestId,
+    requestId: input.requestId,
+    responderBlockId: input.responderBlockId,
   };
 
   const promptText = readPromptTextFromBlocks(input.interaction.messageBlocks);
@@ -329,7 +365,7 @@ async function handleViewSubmission(
     send: SendFn<SlackChannelState>;
     waitUntil: (task: Promise<unknown>) => void;
   },
-  _deps: InteractionHandlerDeps,
+  deps: InteractionHandlerDeps,
 ): Promise<Response> {
   const ack = new Response("ok", { status: 200 });
   const view = payload.view as
@@ -355,6 +391,7 @@ async function handleViewSubmission(
     !metadata.requestId ||
     !metadata.messageTs ||
     !metadata.channelId ||
+    !metadata.responderBlockId ||
     !metadata.threadTs
   ) {
     return ack;
@@ -371,6 +408,25 @@ async function handleViewSubmission(
   const user = payload.user as { id: string; team_id?: string; username?: string; name?: string };
   const triggeringUserId = user.id;
   const teamId = user.team_id ?? team?.id ?? null;
+
+  if (
+    metadata.responderBlockId !==
+    buildHitlResponderBlockId({
+      requestId: metadata.requestId,
+      responderUserId: triggeringUserId,
+    })
+  ) {
+    queueHitlRejectionNotice({
+      channelId: metadata.channelId,
+      ctx,
+      deps,
+      reason: "unauthorized",
+      teamId: teamId ?? undefined,
+      threadTs: metadata.threadTs,
+      userId: triggeringUserId,
+    });
+    return ack;
+  }
 
   ctx.waitUntil(
     ctx
@@ -403,14 +459,40 @@ async function handleViewSubmission(
       channelId: metadata.channelId,
       messageTs: metadata.messageTs,
       answerLabel: text,
-      userId: triggeringUserId ?? undefined,
-      deps: _deps,
+      deps,
     }).catch((error: unknown) => {
       log.error("freeform answered-card update failed", { error });
     }),
   );
 
   return ack;
+}
+
+function queueHitlRejectionNotice(input: {
+  readonly channelId: string;
+  readonly ctx: { waitUntil: (task: Promise<unknown>) => void };
+  readonly deps: InteractionHandlerDeps;
+  readonly reason: HitlRejectionReason;
+  readonly teamId: string | undefined;
+  readonly threadTs: string;
+  readonly userId: string;
+}): void {
+  const { thread } = buildSlackBinding({
+    botToken: input.deps.config.credentials?.botToken,
+    channelId: input.channelId,
+    teamId: input.teamId,
+    threadTs: input.threadTs,
+  });
+  input.ctx.waitUntil(
+    thread
+      .postEphemeral(
+        input.userId,
+        input.reason === "unbound" ? UNBOUND_HITL_RESPONSE : UNAUTHORIZED_HITL_RESPONSE,
+      )
+      .catch((error: unknown) => {
+        log.error("HITL rejection notice failed", { error });
+      }),
+  );
 }
 
 async function updateAnsweredHitlCard(
@@ -426,7 +508,6 @@ async function updateAnsweredHitlCard(
   const blocks = buildAnsweredBlocks({
     promptBlock: findPromptBlock(interaction.messageBlocks),
     answerLabel,
-    userId: hitlAction.user.id,
   });
 
   const token = await resolveSlackBotToken(deps.config.credentials?.botToken);
@@ -452,13 +533,11 @@ async function updateAnsweredFreeformCard(input: {
   readonly channelId: string;
   readonly messageTs: string;
   readonly answerLabel: string;
-  readonly userId?: string;
   readonly deps: InteractionHandlerDeps;
 }): Promise<void> {
   const blocks = buildAnsweredBlocks({
     promptBlock: undefined,
     answerLabel: input.answerLabel,
-    userId: input.userId,
   });
   const token = await resolveSlackBotToken(input.deps.config.credentials?.botToken);
   const response = await fetch("https://slack.com/api/chat.update", {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -10,8 +10,11 @@ import { ContextContainer, contextStorage } from "#context/container.js";
 import { SessionKey } from "#context/keys.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import { decodeSlackApiBody } from "#public/channels/slack/api-encoding.js";
+import { buildSlackAuthContext } from "#public/channels/slack/auth.js";
 import {
+  buildHitlResponderBlockId,
   HITL_ACTION_PREFIX,
+  HITL_FREEFORM_ACTION_PREFIX,
   HITL_FREEFORM_MODAL_ACTION_ID,
   HITL_FREEFORM_MODAL_BLOCK_ID,
   HITL_FREEFORM_MODAL_CALLBACK_ID,
@@ -65,9 +68,15 @@ function stubAccessor() {
 
 const stubAlsContext = (() => {
   const ctx = new ContextContainer();
+  const current = buildSlackAuthContext({
+    channelId: "C01",
+    teamId: "T01",
+    threadTs: "1700000000.000001",
+    userId: "U_REQUESTER",
+  });
   ctx.setVirtualContext(SessionKey, {
     sessionId: "test-session",
-    auth: { current: null, initiator: null },
+    auth: { current, initiator: current },
     turn: { id: "test-turn", sequence: 0 },
   });
   return ctx;
@@ -370,6 +379,12 @@ describe("slackChannel() default event handlers", () => {
     });
 
     const actions = body.blocks.find((block) => Array.isArray(block.elements));
+    expect(actions).toMatchObject({
+      block_id: buildHitlResponderBlockId({
+        requestId: "approval_abc123",
+        responderUserId: "U_REQUESTER",
+      }),
+    });
     const actionIds = actions?.elements?.map((element) => element.action_id) ?? [];
     expect(actionIds).toEqual([
       `${HITL_ACTION_PREFIX}approval_abc123:button:0`,
@@ -1236,6 +1251,10 @@ describe("slackChannel() HITL interaction pipeline", () => {
         actions: [
           {
             action_id: `${HITL_ACTION_PREFIX}approval_abc123:button:0`,
+            block_id: buildHitlResponderBlockId({
+              requestId: "approval_abc123",
+              responderUserId: "U_APPROVER",
+            }),
             text: { type: "plain_text", text: "Approve" },
             value: "approve",
           },
@@ -1271,11 +1290,104 @@ describe("slackChannel() HITL interaction pipeline", () => {
         triggeringUserId: "U_APPROVER",
       },
     });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://slack.com/api/chat.update");
+    const updateBody = parseSlackRequestBody(init as RequestInit);
+    expect(JSON.stringify(updateBody.blocks)).not.toContain("U_APPROVER");
+  });
+
+  it("rejects HITL buttons from another user", async () => {
+    const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
+    const { send } = await firePost(
+      channel,
+      buildSignedInteractionRequest({
+        actions: [
+          {
+            action_id: `${HITL_ACTION_PREFIX}approval_abc123:button:0`,
+            block_id: buildHitlResponderBlockId({
+              requestId: "approval_abc123",
+              responderUserId: "U_OWNER",
+            }),
+            value: "approve",
+          },
+        ],
+        channel: { id: "C01" },
+        message: { ts: "1700000000.000010" },
+        team: { id: "T01" },
+        type: "block_actions",
+        user: { id: "U_INTRUDER" },
+      }),
+    );
+
+    expect(send).not.toHaveBeenCalled();
+    expect(String(fetchMock.mock.calls[0]![0])).toBe("https://slack.com/api/chat.postEphemeral");
+  });
+
+  it("opens a freeform modal for the bound Slack user", async () => {
+    const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
+
+    await firePost(
+      channel,
+      buildSignedInteractionRequest({
+        actions: [
+          {
+            action_id: `${HITL_FREEFORM_ACTION_PREFIX}call_abc123`,
+            block_id: buildHitlResponderBlockId({
+              requestId: "call_abc123",
+              responderUserId: "U_OWNER",
+            }),
+            value: "call_abc123",
+          },
+        ],
+        channel: { id: "C01" },
+        message: { thread_ts: "1700000000.000001", ts: "1700000000.000010" },
+        team: { id: "T01" },
+        trigger_id: "trigger-1",
+        type: "block_actions",
+        user: { id: "U_OWNER" },
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const requestBody = JSON.parse(String((init as RequestInit).body)) as {
+      view: { private_metadata: string };
+    };
+    const metadata = JSON.parse(requestBody.view.private_metadata) as Record<string, unknown>;
+    expect(metadata.responderBlockId).toBe(
+      buildHitlResponderBlockId({
+        requestId: "call_abc123",
+        responderUserId: "U_OWNER",
+      }),
+    );
+
+    fetchMock.mockClear();
+    const rejected = await firePost(
+      channel,
+      buildSignedInteractionRequest({
+        team: { id: "T01" },
+        type: "view_submission",
+        user: { id: "U_INTRUDER" },
+        view: {
+          callback_id: HITL_FREEFORM_MODAL_CALLBACK_ID,
+          private_metadata: requestBody.view.private_metadata,
+          state: {
+            values: {
+              [HITL_FREEFORM_MODAL_BLOCK_ID]: {
+                [HITL_FREEFORM_MODAL_ACTION_ID]: { value: "delete it" },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(rejected.send).not.toHaveBeenCalled();
+    expect(String(fetchMock.mock.calls[0]![0])).toBe("https://slack.com/api/chat.postEphemeral");
   });
 
   it("resumes freeform modal answers with the submitting Slack user auth", async () => {
     const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
-
     const { send } = await firePost(
       channel,
       buildSignedInteractionRequest({
@@ -1294,6 +1406,10 @@ describe("slackChannel() HITL interaction pipeline", () => {
             continuationToken: "C01:1700000000.000001",
             messageTs: "1700000000.000010",
             requestId: "call_abc123",
+            responderBlockId: buildHitlResponderBlockId({
+              requestId: "call_abc123",
+              responderUserId: "U_SUBMITTER",
+            }),
             threadTs: "1700000000.000001",
           }),
           state: {

--- a/packages/eve/test/scenarios/slack-hitl-authorization.scenario.test.ts
+++ b/packages/eve/test/scenarios/slack-hitl-authorization.scenario.test.ts
@@ -1,0 +1,248 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHmac } from "node:crypto";
+import { once } from "node:events";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { SLACK_HITL_AUTHORIZATION_DESCRIPTOR } from "#internal/testing/scenario-apps/slack-hitl-authorization.js";
+import { useScenarioApp } from "#internal/testing/scenario-app.js";
+import { stripAnsi } from "#cli/dev/tui/terminal-text.js";
+
+const SIGNING_SECRET = "scenario-signing-secret";
+const CHANNEL_ID = "C_SCENARIO";
+const TEAM_ID = "T_SCENARIO";
+const THREAD_TS = "1700000000.000001";
+const USER_A = "U_OWNER_A";
+const USER_B = "U_OWNER_B";
+
+const hitlCardSchema = z.object({
+  actionId: z.string(),
+  blockId: z.string(),
+  value: z.string(),
+});
+type HitlCard = z.infer<typeof hitlCardSchema>;
+
+const slackCallSchema = z.object({
+  api: z.string(),
+  card: hitlCardSchema.optional(),
+  user: z.string().nullable(),
+});
+type SlackCall = z.infer<typeof slackCallSchema>;
+
+const scenarioApp = useScenarioApp();
+
+describe("Slack HITL authorization contract", () => {
+  it("binds each durable prompt to the current Slack-authenticated caller", async () => {
+    const app = await scenarioApp(SLACK_HITL_AUTHORIZATION_DESCRIPTOR);
+    const callsPath = join(app.appRoot, "slack-calls.jsonl");
+    await writeFile(callsPath, "");
+    const server = await startEveDev(app.appRoot, callsPath);
+
+    try {
+      expect((await postSlack(server.url, mention(USER_A, "owner-a", "000003"))).status).toBe(200);
+      const firstCard = await waitFor("first HITL card", async () =>
+        findCard(await readCalls(callsPath), 0),
+      );
+      const sessionRunIds = await waitFor("durable Slack session", async () => {
+        const ids = await readSessionRunIds(app.appRoot);
+        return ids.length === 1 ? ids : null;
+      });
+
+      let callIndex = (await readCalls(callsPath)).length;
+      expect((await postSlack(server.url, interaction(firstCard, USER_A))).status).toBe(200);
+      await waitFor("first completed reply", async () =>
+        findCall(await readCalls(callsPath), callIndex, "chat.postMessage"),
+      );
+
+      callIndex = (await readCalls(callsPath)).length;
+      expect((await postSlack(server.url, mention(USER_B, "owner-b", "000004"))).status).toBe(200);
+      const secondCard = await waitFor("second HITL card", async () =>
+        findCard(await readCalls(callsPath), callIndex),
+      );
+      expect(secondCard.blockId).not.toBe(firstCard.blockId);
+      expect(await readSessionRunIds(app.appRoot)).toEqual(sessionRunIds);
+
+      callIndex = (await readCalls(callsPath)).length;
+      expect((await postSlack(server.url, interaction(secondCard, USER_A))).status).toBe(200);
+      await waitFor("stale-user rejection", async () =>
+        findCall(await readCalls(callsPath), callIndex, "chat.postEphemeral", USER_A),
+      );
+      expect(findCall(await readCalls(callsPath), callIndex, "chat.update")).toBeNull();
+
+      callIndex = (await readCalls(callsPath)).length;
+      expect((await postSlack(server.url, interaction(secondCard, USER_B))).status).toBe(200);
+      await waitFor("second completed reply", async () =>
+        findCall(await readCalls(callsPath), callIndex, "chat.postMessage"),
+      );
+    } finally {
+      await server.stop();
+    }
+  }, 360_000);
+});
+
+async function startEveDev(appRoot: string, callsPath: string) {
+  const preload = pathToFileURL(join(appRoot, "slack-fetch-preload.mjs")).href;
+  const child = spawn(
+    process.execPath,
+    [join(appRoot, "node_modules", "eve", "bin", "eve.js"), "dev", "--no-ui", "--port", "0"],
+    {
+      cwd: appRoot,
+      env: {
+        ...process.env,
+        EVE_SLACK_CALLS_PATH: callsPath,
+        NODE_ENV: "test",
+        NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${preload}`].filter(Boolean).join(" "),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let output = "";
+  child.stdout.setEncoding("utf8").on("data", (chunk: string) => (output += chunk));
+  child.stderr.setEncoding("utf8").on("data", (chunk: string) => (output += chunk));
+
+  try {
+    const url = await waitFor(
+      "eve dev server URL",
+      () => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(`eve dev exited before startup.\n${output}`);
+        }
+        return /server listening at (https?:\/\/\S+)/u.exec(stripAnsi(output))?.[1] ?? null;
+      },
+      120_000,
+    );
+    return { url, stop: () => stopProcess(child) };
+  } catch (error) {
+    await stopProcess(child);
+    throw error;
+  }
+}
+
+async function stopProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exit = once(child, "exit");
+  const killTimer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+  killTimer.unref();
+  child.kill("SIGTERM");
+  await exit;
+  clearTimeout(killTimer);
+}
+
+async function postSlack(serverUrl: string, payload: Record<string, unknown>): Promise<Response> {
+  const isInteraction = payload.type === "block_actions";
+  const body = isInteraction
+    ? new URLSearchParams({ payload: JSON.stringify(payload) }).toString()
+    : JSON.stringify(payload);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = createHmac("sha256", SIGNING_SECRET)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex");
+  return await fetch(new URL("/eve/v1/slack", serverUrl), {
+    body,
+    headers: {
+      "content-type": isInteraction ? "application/x-www-form-urlencoded" : "application/json",
+      "x-slack-request-timestamp": String(timestamp),
+      "x-slack-signature": `v0=${signature}`,
+    },
+    method: "POST",
+  });
+}
+
+function mention(user: string, note: string, suffix: string): Record<string, unknown> {
+  const ts = `1700000000.${suffix}`;
+  return {
+    event: {
+      channel: CHANNEL_ID,
+      event_ts: ts,
+      text: `Use guarded-echo exactly once with note "${note}".`,
+      thread_ts: THREAD_TS,
+      ts,
+      type: "app_mention",
+      user,
+    },
+    event_id: `Ev_${note}`,
+    team_id: TEAM_ID,
+    type: "event_callback",
+  };
+}
+
+function interaction(card: HitlCard, user: string): Record<string, unknown> {
+  return {
+    actions: [
+      {
+        action_id: card.actionId,
+        block_id: card.blockId,
+        value: card.value,
+      },
+    ],
+    channel: { id: CHANNEL_ID },
+    message: { thread_ts: THREAD_TS, ts: "1" },
+    team: { id: TEAM_ID },
+    type: "block_actions",
+    user: { id: user, team_id: TEAM_ID },
+  };
+}
+
+async function readCalls(path: string): Promise<SlackCall[]> {
+  return (await readFile(path, "utf8"))
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const value: unknown = JSON.parse(line);
+      return slackCallSchema.parse(value);
+    });
+}
+
+function findCard(calls: readonly SlackCall[], start: number): HitlCard | null {
+  return (
+    calls.slice(start).find((call) => call.api === "chat.postMessage" && call.card)?.card ?? null
+  );
+}
+
+function findCall(
+  calls: readonly SlackCall[],
+  start: number,
+  api: string,
+  user?: string,
+): SlackCall | null {
+  return (
+    calls
+      .slice(start)
+      .find((call) => call.api === api && (user === undefined || call.user === user)) ?? null
+  );
+}
+
+async function readSessionRunIds(appRoot: string): Promise<string[]> {
+  const root = join(appRoot, ".workflow-data", "runs");
+  const entries = await readdir(root).catch(() => []);
+  const runs = await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith(".json"))
+      .map(async (entry) => {
+        const value: unknown = JSON.parse(await readFile(join(root, entry), "utf8"));
+        return z.object({ runId: z.string(), workflowName: z.string() }).parse(value);
+      }),
+  );
+  return runs
+    .filter((run) => run.workflowName === "workflow//eve//workflowEntry")
+    .map((run) => run.runId)
+    .sort();
+}
+
+async function waitFor<T>(
+  description: string,
+  load: () => T | null | Promise<T | null>,
+  timeout = 30_000,
+): Promise<T> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const value = await load();
+    if (value !== null) return value;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${description}.`);
+}


### PR DESCRIPTION
## Summary

This is a channel-only alternative to #142.

- Derive the allowed responder from `ctx.session.auth.current` inside Slack's default `input.requested` handler.
- Bind each Slack HITL block to that user and reject mismatched signed button clicks or modal submissions.
- Keep responder identity out of answered cards.
- Fail closed with recovery guidance when the prompt has no Slack-authenticated caller or predates responder binding.

Production changes stay in `defaults.ts`, `hitl.ts`, and `interactions.ts`. This does not change generic `send()`, harness delivery, or `slackChannel.ts`.

## Hypothesis

This approach works if the verified Slack actor remains the current caller identity through the harness. The default `onAppMention` and `onDirectMessage` handlers already satisfy that contract.

## Known limitation

Built-in Slack HITL only works when Slack auth remains the current session auth. This includes the default inbound handlers and custom handlers that return `defaultSlackAuth(message, ctx)` or preserve its `slack-webhook` authenticator and `user_id` attribute.

A custom `onAppMention` or `onDirectMessage` handler may instead replace session auth with an application principal. In that configuration, `input.requested` cannot recover the verified Slack actor from `ctx.session.auth.current`, so it does not render the HITL controls and fails closed. This PR does not support custom session auth and built-in Slack HITL together.

#142 carries the verified Slack actor independently of session auth and supports that combination. The Slack Dev Sandbox screenshots below exercise this PR's supported default-auth path; they do not cover custom session auth.

## Verification

### Full Slack scenario

`packages/eve/test/scenarios/slack-hitl-authorization.scenario.test.ts` boots a real `eve dev` process, sends signed Slack webhook and interaction payloads through the Slack channel route, and records outbound Slack API calls. It verifies that:

- User A creates and answers the first approval prompt.
- User B continues the same durable Slack thread and receives a prompt bound to User B.
- Both turns use the same durable session.
- User A is privately rejected from User B's prompt without updating the card.
- User B answers the prompt and resumes the parked turn.

The scenario was copied from #142. Its fixture now uses the default Slack auth instead of an unrelated shared principal because this PR deliberately derives the responder from current session auth.

## Slack Dev Sandbox
<img width="319" height="480" alt="Screenshot 2026-06-21 at 02 50 47" src="https://github.com/user-attachments/assets/4d646438-3346-4207-8570-464b70e2107a" />

<img width="318" height="543" alt="Screenshot 2026-06-21 at 02 51 27" src="https://github.com/user-attachments/assets/664de0d6-d7fb-41fd-8700-e3f72a2b499f" />
