### PR TITLE
feat(eve): support structured output in cross-channel receive

### DIFF
--- a/.changeset/cross-channel-output-schema.md
+++ b/.changeset/cross-channel-output-schema.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow cross-channel `receive(...)` calls from routes and schedules to request turn-scoped structured output with Standard Schema or raw JSON Schema.

--- a/.changeset/cross-channel-output-schema.md
+++ b/.changeset/cross-channel-output-schema.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow cross-channel `receive(...)` calls from routes and schedules to request turn-scoped structured output with Standard Schema or raw JSON Schema.
+Allow cross-channel `receive(...)` calls from routes and schedules to request turn-scoped structured output with Standard JSON Schema or raw JSON Schema. Fresh conversation deliveries also clear schemas retained by earlier failed turns while active runtime and HITL continuations preserve them.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -48,7 +48,7 @@ Declare routes with the `POST()` and `GET()` helpers. Each route handler receive
 
 - `send(message, { auth, continuationToken, state? })` starts or resumes a session. Returns a `Session`.
 - `getSession(sessionId)` looks up an existing session. The returned `Session` exposes `getEventStream({ startIndex? })` for streaming.
-- `receive(channel, ...)` hands inbound work to a different channel for cross-channel hand-off.
+- `receive(channel, { message, target, auth, outputSchema? })` hands inbound work to a different channel for cross-channel hand-off.
 - `params` holds route parameters extracted from the path pattern.
 - `waitUntil(promise)` extends the request lifetime for background work.
 - `requestIp` is the client IP, or `null` when the host cannot provide it.
@@ -102,7 +102,13 @@ Route handlers can start a session on a different channel via `args.receive(chan
 
 ```ts
 import { defineChannel, POST } from "eve/channels";
+import { z } from "zod";
 import slack from "./slack.js";
+
+const investigationSchema = z.object({
+  summary: z.string(),
+  severity: z.enum(["low", "medium", "high"]),
+});
 
 export default defineChannel({
   routes: [
@@ -112,6 +118,7 @@ export default defineChannel({
       args.waitUntil(
         args.receive(slack, {
           message: `Investigate ${incident.reference}: ${incident.title}`,
+          outputSchema: investigationSchema,
           target: { channelId: "C0123ABC" },
           auth: {
             authenticator: "incidentio",
@@ -130,10 +137,13 @@ export default defineChannel({
 
 Semantics:
 
-- The target channel's authored `receive(input, { send })` hook owns the continuation-token format and initial state. Callers supply only `{ message, target, auth }`.
+- The target channel's authored `receive(input, { send })` hook owns the continuation-token format and initial state. Callers supply `{ message, target, auth, outputSchema? }`.
+- `outputSchema` accepts Standard Schema or raw JSON Schema. eve applies it to the target's framework-provided `send`, so the target channel does not need schema-specific forwarding. The schema applies only to this turn; successful structured output emits `result.completed`.
 - `auth` flows through to `session.auth.initiator` so the target's event handlers and the agent's tools can read who started the session.
 - Calling `args.receive(...)` does not also start a session on the current channel. The inbound channel's response is whatever the route handler returns explicitly.
 - The first argument is the target channel module's default export. Import it directly from `agent/channels/<name>.ts`. Identity is matched by reference.
+
+See [Output Schema](../guides/client/output-schema) for schema formats, result events, and per-turn behavior.
 
 ## Channel metadata
 

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -138,7 +138,8 @@ export default defineChannel({
 Semantics:
 
 - The target channel's authored `receive(input, { send })` hook owns the continuation-token format and initial state. Callers supply `{ message, target, auth, outputSchema? }`.
-- `outputSchema` accepts Standard Schema or raw JSON Schema. eve applies it to the target's framework-provided `send`, so the target channel does not need schema-specific forwarding. The schema applies only to this turn; successful structured output emits `result.completed`.
+- `outputSchema` accepts Standard JSON Schema (for example, Zod 4) or raw JSON Schema. eve applies it to the target's framework-provided `send`, so the target channel does not need schema-specific forwarding. The schema applies only to this turn; successful structured output emits `result.completed`.
+- `receive(...)` still resolves to a `Session`, not the structured value. Read the result asynchronously from `result.completed` in an agent hook or the session stream.
 - `auth` flows through to `session.auth.initiator` so the target's event handlers and the agent's tools can read who started the session.
 - Calling `args.receive(...)` does not also start a session on the current channel. The inbound channel's response is whatever the route handler returns explicitly.
 - The first argument is the target channel module's default export. Import it directly from `agent/channels/<name>.ts`. Identity is matched by reference.

--- a/docs/guides/client/output-schema.mdx
+++ b/docs/guides/client/output-schema.mdx
@@ -42,9 +42,9 @@ console.log(result.data?.count);
 
 `result.data` is `undefined` when the turn did not produce a structured result.
 
-## Standard Schema
+## Standard JSON Schema
 
-The client also accepts Standard Schema implementations such as Zod, Valibot, and ArkType. The schema is lowered to JSON Schema before the request is sent:
+The client also accepts schemas that implement [Standard JSON Schema](https://standardschema.dev/json-schema), such as Zod 4. The schema is lowered to plain JSON Schema before the request is sent. Libraries that implement only Standard Schema validation need their JSON Schema adapter first; for example, Valibot provides `toStandardJsonSchema` through `@valibot/to-json-schema`.
 
 ```ts
 import { z } from "zod";

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -77,7 +77,7 @@ export default defineSchedule({
 });
 ```
 
-- `receive(channel, { message, target, auth, outputSchema? })`: starts a session on another channel. Same contract as a route handler's `args.receive`; `outputSchema` accepts Standard Schema or raw JSON Schema for this turn.
+- `receive(channel, { message, target, auth, outputSchema? })`: starts a session on another channel. Same contract as a route handler's `args.receive`; `outputSchema` accepts Standard JSON Schema (for example, Zod 4) or raw JSON Schema for this turn.
 - `waitUntil(promise)`: extends the cron task's lifetime so the parked session and any in-flight fetches settle before the task ends. Wrap the `receive` call in it.
 - `appAuth`: the app principal (`{ authenticator: "app", principalId: "eve:app", principalType: "runtime" }`). Pass it as `receive(..., { auth: appAuth })` for work the agent does on its own behalf.
 
@@ -113,7 +113,7 @@ export default defineSchedule({
 });
 ```
 
-Adding a schema does not change the target's run mode or durability. The schema applies only to the delivered turn, and successful structured completion emits `result.completed` for an [agent hook](./guides/hooks) or session event consumer.
+Adding a schema does not change the target's run mode or durability. The schema applies only to the delivered turn, and successful structured completion emits `result.completed` for an [agent hook](./guides/hooks) or session event consumer. `receive(...)` still resolves to a `Session`, so read the structured value asynchronously from that event rather than from the return value.
 
 ## Trigger a schedule while iterating
 

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -77,11 +77,43 @@ export default defineSchedule({
 });
 ```
 
-- `receive(channel, { message, target, auth })`: starts a session on another channel. Same contract as a route handler's `args.receive`.
+- `receive(channel, { message, target, auth, outputSchema? })`: starts a session on another channel. Same contract as a route handler's `args.receive`; `outputSchema` accepts Standard Schema or raw JSON Schema for this turn.
 - `waitUntil(promise)`: extends the cron task's lifetime so the parked session and any in-flight fetches settle before the task ends. Wrap the `receive` call in it.
 - `appAuth`: the app principal (`{ authenticator: "app", principalId: "eve:app", principalType: "runtime" }`). Pass it as `receive(..., { auth: appAuth })` for work the agent does on its own behalf.
 
 A handler-form session runs on the same durable runtime engine as any other session, so it can park (durably suspend), for instance when the channel handoff is waiting for a Slack reply. Only markdown task mode is barred from waiting.
+
+### Structured handoffs
+
+Pass `outputSchema` when a scheduled handoff needs a structured result:
+
+```ts title="agent/schedules/daily-assessment.ts"
+import { defineSchedule } from "eve/schedules";
+import { z } from "zod";
+
+import slack from "../channels/slack.js";
+
+const assessmentSchema = z.object({
+  summary: z.string(),
+  priority: z.enum(["low", "medium", "high"]),
+});
+
+export default defineSchedule({
+  cron: "0 9 * * 1-5",
+  run({ receive, waitUntil, appAuth }) {
+    waitUntil(
+      receive(slack, {
+        message: "Assess today's queue and summarize the priorities.",
+        target: { channelId: "C0123ABC" },
+        auth: appAuth,
+        outputSchema: assessmentSchema,
+      }),
+    );
+  },
+});
+```
+
+Adding a schema does not change the target's run mode or durability. The schema applies only to the delivered turn, and successful structured completion emits `result.completed` for an [agent hook](./guides/hooks) or session event consumer.
 
 ## Trigger a schedule while iterating
 

--- a/e2e/fixtures/agent-channels/agent/channels/webhook.ts
+++ b/e2e/fixtures/agent-channels/agent/channels/webhook.ts
@@ -13,8 +13,9 @@ export default defineChannel({
       const body = (await req.json().catch(() => ({}))) as {
         message?: string;
         sessionRef?: string;
+        structured?: boolean;
       };
-      const session = await args.receive(target, {
+      const options = {
         message: body.message ?? "Reply with the single word: hello.",
         target: { sessionRef: body.sessionRef ?? crypto.randomUUID() },
         auth: {
@@ -23,7 +24,21 @@ export default defineChannel({
           principalId: "smoke-test",
           principalType: "service",
         },
-      });
+      } as const;
+      const session = body.structured
+        ? await args.receive(target, {
+            ...options,
+            outputSchema: {
+              additionalProperties: false,
+              properties: {
+                count: { type: "integer" },
+                title: { type: "string" },
+              },
+              required: ["title", "count"],
+              type: "object",
+            },
+          })
+        : await args.receive(target, options);
       return Response.json({ ok: true, sessionId: session.id });
     }),
   ],

--- a/e2e/fixtures/agent-channels/evals/custom-channels/cross-channel-output-schema.eval.ts
+++ b/e2e/fixtures/agent-channels/evals/custom-channels/cross-channel-output-schema.eval.ts
@@ -1,0 +1,41 @@
+import { defineEval } from "eve/evals";
+
+import { postChannel } from "./shared.js";
+
+/** Structured-output smoke for the cross-channel `args.receive` handoff. */
+export default defineEval({
+  description: "Custom channel smoke: structured cross-channel receive.",
+
+  async test(t) {
+    const payload = await postChannel<{ ok: boolean; sessionId?: string }>(t.target, "/webhook", {
+      message: "Return a structured summary of this handoff.",
+      structured: true,
+    });
+    if (payload.ok !== true || typeof payload.sessionId !== "string") {
+      throw new Error(`Unexpected webhook response: ${JSON.stringify(payload)}`);
+    }
+
+    const session = await t.target.attachSession(payload.sessionId);
+    const results = session.events.filter((event) => event.type === "result.completed");
+    if (results.length !== 1) {
+      throw new Error(`Expected one result.completed event, received ${results.length}.`);
+    }
+
+    const result = results[0]?.data.result;
+    if (
+      !isRecord(result) ||
+      typeof result.title !== "string" ||
+      typeof result.count !== "number" ||
+      !Number.isInteger(result.count)
+    ) {
+      throw new Error(`Unexpected structured result: ${JSON.stringify(result)}`);
+    }
+
+    t.didNotFail();
+    t.completed();
+  },
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/e2e/fixtures/agent-channels/evals/custom-channels/cross-channel-output-schema.eval.ts
+++ b/e2e/fixtures/agent-channels/evals/custom-channels/cross-channel-output-schema.eval.ts
@@ -26,7 +26,9 @@ export default defineEval({
       !isRecord(result) ||
       typeof result.title !== "string" ||
       typeof result.count !== "number" ||
-      !Number.isInteger(result.count)
+      !Number.isInteger(result.count) ||
+      Object.keys(result).some((key) => key !== "count" && key !== "title") ||
+      Object.keys(result).length !== 2
     ) {
       throw new Error(`Unexpected structured result: ${JSON.stringify(result)}`);
     }

--- a/e2e/fixtures/agent-channels/evals/custom-channels/cross-channel-output-schema.eval.ts
+++ b/e2e/fixtures/agent-channels/evals/custom-channels/cross-channel-output-schema.eval.ts
@@ -8,7 +8,8 @@ export default defineEval({
 
   async test(t) {
     const payload = await postChannel<{ ok: boolean; sessionId?: string }>(t.target, "/webhook", {
-      message: "Return a structured summary of this handoff.",
+      message:
+        'Return exactly one structured result with title "handoff" and count 1. Do not answer in prose.',
       structured: true,
     });
     if (payload.ok !== true || typeof payload.sessionId !== "string") {
@@ -18,7 +19,17 @@ export default defineEval({
     const session = await t.target.attachSession(payload.sessionId);
     const results = session.events.filter((event) => event.type === "result.completed");
     if (results.length !== 1) {
-      throw new Error(`Expected one result.completed event, received ${results.length}.`);
+      const failures = session.events.filter(
+        (event) =>
+          event.type === "session.failed" ||
+          event.type === "turn.failed" ||
+          event.type === "step.failed",
+      );
+      throw new Error(
+        `Expected one result.completed event, received ${results.length}. ` +
+          `Observed events: ${session.events.map((event) => event.type).join(", ")}. ` +
+          `Failures: ${JSON.stringify(failures)}.`,
+      );
     }
 
     const result = results[0]?.data.result;

--- a/packages/eve/src/channel/cross-channel-receive.test.ts
+++ b/packages/eve/src/channel/cross-channel-receive.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index.js";
 
 import { CHANNEL_SENTINEL, type CompiledChannel } from "#channel/compiled-channel.js";
 import {
@@ -6,7 +7,9 @@ import {
   type CrossChannelTarget,
 } from "#channel/cross-channel-receive.js";
 import type { Session } from "#channel/session.js";
-import type { Runtime } from "#channel/types.js";
+import type { RunHandle, Runtime } from "#channel/types.js";
+import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
 
 function makeRuntime(): Runtime {
   return {
@@ -26,12 +29,51 @@ function makeSession(): Session {
   };
 }
 
+function makeRunHandle(): RunHandle {
+  return {
+    continuationToken: "target:thread",
+    events: new ReadableStream<HandleMessageStreamEvent>(),
+    sessionId: "new-session-id",
+  };
+}
+
 function makeChannel(name: string): {
   target: CrossChannelTarget;
   receive: ReturnType<typeof vi.fn>;
   definition: CompiledChannel;
 } {
   const receive = vi.fn().mockResolvedValue(makeSession());
+  const definition: CompiledChannel = {
+    __kind: CHANNEL_SENTINEL,
+    routes: [{ method: "POST", path: `/${name}`, handler: async () => new Response("ok") }],
+    adapter: { kind: `channel:${name}` },
+    receive,
+  };
+  return {
+    target: {
+      name,
+      definition,
+      receive,
+      adapter: definition.adapter,
+    },
+    receive,
+    definition,
+  };
+}
+
+function makeForwardingChannel(name: string, channelOutputSchema?: { readonly type: string }) {
+  type ReceiveFn = NonNullable<CompiledChannel["receive"]>;
+  const receive = vi.fn<ReceiveFn>(async (input, { send }) =>
+    send(
+      channelOutputSchema === undefined
+        ? input.message
+        : { message: input.message, outputSchema: channelOutputSchema },
+      {
+        auth: input.auth,
+        continuationToken: "thread",
+      },
+    ),
+  );
   const definition: CompiledChannel = {
     __kind: CHANNEL_SENTINEL,
     routes: [{ method: "POST", path: `/${name}`, handler: async () => new Response("ok") }],
@@ -70,6 +112,176 @@ describe("createCrossChannelReceiveFn", () => {
       auth: expect.objectContaining({ principalId: "u" }),
     });
     expect(typeof ctx.send).toBe("function");
+  });
+
+  it("normalizes and injects a Standard Schema when resuming a session", async () => {
+    const normalizedSchema = {
+      additionalProperties: false,
+      properties: { summary: { type: "string" } },
+      required: ["summary"],
+      type: "object",
+    } as const;
+    const inputConverter = vi.fn(() => ({ type: "string" }));
+    const outputConverter = vi.fn(() => normalizedSchema);
+    const outputSchema: StandardJSONSchemaV1 = {
+      "~standard": {
+        jsonSchema: { input: inputConverter, output: outputConverter },
+        vendor: "test",
+        version: 1,
+      },
+    };
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, {
+      auth: null,
+      message: "assess this",
+      outputSchema,
+      target: {},
+    });
+
+    expect(outputConverter).toHaveBeenCalledWith({ target: "draft-07" });
+    expect(inputConverter).not.toHaveBeenCalled();
+    expect(target.receive.mock.calls[0]![0]).toEqual({
+      auth: null,
+      message: "assess this",
+      target: {},
+    });
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload.outputSchema).toEqual(
+      normalizedSchema,
+    );
+  });
+
+  it("rejects an unsupported Standard Schema before invoking the target receive hook", async () => {
+    const outputSchema: StandardJSONSchemaV1 = {
+      "~standard": {
+        jsonSchema: {
+          input: () => ({ type: "object" }),
+          output: () => {
+            throw new Error("draft-07 output conversion is unsupported");
+          },
+        },
+        vendor: "test",
+        version: 1,
+      },
+    };
+    const runtime = makeRuntime();
+    const target = makeChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await expect(
+      fn(target.definition, {
+        auth: null,
+        message: "assess this",
+        outputSchema,
+        target: {},
+      }),
+    ).rejects.toThrow("draft-07 output conversion is unsupported");
+
+    expect(target.receive).not.toHaveBeenCalled();
+    expect(runtime.deliver).not.toHaveBeenCalled();
+    expect(runtime.run).not.toHaveBeenCalled();
+  });
+
+  it("injects a raw output schema when starting a new session", async () => {
+    const outputSchema = {
+      properties: { verdict: { type: "string" } },
+      required: ["verdict"],
+      type: "object",
+    } as const;
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockRejectedValue(new RuntimeNoActiveSessionError("target:thread"));
+    vi.mocked(runtime.run).mockResolvedValue(makeRunHandle());
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, {
+      auth: null,
+      message: "assess this",
+      outputSchema,
+      target: {},
+    });
+
+    expect(vi.mocked(runtime.run).mock.calls[0]![0]).toMatchObject({
+      continuationToken: "target:thread",
+      input: { message: "assess this", outputSchema },
+      mode: "conversation",
+    });
+  });
+
+  it("injects a raw output schema when resuming a session", async () => {
+    const outputSchema = {
+      properties: { verdict: { type: "string" } },
+      required: ["verdict"],
+      type: "object",
+    } as const;
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, {
+      auth: null,
+      message: "retry this assessment",
+      outputSchema,
+      target: {},
+    });
+
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0]).toMatchObject({
+      continuationToken: "target:thread",
+      payload: { message: "retry this assessment", outputSchema },
+    });
+    expect(runtime.run).not.toHaveBeenCalled();
+  });
+
+  it("overrides a target channel's send schema with the outer schema", async () => {
+    const channelSchema = { type: "string" } as const;
+    const outputSchema = { type: "object" } as const;
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target", channelSchema);
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, { auth: null, message: "assess this", outputSchema, target: {} });
+
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload.outputSchema).toEqual(outputSchema);
+  });
+
+  it("preserves a target channel's send schema when no outer schema is provided", async () => {
+    const channelSchema = { type: "string" } as const;
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target", channelSchema);
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, { auth: null, message: "plain", target: {} });
+
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload.outputSchema).toEqual(
+      channelSchema,
+    );
+  });
+
+  it("injects the outer schema into structured user content", async () => {
+    const outputSchema = { type: "object" } as const;
+    const message = [{ text: "inspect this image", type: "text" as const }];
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, {
+      auth: null,
+      message,
+      outputSchema,
+      target: {},
+    });
+
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload).toMatchObject({
+      message,
+      outputSchema,
+    });
   });
 
   it("resolves the target by reference identity even when multiple channels are registered", async () => {

--- a/packages/eve/src/channel/cross-channel-receive.test.ts
+++ b/packages/eve/src/channel/cross-channel-receive.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index.js";
 
 import { CHANNEL_SENTINEL, type CompiledChannel } from "#channel/compiled-channel.js";
@@ -114,7 +115,7 @@ describe("createCrossChannelReceiveFn", () => {
     expect(typeof ctx.send).toBe("function");
   });
 
-  it("normalizes and injects a Standard Schema when resuming a session", async () => {
+  it("normalizes and injects Standard JSON Schema when resuming a session", async () => {
     const normalizedSchema = {
       additionalProperties: false,
       properties: { summary: { type: "string" } },
@@ -154,7 +155,35 @@ describe("createCrossChannelReceiveFn", () => {
     );
   });
 
-  it("rejects an unsupported Standard Schema before invoking the target receive hook", async () => {
+  it("accepts and normalizes a Zod schema through the public receive type", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, {
+      auth: null,
+      message: "assess this",
+      outputSchema: z.object({
+        summary: z.string(),
+        verdict: z.enum(["approve", "reject"]),
+      }),
+      target: {},
+    });
+
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload.outputSchema).toEqual({
+      $schema: "http://json-schema.org/draft-07/schema#",
+      additionalProperties: false,
+      properties: {
+        summary: { type: "string" },
+        verdict: { enum: ["approve", "reject"], type: "string" },
+      },
+      required: ["summary", "verdict"],
+      type: "object",
+    });
+  });
+
+  it("rejects unsupported Standard JSON Schema before invoking the target receive hook", async () => {
     const outputSchema: StandardJSONSchemaV1 = {
       "~standard": {
         jsonSchema: {
@@ -261,6 +290,56 @@ describe("createCrossChannelReceiveFn", () => {
     expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload.outputSchema).toEqual(
       channelSchema,
     );
+  });
+
+  it("keeps schemas isolated between concurrent receive invocations", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+    const firstSchema = { properties: { first: { type: "string" } }, type: "object" } as const;
+    const secondSchema = { properties: { second: { type: "number" } }, type: "object" } as const;
+
+    await Promise.all([
+      fn(target.definition, {
+        auth: null,
+        message: "first",
+        outputSchema: firstSchema,
+        target: {},
+      }),
+      fn(target.definition, {
+        auth: null,
+        message: "second",
+        outputSchema: secondSchema,
+        target: {},
+      }),
+    ]);
+
+    const payloads = vi.mocked(runtime.deliver).mock.calls.map(([input]) => input.payload);
+    expect(payloads).toEqual([
+      expect.objectContaining({ message: "first", outputSchema: firstSchema }),
+      expect.objectContaining({ message: "second", outputSchema: secondSchema }),
+    ]);
+  });
+
+  it("does not carry an outer schema into a later schema-free receive", async () => {
+    const runtime = makeRuntime();
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const target = makeForwardingChannel("target");
+    const fn = createCrossChannelReceiveFn(runtime, [target.target]);
+
+    await fn(target.definition, {
+      auth: null,
+      message: "structured",
+      outputSchema: { type: "object" },
+      target: {},
+    });
+    await fn(target.definition, { auth: null, message: "plain", target: {} });
+
+    expect(vi.mocked(runtime.deliver).mock.calls[0]![0].payload.outputSchema).toEqual({
+      type: "object",
+    });
+    expect(vi.mocked(runtime.deliver).mock.calls[1]![0].payload.outputSchema).toBeUndefined();
   });
 
   it("injects the outer schema into structured user content", async () => {

--- a/packages/eve/src/channel/cross-channel-receive.ts
+++ b/packages/eve/src/channel/cross-channel-receive.ts
@@ -14,16 +14,15 @@ import type { JsonObject } from "#shared/json.js";
 type OutputSchemaDefinition = StandardJSONSchemaV1<unknown, unknown> | JsonObject;
 
 /**
- * Options accepted by {@link CrossChannelReceiveFn}. Mirrors the input
- * argument of a channel's authored `receive(input, { send })` hook —
- * the runtime constructs `send` internally so route-handler callers
- * only supply the platform target, payload, auth, and optional turn policy.
+ * Options accepted by {@link CrossChannelReceiveFn}. Includes the fields from
+ * a channel's authored `receive(input, { send })` input plus optional
+ * framework-managed turn policy. The runtime constructs `send` internally.
  */
 export interface CrossChannelReceiveOptions<TTarget = Record<string, unknown>> {
   readonly message: string | UserContent;
   readonly target: TTarget;
   readonly auth: SessionAuthContext | null;
-  /** Standard Schema or raw JSON Schema required for this turn's result. */
+  /** Standard JSON Schema or raw JSON Schema required for this turn's result. */
   readonly outputSchema?: OutputSchemaDefinition;
 }
 

--- a/packages/eve/src/channel/cross-channel-receive.ts
+++ b/packages/eve/src/channel/cross-channel-receive.ts
@@ -1,4 +1,5 @@
 import type { UserContent } from "ai";
+import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index.js";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
 import { isCompiledChannel, type CompiledChannel } from "#channel/compiled-channel.js";
@@ -7,17 +8,23 @@ import { createSendFn } from "#channel/send.js";
 import type { Session } from "#channel/session.js";
 import type { Runtime, SessionAuthContext } from "#channel/types.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
+import { normalizeJsonSchemaDefinition } from "#shared/json-schema.js";
+import type { JsonObject } from "#shared/json.js";
+
+type OutputSchemaDefinition = StandardJSONSchemaV1<unknown, unknown> | JsonObject;
 
 /**
  * Options accepted by {@link CrossChannelReceiveFn}. Mirrors the input
  * argument of a channel's authored `receive(input, { send })` hook —
  * the runtime constructs `send` internally so route-handler callers
- * only supply the platform target, payload, and auth.
+ * only supply the platform target, payload, auth, and optional turn policy.
  */
 export interface CrossChannelReceiveOptions<TTarget = Record<string, unknown>> {
   readonly message: string | UserContent;
   readonly target: TTarget;
   readonly auth: SessionAuthContext | null;
+  /** Standard Schema or raw JSON Schema required for this turn's result. */
+  readonly outputSchema?: OutputSchemaDefinition;
 }
 
 /**
@@ -79,9 +86,14 @@ export function createCrossChannelReceiveFn(
 ): CrossChannelReceiveFn {
   return async (channel, options) => {
     const targetChannel = resolveTargetByReference(channel, channels);
+    const outputSchema =
+      options.outputSchema === undefined
+        ? undefined
+        : normalizeJsonSchemaDefinition(options.outputSchema, "output");
     return await invokeChannelReceive({
       runtime,
       target: targetChannel,
+      outputSchema,
       input: {
         message: options.message as string,
         target: options.target as Readonly<Record<string, unknown>>,
@@ -99,6 +111,7 @@ export function createCrossChannelReceiveFn(
 interface InvokeChannelReceiveInput {
   readonly runtime: Runtime;
   readonly target: Pick<CrossChannelTarget, "name" | "receive" | "adapter">;
+  readonly outputSchema?: JsonObject;
   readonly input: {
     readonly message: string;
     readonly target: Readonly<Record<string, unknown>>;
@@ -121,7 +134,18 @@ export async function invokeChannelReceive(args: InvokeChannelReceiveInput): Pro
   if (!args.target.adapter) {
     throw new Error(args.describeMissingAdapter());
   }
-  const send = createSendFn(args.runtime, args.target.adapter, args.target.name);
+  const baseSend = createSendFn(args.runtime, args.target.adapter, args.target.name);
+  const outputSchema = args.outputSchema;
+  const send: typeof baseSend =
+    outputSchema === undefined
+      ? baseSend
+      : (input, options) =>
+          baseSend(
+            typeof input === "string" || Array.isArray(input)
+              ? { message: input, outputSchema }
+              : { ...input, outputSchema },
+            options,
+          );
   return await args.target.receive(args.input, { send });
 }
 

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -93,6 +93,11 @@ describe("ScheduleDispatcher", () => {
   describe("run handler form", () => {
     it("invokes the author's run() with { receive, waitUntil, appAuth }", async () => {
       const runtime = createMockRuntime();
+      const outputSchema = {
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+        type: "object",
+      } as const;
       vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-test");
       vi.stubEnv("SLACK_SIGNING_SECRET", "test-secret");
       try {
@@ -111,6 +116,7 @@ describe("ScheduleDispatcher", () => {
             observed.hasWaitUntil = typeof waitUntil === "function";
             await receive(definition, {
               message: "post the digest",
+              outputSchema,
               target: { channelId: "C0123ABC" },
               auth: appAuth,
             });
@@ -125,6 +131,7 @@ describe("ScheduleDispatcher", () => {
         const runInput = vi.mocked(runtime.run).mock.calls[0]![0];
         expect(runInput.continuationToken).toBe("slack:C0123ABC:");
         expect(runInput.auth).toEqual(SCHEDULE_APP_AUTH);
+        expect(runInput.input.outputSchema).toEqual(outputSchema);
       } finally {
         vi.unstubAllEnvs();
       }

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -150,8 +150,8 @@ export interface SendTurnPayload<TOutput = unknown> {
   /**
    * Optional schema the harness must satisfy before this turn terminates.
    *
-   * The client lowers Standard Schema implementations (Zod, Valibot,
-   * ArkType, etc.) to JSON Schema before sending the request. The server is
+   * The client lowers Standard JSON Schema implementations (for example,
+   * Zod 4) to plain JSON Schema before sending the request. The server is
    * authoritative for validation; {@link MessageResult.data} is typed to this
    * schema's output type and is not revalidated client-side.
    */

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -131,7 +131,7 @@ const threadContextAdapter: ChannelAdapter = {
     const thread = adapterCtx.ctx.ensure(ThreadKey, () => "unset");
     const message = payload.message ?? "";
 
-    return { message: `thread=${thread}; user=${message}` };
+    return { message: `thread=${thread}; user=${message}`, outputSchema: payload.outputSchema };
   },
 };
 
@@ -521,6 +521,74 @@ describe("turnStep", () => {
     expect(second.serializedContext[ThreadKey.name]).toBe("alpha");
   });
 
+  it("does not leak a schema retained by a failed turn into the next delivery", async () => {
+    const outputSchema = {
+      properties: { assessment: { type: "string" } },
+      required: ["assessment"],
+      type: "object",
+    } as const;
+    const initialSession = createStubSession({ outputSchema });
+    const failedSession = createStubSession({ outputSchema });
+    installSessionStoreMocks([initialSession, failedSession]);
+
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {} as never,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+
+    const observedSchemas: Array<HarnessSession["outputSchema"]> = [];
+    let invocationCount = 0;
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (session): Promise<StepResult> => {
+        observedSchemas.push(session.outputSchema);
+        invocationCount += 1;
+        return invocationCount === 1
+          ? { next: null, session: failedSession }
+          : { next: { done: true, output: "plain follow-up" }, session };
+      };
+    });
+
+    const parentWritable = createTestWritable();
+    const first = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "assess this", outputSchema }],
+      },
+      parentWritable,
+      serializedContext: createSerializedContext(),
+      sessionState: createStubSessionState(),
+    });
+    expect(first.action).toBe("park");
+
+    await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "answer normally" }],
+      },
+      parentWritable,
+      serializedContext: first.serializedContext,
+      sessionState: first.sessionState,
+    });
+
+    expect(observedSchemas).toEqual([outputSchema, undefined]);
+  });
+
   it("refreshes the system prompt from the current bundled deployment", async () => {
     const session = createStubSession({
       agent: {
@@ -892,7 +960,7 @@ describe("resolveEffectiveOutputSchema", () => {
 
   it("uses a run-scoped schema in either mode", () => {
     for (const mode of ["conversation", "task"] as const) {
-      const session = createStubSession();
+      const session = createStubSession({ outputSchema: agentSchema });
       const resolved = resolveEffectiveOutputSchema({
         agentOutputSchema: agentSchema,
         input: { outputSchema: runSchema },
@@ -931,5 +999,68 @@ describe("resolveEffectiveOutputSchema", () => {
       session,
     });
     expect(resolved).toBe(session);
+  });
+
+  it("preserves the in-effect schema on a runtime-action continuation", () => {
+    const session = createStubSession({ outputSchema: runSchema });
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { runtimeActionResults: [] },
+      mode: "conversation",
+      session,
+    });
+    expect(resolved).toBe(session);
+  });
+
+  it("clears a failed turn's schema from the next plain conversation delivery", () => {
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { message: "try again without structured output" },
+      mode: "conversation",
+      session: createStubSession({ outputSchema: runSchema }),
+    });
+    expect(resolved.outputSchema).toBeUndefined();
+  });
+
+  it("treats an empty input-response array as a fresh conversation delivery", () => {
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { inputResponses: [], message: "try again without structured output" },
+      mode: "conversation",
+      session: createStubSession({ outputSchema: runSchema }),
+    });
+    expect(resolved.outputSchema).toBeUndefined();
+  });
+
+  it("preserves the caller's run schema across a conversation-mode HITL response", () => {
+    const session = createStubSession({ outputSchema: runSchema });
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
+      mode: "conversation",
+      session,
+    });
+    expect(resolved).toBe(session);
+  });
+
+  it("preserves the caller's run schema across a task-mode HITL response", () => {
+    const session = createStubSession({ outputSchema: runSchema });
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
+      mode: "task",
+      session,
+    });
+    expect(resolved).toBe(session);
+  });
+
+  it("replaces stale task state with the agent schema on a fresh task delivery", () => {
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { message: "run the task" },
+      mode: "task",
+      session: createStubSession({ outputSchema: runSchema }),
+    });
+    expect(resolved.outputSchema).toEqual(agentSchema);
   });
 });

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -7,6 +7,7 @@ import { ContextKey } from "#context/key.js";
 import { AuthKey, ContinuationTokenKey, ModeKey, SessionIdKey } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { serializeContext } from "#context/serialize.js";
+import { setPendingInputBatch } from "#harness/input-requests.js";
 import { setPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
 import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
@@ -131,7 +132,11 @@ const threadContextAdapter: ChannelAdapter = {
     const thread = adapterCtx.ctx.ensure(ThreadKey, () => "unset");
     const message = payload.message ?? "";
 
-    return { message: `thread=${thread}; user=${message}`, outputSchema: payload.outputSchema };
+    return {
+      inputResponses: payload.inputResponses,
+      message: `thread=${thread}; user=${message}`,
+      outputSchema: payload.outputSchema,
+    };
   },
 };
 
@@ -521,7 +526,7 @@ describe("turnStep", () => {
     expect(second.serializedContext[ThreadKey.name]).toBe("alpha");
   });
 
-  it("does not leak a schema retained by a failed turn into the next delivery", async () => {
+  it("does not let stale input responses leak a failed turn's schema into the next delivery", async () => {
     const outputSchema = {
       properties: { assessment: { type: "string" } },
       required: ["assessment"],
@@ -579,7 +584,12 @@ describe("turnStep", () => {
     await turnStep({
       input: {
         kind: "deliver",
-        payloads: [{ message: "answer normally" }],
+        payloads: [
+          {
+            inputResponses: [{ optionId: "approve", requestId: "stale-approval" }],
+            message: "answer normally",
+          },
+        ],
       },
       parentWritable,
       serializedContext: first.serializedContext,
@@ -1033,7 +1043,7 @@ describe("resolveEffectiveOutputSchema", () => {
   });
 
   it("preserves the caller's run schema across a conversation-mode HITL response", () => {
-    const session = createStubSession({ outputSchema: runSchema });
+    const session = createPendingInputSession(createStubSession({ outputSchema: runSchema }));
     const resolved = resolveEffectiveOutputSchema({
       agentOutputSchema: agentSchema,
       input: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
@@ -1044,10 +1054,57 @@ describe("resolveEffectiveOutputSchema", () => {
   });
 
   it("preserves the caller's run schema across a task-mode HITL response", () => {
-    const session = createStubSession({ outputSchema: runSchema });
+    const session = createPendingInputSession(createStubSession({ outputSchema: runSchema }));
     const resolved = resolveEffectiveOutputSchema({
       agentOutputSchema: agentSchema,
       input: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
+      mode: "task",
+      session,
+    });
+    expect(resolved).toBe(session);
+  });
+
+  it("preserves the caller's run schema when a message resolves pending HITL", () => {
+    const session = createPendingInputSession(createStubSession({ outputSchema: runSchema }));
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { message: "continue without approving" },
+      mode: "conversation",
+      session,
+    });
+    expect(resolved).toBe(session);
+  });
+
+  it("clears a failed turn's schema when non-empty input responses are stale", () => {
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: {
+        inputResponses: [{ optionId: "approve", requestId: "stale-approval" }],
+        message: "start a fresh turn",
+      },
+      mode: "conversation",
+      session: createStubSession({ outputSchema: runSchema }),
+    });
+    expect(resolved.outputSchema).toBeUndefined();
+  });
+
+  it("clears a failed turn's schema for stale response-only input", () => {
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: {
+        inputResponses: [{ text: "late reply", requestId: "stale-question" }],
+      },
+      mode: "conversation",
+      session: createStubSession({ outputSchema: runSchema }),
+    });
+    expect(resolved.outputSchema).toBeUndefined();
+  });
+
+  it("preserves the in-flight policy for a pending context-only delivery", () => {
+    const session = createPendingInputSession(createStubSession({ outputSchema: runSchema }));
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: agentSchema,
+      input: { context: ["delivery context"] },
       mode: "task",
       session,
     });
@@ -1063,4 +1120,39 @@ describe("resolveEffectiveOutputSchema", () => {
     });
     expect(resolved.outputSchema).toEqual(agentSchema);
   });
+
+  it("clears stale task state on a fresh delivery when the agent has no schema", () => {
+    const resolved = resolveEffectiveOutputSchema({
+      agentOutputSchema: undefined,
+      input: { message: "run the task" },
+      mode: "task",
+      session: createStubSession({ outputSchema: runSchema }),
+    });
+    expect(resolved.outputSchema).toBeUndefined();
+  });
 });
+
+function createPendingInputSession(session: HarnessSession): HarnessSession {
+  return setPendingInputBatch({
+    requests: [
+      {
+        action: {
+          callId: "approval-call",
+          input: {},
+          kind: "tool-call",
+          toolName: "protected-action",
+        },
+        allowFreeform: false,
+        display: "confirmation",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "deny", label: "Deny" },
+        ],
+        prompt: "Approve the protected action?",
+        requestId: "approval-1",
+      },
+    ],
+    responseMessages: [],
+    session,
+  });
+}

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -439,8 +439,11 @@ export function reconcileSessionContinuationToken(
  * wins. With no run-scoped schema, a task run adopts the agent's declared
  * return schema — its function-output contract, which only applies when the
  * agent is invoked as a function (subagent / schedule / job), i.e. task mode.
- * A conversation run with no run-scoped schema enforces nothing. Continuation
- * steps (no new `StepInput`) preserve whatever is already in effect.
+ * A conversation run with no run-scoped schema enforces nothing. Fresh
+ * conversation deliveries replace the previous turn's policy. Runtime-owned
+ * continuation steps and HITL responses preserve whatever is already in
+ * effect because their callers cannot attach the original run-scoped schema
+ * again.
  */
 export function resolveEffectiveOutputSchema(input: {
   readonly agentOutputSchema: JsonObject | undefined;
@@ -454,11 +457,21 @@ export function resolveEffectiveOutputSchema(input: {
     return { ...session, outputSchema: stepInput.outputSchema };
   }
 
-  if (mode === "task" && session.outputSchema === undefined && agentOutputSchema !== undefined) {
+  if (
+    stepInput === undefined ||
+    stepInput.runtimeActionResults !== undefined ||
+    (stepInput.inputResponses?.length ?? 0) > 0
+  ) {
+    return session;
+  }
+
+  if (mode === "task" && agentOutputSchema !== undefined) {
     return { ...session, outputSchema: agentOutputSchema };
   }
 
-  return session;
+  if (session.outputSchema === undefined) return session;
+  const { outputSchema: _outputSchema, ...withoutOutputSchema } = session;
+  return withoutOutputSchema;
 }
 
 const log = createLogger("execution.workflow-entry");

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -441,9 +441,9 @@ export function reconcileSessionContinuationToken(
  * agent is invoked as a function (subagent / schedule / job), i.e. task mode.
  * A conversation run with no run-scoped schema enforces nothing. Fresh
  * conversation deliveries replace the previous turn's policy. Runtime-owned
- * continuation steps and HITL responses preserve whatever is already in
- * effect because their callers cannot attach the original run-scoped schema
- * again.
+ * continuation steps and pending HITL resolution preserve whatever is already
+ * in effect because their callers cannot attach the original run-scoped
+ * schema again.
  */
 export function resolveEffectiveOutputSchema(input: {
   readonly agentOutputSchema: JsonObject | undefined;
@@ -460,7 +460,7 @@ export function resolveEffectiveOutputSchema(input: {
   if (
     stepInput === undefined ||
     stepInput.runtimeActionResults !== undefined ||
-    (stepInput.inputResponses?.length ?? 0) > 0
+    hasPendingInputBatch(session.state)
   ) {
     return session;
   }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -856,6 +856,8 @@ describe("createToolLoopHarness", () => {
         type: "step.failed",
       }),
     );
+    expect(events.some((event) => event.type === "result.completed")).toBe(false);
+    expect(result.session.outputSchema).toEqual({ type: "object" });
   });
 
   it("returns only the final assistant reply when a completed task step includes tool work", async () => {

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -93,8 +93,10 @@ export interface StepInput {
    */
   readonly context?: readonly string[];
   /**
-   * Run-scoped schema that replaces the session's current output schema when
-   * present. Omitted continuations keep the existing schema.
+   * Run-scoped schema that replaces the session's current output schema for
+   * this turn. Runtime-owned continuations and pending input responses preserve
+   * it; a fresh delivery that omits it clears any schema retained by an earlier
+   * failed turn.
    */
   readonly outputSchema?: JsonObject;
   /**

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -94,7 +94,7 @@ export interface StepInput {
   readonly context?: readonly string[];
   /**
    * Run-scoped schema that replaces the session's current output schema for
-   * this turn. Runtime-owned continuations and pending input responses preserve
+   * this turn. Runtime-owned continuations and pending HITL resolution preserve
    * it; a fresh delivery that omits it clears any schema retained by an earlier
    * failed turn.
    */

--- a/packages/eve/src/internal/testing/scenario-apps/cross-channel-output-schema-portability.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/cross-channel-output-schema-portability.ts
@@ -1,0 +1,71 @@
+import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
+
+export const CROSS_CHANNEL_OUTPUT_SCHEMA_PORTABILITY_DESCRIPTOR: ScenarioAppDescriptor = {
+  files: {
+    "agent/channels/source.ts": `import { defineChannel, POST } from "eve/channels";
+
+import target, { summarySchema } from "./target.js";
+
+export default defineChannel({
+  routes: [
+    POST("/api/handoff", async (req, { receive }) => {
+      const body = (await req.json()) as { message: string; threadId: string };
+      const session = await receive(target, {
+        auth: null,
+        message: body.message,
+        outputSchema: summarySchema,
+        target: { threadId: body.threadId },
+      });
+      return Response.json({ sessionId: session.id });
+    }),
+  ],
+});
+`,
+    "agent/channels/target.ts": `import { defineChannel, POST } from "eve/channels";
+
+export const summarySchema = {
+  "~standard": {
+    version: 1,
+    vendor: "portability-test",
+    jsonSchema: {
+      input: () => ({ type: "object" }),
+      output: () => ({
+        type: "object",
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+      }),
+    },
+  },
+} as const;
+
+export default defineChannel<undefined, void, { threadId: string }>({
+  routes: [POST("/api/target", async () => new Response("ok"))],
+  receive(input, { send }) {
+    return send(input.message, {
+      auth: input.auth,
+      continuationToken: input.target.threadId,
+    });
+  },
+});
+`,
+    "agent/schedules/daily-summary.ts": `import { defineSchedule } from "eve/schedules";
+
+import target, { summarySchema } from "../channels/target.js";
+
+export default defineSchedule({
+  cron: "0 9 * * *",
+  run({ receive, waitUntil, appAuth }) {
+    waitUntil(
+      receive(target, {
+        auth: appAuth,
+        message: "Prepare the daily summary.",
+        outputSchema: summarySchema,
+        target: { threadId: "daily" },
+      }),
+    );
+  },
+});
+`,
+  },
+  name: "cross-channel-output-schema-portability",
+};

--- a/packages/eve/src/internal/testing/scenario-apps/index.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/index.ts
@@ -1,4 +1,5 @@
 export { CUSTOM_CHANNEL_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/custom-channel-portability.js";
+export { CROSS_CHANNEL_OUTPUT_SCHEMA_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/cross-channel-output-schema-portability.js";
 export { DISCORD_ROUTE_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/discord-route-portability.js";
 export { EXTENSION_AGENT_DESCRIPTOR } from "#internal/testing/scenario-apps/extension-agent.js";
 export { GITHUB_ROUTE_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/github-route-portability.js";

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "vitest";
 
 import type { ScenarioAppDescriptor } from "../../src/internal/testing/scenario-app.js";
 import {
+  CROSS_CHANNEL_OUTPUT_SCHEMA_PORTABILITY_DESCRIPTOR,
   EVE_ROUTE_PORTABILITY_DESCRIPTOR,
   DISCORD_ROUTE_PORTABILITY_DESCRIPTOR,
   GITHUB_ROUTE_PORTABILITY_DESCRIPTOR,
@@ -89,6 +90,23 @@ export default defineSandbox({
       },
       "./sandbox/vercel": {
         types: "./dist/src/public/sandbox/vercel.d.ts",
+      },
+    },
+  },
+  {
+    descriptor: CROSS_CHANNEL_OUTPUT_SCHEMA_PORTABILITY_DESCRIPTOR,
+    include: [
+      "src/public/definitions/defineChannel.ts",
+      "src/public/definitions/schedule.ts",
+      "src/public/schedules/index.ts",
+    ],
+    name: "lets tsc typecheck structured cross-channel receives from routes and schedules",
+    packageExports: {
+      "./channels": {
+        types: "./dist/src/public/definitions/defineChannel.d.ts",
+      },
+      "./schedules": {
+        types: "./dist/src/public/schedules/index.d.ts",
       },
     },
   },

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -95,15 +95,11 @@ export default defineSandbox({
   },
   {
     descriptor: CROSS_CHANNEL_OUTPUT_SCHEMA_PORTABILITY_DESCRIPTOR,
-    include: [
-      "src/public/definitions/defineChannel.ts",
-      "src/public/definitions/schedule.ts",
-      "src/public/schedules/index.ts",
-    ],
+    include: ["src/public/channels/index.ts", "src/public/schedules/index.ts"],
     name: "lets tsc typecheck structured cross-channel receives from routes and schedules",
     packageExports: {
       "./channels": {
-        types: "./dist/src/public/definitions/defineChannel.d.ts",
+        types: "./dist/src/public/channels/index.d.ts",
       },
       "./schedules": {
         types: "./dist/src/public/schedules/index.d.ts",


### PR DESCRIPTION
### Description

Adds turn-scoped structured output to cross-channel `receive(...)` calls.

- Lets route handlers and schedules pass `outputSchema` alongside `message`, `target`, and `auth`.
- Accepts Standard JSON Schema or raw JSON Schema and normalizes it before the durable runtime boundary.
- Applies the caller schema through the framework-provided target `send` without changing `ReceiveInput` or channel-specific targets.
- Keeps run mode, durability, continuation tokens, auth, and the existing `result.completed` lifecycle unchanged.
- Clears schemas retained by failed turns from later fresh deliveries while preserving runtime, pending HITL, and other internal continuations.

Closes #224.

### How did you test your changes?

- `pnpm test:unit` — 386 files and 3,902 tests passed
- `pnpm test:integration` — 45 files and 368 tests passed
- `pnpm test:scenario` — 42 files and 261 tests passed; 15 platform-specific tests skipped
- `NODE_ENV=test pnpm --filter agent-channels test:e2e` — 2 evals and 5 gates passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `pnpm build`
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm guard:fixtures`
- `pnpm check:deps`
- `pnpm changeset status`

The local model-driven TUI smoke cases require AI Gateway credentials that are unavailable in this environment. Their credential-free cases passed; the hosted CI TUI job covers the complete suite.

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset because this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
