### PR TITLE
Validate custom workflow world compatibility

### DIFF
--- a/.changeset/workflow-world-peer-validation.md
+++ b/.changeset/workflow-world-peer-validation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Validate custom `experimental.workflow.world` packages during build. eve now rejects world packages whose `@workflow/world` dependency metadata is not compatible with the Workflow world version bundled by eve, so incompatible adapters fail before runtime startup.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -36,7 +36,7 @@ export default defineAgent({
 });
 ```
 
-The world package should read credentials and host-specific options from runtime environment variables. It should export a default factory or `createWorld()` function. See [Workflow Worlds](https://workflow-sdk.dev/worlds) for the underlying SDK abstraction.
+The world package should read credentials and host-specific options from runtime environment variables. It should export a default factory or `createWorld()` function and declare a dependency or peer dependency on `@workflow/world` compatible with the version used by eve. See [Workflow Worlds](https://workflow-sdk.dev/worlds) for the underlying SDK abstraction.
 
 ## 2. Environment variables and secrets
 

--- a/packages/eve/scripts/vendor-compiled/declarations/semver.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/semver.d.ts
@@ -15,6 +15,7 @@ export interface SemVerApi {
   intersects(rangeA: string, rangeB: string): boolean;
   minVersion(range: string): SemVer | null;
   subset(candidateRange: string, requiredRange: string): boolean;
+  valid(version: string): string | null;
   validRange(range: string): string | null;
 }
 

--- a/packages/eve/src/internal/application/compiled-artifacts.ts
+++ b/packages/eve/src/internal/application/compiled-artifacts.ts
@@ -7,6 +7,7 @@ import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { createCompiledModuleMapSource } from "#compiler/module-map.js";
 import { stringifyEsmImportSpecifier } from "#internal/application/import-specifier.js";
 import { resolvePackageSourceFilePath } from "#internal/application/package.js";
+import { validateWorkflowWorldPackage } from "#internal/workflow/world-package-validation.js";
 import type { AgentWorkflowWorldDefinition } from "#shared/agent-definition.js";
 
 /**
@@ -45,8 +46,13 @@ export async function writeCompiledArtifactsFiles(input: {
   const bootstrapPath = join(input.outDir, "compiled-artifacts-bootstrap.mjs");
   const instrumentationPluginPath = join(input.outDir, "compiled-artifacts-instrumentation.mjs");
   const instrumentationPath = resolveInstrumentationModule(input.compileResult.manifest.agentRoot);
+  const workflowWorld = input.compileResult.manifest.config.experimental?.workflow?.world;
 
   await mkdir(input.outDir, { recursive: true });
+  validateWorkflowWorldPackage({
+    appRoot: input.compileResult.project.appRoot,
+    world: workflowWorld,
+  });
   await writeFile(
     bootstrapPath,
     await createCompiledArtifactsBootstrapSource({

--- a/packages/eve/src/internal/workflow/world-package-validation.ts
+++ b/packages/eve/src/internal/workflow/world-package-validation.ts
@@ -1,0 +1,258 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+import semver from "#compiled/semver/index.js";
+import { resolvePackageRoot } from "#internal/application/package.js";
+
+const WORKFLOW_WORLD_PACKAGE_NAME = "@workflow/world";
+const EVE_WORKFLOW_WORLD_SUPPORTED_RANGE = ">=5.0.0-0 <6.0.0-0";
+const EVE_WORKFLOW_WORLD_SUPPORTED_MAJOR = 5;
+interface WorkflowWorldSemverApi {
+  readonly validRange: (range: string) => string | null;
+  readonly intersects: (
+    rangeA: string,
+    rangeB: string,
+    options?: { readonly includePrerelease?: boolean },
+  ) => boolean;
+  readonly minVersion: (range: string) => { readonly major: number } | null;
+  readonly valid: (version: string) => string | null;
+}
+
+const semverApi = semver as WorkflowWorldSemverApi;
+
+interface PackageJson {
+  readonly name?: unknown;
+  readonly dependencies?: Record<string, unknown>;
+  readonly peerDependencies?: Record<string, unknown>;
+}
+
+interface VendorStamp {
+  readonly moduleVersions?: Record<string, unknown>;
+}
+
+interface DeclaredWorkflowWorldDependency {
+  readonly kind: "dependency" | "peerDependency";
+  readonly range: string;
+}
+
+export function validateWorkflowWorldPackage(input: {
+  readonly appRoot: string;
+  readonly world: string | undefined;
+}): void {
+  if (input.world === undefined) {
+    return;
+  }
+
+  const eveWorkflowWorldVersion = resolveEveWorkflowWorldVersion();
+  validateVendoredWorkflowWorldVersion(eveWorkflowWorldVersion);
+  const packageName = parsePackageName(input.world);
+  const packageJsonPath = resolveInstalledPackageJsonPath(input.appRoot, packageName);
+
+  if (packageJsonPath === undefined) {
+    throw new Error(
+      `Configured Workflow world package "${input.world}" could not be resolved from "${input.appRoot}". Install it in the app before using "experimental.workflow.world".`,
+    );
+  }
+
+  const packageJson = readPackageJson(packageJsonPath);
+  const declaredDependency = resolveDeclaredWorkflowWorldDependency(packageJson);
+
+  if (declaredDependency === undefined) {
+    throw new Error(
+      `Configured Workflow world package "${input.world}" must declare a dependency or peerDependency on "${WORKFLOW_WORLD_PACKAGE_NAME}" compatible with eve's supported "${WORKFLOW_WORLD_PACKAGE_NAME}" range (${EVE_WORKFLOW_WORLD_SUPPORTED_RANGE}).`,
+    );
+  }
+
+  if (semverApi.validRange(declaredDependency.range) === null) {
+    throw new Error(
+      `Configured Workflow world package "${input.world}" declares an invalid "${WORKFLOW_WORLD_PACKAGE_NAME}" ${declaredDependency.kind} range: ${JSON.stringify(declaredDependency.range)}.`,
+    );
+  }
+
+  if (
+    !isDeclaredWorkflowWorldDependencyCompatible({
+      declaredDependency,
+    })
+  ) {
+    throw new Error(
+      `Configured Workflow world package "${input.world}" declares "${WORKFLOW_WORLD_PACKAGE_NAME}" ${declaredDependency.kind} ${JSON.stringify(declaredDependency.range)}, but eve supports "${WORKFLOW_WORLD_PACKAGE_NAME}" ${EVE_WORKFLOW_WORLD_SUPPORTED_RANGE}. Install a world package version that supports eve's Workflow world dependency.`,
+    );
+  }
+}
+
+function resolveDeclaredWorkflowWorldDependency(
+  packageJson: PackageJson,
+): DeclaredWorkflowWorldDependency | undefined {
+  const peerRange = packageJson.peerDependencies?.[WORKFLOW_WORLD_PACKAGE_NAME];
+
+  if (typeof peerRange === "string" && peerRange.trim() !== "") {
+    return {
+      kind: "peerDependency",
+      range: peerRange,
+    };
+  }
+
+  const dependencyRange = packageJson.dependencies?.[WORKFLOW_WORLD_PACKAGE_NAME];
+
+  if (typeof dependencyRange === "string" && dependencyRange.trim() !== "") {
+    return {
+      kind: "dependency",
+      range: dependencyRange,
+    };
+  }
+
+  return undefined;
+}
+
+function isDeclaredWorkflowWorldDependencyCompatible(input: {
+  readonly declaredDependency: DeclaredWorkflowWorldDependency;
+}): boolean {
+  const minimumVersion = semverApi.minVersion(input.declaredDependency.range);
+
+  if (minimumVersion?.major !== EVE_WORKFLOW_WORLD_SUPPORTED_MAJOR) {
+    return false;
+  }
+
+  return semverApi.intersects(input.declaredDependency.range, EVE_WORKFLOW_WORLD_SUPPORTED_RANGE, {
+    includePrerelease: true,
+  });
+}
+
+function validateVendoredWorkflowWorldVersion(version: string): void {
+  if (
+    !semverApi.intersects(version, EVE_WORKFLOW_WORLD_SUPPORTED_RANGE, {
+      includePrerelease: true,
+    })
+  ) {
+    throw new Error(
+      `eve vendors "${WORKFLOW_WORLD_PACKAGE_NAME}" ${version}, which is outside its supported range ${EVE_WORKFLOW_WORLD_SUPPORTED_RANGE}.`,
+    );
+  }
+}
+
+function resolveEveWorkflowWorldVersion(): string {
+  const packageRoot = resolvePackageRoot();
+
+  for (const stampPath of [
+    join(packageRoot, ".generated", "compiled", ".vendor-stamp.json"),
+    join(packageRoot, "dist", "src", "compiled", ".vendor-stamp.json"),
+  ]) {
+    if (!existsSync(stampPath)) {
+      continue;
+    }
+
+    const stamp = readVendorStamp(stampPath);
+    const version = stamp.moduleVersions?.[WORKFLOW_WORLD_PACKAGE_NAME];
+
+    if (typeof version === "string" && semverApi.valid(version) !== null) {
+      return version;
+    }
+  }
+
+  throw new Error(
+    `eve compiled vendor stamp must declare a valid "${WORKFLOW_WORLD_PACKAGE_NAME}" version.`,
+  );
+}
+
+function parsePackageName(specifier: string): string {
+  const parts = specifier.split("/");
+  if (specifier.startsWith("@")) {
+    if (parts.length < 2 || parts[0] === "" || parts[1] === "") {
+      throw new Error(
+        `"experimental.workflow.world" must be a package name, received ${JSON.stringify(specifier)}.`,
+      );
+    }
+
+    return `${parts[0]}/${parts[1]}`;
+  }
+
+  if (parts[0] === "") {
+    throw new Error(
+      `"experimental.workflow.world" must be a package name, received ${JSON.stringify(specifier)}.`,
+    );
+  }
+
+  return parts[0]!;
+}
+
+function resolveInstalledPackageJsonPath(appRoot: string, packageName: string): string | undefined {
+  const require = createRequire(join(appRoot, "package.json"));
+  const resolvedEntrypointPath = tryResolvePackageEntrypoint(require, packageName);
+  const resolvedPackageJsonPath =
+    resolvedEntrypointPath === undefined
+      ? tryResolvePackageJson(require, packageName)
+      : findPackageJsonForResolvedEntrypoint(resolvedEntrypointPath, packageName);
+
+  if (resolvedPackageJsonPath !== undefined) {
+    return resolvedPackageJsonPath;
+  }
+
+  let currentDirectory = appRoot;
+
+  while (true) {
+    const candidate = join(currentDirectory, "node_modules", packageName, "package.json");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return undefined;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+}
+
+function tryResolvePackageEntrypoint(
+  require: NodeJS.Require,
+  packageName: string,
+): string | undefined {
+  try {
+    return require.resolve(packageName);
+  } catch {
+    return undefined;
+  }
+}
+
+function tryResolvePackageJson(require: NodeJS.Require, packageName: string): string | undefined {
+  try {
+    return require.resolve(`${packageName}/package.json`);
+  } catch {
+    return undefined;
+  }
+}
+
+function findPackageJsonForResolvedEntrypoint(
+  resolvedEntrypointPath: string,
+  packageName: string,
+): string | undefined {
+  let currentDirectory = dirname(resolvedEntrypointPath);
+
+  while (true) {
+    const candidate = join(currentDirectory, "package.json");
+
+    if (existsSync(candidate)) {
+      const packageJson = readPackageJson(candidate);
+      if (packageJson.name === packageName) {
+        return candidate;
+      }
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return undefined;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+}
+
+function readPackageJson(packageJsonPath: string): PackageJson {
+  return JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
+}
+
+function readVendorStamp(stampPath: string): VendorStamp {
+  return JSON.parse(readFileSync(stampPath, "utf8")) as VendorStamp;
+}

--- a/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
@@ -13,13 +13,284 @@ import {
   createRuntimeSession,
   withRuntimeSession,
 } from "../../src/runtime/sessions/runtime-session.js";
-import { useTemporaryAppRoots } from "../../src/internal/testing/use-temporary-app-roots.js";
+import {
+  useTemporaryAppRoots,
+  useTemporaryDirectories,
+} from "../../src/internal/testing/use-temporary-app-roots.js";
 
 const createAppRoot = useTemporaryAppRoots();
+const createTemporaryDirectory = useTemporaryDirectories();
 
 describe("writeCompiledArtifactsFiles", () => {
   afterEach(() => {
     delete (globalThis as Record<string, unknown>).__eveInstrumentationLoaded;
+  });
+
+  it("accepts a Workflow world package whose peer range supports eve's Workflow world dependency", async () => {
+    const { agentRoot, appRoot } = await createAppRoot("eve-compiled-artifacts-world-valid-", {
+      files: createWorkflowWorldPackageFiles({
+        dependencyKind: "peerDependencies",
+        workflowWorldRange: ">=5.0.0-0",
+      }),
+      packageName: "compiled-artifacts-world-valid-test-agent",
+    });
+    const outDir = join(appRoot, ".workflow-build");
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: {",
+        "    workflow: {",
+        '      world: "@acme/eve-workflow-world",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+
+    const compileResult = await compileAgent({
+      startPath: appRoot,
+    });
+    const generatedArtifacts = await writeCompiledArtifactsFiles({
+      compileResult,
+      outDir,
+    });
+
+    await expect(readFile(generatedArtifacts.bootstrapPath, "utf8")).resolves.toContain(
+      'import * as workflowWorldModule from "@acme/eve-workflow-world";',
+    );
+  });
+
+  it("accepts a Workflow world package whose stable v5 peer range supports eve's Workflow world major", async () => {
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-compiled-artifacts-world-valid-stable-peer-",
+      {
+        files: createWorkflowWorldPackageFiles({
+          dependencyKind: "peerDependencies",
+          workflowWorldRange: "^5.0.0",
+        }),
+        packageName: "compiled-artifacts-world-valid-stable-peer-test-agent",
+      },
+    );
+    const outDir = join(appRoot, ".workflow-build");
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: {",
+        "    workflow: {",
+        '      world: "@acme/eve-workflow-world",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+
+    const compileResult = await compileAgent({
+      startPath: appRoot,
+    });
+    const generatedArtifacts = await writeCompiledArtifactsFiles({
+      compileResult,
+      outDir,
+    });
+
+    await expect(readFile(generatedArtifacts.bootstrapPath, "utf8")).resolves.toContain(
+      'import * as workflowWorldModule from "@acme/eve-workflow-world";',
+    );
+  });
+
+  it("accepts a Workflow world package whose regular dependency is on eve's Workflow world major", async () => {
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-compiled-artifacts-world-valid-dependency-",
+      {
+        files: createWorkflowWorldPackageFiles({
+          dependencyKind: "dependencies",
+          workflowWorldRange: "5.0.0-beta.18",
+        }),
+        packageName: "compiled-artifacts-world-valid-dependency-test-agent",
+      },
+    );
+    const outDir = join(appRoot, ".workflow-build");
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: {",
+        "    workflow: {",
+        '      world: "@acme/eve-workflow-world",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+
+    const compileResult = await compileAgent({
+      startPath: appRoot,
+    });
+    const generatedArtifacts = await writeCompiledArtifactsFiles({
+      compileResult,
+      outDir,
+    });
+
+    await expect(readFile(generatedArtifacts.bootstrapPath, "utf8")).resolves.toContain(
+      'import * as workflowWorldModule from "@acme/eve-workflow-world";',
+    );
+  });
+
+  it("accepts a Workflow world package hoisted to a parent workspace node_modules", async () => {
+    const workspaceRoot = await createTemporaryDirectory("eve-compiled-artifacts-world-hoisted-");
+    const appRoot = join(workspaceRoot, "apps", "agent-app");
+    const agentRoot = join(appRoot, "agent");
+    const outDir = join(appRoot, ".workflow-build");
+
+    await mkdir(agentRoot, { recursive: true });
+    await writeFile(
+      join(appRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "compiled-artifacts-world-hoisted-test-agent",
+          private: true,
+          type: "module",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    for (const [relativePath, contents] of Object.entries(
+      createWorkflowWorldPackageFiles({
+        dependencyKind: "dependencies",
+        workflowWorldRange: "5.0.0-beta.18",
+      }),
+    )) {
+      const destinationPath = join(workspaceRoot, relativePath);
+
+      await mkdir(join(destinationPath, ".."), { recursive: true });
+      await writeFile(destinationPath, contents);
+    }
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: {",
+        "    workflow: {",
+        '      world: "@acme/eve-workflow-world",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+
+    const compileResult = await compileAgent({
+      startPath: appRoot,
+    });
+    const generatedArtifacts = await writeCompiledArtifactsFiles({
+      compileResult,
+      outDir,
+    });
+
+    await expect(readFile(generatedArtifacts.bootstrapPath, "utf8")).resolves.toContain(
+      'import * as workflowWorldModule from "@acme/eve-workflow-world";',
+    );
+  });
+
+  it("rejects a Workflow world package whose regular dependency is on Workflow world v4", async () => {
+    const { agentRoot, appRoot } = await createAppRoot("eve-compiled-artifacts-world-invalid-", {
+      files: createWorkflowWorldPackageFiles({
+        dependencyKind: "dependencies",
+        workflowWorldRange: "4.2.0",
+      }),
+      packageName: "compiled-artifacts-world-invalid-test-agent",
+    });
+    const outDir = join(appRoot, ".workflow-build");
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: {",
+        "    workflow: {",
+        '      world: "@acme/eve-workflow-world",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+
+    const compileResult = await compileAgent({
+      startPath: appRoot,
+    });
+
+    await expect(
+      writeCompiledArtifactsFiles({
+        compileResult,
+        outDir,
+      }),
+    ).rejects.toThrow(
+      'Configured Workflow world package "@acme/eve-workflow-world" declares "@workflow/world" dependency "4.2.0", but eve supports "@workflow/world" >=5.0.0-0 <6.0.0-0',
+    );
+  });
+
+  it("rejects a Workflow world package whose peer range starts on Workflow world v4", async () => {
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-compiled-artifacts-world-invalid-peer-",
+      {
+        files: createWorkflowWorldPackageFiles({
+          dependencyKind: "peerDependencies",
+          workflowWorldRange: ">=4.0.0",
+        }),
+        packageName: "compiled-artifacts-world-invalid-peer-test-agent",
+      },
+    );
+    const outDir = join(appRoot, ".workflow-build");
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: {",
+        "    workflow: {",
+        '      world: "@acme/eve-workflow-world",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+
+    const compileResult = await compileAgent({
+      startPath: appRoot,
+    });
+
+    await expect(
+      writeCompiledArtifactsFiles({
+        compileResult,
+        outDir,
+      }),
+    ).rejects.toThrow(
+      'Configured Workflow world package "@acme/eve-workflow-world" declares "@workflow/world" peerDependency ">=4.0.0", but eve supports "@workflow/world" >=5.0.0-0 <6.0.0-0',
+    );
   });
 
   it("installs compile metadata into bundled compiled artifacts", async () => {
@@ -199,3 +470,33 @@ describe("writeCompiledArtifactsFiles", () => {
     ).resolves.toBe("Always confirm the source of truth.\n");
   });
 });
+
+function createWorkflowWorldPackageFiles(input: {
+  readonly dependencyKind: "dependencies" | "peerDependencies";
+  readonly workflowWorldRange: string;
+}): Record<string, string> {
+  return {
+    "node_modules/@acme/eve-workflow-world/index.js": [
+      "export default function createWorld() {",
+      "  return {",
+      "    createQueueHandler() {},",
+      "    events: {},",
+      "  };",
+      "}",
+      "",
+    ].join("\n"),
+    "node_modules/@acme/eve-workflow-world/package.json": `${JSON.stringify(
+      {
+        [input.dependencyKind]: {
+          "@workflow/world": input.workflowWorldRange,
+        },
+        exports: "./index.js",
+        name: "@acme/eve-workflow-world",
+        type: "module",
+        version: "1.0.0",
+      },
+      null,
+      2,
+    )}\n`,
+  };
+}


### PR DESCRIPTION
## Summary
- validate configured experimental.workflow.world packages against eve's @workflow/world version
- support peer dependency, regular dependency, and hoisted monorepo package resolution cases
- document the compatibility requirement and add a changeset

## Verification
- pnpm --filter eve exec vitest run --config vitest.scenario.config.ts ./test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
- pnpm --filter eve typecheck
- pnpm docs:check
- pnpm exec oxlint packages/eve/src/internal/workflow/world-package-validation.ts packages/eve/src/internal/application/compiled-artifacts.ts packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
- pnpm exec oxfmt --check packages/eve/src/internal/workflow/world-package-validation.ts packages/eve/src/internal/application/compiled-artifacts.ts packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts docs/agent-config.md docs/guides/deployment.md .changeset/workflow-world-peer-validation.md
- pnpm --filter eve build