### PR TITLE
fix(eve): surface gateway rejection details

### DIFF
--- a/.changeset/gateway-error-detail.md
+++ b/.changeset/gateway-error-detail.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve specific AI Gateway 400 rejection details in model-call failure summaries so channels surface actionable context instead of only a generic request-rejected message.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -260,6 +260,25 @@ describe("summarizeKnownModelCallRequestError", () => {
       message: "AI Gateway rejected the model request before the agent produced a response.",
     });
   });
+
+  it("keeps specific Gateway 400 rejection details in the summary", () => {
+    const summary = summarizeKnownModelCallRequestError(
+      gatewayModelCallError({
+        gatewayName: "GatewayInvalidRequestError",
+        gatewayType: "invalid_request_error",
+        statusCode: 400,
+        upstreamMessage: "input tokens exceed the model context window",
+        upstreamStatusCode: 400,
+        upstreamType: "invalid_request_error",
+      }),
+    );
+
+    expect(summary).toEqual({
+      name: "AI Gateway model request rejected",
+      message:
+        "AI Gateway rejected the model request before the agent produced a response. Gateway detail: input tokens exceed the model context window",
+    });
+  });
 });
 
 /**

--- a/packages/eve/src/harness/model-call-error.ts
+++ b/packages/eve/src/harness/model-call-error.ts
@@ -2,6 +2,7 @@ import { isObject } from "#shared/guards.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
 
 const RESPONSE_BODY_SNIPPET_LIMIT = 1_000;
+const GATEWAY_REQUEST_SUMMARY_DETAIL_LIMIT = 240;
 const GATEWAY_MODEL_REQUEST_REJECTED_MESSAGE =
   "AI Gateway rejected the model request before the agent produced a response.";
 
@@ -131,11 +132,33 @@ export function summarizeKnownModelCallRequestError(
   if (signals.statusCode === 400 && isGatewayErrorSignal(signals)) {
     return {
       name: "AI Gateway model request rejected",
-      message: GATEWAY_MODEL_REQUEST_REJECTED_MESSAGE,
+      message: formatGatewayModelRequestRejectedMessage(signals),
     };
   }
 
   return null;
+}
+
+function formatGatewayModelRequestRejectedMessage(signals: ModelCallErrorSignals): string {
+  const detail = signals.upstreamMessage?.trim();
+  if (detail === undefined || detail.length === 0 || isGenericGatewayRejectionMessage(detail)) {
+    return GATEWAY_MODEL_REQUEST_REJECTED_MESSAGE;
+  }
+
+  return `${GATEWAY_MODEL_REQUEST_REJECTED_MESSAGE} Gateway detail: ${truncateSummaryDetail(
+    detail,
+  )}`;
+}
+
+function isGenericGatewayRejectionMessage(message: string): boolean {
+  return /^(bad request|internal server error)$/i.test(message.trim());
+}
+
+function truncateSummaryDetail(value: string): string {
+  if (value.length <= GATEWAY_REQUEST_SUMMARY_DETAIL_LIMIT) {
+    return value;
+  }
+  return `${value.slice(0, GATEWAY_REQUEST_SUMMARY_DETAIL_LIMIT - 1).trimEnd()}…`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- preserve specific AI Gateway 400 upstream rejection messages in model-call failure summaries
- keep generic upstream boilerplate like \"Bad Request\" collapsed to the existing generic message
- add a patch changeset for eve

## Testing
- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/model-call-error.test.ts
- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/model-call-error.test.ts src/harness/tool-loop.test.ts -t \"Gateway 400|Gateway invalid-request|structural 4xx|model request\"

Note: I isolated this PR in a temporary worktree to avoid unrelated local changes. Running pnpm directly in that temp worktree hit an esbuild postinstall mismatch (`Expected \"0.28.0\" but got \"0.25.12\"`), so the test commands above were run from the main checkout with the same patch applied.