### PR TITLE
feat(eve): auto-open model setup and highlight selections

### DIFF
--- a/.changeset/early-model-onboarding.md
+++ b/.changeset/early-model-onboarding.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The dev TUI now opens `/model` when the runtime confirms no model provider is configured and refreshes model access after setup. Selected rows now use padded inverse labels with a filled arrow.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -16,7 +16,7 @@ On startup the TUI prints a brand line with your agent's name, plus a rotating t
  Use /channels to add more ways to reach your agent.
 ```
 
-If agent discovery reported problems, an error and warning count renders between the two lines. Instructions, tools, skills, and subagents are one `eve info` away, and `/help` lists every command. The TUI also runs a startup check. A missing model-provider setup surfaces as an attention line (`⚠ 1 setup issue: model provider not linked · /model`) so the fix is visible before the first message fails, with each command's outcome hanging under it on a `⎿` connector.
+If agent discovery reported problems, an error and warning count renders between the two lines. Instructions, tools, skills, and subagents are one `eve info` away, and `/help` lists every command. The TUI also runs a startup check. When the runtime confirms that no model provider is configured, it opens the `/model` provider questions before the first prompt. When the available evidence cannot confirm that state, missing setup remains visible as an attention line, with each command's outcome hanging under it on a `⎿` connector.
 
 ## Reading the transcript
 
@@ -30,7 +30,7 @@ Errors render compactly with docs links highlighted. A code bug escaping your ag
 
 ## Slash commands
 
-Each command echoes as an invocation line, asks through a bordered panel that takes the input area's place (one question at a time, separate from the chat transcript), and finishes with a one-line `⎿` result. Loading states stay on the ephemeral status line instead of piling into the transcript.
+Each command echoes as an invocation line, asks through a bordered panel that takes the input area's place (one question at a time, separate from the chat transcript), and finishes with a one-line `⎿` result. Loading states stay on the ephemeral status line instead of piling into the transcript. Setup menus render the selected option with a filled arrow and an inverse label padded by one space on each side. The label is blue normally and yellow for warning rows.
 
 | Command     | Does                                                                                                                              |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
@@ -46,9 +46,9 @@ Each command echoes as an invocation line, asks through a bordered panel that ta
 
 ### Configure the model and provider
 
-Bare `/model` opens the configure menu. "Change model" runs the same searchable model picker setup uses (the Vercel AI Gateway catalog, pre-selected on the model the runtime is serving). A model change is written into your agent's authored source, and the command reports success only after eve confirms the new id. `/model <provider/model-id>` applies one directly, skipping the menu.
+Bare `/model` opens the configure menu. When no provider is configured, it opens the provider questions directly; Esc returns to the configure menu. "Change model" runs the same searchable model picker setup uses (the Vercel AI Gateway catalog, pre-selected on the model the runtime is serving). A model change is written into your agent's authored source, and the command reports success only after eve confirms the new id. `/model <provider/model-id>` applies one directly, skipping the menu.
 
-The provider row opens the provider questions: which model provider to use, and how to connect. Picking something other than Vercel AI Gateway shows wiring instructions for your own provider and stops there, leaving any existing setup untouched. For Vercel AI Gateway, you either paste your own `AI_GATEWAY_API_KEY` (saved straight to `.env.local`) or connect via a project. Connecting via a project asks for a Vercel team, opens that team's existing-project list (picking again re-links), then pulls the project's environment so an AI Gateway credential lands in `.env.local`. The dev server reloads env files automatically, with no restart needed.
+The provider row opens the provider questions: which model provider to use, and how to connect. Picking something other than Vercel AI Gateway shows wiring instructions for your own provider and stops there, leaving any existing setup untouched. For Vercel AI Gateway, you either paste your own `AI_GATEWAY_API_KEY` (saved straight to `.env.local`) or connect via a project. Connecting via a project asks for a Vercel team, opens that team's existing-project list (picking again re-links), then pulls the project's environment so an AI Gateway credential lands in `.env.local`. The dev TUI reloads env files, re-reads the runtime's model endpoint, and clears the setup warning automatically; no restart is needed.
 
 The provider row demands attention (a bold yellow "Configure provider" with "Required to enable the agent") until a link or gateway credential is detected, then names the connection afterward (for example "AI Gateway (Linked to my-project in my-team)"). Each action's latest outcome stays visible beneath the menu (for example "✓ Model changed to openai/gpt-5.5"). When a turn fails because AI Gateway authentication is missing or stale, the error points you at `/model` directly.
 

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -168,8 +168,6 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
     ]);
     // Substring assertions keep the expectations color-agnostic; picocolors
     // decides at import time whether the strings carry escape codes. The boot
@@ -182,7 +180,7 @@ describe("runInitCommand", () => {
     expect(output.messages[1]).toContain("in 467ms");
     expect(output.messages[2]).toContain("Installed dependencies");
     expect(output.messages[2]).toContain("in 13.2s");
-    expect(output.messages[3]).toContain("$ eve dev --input /model");
+    expect(output.messages[3]).toContain("$ eve dev");
   });
 
   it("uses an explicit init package spec for fresh project scaffolds", async () => {
@@ -240,8 +238,6 @@ describe("runInitCommand", () => {
         "exec",
         "eve",
         "dev",
-        "--input",
-        "/model",
       ]);
       expect(output.messages[1]).toContain("Created an eve agent in ");
       expect(output.messages[1]).toContain(projectPath);
@@ -249,9 +245,9 @@ describe("runInitCommand", () => {
   );
 
   it.each([
-    ["npm", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", ["eve", "dev", "--input", "/model"]],
-    ["bun", ["x", "eve", "dev", "--input", "/model"]],
+    ["npm", ["exec", "--", "eve", "dev"]],
+    ["yarn", ["eve", "dev"]],
+    ["bun", ["x", "eve", "dev"]],
   ] as const)(
     "scaffolds a fresh project owned by the invoking manager %s without pnpm policy",
     async (kind, devArguments) => {
@@ -303,20 +299,14 @@ describe("runInitCommand", () => {
       projectPath,
       expect.anything(),
     );
-    expect(deps.spawnPackageManager).toHaveBeenCalledWith("bun", projectPath, [
-      "x",
-      "eve",
-      "dev",
-      "--input",
-      "/model",
-    ]);
+    expect(deps.spawnPackageManager).toHaveBeenCalledWith("bun", projectPath, ["x", "eve", "dev"]);
   });
 
   it.each([
-    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", "yarn.lock", "npm", ["eve", "dev", "--input", "/model"]],
-    ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--input", "/model"]],
-    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--input", "/model"]],
+    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev"]],
+    ["yarn", "yarn.lock", "npm", ["eve", "dev"]],
+    ["bun", "bun.lock", "npm", ["x", "eve", "dev"]],
+    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev"]],
   ] as const)(
     "scaffolds a fresh named project with the ancestor %s lockfile before the launcher",
     async (kind, lockfile, invokingManager, devArguments) => {
@@ -369,8 +359,6 @@ describe("runInitCommand", () => {
       "--",
       "eve",
       "dev",
-      "--input",
-      "/model",
     ]);
   });
 
@@ -385,7 +373,7 @@ describe("runInitCommand", () => {
     expect(deps.spawnPackageManager).toHaveBeenCalledWith(
       "pnpm",
       join(parentDirectory, "my-agent"),
-      ["exec", "eve", "dev", "--input", "/model"],
+      ["exec", "eve", "dev"],
     );
   });
 
@@ -416,8 +404,6 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
     ]);
   });
 

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -302,7 +302,12 @@ async function runInitSteps(input: {
       );
       project = { kind: "created", packageManager, projectPath };
     } else {
-      const addition = await addToExistingProject(existingDirectory, options, dependencies, evePackage);
+      const addition = await addToExistingProject(
+        existingDirectory,
+        options,
+        dependencies,
+        evePackage,
+      );
       project =
         addition.nodeEngineOverride === undefined
           ? {
@@ -394,7 +399,6 @@ export async function runInitCommand(
   dependencies: InitCommandDependencies = defaultDependencies,
 ): Promise<void> {
   const result = await runInitSteps({ dependencies, logger, options, parentDirectory, target });
-  const freshScaffold = result.kind === "created";
 
   if (result.kind === "created") {
     logger.log(
@@ -429,10 +433,8 @@ export async function runInitCommand(
   // Strictly the eve binary, never the project's dev script, which in an
   // existing app may start unrelated processes. Exec-style runs do not echo
   // the command the way run-scripts do, so the handoff line is printed here.
-  const devArguments = freshScaffold
-    ? [...eveDevArguments(result.packageManager), "--input", "/model"]
-    : eveDevArguments(result.packageManager);
-  logger.log(pc.dim(freshScaffold ? "$ eve dev --input /model" : "$ eve dev"));
+  const devArguments = eveDevArguments(result.packageManager);
+  logger.log(pc.dim("$ eve dev"));
   if (
     !(await dependencies.spawnPackageManager(
       result.packageManager,

--- a/packages/eve/src/cli/dev/tui/command-typeahead.test.ts
+++ b/packages/eve/src/cli/dev/tui/command-typeahead.test.ts
@@ -132,15 +132,40 @@ describe("typeaheadCompletion", () => {
 describe("renderCommandSuggestions", () => {
   it("marks the highlighted row and shows aliases and descriptions, not argument hints", () => {
     const state = moveTypeaheadSelection(typeaheadFor(COMMANDS, "/"), 1);
-    const rows = renderCommandSuggestions(state, theme, 80).map(stripAnsi);
+    const colored = createTheme({ color: true, unicode: true });
+    const rendered = renderCommandSuggestions(state, colored, 80);
+    expect(rendered[1]).toContain(
+      colored.colors.inverse(colored.colors.blue(` ${colored.glyph.selectedPointer} /model `)),
+    );
+    const rows = rendered.map(stripAnsi);
     expect(rows).toHaveLength(COMMANDS.length);
-    expect(rows[1]).toContain(theme.glyph.prompt);
-    expect(rows[0]).not.toContain(theme.glyph.prompt);
+    expect(rows[0]?.startsWith("   /help")).toBe(true);
+    expect(rows[1]?.startsWith(" ▶ /model ")).toBe(true);
+    expect(rows[1]).toContain(theme.glyph.selectedPointer);
+    expect(rows[0]).not.toContain(theme.glyph.selectedPointer);
     expect(rows[1]).toContain("/model");
     expect(rows[1]).toContain("model command");
     // The argument hint is held back for the inline exact-match view.
     expect(rows[1]).not.toContain("[provider/model]");
     expect(rows[3]).toContain("/exit (/quit)");
+  });
+
+  it("keeps aliases and descriptions fixed when the selected label gains padding", () => {
+    const initial = typeaheadFor(COMMANDS, "/");
+    const next = moveTypeaheadSelection(initial, 1);
+    const helpSelected = renderCommandSuggestions(initial, theme, 80).map(stripAnsi);
+    const helpUnselected = renderCommandSuggestions(next, theme, 80).map(stripAnsi);
+
+    expect(helpSelected[0]?.indexOf("help command")).toBe(
+      helpUnselected[0]?.indexOf("help command"),
+    );
+
+    const exitSelected = renderCommandSuggestions(
+      moveTypeaheadSelection(initial, -1),
+      theme,
+      80,
+    ).map(stripAnsi);
+    expect(exitSelected[3]?.indexOf("(/quit)")).toBe(helpUnselected[3]?.indexOf("(/quit)"));
   });
 
   it("windows long lists around the highlight without a count row", () => {
@@ -171,6 +196,6 @@ describe("renderCommandSuggestions", () => {
     const state = typeaheadFor(PROMPT_COMMANDS, "/");
     const rows = renderCommandSuggestions(state, theme, 80).map(stripAnsi);
     expect(rows[0]).toContain("/help");
-    expect(rows[0]).toContain(theme.glyph.prompt);
+    expect(rows[0]).toContain(theme.glyph.selectedPointer);
   });
 });

--- a/packages/eve/src/cli/dev/tui/command-typeahead.ts
+++ b/packages/eve/src/cli/dev/tui/command-typeahead.ts
@@ -9,6 +9,7 @@
 import type { PromptCommandSpec } from "./prompt-commands.js";
 import { sliceVisible, visibleLength } from "./terminal-text.js";
 import type { Theme } from "./theme.js";
+import { renderCursorRow } from "#setup/cli/option-row.js";
 
 /**
  * The typeahead keeps the list scannable; extra matches window around the
@@ -117,7 +118,7 @@ export function inlineCommandHint(state: CommandTypeaheadState): string | undefi
 
 /**
  * Paints the suggestion rows (the select-question grammar): the highlight
- * carries the cursor glyph and a blue name, every row shows its aliases and
+ * carries the cursor glyph and inverse-blue name, every row shows its aliases and
  * description dim, and overflow windows around the highlight. The argument
  * hint is held back for the inline exact-match view ({@link inlineCommandHint})
  * — it only earns space once a single command is committed to.
@@ -145,11 +146,18 @@ export function renderCommandSuggestions(
 
   const rows = visible.map((spec, offset) => {
     const isCursor = start + offset === state.selectedIndex;
-    const cursor = isCursor ? c.cyan(theme.glyph.prompt) : " ";
-    const name = isCursor ? c.blue(`/${spec.name}`) : `/${spec.name}`;
-    const detail = invocation(spec).slice(`/${spec.name}`.length);
-    const pad = " ".repeat(column - invocation(spec).length);
-    return `${cursor} ${name}${c.dim(detail)}${pad}${c.dim(spec.description)}`;
+    const name = `/${spec.name}`;
+    const content = isCursor ? `${theme.glyph.selectedPointer} ${name}` : `  ${name}`;
+    const selection = renderCursorRow(content, isCursor, c);
+    let detail = invocation(spec).slice(`/${spec.name}`.length);
+    let pad = " ".repeat(column - invocation(spec).length);
+    // The selected label's trailing inverse cell replaces the first suffix
+    // space so aliases and descriptions stay in the same columns.
+    if (isCursor) {
+      if (detail.startsWith(" ")) detail = detail.slice(1);
+      else pad = pad.slice(1);
+    }
+    return `${selection}${c.dim(detail)}${pad}${c.dim(spec.description)}`;
   });
 
   return rows.map((row) => (visibleLength(row) > width ? sliceVisible(row, width) : row));

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.test.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.test.ts
@@ -108,6 +108,41 @@ describe("createPromptCommandHandler", () => {
     });
   });
 
+  it("forwards automatic provider entry and model-access changes", async () => {
+    const runTuiSetupCommand = vi.fn(async () => ({
+      message: "Connected to AI Gateway via AI_GATEWAY_API_KEY in .env.local.",
+      preserveFlowDiagnostics: false,
+      effect: { kind: "model-access-changed" } as const,
+    }));
+    vi.doMock("./setup-commands.js", () => ({
+      SETUP_FLOW_TITLES: { model: "Configure the agent model" },
+      runTuiSetupCommand,
+    }));
+
+    try {
+      const setupFlow = setupFlowRenderer();
+      const handler = createPromptCommandHandler({ appRoot: APP_ROOT });
+
+      await expect(
+        handler.handle(
+          { type: "extension", name: "model", argument: "" },
+          { ...context({ setupFlow }), initialModelStep: "provider" },
+        ),
+      ).resolves.toEqual({
+        message: "Connected to AI Gateway via AI_GATEWAY_API_KEY in .env.local.",
+        effect: { kind: "model-access-changed" },
+      });
+      expect(runTuiSetupCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ initialModelStep: "provider" }),
+      );
+      expect(setupFlow.begin).toHaveBeenCalledWith("Configure the agent model");
+      expect(setupFlow.end).toHaveBeenCalledWith({ preserveDiagnostics: false });
+    } finally {
+      vi.doUnmock("./setup-commands.js");
+      vi.resetModules();
+    }
+  });
+
   it("folds setup-module load failures at the command adapter boundary", async () => {
     vi.doMock("./setup-commands.js", () => {
       throw new Error("Cannot find package 'oxc-parser'");

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -84,11 +84,14 @@ export function createPromptCommandHandler(
           appRoot,
           renderer: flow,
         };
+        if (context.initialModelStep !== undefined) {
+          commandInput.initialModelStep = context.initialModelStep;
+        }
         if (options.flows !== undefined) commandInput.flows = options.flows;
         const result = await runTuiSetupCommand(commandInput);
         preserveFlowDiagnostics = result.preserveFlowDiagnostics;
         const outcome: PromptCommandOutcome = { message: result.message };
-        if (result.vercelEffect !== undefined) outcome.vercelEffect = result.vercelEffect;
+        if (result.effect !== undefined) outcome.effect = result.effect;
         return outcome;
       } finally {
         flow.end({ preserveDiagnostics: preserveFlowDiagnostics });

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -18,6 +18,8 @@ import {
   type PromptCommandOutcome,
 } from "./runner.js";
 import { createPromptCommandHandler } from "./prompt-command-handler.js";
+import type { BootDetection, SetupIssue } from "./setup-issues.js";
+import { createFakeSetupFlowRenderer } from "./test/fake-setup-flow-renderer.js";
 import type { VercelStatusSnapshot } from "./vercel-status.js";
 
 /**
@@ -1234,9 +1236,9 @@ describe("EveTUIRunner Vercel status line", () => {
     const outcomes: Record<string, PromptCommandOutcome> = {
       channels: {
         message: "Channels added: slack — run /deploy to ship them.",
-        vercelEffect: { kind: "channels-added" },
+        effect: { kind: "channels-added" },
       },
-      deploy: { message: "Deployed.", vercelEffect: { kind: "deployed" } },
+      deploy: { message: "Deployed.", effect: { kind: "deployed" } },
     };
 
     const runner = new EveTUIRunner({
@@ -1255,6 +1257,46 @@ describe("EveTUIRunner Vercel status line", () => {
       { identity, pendingDeploy: false },
     ]);
     expect(detectIdentity).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes agent info only after a model-access change", async () => {
+    const client = stubClient();
+    const info = vi.spyOn(client, "info").mockResolvedValue(AGENT_INFO);
+    const prompts: Array<string | undefined> = ["/channels", "/model", undefined];
+    const infoCallsAtPrompt: number[] = [];
+    const renderer = fakeRenderer({
+      readPrompt: vi.fn(async () => {
+        infoCallsAtPrompt.push(info.mock.calls.length);
+        return prompts.shift();
+      }),
+    });
+    const channelsOutcome: PromptCommandOutcome = {
+      message: "Channels added.",
+      effect: { kind: "channels-added" },
+    };
+    const modelOutcome: PromptCommandOutcome = {
+      message: "Connected to AI Gateway.",
+      effect: { kind: "model-access-changed" },
+    };
+
+    const runner = new EveTUIRunner({
+      session: stubSession(),
+      client,
+      renderer,
+      serverUrl: "http://localhost:3000",
+      name: "Weather Agent",
+      appRoot: "/tmp/weather-agent",
+      bootDetections: [],
+      detectProjectIdentity: vi.fn(async () => undefined),
+      promptCommandHandler: {
+        handle: async (command) => (command.name === "model" ? modelOutcome : channelsOutcome),
+      },
+    });
+
+    await runner.run();
+
+    expect(infoCallsAtPrompt).toEqual([1, 1, 2]);
+    expect(info).toHaveBeenCalledTimes(2);
   });
 
   it("never pushes Vercel status for a remote --url session", async () => {
@@ -1332,10 +1374,18 @@ describe("EveTUIRunner gateway-auth failure rendering", () => {
 });
 
 describe("EveTUIRunner boot setup detection", () => {
-  function bootRunner(input: {
-    appRoot?: string;
-    issues: Array<{ label: string; command: string }>;
-  }) {
+  const disconnectedGatewayInfo: AgentInfoResult = {
+    ...AGENT_INFO,
+    agent: {
+      ...AGENT_INFO.agent,
+      model: {
+        ...AGENT_INFO.agent.model,
+        endpoint: { kind: "gateway", connected: false },
+      },
+    },
+  };
+
+  function bootRunner(input: { appRoot?: string; issues: SetupIssue[] }) {
     const warnings: string[] = [];
     const session = sessionYielding([]);
     const renderer: AgentTUIRenderer = {
@@ -1353,19 +1403,186 @@ describe("EveTUIRunner boot setup detection", () => {
     return { runner: new EveTUIRunner(options), warnings };
   }
 
+  function providerSetupRefreshRunner(input: {
+    refreshInfo: () => Promise<AgentInfoResult>;
+    renderer?: Partial<AgentTUIRenderer>;
+    bootDetections?: BootDetection[];
+  }) {
+    const client = stubClient();
+    vi.spyOn(client, "info")
+      .mockResolvedValueOnce(disconnectedGatewayInfo)
+      .mockImplementationOnce(input.refreshInfo);
+    const renderer = fakeRenderer({
+      renderSetupWarning: vi.fn(),
+      setupFlow: createFakeSetupFlowRenderer(),
+      ...input.renderer,
+    });
+    const runner = new EveTUIRunner({
+      session: stubSession(),
+      client,
+      renderer,
+      serverUrl: "http://localhost:3000",
+      name: "Weather Agent",
+      appRoot: "/tmp/weather-agent",
+      bootDetections: input.bootDetections ?? [
+        {
+          id: "test",
+          detect: () => [
+            {
+              kind: "model-provider-unconfigured",
+              label: "model provider not linked",
+              command: "/model",
+            },
+          ],
+        },
+      ],
+      detectProjectIdentity: vi.fn(async () => undefined),
+      getVercelAuthStatus: vi.fn(async (): Promise<"authenticated"> => "authenticated"),
+      promptCommandHandler: {
+        handle: async () => ({
+          message: "Connected to AI Gateway via AI_GATEWAY_API_KEY in .env.local.",
+          effect: { kind: "model-access-changed" },
+        }),
+      },
+    });
+
+    return { client, runner };
+  }
+
   it("surfaces detected issues as the attention line at boot", async () => {
     const { runner, warnings } = bootRunner({
       appRoot: "/tmp/weather-agent",
-      issues: [{ label: "AI Gateway credentials", command: "/model" }],
+      issues: [{ kind: "attention", label: "AI Gateway credentials", command: "/model" }],
     });
     await runner.run();
 
     expect(warnings).toEqual(["1 setup issue: AI Gateway credentials · /model"]);
   });
 
+  it("opens /model before the first prompt when the provider is unset", async () => {
+    const order: string[] = [];
+    const handle = vi.fn(async () => {
+      order.push("model");
+      return { message: "/model cancelled." };
+    });
+    const renderer = fakeRenderer({
+      readPrompt: vi.fn(async (options?: AgentTUISessionOptions) => {
+        order.push("prompt");
+        expect(options?.initialDraft).toBe("draft me");
+        return undefined;
+      }),
+      setupFlow: createFakeSetupFlowRenderer(),
+    });
+    const runner = new EveTUIRunner({
+      session: sessionYielding([]),
+      renderer,
+      name: "Weather Agent",
+      appRoot: "/tmp/weather-agent",
+      initialInput: "draft me",
+      bootDetections: [
+        {
+          id: "test",
+          detect: () => [
+            {
+              kind: "model-provider-unconfigured",
+              label: "model provider not linked",
+              command: "/model",
+            },
+          ],
+        },
+      ],
+      promptCommandHandler: { handle },
+    });
+
+    await runner.run();
+
+    expect(order).toEqual(["model", "prompt"]);
+    expect(handle).toHaveBeenCalledWith(
+      { type: "extension", name: "model", argument: "" },
+      { renderer, title: "Weather Agent", initialModelStep: "provider" },
+    );
+  });
+
+  it("refreshes the gateway endpoint after automatic provider setup", async () => {
+    const connectedInfo: AgentInfoResult = {
+      ...AGENT_INFO,
+      agent: {
+        ...AGENT_INFO.agent,
+        model: {
+          ...AGENT_INFO.agent.model,
+          endpoint: { kind: "gateway", connected: true, credential: "api-key" },
+        },
+      },
+    };
+    const clearSetupWarning = vi.fn();
+    const headers: AgentTUIAgentHeader[] = [];
+    const detect = vi.fn(({ info }: { info?: AgentInfoResult }) =>
+      info?.agent.model.endpoint?.kind === "gateway" && !info.agent.model.endpoint.connected
+        ? [
+            {
+              kind: "model-provider-unconfigured" as const,
+              label: "model provider not linked",
+              command: "/model" as const,
+            },
+          ]
+        : [],
+    );
+    const { client, runner } = providerSetupRefreshRunner({
+      refreshInfo: async () => connectedInfo,
+      bootDetections: [{ id: "test", detect }],
+      renderer: {
+        clearSetupWarning,
+        renderAgentHeader: (header) => headers.push(header),
+      },
+    });
+
+    await runner.run();
+    await vi.waitFor(() => expect(clearSetupWarning).toHaveBeenCalled());
+
+    expect(client.info).toHaveBeenCalledTimes(2);
+    expect(detect.mock.calls.at(-1)?.[0].info).toBe(connectedInfo);
+    expect(headers.map((header) => header.info?.agent.model.endpoint)).toEqual([
+      { kind: "gateway", connected: false },
+      { kind: "gateway", connected: true, credential: "api-key" },
+    ]);
+  });
+
+  it("drops stale disconnected evidence when the post-setup info refresh fails", async () => {
+    const clearSetupWarning = vi.fn();
+    const headers: AgentTUIAgentHeader[] = [];
+    const detect = vi.fn(({ info }: { info?: AgentInfoResult }) =>
+      info?.agent.model.endpoint?.kind === "gateway" && !info.agent.model.endpoint.connected
+        ? [
+            {
+              kind: "model-provider-unconfigured" as const,
+              label: "model provider not linked",
+              command: "/model" as const,
+            },
+          ]
+        : [],
+    );
+    const { client, runner } = providerSetupRefreshRunner({
+      refreshInfo: async () => {
+        throw new Error("info unavailable");
+      },
+      bootDetections: [{ id: "test", detect }],
+      renderer: {
+        clearSetupWarning,
+        renderAgentHeader: (header) => headers.push(header),
+      },
+    });
+
+    await runner.run();
+    await vi.waitFor(() => expect(clearSetupWarning).toHaveBeenCalled());
+
+    expect(client.info).toHaveBeenCalledTimes(2);
+    expect(detect.mock.calls.at(-1)?.[0].info).toBeUndefined();
+    expect(headers.at(-1)?.info).toBeUndefined();
+  });
+
   it("stays quiet without a local setup context, even with issues", async () => {
     const { runner, warnings } = bootRunner({
-      issues: [{ label: "AI Gateway credentials", command: "/model" }],
+      issues: [{ kind: "attention", label: "AI Gateway credentials", command: "/model" }],
     });
     await runner.run();
 

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -20,6 +20,7 @@ import {
   ClientSession,
   isCurrentTurnBoundaryEvent,
 } from "#client/index.js";
+import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import { subscribeDevelopmentSandboxPrewarmLogs } from "#execution/sandbox/development-prewarm.js";
 import {
   createDevelopmentRuntimeArtifactSessionRefresher,
@@ -49,6 +50,7 @@ import {
 import {
   BOOT_DETECTIONS,
   CLI_MISSING_SETUP_ISSUE,
+  automaticSetupCommand,
   detectSetupIssues,
   formatSetupIssuesLine,
   LOGIN_SETUP_ISSUE,
@@ -278,14 +280,16 @@ export type AgentTUIRenderer = {
 export interface PromptCommandHandlerContext {
   readonly renderer: AgentTUIRenderer;
   readonly title: string;
+  /** Provider entry authorized by confirmed boot-time model-access evidence. */
+  readonly initialModelStep?: "provider";
 }
 
 /** What one handled slash command leaves behind for the runner to apply. */
 export interface PromptCommandOutcome {
   /** Outcome line rendered under the echoed command; absent renders nothing. */
   message?: string;
-  /** Vercel status-line effect the runner applies to its tracker. */
-  vercelEffect?: VercelStatusEffect;
+  /** Post-command work; model access also re-probes the Vercel identity. */
+  effect?: VercelStatusEffect | { kind: "model-access-changed" };
 }
 
 export interface PromptCommandHandler {
@@ -503,7 +507,15 @@ export class EveTUIRunner {
     } catch {
       info = undefined;
     }
+    this.#reportBeforeFirstPaint();
+    this.#replaceAgentInfo(info);
+    await this.#renderSetupIssues(info);
+  }
+
+  #replaceAgentInfo(info: AgentInfoResult | undefined): void {
     this.#agentInfo = info;
+    const serverUrl = this.#serverUrl;
+    if (serverUrl === undefined) return;
 
     const header: AgentTUIAgentHeader = {
       name: this.#name,
@@ -511,9 +523,7 @@ export class EveTUIRunner {
     };
     if (info !== undefined) header.info = info;
     if (this.#appRoot !== undefined) header.tip = this.#headerTip;
-    this.#reportBeforeFirstPaint();
     this.#renderer.renderAgentHeader?.(header);
-    await this.#renderSetupIssues(info);
   }
 
   #reportBeforeFirstPaint(): void {
@@ -541,6 +551,7 @@ export class EveTUIRunner {
   async #run() {
     const title = this.#name;
     let prompt: string | undefined;
+    let automaticSetup: ReturnType<typeof automaticSetupCommand> = undefined;
     let pendingInputResponses: readonly InputResponse[] | undefined;
     let hasRunTurn = false;
     let streamWithoutPrompt = false;
@@ -553,6 +564,11 @@ export class EveTUIRunner {
     // Fire-and-forget: the link identity is network-bound to resolve, and the
     // first prompt must not wait on it. The segment appears when it lands.
     this.#vercelStatus?.refreshIdentity();
+
+    if (this.#promptCommandHandler !== undefined && this.#renderer.setupFlow !== undefined) {
+      automaticSetup = automaticSetupCommand(this.#bootIssues);
+      prompt = automaticSetup?.prompt;
+    }
 
     while (true) {
       if (!streamWithoutPrompt) {
@@ -625,21 +641,27 @@ export class EveTUIRunner {
 
         if (command?.type === "extension") {
           try {
+            const initialModelStep =
+              command.name === "model" ? automaticSetup?.initialModelStep : undefined;
+            const context: PromptCommandHandlerContext =
+              initialModelStep === undefined
+                ? { renderer: this.#renderer, title }
+                : { renderer: this.#renderer, title, initialModelStep };
+            automaticSetup = undefined;
             const outcome =
               this.#promptCommandHandler === undefined
                 ? { message: `/${command.name} is not available in this session.` }
-                : await this.#promptCommandHandler.handle(command, {
-                    renderer: this.#renderer,
-                    title,
-                  });
+                : await this.#promptCommandHandler.handle(command, context);
             if (outcome?.message !== undefined) this.#renderCommandOutcome(outcome.message);
-            if (outcome?.vercelEffect !== undefined) {
-              this.#vercelStatus?.applyEffect(outcome.vercelEffect);
-              // A command changed Vercel state (e.g. /login). Stop a still-pending
-              // boot probe from painting a now-stale hint, and re-evaluate the
-              // attention line so a fixed issue clears instead of lingering.
+            const effect = outcome?.effect;
+            if (effect?.kind === "model-access-changed") {
+              this.#vercelStatus?.applyEffect({ kind: "refresh-identity" });
               this.#authHintStale = true;
-              void this.#refreshSetupAttention();
+              await this.#refreshModelAccess();
+            } else if (effect !== undefined) {
+              this.#vercelStatus?.applyEffect(effect);
+              this.#authHintStale = true;
+              void this.#refreshSetupAttention(this.#agentInfo);
             }
           } catch (error) {
             if (isInterruptedError(error)) return;
@@ -913,13 +935,13 @@ export class EveTUIRunner {
 
   async #renderSetupIssues(info: AgentInfoResult | undefined): Promise<void> {
     if (this.#appRoot === undefined) return;
-    if (this.#renderer.renderSetupWarning === undefined) return;
     const context: BootDetectionContext = {
       appRoot: this.#appRoot,
       env: process.env,
     };
     if (info !== undefined) context.info = info;
     this.#bootIssues = await detectSetupIssues(context, this.#bootDetections);
+    if (this.#renderer.renderSetupWarning === undefined) return;
     this.#paintSetupAttention();
     // Login state is a `vercel whoami` round-trip — too costly for the
     // cheap-and-local boot detections above — so it rides its own probe off
@@ -953,17 +975,17 @@ export class EveTUIRunner {
   }
 
   /**
-   * Re-evaluates the attention line after a setup command changed Vercel state,
+   * Re-evaluates the attention line after a setup command changed local state,
    * so a fixed issue clears (e.g. the `not logged in · /login` line disappears
    * once `/login` succeeds) instead of lingering stale. Authoritative: unlike
    * the boot probe it re-reads detections and auth and is not stale-guarded.
    */
-  async #refreshSetupAttention(): Promise<void> {
+  async #refreshSetupAttention(info: AgentInfoResult | undefined): Promise<void> {
     const appRoot = this.#appRoot;
     if (appRoot === undefined) return;
     if (this.#renderer.renderSetupWarning === undefined) return;
     const context: BootDetectionContext = { appRoot, env: process.env };
-    if (this.#agentInfo !== undefined) context.info = this.#agentInfo;
+    if (info !== undefined) context.info = info;
     try {
       this.#bootIssues = await detectSetupIssues(context, this.#bootDetections);
       const status = await this.#getVercelAuthStatus(appRoot, {
@@ -1032,28 +1054,33 @@ export class EveTUIRunner {
     }
   }
 
+  /**
+   * Setup commands can write env files before the dev watcher reloads them.
+   * Reload first, then replace the cached `/info` response that owns the status
+   * bar's endpoint state. The slower Vercel auth probe stays off the prompt path.
+   */
+  async #refreshModelAccess(): Promise<void> {
+    const appRoot = this.#appRoot;
+    if (appRoot === undefined) return;
+
+    loadDevelopmentEnvironmentFiles(appRoot);
+    const refreshedInfo = await this.#readAgentInfo();
+    this.#replaceAgentInfo(refreshedInfo);
+    void this.#refreshSetupAttention(refreshedInfo);
+  }
+
+  async #readAgentInfo(): Promise<AgentInfoResult | undefined> {
+    try {
+      return await this.#client?.info();
+    } catch {
+      return undefined;
+    }
+  }
+
   async #handleRuntimeArtifactsChanged(): Promise<void> {
     const previousInfo = this.#agentInfo;
-    let nextInfo: AgentInfoResult | undefined;
-
-    try {
-      nextInfo = await this.#client?.info();
-    } catch {
-      nextInfo = undefined;
-    }
-
-    if (nextInfo !== undefined) {
-      this.#agentInfo = nextInfo;
-      if (this.#serverUrl !== undefined) {
-        const header: AgentTUIAgentHeader = {
-          info: nextInfo,
-          name: this.#name,
-          serverUrl: this.#serverUrl,
-        };
-        if (this.#appRoot !== undefined) header.tip = this.#headerTip;
-        this.#renderer.renderAgentHeader?.(header);
-      }
-    }
+    const nextInfo = await this.#readAgentInfo();
+    if (nextInfo !== undefined) this.#replaceAgentInfo(nextInfo);
 
     if (!this.#renderer.renderAgentHeader || nextInfo === undefined) {
       this.#renderer.renderNotice?.(formatAgentUpdateNotice(previousInfo, nextInfo));

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -72,6 +72,7 @@ function run(input: {
   command: "vc" | "login" | "model" | "channels" | "deploy";
   flows: TuiSetupFlows;
   renderer?: TuiSetupCommandRenderer;
+  initialModelStep?: "provider";
 }) {
   const fake = createFakePrompter({});
   const commandInput: TuiSetupCommandInput = {
@@ -81,6 +82,9 @@ function run(input: {
     createPrompter: () => fake.prompter,
     flows: input.flows,
   };
+  if (input.initialModelStep !== undefined) {
+    commandInput.initialModelStep = input.initialModelStep;
+  }
   return runTuiSetupCommand(commandInput);
 }
 
@@ -92,6 +96,16 @@ describe("runTuiSetupCommand", () => {
       preserveFlowDiagnostics: false,
     });
     expect(flows.runModelFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
+  });
+
+  it("forwards an automatic provider entry to the model flow", async () => {
+    const flows = fakeFlows();
+
+    await run({ command: "model", flows, initialModelStep: "provider" });
+
+    expect(flows.runModelFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ appRoot: APP_ROOT, initialStep: "provider" }),
+    );
   });
 
   it("stacks the model and provider outcome lines when both menu actions ran", async () => {
@@ -110,7 +124,7 @@ describe("runTuiSetupCommand", () => {
         "Model changed to openai/gpt-5.5. Live on your next prompt.\n" +
         "Project linked. Connected to AI Gateway via AI_GATEWAY_API_KEY.",
       preserveFlowDiagnostics: false,
-      vercelEffect: { kind: "refresh-identity" },
+      effect: { kind: "model-access-changed" },
     });
   });
 
@@ -127,7 +141,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "model", flows })).resolves.toEqual({
       message: "Project linked. Connected to AI Gateway via VERCEL_OIDC_TOKEN.",
       preserveFlowDiagnostics: false,
-      vercelEffect: { kind: "refresh-identity" },
+      effect: { kind: "model-access-changed" },
     });
   });
 
@@ -144,7 +158,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "model", flows })).resolves.toEqual({
       message: "Connected to AI Gateway via AI_GATEWAY_API_KEY in .env.local.",
       preserveFlowDiagnostics: false,
-      vercelEffect: { kind: "refresh-identity" },
+      effect: { kind: "model-access-changed" },
     });
   });
 
@@ -171,7 +185,7 @@ describe("runTuiSetupCommand", () => {
     expect(notice).toEqual({
       message: "Channels added: slack — run /deploy to ship them.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
     });
     expect(flows.runChannelsFlow).toHaveBeenCalledWith(
       expect.objectContaining({ appRoot: APP_ROOT }),
@@ -198,7 +212,7 @@ describe("runTuiSetupCommand", () => {
       message:
         "Deployed: https://my-agent.vercel.app\n" + `Chat with your agent in Slack: ${expectedUrl}`,
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "deployed" },
+      effect: { kind: "deployed" },
     });
     expect(flows.runDeployFlow).toHaveBeenCalledWith(
       expect.objectContaining({ interactive: true }),
@@ -219,7 +233,7 @@ describe("runTuiSetupCommand", () => {
     expect(notice).toEqual({
       message: "Deployed: https://my-agent.vercel.app\nMessage your agent in Slack to see it live.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "deployed" },
+      effect: { kind: "deployed" },
     });
   });
 
@@ -236,7 +250,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "channels", flows })).resolves.toEqual({
       message: "Channels added, but /deploy was cancelled. Run /deploy to ship them.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
     });
   });
 
@@ -254,7 +268,7 @@ describe("runTuiSetupCommand", () => {
       message:
         "Channels added, but this directory is not linked to Vercel. Run /model, then /deploy.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
     });
   });
 
@@ -273,7 +287,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "channels", flows })).resolves.toEqual({
       message: "Channels added, but /deploy failed: build failed",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
     });
   });
 
@@ -299,7 +313,7 @@ describe("runTuiSetupCommand", () => {
       message:
         "Channel files changed, but /channels failed: Slack connector UID update is required before deployment.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
     });
   });
 
@@ -308,7 +322,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "deploy", flows })).resolves.toEqual({
       message: "Deployed: https://my-agent.vercel.app",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "deployed" },
+      effect: { kind: "deployed" },
     });
     expect(flows.runDeployFlow).toHaveBeenCalledWith(
       expect.objectContaining({ interactive: true }),
@@ -407,7 +421,43 @@ describe("runTuiSetupCommand", () => {
     await expect(result).resolves.toEqual({
       message: "/channels interrupted.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
+    });
+  });
+
+  it("preserves model access refreshes when provider setup is interrupted", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(
+        ({ signal }) =>
+          new Promise((resolve) => {
+            signal?.addEventListener(
+              "abort",
+              () =>
+                resolve({
+                  kind: "done",
+                  providerOutcome: {
+                    credential: "AI_GATEWAY_API_KEY",
+                    status: {
+                      kind: "gateway-key",
+                      envKey: "AI_GATEWAY_API_KEY",
+                      envFile: ".env.local",
+                    },
+                  },
+                }),
+              { once: true },
+            );
+          }),
+      ),
+    });
+
+    const result = run({ command: "model", flows, renderer });
+    renderer.fireInterrupt();
+
+    await expect(result).resolves.toEqual({
+      message: "/model interrupted.",
+      preserveFlowDiagnostics: true,
+      effect: { kind: "model-access-changed" },
     });
   });
 
@@ -455,7 +505,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "login", flows })).resolves.toEqual({
       message: "Logged in to Vercel.",
       preserveFlowDiagnostics: false,
-      vercelEffect: { kind: "refresh-identity" },
+      effect: { kind: "refresh-identity" },
     });
   });
 
@@ -562,7 +612,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "vc", flows })).resolves.toEqual({
       message: "Installed the Vercel CLI. Run /login next.",
       preserveFlowDiagnostics: false,
-      vercelEffect: { kind: "refresh-identity" },
+      effect: { kind: "refresh-identity" },
     });
   });
 
@@ -614,7 +664,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "channels", flows })).resolves.toEqual({
       message: "Channels added. You're not logged in to Vercel — run /login, then retry /deploy.",
       preserveFlowDiagnostics: true,
-      vercelEffect: { kind: "channels-added" },
+      effect: { kind: "channels-added" },
     });
   });
 });

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -44,6 +44,8 @@ export interface TuiSetupCommandInput {
   appRoot: string;
   /** The renderer surface the TUI-native prompter drives. */
   renderer: TuiSetupCommandRenderer;
+  /** Initial model-flow step authorized by the runner's boot evidence. */
+  initialModelStep?: "provider";
   /** Test seam; defaults to the real TUI-native prompter over `renderer`. */
   createPrompter?: (renderer: TuiPrompterRenderer) => Prompter;
   /** Test seam; defaults to the real setup flows. */
@@ -63,8 +65,8 @@ export interface TuiSetupCommandResult {
   message: string;
   /** Keep warning/error lines after the bordered panel closes. */
   preserveFlowDiagnostics: boolean;
-  /** Status-line effect of this command, when it changed link/deploy state. */
-  vercelEffect?: VercelStatusEffect;
+  /** Status refresh required after the command settles. */
+  effect?: VercelStatusEffect | { kind: "model-access-changed" };
 }
 
 /**
@@ -129,12 +131,11 @@ export async function runTuiSetupCommand(
     interrupted = true;
     controller.abort(new WizardCancelledError());
     const settled = await execution;
-    const result: TuiSetupCommandResult = {
+    return {
+      ...settled,
       message: `/${command} interrupted.`,
       preserveFlowDiagnostics: true,
     };
-    if (settled.vercelEffect !== undefined) result.vercelEffect = settled.vercelEffect;
-    return result;
   } finally {
     interrupt.dispose();
     // A flow that threw or was abandoned mid-wait must not leave the footer spinning.
@@ -169,7 +170,15 @@ async function executeSetupCommand(
         return loginResultMessage(await flows.runLoginFlow({ appRoot, prompter, signal }));
       }
       case "model": {
-        const result = await flows.runModelFlow({ appRoot, prompter, signal });
+        const modelInput: Parameters<TuiSetupFlows["runModelFlow"]>[0] = {
+          appRoot,
+          prompter,
+          signal,
+        };
+        if (input.initialModelStep !== undefined) {
+          modelInput.initialStep = input.initialModelStep;
+        }
+        const result = await flows.runModelFlow(modelInput);
         if (result.kind === "cancelled") {
           return { message: "/model cancelled.", preserveFlowDiagnostics: false };
         }
@@ -185,10 +194,10 @@ async function executeSetupCommand(
           message: lines.join("\n"),
           preserveFlowDiagnostics: false,
         };
-        // Provider setup can relink the project. Re-probe once after the flow
-        // instead of threading link-specific state through every result layer.
+        // Provider setup can change both the local env and Vercel identity.
+        // The runner refreshes the complete model-access view after the flow.
         if (result.providerOutcome !== undefined) {
-          outcome.vercelEffect = { kind: "refresh-identity" };
+          outcome.effect = { kind: "model-access-changed" };
         }
         return outcome;
       }
@@ -214,7 +223,7 @@ async function executeSetupCommand(
             return {
               message: `Channels added: ${result.addedChannels.join(", ")} — run /deploy to ship them.`,
               preserveFlowDiagnostics: true,
-              vercelEffect: { kind: "channels-added" },
+              effect: { kind: "channels-added" },
             };
         }
       }
@@ -233,7 +242,7 @@ async function executeSetupCommand(
           message:
             result.productionUrl === undefined ? "Deployed." : `Deployed: ${result.productionUrl}`,
           preserveFlowDiagnostics: true,
-          vercelEffect: { kind: "deployed" },
+          effect: { kind: "deployed" },
         };
       }
     }
@@ -334,7 +343,7 @@ async function runDeployAndChat(
   return {
     message: `${live}\n${chatLine}`,
     preserveFlowDiagnostics: true,
-    vercelEffect: { kind: "deployed" },
+    effect: { kind: "deployed" },
   };
 }
 
@@ -356,7 +365,7 @@ function installVercelCliResultMessage(result: InstallVercelCliResult): TuiSetup
         message: "Installed the Vercel CLI. Run /login next.",
         preserveFlowDiagnostics: false,
         // The CLI now resolves, so the status line's identity probe can run.
-        vercelEffect: { kind: "refresh-identity" },
+        effect: { kind: "refresh-identity" },
       };
   }
 }
@@ -384,7 +393,7 @@ function loginResultMessage(result: LoginFlowResult): TuiSetupCommandResult {
         preserveFlowDiagnostics: false,
         // A now-valid `whoami` lets a previously-linked directory resolve its
         // project identity for the status line.
-        vercelEffect: { kind: "refresh-identity" },
+        effect: { kind: "refresh-identity" },
       };
     case "unavailable":
       return {
@@ -398,7 +407,7 @@ function pendingChannelsResult(message: string): TuiSetupCommandResult {
   return {
     message,
     preserveFlowDiagnostics: true,
-    vercelEffect: { kind: "channels-added" },
+    effect: { kind: "channels-added" },
   };
 }
 

--- a/packages/eve/src/cli/dev/tui/setup-issues.integration.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.integration.test.ts
@@ -2,9 +2,53 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { detectSetupIssues } from "./setup-issues.js";
+import { Client, type AgentInfoResult } from "#client/index.js";
+
+import { EveTUIRunner, type AgentTUIRenderer } from "./runner.js";
+import { automaticSetupCommand, detectSetupIssues } from "./setup-issues.js";
+import { createFakeSetupFlowRenderer } from "./test/fake-setup-flow-renderer.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const DISCONNECTED_GATEWAY_INFO: AgentInfoResult = {
+  agent: {
+    agentRoot: "/app/agent",
+    appRoot: "/app",
+    model: {
+      endpoint: { kind: "gateway", connected: false },
+      id: "openai/gpt-5.5",
+      routing: { kind: "gateway", target: "openai" },
+    },
+    name: "Agent",
+  },
+  capabilities: { devRoutes: true },
+  channels: { authored: [], available: [], disabledFramework: [], framework: [] },
+  connections: [],
+  diagnostics: { discoveryErrors: 0, discoveryWarnings: 0 },
+  hooks: [],
+  instructions: { dynamic: [], static: null },
+  kind: "eve-agent-info",
+  mode: "development",
+  sandbox: null,
+  schedules: [],
+  skills: { dynamic: [], static: [] },
+  subagents: { local: [], total: 0 },
+  tools: {
+    authored: [],
+    available: [],
+    disabledFramework: [],
+    dynamic: [],
+    framework: [],
+    reserved: [],
+  },
+  version: 1,
+  workflow: { enabled: false, toolName: "Workflow" },
+  workspace: { resourceRoot: null, rootEntries: [] },
+};
 
 async function linkedAppRoot(): Promise<string> {
   const appRoot = await mkdtemp(join(tmpdir(), "eve-boot-detect-"));
@@ -23,6 +67,72 @@ describe("BOOT_DETECTIONS against a real directory", () => {
   it("diagnoses missing credentials (not the link) when the directory is linked", async () => {
     const appRoot = await linkedAppRoot();
     const issues = await detectSetupIssues({ appRoot, env: {} });
-    expect(issues).toEqual([{ label: "AI Gateway credentials missing", command: "/model" }]);
+    expect(issues).toEqual([
+      { kind: "attention", label: "AI Gateway credentials missing", command: "/model" },
+    ]);
+  });
+
+  it("authorizes model setup when the runtime confirms a linked project is disconnected", async () => {
+    const appRoot = await linkedAppRoot();
+    const issues = await detectSetupIssues({
+      appRoot,
+      env: {},
+      info: DISCONNECTED_GATEWAY_INFO,
+    });
+
+    expect(issues).toEqual([
+      {
+        kind: "model-provider-unconfigured",
+        label: "AI Gateway credentials missing",
+        command: "/model",
+      },
+    ]);
+    expect(automaticSetupCommand(issues)).toEqual({
+      prompt: "/model",
+      initialModelStep: "provider",
+    });
+  });
+
+  it("opens model setup from the default detection before the first prompt", async () => {
+    const appRoot = await linkedAppRoot();
+    const client = new Client({ host: "http://localhost:3000" });
+    vi.spyOn(client, "info").mockResolvedValue(DISCONNECTED_GATEWAY_INFO);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ revision: "snapshot-a" })),
+    );
+    const order: string[] = [];
+    const handle = vi.fn(async () => {
+      order.push("model");
+      return { message: "/model cancelled." };
+    });
+    const readPrompt = vi.fn(async () => {
+      order.push("prompt");
+      return undefined;
+    });
+    const renderer: AgentTUIRenderer = {
+      readPrompt,
+      renderStream: vi.fn(async () => {}),
+      setupFlow: createFakeSetupFlowRenderer(),
+    };
+    const runner = new EveTUIRunner({
+      appRoot,
+      client,
+      detectProjectIdentity: vi.fn(async () => undefined),
+      getVercelAuthStatus: vi.fn(async (): Promise<"authenticated"> => "authenticated"),
+      promptCommandHandler: { handle },
+      renderer,
+      serverUrl: "http://localhost:3000",
+      session: client.session(),
+    });
+
+    await runner.run();
+
+    expect(handle).toHaveBeenCalledExactlyOnceWith(
+      { type: "extension", name: "model", argument: "" },
+      { renderer, title: "eve", initialModelStep: "provider" },
+    );
+    expect(readPrompt).toHaveBeenCalledOnce();
+    expect(order).toEqual(["model", "prompt"]);
   });
 });

--- a/packages/eve/src/cli/dev/tui/setup-issues.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   BOOT_DETECTIONS,
   CLI_MISSING_SETUP_ISSUE,
+  automaticSetupCommand,
   detectSetupIssues,
   formatSetupIssuesLine,
   LOGIN_SETUP_ISSUE,
@@ -58,9 +59,32 @@ function infoWithRouting(
 }
 
 describe("BOOT_DETECTIONS", () => {
-  it("diagnoses an unlinked directory as ONE issue — the missing link subsumes credentials", async () => {
+  it("keeps an unavailable runtime diagnostic-only", async () => {
     const issues = await detectSetupIssues(context());
-    expect(issues).toEqual([{ label: "model provider not linked", command: "/model" }]);
+    expect(issues).toEqual([
+      { kind: "attention", label: "model provider not linked", command: "/model" },
+    ]);
+    expect(automaticSetupCommand(issues)).toBeUndefined();
+  });
+
+  it("opens model setup only when the runtime confirms the gateway is disconnected", async () => {
+    const info = infoWithRouting(
+      { kind: "gateway", target: "openai" },
+      { kind: "gateway", connected: false },
+    );
+
+    const issues = await detectSetupIssues(context({ info }));
+    expect(issues).toEqual([
+      {
+        kind: "model-provider-unconfigured",
+        label: "model provider not linked",
+        command: "/model",
+      },
+    ]);
+    expect(automaticSetupCommand(issues)).toEqual({
+      prompt: "/model",
+      initialModelStep: "provider",
+    });
   });
 
   it("stays quiet when either gateway credential is present, linked or not", async () => {
@@ -99,16 +123,18 @@ describe("BOOT_DETECTIONS", () => {
 
 describe("formatSetupIssuesLine", () => {
   it("mirrors the Claude Code attention-line shape", () => {
-    expect(formatSetupIssuesLine([{ label: "AI Gateway credentials", command: "/model" }])).toBe(
-      "1 setup issue: AI Gateway credentials · /model",
-    );
+    expect(
+      formatSetupIssuesLine([
+        { kind: "attention", label: "AI Gateway credentials", command: "/model" },
+      ]),
+    ).toBe("1 setup issue: AI Gateway credentials · /model");
   });
 
   it("pluralizes and joins multiple issues", () => {
     expect(
       formatSetupIssuesLine([
-        { label: "AI Gateway credentials", command: "/model" },
-        { label: "Channels", command: "/channels" },
+        { kind: "attention", label: "AI Gateway credentials", command: "/model" },
+        { kind: "attention", label: "Channels", command: "/channels" },
       ]),
     ).toBe("2 setup issues: AI Gateway credentials · /model, Channels · /channels");
   });
@@ -131,7 +157,11 @@ describe("formatSetupIssuesLine", () => {
 
 describe("orderedSetupIssues", () => {
   it("puts the auth prerequisite before the boot detections", () => {
-    const modelIssue = { label: "model provider not linked", command: "/model" };
+    const modelIssue = {
+      kind: "model-provider-unconfigured" as const,
+      label: "model provider not linked",
+      command: "/model" as const,
+    };
     expect(orderedSetupIssues([modelIssue], CLI_MISSING_SETUP_ISSUE)).toEqual([
       CLI_MISSING_SETUP_ISSUE,
       modelIssue,
@@ -143,7 +173,9 @@ describe("orderedSetupIssues", () => {
   });
 
   it("returns the boot issues unchanged when no auth prerequisite is unmet", () => {
-    const boot = [{ label: "AI Gateway credentials missing", command: "/model" }];
+    const boot = [
+      { kind: "attention" as const, label: "AI Gateway credentials missing", command: "/model" },
+    ];
     expect(orderedSetupIssues(boot, undefined)).toEqual(boot);
   });
 });

--- a/packages/eve/src/cli/dev/tui/setup-issues.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.ts
@@ -4,12 +4,21 @@ import type { AgentInfoResult } from "#client/index.js";
 import { pathExists } from "#setup/path-exists.js";
 
 /** One boot-time setup problem the TUI can point at a fixing command. */
-export interface SetupIssue {
-  /** Short category label, e.g. "AI Gateway credentials". */
-  label: string;
-  /** The slash command that fixes it, e.g. "/model". */
-  command: string;
-}
+export type SetupIssue =
+  | {
+      /** Diagnostics never authorize a command by themselves. */
+      kind: "attention";
+      /** Short category label, e.g. "AI Gateway credentials". */
+      label: string;
+      /** The slash command that fixes it, e.g. "/model". */
+      command: string;
+    }
+  | {
+      /** Positive runtime evidence that no model provider is configured. */
+      kind: "model-provider-unconfigured";
+      label: string;
+      command: "/model";
+    };
 
 /** What a boot detection may inspect. */
 export interface BootDetectionContext {
@@ -31,39 +40,59 @@ export interface BootDetection {
   detect(context: BootDetectionContext): SetupIssue[] | Promise<SetupIssue[]>;
 }
 
+type ModelProviderAccess = "configured" | "unconfigured" | "unknown";
+
+/** Classifies only evidence the boot path can actually observe. */
+function modelProviderAccess(
+  context: Pick<BootDetectionContext, "env" | "info">,
+): ModelProviderAccess {
+  const endpoint = context.info?.agent.model.endpoint;
+  if (endpoint?.kind === "external") return "configured";
+  if (endpoint?.kind === "gateway") {
+    return endpoint.connected ? "configured" : "unconfigured";
+  }
+
+  // Older servers omit the composed endpoint status. Their routing and the
+  // dev process's loaded env can prove configuration, but absence proves
+  // nothing about credentials available only inside the running server.
+  if (context.info?.agent.model.routing?.kind === "external") return "configured";
+  if (context.env.AI_GATEWAY_API_KEY || context.env.VERCEL_OIDC_TOKEN) return "configured";
+  return "unknown";
+}
+
 /**
  * One diagnosis for the model-provider path. An external-provider model is
  * skipped entirely: it reaches the model with its own provider key, so gateway
  * linking and credentials don't apply (and /model can't reconfigure it). For a
  * gateway model it reports only the most-root cause; an unlinked directory
  * implies missing OIDC, so listing both would double-count what /model's
- * provider step fixes in one pass. With either gateway credential present the
- * provider is satisfied and an unlinked directory is not flagged (linking only
- * matters for deploy). A hint, not an error: the model call stays the source of
- * truth.
+ * provider step fixes in one pass. The composed runtime endpoint is
+ * authoritative when available; legacy routing and local env can prove a
+ * provider is configured, but their absence remains unknown and cannot launch
+ * setup. A hint, not an error: the model call stays the source of truth.
  */
 const modelProvider: BootDetection = {
   id: "model-provider",
   async detect({ appRoot, env, info }) {
-    const endpoint = info?.agent.model.endpoint;
-    const isEndpointExternal =
-      endpoint?.kind === "external" ||
-      (endpoint === undefined && info?.agent.model.routing?.kind === "external");
-    const isAIGatewayConnected = endpoint?.kind === "gateway" && endpoint.connected;
+    const access = modelProviderAccess({ env, info });
 
-    // The running server owns endpoint readiness. Fall back to routing and
-    // local credential checks only when talking to a legacy server that did
-    // not return the composed endpoint state.
-    if (isEndpointExternal || isAIGatewayConnected) {
+    if (access === "configured") {
       return [];
     }
-    if (env.AI_GATEWAY_API_KEY || env.VERCEL_OIDC_TOKEN) {
-      return [];
+    const linked = await pathExists(join(appRoot, ".vercel", "project.json"));
+    if (access === "unconfigured") {
+      return [
+        {
+          kind: "model-provider-unconfigured",
+          label: linked ? "AI Gateway credentials missing" : "model provider not linked",
+          command: "/model",
+        },
+      ];
     }
-    if (!(await pathExists(join(appRoot, ".vercel", "project.json")))) {
-      return [{ label: "model provider not linked", command: "/model" }];
+    if (linked) {
+      return [{ kind: "attention", label: "AI Gateway credentials missing", command: "/model" }];
     }
-    return [{ label: "AI Gateway credentials missing", command: "/model" }];
+    return [{ kind: "attention", label: "model provider not linked", command: "/model" }];
   },
 };
 
@@ -77,7 +106,11 @@ export const BOOT_DETECTIONS: readonly BootDetection[] = [modelProvider];
  * runner probes it off the critical path and renders this issue only when the
  * probe resolves logged-out.
  */
-export const LOGIN_SETUP_ISSUE: SetupIssue = { label: "not logged in", command: "/login" };
+export const LOGIN_SETUP_ISSUE: SetupIssue = {
+  kind: "attention",
+  label: "not logged in",
+  command: "/login",
+};
 
 /**
  * The CLI-missing hint, surfaced by the same off-critical-path probe as
@@ -86,6 +119,7 @@ export const LOGIN_SETUP_ISSUE: SetupIssue = { label: "not logged in", command: 
  * command (`/vc`) rather than a logged-out state the probe can't determine.
  */
 export const CLI_MISSING_SETUP_ISSUE: SetupIssue = {
+  kind: "attention",
   label: "Vercel CLI not found",
   command: "/vc",
 };
@@ -117,6 +151,21 @@ export function orderedSetupIssues(
   authIssue: SetupIssue | undefined,
 ): SetupIssue[] {
   return authIssue === undefined ? [...bootIssues] : [authIssue, ...bootIssues];
+}
+
+/** The command and entry step authorized by positive setup evidence. */
+export interface AutomaticSetupCommand {
+  prompt: "/model";
+  initialModelStep: "provider";
+}
+
+/** Returns the only command authorized to run from positive setup evidence. */
+export function automaticSetupCommand(
+  issues: readonly SetupIssue[],
+): AutomaticSetupCommand | undefined {
+  return issues.some((issue) => issue.kind === "model-provider-unconfigured")
+    ? { prompt: "/model", initialModelStep: "provider" }
+    : undefined;
 }
 
 /**

--- a/packages/eve/src/cli/dev/tui/setup-panel.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.test.ts
@@ -118,7 +118,7 @@ describe("renderSelectQuestion", () => {
     expect(text).not.toContain("▔".repeat(10));
     // The lone hint sits one space past its own label — the longer hint-less
     // "Link an existing project" no longer pads the column open.
-    expect(text).toContain("  ▷ Create a new project · fastest");
+    expect(text).toContain("   ▶ Create a new project · fastest");
     expect(text).toContain("    Link an existing project");
     expect(text).not.toContain("1.");
     expect(text).toContain("esc to cancel");
@@ -137,7 +137,7 @@ describe("renderSelectQuestion", () => {
       60,
     );
 
-    expect(rows).toContain("  . Link an existing project");
+    expect(rows).toContain("   . Link an existing project");
     expect(rows.join("\n")).not.toContain("◦");
   });
 
@@ -154,8 +154,20 @@ describe("renderSelectQuestion", () => {
       60,
     ).join("\n");
 
-    expect(text).toContain("  ▷ Link to another project");
+    expect(text).toContain("   ▶ Link to another project ");
     expect(text).not.toContain("1.");
+
+    const colored = renderSelectQuestion(
+      {
+        kind: "single",
+        message: "Already linked to weather-agent in Acme",
+        options: lone,
+        select: initialSelectState({ options: lone }),
+      },
+      colorTheme,
+      60,
+    ).join("\n");
+    expect(colored).toContain("\x1b[7m\x1b[34m ▶ Link to another project \x1b[39m\x1b[27m");
   });
 
   it("renders completed task rows as focusable but not highlighted actions", () => {
@@ -191,15 +203,17 @@ describe("renderSelectQuestion", () => {
     );
 
     // The focused completed row reads as inert: a dim pointer, not a check.
-    expect(rows).toContain("  ▷ Terminal UI · Already installed");
-    expect(rows).not.toContain("  ✓ Terminal UI");
+    expect(rows).toContain("   ▷ Terminal UI · Already installed");
+    expect(rows).not.toContain("   ✓ Terminal UI");
     // An unfocused completed row keeps its check.
-    expect(rows).toContain("  ✓ Web Chat");
-    expect(rows).toContain("  ◦ Slack       · Creates slackbot and deploys to Vercel");
-    expect(rows).toContain("    Done");
+    expect(rows).toContain("   ✓ Web Chat");
+    expect(rows).toContain("   ◦ Slack       · Creates slackbot and deploys to Vercel");
+    expect(rows).toContain("     Done");
     expect(rows).toContain("  ⚠ Overwrote /tmp/weather-agent");
     expect(rows).toContain("  ✓ Scaffolded channel: web");
-    expect(rows.indexOf("    Done")).toBeLessThan(rows.indexOf("  ⚠ Overwrote /tmp/weather-agent"));
+    expect(rows.indexOf("     Done")).toBeLessThan(
+      rows.indexOf("  ⚠ Overwrote /tmp/weather-agent"),
+    );
     expect(rows.at(-1)).toContain("↑/↓ move · enter to select · esc to cancel");
 
     const coloredRow = renderSelectQuestion(
@@ -231,7 +245,7 @@ describe("renderSelectQuestion", () => {
       theme,
       60,
     ).join("\n");
-    expect(multi).toContain("  ▷ Create a new project");
+    expect(multi).toContain("   ▶ Create a new project ");
     expect(multi).not.toContain("1.");
 
     const searchable = renderSelectQuestion(
@@ -448,11 +462,11 @@ describe("renderSelectQuestion", () => {
     expect(rows).toEqual([
       "  Configure the agent's model",
       "",
-      "  ▷ Change model",
-      "    anthropic/claude-sonnet-4.6",
+      "   ▶ Change model ",
+      "     anthropic/claude-sonnet-4.6",
       "",
-      "  ◦ Change provider",
-      "    AI Gateway (Linked to my-agent)",
+      "   ◦ Change provider",
+      "     AI Gateway (Linked to my-agent)",
       "",
       "  ✓ Model changed to openai/gpt-5.5",
       "",
@@ -513,6 +527,30 @@ describe("renderSelectQuestion", () => {
     expect(text).toContain("\x1b[1mmy-agent\x1b[22m\x1b[2m)");
   });
 
+  it("keeps a warning row yellow under the cursor highlight", () => {
+    const options = [
+      {
+        value: "provider",
+        label: "Configure model access",
+        accent: "warning" as const,
+      },
+    ];
+    const rows = renderSelectQuestion(
+      {
+        kind: "stacked",
+        message: "",
+        options,
+        select: initialSelectState({ options }),
+      },
+      colorTheme,
+      80,
+    );
+
+    expect(rows).toContain(
+      `  ${colorTheme.colors.inverse(colorTheme.colors.yellow(" ▶ Configure model access "))}`,
+    );
+  });
+
   it("renders checkboxes and the Submit row for a multi-select", () => {
     const select = initialSelectState({
       options: OPTIONS,
@@ -530,7 +568,7 @@ describe("renderSelectQuestion", () => {
       60,
     ).join("\n");
 
-    expect(text).toContain("▷ Create a new project");
+    expect(text).toContain("▶ Create a new project");
     expect(text).toContain("✓ Link an existing project");
     expect(text).toContain("Submit");
     expect(text).toContain("space to toggle");
@@ -620,7 +658,7 @@ describe("renderSelectQuestion", () => {
 
     expect(context).toContain("\x1b[2m· Waiting for you to complete setup in the browser\x1b[22m");
     expect(context).not.toContain("▷");
-    expect(retry).toContain("\x1b[36m▷\x1b[39m");
+    expect(retry).toContain(colorTheme.colors.inverse(colorTheme.colors.blue(" ▶ Try again ")));
   });
 });
 

--- a/packages/eve/src/cli/dev/tui/setup-panel.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.ts
@@ -15,7 +15,12 @@
  */
 
 import type { ChannelSetupAction, PromptOption } from "#setup/cli/index.js";
-import { renderOptionRow, resolveOptionRowState } from "#setup/cli/option-row.js";
+import {
+  renderOptionRow,
+  renderOptionRowContinuation,
+  renderCursorRow,
+  resolveOptionRowState,
+} from "#setup/cli/option-row.js";
 import { filterOptions, submitRowIndex, type SelectState } from "#setup/cli/select-state.js";
 import type { SelectNotice } from "#setup/prompter.js";
 import { graphemes } from "#shared/text-boundaries.js";
@@ -239,6 +244,7 @@ function optionRow(input: {
     colors: theme.colors,
     glyphs: {
       pointer: theme.glyph.pointer,
+      selectedPointer: theme.glyph.selectedPointer,
       success: theme.glyph.success,
       placeholder: theme.glyph.option,
       dot: theme.glyph.dot,
@@ -437,7 +443,7 @@ function appendSelectOptionRows(input: {
     );
 
     if (stackedHint !== undefined) {
-      rows.push(`${" ".repeat(4)}${dimWithEmphasis(stackedHint, theme)}`);
+      rows.push(`  ${renderOptionRowContinuation(dimWithEmphasis(stackedHint, theme))}`);
     }
     // Disabled descriptions explain why an inert row cannot be selected, so
     // keep them visible even though the cursor skips that row.
@@ -451,9 +457,10 @@ function appendSelectOptionRows(input: {
 function appendSubmitRow(rows: string[], cursor: number, submitIndex: number, theme: Theme): void {
   if (submitIndex < 0) return;
   const onSubmit = cursor === submitIndex;
-  const pointer = onSubmit ? theme.colors.cyan(theme.glyph.pointer) : " ";
-  const label = onSubmit ? theme.colors.cyan(theme.colors.bold("Submit")) : "Submit";
-  rows.push("", `  ${pointer} ${label}`);
+  const content = onSubmit
+    ? `${theme.glyph.selectedPointer} ${theme.colors.bold("Submit")}`
+    : "  Submit";
+  rows.push("", `  ${renderCursorRow(content, onSubmit, theme.colors)}`);
 }
 
 function appendSelectNotices(
@@ -545,7 +552,6 @@ export function renderSelectQuestion(
   // An empty message (e.g. a panel-titled menu) contributes no header rows;
   // the panel's own spacing does the separating.
   const rows = selectMessageRows(state.message, presentation.layout, theme);
-
   if (presentation.filter !== undefined) {
     rows.push(`  ${searchFilter(state.select.filter, presentation.filter.placeholder, theme)}`);
   }

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -734,6 +734,42 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("renders the selected question option as a padded inverse-blue label", async () => {
+    const { screen, input, renderer } = makeRenderer();
+
+    const answer = renderer.readInputQuestion({
+      requestId: "q1",
+      prompt: "Choose access",
+      display: "select",
+      options: [
+        { id: "gateway", label: "AI Gateway", description: "Managed access" },
+        { id: "external", label: "Other providers", description: "Direct access" },
+      ],
+    });
+
+    const selected = screen
+      .snapshot()
+      .split("\n")
+      .find((line) => line.includes("AI Gateway"));
+    expect(selected).toContain(" ▶ AI Gateway ");
+    expect(screen.rawOutput()).toContain("\x1b[7m");
+    expect(screen.rawOutput()).toContain("\x1b[34m");
+
+    const selectedDescriptionColumn = selected?.indexOf("— Managed access");
+    expect(selectedDescriptionColumn).toBeGreaterThanOrEqual(0);
+    input.down();
+    const unselected = screen
+      .snapshot()
+      .split("\n")
+      .find((line) => line.includes("AI Gateway"));
+    expect(unselected?.indexOf("— Managed access")).toBe(selectedDescriptionColumn);
+    input.up();
+
+    input.enter();
+    await expect(answer).resolves.toEqual({ optionId: "gateway" });
+    renderer.shutdown();
+  });
+
   it("edits freeform question input across lines", async () => {
     const { input, renderer } = makeRenderer();
 
@@ -2037,6 +2073,8 @@ describe("TerminalRenderer command typeahead", () => {
     expect(snapshot).toContain("/help");
     expect(snapshot).toContain("Show available commands");
     expect(snapshot).toContain("Configure the agent's model and provider");
+    const promptLine = snapshot.split("\n").find((line) => line.includes("❯ /"));
+    expect(promptLine?.startsWith(" ❯ /")).toBe(true);
 
     input.enter();
     // The highlighted default — /help leads the registry — is what a bare

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -50,6 +50,7 @@ import {
   selectValueAtCursor,
   type SelectState,
 } from "#setup/cli/select-state.js";
+import { renderCursorRow } from "#setup/cli/option-row.js";
 import type {
   AssistantResponseStatsMode,
   LogDisplayMode,
@@ -2829,8 +2830,8 @@ function promptInputRows({
   );
   const promptGlyph = c.cyan(theme.glyph.prompt);
   const ellipsis = c.dim(theme.glyph.ellipsis);
-  // Reserve the gutter and the block caret's trailing cell at end-of-line.
-  const budget = Math.max(1, width - 3);
+  // Reserve the leading pad, gutter, and block caret's trailing cell at end-of-line.
+  const budget = Math.max(1, width - 4);
   const out: string[] = [];
   for (let r = top; r < top + visibleCount; r += 1) {
     const row = layout.rows[r]!;
@@ -2857,7 +2858,7 @@ function promptInputRows({
     } else {
       body = style(row.text);
     }
-    out.push(clip(`${gutter} ${body}`, width));
+    out.push(clip(` ${gutter} ${body}`, width));
   }
   out.push("");
   return out;
@@ -3068,17 +3069,20 @@ function formatQuestionContent(
       const labelText = stripTerminalControls(option.label);
       const descriptionText =
         option.description === undefined ? "" : stripTerminalControls(option.description);
-      const description = descriptionText.length > 0 ? `  ${c.dim(`— ${descriptionText}`)}` : "";
       const selected = highlight === index;
-      const marker = selected ? `${c.cyan(theme.glyph.pointer)} ` : "  ";
-      const label = selected ? c.cyan(labelText) : labelText;
-      lines.push(`${marker}${label}${description}`);
+      const description =
+        descriptionText.length > 0
+          ? `${selected ? " " : "  "}${c.dim(`— ${descriptionText}`)}`
+          : "";
+      const content = selected ? `${theme.glyph.selectedPointer} ${labelText}` : `  ${labelText}`;
+      const selection = renderCursorRow(content, selected, c);
+      lines.push(`${selection}${description}`);
     }
     if (question.allowFreeform === true) {
       const selected = highlight === options.length;
-      const marker = selected ? `${c.cyan(theme.glyph.pointer)} ` : "  ";
       const label = "Type your own answer";
-      lines.push(`${marker}${selected ? c.cyan(label) : c.dim(label)}`);
+      const content = selected ? `${theme.glyph.selectedPointer} ${label}` : `  ${c.dim(label)}`;
+      lines.push(renderCursorRow(content, selected, c));
     }
   } else {
     lines.push(c.dim("  (type your answer)"));

--- a/packages/eve/src/cli/dev/tui/test/fake-setup-flow-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/test/fake-setup-flow-renderer.ts
@@ -1,0 +1,23 @@
+import type { SetupFlowRenderer } from "../setup-flow.js";
+
+export function createFakeSetupFlowRenderer(
+  overrides: Partial<SetupFlowRenderer> = {},
+): SetupFlowRenderer {
+  return {
+    begin: () => {},
+    end: () => {},
+    readSelect: async () => undefined,
+    readEditableSelect: async () => undefined,
+    readText: async () => undefined,
+    readAcknowledge: async () => {},
+    readChoice: () => ({ choice: Promise.resolve(undefined), close: () => {} }),
+    setStatus: () => {},
+    renderLine: () => {},
+    renderOutput: () => {},
+    waitForInterrupt: () => ({
+      promise: new Promise<void>(() => {}),
+      dispose: () => {},
+    }),
+    ...overrides,
+  };
+}

--- a/packages/eve/src/cli/dev/tui/theme.ts
+++ b/packages/eve/src/cli/dev/tui/theme.ts
@@ -81,8 +81,10 @@ export interface ThemeGlyphs {
   connection: string;
   /** `→` — separates a tool call from its summarized result. */
   arrow: string;
-  /** `▷` — selected-option marker in question lists. */
+  /** `▷` — cursor marker for an inert option. */
   pointer: string;
+  /** `▶` — cursor marker for an actionable option. */
+  selectedPointer: string;
   /** `◦` — available, unselected option marker. */
   option: string;
   /** `❯` — the input prompt mark. */
@@ -116,6 +118,7 @@ const UNICODE_GLYPHS: ThemeGlyphs = {
   connection: "●",
   arrow: "→",
   pointer: "▷",
+  selectedPointer: "▶",
   option: "◦",
   prompt: "❯",
   elbow: "⎿",
@@ -140,6 +143,7 @@ const ASCII_GLYPHS: ThemeGlyphs = {
   connection: "*",
   arrow: "->",
   pointer: ">",
+  selectedPointer: ">",
   option: ".",
   prompt: ">",
   elbow: "`-",

--- a/packages/eve/src/setup/cli/option-row.test.ts
+++ b/packages/eve/src/setup/cli/option-row.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   renderOptionRow,
+  renderOptionRowContinuation,
   resolveOptionRowState,
   UNICODE_ROW_GLYPHS,
   type OptionRowState,
@@ -9,9 +10,10 @@ import {
 } from "./option-row.js";
 
 const colors: RowColors = {
+  blue: (text) => `<blue>${text}</blue>`,
   dim: (text) => `<dim>${text}</dim>`,
   green: (text) => `<green>${text}</green>`,
-  cyan: (text) => `<cyan>${text}</cyan>`,
+  inverse: (text) => `<inverse>${text}</inverse>`,
   yellow: (text) => `<yellow>${text}</yellow>`,
 };
 
@@ -34,27 +36,48 @@ function row(
 }
 
 describe("renderOptionRow", () => {
-  test("hover changes the icon to a cyan pointer and tints the label", () => {
-    expect(row({ label: "Yes", isCursor: true })).toBe("<cyan>▷</cyan> <cyan>Yes</cyan>");
+  test("owns continuation indentation at the option label column", () => {
+    const option = row({ label: "Option" });
+    const continuation = renderOptionRowContinuation("Hint");
+
+    expect(continuation).toBe("   Hint");
+    expect(continuation.indexOf("Hint")).toBe(option.indexOf("Option"));
+  });
+
+  test("highlights the cursor row in inverse blue and keeps its hint outside", () => {
+    expect(row({ label: "Yes", hint: "Create a project", isCursor: true })).toBe(
+      "<inverse><blue> ▶ Yes </blue></inverse><dim>· Create a project</dim>",
+    );
+  });
+
+  test("keeps the hint column fixed when selection adds trailing padding", () => {
+    const visible = (text: string) => text.replaceAll(/<[^>]+>/g, "");
+    const unselected = visible(row({ label: "Slack", hint: "persistent" }));
+    const selected = visible(row({ label: "Slack", hint: "persistent", isCursor: true }));
+
+    expect(selected.indexOf("·")).toBe(unselected.indexOf("·"));
   });
 
   test("an un-hovered available row is a blank glyph and a plain label", () => {
-    expect(row({ label: "No" })).toBe("  No");
+    expect(row({ label: "No" })).toBe("   No");
   });
 
-  test("a warning-accent row under the cursor paints the pointer and label yellow", () => {
+  test("a warning accent stays yellow under the cursor highlight", () => {
+    expect(row({ label: "Configure provider", accent: "warning" })).toBe(
+      "   <yellow>Configure provider</yellow>",
+    );
     expect(row({ label: "Configure provider", isCursor: true, accent: "warning" })).toBe(
-      "<yellow>▷</yellow> <yellow>Configure provider</yellow>",
+      "<inverse><yellow> ▶ Configure provider </yellow></inverse>",
     );
   });
 
   test("an un-hovered available row shows the placeholder dot when asked", () => {
-    expect(row({ label: "Slack", placeholder: true })).toBe("<dim>◦</dim> Slack");
+    expect(row({ label: "Slack", placeholder: true })).toBe(" <dim>◦</dim> Slack");
   });
 
   test("a checked row off the cursor shows a green check (single column, no checkbox)", () => {
     expect(row({ label: "Slack", state: { kind: "available", checked: true } })).toBe(
-      "<green>✓</green> Slack",
+      " <green>✓</green> Slack",
     );
   });
 
@@ -65,7 +88,7 @@ describe("renderOptionRow", () => {
         isCursor: true,
         state: { kind: "available", checked: true },
       }),
-    ).toBe("<cyan>▷</cyan> <cyan>Web Chat</cyan>");
+    ).toBe("<inverse><blue> ▶ Web Chat </blue></inverse>");
   });
 
   test("a completed row under the cursor reads as inert: a dim pointer and dim label", () => {
@@ -76,12 +99,12 @@ describe("renderOptionRow", () => {
         state: { kind: "completed" },
         focusHint: "Already installed",
       }),
-    ).toBe("<dim>▷</dim> <dim>Web Chat</dim><dim> · Already installed</dim>");
+    ).toBe(" <dim>▷</dim> <dim>Web Chat</dim><dim> · Already installed</dim>");
   });
 
   test("a completed row off the cursor keeps its green check", () => {
     expect(row({ label: "Web Chat", state: { kind: "completed" } })).toBe(
-      "<green>✓</green> <dim>Web Chat</dim>",
+      " <green>✓</green> <dim>Web Chat</dim>",
     );
   });
 
@@ -91,7 +114,7 @@ describe("renderOptionRow", () => {
         label: "Terminal UI",
         state: { kind: "locked", reason: "always available" },
       }),
-    ).toBe("<dim><green>✓</green></dim> <dim>Terminal UI (always available)</dim>");
+    ).toBe(" <dim><green>✓</green></dim> <dim>Terminal UI (always available)</dim>");
   });
 
   test("disabled rows dim the label and reason — no strikethrough", () => {
@@ -100,7 +123,7 @@ describe("renderOptionRow", () => {
         label: "Slack",
         state: { kind: "disabled", reason: "needs a Vercel project" },
       }),
-    ).toBe("  <dim>Slack (needs a Vercel project)</dim>");
+    ).toBe("   <dim>Slack (needs a Vercel project)</dim>");
   });
 
   test("an un-hovered disabled menu row keeps the placeholder glyph", () => {
@@ -110,7 +133,7 @@ describe("renderOptionRow", () => {
         state: { kind: "disabled", reason: "needs a Vercel project" },
         placeholder: true,
       }),
-    ).toBe("<dim>◦</dim> <dim>Slack (needs a Vercel project)</dim>");
+    ).toBe(" <dim>◦</dim> <dim>Slack (needs a Vercel project)</dim>");
   });
 
   test("a disabled row under the cursor reads as inert: a dim pointer, not the placeholder", () => {
@@ -121,7 +144,7 @@ describe("renderOptionRow", () => {
         state: { kind: "disabled" },
         placeholder: true,
       }),
-    ).toBe("<dim>▷</dim> <dim>Waiting</dim>");
+    ).toBe(" <dim>▷</dim> <dim>Waiting</dim>");
   });
 
   test("warning-toned disabled rows keep the label dim and turn the reason yellow", () => {
@@ -134,20 +157,20 @@ describe("renderOptionRow", () => {
           reasonTone: "warning",
         },
       }),
-    ).toBe("  <dim>Slack</dim><yellow> (Requires Vercel account, see /model)</yellow>");
+    ).toBe("   <dim>Slack</dim><yellow> (Requires Vercel account, see /model)</yellow>");
   });
 
   test("a hint tab-aligns behind a padded label column", () => {
     expect(
       row({ label: "Slack", hint: "creates a slackbot", placeholder: true, hintPadding: 6 }),
-    ).toBe("<dim>◦</dim> Slack<dim>       · creates a slackbot</dim>");
+    ).toBe(" <dim>◦</dim> Slack<dim>       · creates a slackbot</dim>");
   });
 
   test("a persistent hint shows on any row; a focus hint only under the cursor", () => {
-    expect(row({ label: "Slack", hint: "persistent" })).toBe("  Slack<dim> · persistent</dim>");
-    expect(row({ label: "Slack", focusHint: "only on hover" })).toBe("  Slack");
+    expect(row({ label: "Slack", hint: "persistent" })).toBe("   Slack<dim> · persistent</dim>");
+    expect(row({ label: "Slack", focusHint: "only on hover" })).toBe("   Slack");
     expect(row({ label: "Slack", isCursor: true, focusHint: "only on hover" })).toBe(
-      "<cyan>▷</cyan> <cyan>Slack</cyan><dim> · only on hover</dim>",
+      "<inverse><blue> ▶ Slack </blue></inverse><dim>· only on hover</dim>",
     );
   });
 

--- a/packages/eve/src/setup/cli/option-row.ts
+++ b/packages/eve/src/setup/cli/option-row.ts
@@ -13,16 +13,19 @@
 
 /** The color primitives the row painter needs; satisfied by both the TUI theme and the CLI palette. */
 export interface RowColors {
+  blue(text: string): string;
   dim(text: string): string;
   green(text: string): string;
-  cyan(text: string): string;
+  inverse(text: string): string;
   yellow(text: string): string;
 }
 
 /** The glyphs the row painter draws; the TUI passes theme-derived values, the CLI the unicode set. */
 export interface RowGlyphs {
-  /** Hover marker — the icon a row changes to under the cursor. */
+  /** Hollow cursor marker for an inert row. */
   pointer: string;
+  /** Filled cursor marker for an actionable row. */
+  selectedPointer: string;
   /** Completed / checked marker. */
   success: string;
   /** Available, un-hovered marker. */
@@ -34,6 +37,7 @@ export interface RowGlyphs {
 /** Canonical unicode glyphs; the CLI prompts render with these. */
 export const UNICODE_ROW_GLYPHS: RowGlyphs = {
   pointer: "▷",
+  selectedPointer: "▶",
   success: "✓",
   placeholder: "◦",
   dot: "·",
@@ -60,9 +64,8 @@ interface OptionRowInput {
   /** Spaces inserted before the hint's dot so hints tab-align to a shared column. */
   hintPadding?: number;
   /**
-   * Accent for the cursor pointer and active label. Defaults to cyan; "warning"
-   * makes them yellow so the pointer matches an attention row (e.g. a required,
-   * yellow-labelled action).
+   * Accent for an available row. "warning" keeps an attention row yellow at
+   * rest and under the cursor highlight.
    */
   accent?: "warning";
 }
@@ -133,19 +136,18 @@ function disabledLabel(
 
 function optionRowPresentation(input: OptionRowInput): OptionRowPresentation {
   const { colors: c, glyphs, state } = input;
-  const activeColor = input.accent === "warning" ? c.yellow : c.cyan;
 
   switch (state.kind) {
     case "available":
       if (input.isCursor) {
         return {
-          glyph: activeColor(glyphs.pointer),
-          label: activeColor(input.label),
+          glyph: glyphs.selectedPointer,
+          label: input.label,
         };
       }
       return {
         glyph: state.checked ? c.green(glyphs.success) : unfocusedGlyph(input),
-        label: input.label,
+        label: input.accent === "warning" ? c.yellow(input.label) : input.label,
       };
     case "completed":
       return {
@@ -168,6 +170,23 @@ function optionRowPresentation(input: OptionRowInput): OptionRowPresentation {
   return exhaustive;
 }
 
+/** Paints a row with the shared leading cell and optional cursor highlight. */
+export function renderCursorRow(
+  text: string,
+  selected: boolean,
+  colors: Pick<RowColors, "blue" | "inverse" | "yellow">,
+  accent?: "warning",
+): string {
+  if (!selected) return ` ${text}`;
+  const color = accent === "warning" ? colors.yellow : colors.blue;
+  return colors.inverse(color(` ${text} `));
+}
+
+/** Prefixes a continuation line so its text starts in the option label column. */
+export function renderOptionRowContinuation(text: string): string {
+  return `   ${text}`;
+}
+
 /**
  * Paints one option row as `glyph label · hint`. The glyph reflects state with
  * hover taking precedence for focusable rows: available rows use the active
@@ -178,12 +197,16 @@ function optionRowPresentation(input: OptionRowInput): OptionRowPresentation {
 export function renderOptionRow(input: OptionRowInput): string {
   const { colors: c, glyphs } = input;
   const { glyph, label } = optionRowPresentation(input);
+  const selected = input.isCursor && input.state.kind === "available";
 
   let hintText = input.hint;
   if (input.isCursor && input.focusHint !== undefined) hintText = input.focusHint;
   let hint = "";
   if (hintText !== undefined) {
-    hint = c.dim(`${" ".repeat((input.hintPadding ?? 0) + 1)}${glyphs.dot} ${hintText}`);
+    const separatorWidth = Math.max(0, (input.hintPadding ?? 0) + 1 - Number(selected));
+    hint = c.dim(`${" ".repeat(separatorWidth)}${glyphs.dot} ${hintText}`);
   }
-  return `${glyph} ${label}${hint}`;
+  const content = `${glyph} ${label}`;
+  const row = renderCursorRow(content, selected, c, input.accent);
+  return `${row}${hint}`;
 }

--- a/packages/eve/src/setup/cli/prompt-ui.test.ts
+++ b/packages/eve/src/setup/cli/prompt-ui.test.ts
@@ -12,6 +12,7 @@ import {
 const identity = (text: string) => text;
 
 const colors: PromptColors = {
+  blue: identity,
   bold: identity,
   cyan: identity,
   dim: identity,
@@ -26,10 +27,12 @@ const colors: PromptColors = {
 
 const styledColors: PromptColors = {
   ...colors,
+  blue: (text) => `<blue>${text}</blue>`,
   bold: (text) => `<b>${text}</b>`,
   dim: (text) => `<dim>${text}</dim>`,
   green: (text) => `<green>${text}</green>`,
   cyan: (text) => `<cyan>${text}</cyan>`,
+  inverse: (text) => `<inverse>${text}</inverse>`,
   strikethrough: (text) => `<strike>${text}</strike>`,
   yellow: (text) => `<yellow>${text}</yellow>`,
 };
@@ -75,7 +78,7 @@ describe("renderSelectPrompt", () => {
     });
 
     expect(rendered).toContain(
-      "<cyan>▷</cyan> <cyan>Yes</cyan><dim> · Create or link a project</dim>",
+      "<inverse><blue> ▶ Yes </blue></inverse><dim>· Create or link a project</dim>",
     );
     // No check or legacy checkbox glyphs on a single-select row.
     expect(rendered).not.toContain("✓");
@@ -119,7 +122,9 @@ describe("renderSelectPrompt", () => {
       state: "active",
     });
 
-    expect(rendered).toContain("<cyan>No</cyan>\n│    <dim>Set up locally and wire yourself</dim>");
+    expect(rendered).toContain(
+      "<inverse><blue> ▶ No </blue></inverse>\n│    <dim>Set up locally and wire yourself</dim>",
+    );
     // The non-highlighted option keeps its description hidden.
     expect(rendered).not.toContain("Fastest path to production");
   });
@@ -224,7 +229,7 @@ describe("renderMultiselectPrompt", () => {
     });
 
     // Cursor row (Web Chat): the pointer. Selected row off-cursor (Slack): a check.
-    expect(rendered).toContain("<cyan>▷</cyan> <cyan>Web Chat</cyan>");
+    expect(rendered).toContain("<inverse><blue> ▶ Web Chat </blue></inverse>");
     expect(rendered).toContain("<green>✓</green> Slack");
     // No key legend: the Submit row carries the confirm affordance.
     expect(rendered).not.toContain("space");
@@ -246,10 +251,20 @@ describe("renderMultiselectPrompt", () => {
       });
 
     // A blank rail line sets the bold Submit row (with its green check) apart.
-    expect(render(0)).toContain("│\n│    <dim><b>Submit</b></dim> <green>✓</green>");
+    expect(render(0)).toContain("│\n│     <dim><b>Submit</b></dim> <green>✓</green>");
     // Cursor one past the options sits on the Submit row: the pointer plus a
     // bright label.
-    expect(render(2)).toContain("<cyan>▷</cyan> <b>Submit</b> <green>✓</green>");
+    expect(render(2)).toContain(
+      "<inverse><blue> ▶ <b>Submit</b> </blue></inverse><green>✓</green>",
+    );
+    const visible = (text: string) => text.replaceAll(/<[^>]+>/g, "");
+    const unselected = visible(render(0))
+      .split("\n")
+      .find((line) => line.includes("Submit"));
+    const selected = visible(render(2))
+      .split("\n")
+      .find((line) => line.includes("Submit"));
+    expect(selected?.indexOf("✓")).toBe(unselected?.indexOf("✓"));
   });
 
   test("labels the Submit row with the caller-computed label", () => {
@@ -280,7 +295,7 @@ describe("renderMultiselectPrompt", () => {
       state: "active",
     });
 
-    expect(rendered).toContain("<cyan>▷</cyan> <cyan>Web Chat</cyan>");
+    expect(rendered).toContain("<inverse><blue> ▶ Web Chat </blue></inverse>");
     // A locked row is mandatory rather than user-selected, so both its check
     // and label stay dim while the reason remains inline.
     expect(rendered).toContain(
@@ -328,7 +343,7 @@ describe("renderSearchableSelect", () => {
       submitDisplay: "",
     });
 
-    expect(rendered).toContain("<cyan>▷</cyan> <cyan>alpha</cyan>");
+    expect(rendered).toContain("<inverse><blue> ▶ alpha </blue></inverse>");
     expect(rendered).toContain("<cyan>enter</cyan><dim> to select</dim>");
     expect(rendered).not.toContain("space");
     expect(rendered).not.toContain("◻");
@@ -348,7 +363,7 @@ describe("renderSearchableSelect", () => {
       submitDisplay: "",
     });
 
-    expect(rendered).toContain("<cyan>▷</cyan> <cyan>alpha</cyan>");
+    expect(rendered).toContain("<inverse><blue> ▶ alpha </blue></inverse>");
     expect(rendered).toContain("<green>✓</green> beta");
     expect(rendered).toContain("<dim><b>Submit</b></dim> <green>✓</green>");
     // The Submit row replaces the key legend; only the filter hint remains.
@@ -370,9 +385,9 @@ describe("renderSearchableSelect", () => {
       submitDisplay: "",
     });
 
-    expect(rendered).toContain("<cyan>▷</cyan> <b>Submit</b> <green>✓</green>");
+    expect(rendered).toContain("<inverse><blue> ▶ <b>Submit</b> </blue></inverse><green>✓</green>");
     // No option row carries the pointer while the cursor sits on Submit.
-    expect(rendered).not.toContain("<cyan>▷</cyan> <cyan>alpha</cyan>");
+    expect(rendered).not.toContain("<inverse><blue> ▶ alpha </blue></inverse>");
   });
 
   test("a leading featured run sizes the default viewport; scrolling reaches the rest", () => {

--- a/packages/eve/src/setup/cli/prompt-ui.ts
+++ b/packages/eve/src/setup/cli/prompt-ui.ts
@@ -2,7 +2,12 @@ import type { Writable } from "node:stream";
 
 import { wrapTextWithPrefix } from "@clack/core";
 
-import { renderOptionRow, resolveOptionRowState, UNICODE_ROW_GLYPHS } from "./option-row.js";
+import {
+  renderCursorRow,
+  renderOptionRow,
+  resolveOptionRowState,
+  UNICODE_ROW_GLYPHS,
+} from "./option-row.js";
 
 /** Terminal lifecycle state accepted by the shared prompt renderer. */
 export type PromptState = "initial" | "active" | "submit" | "cancel" | "error";
@@ -12,6 +17,7 @@ export type PromptValue = string | number | boolean;
 
 /** Coloring operations used by prompt rendering without coupling to a color library. */
 export interface PromptColors {
+  blue(text: string): string;
   bold(text: string): string;
   cyan(text: string): string;
   dim(text: string): string;
@@ -28,17 +34,16 @@ export interface PromptColors {
 export interface PromptOption<T extends PromptValue> {
   value: T;
   label: string;
-  /** Short inline annotation shown in parentheses while the option is highlighted. */
+  /** Supporting copy; stacked prompts render newline-separated text on separate rows. */
   hint?: string;
   /** Short inline annotation shown dimmed only while the cursor is on this row. */
   focusHint?: string;
   /**
-   * Longer, display-only explanation shown dimmed on the line below the option
-   * while it is highlighted during navigation. It is navigation-only: once a
-   * choice is submitted only the label remains.
+   * Longer, display-only explanation for the highlighted option. Its prompt
+   * chooses the placement; it is hidden once a choice is submitted.
    */
   description?: string;
-  /** Cursor-pointer/active-label accent; "warning" turns them yellow for an attention row. */
+  /** Row accent; "warning" stays yellow both at rest and under the cursor. */
   accent?: "warning";
   disabled?: boolean;
   disabledReason?: string;
@@ -353,7 +358,7 @@ function descriptionLine<T extends PromptValue>(
 /**
  * Renders the virtual Submit row that closes every multi-select list. It has
  * no checkbox — its bold label sits in the checkbox column, trails a green
- * check, and brightens under the cursor; enter confirms the checklist only
+ * check, and uses the shared cursor highlight; enter confirms the checklist only
  * from here. The label reads "Skip" while an optional checklist has nothing
  * picked (the caller computes that), so an empty confirm is honest about what
  * it does. Callers put a blank rail line above it to set it apart from the
@@ -364,9 +369,12 @@ export function renderSubmitRow(
   colors: PromptColors,
   label: string = "Submit",
 ): string {
-  const arrow = isCursor ? colors.cyan(UNICODE_ROW_GLYPHS.pointer) : " ";
   const bold = colors.bold(label);
-  return `${arrow} ${isCursor ? bold : colors.dim(bold)} ${colors.green(UNICODE_ROW_GLYPHS.success)}`;
+  const content = isCursor
+    ? `${UNICODE_ROW_GLYPHS.selectedPointer} ${bold}`
+    : `  ${colors.dim(bold)}`;
+  const suffixSeparator = isCursor ? "" : " ";
+  return `${renderCursorRow(content, isCursor, colors)}${suffixSeparator}${colors.green(UNICODE_ROW_GLYPHS.success)}`;
 }
 
 function renderMultiselectRows<T extends PromptValue>(input: {

--- a/packages/eve/src/setup/cli/rail-log.test.ts
+++ b/packages/eve/src/setup/cli/rail-log.test.ts
@@ -8,6 +8,7 @@ import type { PromptColors } from "./prompt-ui.js";
 const identity = (text: string) => text;
 
 const colors: PromptColors = {
+  blue: identity,
   bold: identity,
   cyan: identity,
   dim: identity,

--- a/packages/eve/src/setup/flows/model.test.ts
+++ b/packages/eve/src/setup/flows/model.test.ts
@@ -44,7 +44,9 @@ function flowDeps(overrides: Partial<ModelFlowDeps> = {}): Partial<ModelFlowDeps
         ({ kind: "changed", to: slug }) as const,
     ),
     selectModel: { fetchModels: async () => CATALOG },
-    detectProviderStatus: vi.fn(async () => ({ kind: "unset" }) as const),
+    detectProviderStatus: vi.fn(
+      async () => ({ kind: "gateway-project", projectName: "my-agent" }) as const,
+    ),
     runVercelFlow: vi.fn(async () => ({ kind: "done" }) as const),
     ...overrides,
   };
@@ -94,7 +96,7 @@ function scriptedPrompter(input: { menu: (PrompterValue | "esc")[]; picker?: str
 }
 
 describe("runModelFlow", () => {
-  it("paints a stacked menu with the running model and a required provider row", async () => {
+  it("paints a stacked menu with the running model and configured provider", async () => {
     const { prompter, menuPaints } = scriptedPrompter({ menu: ["esc"] });
 
     await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps: flowDeps() })).resolves.toEqual({
@@ -107,17 +109,14 @@ describe("runModelFlow", () => {
           { value: "model", label: "Change model", hint: "anthropic/claude-sonnet-4.6" },
           {
             value: "provider",
-            label: pc.bold(pc.yellow("Configure provider")),
-            hint: "Required to enable the agent",
-            accent: "warning",
+            label: "Change provider",
+            hint: `AI Gateway (Linked to ${pc.bold("my-agent")})`,
           },
           { value: "done", label: "Done" },
         ],
         notices: [],
         hintLayout: "stacked",
-        // An unconfigured provider is what the agent needs first, so the menu
-        // opens on that row.
-        initialValue: "provider",
+        initialValue: "model",
       },
     ]);
   });
@@ -292,8 +291,8 @@ describe("runModelFlow", () => {
     expect(menuPaints).toHaveLength(1);
   });
 
-  it("returns to the prompt after provider setup", async () => {
-    const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider"] });
+  it("opens provider setup directly when none is configured", async () => {
+    const { prompter, menuPaints } = scriptedPrompter({ menu: [] });
     const detectProviderStatus = vi
       .fn<ModelFlowDeps["detectProviderStatus"]>()
       .mockResolvedValueOnce({ kind: "unset" })
@@ -313,7 +312,33 @@ describe("runModelFlow", () => {
 
     expect(runVercelFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
     expect(detectProviderStatus).toHaveBeenCalledTimes(2);
-    expect(menuPaints).toHaveLength(1);
+    expect(menuPaints).toHaveLength(0);
+  });
+
+  it("honors confirmed provider entry when link metadata looks configured", async () => {
+    const { prompter, menuPaints } = scriptedPrompter({ menu: [] });
+    const runVercelFlow = vi.fn<ModelFlowDeps["runVercelFlow"]>(
+      async () => ({ kind: "done", credential: "VERCEL_OIDC_TOKEN" }) as const,
+    );
+    const deps = flowDeps({ runVercelFlow });
+
+    await expect(
+      runModelFlow({
+        appRoot: APP_ROOT,
+        prompter,
+        initialStep: "provider",
+        deps,
+      }),
+    ).resolves.toEqual({
+      kind: "done",
+      providerOutcome: {
+        credential: "VERCEL_OIDC_TOKEN",
+        status: { kind: "gateway-project", projectName: "my-agent" },
+      },
+    });
+
+    expect(runVercelFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
+    expect(menuPaints).toHaveLength(0);
   });
 
   it("treats the external-provider branch as informational — no notice, no outcome", async () => {

--- a/packages/eve/src/setup/flows/model.ts
+++ b/packages/eve/src/setup/flows/model.ts
@@ -226,6 +226,8 @@ export async function detectModelProviderStatus(
 export async function runModelFlow(input: {
   appRoot: string;
   prompter: Prompter;
+  /** Opens provider setup before the root menu when runtime evidence requires it. */
+  initialStep?: "provider";
   signal?: AbortSignal;
   deps?: Partial<ModelFlowDeps>;
 }): Promise<ModelFlowResult> {
@@ -277,20 +279,29 @@ export async function runModelFlow(input: {
         : routing?.kind === "external"
           ? "done"
           : "provider";
+  // A gateway model with no provider cannot run. Skip the menu's extra Enter
+  // and open provider setup as soon as that state is confirmed.
+  let openProviderFirst =
+    routing?.kind !== "external" && (input.initialStep === "provider" || provider.kind === "unset");
 
   while (true) {
     let pick: ModelMenuRow;
-    try {
-      pick = await prompter.select<ModelMenuRow>({
-        message: MODEL_MENU_MESSAGE,
-        options: modelMenuRows(current, provider, routing, editable),
-        hintLayout: "stacked",
-        initialValue: nextSelection,
-        notices: externalNotice === undefined ? [] : [externalNotice],
-      });
-    } catch (error) {
-      if (!(error instanceof WizardCancelledError)) throw error;
-      break;
+    if (openProviderFirst) {
+      openProviderFirst = false;
+      pick = "provider";
+    } else {
+      try {
+        pick = await prompter.select<ModelMenuRow>({
+          message: MODEL_MENU_MESSAGE,
+          options: modelMenuRows(current, provider, routing, editable),
+          hintLayout: "stacked",
+          initialValue: nextSelection,
+          notices: externalNotice === undefined ? [] : [externalNotice],
+        });
+      } catch (error) {
+        if (!(error instanceof WizardCancelledError)) throw error;
+        break;
+      }
     }
 
     if (pick === "done") break;

--- a/packages/eve/src/setup/quit-guard.test.ts
+++ b/packages/eve/src/setup/quit-guard.test.ts
@@ -6,6 +6,7 @@ import { initialQuitGuardState, quitHintNote, reduceQuitGuard } from "./quit-gua
 const identity = (text: string) => text;
 
 const colors: PromptColors = {
+  blue: identity,
   bold: identity,
   cyan: identity,
   dim: identity,

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -189,7 +189,7 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--input", "/model"],
+        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev"],
         cwd: canonicalProjectDir,
       },
     ]);
@@ -232,7 +232,7 @@ describe("eve init smoke", () => {
       "--no-frozen-lockfile",
       "--config.minimum-release-age=0",
     ]);
-    expect(devCall?.args.slice(-5)).toEqual(["exec", "eve", "dev", "--input", "/model"]);
+    expect(devCall?.args.slice(-3)).toEqual(["exec", "eve", "dev"]);
   });
 
   it("adds Web Chat through npm without writing pnpm configuration", async () => {
@@ -257,7 +257,7 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["exec", "--", "eve", "dev", "--input", "/model"],
+        args: ["exec", "--", "eve", "dev"],
         cwd: canonicalProjectDir,
       },
     ]);
@@ -353,7 +353,7 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--input", "/model"],
+        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev"],
         cwd: canonicalProjectDir,
       },
     ]);

--- a/packages/eve/test/tui-client/tui-packed-install-model.ts
+++ b/packages/eve/test/tui-client/tui-packed-install-model.ts
@@ -7,15 +7,15 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { theme } from "./lib/theme.ts";
 
 /**
- * End-to-end proof that the *packed* eve artifact can run `/model` after a
- * consumer-shaped install.
+ * End-to-end proof that the *packed* eve artifact can auto-open `/model` after
+ * a consumer-shaped install.
  *
  * Every other smoke test resolves eve's modules inside the workspace, where
  * devDependencies are installed — so a runtime import of an undeclared
  * dependency still resolves and the bug ships. This test packs the built
  * package (`pnpm pack`), installs the tarball into an empty project with npm
  * (which installs only declared dependencies, exactly like a user install),
- * and drives the installed TUI through the `/model` configure menu.
+ * and drives the installed TUI through automatic provider setup.
  *
  * Regression: eve 0.6.x–0.7.0 imported `oxc-parser` from the `/model` flow
  * while declaring it only as a devDependency. In a scaffolded project the
@@ -106,22 +106,33 @@ void (async () => {
       name: "Packed install model command",
       appRoot: consumerRoot,
       promptCommandHandler: createPromptCommandHandler({ appRoot: consumerRoot }),
+      bootDetections: [
+        {
+          id: "test-unconfigured-provider",
+          detect: () => [
+            {
+              kind: "model-provider-unconfigured",
+              label: "model provider not linked",
+              command: "/model",
+            },
+          ],
+        },
+      ],
     });
     const runPromise = runner.run();
 
     try {
-      await screen.waitForText("❯", 5_000);
-      input.type("/model");
-      input.enter();
-      // The configure menu paints only after the installed `/model` flow's
-      // module graph loaded — the exact surface the oxc-parser regression
-      // crashed. A "/model failed:" outcome line would keep this wait timing
-      // out until the snapshot below reports it.
+      // The provider picker paints before the first prompt only when boot
+      // detection launched the installed `/model` flow and its module graph
+      // loaded — the exact surface the oxc-parser regression crashed.
       await screen.waitForText("Configure the agent model", 15_000);
-      console.log(theme.muted("[tui-packed-install] /model opened the configure menu"));
+      await screen.waitForText("Which model provider do you want to use?", 15_000);
+      console.log(theme.muted("[tui-packed-install] /model auto-opened provider setup"));
 
       input.send("\x1b");
-      await waitForAnyScreenText(screen, ["/model cancelled.", "/model interrupted."], 5_000);
+      await screen.waitForText("Change model", 5_000);
+      input.send("\x1b");
+      await screen.waitForText("/model cancelled.", 5_000);
       await screen.waitForText("❯", 5_000);
 
       input.type("/exit");
@@ -177,26 +188,4 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, message: string):
   } finally {
     if (timer !== undefined) clearTimeout(timer);
   }
-}
-
-async function waitForAnyScreenText(
-  screen: { snapshot(): string },
-  texts: readonly string[],
-  ms: number,
-): Promise<void> {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < ms) {
-    const snapshot = screen.snapshot();
-    if (texts.some((text) => snapshot.includes(text))) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-
-  throw new Error(
-    [`Timed out waiting for one of: ${texts.join(", ")}`, `Screen:\n${screen.snapshot()}`].join(
-      "\n\n",
-    ),
-  );
 }

--- a/packages/eve/test/tui-client/tui-questions-freeform.ts
+++ b/packages/eve/test/tui-client/tui-questions-freeform.ts
@@ -53,7 +53,7 @@ run({ app: "agent-tui-client", kind: "local-build" }, async (target) => {
   input.type(promptLines.join(" · "));
   input.enter();
 
-  await screen.waitForText("▷ Production", 60_000);
+  await screen.waitForText("▶ Production", 60_000);
   console.log(theme.muted("[tui-freeform] select UI live, highlight on Production"));
 
   await sleep(500);
@@ -62,7 +62,7 @@ run({ app: "agent-tui-client", kind: "local-build" }, async (target) => {
   input.emit("data", Buffer.from("\x1B[B")); // → Staging
   input.emit("data", Buffer.from("\x1B[B")); // → Preview
   input.emit("data", Buffer.from("\x1B[B")); // → Type your own answer
-  await screen.waitForText("▷ Type your own answer", 2_000);
+  await screen.waitForText("▶ Type your own answer", 2_000);
   console.log(theme.muted("[tui-freeform] highlight moved to freeform row"));
 
   // Enter on the freeform row activates text mode. Text mode clears the

--- a/packages/eve/test/tui-client/tui-questions.ts
+++ b/packages/eve/test/tui-client/tui-questions.ts
@@ -19,7 +19,7 @@ import { theme } from "./lib/theme.ts";
  *   3. Type a prompt that asks the model to call `ask_question` with
  *      two options (red/blue).
  *   4. Wait for the question section to display the select indicator
- *      (`▷ <label>`), which proves the dedicated question UI is up.
+ *      (`▶ <label>`), which proves the dedicated question UI is up.
  *   5. Send Down arrow + Enter to pick the second option (blue).
  *   6. Wait for the answered marker in the body section.
  *   7. Wait for the post-answer assistant turn to render. The runner
@@ -63,7 +63,7 @@ run({ app: "agent-tui-client", kind: "local-build" }, async (target) => {
   input.type(promptLines.join(" · "));
   input.enter();
 
-  await screen.waitForText("▷ Red", 60_000);
+  await screen.waitForText("▶ Red", 60_000);
   console.log(theme.muted("[tui-questions] select UI is live, highlight on Red"));
 
   // Bridges a server-side race where the park hook isn't yet
@@ -73,7 +73,7 @@ run({ app: "agent-tui-client", kind: "local-build" }, async (target) => {
   await sleep(500);
 
   input.emit("data", Buffer.from("\x1B[B"));
-  await screen.waitForText("▷ Blue", 2_000);
+  await screen.waitForText("▶ Blue", 2_000);
   console.log(theme.muted("[tui-questions] highlight moved to Blue"));
 
   input.enter();


### PR DESCRIPTION
## Summary

- Open `/model` only when the running agent positively reports an unconfigured model provider.
- Carry that boot-time evidence into the model flow so linked-but-disconnected projects enter provider setup directly.
- Reload model access after provider setup and replace the cached endpoint state used by the TUI header and setup warning.
- Give selected rows a shared padded inverse treatment with a filled pointer while preserving suffix-column alignment.

The runtime-evidence gate and refresh lifecycle are covered at the unit, integration, scenario, and packed-install levels. The packed consumer confirms a fresh unconfigured agent auto-opens provider setup.