### PR TITLE
fix: load dev snapshots with authored-source resolver

### DIFF
--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -5,8 +5,14 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
+import { createCompiledAgentManifest, ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
+import { createCompiledModuleMapSource } from "#compiler/module-map.js";
 import { loadAuthoredModuleNamespace } from "#internal/authored-module-loader.js";
 import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+import { createDiskRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
+import { createRuntimeSession, withRuntimeSession } from "#runtime/sessions/runtime-session.js";
+import { createNitroArtifactsConfig } from "#internal/nitro/host/artifacts-config.js";
 import {
   activateDevelopmentRuntimeArtifactsSnapshot,
   pruneDevelopmentRuntimeArtifactsSnapshots,
@@ -19,6 +25,100 @@ import {
 import { resolveNitroCompiledArtifactsSource } from "#internal/nitro/routes/runtime-artifacts.js";
 
 const createScratchDirectory = useTemporaryDirectories();
+
+async function createNextStyleImportSnapshotFixture(): Promise<{ readonly appRoot: string }> {
+  const appRoot = await createScratchDirectory("eve-dev-runtime-next-imports-");
+  const agentRoot = join(appRoot, "agent");
+  const compileDirectoryPath = join(appRoot, ".eve", "compile");
+  const manifestPath = join(compileDirectoryPath, "compiled-agent-manifest.json");
+  const moduleMapPath = join(compileDirectoryPath, "module-map.mjs");
+
+  await mkdir(agentRoot, { recursive: true });
+  await mkdir(join(appRoot, "src", "features", "editor", "eve"), { recursive: true });
+  await mkdir(compileDirectoryPath, { recursive: true });
+  await writeFile(join(appRoot, "package.json"), '{"name":"next-agent","type":"module"}\n');
+  await writeFile(
+    join(appRoot, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(agentRoot, "agent.ts"),
+    [
+      'import { createEveModelRouter } from "./model-router";',
+      'import { authSessionAuth } from "@/features/editor/eve/auth-session";',
+      "",
+      "export const routed = createEveModelRouter(authSessionAuth);",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(agentRoot, "model-router.ts"),
+    [
+      "export function createEveModelRouter(auth: string) {",
+      "  return `router:${auth}`;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(appRoot, "src", "features", "editor", "eve", "auth-session.ts"),
+    'export const authSessionAuth = "session-auth";\n',
+  );
+
+  const manifest = createCompiledAgentManifest({
+    agentRoot,
+    appRoot,
+    config: {
+      model: {
+        id: "openai/gpt-5.4-mini",
+        routing: {
+          kind: "gateway",
+          target: "openai/gpt-5.4-mini",
+        },
+      },
+      name: "Next Imports Agent",
+      source: {
+        logicalPath: "agent.ts",
+        sourceId: "agent.ts",
+        sourceKind: "module",
+      },
+    },
+    instructions: {
+      logicalPath: "instructions.md",
+      markdown: "Use the routed model.",
+      name: "instructions",
+      sourceId: "instructions.md",
+      sourceKind: "markdown",
+    },
+  });
+
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(
+    moduleMapPath,
+    createCompiledModuleMapSource({
+      manifest,
+      moduleMapPath,
+    }),
+  );
+
+  await publishDevelopmentRuntimeArtifactsSnapshot({
+    paths: { compileDirectoryPath },
+    project: { appRoot },
+  } as CompileAgentResult);
+
+  return { appRoot };
+}
 
 describe("development runtime artifact snapshots", () => {
   it("stages snapshots without moving the latest runtime pointer", async () => {
@@ -199,6 +299,43 @@ describe("development runtime artifact snapshots", () => {
         "utf8",
       ),
     ).resolves.toContain(JSON.stringify(join(snapshot.runtimeAppRoot, "agent")));
+  });
+
+  it("hydrates Next-style agent imports from dev runtime snapshots", async () => {
+    const { appRoot } = await createNextStyleImportSnapshotFixture();
+
+    await withRuntimeSession(createRuntimeSession("next-imports-regression"), async () => {
+      const bundle = await getCompiledRuntimeAgentBundle({
+        compiledArtifactsSource: resolveNitroCompiledArtifactsSource(
+          createNitroArtifactsConfig({ appRoot, dev: true }),
+        ),
+      });
+      const agentModule = bundle.moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules["agent.ts"];
+
+      expect(agentModule).toMatchObject({
+        routed: "router:session-auth",
+      });
+    });
+  });
+
+  it("hydrates Next-style agent imports when dev snapshot artifacts are loaded from disk", async () => {
+    const { appRoot } = await createNextStyleImportSnapshotFixture();
+    const runtimeAppRoot = readDevelopmentRuntimeArtifactsSnapshotRoot(
+      resolveDevelopmentRuntimeArtifactsPointerPath(appRoot),
+    );
+
+    expect(runtimeAppRoot).toBeDefined();
+
+    await withRuntimeSession(createRuntimeSession("next-imports-direct-disk-repro"), async () => {
+      const bundle = await getCompiledRuntimeAgentBundle({
+        compiledArtifactsSource: createDiskRuntimeCompiledArtifactsSource(runtimeAppRoot!),
+      });
+      const agentModule = bundle.moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules["agent.ts"];
+
+      expect(agentModule).toMatchObject({
+        routed: "router:session-auth",
+      });
+    });
   });
 
   it("keeps compatibility with v1 dev runtime pointers", async () => {

--- a/packages/eve/src/runtime/sessions/compiled-agent-cache.ts
+++ b/packages/eve/src/runtime/sessions/compiled-agent-cache.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from "node:url";
 
 import type { CompiledModuleMap } from "#compiler/module-map.js";
+import { resolvePackageSourceFilePath } from "#internal/application/package.js";
 import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
 import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
 import type { RuntimeAdapterRegistry } from "#runtime/channels/registry.js";
@@ -40,12 +41,35 @@ export interface CompiledRuntimeAgentBundle {
 
 const isCacheDisabled = process.env.EVE_DISABLE_AGENT_CACHE === "1";
 
+function isDevelopmentRuntimeSnapshotRoot(appRoot: string): boolean {
+  return appRoot.replaceAll("\\", "/").includes("/.eve/dev-runtime/snapshots/");
+}
+
+function normalizeCompiledArtifactsSource(
+  compiledArtifactsSource: RuntimeCompiledArtifactsSource,
+): RuntimeCompiledArtifactsSource {
+  if (
+    compiledArtifactsSource.kind !== "disk" ||
+    compiledArtifactsSource.moduleMapLoaderPath !== undefined ||
+    !isDevelopmentRuntimeSnapshotRoot(compiledArtifactsSource.appRoot)
+  ) {
+    return compiledArtifactsSource;
+  }
+
+  return {
+    ...compiledArtifactsSource,
+    moduleMapLoaderPath: resolvePackageSourceFilePath("src/internal/authored-module-map-loader.ts"),
+  };
+}
+
 async function loadFullBundle(
   compiledArtifactsSource: RuntimeCompiledArtifactsSource,
 ): Promise<CompiledRuntimeAgentBundle> {
+  const normalizedCompiledArtifactsSource =
+    normalizeCompiledArtifactsSource(compiledArtifactsSource);
   const [manifest, moduleMap] = await Promise.all([
-    loadCompiledManifest({ compiledArtifactsSource }),
-    loadRuntimeCompiledModuleMap(compiledArtifactsSource),
+    loadCompiledManifest({ compiledArtifactsSource: normalizedCompiledArtifactsSource }),
+    loadRuntimeCompiledModuleMap(normalizedCompiledArtifactsSource),
   ]);
   const graph = await resolveRuntimeAgentGraph({ manifest, moduleMap });
   const rootNode = graph.root;
@@ -54,7 +78,7 @@ async function loadFullBundle(
     adapterRegistry: createRuntimeAdapterRegistry({
       channels: collectResolvedChannels(graph),
     }),
-    compiledArtifactsSource,
+    compiledArtifactsSource: normalizedCompiledArtifactsSource,
     graph,
     hookRegistry: rootNode.hookRegistry,
     moduleMap,
@@ -99,13 +123,18 @@ async function loadAuthoredSourceCompiledModuleMap(
 async function getOrLoadFullBundle(
   compiledArtifactsSource: RuntimeCompiledArtifactsSource,
 ): Promise<CompiledRuntimeAgentBundle> {
+  const normalizedCompiledArtifactsSource =
+    normalizeCompiledArtifactsSource(compiledArtifactsSource);
+
   if (isCacheDisabled) {
-    return loadFullBundle(compiledArtifactsSource);
+    return loadFullBundle(normalizedCompiledArtifactsSource);
   }
 
   const session = getActiveRuntimeSession();
-  const sourceKey = getRuntimeCompiledArtifactsCacheKey(compiledArtifactsSource);
-  const cacheKey = await resolveRuntimeCompiledArtifactsVersionedCacheKey(compiledArtifactsSource);
+  const sourceKey = getRuntimeCompiledArtifactsCacheKey(normalizedCompiledArtifactsSource);
+  const cacheKey = await resolveRuntimeCompiledArtifactsVersionedCacheKey(
+    normalizedCompiledArtifactsSource,
+  );
   const previousKey = session.bundleCacheKeyBySourceKey.get(sourceKey);
 
   if (previousKey !== undefined && previousKey !== cacheKey) {
@@ -119,7 +148,7 @@ async function getOrLoadFullBundle(
     return cached;
   }
 
-  const bundlePromise = loadFullBundle(compiledArtifactsSource).catch((error) => {
+  const bundlePromise = loadFullBundle(normalizedCompiledArtifactsSource).catch((error) => {
     session.bundleCache.delete(cacheKey);
 
     if (session.bundleCacheKeyBySourceKey.get(sourceKey) === cacheKey) {


### PR DESCRIPTION
## Summary

Fix dev runtime snapshot loading so snapshotted authored agent modules always hydrate through Eve’s authored-source resolver instead of falling through to direct Node ESM imports.

This prevents Next-style agent imports such as extensionless relative imports and `@/*` tsconfig path aliases from failing when a dev snapshot artifact source is reconstructed without `moduleMapLoaderPath`.

## Changes

- Add regression coverage for a Next-shaped app using:
  - `@/* -> ./src/*` in `tsconfig.json`
  - `agent/agent.ts` importing `./model-router`
  - `agent/agent.ts` importing `@/features/...`
- Normalize disk artifact sources rooted inside `.eve/dev-runtime/snapshots/` to include the authored-source module map loader.
- Preserve the normalized artifact source on the resolved runtime bundle so workflow context serialization keeps the loader path for later durable steps.

## Verification

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts`
- `pnpm --filter eve exec oxfmt --check src/internal/nitro/dev-runtime-artifacts.integration.test.ts src/runtime/sessions/compiled-agent-cache.ts`