### PR TITLE
fix: ignore terminal workflow snapshot refs

### DIFF
--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -201,12 +201,13 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(staleSnapshotRoot)).toBe(false);
   });
 
-  it("preserves stale snapshots referenced by durable workflow data", async () => {
+  it("preserves snapshots referenced by active durable workflow data", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-durable-");
     const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
     const activeSnapshotRoot = join(snapshotsRoot, "active");
     const posixParkedTurnSnapshotRoot = join(snapshotsRoot, "parked-turn-posix");
     const windowsParkedTurnSnapshotRoot = join(snapshotsRoot, "parked-turn-windows");
+    const completedTurnSnapshotRoot = join(snapshotsRoot, "completed-turn");
     const staleSnapshotRoot = join(snapshotsRoot, "stale");
     const oldSnapshotTime = new Date(1_000);
     const now = 1_000_000;
@@ -215,6 +216,7 @@ describe("development runtime artifact snapshots", () => {
       activeSnapshotRoot,
       posixParkedTurnSnapshotRoot,
       windowsParkedTurnSnapshotRoot,
+      completedTurnSnapshotRoot,
       staleSnapshotRoot,
     ]) {
       await mkdir(snapshotRoot, { recursive: true });
@@ -235,6 +237,7 @@ describe("development runtime artifact snapshots", () => {
       join(appRoot, ".workflow-data", "default", "runs", "parked-turn.json"),
       `${JSON.stringify(
         {
+          status: "running",
           input: {
             serializedContext: {
               "eve.bundle": {
@@ -255,6 +258,7 @@ describe("development runtime artifact snapshots", () => {
       join(appRoot, ".workflow-data", "default", "runs", "parked-turn-windows.json"),
       `${JSON.stringify(
         {
+          status: "running",
           input: {
             serializedContext: {
               "eve.bundle": {
@@ -275,6 +279,27 @@ describe("development runtime artifact snapshots", () => {
       )}\n`,
     );
 
+    await writeFile(
+      join(appRoot, ".workflow-data", "default", "runs", "completed-turn.json"),
+      `${JSON.stringify(
+        {
+          status: "completed",
+          input: {
+            serializedContext: {
+              "eve.bundle": {
+                source: {
+                  appRoot: join(completedTurnSnapshotRoot, "source", "app").replaceAll("\\", "/"),
+                  kind: "disk",
+                },
+              },
+            },
+          },
+          workflowId: "workflow//eve//turnWorkflow",
+        },
+        null,
+        2,
+      )}\n`,
+    );
     await pruneDevelopmentRuntimeArtifactsSnapshots({
       appRoot,
       now,
@@ -285,6 +310,7 @@ describe("development runtime artifact snapshots", () => {
     await expect(readdir(snapshotsRoot)).resolves.toEqual(
       expect.arrayContaining(["active", "parked-turn-posix", "parked-turn-windows"]),
     );
+    expect(existsSync(completedTurnSnapshotRoot)).toBe(false);
     expect(existsSync(staleSnapshotRoot)).toBe(false);
   });
 

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -12,6 +12,7 @@ const DEV_RUNTIME_ARTIFACTS_POINTER_VERSION = 2;
 const DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS = 15 * 60 * 1000;
 const DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT = 5;
 const DEV_RUNTIME_WORKFLOW_DATA_MAX_SCAN_BYTES = 1024 * 1024;
+const TERMINAL_WORKFLOW_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "canceled"]);
 
 interface DevelopmentRuntimeArtifactsPointerV1 {
   readonly appRoot: string;
@@ -353,6 +354,10 @@ async function collectSnapshotPathsFromDirectory(input: {
       }
 
       const source = await readFile(path, "utf8");
+      if (!shouldScanWorkflowDataSource(source)) {
+        return;
+      }
+
       for (const snapshotPath of collectSnapshotPathsFromText(source, input.snapshotsDirectory)) {
         input.snapshotPaths.add(snapshotPath);
       }
@@ -378,6 +383,29 @@ function collectSnapshotPathsFromText(
   }
 
   return [...snapshotPaths];
+}
+
+function shouldScanWorkflowDataSource(source: string): boolean {
+  const value = parseJsonObject(source);
+  if (value === undefined) {
+    return true;
+  }
+
+  const status = value.status;
+  return typeof status !== "string" || !TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
+}
+
+function parseJsonObject(source: string): Record<string, unknown> | undefined {
+  try {
+    const value = JSON.parse(source) as unknown;
+    return isObjectRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function escapeRegExp(value: string): string {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/eve/pull/181.

Skips terminal workflow run records when preserving dev-runtime snapshots from local workflow data, so completed runs do not keep old snapshots alive.

Tested with:
- `pnpm exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts -t "preserves snapshots referenced by active durable workflow data"`