### PR TITLE
fix: preserve parked dev runtime snapshots

### DIFF
--- a/.changeset/quiet-dev-snapshots.md
+++ b/.changeset/quiet-dev-snapshots.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve dev-runtime snapshots that are still referenced by local durable workflow data so parked HITL turns can resume after `eve dev` rebuilds.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -205,12 +205,18 @@ describe("development runtime artifact snapshots", () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-durable-");
     const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
     const activeSnapshotRoot = join(snapshotsRoot, "active");
-    const parkedTurnSnapshotRoot = join(snapshotsRoot, "parked-turn");
+    const posixParkedTurnSnapshotRoot = join(snapshotsRoot, "parked-turn-posix");
+    const windowsParkedTurnSnapshotRoot = join(snapshotsRoot, "parked-turn-windows");
     const staleSnapshotRoot = join(snapshotsRoot, "stale");
     const oldSnapshotTime = new Date(1_000);
     const now = 1_000_000;
 
-    for (const snapshotRoot of [activeSnapshotRoot, parkedTurnSnapshotRoot, staleSnapshotRoot]) {
+    for (const snapshotRoot of [
+      activeSnapshotRoot,
+      posixParkedTurnSnapshotRoot,
+      windowsParkedTurnSnapshotRoot,
+      staleSnapshotRoot,
+    ]) {
       await mkdir(snapshotRoot, { recursive: true });
       await writeFile(join(snapshotRoot, "marker.txt"), snapshotRoot);
       await utimes(snapshotRoot, oldSnapshotTime, oldSnapshotTime);
@@ -233,7 +239,30 @@ describe("development runtime artifact snapshots", () => {
             serializedContext: {
               "eve.bundle": {
                 source: {
-                  appRoot: join(parkedTurnSnapshotRoot, "source", "app"),
+                  appRoot: join(posixParkedTurnSnapshotRoot, "source", "app").replaceAll("\\", "/"),
+                  kind: "disk",
+                },
+              },
+            },
+          },
+          workflowId: "workflow//eve//turnWorkflow",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(appRoot, ".workflow-data", "default", "runs", "parked-turn-windows.json"),
+      `${JSON.stringify(
+        {
+          input: {
+            serializedContext: {
+              "eve.bundle": {
+                source: {
+                  appRoot: join(windowsParkedTurnSnapshotRoot, "source", "app").replaceAll(
+                    "/",
+                    "\\",
+                  ),
                   kind: "disk",
                 },
               },
@@ -254,7 +283,7 @@ describe("development runtime artifact snapshots", () => {
     });
 
     await expect(readdir(snapshotsRoot)).resolves.toEqual(
-      expect.arrayContaining(["active", "parked-turn"]),
+      expect.arrayContaining(["active", "parked-turn-posix", "parked-turn-windows"]),
     );
     expect(existsSync(staleSnapshotRoot)).toBe(false);
   });

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -201,6 +201,64 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(staleSnapshotRoot)).toBe(false);
   });
 
+  it("preserves stale snapshots referenced by durable workflow data", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-durable-");
+    const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
+    const activeSnapshotRoot = join(snapshotsRoot, "active");
+    const parkedTurnSnapshotRoot = join(snapshotsRoot, "parked-turn");
+    const staleSnapshotRoot = join(snapshotsRoot, "stale");
+    const oldSnapshotTime = new Date(1_000);
+    const now = 1_000_000;
+
+    for (const snapshotRoot of [activeSnapshotRoot, parkedTurnSnapshotRoot, staleSnapshotRoot]) {
+      await mkdir(snapshotRoot, { recursive: true });
+      await writeFile(join(snapshotRoot, "marker.txt"), snapshotRoot);
+      await utimes(snapshotRoot, oldSnapshotTime, oldSnapshotTime);
+    }
+
+    await activateDevelopmentRuntimeArtifactsSnapshot({
+      appRoot,
+      snapshot: {
+        runtimeAppRoot: join(activeSnapshotRoot, "source", "app"),
+        snapshotRoot: activeSnapshotRoot,
+        snapshotSourceRoot: join(activeSnapshotRoot, "source"),
+      },
+    });
+    await mkdir(join(appRoot, ".workflow-data", "default", "runs"), { recursive: true });
+    await writeFile(
+      join(appRoot, ".workflow-data", "default", "runs", "parked-turn.json"),
+      `${JSON.stringify(
+        {
+          input: {
+            serializedContext: {
+              "eve.bundle": {
+                source: {
+                  appRoot: join(parkedTurnSnapshotRoot, "source", "app"),
+                  kind: "disk",
+                },
+              },
+            },
+          },
+          workflowId: "workflow//eve//turnWorkflow",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    await pruneDevelopmentRuntimeArtifactsSnapshots({
+      appRoot,
+      now,
+      recentWindowMs: 0,
+      retainCount: 0,
+    });
+
+    await expect(readdir(snapshotsRoot)).resolves.toEqual(
+      expect.arrayContaining(["active", "parked-turn"]),
+    );
+    expect(existsSync(staleSnapshotRoot)).toBe(false);
+  });
+
   it("removes a partially staged snapshot when staging fails", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-failed-stage-");
     const agentRoot = join(appRoot, "agent");

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -11,6 +11,7 @@ const DEV_RUNTIME_ARTIFACTS_DIRECTORY = "dev-runtime";
 const DEV_RUNTIME_ARTIFACTS_POINTER_VERSION = 2;
 const DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS = 15 * 60 * 1000;
 const DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT = 5;
+const DEV_RUNTIME_WORKFLOW_DATA_MAX_SCAN_BYTES = 1024 * 1024;
 
 interface DevelopmentRuntimeArtifactsPointerV1 {
   readonly appRoot: string;
@@ -180,7 +181,10 @@ export async function pruneDevelopmentRuntimeArtifactsSnapshots(input: {
   const pointer = readDevelopmentRuntimeArtifactsPointer(
     resolveDevelopmentRuntimeArtifactsPointerPath(input.appRoot),
   );
-  const protectedPaths = collectProtectedSnapshotPaths(pointer);
+  const protectedPaths = [
+    ...collectProtectedSnapshotPaths(pointer),
+    ...(await collectWorkflowDataSnapshotPaths({ appRoot: input.appRoot, snapshotsDirectory })),
+  ];
   const now = input.now ?? Date.now();
   const recentWindowMs = input.recentWindowMs ?? DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS;
   const retainCount = input.retainCount ?? DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT;
@@ -290,6 +294,94 @@ function collectProtectedSnapshotPaths(
   }
 
   return [pointer.runtimeAppRoot, pointer.snapshotRoot];
+}
+
+async function collectWorkflowDataSnapshotPaths(input: {
+  readonly appRoot: string;
+  readonly snapshotsDirectory: string;
+}): Promise<readonly string[]> {
+  const workflowDataDirectory = join(input.appRoot, ".workflow-data");
+  const snapshotPaths = new Set<string>();
+
+  await collectSnapshotPathsFromDirectory({
+    directory: workflowDataDirectory,
+    snapshotPaths,
+    snapshotsDirectory: input.snapshotsDirectory,
+  });
+
+  return [...snapshotPaths];
+}
+
+async function collectSnapshotPathsFromDirectory(input: {
+  readonly directory: string;
+  readonly snapshotPaths: Set<string>;
+  readonly snapshotsDirectory: string;
+}): Promise<void> {
+  let entries: Dirent<string>[];
+
+  try {
+    entries = await readdir(input.directory, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(input.directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await collectSnapshotPathsFromDirectory({
+          directory: path,
+          snapshotPaths: input.snapshotPaths,
+          snapshotsDirectory: input.snapshotsDirectory,
+        });
+        return;
+      }
+
+      if (!entry.isFile()) {
+        return;
+      }
+
+      const fileStats = await stat(path);
+      // Local workflow run payloads are small; keep this best-effort scan cheap.
+      if (fileStats.size > DEV_RUNTIME_WORKFLOW_DATA_MAX_SCAN_BYTES) {
+        return;
+      }
+
+      const source = await readFile(path, "utf8");
+      for (const snapshotPath of collectSnapshotPathsFromText(source, input.snapshotsDirectory)) {
+        input.snapshotPaths.add(snapshotPath);
+      }
+    }),
+  );
+}
+
+function collectSnapshotPathsFromText(
+  source: string,
+  snapshotsDirectory: string,
+): readonly string[] {
+  const snapshotPaths = new Set<string>();
+  const normalizedSnapshotsDirectory = snapshotsDirectory.replaceAll("\\", "/");
+  const pattern = new RegExp(`${escapeRegExp(normalizedSnapshotsDirectory)}/([^/"'\\s]+)`, "gu");
+  const normalizedSource = source.replaceAll("\\\\", "/").replaceAll("\\", "/");
+
+  for (const match of normalizedSource.matchAll(pattern)) {
+    const snapshotName = match[1];
+
+    if (snapshotName !== undefined && snapshotName.length > 0) {
+      snapshotPaths.add(join(snapshotsDirectory, snapshotName));
+    }
+  }
+
+  return [...snapshotPaths];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function pathsOverlap(left: string, right: string): boolean {


### PR DESCRIPTION
## Summary
- Add regression coverage for stale dev-runtime snapshots referenced by durable workflow data.
- Preserve snapshots that are still present in local workflow payloads so parked HITL turns can resume after `eve dev` rebuilds.
- Handle JSON-escaped Windows paths when scanning durable workflow data.

## Tests
- `pnpm exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts -t "preserves stale snapshots referenced by durable workflow data"`

Closes: https://github.com/vercel/eve/issues/172