### PR TITLE
Docs: lowercase eve resource copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ channels, subagents, and schedules are all files — and eve compiles and runs i
 See the [README](./README.md) for the full overview and
 [`docs/`](./docs) for user-facing documentation.
 
+Always style the framework name as `eve`, lowercase, in user-facing copy,
+docs, prompts, comments, and headings.
+
 ## Repository layout
 
 - `packages/eve` — the framework and `eve` CLI (the main package)

--- a/apps/docs/lib/resources/data.ts
+++ b/apps/docs/lib/resources/data.ts
@@ -31,14 +31,14 @@ export const resources: Resource[] = [
   },
   {
     kind: "Template",
-    title: "Eve Chat Template",
+    title: "eve Chat Template",
     description:
-      "A persisted Next.js chat template for Eve, built with shadcn/ui, Tailwind CSS, Streamdown, Better Auth, Drizzle, Neon, and Upstash Redis.",
+      "A persisted Next.js chat template for eve, built with shadcn/ui, Tailwind CSS, Streamdown, Better Auth, Drizzle, Neon, and Upstash Redis.",
     href: "https://vercel.com/templates/eve/eve-chat-template",
   },
   {
     kind: "Template",
-    title: "Eve Slack Agent",
+    title: "eve Slack Agent",
     description:
       "A Slack agent template with webhook handling, Vercel Connect, a starter agent, and an example tool ready to deploy on Vercel.",
     href: "https://vercel.com/templates/eve/eve-slack-agent",
@@ -52,9 +52,9 @@ export const resources: Resource[] = [
   },
   {
     kind: "Reference",
-    title: "Eve Knowledge Base",
+    title: "eve Knowledge Base",
     description:
-      "Vercel's Eve hub with getting-started guides, build guides, templates, docs, integrations, and community links.",
+      "Vercel's eve hub with getting-started guides, build guides, templates, docs, integrations, and community links.",
     href: "https://vercel.com/kb/eve",
   },
 ];


### PR DESCRIPTION
## Summary
- lowercase eve in the resources page data added by #113
- add AGENTS.md guidance that eve should remain lowercase in copy, docs, prompts, comments, and headings

## Tests
- node ./scripts/check-docs.mjs && node ./scripts/check-doc-snippets.mjs && node ./scripts/check-doc-mdx.mjs

Note: pnpm docs:check in the throwaway worktree hit a local esbuild postinstall mismatch while bootstrapping dependencies, so I ran the underlying docs-check scripts directly against the same worktree.