### PR TITLE
Fix dotted code imports before asset fallback

### DIFF
--- a/.changeset/dotted-code-imports.md
+++ b/.changeset/dotted-code-imports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix authored module bundling for relative code imports whose basename contains dots, such as `./Reflect.getPrototypeOf` or `./mock-registry.schemas`.

--- a/packages/eve/src/internal/authored-asset-import-plugin.ts
+++ b/packages/eve/src/internal/authored-asset-import-plugin.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { dirname, extname, isAbsolute, resolve } from "node:path";
 
 const AUTHORED_ASSET_CODE_EXTENSIONS = [
@@ -20,13 +20,21 @@ const AUTHORED_ASSET_CODE_EXTENSIONS = [
 export function createAuthoredAssetImportPlugin(): Record<string, unknown> {
   return {
     name: "eve-authored-asset-import",
-    resolveId(source: string, importer: string | undefined) {
+    async resolveId(source: string, importer: string | undefined) {
       if (!isPotentialAuthoredAssetImport(source) || importer === undefined) {
         return undefined;
       }
 
       const { path, suffix } = splitImportSuffix(source);
       const resolvedPath = isAbsolute(path) ? path : resolve(dirname(importer), path);
+
+      if (suffix === "" && !(await pathExists(resolvedPath))) {
+        const codePath = await resolveExistingCodeImportPath(resolvedPath);
+
+        if (codePath !== undefined) {
+          return codePath;
+        }
+      }
 
       return `${resolvedPath}${suffix}`;
     },
@@ -70,6 +78,31 @@ async function readAssetText(path: string): Promise<string | undefined> {
   } catch (error) {
     if (isPathNotFoundError(error)) {
       return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function resolveExistingCodeImportPath(path: string): Promise<string | undefined> {
+  for (const extension of AUTHORED_ASSET_CODE_EXTENSIONS) {
+    const candidatePath = `${path}${extension}`;
+
+    if (await pathExists(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return undefined;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if (isPathNotFoundError(error)) {
+      return false;
     }
 
     throw error;

--- a/packages/eve/src/internal/authored-module-loader.scenario.test.ts
+++ b/packages/eve/src/internal/authored-module-loader.scenario.test.ts
@@ -763,6 +763,53 @@ describe("loadAuthoredModuleNamespace", () => {
     });
   });
 
+  it("loads authored code imports with dotted basenames", async () => {
+    const app = await scenarioApp({
+      files: {
+        "agent/helpers/Reflect.getPrototypeOf.js": [
+          '"use strict";',
+          "",
+          "module.exports = Object.getPrototypeOf;",
+          "",
+        ].join("\n"),
+        "agent/helpers/mock-registry.schemas.ts": [
+          'export const schemaName = "mock-registry";',
+          "",
+        ].join("\n"),
+        "agent/helpers/usesCommonjsDottedImport.js": [
+          '"use strict";',
+          "",
+          'const getPrototypeOf = require("./Reflect.getPrototypeOf");',
+          "",
+          "exports.getPrototypeName = function getPrototypeName(value) {",
+          "  return getPrototypeOf(value).constructor.name;",
+          "};",
+          "",
+        ].join("\n"),
+        "agent/tools/use_dotted_code_imports.ts": [
+          'import { schemaName } from "../helpers/mock-registry.schemas";',
+          'import { getPrototypeName } from "../helpers/usesCommonjsDottedImport.js";',
+          "",
+          "export const result = {",
+          "  prototypeName: getPrototypeName({}),",
+          "  schemaName,",
+          "};",
+          "",
+        ].join("\n"),
+      },
+      name: "dotted-code-imports",
+    });
+
+    const moduleNamespace = await loadAuthoredModuleNamespace(
+      join(app.appRoot, "agent", "tools", "use_dotted_code_imports.ts"),
+    );
+
+    expect(moduleNamespace.result).toEqual({
+      prototypeName: "Object",
+      schemaName: "mock-registry",
+    });
+  });
+
   it("recovers in the same process once a missing package is installed", async () => {
     // Regression: bundling used to emit unresolvable package imports as
     // bare externals, so the loader handed Node an import that could not


### PR DESCRIPTION
### Description

Fixes #133.

Authored asset imports currently claim relative specifiers with dotted basenames before the normal code resolver can append TypeScript/JavaScript extensions. That makes code imports like `./Reflect.getPrototypeOf` and `../helpers/mock-registry.schemas` fail as missing assets even when matching `.js` or `.ts` files exist.

This changes the asset import plugin to check for an adjacent authored code file with Eve's normal resolver extensions before falling back to asset handling. It also adds a scenario regression for both a CommonJS dotted-basename require and a local TypeScript dotted-basename import.

### How did you test your changes?

- `pnpm exec vitest run --config vitest.scenario.config.ts src/internal/authored-module-loader.scenario.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm exec oxfmt -- packages/eve/src/internal/authored-asset-import-plugin.ts packages/eve/src/internal/authored-module-loader.scenario.test.ts .changeset/dotted-code-imports.md`
- `git diff --check`

Note: the local machine is running Node `v22.22.3`, while Eve requires Node `>=24`, so the pnpm commands emit engine warnings. The focused scenario regression and package typecheck pass.

### PR Checklist

- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
