### PR TITLE
Respect workspaces during init scaffolding

### DIFF
--- a/.changeset/polite-package-workspaces.md
+++ b/.changeset/polite-package-workspaces.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make `eve init` respect ancestor package-manager workspaces when scaffolding nested packages. The scaffold now updates workspace-owned package policy at the npm, pnpm, Yarn, or Bun workspace root instead of writing nested root-only config into the generated package.

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -391,6 +391,199 @@ describe("runInitCommand", () => {
     },
   );
 
+  it("scaffolds a fresh pnpm workspace member without nested workspace policy", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-pnpm-workspace-"));
+    const appsDirectory = join(workspaceRoot, "apps");
+    await mkdir(appsDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+    const output = logger();
+    const deps = dependencies();
+    deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+    await runInitCommand(output, appsDirectory, "my-agent", {}, deps);
+
+    const projectPath = join(appsDirectory, "my-agent");
+    await expect(pathExists(join(projectPath, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
+      "packages:\n  - apps/*\n\nallowBuilds:\n  sharp: false\n\nminimumReleaseAgeExclude:\n  - eve\n",
+    );
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectPath, "package.json"), "utf8"),
+    ) as {
+      dependencies: Record<string, string>;
+      engines?: unknown;
+      overrides?: unknown;
+      resolutions?: unknown;
+    };
+    expect(projectPackageJson.dependencies.eve).toBe("^0.6.0");
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(projectPackageJson.overrides).toBeUndefined();
+    expect(projectPackageJson.resolutions).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+    expect(output.messages.join("\n")).toContain(
+      `⚠ Updated workspace root configuration at ${join(workspaceRoot, "pnpm-workspace.yaml")}`,
+    );
+    expect(output.messages.join("\n")).toContain(
+      `⚠ Updated workspace root package.json at ${join(workspaceRoot, "package.json")} (Overrode package.json engines.node from "22.x" to "24.x"`,
+    );
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      projectPath,
+      expect.anything(),
+    );
+  });
+
+  it("scaffolds under an unclaimed pnpm workspace directory by adding a package pattern", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-pnpm-unclaimed-workspace-"));
+    const agentsDirectory = join(workspaceRoot, "agents");
+    await mkdir(agentsDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+    const output = logger();
+    const deps = dependencies();
+    deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+    await runInitCommand(output, agentsDirectory, "my-agent", {}, deps);
+
+    const projectPath = join(agentsDirectory, "my-agent");
+    await expect(pathExists(join(projectPath, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
+      "packages:\n  - apps/*\n  - agents/*\n\nallowBuilds:\n  sharp: false\n\nminimumReleaseAgeExclude:\n  - eve\n",
+    );
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectPath, "package.json"), "utf8"),
+    ) as {
+      engines?: unknown;
+      overrides?: unknown;
+      resolutions?: unknown;
+    };
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(projectPackageJson.overrides).toBeUndefined();
+    expect(projectPackageJson.resolutions).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      projectPath,
+      expect.anything(),
+    );
+  });
+
+  it("adds Web Chat under an unclaimed pnpm workspace directory without nested workspace policy", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-web-pnpm-workspace-"));
+    const agentsDirectory = join(workspaceRoot, "agents");
+    await mkdir(agentsDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+    const output = logger();
+    const deps = dependencies();
+    deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+    await runInitCommand(output, agentsDirectory, "web-agent", { channelWebNextjs: true }, deps);
+
+    const projectPath = join(agentsDirectory, "web-agent");
+    await expect(pathExists(join(projectPath, "app/page.tsx"))).resolves.toBe(true);
+    await expect(pathExists(join(projectPath, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
+      "packages:\n  - apps/*\n  - agents/*\n\nallowBuilds:\n  sharp: false\n\nminimumReleaseAgeExclude:\n  - eve\n",
+    );
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectPath, "package.json"), "utf8"),
+    ) as {
+      dependencies: Record<string, string>;
+      engines?: unknown;
+      overrides?: unknown;
+      resolutions?: unknown;
+    };
+    expect(projectPackageJson.dependencies.eve).toBe("^0.6.0");
+    expect(projectPackageJson.dependencies.next).toBe("16.0.0");
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(projectPackageJson.overrides).toBeUndefined();
+    expect(projectPackageJson.resolutions).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      projectPath,
+      expect.anything(),
+    );
+  });
+
+  it.each([
+    ["yarn", "yarn.lock", "resolutions", ["eve", "dev"]],
+    ["bun", "bun.lock", "overrides", ["x", "eve", "dev"]],
+  ] as const)(
+    "scaffolds a fresh %s workspace member without nested root-only package fields",
+    async (kind, lockfile, rootAiPinField, devArguments) => {
+      const workspaceRoot = await mkdtemp(join(tmpdir(), `eve-init-${kind}-workspace-member-`));
+      const appsDirectory = join(workspaceRoot, "apps");
+      await mkdir(appsDirectory, { recursive: true });
+      await writeFile(
+        join(workspaceRoot, "package.json"),
+        `${JSON.stringify(
+          {
+            private: true,
+            engines: { node: "22.x" },
+            workspaces: ["apps/*"],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await writeFile(join(workspaceRoot, lockfile), "", "utf8");
+      const output = logger();
+      const deps = dependencies();
+      deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+      await runInitCommand(output, appsDirectory, "my-agent", {}, deps);
+
+      const projectPath = join(appsDirectory, "my-agent");
+      const projectPackageJson = JSON.parse(
+        await readFile(join(projectPath, "package.json"), "utf8"),
+      ) as {
+        engines?: unknown;
+        overrides?: unknown;
+        resolutions?: unknown;
+      };
+      expect(projectPackageJson.engines).toBeUndefined();
+      expect(projectPackageJson.overrides).toBeUndefined();
+      expect(projectPackageJson.resolutions).toBeUndefined();
+      const rootPackageJson = JSON.parse(
+        await readFile(join(workspaceRoot, "package.json"), "utf8"),
+      ) as {
+        engines?: { node?: string };
+        overrides?: { ai?: string };
+        resolutions?: { ai?: string };
+      };
+      expect(rootPackageJson.engines?.node).toBe("24.x");
+      expect(rootPackageJson[rootAiPinField]?.ai).toBe("7.0.0");
+      expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+        kind,
+        projectPath,
+        expect.anything(),
+      );
+      expect(deps.spawnPackageManager).toHaveBeenCalledWith(kind, projectPath, [...devArguments]);
+    },
+  );
+
   it("adds Web Chat to an npm-owned fresh scaffold without pnpm configuration", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-agent-web-npm-"));
     const output = logger();
@@ -652,6 +845,44 @@ describe("runInitCommand", () => {
     );
     expect(deps.tryInitializeGit).not.toHaveBeenCalled();
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("bun", projectRoot, ["x", "eve", "dev"]);
+  });
+
+  it("adds an agent to an existing pnpm workspace member without nested root-only policy", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-existing-pnpm-workspace-"));
+    const appsDirectory = join(workspaceRoot, "apps");
+    const projectRoot = join(appsDirectory, "host-app");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+    await writeFile(join(projectRoot, "package.json"), '{ "name": "host-app" }\n', "utf8");
+    const output = logger();
+    const deps = dependencies();
+    deps.detectInvokingPackageManager.mockReturnValue("npm");
+
+    await runInitCommand(output, appsDirectory, "host-app", {}, deps);
+
+    expect(await readFile(join(projectRoot, "agent/agent.ts"), "utf8")).toContain(
+      DEFAULT_AGENT_MODEL_ID,
+    );
+    await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectRoot, "package.json"), "utf8"),
+    ) as { dependencies: Record<string, string>; engines?: unknown };
+    expect(projectPackageJson.dependencies.eve).toBe("^0.6.0");
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      projectRoot,
+      expect.anything(),
+    );
+    expect(deps.tryInitializeGit).not.toHaveBeenCalled();
   });
 
   it("reports agent file conflicts before writing anything", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -27,6 +27,7 @@ import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
 import { addAgentToProject } from "#setup/scaffold/create/add-to-project.js";
 import { ensureChannel, scaffoldBaseProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
+import type { WorkspaceRootMutation } from "#setup/scaffold/workspace-root.js";
 import {
   DEFAULT_EVE_PACKAGE_CONTRACT,
   type EvePackageContract,
@@ -120,6 +121,30 @@ async function moveDirectoryContents(sourceRoot: string, targetRoot: string): Pr
   }
 }
 
+function uniqueWorkspaceRootMutations(
+  mutations: readonly WorkspaceRootMutation[],
+): WorkspaceRootMutation[] {
+  const byKey = new Map<string, WorkspaceRootMutation>();
+  for (const mutation of mutations) {
+    const key = `${mutation.kind}:${mutation.path}`;
+    const existing = byKey.get(key);
+    byKey.set(key, {
+      ...mutation,
+      nodeEngineOverride: mutation.nodeEngineOverride ?? existing?.nodeEngineOverride,
+    });
+  }
+  return [...byKey.values()];
+}
+
+function formatWorkspaceRootMutationWarning(mutation: WorkspaceRootMutation): string {
+  const target = mutation.kind === "package-json" ? "package.json" : "configuration";
+  const suffix =
+    mutation.nodeEngineOverride === undefined
+      ? ""
+      : ` (${formatNodeEngineOverrideWarning(mutation.nodeEngineOverride)})`;
+  return `Updated workspace root ${target} at ${mutation.path}${suffix}`;
+}
+
 /**
  * Adds the agent to an existing project and returns the
  * detected manager, which drives the install and dev handoff.
@@ -172,7 +197,7 @@ async function scaffoldProject(
   options: InitCommandOptions,
   dependencies: InitCommandDependencies,
   evePackage: EvePackageContract | undefined,
-): Promise<string> {
+): Promise<{ projectPath: string; workspaceRootMutations: WorkspaceRootMutation[] }> {
   const parentPath = resolve(parentDirectory);
   const createInPlace = projectName === CURRENT_DIRECTORY_PROJECT_NAME;
   const projectPath = createInPlace ? parentPath : join(parentPath, projectName);
@@ -183,6 +208,7 @@ async function scaffoldProject(
   }
 
   const stagingDirectory = await mkdtemp(join(parentPath, ".eve-init-"));
+  const workspaceRootMutations: WorkspaceRootMutation[] = [];
   try {
     const stagedProjectName = createInPlace ? basename(projectPath) : projectName;
     const scaffoldOptions = {
@@ -190,7 +216,11 @@ async function scaffoldProject(
       model: DEFAULT_AGENT_MODEL_ID,
       evePackage,
       targetDirectory: stagingDirectory,
+      workspaceProbeDirectory: projectPath,
       packageManager,
+      onWorkspaceRootMutation: (mutation: WorkspaceRootMutation) => {
+        workspaceRootMutations.push(mutation);
+      },
     };
     const stagedProjectPath = await dependencies.scaffoldBaseProject(scaffoldOptions);
 
@@ -199,7 +229,11 @@ async function scaffoldProject(
         projectRoot: stagedProjectPath,
         kind: "web",
         packageManager,
+        workspaceProbeDirectory: projectPath,
         configureVercelServices: false,
+        onWorkspaceRootMutation: (mutation: WorkspaceRootMutation) => {
+          workspaceRootMutations.push(mutation);
+        },
       });
     }
 
@@ -208,7 +242,10 @@ async function scaffoldProject(
     } else {
       await rename(stagedProjectPath, projectPath);
     }
-    return projectPath;
+    return {
+      projectPath,
+      workspaceRootMutations: uniqueWorkspaceRootMutations(workspaceRootMutations),
+    };
   } finally {
     await rm(stagingDirectory, { recursive: true, force: true });
   }
@@ -225,6 +262,7 @@ type PreparedInitProject =
       kind: "created";
       packageManager: PackageManagerKind;
       projectPath: string;
+      workspaceRootMutations: WorkspaceRootMutation[];
     };
 
 type InitResult = {
@@ -241,6 +279,7 @@ type InitResult = {
   | {
       gitResult: GitInitResult;
       kind: "created";
+      workspaceRootMutations: WorkspaceRootMutation[];
     }
 );
 
@@ -302,7 +341,7 @@ async function runInitSteps(input: {
       const plannedProjectPath =
         projectName === CURRENT_DIRECTORY_PROJECT_NAME ? parentPath : join(parentPath, projectName);
       const packageManager = await resolveScaffoldPackageManager(plannedProjectPath, dependencies);
-      const projectPath = await scaffoldProject(
+      const scaffold = await scaffoldProject(
         parentDirectory,
         projectName,
         packageManager,
@@ -310,7 +349,12 @@ async function runInitSteps(input: {
         dependencies,
         evePackage,
       );
-      project = { kind: "created", packageManager, projectPath };
+      project = {
+        kind: "created",
+        packageManager,
+        projectPath: scaffold.projectPath,
+        workspaceRootMutations: scaffold.workspaceRootMutations,
+      };
     } else {
       const addition = await addToExistingProject(
         existingDirectory,
@@ -426,6 +470,9 @@ export async function runInitCommand(
     logger.log(
       `${pc.green("✓")} Created an ${EVE_WORDMARK} agent in ${pc.bold(result.projectPath)} ${pc.dim(`in ${formatElapsed(result.agentElapsedMs)}`)}`,
     );
+    for (const mutation of result.workspaceRootMutations) {
+      logger.log(pc.yellow(`⚠ ${formatWorkspaceRootMutationWarning(mutation)}`));
+    }
   } else {
     logger.log(
       `${pc.green("✓")} Added an ${EVE_WORDMARK} agent to ${pc.bold(result.projectPath)} ${pc.dim(`in ${formatElapsed(result.agentElapsedMs)}`)}`,

--- a/packages/eve/src/setup/package-manager.test.ts
+++ b/packages/eve/src/setup/package-manager.test.ts
@@ -27,6 +27,7 @@ describe("resolvePackageManager", () => {
 
   it.each([
     ["pnpm-lock.yaml", "pnpm"],
+    ["pnpm-workspace.yaml", "pnpm"],
     ["package-lock.json", "npm"],
     ["yarn.lock", "yarn"],
     ["bun.lock", "bun"],

--- a/packages/eve/src/setup/package-manager.ts
+++ b/packages/eve/src/setup/package-manager.ts
@@ -13,9 +13,10 @@ export interface DetectedPackageManager {
   source: PackageManagerSource;
 }
 
-/** Lockfiles in detection precedence order. */
+/** Package-manager marker files in detection precedence order. */
 const LOCKFILE_MANAGERS: ReadonlyArray<readonly [string, PackageManagerKind]> = [
   ["pnpm-lock.yaml", "pnpm"],
+  ["pnpm-workspace.yaml", "pnpm"],
   ["package-lock.json", "npm"],
   ["yarn.lock", "yarn"],
   ["bun.lock", "bun"],
@@ -28,7 +29,8 @@ function isPackageManagerKind(value: string): value is PackageManagerKind {
 
 /**
  * Resolves a project's package manager from gathered facts: an explicit
- * `packageManager` field wins, then the first known lockfile, then pnpm.
+ * `packageManager` field wins, then the first known package-manager marker,
+ * then pnpm.
  */
 export function resolvePackageManager(input: {
   packageManagerField?: string;

--- a/packages/eve/src/setup/primitives/pm/index.ts
+++ b/packages/eve/src/setup/primitives/pm/index.ts
@@ -28,6 +28,7 @@ export { bunPackageManager, npmPackageManager, pnpmPackageManager, yarnPackageMa
 export { PNPM_WORKSPACE_CONTENT, PNPM_WORKSPACE_PATH } from "./pnpm.js";
 export type {
   PackageManagerConfigurationResult,
+  PackageManagerConfigurationOptions,
   PackageManagerInstallOptions,
   PackageManagerInvocation,
   PackageManagerStrategy,

--- a/packages/eve/src/setup/primitives/pm/pnpm.ts
+++ b/packages/eve/src/setup/primitives/pm/pnpm.ts
@@ -1,8 +1,12 @@
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, extname, join, resolve } from "node:path";
 
 import { pathExists } from "../../path-exists.js";
+import {
+  workspacePatternForProject,
+  workspacePatternsClaimProject,
+} from "../../scaffold/workspace-glob.js";
 
 import type { PackageManagerStrategy } from "./types.js";
 
@@ -101,14 +105,117 @@ async function ensurePnpmWorkspacePolicy(filePath: string): Promise<"skipped" | 
 }
 
 /** Whether pnpm can walk from this project into a parent-owned workspace. */
-export function hasAncestorPnpmWorkspace(projectRoot: string): boolean {
+export function findAncestorPnpmWorkspaceRoot(projectRoot: string): string | undefined {
   let dir = dirname(resolve(projectRoot));
   while (true) {
-    if (existsSync(join(dir, PNPM_WORKSPACE_PATH))) return true;
+    if (existsSync(join(dir, PNPM_WORKSPACE_PATH))) return dir;
     const parent = dirname(dir);
-    if (parent === dir) return false;
+    if (parent === dir) return undefined;
     dir = parent;
   }
+}
+
+/** Whether pnpm can walk from this project into a parent-owned workspace. */
+export function hasAncestorPnpmWorkspace(projectRoot: string): boolean {
+  return findAncestorPnpmWorkspaceRoot(projectRoot) !== undefined;
+}
+
+function parsePnpmWorkspacePackagePatterns(source: string): string[] | undefined {
+  const lines = source.split(/\r?\n/u);
+  const packagesIndex = lines.findIndex((line) => /^\s*packages:/u.test(line));
+  if (packagesIndex < 0) return undefined;
+
+  // This deliberately supports the common workspace shapes eve needs to edit:
+  // a block sequence (`packages:\n  - apps/*`) and a simple inline sequence.
+  // More complex YAML falls back to "unknown"; callers then treat the ancestor
+  // as workspace-owned instead of creating nested standalone package-manager
+  // state under an ambiguous monorepo.
+  const inlineMatch = /^\s*packages:\s*\[(.*)\]\s*(?:#.*)?$/u.exec(lines[packagesIndex] ?? "");
+  if (inlineMatch !== null) {
+    const entries = inlineMatch[1]!.trim();
+    if (entries.length === 0) return [];
+    return entries
+      .split(",")
+      .map((entry) => entry.trim().replace(/^['"]|['"]$/gu, ""))
+      .filter((entry) => entry.length > 0);
+  }
+
+  if (lines[packagesIndex]?.trim() !== "packages:") return undefined;
+
+  const patterns: string[] = [];
+  for (const line of lines.slice(packagesIndex + 1)) {
+    if (/^\S/u.test(line)) break;
+    const match = /^\s*-\s*(.+?)\s*$/u.exec(line);
+    if (match === null) continue;
+    patterns.push(match[1]!.replace(/^['"]|['"]$/gu, ""));
+  }
+  return patterns;
+}
+
+/**
+ * Returns the ancestor workspace root only when the workspace manifest's
+ * package candidates include `projectRoot`. If the manifest cannot be parsed,
+ * it is treated as a workspace owner so setup does not silently create nested
+ * standalone package-manager state in an ambiguous monorepo.
+ */
+export function findClaimingAncestorPnpmWorkspaceRoot(projectRoot: string): string | undefined {
+  const workspaceRoot = findAncestorPnpmWorkspaceRoot(projectRoot);
+  if (workspaceRoot === undefined) return undefined;
+
+  let patterns: string[] | undefined;
+  try {
+    patterns = parsePnpmWorkspacePackagePatterns(
+      readFileSync(join(workspaceRoot, PNPM_WORKSPACE_PATH), "utf8"),
+    );
+  } catch {
+    return workspaceRoot;
+  }
+  if (patterns === undefined) return workspaceRoot;
+
+  return workspacePatternsClaimProject(patterns, workspaceRoot, projectRoot)
+    ? workspaceRoot
+    : undefined;
+}
+
+function withPnpmWorkspacePackagePattern(source: string, pattern: string): string {
+  const normalized = source.endsWith("\n") ? source : `${source}\n`;
+  const lines = normalized.split("\n");
+  const packagesIndex = lines.findIndex((line) => line.trim() === "packages:");
+
+  if (packagesIndex < 0) {
+    const prefix = normalized.trim().length === 0 ? "" : `${normalized}\n`;
+    return `${prefix}packages:\n  - ${pattern}\n`;
+  }
+
+  const blockEnd = findYamlBlockEnd(lines, packagesIndex);
+  let insertAt = blockEnd;
+  while (insertAt > packagesIndex + 1 && lines[insertAt - 1] === "") {
+    insertAt -= 1;
+  }
+  lines.splice(insertAt, 0, `  - ${pattern}`);
+  return lines.join("\n");
+}
+
+export async function ensurePnpmWorkspaceIncludesProject(
+  projectRoot: string,
+): Promise<"skipped" | "written"> {
+  const workspaceRoot = findAncestorPnpmWorkspaceRoot(projectRoot);
+  if (workspaceRoot === undefined || resolve(workspaceRoot) === resolve(projectRoot)) {
+    return "skipped";
+  }
+  if (findClaimingAncestorPnpmWorkspaceRoot(projectRoot) === workspaceRoot) {
+    return "skipped";
+  }
+
+  const filePath = join(workspaceRoot, PNPM_WORKSPACE_PATH);
+  const current = await readFile(filePath, "utf8");
+  const next = withPnpmWorkspacePackagePattern(
+    current,
+    workspacePatternForProject(workspaceRoot, projectRoot),
+  );
+  if (next === current) return "skipped";
+  await writeFile(filePath, next, "utf8");
+  return "written";
 }
 
 /**
@@ -151,9 +258,14 @@ export function pnpmWorkspaceClaimsProject(
 export const pnpmPackageManager = {
   kind: "pnpm",
   scaffoldFiles: { [PNPM_WORKSPACE_PATH]: PNPM_WORKSPACE_CONTENT },
-  async applyProjectConfiguration(projectRoot) {
-    const filePath = join(projectRoot, PNPM_WORKSPACE_PATH);
-    const result = await ensurePnpmWorkspacePolicy(filePath);
+  async applyProjectConfiguration(projectRoot, options) {
+    const workspaceProbeRoot = options?.workspaceProbeRoot ?? projectRoot;
+    const workspaceMembershipResult = await ensurePnpmWorkspaceIncludesProject(workspaceProbeRoot);
+    const workspaceRoot = findClaimingAncestorPnpmWorkspaceRoot(workspaceProbeRoot);
+    const filePath = join(workspaceRoot ?? projectRoot, PNPM_WORKSPACE_PATH);
+    const policyResult = await ensurePnpmWorkspacePolicy(filePath);
+    const result =
+      workspaceMembershipResult === "written" || policyResult === "written" ? "written" : "skipped";
     return result === "written"
       ? { filesSkipped: [], filesWritten: [filePath] }
       : { filesSkipped: [filePath], filesWritten: [] };

--- a/packages/eve/src/setup/primitives/pm/types.ts
+++ b/packages/eve/src/setup/primitives/pm/types.ts
@@ -13,6 +13,16 @@ export interface PackageManagerConfigurationResult {
   readonly filesWritten: readonly string[];
 }
 
+/** Context for manager-owned project configuration. */
+export interface PackageManagerConfigurationOptions {
+  /**
+   * Final project path used to discover ancestor workspaces. This differs from
+   * `projectRoot` only when a scaffold is staged in a temporary directory
+   * before being moved into place.
+   */
+  readonly workspaceProbeRoot?: string;
+}
+
 export interface PackageManagerInstallOptions {
   /** Disables the manager's minimum-release-age cooldown for this run when supported. */
   readonly bypassMinimumReleaseAge?: boolean;
@@ -34,7 +44,10 @@ export interface PackageManagerStrategy {
   /** Manager-owned files included when creating a fresh project. */
   readonly scaffoldFiles: Readonly<Record<string, string>>;
   /** Adds or reconciles manager-owned configuration in an existing project. */
-  applyProjectConfiguration(projectRoot: string): Promise<PackageManagerConfigurationResult>;
+  applyProjectConfiguration(
+    projectRoot: string,
+    options?: PackageManagerConfigurationOptions,
+  ): Promise<PackageManagerConfigurationResult>;
   /** Arguments that run the project-local eve development command. */
   devArguments(): readonly string[];
   /** Arguments that install project dependencies. */

--- a/packages/eve/src/setup/scaffold/create/add-to-project.ts
+++ b/packages/eve/src/setup/scaffold/create/add-to-project.ts
@@ -3,10 +3,14 @@ import { join } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import type { NodeEngineOverride } from "../../node-engine.js";
-import { getPackageManagerStrategy } from "../../primitives/pm/index.js";
 import { pathExists, writeTextFile } from "../files.js";
 import { patchPackageJson, type PackageJsonPatch } from "../update/package-json.js";
 import { resolveVersionToken } from "../version-tokens.js";
+import {
+  applyPackageManagerWorkspaceConfiguration,
+  isPackageManagerWorkspaceMember,
+  patchWorkspaceRootPackageJson,
+} from "../workspace-root.js";
 import {
   agentTemplateFiles,
   DEFAULT_AI_PACKAGE_VERSION,
@@ -72,6 +76,7 @@ function hasDeclaredDependency(packageJson: unknown, dependencyName: string): bo
 export async function addAgentToProject(
   options: AddAgentToProjectOptions,
 ): Promise<AddAgentToProjectResult> {
+  const packageManager = options.packageManager ?? "pnpm";
   const packageJsonPath = join(options.projectRoot, "package.json");
   if (!(await pathExists(packageJsonPath))) {
     throw new Error(
@@ -134,21 +139,35 @@ export async function addAgentToProject(
       additions[name] = version;
     }
   }
-  const patch: PackageJsonPatch = {
-    nodeEngineRequirement: evePackage.nodeEngine,
-  };
+  const patch: PackageJsonPatch = {};
   if (Object.keys(additions).length > 0) {
     patch.dependencies = additions;
   }
+  const workspaceMember = isPackageManagerWorkspaceMember(packageManager, options.projectRoot);
+  if (!workspaceMember) {
+    patch.nodeEngineRequirement = evePackage.nodeEngine;
+  }
   const patchResult = await patchPackageJson(packageJsonPath, patch);
 
-  await getPackageManagerStrategy(options.packageManager ?? "pnpm").applyProjectConfiguration(
+  const workspacePatchResult = await patchWorkspaceRootPackageJson(
+    packageManager,
     options.projectRoot,
+    {
+      aiPackageVersion: aiVersion,
+      nodeEngineRequirement: evePackage.nodeEngine,
+    },
   );
+  const nodeEngineOverride =
+    workspacePatchResult.nodeEngineOverride ?? patchResult.nodeEngineOverride;
+
+  await applyPackageManagerWorkspaceConfiguration({
+    packageManager,
+    projectRoot: options.projectRoot,
+  });
 
   return {
     filesWritten,
     dependenciesAdded: Object.keys(additions).sort(),
-    nodeEngineOverride: patchResult.nodeEngineOverride,
+    nodeEngineOverride,
   };
 }

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -3,10 +3,15 @@ import { basename, join, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor } from "../../node-engine.js";
-import { getPackageManagerStrategy } from "../../primitives/pm/index.js";
 import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "../update/module-files.js";
 import { pathExists, writeTextFile } from "../files.js";
 import { resolveVersionToken } from "../version-tokens.js";
+import {
+  applyPackageManagerWorkspaceConfiguration,
+  isPackageManagerWorkspaceMember,
+  patchWorkspaceRootPackageJson,
+  type WorkspaceRootMutation,
+} from "../workspace-root.js";
 import { WEB_APP_TEMPLATE_FILES } from "./web-template.js";
 
 export const CURRENT_DIRECTORY_PROJECT_NAME = ".";
@@ -152,7 +157,7 @@ export default defineAgent({
 // and abort the install (ERESOLVE). Forcing `ai` through `overrides` (npm/bun)
 // and `resolutions` (yarn) keeps the whole tree on that exact version; pnpm
 // already tolerates the unmet optional peer and ignores both fields.
-function packageJsonTemplate(): string {
+function packageJsonTemplate(includeRootOnlyFields: boolean): string {
   return `{
   "name": "__EVE_INIT_APP_NAME__",
   "version": "0.0.0",
@@ -176,7 +181,12 @@ function packageJsonTemplate(): string {
   "devDependencies": {
     "@types/node": "__EVE_INIT_TYPES_NODE_VERSION__",
     "typescript": "__EVE_INIT_TYPESCRIPT_VERSION__"
-  },
+  }${includeRootOnlyFields ? ROOT_ONLY_PACKAGE_JSON_TEMPLATE_SUFFIX : ""}
+}
+`;
+}
+
+const ROOT_ONLY_PACKAGE_JSON_TEMPLATE_SUFFIX = `,
   "overrides": {
     "ai": "__EVE_INIT_AI_SDK_VERSION__"
   },
@@ -186,9 +196,7 @@ function packageJsonTemplate(): string {
   "engines": {
     "node": "__EVE_INIT_NODE_ENGINE__"
   }
-}
 `;
-}
 
 const AGENT_INSTRUCTIONS_TEMPLATE = `# Identity
 
@@ -245,13 +253,12 @@ This project uses the eve framework. Before writing code, always read the releva
 
 function templateFiles(
   byokProvider: boolean,
-  packageManager: PackageManagerKind,
+  includeRootOnlyPackageJsonFields: boolean,
 ): Record<string, string> {
   return {
     "agent/agent.ts": byokProvider ? BYOK_AGENT_TEMPLATE : BASE_AGENT_TEMPLATE,
     ...SHARED_TEMPLATE_FILES,
-    "package.json": packageJsonTemplate(),
-    ...getPackageManagerStrategy(packageManager).scaffoldFiles,
+    "package.json": packageJsonTemplate(includeRootOnlyPackageJsonFields),
   };
 }
 
@@ -292,6 +299,13 @@ export interface ScaffoldBaseProjectOptions {
   zodPackageVersion?: string;
   typescriptPackageVersion?: string;
   /**
+   * Final project path used to discover ancestor workspaces. This differs from
+   * the write target only when the CLI stages a scaffold before moving it into
+   * place.
+   */
+  workspaceProbeDirectory?: string;
+  onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>;
+  /**
    * Scaffold an inline provider `byok` block in `agent.ts` that reads the
    * provider key from `process.env` instead of relying on the managed Vercel
    * AI Gateway. `process` is typed by the `@types/node` every scaffold ships.
@@ -307,6 +321,8 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
   const packageManager = options.packageManager ?? "pnpm";
   const evePackage = resolveEvePackageContract(options.evePackage);
   const nodeEngine = pinnedNodeEngineMajor(evePackage.nodeEngine);
+  const workspaceProbeRoot = resolve(options.workspaceProbeDirectory ?? targetRoot);
+  const workspaceMember = isPackageManagerWorkspaceMember(packageManager, workspaceProbeRoot);
 
   if (createInPlace) {
     await assertCanCreateInPlace(targetRoot, overwriteExisting);
@@ -343,7 +359,7 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
 
   await mkdir(targetRoot, { recursive: true });
 
-  for (const [relPath, content] of Object.entries(templateFiles(byokProvider, packageManager))) {
+  for (const [relPath, content] of Object.entries(templateFiles(byokProvider, !workspaceMember))) {
     const filePath = `${targetRoot}/${relPath}`;
     const existed = await pathExists(filePath);
     await writeTextFile(filePath, renderTemplate(content, ctx), {
@@ -353,6 +369,19 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
       await options.onOverwriteFile?.(filePath);
     }
   }
+
+  await applyPackageManagerWorkspaceConfiguration({
+    packageManager,
+    projectRoot: targetRoot,
+    workspaceProbeRoot,
+    onWorkspaceRootMutation: options.onWorkspaceRootMutation,
+  });
+
+  await patchWorkspaceRootPackageJson(packageManager, workspaceProbeRoot, {
+    aiPackageVersion: ctx.aiPackageVersion,
+    nodeEngineRequirement: evePackage.nodeEngine,
+    onWorkspaceRootMutation: options.onWorkspaceRootMutation,
+  });
 
   return targetRoot;
 }

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -486,6 +486,52 @@ describe("ensureChannel", () => {
     expect(result.filesWritten).toContain(pnpmWorkspacePath);
   });
 
+  test("adds Web Chat pnpm policy and a missing package pattern at the ancestor workspace root", async () => {
+    const workspaceRoot = await createTempDir();
+    const projectRoot = join(workspaceRoot, "agents", "agent");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+    await writeFile(
+      join(projectRoot, "package.json"),
+      `${JSON.stringify({ name: "agent", type: "module" }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await ensureChannel({
+      projectRoot,
+      kind: "web",
+      webPackageVersions: TEST_WEB_PACKAGE_VERSIONS,
+    });
+    if (result.kind !== "web" || result.action === "skipped") {
+      throw new Error(`Expected Web Chat to be created, got ${result.kind}:${result.action}`);
+    }
+
+    expect(result.filesWritten).toContain(join(workspaceRoot, "pnpm-workspace.yaml"));
+    expect(result.filesWritten).not.toContain(join(projectRoot, "pnpm-workspace.yaml"));
+    await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
+      "packages:\n  - apps/*\n  - agents/*\n\nallowBuilds:\n  sharp: false\n\nminimumReleaseAgeExclude:\n  - eve\n",
+    );
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectRoot, "package.json"), "utf8"),
+    ) as { engines?: unknown; dependencies: Record<string, string> };
+    expect(projectPackageJson.dependencies.eve).toBe("^0.25.0");
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+    expect(result.nodeEngineOverride).toEqual({
+      kind: "overridden",
+      next: "24.x",
+      previous: "22.x",
+    });
+  });
+
   test("skips Web Chat when Next.js is already present", async () => {
     const projectRoot = await createTempDir();
     const pagePath = join(projectRoot, "app/page.tsx");
@@ -716,6 +762,208 @@ describe("scaffoldBaseProject", () => {
         '"eve": "^0.25.0"',
       );
       await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    },
+  );
+
+  test("scaffolds a pnpm workspace member without nested root-only package files", async () => {
+    const workspaceRoot = await createTempDir();
+    const targetDirectory = join(workspaceRoot, "apps");
+    await mkdir(targetDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+
+    const projectRoot = await scaffoldBaseProject({
+      projectName: "demo-agent",
+      model: "openai/gpt-5-mini",
+      targetDirectory,
+      evePackage: TEST_EVE_PACKAGE,
+      aiPackageVersion: "7.0.0",
+      connectPackageVersion: "0.2.2",
+      zodPackageVersion: "4.4.3",
+      typescriptPackageVersion: "7.0.1-rc",
+    });
+
+    await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
+      "packages:\n  - apps/*\n\nallowBuilds:\n  sharp: false\n\nminimumReleaseAgeExclude:\n  - eve\n",
+    );
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies: Record<string, string>;
+      engines?: unknown;
+      overrides?: unknown;
+      resolutions?: unknown;
+    };
+    expect(projectPackageJson.dependencies.eve).toBe("^0.25.0");
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(projectPackageJson.overrides).toBeUndefined();
+    expect(projectPackageJson.resolutions).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+  });
+
+  test("scaffolds under an unclaimed pnpm workspace directory by adding a package pattern", async () => {
+    const workspaceRoot = await createTempDir();
+    const targetDirectory = join(workspaceRoot, "agents");
+    await mkdir(targetDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+
+    const projectRoot = await scaffoldBaseProject({
+      projectName: "demo-agent",
+      model: "openai/gpt-5-mini",
+      targetDirectory,
+      evePackage: TEST_EVE_PACKAGE,
+      aiPackageVersion: "7.0.0",
+      connectPackageVersion: "0.2.2",
+      zodPackageVersion: "4.4.3",
+      typescriptPackageVersion: "7.0.1-rc",
+    });
+
+    await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
+      "packages:\n  - apps/*\n  - agents/*\n\nallowBuilds:\n  sharp: false\n\nminimumReleaseAgeExclude:\n  - eve\n",
+    );
+    const projectPackageJson = JSON.parse(
+      await readFile(join(projectRoot, "package.json"), "utf8"),
+    ) as {
+      engines?: unknown;
+      overrides?: unknown;
+      resolutions?: unknown;
+    };
+    expect(projectPackageJson.engines).toBeUndefined();
+    expect(projectPackageJson.overrides).toBeUndefined();
+    expect(projectPackageJson.resolutions).toBeUndefined();
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+  });
+
+  test.each([
+    ["npm", "overrides"],
+    ["bun", "overrides"],
+    ["yarn", "resolutions"],
+  ] as const)(
+    "scaffolds a %s workspace member with root-only package fields at the workspace root",
+    async (packageManager, rootAiPinField) => {
+      const workspaceRoot = await createTempDir();
+      const targetDirectory = join(workspaceRoot, "apps");
+      await mkdir(targetDirectory, { recursive: true });
+      await writeFile(
+        join(workspaceRoot, "package.json"),
+        `${JSON.stringify(
+          {
+            private: true,
+            engines: { node: "22.x" },
+            workspaces: ["apps/*"],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const projectRoot = await scaffoldBaseProject({
+        projectName: "demo-agent",
+        model: "openai/gpt-5-mini",
+        packageManager,
+        targetDirectory,
+        evePackage: TEST_EVE_PACKAGE,
+        aiPackageVersion: "7.0.0",
+        connectPackageVersion: "0.2.2",
+        zodPackageVersion: "4.4.3",
+        typescriptPackageVersion: "7.0.1-rc",
+      });
+
+      const projectPackageJson = JSON.parse(
+        await readFile(join(projectRoot, "package.json"), "utf8"),
+      ) as {
+        engines?: unknown;
+        overrides?: unknown;
+        resolutions?: unknown;
+      };
+      expect(projectPackageJson.engines).toBeUndefined();
+      expect(projectPackageJson.overrides).toBeUndefined();
+      expect(projectPackageJson.resolutions).toBeUndefined();
+      const rootPackageJson = JSON.parse(
+        await readFile(join(workspaceRoot, "package.json"), "utf8"),
+      ) as {
+        engines?: { node?: string };
+        overrides?: { ai?: string };
+        resolutions?: { ai?: string };
+      };
+      expect(rootPackageJson.engines?.node).toBe("24.x");
+      expect(rootPackageJson[rootAiPinField]?.ai).toBe("7.0.0");
+    },
+  );
+
+  test.each([
+    ["npm", "overrides"],
+    ["bun", "overrides"],
+    ["yarn", "resolutions"],
+  ] as const)(
+    "scaffolds under an unclaimed %s workspace directory by adding a package pattern",
+    async (packageManager, rootAiPinField) => {
+      const workspaceRoot = await createTempDir();
+      const targetDirectory = join(workspaceRoot, "agents");
+      await mkdir(targetDirectory, { recursive: true });
+      await writeFile(
+        join(workspaceRoot, "package.json"),
+        `${JSON.stringify(
+          {
+            private: true,
+            engines: { node: "22.x" },
+            workspaces: ["apps/*"],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const projectRoot = await scaffoldBaseProject({
+        projectName: "demo-agent",
+        model: "openai/gpt-5-mini",
+        packageManager,
+        targetDirectory,
+        evePackage: TEST_EVE_PACKAGE,
+        aiPackageVersion: "7.0.0",
+        connectPackageVersion: "0.2.2",
+        zodPackageVersion: "4.4.3",
+        typescriptPackageVersion: "7.0.1-rc",
+      });
+
+      const projectPackageJson = JSON.parse(
+        await readFile(join(projectRoot, "package.json"), "utf8"),
+      ) as {
+        engines?: unknown;
+        overrides?: unknown;
+        resolutions?: unknown;
+      };
+      expect(projectPackageJson.engines).toBeUndefined();
+      expect(projectPackageJson.overrides).toBeUndefined();
+      expect(projectPackageJson.resolutions).toBeUndefined();
+      const rootPackageJson = JSON.parse(
+        await readFile(join(workspaceRoot, "package.json"), "utf8"),
+      ) as {
+        engines?: { node?: string };
+        overrides?: { ai?: string };
+        resolutions?: { ai?: string };
+        workspaces?: string[];
+      };
+      expect(rootPackageJson.workspaces).toEqual(["apps/*", "agents/*"]);
+      expect(rootPackageJson.engines?.node).toBe("24.x");
+      expect(rootPackageJson[rootAiPinField]?.ai).toBe("7.0.0");
     },
   );
 

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -3,11 +3,16 @@ import { basename, join, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor, type NodeEngineOverride } from "../../node-engine.js";
-import { getPackageManagerStrategy } from "../../primitives/pm/index.js";
 import { pathExists, writeTextFile } from "../files.js";
 import { resolveVersionToken } from "../version-tokens.js";
+import {
+  applyPackageManagerWorkspaceConfiguration,
+  isPackageManagerWorkspaceMember,
+  patchWorkspaceRootPackageJson,
+  type WorkspaceRootMutation,
+} from "../workspace-root.js";
 import { getSupportedModuleBaseName, matchesSupportedModuleBaseName } from "./module-files.js";
-import { patchPackageJson } from "./package-json.js";
+import { patchPackageJson, type PackageJsonPatch } from "./package-json.js";
 import {
   CURRENT_DIRECTORY_PROJECT_NAME,
   DEFAULT_EVE_PACKAGE_CONTRACT,
@@ -253,12 +258,16 @@ function formatEveDependencySpecifier(versionOrSpecifier: string): string {
 }
 
 async function patchWebPackageJson(
-  packageJsonPath: string,
+  projectRoot: string,
+  packageManager: PackageManagerKind,
+  workspaceProbeRoot: string,
   options: Required<WebPackageVersions>,
+  onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>,
 ): Promise<{
   mutations: PackageJsonMutation[];
   nodeEngineOverride?: NodeEngineOverride;
 }> {
+  const packageJsonPath = join(projectRoot, "package.json");
   if (!(await pathExists(packageJsonPath))) return { mutations: [] };
 
   // Resolved here, not at the defaults site, so a project without a
@@ -291,12 +300,27 @@ async function patchWebPackageJson(
   } satisfies Record<string, string>;
   const scripts = WEB_APP_TEMPLATE_PACKAGE_JSON.scripts;
 
-  const patchResult = await patchPackageJson(packageJsonPath, {
+  const workspaceMember = isPackageManagerWorkspaceMember(packageManager, workspaceProbeRoot);
+  const packageJsonPatch: PackageJsonPatch = {
     dependencies,
     devDependencies,
     scripts,
-    nodeEngineRequirement: evePackage.nodeEngine,
-  });
+  };
+  if (!workspaceMember) {
+    packageJsonPatch.nodeEngineRequirement = evePackage.nodeEngine;
+  }
+  const patchResult = await patchPackageJson(packageJsonPath, packageJsonPatch);
+  const workspacePatchResult = await patchWorkspaceRootPackageJson(
+    packageManager,
+    workspaceProbeRoot,
+    {
+      aiPackageVersion: dependencies.ai,
+      nodeEngineRequirement: evePackage.nodeEngine,
+      onWorkspaceRootMutation,
+    },
+  );
+  const nodeEngineOverride =
+    workspacePatchResult.nodeEngineOverride ?? patchResult.nodeEngineOverride;
 
   return {
     mutations: [
@@ -307,7 +331,7 @@ async function patchWebPackageJson(
         scripts: Object.keys(scripts),
       },
     ],
-    nodeEngineOverride: patchResult.nodeEngineOverride,
+    nodeEngineOverride,
   };
 }
 
@@ -437,6 +461,12 @@ export interface EnsureChannelOptions {
   kind: ChannelKind;
   /** Manager that owns generated project configuration. Defaults to pnpm. */
   packageManager?: PackageManagerKind;
+  /**
+   * Final project path used to discover ancestor workspaces. This differs from
+   * `projectRoot` only when scaffolding writes into a temporary staging
+   * directory before moving the project into place.
+   */
+  workspaceProbeDirectory?: string;
   force?: boolean;
   /** Exact UID returned by Vercel Connect; takes precedence over the derived slug. */
   slackConnectorUid?: string;
@@ -445,6 +475,7 @@ export interface EnsureChannelOptions {
   webPackageVersions?: WebPackageVersions;
   /** When false, Web Chat leaves Vercel Services config unwritten for preview-only scaffolds. */
   configureVercelServices?: boolean;
+  onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>;
 }
 
 export interface WebPackageVersions {
@@ -486,7 +517,15 @@ async function ensureWebChannel(
   }
 
   const webPackageVersions = resolveWebPackageVersions(options.webPackageVersions);
-  const packageJsonPatch = await patchWebPackageJson(packageJsonPath, webPackageVersions);
+  const packageManager = options.packageManager ?? "pnpm";
+  const workspaceProbeRoot = resolve(options.workspaceProbeDirectory ?? options.projectRoot);
+  const packageJsonPatch = await patchWebPackageJson(
+    options.projectRoot,
+    packageManager,
+    workspaceProbeRoot,
+    webPackageVersions,
+    options.onWorkspaceRootMutation,
+  );
   const filesWritten: string[] = [];
   const filesOverwritten: string[] = [];
   const competingNextConfigFiles: string[] = [];
@@ -504,9 +543,12 @@ async function ensureWebChannel(
     }
   }
 
-  const packageManagerConfiguration = await getPackageManagerStrategy(
-    options.packageManager ?? "pnpm",
-  ).applyProjectConfiguration(options.projectRoot);
+  const packageManagerConfiguration = await applyPackageManagerWorkspaceConfiguration({
+    packageManager,
+    projectRoot: options.projectRoot,
+    workspaceProbeRoot,
+    onWorkspaceRootMutation: options.onWorkspaceRootMutation,
+  });
   filesWritten.push(...packageManagerConfiguration.filesWritten);
   filesSkipped.push(...packageManagerConfiguration.filesSkipped);
 
@@ -528,12 +570,16 @@ async function ensureWebChannel(
   }
 
   competingNextConfigFiles.push(...(await findCompetingNextConfigFiles(options.projectRoot)));
+  const uniqueFilesWritten = [...new Set(filesWritten)];
+  const uniqueFilesSkipped = [...new Set(filesSkipped)].filter(
+    (filePath) => !uniqueFilesWritten.includes(filePath),
+  );
 
   const result: WebChannelWrittenResult = {
     kind: "web",
     action: webEntryAlreadyExists ? "overwritten" : "created",
-    filesWritten,
-    filesSkipped,
+    filesWritten: uniqueFilesWritten,
+    filesSkipped: uniqueFilesSkipped,
     packageJsonUpdated: packageJsonPatch.mutations,
   };
   if (filesOverwritten.length > 0) {

--- a/packages/eve/src/setup/scaffold/update/package-json.ts
+++ b/packages/eve/src/setup/scaffold/update/package-json.ts
@@ -5,6 +5,8 @@ import { reconcileNodeEngine, type NodeEngineOverride } from "../../node-engine.
 export interface PackageJsonPatch {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
+  resolutions?: Record<string, string>;
   scripts?: Record<string, string>;
   /**
    * eve's required Node.js range (e.g. `">=24"`). When the target's
@@ -16,12 +18,15 @@ export interface PackageJsonPatch {
 }
 
 export interface PackageJsonPatchResult {
+  changed: boolean;
   nodeEngineOverride?: NodeEngineOverride;
 }
 
 interface PackageJsonShape {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
+  resolutions?: Record<string, string>;
   scripts?: Record<string, string>;
   engines?: unknown;
   [key: string]: unknown;
@@ -51,6 +56,16 @@ export async function patchPackageJson(
     };
     changed = true;
   }
+  if (patch.overrides !== undefined) {
+    const overrides = isJsonObject(parsed.overrides) ? parsed.overrides : {};
+    parsed.overrides = { ...overrides, ...patch.overrides };
+    changed = true;
+  }
+  if (patch.resolutions !== undefined) {
+    const resolutions = isJsonObject(parsed.resolutions) ? parsed.resolutions : {};
+    parsed.resolutions = { ...resolutions, ...patch.resolutions };
+    changed = true;
+  }
   if (patch.scripts !== undefined) {
     parsed.scripts = { ...parsed.scripts, ...patch.scripts };
     changed = true;
@@ -70,5 +85,5 @@ export async function patchPackageJson(
   if (changed) {
     await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
   }
-  return { nodeEngineOverride };
+  return { changed, nodeEngineOverride };
 }

--- a/packages/eve/src/setup/scaffold/workspace-glob.test.ts
+++ b/packages/eve/src/setup/scaffold/workspace-glob.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  workspacePatternClaimsRelativePath,
+  workspacePatternForProject,
+  workspacePatternsClaimProject,
+} from "./workspace-glob.js";
+
+describe("workspace glob helpers", () => {
+  it.each([
+    ["apps/web", "apps/web", true],
+    ["./apps/*", "apps/web", true],
+    ["apps/*", "apps/web/nested", false],
+    ["apps/**", "apps/web/nested", true],
+    ["packages/*/fixtures", "packages/eve/fixtures", true],
+    ["packages/*/fixtures", "packages/eve/test/fixtures", false],
+  ] as const)("checks whether pattern %j claims %j", (pattern, relativePath, expected) => {
+    expect(workspacePatternClaimsRelativePath(pattern, relativePath)).toBe(expected);
+  });
+
+  it("applies negative patterns after positive matches", () => {
+    expect(
+      workspacePatternsClaimProject(
+        ["apps/**", "!apps/private/**"],
+        "/repo",
+        "/repo/apps/web/agent",
+      ),
+    ).toBe(true);
+    expect(
+      workspacePatternsClaimProject(
+        ["apps/**", "!apps/private/**"],
+        "/repo",
+        "/repo/apps/private/agent",
+      ),
+    ).toBe(false);
+  });
+
+  it("derives the sibling package pattern for a nested project path", () => {
+    expect(workspacePatternForProject("/repo", "/repo/agents/my-agent")).toBe("agents/*");
+    expect(workspacePatternForProject("/repo", "/repo/apps/eve/my-agent")).toBe("apps/eve/*");
+    expect(workspacePatternForProject("/repo", "/repo/my-agent")).toBe("my-agent");
+  });
+});

--- a/packages/eve/src/setup/scaffold/workspace-glob.ts
+++ b/packages/eve/src/setup/scaffold/workspace-glob.ts
@@ -1,0 +1,65 @@
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+function escapeRegex(input: string): string {
+  return input.replace(/[\\^$+?.()|[\]{}]/gu, "\\$&");
+}
+
+function workspacePatternToRegex(pattern: string): RegExp {
+  const normalized = pattern.replaceAll("\\", "/").replace(/^\.\/+/u, "");
+  let source = "^";
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    if (char === "*") {
+      if (normalized[index + 1] === "*") {
+        source += ".*";
+        index += 1;
+      } else {
+        source += "[^/]*";
+      }
+    } else {
+      source += escapeRegex(char ?? "");
+    }
+  }
+  source += "$";
+  return new RegExp(source, "u");
+}
+
+export function workspaceRelativePath(workspaceRoot: string, projectRoot: string): string {
+  return relative(workspaceRoot, resolve(projectRoot)).split(sep).join("/");
+}
+
+export function isPathInside(parentPath: string, childPath: string): boolean {
+  const relativePath = relative(resolve(parentPath), resolve(childPath));
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+export function workspacePatternForProject(workspaceRoot: string, projectRoot: string): string {
+  const relativePath = workspaceRelativePath(workspaceRoot, projectRoot);
+  if (relativePath.length === 0) return ".";
+  const parts = relativePath.split("/");
+  if (parts.length === 1) return relativePath;
+  return `${parts.slice(0, -1).join("/")}/*`;
+}
+
+export function workspacePatternClaimsRelativePath(pattern: string, relativePath: string): boolean {
+  const normalized = pattern.replaceAll("\\", "/").replace(/^\.\/+/u, "");
+  if (normalized === "." || normalized === relativePath) return true;
+  return workspacePatternToRegex(normalized).test(relativePath);
+}
+
+export function workspacePatternsClaimProject(
+  patterns: readonly string[],
+  workspaceRoot: string,
+  projectRoot: string,
+): boolean {
+  const relativePath = workspaceRelativePath(workspaceRoot, projectRoot);
+  const positives = patterns.filter((pattern) => !pattern.startsWith("!"));
+  const negatives = patterns
+    .filter((pattern) => pattern.startsWith("!"))
+    .map((pattern) => pattern.slice(1));
+  const included = positives.some((pattern) =>
+    workspacePatternClaimsRelativePath(pattern, relativePath),
+  );
+  if (!included) return false;
+  return !negatives.some((pattern) => workspacePatternClaimsRelativePath(pattern, relativePath));
+}

--- a/packages/eve/src/setup/scaffold/workspace-root.ts
+++ b/packages/eve/src/setup/scaffold/workspace-root.ts
@@ -1,0 +1,259 @@
+import { existsSync, readFileSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import type { NodeEngineOverride } from "../node-engine.js";
+import type { PackageManagerKind } from "../package-manager.js";
+import { getPackageManagerStrategy } from "../primitives/pm/index.js";
+import {
+  ensurePnpmWorkspaceIncludesProject,
+  findAncestorPnpmWorkspaceRoot,
+} from "../primitives/pm/pnpm.js";
+import {
+  isPathInside,
+  workspacePatternForProject,
+  workspacePatternsClaimProject,
+} from "./workspace-glob.js";
+import { patchPackageJson } from "./update/package-json.js";
+import type { PackageJsonPatch, PackageJsonPatchResult } from "./update/package-json.js";
+
+interface PackageJsonWorkspaceShape {
+  workspaces?: unknown;
+}
+
+export interface WorkspaceRootMutation {
+  kind: "package-json" | "workspace-config";
+  nodeEngineOverride?: NodeEngineOverride;
+  path: string;
+}
+
+export interface WorkspaceRootPackageJsonPatchResult extends PackageJsonPatchResult {
+  /** Root package.json path when an ancestor workspace root was eligible for patching. */
+  path?: string;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function packageJsonWorkspacePatterns(packageJson: PackageJsonWorkspaceShape): string[] {
+  const workspaces = packageJson.workspaces;
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter((entry): entry is string => typeof entry === "string");
+  }
+  if (!isJsonObject(workspaces) || !Array.isArray(workspaces.packages)) return [];
+  return workspaces.packages.filter((entry): entry is string => typeof entry === "string");
+}
+
+function readPackageJsonWorkspacePatterns(packageJsonPath: string): string[] | undefined {
+  const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+  if (!isJsonObject(parsed)) return undefined;
+  const patterns = packageJsonWorkspacePatterns(parsed as PackageJsonWorkspaceShape);
+  return patterns.length === 0 ? undefined : patterns;
+}
+
+function findAncestorPackageJsonWorkspaceRoot(projectRoot: string): string | undefined {
+  let dir = dirname(resolve(projectRoot));
+  while (true) {
+    const packageJsonPath = join(dir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      try {
+        if (readPackageJsonWorkspacePatterns(packageJsonPath) !== undefined) return dir;
+      } catch {
+        // Keep walking; an unreadable package.json is not a reliable workspace owner.
+      }
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+function findClaimingPackageJsonWorkspaceRoot(projectRoot: string): string | undefined {
+  const workspaceRoot = findAncestorPackageJsonWorkspaceRoot(projectRoot);
+  if (workspaceRoot === undefined) return undefined;
+  let patterns: string[] | undefined;
+  try {
+    patterns = readPackageJsonWorkspacePatterns(join(workspaceRoot, "package.json"));
+  } catch {
+    return undefined;
+  }
+  return patterns !== undefined &&
+    workspacePatternsClaimProject(patterns, workspaceRoot, projectRoot)
+    ? workspaceRoot
+    : undefined;
+}
+
+/** Ancestor package-manager workspace root that owns root-only package.json fields. */
+function findPackageManagerWorkspaceRoot(
+  packageManager: PackageManagerKind,
+  projectRoot: string,
+): string | undefined {
+  switch (packageManager) {
+    case "pnpm":
+      return findAncestorPnpmWorkspaceRoot(projectRoot);
+    case "bun":
+    case "npm":
+    case "yarn":
+      return findAncestorPackageJsonWorkspaceRoot(projectRoot);
+  }
+}
+
+export function isPackageManagerWorkspaceMember(
+  packageManager: PackageManagerKind,
+  projectRoot: string,
+): boolean {
+  const workspaceRoot = findPackageManagerWorkspaceRoot(packageManager, projectRoot);
+  return workspaceRoot !== undefined && resolve(workspaceRoot) !== resolve(projectRoot);
+}
+
+function workspaceRootPackageJsonPath(
+  packageManager: PackageManagerKind,
+  projectRoot: string,
+): string | undefined {
+  const workspaceRoot = findPackageManagerWorkspaceRoot(packageManager, projectRoot);
+  return workspaceRoot === undefined ? undefined : join(workspaceRoot, "package.json");
+}
+
+async function ensurePackageJsonWorkspaceIncludesProject(
+  projectRoot: string,
+): Promise<string | undefined> {
+  const workspaceRoot = findAncestorPackageJsonWorkspaceRoot(projectRoot);
+  if (workspaceRoot === undefined || resolve(workspaceRoot) === resolve(projectRoot)) {
+    return undefined;
+  }
+  if (findClaimingPackageJsonWorkspaceRoot(projectRoot) === workspaceRoot) {
+    return undefined;
+  }
+
+  const packageJsonPath = join(workspaceRoot, "package.json");
+  const parsed = JSON.parse(await readFile(packageJsonPath, "utf8")) as PackageJsonWorkspaceShape;
+  const pattern = workspacePatternForProject(workspaceRoot, projectRoot);
+  if (Array.isArray(parsed.workspaces)) {
+    parsed.workspaces = [...parsed.workspaces, pattern];
+  } else if (isJsonObject(parsed.workspaces) && Array.isArray(parsed.workspaces.packages)) {
+    parsed.workspaces = {
+      ...parsed.workspaces,
+      packages: [...parsed.workspaces.packages, pattern],
+    };
+  } else {
+    return undefined;
+  }
+  await writeFile(packageJsonPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+  return packageJsonPath;
+}
+
+async function ensurePackageManagerWorkspaceIncludesProject(
+  packageManager: PackageManagerKind,
+  projectRoot: string,
+): Promise<string | undefined> {
+  switch (packageManager) {
+    case "pnpm": {
+      const workspaceRoot = findAncestorPnpmWorkspaceRoot(projectRoot);
+      if (workspaceRoot === undefined) return undefined;
+      const result = await ensurePnpmWorkspaceIncludesProject(projectRoot);
+      return result === "written" ? join(workspaceRoot, "pnpm-workspace.yaml") : undefined;
+    }
+    case "bun":
+    case "npm":
+    case "yarn":
+      return ensurePackageJsonWorkspaceIncludesProject(projectRoot);
+  }
+}
+
+function packageManagerRootOnlyPackageJsonPatch(
+  packageManager: PackageManagerKind,
+  input: {
+    readonly aiPackageVersion?: string;
+    readonly nodeEngineRequirement?: string;
+  },
+): PackageJsonPatch {
+  const patch: PackageJsonPatch = {};
+  if (input.nodeEngineRequirement !== undefined) {
+    patch.nodeEngineRequirement = input.nodeEngineRequirement;
+  }
+  if (input.aiPackageVersion !== undefined) {
+    switch (packageManager) {
+      case "bun":
+      case "npm":
+        patch.overrides = { ai: input.aiPackageVersion };
+        break;
+      case "yarn":
+        patch.resolutions = { ai: input.aiPackageVersion };
+        break;
+      case "pnpm":
+        break;
+    }
+  }
+  return patch;
+}
+
+/** Applies root-only package.json fields to an ancestor workspace package.json. */
+export async function patchWorkspaceRootPackageJson(
+  packageManager: PackageManagerKind,
+  projectRoot: string,
+  input: {
+    readonly aiPackageVersion?: string;
+    readonly nodeEngineRequirement?: string;
+    readonly onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>;
+  },
+): Promise<WorkspaceRootPackageJsonPatchResult> {
+  if (!isPackageManagerWorkspaceMember(packageManager, projectRoot)) {
+    return { changed: false };
+  }
+
+  const path = workspaceRootPackageJsonPath(packageManager, projectRoot);
+  if (path === undefined || !existsSync(path)) {
+    return { changed: false };
+  }
+
+  const result = await patchPackageJson(
+    path,
+    packageManagerRootOnlyPackageJsonPatch(packageManager, input),
+  );
+  if (result.changed) {
+    await input.onWorkspaceRootMutation?.({
+      kind: "package-json",
+      nodeEngineOverride: result.nodeEngineOverride,
+      path,
+    });
+  }
+  return { ...result, path };
+}
+
+/** Applies manager-owned project files and reports ancestor workspace mutations. */
+export async function applyPackageManagerWorkspaceConfiguration(input: {
+  readonly packageManager: PackageManagerKind;
+  readonly projectRoot: string;
+  readonly workspaceProbeRoot?: string;
+  readonly onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>;
+}): Promise<{
+  filesSkipped: string[];
+  filesWritten: string[];
+}> {
+  const workspaceProbeRoot = resolve(input.workspaceProbeRoot ?? input.projectRoot);
+  const workspaceConfigPath =
+    input.packageManager === "pnpm"
+      ? undefined
+      : await ensurePackageManagerWorkspaceIncludesProject(
+          input.packageManager,
+          workspaceProbeRoot,
+        );
+  const packageManagerResult = await getPackageManagerStrategy(
+    input.packageManager,
+  ).applyProjectConfiguration(input.projectRoot, { workspaceProbeRoot });
+  const filesWritten = [
+    ...(workspaceConfigPath === undefined ? [] : [workspaceConfigPath]),
+    ...packageManagerResult.filesWritten,
+  ];
+  const filesSkipped = [...packageManagerResult.filesSkipped];
+
+  for (const filePath of filesWritten) {
+    if (!isPathInside(input.projectRoot, filePath)) {
+      await input.onWorkspaceRootMutation?.({ kind: "workspace-config", path: filePath });
+    }
+  }
+
+  return { filesSkipped, filesWritten };
+}


### PR DESCRIPTION
## Summary
- detect ancestor package-manager workspaces for npm, pnpm, Yarn, and Bun during `eve init` scaffolding
- integrate fresh scaffolds into existing workspaces, including adding missing workspace package patterns such as `agents/*`
- keep workspace member package.json files free of root-only `engines`, `overrides`, and `resolutions` while patching the workspace root instead
- apply pnpm workspace policy at the workspace root instead of creating nested `pnpm-workspace.yaml` files
- share workspace glob matching in one helper and print warnings when init updates ancestor workspace files

## Tests
- `CI=true pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/scaffold/workspace-glob.test.ts src/setup/package-manager.test.ts`
- `CI=true pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/setup/scaffold/index.integration.test.ts src/cli/commands/init.integration.test.ts`
- `CI=true pnpm --filter eve typecheck`
- `CI=true pnpm fmt`
- `CI=true pnpm lint`
- `CI=true pnpm guard:invariants`
- `CI=true pnpm build`