### PR TITLE
fix(eve): forward stream cancel so parked dev sessions stop leaking polls

### DIFF
--- a/.changeset/streaming-parked-session-leak.md
+++ b/.changeset/streaming-parked-session-leak.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `eve dev` streaming throughput and time-to-first-token degrading as parked (`ask_question` / HITL) sessions accumulate. The dev runtime's NDJSON event-stream reader now forwards cancellation to the underlying run stream, so disconnecting from a parked session no longer leaks a filesystem polling loop for the life of the dev server.

--- a/packages/eve/src/client/ndjson.ts
+++ b/packages/eve/src/client/ndjson.ts
@@ -38,12 +38,14 @@ export async function* readNdjsonStream(
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let reachedEof = false;
 
   try {
     while (true) {
       const result = await reader.read();
 
       if (result.done) {
+        reachedEof = true;
         // Flush any remaining bytes in the decoder.
         buffer += decoder.decode();
         break;
@@ -73,6 +75,11 @@ export async function* readNdjsonStream(
       yield JSON.parse(trailing) as HandleMessageStreamEvent;
     }
   } finally {
+    if (!reachedEof) {
+      // Breaking an async iteration must close the response body; releasing
+      // its lock alone leaves the server-side stream open.
+      await reader.cancel().catch(() => {});
+    }
     reader.releaseLock();
   }
 }

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -141,6 +141,36 @@ describe("ClientSession", () => {
     });
   });
 
+  it("cancels a parked stream after collecting its result", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            `${JSON.stringify({ type: "session.waiting", data: { wait: "next-user-message" } })}\n`,
+          ),
+        );
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createAcceptedResponse();
+      }
+
+      return new Response(stream);
+    });
+    const session = createSession();
+
+    const result = await (await session.send("first")).result();
+
+    expect(result.status).toBe("waiting");
+    expect(cancelled).toBe(true);
+  });
+
   it("resets the session by default after consuming through session.completed", async () => {
     const requests: Array<{ body?: unknown; method: string; url: string }> = [];
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {

--- a/packages/eve/src/execution/ndjson-stream.test.ts
+++ b/packages/eve/src/execution/ndjson-stream.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNdjsonStream } from "#execution/ndjson-stream.js";
+
+const encoder = new TextEncoder();
+
+async function drain<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader();
+  const values: T[] = [];
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      values.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return values;
+}
+
+describe("parseNdjsonStream", () => {
+  it("parses newline-delimited JSON into values", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"i":0}\n{"i":1}\n'));
+        controller.enqueue(encoder.encode('{"i":2}\n'));
+        controller.close();
+      },
+    });
+
+    const values = await drain(parseNdjsonStream<{ i: number }>(() => source));
+
+    expect(values).toEqual([{ i: 0 }, { i: 1 }, { i: 2 }]);
+  });
+
+  it("emits a trailing line that is not newline-terminated at EOF", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"i":0}\n{"i":1}'));
+        controller.close();
+      },
+    });
+
+    const values = await drain(parseNdjsonStream<{ i: number }>(() => source));
+
+    expect(values).toEqual([{ i: 0 }, { i: 1 }]);
+  });
+
+  it("reassembles values split across chunk boundaries", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"i":'));
+        controller.enqueue(encoder.encode("0}\n"));
+        controller.close();
+      },
+    });
+
+    const values = await drain(parseNdjsonStream<{ i: number }>(() => source));
+
+    expect(values).toEqual([{ i: 0 }]);
+  });
+
+  // Regression guard for the parked-session streaming leak: a parked
+  // (`session.waiting`) durable run never closes its event stream, so the
+  // world-local streamer keeps a filesystem poll alive until its reader is
+  // cancelled. Cancelling the parsed stream must forward the cancel to the
+  // source — otherwise the poll leaks for the life of the dev server and
+  // degrades streaming for every other session.
+  it("forwards cancellation to a source that never reaches EOF", async () => {
+    let cancelledReason: unknown = Symbol("not-cancelled");
+
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Emit one line, then stay open forever (the parked-run shape).
+        controller.enqueue(encoder.encode('{"i":0}\n'));
+      },
+      cancel(reason) {
+        cancelledReason = reason;
+      },
+    });
+
+    const parsed = parseNdjsonStream<{ i: number }>(() => source);
+    const reader = parsed.getReader();
+
+    const first = await reader.read();
+    expect(first.value).toEqual({ i: 0 });
+
+    await reader.cancel("client-disconnect");
+
+    expect(cancelledReason).toBe("client-disconnect");
+  });
+
+  it("surfaces source errors to the consumer", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("source exploded"));
+      },
+    });
+
+    await expect(drain(parseNdjsonStream(() => source))).rejects.toThrow("source exploded");
+  });
+});

--- a/packages/eve/src/execution/ndjson-stream.ts
+++ b/packages/eve/src/execution/ndjson-stream.ts
@@ -1,0 +1,73 @@
+/**
+ * Transforms a byte stream of newline-delimited JSON (NDJSON) into a
+ * stream of parsed values.
+ *
+ * The byte stream is produced lazily by `createByteStream`, so the
+ * underlying source (a world-local run readable) is only opened when the
+ * returned stream is consumed.
+ *
+ * Cancellation is forwarded to the source. When the returned stream is
+ * cancelled — e.g. an SSE client disconnects and the server cancels the
+ * response body — the underlying reader is cancelled too. This matters for
+ * runs that never reach EOF: a parked (`session.waiting`) durable run keeps
+ * its event stream open indefinitely, and the world-local streamer runs a
+ * filesystem poll until its reader is cancelled. Without forwarding the
+ * cancel, the read loop below would block on `reader.read()` forever and
+ * that poll would leak for the life of the process, degrading streaming
+ * throughput for every other session.
+ */
+export function parseNdjsonStream<T>(
+  createByteStream: () => ReadableStream<Uint8Array>,
+): ReadableStream<T> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let cancelled = false;
+
+  return new ReadableStream<T>({
+    async start(controller) {
+      reader = createByteStream().getReader();
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+
+          for (
+            let newlineIndex = buffer.indexOf("\n");
+            newlineIndex !== -1;
+            newlineIndex = buffer.indexOf("\n")
+          ) {
+            const line = buffer.slice(0, newlineIndex).trim();
+            buffer = buffer.slice(newlineIndex + 1);
+
+            if (line.length > 0) {
+              controller.enqueue(JSON.parse(line) as T);
+            }
+          }
+        }
+
+        // A cancel resolves the pending read with `done`; bail before
+        // touching the controller, which the cancel has already closed.
+        if (cancelled) return;
+
+        buffer += decoder.decode();
+        const trailing = buffer.trim();
+        if (trailing.length > 0) {
+          controller.enqueue(JSON.parse(trailing) as T);
+        }
+        controller.close();
+      } catch (error) {
+        if (!cancelled) controller.error(error);
+      } finally {
+        reader.releaseLock();
+      }
+    },
+    async cancel(reason) {
+      cancelled = true;
+      await reader?.cancel(reason);
+    },
+  });
+}

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -19,6 +19,7 @@ import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { buildRunContext } from "#execution/runtime-context.js";
+import { parseNdjsonStream } from "#execution/ndjson-stream.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 
 const WORKFLOW_ENTRY_NAME = "workflowEntry";
@@ -105,7 +106,9 @@ export function createWorkflowRuntime(config: {
 
       let events: ReadableStream<HandleMessageStreamEvent> | undefined;
       const getEvents = () => {
-        events ??= parseNdjsonStream(() => getRun(run.runId).getReadable());
+        events ??= parseNdjsonStream<HandleMessageStreamEvent>(() =>
+          getRun(run.runId).getReadable(),
+        );
         return events;
       };
 
@@ -146,7 +149,7 @@ export function createWorkflowRuntime(config: {
       sessionId: string,
       options?: GetEventStreamOptions,
     ): Promise<ReadableStream<HandleMessageStreamEvent>> {
-      return parseNdjsonStream(() =>
+      return parseNdjsonStream<HandleMessageStreamEvent>(() =>
         getRun(sessionId).getReadable({ startIndex: options?.startIndex }),
       );
     },
@@ -206,50 +209,4 @@ function normalizeWorkflowHook(value: unknown): WorkflowHookRecord {
   return {
     runId,
   };
-}
-
-function parseNdjsonStream(
-  createByteStream: () => ReadableStream<Uint8Array>,
-): ReadableStream<HandleMessageStreamEvent> {
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  return new ReadableStream<HandleMessageStreamEvent>({
-    async start(controller) {
-      const reader = createByteStream().getReader();
-      try {
-        while (true) {
-          const { value, done } = await reader.read();
-
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-
-          for (
-            let newlineIndex = buffer.indexOf("\n");
-            newlineIndex !== -1;
-            newlineIndex = buffer.indexOf("\n")
-          ) {
-            const line = buffer.slice(0, newlineIndex).trim();
-            buffer = buffer.slice(newlineIndex + 1);
-
-            if (line.length > 0) {
-              controller.enqueue(JSON.parse(line) as HandleMessageStreamEvent);
-            }
-          }
-        }
-
-        buffer += decoder.decode();
-        const trailing = buffer.trim();
-        if (trailing.length > 0) {
-          controller.enqueue(JSON.parse(trailing) as HandleMessageStreamEvent);
-        }
-        controller.close();
-      } catch (error) {
-        controller.error(error);
-      } finally {
-        reader.releaseLock();
-      }
-    },
-  });
 }


### PR DESCRIPTION
## What
- Give `parseNdjsonStream` a `cancel()` that forwards to the underlying run stream; move it into its own module.
- Add a unit test proving cancel reaches a never-closing source.
- Patch changeset.

In `eve dev`, TTFT and token throughput got monotonically worse as parked (`ask_question`/HITL) sessions piled up. Numbers from #136:

| outstanding parked sessions | TTFT | inter-token p90 |
|---|---|---|
| 0 | 4.2 s | 18 ms |
| 3 | 10.7 s | 67 ms |
| 5–6 | a new turn couldn't finish parking in 25 s | — |

Restarting `eve dev` cleared it; Vercel never showed it. So it's the local workflow world, not the agent or model.

## Root cause
A parked run suspends on a hook and never writes EOF to its event stream. `parseNdjsonStream` reads that stream in a `while (true)` loop and had no `cancel` handler. When the SSE client disconnects, srvx cancels the response body and the cancel flows down through `serializeAsNdjson`'s `pipeThrough` — then dead-ends. The inner `@workflow/world-local` stream is never cancelled.

That stream keeps a `setInterval(fs.readdir, 100)` alive (its cross-process delivery fallback) until EOF or cancel. A parked session gets neither, so every abandoned stream leaks one 100 ms poll for the life of the dev server. The polls share one flat chunk dir and one 4-thread libuv pool, so the active session's reads queue behind them — roughly O(N²).

I confirmed the leak by driving the real world-local streamer: each abandoned parked stream adds one `Timeout` handle (`process.getActiveResourcesInfo()`), and cancelling reclaims it. `readDurableSession` already cancels its reader in `finally` — `parseNdjsonStream` was the only consumer that didn't.

## Fix
`parseNdjsonStream` now defines `cancel()` that forwards to the inner reader, with a guard against the close/cancel race. Disconnecting a parked session cancels the world-local stream, which clears its interval.

## Scope
Eve-side fix. The upstream amplifier — one `setInterval` per open stream, each `readdir`-ing a shared flat chunk dir — lives in `@workflow/world-local`. Worth a follow-up there (per-stream subdirs or a single shared poll), but not needed to close this.

Fixes #136

## Proof: TTFT stays flat as parked sessions accumulate

Ran the issue's experiment against a real `eve dev` server over the HTTP/SSE API, using the deterministic mock model (`NODE_ENV=test`) so model latency is out of the picture — this isolates the local runtime. Each "parked" session is an `ask_question` HITL park, then disconnected (the issue's scenario). TTFT = time to first `message.appended`, median of 4 fresh turns at each level. Fixture: `e2e/fixtures/agent-basic-runtime`.

| parked sessions | TTFT before (base) | TTFT after (fix) |
|---|---|---|
| 0 | 45 ms | 42 ms |
| 25 | 44 ms | 41 ms |
| 50 | 48 ms | 42 ms |
| 100 | 70 ms | 42 ms |

After the fix, TTFT stays flat out to **200 parked sessions** (43 ms, with ~1,900 chunk files on disk). Before, it climbs monotonically, and past ~100 parked it falls off a cliff: at higher counts a single fresh turn blew past 20 s (measurements timed out), and even *parking* new sessions stalls — the fixed build reaches 200 parked in seconds, the buggy build can't practically get there. That's the issue's "a single new turn could not even finish parking within 25 s."

The mock model writes ~9 chunks per turn vs. hundreds for a real streaming model, so the per-parked-session cost here is much smaller than the issue's Azure-OpenAI numbers (2.5× TTFT at 3 parked). Same mechanism, scaled down — the shape is the point: TTFT rises with parked count before, flat after.

Mechanism confirmed independently: driving the real `@workflow/world-local` streamer, each abandoned parked stream adds exactly one libuv `Timeout` handle (`process.getActiveResourcesInfo()`), and cancelling reclaims it. The fix makes the disconnect-cancel propagate, so the handle count returns to baseline instead of growing one-per-parked-session.
