### PR TITLE
fix(eve): sandbox process - simplify command adapter

### DIFF
--- a/.changeset/strong-sandbox-processes.md
+++ b/.changeset/strong-sandbox-processes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Strengthen Vercel and just-bash process streaming with deterministic completion, safe output cancellation, and idempotent process operations.

--- a/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
@@ -1,12 +1,13 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import type { IFileSystem, SandboxCommand as JustBashSandboxCommand } from "just-bash";
+import type { IFileSystem } from "just-bash";
 
 import {
   createFileBackedInternalSandboxSession,
   pathExists,
 } from "#execution/sandbox/bindings/local-backend-utils.js";
+import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
 import { shellQuote } from "#execution/sandbox/shell-quote.js";
 import { buildSandboxSession } from "#execution/sandbox/session.js";
 import { loadOptionalEnginePackage } from "#internal/application/optional-package-install.js";
@@ -151,7 +152,10 @@ export async function createBashSandbox(input: {
         env: options.env,
         signal: options.abortSignal,
       });
-      return adaptJustBashCommandToSandboxProcess(command);
+      return adaptMultiplexedCommandToSandboxProcess({
+        command,
+        getOutput: (log) => log.type,
+      });
     },
     async writeFiles(files) {
       for (const file of files) {
@@ -163,72 +167,6 @@ export async function createBashSandbox(input: {
         // just-bash filesystem accepts directly alongside strings.
         await filesystem.writeFile(file.path, file.content);
       }
-    },
-  };
-}
-
-/**
- * Wraps a `just-bash` detached command in the AI SDK
- * `Experimental_SandboxProcess` shape: two `ReadableStream<Uint8Array>`
- * for stdout/stderr (split from a single log iterator), a `wait()` that
- * resolves with the exit code, and an idempotent `kill()`.
- */
-function adaptJustBashCommandToSandboxProcess(command: JustBashSandboxCommand): SandboxProcess {
-  const encoder = new TextEncoder();
-  let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
-  let stderrController: ReadableStreamDefaultController<Uint8Array> | undefined;
-  let streamingDone = false;
-  let streamingError: unknown;
-
-  const stdout = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stdoutController = controller;
-    },
-  });
-  const stderr = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stderrController = controller;
-    },
-  });
-
-  void (async () => {
-    try {
-      for await (const message of command.logs()) {
-        const chunk = encoder.encode(message.data);
-        if (message.type === "stdout") {
-          stdoutController?.enqueue(chunk);
-        } else {
-          stderrController?.enqueue(chunk);
-        }
-      }
-    } catch (error) {
-      streamingError = error;
-      stdoutController?.error(error);
-      stderrController?.error(error);
-    } finally {
-      streamingDone = true;
-      if (streamingError === undefined) {
-        stdoutController?.close();
-        stderrController?.close();
-      }
-    }
-  })();
-
-  return {
-    stdout,
-    stderr,
-    async wait() {
-      const finished = await command.wait();
-      while (!streamingDone) {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      }
-      if (streamingError !== undefined) {
-        throw streamingError;
-      }
-      return { exitCode: finished.exitCode };
-    },
-    async kill() {
-      await command.kill();
     },
   };
 }

--- a/packages/eve/src/execution/sandbox/bindings/vercel-sdk-types.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-sdk-types.ts
@@ -1,7 +1,5 @@
 import type * as Vercel from "#compiled/@vercel/sandbox/index.js";
 
-export type VercelCommand = Vercel.Command;
-
 export type VercelCreateOptions = NonNullable<Parameters<typeof Vercel.Sandbox.create>[0]>;
 
 export type VercelGetOptions = Parameters<typeof Vercel.Sandbox.get>[0];

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -17,8 +17,8 @@ function createMockCommandResult() {
 /*
  * A detached command, as returned by `runCommand({ detached: true })`,
  * is adapted into the `Experimental_SandboxProcess` shape — the adapter
- * drains `logs()`, then awaits `wait()`. This mock yields no log lines
- * and exits 0 so `spawn` and `run` resolve without real I/O.
+ * drains `logs()` alongside `wait()`. This mock yields no log lines and
+ * exits 0 so `spawn` and `run` resolve without real I/O.
  */
 function createMockDetachedCommand() {
   return {

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -28,6 +28,7 @@ import type {
 } from "#public/sandbox/vercel-sandbox.js";
 import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
 import { createLoggingSandboxSession } from "#execution/sandbox/logging-session.js";
+import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
 import { buildSandboxSession } from "#execution/sandbox/session.js";
 import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
 import {
@@ -42,7 +43,6 @@ import {
 import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
 import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
 import type {
-  VercelCommand,
   VercelCreateOptions,
   VercelModule,
   VercelSandbox,
@@ -485,7 +485,10 @@ function createVercelInternalSandboxSession(
         env: options.env,
         signal: options.abortSignal,
       });
-      return adaptVercelCommandToSandboxProcess(command);
+      return adaptMultiplexedCommandToSandboxProcess({
+        command,
+        getOutput: (log) => log.stream,
+      });
     },
     async readFile(options: SandboxReadFileOptions) {
       return normalizeVercelReadStream(await sandbox.readFile({ path: options.path }));
@@ -500,72 +503,6 @@ function createVercelInternalSandboxSession(
         recursive: options.recursive,
         signal: options.abortSignal,
       });
-    },
-  };
-}
-
-/**
- * Wraps a Vercel `Command` (returned from `runCommand({ detached: true })`)
- * in the AI SDK `Experimental_SandboxProcess` shape. Splits the single
- * `logs()` iterator into two byte streams, exposes a `wait()` that
- * resolves with the exit code, and forwards `kill()` to the SDK.
- */
-function adaptVercelCommandToSandboxProcess(command: VercelCommand): SandboxProcess {
-  const encoder = new TextEncoder();
-  let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
-  let stderrController: ReadableStreamDefaultController<Uint8Array> | undefined;
-  let streamingDone = false;
-  let streamingError: unknown;
-
-  const stdout = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stdoutController = controller;
-    },
-  });
-  const stderr = new ReadableStream<Uint8Array>({
-    start(controller) {
-      stderrController = controller;
-    },
-  });
-
-  void (async () => {
-    try {
-      for await (const message of command.logs()) {
-        const chunk = encoder.encode(message.data);
-        if (message.stream === "stdout") {
-          stdoutController?.enqueue(chunk);
-        } else {
-          stderrController?.enqueue(chunk);
-        }
-      }
-    } catch (error) {
-      streamingError = error;
-      stdoutController?.error(error);
-      stderrController?.error(error);
-    } finally {
-      streamingDone = true;
-      if (streamingError === undefined) {
-        stdoutController?.close();
-        stderrController?.close();
-      }
-    }
-  })();
-
-  return {
-    stdout,
-    stderr,
-    async wait() {
-      const finished = await command.wait();
-      while (!streamingDone) {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      }
-      if (streamingError !== undefined) {
-        throw streamingError;
-      }
-      return { exitCode: finished.exitCode };
-    },
-    async kill() {
-      await command.kill();
     },
   };
 }

--- a/packages/eve/src/execution/sandbox/multiplexed-command.test.ts
+++ b/packages/eve/src/execution/sandbox/multiplexed-command.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
+
+interface TestLog {
+  readonly data: string;
+  readonly output: "stderr" | "stdout";
+}
+
+async function readText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return text + decoder.decode();
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+}
+
+function logs(...values: ReadonlyArray<TestLog>): () => AsyncIterable<TestLog> {
+  return async function* generateLogs() {
+    yield* values;
+  };
+}
+
+describe("adaptMultiplexedCommandToSandboxProcess", () => {
+  it("splits logs and waits for both command and log completion", async () => {
+    const releaseLogs = Promise.withResolvers<void>();
+    const waitingForLogs = Promise.withResolvers<void>();
+    const command = {
+      kill: vi.fn(async () => undefined),
+      async *logs() {
+        yield { data: "out one\n", output: "stdout" } as const;
+        waitingForLogs.resolve();
+        await releaseLogs.promise;
+        yield { data: "err\n", output: "stderr" } as const;
+        yield { data: "out two\n", output: "stdout" } as const;
+      },
+      wait: vi.fn(async () => ({ exitCode: 7 })),
+    };
+    const process = adaptMultiplexedCommandToSandboxProcess({
+      command,
+      getOutput: (log) => log.output,
+    });
+    const stdout = readText(process.stdout);
+    const stderr = readText(process.stderr);
+
+    await waitingForLogs.promise;
+    let waitSettled = false;
+    const firstWait = Promise.resolve(process.wait()).then((result) => {
+      waitSettled = true;
+      return result;
+    });
+    const secondWait = Promise.resolve(process.wait());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(waitSettled).toBe(false);
+
+    releaseLogs.resolve();
+    await expect(firstWait).resolves.toEqual({ exitCode: 7 });
+    await expect(secondWait).resolves.toEqual({ exitCode: 7 });
+    await expect(stdout).resolves.toBe("out one\nout two\n");
+    await expect(stderr).resolves.toBe("err\n");
+    expect(command.wait).toHaveBeenCalledOnce();
+  });
+
+  it("propagates log failures to both streams and wait", async () => {
+    const failure = new Error("log transport failed");
+    const command = {
+      kill: vi.fn(async () => undefined),
+      async *logs() {
+        yield { data: "partial", output: "stdout" } as const;
+        throw failure;
+      },
+      wait: vi.fn(async () => ({ exitCode: 0 })),
+    };
+    const process = adaptMultiplexedCommandToSandboxProcess({
+      command,
+      getOutput: (log) => log.output,
+    });
+
+    await expect(readText(process.stdout)).rejects.toBe(failure);
+    await expect(readText(process.stderr)).rejects.toBe(failure);
+    await expect(process.wait()).rejects.toBe(failure);
+  });
+
+  it("continues routing logs after one output is canceled", async () => {
+    const releaseLogs = Promise.withResolvers<void>();
+    const command = {
+      kill: vi.fn(async () => undefined),
+      async *logs() {
+        await releaseLogs.promise;
+        yield { data: "discarded", output: "stdout" } as const;
+        yield { data: "preserved", output: "stderr" } as const;
+      },
+      wait: vi.fn(async () => ({ exitCode: 0 })),
+    };
+    const process = adaptMultiplexedCommandToSandboxProcess({
+      command,
+      getOutput: (log) => log.output,
+    });
+
+    await process.stdout.cancel();
+    const stderr = readText(process.stderr);
+    releaseLogs.resolve();
+
+    await expect(stderr).resolves.toBe("preserved");
+    await expect(process.wait()).resolves.toEqual({ exitCode: 0 });
+  });
+
+  it("invokes command kill only once", async () => {
+    const releaseKill = Promise.withResolvers<void>();
+    const command = {
+      kill: vi.fn(() => releaseKill.promise),
+      logs: logs(),
+      wait: vi.fn(async () => ({ exitCode: 0 })),
+    };
+    const process = adaptMultiplexedCommandToSandboxProcess({
+      command,
+      getOutput: (log) => log.output,
+    });
+
+    const firstKill = process.kill();
+    const secondKill = process.kill();
+    await Promise.resolve();
+    expect(command.kill).toHaveBeenCalledOnce();
+
+    releaseKill.resolve();
+    await Promise.all([firstKill, secondKill]);
+    await process.kill();
+    expect(command.kill).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/execution/sandbox/multiplexed-command.ts
+++ b/packages/eve/src/execution/sandbox/multiplexed-command.ts
@@ -1,0 +1,98 @@
+import type { SandboxProcess } from "#shared/sandbox-session.js";
+
+type OutputName = "stderr" | "stdout";
+
+interface MultiplexedCommand<Log extends { readonly data: string }> {
+  kill(): PromiseLike<void>;
+  logs(): AsyncIterable<Log>;
+  wait(): PromiseLike<{ readonly exitCode: number }>;
+}
+
+interface OutputChannel {
+  readonly stream: ReadableStream<Uint8Array>;
+  close(): void;
+  enqueue(chunk: Uint8Array): void;
+  error(cause: unknown): void;
+}
+
+function createOutputChannel(): OutputChannel {
+  let canceled = false;
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    cancel() {
+      canceled = true;
+    },
+    start(value) {
+      controller = value;
+    },
+  });
+
+  return {
+    stream,
+    close() {
+      if (!canceled) {
+        controller.close();
+      }
+    },
+    enqueue(chunk) {
+      if (!canceled) {
+        controller.enqueue(chunk);
+      }
+    },
+    error(cause) {
+      if (!canceled) {
+        controller.error(cause);
+      }
+    },
+  };
+}
+
+/**
+ * Adapts a detached command with one tagged log iterator to a sandbox process
+ * with independent stdout and stderr streams.
+ */
+export function adaptMultiplexedCommandToSandboxProcess<
+  Log extends { readonly data: string },
+>(input: {
+  readonly command: MultiplexedCommand<Log>;
+  readonly getOutput: (log: Log) => OutputName;
+}): SandboxProcess {
+  const encoder = new TextEncoder();
+  const stdout = createOutputChannel();
+  const stderr = createOutputChannel();
+  const outputs: Record<OutputName, OutputChannel> = { stderr, stdout };
+
+  const logsDone = (async () => {
+    try {
+      for await (const log of input.command.logs()) {
+        outputs[input.getOutput(log)].enqueue(encoder.encode(log.data));
+      }
+      stdout.close();
+      stderr.close();
+    } catch (error) {
+      stdout.error(error);
+      stderr.error(error);
+      throw error;
+    }
+  })();
+  // The streams surface log failures immediately; retain the rejection for wait().
+  void logsDone.catch(() => undefined);
+
+  let waitPromise: Promise<{ exitCode: number }> | undefined;
+  let killPromise: Promise<void> | undefined;
+
+  return {
+    stderr: stderr.stream,
+    stdout: stdout.stream,
+    wait() {
+      return (waitPromise ??= Promise.resolve().then(async () => {
+        const finished = await input.command.wait();
+        await logsDone;
+        return { exitCode: finished.exitCode };
+      }));
+    },
+    kill() {
+      return (killPromise ??= Promise.resolve().then(() => input.command.kill()));
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- replace the duplicated Vercel and just-bash command adapters with one internal multiplexed-log adapter
- await log completion directly instead of polling, and make `wait()` and `kill()` idempotent
- keep stdout and stderr cancellation independent, with focused lifecycle tests

## Why

Both backends expose one tagged async log iterator, while Eve's sandbox process contract requires independent byte streams. The previous duplicated adapters polled for log completion with `setTimeout(0)`, delegated repeated kills to the provider, and could break the remaining output stream when its sibling was canceled.

## Impact

Vercel and just-bash now share the same provider-neutral process adaptation. This reduces production code and makes completion, cancellation, and provider failures deterministic without changing the public API.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` (3,766 tests)
- `pnpm test:integration` (339 tests)
- `pnpm test:scenario` (255 passed, 15 skipped)
- `pnpm exec eve eval --strict` from `e2e/fixtures/agent-tools-sandbox` was attempted, but the fixture could not call its model because this environment has no AI Gateway credentials
