### PR TITLE
fix(eve): set framework preset only for standalone projects

### DIFF
--- a/.changeset/eve-framework-preset.md
+++ b/.changeset/eve-framework-preset.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Set the Vercel framework preset when creating new Eve projects.
+Set the Eve Vercel framework preset when creating standalone Eve projects.

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -529,7 +529,7 @@ describe("isNextJsProject", () => {
     await expect(isNextJsProject(projectRoot)).resolves.toBe(false);
   });
 
-  test("finds a next dependency in any dependency field", async () => {
+  test("finds a next dependency in the Vercel framework dependency fields", async () => {
     const projectRoot = await createTempDir();
     await writeFile(
       join(projectRoot, "package.json"),
@@ -577,7 +577,7 @@ describe("hasVercelHostFramework", () => {
     await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(true);
   });
 
-  test("recognizes a host framework resolved from an ancestor node_modules", async () => {
+  test("does not infer a host framework from ancestor node_modules alone", async () => {
     const workspaceRoot = await createTempDir();
     const projectRoot = join(workspaceRoot, "apps", "agent");
     await mkdir(projectRoot, { recursive: true });
@@ -589,7 +589,22 @@ describe("hasVercelHostFramework", () => {
       "utf8",
     );
 
-    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(true);
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(false);
+  });
+
+  test("ignores dependency fields Vercel framework detection does not inspect", async () => {
+    const projectRoot = await createTempDir();
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({
+        name: "demo",
+        optionalDependencies: { next: "16.2.6" },
+        peerDependencies: { nuxt: "4.3.3" },
+      }),
+      "utf8",
+    );
+
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(false);
   });
 
   test("does not scan unrelated sibling package manifests", async () => {

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vitest";
 import {
   deriveSlackConnectorSlug,
   ensureChannel,
+  hasVercelHostFramework,
   isNextJsProject,
   listAuthoredChannels,
   normalizeSlackConnectorSlug,
@@ -548,6 +549,43 @@ describe("isNextJsProject", () => {
     );
 
     await expect(isNextJsProject(projectRoot)).resolves.toBe(false);
+  });
+});
+
+describe("hasVercelHostFramework", () => {
+  test("reads as no host app when package.json is missing", async () => {
+    const projectRoot = await createTempDir();
+
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(false);
+  });
+
+  test.each([
+    ["Next.js", { next: "16.2.6" }],
+    ["Nuxt", { nuxt: "4.3.3" }],
+    ["Nuxt 3", { nuxt3: "3.19.7" }],
+    ["Nuxt edge", { "nuxt-edge": "3.0.0-rc.13" }],
+    ["Nuxt nightly", { "nuxt-nightly": "3.0.0-27575307.749db41" }],
+    ["SvelteKit", { "@sveltejs/kit": "2.60.0" }],
+  ])("recognizes %s as the root Vercel framework", async (_label, dependencies) => {
+    const projectRoot = await createTempDir();
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ name: "demo", devDependencies: dependencies }),
+      "utf8",
+    );
+
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(true);
+  });
+
+  test("ignores standalone eve projects", async () => {
+    const projectRoot = await createTempDir();
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ name: "demo", dependencies: { eve: "0.25.0" } }),
+      "utf8",
+    );
+
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(false);
   });
 });
 

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -577,6 +577,37 @@ describe("hasVercelHostFramework", () => {
     await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(true);
   });
 
+  test("recognizes a host framework resolved from an ancestor node_modules", async () => {
+    const workspaceRoot = await createTempDir();
+    const projectRoot = join(workspaceRoot, "apps", "agent");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(join(projectRoot, "package.json"), JSON.stringify({ name: "agent" }), "utf8");
+    await mkdir(join(workspaceRoot, "node_modules", "next"), { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "node_modules", "next", "package.json"),
+      JSON.stringify({ name: "next", version: "16.2.6" }),
+      "utf8",
+    );
+
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(true);
+  });
+
+  test("does not scan unrelated sibling package manifests", async () => {
+    const workspaceRoot = await createTempDir();
+    const projectRoot = join(workspaceRoot, "apps", "agent");
+    const siblingRoot = join(workspaceRoot, "apps", "web");
+    await mkdir(projectRoot, { recursive: true });
+    await mkdir(siblingRoot, { recursive: true });
+    await writeFile(join(projectRoot, "package.json"), JSON.stringify({ name: "agent" }), "utf8");
+    await writeFile(
+      join(siblingRoot, "package.json"),
+      JSON.stringify({ name: "web", dependencies: { next: "16.2.6" } }),
+      "utf8",
+    );
+
+    await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(false);
+  });
+
   test("ignores standalone eve projects", async () => {
     const projectRoot = await createTempDir();
     await writeFile(

--- a/packages/eve/src/setup/scaffold/index.ts
+++ b/packages/eve/src/setup/scaffold/index.ts
@@ -12,6 +12,7 @@ export {
   SLACK_CHANNEL_DEFAULT_ROUTE,
   deriveSlackConnectorSlug,
   ensureChannel,
+  hasVercelHostFramework,
   isNextJsProject,
   listAuthoredChannels,
   normalizeSlackConnectorSlug,

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -31,6 +31,14 @@ const DEFAULT_TYPES_REACT_PACKAGE_VERSION = "__TYPES_REACT_VERSION__";
 const DEFAULT_TYPES_REACT_DOM_PACKAGE_VERSION = "__TYPES_REACT_DOM_VERSION__";
 const CONNECT_PACKAGE_NAME = "@vercel/connect";
 const NEXT_PACKAGE_NAME = "next";
+const VERCEL_HOST_FRAMEWORK_PACKAGE_NAMES = [
+  "@sveltejs/kit",
+  NEXT_PACKAGE_NAME,
+  "nuxt",
+  "nuxt3",
+  "nuxt-edge",
+  "nuxt-nightly",
+] as const;
 const PACKAGE_DEPENDENCY_FIELDS = [
   "dependencies",
   "devDependencies",
@@ -167,6 +175,18 @@ async function hasPackageDependency(
   return isJsonObject(parsed) && packageJsonHasDependency(parsed, dependencyName);
 }
 
+async function hasAnyPackageDependency(
+  packageJsonPath: string,
+  dependencyNames: readonly string[],
+): Promise<boolean> {
+  if (!(await pathExists(packageJsonPath))) return false;
+
+  const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  if (!isJsonObject(parsed)) return false;
+
+  return dependencyNames.some((dependencyName) => packageJsonHasDependency(parsed, dependencyName));
+}
+
 /**
  * Whether the project already carries a Next.js app: `package.json` declares a
  * `next` dependency in any dependency field. This is the exact predicate the
@@ -176,6 +196,18 @@ async function hasPackageDependency(
  */
 export async function isNextJsProject(projectRoot: string): Promise<boolean> {
   return hasPackageDependency(join(projectRoot, "package.json"), NEXT_PACKAGE_NAME);
+}
+
+/**
+ * Whether the root app declares a Vercel framework that should own the
+ * top-level deployment while eve runs as a sibling service. These match Eve's
+ * current framework integrations: Next.js, Nuxt, and SvelteKit.
+ */
+export async function hasVercelHostFramework(projectRoot: string): Promise<boolean> {
+  return hasAnyPackageDependency(
+    join(projectRoot, "package.json"),
+    VERCEL_HOST_FRAMEWORK_PACKAGE_NAMES,
+  );
 }
 
 async function ensurePackageDependency(

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -1,7 +1,5 @@
-import { realpathSync } from "node:fs";
 import { readFile, readdir, writeFile } from "node:fs/promises";
-import { createRequire } from "node:module";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor, type NodeEngineOverride } from "../../node-engine.js";
@@ -41,12 +39,7 @@ const VERCEL_HOST_FRAMEWORK_PACKAGE_NAMES = [
   "nuxt-edge",
   "nuxt-nightly",
 ] as const;
-const PACKAGE_DEPENDENCY_FIELDS = [
-  "dependencies",
-  "devDependencies",
-  "peerDependencies",
-  "optionalDependencies",
-] as const;
+const PACKAGE_DEPENDENCY_FIELDS = ["dependencies", "devDependencies"] as const;
 const USER_AUTHORED_CHANNEL_DIR = "agent/channels";
 const WEB_CHANNEL_PATH = "agent/channels/eve.ts";
 const WEB_NEXT_CONFIG_PATH = "next.config.ts";
@@ -186,59 +179,13 @@ async function hasAnyPackageDependency(
   const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
   if (!isJsonObject(parsed)) return false;
 
-  return dependencyNames.some(
-    (dependencyName) =>
-      packageJsonHasDependency(parsed, dependencyName) ||
-      canResolvePackageDependency(packageJsonPath, dependencyName),
-  );
-}
-
-function canResolvePackageDependency(packageJsonPath: string, dependencyName: string): boolean {
-  const requireFromProject = createRequire(packageJsonPath);
-  let resolvedPath: string;
-  try {
-    resolvedPath = requireFromProject.resolve(`${dependencyName}/package.json`);
-  } catch {
-    return false;
-  }
-  return ancestorNodeModulesPaths(packageJsonPath).some((nodeModulesPath) =>
-    isPathInside(resolvedPath, nodeModulesPath),
-  );
-}
-
-function ancestorNodeModulesPaths(packageJsonPath: string): string[] {
-  const paths: string[] = [];
-  let directory = dirname(resolve(packageJsonPath));
-  while (true) {
-    paths.push(join(directory, "node_modules"));
-    const parent = dirname(directory);
-    if (parent === directory) break;
-    directory = parent;
-  }
-  return paths;
-}
-
-function isPathInside(path: string, directory: string): boolean {
-  const normalizedPath = canonicalPath(path);
-  const normalizedDirectory = canonicalPath(directory);
-  const pathFromDirectory = relative(normalizedDirectory, normalizedPath);
-  return (
-    pathFromDirectory === "" ||
-    (!pathFromDirectory.startsWith("..") && !isAbsolute(pathFromDirectory))
-  );
-}
-
-function canonicalPath(path: string): string {
-  try {
-    return realpathSync.native(path);
-  } catch {
-    return resolve(path);
-  }
+  return dependencyNames.some((dependencyName) => packageJsonHasDependency(parsed, dependencyName));
 }
 
 /**
  * Whether the project already carries a Next.js app: `package.json` declares a
- * `next` dependency in any dependency field. This is the exact predicate the
+ * `next` dependency in the same dependency fields Vercel framework detection
+ * checks. This is the exact predicate the
  * web scaffold skips on (`skipReason: "nextjs-project"`), so pickers can mark
  * Web Chat as already present precisely when scaffolding would be a no-op.
  * A missing `package.json` reads as "no app".
@@ -248,9 +195,9 @@ export async function isNextJsProject(projectRoot: string): Promise<boolean> {
 }
 
 /**
- * Whether the root app declares or can resolve a Vercel framework that should
- * own the top-level deployment while eve runs as a sibling service. These match
- * Eve's current framework integrations: Next.js, Nuxt, and SvelteKit.
+ * Whether the root app declares a Vercel framework that should own the
+ * top-level deployment while eve runs as a sibling service. These match Eve's
+ * current framework integrations: Next.js, Nuxt, and SvelteKit.
  */
 export async function hasVercelHostFramework(projectRoot: string): Promise<boolean> {
   return hasAnyPackageDependency(

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -1,5 +1,7 @@
+import { realpathSync } from "node:fs";
 import { readFile, readdir, writeFile } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor, type NodeEngineOverride } from "../../node-engine.js";
@@ -184,7 +186,54 @@ async function hasAnyPackageDependency(
   const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
   if (!isJsonObject(parsed)) return false;
 
-  return dependencyNames.some((dependencyName) => packageJsonHasDependency(parsed, dependencyName));
+  return dependencyNames.some(
+    (dependencyName) =>
+      packageJsonHasDependency(parsed, dependencyName) ||
+      canResolvePackageDependency(packageJsonPath, dependencyName),
+  );
+}
+
+function canResolvePackageDependency(packageJsonPath: string, dependencyName: string): boolean {
+  const requireFromProject = createRequire(packageJsonPath);
+  let resolvedPath: string;
+  try {
+    resolvedPath = requireFromProject.resolve(`${dependencyName}/package.json`);
+  } catch {
+    return false;
+  }
+  return ancestorNodeModulesPaths(packageJsonPath).some((nodeModulesPath) =>
+    isPathInside(resolvedPath, nodeModulesPath),
+  );
+}
+
+function ancestorNodeModulesPaths(packageJsonPath: string): string[] {
+  const paths: string[] = [];
+  let directory = dirname(resolve(packageJsonPath));
+  while (true) {
+    paths.push(join(directory, "node_modules"));
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return paths;
+}
+
+function isPathInside(path: string, directory: string): boolean {
+  const normalizedPath = canonicalPath(path);
+  const normalizedDirectory = canonicalPath(directory);
+  const pathFromDirectory = relative(normalizedDirectory, normalizedPath);
+  return (
+    pathFromDirectory === "" ||
+    (!pathFromDirectory.startsWith("..") && !isAbsolute(pathFromDirectory))
+  );
+}
+
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync.native(path);
+  } catch {
+    return resolve(path);
+  }
 }
 
 /**
@@ -199,9 +248,9 @@ export async function isNextJsProject(projectRoot: string): Promise<boolean> {
 }
 
 /**
- * Whether the root app declares a Vercel framework that should own the
- * top-level deployment while eve runs as a sibling service. These match Eve's
- * current framework integrations: Next.js, Nuxt, and SvelteKit.
+ * Whether the root app declares or can resolve a Vercel framework that should
+ * own the top-level deployment while eve runs as a sibling service. These match
+ * Eve's current framework integrations: Next.js, Nuxt, and SvelteKit.
  */
 export async function hasVercelHostFramework(projectRoot: string): Promise<boolean> {
   return hasAnyPackageDependency(

--- a/packages/eve/src/setup/vercel-project.test.ts
+++ b/packages/eve/src/setup/vercel-project.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createPromptCommandOutput, WHIMSY_POOLS } from "#setup/cli/index.js";
 import { captureVercel, runVercel, type VercelCaptureResult } from "#setup/primitives/index.js";
+import { hasVercelHostFramework } from "#setup/scaffold/index.js";
 
 import { HumanActionRequiredError } from "#setup/human-action.js";
 import type { Prompter, PrompterValue, SingleSelectOptions } from "./prompter.js";
@@ -28,8 +29,17 @@ vi.mock("#setup/primitives/index.js", async (importOriginal) => {
   };
 });
 
+vi.mock("#setup/scaffold/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("#setup/scaffold/index.js")>();
+  return {
+    ...original,
+    hasVercelHostFramework: vi.fn(async () => false),
+  };
+});
+
 const mockedCaptureVercel = vi.mocked(captureVercel);
 const mockedRunVercel = vi.mocked(runVercel);
+const mockedHasVercelHostFramework = vi.mocked(hasVercelHostFramework);
 
 /** Wraps stdout as a successful capture result for the mocked `captureVercel`. */
 const captured = (stdout: string): VercelCaptureResult => ({ ok: true, stdout });
@@ -57,6 +67,8 @@ beforeEach(() => {
   mockedCaptureVercel.mockReset();
   mockedRunVercel.mockReset();
   mockedRunVercel.mockResolvedValue(true);
+  mockedHasVercelHostFramework.mockReset();
+  mockedHasVercelHostFramework.mockResolvedValue(false);
 });
 
 describe("listTeams", () => {
@@ -458,6 +470,43 @@ describe("linkProject", () => {
       1,
       ["link", "--project", "prj_new", "--scope", "team-a", "--yes"],
       { cwd: "/tmp/eve-agent", onOutput: expect.any(Function), nonInteractive: true },
+    );
+  });
+
+  it("leaves the framework preset unset for host framework projects", async () => {
+    mockedHasVercelHostFramework.mockResolvedValueOnce(true);
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured(JSON.stringify({ id: "prj_new", name: "my-web-agent" })));
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-web-agent",
+        { kind: "new", project: "my-web-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+      ),
+    ).resolves.toBe(true);
+
+    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
+      2,
+      [
+        "api",
+        "/v10/projects",
+        "--scope",
+        "team-a",
+        "--method",
+        "POST",
+        "--raw-field",
+        "name=my-web-agent",
+        "--raw",
+      ],
+      { cwd: "/tmp/eve-web-agent", onOutput: expect.any(Function) },
     );
   });
 });

--- a/packages/eve/src/setup/vercel-project.ts
+++ b/packages/eve/src/setup/vercel-project.ts
@@ -1,6 +1,7 @@
 import { createPromptCommandOutput, whimsyFor } from "#setup/cli/index.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
 import { captureVercel, runVercel, type VercelCaptureFailure } from "#setup/primitives/index.js";
+import { hasVercelHostFramework } from "#setup/scaffold/index.js";
 import pc from "picocolors";
 import { z } from "zod";
 
@@ -230,22 +231,29 @@ async function createProject(
   onOutput: ReturnType<typeof createPromptCommandOutput>,
   options: VercelProjectOperationOptions,
 ): Promise<VercelProjectReference> {
-  const result = await captureVercel(
-    [
-      "api",
-      "/v10/projects",
-      "--scope",
-      team,
-      "--method",
-      "POST",
-      "--raw-field",
-      `name=${projectName}`,
-      "--raw-field",
-      `framework=${EVE_FRAMEWORK_PRESET}`,
-      "--raw",
-    ],
-    { cwd: projectRoot, onOutput, signal: options.signal },
-  );
+  const createProjectArgs = [
+    "api",
+    "/v10/projects",
+    "--scope",
+    team,
+    "--method",
+    "POST",
+    "--raw-field",
+    `name=${projectName}`,
+  ];
+  // Host framework integrations (Next.js, Nuxt, SvelteKit) own the top-level
+  // Vercel build. Leaving the preset unset lets Vercel detect that framework
+  // while vercel.json/build-output config owns the internal Eve service.
+  if (!(await hasVercelHostFramework(projectRoot))) {
+    createProjectArgs.push("--raw-field", `framework=${EVE_FRAMEWORK_PRESET}`);
+  }
+  createProjectArgs.push("--raw");
+
+  const result = await captureVercel(createProjectArgs, {
+    cwd: projectRoot,
+    onOutput,
+    signal: options.signal,
+  });
   if (result.ok) {
     return parseProjectReference(result.stdout, `created project ${projectName}`);
   }


### PR DESCRIPTION
## Summary

Follow-up to #151: set the Eve framework preset only when creating standalone Eve projects.

If the root app already declares a host framework that Eve integrates with today (Next.js, Nuxt, or SvelteKit), the new Vercel project leaves `framework` unset so Vercel can auto-detect the top-level app framework on deploy. Eve still runs as the sibling service through the generated `vercel.json` / Build Output config.

Detector alignment was checked against `vercel/vercel`: the CLI project setup path uses `detectProjects()` from `@vercel/fs-detectors` over `@vercel/frameworks`; `matchPackage` detection checks the package root manifest. This PR mirrors the relevant package detectors for Next.js (`next`), Nuxt (`nuxt`, `nuxt3`, `nuxt-edge`, `nuxt-nightly`), and SvelteKit (`@sveltejs/kit`) without inferring a framework from hoisted `node_modules` or unrelated sibling package manifests.

## Verification

- `fnm exec --using=24 pnpm --filter eve run typecheck`
- `fnm exec --using=24 pnpm --filter eve run test:integration -- src/setup/scaffold/index.integration.test.ts`
- `fnm exec --using=24 pnpm --filter eve run test:unit -- src/setup/vercel-project.test.ts`
- `git diff --check`
- Real web-chat smoke from the local Eve package:
  - Project creation left `framework` absent before deploy.
  - Deployment detected Next.js, completed successfully, and project metadata reported `framework: "nextjs"` after deploy.
  - A control smoke with forced `framework=eve` failed after `next build` with missing `.output`, confirming why host-framework apps must remain unset.
