### PR TITLE
feat(slack): add onEmpty delivery policy for proactive sessions

### DIFF
--- a/.changeset/empty-delivery-policy.md
+++ b/.changeset/empty-delivery-policy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add an `onEmpty` delivery policy to the Slack channel's `receive(slack, { target })`. A proactive (e.g. scheduled) run that finishes with no deliverable now suppresses by default, posts a built-in heartbeat line with `onEmpty: "heartbeat"`, or posts a custom line with `onEmpty: { heartbeat: "…" }` — so scheduled "check" tasks can stay quiet on a no-op run while still offering an opt-in liveness signal, without hand-rolling a sentinel string. Whitespace-only final messages are now also treated as empty.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -121,6 +121,22 @@ events: {
 
 Start a session without an inbound message through `receive(slack, { message, target, auth })` from a schedule `run` handler, or `args.receive(slack, ...)` from another channel. The proactive target shape is `{ channelId }`.
 
+Use `target.onEmpty` to control what a proactive run does when it finishes with no deliverable — an empty or whitespace-only final assistant message. This is the same situation an interactive turn handles by posting nothing; `onEmpty` makes that an explicit, per-session choice for runs (typically scheduled "check" tasks) where silence is ambiguous:
+
+- `"suppress"` (default) — post nothing, exactly as today.
+- `"heartbeat"` — post a short built-in confirmation line so the caller can tell the run executed.
+- `{ heartbeat: "…" }` — post your own line instead of the built-in one.
+
+```ts
+await receive(slack, {
+  message: "Check for new incidents and report only if there are any.",
+  target: { channelId, onEmpty: "heartbeat" },
+  auth,
+});
+```
+
+The agent still decides when there is nothing to report — instruct it to end such a turn with an empty message, and the channel applies the policy. No sentinel string required.
+
 ### Attachments
 
 Inbound files behind authenticated Slack URLs are staged with `fetchFile`. See [File uploads](./custom#file-uploads) for the `fetchFile` contract.

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SessionContext } from "#public/definitions/callback-context.js";
 import { defaultEvents } from "#public/channels/slack/defaults.js";
-import type { SlackChannelState, SlackEventContext } from "#public/channels/slack/slackChannel.js";
+import type {
+  SlackChannelEvents,
+  SlackChannelState,
+  SlackEventContext,
+} from "#public/channels/slack/slackChannel.js";
 
 const sessionCtx = {} as SessionContext;
 
@@ -183,5 +187,80 @@ describe("defaultEvents authorization.completed", () => {
     expect(request).not.toHaveBeenCalled();
     expect(post).not.toHaveBeenCalled();
     expect(postEphemeral).not.toHaveBeenCalled();
+  });
+});
+
+type MessageCompletedData = Parameters<NonNullable<SlackChannelEvents["message.completed"]>>[0];
+
+function messageCompletedEvent(
+  overrides: { finishReason?: MessageCompletedData["finishReason"]; message?: string | null } = {},
+): MessageCompletedData {
+  return {
+    finishReason: overrides.finishReason ?? "stop",
+    message: overrides.message === undefined ? "Here is the result." : overrides.message,
+    sequence: 1,
+    stepIndex: 0,
+    turnId: "turn_0",
+  };
+}
+
+describe("defaultEvents message.completed", () => {
+  it("posts a non-empty final message", async () => {
+    const { channel, post } = buildChannelStub();
+    await defaultEvents["message.completed"]!(messageCompletedEvent(), channel, sessionCtx);
+    expect(post).toHaveBeenCalledWith("Here is the result.");
+  });
+
+  it("suppresses an empty or whitespace-only final message by default", async () => {
+    for (const message of ["", "   \n  "]) {
+      const { channel, post } = buildChannelStub();
+      await defaultEvents["message.completed"]!(
+        messageCompletedEvent({ message }),
+        channel,
+        sessionCtx,
+      );
+      expect(post).not.toHaveBeenCalled();
+    }
+  });
+
+  it("posts the built-in heartbeat on an empty run when onEmpty is 'heartbeat'", async () => {
+    const { channel, post } = buildChannelStub({ onEmpty: "heartbeat" });
+    await defaultEvents["message.completed"]!(
+      messageCompletedEvent({ message: "" }),
+      channel,
+      sessionCtx,
+    );
+    expect(post).toHaveBeenCalledWith("✓ Ran — nothing new to report.");
+  });
+
+  it("posts a custom heartbeat line when onEmpty supplies one", async () => {
+    const { channel, post } = buildChannelStub({ onEmpty: { heartbeat: "✓ digest ran, no news" } });
+    await defaultEvents["message.completed"]!(
+      messageCompletedEvent({ message: "  " }),
+      channel,
+      sessionCtx,
+    );
+    expect(post).toHaveBeenCalledWith("✓ digest ran, no news");
+  });
+
+  it("posts real content even when onEmpty heartbeat is set", async () => {
+    const { channel, post } = buildChannelStub({ onEmpty: "heartbeat" });
+    await defaultEvents["message.completed"]!(
+      messageCompletedEvent({ message: "Found 3 new issues." }),
+      channel,
+      sessionCtx,
+    );
+    expect(post).toHaveBeenCalledWith("Found 3 new issues.");
+  });
+
+  it("buffers tool-call narration without posting or heartbeating", async () => {
+    const { channel, post } = buildChannelStub({ onEmpty: "heartbeat" });
+    await defaultEvents["message.completed"]!(
+      messageCompletedEvent({ finishReason: "tool-calls", message: "Checking the dashboard..." }),
+      channel,
+      sessionCtx,
+    );
+    expect(post).not.toHaveBeenCalled();
+    expect(channel.state.pendingToolCallMessage).toBe("Checking the dashboard...");
   });
 });

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -16,12 +16,27 @@ import type {
   SlackChannelEvents,
   SlackChannelInternalEvents,
   SlackContext,
+  SlackEmptyDeliveryPolicy,
   SlackMentionResult,
 } from "#public/channels/slack/slackChannel.js";
 
 const log = createLogger("slack.defaults");
 const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
 const REASONING_TYPING_MIN_PROGRESS_CHARS = 4;
+const DEFAULT_EMPTY_HEARTBEAT = "✓ Ran — nothing new to report.";
+
+/**
+ * Resolves the heartbeat line for a run that produced no deliverable, or
+ * `null` to post nothing. `"suppress"` and an absent policy both suppress.
+ */
+function resolveEmptyHeartbeat(policy: SlackEmptyDeliveryPolicy | undefined): string | null {
+  if (policy === "heartbeat") return DEFAULT_EMPTY_HEARTBEAT;
+  if (typeof policy === "object") {
+    const text = policy.heartbeat.trim();
+    return text.length > 0 ? text : DEFAULT_EMPTY_HEARTBEAT;
+  }
+  return null;
+}
 
 /**
  * Workspace-scoped projection of the Slack actor that produced
@@ -162,7 +177,14 @@ export const defaultEvents: SlackChannelInternalEvents = {
       return;
     }
     channel.state.pendingToolCallMessage = null;
-    if (event.message) await channel.thread.post(event.message);
+    if (event.message && event.message.trim().length > 0) {
+      await channel.thread.post(event.message);
+      return;
+    }
+    // No deliverable: suppress by default, or post the opt-in heartbeat a
+    // proactive (receive-started) session asked for via target.onEmpty.
+    const heartbeat = resolveEmptyHeartbeat(channel.state.onEmpty);
+    if (heartbeat) await channel.thread.post(heartbeat);
   },
 
   async "turn.failed"(event, channel, _ctx) {

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -18,6 +18,7 @@ export {
   type SlackChannelEvents,
   type SlackChannelState,
   type SlackContext,
+  type SlackEmptyDeliveryPolicy,
   type SlackEventContext,
   type SlackHandle,
   type SlackInboundResult,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1454,6 +1454,20 @@ describe("slackChannel().receive", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("threads target.onEmpty into the seeded session state", async () => {
+    const send = vi.fn().mockResolvedValue({ id: "s", continuationToken: "ct" });
+    await buildReceive()(
+      {
+        message: "run the check",
+        target: { channelId: "C123", onEmpty: { heartbeat: "✓ ran, no news" } },
+        auth: null,
+      },
+      { send },
+    );
+    const [, options] = send.mock.calls[0]!;
+    expect(options.state.onEmpty).toEqual({ heartbeat: "✓ ran, no news" });
+  });
+
   it("posts the initial card before send and threads under its ts", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ ok: true, ts: "1800000000.000900" }), {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -185,6 +185,12 @@ export interface SlackChannelState {
    * resolution outcome.
    */
   pendingAuthMessageTs?: Record<string, string>;
+  /**
+   * Delivery policy for a run with no deliverable, seeded by
+   * `receive(slack, { target: { onEmpty } })`. Absent for interactive
+   * (mention/DM) sessions, which always suppress an empty final message.
+   */
+  onEmpty?: SlackEmptyDeliveryPolicy;
 }
 
 /**
@@ -226,6 +232,20 @@ export interface SlackChannelCredentials {
   readonly webhookVerifier?: SlackWebhookVerifier;
 }
 
+/**
+ * What a proactive (`receive`-started) session does when its run produces
+ * no deliverable — an empty or whitespace-only final assistant message.
+ *
+ * - `"suppress"` (default): post nothing, the same as an empty interactive turn.
+ * - `"heartbeat"`: post a short built-in confirmation line so the caller can
+ *   tell the run executed.
+ * - `{ heartbeat }`: post the given line instead of the built-in one.
+ *
+ * Lets a scheduled "check" task stay quiet on a no-op run while still offering
+ * an opt-in liveness signal, without the agent hand-rolling a sentinel string.
+ */
+export type SlackEmptyDeliveryPolicy = "suppress" | "heartbeat" | { readonly heartbeat: string };
+
 /** Target accepted by `receive(slack, { target })` for proactive sessions. */
 export interface SlackReceiveTarget {
   readonly channelId: string;
@@ -237,6 +257,11 @@ export interface SlackReceiveTarget {
    * exclusive with {@link threadTs}.
    */
   readonly initialMessage?: SlackInitialMessage;
+  /**
+   * Delivery policy for a run that finishes with no deliverable. Defaults to
+   * `"suppress"`. See {@link SlackEmptyDeliveryPolicy}.
+   */
+  readonly onEmpty?: SlackEmptyDeliveryPolicy;
 }
 
 /**
@@ -584,15 +609,18 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
         threadTs = posted.id;
       }
 
+      const state: SlackChannelState = {
+        channelId,
+        threadTs: threadTs || null,
+        teamId: null,
+        triggeringUserId: null,
+      };
+      if (receiveTarget.onEmpty !== undefined) state.onEmpty = receiveTarget.onEmpty;
+
       return send(input.message, {
         auth: input.auth,
         continuationToken: slackContinuationToken(channelId, threadTs),
-        state: {
-          channelId,
-          threadTs: threadTs || null,
-          teamId: null,
-          triggeringUserId: null,
-        },
+        state,
       });
     },
 


### PR DESCRIPTION
## Problem

A proactive session started via `receive(slack, { message, target, auth })` — most commonly a scheduled "check" task — delivers its final assistant message like any turn. So a run that finds **nothing to report** either posts noise, or (if it emits an empty message) goes completely silent with no way to tell it actually ran. There's no first-class way for a run to signal "I executed, there's nothing to deliver," and no opt-in liveness signal.

This came up building scheduled tasks for an internal agent (`v`): a daily "check for X" task posts a full response even when there's nothing new, and suppressing it entirely leaves users unsure the schedule is alive. Today the only workaround is a per-agent magic-string sentinel that the channel's `message.completed` override has to recognize.

## Change

Add an `onEmpty` delivery policy to the Slack `receive` target, threaded into session state and honored by the default `message.completed` handler:

```ts
await receive(slack, {
  message: "Check for new incidents; report only if there are any.",
  target: { channelId, onEmpty: "heartbeat" },
  auth,
});
```

- `"suppress"` (default) — post nothing, identical to today's behavior for an empty turn.
- `"heartbeat"` — post a short built-in confirmation line (`✓ Ran — nothing new to report.`).
- `{ heartbeat: "…" }` — post a caller-supplied line instead (e.g. with the schedule's name).

The agent still decides *when* there's nothing to report (instruct it to end such a turn with an empty message); the channel just applies the policy. No sentinel string required.

### Notes

- **Scoped to the Slack channel.** `onEmpty` rides on the channel-specific `receive` *target*, so the generic cross-channel `receive` path is untouched. Other channels can adopt the same shape later.
- **Backward compatible.** Interactive (mention/DM) sessions carry no `onEmpty` and continue to suppress empty output. Only addition: a whitespace-only final message is now treated as empty (previously it would post blank text).
- New `SlackEmptyDeliveryPolicy` type exported from `eve/channels/slack`.

## Tests / checks

- `defaults.test.ts`: posts real content; suppresses empty/whitespace by default; built-in heartbeat; custom heartbeat; real content wins over heartbeat; tool-call narration still buffers without posting.
- `slackChannel.test.ts`: `receive` threads `target.onEmpty` into seeded session state.
- Full eve unit tier green (3839 tests), `typecheck`, `lint`, `fmt`, `guard:invariants`, and `docs:check` all pass. Changeset added (patch). Docs updated (`channels/slack` → Proactive sessions).

## Context

Companion to the agent-side workaround in our internal repo (a prompt sentinel + a one-line `message.completed` guard); this lands the capability in the framework so agents don't each reinvent it.