### PR TITLE
fix(eve): harden optional engine loading

### DIFF
--- a/.changeset/clear-microsandbox-load-errors.md
+++ b/.changeset/clear-microsandbox-load-errors.md
@@ -1,0 +1,8 @@
+---
+"eve": patch
+---
+
+Make optional sandbox engine loading more resilient after auto-install. eve now
+probes installed engine packages in a cache-isolated worker, checks ancestor
+`node_modules` directories for workspace-hoisted installs, and reports a clear
+post-install diagnostic when an engine package still cannot be loaded.

--- a/packages/eve/src/internal/application/optional-package-install.test.ts
+++ b/packages/eve/src/internal/application/optional-package-install.test.ts
@@ -1,6 +1,8 @@
 import { ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { PassThrough } from "node:stream";
+import { Worker } from "node:worker_threads";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -29,8 +31,64 @@ vi.mock("node:fs/promises", () => ({
   writeFile: vi.fn(async () => {}),
 }));
 
+const workerMockState = vi.hoisted(() => {
+  type Listener = (...args: unknown[]) => void;
+  type WorkerMessage = Error | { readonly message?: string; readonly ok: boolean };
+
+  const state = {
+    messages: [] as WorkerMessage[],
+    workers: [] as Array<{
+      readonly code: string;
+      readonly options: { readonly workerData?: unknown };
+    }>,
+    Worker: vi.fn(function (code: string, options: { readonly workerData?: unknown }) {
+      const listeners = new Map<string, Listener[]>();
+      const worker = {
+        off(event: string, listener: Listener) {
+          listeners.set(
+            event,
+            (listeners.get(event) ?? []).filter((candidate) => candidate !== listener),
+          );
+          return worker;
+        },
+        once(event: string, listener: Listener) {
+          listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+          return worker;
+        },
+        terminate: vi.fn(async () => 0),
+      };
+      const emit = (event: string, ...args: unknown[]) => {
+        const eventListeners = listeners.get(event) ?? [];
+        listeners.delete(event);
+        for (const listener of eventListeners) listener(...args);
+      };
+
+      state.workers.push({ code, options });
+      queueMicrotask(() => {
+        const message = state.messages.shift() ?? { ok: true };
+        if (message instanceof Error) {
+          emit("error", message);
+          return;
+        }
+        emit("message", message);
+        emit("exit", 0);
+      });
+
+      return worker;
+    }),
+  };
+  return state;
+});
+
+vi.mock("node:worker_threads", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:worker_threads")>()),
+  Worker: workerMockState.Worker,
+}));
+
 const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFile = vi.mocked(readFile);
 const mockedSpawn = vi.mocked(spawn);
+const mockedWorker = vi.mocked(Worker);
 
 function createMockChildProcess() {
   return Object.assign(new ChildProcess(), {
@@ -52,7 +110,10 @@ function mockProcessPlatform(platform: NodeJS.Platform): () => void {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
+  workerMockState.messages = [];
+  workerMockState.workers = [];
   mockedExistsSync.mockReturnValue(false);
+  mockedReadFile.mockResolvedValue("{}");
   mockedSpawn.mockImplementation(() => {
     const child = createMockChildProcess();
     queueMicrotask(() => child.emit("close", 0));
@@ -141,6 +202,108 @@ describe("loadOptionalEnginePackage", () => {
 
     await expect(Promise.all([first, second])).resolves.toEqual([loadedModule, loadedModule]);
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps a post-install load failure with an actionable diagnostic", async () => {
+    const appRoot = "/repo/misconfigured-app";
+    vi.stubEnv(EVE_DEV_ENV_FLAG, "1");
+    const importModule = vi.fn(async () => {
+      throw Object.assign(new Error("Cannot find package 'microsandbox'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      });
+    });
+    const importInstalledModule = vi.fn(async () => {
+      throw Object.assign(new Error("Cannot find package 'microsandbox'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      });
+    });
+
+    await expect(
+      loadOptionalEnginePackage({
+        appRoot,
+        autoInstall: true,
+        importInstalledModule,
+        importModule,
+        missingMessage: "missing microsandbox",
+        packageName: "microsandbox",
+      }),
+    ).rejects.toThrow(
+      'missing microsandbox Automatic installation completed, but "microsandbox" still could not be loaded from "/repo/misconfigured-app".',
+    );
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(importInstalledModule).toHaveBeenCalledTimes(2);
+  });
+
+  it("wraps a missing package root after successful auto-install", async () => {
+    const appRoot = "/repo/missing-root-app";
+    vi.stubEnv(EVE_DEV_ENV_FLAG, "1");
+    const importModule = vi.fn(async () => {
+      throw Object.assign(new Error("Cannot find package 'microsandbox'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      });
+    });
+
+    const result = loadOptionalEnginePackage({
+      appRoot,
+      autoInstall: true,
+      importModule,
+      missingMessage: "missing microsandbox",
+      packageName: "microsandbox",
+    });
+
+    await expect(result).rejects.toThrow(
+      'missing microsandbox Automatic installation completed, but "microsandbox" still could not be loaded from "/repo/missing-root-app".',
+    );
+    await expect(result).rejects.toThrow("Could not find installed optional dependency");
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(importModule).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks installed packages in an isolated worker before auto-installing", async () => {
+    const appRoot = "/repo/worker-app";
+    vi.stubEnv(EVE_DEV_ENV_FLAG, "1");
+    mockedExistsSync.mockImplementation(
+      (path) => path === "/repo/worker-app/node_modules/microsandbox/package.json",
+    );
+    mockedReadFile.mockResolvedValue(
+      JSON.stringify({
+        exports: {
+          ".": {
+            import: "./dist/index.js",
+          },
+        },
+      }),
+    );
+    workerMockState.messages.push({
+      ok: false,
+      message: "worker cache-isolated miss",
+    });
+    const importModule = vi.fn(async () => {
+      throw Object.assign(new Error("Cannot find package 'microsandbox'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      });
+    });
+
+    await expect(
+      loadOptionalEnginePackage({
+        appRoot,
+        autoInstall: true,
+        importModule,
+        missingMessage: "missing microsandbox",
+        packageName: "microsandbox",
+      }),
+    ).rejects.toThrow(
+      'missing microsandbox Automatic installation completed, but "microsandbox" still could not be loaded from "/repo/worker-app".',
+    );
+
+    expect(mockedWorker).toHaveBeenCalledTimes(1);
+    expect(workerMockState.workers[0]?.options.workerData).toEqual({
+      entrypointHref: "file:///repo/worker-app/node_modules/microsandbox/dist/index.js",
+    });
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(importModule).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/eve/src/internal/application/optional-package-install.ts
+++ b/packages/eve/src/internal/application/optional-package-install.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
 
 /**
  * Environment flag set by `eve dev` so runtime code can distinguish the
@@ -135,13 +136,23 @@ export async function loadOptionalEnginePackage<T>(input: {
           appRoot: input.appRoot,
           packageName: input.packageName,
         }));
+    const isInstalledModuleLoadable =
+      input.importInstalledModule === undefined
+        ? async () => await isInstalledEnginePackageLoadable(input)
+        : async () => {
+            try {
+              await importInstalledModule();
+              return true;
+            } catch {
+              return false;
+            }
+          };
 
     try {
       await withOptionalPackageInstallLock(input, async () => {
-        try {
-          await importInstalledModule();
+        if (await isInstalledModuleLoadable()) {
           return;
-        } catch {}
+        }
 
         await installPackageIntoProject({
           appRoot: input.appRoot,
@@ -155,7 +166,17 @@ export async function loadOptionalEnginePackage<T>(input: {
       );
     }
 
-    return await importInstalledModule();
+    try {
+      return await importInstalledModule();
+    } catch (postInstallImportError) {
+      throw new Error(
+        `${input.missingMessage} Automatic installation completed, but "${input.packageName}" ` +
+          `still could not be loaded from "${input.appRoot}". This usually means the package ` +
+          "manager installed into a different workspace, node_modules is unavailable, or the " +
+          `Node/package-manager environment changed while eve dev was running. Last load error: ${toMessage(postInstallImportError)}`,
+        { cause: postInstallImportError },
+      );
+    }
   }
 }
 
@@ -163,7 +184,28 @@ async function importInstalledEnginePackage<T>(input: {
   readonly appRoot: string;
   readonly packageName: string;
 }): Promise<T> {
-  const packageRoot = join(input.appRoot, "node_modules", ...input.packageName.split("/"));
+  const entrypointHref = await resolveInstalledEnginePackageEntrypointHref(input);
+  return (await import(entrypointHref)) as T;
+}
+
+async function isInstalledEnginePackageLoadable(input: {
+  readonly appRoot: string;
+  readonly packageName: string;
+}): Promise<boolean> {
+  try {
+    const entrypointHref = await resolveInstalledEnginePackageEntrypointHref(input);
+    await importEntrypointInWorker(entrypointHref);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveInstalledEnginePackageEntrypointHref(input: {
+  readonly appRoot: string;
+  readonly packageName: string;
+}): Promise<string> {
+  const packageRoot = findInstalledPackageRoot(input);
   const packageJsonPath = join(packageRoot, "package.json");
   const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
     readonly exports?: unknown;
@@ -174,7 +216,99 @@ async function importInstalledEnginePackage<T>(input: {
   if (entry.startsWith("/")) {
     throw new Error(`Invalid absolute entrypoint for optional package "${input.packageName}".`);
   }
-  return (await import(pathToFileURL(join(packageRoot, entry)).href)) as T;
+  return pathToFileURL(join(packageRoot, entry)).href;
+}
+
+async function importEntrypointInWorker(entrypointHref: string): Promise<void> {
+  const worker = new Worker(
+    `
+const { parentPort, workerData } = require("node:worker_threads");
+
+(async () => {
+  try {
+    await import(workerData.entrypointHref);
+    parentPort.postMessage({ ok: true });
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+})();
+`,
+    {
+      eval: true,
+      workerData: { entrypointHref },
+    },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      worker.off("error", handleError);
+      worker.off("exit", handleExit);
+      worker.off("message", handleMessage);
+      void worker.terminate().catch(() => {});
+      callback();
+    };
+    const handleError = (error: Error) => settle(() => reject(error));
+    const handleExit = (code: number) => {
+      if (code !== 0) {
+        settle(() =>
+          reject(
+            new Error(`Optional dependency worker exited before loading module (code ${code}).`),
+          ),
+        );
+      }
+    };
+    const handleMessage = (message: unknown) => {
+      const result = message as { readonly ok?: unknown; readonly message?: unknown };
+      settle(() => {
+        if (result.ok === true) {
+          resolve();
+          return;
+        }
+        reject(
+          new Error(
+            typeof result.message === "string"
+              ? result.message
+              : "Optional dependency worker failed to load module.",
+          ),
+        );
+      });
+    };
+
+    worker.once("error", handleError);
+    worker.once("exit", handleExit);
+    worker.once("message", handleMessage);
+  });
+}
+
+function findInstalledPackageRoot(input: {
+  readonly appRoot: string;
+  readonly packageName: string;
+}): string {
+  const packagePathSegments = input.packageName.split("/");
+  const checkedPaths: string[] = [];
+  let current = input.appRoot;
+
+  for (;;) {
+    const packageRoot = join(current, "node_modules", ...packagePathSegments);
+    checkedPaths.push(packageRoot);
+    if (existsSync(join(packageRoot, "package.json"))) {
+      return packageRoot;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      throw new Error(
+        `Could not find installed optional dependency "${input.packageName}". Checked: ${checkedPaths.join(", ")}`,
+      );
+    }
+    current = parent;
+  }
 }
 
 function resolvePackageEntryPoint(packageJson: {


### PR DESCRIPTION
## Summary
- probe optional sandbox engine packages in an isolated worker before auto-installing
- search ancestor node_modules directories for workspace-hoisted installs
- wrap post-install load failures with an eve-owned diagnostic instead of raw module-not-found

## Verification
- ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/internal/application/optional-package-install.test.ts