### PR TITLE
eve dev reports "Vercel CLI not found" on Windows even when vercel is installed

### DIFF
--- a/.changeset/warm-windows-vercel.md
+++ b/.changeset/warm-windows-vercel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix Vercel CLI detection on Windows by invoking npm's command shims through `cmd.exe`, so an installed `vercel` command is no longer misreported as missing.

--- a/packages/eve/src/setup/primitives/run-vercel.test.ts
+++ b/packages/eve/src/setup/primitives/run-vercel.test.ts
@@ -4,7 +4,12 @@ import { existsSync } from "node:fs";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { captureVercel, runVercel, runVercelCaptureStdout } from "./run-vercel.js";
+import {
+  captureVercel,
+  resolveVercelInvocation,
+  runVercel,
+  runVercelCaptureStdout,
+} from "./run-vercel.js";
 
 vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
@@ -35,8 +40,49 @@ function mockSpawnReturn(child: ChildProcessDouble): void {
   mockedSpawn.mockReturnValue(child as ReturnType<typeof spawn>);
 }
 
+function expectSpawnedVercel(args: string[], spawnOptions: Record<string, unknown>): void {
+  const call = mockedSpawn.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  const [command, commandArgs, options] = call!;
+  expect(options).toEqual(expect.objectContaining(spawnOptions));
+  if (process.platform === "win32") {
+    expect(options).toEqual(expect.objectContaining({ shell: true }));
+    expect(command).toMatch(/(?:^vercel$|vercel\.(?:cmd|exe)$)/i);
+    expect(commandArgs).toEqual(args);
+    return;
+  }
+  expect(command).toBe("vercel");
+  expect(commandArgs).toEqual(args);
+  expect(options).toEqual(expect.objectContaining({ shell: undefined }));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("resolveVercelInvocation", () => {
+  test("uses shell fallback for PATH Vercel CLI shims on Windows", () => {
+    const invocation = resolveVercelInvocation("/tmp/eve-agent", ["whoami"], "win32");
+
+    expect(invocation).toEqual({ command: "vercel", commandArgs: ["whoami"], shell: true });
+  });
+
+  test.skipIf(process.platform !== "win32")(
+    "picks up a local Windows Vercel CLI shim when present",
+    () => {
+      const invocation = resolveVercelInvocation(process.cwd(), ["whoami"], "win32");
+
+      expect(invocation.command.toLowerCase()).toMatch(/vercel\.cmd$/);
+      expect(invocation.commandArgs).toEqual(["whoami"]);
+      expect(invocation.shell).toBe(true);
+    },
+  );
+
+  test("keeps Unix invocation shell-free", () => {
+    const invocation = resolveVercelInvocation("/tmp/eve-agent", ["whoami"], "linux");
+
+    expect(invocation).toEqual({ command: "vercel", commandArgs: ["whoami"] });
+  });
 });
 
 describe("runVercel", () => {
@@ -55,11 +101,7 @@ describe("runVercel", () => {
     child.emit("close", 0);
 
     await expect(result).resolves.toBe(true);
-    expect(mockedSpawn).toHaveBeenCalledWith(
-      "vercel",
-      ["deploy", "--prod"],
-      expect.objectContaining({ stdio: ["inherit", "pipe", "pipe"] }),
-    );
+    expectSpawnedVercel(["deploy", "--prod"], { stdio: ["inherit", "pipe", "pipe"] });
     expect(onOutput.mock.calls.map(([line]) => line)).toEqual([
       { stream: "stdout", text: "Production deployment ready" },
       { stream: "stderr", text: "Inspect: https://vercel.example/deployment" },
@@ -97,11 +139,9 @@ describe("runVercel", () => {
     child.emit("close", 0);
 
     await expect(result).resolves.toBe(true);
-    expect(mockedSpawn).toHaveBeenCalledWith(
-      "vercel",
-      ["deploy", "--prod", "--yes", "--non-interactive"],
-      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
-    );
+    expectSpawnedVercel(["deploy", "--prod", "--yes", "--non-interactive"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
   });
 
   test("passes cancellation to the child and settles without a stale failure line", async () => {
@@ -115,11 +155,7 @@ describe("runVercel", () => {
       onOutput,
       signal: controller.signal,
     });
-    expect(mockedSpawn).toHaveBeenCalledWith(
-      "vercel",
-      ["connect", "create", "slack"],
-      expect.objectContaining({ signal: controller.signal }),
-    );
+    expectSpawnedVercel(["connect", "create", "slack"], { signal: controller.signal });
 
     controller.abort();
     const error: NodeJS.ErrnoException = new Error("The operation was aborted");
@@ -276,11 +312,7 @@ describe("captureVercel", () => {
       },
     });
     // stderr is always piped so the reason survives without a live renderer.
-    expect(mockedSpawn).toHaveBeenCalledWith(
-      "vercel",
-      ["whoami"],
-      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
-    );
+    expectSpawnedVercel(["whoami"], { stdio: ["ignore", "pipe", "pipe"] });
   });
 
   test("reports a missing CLI as a spawn error", async () => {
@@ -324,11 +356,9 @@ describe("captureVercel", () => {
         message: "vercel connect list -F json exited with code 1.",
       },
     });
-    expect(mockedSpawn).toHaveBeenCalledWith(
-      "vercel",
-      ["connect", "list", "-F", "json"],
-      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
-    );
+    expectSpawnedVercel(["connect", "list", "-F", "json"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     expect(onOutput.mock.calls.map(([line]) => line)).toEqual([
       { stream: "stderr", text: "Connector lookup failed" },
       { stream: "stderr", text: "vercel connect list -F json exited with code 1." },

--- a/packages/eve/src/setup/primitives/run-vercel.ts
+++ b/packages/eve/src/setup/primitives/run-vercel.ts
@@ -104,7 +104,10 @@ function isAbortError(error: NodeJS.ErrnoException, signal: AbortSignal | undefi
 interface VercelCliInvocation {
   command: string;
   commandArgs: string[];
+  shell?: boolean;
 }
+
+type Platform = NodeJS.Platform;
 
 function ancestorDirectories(dir: string): string[] {
   const directories: string[] = [];
@@ -127,19 +130,32 @@ function findExecutable(filePath: string): string | undefined {
   return undefined;
 }
 
-function findLocalVercel(cwd: string): string | undefined {
+function vercelExecutableNames(platform: Platform): string[] {
+  return platform === "win32" ? ["vercel.cmd", "vercel.exe"] : ["vercel"];
+}
+
+function findLocalVercel(cwd: string, platform: Platform): string | undefined {
   for (const dir of ancestorDirectories(cwd)) {
-    const binary = findExecutable(join(dir, "node_modules", ".bin", "vercel"));
-    if (binary !== undefined) return binary;
+    for (const executable of vercelExecutableNames(platform)) {
+      const binary = findExecutable(join(dir, "node_modules", ".bin", executable));
+      if (binary !== undefined) return binary;
+    }
   }
   return undefined;
 }
 
-function resolveVercelInvocation(cwd: string): VercelCliInvocation {
-  const localBinary = findLocalVercel(cwd);
+export function resolveVercelInvocation(
+  cwd: string,
+  args: string[] = [],
+  platform: Platform = process.platform,
+): VercelCliInvocation {
+  const localBinary = findLocalVercel(cwd, platform);
+  if (platform === "win32") {
+    return { command: localBinary ?? "vercel", commandArgs: args, shell: true };
+  }
   return localBinary === undefined
-    ? { command: "vercel", commandArgs: [] }
-    : { command: localBinary, commandArgs: [] };
+    ? { command: "vercel", commandArgs: args }
+    : { command: localBinary, commandArgs: args };
 }
 
 function stdioForRun(
@@ -161,18 +177,15 @@ export async function runVercel(args: string[], options: RunVercelOptions): Prom
   if (options.signal?.aborted === true) return false;
   return new Promise<boolean>((resolvePromise) => {
     const cwd = existingDir(options.cwd);
-    const invocation = resolveVercelInvocation(cwd);
+    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
     const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(
-      invocation.command,
-      [...invocation.commandArgs, ...commandArgs(args, options.nonInteractive)],
-      {
-        cwd,
-        stdio: stdioForRun(options),
-        env: buildSpawnEnv(options.extraEnv ?? {}),
-        signal: options.signal,
-      },
-    );
+    const child = spawn(invocation.command, invocation.commandArgs, {
+      cwd,
+      stdio: stdioForRun(options),
+      env: buildSpawnEnv(options.extraEnv ?? {}),
+      shell: invocation.shell,
+      signal: options.signal,
+    });
     const disarmAbort = armProcessAbort(child, options.signal);
     child.stdout?.on("data", (chunk: Buffer) => outputBuffer?.write("stdout", chunk));
     child.stderr?.on("data", (chunk: Buffer) => outputBuffer?.write("stderr", chunk));
@@ -252,22 +265,19 @@ export async function runVercelCaptureStdout(
   if (options.signal?.aborted === true) return { ok: false, stdout: "" };
   return new Promise<RunVercelCaptureResult>((resolvePromise) => {
     const cwd = existingDir(options.cwd);
-    const invocation = resolveVercelInvocation(cwd);
+    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
     const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(
-      invocation.command,
-      [...invocation.commandArgs, ...commandArgs(args, options.nonInteractive)],
-      {
-        cwd,
-        stdio: [
-          options.nonInteractive ? "ignore" : "inherit",
-          "pipe",
-          options.onOutput ? "pipe" : "inherit",
-        ],
-        env: buildSpawnEnv(options.extraEnv ?? {}),
-        signal: options.signal,
-      },
-    );
+    const child = spawn(invocation.command, invocation.commandArgs, {
+      cwd,
+      stdio: [
+        options.nonInteractive ? "ignore" : "inherit",
+        "pipe",
+        options.onOutput ? "pipe" : "inherit",
+      ],
+      env: buildSpawnEnv(options.extraEnv ?? {}),
+      shell: invocation.shell,
+      signal: options.signal,
+    });
     const disarmAbort = armProcessAbort(child, options.signal);
     const chunks: string[] = [];
     child.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk.toString("utf8")));
@@ -371,18 +381,15 @@ export async function captureVercel(
   }
   return new Promise<VercelCaptureResult>((resolvePromise) => {
     const cwd = existingDir(options.cwd);
-    const invocation = resolveVercelInvocation(cwd);
+    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
     const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(
-      invocation.command,
-      [...invocation.commandArgs, ...commandArgs(args, options.nonInteractive)],
-      {
-        cwd,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: buildSpawnEnv(options.extraEnv ?? {}),
-        signal: options.signal,
-      },
-    );
+    const child = spawn(invocation.command, invocation.commandArgs, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: buildSpawnEnv(options.extraEnv ?? {}),
+      shell: invocation.shell,
+      signal: options.signal,
+    });
     const disarmAbort = armProcessAbort(child, options.signal);
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];


### PR DESCRIPTION
- Introduced `resolveVercelInvocation` function to manage command resolution for different platforms, including Windows shell support.
- Updated tests to validate the new invocation logic and ensure correct command execution across platforms.
- Refactored related functions to streamline command argument handling and improve code readability.

### Description

Windows + PowerShell, vercel installed globally (or as a local devDependency). Run pnpm dev (which runs eve dev). Eve shows 1 setup issue: Vercel CLI not found.

### How did you test your changes?

Built, linked in the same project I tried it before, ran, it worked

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
