### PR TITLE
fix(e2e): allow dynamic multi-turn tool retries

### DIFF
--- a/e2e/fixtures/agent-tools/evals/dynamic-tools/multi-turn.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/dynamic-tools/multi-turn.eval.ts
@@ -28,10 +28,5 @@ export default defineEval({
 
     t.didNotFail();
     t.completed();
-    t.calledTool(ECHO_TOOL, {
-      isError: false,
-      output: { token: DYNAMIC_ECHO_TOKEN },
-      times: 2,
-    });
   },
 });


### PR DESCRIPTION
## What

The `dynamic-tools/multi-turn` eval no longer requires exactly two matching `echo_dynamic` tool calls across the whole run.

The eval already checks the important behavior inside each turn:

- turn one calls `echo_dynamic` and gets `dynamic-echo-ok-X7R2`
- turn two calls `echo_dynamic` after session serialization and gets the same token

This fixes a valid retry case where the model calls the turn two tool more than once. In that case, the dynamic tool is still working, but the old run-wide `times: 2` assertion fails because it sees three successful calls.

Closes #122.

## How

Removed the final run-wide `t.calledTool(ECHO_TOOL, { ..., times: 2 })` assertion from `dynamic-tools/multi-turn`.

The per-turn `requireToolOutput(...)` checks stay in place, so the eval still verifies that the dynamic tool survives across turns and returns the expected token each time.

## Tests / changeset

- No changeset needed: this only changes an e2e fixture assertion, not the published `eve` package behavior.
- No runtime or assertion API changes.

## Verification

- `fnm exec --using v24.15.0 pnpm typecheck`
- `fnm exec --using v24.15.0 pnpm fmt`
- `fnm exec --using v24.15.0 pnpm lint`
- `fnm exec --using v24.15.0 pnpm build`
- `git diff --check`
