### PR TITLE
Emit inline tool action requests on execution start

### DIFF
--- a/.changeset/early-inline-tool-actions.md
+++ b/.changeset/early-inline-tool-actions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit inline authored tool action requests when tool execution starts, so channels can show pending tool work before long-running `action.result` events arrive.

--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -208,9 +208,14 @@ export function buildStepHooks(input: StepHooksInput): StepHooks {
  * arguments — the runtime event stream only sees successfully parsed
  * tool calls.
  *
- * `handledInlineToolResultCallIds` lists approval-resume tool-result
- * call ids the stream already handled inline (see `emitStreamContent`).
- * This skips them to avoid double-emission.
+ * `handledInlineActionRequestCallIds` lists tool-call request ids already
+ * emitted from the AI SDK's tool-execution-start callback. This skips the
+ * finish-time `actions.requested` projection while still emitting the
+ * corresponding `action.result`.
+ *
+ * `handledInlineToolResultCallIds` lists approval-resume tool-result call ids
+ * the stream already handled inline (see `emitStreamContent`). This skips them
+ * to avoid double-emission.
  */
 export async function emitStepActions(
   emitFn: HarnessEmitFn,
@@ -218,6 +223,7 @@ export async function emitStepActions(
   step: HarnessStepResult,
   options: {
     readonly excludedActionToolNames: ReadonlySet<string>;
+    readonly handledInlineActionRequestCallIds?: ReadonlySet<string>;
     readonly handledInlineToolResultCallIds?: ReadonlySet<string>;
     readonly tools: ToolLoopHarnessConfig["tools"];
   },
@@ -242,7 +248,11 @@ export async function emitStepActions(
 
   // actions.requested
   const actions = (step.toolCalls as TypedToolCall<ToolSet>[])
-    .filter((tc) => !isExcluded(tc.toolCallId, tc.toolName))
+    .filter(
+      (tc) =>
+        !isExcluded(tc.toolCallId, tc.toolName) &&
+        !options.handledInlineActionRequestCallIds?.has(tc.toolCallId),
+    )
     .map((toolCall) =>
       createRuntimeActionRequestFromToolCall({
         toolCall,

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -257,6 +257,7 @@ async function* createMockFullStream(
 }
 
 type MockAgentSettings = {
+  onToolExecutionStart?: (event: { toolCall: Record<string, unknown> }) => Promise<void> | void;
   onStepFinish?: (step: unknown) => Promise<void> | void;
   output?: unknown;
   prepareStep?: (input: unknown) => Promise<unknown> | unknown;
@@ -1588,6 +1589,95 @@ describe("createToolLoopHarness", () => {
       status: "completed",
       turnId: "turn_0",
     });
+  });
+
+  it("emits actions.requested when inline tool execution starts", async () => {
+    const toolCall = {
+      input: { a: 1, b: 2 },
+      toolCallId: "call-1",
+      toolName: "add",
+      type: "tool-call",
+    };
+    const toolResult = {
+      input: { a: 1, b: 2 },
+      output: "42",
+      toolCallId: "call-1",
+      toolName: "add",
+      type: "tool-result",
+    };
+    const result = {
+      finishReason: "tool-calls",
+      response: {
+        messages: [
+          {
+            content: [{ text: "Let me add those.", type: "text" }, toolCall],
+            role: "assistant",
+          },
+          {
+            content: [toolResult],
+            role: "tool",
+          },
+        ],
+      },
+      text: "",
+      toolCalls: [toolCall],
+      toolResults: [toolResult],
+    };
+
+    vi.mocked(ToolLoopAgent).mockImplementation(function (
+      this: Record<string, unknown>,
+      settings: MockAgentSettings,
+    ) {
+      const { onStepFinish, onToolExecutionStart, prepareStep } = settings;
+
+      this.stream = vi.fn().mockImplementation(async (options: { messages: unknown[] }) => {
+        if (prepareStep) {
+          await prepareStep({
+            messages: options.messages,
+            steps: [],
+            stepNumber: 0,
+            model: {},
+            context: undefined,
+          });
+        }
+        const fullStream = (async function* (): AsyncIterable<Record<string, unknown>> {
+          yield { id: "text-1", text: "Let me add those.", type: "text-delta" };
+          yield toolCall;
+          await onToolExecutionStart?.({ toolCall });
+          yield toolResult;
+          yield { finishReason: "tool-calls", type: "finish-step" };
+        })();
+        if (onStepFinish) {
+          void Promise.resolve().then(() => onStepFinish(result));
+        }
+        return { fullStream, steps: Promise.resolve([result]) };
+      });
+
+      this.generate = vi.fn().mockResolvedValue(result);
+      return this as unknown as ToolLoopAgent;
+    } as unknown as MockAgentConstructor);
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+
+    await runStep(createTestSession(), { message: "Add 1 and 2" });
+
+    expect(getCompatibilityEventTypes(events)).toEqual([
+      "session.started",
+      "turn.started",
+      "message.received",
+      "step.started",
+      "actions.requested",
+      "message.completed",
+      "action.result",
+      "step.completed",
+    ]);
+    expect(events.filter((event) => event.type === "actions.requested")).toHaveLength(1);
+    expect(
+      events
+        .filter((event) => event.type === "actions.requested" || event.type === "action.result")
+        .map((event) => event.type),
+    ).toEqual(["actions.requested", "action.result"]);
   });
 
   it("skips AI-SDK-marked invalid tool calls so a malformed JSON payload does not crash the harness", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -32,6 +32,7 @@ import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js
 import { toErrorMessage } from "#shared/errors.js";
 import {
   createActionResultEvent,
+  createActionsRequestedEvent,
   createCompactionCompletedEvent,
   createCompactionRequestedEvent,
   createInputRequestedEvent,
@@ -700,6 +701,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         modelReference: session.agent.modelReference,
         tools: effectiveTools,
       });
+      const excludedActionToolNames = new Set([
+        ASK_QUESTION_TOOL_NAME,
+        CODE_MODE_TOOL_NAME,
+        FINAL_OUTPUT_TOOL_NAME,
+      ]);
+      const handledInlineActionRequestCallIds = new Set<string>();
 
       const hooks = buildStepHooks({
         cachePath,
@@ -715,6 +722,28 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         headers: attributionHeaders,
         instructions,
         model,
+        onToolExecutionStart:
+          emit === undefined
+            ? undefined
+            : async ({ toolCall }: { toolCall: TypedToolCall<ToolSet> }) => {
+                if (excludedActionToolNames.has(toolCall.toolName)) {
+                  return;
+                }
+                handledInlineActionRequestCallIds.add(toolCall.toolCallId);
+                await emit(
+                  createActionsRequestedEvent({
+                    actions: [
+                      createRuntimeActionRequestFromToolCall({
+                        toolCall,
+                        tools: config.tools,
+                      }),
+                    ],
+                    sequence: emissionState.sequence,
+                    stepIndex: emissionState.stepIndex,
+                    turnId: emissionState.turnId,
+                  }),
+                );
+              },
         onToolExecutionEnd: logToolExecutionError,
         // Replaces the AI SDK's default `console.error`; the harness still
         // emits stream events, this just keeps the raw error from being silent.
@@ -749,11 +778,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             throw new EmptyModelResponseError();
           }
           await emitStepActions(emit, emissionState, stepResult, {
-            excludedActionToolNames: new Set([
-              ASK_QUESTION_TOOL_NAME,
-              CODE_MODE_TOOL_NAME,
-              FINAL_OUTPUT_TOOL_NAME,
-            ]),
+            excludedActionToolNames,
+            handledInlineActionRequestCallIds,
             handledInlineToolResultCallIds,
             tools: config.tools,
           });


### PR DESCRIPTION
### Description

<!-- Write a short summary of the problem and solution. -->

### How did you test your changes?

<!-- Include the commands you ran and any manual coverage. -->

### PR Checklist

- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
