### PR TITLE
Limit container image push workflow triggers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/container.yml
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- add Docker-related path filters to the container image workflow's main-branch push trigger
- keep image publishing limited to Dockerfile, .dockerignore, or workflow changes

## Testing
- not run; workflow trigger-only change