### PR TITLE
feat(eve): sandbox - add AWS Lambda MicroVM backend

### DIFF
--- a/.changeset/calm-microvms-sandbox.md
+++ b/.changeset/calm-microvms-sandbox.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add the explicit `awsLambdaMicrovm()` sandbox backend with eve-managed ARM64 images, native suspend and resume, and durable full-filesystem S3 checkpoints.

--- a/docs/guides/aws-lambda-microvms.md
+++ b/docs/guides/aws-lambda-microvms.md
@@ -1,0 +1,224 @@
+---
+title: "AWS Lambda MicroVM sandboxes"
+description: "Configure eve's explicit AWS Lambda MicroVM backend, IAM boundaries, S3 checkpoints, networking, lifecycle, and operations."
+---
+
+The `awsLambdaMicrovm()` backend runs each durable eve sandbox in an ARM64 [AWS Lambda MicroVM](https://docs.aws.amazon.com/lambda/latest/dg/lambda-microvms-guide.html). It is explicit opt-in: `defaultBackend()` never selects AWS.
+
+eve creates and tags MicroVM images, launches MicroVMs, and stores image artifacts, leases, template descriptors, and full-filesystem checkpoints under one prefix in your S3 bucket. eve does not create the bucket, IAM roles, VPCs, or network connectors.
+
+## Configure the backend
+
+Create the bucket and roles first, then author the sandbox:
+
+```ts title="agent/sandbox/sandbox.ts"
+import { defineSandbox } from "eve/sandbox";
+import { awsLambdaMicrovm } from "eve/sandbox/aws-lambda";
+
+export default defineSandbox({
+  backend: awsLambdaMicrovm({
+    applicationId: "analytics-agent",
+    region: "us-east-1",
+    artifactBucket: "company-eve-sandboxes",
+    buildRoleArn: process.env.EVE_AWS_BUILD_ROLE_ARN!,
+    executionRoleArn: process.env.EVE_AWS_EXECUTION_ROLE_ARN,
+  }),
+  async bootstrap({ use }) {
+    const sandbox = await use();
+    await sandbox.run({ command: "dnf install -y git jq" });
+  },
+});
+```
+
+`applicationId` is a stable resource namespace, not a display label. Keep it identical at build and runtime. The bucket must be in `region`. The default prefix is `eve/lambda-microvms/<application-id-hash>`; set `artifactPrefix` when the bucket policy requires a fixed path.
+
+The important defaults are 2 GiB baseline memory, an eight-hour maximum lifetime, suspension after five minutes without endpoint traffic, suspended retention for 30 minutes, automatic resume, managed internet egress, no shell access, and no guest execution role. Supplying an execution role enables CloudWatch runtime logging by default. Set `runtimeLogging: false` to disable it.
+
+`eve dev`, `eve start`, and `eve build` provision the required template. A deployed runtime only opens a template that already exists; it does not build an image with runtime credentials.
+
+## Persistence and lifecycle
+
+Native AWS suspension retains memory, files, and running processes. Before eve explicitly suspends a session, it freezes workload processes and publishes the complete writable overlay to S3. The archive preserves numeric ownership, modes, links, ACLs, xattrs, device entries, and overlay whiteouts. It excludes `/proc`, `/sys`, `/dev`, `/run`, and controller state.
+
+AWS terminates every MicroVM by its configured maximum duration, at the end of suspended retention, or after an operational failure. On the next turn, eve launches the exact image version recorded in the checkpoint and restores all writable paths, including changes under `/etc`, `/usr/local`, `/root`, `/var`, `/tmp`, and `/workspace`. Files survive replacement; processes do not. If AWS has recalled or removed the recorded image version, eve leaves the checkpoint intact and fails instead of restoring only `/workspace` onto a different image.
+
+S3 conditional manifests and per-session leases reject concurrent writers. eve never puts AWS credentials, auth tokens, or presigned URLs in durable session metadata.
+
+## IAM boundaries
+
+Use separate identities for the caller running `eve build`, the deployed runtime caller, the Lambda build role, and the optional guest execution role. Replace the account, Region, bucket, prefix, role, and image values below with your own. Tighten `Resource` entries further where your IAM setup supports it.
+
+Both service roles trust Lambda. Add confused-deputy conditions:
+
+```json title="Build role trust policy"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "lambda.amazonaws.com" },
+      "Action": ["sts:AssumeRole", "sts:TagSession"],
+      "Condition": {
+        "StringEquals": { "aws:SourceAccount": "123456789012" },
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:lambda:us-east-1:123456789012:microvm-image:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+The build role reads the uploaded image artifact and writes build logs. It does not need permission to manage images:
+
+```json title="Build role permissions"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::company-eve-sandboxes/eve/lambda-microvms/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:aws:logs:us-east-1:123456789012:*"
+    }
+  ]
+}
+```
+
+The build caller manages images, tags resources, passes the service roles, and reads and writes the artifact prefix:
+
+```json title="Build caller policy"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:CreateMicrovmImage",
+        "lambda:GetMicrovmImageVersion",
+        "lambda:ListMicrovmImages",
+        "lambda:ListMicrovmImageVersions",
+        "lambda:ListManagedMicrovmImages",
+        "lambda:ListManagedMicrovmImageVersions",
+        "lambda:RunMicrovm",
+        "lambda:GetMicrovm",
+        "lambda:SuspendMicrovm",
+        "lambda:ResumeMicrovm",
+        "lambda:TerminateMicrovm",
+        "lambda:CreateMicrovmAuthToken",
+        "lambda:TagResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": [
+        "arn:aws:iam::123456789012:role/eve-microvm-build",
+        "arn:aws:iam::123456789012:role/eve-microvm-guest"
+      ],
+      "Condition": {
+        "StringEquals": { "iam:PassedToService": "lambda.amazonaws.com" }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetBucketLocation",
+      "Resource": "arn:aws:s3:::company-eve-sandboxes"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
+      "Resource": "arn:aws:s3:::company-eve-sandboxes/eve/lambda-microvms/*"
+    }
+  ]
+}
+```
+
+The runtime caller needs lifecycle, token, tag, S3 checkpoint, and execution-role pass permissions, but not image creation or build-role pass permissions:
+
+```json title="Runtime caller policy"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:RunMicrovm",
+        "lambda:GetMicrovm",
+        "lambda:SuspendMicrovm",
+        "lambda:ResumeMicrovm",
+        "lambda:TerminateMicrovm",
+        "lambda:CreateMicrovmAuthToken",
+        "lambda:TagResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::123456789012:role/eve-microvm-guest",
+      "Condition": {
+        "StringEquals": { "iam:PassedToService": "lambda.amazonaws.com" }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetBucketLocation",
+      "Resource": "arn:aws:s3:::company-eve-sandboxes"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"],
+      "Resource": "arn:aws:s3:::company-eve-sandboxes/eve/lambda-microvms/*"
+    }
+  ]
+}
+```
+
+The runtime caller needs read access to image and template objects and read/write access to session manifests, leases, temporary multipart objects, and checkpoints. Keep build and runtime prefixes separate with bucket-policy conditions when your organization requires stricter deployment separation.
+
+The optional execution role is guest-visible through IMDS. Its trust policy should use the same service principal and `aws:SourceAccount`, with a MicroVM source ARN:
+
+```json title="Guest execution role trust policy"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "lambda.amazonaws.com" },
+      "Action": ["sts:AssumeRole", "sts:TagSession"],
+      "Condition": {
+        "StringEquals": { "aws:SourceAccount": "123456789012" },
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:lambda:us-east-1:123456789012:microvm:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+Grant that role only the AWS APIs workload code is intentionally allowed to call, plus CloudWatch Logs permissions when runtime logging is enabled. Never grant it access to the artifact prefix or checkpoint bucket. Omitting `executionRoleArn` is the safest default and prevents guest AWS credentials.
+
+See AWS's [security and permissions](https://docs.aws.amazon.com/lambda/latest/dg/microvms-security.html) documentation for the current action and ARN reference.
+
+## Networking
+
+eve always attaches AWS's `ALL_INGRESS` connector and creates auth tokens scoped only to controller port 8080. Tokens last at most 60 minutes, are refreshed before expiry, and are never persisted. `shellAccess: true` additionally attaches `SHELL_INGRESS`; shell tokens still come from AWS's separate shell-token API.
+
+Build and runtime egress use `INTERNET_EGRESS` by default. Pass custom connector ARNs through `buildEgressNetworkConnectorArns` and `runtimeEgressNetworkConnectorArns`. An explicit empty array means no egress. Connectors are fixed at launch, so `sandbox.setNetworkPolicy()` throws for this backend. Configure VPC security groups, network ACLs, routing, and DNS on the connector instead.
+
+The controller uploads and restores checkpoints through short-lived S3 presigned URLs. A restricted VPC path must therefore reach the bucket, normally through an S3 gateway endpoint or controlled NAT. See AWS's [MicroVM networking](https://docs.aws.amazon.com/lambda/latest/dg/microvms-networking.html) guide.
+
+## Operations and retention
+
+Image build logs use `/aws/lambda/microvms/<image-name>` unless you supply another CloudWatch target. Runtime logs use the configured `runtimeLogging` group. eve logs lifecycle phases and failures, but not command text or environment values. Enable CloudTrail management events for Lambda operations and S3 data events on the artifact prefix when you need an audit trail.
+
+eve does not prune images or durable checkpoints. Configure S3 lifecycle rules appropriate to your retention policy for abandoned multipart uploads, temporary objects, noncurrent object versions, old checkpoint generations, and deleted applications. Do not expire the currently referenced checkpoint or template descriptor.
+
+For failures, start with the image version `stateReason`, its CloudWatch build stream, and AWS's [troubleshooting guide](https://docs.aws.amazon.com/lambda/latest/dg/microvms-troubleshooting.html). Also review AWS's [snapshot model](https://docs.aws.amazon.com/lambda/latest/dg/microvms-images-snapshots.html) and [best practices](https://docs.aws.amazon.com/lambda/latest/dg/microvms-best-practices.html).

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -95,19 +95,20 @@ export default defineSandbox({
 
 Leave `backend` off and eve falls back to `defaultBackend()`, which picks the Vercel backend on hosted builds and the local backend everywhere else. One definition, both environments.
 
-For a self-deployed process, leave `defaultBackend()` in place or choose an explicit non-Vercel backend such as Docker or microsandbox. If those do not match your infrastructure, write a custom `SandboxBackend` adapter that creates sessions in your own container, VM, or isolation service. Do not pin `vercel()` unless that process should create hosted Vercel sandboxes.
+For a self-deployed process, leave `defaultBackend()` in place or choose an explicit backend such as Docker, microsandbox, or AWS Lambda MicroVMs. The AWS backend remains explicit even on AWS-hosted applications and uses the caller's standard AWS credential chain. See [AWS Lambda MicroVM sandboxes](./aws-lambda-microvms) for the bucket, IAM, connector, and retention setup. If those do not match your infrastructure, write a custom `SandboxBackend` adapter that creates sessions in your own container, VM, or isolation service. Do not pin `vercel()` unless that process should create hosted Vercel sandboxes.
 
-## 5. Build-time sandbox prewarm
+## 5. Build-time sandbox provisioning
 
-During hosted builds, eve prewarms reusable Vercel sandbox templates so the first session doesn't pay the cold-start cost:
+Backends opt into remote provisioning during `eve build`. The build fails if a required image or template cannot be created, so a deployable artifact never points at missing remote state:
 
-- Prewarm runs only when both `VERCEL` and `VERCEL_DEPLOYMENT_ID` are present.
-- A sandbox with no `bootstrap()` and no workspace seed files gets skipped.
+- Vercel prewarm runs only when both `VERCEL` and `VERCEL_DEPLOYMENT_ID` are present.
+- AWS Lambda MicroVM provisioning runs for every explicit AWS backend, including sandboxes with no `bootstrap()` or workspace seed files, because the controller image is mandatory.
+- Other backends skip a sandbox with no `bootstrap()` and no workspace seed files unless they explicitly require a template.
 - Seed-only templates are keyed by skills and workspace file contents, so unchanged seeds reuse a template across deploys.
 - Templates with a `bootstrap()` are keyed by the optional resolved `revalidationKey()` plus the authored sandbox source and seed contents, so matching inputs reuse a template across deploys.
 - Each template shows up in the build log as either `reused cached` or `built`.
 - Prewarming only covers template construction. `onSession()` still runs at runtime, once per session.
-- **If build-time prewarm fails, the build fails.**
+- **If build-time provisioning fails, the build fails.**
 
 If `VERCEL` is set but `VERCEL_DEPLOYMENT_ID` is missing, eve warns that it skipped prewarming. Do not deploy that build with `vercel deploy --prebuilt`; its output may reference sandbox templates that were never provisioned. Run `vercel deploy` instead so Vercel builds the source in its hosted build environment.
 
@@ -144,7 +145,7 @@ Self-deployed agents should make the Vercel-specific choices explicit:
 - Install the AI SDK package for your provider, then use a direct provider model object and `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` when you want no Gateway dependency.
 - Use `AI_GATEWAY_API_KEY` if you still want Gateway routing from a non-Vercel host.
 - Replace `vercelOidc()` with auth that your host can verify.
-- Use `defaultBackend()`, a pinned non-Vercel sandbox backend such as Docker or microsandbox, or your own `SandboxBackend` adapter.
+- Use `defaultBackend()`, a pinned sandbox backend such as Docker, microsandbox, or AWS Lambda MicroVMs, or your own `SandboxBackend` adapter.
 - If the agent defines schedules, the default `eve build && eve start` path starts Nitro's schedule runner, and Vercel wires schedules to Vercel Cron automatically. If you adapt the output to a custom HTTP-only host or preset, make sure it also runs Nitro scheduled tasks, or trigger the same work from your own scheduler.
 - Treat Vercel Cron, Vercel Sandbox prewarm, Vercel Deployment Protection bypass, and the Agent Runs dashboard as Vercel-only conveniences.
 

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -2,6 +2,7 @@
   "title": "Guides",
   "pages": [
     "deployment",
+    "aws-lambda-microvms",
     "auth-and-route-protection",
     "instrumentation",
     "hooks",

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -82,7 +82,9 @@ A few non-`define*` helpers round out the set: `disableTool` and `ExperimentalWo
 | `eve/skills`                                                | `defineSkill`, `defineDynamic`                                       |
 | `eve/instructions`                                          | `defineInstructions`, `defineDynamic`                                |
 | `eve/context`                                               | `defineState`, session and state types                               |
-| `eve/sandbox`                                               | `defineSandbox`, backends                                            |
+| `eve/sandbox`                                               | `defineSandbox`, `defaultBackend`, `SandboxBackend*` types           |
+| `eve/sandbox/aws-lambda`                                    | `awsLambdaMicrovm`, AWS Lambda MicroVM option types                  |
+| `eve/sandbox/{docker,just-bash,microsandbox,vercel}`        | pinned sandbox backend factories and their option types              |
 | `eve/instrumentation`                                       | `defineInstrumentation`, `isChannel`                                 |
 | `eve/evals`                                                 | `defineEval`, `defineEvalConfig`, eval types                         |
 | `eve/evals/expect`                                          | `includes`, `equals`, `matches`, `similarity`                        |

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -112,17 +112,18 @@ export default defineSandbox({
 
 ## Backends
 
-The backend decides where the sandbox runs. eve ships four pinned factories from nested `eve/sandbox/*` imports plus an availability-aware default from `eve/sandbox`:
+The backend decides where the sandbox runs. eve ships five pinned factories from nested `eve/sandbox/*` imports plus an availability-aware default from `eve/sandbox`:
 
-| Backend            | Runs the sandbox                                                                               |
-| ------------------ | ---------------------------------------------------------------------------------------------- |
-| `vercel()`         | on [Vercel Sandbox](https://vercel.com/docs/sandbox).                                          |
-| `docker()`         | locally in a Docker container, driven through the `docker` CLI.                                |
-| `microsandbox()`   | locally in a lightweight [microsandbox](https://www.npmjs.com/package/microsandbox) VM.        |
-| `justbash()`       | locally in the pure-JS `just-bash` interpreter (no daemon or VM, but no real binaries either). |
-| `defaultBackend()` | picks the best available: Vercel Sandbox on hosted Vercel → Docker → microsandbox → just-bash. |
+| Backend              | Runs the sandbox                                                                               |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| `vercel()`           | on [Vercel Sandbox](https://vercel.com/docs/sandbox).                                          |
+| `awsLambdaMicrovm()` | on AWS Lambda MicroVMs, with full-filesystem S3 checkpoints.                                   |
+| `docker()`           | locally in a Docker container, driven through the `docker` CLI.                                |
+| `microsandbox()`     | locally in a lightweight [microsandbox](https://www.npmjs.com/package/microsandbox) VM.        |
+| `justbash()`         | locally in the pure-JS `just-bash` interpreter (no daemon or VM, but no real binaries either). |
+| `defaultBackend()`   | picks the best available: Vercel Sandbox on hosted Vercel → Docker → microsandbox → just-bash. |
 
-Configuring a pinned factory uses that backend unconditionally. `docker()` always requires a reachable Docker daemon, and `vercel()` always creates hosted sandboxes (including from local dev, with Vercel credentials).
+Configuring a pinned factory uses that backend unconditionally. `docker()` always requires a reachable Docker daemon, `vercel()` always creates hosted sandboxes, and `awsLambdaMicrovm()` always uses real AWS resources, including from local development.
 
 With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use in priority order:
 
@@ -130,6 +131,8 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 2. **Docker** when a daemon is reachable through a Docker-compatible `docker` CLI (Docker Desktop, OrbStack, Colima, Podman via its docker-compatible CLI; override the binary with `EVE_DOCKER_PATH`).
 3. **microsandbox** when the host supports it: macOS on Apple Silicon, or glibc Linux with KVM enabled.
 4. **just-bash** as the dependency-free fallback.
+
+AWS Lambda MicroVMs are intentionally absent from this ordering. Selecting AWS always requires the explicit `eve/sandbox/aws-lambda` factory.
 
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 
@@ -152,6 +155,29 @@ export default defineSandbox({
 ### microsandbox
 
 `microsandbox()` runs each sandbox in a lightweight local VM with snapshot-backed templates, a `vercel-sandbox` user, and a firewall capable of domain-level network policies and credential brokering. It is the closest local match to hosted Vercel Sandbox. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. During framework setup, before authored bootstrap code runs, eve verifies Bash and creates `/workspace` and the sandbox user. Install authored runtime tools in sandbox bootstrap or provide them through a custom image. Supported hosts are macOS on Apple Silicon, or Linux (glibc) with KVM. The `microsandbox` npm package and its VM runtime are not bundled with eve, so `eve dev` installs both automatically when missing (disable with `setup: { autoInstall: false }`); production processes fail with actionable install errors instead.
+
+### AWS Lambda MicroVMs
+
+`awsLambdaMicrovm()` provisions an ARM64 eve controller image and launches one AWS Lambda MicroVM per durable sandbox session. Users provide a same-Region S3 bucket, build role, caller permissions, and any custom network connectors; eve does not create cloud infrastructure.
+
+```ts title="agent/sandbox/sandbox.ts"
+import { defineSandbox } from "eve/sandbox";
+import { awsLambdaMicrovm } from "eve/sandbox/aws-lambda";
+
+export default defineSandbox({
+  backend: awsLambdaMicrovm({
+    applicationId: "analytics-agent",
+    region: "us-east-1",
+    artifactBucket: "company-eve-sandboxes",
+    buildRoleArn: process.env.EVE_AWS_BUILD_ROLE_ARN!,
+    executionRoleArn: process.env.EVE_AWS_EXECUTION_ROLE_ARN,
+  }),
+});
+```
+
+Native suspend and resume preserve memory and processes while the MicroVM exists. eve also checkpoints the complete writable filesystem to S3 before explicit suspension. After AWS's eight-hour maximum lifetime or another termination, eve restores the exact recorded image version and filesystem, but background processes are gone. If that image version is unavailable, restoration fails without discarding the checkpoint or falling back to workspace-only state.
+
+Egress and VPC connectors are immutable at launch; configure them on the factory. An empty connector array disables egress, and restricted VPC networking must still reach the checkpoint bucket. `setNetworkPolicy()` is unsupported. See [AWS Lambda MicroVM sandboxes](./guides/aws-lambda-microvms) for IAM policies, lifecycle details, retention, networking, and troubleshooting.
 
 ### just-bash
 
@@ -183,7 +209,14 @@ export default defineSandbox({
 });
 ```
 
-Sessions are persistent, and how the underlying runtime idles out depends on the backend. On the Vercel backend, the VM times out after a period of inactivity (default 30 minutes); eve preserves the filesystem and resumes the sandbox on the next message as if nothing happened, even days later. The Docker backend keeps a long-lived container per durable session and persists `/workspace` across turns without that timeout, and the just-bash backend stores its virtual filesystem under `.eve/sandbox-cache/`. In every case, `/workspace` survives between turns for the same session.
+Sessions are persistent, and how the underlying runtime idles out depends on the backend. On the Vercel backend, the VM times out after a period of inactivity (default 30 minutes); eve preserves the filesystem and resumes the sandbox on the next message as if nothing happened, even days later. The Docker backend keeps a long-lived container per durable session, and the just-bash backend stores its virtual filesystem under `.eve/sandbox-cache/`. AWS Lambda MicroVMs preserve memory and processes across native suspension, then restore files without processes after termination. In every case, `/workspace` survives between turns for the same session.
+
+| Capability                                | Vercel             | Docker             | microsandbox       | just-bash   | AWS Lambda MicroVMs                   |
+| ----------------------------------------- | ------------------ | ------------------ | ------------------ | ----------- | ------------------------------------- |
+| `/workspace` process and file APIs        | Yes                | Yes                | Yes                | Simulated   | Yes                                   |
+| Files survive provider replacement        | Yes                | Container lifetime | Snapshot           | Local cache | Full writable filesystem via S3       |
+| Running processes survive idle suspension | Provider-dependent | n/a                | Snapshot-dependent | n/a         | Yes, until termination or eight hours |
+| Runtime network-policy changes            | Yes                | Allow/deny only    | Yes                | No          | No; connectors are launch-time only   |
 
 ## Network policy
 
@@ -203,7 +236,7 @@ Default egress is `allow-all`. For non-public, sensitive, regulated, or producti
 
 Set it on the factory (`vercel({ networkPolicy: "deny-all" })`) and it applies before authored `bootstrap` code runs; framework-owned base setup may briefly keep egress open to install required packages. Set it in `onSession`'s `use()` to override per-session. The common pattern combines both: leave the factory open so `bootstrap` can `git clone`, then lock down in `onSession`. To change the policy mid-turn, call `sandbox.setNetworkPolicy(...)` on the live handle.
 
-Domain-level allow-lists and credential brokering are supported by `vercel()` and `microsandbox()`. The Docker backend honors only `"allow-all"` and `"deny-all"` (at creation and via `setNetworkPolicy`); the just-bash backend rejects `setNetworkPolicy` entirely.
+Domain-level allow-lists and credential brokering are supported by `vercel()` and `microsandbox()`. The Docker backend honors only `"allow-all"` and `"deny-all"` (at creation and via `setNetworkPolicy`); just-bash rejects `setNetworkPolicy`, and AWS Lambda MicroVMs require launch-time egress or VPC connectors instead.
 
 ## Credential brokering
 

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -131,6 +131,11 @@
       "import": "./dist/src/public/sandbox/index.js",
       "default": "./dist/src/public/sandbox/index.js"
     },
+    "./sandbox/aws-lambda": {
+      "types": "./dist/src/public/sandbox/aws-lambda.d.ts",
+      "import": "./dist/src/public/sandbox/aws-lambda.js",
+      "default": "./dist/src/public/sandbox/aws-lambda.js"
+    },
     "./sandbox/docker": {
       "types": "./dist/src/public/sandbox/docker.d.ts",
       "import": "./dist/src/public/sandbox/docker.js",
@@ -293,6 +298,9 @@
     "@ai-sdk/openai": "catalog:",
     "@ai-sdk/otel": "catalog:",
     "@ai-sdk/provider": "catalog:",
+    "@aws-sdk/client-lambda-microvms": "3.1075.0",
+    "@aws-sdk/client-s3": "3.1073.0",
+    "@aws-sdk/s3-request-presigner": "3.1073.0",
     "@chat-adapter/slack": "4.29.0",
     "@chat-adapter/state-memory": "4.29.0",
     "@clack/core": "1.3.1",

--- a/packages/eve/scripts/copy-runtime-assets.mjs
+++ b/packages/eve/scripts/copy-runtime-assets.mjs
@@ -3,10 +3,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
-// The coding-agent setup and handoff prompts are composed at runtime from these
-// section files (see cli/commands/agent-instructions.ts), so they must ship in
-// the package next to the compiled module that reads them.
-const runtimeAssetDirs = ["src/cli/commands/agent-prompt"];
+// These files are read at runtime by their compiled modules, so they must ship
+// beside the JavaScript output instead of remaining source-only assets.
+const runtimeAssetDirs = [
+  "src/cli/commands/agent-prompt",
+  "src/execution/sandbox/bindings/aws-lambda-microvms/controller",
+];
 
 export async function copyRuntimeAssets() {
   for (const relativePath of runtimeAssetDirs) {

--- a/packages/eve/scripts/vendor-compiled/@aws-sdk/lambda-microvms.mjs
+++ b/packages/eve/scripts/vendor-compiled/@aws-sdk/lambda-microvms.mjs
@@ -1,0 +1,20 @@
+import { fileURLToPath } from "node:url";
+
+import { loadDeclaration } from "../_shared.mjs";
+
+const wrapperEntry = fileURLToPath(
+  new URL("../entries/@aws-sdk/lambda-microvms.mjs", import.meta.url),
+);
+
+export default {
+  packageName: "@aws-sdk/client-lambda-microvms",
+  compiledPath: "@aws-sdk/client-lambda-microvms",
+  bundling: "standalone",
+  entries: [
+    {
+      input: wrapperEntry,
+      outputPath: "index",
+      declaration: await loadDeclaration("@aws-sdk/client-lambda-microvms.d.ts"),
+    },
+  ],
+};

--- a/packages/eve/scripts/vendor-compiled/@aws-sdk/s3-request-presigner.mjs
+++ b/packages/eve/scripts/vendor-compiled/@aws-sdk/s3-request-presigner.mjs
@@ -1,0 +1,20 @@
+import { fileURLToPath } from "node:url";
+
+import { loadDeclaration } from "../_shared.mjs";
+
+const wrapperEntry = fileURLToPath(
+  new URL("../entries/@aws-sdk/s3-request-presigner.mjs", import.meta.url),
+);
+
+export default {
+  packageName: "@aws-sdk/s3-request-presigner",
+  compiledPath: "@aws-sdk/s3-request-presigner",
+  bundling: "standalone",
+  entries: [
+    {
+      input: wrapperEntry,
+      outputPath: "index",
+      declaration: await loadDeclaration("@aws-sdk/s3-request-presigner.d.ts"),
+    },
+  ],
+};

--- a/packages/eve/scripts/vendor-compiled/@aws-sdk/s3.mjs
+++ b/packages/eve/scripts/vendor-compiled/@aws-sdk/s3.mjs
@@ -1,0 +1,18 @@
+import { fileURLToPath } from "node:url";
+
+import { loadDeclaration } from "../_shared.mjs";
+
+const wrapperEntry = fileURLToPath(new URL("../entries/@aws-sdk/s3.mjs", import.meta.url));
+
+export default {
+  packageName: "@aws-sdk/client-s3",
+  compiledPath: "@aws-sdk/client-s3",
+  bundling: "standalone",
+  entries: [
+    {
+      input: wrapperEntry,
+      outputPath: "index",
+      declaration: await loadDeclaration("@aws-sdk/client-s3.d.ts"),
+    },
+  ],
+};

--- a/packages/eve/scripts/vendor-compiled/declarations/@aws-sdk/client-lambda-microvms.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@aws-sdk/client-lambda-microvms.d.ts
@@ -1,0 +1,32 @@
+interface AwsClientConfig {
+  readonly region: string;
+}
+
+interface AwsCommandInput {
+  readonly [key: string]: unknown;
+}
+
+declare class AwsCommand {
+  constructor(input: AwsCommandInput);
+}
+
+export class LambdaMicrovmsClient {
+  constructor(config: AwsClientConfig);
+  send(command: AwsCommand): Promise<Record<string, unknown>>;
+  destroy(): void;
+}
+
+export class CreateMicrovmAuthTokenCommand extends AwsCommand {}
+export class CreateMicrovmImageCommand extends AwsCommand {}
+export class GetMicrovmCommand extends AwsCommand {}
+export class GetMicrovmImageCommand extends AwsCommand {}
+export class GetMicrovmImageVersionCommand extends AwsCommand {}
+export class ListManagedMicrovmImagesCommand extends AwsCommand {}
+export class ListManagedMicrovmImageVersionsCommand extends AwsCommand {}
+export class ListMicrovmImagesCommand extends AwsCommand {}
+export class ListMicrovmImageVersionsCommand extends AwsCommand {}
+export class ResumeMicrovmCommand extends AwsCommand {}
+export class RunMicrovmCommand extends AwsCommand {}
+export class SuspendMicrovmCommand extends AwsCommand {}
+export class TagResourceCommand extends AwsCommand {}
+export class TerminateMicrovmCommand extends AwsCommand {}

--- a/packages/eve/scripts/vendor-compiled/declarations/@aws-sdk/client-s3.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@aws-sdk/client-s3.d.ts
@@ -1,0 +1,27 @@
+interface AwsClientConfig {
+  readonly region: string;
+}
+
+interface AwsCommandInput {
+  readonly [key: string]: unknown;
+}
+
+export class S3Command {
+  constructor(input: AwsCommandInput);
+}
+
+export class S3Client {
+  constructor(config: AwsClientConfig);
+  send(command: S3Command): Promise<Record<string, unknown>>;
+  destroy(): void;
+}
+
+export class AbortMultipartUploadCommand extends S3Command {}
+export class CompleteMultipartUploadCommand extends S3Command {}
+export class CreateMultipartUploadCommand extends S3Command {}
+export class DeleteObjectCommand extends S3Command {}
+export class GetBucketLocationCommand extends S3Command {}
+export class GetObjectCommand extends S3Command {}
+export class HeadObjectCommand extends S3Command {}
+export class PutObjectCommand extends S3Command {}
+export class UploadPartCommand extends S3Command {}

--- a/packages/eve/scripts/vendor-compiled/declarations/@aws-sdk/s3-request-presigner.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@aws-sdk/s3-request-presigner.d.ts
@@ -1,0 +1,7 @@
+import type { S3Client, S3Command } from "#compiled/@aws-sdk/client-s3/index.js";
+
+export function getSignedUrl(
+  client: S3Client,
+  command: S3Command,
+  options?: { readonly expiresIn?: number },
+): Promise<string>;

--- a/packages/eve/scripts/vendor-compiled/entries/@aws-sdk/lambda-microvms.mjs
+++ b/packages/eve/scripts/vendor-compiled/entries/@aws-sdk/lambda-microvms.mjs
@@ -1,0 +1,17 @@
+export {
+  CreateMicrovmAuthTokenCommand,
+  CreateMicrovmImageCommand,
+  GetMicrovmCommand,
+  GetMicrovmImageCommand,
+  GetMicrovmImageVersionCommand,
+  LambdaMicrovmsClient,
+  ListManagedMicrovmImagesCommand,
+  ListManagedMicrovmImageVersionsCommand,
+  ListMicrovmImagesCommand,
+  ListMicrovmImageVersionsCommand,
+  ResumeMicrovmCommand,
+  RunMicrovmCommand,
+  SuspendMicrovmCommand,
+  TagResourceCommand,
+  TerminateMicrovmCommand,
+} from "@aws-sdk/client-lambda-microvms";

--- a/packages/eve/scripts/vendor-compiled/entries/@aws-sdk/s3-request-presigner.mjs
+++ b/packages/eve/scripts/vendor-compiled/entries/@aws-sdk/s3-request-presigner.mjs
@@ -1,0 +1,1 @@
+export { getSignedUrl } from "@aws-sdk/s3-request-presigner";

--- a/packages/eve/scripts/vendor-compiled/entries/@aws-sdk/s3.mjs
+++ b/packages/eve/scripts/vendor-compiled/entries/@aws-sdk/s3.mjs
@@ -1,0 +1,12 @@
+export {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  DeleteObjectCommand,
+  GetBucketLocationCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";

--- a/packages/eve/scripts/vendor-compiled/index.mjs
+++ b/packages/eve/scripts/vendor-compiled/index.mjs
@@ -10,6 +10,10 @@ import openai from "./@ai-sdk/openai.mjs";
 import otel from "./@ai-sdk/otel.mjs";
 import provider from "./@ai-sdk/provider.mjs";
 
+import awsLambdaMicrovms from "./@aws-sdk/lambda-microvms.mjs";
+import awsS3 from "./@aws-sdk/s3.mjs";
+import awsS3RequestPresigner from "./@aws-sdk/s3-request-presigner.mjs";
+
 import chatAdapterSlack from "./@chat-adapter/slack.mjs";
 import chatAdapterStateMemory from "./@chat-adapter/state-memory.mjs";
 
@@ -37,6 +41,9 @@ import zodValidationError from "./zod-validation-error.mjs";
 
 export const MODULES = [
   anthropic,
+  awsLambdaMicrovms,
+  awsS3,
+  awsS3RequestPresigner,
   chat,
   chatAdapterSlack,
   chatAdapterStateMemory,

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -39,7 +39,7 @@ export const ROOT_COMPILED_AGENT_NODE_ID = "__root__";
 /**
  * Current compiled manifest schema version.
  */
-export const COMPILED_AGENT_MANIFEST_VERSION = 30;
+export const COMPILED_AGENT_MANIFEST_VERSION = 31;
 
 /**
  * Compiled channel entry preserved in the compiled manifest.
@@ -426,6 +426,14 @@ const compiledSandboxDefinitionSchema = z
      * backend's name could not be resolved at compile time.
      */
     backendName: z.string().optional(),
+    backendProvisioning: z
+      .object({
+        prewarmAtBuild: z.boolean(),
+        requiresTemplate: z.boolean(),
+        scopeKey: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     description: z.string().optional(),
     exportName: z.string().optional(),
     logicalPath: z.string(),

--- a/packages/eve/src/compiler/normalize-sandbox.ts
+++ b/packages/eve/src/compiler/normalize-sandbox.ts
@@ -41,6 +41,7 @@ export async function compileSandboxDefinition(
 
   return {
     backendName: resolveCompiledBackendName(normalized.backend),
+    backendProvisioning: resolveCompiledBackendProvisioning(normalized.backend),
     description: normalized.description,
     exportName: source.exportName,
     logicalPath: source.logicalPath,
@@ -49,6 +50,34 @@ export async function compileSandboxDefinition(
     sourceId: source.sourceId,
     sourceKind: "module",
   };
+}
+
+function resolveCompiledBackendProvisioning(
+  backend:
+    | {
+        readonly provisioning?: {
+          readonly prewarmAtBuild: boolean;
+          readonly requiresTemplate: boolean;
+          readonly scopeKey?: string;
+        };
+      }
+    | undefined,
+): CompiledSandboxDefinition["backendProvisioning"] {
+  if (backend === undefined) {
+    return undefined;
+  }
+  try {
+    const provisioning = backend.provisioning;
+    return provisioning === undefined
+      ? undefined
+      : {
+          prewarmAtBuild: provisioning.prewarmAtBuild,
+          requiresTemplate: provisioning.requiresTemplate,
+          scopeKey: provisioning.scopeKey,
+        };
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/api.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/api.ts
@@ -1,0 +1,95 @@
+export type AwsLambdaMicrovmState =
+  | "PENDING"
+  | "RUNNING"
+  | "SUSPENDED"
+  | "SUSPENDING"
+  | "TERMINATED"
+  | "TERMINATING";
+
+export interface AwsLambdaMicrovmRecord {
+  readonly endpoint: string;
+  readonly imageArn: string;
+  readonly imageVersion: string;
+  readonly microvmId: string;
+  readonly state: AwsLambdaMicrovmState;
+  readonly stateReason?: string;
+}
+
+export interface AwsLambdaMicrovmImageRecord {
+  readonly imageArn: string;
+  readonly latestActiveImageVersion?: string;
+  readonly name: string;
+}
+
+export interface AwsLambdaMicrovmImageVersionRecord {
+  readonly imageArn: string;
+  readonly imageVersion: string;
+  readonly state:
+    | "PENDING"
+    | "IN_PROGRESS"
+    | "SUCCESSFUL"
+    | "FAILED"
+    | "DELETING"
+    | "DELETED"
+    | "DELETE_FAILED";
+  readonly stateReason?: string;
+  readonly status?: "ACTIVE" | "INACTIVE";
+}
+
+export interface AwsLambdaMicrovmCreateImageInput {
+  readonly baseImageArn: string;
+  readonly baseImageVersion: string;
+  readonly buildRoleArn: string;
+  readonly clientToken: string;
+  readonly codeArtifactUri: string;
+  readonly description: string;
+  readonly egressNetworkConnectorArns: readonly string[];
+  readonly environmentVariables: Readonly<Record<string, string>>;
+  readonly logging: AwsLambdaMicrovmLogging;
+  readonly memoryMiB: number;
+  readonly name: string;
+  readonly tags: Readonly<Record<string, string>>;
+}
+
+export interface AwsLambdaMicrovmRunInput {
+  readonly clientToken: string;
+  readonly egressNetworkConnectorArns: readonly string[];
+  readonly executionRoleArn?: string;
+  readonly idlePolicy: {
+    readonly autoResumeEnabled: boolean;
+    readonly maxIdleDurationSeconds: number;
+    readonly suspendedDurationSeconds: number;
+  };
+  readonly imageArn: string;
+  readonly imageVersion: string;
+  readonly ingressNetworkConnectorArns: readonly string[];
+  readonly logging: AwsLambdaMicrovmLogging;
+  readonly maximumDurationSeconds: number;
+  readonly runHookPayload: string;
+}
+
+export type AwsLambdaMicrovmLogging =
+  | { readonly disabled: true }
+  | { readonly cloudWatch: { readonly logGroup?: string; readonly logStream?: string } };
+
+export interface AwsLambdaMicrovmApi {
+  createAuthToken(microvmId: string): Promise<string>;
+  createImage(input: AwsLambdaMicrovmCreateImageInput): Promise<AwsLambdaMicrovmImageVersionRecord>;
+  destroy(): void;
+  getImageVersion(
+    imageArn: string,
+    imageVersion: string,
+  ): Promise<AwsLambdaMicrovmImageVersionRecord>;
+  getMicrovm(microvmId: string): Promise<AwsLambdaMicrovmRecord | null>;
+  listImages(name: string): Promise<readonly AwsLambdaMicrovmImageRecord[]>;
+  listImageVersions(imageArn: string): Promise<readonly AwsLambdaMicrovmImageVersionRecord[]>;
+  listManagedImages(): Promise<readonly { readonly imageArn: string }[]>;
+  listManagedImageVersions(
+    imageArn: string,
+  ): Promise<readonly { readonly imageArn: string; readonly imageVersion: string }[]>;
+  resumeMicrovm(microvmId: string): Promise<void>;
+  runMicrovm(input: AwsLambdaMicrovmRunInput): Promise<AwsLambdaMicrovmRecord>;
+  suspendMicrovm(microvmId: string): Promise<void>;
+  tagResource(resourceArn: string, tags: Readonly<Record<string, string>>): Promise<void>;
+  terminateMicrovm(microvmId: string): Promise<void>;
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/backend.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/backend.integration.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AwsLambdaMicrovmApi, AwsLambdaMicrovmRecord } from "./api.js";
+import {
+  AWS_LAMBDA_MICROVM_BACKEND_NAME,
+  createAwsLambdaMicrovmSandbox,
+  type AwsLambdaMicrovmBackendServices,
+} from "./backend.js";
+import type {
+  AwsLambdaMicrovmController,
+  ControllerCheckpointPreparation,
+  ControllerProcess,
+} from "./controller-client.js";
+import type { AwsLambdaMicrovmStorage, StoredJson } from "./storage.js";
+
+const OPTIONS = {
+  applicationId: "integration-agent",
+  artifactBucket: "sandbox-artifacts",
+  buildRoleArn: "arn:aws:iam::123456789012:role/eve-build",
+  region: "us-east-1",
+} as const;
+
+describe("AWS Lambda MicroVM backend", () => {
+  it("requires and reuses an empty build-time template", async () => {
+    const fixture = createServicesFixture();
+    const backend = createAwsLambdaMicrovmSandbox({ options: OPTIONS, services: fixture.services });
+
+    expect(backend.name).toBe(AWS_LAMBDA_MICROVM_BACKEND_NAME);
+    expect(backend.provisioning).toEqual({
+      prewarmAtBuild: true,
+      requiresTemplate: true,
+      scopeKey: "integration-agent",
+    });
+
+    await expect(
+      backend.prewarm({
+        runtimeContext: { appRoot: "/app" },
+        seedFiles: [],
+        templateKey: "template-empty",
+      }),
+    ).resolves.toEqual({ reused: false });
+    await expect(
+      backend.prewarm({
+        runtimeContext: { appRoot: "/app" },
+        seedFiles: [],
+        templateKey: "template-empty",
+      }),
+    ).resolves.toEqual({ reused: true });
+
+    expect(fixture.api.createImage).toHaveBeenCalledTimes(1);
+    expect(fixture.api.createImage).toHaveBeenCalledWith(
+      expect.objectContaining({ logging: { cloudWatch: {} } }),
+    );
+    expect(fixture.api.runMicrovm).not.toHaveBeenCalled();
+    expect(fixture.storage.bytes.size).toBe(1);
+  });
+
+  it("bootstraps, checkpoints, suspends, and restores a terminated session", async () => {
+    const fixture = createServicesFixture();
+    const backend = createAwsLambdaMicrovmSandbox({ options: OPTIONS, services: fixture.services });
+
+    await backend.prewarm({
+      async bootstrap({ use }) {
+        const session = await use();
+        await session.writeTextFile({ content: "installed", path: "/usr/local/eve-marker" });
+      },
+      runtimeContext: { appRoot: "/app" },
+      seedFiles: [{ content: "seed", path: "/workspace/seed.txt" }],
+      templateKey: "template-full",
+    });
+
+    expect(fixture.api.runMicrovm).toHaveBeenCalledTimes(1);
+    expect(fixture.api.runMicrovm).toHaveBeenCalledWith(
+      expect.objectContaining({ logging: { disabled: true } }),
+    );
+    expect(fixture.api.terminateMicrovm).toHaveBeenCalledTimes(1);
+    expect(fixture.api.tagResource).toHaveBeenCalledWith(
+      "arn:aws:lambda:us-east-1:123456789012:microvm:mvm-1",
+      expect.objectContaining({
+        "eve:application": expect.any(String),
+        "eve:controller": "1",
+        "eve:owner": "eve",
+        "eve:template": expect.any(String),
+      }),
+    );
+
+    const handle = await backend.create({
+      runtimeContext: { appRoot: "/app" },
+      sessionKey: "session-one",
+      templateKey: "template-full",
+    });
+    expect(fixture.controllers.at(-1)?.restored).toHaveLength(1);
+
+    await handle.session.writeTextFile({ content: "changed", path: "/etc/eve.conf" });
+    const state = await handle.captureState();
+
+    expect(state.backendName).toBe(AWS_LAMBDA_MICROVM_BACKEND_NAME);
+    expect(state.metadata).toMatchObject({
+      checkpoint: { generation: 2 },
+      imageArn: "arn:aws:lambda:us-east-1:123456789012:microvm-image:eve-test",
+      imageVersion: "1",
+      manifestEtag: expect.any(String),
+    });
+    expect(fixture.storage.completedSha256s).toEqual(["a".repeat(64), "a".repeat(64)]);
+    expect(fixture.api.suspendMicrovm).toHaveBeenCalledTimes(1);
+
+    await handle.dispose();
+    expect(fixture.api.terminateMicrovm).toHaveBeenCalledTimes(2);
+
+    const restored = await backend.create({
+      existingMetadata: state.metadata,
+      runtimeContext: { appRoot: "/app" },
+      sessionKey: "session-one",
+      templateKey: "template-full",
+    });
+    expect(fixture.api.runMicrovm).toHaveBeenCalledTimes(3);
+    expect(fixture.controllers.at(-1)?.restored.at(-1)?.sha256).toBe("a".repeat(64));
+    await restored.dispose();
+  });
+
+  it("rejects runtime network-policy mutation", async () => {
+    const fixture = createServicesFixture();
+    const backend = createAwsLambdaMicrovmSandbox({ options: OPTIONS, services: fixture.services });
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/app" },
+      seedFiles: [],
+      templateKey: "template-network",
+    });
+    const handle = await backend.create({
+      runtimeContext: { appRoot: "/app" },
+      sessionKey: "session-network",
+      templateKey: "template-network",
+    });
+
+    await expect(handle.session.setNetworkPolicy("deny-all")).rejects.toThrow(
+      /immutable after launch/,
+    );
+  });
+
+  it("terminates a newly launched MicroVM when controller startup fails", async () => {
+    const fixture = createServicesFixture({ controllerReadyError: new Error("not ready") });
+    const backend = createAwsLambdaMicrovmSandbox({ options: OPTIONS, services: fixture.services });
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/app" },
+      seedFiles: [],
+      templateKey: "template-failing-controller",
+    });
+
+    await expect(
+      backend.create({
+        runtimeContext: { appRoot: "/app" },
+        sessionKey: "session-failing-controller",
+        templateKey: "template-failing-controller",
+      }),
+    ).rejects.toThrow("not ready");
+    expect(fixture.api.terminateMicrovm).toHaveBeenCalledWith("mvm-1");
+  });
+});
+
+function createServicesFixture(input: { readonly controllerReadyError?: Error } = {}): {
+  readonly api: ReturnType<typeof createFakeApi>;
+  readonly controllers: FakeController[];
+  readonly services: AwsLambdaMicrovmBackendServices;
+  readonly storage: FakeStorage;
+} {
+  const api = createFakeApi();
+  const storage = new FakeStorage();
+  const controllers: FakeController[] = [];
+  return {
+    api,
+    controllers,
+    services: {
+      api,
+      createController() {
+        const controller = new FakeController(input.controllerReadyError);
+        controllers.push(controller);
+        return controller;
+      },
+      storage,
+    },
+    storage,
+  };
+}
+
+function createFakeApi() {
+  const microvms = new Map<string, AwsLambdaMicrovmRecord>();
+  let imageCreated = false;
+  let nextMicrovm = 1;
+  const imageArn = "arn:aws:lambda:us-east-1:123456789012:microvm-image:eve-test";
+
+  return {
+    createAuthToken: vi.fn(async () => "token"),
+    createImage: vi.fn(async () => {
+      imageCreated = true;
+      return { imageArn, imageVersion: "1", state: "PENDING" as const };
+    }),
+    destroy: vi.fn(),
+    getImageVersion: vi.fn(async () => ({
+      imageArn,
+      imageVersion: "1",
+      state: "SUCCESSFUL" as const,
+      status: "ACTIVE" as const,
+    })),
+    getMicrovm: vi.fn(async (microvmId: string) => microvms.get(microvmId) ?? null),
+    listImages: vi.fn(async (name: string) =>
+      imageCreated ? [{ imageArn, latestActiveImageVersion: "1", name }] : [],
+    ),
+    listImageVersions: vi.fn(async () =>
+      imageCreated ? [{ imageArn, imageVersion: "1", state: "PENDING" as const }] : [],
+    ),
+    listManagedImages: vi.fn(async () => [
+      { imageArn: "arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1" },
+    ]),
+    listManagedImageVersions: vi.fn(async (managedImageArn: string) => [
+      { imageArn: managedImageArn, imageVersion: "0" },
+    ]),
+    resumeMicrovm: vi.fn(async (microvmId: string) => {
+      const current = microvms.get(microvmId);
+      if (current !== undefined) microvms.set(microvmId, { ...current, state: "RUNNING" });
+    }),
+    runMicrovm: vi.fn(async (input) => {
+      const microvmId = `mvm-${nextMicrovm++}`;
+      const record: AwsLambdaMicrovmRecord = {
+        endpoint: `https://${microvmId}.example.test`,
+        imageArn: input.imageArn,
+        imageVersion: input.imageVersion,
+        microvmId,
+        state: "RUNNING",
+      };
+      microvms.set(microvmId, record);
+      return record;
+    }),
+    suspendMicrovm: vi.fn(async (microvmId: string) => {
+      const current = microvms.get(microvmId);
+      if (current !== undefined) microvms.set(microvmId, { ...current, state: "SUSPENDED" });
+    }),
+    tagResource: vi.fn(async () => {}),
+    terminateMicrovm: vi.fn(async (microvmId: string) => {
+      const current = microvms.get(microvmId);
+      if (current !== undefined) microvms.set(microvmId, { ...current, state: "TERMINATED" });
+    }),
+  } satisfies AwsLambdaMicrovmApi;
+}
+
+class FakeStorage implements AwsLambdaMicrovmStorage {
+  readonly bytes = new Map<string, Uint8Array>();
+  readonly completedSha256s: string[] = [];
+  readonly json = new Map<string, StoredJson<unknown>>();
+  readonly objects = new Map<string, { readonly etag?: string; readonly size: number }>();
+  #etag = 0;
+
+  async abortMultipartUpload(): Promise<void> {}
+  async assertBucketRegion(): Promise<void> {}
+  async completeMultipartUpload(
+    key: string,
+    _uploadId: string,
+    _parts: readonly { readonly etag: string; readonly partNumber: number }[],
+    sha256: string,
+  ): Promise<{ etag?: string }> {
+    this.completedSha256s.push(sha256);
+    const etag = `object-${++this.#etag}`;
+    this.objects.set(key, { etag, size: 12 });
+    return { etag };
+  }
+  async createMultipartUpload(): Promise<string> {
+    return "upload-1";
+  }
+  async deleteObject(key: string, condition: { readonly etag?: string } = {}): Promise<void> {
+    const current = this.json.get(key);
+    if (condition.etag !== undefined && current?.etag !== condition.etag) {
+      throw new Error("precondition failed");
+    }
+    this.bytes.delete(key);
+    this.json.delete(key);
+    this.objects.delete(key);
+  }
+  destroy(): void {}
+  async getJson<T>(key: string): Promise<StoredJson<T> | null> {
+    return (this.json.get(key) as StoredJson<T> | undefined) ?? null;
+  }
+  async hasObject(key: string): Promise<boolean> {
+    return this.bytes.has(key);
+  }
+  async getObjectInfo(key: string): Promise<{ etag?: string; size: number } | null> {
+    const object = this.objects.get(key);
+    if (object !== undefined) return object;
+    const bytes = this.bytes.get(key);
+    return bytes === undefined ? null : { size: bytes.byteLength };
+  }
+  async presignGet(key: string): Promise<string> {
+    return `https://s3.example.test/${key}`;
+  }
+  async presignUploadParts(
+    _key: string,
+    _uploadId: string,
+    count: number,
+  ): Promise<readonly string[]> {
+    return Array.from({ length: count }, (_, index) => `https://s3.example.test/part/${index + 1}`);
+  }
+  async putBytes(key: string, bytes: Uint8Array): Promise<void> {
+    this.bytes.set(key, bytes);
+    this.objects.set(key, { size: bytes.byteLength });
+  }
+  async putJson(
+    key: string,
+    value: unknown,
+    condition: { readonly absent?: boolean; readonly etag?: string } = {},
+  ): Promise<{ etag: string }> {
+    const current = this.json.get(key);
+    if (condition.absent === true && current !== undefined) throw new Error("precondition failed");
+    if (condition.etag !== undefined && current?.etag !== condition.etag) {
+      throw new Error("precondition failed");
+    }
+    const etag = `json-${++this.#etag}`;
+    this.json.set(key, { etag, value });
+    return { etag };
+  }
+}
+
+class FakeController implements AwsLambdaMicrovmController {
+  dirty = false;
+  readonly restored: { sha256: string; url: string }[] = [];
+  readonly #readyError?: Error;
+
+  constructor(readyError?: Error) {
+    this.#readyError = readyError;
+  }
+
+  async checkpointCommitted(): Promise<void> {
+    this.dirty = false;
+  }
+  async checkpointRelease(): Promise<void> {}
+  async checkpointUpload(): Promise<readonly { etag: string; partNumber: number }[]> {
+    return [{ etag: '"part-1"', partNumber: 1 }];
+  }
+  pauseHeartbeats(): void {}
+  async prepareCheckpoint(): Promise<ControllerCheckpointPreparation> {
+    return this.dirty
+      ? {
+          checkpointId: "checkpoint-1",
+          dirty: true,
+          partCount: 1,
+          partSize: 64 * 1024 * 1024,
+          sha256: "a".repeat(64),
+          size: 12,
+        }
+      : { dirty: false };
+  }
+  async readFile(): Promise<ReadableStream<Uint8Array> | null> {
+    return null;
+  }
+  async removePath(): Promise<void> {
+    this.dirty = true;
+  }
+  async restoreCheckpoint(input: { sha256: string; size: number; url: string }): Promise<void> {
+    this.restored.push(input);
+  }
+  resumeHeartbeats(): void {}
+  async spawn(): Promise<ControllerProcess> {
+    this.dirty = true;
+    return {
+      async kill() {},
+      stderr: byteStream(""),
+      stdout: byteStream(""),
+      async wait() {
+        return { exitCode: 0 };
+      },
+    };
+  }
+  async waitUntilReady(): Promise<void> {
+    if (this.#readyError !== undefined) throw this.#readyError;
+  }
+  async writeFile(): Promise<void> {
+    this.dirty = true;
+  }
+}
+
+function byteStream(value: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(value));
+      controller.close();
+    },
+  });
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/backend.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/backend.ts
@@ -1,0 +1,554 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { createLoggingSandboxSession } from "#execution/sandbox/logging-session.js";
+import type {
+  SandboxBackend,
+  SandboxBackendCreateInput,
+  SandboxBackendHandle,
+  SandboxBackendPrewarmInput,
+  SandboxBackendPrewarmResult,
+} from "#public/definitions/sandbox-backend.js";
+import { SandboxTemplateNotProvisionedError } from "#public/definitions/sandbox-backend.js";
+import type { AwsLambdaMicrovmSandboxOptions } from "#public/sandbox/aws-lambda-microvm-sandbox.js";
+
+import type {
+  AwsLambdaMicrovmApi,
+  AwsLambdaMicrovmLogging,
+  AwsLambdaMicrovmRecord,
+} from "./api.js";
+import {
+  restoreAwsLambdaMicrovmCheckpoint,
+  uploadAwsLambdaMicrovmCheckpoint,
+} from "./checkpoint.js";
+import {
+  HttpAwsLambdaMicrovmController,
+  type AwsLambdaMicrovmController,
+} from "./controller-client.js";
+import { AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION } from "./image-artifact.js";
+import { acquireAwsLambdaMicrovmLease, type AwsLambdaMicrovmLease } from "./lease.js";
+import {
+  AWS_LAMBDA_MICROVM_METADATA_VERSION,
+  type AwsLambdaMicrovmCheckpoint,
+  type AwsLambdaMicrovmSessionMetadata,
+  type AwsLambdaMicrovmTemplateDescriptor,
+  parseAwsLambdaMicrovmSessionMetadata,
+  parseAwsLambdaMicrovmTemplateDescriptor,
+} from "./metadata.js";
+import { resolveAwsLambdaMicrovmOptions, type ResolvedAwsLambdaMicrovmOptions } from "./options.js";
+import { ensureAwsLambdaMicrovmImage } from "./provision.js";
+import { SdkAwsLambdaMicrovmApi } from "./sdk-api.js";
+import { createAwsLambdaMicrovmSession } from "./session.js";
+import { SdkAwsLambdaMicrovmStorage, type AwsLambdaMicrovmStorage } from "./storage.js";
+
+export const AWS_LAMBDA_MICROVM_BACKEND_NAME = "aws-lambda-microvms";
+
+export interface AwsLambdaMicrovmBackendServices {
+  readonly api: AwsLambdaMicrovmApi;
+  readonly createController: (microvm: AwsLambdaMicrovmRecord) => AwsLambdaMicrovmController;
+  readonly storage: AwsLambdaMicrovmStorage;
+}
+
+export interface CreateAwsLambdaMicrovmSandboxInput {
+  readonly options: AwsLambdaMicrovmSandboxOptions;
+  readonly services?: AwsLambdaMicrovmBackendServices;
+}
+
+/** Creates the built-in AWS Lambda MicroVM sandbox backend. */
+export function createAwsLambdaMicrovmSandbox(
+  input: CreateAwsLambdaMicrovmSandboxInput,
+): SandboxBackend {
+  const options = resolveAwsLambdaMicrovmOptions(input.options);
+  const services = input.services ?? createDefaultServices(options);
+
+  return {
+    name: AWS_LAMBDA_MICROVM_BACKEND_NAME,
+    provisioning: {
+      prewarmAtBuild: true,
+      requiresTemplate: true,
+      scopeKey: options.applicationId,
+    },
+    async create(createInput) {
+      return await createSessionHandle({ createInput, options, services });
+    },
+    async prewarm(prewarmInput) {
+      return await prewarmTemplate({ options, prewarmInput, services });
+    },
+  };
+}
+
+function createDefaultServices(
+  options: ResolvedAwsLambdaMicrovmOptions,
+): AwsLambdaMicrovmBackendServices {
+  const api = new SdkAwsLambdaMicrovmApi(options.region);
+  return {
+    api,
+    createController: (microvm) => new HttpAwsLambdaMicrovmController({ api, microvm }),
+    storage: new SdkAwsLambdaMicrovmStorage({
+      bucket: options.artifactBucket,
+      region: options.region,
+    }),
+  };
+}
+
+async function prewarmTemplate(input: {
+  readonly options: ResolvedAwsLambdaMicrovmOptions;
+  readonly prewarmInput: SandboxBackendPrewarmInput;
+  readonly services: AwsLambdaMicrovmBackendServices;
+}): Promise<SandboxBackendPrewarmResult> {
+  await input.services.storage.assertBucketRegion();
+  const lease = await acquireAwsLambdaMicrovmLease({
+    key: templateLeaseKey(input.options, input.prewarmInput.templateKey),
+    storage: input.services.storage,
+    ttlMs: 10 * 60 * 1000,
+    waitMs: 30 * 60 * 1000,
+  });
+  try {
+    return await prewarmTemplateWithLease(input);
+  } finally {
+    await lease.release();
+  }
+}
+
+async function prewarmTemplateWithLease(input: {
+  readonly options: ResolvedAwsLambdaMicrovmOptions;
+  readonly prewarmInput: SandboxBackendPrewarmInput;
+  readonly services: AwsLambdaMicrovmBackendServices;
+}): Promise<SandboxBackendPrewarmResult> {
+  const descriptorKey = templateDescriptorKey(input.options, input.prewarmInput.templateKey);
+  const templateHash = hashKey(input.prewarmInput.templateKey);
+  const existing = await input.services.storage.getJson<unknown>(descriptorKey);
+  const image = await ensureAwsLambdaMicrovmImage({
+    api: input.services.api,
+    log: input.prewarmInput.log,
+    options: input.options,
+    storage: input.services.storage,
+  });
+  if (existing !== null) {
+    const descriptor = parseAwsLambdaMicrovmTemplateDescriptor(existing.value);
+    if (
+      descriptor.configHash === image.configHash &&
+      descriptor.controllerProtocolVersion === AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION &&
+      descriptor.imageArn === image.imageArn &&
+      descriptor.imageVersion === image.imageVersion &&
+      descriptor.region === input.options.region &&
+      descriptor.templateHash === templateHash
+    ) {
+      return { reused: true };
+    }
+  }
+
+  let checkpoint: AwsLambdaMicrovmCheckpoint | undefined;
+  let pendingCheckpoint: Awaited<ReturnType<typeof uploadAwsLambdaMicrovmCheckpoint>> | undefined;
+  let temporaryMicrovm: AwsLambdaMicrovmRecord | undefined;
+  try {
+    if (input.prewarmInput.bootstrap !== undefined || input.prewarmInput.seedFiles.length > 0) {
+      temporaryMicrovm = await runMicrovm({
+        egressNetworkConnectorArns: input.options.buildEgressNetworkConnectorArns,
+        imageArn: image.imageArn,
+        imageVersion: image.imageVersion,
+        options: input.options,
+        purposeKey: input.prewarmInput.templateKey,
+        templateHash,
+        services: input.services,
+      });
+      const controller = input.services.createController(temporaryMicrovm);
+      await controller.waitUntilReady();
+      const session = createAwsLambdaMicrovmSession({
+        controller,
+        id: input.prewarmInput.templateKey,
+      });
+
+      if (input.prewarmInput.bootstrap !== undefined) {
+        input.prewarmInput.log?.("running sandbox bootstrap");
+        await input.prewarmInput.bootstrap({
+          use: async () => createLoggingSandboxSession({ log: input.prewarmInput.log, session }),
+        });
+      }
+      for (const file of input.prewarmInput.seedFiles) {
+        if (typeof file.content === "string") {
+          await session.writeTextFile({ content: file.content, path: file.path });
+        } else {
+          await session.writeBinaryFile({ content: file.content, path: file.path });
+        }
+      }
+
+      input.prewarmInput.log?.("capturing full-filesystem template checkpoint");
+      pendingCheckpoint = await uploadAwsLambdaMicrovmCheckpoint({
+        controller,
+        generation: 1,
+        objectKeyPrefix: `${input.options.artifactPrefix}/templates/${hashKey(input.prewarmInput.templateKey)}/checkpoints`,
+        storage: input.services.storage,
+      });
+      if (pendingCheckpoint === null) {
+        throw new Error("AWS Lambda MicroVM template changed no filesystem state during prewarm.");
+      }
+      checkpoint = pendingCheckpoint.checkpoint;
+    }
+
+    const descriptor: AwsLambdaMicrovmTemplateDescriptor = {
+      checkpoint,
+      configHash: image.configHash,
+      controllerProtocolVersion: AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION,
+      imageArn: image.imageArn,
+      imageVersion: image.imageVersion,
+      region: input.options.region,
+      templateHash,
+      version: AWS_LAMBDA_MICROVM_METADATA_VERSION,
+    };
+    await input.services.storage.putJson(descriptorKey, descriptor, {
+      absent: existing === null,
+      etag: existing?.etag,
+    });
+    await pendingCheckpoint?.commit();
+    return { reused: false };
+  } catch (error) {
+    await pendingCheckpoint?.release().catch(() => undefined);
+    throw new Error(
+      `Failed to prewarm AWS Lambda MicroVM template "${input.prewarmInput.templateKey}": ${errorMessage(error)}`,
+      { cause: error },
+    );
+  } finally {
+    if (temporaryMicrovm !== undefined) {
+      await input.services.api.terminateMicrovm(temporaryMicrovm.microvmId).catch(() => undefined);
+    }
+  }
+}
+
+async function createSessionHandle(input: {
+  readonly createInput: SandboxBackendCreateInput;
+  readonly options: ResolvedAwsLambdaMicrovmOptions;
+  readonly services: AwsLambdaMicrovmBackendServices;
+}): Promise<SandboxBackendHandle> {
+  await input.services.storage.assertBucketRegion();
+  const initialLease = await acquireAwsLambdaMicrovmLease({
+    key: sessionLeaseKey(input.options, input.createInput.sessionKey),
+    storage: input.services.storage,
+  });
+  try {
+    return await createLeasedSessionHandle({ ...input, initialLease });
+  } catch (error) {
+    await initialLease.release().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function createLeasedSessionHandle(input: {
+  readonly createInput: SandboxBackendCreateInput;
+  readonly initialLease: AwsLambdaMicrovmLease;
+  readonly options: ResolvedAwsLambdaMicrovmOptions;
+  readonly services: AwsLambdaMicrovmBackendServices;
+}): Promise<SandboxBackendHandle> {
+  const templateKey = input.createInput.templateKey;
+  if (templateKey === null) {
+    throw new Error("The AWS Lambda MicroVM backend requires a prewarmed template.");
+  }
+  const storedTemplate = await input.services.storage.getJson<unknown>(
+    templateDescriptorKey(input.options, templateKey),
+  );
+  if (storedTemplate === null) {
+    throw new SandboxTemplateNotProvisionedError({
+      backendName: AWS_LAMBDA_MICROVM_BACKEND_NAME,
+      templateKey,
+    });
+  }
+  const template = parseAwsLambdaMicrovmTemplateDescriptor(storedTemplate.value);
+  if (template.region !== input.options.region) {
+    throw new Error(
+      `AWS Lambda MicroVM template is in ${template.region}, but this backend is configured for ${input.options.region}.`,
+    );
+  }
+  assertControllerCompatibility(template.controllerProtocolVersion);
+
+  const manifestKey = sessionManifestKey(input.options, input.createInput.sessionKey);
+  const storedSession = await input.services.storage.getJson<unknown>(manifestKey);
+  const persistedSession =
+    storedSession === null
+      ? parseAwsLambdaMicrovmSessionMetadata(input.createInput.existingMetadata)
+      : parseAwsLambdaMicrovmSessionMetadata({
+          ...expectRecord(storedSession.value, "session manifest"),
+          manifestEtag: storedSession.etag,
+        });
+  if (persistedSession !== undefined) {
+    assertControllerCompatibility(persistedSession.controllerProtocolVersion);
+  }
+
+  const source = persistedSession ?? template;
+  let microvm = await reattachMicrovm(input.services.api, persistedSession);
+  let launchedMicrovm = false;
+  if (
+    microvm !== null &&
+    (microvm.imageArn !== source.imageArn || microvm.imageVersion !== source.imageVersion)
+  ) {
+    await input.services.api.terminateMicrovm(microvm.microvmId).catch(() => undefined);
+    microvm = null;
+  }
+  if (microvm === null) {
+    microvm = await runMicrovm({
+      egressNetworkConnectorArns: input.options.runtimeEgressNetworkConnectorArns,
+      imageArn: source.imageArn,
+      imageVersion: source.imageVersion,
+      options: input.options,
+      purposeKey: input.createInput.sessionKey,
+      sessionKey: input.createInput.sessionKey,
+      services: input.services,
+      templateHash: source.templateHash,
+    });
+    launchedMicrovm = true;
+  }
+  const activeMicrovm = microvm;
+
+  const controller = input.services.createController(activeMicrovm);
+  try {
+    await controller.waitUntilReady();
+    if (persistedSession === undefined || persistedSession.microvmId !== activeMicrovm.microvmId) {
+      if (source.checkpoint !== undefined) {
+        await restoreAwsLambdaMicrovmCheckpoint({
+          checkpoint: source.checkpoint,
+          controller,
+          storage: input.services.storage,
+        });
+      }
+    }
+  } catch (error) {
+    if (launchedMicrovm) {
+      await input.services.api.terminateMicrovm(activeMicrovm.microvmId).catch(() => undefined);
+    }
+    throw error;
+  }
+
+  let metadata: AwsLambdaMicrovmSessionMetadata | undefined = persistedSession;
+  let lease: AwsLambdaMicrovmLease | undefined = input.initialLease;
+  let captured = false;
+  let controllerPaused = false;
+  let disposed = false;
+
+  async function ensureLease(): Promise<AwsLambdaMicrovmLease> {
+    lease ??= await acquireAwsLambdaMicrovmLease({
+      key: sessionLeaseKey(input.options, input.createInput.sessionKey),
+      storage: input.services.storage,
+    });
+    await lease.ensureHeld();
+    return lease;
+  }
+
+  async function ensureActive(): Promise<void> {
+    await ensureLease();
+    if (!controllerPaused) return;
+    const current = await input.services.api.getMicrovm(activeMicrovm.microvmId);
+    if (current === null || current.state === "TERMINATED" || current.state === "TERMINATING") {
+      throw new Error(
+        "AWS Lambda MicroVM was terminated after this handle captured state. Open a new sandbox handle to restore its checkpoint.",
+      );
+    }
+    if (current.state === "SUSPENDED" || current.state === "SUSPENDING") {
+      await input.services.api.resumeMicrovm(activeMicrovm.microvmId);
+    }
+    controller.resumeHeartbeats();
+    await controller.waitUntilReady();
+    controllerPaused = false;
+  }
+
+  const session = createAwsLambdaMicrovmSession({
+    beforeOperation: ensureActive,
+    controller,
+    id: input.createInput.sessionKey,
+    onMutate() {
+      captured = false;
+    },
+  });
+
+  async function capture(): Promise<AwsLambdaMicrovmSessionMetadata> {
+    if (disposed) throw new Error("AWS Lambda MicroVM sandbox handle is disposed.");
+    await ensureActive();
+    const activeLease = await ensureLease();
+    const previousCheckpoint = metadata?.checkpoint ?? source.checkpoint;
+    const pending = await uploadAwsLambdaMicrovmCheckpoint({
+      controller,
+      generation: (previousCheckpoint?.generation ?? 0) + 1,
+      objectKeyPrefix: `${input.options.artifactPrefix}/sessions/${hashKey(input.createInput.sessionKey)}/checkpoints`,
+      storage: input.services.storage,
+    });
+    const checkpoint = pending?.checkpoint ?? previousCheckpoint;
+    const body: Omit<AwsLambdaMicrovmSessionMetadata, "manifestEtag"> = {
+      checkpoint,
+      configHash: source.configHash,
+      controllerProtocolVersion: AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION,
+      imageArn: source.imageArn,
+      imageVersion: source.imageVersion,
+      microvmId: activeMicrovm.microvmId,
+      region: source.region,
+      templateHash: source.templateHash,
+      version: AWS_LAMBDA_MICROVM_METADATA_VERSION,
+    };
+    try {
+      const stored = await input.services.storage.putJson(manifestKey, body, {
+        absent: metadata === undefined,
+        etag: metadata?.manifestEtag,
+      });
+      const nextMetadata: AwsLambdaMicrovmSessionMetadata = {
+        ...body,
+        manifestEtag: stored.etag,
+      };
+      metadata = nextMetadata;
+      await pending?.commit();
+      controller.pauseHeartbeats();
+      try {
+        await input.services.api.suspendMicrovm(activeMicrovm.microvmId);
+      } catch (error) {
+        controller.resumeHeartbeats();
+        await controller.checkpointRelease().catch(() => undefined);
+        throw error;
+      }
+      controllerPaused = true;
+      captured = true;
+      await activeLease.release();
+      lease = undefined;
+      return nextMetadata;
+    } catch (error) {
+      await pending?.release().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  return {
+    async captureState() {
+      return {
+        backendName: AWS_LAMBDA_MICROVM_BACKEND_NAME,
+        metadata: { ...(await capture()) },
+        sessionKey: input.createInput.sessionKey,
+      };
+    },
+    async dispose() {
+      if (disposed) return;
+      if (!captured) await capture();
+      const activeLease = await ensureLease();
+      try {
+        await input.services.api.terminateMicrovm(activeMicrovm.microvmId);
+        disposed = true;
+      } finally {
+        await activeLease.release();
+        lease = undefined;
+      }
+    },
+    session,
+    useSessionFn: async () => session,
+  };
+}
+
+async function reattachMicrovm(
+  api: AwsLambdaMicrovmApi,
+  metadata: AwsLambdaMicrovmSessionMetadata | undefined,
+): Promise<AwsLambdaMicrovmRecord | null> {
+  if (metadata === undefined) return null;
+  const microvm = await api.getMicrovm(metadata.microvmId);
+  if (microvm === null || microvm.state === "TERMINATED" || microvm.state === "TERMINATING") {
+    return null;
+  }
+  if (microvm.state === "SUSPENDED" || microvm.state === "SUSPENDING") {
+    await api.resumeMicrovm(microvm.microvmId);
+  }
+  return microvm;
+}
+
+async function runMicrovm(input: {
+  readonly egressNetworkConnectorArns: readonly string[];
+  readonly imageArn: string;
+  readonly imageVersion: string;
+  readonly options: ResolvedAwsLambdaMicrovmOptions;
+  readonly purposeKey: string;
+  readonly sessionKey?: string;
+  readonly services: AwsLambdaMicrovmBackendServices;
+  readonly templateHash: string;
+}): Promise<AwsLambdaMicrovmRecord> {
+  const ingressNetworkConnectorArns = [input.options.httpIngressNetworkConnectorArn];
+  if (input.options.shellIngressNetworkConnectorArn !== undefined) {
+    ingressNetworkConnectorArns.push(input.options.shellIngressNetworkConnectorArn);
+  }
+  const microvm = await input.services.api.runMicrovm({
+    clientToken: randomUUID(),
+    egressNetworkConnectorArns: input.egressNetworkConnectorArns,
+    executionRoleArn: input.options.executionRoleArn,
+    idlePolicy: input.options.idlePolicy,
+    imageArn: input.imageArn,
+    imageVersion: input.imageVersion,
+    ingressNetworkConnectorArns,
+    logging: resolveLogging(input.options),
+    maximumDurationSeconds: input.options.maximumDurationSeconds,
+    runHookPayload: JSON.stringify({
+      controllerProtocolVersion: AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION,
+      eveSession: hashKey(input.purposeKey),
+    }),
+  });
+  try {
+    await input.services.api.tagResource(microvmArn(microvm), {
+      ...input.options.tags,
+      "eve:application": input.options.applicationHash,
+      "eve:controller": String(AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION),
+      "eve:owner": "eve",
+      ...(input.sessionKey === undefined
+        ? {}
+        : { "eve:session": hashKey(input.sessionKey).slice(0, 32) }),
+      "eve:template": input.templateHash.slice(0, 32),
+    });
+    return microvm;
+  } catch (error) {
+    await input.services.api.terminateMicrovm(microvm.microvmId).catch(() => undefined);
+    throw error;
+  }
+}
+
+function microvmArn(microvm: AwsLambdaMicrovmRecord): string {
+  const [arn, partition, service, region, account] = microvm.imageArn.split(":");
+  if (arn !== "arn" || service !== "lambda" || !partition || !region || !account) {
+    throw new Error(`AWS Lambda MicroVM image returned an invalid ARN: ${microvm.imageArn}.`);
+  }
+  return `arn:${partition}:lambda:${region}:${account}:microvm:${microvm.microvmId}`;
+}
+
+function resolveLogging(options: ResolvedAwsLambdaMicrovmOptions): AwsLambdaMicrovmLogging {
+  return options.runtimeLogging === false
+    ? { disabled: true }
+    : { cloudWatch: options.runtimeLogging };
+}
+
+function templateDescriptorKey(
+  options: ResolvedAwsLambdaMicrovmOptions,
+  templateKey: string,
+): string {
+  return `${options.artifactPrefix}/templates/${hashKey(templateKey)}/manifest.json`;
+}
+
+function sessionManifestKey(options: ResolvedAwsLambdaMicrovmOptions, sessionKey: string): string {
+  return `${options.artifactPrefix}/sessions/${hashKey(sessionKey)}/manifest.json`;
+}
+
+function sessionLeaseKey(options: ResolvedAwsLambdaMicrovmOptions, sessionKey: string): string {
+  return `${options.artifactPrefix}/sessions/${hashKey(sessionKey)}/lease.json`;
+}
+
+function templateLeaseKey(options: ResolvedAwsLambdaMicrovmOptions, templateKey: string): string {
+  return `${options.artifactPrefix}/templates/${hashKey(templateKey)}/lease.json`;
+}
+
+function hashKey(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function assertControllerCompatibility(version: number): void {
+  if (version !== AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION) {
+    throw new Error(
+      `AWS Lambda MicroVM checkpoint requires controller protocol ${version}, but this eve version supports ${AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION}.`,
+    );
+  }
+}
+
+function expectRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid AWS Lambda MicroVM ${name}.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/checkpoint.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/checkpoint.ts
@@ -1,0 +1,97 @@
+import type { AwsLambdaMicrovmController } from "./controller-client.js";
+import type { AwsLambdaMicrovmCheckpoint } from "./metadata.js";
+import type { AwsLambdaMicrovmStorage } from "./storage.js";
+
+export interface PendingAwsLambdaMicrovmCheckpoint {
+  readonly checkpoint: AwsLambdaMicrovmCheckpoint;
+  commit(): Promise<void>;
+  release(): Promise<void>;
+}
+
+export async function uploadAwsLambdaMicrovmCheckpoint(input: {
+  readonly controller: AwsLambdaMicrovmController;
+  readonly generation: number;
+  readonly objectKeyPrefix: string;
+  readonly storage: AwsLambdaMicrovmStorage;
+}): Promise<PendingAwsLambdaMicrovmCheckpoint | null> {
+  const preparation = await input.controller.prepareCheckpoint();
+  if (!preparation.dirty) return null;
+
+  const checkpointId = expectDefined(preparation.checkpointId, "checkpointId");
+  const partCount = expectDefined(preparation.partCount, "partCount");
+  const sha256 = expectDefined(preparation.sha256, "sha256");
+  const size = expectDefined(preparation.size, "size");
+  const key = `${input.objectKeyPrefix}/${input.generation}-${sha256}.tar.zst`;
+  const uploadId = await input.storage.createMultipartUpload(key);
+  let completed = false;
+  let completedEtag: string | undefined;
+
+  try {
+    const urls = await input.storage.presignUploadParts(key, uploadId, partCount);
+    const parts = await input.controller.checkpointUpload(checkpointId, urls);
+    if (parts.length !== partCount) {
+      throw new Error(
+        `AWS Lambda MicroVM controller uploaded ${parts.length} checkpoint parts; expected ${partCount}.`,
+      );
+    }
+    const result = await input.storage.completeMultipartUpload(key, uploadId, parts, sha256);
+    const stored = await input.storage.getObjectInfo(key);
+    if (stored === null || stored.size !== size) {
+      throw new Error(
+        `AWS Lambda MicroVM checkpoint object verification failed for ${key}: expected ${size} bytes.`,
+      );
+    }
+    completedEtag = result.etag ?? stored.etag;
+    completed = true;
+  } catch (error) {
+    if (!completed) {
+      await input.storage.abortMultipartUpload(key, uploadId).catch(() => undefined);
+    }
+    await input.controller.checkpointRelease().catch(() => undefined);
+    throw error;
+  }
+
+  let finalized = false;
+  return {
+    checkpoint: { etag: completedEtag, generation: input.generation, key, sha256, size },
+    async commit() {
+      if (finalized) return;
+      await input.controller.checkpointCommitted(checkpointId);
+      finalized = true;
+    },
+    async release() {
+      if (finalized) return;
+      await input.controller.checkpointRelease();
+      finalized = true;
+    },
+  };
+}
+
+export async function restoreAwsLambdaMicrovmCheckpoint(input: {
+  readonly checkpoint: AwsLambdaMicrovmCheckpoint;
+  readonly controller: AwsLambdaMicrovmController;
+  readonly storage: AwsLambdaMicrovmStorage;
+}): Promise<void> {
+  const stored = await input.storage.getObjectInfo(input.checkpoint.key);
+  if (
+    stored === null ||
+    stored.size !== input.checkpoint.size ||
+    (input.checkpoint.etag !== undefined && stored.etag !== input.checkpoint.etag)
+  ) {
+    throw new Error(
+      `AWS Lambda MicroVM checkpoint ${input.checkpoint.key} no longer matches its manifest.`,
+    );
+  }
+  await input.controller.restoreCheckpoint({
+    sha256: input.checkpoint.sha256,
+    size: input.checkpoint.size,
+    url: await input.storage.presignGet(input.checkpoint.key),
+  });
+}
+
+function expectDefined<T>(value: T | undefined, name: string): T {
+  if (value === undefined) {
+    throw new Error(`AWS Lambda MicroVM controller omitted ${name} for a dirty checkpoint.`);
+  }
+  return value;
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller-client.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller-client.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AwsLambdaMicrovmApi, AwsLambdaMicrovmRecord } from "./api.js";
+import { HttpAwsLambdaMicrovmController } from "./controller-client.js";
+
+const MICROVM: AwsLambdaMicrovmRecord = {
+  endpoint: "https://mvm.example.test",
+  imageArn: "arn:aws:lambda:us-east-1:123456789012:microvm-image:test",
+  imageVersion: "1.0",
+  microvmId: "mvm-test",
+  state: "RUNNING",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("AWS Lambda MicroVM controller client", () => {
+  it("refreshes a port-scoped token once after an authentication failure", async () => {
+    const api = fakeApi();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
+      .mockResolvedValueOnce(jsonResponse({ protocolVersion: 1, status: "ready" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = new HttpAwsLambdaMicrovmController({ api, microvm: MICROVM });
+    await controller.waitUntilReady(1000);
+
+    expect(api.createAuthToken).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://mvm.example.test/v1/health",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-aws-proxy-auth": "token-2",
+          "x-aws-proxy-port": "8080",
+        }),
+      }),
+    );
+  });
+
+  it("streams file reads in bounded chunks", async () => {
+    const api = fakeApi();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(byteResponse("first", 5, false))
+      .mockResolvedValueOnce(byteResponse("second", 11, true));
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new HttpAwsLambdaMicrovmController({ api, microvm: MICROVM });
+
+    const stream = await controller.readFile("/workspace/data.bin");
+    expect(stream).not.toBeNull();
+    const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+
+    expect(new TextDecoder().decode(bytes)).toBe("firstsecond");
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      expect.stringContaining("offset=0"),
+      expect.stringContaining("offset=5"),
+    ]);
+  });
+
+  it("uploads large writes in chunks and commits atomically", async () => {
+    const api = fakeApi();
+    const requests: { readonly bodySize: number; readonly url: string }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (url, init) => {
+        const body = init?.body;
+        requests.push({
+          bodySize: body instanceof Uint8Array ? body.byteLength : 0,
+          url: String(url),
+        });
+        if (String(url).endsWith("/v1/files/writes")) {
+          return jsonResponse({ writeId: "write-1" }, 201);
+        }
+        return jsonResponse({ status: "ok" });
+      }),
+    );
+    const controller = new HttpAwsLambdaMicrovmController({ api, microvm: MICROVM });
+
+    await controller.writeFile("/workspace/data.bin", new Uint8Array(4 * 1024 * 1024 + 1));
+
+    expect(requests).toEqual([
+      { bodySize: 0, url: "https://mvm.example.test/v1/files/writes" },
+      {
+        bodySize: 4 * 1024 * 1024,
+        url: "https://mvm.example.test/v1/files/writes/write-1?offset=0",
+      },
+      {
+        bodySize: 1,
+        url: `https://mvm.example.test/v1/files/writes/write-1?offset=${4 * 1024 * 1024}`,
+      },
+      { bodySize: 0, url: "https://mvm.example.test/v1/files/writes/write-1/commit" },
+    ]);
+  });
+
+  it("retries an idempotent process start after a transient failure", async () => {
+    const api = fakeApi();
+    const processBodies: string[] = [];
+    let startAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (url, init) => {
+        const path = new URL(String(url)).pathname;
+        if (path === "/v1/processes" && init?.method === "POST") {
+          processBodies.push(String(init.body));
+          startAttempts++;
+          return startAttempts === 1
+            ? new Response("unavailable", { status: 503 })
+            : jsonResponse({ processId: "process-1" }, 201);
+        }
+        if (path.endsWith("/logs/stdout") || path.endsWith("/logs/stderr")) {
+          return byteResponse("", 0, true);
+        }
+        return jsonResponse({ exitCode: 0, state: "exited" });
+      }),
+    );
+    const controller = new HttpAwsLambdaMicrovmController({ api, microvm: MICROVM });
+
+    const process = await controller.spawn({ command: "true" });
+    await Promise.all([
+      process.wait(),
+      new Response(process.stdout).arrayBuffer(),
+      new Response(process.stderr).arrayBuffer(),
+    ]);
+
+    expect(startAttempts).toBe(2);
+    expect(processBodies[1]).toBe(processBodies[0]);
+  });
+});
+
+function fakeApi(): AwsLambdaMicrovmApi & { readonly createAuthToken: ReturnType<typeof vi.fn> } {
+  let token = 0;
+  return {
+    createAuthToken: vi.fn(async () => `token-${++token}`),
+    async createImage() {
+      throw new Error("not used");
+    },
+    destroy() {},
+    async getImageVersion() {
+      throw new Error("not used");
+    },
+    async getMicrovm() {
+      return MICROVM;
+    },
+    async listImages() {
+      return [];
+    },
+    async listImageVersions() {
+      return [];
+    },
+    async listManagedImages() {
+      return [];
+    },
+    async listManagedImageVersions() {
+      return [];
+    },
+    async resumeMicrovm() {},
+    async runMicrovm() {
+      return MICROVM;
+    },
+    async suspendMicrovm() {},
+    async tagResource() {},
+    async terminateMicrovm() {},
+  };
+}
+
+function byteResponse(value: string, nextOffset: number, complete: boolean): Response {
+  return new Response(new TextEncoder().encode(value), {
+    headers: {
+      "x-eve-complete": String(complete),
+      "x-eve-next-offset": String(nextOffset),
+    },
+  });
+}
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller-client.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller-client.ts
@@ -1,0 +1,531 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import type { AwsLambdaMicrovmApi, AwsLambdaMicrovmRecord } from "./api.js";
+
+const TOKEN_REFRESH_MS = 55 * 60 * 1000;
+const PROCESS_POLL_MS = 100;
+const FILE_CHUNK_SIZE = 4 * 1024 * 1024;
+const TRANSIENT_ATTEMPTS = 4;
+
+export interface ControllerCheckpointPreparation {
+  readonly checkpointId?: string;
+  readonly dirty: boolean;
+  readonly partCount?: number;
+  readonly partSize?: number;
+  readonly sha256?: string;
+  readonly size?: number;
+}
+
+export interface ControllerProcess {
+  readonly stderr: ReadableStream<Uint8Array>;
+  readonly stdout: ReadableStream<Uint8Array>;
+  kill(): Promise<void>;
+  wait(): Promise<{ readonly exitCode: number }>;
+}
+
+export interface AwsLambdaMicrovmController {
+  checkpointCommitted(checkpointId: string): Promise<void>;
+  checkpointRelease(): Promise<void>;
+  checkpointUpload(
+    checkpointId: string,
+    urls: readonly string[],
+  ): Promise<readonly { readonly etag: string; readonly partNumber: number }[]>;
+  pauseHeartbeats(): void;
+  prepareCheckpoint(): Promise<ControllerCheckpointPreparation>;
+  readFile(path: string, abortSignal?: AbortSignal): Promise<ReadableStream<Uint8Array> | null>;
+  removePath(input: {
+    readonly abortSignal?: AbortSignal;
+    readonly force?: boolean;
+    readonly path: string;
+    readonly recursive?: boolean;
+  }): Promise<void>;
+  restoreCheckpoint(input: {
+    readonly sha256: string;
+    readonly size: number;
+    readonly url: string;
+  }): Promise<void>;
+  resumeHeartbeats(): void;
+  spawn(input: {
+    readonly abortSignal?: AbortSignal;
+    readonly command: string;
+    readonly env?: Readonly<Record<string, string>>;
+    readonly workingDirectory?: string;
+  }): Promise<ControllerProcess>;
+  waitUntilReady(timeoutMs?: number): Promise<void>;
+  writeFile(path: string, bytes: Uint8Array, abortSignal?: AbortSignal): Promise<void>;
+}
+
+export class HttpAwsLambdaMicrovmController implements AwsLambdaMicrovmController {
+  readonly #api: AwsLambdaMicrovmApi;
+  readonly #endpoint: string;
+  readonly #microvmId: string;
+  #heartbeatsEnabled = true;
+  readonly #heartbeatWaiters = new Set<() => void>();
+  #token?: { readonly expiresAt: number; readonly value: string };
+  #tokenPromise?: Promise<string>;
+
+  constructor(input: {
+    readonly api: AwsLambdaMicrovmApi;
+    readonly microvm: AwsLambdaMicrovmRecord;
+  }) {
+    this.#api = input.api;
+    this.#endpoint = input.microvm.endpoint.replace(/\/+$/, "");
+    this.#microvmId = input.microvm.microvmId;
+  }
+
+  async checkpointCommitted(checkpointId: string): Promise<void> {
+    await this.#json(
+      "/v1/checkpoints/commit",
+      {
+        body: { checkpointId },
+        method: "POST",
+      },
+      true,
+    );
+  }
+
+  async checkpointRelease(): Promise<void> {
+    await this.#json("/v1/checkpoints/release", { method: "POST" }, true);
+  }
+
+  async checkpointUpload(
+    checkpointId: string,
+    urls: readonly string[],
+  ): Promise<readonly { readonly etag: string; readonly partNumber: number }[]> {
+    const output = await this.#json(
+      "/v1/checkpoints/upload",
+      {
+        body: { checkpointId, urls },
+        method: "POST",
+      },
+      true,
+    );
+    if (!Array.isArray(output.parts)) {
+      throw new Error("AWS Lambda MicroVM controller returned invalid checkpoint parts.");
+    }
+    return output.parts.map((value, index) => {
+      const record = expectRecord(value, `parts[${index}]`);
+      return {
+        etag: expectString(record.etag, `parts[${index}].etag`),
+        partNumber: expectPositiveInteger(record.partNumber, `parts[${index}].partNumber`),
+      };
+    });
+  }
+
+  pauseHeartbeats(): void {
+    this.#heartbeatsEnabled = false;
+  }
+
+  async prepareCheckpoint(): Promise<ControllerCheckpointPreparation> {
+    const output = await this.#json("/v1/checkpoints/prepare", { method: "POST" });
+    if (output.dirty === false) return { dirty: false };
+    if (output.dirty !== true) {
+      throw new Error("AWS Lambda MicroVM controller returned invalid checkpoint state.");
+    }
+    return {
+      checkpointId: expectString(output.checkpointId, "checkpointId"),
+      dirty: true,
+      partCount: expectPositiveInteger(output.partCount, "partCount"),
+      partSize: expectPositiveInteger(output.partSize, "partSize"),
+      sha256: expectSha256(output.sha256),
+      size: expectNonNegativeInteger(output.size, "size"),
+    };
+  }
+
+  async readFile(
+    path: string,
+    abortSignal?: AbortSignal,
+  ): Promise<ReadableStream<Uint8Array> | null> {
+    const first = await this.#readFileChunk(path, 0, abortSignal);
+    if (first === null) return null;
+    let next = first;
+    return new ReadableStream<Uint8Array>({
+      pull: async (controller) => {
+        try {
+          const current = next;
+          if (current.bytes.byteLength > 0) controller.enqueue(current.bytes);
+          if (current.complete) {
+            controller.close();
+            return;
+          }
+          next = expectDefined(
+            await this.#readFileChunk(path, current.nextOffset, abortSignal),
+            "file chunk",
+          );
+        } catch (error) {
+          controller.error(error);
+        }
+      },
+    });
+  }
+
+  async removePath(input: {
+    readonly abortSignal?: AbortSignal;
+    readonly force?: boolean;
+    readonly path: string;
+    readonly recursive?: boolean;
+  }): Promise<void> {
+    const query = new URLSearchParams({
+      force: String(input.force === true),
+      path: input.path,
+      recursive: String(input.recursive === true),
+    });
+    await this.#json(`/v1/files?${query}`, { method: "DELETE", signal: input.abortSignal });
+  }
+
+  async restoreCheckpoint(input: {
+    readonly sha256: string;
+    readonly size: number;
+    readonly url: string;
+  }): Promise<void> {
+    await this.#json("/v1/checkpoints/restore", { body: input, method: "POST" }, true);
+  }
+
+  resumeHeartbeats(): void {
+    if (this.#heartbeatsEnabled) return;
+    this.#heartbeatsEnabled = true;
+    for (const resolve of this.#heartbeatWaiters) resolve();
+    this.#heartbeatWaiters.clear();
+  }
+
+  async spawn(input: {
+    readonly abortSignal?: AbortSignal;
+    readonly command: string;
+    readonly env?: Readonly<Record<string, string>>;
+    readonly workingDirectory?: string;
+  }): Promise<ControllerProcess> {
+    const requestId = randomUUID();
+    const output = await this.#json(
+      "/v1/processes",
+      {
+        body: {
+          command: input.command,
+          env: input.env,
+          requestId,
+          workingDirectory: input.workingDirectory,
+        },
+        method: "POST",
+        signal: input.abortSignal,
+      },
+      true,
+    );
+    const processId = expectString(output.processId, "processId");
+    const process = this.#createProcess(processId);
+    input.abortSignal?.addEventListener("abort", () => void process.kill().catch(() => undefined), {
+      once: true,
+    });
+    return process;
+  }
+
+  async waitUntilReady(timeoutMs = 120_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      try {
+        const output = await this.#json("/v1/health");
+        if (output.status === "ready" && output.protocolVersion === 1) return;
+        lastError = new Error("Controller returned an incompatible protocol response.");
+      } catch (error) {
+        lastError = error;
+      }
+      await sleep(500);
+    }
+    throw new Error(
+      `AWS Lambda MicroVM controller did not become ready: ${errorMessage(lastError)}`,
+      {
+        cause: lastError,
+      },
+    );
+  }
+
+  async writeFile(path: string, bytes: Uint8Array, abortSignal?: AbortSignal): Promise<void> {
+    const output = await this.#json("/v1/files/writes", {
+      body: { path },
+      method: "POST",
+      signal: abortSignal,
+    });
+    const writeId = expectString(output.writeId, "writeId");
+    try {
+      for (let offset = 0; offset < bytes.byteLength || offset === 0; offset += FILE_CHUNK_SIZE) {
+        const response = await this.#request(
+          `/v1/files/writes/${encodeURIComponent(writeId)}?offset=${offset}`,
+          {
+            body: bytes.subarray(offset, Math.min(bytes.byteLength, offset + FILE_CHUNK_SIZE)),
+            headers: { "content-type": "application/octet-stream" },
+            method: "PUT",
+            signal: abortSignal,
+          },
+        );
+        await expectOk(response);
+        if (bytes.byteLength === 0) break;
+      }
+      await this.#json(`/v1/files/writes/${encodeURIComponent(writeId)}/commit`, {
+        method: "POST",
+        signal: abortSignal,
+      });
+    } catch (error) {
+      await this.#json(`/v1/files/writes/${encodeURIComponent(writeId)}`, {
+        method: "DELETE",
+      }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  #createProcess(processId: string): ControllerProcess {
+    const stdout = this.#createLogStream(processId, "stdout");
+    const stderr = this.#createLogStream(processId, "stderr");
+    const waitPromise = this.#waitForProcess(processId);
+    let killPromise: Promise<void> | undefined;
+    return {
+      stderr,
+      stdout,
+      kill: () =>
+        (killPromise ??= this.#json(
+          `/v1/processes/${encodeURIComponent(processId)}`,
+          {
+            method: "DELETE",
+          },
+          true,
+        ).then(() => undefined)),
+      wait: () => waitPromise,
+    };
+  }
+
+  async #waitForProcess(processId: string): Promise<{ readonly exitCode: number }> {
+    for (;;) {
+      await this.#waitForHeartbeats();
+      const output = await this.#json(`/v1/processes/${encodeURIComponent(processId)}`, {}, true);
+      if (output.state === "exited") {
+        return { exitCode: expectInteger(output.exitCode, "exitCode") };
+      }
+      if (output.state !== "running") {
+        throw new Error(`AWS Lambda MicroVM process returned state ${String(output.state)}.`);
+      }
+      await sleep(PROCESS_POLL_MS);
+    }
+  }
+
+  #createLogStream(processId: string, outputName: "stderr" | "stdout"): ReadableStream<Uint8Array> {
+    let canceled = false;
+    return new ReadableStream<Uint8Array>({
+      cancel() {
+        canceled = true;
+      },
+      start: (controller) => {
+        void (async () => {
+          let offset = 0;
+          try {
+            while (!canceled) {
+              await this.#waitForHeartbeats();
+              const response = await this.#request(
+                `/v1/processes/${encodeURIComponent(processId)}/logs/${outputName}?offset=${offset}`,
+                {},
+                true,
+              );
+              await expectOk(response);
+              const chunk = new Uint8Array(await response.arrayBuffer());
+              const nextOffset = Number(response.headers.get("x-eve-next-offset"));
+              if (!Number.isInteger(nextOffset) || nextOffset < offset) {
+                throw new Error("AWS Lambda MicroVM controller returned an invalid log offset.");
+              }
+              offset = nextOffset;
+              if (chunk.byteLength > 0) controller.enqueue(chunk);
+              if (response.headers.get("x-eve-complete") === "true") break;
+              if (chunk.byteLength === 0) await sleep(PROCESS_POLL_MS);
+            }
+            if (!canceled) controller.close();
+          } catch (error) {
+            if (!canceled) controller.error(error);
+          }
+        })();
+      },
+    });
+  }
+
+  async #json(
+    path: string,
+    init: Omit<RequestInit, "body"> & { readonly body?: unknown } = {},
+    retryTransient = false,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.#request(
+      path,
+      {
+        ...init,
+        body: init.body === undefined ? undefined : JSON.stringify(init.body),
+        headers:
+          init.body === undefined
+            ? init.headers
+            : { ...init.headers, "content-type": "application/json" },
+      },
+      retryTransient,
+    );
+    await expectOk(response);
+    const value = (await response.json()) as unknown;
+    return expectRecord(value, "response");
+  }
+
+  async #request(path: string, init: RequestInit = {}, retryTransient = false): Promise<Response> {
+    let lastError: unknown;
+    const attempts = retryTransient ? TRANSIENT_ATTEMPTS : 1;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        const response = await this.#authenticatedRequest(path, init);
+        if (!isTransientStatus(response.status) || attempt === attempts - 1) {
+          return response;
+        }
+        await response.body?.cancel().catch(() => undefined);
+        await sleep(retryDelayMs(attempt, response.headers.get("retry-after")));
+      } catch (error) {
+        if (init.signal?.aborted || attempt === attempts - 1) throw error;
+        lastError = error;
+        await sleep(retryDelayMs(attempt));
+      }
+    }
+    throw new Error("AWS Lambda MicroVM controller request exhausted transient retries.", {
+      cause: lastError,
+    });
+  }
+
+  async #authenticatedRequest(path: string, init: RequestInit): Promise<Response> {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const token = await this.#getToken(attempt > 0);
+      const response = await fetch(`${this.#endpoint}${path}`, {
+        ...init,
+        headers: {
+          ...init.headers,
+          "x-aws-proxy-auth": token,
+          "x-aws-proxy-port": "8080",
+        },
+      });
+      if (response.status !== 403 || attempt > 0) return response;
+      this.#token = undefined;
+    }
+    throw new Error("AWS Lambda MicroVM controller authentication failed.");
+  }
+
+  async #getToken(force: boolean): Promise<string> {
+    if (force) {
+      this.#token = undefined;
+      this.#tokenPromise = undefined;
+    }
+    if (!force && this.#token !== undefined && this.#token.expiresAt > Date.now()) {
+      return this.#token.value;
+    }
+    if (this.#tokenPromise !== undefined) return await this.#tokenPromise;
+    this.#tokenPromise = this.#api.createAuthToken(this.#microvmId).then((value) => {
+      this.#token = { expiresAt: Date.now() + TOKEN_REFRESH_MS, value };
+      return value;
+    });
+    try {
+      return await this.#tokenPromise;
+    } finally {
+      this.#tokenPromise = undefined;
+    }
+  }
+
+  async #readFileChunk(
+    path: string,
+    offset: number,
+    abortSignal?: AbortSignal,
+  ): Promise<{
+    readonly bytes: Uint8Array;
+    readonly complete: boolean;
+    readonly nextOffset: number;
+  } | null> {
+    const query = new URLSearchParams({
+      limit: String(FILE_CHUNK_SIZE),
+      offset: String(offset),
+      path,
+    });
+    const response = await this.#request(`/v1/files?${query}`, { signal: abortSignal }, true);
+    if (response.status === 404) return null;
+    await expectOk(response);
+    const nextOffset = Number(response.headers.get("x-eve-next-offset"));
+    if (!Number.isInteger(nextOffset) || nextOffset < offset) {
+      throw new Error("AWS Lambda MicroVM controller returned an invalid file offset.");
+    }
+    return {
+      bytes: new Uint8Array(await response.arrayBuffer()),
+      complete: response.headers.get("x-eve-complete") === "true",
+      nextOffset,
+    };
+  }
+
+  async #waitForHeartbeats(): Promise<void> {
+    if (this.#heartbeatsEnabled) return;
+    await new Promise<void>((resolve) => this.#heartbeatWaiters.add(resolve));
+  }
+}
+
+async function expectOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  const body = await response.text().catch(() => "");
+  throw new Error(
+    `AWS Lambda MicroVM controller request failed with HTTP ${response.status}${body ? `: ${body}` : ""}.`,
+  );
+}
+
+function expectRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`AWS Lambda MicroVM controller returned invalid ${name}.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`AWS Lambda MicroVM controller returned invalid ${name}.`);
+  }
+  return value;
+}
+
+function expectInteger(value: unknown, name: string): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(`AWS Lambda MicroVM controller returned invalid ${name}.`);
+  }
+  return Number(value);
+}
+
+function expectPositiveInteger(value: unknown, name: string): number {
+  const result = expectInteger(value, name);
+  if (result < 1) throw new Error(`AWS Lambda MicroVM controller returned invalid ${name}.`);
+  return result;
+}
+
+function expectNonNegativeInteger(value: unknown, name: string): number {
+  const result = expectInteger(value, name);
+  if (result < 0) throw new Error(`AWS Lambda MicroVM controller returned invalid ${name}.`);
+  return result;
+}
+
+function expectSha256(value: unknown): string {
+  const digest = expectString(value, "sha256");
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new Error("AWS Lambda MicroVM controller returned invalid sha256.");
+  }
+  return digest;
+}
+
+function expectDefined<T>(value: T | null | undefined, name: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`AWS Lambda MicroVM controller omitted ${name}.`);
+  }
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isTransientStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function retryDelayMs(attempt: number, retryAfter: string | null = null): number {
+  const retryAfterSeconds = retryAfter === null ? Number.NaN : Number(retryAfter);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return Math.min(1000, retryAfterSeconds * 1000);
+  }
+  return 50 * 2 ** attempt + Math.floor(Math.random() * 26);
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller.scenario.test.ts
@@ -1,0 +1,256 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+const runControllerScenarios = process.env.EVE_RUN_AWS_MICROVM_CONTROLLER_SCENARIOS === "1";
+const runFile = promisify(execFile);
+const createScratchDirectory = useTemporaryDirectories();
+const controllerContext = fileURLToPath(new URL("./controller", import.meta.url));
+const runId = `eve-aws-controller-${Date.now()}`;
+const image = `${runId}:test`;
+const containers = [`${runId}-source`, `${runId}-restore`] as const;
+
+describe.runIf(runControllerScenarios)("AWS Lambda MicroVM ARM64 controller", () => {
+  afterAll(async () => {
+    for (const container of containers) {
+      await docker(["rm", "-f", container]).catch(() => undefined);
+    }
+    await docker(["rmi", "-f", image]).catch(() => undefined);
+  }, 60_000);
+
+  it(
+    "restores the complete overlay into a fresh ARM64 container",
+    async () => {
+      await docker(["build", "--platform", "linux/arm64", "-t", image, controllerContext]);
+      const sourcePort = await startContainer(containers[0]);
+      await waitForHealth(sourcePort);
+      await postJson(
+        `http://127.0.0.1:${sourcePort.hooks}/aws/lambda-microvms/runtime/v1/validate`,
+        {},
+      );
+      await postJson(`http://127.0.0.1:${sourcePort.hooks}/aws/lambda-microvms/runtime/v1/run`, {
+        microvmId: "mvm-scenario",
+        runHookPayload: JSON.stringify({ controllerProtocolVersion: 1 }),
+      });
+
+      await runCommand(sourcePort.control, "background", "sleep 300 &", false);
+      await docker(["pause", containers[0]]);
+      await docker(["unpause", containers[0]]);
+      expect(await processStatus(sourcePort.control, "background")).toMatchObject({
+        state: "running",
+      });
+      await fetchOk(`http://127.0.0.1:${sourcePort.control}/v1/processes/background`, {
+        method: "DELETE",
+      });
+
+      await runCommand(
+        sourcePort.control,
+        "write-state",
+        [
+          "test ! -e /opt/eve/controller",
+          "if readlink /proc/1/exe | grep -q python; then echo controller-visible >&2; exit 1; fi",
+          "if find /dev -type b -print -quit | grep -q .; then echo block-device-visible >&2; exit 1; fi",
+          "if unshare --mount /bin/true 2>/dev/null; then echo unexpected-unshare >&2; exit 1; fi",
+          "if mknod /tmp/eve-block b 7 0 2>/dev/null; then echo unexpected-mknod >&2; exit 1; fi",
+          "test -e /etc/GREP_COLORS",
+          "rm /etc/GREP_COLORS",
+          "printf '#!/bin/bash\\necho hello-from-eve\\n' > /usr/local/bin/eve-greet",
+          "chmod 0755 /usr/local/bin/eve-greet",
+          "printf system > /etc/eve.conf",
+          "mkdir -p /root/eve /var/lib/eve /workspace",
+          "printf root > /root/eve/state",
+          "printf var > /var/lib/eve/state",
+          "printf tmp > /tmp/eve-state",
+          "printf workspace > /workspace/state.txt",
+          "setfattr -n user.eve -v xattr /workspace/state.txt",
+          "setfacl -m u:1234:r /workspace/state.txt",
+          "ln /workspace/state.txt /workspace/state.hardlink",
+          "ln -s state.txt /workspace/state.symlink",
+        ].join(" && "),
+      );
+      const checkpoint = await postJson<{
+        checkpointId: string;
+        sha256: string;
+        size: number;
+      }>(`http://127.0.0.1:${sourcePort.control}/v1/checkpoints/prepare`, {});
+      const scratch = await createScratchDirectory("eve-aws-controller-");
+      const archive = `${scratch}/checkpoint.tar.zst`;
+      await docker([
+        "cp",
+        `${containers[0]}:/opt/eve/state/archives/${checkpoint.checkpointId}.tar.zst`,
+        archive,
+      ]);
+      await docker(["rm", "-f", containers[0]]);
+
+      const restorePort = await startContainer(containers[1]);
+      await waitForHealth(restorePort);
+      await docker(["cp", archive, `${containers[1]}:/tmp/checkpoint.tar.zst`]);
+      await docker([
+        "exec",
+        "-d",
+        containers[1],
+        "python3",
+        "-m",
+        "http.server",
+        "18081",
+        "--bind",
+        "127.0.0.1",
+        "--directory",
+        "/tmp",
+      ]);
+      await waitForArchiveServer(containers[1]);
+      await postJson(`http://127.0.0.1:${restorePort.control}/v1/checkpoints/restore`, {
+        sha256: checkpoint.sha256,
+        size: checkpoint.size,
+        url: "http://127.0.0.1:18081/checkpoint.tar.zst",
+      });
+
+      const output = await runCommand(
+        restorePort.control,
+        "verify-state",
+        [
+          "test ! -e /etc/GREP_COLORS",
+          'test "$(cat /etc/eve.conf)" = system',
+          'test "$(cat /root/eve/state)" = root',
+          'test "$(cat /var/lib/eve/state)" = var',
+          'test "$(cat /tmp/eve-state)" = tmp',
+          'test "$(cat /workspace/state.txt)" = workspace',
+          'test "$(/usr/local/bin/eve-greet)" = hello-from-eve',
+          'test "$(getfattr --only-values -n user.eve /workspace/state.txt)" = xattr',
+          "getfacl -cp /workspace/state.txt | grep -q 'user:1234:r--'",
+          'test "$(stat -c %i /workspace/state.txt)" = "$(stat -c %i /workspace/state.hardlink)"',
+          'test "$(readlink /workspace/state.symlink)" = state.txt',
+          "printf verified",
+        ].join(" && "),
+      );
+      expect(output).toBe("verified");
+    },
+    5 * 60_000,
+  );
+});
+
+async function startContainer(
+  name: string,
+): Promise<{ readonly control: number; readonly hooks: number }> {
+  await docker([
+    "run",
+    "--privileged",
+    "--platform",
+    "linux/arm64",
+    "--name",
+    name,
+    "-P",
+    "-d",
+    image,
+  ]);
+  return {
+    control: await mappedPort(name, 8080),
+    hooks: await mappedPort(name, 9000),
+  };
+}
+
+async function mappedPort(container: string, port: number): Promise<number> {
+  const { stdout } = await docker(["port", container, `${port}/tcp`]);
+  const value = Number(stdout.trim().split(":").at(-1));
+  if (!Number.isInteger(value)) throw new Error(`Docker returned an invalid port: ${stdout}`);
+  return value;
+}
+
+async function waitForHealth(ports: { readonly control: number }): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      await fetchOk(`http://127.0.0.1:${ports.control}/v1/health`);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  throw new Error("Controller did not become healthy.", { cause: lastError });
+}
+
+async function waitForArchiveServer(container: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 30; attempt++) {
+    try {
+      await docker([
+        "exec",
+        container,
+        "python3",
+        "-c",
+        "import urllib.request; urllib.request.urlopen('http://127.0.0.1:18081/checkpoint.tar.zst').read(1)",
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw new Error("Checkpoint server did not become healthy.", { cause: lastError });
+}
+
+async function runCommand(
+  port: number,
+  requestId: string,
+  command: string,
+  wait = true,
+): Promise<string> {
+  await postJson(`http://127.0.0.1:${port}/v1/processes`, { command, requestId });
+  if (!wait) return "";
+  for (;;) {
+    const status = await processStatus(port, requestId);
+    if (status.state === "exited") {
+      const [stdout, stderr] = await Promise.all([
+        readProcessLog(port, requestId, "stdout"),
+        readProcessLog(port, requestId, "stderr"),
+      ]);
+      expect(status.exitCode, `stdout:\n${stdout}\nstderr:\n${stderr}`).toBe(0);
+      return stdout;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function readProcessLog(
+  port: number,
+  processId: string,
+  stream: "stderr" | "stdout",
+): Promise<string> {
+  return await (
+    await fetchOk(`http://127.0.0.1:${port}/v1/processes/${processId}/logs/${stream}?offset=0`)
+  ).text();
+}
+
+async function processStatus(
+  port: number,
+  processId: string,
+): Promise<{ readonly exitCode: number | null; readonly state: string }> {
+  const response = await fetchOk(`http://127.0.0.1:${port}/v1/processes/${processId}`);
+  return (await response.json()) as { exitCode: number | null; state: string };
+}
+
+async function postJson<T = Record<string, unknown>>(url: string, value: unknown): Promise<T> {
+  const response = await fetchOk(url, {
+    body: JSON.stringify(value),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  return (await response.json()) as T;
+}
+
+async function fetchOk(url: string, init?: RequestInit): Promise<Response> {
+  const response = await fetch(url, init);
+  if (!response.ok) throw new Error(`${response.status} ${await response.text()}`);
+  return response;
+}
+
+async function docker(args: readonly string[]): Promise<{ stdout: string; stderr: string }> {
+  return await runFile(process.env.EVE_DOCKER_PATH ?? "docker", [...args], {
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/Dockerfile
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/lambda/microvms:al2023-minimal@sha256:1cc40991f5cab3fc8d2dd16350354d5780ea9e878fcf9f46904dddd63a7b983b
+
+RUN dnf install -y acl attr e2fsprogs findutils gzip iproute procps-ng python3 shadow-utils tar \
+      util-linux which zstd && \
+    dnf clean all && \
+    mkdir -p /opt/eve/lower /opt/eve/state /opt/eve/controller && \
+    tar --acls --xattrs --xattrs-include='*' --numeric-owner --one-file-system \
+      --exclude=./opt/eve --exclude=./proc --exclude=./sys --exclude=./dev --exclude=./run \
+      -C / -cf - . | tar --acls --xattrs --xattrs-include='*' --numeric-owner -C /opt/eve/lower -xf - && \
+    mkdir -p /opt/eve/lower/dev /opt/eve/lower/proc /opt/eve/lower/run \
+      /opt/eve/lower/sys /opt/eve/lower/tmp /opt/eve/lower/workspace && \
+    chmod 1777 /opt/eve/lower/tmp
+
+COPY controller.py /opt/eve/controller/controller.py
+COPY launcher.py /opt/eve/controller/launcher.py
+COPY start.sh /opt/eve/controller/start.sh
+RUN chmod 0755 /opt/eve/controller/start.sh /opt/eve/controller/controller.py \
+      /opt/eve/controller/launcher.py
+
+EXPOSE 8080 9000
+ENTRYPOINT ["/opt/eve/controller/start.sh"]

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/controller.py
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/controller.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import posixpath
+import shutil
+import signal
+import stat
+import subprocess
+import threading
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PROTOCOL_VERSION = 1
+LOWER_SOURCE = "/opt/eve/lower"
+STATE = "/opt/eve/state"
+BACKING_IMAGE = f"{STATE}/controlled-root.ext4"
+BACKING = f"{STATE}/controlled-root"
+LOWER = f"{BACKING}/lower"
+UPPER = f"{BACKING}/upper"
+WORK = f"{BACKING}/work"
+ROOT = f"{BACKING}/root"
+LOGS = f"{STATE}/logs"
+ARCHIVES = f"{STATE}/archives"
+PART_SIZE = 64 * 1024 * 1024
+FILE_CHUNK_SIZE = 4 * 1024 * 1024
+
+state_lock = threading.RLock()
+processes = {}
+writes = {}
+dirty = False
+frozen = False
+microvm_id = None
+
+
+def run_checked(args, **kwargs):
+    return subprocess.run(args, check=True, **kwargs)
+
+
+def is_mounted(path):
+    return subprocess.run(
+        ["mountpoint", "-q", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    ).returncode == 0
+
+
+def ensure_directories():
+    for path in (STATE, BACKING, LOGS, ARCHIVES):
+        os.makedirs(path, exist_ok=True)
+
+
+def ensure_backing_filesystem():
+    ensure_directories()
+    if not os.path.exists(BACKING_IMAGE):
+        run_checked(["truncate", "-s", "30G", BACKING_IMAGE])
+        run_checked(["mkfs.ext4", "-q", "-m", "0", BACKING_IMAGE])
+    mount_if_needed(["mount", "-o", "loop", BACKING_IMAGE, BACKING], BACKING)
+    initialized = f"{BACKING}/.initialized"
+    if not os.path.exists(initialized):
+        for path in (LOWER, UPPER, WORK, ROOT):
+            os.makedirs(path, exist_ok=True)
+        source = subprocess.Popen(
+            [
+                "tar", "--acls", "--xattrs", "--xattrs-include=*", "--numeric-owner",
+                "--one-file-system", "-C", LOWER_SOURCE, "-cf", "-", ".",
+            ],
+            stdout=subprocess.PIPE,
+        )
+        try:
+            run_checked(
+                [
+                    "tar", "--acls", "--xattrs", "--xattrs-include=*", "--numeric-owner",
+                    "-C", LOWER, "-xf", "-",
+                ],
+                stdin=source.stdout,
+            )
+        finally:
+            if source.stdout is not None:
+                source.stdout.close()
+        if source.wait() != 0:
+            raise RuntimeError("failed to initialize the controlled root filesystem")
+        open(initialized, "wb").close()
+
+
+def mount_if_needed(args, target):
+    if not is_mounted(target):
+        run_checked(args)
+
+
+def ensure_mounted():
+    ensure_backing_filesystem()
+    for path in (LOWER, UPPER, WORK, ROOT):
+        os.makedirs(path, exist_ok=True)
+    mount_if_needed(
+        ["mount", "-t", "overlay", "overlay", "-o", f"lowerdir={LOWER},upperdir={UPPER},workdir={WORK}", ROOT],
+        ROOT,
+    )
+    run_checked(["mount", "--make-rprivate", ROOT])
+    for name in ("proc", "dev", "sys", "run"):
+        os.makedirs(f"{ROOT}/{name}", exist_ok=True)
+    mount_if_needed(["mount", "-t", "proc", "proc", f"{ROOT}/proc"], f"{ROOT}/proc")
+    ensure_device_mounts()
+    mount_if_needed(["mount", "--rbind", "/sys", f"{ROOT}/sys"], f"{ROOT}/sys")
+    run_checked(["mount", "--make-rslave", f"{ROOT}/sys"])
+    mount_if_needed(["mount", "-t", "tmpfs", "tmpfs", f"{ROOT}/run"], f"{ROOT}/run")
+
+
+def ensure_device_mounts():
+    device_root = f"{ROOT}/dev"
+    mount_if_needed(
+        ["mount", "-t", "tmpfs", "-o", "mode=755,nosuid", "tmpfs", device_root],
+        device_root,
+    )
+    for name in ("full", "null", "random", "tty", "urandom", "zero"):
+        target = f"{device_root}/{name}"
+        if not os.path.exists(target):
+            open(target, "wb").close()
+        mount_if_needed(["mount", "--bind", f"/dev/{name}", target], target)
+    shared_memory = f"{device_root}/shm"
+    os.makedirs(shared_memory, exist_ok=True)
+    mount_if_needed(
+        ["mount", "-t", "tmpfs", "-o", "mode=1777,nosuid,nodev", "tmpfs", shared_memory],
+        shared_memory,
+    )
+    for name, target in (
+        ("fd", "/proc/self/fd"),
+        ("stdin", "/proc/self/fd/0"),
+        ("stdout", "/proc/self/fd/1"),
+        ("stderr", "/proc/self/fd/2"),
+    ):
+        path = f"{device_root}/{name}"
+        if not os.path.lexists(path):
+            os.symlink(target, path)
+
+
+def unmount_root():
+    if is_mounted(ROOT):
+        subprocess.run(["umount", "-R", ROOT], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def sandbox_path(value):
+    if not isinstance(value, str) or not value.startswith("/"):
+        raise ValueError("Sandbox paths must be absolute.")
+    normalized = posixpath.normpath(value)
+    if normalized in ("/proc", "/sys", "/dev", "/run") or normalized.startswith(("/proc/", "/sys/", "/dev/", "/run/")):
+        raise ValueError("Pseudo-filesystem paths are not available through file APIs.")
+    return normalized
+
+
+def chroot_command(command, cwd="/workspace", env=None):
+    cwd = sandbox_path(cwd)
+    process_env = {"HOME": "/root", "LANG": "C.UTF-8", "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+    workload_environment = dict(process_env)
+    if env:
+        workload_environment.update({str(key): str(value) for key, value in env.items()})
+    launcher_payload = json.dumps(
+        {"command": command, "cwd": cwd, "environment": workload_environment},
+        separators=(",", ":"),
+    )
+    return [
+        "unshare", "--mount", "--pid", "--fork", "--kill-child", f"--mount-proc={ROOT}/proc",
+        "/usr/bin/python3", "/opt/eve/controller/launcher.py", ROOT, launcher_payload,
+    ], process_env
+
+
+def shell_quote(value):
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def start_process(payload):
+    global dirty
+    command = payload.get("command")
+    if not isinstance(command, str) or not command:
+        raise ValueError("command must be a non-empty string")
+    ensure_mounted()
+    process_id = payload.get("requestId") or str(uuid.uuid4())
+    with state_lock:
+        if process_id in processes:
+            return process_id
+        stdout_path = f"{LOGS}/{process_id}.stdout"
+        stderr_path = f"{LOGS}/{process_id}.stderr"
+        stdout_file = open(stdout_path, "ab", buffering=0)
+        stderr_file = open(stderr_path, "ab", buffering=0)
+        args, env = chroot_command(command, payload.get("workingDirectory") or "/workspace", payload.get("env"))
+        process = subprocess.Popen(
+            args,
+            env=env,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
+        processes[process_id] = {
+            "process": process,
+            "stdout": stdout_path,
+            "stderr": stderr_path,
+            "stdoutFile": stdout_file,
+            "stderrFile": stderr_file,
+        }
+        dirty = True
+    return process_id
+
+
+def process_status(process_id):
+    entry = processes.get(process_id)
+    if entry is None:
+        raise KeyError(process_id)
+    exit_code = entry["process"].poll()
+    running = process_group_running(entry)
+    if not running and not entry["stdoutFile"].closed:
+        entry["stdoutFile"].close()
+        entry["stderrFile"].close()
+    return {"state": "running" if running else "exited", "exitCode": None if running else exit_code}
+
+
+def process_group_running(entry):
+    if entry["process"].poll() is None:
+        return True
+    try:
+        os.killpg(entry["process"].pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def process_log(process_id, stream, offset):
+    if stream not in ("stdout", "stderr"):
+        raise ValueError("stream must be stdout or stderr")
+    entry = processes.get(process_id)
+    if entry is None:
+        raise KeyError(process_id)
+    path = entry[stream]
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(offset)
+            data = handle.read(1024 * 1024)
+            next_offset = handle.tell()
+    except FileNotFoundError:
+        data = b""
+        next_offset = offset
+    complete = not process_group_running(entry) and next_offset >= os.path.getsize(path)
+    return data, next_offset, complete
+
+
+def kill_process(process_id):
+    entry = processes.get(process_id)
+    if entry is None:
+        return
+    if process_group_running(entry):
+        try:
+            os.killpg(entry["process"].pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def freeze_workload():
+    global frozen
+    with state_lock:
+        if frozen:
+            return
+        for entry in processes.values():
+            if process_group_running(entry):
+                try:
+                    os.killpg(entry["process"].pid, signal.SIGSTOP)
+                except ProcessLookupError:
+                    pass
+        run_checked(["sync"])
+        frozen = True
+
+
+def release_workload():
+    global frozen
+    with state_lock:
+        if not frozen:
+            return
+        for entry in processes.values():
+            if process_group_running(entry):
+                try:
+                    os.killpg(entry["process"].pid, signal.SIGCONT)
+                except ProcessLookupError:
+                    pass
+        frozen = False
+
+
+def prepare_checkpoint():
+    if not dirty:
+        return {"dirty": False}
+    freeze_workload()
+    checkpoint_id = str(uuid.uuid4())
+    archive_path = f"{ARCHIVES}/{checkpoint_id}.tar.zst"
+    run_checked([
+        "tar", "--xattrs", "--xattrs-include=*", "--acls", "--numeric-owner", "--sparse", "--one-file-system",
+        "--zstd", "-cf", archive_path, "-C", UPPER, "."
+    ])
+    size = os.path.getsize(archive_path)
+    digest = file_sha256(archive_path)
+    return {
+        "dirty": True,
+        "checkpointId": checkpoint_id,
+        "size": size,
+        "sha256": digest,
+        "partSize": PART_SIZE,
+        "partCount": max(1, (size + PART_SIZE - 1) // PART_SIZE),
+    }
+
+
+def upload_checkpoint(payload):
+    checkpoint_id = payload.get("checkpointId")
+    urls = payload.get("urls")
+    if not isinstance(checkpoint_id, str) or not isinstance(urls, list):
+        raise ValueError("checkpointId and urls are required")
+    archive_path = f"{ARCHIVES}/{checkpoint_id}.tar.zst"
+    parts = []
+    with open(archive_path, "rb") as handle:
+        for index, url in enumerate(urls, start=1):
+            data = handle.read(PART_SIZE)
+            request = urllib.request.Request(url, data=data, method="PUT")
+            with urllib.request.urlopen(request, timeout=300) as response:
+                etag = response.headers.get("ETag")
+            if not etag:
+                raise RuntimeError(f"S3 upload part {index} returned no ETag")
+            parts.append({"partNumber": index, "etag": etag})
+    return {"parts": parts}
+
+
+def commit_checkpoint(payload):
+    global dirty
+    checkpoint_id = payload.get("checkpointId")
+    if isinstance(checkpoint_id, str):
+        try:
+            os.remove(f"{ARCHIVES}/{checkpoint_id}.tar.zst")
+        except FileNotFoundError:
+            pass
+    dirty = False
+
+
+def restore_checkpoint(payload):
+    global dirty
+    url = payload.get("url")
+    expected = payload.get("sha256")
+    expected_size = payload.get("size")
+    if not isinstance(url, str) or not isinstance(expected, str) or not isinstance(expected_size, int):
+        raise ValueError("url, sha256, and size are required")
+    archive_path = f"{ARCHIVES}/restore-{uuid.uuid4()}.tar.zst"
+    with urllib.request.urlopen(url, timeout=300) as response, open(archive_path, "wb") as output:
+        shutil.copyfileobj(response, output)
+    if os.path.getsize(archive_path) != expected_size or file_sha256(archive_path) != expected:
+        os.remove(archive_path)
+        raise ValueError("Checkpoint checksum did not match its manifest.")
+    with state_lock:
+        if any(process_group_running(entry) for entry in processes.values()):
+            raise RuntimeError("Cannot restore while workload processes are running.")
+        unmount_root()
+        shutil.rmtree(UPPER, ignore_errors=True)
+        shutil.rmtree(WORK, ignore_errors=True)
+        os.makedirs(UPPER, exist_ok=True)
+        os.makedirs(WORK, exist_ok=True)
+        run_checked(["tar", "--xattrs", "--xattrs-include=*", "--acls", "--numeric-owner", "--same-owner", "--zstd", "-xf", archive_path, "-C", UPPER])
+        os.remove(archive_path)
+        ensure_mounted()
+        dirty = False
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_file(path, offset, limit):
+    path = sandbox_path(path)
+    script = (
+        "import os,sys; p=sys.argv[1]; "
+        "\nif not os.path.exists(p): sys.exit(44)"
+        "\nwith open(p, 'rb', buffering=0) as f: f.seek(int(sys.argv[2])); sys.stdout.buffer.write(f.read(int(sys.argv[3])))"
+    )
+    result = subprocess.run(
+        ["chroot", ROOT, "/usr/bin/python3", "-c", script, path, str(offset), str(limit)],
+        capture_output=True,
+    )
+    if result.returncode == 44:
+        return None
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.decode("utf-8", "replace"))
+    return result.stdout, len(result.stdout) < limit
+
+
+def begin_write(path):
+    path = sandbox_path(path)
+    write_id = str(uuid.uuid4())
+    os.makedirs(f"{STATE}/writes", exist_ok=True)
+    temporary_path = f"{STATE}/writes/{write_id}"
+    open(temporary_path, "wb").close()
+    writes[write_id] = {"path": path, "temporaryPath": temporary_path, "offset": 0}
+    return write_id
+
+
+def write_chunk(write_id, offset, content):
+    entry = writes.get(write_id)
+    if entry is None:
+        raise KeyError(write_id)
+    if offset != entry["offset"]:
+        raise ValueError(f"write chunk offset {offset} did not match expected offset {entry['offset']}")
+    with open(entry["temporaryPath"], "ab", buffering=0) as output:
+        output.write(content)
+    entry["offset"] += len(content)
+
+
+def commit_write(write_id):
+    global dirty
+    entry = writes.pop(write_id, None)
+    if entry is None:
+        raise KeyError(write_id)
+    path = entry["path"]
+    parent = posixpath.dirname(path)
+    script = (
+        f"mkdir -p -- {shell_quote(parent)} && "
+        f"temporary=$(mktemp {shell_quote(parent + '/.eve-write.XXXXXX')}) && "
+        f"cat > \"$temporary\" && mv -f -- \"$temporary\" {shell_quote(path)}"
+    )
+    try:
+        with open(entry["temporaryPath"], "rb") as content:
+            run_checked(["chroot", ROOT, "/bin/bash", "-lc", script], stdin=content)
+        dirty = True
+    finally:
+        try:
+            os.remove(entry["temporaryPath"])
+        except FileNotFoundError:
+            pass
+
+
+def abort_write(write_id):
+    entry = writes.pop(write_id, None)
+    if entry is None:
+        return
+    try:
+        os.remove(entry["temporaryPath"])
+    except FileNotFoundError:
+        pass
+
+
+def reset_for_run(payload):
+    global dirty, frozen, microvm_id
+    microvm_id = payload.get("microvmId")
+    if not isinstance(microvm_id, str) or not microvm_id:
+        raise ValueError("run hook payload omitted microvmId")
+    run_hook_payload = payload.get("runHookPayload")
+    if isinstance(run_hook_payload, str) and run_hook_payload:
+        decoded = json.loads(run_hook_payload)
+        if decoded.get("controllerProtocolVersion") != PROTOCOL_VERSION:
+            raise ValueError("run hook requested an incompatible controller protocol")
+    for write_id in list(writes):
+        abort_write(write_id)
+    shutil.rmtree(LOGS, ignore_errors=True)
+    shutil.rmtree(ARCHIVES, ignore_errors=True)
+    os.makedirs(LOGS, exist_ok=True)
+    os.makedirs(ARCHIVES, exist_ok=True)
+    processes.clear()
+    dirty = False
+    frozen = False
+
+
+def validate_controller():
+    ensure_mounted()
+    run_checked(["unshare", "--mount", "/bin/true"])
+    run_checked(["chroot", ROOT, "/bin/true"])
+    validation_directory = f"{UPPER}/.eve-capability-validation"
+    shutil.rmtree(validation_directory, ignore_errors=True)
+    os.makedirs(validation_directory)
+    probe = f"{validation_directory}/probe"
+    whiteout = f"{validation_directory}/whiteout"
+    try:
+        with open(probe, "wb") as output:
+            output.write(b"eve")
+        os.setxattr(probe, b"user.eve", b"validation")
+        run_checked(["setfacl", "-m", "u:1234:r", probe])
+        os.mknod(whiteout, stat.S_IFCHR | 0o600, os.makedev(0, 0))
+        if not stat.S_ISCHR(os.lstat(whiteout).st_mode):
+            raise RuntimeError("overlay whiteout capability validation failed")
+    finally:
+        shutil.rmtree(validation_directory, ignore_errors=True)
+
+
+def remove_path(path, recursive, force):
+    global dirty
+    path = sandbox_path(path)
+    flags = ("r" if recursive else "") + ("f" if force else "")
+    args = ["chroot", ROOT, "rm"] + ([f"-{flags}"] if flags else []) + ["--", path]
+    run_checked(args)
+    dirty = True
+
+
+class JsonHandler(BaseHTTPRequestHandler):
+    server_version = "eve-lambda-microvm/1"
+
+    def log_message(self, format_string, *args):
+        print(json.dumps({"component": "controller", "message": format_string % args}), flush=True)
+
+    def read_body(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        return self.rfile.read(length) if length else b""
+
+    def read_json(self):
+        body = self.read_body()
+        return json.loads(body) if body else {}
+
+    def send_json(self, status, value):
+        body = json.dumps(value, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def send_bytes(self, status, value, headers=None):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(value)))
+        for key, item in (headers or {}).items():
+            self.send_header(key, str(item))
+        self.end_headers()
+        self.wfile.write(value)
+
+    def handle_error(self, error):
+        status = 404 if isinstance(error, KeyError) else 400 if isinstance(error, ValueError) else 500
+        self.send_json(status, {"error": type(error).__name__, "message": str(error)})
+
+
+class ControlHandler(JsonHandler):
+    def do_GET(self):
+        try:
+            parsed = urlparse(self.path)
+            if parsed.path in ("/", "/v1/health", "/v1/heartbeat"):
+                ensure_mounted()
+                self.send_json(200, {"protocolVersion": PROTOCOL_VERSION, "status": "ready", "microvmId": microvm_id})
+                return
+            if parsed.path == "/v1/files":
+                query = parse_qs(parsed.query)
+                offset = int(query.get("offset", ["0"])[0])
+                limit = int(query.get("limit", [str(FILE_CHUNK_SIZE)])[0])
+                if offset < 0 or limit < 1 or limit > FILE_CHUNK_SIZE:
+                    raise ValueError("file offset or limit is invalid")
+                result = read_file(query.get("path", [""])[0], offset, limit)
+                if result is None:
+                    self.send_json(404, {"error": "NotFound"})
+                else:
+                    content, complete = result
+                    self.send_bytes(200, content, {
+                        "X-Eve-Next-Offset": offset + len(content),
+                        "X-Eve-Complete": str(complete).lower(),
+                    })
+                return
+            segments = parsed.path.strip("/").split("/")
+            if len(segments) == 3 and segments[:2] == ["v1", "processes"]:
+                self.send_json(200, process_status(segments[2]))
+                return
+            if len(segments) == 5 and segments[:2] == ["v1", "processes"] and segments[3] == "logs":
+                offset = int(parse_qs(parsed.query).get("offset", ["0"])[0])
+                data, next_offset, complete = process_log(segments[2], segments[4], offset)
+                self.send_bytes(200, data, {"X-Eve-Next-Offset": next_offset, "X-Eve-Complete": str(complete).lower()})
+                return
+            self.send_json(404, {"error": "NotFound"})
+        except Exception as error:
+            self.handle_error(error)
+
+    def do_POST(self):
+        try:
+            if self.path == "/v1/processes":
+                self.send_json(201, {"processId": start_process(self.read_json())})
+            elif self.path == "/v1/files/writes":
+                self.send_json(201, {"writeId": begin_write(self.read_json().get("path"))})
+            elif self.path.startswith("/v1/files/writes/") and self.path.endswith("/commit"):
+                write_id = self.path.split("/")[4]
+                commit_write(write_id)
+                self.send_json(200, {"status": "written"})
+            elif self.path == "/v1/checkpoints/prepare":
+                self.send_json(200, prepare_checkpoint())
+            elif self.path == "/v1/checkpoints/upload":
+                self.send_json(200, upload_checkpoint(self.read_json()))
+            elif self.path == "/v1/checkpoints/commit":
+                commit_checkpoint(self.read_json())
+                self.send_json(200, {"status": "committed"})
+            elif self.path == "/v1/checkpoints/release":
+                release_workload()
+                self.send_json(200, {"status": "released"})
+            elif self.path == "/v1/checkpoints/restore":
+                restore_checkpoint(self.read_json())
+                self.send_json(200, {"status": "restored"})
+            else:
+                self.send_json(404, {"error": "NotFound"})
+        except Exception as error:
+            self.handle_error(error)
+
+    def do_PUT(self):
+        try:
+            parsed = urlparse(self.path)
+            segments = parsed.path.strip("/").split("/")
+            if len(segments) != 4 or segments[:3] != ["v1", "files", "writes"]:
+                self.send_json(404, {"error": "NotFound"})
+                return
+            offset = int(parse_qs(parsed.query).get("offset", ["-1"])[0])
+            write_chunk(segments[3], offset, self.read_body())
+            self.send_json(200, {"status": "accepted"})
+        except Exception as error:
+            self.handle_error(error)
+
+    def do_DELETE(self):
+        try:
+            parsed = urlparse(self.path)
+            if parsed.path == "/v1/files":
+                query = parse_qs(parsed.query)
+                remove_path(query.get("path", [""])[0], query.get("recursive", ["false"])[0] == "true", query.get("force", ["false"])[0] == "true")
+                self.send_json(200, {"status": "removed"})
+                return
+            segments = parsed.path.strip("/").split("/")
+            if len(segments) == 4 and segments[:3] == ["v1", "files", "writes"]:
+                abort_write(segments[3])
+                self.send_json(200, {"status": "aborted"})
+                return
+            if len(segments) == 3 and segments[:2] == ["v1", "processes"]:
+                kill_process(segments[2])
+                self.send_json(200, {"status": "killed"})
+                return
+            self.send_json(404, {"error": "NotFound"})
+        except Exception as error:
+            self.handle_error(error)
+
+
+class HookHandler(JsonHandler):
+    def do_POST(self):
+        global microvm_id
+        try:
+            payload = self.read_json()
+            if self.path.endswith(("/ready", "/validate")):
+                validate_controller()
+            elif self.path.endswith("/run"):
+                ensure_mounted()
+                reset_for_run(payload)
+            elif self.path.endswith("/suspend"):
+                run_checked(["sync"])
+            elif self.path.endswith("/resume"):
+                ensure_mounted()
+                release_workload()
+            elif not self.path.endswith("/terminate"):
+                self.send_json(404, {"error": "NotFound"})
+                return
+            self.send_json(200, {"status": "ok"})
+        except Exception as error:
+            self.handle_error(error)
+
+
+def serve(server):
+    server.serve_forever()
+
+
+def main():
+    ensure_mounted()
+    control = ThreadingHTTPServer(("0.0.0.0", 8080), ControlHandler)
+    hooks = ThreadingHTTPServer(("0.0.0.0", 9000), HookHandler)
+    threading.Thread(target=serve, args=(hooks,), daemon=True).start()
+    control.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/launcher.py
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/launcher.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import ctypes
+import errno
+import json
+import os
+import sys
+
+PR_CAPBSET_DROP = 24
+PR_SET_NO_NEW_PRIVS = 38
+PR_CAP_AMBIENT = 47
+PR_CAP_AMBIENT_CLEAR_ALL = 4
+
+DANGEROUS_CAPABILITIES = (
+    12,  # CAP_NET_ADMIN
+    13,  # CAP_NET_RAW
+    16,  # CAP_SYS_MODULE
+    17,  # CAP_SYS_RAWIO
+    18,  # CAP_SYS_CHROOT
+    19,  # CAP_SYS_PTRACE
+    20,  # CAP_SYS_PACCT
+    21,  # CAP_SYS_ADMIN
+    22,  # CAP_SYS_BOOT
+    25,  # CAP_SYS_TIME
+    26,  # CAP_SYS_TTY_CONFIG
+    27,  # CAP_MKNOD
+    30,  # CAP_AUDIT_CONTROL
+    31,  # CAP_SETFCAP
+    32,  # CAP_MAC_OVERRIDE
+    33,  # CAP_MAC_ADMIN
+    34,  # CAP_SYSLOG
+    35,  # CAP_WAKE_ALARM
+    36,  # CAP_BLOCK_SUSPEND
+    37,  # CAP_AUDIT_READ
+    38,  # CAP_PERFMON
+    39,  # CAP_BPF
+    40,  # CAP_CHECKPOINT_RESTORE
+)
+
+
+def prctl(option, argument):
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(option, argument, 0, 0, 0) == 0:
+        return
+    error = ctypes.get_errno()
+    if error != errno.EINVAL:
+        raise OSError(error, os.strerror(error))
+
+
+def parse_payload(value):
+    payload = json.loads(value)
+    if not isinstance(payload, dict):
+        raise ValueError("launcher payload must be an object")
+    command = payload.get("command")
+    cwd = payload.get("cwd")
+    environment = payload.get("environment")
+    if not isinstance(command, str) or not command:
+        raise ValueError("launcher command is invalid")
+    if not isinstance(cwd, str) or not cwd.startswith("/"):
+        raise ValueError("launcher working directory is invalid")
+    if not isinstance(environment, dict):
+        raise ValueError("launcher environment is invalid")
+    normalized_environment = {}
+    for key, entry in environment.items():
+        if not isinstance(key, str) or not key or "=" in key or "\0" in key:
+            raise ValueError("launcher environment key is invalid")
+        if not isinstance(entry, str) or "\0" in entry:
+            raise ValueError("launcher environment value is invalid")
+        normalized_environment[key] = entry
+    return command, cwd, normalized_environment
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise ValueError("launcher requires a sandbox root and payload")
+    command, cwd, environment = parse_payload(sys.argv[2])
+    os.chroot(sys.argv[1])
+    os.chdir(cwd)
+    for capability in DANGEROUS_CAPABILITIES:
+        prctl(PR_CAPBSET_DROP, capability)
+    prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL)
+    prctl(PR_SET_NO_NEW_PRIVS, 1)
+    workload = f"{command}\nstatus=$?\nwait\nexit $status"
+    os.execve("/bin/bash", ["/bin/bash", "-lc", workload], environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/start.sh
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/controller/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec python3 /opt/eve/controller/controller.py

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/deterministic-zip.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/deterministic-zip.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { createDeterministicZip } from "./deterministic-zip.js";
+
+describe("createDeterministicZip", () => {
+  it("is stable regardless of input ordering", () => {
+    const first = createDeterministicZip([
+      { content: Buffer.from("two"), path: "b.txt" },
+      { content: Buffer.from("one"), path: "a.txt" },
+    ]);
+    const second = createDeterministicZip([
+      { content: Buffer.from("one"), path: "a.txt" },
+      { content: Buffer.from("two"), path: "b.txt" },
+    ]);
+
+    expect(first).toEqual(second);
+    expect(first.readUInt32LE(0)).toBe(0x04034b50);
+    expect(first.readUInt32LE(first.byteLength - 22)).toBe(0x06054b50);
+  });
+
+  it("rejects traversal paths", () => {
+    expect(() => createDeterministicZip([{ content: Buffer.alloc(0), path: "../secret" }])).toThrow(
+      /Invalid ZIP entry path/,
+    );
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/deterministic-zip.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/deterministic-zip.ts
@@ -1,0 +1,93 @@
+interface ZipFile {
+  readonly content: Uint8Array;
+  readonly mode?: number;
+  readonly path: string;
+}
+
+const UTF8_FLAG = 0x0800;
+const VERSION_NEEDED = 20;
+const UNIX_VERSION_MADE_BY = 0x031e;
+
+/** Creates a byte-for-byte stable, uncompressed ZIP archive. */
+export function createDeterministicZip(files: readonly ZipFile[]): Buffer {
+  const sorted = [...files].sort((left, right) => left.path.localeCompare(right.path));
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const file of sorted) {
+    const path = normalizeZipPath(file.path);
+    const name = Buffer.from(path, "utf8");
+    const content = Buffer.from(file.content);
+    const crc = crc32(content);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(VERSION_NEEDED, 4);
+    local.writeUInt16LE(UTF8_FLAG, 6);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(0, 10);
+    local.writeUInt16LE(0x21, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(content.byteLength, 18);
+    local.writeUInt32LE(content.byteLength, 22);
+    local.writeUInt16LE(name.byteLength, 26);
+    local.writeUInt16LE(0, 28);
+    localParts.push(local, name, content);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(UNIX_VERSION_MADE_BY, 4);
+    central.writeUInt16LE(VERSION_NEEDED, 6);
+    central.writeUInt16LE(UTF8_FLAG, 8);
+    central.writeUInt16LE(0, 10);
+    central.writeUInt16LE(0, 12);
+    central.writeUInt16LE(0x21, 14);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(content.byteLength, 20);
+    central.writeUInt32LE(content.byteLength, 24);
+    central.writeUInt16LE(name.byteLength, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt16LE(0, 34);
+    central.writeUInt16LE(0, 36);
+    central.writeUInt32LE((((file.mode ?? 0o100644) & 0xffff) << 16) >>> 0, 38);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+
+    offset += local.byteLength + name.byteLength + content.byteLength;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(sorted.length, 8);
+  end.writeUInt16LE(sorted.length, 10);
+  end.writeUInt32LE(centralDirectory.byteLength, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+function normalizeZipPath(path: string): string {
+  const normalized = path.replaceAll("\\", "/").replace(/^\/+/, "");
+  if (
+    normalized.length === 0 ||
+    normalized.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    throw new Error(`Invalid ZIP entry path "${path}".`);
+  }
+  return normalized;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/image-artifact.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/image-artifact.ts
@@ -1,0 +1,30 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import { createDeterministicZip } from "./deterministic-zip.js";
+
+export const AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION = 1;
+
+/** Builds the deterministic Docker context uploaded for a Lambda MicroVM image. */
+export async function buildAwsLambdaMicrovmImageArtifact(): Promise<{
+  readonly bytes: Buffer;
+  readonly sha256: string;
+}> {
+  const [dockerfile, controller, launcher, start] = await Promise.all([
+    readControllerAsset("Dockerfile"),
+    readControllerAsset("controller.py"),
+    readControllerAsset("launcher.py"),
+    readControllerAsset("start.sh"),
+  ]);
+  const bytes = createDeterministicZip([
+    { content: controller, mode: 0o100755, path: "controller.py" },
+    { content: dockerfile, path: "Dockerfile" },
+    { content: launcher, mode: 0o100755, path: "launcher.py" },
+    { content: start, mode: 0o100755, path: "start.sh" },
+  ]);
+  return { bytes, sha256: createHash("sha256").update(bytes).digest("hex") };
+}
+
+async function readControllerAsset(name: string): Promise<Buffer> {
+  return await readFile(new URL(`./controller/${name}`, import.meta.url));
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/lease.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/lease.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { acquireAwsLambdaMicrovmLease } from "./lease.js";
+import type { AwsLambdaMicrovmStorage, StoredJson } from "./storage.js";
+
+describe("AWS Lambda MicroVM S3 leases", () => {
+  it("serializes holders with conditional writes and deletes", async () => {
+    const storage = new MemoryStorage();
+    const first = await acquireAwsLambdaMicrovmLease({ key: "lease", storage, waitMs: 0 });
+
+    await expect(
+      acquireAwsLambdaMicrovmLease({ key: "lease", storage, waitMs: 0 }),
+    ).rejects.toThrow(/held by another runtime/);
+
+    await first.release();
+    const second = await acquireAwsLambdaMicrovmLease({ key: "lease", storage, waitMs: 0 });
+    await expect(second.ensureHeld()).resolves.toBeUndefined();
+    await second.release();
+  });
+
+  it("replaces an expired lease using its exact ETag", async () => {
+    const storage = new MemoryStorage();
+    storage.json.set("lease", {
+      etag: '"old"',
+      value: { expiresAt: 0, holder: "stale", version: 1 },
+    });
+
+    const lease = await acquireAwsLambdaMicrovmLease({ key: "lease", storage, waitMs: 0 });
+    await expect(lease.ensureHeld()).resolves.toBeUndefined();
+    await lease.release();
+    expect(storage.json.has("lease")).toBe(false);
+  });
+});
+
+class MemoryStorage implements AwsLambdaMicrovmStorage {
+  readonly json = new Map<string, StoredJson<unknown>>();
+  #etag = 0;
+
+  async abortMultipartUpload(): Promise<void> {}
+  async assertBucketRegion(): Promise<void> {}
+  async completeMultipartUpload(): Promise<{ readonly etag?: string }> {
+    return {};
+  }
+  async createMultipartUpload(): Promise<string> {
+    return "upload";
+  }
+  async deleteObject(key: string, condition: { readonly etag?: string } = {}): Promise<void> {
+    const current = this.json.get(key);
+    if (condition.etag !== undefined && current?.etag !== condition.etag) {
+      throw preconditionError();
+    }
+    this.json.delete(key);
+  }
+  destroy(): void {}
+  async getJson<T>(key: string): Promise<StoredJson<T> | null> {
+    return (this.json.get(key) as StoredJson<T> | undefined) ?? null;
+  }
+  async hasObject(): Promise<boolean> {
+    return false;
+  }
+  async getObjectInfo(): Promise<null> {
+    return null;
+  }
+  async presignGet(): Promise<string> {
+    return "https://example.test/get";
+  }
+  async presignUploadParts(): Promise<readonly string[]> {
+    return [];
+  }
+  async putBytes(): Promise<void> {}
+  async putJson(
+    key: string,
+    value: unknown,
+    condition: { readonly absent?: boolean; readonly etag?: string } = {},
+  ): Promise<{ readonly etag: string }> {
+    const current = this.json.get(key);
+    if (
+      (condition.absent === true && current !== undefined) ||
+      (condition.etag !== undefined && current?.etag !== condition.etag)
+    ) {
+      throw preconditionError();
+    }
+    const etag = `"${++this.#etag}"`;
+    this.json.set(key, { etag, value });
+    return { etag };
+  }
+}
+
+function preconditionError(): Error {
+  return Object.assign(new Error("precondition failed"), {
+    $metadata: { httpStatusCode: 412 },
+    name: "PreconditionFailed",
+  });
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/lease.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/lease.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import type { AwsLambdaMicrovmStorage } from "./storage.js";
+
+const LEASE_VERSION = 1;
+
+interface LeaseDocument {
+  readonly expiresAt: number;
+  readonly holder: string;
+  readonly version: typeof LEASE_VERSION;
+}
+
+export interface AwsLambdaMicrovmLease {
+  ensureHeld(): Promise<void>;
+  release(): Promise<void>;
+}
+
+export async function acquireAwsLambdaMicrovmLease(input: {
+  readonly key: string;
+  readonly storage: AwsLambdaMicrovmStorage;
+  readonly ttlMs?: number;
+  readonly waitMs?: number;
+}): Promise<AwsLambdaMicrovmLease> {
+  const holder = randomUUID();
+  const ttlMs = input.ttlMs ?? 10 * 60 * 1000;
+  const deadline = Date.now() + (input.waitMs ?? 30_000);
+  let etag: string;
+
+  for (;;) {
+    const now = Date.now();
+    const current = await input.storage.getJson<unknown>(input.key);
+    try {
+      if (current === null) {
+        etag = (
+          await input.storage.putJson(input.key, leaseDocument(holder, now + ttlMs), {
+            absent: true,
+          })
+        ).etag;
+        break;
+      }
+      const document = parseLease(current.value);
+      if (document.expiresAt <= now) {
+        etag = (
+          await input.storage.putJson(input.key, leaseDocument(holder, now + ttlMs), {
+            etag: current.etag,
+          })
+        ).etag;
+        break;
+      }
+      if (now >= deadline) {
+        throw new Error(
+          `AWS Lambda MicroVM lease ${input.key} is held by another runtime until ${new Date(document.expiresAt).toISOString()}.`,
+        );
+      }
+    } catch (error) {
+      if (!isPreconditionFailed(error)) throw error;
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out acquiring AWS Lambda MicroVM lease ${input.key}.`, {
+          cause: error,
+        });
+      }
+    }
+    await sleep(250 + Math.floor(Math.random() * 251));
+  }
+
+  let currentEtag = etag;
+  let expiresAt = Date.now() + ttlMs;
+  let released = false;
+  let lost: unknown;
+  let operations = Promise.resolve();
+
+  function enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const pending = operations.then(operation);
+    operations = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
+  }
+
+  async function renew(): Promise<void> {
+    if (released || lost !== undefined) return;
+    const nextExpiresAt = Date.now() + ttlMs;
+    try {
+      currentEtag = (
+        await input.storage.putJson(input.key, leaseDocument(holder, nextExpiresAt), {
+          etag: currentEtag,
+        })
+      ).etag;
+      expiresAt = nextExpiresAt;
+    } catch (error) {
+      lost = error;
+      throw error;
+    }
+  }
+
+  const renewalTimer = setInterval(
+    () => {
+      void enqueue(renew).catch(() => undefined);
+    },
+    Math.max(1000, Math.floor(ttlMs / 3)),
+  );
+  renewalTimer.unref?.();
+
+  return {
+    async ensureHeld() {
+      if (released) throw new Error(`AWS Lambda MicroVM lease ${input.key} was released.`);
+      if (lost !== undefined) {
+        throw new Error(`AWS Lambda MicroVM lease ${input.key} was lost.`, { cause: lost });
+      }
+      if (expiresAt - Date.now() < ttlMs / 3) await enqueue(renew);
+    },
+    async release() {
+      if (released) return;
+      clearInterval(renewalTimer);
+      await enqueue(async () => {
+        if (lost !== undefined) {
+          throw new Error(`AWS Lambda MicroVM lease ${input.key} was lost.`, { cause: lost });
+        }
+        await input.storage.deleteObject(input.key, { etag: currentEtag });
+      });
+      released = true;
+    },
+  };
+}
+
+function leaseDocument(holder: string, expiresAt: number): LeaseDocument {
+  return { expiresAt, holder, version: LEASE_VERSION };
+}
+
+function parseLease(value: unknown): LeaseDocument {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Invalid AWS Lambda MicroVM lease document.");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== LEASE_VERSION ||
+    typeof record.holder !== "string" ||
+    !Number.isFinite(record.expiresAt)
+  ) {
+    throw new Error("Invalid AWS Lambda MicroVM lease document.");
+  }
+  return {
+    expiresAt: Number(record.expiresAt),
+    holder: record.holder,
+    version: LEASE_VERSION,
+  };
+}
+
+function isPreconditionFailed(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const record = error as {
+    readonly $metadata?: { readonly httpStatusCode?: unknown };
+    readonly message?: unknown;
+    readonly name?: unknown;
+  };
+  return (
+    record.name === "PreconditionFailed" ||
+    record.$metadata?.httpStatusCode === 412 ||
+    (typeof record.message === "string" && /precondition failed/i.test(record.message))
+  );
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/metadata.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/metadata.ts
@@ -1,0 +1,113 @@
+export const AWS_LAMBDA_MICROVM_METADATA_VERSION = 1;
+
+export interface AwsLambdaMicrovmCheckpoint {
+  readonly etag?: string;
+  readonly generation: number;
+  readonly key: string;
+  readonly sha256: string;
+  readonly size: number;
+}
+
+export interface AwsLambdaMicrovmTemplateDescriptor {
+  readonly checkpoint?: AwsLambdaMicrovmCheckpoint;
+  readonly configHash: string;
+  readonly controllerProtocolVersion: number;
+  readonly imageArn: string;
+  readonly imageVersion: string;
+  readonly region: string;
+  readonly templateHash: string;
+  readonly version: typeof AWS_LAMBDA_MICROVM_METADATA_VERSION;
+}
+
+export interface AwsLambdaMicrovmSessionMetadata extends AwsLambdaMicrovmTemplateDescriptor {
+  readonly checkpoint?: AwsLambdaMicrovmCheckpoint;
+  readonly manifestEtag: string;
+  readonly microvmId: string;
+}
+
+export function parseAwsLambdaMicrovmTemplateDescriptor(
+  value: unknown,
+): AwsLambdaMicrovmTemplateDescriptor {
+  const record = expectRecord(value, "template descriptor");
+  expectVersion(record.version);
+  return {
+    checkpoint: parseCheckpoint(record.checkpoint),
+    configHash: expectString(record.configHash, "configHash"),
+    controllerProtocolVersion: expectPositiveInteger(
+      record.controllerProtocolVersion,
+      "controllerProtocolVersion",
+    ),
+    imageArn: expectString(record.imageArn, "imageArn"),
+    imageVersion: expectString(record.imageVersion, "imageVersion"),
+    region: expectString(record.region, "region"),
+    templateHash: expectSha256(record.templateHash, "templateHash"),
+    version: AWS_LAMBDA_MICROVM_METADATA_VERSION,
+  };
+}
+
+export function parseAwsLambdaMicrovmSessionMetadata(
+  value: unknown,
+): AwsLambdaMicrovmSessionMetadata | undefined {
+  if (value === undefined) return undefined;
+  const record = expectRecord(value, "session metadata");
+  return {
+    ...parseAwsLambdaMicrovmTemplateDescriptor(record),
+    manifestEtag: expectString(record.manifestEtag, "manifestEtag"),
+    microvmId: expectString(record.microvmId, "microvmId"),
+  };
+}
+
+function parseCheckpoint(value: unknown): AwsLambdaMicrovmCheckpoint | undefined {
+  if (value === undefined) return undefined;
+  const record = expectRecord(value, "checkpoint");
+  const etag = record.etag;
+  return {
+    etag: typeof etag === "string" && etag.length > 0 ? etag : undefined,
+    generation: expectPositiveInteger(record.generation, "checkpoint.generation"),
+    key: expectString(record.key, "checkpoint.key"),
+    sha256: expectSha256(record.sha256),
+    size: expectNonNegativeInteger(record.size, "checkpoint.size"),
+  };
+}
+
+function expectVersion(value: unknown): void {
+  if (value !== AWS_LAMBDA_MICROVM_METADATA_VERSION) {
+    throw new Error(`Unsupported AWS Lambda MicroVM metadata version ${String(value)}.`);
+  }
+}
+
+function expectRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid AWS Lambda MicroVM ${name}.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Invalid AWS Lambda MicroVM ${name}.`);
+  }
+  return value;
+}
+
+function expectPositiveInteger(value: unknown, name: string): number {
+  if (!Number.isInteger(value) || Number(value) < 1) {
+    throw new Error(`Invalid AWS Lambda MicroVM ${name}.`);
+  }
+  return Number(value);
+}
+
+function expectNonNegativeInteger(value: unknown, name: string): number {
+  if (!Number.isInteger(value) || Number(value) < 0) {
+    throw new Error(`Invalid AWS Lambda MicroVM ${name}.`);
+  }
+  return Number(value);
+}
+
+function expectSha256(value: unknown, name = "checkpoint.sha256"): string {
+  const digest = expectString(value, name);
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new Error(`Invalid AWS Lambda MicroVM ${name}.`);
+  }
+  return digest;
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/options.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/options.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAwsLambdaMicrovmOptions } from "./options.js";
+
+const REQUIRED = {
+  applicationId: "analytics-agent",
+  artifactBucket: "company-sandboxes",
+  buildRoleArn: "arn:aws:iam::123456789012:role/eve-build",
+  region: "us-east-1",
+} as const;
+
+describe("resolveAwsLambdaMicrovmOptions", () => {
+  it("applies secure lifecycle and connector defaults", () => {
+    const resolved = resolveAwsLambdaMicrovmOptions(REQUIRED);
+
+    expect(resolved).toMatchObject({
+      artifactPrefix: expect.stringMatching(/^eve\/lambda-microvms\/[a-f0-9]{20}$/),
+      executionRoleArn: undefined,
+      idlePolicy: {
+        autoResumeEnabled: true,
+        maxIdleDurationSeconds: 300,
+        suspendedDurationSeconds: 1800,
+      },
+      maximumDurationSeconds: 28_800,
+      memoryMiB: 2048,
+      runtimeLogging: false,
+      shellIngressNetworkConnectorArn: undefined,
+    });
+    expect(resolved.httpIngressNetworkConnectorArn).toContain(":ALL_INGRESS");
+    expect(resolved.runtimeEgressNetworkConnectorArns).toEqual([
+      expect.stringContaining(":INTERNET_EGRESS"),
+    ]);
+  });
+
+  it("enables CloudWatch by default when an execution role is supplied", () => {
+    expect(
+      resolveAwsLambdaMicrovmOptions({
+        ...REQUIRED,
+        executionRoleArn: "arn:aws:iam::123456789012:role/eve-runtime",
+      }).runtimeLogging,
+    ).toEqual({ logGroup: expect.stringMatching(/^\/aws\/lambda-microvms\/eve-/) });
+  });
+
+  it("preserves explicit empty egress and enables shell ingress", () => {
+    const resolved = resolveAwsLambdaMicrovmOptions({
+      ...REQUIRED,
+      buildEgressNetworkConnectorArns: [],
+      runtimeEgressNetworkConnectorArns: [],
+      shellAccess: true,
+    });
+
+    expect(resolved.buildEgressNetworkConnectorArns).toEqual([]);
+    expect(resolved.runtimeEgressNetworkConnectorArns).toEqual([]);
+    expect(resolved.shellIngressNetworkConnectorArn).toContain(":SHELL_INGRESS");
+  });
+
+  it("rejects unsupported memory and duration values", () => {
+    expect(() => resolveAwsLambdaMicrovmOptions({ ...REQUIRED, memoryMiB: 768 as never })).toThrow(
+      /memoryMiB/,
+    );
+    expect(() =>
+      resolveAwsLambdaMicrovmOptions({ ...REQUIRED, maximumDurationSeconds: 28_801 }),
+    ).toThrow(/maximumDurationSeconds/);
+  });
+
+  it("validates custom base images and reserved tags", () => {
+    expect(() =>
+      resolveAwsLambdaMicrovmOptions({
+        ...REQUIRED,
+        baseImage: { arn: " ", version: "1" },
+      }),
+    ).toThrow(/baseImage\.arn/);
+    expect(() =>
+      resolveAwsLambdaMicrovmOptions({
+        ...REQUIRED,
+        tags: { "eve:session": "raw-session-id" },
+      }),
+    ).toThrow(/reserved prefix/);
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/options.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/options.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto";
+
+import type {
+  AwsLambdaMicrovmBaseImage,
+  AwsLambdaMicrovmCloudWatchLogging,
+  AwsLambdaMicrovmIdlePolicy,
+  AwsLambdaMicrovmMemoryMiB,
+  AwsLambdaMicrovmSandboxOptions,
+} from "#public/sandbox/aws-lambda-microvm-sandbox.js";
+
+const MEMORY_VALUES = new Set<AwsLambdaMicrovmMemoryMiB>([512, 1024, 2048, 4096, 8192]);
+const MAXIMUM_DURATION_SECONDS = 28_800;
+
+export interface ResolvedAwsLambdaMicrovmOptions {
+  readonly applicationId: string;
+  readonly applicationHash: string;
+  readonly artifactBucket: string;
+  readonly artifactPrefix: string;
+  readonly baseImage?: AwsLambdaMicrovmBaseImage;
+  readonly buildEgressNetworkConnectorArns: readonly string[];
+  readonly buildRoleArn: string;
+  readonly executionRoleArn?: string;
+  readonly httpIngressNetworkConnectorArn: string;
+  readonly idlePolicy: AwsLambdaMicrovmIdlePolicy;
+  readonly maximumDurationSeconds: number;
+  readonly memoryMiB: AwsLambdaMicrovmMemoryMiB;
+  readonly region: string;
+  readonly runtimeEgressNetworkConnectorArns: readonly string[];
+  readonly runtimeLogging: AwsLambdaMicrovmCloudWatchLogging | false;
+  readonly shellIngressNetworkConnectorArn?: string;
+  readonly tags: Readonly<Record<string, string>>;
+}
+
+export function resolveAwsLambdaMicrovmOptions(
+  options: AwsLambdaMicrovmSandboxOptions,
+): ResolvedAwsLambdaMicrovmOptions {
+  const applicationId = expectNonEmpty("applicationId", options.applicationId);
+  const region = expectNonEmpty("region", options.region);
+  const artifactBucket = expectNonEmpty("artifactBucket", options.artifactBucket);
+  const buildRoleArn = expectNonEmpty("buildRoleArn", options.buildRoleArn);
+  const baseImage =
+    options.baseImage === undefined
+      ? undefined
+      : {
+          arn: expectNonEmpty("baseImage.arn", options.baseImage.arn),
+          version: expectNonEmpty("baseImage.version", options.baseImage.version),
+        };
+  const applicationHash = sha256(applicationId).slice(0, 20);
+  const memoryMiB = options.memoryMiB ?? 2048;
+  if (!MEMORY_VALUES.has(memoryMiB)) {
+    throw new Error("AWS Lambda MicroVM memoryMiB must be one of 512, 1024, 2048, 4096, or 8192.");
+  }
+
+  const maximumDurationSeconds = options.maximumDurationSeconds ?? MAXIMUM_DURATION_SECONDS;
+  if (
+    !Number.isInteger(maximumDurationSeconds) ||
+    maximumDurationSeconds < 1 ||
+    maximumDurationSeconds > MAXIMUM_DURATION_SECONDS
+  ) {
+    throw new Error(
+      "AWS Lambda MicroVM maximumDurationSeconds must be an integer from 1 to 28800.",
+    );
+  }
+
+  const idlePolicy: AwsLambdaMicrovmIdlePolicy = {
+    autoResumeEnabled: options.idlePolicy?.autoResumeEnabled ?? true,
+    maxIdleDurationSeconds: options.idlePolicy?.maxIdleDurationSeconds ?? 300,
+    suspendedDurationSeconds: options.idlePolicy?.suspendedDurationSeconds ?? 1800,
+  };
+  for (const [name, value] of Object.entries(idlePolicy)) {
+    if (name === "autoResumeEnabled") continue;
+    if (!Number.isInteger(value) || Number(value) < 1) {
+      throw new Error(`AWS Lambda MicroVM idlePolicy.${name} must be a positive integer.`);
+    }
+  }
+
+  const managedConnectorPrefix = `arn:aws:lambda:${region}:aws:network-connector:aws-network-connector`;
+  const internetEgress = `${managedConnectorPrefix}:INTERNET_EGRESS`;
+  const executionRoleArn = optionalNonEmpty("executionRoleArn", options.executionRoleArn);
+  const artifactPrefix = normalizePrefix(
+    options.artifactPrefix ?? `eve/lambda-microvms/${applicationHash}`,
+  );
+
+  return {
+    applicationHash,
+    applicationId,
+    artifactBucket,
+    artifactPrefix,
+    baseImage,
+    buildEgressNetworkConnectorArns: normalizeStringArray(
+      "buildEgressNetworkConnectorArns",
+      options.buildEgressNetworkConnectorArns ?? [internetEgress],
+    ),
+    buildRoleArn,
+    executionRoleArn,
+    httpIngressNetworkConnectorArn: `${managedConnectorPrefix}:ALL_INGRESS`,
+    idlePolicy,
+    maximumDurationSeconds,
+    memoryMiB,
+    region,
+    runtimeEgressNetworkConnectorArns: normalizeStringArray(
+      "runtimeEgressNetworkConnectorArns",
+      options.runtimeEgressNetworkConnectorArns ?? [internetEgress],
+    ),
+    runtimeLogging:
+      options.runtimeLogging ??
+      (executionRoleArn === undefined
+        ? false
+        : { logGroup: `/aws/lambda-microvms/eve-${applicationHash}` }),
+    shellIngressNetworkConnectorArn:
+      options.shellAccess === true ? `${managedConnectorPrefix}:SHELL_INGRESS` : undefined,
+    tags: normalizeTags(options.tags),
+  };
+}
+
+function expectNonEmpty(name: string, value: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error(`AWS Lambda MicroVM ${name} must be a non-empty string.`);
+  }
+  return normalized;
+}
+
+function optionalNonEmpty(name: string, value: string | undefined): string | undefined {
+  return value === undefined ? undefined : expectNonEmpty(name, value);
+}
+
+function normalizePrefix(value: string): string {
+  const normalized = value.trim().replace(/^\/+|\/+$/g, "");
+  if (normalized.length === 0) {
+    throw new Error(
+      "AWS Lambda MicroVM artifactPrefix must contain at least one non-slash character.",
+    );
+  }
+  return normalized;
+}
+
+function normalizeStringArray(name: string, values: readonly string[]): readonly string[] {
+  return values.map((value, index) => expectNonEmpty(`${name}[${index}]`, value));
+}
+
+function normalizeTags(
+  value: Readonly<Record<string, string>> | undefined,
+): Readonly<Record<string, string>> {
+  if (value === undefined) return {};
+  const entries = Object.entries(value)
+    .map(([key, entry]) => [expectNonEmpty("tag key", key), entry] as const)
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length > 45) {
+    throw new Error("AWS Lambda MicroVM tags may contain at most 45 user-defined entries.");
+  }
+  for (const [key, entry] of entries) {
+    if (key.startsWith("aws:") || key.startsWith("eve:")) {
+      throw new Error(`AWS Lambda MicroVM tag key "${key}" uses a reserved prefix.`);
+    }
+    if (key.length > 128 || entry.length > 256) {
+      throw new Error(`AWS Lambda MicroVM tag "${key}" exceeds AWS tag length limits.`);
+    }
+  }
+  return Object.fromEntries(entries);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/provision.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/provision.ts
@@ -1,0 +1,247 @@
+import { createHash } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import type { AwsLambdaMicrovmApi, AwsLambdaMicrovmImageVersionRecord } from "./api.js";
+import {
+  buildAwsLambdaMicrovmImageArtifact,
+  AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION,
+} from "./image-artifact.js";
+import type { ResolvedAwsLambdaMicrovmOptions } from "./options.js";
+import type { AwsLambdaMicrovmStorage } from "./storage.js";
+
+const IMAGE_BUILD_TIMEOUT_MS = 30 * 60 * 1000;
+
+export interface ProvisionedAwsLambdaMicrovmImage {
+  readonly configHash: string;
+  readonly imageArn: string;
+  readonly imageVersion: string;
+}
+
+export async function ensureAwsLambdaMicrovmImage(input: {
+  readonly api: AwsLambdaMicrovmApi;
+  readonly log?: (message: string) => void;
+  readonly options: ResolvedAwsLambdaMicrovmOptions;
+  readonly storage: AwsLambdaMicrovmStorage;
+}): Promise<ProvisionedAwsLambdaMicrovmImage> {
+  const artifact = await buildAwsLambdaMicrovmImageArtifact();
+  const baseImage = await resolveBaseImage(input.api, input.options);
+  const imageHash = hashStable({
+    artifact: artifact.sha256,
+    baseImage,
+    buildEgress: input.options.buildEgressNetworkConnectorArns,
+    controllerProtocolVersion: AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION,
+    memoryMiB: input.options.memoryMiB,
+  });
+  const configHash = hashStable({
+    imageHash,
+    executionRoleArn: input.options.executionRoleArn,
+    idlePolicy: input.options.idlePolicy,
+    maximumDurationSeconds: input.options.maximumDurationSeconds,
+    runtimeEgress: input.options.runtimeEgressNetworkConnectorArns,
+    runtimeLogging: input.options.runtimeLogging,
+    shellIngress: input.options.shellIngressNetworkConnectorArn,
+  });
+  const artifactKey = `${input.options.artifactPrefix}/images/${artifact.sha256}.zip`;
+  const imageName = `eve-${input.options.applicationHash}-${imageHash.slice(0, 12)}`;
+
+  if (!(await input.storage.hasObject(artifactKey))) {
+    input.log?.("uploading deterministic MicroVM image artifact");
+    await input.storage.putBytes(artifactKey, artifact.bytes, {
+      "eve-application": input.options.applicationHash,
+      "eve-controller": String(AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION),
+      "eve-sha256": artifact.sha256,
+    });
+  }
+
+  const existing = (await input.api.listImages(imageName)).find(
+    (image) => image.name === imageName,
+  );
+  if (existing !== undefined) {
+    const version =
+      (await resolveExistingVersion(
+        input.api,
+        existing.imageArn,
+        existing.latestActiveImageVersion,
+      )) ?? (await waitForCreatedImageVersion(input.api, existing.imageArn, input.log));
+    input.log?.(`reusing MicroVM image ${existing.imageArn}:${version.imageVersion}`);
+    return { configHash, imageArn: existing.imageArn, imageVersion: version.imageVersion };
+  }
+
+  input.log?.(`building MicroVM image ${imageName}`);
+  let created: AwsLambdaMicrovmImageVersionRecord;
+  try {
+    created = await input.api.createImage({
+      baseImageArn: baseImage.arn,
+      baseImageVersion: baseImage.version,
+      buildRoleArn: input.options.buildRoleArn,
+      clientToken: imageHash,
+      codeArtifactUri: `s3://${input.options.artifactBucket}/${artifactKey}`,
+      description: `eve sandbox image for ${input.options.applicationId}`,
+      egressNetworkConnectorArns: input.options.buildEgressNetworkConnectorArns,
+      environmentVariables: {},
+      logging: { cloudWatch: {} },
+      memoryMiB: input.options.memoryMiB,
+      name: imageName,
+      tags: {
+        ...input.options.tags,
+        "eve:application": input.options.applicationHash,
+        "eve:config": configHash.slice(0, 32),
+        "eve:controller": String(AWS_LAMBDA_MICROVM_CONTROLLER_PROTOCOL_VERSION),
+        "eve:owner": "eve",
+      },
+    });
+  } catch (error) {
+    if (!isConflict(error)) throw error;
+    const raced = (await input.api.listImages(imageName)).find((image) => image.name === imageName);
+    if (raced === undefined) throw error;
+    const version =
+      (await resolveExistingVersion(input.api, raced.imageArn, raced.latestActiveImageVersion)) ??
+      (await waitForCreatedImageVersion(input.api, raced.imageArn, input.log));
+    return { configHash, imageArn: raced.imageArn, imageVersion: version.imageVersion };
+  }
+
+  const active = await waitForImageVersion(
+    input.api,
+    created.imageArn,
+    created.imageVersion,
+    input.log,
+  );
+  return { configHash, imageArn: active.imageArn, imageVersion: active.imageVersion };
+}
+
+async function waitForCreatedImageVersion(
+  api: AwsLambdaMicrovmApi,
+  imageArn: string,
+  log?: (message: string) => void,
+): Promise<AwsLambdaMicrovmImageVersionRecord> {
+  const deadline = Date.now() + IMAGE_BUILD_TIMEOUT_MS;
+  for (;;) {
+    const versions = await api.listImageVersions(imageArn);
+    const latest = [...versions].sort((left, right) =>
+      compareVersionsDescending(left.imageVersion, right.imageVersion),
+    )[0];
+    if (latest !== undefined) {
+      return await waitForImageVersion(api, imageArn, latest.imageVersion, log, deadline);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for AWS Lambda MicroVM image ${imageArn} to create a version.`,
+      );
+    }
+    log?.("waiting for AWS Lambda MicroVM image version creation");
+    await sleepWithJitter();
+  }
+}
+
+async function resolveBaseImage(
+  api: AwsLambdaMicrovmApi,
+  options: ResolvedAwsLambdaMicrovmOptions,
+): Promise<{ readonly arn: string; readonly version: string }> {
+  if (options.baseImage !== undefined) {
+    return { arn: options.baseImage.arn, version: options.baseImage.version };
+  }
+  const managed = await api.listManagedImages();
+  const image = managed.find((candidate) => candidate.imageArn.endsWith(":microvm-image:al2023-1"));
+  if (image === undefined) {
+    throw new Error(
+      `AWS Lambda MicroVMs are unavailable in ${options.region}: managed image al2023-1 was not found.`,
+    );
+  }
+  const versions = await api.listManagedImageVersions(image.imageArn);
+  const version = [...versions].sort((left, right) =>
+    compareVersionsDescending(left.imageVersion, right.imageVersion),
+  )[0];
+  if (version === undefined) {
+    throw new Error(`AWS managed MicroVM image ${image.imageArn} has no available versions.`);
+  }
+  return { arn: image.imageArn, version: version.imageVersion };
+}
+
+async function resolveExistingVersion(
+  api: AwsLambdaMicrovmApi,
+  imageArn: string,
+  latestActiveImageVersion: string | undefined,
+): Promise<AwsLambdaMicrovmImageVersionRecord | undefined> {
+  if (latestActiveImageVersion !== undefined) {
+    return await waitForImageVersion(api, imageArn, latestActiveImageVersion);
+  }
+  const versions = await api.listImageVersions(imageArn);
+  const latest = [...versions].sort((left, right) =>
+    compareVersionsDescending(left.imageVersion, right.imageVersion),
+  )[0];
+  return latest === undefined
+    ? undefined
+    : await waitForImageVersion(api, imageArn, latest.imageVersion);
+}
+
+async function waitForImageVersion(
+  api: AwsLambdaMicrovmApi,
+  imageArn: string,
+  imageVersion: string,
+  log?: (message: string) => void,
+  deadline = Date.now() + IMAGE_BUILD_TIMEOUT_MS,
+): Promise<AwsLambdaMicrovmImageVersionRecord> {
+  for (;;) {
+    const image = await api.getImageVersion(imageArn, imageVersion);
+    if (image.state === "SUCCESSFUL" && image.status !== "INACTIVE") return image;
+    if (
+      image.state === "FAILED" ||
+      image.state === "DELETING" ||
+      image.state === "DELETED" ||
+      image.state === "DELETE_FAILED" ||
+      image.status === "INACTIVE"
+    ) {
+      throw new Error(
+        `AWS Lambda MicroVM image ${imageArn}:${imageVersion} is unavailable: ${image.stateReason ?? `${image.state}/${image.status ?? "UNKNOWN"}`}. Check the configured CloudWatch build logs (default ${defaultBuildLogGroup(imageArn)}).`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for AWS Lambda MicroVM image ${imageArn}:${imageVersion}.`,
+      );
+    }
+    log?.(`waiting for MicroVM image ${imageVersion} (${image.state.toLowerCase()})`);
+    await sleepWithJitter();
+  }
+}
+
+async function sleepWithJitter(): Promise<void> {
+  await sleep(1500 + Math.floor(Math.random() * 1501));
+}
+
+function compareVersionsDescending(left: string, right: string): number {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+  if (Number.isFinite(leftNumber) && Number.isFinite(rightNumber)) return rightNumber - leftNumber;
+  return right.localeCompare(left);
+}
+
+function hashStable(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value)).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (typeof value === "object" && value !== null) {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function isConflict(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ["ConflictException", "ResourceConflictException"].includes(
+      String((error as { readonly name?: unknown }).name),
+    )
+  );
+}
+
+function defaultBuildLogGroup(imageArn: string): string {
+  return `/aws/lambda/microvms/${imageArn.slice(imageArn.lastIndexOf(":") + 1)}`;
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/sdk-api.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/sdk-api.ts
@@ -1,0 +1,337 @@
+import {
+  CreateMicrovmAuthTokenCommand,
+  CreateMicrovmImageCommand,
+  GetMicrovmCommand,
+  GetMicrovmImageVersionCommand,
+  LambdaMicrovmsClient,
+  ListManagedMicrovmImagesCommand,
+  ListManagedMicrovmImageVersionsCommand,
+  ListMicrovmImageVersionsCommand,
+  ListMicrovmImagesCommand,
+  ResumeMicrovmCommand,
+  RunMicrovmCommand,
+  SuspendMicrovmCommand,
+  TagResourceCommand,
+  TerminateMicrovmCommand,
+} from "#compiled/@aws-sdk/client-lambda-microvms/index.js";
+
+import type {
+  AwsLambdaMicrovmApi,
+  AwsLambdaMicrovmCreateImageInput,
+  AwsLambdaMicrovmImageRecord,
+  AwsLambdaMicrovmImageVersionRecord,
+  AwsLambdaMicrovmLogging,
+  AwsLambdaMicrovmRecord,
+  AwsLambdaMicrovmRunInput,
+  AwsLambdaMicrovmState,
+} from "./api.js";
+
+export class SdkAwsLambdaMicrovmApi implements AwsLambdaMicrovmApi {
+  readonly #client: LambdaMicrovmsClient;
+
+  constructor(region: string) {
+    this.#client = new LambdaMicrovmsClient({ region });
+  }
+
+  async createAuthToken(microvmId: string): Promise<string> {
+    const output = await this.#client.send(
+      new CreateMicrovmAuthTokenCommand({
+        allowedPorts: [{ port: 8080 }],
+        expirationInMinutes: 60,
+        microvmIdentifier: microvmId,
+      }),
+    );
+    const authToken = expectRecord(output.authToken, "authToken");
+    return expectString(authToken["X-aws-proxy-auth"], 'authToken["X-aws-proxy-auth"]');
+  }
+
+  async createImage(
+    input: AwsLambdaMicrovmCreateImageInput,
+  ): Promise<AwsLambdaMicrovmImageVersionRecord> {
+    const output = await this.#client.send(
+      new CreateMicrovmImageCommand({
+        additionalOsCapabilities: ["ALL"],
+        baseImageArn: input.baseImageArn,
+        baseImageVersion: input.baseImageVersion,
+        buildRoleArn: input.buildRoleArn,
+        clientToken: input.clientToken,
+        codeArtifact: { uri: input.codeArtifactUri },
+        cpuConfigurations: [{ architecture: "ARM_64" }],
+        description: input.description,
+        egressNetworkConnectors: [...input.egressNetworkConnectorArns],
+        environmentVariables: { ...input.environmentVariables },
+        hooks: {
+          microvmHooks: {
+            resume: "ENABLED",
+            resumeTimeoutInSeconds: 30,
+            run: "ENABLED",
+            runTimeoutInSeconds: 30,
+            suspend: "ENABLED",
+            suspendTimeoutInSeconds: 30,
+            terminate: "ENABLED",
+            terminateTimeoutInSeconds: 30,
+          },
+          microvmImageHooks: {
+            ready: "ENABLED",
+            readyTimeoutInSeconds: 900,
+            validate: "ENABLED",
+            validateTimeoutInSeconds: 900,
+          },
+          port: 9000,
+        },
+        logging: toSdkLogging(input.logging),
+        name: input.name,
+        resources: [{ minimumMemoryInMiB: input.memoryMiB }],
+        tags: { ...input.tags },
+      }),
+    );
+    return {
+      imageArn: expectString(output.imageArn, "imageArn"),
+      imageVersion: expectString(output.imageVersion, "imageVersion"),
+      state: "PENDING",
+    };
+  }
+
+  destroy(): void {
+    this.#client.destroy();
+  }
+
+  async getImageVersion(
+    imageArn: string,
+    imageVersion: string,
+  ): Promise<AwsLambdaMicrovmImageVersionRecord> {
+    return imageVersionFromOutput(
+      await this.#client.send(
+        new GetMicrovmImageVersionCommand({
+          imageIdentifier: imageArn,
+          imageVersion,
+        }),
+      ),
+    );
+  }
+
+  async getMicrovm(microvmId: string): Promise<AwsLambdaMicrovmRecord | null> {
+    try {
+      return microvmFromOutput(
+        await this.#client.send(new GetMicrovmCommand({ microvmIdentifier: microvmId })),
+      );
+    } catch (error) {
+      if (isAwsNotFound(error)) return null;
+      throw error;
+    }
+  }
+
+  async listImages(name: string): Promise<readonly AwsLambdaMicrovmImageRecord[]> {
+    const items: AwsLambdaMicrovmImageRecord[] = [];
+    let nextToken: string | undefined;
+    do {
+      const output = await this.#client.send(
+        new ListMicrovmImagesCommand({ maxResults: 100, nameFilter: name, nextToken }),
+      );
+      for (const item of expectArray(output.items, "items")) {
+        const record = expectRecord(item, "image item");
+        items.push({
+          imageArn: expectString(record.imageArn, "imageArn"),
+          latestActiveImageVersion: optionalString(record.latestActiveImageVersion),
+          name: expectString(record.name, "name"),
+        });
+      }
+      nextToken = optionalString(output.nextToken);
+    } while (nextToken !== undefined);
+    return items;
+  }
+
+  async listImageVersions(
+    imageArn: string,
+  ): Promise<readonly AwsLambdaMicrovmImageVersionRecord[]> {
+    const items: AwsLambdaMicrovmImageVersionRecord[] = [];
+    let nextToken: string | undefined;
+    do {
+      const output = await this.#client.send(
+        new ListMicrovmImageVersionsCommand({
+          imageIdentifier: imageArn,
+          maxResults: 100,
+          nextToken,
+        }),
+      );
+      for (const item of expectArray(output.items, "items")) {
+        items.push(imageVersionFromOutput(expectRecord(item, "image version item")));
+      }
+      nextToken = optionalString(output.nextToken);
+    } while (nextToken !== undefined);
+    return items;
+  }
+
+  async listManagedImages(): Promise<readonly { readonly imageArn: string }[]> {
+    const items: { imageArn: string }[] = [];
+    let nextToken: string | undefined;
+    do {
+      const output = await this.#client.send(
+        new ListManagedMicrovmImagesCommand({ maxResults: 100, nextToken }),
+      );
+      for (const item of expectArray(output.items, "items")) {
+        items.push({
+          imageArn: expectString(expectRecord(item, "image item").imageArn, "imageArn"),
+        });
+      }
+      nextToken = optionalString(output.nextToken);
+    } while (nextToken !== undefined);
+    return items;
+  }
+
+  async listManagedImageVersions(
+    imageArn: string,
+  ): Promise<readonly { readonly imageArn: string; readonly imageVersion: string }[]> {
+    const items: { imageArn: string; imageVersion: string }[] = [];
+    let nextToken: string | undefined;
+    do {
+      const output = await this.#client.send(
+        new ListManagedMicrovmImageVersionsCommand({
+          imageIdentifier: imageArn,
+          maxResults: 100,
+          nextToken,
+        }),
+      );
+      for (const item of expectArray(output.items, "items")) {
+        const record = expectRecord(item, "image version item");
+        items.push({
+          imageArn: expectString(record.imageArn, "imageArn"),
+          imageVersion: expectString(record.imageVersion, "imageVersion"),
+        });
+      }
+      nextToken = optionalString(output.nextToken);
+    } while (nextToken !== undefined);
+    return items;
+  }
+
+  async resumeMicrovm(microvmId: string): Promise<void> {
+    await this.#client.send(new ResumeMicrovmCommand({ microvmIdentifier: microvmId }));
+  }
+
+  async runMicrovm(input: AwsLambdaMicrovmRunInput): Promise<AwsLambdaMicrovmRecord> {
+    return microvmFromOutput(
+      await this.#client.send(
+        new RunMicrovmCommand({
+          clientToken: input.clientToken,
+          egressNetworkConnectors: [...input.egressNetworkConnectorArns],
+          executionRoleArn: input.executionRoleArn,
+          idlePolicy: input.idlePolicy,
+          imageIdentifier: input.imageArn,
+          imageVersion: input.imageVersion,
+          ingressNetworkConnectors: [...input.ingressNetworkConnectorArns],
+          logging: toSdkLogging(input.logging),
+          maximumDurationInSeconds: input.maximumDurationSeconds,
+          runHookPayload: input.runHookPayload,
+        }),
+      ),
+    );
+  }
+
+  async suspendMicrovm(microvmId: string): Promise<void> {
+    await this.#client.send(new SuspendMicrovmCommand({ microvmIdentifier: microvmId }));
+  }
+
+  async tagResource(resourceArn: string, tags: Readonly<Record<string, string>>): Promise<void> {
+    await this.#client.send(new TagResourceCommand({ Resource: resourceArn, Tags: { ...tags } }));
+  }
+
+  async terminateMicrovm(microvmId: string): Promise<void> {
+    await this.#client.send(new TerminateMicrovmCommand({ microvmIdentifier: microvmId }));
+  }
+}
+
+function toSdkLogging(logging: AwsLambdaMicrovmLogging): Record<string, unknown> {
+  return "disabled" in logging ? { disabled: {} } : { cloudWatch: logging.cloudWatch };
+}
+
+function imageVersionFromOutput(
+  output: Record<string, unknown>,
+): AwsLambdaMicrovmImageVersionRecord {
+  return {
+    imageArn: expectString(output.imageArn, "imageArn"),
+    imageVersion: expectString(output.imageVersion, "imageVersion"),
+    state: expectImageVersionState(output.state),
+    stateReason: optionalString(output.stateReason),
+    status: expectImageVersionStatus(output.status),
+  };
+}
+
+function microvmFromOutput(output: Record<string, unknown>): AwsLambdaMicrovmRecord {
+  const rawEndpoint = expectString(output.endpoint, "endpoint");
+  return {
+    endpoint: rawEndpoint.startsWith("http") ? rawEndpoint : `https://${rawEndpoint}`,
+    imageArn: expectString(output.imageArn, "imageArn"),
+    imageVersion: expectString(output.imageVersion, "imageVersion"),
+    microvmId: expectString(output.microvmId, "microvmId"),
+    state: expectMicrovmState(output.state),
+    stateReason: optionalString(output.stateReason),
+  };
+}
+
+function expectMicrovmState(value: unknown): AwsLambdaMicrovmState {
+  if (
+    value === "PENDING" ||
+    value === "RUNNING" ||
+    value === "SUSPENDED" ||
+    value === "SUSPENDING" ||
+    value === "TERMINATED" ||
+    value === "TERMINATING"
+  ) {
+    return value;
+  }
+  throw new Error(`AWS Lambda MicroVM returned invalid state ${String(value)}.`);
+}
+
+function expectImageVersionState(value: unknown): AwsLambdaMicrovmImageVersionRecord["state"] {
+  if (
+    value === "PENDING" ||
+    value === "IN_PROGRESS" ||
+    value === "SUCCESSFUL" ||
+    value === "FAILED" ||
+    value === "DELETING" ||
+    value === "DELETE_FAILED" ||
+    value === "DELETED"
+  ) {
+    return value;
+  }
+  throw new Error(`AWS Lambda MicroVM returned invalid image state ${String(value)}.`);
+}
+
+function expectImageVersionStatus(value: unknown): AwsLambdaMicrovmImageVersionRecord["status"] {
+  if (value === undefined || value === "ACTIVE" || value === "INACTIVE") return value;
+  throw new Error(`AWS Lambda MicroVM returned invalid image status ${String(value)}.`);
+}
+
+function expectRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`AWS Lambda MicroVM response field ${name} is invalid.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectArray(value: unknown, name: string): readonly unknown[] {
+  if (!Array.isArray(value))
+    throw new Error(`AWS Lambda MicroVM response field ${name} is invalid.`);
+  return value;
+}
+
+function expectString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`AWS Lambda MicroVM response field ${name} is invalid.`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isAwsNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ((error as { readonly name?: unknown }).name === "ResourceNotFoundException" ||
+      (error as { readonly $metadata?: { readonly httpStatusCode?: unknown } }).$metadata
+        ?.httpStatusCode === 404)
+  );
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/session.ts
@@ -1,0 +1,69 @@
+import { posix } from "node:path";
+
+import { buildSandboxSession } from "#execution/sandbox/session.js";
+import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
+import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
+import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
+import type {
+  InternalSandboxSession,
+  SandboxSession,
+  SandboxSpawnOptions,
+} from "#shared/sandbox-session.js";
+
+import type { AwsLambdaMicrovmController } from "./controller-client.js";
+
+export function createAwsLambdaMicrovmSession(input: {
+  readonly beforeOperation?: () => Promise<void>;
+  readonly controller: AwsLambdaMicrovmController;
+  readonly id: string;
+  readonly onMutate?: () => void;
+}): SandboxSession {
+  const primitives: InternalSandboxSession = {
+    id: input.id,
+    async readFile(options) {
+      await input.beforeOperation?.();
+      return await input.controller.readFile(options.path, options.abortSignal);
+    },
+    async removePath(options) {
+      await input.beforeOperation?.();
+      input.onMutate?.();
+      await input.controller.removePath(options);
+    },
+    resolvePath,
+    async spawn(options: SandboxSpawnOptions) {
+      await input.beforeOperation?.();
+      input.onMutate?.();
+      return await input.controller.spawn({
+        abortSignal: options.abortSignal,
+        command: options.command,
+        env: options.env,
+        workingDirectory: resolvePath(options.workingDirectory ?? WORKSPACE_ROOT),
+      });
+    },
+    async writeFile(options) {
+      await input.beforeOperation?.();
+      input.onMutate?.();
+      await input.controller.writeFile(
+        options.path,
+        await streamToBuffer(options.content),
+        options.abortSignal,
+      );
+    },
+  };
+
+  return buildSandboxSession(primitives, async (policy) => {
+    await input.beforeOperation?.();
+    await rejectRuntimeNetworkPolicy(policy);
+  });
+}
+
+function resolvePath(path: string): string {
+  if (posix.isAbsolute(path)) return posix.normalize(path);
+  return posix.resolve(WORKSPACE_ROOT, path);
+}
+
+async function rejectRuntimeNetworkPolicy(_policy: SandboxNetworkPolicy): Promise<void> {
+  throw new Error(
+    "AWS Lambda MicroVM network connectors are immutable after launch. Configure runtimeEgressNetworkConnectorArns in awsLambdaMicrovm().",
+  );
+}

--- a/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/storage.ts
+++ b/packages/eve/src/execution/sandbox/bindings/aws-lambda-microvms/storage.ts
@@ -1,0 +1,289 @@
+import {
+  AbortMultipartUploadCommand,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  DeleteObjectCommand,
+  GetBucketLocationCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  UploadPartCommand,
+} from "#compiled/@aws-sdk/client-s3/index.js";
+import { getSignedUrl } from "#compiled/@aws-sdk/s3-request-presigner/index.js";
+
+export interface StoredJson<T> {
+  readonly etag: string;
+  readonly value: T;
+}
+
+export interface StoredObjectInfo {
+  readonly etag?: string;
+  readonly size: number;
+}
+
+export interface AwsLambdaMicrovmStorage {
+  abortMultipartUpload(key: string, uploadId: string): Promise<void>;
+  assertBucketRegion(): Promise<void>;
+  completeMultipartUpload(
+    key: string,
+    uploadId: string,
+    parts: readonly { readonly etag: string; readonly partNumber: number }[],
+    sha256: string,
+  ): Promise<{ readonly etag?: string }>;
+  createMultipartUpload(key: string): Promise<string>;
+  deleteObject(key: string, condition?: { readonly etag?: string }): Promise<void>;
+  destroy(): void;
+  getJson<T>(key: string): Promise<StoredJson<T> | null>;
+  getObjectInfo(key: string): Promise<StoredObjectInfo | null>;
+  hasObject(key: string): Promise<boolean>;
+  presignGet(key: string, expiresInSeconds?: number): Promise<string>;
+  presignUploadParts(
+    key: string,
+    uploadId: string,
+    count: number,
+    expiresInSeconds?: number,
+  ): Promise<readonly string[]>;
+  putBytes(
+    key: string,
+    bytes: Uint8Array,
+    metadata?: Readonly<Record<string, string>>,
+  ): Promise<void>;
+  putJson(
+    key: string,
+    value: unknown,
+    condition?: { readonly etag?: string; readonly absent?: boolean },
+  ): Promise<{ readonly etag: string }>;
+}
+
+export class SdkAwsLambdaMicrovmStorage implements AwsLambdaMicrovmStorage {
+  readonly #bucket: string;
+  readonly #client: S3Client;
+  readonly #region: string;
+
+  constructor(input: { readonly bucket: string; readonly region: string }) {
+    this.#bucket = input.bucket;
+    this.#region = input.region;
+    this.#client = new S3Client({ region: input.region });
+  }
+
+  async abortMultipartUpload(key: string, uploadId: string): Promise<void> {
+    await this.#client.send(
+      new AbortMultipartUploadCommand({ Bucket: this.#bucket, Key: key, UploadId: uploadId }),
+    );
+  }
+
+  async assertBucketRegion(): Promise<void> {
+    const output = await this.#client.send(new GetBucketLocationCommand({ Bucket: this.#bucket }));
+    const location = normalizeBucketRegion(output.LocationConstraint);
+    if (location !== this.#region) {
+      throw new Error(
+        `AWS Lambda MicroVM artifact bucket "${this.#bucket}" is in ${location}, but the backend region is ${this.#region}.`,
+      );
+    }
+  }
+
+  async completeMultipartUpload(
+    key: string,
+    uploadId: string,
+    parts: readonly { readonly etag: string; readonly partNumber: number }[],
+    sha256: string,
+  ): Promise<{ readonly etag?: string }> {
+    const checksum = sha256Base64(sha256);
+    const output = await this.#client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: this.#bucket,
+        ChecksumSHA256: checksum,
+        ChecksumType: "FULL_OBJECT",
+        Key: key,
+        MultipartUpload: {
+          Parts: parts.map((part) => ({ ETag: part.etag, PartNumber: part.partNumber })),
+        },
+        UploadId: uploadId,
+      }),
+    );
+    if (output.ChecksumSHA256 !== checksum || output.ChecksumType !== "FULL_OBJECT") {
+      throw new Error(`AWS S3 did not verify the full SHA-256 checksum for ${key}.`);
+    }
+    return { etag: optionalString(output.ETag) };
+  }
+
+  async createMultipartUpload(key: string): Promise<string> {
+    const output = await this.#client.send(
+      new CreateMultipartUploadCommand({
+        Bucket: this.#bucket,
+        ChecksumAlgorithm: "SHA256",
+        ChecksumType: "FULL_OBJECT",
+        ContentType: "application/zstd",
+        Key: key,
+      }),
+    );
+    return expectString(output.UploadId, "UploadId");
+  }
+
+  async deleteObject(key: string, condition: { readonly etag?: string } = {}): Promise<void> {
+    await this.#client.send(
+      new DeleteObjectCommand({
+        Bucket: this.#bucket,
+        IfMatch: condition.etag,
+        Key: key,
+      }),
+    );
+  }
+
+  destroy(): void {
+    this.#client.destroy();
+  }
+
+  async getJson<T>(key: string): Promise<StoredJson<T> | null> {
+    try {
+      const output = await this.#client.send(
+        new GetObjectCommand({ Bucket: this.#bucket, Key: key }),
+      );
+      const text = await bodyToString(output.Body);
+      return { etag: expectString(output.ETag, "ETag"), value: JSON.parse(text) as T };
+    } catch (error) {
+      if (isS3NotFound(error)) return null;
+      throw error;
+    }
+  }
+
+  async hasObject(key: string): Promise<boolean> {
+    return (await this.getObjectInfo(key)) !== null;
+  }
+
+  async getObjectInfo(key: string): Promise<StoredObjectInfo | null> {
+    try {
+      const output = await this.#client.send(
+        new HeadObjectCommand({ Bucket: this.#bucket, Key: key }),
+      );
+      return {
+        etag: optionalString(output.ETag),
+        size: expectNonNegativeInteger(output.ContentLength, "ContentLength"),
+      };
+    } catch (error) {
+      if (isS3NotFound(error)) return null;
+      throw error;
+    }
+  }
+
+  async presignGet(key: string, expiresInSeconds = 900): Promise<string> {
+    return await getSignedUrl(
+      this.#client,
+      new GetObjectCommand({ Bucket: this.#bucket, Key: key }),
+      { expiresIn: expiresInSeconds },
+    );
+  }
+
+  async presignUploadParts(
+    key: string,
+    uploadId: string,
+    count: number,
+    expiresInSeconds = 3600,
+  ): Promise<readonly string[]> {
+    return await Promise.all(
+      Array.from(
+        { length: count },
+        async (_, index) =>
+          await getSignedUrl(
+            this.#client,
+            new UploadPartCommand({
+              Bucket: this.#bucket,
+              Key: key,
+              PartNumber: index + 1,
+              UploadId: uploadId,
+            }),
+            { expiresIn: expiresInSeconds },
+          ),
+      ),
+    );
+  }
+
+  async putBytes(
+    key: string,
+    bytes: Uint8Array,
+    metadata?: Readonly<Record<string, string>>,
+  ): Promise<void> {
+    await this.#client.send(
+      new PutObjectCommand({
+        Body: bytes,
+        Bucket: this.#bucket,
+        ContentType: "application/zip",
+        Key: key,
+        Metadata: metadata === undefined ? undefined : { ...metadata },
+      }),
+    );
+  }
+
+  async putJson(
+    key: string,
+    value: unknown,
+    condition: { readonly etag?: string; readonly absent?: boolean } = {},
+  ): Promise<{ readonly etag: string }> {
+    const output = await this.#client.send(
+      new PutObjectCommand({
+        Body: `${JSON.stringify(value)}\n`,
+        Bucket: this.#bucket,
+        ContentType: "application/json",
+        IfMatch: condition.etag,
+        IfNoneMatch: condition.absent === true ? "*" : undefined,
+        Key: key,
+      }),
+    );
+    return { etag: expectString(output.ETag, "ETag") };
+  }
+}
+
+async function bodyToString(body: unknown): Promise<string> {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "transformToString" in body &&
+    typeof (body as { readonly transformToString?: unknown }).transformToString === "function"
+  ) {
+    return await (body as { transformToString(): Promise<string> }).transformToString();
+  }
+  if (body instanceof Uint8Array) return Buffer.from(body).toString("utf8");
+  throw new Error("AWS S3 returned an unsupported object body.");
+}
+
+function normalizeBucketRegion(value: unknown): string {
+  if (value === undefined || value === null || value === "") return "us-east-1";
+  if (value === "EU") return "eu-west-1";
+  return expectString(value, "LocationConstraint");
+}
+
+function expectString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`AWS S3 response field ${name} is invalid.`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function expectNonNegativeInteger(value: unknown, name: string): number {
+  if (!Number.isInteger(value) || Number(value) < 0) {
+    throw new Error(`AWS S3 response field ${name} is invalid.`);
+  }
+  return Number(value);
+}
+
+function sha256Base64(value: string): string {
+  if (!/^[a-f0-9]{64}$/.test(value)) {
+    throw new Error("AWS Lambda MicroVM checkpoint SHA-256 is invalid.");
+  }
+  return Buffer.from(value, "hex").toString("base64");
+}
+
+function isS3NotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (["NotFound", "NoSuchKey"].includes(String((error as { readonly name?: unknown }).name)) ||
+      (error as { readonly $metadata?: { readonly httpStatusCode?: unknown } }).$metadata
+        ?.httpStatusCode === 404)
+  );
+}

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -75,6 +75,10 @@ export function createVercelSandbox(
 
   return {
     name: "vercel",
+    provisioning: {
+      prewarmAtBuild: true,
+      requiresTemplate: false,
+    },
     async create(
       createInput: SandboxBackendCreateInput,
     ): Promise<SandboxBackendHandle<VercelSandboxSessionUseOptions>> {

--- a/packages/eve/src/execution/sandbox/ensure.ts
+++ b/packages/eve/src/execution/sandbox/ensure.ts
@@ -77,6 +77,7 @@ export async function ensureSandboxAccess(input: EnsureSandboxAccessInput): Prom
 
     const keys = await createRuntimeSandboxKeys({
       backendName: backend.name,
+      backendScopeKey: backend.provisioning?.scopeKey,
       compiledArtifactsSource: input.compiledArtifactsSource,
       nodeId: input.nodeId,
       sessionId: input.sessionId,

--- a/packages/eve/src/execution/sandbox/lazy-backend.ts
+++ b/packages/eve/src/execution/sandbox/lazy-backend.ts
@@ -2,8 +2,8 @@ import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
 
 /**
  * Wraps a backend-producing function in a `SandboxBackend` proxy that
- * invokes the function exactly once, on first access to any of `.name`,
- * `.create`, or `.prewarm`. Subsequent accesses return the same cached
+ * invokes the function exactly once, on first access to any public backend
+ * property. Subsequent accesses return the same cached
  * underlying backend.
  *
  * Used by `defaultSandbox()` for env-conditional selection, and by the
@@ -26,6 +26,9 @@ export function lazyBackend<BO, SO>(factory: () => SandboxBackend<BO, SO>): Sand
   return {
     get name() {
       return resolve().name;
+    },
+    get provisioning() {
+      return resolve().provisioning;
     },
     create(input) {
       return resolve().create(input);

--- a/packages/eve/src/execution/sandbox/prewarm.test.ts
+++ b/packages/eve/src/execution/sandbox/prewarm.test.ts
@@ -68,6 +68,36 @@ describe("prewarmAppSandboxes", () => {
     expect(inputs).toHaveLength(0);
     expect(signatures).toHaveLength(1);
   });
+
+  it("prewarms a required template without bootstrap or seed files", async () => {
+    const appRoot = process.cwd();
+    const inputs: SandboxBackendPrewarmInput[] = [];
+
+    await prewarmAppSandboxes({
+      appRoot,
+      compiledArtifactsSource: createDiskRuntimeCompiledArtifactsSource(appRoot),
+      dispatch: recordPrewarmInputs(inputs),
+      loadAgentGraph: async () => createGraph({ emptyRequiredTemplate: true }),
+    });
+
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]).toMatchObject({ bootstrap: undefined, seedFiles: [] });
+  });
+
+  it("filters build-time prewarm targets by backend capability", async () => {
+    const appRoot = process.cwd();
+    const inputs: SandboxBackendPrewarmInput[] = [];
+
+    await prewarmAppSandboxes({
+      appRoot,
+      compiledArtifactsSource: createDiskRuntimeCompiledArtifactsSource(appRoot),
+      dispatch: recordPrewarmInputs(inputs),
+      loadAgentGraph: async () => createGraph(),
+      shouldPrewarmBackend: (backend) => backend.provisioning?.prewarmAtBuild === true,
+    });
+
+    expect(inputs).toHaveLength(0);
+  });
 });
 
 function recordPrewarmInputs(inputs: SandboxBackendPrewarmInput[]) {
@@ -82,7 +112,7 @@ function recordPrewarmInputs(inputs: SandboxBackendPrewarmInput[]) {
   };
 }
 
-function createGraph(): ResolvedAgentGraphBundle {
+function createGraph(options: { emptyRequiredTemplate?: boolean } = {}): ResolvedAgentGraphBundle {
   const backend: SandboxBackend = {
     async create() {
       throw new Error("Unexpected create call.");
@@ -91,9 +121,12 @@ function createGraph(): ResolvedAgentGraphBundle {
     async prewarm() {
       return { reused: true };
     },
+    provisioning: options.emptyRequiredTemplate
+      ? { prewarmAtBuild: true, requiresTemplate: true, scopeKey: "test-app" }
+      : undefined,
   };
   const definition: ResolvedSandboxDefinition = {
-    async bootstrap() {},
+    bootstrap: options.emptyRequiredTemplate ? undefined : async () => {},
     backend,
     logicalPath: "agent/sandbox/sandbox.ts",
     revalidationKey: "stable-bootstrap",

--- a/packages/eve/src/execution/sandbox/prewarm.ts
+++ b/packages/eve/src/execution/sandbox/prewarm.ts
@@ -56,6 +56,7 @@ interface PrewarmSandboxesInput {
   readonly log?: (message: string) => void;
   readonly dispatch?: SandboxBackendPrewarmDispatch;
   readonly onPrewarmSignature?: (signature: string) => void;
+  readonly shouldPrewarmBackend?: (backend: SandboxBackend) => boolean;
   readonly shouldPrewarmSignature?: (signature: string) => boolean;
 }
 
@@ -150,6 +151,7 @@ export async function prewarmAppSandboxes(input: {
   readonly log?: (message: string) => void;
   readonly dispatch?: SandboxBackendPrewarmDispatch;
   readonly onPrewarmSignature?: (signature: string) => void;
+  readonly shouldPrewarmBackend?: (backend: SandboxBackend) => boolean;
   readonly shouldPrewarmSignature?: (signature: string) => boolean;
 }): Promise<void> {
   const compiledArtifactsSource =
@@ -169,6 +171,7 @@ export async function prewarmAppSandboxes(input: {
     graph,
     log: input.log,
     onPrewarmSignature: input.onPrewarmSignature,
+    shouldPrewarmBackend: input.shouldPrewarmBackend,
     shouldPrewarmSignature: input.shouldPrewarmSignature,
   });
 }
@@ -224,6 +227,7 @@ async function collectPrewarmTargets(input: {
   readonly appRoot: string;
   readonly compiledArtifactsSource: RuntimeCompiledArtifactsSource;
   readonly graph: ResolvedAgentGraphBundle;
+  readonly shouldPrewarmBackend?: (backend: SandboxBackend) => boolean;
 }): Promise<readonly PrewarmTarget[]> {
   const compileDirectoryPath = resolveRuntimeCompilerArtifactPaths(
     input.appRoot,
@@ -234,12 +238,17 @@ async function collectPrewarmTargets(input: {
 
   await Promise.all(
     collectNodeSandboxes(input.graph).map(async ({ definition, nodeId, workspaceResourceRoot }) => {
+      if (input.shouldPrewarmBackend?.(definition.backend) === false) {
+        return;
+      }
+
       const templatePlan = createRuntimeSandboxTemplatePlan({
         definition,
         workspaceResourceRoot,
       });
       const templateKey = await createRuntimeSandboxTemplateKey({
         backendName: definition.backend.name,
+        backendScopeKey: definition.backend.provisioning?.scopeKey,
         compiledArtifactsSource: input.compiledArtifactsSource,
         nodeId,
         sourceId: definition.sourceId,

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -57,7 +57,7 @@ const createApplicationNitroMock = vi.fn();
 const prepareApplicationHostMock = vi.fn();
 const prepareMock = vi.fn(async () => undefined);
 const prerenderMock = vi.fn(async () => undefined);
-const runVercelBuildPrewarmMock = vi.fn(async () => undefined);
+const runBuildSandboxPrewarmMock = vi.fn(async () => undefined);
 const workflowBuilderBuildVercelOutputMock = vi.fn(async (_options: unknown) => undefined);
 const workflowBuilderConstructors: unknown[] = [];
 
@@ -77,7 +77,7 @@ vi.mock("./prepare-application-host.js", () => ({
 }));
 
 vi.mock("./vercel-build-prewarm.js", () => ({
-  runVercelBuildPrewarm: runVercelBuildPrewarmMock,
+  runBuildSandboxPrewarm: runBuildSandboxPrewarmMock,
 }));
 
 vi.mock("../../workflow-bundle/builder.js", () => ({
@@ -179,7 +179,10 @@ describe("buildApplication", () => {
       )}\n`,
     );
     expect(workflowBuilderBuildVercelOutputMock).not.toHaveBeenCalled();
-    expect(runVercelBuildPrewarmMock).not.toHaveBeenCalled();
+    expect(runBuildSandboxPrewarmMock).toHaveBeenCalledWith({
+      appRoot,
+      log: expect.any(Function),
+    });
 
     const summary = JSON.parse(
       await readFile(join(appRoot, VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH), "utf8"),
@@ -323,7 +326,7 @@ describe("buildApplication", () => {
       "export const handleUpgrade = originalModule.handleUpgrade",
     );
     await expect(readFile(staleFlowOutputPath, "utf8")).rejects.toThrow();
-    expect(runVercelBuildPrewarmMock).toHaveBeenCalledWith({
+    expect(runBuildSandboxPrewarmMock).toHaveBeenCalledWith({
       appRoot,
       log: expect.any(Function),
     });

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -15,7 +15,7 @@ import { normalizeEveVercelFunctionOutput } from "#internal/workflow-bundle/verc
 import { createApplicationNitro } from "#internal/nitro/host/create-application-nitro.js";
 import { emitVercelAgentSummary } from "#internal/nitro/host/build-vercel-agent-summary.js";
 import { prepareApplicationHost } from "#internal/nitro/host/prepare-application-host.js";
-import { runVercelBuildPrewarm } from "#internal/nitro/host/vercel-build-prewarm.js";
+import { runBuildSandboxPrewarm } from "#internal/nitro/host/vercel-build-prewarm.js";
 import type { NitroBuildSurface, PreparedApplicationHost } from "#internal/nitro/host/types.js";
 import { findClosestVercelOutputDirectory } from "#shared/vercel-output-directory.js";
 
@@ -235,6 +235,12 @@ export async function buildApplication(rootDir: string): Promise<string> {
 
     try {
       const outputDirectory = await buildNitroOutput(nitro);
+      await runBuildSandboxPrewarm({
+        appRoot: preparedHost.appRoot,
+        log(message) {
+          console.log(message);
+        },
+      });
       await emitVercelAgentSummary({
         manifest: preparedHost.compileResult.manifest,
         appRoot: preparedHost.appRoot,
@@ -257,7 +263,7 @@ export async function buildApplication(rootDir: string): Promise<string> {
     // Run sandbox prewarm before emitting the workflow functions so a
     // prewarm failure aborts the build before we spend time bundling
     // function output that we would never deploy.
-    await runVercelBuildPrewarm({
+    await runBuildSandboxPrewarm({
       appRoot: preparedHost.appRoot,
       log(message) {
         console.log(message);

--- a/packages/eve/src/internal/nitro/host/vercel-build-prewarm.test.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-prewarm.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
+
+interface PrewarmInput {
+  readonly shouldPrewarmBackend?: (backend: SandboxBackend) => boolean;
+}
+
+const mocks = vi.hoisted(() => ({
+  prewarmAppSandboxes: vi.fn(async (_input: PrewarmInput) => undefined),
+}));
+
+vi.mock("#execution/sandbox/prewarm.js", () => ({
+  prewarmAppSandboxes: mocks.prewarmAppSandboxes,
+}));
+
+import { runBuildSandboxPrewarm } from "./vercel-build-prewarm.js";
+
+describe("runBuildSandboxPrewarm", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("selects opted-in non-Vercel backends on ordinary builds", async () => {
+    await runBuildSandboxPrewarm({ appRoot: "/tmp/app" });
+
+    const predicate = mocks.prewarmAppSandboxes.mock.calls[0]?.[0].shouldPrewarmBackend;
+    expect(
+      predicate?.({
+        name: "aws-lambda-microvms",
+        provisioning: { prewarmAtBuild: true, requiresTemplate: true },
+      } as never),
+    ).toBe(true);
+    expect(predicate?.({ name: "docker" } as never)).toBe(false);
+  });
+
+  it("requires a deployment id before selecting Vercel", async () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_test");
+
+    await runBuildSandboxPrewarm({ appRoot: "/tmp/app" });
+
+    const predicate = mocks.prewarmAppSandboxes.mock.calls[0]?.[0].shouldPrewarmBackend;
+    expect(
+      predicate?.({
+        name: "vercel",
+        provisioning: { prewarmAtBuild: true, requiresTemplate: false },
+      } as never),
+    ).toBe(true);
+  });
+});

--- a/packages/eve/src/internal/nitro/host/vercel-build-prewarm.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-prewarm.ts
@@ -1,4 +1,5 @@
 import { prewarmAppSandboxes } from "#execution/sandbox/prewarm.js";
+import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
 
 type PrewarmAppSandboxesInput = Parameters<typeof prewarmAppSandboxes>[0];
 
@@ -26,13 +27,25 @@ export function shouldPrewarmVercelBuild(): boolean {
 }
 
 /**
- * Vercel build-time sandbox prewarm hook. Failures here are treated as
- * build failures because the same sandbox bootstrap would otherwise
- * break at runtime.
+ * Build-time sandbox prewarm hook. Failures are build failures because the
+ * same provisioning or bootstrap would otherwise fail after deployment.
  *
- * Returns `true` when the prewarm ran, `false` when the current
- * environment is not a Vercel build.
+ * Backends opt in through `provisioning.prewarmAtBuild`. Vercel remains
+ * restricted to builds with a deployment id because that id participates in
+ * its template scope; other remote backends can prewarm in any build host.
  */
+export async function runBuildSandboxPrewarm(input: PrewarmAppSandboxesInput): Promise<void> {
+  if (process.env.VERCEL?.trim() && !process.env.VERCEL_DEPLOYMENT_ID?.trim()) {
+    console.warn(VERCEL_BUILD_PREWARM_SKIPPED_WARNING);
+  }
+
+  await prewarmAppSandboxes({
+    ...input,
+    shouldPrewarmBackend: shouldPrewarmBackendAtBuild,
+  });
+}
+
+/** Backwards-compatible Vercel-only entry used by the Vercel build scenario harness. */
 export async function runVercelBuildPrewarm(input: PrewarmAppSandboxesInput): Promise<boolean> {
   if (!shouldPrewarmVercelBuild()) {
     if (process.env.VERCEL?.trim() && !process.env.VERCEL_DEPLOYMENT_ID?.trim()) {
@@ -42,4 +55,11 @@ export async function runVercelBuildPrewarm(input: PrewarmAppSandboxesInput): Pr
   }
   await prewarmAppSandboxes(input);
   return true;
+}
+
+function shouldPrewarmBackendAtBuild(backend: SandboxBackend): boolean {
+  if (backend.provisioning?.prewarmAtBuild !== true) {
+    return false;
+  }
+  return backend.name !== "vercel" || shouldPrewarmVercelBuild();
 }

--- a/packages/eve/src/public/definitions/sandbox-backend.ts
+++ b/packages/eve/src/public/definitions/sandbox-backend.ts
@@ -7,6 +7,7 @@ export type {
   SandboxBackendCreateInput,
   SandboxBackendPrewarmInput,
   SandboxBackendPrewarmResult,
+  SandboxBackendProvisioning,
   SandboxBackend,
 } from "#shared/sandbox-backend.js";
 

--- a/packages/eve/src/public/sandbox/aws-lambda-microvm-sandbox.ts
+++ b/packages/eve/src/public/sandbox/aws-lambda-microvm-sandbox.ts
@@ -1,0 +1,63 @@
+/** Supported baseline memory allocations for an AWS Lambda MicroVM image. */
+export type AwsLambdaMicrovmMemoryMiB = 512 | 1024 | 2048 | 4096 | 8192;
+
+/** Idle suspension and retention policy applied to each MicroVM session. */
+export interface AwsLambdaMicrovmIdlePolicy {
+  /** Seconds without proxy traffic before AWS suspends the MicroVM. */
+  readonly maxIdleDurationSeconds: number;
+  /** Seconds AWS retains a suspended MicroVM before terminating it. */
+  readonly suspendedDurationSeconds: number;
+  /** Whether authenticated ingress automatically resumes a suspended MicroVM. */
+  readonly autoResumeEnabled: boolean;
+}
+
+/** Exact Lambda-managed base image override used for eve image builds. */
+export interface AwsLambdaMicrovmBaseImage {
+  readonly arn: string;
+  readonly version: string;
+}
+
+/** CloudWatch logging configuration for image builds and MicroVM sessions. */
+export interface AwsLambdaMicrovmCloudWatchLogging {
+  readonly logGroup?: string;
+  readonly logStream?: string;
+}
+
+/**
+ * Options accepted by {@link awsLambdaMicrovm}.
+ *
+ * eve creates Lambda MicroVM images and S3 artifacts, but never creates the
+ * bucket, IAM roles, VPCs, or custom network connectors named here.
+ */
+export interface AwsLambdaMicrovmSandboxOptions {
+  /** Stable application namespace shared by build and deployed runtime. */
+  readonly applicationId: string;
+  /** AWS region containing the bucket, image, connectors, and MicroVMs. */
+  readonly region: string;
+  /** Existing same-region S3 bucket used for image artifacts and checkpoints. */
+  readonly artifactBucket: string;
+  /** IAM role AWS assumes while building the MicroVM image. */
+  readonly buildRoleArn: string;
+  /** Prefix inside `artifactBucket`; defaults to an application-scoped eve prefix. */
+  readonly artifactPrefix?: string;
+  /** Optional execution role exposed to code inside the MicroVM through IMDS. */
+  readonly executionRoleArn?: string;
+  /** Baseline memory for the image. Defaults to 2048 MiB. */
+  readonly memoryMiB?: AwsLambdaMicrovmMemoryMiB;
+  /** Maximum MicroVM lifetime in seconds. Defaults to AWS's 28,800 second limit. */
+  readonly maximumDurationSeconds?: number;
+  /** Idle policy. Defaults to 5 minutes running and 30 minutes suspended. */
+  readonly idlePolicy?: Partial<AwsLambdaMicrovmIdlePolicy>;
+  /** Exact managed base image. Omit to use the newest available AL2023 image. */
+  readonly baseImage?: AwsLambdaMicrovmBaseImage;
+  /** Egress connectors used for image build and template bootstrap. */
+  readonly buildEgressNetworkConnectorArns?: readonly string[];
+  /** Egress connectors used for live agent sessions. */
+  readonly runtimeEgressNetworkConnectorArns?: readonly string[];
+  /** Adds AWS's shell ingress connector. Disabled by default. */
+  readonly shellAccess?: boolean;
+  /** CloudWatch configuration, or `false` to disable logging. */
+  readonly runtimeLogging?: AwsLambdaMicrovmCloudWatchLogging | false;
+  /** Tags attached to eve-owned image and MicroVM resources. */
+  readonly tags?: Readonly<Record<string, string>>;
+}

--- a/packages/eve/src/public/sandbox/aws-lambda.ts
+++ b/packages/eve/src/public/sandbox/aws-lambda.ts
@@ -1,0 +1,8 @@
+export { awsLambdaMicrovm } from "#public/sandbox/backends/aws-lambda.js";
+export type {
+  AwsLambdaMicrovmBaseImage,
+  AwsLambdaMicrovmCloudWatchLogging,
+  AwsLambdaMicrovmIdlePolicy,
+  AwsLambdaMicrovmMemoryMiB,
+  AwsLambdaMicrovmSandboxOptions,
+} from "#public/sandbox/aws-lambda-microvm-sandbox.js";

--- a/packages/eve/src/public/sandbox/backends/aws-lambda.ts
+++ b/packages/eve/src/public/sandbox/backends/aws-lambda.ts
@@ -1,0 +1,15 @@
+import { createAwsLambdaMicrovmSandbox } from "#execution/sandbox/bindings/aws-lambda-microvms/backend.js";
+import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
+import type { AwsLambdaMicrovmSandboxOptions } from "#public/sandbox/aws-lambda-microvm-sandbox.js";
+
+/**
+ * Constructs an explicit AWS Lambda MicroVM sandbox backend.
+ *
+ * The backend provisions eve-owned image versions and stores durable
+ * full-filesystem checkpoints in the supplied S3 bucket. It is never selected
+ * by {@link import("../index.js").defaultBackend}; configuring it always uses
+ * real AWS resources, including during local development.
+ */
+export function awsLambdaMicrovm(options: AwsLambdaMicrovmSandboxOptions): SandboxBackend {
+  return createAwsLambdaMicrovmSandbox({ options });
+}

--- a/packages/eve/src/public/sandbox/index.ts
+++ b/packages/eve/src/public/sandbox/index.ts
@@ -27,6 +27,7 @@ export type {
   SandboxBackendCreateInput,
   SandboxBackendHandle,
   SandboxBackendPrewarmInput,
+  SandboxBackendProvisioning,
   SandboxBackendRuntimeContext,
   SandboxBackendSessionState,
   SandboxSeedFile,

--- a/packages/eve/src/runtime/sandbox/keys.test.ts
+++ b/packages/eve/src/runtime/sandbox/keys.test.ts
@@ -74,6 +74,24 @@ function withBundledMetadata<T>(
 }
 
 describe("createRuntimeSandboxTemplateKey", () => {
+  it("uses an explicit backend scope without changing the version hash", async () => {
+    const templateKey = await withBundledMetadata(
+      createMetadataFixture("9.9.9-test"),
+      async () =>
+        await createRuntimeSandboxTemplateKey({
+          backendName: "aws-lambda-microvms",
+          backendScopeKey: "analytics-agent",
+          compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
+          nodeId: "__root__",
+          sourceId: "eve:default-sandbox",
+          templatePlan: { contentHash: CONTENT_HASH, kind: "workspace-content" },
+        }),
+    );
+
+    const scope = sha256("backend:aws-lambda-microvms:analytics-agent").slice(0, 16);
+    expect(templateKey).toContain(`eve-sbx-tpl-aws-lambda-microvms-${scope}-`);
+  });
+
   it("derives the version segment from compile metadata so build and runtime agree", async () => {
     const templateKey = await withBundledMetadata(
       createMetadataFixture("9.9.9-test"),

--- a/packages/eve/src/runtime/sandbox/keys.ts
+++ b/packages/eve/src/runtime/sandbox/keys.ts
@@ -19,6 +19,7 @@ const RUNTIME_SANDBOX_CONTRACT_VERSION = 6;
  */
 interface CreateRuntimeSandboxKeysInput {
   readonly backendName: string;
+  readonly backendScopeKey?: string;
   readonly compiledArtifactsSource: RuntimeCompiledArtifactsSource;
   readonly nodeId: string;
   readonly sessionId: string;
@@ -51,6 +52,7 @@ export async function createRuntimeSandboxKeys(input: CreateRuntimeSandboxKeysIn
  */
 export async function createRuntimeSandboxTemplateKey(input: {
   readonly backendName: string;
+  readonly backendScopeKey?: string;
   readonly compiledArtifactsSource: RuntimeCompiledArtifactsSource;
   readonly nodeId: string;
   readonly sourceId: string;
@@ -63,6 +65,7 @@ export async function createRuntimeSandboxTemplateKey(input: {
   const metadata = await loadCompileMetadataForKeys(input.compiledArtifactsSource);
   const scope = await resolveRuntimeSandboxScope({
     backendName: input.backendName,
+    backendScopeKey: input.backendScopeKey,
     compiledArtifactsSource: input.compiledArtifactsSource,
     scopeKind: input.templatePlan.kind === "source-graph" ? "deployment" : "stable",
   });
@@ -107,12 +110,14 @@ async function loadCompileMetadataForKeys(
 
 async function createRuntimeSandboxSessionKey(input: {
   readonly backendName: string;
+  readonly backendScopeKey?: string;
   readonly compiledArtifactsSource: RuntimeCompiledArtifactsSource;
   readonly nodeId: string;
   readonly sessionId: string;
 }): Promise<string> {
   const scope = await resolveRuntimeSandboxScope({
     backendName: input.backendName,
+    backendScopeKey: input.backendScopeKey,
     compiledArtifactsSource: input.compiledArtifactsSource,
     scopeKind: "deployment",
   });
@@ -137,9 +142,15 @@ async function createRuntimeSandboxSessionKey(input: {
  */
 async function resolveRuntimeSandboxScope(input: {
   readonly backendName: string;
+  readonly backendScopeKey?: string;
   readonly compiledArtifactsSource: RuntimeCompiledArtifactsSource;
   readonly scopeKind: "deployment" | "stable";
 }): Promise<string> {
+  const backendScopeKey = input.backendScopeKey?.trim();
+  if (backendScopeKey !== undefined && backendScopeKey.length > 0) {
+    return createStableHash(`backend:${input.backendName}:${backendScopeKey}`).slice(0, 16);
+  }
+
   if (input.backendName === "vercel") {
     if (input.scopeKind === "stable") {
       const projectScope = resolveVercelProjectScope();

--- a/packages/eve/src/runtime/sandbox/template-plan.test.ts
+++ b/packages/eve/src/runtime/sandbox/template-plan.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
+import { createRuntimeSandboxTemplatePlan } from "#runtime/sandbox/template-plan.js";
+import type { ResolvedSandboxDefinition } from "#runtime/types.js";
+
+function createDefinition(backend: SandboxBackend): ResolvedSandboxDefinition {
+  return {
+    backend,
+    logicalPath: "agent/sandbox.ts",
+    sourceHash: "source-hash",
+    sourceId: "agent/sandbox",
+    sourceKind: "module",
+  };
+}
+
+function createBackend(requiresTemplate: boolean): SandboxBackend {
+  return {
+    async create() {
+      throw new Error("Unexpected create call.");
+    },
+    name: "test",
+    async prewarm() {
+      return { reused: true };
+    },
+    provisioning: {
+      prewarmAtBuild: true,
+      requiresTemplate,
+    },
+  };
+}
+
+describe("createRuntimeSandboxTemplatePlan", () => {
+  it("requires a source-graph template for an otherwise-empty remote backend", () => {
+    expect(
+      createRuntimeSandboxTemplatePlan({
+        definition: createDefinition(createBackend(true)),
+        workspaceResourceRoot: { logicalPath: "", rootEntries: [] },
+      }),
+    ).toEqual({ kind: "source-graph" });
+  });
+
+  it("keeps an otherwise-empty ordinary backend template-less", () => {
+    expect(
+      createRuntimeSandboxTemplatePlan({
+        definition: createDefinition(createBackend(false)),
+        workspaceResourceRoot: { logicalPath: "", rootEntries: [] },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+});

--- a/packages/eve/src/runtime/sandbox/template-plan.ts
+++ b/packages/eve/src/runtime/sandbox/template-plan.ts
@@ -46,7 +46,9 @@ export function createRuntimeSandboxTemplatePlan(input: {
   }
 
   if (input.workspaceResourceRoot.rootEntries.length === 0) {
-    return { kind: "none" };
+    return input.definition.backend.provisioning?.requiresTemplate === true
+      ? { kind: "source-graph" }
+      : { kind: "none" };
   }
 
   return {

--- a/packages/eve/src/shared/sandbox-backend.ts
+++ b/packages/eve/src/shared/sandbox-backend.ts
@@ -119,13 +119,30 @@ export interface SandboxBackendPrewarmResult {
 }
 
 /**
+ * Declares provisioning behavior that eve cannot infer from authored
+ * bootstrap or workspace files alone.
+ *
+ * Remote backends use this capability to require an otherwise-empty
+ * template, choose a stable resource namespace across deployments, and
+ * request provisioning during `eve build`.
+ */
+export interface SandboxBackendProvisioning {
+  /** Whether the backend needs a template even with no bootstrap or seed files. */
+  readonly requiresTemplate: boolean;
+  /** Optional stable namespace used instead of a deployment or filesystem scope. */
+  readonly scopeKey?: string;
+  /** Whether `eve build` must provision this backend before producing deployable output. */
+  readonly prewarmAtBuild: boolean;
+}
+
+/**
  * Pluggable sandbox backend.
  *
  * A `SandboxBackend` is a value an author attaches to a
  * {@link SandboxDefinition} to choose which underlying runtime hosts the
  * sandbox. eve ships built-in backends (`docker()`,
- * `justbash()`, `microsandbox()`,
- * `vercel()`, and the availability-aware
+ * `justbash()`, `microsandbox()`, `vercel()`, the explicit AWS Lambda
+ * MicroVM backend, and the availability-aware
  * `defaultSandbox()`), but the interface is public so authors can write
  * their own.
  *
@@ -144,6 +161,8 @@ export interface SandboxBackend<BO = Record<string, never>, SO = Record<string, 
    * `"local"`. Custom backends pick a unique string.
    */
   readonly name: string;
+  /** Optional remote-resource provisioning requirements for this backend. */
+  readonly provisioning?: SandboxBackendProvisioning;
   /**
    * Creates or reattaches one live sandbox session from a template
    * previously captured by {@link SandboxBackend.prewarm}. Throws

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -43,6 +43,7 @@ const PORTABILITY_CASES: readonly PortabilityCase[] = [
     descriptor: {
       files: {
         "agent/sandbox.ts": `import { defaultBackend, defineSandbox } from "eve/sandbox";
+import { awsLambdaMicrovm, type AwsLambdaMicrovmSandboxOptions } from "eve/sandbox/aws-lambda";
 import { docker } from "eve/sandbox/docker";
 import { justbash } from "eve/sandbox/just-bash";
 import { microsandbox } from "eve/sandbox/microsandbox";
@@ -58,6 +59,9 @@ const fallback = defaultBackend({
 void docker;
 void justbash;
 void microsandbox;
+const awsOptions = {} as AwsLambdaMicrovmSandboxOptions;
+void awsLambdaMicrovm;
+void awsOptions;
 
 export default defineSandbox({
   backend: process.env.VERCEL === "1" ? vercel() : fallback,
@@ -68,6 +72,7 @@ export default defineSandbox({
     },
     include: [
       "src/public/sandbox/index.ts",
+      "src/public/sandbox/aws-lambda.ts",
       "src/public/sandbox/docker.ts",
       "src/public/sandbox/just-bash.ts",
       "src/public/sandbox/microsandbox.ts",
@@ -77,6 +82,9 @@ export default defineSandbox({
     packageExports: {
       "./sandbox": {
         types: "./dist/src/public/sandbox/index.d.ts",
+      },
+      "./sandbox/aws-lambda": {
+        types: "./dist/src/public/sandbox/aws-lambda.d.ts",
       },
       "./sandbox/docker": {
         types: "./dist/src/public/sandbox/docker.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         version: 0.4.0(@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(h3@1.15.11)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(1bf1af76e23df0ef2782fcce60ed20a8)
+        version: 2.0.1(9c72eb96889ecc3c39cc0615d75eb942)
       '@vercel/eve-catalog':
         specifier: workspace:*
         version: link:../../packages/eve-catalog
@@ -139,7 +139,7 @@ importers:
         version: 1.7.2(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(1bf1af76e23df0ef2782fcce60ed20a8)
+        version: 2.0.0(9c72eb96889ecc3c39cc0615d75eb942)
       ai:
         specifier: 6.0.191
         version: 6.0.191(zod@4.4.3)
@@ -352,7 +352,7 @@ importers:
         version: link:../../../packages/eve
       nuxt:
         specifier: ^4.0.0
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       vue:
         specifier: ^3.5.0
         version: 3.5.35(typescript@6.0.3)
@@ -766,6 +766,15 @@ importers:
       '@ai-sdk/provider':
         specifier: 'catalog:'
         version: 4.0.0-beta.19
+      '@aws-sdk/client-lambda-microvms':
+        specifier: 3.1075.0
+        version: 3.1075.0
+      '@aws-sdk/client-s3':
+        specifier: 3.1073.0
+        version: 3.1073.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: 3.1073.0
+        version: 3.1073.0
       '@chat-adapter/slack':
         specifier: 4.29.0
         version: 4.29.0(ai@7.0.0-beta.178(zod@4.4.3))(zod@4.4.3)
@@ -992,6 +1001,12 @@ packages:
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
     engines: {node: '>=16.0.0'}
 
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -1005,20 +1020,88 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/checksums@3.1000.8':
+    resolution: {integrity: sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-lambda-microvms@3.1075.0':
+    resolution: {integrity: sha512-aRqc4fT/qwwsbhiiaTsY/rNtsZjZMWuDEIYBaWNgQcsGJ8BPQvz3uNq+O08vl8rnRhNf6NotMqXfqyW+byaPeQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1073.0':
+    resolution: {integrity: sha512-/Dvhrff0I4D2YUWSdm8uLKa1bfXdw9BMRDUME6ZeoTrrdQKQDeo2scLDjdpC5X2YdvTc/ZnUCR2HAvD7qXvS1w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.21':
     resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.49':
     resolution: {integrity: sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    resolution: {integrity: sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    resolution: {integrity: sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.21':
     resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1073.0':
+    resolution: {integrity: sha512-nXYVwu3g/yspa5oXxWj3h4GrWsgAcyHeEpNZ6dtj0/Qm5s1Z/wLpYC5XwHeMPVGJZXnFuEQ7EBTe+nMHNnJVGQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.13':
@@ -1031,6 +1114,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.30':
     resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -5748,6 +5835,14 @@ packages:
 
   '@smithy/core@3.25.0':
     resolution: {integrity: sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.25.1':
+    resolution: {integrity: sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.1':
+    resolution: {integrity: sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.5.0':
@@ -11724,6 +11819,7 @@ packages:
 
   stream-to-promise@2.2.0:
     resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
 
   streamdown@2.5.0:
     resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
@@ -13066,6 +13162,21 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
@@ -13092,6 +13203,47 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/checksums@3.1000.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-lambda-microvms@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/middleware-flexible-checksums': 3.974.33
+      '@aws-sdk/middleware-sdk-s3': 3.972.54
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.21':
     dependencies:
       '@aws-sdk/types': 3.973.13
@@ -13103,10 +13255,119 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.25.0
+      '@smithy/signature-v4': 5.5.0
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/credential-provider-imds': 4.4.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.49':
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.8
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.25.0
       '@smithy/types': 4.15.0
@@ -13125,10 +13386,41 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/fetch-http-handler': 5.5.0
+      '@smithy/node-http-handler': 4.8.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1073.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     dependencies:
       '@aws-sdk/types': 3.973.13
       '@smithy/signature-v4': 5.5.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -13145,6 +13437,11 @@ snapshots:
     dependencies:
       '@smithy/types': 4.15.0
       fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -13339,6 +13636,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.6
+
+  '@bomb.sh/tab@0.0.15(cac@6.7.14)(citty@0.2.2)':
+    optionalDependencies:
+      cac: 6.7.14
+      citty: 0.2.2
 
   '@bomb.sh/tab@0.0.15(cac@6.7.14)(citty@0.2.2)(commander@14.0.3)':
     optionalDependencies:
@@ -14451,6 +14753,44 @@ snapshots:
       - magicast
       - supports-color
 
+  '@nuxt/cli@3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)':
+    dependencies:
+      '@bomb.sh/tab': 0.0.15(cac@6.7.14)(citty@0.2.2)
+      '@clack/prompts': 1.5.0
+      c12: 3.3.4(magicast@0.5.3)
+      citty: 0.2.2
+      confbox: 0.2.4
+      consola: 3.4.2
+      debug: 4.4.3
+      defu: 6.1.7
+      exsolve: 1.0.8
+      fuse.js: 7.4.0
+      fzf: 0.5.2
+      giget: 3.2.0
+      jiti: 2.7.0
+      listhen: 1.10.0(srvx@0.11.16)
+      nypm: 0.6.6
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      scule: 1.3.0
+      semver: 7.8.4
+      srvx: 0.11.16
+      std-env: 4.1.0
+      tinyclip: 0.1.13
+      tinyexec: 1.2.2
+      ufo: 1.6.4
+      youch: 4.1.1
+    optionalDependencies:
+      '@nuxt/schema': 4.4.6
+    transitivePeerDependencies:
+      - cac
+      - commander
+      - magicast
+      - supports-color
+
   '@nuxt/devalue@2.0.2': {}
 
   '@nuxt/devtools-kit@3.2.4(magicast@0.5.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
@@ -14658,7 +14998,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.6(355aa972cbce473ecd0a6783b15860ed)':
+  '@nuxt/nitro-server@4.4.6(7b97e63a95ab4dc7b7232f31d0b52bd5)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -14675,8 +15015,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -14684,7 +15024,7 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unctx: 2.5.0
-      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
+      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
       vue: 3.5.35(typescript@6.0.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -14727,7 +15067,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)(typescript@6.0.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -14744,8 +15084,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -14753,7 +15093,7 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unctx: 2.5.0
-      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
+      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
       vue: 3.5.35(typescript@6.0.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -14814,7 +15154,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@4.4.6(357c5152dbdbefdd44e9614a9454cdd1)':
+  '@nuxt/vite-builder@4.4.6(0cd2af055bf9dc22644a544fb6844dd8)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -14832,7 +15172,68 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.15
+      seroval: 1.5.4
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vue: 3.5.35(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
+      rolldown: 1.1.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.60.4)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.4.6(2d1143a32f44addefd747294e848988d)':
+    dependencies:
+      '@nuxt/kit': 4.4.6(magicast@0.5.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
+      '@vitejs/plugin-vue': 6.0.7(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      autoprefixer: 10.5.0(postcss@8.5.15)
+      consola: 3.4.2
+      cssnano: 8.0.1(postcss@8.5.15)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -14875,67 +15276,6 @@ snapshots:
       - vue-tsc
       - yaml
     optional: true
-
-  '@nuxt/vite-builder@4.4.6(772227546e20b752c7ab17acaadd8237)':
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
-      '@vitejs/plugin-vue': 6.0.7(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      autoprefixer: 10.5.0(postcss@8.5.15)
-      consola: 3.4.2
-      cssnano: 8.0.1(postcss@8.5.15)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.15
-      seroval: 1.5.4
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      vue: 3.5.35(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
-      rolldown: 1.1.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.60.4)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
 
   '@nuxt/vite-builder@4.4.6(eb203581bd643ab4f7d80d8bc2915558)':
     dependencies:
@@ -17696,6 +18036,18 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.25.1':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.1':
+    dependencies:
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/fetch-http-handler@5.5.0':
     dependencies:
       '@smithy/core': 3.25.0
@@ -18467,11 +18819,11 @@ snapshots:
       h3: 1.15.11
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@vercel/analytics@2.0.1(1bf1af76e23df0ef2782fcce60ed20a8)':
+  '@vercel/analytics@2.0.1(9c72eb96889ecc3c39cc0615d75eb942)':
     optionalDependencies:
       '@sveltejs/kit': 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.6
       svelte: 5.56.1(@typescript-eslint/types@8.59.4)
       vue: 3.5.35(typescript@6.0.3)
@@ -18619,6 +18971,14 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       ws: 8.21.0
+
+  '@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0)':
+    dependencies:
+      '@vercel/oidc': 3.6.1
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      ws: 8.21.0
+    optional: true
 
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     dependencies:
@@ -18923,11 +19283,11 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/speed-insights@2.0.0(1bf1af76e23df0ef2782fcce60ed20a8)':
+  '@vercel/speed-insights@2.0.0(9c72eb96889ecc3c39cc0615d75eb942)':
     optionalDependencies:
       '@sveltejs/kit': 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.6
       svelte: 5.56.1(@typescript-eslint/types@8.59.4)
       vue: 3.5.35(typescript@6.0.3)
@@ -23377,6 +23737,110 @@ snapshots:
       - supports-color
       - uploadthing
 
+  nitropack@2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.60.4)
+      '@rollup/plugin-commonjs': 29.0.3(rollup@4.60.4)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.60.4)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.4)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.4)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.60.4)
+      '@vercel/nft': 1.10.2(rollup@4.60.4)
+      archiver: 7.0.1
+      c12: 3.3.4(magicast@0.5.3)
+      chokidar: 5.0.0
+      citty: 0.2.2
+      compatx: 0.2.0
+      confbox: 0.2.4
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      croner: 10.0.1
+      crossws: 0.3.5
+      db0: 0.3.4
+      defu: 6.1.7
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.28.0
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.0.8
+      globby: 16.2.0
+      gzip-size: 7.0.0
+      h3: 1.15.11
+      hookable: 5.5.3
+      httpxy: 0.5.3
+      ioredis: 5.11.0
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.10.0(srvx@0.11.16)
+      magic-string: 0.30.21
+      magicast: 0.5.3
+      mime: 4.1.0
+      mlly: 1.8.2
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.60.4
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.60.4)
+      scule: 1.3.0
+      semver: 7.8.4
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1
+      source-map: 0.7.6
+      std-env: 4.1.0
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 6.3.0(oxc-parser@0.131.0)(rolldown@1.1.0)
+      unplugin-utils: 0.3.1
+      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.1
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - srvx
+      - supports-color
+      - uploadthing
+
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.4
@@ -23581,16 +24045,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
-      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.3)
+      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)(typescript@6.0.3)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(357c5152dbdbefdd44e9614a9454cdd1)
+      '@nuxt/vite-builder': 4.4.6(2d1143a32f44addefd747294e848988d)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0
@@ -23711,16 +24175,16 @@ snapshots:
       - yaml
     optional: true
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
-      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.3)
+      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(355aa972cbce473ecd0a6783b15860ed)
+      '@nuxt/nitro-server': 4.4.6(7b97e63a95ab4dc7b7232f31d0b52bd5)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(772227546e20b752c7ab17acaadd8237)
+      '@nuxt/vite-builder': 4.4.6(0cd2af055bf9dc22644a544fb6844dd8)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0
@@ -26258,6 +26722,22 @@ snapshots:
     optionalDependencies:
       '@vercel/blob': 2.4.0
       '@vercel/functions': 3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0)
+      db0: 0.3.4
+      ioredis: 5.11.0
+
+  unstorage@1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.0
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      '@vercel/blob': 2.4.0
+      '@vercel/functions': 3.7.1(@aws-sdk/credential-provider-web-identity@3.972.55)(ws@8.21.0)
       db0: 0.3.4
       ioredis: 5.11.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ minimumReleaseAge: 2880 # 2 days
 
 minimumReleaseAgeExclude:
   - "@ai-sdk/*"
+  - "@aws-sdk/*"
   - "@typescript/typescript-*"
   - "@turbo/*"
   - "@workflow/*"


### PR DESCRIPTION
## Summary

- add the explicit `eve/sandbox/aws-lambda` backend for AWS Lambda MicroVMs
- provision content-addressed ARM64 images and application-scoped templates during prewarm
- run sandbox process and filesystem operations through an eve-owned controller
- persist full writable-filesystem checkpoints through S3 multipart uploads, manifests, and leases
- generalize sandbox backend provisioning metadata and build-time prewarm behavior
- vendor the required AWS clients without adding runtime dependencies
- document IAM, networking, lifecycle, checkpoint, and operational requirements

## Why

AWS Lambda MicroVMs provide isolated sandboxes with lifecycle control, native suspend/resume, and authenticated HTTP ingress. This makes them suitable as an explicit eve sandbox backend when durable full-filesystem state is retained outside the eight-hour MicroVM lifetime.

## Impact

The backend is opt-in and does not change default backend selection. Users provide existing IAM roles, a same-region S3 bucket, and optional network connectors. Runtime network policy remains immutable after launch.

## Validation

- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm build`
- `pnpm test:scenario`
- `EVE_RUN_AWS_MICROVM_CONTROLLER_SCENARIOS=1 pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/execution/sandbox/bindings/aws-lambda-microvms/controller.scenario.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `git diff --check`

## Not completed locally

- Live AWS acceptance was not run because this environment has no AWS credentials.
- `e2e/fixtures/agent-tools-sandbox` was attempted, but all cases stopped before assertions because AI Gateway/OIDC credentials are unavailable.
