### PR TITLE
Validate default tool model output

### DIFF
--- a/.changeset/quiet-tools-serialize.md
+++ b/.changeset/quiet-tools-serialize.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Validate default tool model output before adding it to conversation history, so non-JSON values such as `Date` fail with a serialization error instead of a later invalid-prompt error.

--- a/packages/eve/src/harness/tools.test.ts
+++ b/packages/eve/src/harness/tools.test.ts
@@ -284,6 +284,33 @@ describe("buildToolSet", () => {
     expect(sdkTool.toModelOutput).toBeTypeOf("function");
   });
 
+  it("rejects non-JSON-serializable default model output", () => {
+    const tools: HarnessToolMap = new Map<string, HarnessToolDefinition>([
+      [
+        "timestamp",
+        {
+          description: "Return a timestamp.",
+          execute: async () => ({ now: new Date("2026-01-02T03:04:05.000Z") }),
+          inputSchema: jsonSchema({}),
+          name: "timestamp",
+        },
+      ],
+    ]);
+
+    const result = buildToolSet({ tools });
+    const sdkTool = result.timestamp as {
+      toModelOutput?: (options: { toolCallId: string; input: unknown; output: unknown }) => unknown;
+    };
+
+    expect(() =>
+      sdkTool.toModelOutput?.({
+        toolCallId: "call_1",
+        input: {},
+        output: { now: new Date("2026-01-02T03:04:05.000Z") },
+      }),
+    ).toThrow("Expected a JSON-serializable value.");
+  });
+
   it("toModelOutput wrapper passes only output to the authored function", async () => {
     let capturedOutput: unknown;
     const tools: HarnessToolMap = new Map<string, HarnessToolDefinition>([

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -5,6 +5,7 @@ import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import { ASK_QUESTION_TOOL_NAME } from "#runtime/framework-tools/ask-question.js";
 import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
 import { isObject } from "#shared/guards.js";
+import { parseJsonValue } from "#shared/json.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { resolveWebSearchBackend, resolveWebSearchProviderTool } from "#harness/provider-tools.js";
 import type { HarnessToolMap } from "#harness/types.js";
@@ -77,7 +78,7 @@ export function buildToolSet(input: {
               if (typeof output === "string") {
                 return { type: "text" as const, value: output };
               }
-              return { type: "json" as const, value: (output ?? null) as JSONValue };
+              return { type: "json" as const, value: parseJsonValue(output ?? null) as JSONValue };
             },
           }
         : authorToModelOutput !== undefined


### PR DESCRIPTION
### Description

Refs #238.

Tool results that contain non-JSON values like `Date` can currently fail later as a generic invalid model prompt. This validates the default JSON tool model output before it is added to conversation history, so invalid values fail earlier with a clear serialization error.

### How did you test your changes?

```bash
pnpm --filter eve run build:compiled
pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/tools.test.ts
pnpm --filter eve exec tsc -p tsconfig.json --noEmit --pretty false
pnpm exec oxlint packages/eve/src/harness/tools.ts packages/eve/src/harness/tools.test.ts
pnpm exec oxfmt --check packages/eve/src/harness/tools.ts packages/eve/src/harness/tools.test.ts .changeset/quiet-tools-serialize.md
```

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
