### PR TITLE
fix(eve): set framework preset on project creation

### DIFF
--- a/.changeset/eve-framework-preset.md
+++ b/.changeset/eve-framework-preset.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Set the Vercel framework preset when creating new Eve projects.

--- a/packages/eve/src/setup/vercel-project.test.ts
+++ b/packages/eve/src/setup/vercel-project.test.ts
@@ -448,6 +448,8 @@ describe("linkProject", () => {
         "POST",
         "--raw-field",
         "name=my-agent",
+        "--raw-field",
+        "framework=eve",
         "--raw",
       ],
       { cwd: "/tmp/eve-agent", onOutput: expect.any(Function) },

--- a/packages/eve/src/setup/vercel-project.ts
+++ b/packages/eve/src/setup/vercel-project.ts
@@ -32,6 +32,8 @@ const VercelProjectReferenceSchema = z.object({
 
 type VercelProjectReference = z.infer<typeof VercelProjectReferenceSchema>;
 
+const EVE_FRAMEWORK_PRESET = "eve";
+
 const VercelApiErrorSchema = z.object({
   error: z
     .object({
@@ -238,6 +240,8 @@ async function createProject(
       "POST",
       "--raw-field",
       `name=${projectName}`,
+      "--raw-field",
+      `framework=${EVE_FRAMEWORK_PRESET}`,
       "--raw",
     ],
     { cwd: projectRoot, onOutput, signal: options.signal },


### PR DESCRIPTION
## Summary

- set the Vercel framework preset to `eve` when Eve creates a new project through the raw Projects API
- keep the existing explicit `vercel link --project <id> --yes` flow unchanged
- update the project provisioning unit test to assert `framework=eve` is sent on create

## Repro

Using `npx eve@latest init my-agent-123rwefsd9sfdia9dsfi` and `/model` with `vercel@54.14.5`, the Vercel project was linked for AI Gateway but had no production deployment and inspected as:

```text
Framework Preset  undefined
Build Command     None
Output Directory  None
Install Command   None
```

After `vercel deploy --prod --yes`, the same project reported `framework: "eve"`, so detection works at deploy time. The missing piece is that Eve's `/model` create/link path creates the project with only a name.

## API field

The official Vercel REST API docs for [Create a New Project](https://vercel.com/docs/rest-api/reference/endpoints/projects/create-a-new-project) include `framework` in the create-project request body. The SDK project-management example also creates a project with `framework: 'nextjs'`: https://vercel.com/docs/rest-api/sdk/examples/project-management

I also smoke-tested the Vercel API with a throwaway project and confirmed the existing `/v10/projects` path accepts `framework=eve` during creation; `vercel project inspect` immediately showed the Eve preset before any deploy.

## Test Plan

- `pnpm --filter eve run test:unit -- src/setup/vercel-project.test.ts`
- `pnpm --filter eve run typecheck`
