### PR TITLE
fix(eve): show vercel login device URL in dev TUI /login prompt

### DIFF
--- a/.changeset/famous-steaks-find.md
+++ b/.changeset/famous-steaks-find.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show the vercel login device-authorization URL in the dev TUI /login prompt, so login works on remote servers where no browser opens.

--- a/packages/eve/src/cli/dev/tui/setup-panel.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.ts
@@ -114,6 +114,14 @@ export type FlowPanelContent =
       rows: readonly string[];
       /** The install wait keeps its spinner above the concurrent actions. */
       status?: { text: string; frame: string };
+      /**
+       * Recent child-process output shown above the actions. A question can wait
+       * on a still-streaming subprocess — `/login` parks on the browser OAuth
+       * while `vercel login` prints its device URL — and the user needs that
+       * output (the URL) to act, so it rides alongside the actions rather than
+       * being suppressed the way a single status line is.
+       */
+      preview?: readonly string[];
     }
   | {
       kind: "status";
@@ -137,6 +145,9 @@ const SEARCH_VIEW_SIZE = 8;
 
 /** The flow panel keeps only the freshest progress in view. */
 const FLOW_PANEL_LINE_CAP = 6;
+
+/** How many recent subprocess output lines ride above a parked question. */
+const QUESTION_PREVIEW_CAP = 6;
 
 function questionFooter(hints: readonly string[], theme: Theme): string[] {
   const c = theme.colors;
@@ -200,6 +211,14 @@ export function renderFlowPanel(state: FlowPanelState, theme: Theme, width: numb
           `  ${c.yellow(state.content.status.frame)} ${c.dim(state.content.status.text)}`,
           "",
         );
+      }
+      // Streaming subprocess output (e.g. the `vercel login` device URL) shown
+      // above the actions so a parked question stays actionable.
+      if (state.content.preview !== undefined && state.content.preview.length > 0) {
+        for (const line of state.content.preview.slice(-QUESTION_PREVIEW_CAP)) {
+          rows.push(`    ${c.dim(line)}`);
+        }
+        rows.push("");
       }
       rows.push(...state.content.rows);
       break;

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -2283,3 +2283,33 @@ describe("TerminalRenderer status line", () => {
     renderer.shutdown();
   });
 });
+
+describe("TerminalRenderer setup-flow output during a choice panel", () => {
+  // Regression for the dev TUI `/login` flow: while the choice panel waits on
+  // the browser ("Complete the login in your browser"), `vercel login` streams
+  // its device-authorization URL on stderr through `renderOutput`. A remote
+  // user must be able to read that URL to finish the login by hand, so the open
+  // choice panel has to keep showing the subprocess preview alongside its
+  // actions — not suppress it the way it does a status line.
+  it("shows subprocess output (e.g. a login URL) while a choice panel is open", () => {
+    const { screen, renderer } = makeRenderer();
+    renderer.setupFlow.begin("Vercel");
+    const choice = renderer.setupFlow.readChoice({
+      status: "Logging in to Vercel…",
+      context: "Complete the login in your browser",
+      actions: [{ value: "cancel", label: "Cancel" }],
+    });
+    // `vercel login` prints the device URL, then a later line that would
+    // overwrite the single-line `preview` slot — so the URL only survives in the
+    // output buffer, and the panel must render that, not just the latest line.
+    renderer.setupFlow.renderOutput("Visit https://vercel.com/oauth/device?user_code=ZHHJ-VQJD");
+    renderer.setupFlow.renderOutput("Waiting for authentication...");
+
+    const snapshot = screen.snapshot();
+    choice.close();
+    renderer.shutdown();
+
+    expect(snapshot).toContain("Complete the login in your browser");
+    expect(snapshot).toContain("https://vercel.com/oauth/device?user_code=ZHHJ-VQJD");
+  });
+});

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -2382,10 +2382,15 @@ export class TerminalRenderer implements AgentTUIRenderer {
       // so their panels stay status-free as before.
       if (flow.question !== undefined) {
         const rows = flow.question(width);
-        content = { kind: "question", rows };
-        if (flow.status !== undefined) {
-          content = { kind: "question", rows, status: { text: flow.status, frame } };
-        }
+        content = {
+          kind: "question",
+          rows,
+          // A question can park on a still-streaming subprocess (e.g. /login
+          // waiting on the browser while `vercel login` prints its device URL);
+          // keep that output beside the actions instead of dropping it.
+          ...(flow.status !== undefined ? { status: { text: flow.status, frame } } : {}),
+          ...(flow.outputBuffer.length > 0 ? { preview: flow.outputBuffer } : {}),
+        };
       } else if (flow.status !== undefined) {
         content = { kind: "status", status: { text: flow.status, frame } };
         if (flow.preview !== undefined) {


### PR DESCRIPTION
### Description

In the dev TUI, `/login` runs `vercel login`, which prints a device-authorization URL on stderr. When running **locally** this isn't noticed because a browser opens automatically, but on a **remote server no browser opens** — and the URL was being suppressed by the open choice panel (which waits on "Complete the login in your browser"). With no visible URL, there was no way to finish login by hand.

This change keeps the streaming `vercel login` subprocess output (including the device URL) visible *alongside* the parked prompt's actions, instead of dropping it the way a single status line is. A `preview` field carries the recent output buffer onto the question panel, capped to the last few lines.

### How did you test your changes?

- Added a regression unit test in `packages/eve/src/cli/dev/tui/terminal-renderer.test.ts` ("shows subprocess output (e.g. a login URL) while a choice panel is open") asserting the device URL survives in the panel even after a later output line.
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm fmt` — clean
- `pnpm test` (unit + integration) — passed (323 integration tests; new unit test passes)

### PR Checklist

- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
