### PR TITLE
feat(eve): schedules - support prompt-driven empty delivery

### DIFF
--- a/.changeset/quiet-delivery.md
+++ b/.changeset/quiet-delivery.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Teach agents that conditionally delivered work can finish successfully without sending a message. Empty responses now work naturally for polling schedules that usually have nothing to report.

--- a/.changeset/quiet-delivery.md
+++ b/.changeset/quiet-delivery.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Teach agents that conditionally delivered work can finish successfully without sending a message. Empty responses now work naturally for polling schedules that usually have nothing to report.
+Teach agents that conditionally delivered work can finish successfully without sending a message. Polling schedules can now intentionally skip delivery without treating an accidental blank model response as success.

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -58,17 +58,17 @@ Sweep stale workflow state.
 
 Use a handler when the schedule needs to deliver to a channel, branch on conditions, or compute its arguments at fire time. The handler is in full control. It has no channel of its own, so it passes the work to one with `receive`.
 
-```ts title="agent/schedules/daily-digest.ts"
+```ts title="agent/schedules/critical-alerts.ts"
 import { defineSchedule } from "eve/schedules";
 
 import slack from "../channels/slack.js";
 
 export default defineSchedule({
-  cron: "0 9 * * 1-5",
+  cron: "* * * * *",
   async run({ receive, waitUntil, appAuth }) {
     waitUntil(
       receive(slack, {
-        message: "Summarize yesterday's activity and post the digest.",
+        message: "Check for new critical alerts. Report only when there are any.",
         target: { channelId: "C0123ABC" },
         auth: appAuth,
       }),
@@ -76,6 +76,8 @@ export default defineSchedule({
   },
 });
 ```
+
+The agent does not have to produce a message on every run. When a prompt makes delivery conditional, as in the alert check above, the agent can finish with no text. eve treats that as a successful run and sends nothing to the channel, so frequent polling schedules do not need a separate filter or delivery setting.
 
 - `receive(channel, { message, target, auth })`: starts a session on another channel. Same contract as a route handler's `args.receive`.
 - `waitUntil(promise)`: extends the cron task's lifetime so the parked session and any in-flight fetches settle before the task ends. Wrap the `receive` call in it.

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -77,7 +77,7 @@ export default defineSchedule({
 });
 ```
 
-The agent does not have to produce a message on every run. When a prompt makes delivery conditional, as in the alert check above, the agent can finish with no text. eve treats that as a successful run and sends nothing to the channel, so frequent polling schedules do not need a separate filter or delivery setting.
+The agent does not have to deliver a message on every run. When a prompt makes delivery conditional, as in the alert check above, eve tells the agent how to finish successfully without sending anything to the channel. Frequent polling schedules do not need a separate filter or delivery setting.
 
 - `receive(channel, { message, target, auth })`: starts a session on another channel. Same contract as a route handler's `args.receive`.
 - `waitUntil(promise)`: extends the cron task's lifetime so the parked session and any in-flight fetches settle before the task ends. Wrap the `receive` call in it.

--- a/e2e/fixtures/agent-schedules/agent/channels/quiet-sink.ts
+++ b/e2e/fixtures/agent-schedules/agent/channels/quiet-sink.ts
@@ -10,8 +10,8 @@ export default defineChannel<undefined, void, { id: string }>({
   },
   events: {
     "message.completed"(event) {
-      if (event.finishReason !== "tool-calls") {
-        throw new Error(`Quiet sink received an unexpected message: ${event.message ?? ""}`);
+      if (event.finishReason !== "tool-calls" && event.message !== null) {
+        throw new Error(`Quiet sink received an unexpected message: ${event.message}`);
       }
     },
   },

--- a/e2e/fixtures/agent-schedules/agent/channels/quiet-sink.ts
+++ b/e2e/fixtures/agent-schedules/agent/channels/quiet-sink.ts
@@ -1,0 +1,18 @@
+import { defineChannel, POST } from "eve/channels";
+
+export default defineChannel<undefined, void, { id: string }>({
+  routes: [POST("/quiet-sink", async () => new Response("ok"))],
+  receive(input, { send }) {
+    return send(input.message, {
+      auth: input.auth,
+      continuationToken: input.target.id,
+    });
+  },
+  events: {
+    "message.completed"(event) {
+      if (event.finishReason !== "tool-calls") {
+        throw new Error(`Quiet sink received an unexpected message: ${event.message ?? ""}`);
+      }
+    },
+  },
+});

--- a/e2e/fixtures/agent-schedules/agent/schedules/quiet-alerts.ts
+++ b/e2e/fixtures/agent-schedules/agent/schedules/quiet-alerts.ts
@@ -1,0 +1,10 @@
+import { defineSchedule } from "eve/schedules";
+
+export default defineSchedule({
+  cron: "* * * * *",
+  markdown: [
+    "Call the `check-alerts` tool exactly once with an empty object.",
+    "Report the critical alerts only when the returned `alerts` list is non-empty.",
+    "If the list is empty, finish without any text.",
+  ].join("\n"),
+});

--- a/e2e/fixtures/agent-schedules/agent/schedules/quiet-alerts.ts
+++ b/e2e/fixtures/agent-schedules/agent/schedules/quiet-alerts.ts
@@ -11,7 +11,7 @@ export default defineSchedule({
         message: [
           "Call the `check-alerts` tool exactly once with an empty object.",
           "Report the critical alerts only when the returned `alerts` list is non-empty.",
-          "If the list is empty, finish without any text.",
+          "Do not send a message when the list is empty.",
         ].join("\n"),
         target: { id: "quiet-alerts" },
       }),

--- a/e2e/fixtures/agent-schedules/agent/schedules/quiet-alerts.ts
+++ b/e2e/fixtures/agent-schedules/agent/schedules/quiet-alerts.ts
@@ -1,10 +1,20 @@
 import { defineSchedule } from "eve/schedules";
 
+import quietSink from "../channels/quiet-sink.js";
+
 export default defineSchedule({
   cron: "* * * * *",
-  markdown: [
-    "Call the `check-alerts` tool exactly once with an empty object.",
-    "Report the critical alerts only when the returned `alerts` list is non-empty.",
-    "If the list is empty, finish without any text.",
-  ].join("\n"),
+  run({ receive, waitUntil, appAuth }) {
+    waitUntil(
+      receive(quietSink, {
+        auth: appAuth,
+        message: [
+          "Call the `check-alerts` tool exactly once with an empty object.",
+          "Report the critical alerts only when the returned `alerts` list is non-empty.",
+          "If the list is empty, finish without any text.",
+        ].join("\n"),
+        target: { id: "quiet-alerts" },
+      }),
+    );
+  },
 });

--- a/e2e/fixtures/agent-schedules/agent/tools/check-alerts.ts
+++ b/e2e/fixtures/agent-schedules/agent/tools/check-alerts.ts
@@ -1,0 +1,11 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+export default defineTool({
+  description:
+    "Smoke-test fixture: checks for critical alerts and always returns an empty alert list. Only call when explicitly asked to use `check-alerts`.",
+  inputSchema: z.object({}),
+  async execute() {
+    return { alerts: [] };
+  },
+});

--- a/e2e/fixtures/agent-schedules/evals/quiet-delivery.eval.ts
+++ b/e2e/fixtures/agent-schedules/evals/quiet-delivery.eval.ts
@@ -1,9 +1,9 @@
 import type { HandleMessageStreamEvent } from "eve/client";
 import { defineEval } from "eve/evals";
 
-/** Proves an every-minute polling schedule can complete without delivery. */
+/** Proves an every-minute polling schedule can leave its target channel silent. */
 export default defineEval({
-  description: "Conditional schedule delivery: an empty alert check sends no message.",
+  description: "Conditional channel delivery: an empty scheduled alert check sends no message.",
 
   async test(t) {
     if (!t.target.capabilities.devRoutes) {
@@ -12,6 +12,11 @@ export default defineEval({
     }
 
     const dispatch = await t.target.dispatchSchedule("quiet-alerts");
+    if (dispatch.scheduleId !== "quiet-alerts") {
+      throw new Error(
+        `Expected quiet-alerts dispatch, got ${JSON.stringify(dispatch.scheduleId)}.`,
+      );
+    }
     const [sessionId] = dispatch.sessionIds;
     if (sessionId === undefined) {
       throw new Error("Quiet schedule dispatch returned no session ids.");
@@ -31,6 +36,12 @@ export default defineEval({
     );
     if (!checkedAlerts) {
       throw new Error(`Expected check-alerts to run; saw ${formatTypes(session.events)}.`);
+    }
+
+    if (!session.events.some((event) => event.type === "session.waiting")) {
+      throw new Error(
+        `Expected the target channel session to reach its waiting boundary; saw ${formatTypes(session.events)}.`,
+      );
     }
 
     const delivered = session.events.flatMap((event) =>

--- a/e2e/fixtures/agent-schedules/evals/quiet-delivery.eval.ts
+++ b/e2e/fixtures/agent-schedules/evals/quiet-delivery.eval.ts
@@ -1,0 +1,60 @@
+import type { HandleMessageStreamEvent } from "eve/client";
+import { defineEval } from "eve/evals";
+
+/** Proves an every-minute polling schedule can complete without delivery. */
+export default defineEval({
+  description: "Conditional schedule delivery: an empty alert check sends no message.",
+
+  async test(t) {
+    if (!t.target.capabilities.devRoutes) {
+      t.log("Target has no dev routes (deployed build); schedule dispatch is dev-only. Skipping.");
+      return;
+    }
+
+    const dispatch = await t.target.dispatchSchedule("quiet-alerts");
+    const [sessionId] = dispatch.sessionIds;
+    if (sessionId === undefined) {
+      throw new Error("Quiet schedule dispatch returned no session ids.");
+    }
+
+    const session = await t.target.attachSession(sessionId);
+    const failures = session.events.filter(isFailure);
+    if (failures.length > 0) {
+      throw new Error(`Quiet schedule session failed: ${formatTypes(failures)}`);
+    }
+
+    const checkedAlerts = session.events.some(
+      (event) =>
+        event.type === "action.result" &&
+        event.data.result.kind === "tool-result" &&
+        event.data.result.toolName === "check-alerts",
+    );
+    if (!checkedAlerts) {
+      throw new Error(`Expected check-alerts to run; saw ${formatTypes(session.events)}.`);
+    }
+
+    const delivered = session.events.flatMap((event) =>
+      event.type === "message.completed" && event.data.finishReason !== "tool-calls"
+        ? [event.data.message]
+        : [],
+    );
+    if (delivered.length > 0) {
+      throw new Error(
+        `Expected empty delivery, but the schedule produced ${JSON.stringify(delivered)}.`,
+      );
+    }
+
+    t.didNotFail();
+    t.completed();
+  },
+});
+
+function isFailure(event: HandleMessageStreamEvent): boolean {
+  return (
+    event.type === "session.failed" || event.type === "turn.failed" || event.type === "step.failed"
+  );
+}
+
+function formatTypes(events: readonly HandleMessageStreamEvent[]): string {
+  return JSON.stringify(events.map((event) => event.type));
+}

--- a/e2e/fixtures/agent-schedules/evals/quiet-delivery.eval.ts
+++ b/e2e/fixtures/agent-schedules/evals/quiet-delivery.eval.ts
@@ -44,11 +44,17 @@ export default defineEval({
       );
     }
 
-    const delivered = session.events.flatMap((event) =>
+    const terminalMessages = session.events.flatMap((event) =>
       event.type === "message.completed" && event.data.finishReason !== "tool-calls"
         ? [event.data.message]
         : [],
     );
+    if (!terminalMessages.includes(null)) {
+      throw new Error(
+        `Expected an empty-delivery completion; saw ${JSON.stringify(terminalMessages)}.`,
+      );
+    }
+    const delivered = terminalMessages.filter((message) => message !== null);
     if (delivered.length > 0) {
       throw new Error(
         `Expected empty delivery, but the schedule produced ${JSON.stringify(delivered)}.`,

--- a/packages/eve/src/channel/schedule-auth.test.ts
+++ b/packages/eve/src/channel/schedule-auth.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { isScheduleAppAuth, SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
+
+describe("isScheduleAppAuth", () => {
+  it("recognizes eve's schedule principal", () => {
+    expect(isScheduleAppAuth(SCHEDULE_APP_AUTH)).toBe(true);
+    expect(
+      isScheduleAppAuth({
+        ...SCHEDULE_APP_AUTH,
+        attributes: { deployment: "preview" },
+        issuer: "eve",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects other principals and missing auth", () => {
+    expect(isScheduleAppAuth(null)).toBe(false);
+    expect(isScheduleAppAuth(undefined)).toBe(false);
+    expect(isScheduleAppAuth({ ...SCHEDULE_APP_AUTH, authenticator: "oidc" })).toBe(false);
+    expect(isScheduleAppAuth({ ...SCHEDULE_APP_AUTH, principalId: "another-app" })).toBe(false);
+    expect(isScheduleAppAuth({ ...SCHEDULE_APP_AUTH, principalType: "user" })).toBe(false);
+  });
+});

--- a/packages/eve/src/channel/schedule-auth.ts
+++ b/packages/eve/src/channel/schedule-auth.ts
@@ -1,0 +1,22 @@
+import type { SessionAuthContext } from "#channel/types.js";
+
+/**
+ * Framework-owned principal used when a schedule runs on behalf of the agent.
+ */
+export const SCHEDULE_APP_AUTH: SessionAuthContext = {
+  attributes: {},
+  authenticator: "app",
+  principalId: "eve:app",
+  principalType: "runtime",
+};
+
+/** Returns whether the current request is authenticated as eve's schedule principal. */
+export function isScheduleAppAuth(
+  auth: SessionAuthContext | null | undefined,
+): auth is SessionAuthContext {
+  return (
+    auth?.authenticator === SCHEDULE_APP_AUTH.authenticator &&
+    auth.principalId === SCHEDULE_APP_AUTH.principalId &&
+    auth.principalType === SCHEDULE_APP_AUTH.principalType
+  );
+}

--- a/packages/eve/src/channel/schedule.ts
+++ b/packages/eve/src/channel/schedule.ts
@@ -1,10 +1,11 @@
 import type { ChannelAdapter } from "#channel/adapter.js";
+import { SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
 import {
   createCrossChannelReceiveFn,
   toCrossChannelTargets,
 } from "#channel/cross-channel-receive.js";
 import { createSession, type Session } from "#channel/session.js";
-import type { Runtime, SessionAuthContext } from "#channel/types.js";
+import type { Runtime } from "#channel/types.js";
 import { expectFunction } from "#internal/authored-module.js";
 import type {
   ScheduleDefinition,
@@ -13,16 +14,7 @@ import type {
 } from "#public/definitions/schedule.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 
-/**
- * Pre-built application auth context handed to schedules. Schedules
- * run on behalf of the agent itself, not a downstream user.
- */
-export const SCHEDULE_APP_AUTH: SessionAuthContext = {
-  attributes: {},
-  authenticator: "app",
-  principalId: "eve:app",
-  principalType: "runtime",
-};
+export { SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
 
 /**
  * Durable adapter kind used when a schedule fires without targeting a

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -5,6 +5,7 @@ import {
   createActionResultEvent,
   createActionsRequestedEvent,
   createInputRequestedEvent,
+  createMessageAppendedEvent,
   createMessageCompletedEvent,
   createReasoningCompletedEvent,
   createResultCompletedEvent,
@@ -529,6 +530,49 @@ describe("defaultMessageReducer", () => {
         ],
         role: "assistant",
       },
+    ]);
+  });
+
+  it("removes streamed text for a null message completion", () => {
+    const reducer = defaultMessageReducer();
+    let data = reducer.reduce(
+      reducer.initial(),
+      createMessageCompletedEvent({
+        message: "Earlier step.",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageAppendedEvent({
+        messageDelta: "<eve-empty-delivery/>",
+        messageSoFar: "<eve-empty-delivery/>",
+        sequence: 1,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        message: null,
+        sequence: 1,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+
+    expect(data.messages[0]?.parts).toEqual([
+      { type: "step-start" },
+      {
+        state: "done",
+        stepIndex: 0,
+        text: "Earlier step.",
+        type: "text",
+      },
+      { type: "step-start" },
     ]);
   });
 });

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -231,7 +231,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
     case "message.completed":
       return updateAssistantMessage(data, event.data.turnId, (message) => {
         if (event.data.message === null) {
-          return completeExistingTextPart(message);
+          return removeTextPart(message, event.data.stepIndex);
         }
 
         return upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
@@ -361,14 +361,11 @@ function upsertPart(message: EveAssistantMessage, next: EveMessagePart): EveAssi
   };
 }
 
-function completeExistingTextPart(message: EveAssistantMessage): EveAssistantMessage {
-  const index = findLastIndex(message.parts, (part) => part.type === "text");
-  if (index === -1) {
-    return message;
-  }
-
-  const existing = message.parts[index];
-  if (existing?.type !== "text") {
+function removeTextPart(message: EveAssistantMessage, stepIndex: number): EveAssistantMessage {
+  const parts = message.parts.filter(
+    (part) => part.type !== "text" || part.stepIndex !== stepIndex,
+  );
+  if (parts.length === message.parts.length) {
     return message;
   }
 
@@ -378,11 +375,7 @@ function completeExistingTextPart(message: EveAssistantMessage): EveAssistantMes
       ...message.metadata,
       status: "complete",
     },
-    parts: [
-      ...message.parts.slice(0, index),
-      { ...existing, state: "done" },
-      ...message.parts.slice(index + 1),
-    ],
+    parts,
   };
 }
 
@@ -579,13 +572,4 @@ function stringifyUnknown(value: unknown): string {
   } catch {
     return "Action failed.";
   }
-}
-
-function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    if (predicate(items[index] as T)) {
-      return index;
-    }
-  }
-  return -1;
 }

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -8,6 +8,7 @@ import {
   setHarnessEmissionState,
 } from "#harness/emission.js";
 import type { HarnessEmitFn, HarnessSession } from "#harness/types.js";
+import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 
 async function* streamOf(parts: TextStreamPart<ToolSet>[]): AsyncIterable<TextStreamPart<ToolSet>> {
   for (const part of parts) {
@@ -121,6 +122,79 @@ describe("setHarnessEmissionState", () => {
     const retrieved = getHarnessEmissionState(session.state);
 
     expect(retrieved).toEqual(state);
+  });
+});
+
+describe("emitStreamContent empty delivery", () => {
+  it("suppresses a split sentinel and completes with a null message", async () => {
+    const emit = createEmitStub();
+
+    await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        { id: "text-1", text: "  <eve-empty", type: "text-delta" },
+        { id: "text-1", text: "-delivery/>  ", type: "text-delta" },
+        { finishReason: "stop", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events.map((event) => event.type)).toEqual(["message.completed"]);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ finishReason: "stop", message: null }),
+      }),
+    );
+  });
+
+  it("preserves normal text that initially resembles the sentinel", async () => {
+    const emit = createEmitStub();
+    const message = "<eve-empty-delivery is not a marker";
+
+    await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        { id: "text-1", text: "<eve-empty", type: "text-delta" },
+        { id: "text-1", text: "-delivery is not a marker", type: "text-delta" },
+        { finishReason: "stop", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events.filter((event) => event.type === "message.appended")).toHaveLength(2);
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message }),
+        type: "message.completed",
+      }),
+    );
+  });
+
+  it("skips delivery when the sentinel appears anywhere in the final message", async () => {
+    const emit = createEmitStub();
+
+    await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        {
+          id: "text-1",
+          text: `Internal preamble ${EMPTY_DELIVERY_SENTINEL} trailing text`,
+          type: "text-delta",
+        },
+        { finishReason: "stop", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events.at(-1)).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: null }),
+        type: "message.completed",
+      }),
+    );
   });
 });
 

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -126,7 +126,35 @@ describe("setHarnessEmissionState", () => {
 });
 
 describe("emitStreamContent empty delivery", () => {
-  it("suppresses a split sentinel and completes with a null message", async () => {
+  it("emits each normal text delta before reading the next stream part", async () => {
+    const emit = createEmitStub();
+    let releaseSecondPart!: () => void;
+    const secondPartReady = new Promise<void>((resolve) => {
+      releaseSecondPart = resolve;
+    });
+    async function* controlledStream(): AsyncIterable<TextStreamPart<ToolSet>> {
+      yield { id: "text-1", text: "first", type: "text-delta" } as TextStreamPart<ToolSet>;
+      await secondPartReady;
+      yield { id: "text-1", text: " second", type: "text-delta" } as TextStreamPart<ToolSet>;
+      yield { finishReason: "stop", type: "finish-step" } as TextStreamPart<ToolSet>;
+    }
+
+    const run = emitStreamContent(emit, EMISSION_STATE, controlledStream());
+    try {
+      await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(1));
+      expect(vi.mocked(emit).mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({ messageDelta: "first", messageSoFar: "first" }),
+          type: "message.appended",
+        }),
+      );
+    } finally {
+      releaseSecondPart();
+      await run;
+    }
+  });
+
+  it("streams a split sentinel immediately and completes with a null message", async () => {
     const emit = createEmitStub();
 
     await emitStreamContent(
@@ -140,8 +168,17 @@ describe("emitStreamContent empty delivery", () => {
     );
 
     const events = vi.mocked(emit).mock.calls.map(([event]) => event);
-    expect(events.map((event) => event.type)).toEqual(["message.completed"]);
+    expect(events.map((event) => event.type)).toEqual([
+      "message.appended",
+      "message.appended",
+      "message.completed",
+    ]);
     expect(events[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ messageDelta: "  <eve-empty" }),
+      }),
+    );
+    expect(events.at(-1)).toEqual(
       expect.objectContaining({
         data: expect.objectContaining({ finishReason: "stop", message: null }),
       }),

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -31,6 +31,7 @@ import {
   createTurnStartedEvent,
 } from "#protocol/message.js";
 import type { RunMode } from "#shared/run-mode.js";
+import { EMPTY_DELIVERY_SENTINEL, hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
 import { toError } from "#shared/errors.js";
 import type { JsonObject } from "#shared/json.js";
 import {
@@ -354,6 +355,9 @@ export async function emitStreamContent(
 ): Promise<EmittedStreamContent> {
   let currentReasoning = "";
   let currentMessage = "";
+  let emittedMessage = "";
+  let pendingMessageDeltas: string[] = [];
+  let canBeEmptyDelivery = true;
   let finishReason: AssistantStepFinishReason = "stop";
   let streamError: Error | undefined;
   const toolCallIdsSeenInStream = new Set<string>();
@@ -362,10 +366,28 @@ export async function emitStreamContent(
   const inlineAuthorizationResults: TypedToolResult<ToolSet>[] = [];
   const inlineToolResultParts: InlineToolResultPart[] = [];
 
+  const flushPendingMessageDeltas = async (): Promise<void> => {
+    for (const delta of pendingMessageDeltas) {
+      emittedMessage += delta;
+      await emitFn(
+        createMessageAppendedEvent({
+          messageDelta: delta,
+          messageSoFar: emittedMessage,
+          sequence: state.sequence,
+          stepIndex: state.stepIndex,
+          turnId: state.turnId,
+        }),
+      );
+    }
+    pendingMessageDeltas = [];
+  };
+
   const flushCurrentMessage = async (): Promise<void> => {
     if (currentMessage.length === 0) {
       return;
     }
+    canBeEmptyDelivery = false;
+    await flushPendingMessageDeltas();
     await emitFn(
       createMessageCompletedEvent({
         finishReason: "tool-calls",
@@ -376,6 +398,8 @@ export async function emitStreamContent(
       }),
     );
     currentMessage = "";
+    emittedMessage = "";
+    canBeEmptyDelivery = true;
   };
 
   const emitProviderToolCall = async (toolCall: {
@@ -439,15 +463,11 @@ export async function emitStreamContent(
           currentReasoning = "";
         }
         currentMessage += part.text;
-        await emitFn(
-          createMessageAppendedEvent({
-            messageDelta: part.text,
-            messageSoFar: currentMessage,
-            sequence: state.sequence,
-            stepIndex: state.stepIndex,
-            turnId: state.turnId,
-          }),
-        );
+        pendingMessageDeltas.push(part.text);
+        if (canBeEmptyDelivery && !couldBeEmptyDelivery(currentMessage)) {
+          canBeEmptyDelivery = false;
+        }
+        if (!canBeEmptyDelivery) await flushPendingMessageDeltas();
         break;
       case "tool-call": {
         const toolCall = part as TypedToolCall<ToolSet>;
@@ -571,8 +591,21 @@ export async function emitStreamContent(
     );
   }
 
-  // Flush remaining text.
-  if (currentMessage.length > 0) {
+  // A reserved terminal marker becomes a null completion. Channel adapters
+  // already treat null as no delivery, while the event keeps the successful
+  // terminal boundary observable without leaking the marker to stream clients.
+  if (finishReason !== "tool-calls" && hasEmptyDeliverySentinel(currentMessage)) {
+    await emitFn(
+      createMessageCompletedEvent({
+        finishReason,
+        message: null,
+        sequence: state.sequence,
+        stepIndex: state.stepIndex,
+        turnId: state.turnId,
+      }),
+    );
+  } else if (currentMessage.trim().length > 0) {
+    await flushPendingMessageDeltas();
     await emitFn(
       createMessageCompletedEvent({
         finishReason,
@@ -585,6 +618,13 @@ export async function emitStreamContent(
   }
 
   return { handledInlineToolResultCallIds, inlineAuthorizationResults, inlineToolResultParts };
+}
+
+function couldBeEmptyDelivery(text: string): boolean {
+  const candidate = text.trimStart();
+  if (candidate.length === 0 || EMPTY_DELIVERY_SENTINEL.startsWith(candidate)) return true;
+  if (!candidate.startsWith(EMPTY_DELIVERY_SENTINEL)) return false;
+  return candidate.slice(EMPTY_DELIVERY_SENTINEL.length).trim().length === 0;
 }
 
 function isInlineAuthorizationToolResult(toolResult: TypedToolResult<ToolSet>): boolean {

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -31,7 +31,7 @@ import {
   createTurnStartedEvent,
 } from "#protocol/message.js";
 import type { RunMode } from "#shared/run-mode.js";
-import { EMPTY_DELIVERY_SENTINEL, hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
+import { hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
 import { toError } from "#shared/errors.js";
 import type { JsonObject } from "#shared/json.js";
 import {
@@ -355,9 +355,6 @@ export async function emitStreamContent(
 ): Promise<EmittedStreamContent> {
   let currentReasoning = "";
   let currentMessage = "";
-  let emittedMessage = "";
-  let pendingMessageDeltas: string[] = [];
-  let canBeEmptyDelivery = true;
   let finishReason: AssistantStepFinishReason = "stop";
   let streamError: Error | undefined;
   const toolCallIdsSeenInStream = new Set<string>();
@@ -366,28 +363,10 @@ export async function emitStreamContent(
   const inlineAuthorizationResults: TypedToolResult<ToolSet>[] = [];
   const inlineToolResultParts: InlineToolResultPart[] = [];
 
-  const flushPendingMessageDeltas = async (): Promise<void> => {
-    for (const delta of pendingMessageDeltas) {
-      emittedMessage += delta;
-      await emitFn(
-        createMessageAppendedEvent({
-          messageDelta: delta,
-          messageSoFar: emittedMessage,
-          sequence: state.sequence,
-          stepIndex: state.stepIndex,
-          turnId: state.turnId,
-        }),
-      );
-    }
-    pendingMessageDeltas = [];
-  };
-
   const flushCurrentMessage = async (): Promise<void> => {
     if (currentMessage.length === 0) {
       return;
     }
-    canBeEmptyDelivery = false;
-    await flushPendingMessageDeltas();
     await emitFn(
       createMessageCompletedEvent({
         finishReason: "tool-calls",
@@ -398,8 +377,6 @@ export async function emitStreamContent(
       }),
     );
     currentMessage = "";
-    emittedMessage = "";
-    canBeEmptyDelivery = true;
   };
 
   const emitProviderToolCall = async (toolCall: {
@@ -463,11 +440,15 @@ export async function emitStreamContent(
           currentReasoning = "";
         }
         currentMessage += part.text;
-        pendingMessageDeltas.push(part.text);
-        if (canBeEmptyDelivery && !couldBeEmptyDelivery(currentMessage)) {
-          canBeEmptyDelivery = false;
-        }
-        if (!canBeEmptyDelivery) await flushPendingMessageDeltas();
+        await emitFn(
+          createMessageAppendedEvent({
+            messageDelta: part.text,
+            messageSoFar: currentMessage,
+            sequence: state.sequence,
+            stepIndex: state.stepIndex,
+            turnId: state.turnId,
+          }),
+        );
         break;
       case "tool-call": {
         const toolCall = part as TypedToolCall<ToolSet>;
@@ -591,9 +572,8 @@ export async function emitStreamContent(
     );
   }
 
-  // A reserved terminal marker becomes a null completion. Channel adapters
-  // already treat null as no delivery, while the event keeps the successful
-  // terminal boundary observable without leaking the marker to stream clients.
+  // Channel adapters deliver terminal completions, so the reserved marker
+  // becomes a null completion without delaying normal streaming deltas.
   if (finishReason !== "tool-calls" && hasEmptyDeliverySentinel(currentMessage)) {
     await emitFn(
       createMessageCompletedEvent({
@@ -605,7 +585,6 @@ export async function emitStreamContent(
       }),
     );
   } else if (currentMessage.trim().length > 0) {
-    await flushPendingMessageDeltas();
     await emitFn(
       createMessageCompletedEvent({
         finishReason,
@@ -618,13 +597,6 @@ export async function emitStreamContent(
   }
 
   return { handledInlineToolResultCallIds, inlineAuthorizationResults, inlineToolResultParts };
-}
-
-function couldBeEmptyDelivery(text: string): boolean {
-  const candidate = text.trimStart();
-  if (candidate.length === 0 || EMPTY_DELIVERY_SENTINEL.startsWith(candidate)) return true;
-  if (!candidate.startsWith(EMPTY_DELIVERY_SENTINEL)) return false;
-  return candidate.slice(EMPTY_DELIVERY_SENTINEL.length).trim().length === 0;
 }
 
 function isInlineAuthorizationToolResult(toolResult: TypedToolResult<ToolSet>): boolean {

--- a/packages/eve/src/harness/messages.test.ts
+++ b/packages/eve/src/harness/messages.test.ts
@@ -181,4 +181,14 @@ describe("resolveAssistantStepText", () => {
   it("returns null when the fallback is empty", () => {
     expect(resolveAssistantStepText([], "")).toBeNull();
   });
+
+  it("returns null when assistant text is only whitespace", () => {
+    const messages: ModelMessage[] = [{ content: " \n\t", role: "assistant" }];
+
+    expect(resolveAssistantStepText(messages, undefined)).toBeNull();
+  });
+
+  it("returns null when the fallback is only whitespace", () => {
+    expect(resolveAssistantStepText([], " \n\t")).toBeNull();
+  });
 });

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -71,12 +71,12 @@ export function resolveAssistantStepText(
     }
 
     const text = extractMessageText(message);
-    if (text.length > 0) {
+    if (text.trim().length > 0) {
       return text;
     }
   }
 
-  if (fallback !== undefined && fallback.length > 0) {
+  if (fallback !== undefined && fallback.trim().length > 0) {
     return fallback;
   }
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -22,6 +22,7 @@ import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 import { isCodeModeEnvEnabled } from "#shared/code-mode.js";
+import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 
 declare module "#public/channels/index.js" {
   interface ChannelMetadataMap {
@@ -500,12 +501,18 @@ describe("createToolLoopHarness", () => {
     ]);
   });
 
-  it("parks the conversation when a terminal 'stop' step has no visible assistant text", async () => {
+  it("parks without delivery when a terminal response contains the empty-delivery sentinel", async () => {
     setupMockAgent({
       finishReason: "stop",
-      fullStreamParts: [{ finishReason: "stop", type: "finish-step" }],
-      response: { messages: [{ content: "", role: "assistant" }] },
-      text: "",
+      response: {
+        messages: [
+          {
+            content: `internal ${EMPTY_DELIVERY_SENTINEL} trailing`,
+            role: "assistant",
+          },
+        ],
+      },
+      text: `internal ${EMPTY_DELIVERY_SENTINEL} trailing`,
       toolCalls: [],
       toolResults: [],
     });
@@ -513,22 +520,17 @@ describe("createToolLoopHarness", () => {
     const { emit, events } = createEventCollector();
     const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
 
-    // A clean finish with no output is the model choosing silence (the
-    // post-delivery quiet step); it parks normally with no recovery and
-    // no failure events.
     const result = await runStep(createTestSession(), { message: "Hi" });
 
     expect(result.next).toBeNull();
+    expect(result.session.history).toEqual([{ content: "Hi", role: "user" }]);
     expect(vi.mocked(ToolLoopAgent).mock.calls.length).toBe(1);
-    expect(events.map((event) => event.type)).toEqual([
-      "session.started",
-      "turn.started",
-      "message.received",
-      "step.started",
-      "step.completed",
-      "turn.completed",
-      "session.waiting",
-    ]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: null }),
+        type: "message.completed",
+      }),
+    );
   });
 
   it("keeps executable tools direct when code mode is disabled", async () => {
@@ -673,9 +675,8 @@ describe("createToolLoopHarness", () => {
   it("returns an empty successful result when a task chooses not to deliver", async () => {
     setupMockAgent({
       finishReason: "stop",
-      fullStreamParts: [{ finishReason: "stop", type: "finish-step" }],
-      response: { messages: [{ content: "", role: "assistant" }] },
-      text: "",
+      response: { messages: [{ content: EMPTY_DELIVERY_SENTINEL, role: "assistant" }] },
+      text: EMPTY_DELIVERY_SENTINEL,
       toolCalls: [],
       toolResults: [],
     });
@@ -687,15 +688,12 @@ describe("createToolLoopHarness", () => {
 
     expect(result.next).toEqual({ done: true, output: "" });
     expect(vi.mocked(ToolLoopAgent)).toHaveBeenCalledTimes(1);
-    expect(events.map((event) => event.type)).toEqual([
-      "session.started",
-      "turn.started",
-      "message.received",
-      "step.started",
-      "step.completed",
-      "turn.completed",
-      "session.completed",
-    ]);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: null }),
+        type: "message.completed",
+      }),
+    );
   });
 
   it("emits result.completed when a run output schema is requested", async () => {
@@ -2711,6 +2709,13 @@ describe("createToolLoopHarness", () => {
       usage: {},
     };
 
+    const emptyStopResult: Record<string, unknown> = {
+      ...emptyResult,
+      finishReason: "stop",
+      response: { messages: [{ content: " \n", role: "assistant" }] },
+      text: " \n",
+    };
+
     /**
      * Stream-rejection shape of the empty response: ai@7.0.0-canary.169+
      * (vercel/ai#15938) enqueues NoOutputGeneratedError onto fullStream
@@ -2808,6 +2813,25 @@ describe("createToolLoopHarness", () => {
               typeof message.content === "string" && message.content.includes("was not delivered"),
           ),
         ).toBe(false);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("reissues a blank 'stop' response instead of treating it as intentional silence", async () => {
+      setupFirstThenAgent(emptyStopResult, successResult);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const runStep = createToolLoopHarness(createTestConfig("conversation"));
+
+      try {
+        const result = await runStep(createTestSession(), { message: "Hi" });
+
+        expect(result.next).toBeNull();
+        expect(vi.mocked(ToolLoopAgent)).toHaveBeenCalledTimes(2);
+        expect(result.session.history).toContainEqual({
+          content: "Here is your answer.",
+          role: "assistant",
+        });
       } finally {
         warnSpy.mockRestore();
       }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3,8 +3,16 @@ import { type FilePart, jsonSchema, type LanguageModel, ToolLoopAgent, type User
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
-import { LiveStepToolsKey, SessionDynamicInstructionsKey } from "#context/keys.js";
-import { ChannelInstrumentationKey, SandboxKey } from "#context/keys.js";
+import {
+  AuthKey,
+  ChannelInstrumentationKey,
+  InitiatorAuthKey,
+  LiveStepToolsKey,
+  ParentSessionKey,
+  SandboxKey,
+  SessionDynamicInstructionsKey,
+} from "#context/keys.js";
+import { SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
 import { decodeSandboxRef, isSandboxRefUrl } from "#internal/attachments/sandbox-refs.js";
 import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
@@ -22,7 +30,10 @@ import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 import { isCodeModeEnvEnabled } from "#shared/code-mode.js";
-import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
+import {
+  CONDITIONAL_DELIVERY_INSTRUCTION,
+  EMPTY_DELIVERY_SENTINEL,
+} from "#shared/empty-delivery.js";
 
 declare module "#public/channels/index.js" {
   interface ChannelMetadataMap {
@@ -108,6 +119,22 @@ function createTestConfig(
     ]),
     ...overrides,
   };
+}
+
+function createScheduleContext(): ContextContainer {
+  const ctx = new ContextContainer();
+  ctx.set(AuthKey, SCHEDULE_APP_AUTH);
+  ctx.set(InitiatorAuthKey, SCHEDULE_APP_AUTH);
+  return ctx;
+}
+
+function setDelegatedParent(ctx: ContextContainer): void {
+  ctx.set(ParentSessionKey, {
+    callId: "call-parent",
+    rootSessionId: "session-root",
+    sessionId: "session-parent",
+    turn: { id: "turn-parent", sequence: 0 },
+  });
 }
 
 function createEventCollector(): {
@@ -2807,12 +2834,70 @@ describe("createToolLoopHarness", () => {
           content: expect.stringContaining("was not delivered"),
           role: "user",
         });
+        expect(reissueMessages.at(-1)?.content).not.toContain(EMPTY_DELIVERY_SENTINEL);
         expect(
           result.session.history.some(
             (message) =>
               typeof message.content === "string" && message.content.includes("was not delivered"),
           ),
         ).toBe(false);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("offers conditional delivery on an empty-response retry for a scheduled turn", async () => {
+      setupFirstThenAgent(emptyResult, successResult);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { emit } = createEventCollector();
+      const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+
+      try {
+        await contextStorage.run(createScheduleContext(), () =>
+          runStep(createTestSession(), { message: "Check for alerts." }),
+        );
+
+        const reissueAgent = vi.mocked(ToolLoopAgent).mock.results[1]?.value as {
+          stream: ReturnType<typeof vi.fn>;
+        };
+        const reissueMessages = reissueAgent.stream.mock.calls[0]?.[0]?.messages as Array<{
+          content: unknown;
+          role: string;
+        }>;
+        expect(reissueMessages.at(-1)).toMatchObject({
+          content: expect.stringContaining(EMPTY_DELIVERY_SENTINEL),
+          role: "user",
+        });
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does not offer conditional delivery on a scheduled retry with an output schema", async () => {
+      setupFirstThenAgent(emptyResult, finalOutputResult("Done.", { status: "ok" }));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { emit } = createEventCollector();
+      const runStep = createToolLoopHarness(createTestConfig("task", emit));
+
+      try {
+        await contextStorage.run(createScheduleContext(), () =>
+          runStep(createTestSession({ outputSchema: { type: "object" } }), {
+            message: "Check for alerts.",
+          }),
+        );
+
+        const reissueAgent = vi.mocked(ToolLoopAgent).mock.results[1]?.value as {
+          stream: ReturnType<typeof vi.fn>;
+        };
+        const reissueMessages = reissueAgent.stream.mock.calls[0]?.[0]?.messages as Array<{
+          content: unknown;
+          role: string;
+        }>;
+        expect(reissueMessages.at(-1)).toMatchObject({
+          content: expect.stringContaining("was not delivered"),
+          role: "user",
+        });
+        expect(reissueMessages.at(-1)?.content).not.toContain(EMPTY_DELIVERY_SENTINEL);
       } finally {
         warnSpy.mockRestore();
       }
@@ -6836,6 +6921,84 @@ describe("createToolLoopHarness", () => {
       const session = createTestSession();
 
       await runStep(session, { message: "Hi" });
+
+      const { instructions } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+    });
+
+    it.each(["conversation", "task"] as const)(
+      "adds conditional-delivery guidance to a top-level scheduled %s turn",
+      async (mode) => {
+        setupMockAgent(defaultModelResult());
+        const runStep = createToolLoopHarness(createTestConfig(mode));
+
+        await contextStorage.run(createScheduleContext(), () =>
+          runStep(createTestSession(), { message: "Check for alerts." }),
+        );
+
+        const { instructions } = getLastAgentSettings();
+        expect(instructions).toEqual([
+          { role: "system", content: "You are a test assistant." },
+          { role: "system", content: CONDITIONAL_DELIVERY_INSTRUCTION },
+        ]);
+      },
+    );
+
+    it.each(["conversation", "task"] as const)(
+      "does not add conditional-delivery guidance when a scheduled %s turn has an output schema",
+      async (mode) => {
+        setupMockAgent(finalOutputResult("Done.", { status: "ok" }));
+        const runStep = createToolLoopHarness(createTestConfig(mode));
+
+        await contextStorage.run(createScheduleContext(), () =>
+          runStep(createTestSession({ outputSchema: { type: "object" } }), {
+            message: "Check for alerts.",
+          }),
+        );
+
+        const { instructions } = getLastAgentSettings();
+        expect(instructions).toBe("You are a test assistant.");
+      },
+    );
+
+    it("does not add conditional-delivery guidance to an ordinary task run", async () => {
+      setupMockAgent(defaultModelResult());
+      const runStep = createToolLoopHarness(createTestConfig("task"));
+
+      await runStep(createTestSession(), { message: "Run this task." });
+
+      const { instructions } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+    });
+
+    it("does not add conditional-delivery guidance to a human continuation", async () => {
+      setupMockAgent(defaultModelResult());
+      const runStep = createToolLoopHarness(createTestConfig("conversation"));
+      const ctx = createScheduleContext();
+      ctx.set(AuthKey, {
+        attributes: {},
+        authenticator: "slack",
+        principalId: "U123",
+        principalType: "user",
+      });
+
+      await contextStorage.run(ctx, () =>
+        runStep(createTestSession(), { message: "What happened?" }),
+      );
+
+      const { instructions } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+    });
+
+    it("does not add conditional-delivery guidance to a delegated run", async () => {
+      setupMockAgent(defaultModelResult());
+      const runStep = createToolLoopHarness(createTestConfig("task"));
+      const ctx = createScheduleContext();
+      setDelegatedParent(ctx);
+
+      await contextStorage.run(ctx, () =>
+        runStep(createTestSession(), { message: "Handle delegated work." }),
+      );
 
       const { instructions } = getLastAgentSettings();
       expect(instructions).toBe("You are a test assistant.");

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -670,6 +670,34 @@ describe("createToolLoopHarness", () => {
     expect(result.next).toEqual({ done: true, output: "Hello!" });
   });
 
+  it("returns an empty successful result when a task chooses not to deliver", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      fullStreamParts: [{ finishReason: "stop", type: "finish-step" }],
+      response: { messages: [{ content: "", role: "assistant" }] },
+      text: "",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("task", emit));
+
+    const result = await runStep(createTestSession(), { message: "Check for alerts." });
+
+    expect(result.next).toEqual({ done: true, output: "" });
+    expect(vi.mocked(ToolLoopAgent)).toHaveBeenCalledTimes(1);
+    expect(events.map((event) => event.type)).toEqual([
+      "session.started",
+      "turn.started",
+      "message.received",
+      "step.started",
+      "step.completed",
+      "turn.completed",
+      "session.completed",
+    ]);
+  });
+
   it("emits result.completed when a run output schema is requested", async () => {
     const schema = {
       properties: { title: { type: "string" } },

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -116,6 +116,7 @@ import {
   summarizeKnownModelCallRequestError,
 } from "#harness/model-call-error.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
+import { EMPTY_DELIVERY_SENTINEL, hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
 import { ensureOtelIntegration } from "#harness/otel-integration.js";
 import {
@@ -744,7 +745,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             inlineToolResultParts,
           } = await emitStreamContent(emit, emissionState, streamResult.fullStream);
           const stepResult = await hooks.stepResult;
-          if (isEmptyModelResponse(stepResult)) {
+          if (
+            isEmptyModelResponse(stepResult) &&
+            inlineToolResultParts.length === 0 &&
+            inlineAuthorizationResults.length === 0
+          ) {
             throw new EmptyModelResponseError();
           }
           await emitStepActions(emit, emissionState, stepResult, {
@@ -1305,22 +1310,14 @@ function buildDisabledToolNote(toolNames: readonly string[]): string {
 }
 
 /**
- * True when a step completed with finishReason 'other' while producing no
- * assistant text and no tool calls: the shape of an AI Gateway HTTP 200
- * whose stream carried no content. Scoped to 'other' on purpose: a clean
- * finish ('stop', 'length') with no output means the model chose silence
- * (measured in d0, Jun 2026, as the healthy quiet step after a tool had
- * already delivered the answer, 64/64 over a week), and reissuing it would
- * risk duplicate replies. Braintrust spans carry finishReason and output
- * for every call, so silent steps stay observable without a runtime log.
- *
- * Emptiness is derived through {@link resolveAssistantStepText} so the
- * harness has a single definition of "no visible output".
+ * True when a step produced no assistant text and no tool calls. Intentional
+ * silence uses {@link EMPTY_DELIVERY_SENTINEL}; a genuinely blank response is
+ * ambiguous and must be retried instead of silently dropping a HITL reply.
  */
 function isEmptyModelResponse(step: HarnessStepResult): boolean {
   return (
-    step.finishReason === "other" &&
     step.toolCalls.length === 0 &&
+    step.toolResults.length === 0 &&
     resolveAssistantStepText(step.response.messages, step.text) === null
   );
 }
@@ -1351,9 +1348,7 @@ function rethrowNoOutputAsEmptyResponse(error: unknown): never {
  * (its toolset change busts the prompt cache anyway), this one trails as
  * a user note to keep the cached prefix valid.
  */
-const EMPTY_RESPONSE_NUDGE =
-  "Your previous reply was not delivered. Answer now from the tool results " +
-  "above; do not re-run tools or mention this notice.";
+const EMPTY_RESPONSE_NUDGE = `Your previous reply was empty and was not delivered. Answer now from the tool results above; do not re-run tools or mention this notice. If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
 
 /**
  * Recovers a model call that completed without content (see
@@ -1420,8 +1415,13 @@ async function handleStepResult(input: {
   const { config, emit, promptMessages, result, runStep } = input;
   let { emissionState, session } = input;
 
-  const responseMessages = result.response.messages;
-  const stepOutput = resolveAssistantStepText(responseMessages, result.text);
+  const resolvedStepOutput = resolveAssistantStepText(result.response.messages, result.text);
+  const emptyDelivery =
+    result.finishReason !== "tool-calls" &&
+    result.toolCalls.length === 0 &&
+    hasEmptyDeliverySentinel(resolvedStepOutput);
+  const responseMessages = emptyDelivery ? [] : result.response.messages;
+  const stepOutput = emptyDelivery ? null : resolvedStepOutput;
 
   const baseSession: HarnessSession = {
     ...session,

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -16,6 +16,7 @@ import {
   type TypedToolResult,
 } from "ai";
 import type { SessionCapabilities } from "#channel/types.js";
+import { isScheduleAppAuth } from "#channel/schedule-auth.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import {
   createErrorId,
@@ -26,6 +27,7 @@ import {
 } from "#internal/logging.js";
 import { formatLanguageModelGatewayId } from "#internal/runtime-model.js";
 import { contextStorage } from "#context/container.js";
+import { AuthKey, ParentSessionKey } from "#context/keys.js";
 import { buildDynamicInstructionMessages } from "#context/dynamic-instruction-lifecycle.js";
 import { buildDynamicTools } from "#context/build-dynamic-tools.js";
 import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js";
@@ -116,7 +118,11 @@ import {
   summarizeKnownModelCallRequestError,
 } from "#harness/model-call-error.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
-import { EMPTY_DELIVERY_SENTINEL, hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
+import {
+  CONDITIONAL_DELIVERY_INSTRUCTION,
+  EMPTY_DELIVERY_SENTINEL,
+  hasEmptyDeliverySentinel,
+} from "#shared/empty-delivery.js";
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
 import { ensureOtelIntegration } from "#harness/otel-integration.js";
 import {
@@ -541,6 +547,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
     // Direct harness unit tests may run without an ambient context.
     const ctx = contextStorage.getStore();
+    const emptyDeliveryEnabled =
+      session.outputSchema === undefined &&
+      ctx !== undefined &&
+      isScheduleAppAuth(ctx.get(AuthKey)) &&
+      ctx.get(ParentSessionKey) === undefined;
 
     // --- Execute via ToolLoopAgent ------------------------------------------
 
@@ -572,6 +583,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       if (skillAnnouncement !== undefined && skillAnnouncement.length > 0) {
         systemMessages.push({ role: "system", content: skillAnnouncement });
       }
+    }
+    if (emptyDeliveryEnabled) {
+      systemMessages.push({ role: "system", content: CONDITIONAL_DELIVERY_INSTRUCTION });
     }
 
     const modelMessages = nonSystemMessages;
@@ -866,6 +880,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             }),
           (current) =>
             attemptEmptyResponseRecovery({
+              emptyDeliveryEnabled,
               error: current.error,
               retryCallOptions: current.retryCallOptions,
               runOneModelCall,
@@ -1348,7 +1363,15 @@ function rethrowNoOutputAsEmptyResponse(error: unknown): never {
  * (its toolset change busts the prompt cache anyway), this one trails as
  * a user note to keep the cached prefix valid.
  */
-const EMPTY_RESPONSE_NUDGE = `Your previous reply was empty and was not delivered. Answer now from the tool results above; do not re-run tools or mention this notice. If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
+const EMPTY_RESPONSE_NUDGE =
+  "Your previous reply was empty and was not delivered. Answer now from the tool results above; do not re-run tools or mention this notice.";
+
+function buildEmptyResponseNudge(emptyDeliveryEnabled: boolean): string {
+  if (!emptyDeliveryEnabled) {
+    return EMPTY_RESPONSE_NUDGE;
+  }
+  return `${EMPTY_RESPONSE_NUDGE} If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
+}
 
 /**
  * Recovers a model call that completed without content (see
@@ -1367,6 +1390,7 @@ const EMPTY_RESPONSE_NUDGE = `Your previous reply was empty and was not delivere
  * restore what the earlier recovery removed.
  */
 async function attemptEmptyResponseRecovery(input: {
+  readonly emptyDeliveryEnabled: boolean;
   readonly error: unknown;
   readonly retryCallOptions?: RecoveryRetryCallOptions;
   readonly runOneModelCall: RecoveryModelCallFn;
@@ -1387,7 +1411,7 @@ async function attemptEmptyResponseRecovery(input: {
       ...input.retryCallOptions,
       retryReason: "empty-response",
       suppressStepStartedEmission: true,
-      trailingUserNote: EMPTY_RESPONSE_NUDGE,
+      trailingUserNote: buildEmptyResponseNudge(input.emptyDeliveryEnabled),
     });
     return { outcome: "recovered", result };
   } catch (retryError) {

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -162,7 +162,11 @@ export const defaultEvents: SlackChannelInternalEvents = {
       return;
     }
     channel.state.pendingToolCallMessage = null;
-    if (event.message) await channel.thread.post(event.message);
+    if (!event.message) {
+      await channel.thread.startTyping();
+      return;
+    }
+    await channel.thread.post(event.message);
   },
 
   async "turn.failed"(event, channel, _ctx) {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -320,6 +320,31 @@ describe("slackChannel() default event handlers", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("message.completed clears typing without posting for empty delivery", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("message.completed", {
+        finishReason: "stop",
+        message: null,
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://slack.com/api/assistant.threads.setStatus");
+    expect(parseSlackRequestBody(init as RequestInit)).toMatchObject({ status: "" });
+  });
+
   it("input.requested posts an approval card with Slack-unique button action ids", async () => {
     const adapter = withState(
       getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),

--- a/packages/eve/src/runtime/prompt/compose.ts
+++ b/packages/eve/src/runtime/prompt/compose.ts
@@ -7,12 +7,12 @@ import type {
 import { createWorkspacePromptSection } from "#runtime/workspace/spec.js";
 import type { WorkspaceRuntimeSpec } from "#runtime/workspace/types.js";
 import { formatConnectionsSection } from "#runtime/prompt/connections.js";
+import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 
 const PARALLEL_ACTION_INSTRUCTION =
   "Tool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.";
 
-export const CONDITIONAL_DELIVERY_INSTRUCTION =
-  "Conditional delivery\nNot every turn requires a message. When the current task asks you to check for something and report only when needed, finish with no text if there is nothing to report. Do not send a placeholder or explain that you are staying silent. An empty response is a successful outcome and eve delivers nothing.";
+export const CONDITIONAL_DELIVERY_INSTRUCTION = `Conditional delivery\nOnly when the current task explicitly makes delivery conditional and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL} and no other text. Do not use this marker for ordinary conversations, after input or approval responses, or merely because you have no additional commentary. Never return an empty response; use the marker to intentionally deliver nothing.`;
 
 /**
  * Input for composing the base authored instructions prompt for one

--- a/packages/eve/src/runtime/prompt/compose.ts
+++ b/packages/eve/src/runtime/prompt/compose.ts
@@ -11,6 +11,9 @@ import { formatConnectionsSection } from "#runtime/prompt/connections.js";
 const PARALLEL_ACTION_INSTRUCTION =
   "Tool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.";
 
+export const CONDITIONAL_DELIVERY_INSTRUCTION =
+  "Conditional delivery\nNot every turn requires a message. When the current task asks you to check for something and report only when needed, finish with no text if there is nothing to report. Do not send a placeholder or explain that you are staying silent. An empty response is a successful outcome and eve delivers nothing.";
+
 /**
  * Input for composing the base authored instructions prompt for one
  * resolved agent.
@@ -32,6 +35,7 @@ export function composeRuntimeBasePrompt(input: ComposeRuntimeBasePromptInput): 
     ...createInstructionsPromptBlocks(input.instructions),
     ...createWorkspacePromptBlocks(input.workspaceSpec),
     ...(input.toolsAvailable ? [PARALLEL_ACTION_INSTRUCTION] : []),
+    CONDITIONAL_DELIVERY_INSTRUCTION,
     ...createConnectionsPromptBlocks(input.connections),
     ...createSkillsPromptBlocks(input.skills),
   ];

--- a/packages/eve/src/runtime/prompt/compose.ts
+++ b/packages/eve/src/runtime/prompt/compose.ts
@@ -7,12 +7,9 @@ import type {
 import { createWorkspacePromptSection } from "#runtime/workspace/spec.js";
 import type { WorkspaceRuntimeSpec } from "#runtime/workspace/types.js";
 import { formatConnectionsSection } from "#runtime/prompt/connections.js";
-import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 
 const PARALLEL_ACTION_INSTRUCTION =
   "Tool execution\nA single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.";
-
-export const CONDITIONAL_DELIVERY_INSTRUCTION = `Conditional delivery\nOnly when the current task explicitly makes delivery conditional and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL} and no other text. Do not use this marker for ordinary conversations, after input or approval responses, or merely because you have no additional commentary. Never return an empty response; use the marker to intentionally deliver nothing.`;
 
 /**
  * Input for composing the base authored instructions prompt for one
@@ -35,7 +32,6 @@ export function composeRuntimeBasePrompt(input: ComposeRuntimeBasePromptInput): 
     ...createInstructionsPromptBlocks(input.instructions),
     ...createWorkspacePromptBlocks(input.workspaceSpec),
     ...(input.toolsAvailable ? [PARALLEL_ACTION_INSTRUCTION] : []),
-    CONDITIONAL_DELIVERY_INSTRUCTION,
     ...createConnectionsPromptBlocks(input.connections),
     ...createSkillsPromptBlocks(input.skills),
   ];

--- a/packages/eve/src/shared/empty-delivery.test.ts
+++ b/packages/eve/src/shared/empty-delivery.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { EMPTY_DELIVERY_SENTINEL, hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
+
+describe("hasEmptyDeliverySentinel", () => {
+  it("recognizes the exact sentinel", () => {
+    expect(hasEmptyDeliverySentinel(EMPTY_DELIVERY_SENTINEL)).toBe(true);
+  });
+
+  it("recognizes the sentinel anywhere in the response", () => {
+    expect(hasEmptyDeliverySentinel(`before ${EMPTY_DELIVERY_SENTINEL} after`)).toBe(true);
+  });
+
+  it("rejects absent, empty, and partial sentinels", () => {
+    expect(hasEmptyDeliverySentinel("<eve-empty-delivery>")).toBe(false);
+    expect(hasEmptyDeliverySentinel("")).toBe(false);
+    expect(hasEmptyDeliverySentinel(null)).toBe(false);
+    expect(hasEmptyDeliverySentinel(undefined)).toBe(false);
+  });
+});

--- a/packages/eve/src/shared/empty-delivery.ts
+++ b/packages/eve/src/shared/empty-delivery.ts
@@ -1,0 +1,5 @@
+export const EMPTY_DELIVERY_SENTINEL = "<eve-empty-delivery/>";
+
+export function hasEmptyDeliverySentinel(text: string | null | undefined): boolean {
+  return text?.includes(EMPTY_DELIVERY_SENTINEL) ?? false;
+}

--- a/packages/eve/src/shared/empty-delivery.ts
+++ b/packages/eve/src/shared/empty-delivery.ts
@@ -1,5 +1,7 @@
 export const EMPTY_DELIVERY_SENTINEL = "<eve-empty-delivery/>";
 
+export const CONDITIONAL_DELIVERY_INSTRUCTION = `Conditional delivery\nOnly when the current task explicitly makes delivery conditional and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL} and no other text. Do not use this marker for ordinary conversations, after input or approval responses, or merely because you have no additional commentary. Never return an empty response; use the marker to intentionally deliver nothing.`;
+
 export function hasEmptyDeliverySentinel(text: string | null | undefined): boolean {
   return text?.includes(EMPTY_DELIVERY_SENTINEL) ?? false;
 }

--- a/packages/eve/test/runtime-prompt-compose.test.ts
+++ b/packages/eve/test/runtime-prompt-compose.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  composeRuntimeBasePrompt,
-  CONDITIONAL_DELIVERY_INSTRUCTION,
-} from "../src/runtime/prompt/compose.js";
+import { composeRuntimeBasePrompt } from "../src/runtime/prompt/compose.js";
 
 describe("composeRuntimeBasePrompt", () => {
   it("composes the authored instructions prompt into one runtime instruction block", () => {
@@ -16,10 +13,7 @@ describe("composeRuntimeBasePrompt", () => {
           sourceKind: "markdown",
         },
       }),
-    ).toEqual([
-      "Instructions (instructions)\nYou are a weather assistant.",
-      CONDITIONAL_DELIVERY_INSTRUCTION,
-    ]);
+    ).toEqual(["Instructions (instructions)\nYou are a weather assistant."]);
   });
 
   it("adds a parallel tool execution instruction when tools are available", () => {
@@ -32,7 +26,6 @@ describe("composeRuntimeBasePrompt", () => {
         "Tool execution",
         "A single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
       ].join("\n"),
-      CONDITIONAL_DELIVERY_INSTRUCTION,
     ]);
   });
 
@@ -47,7 +40,7 @@ describe("composeRuntimeBasePrompt", () => {
           sourceKind: "markdown",
         },
       }),
-    ).toEqual([CONDITIONAL_DELIVERY_INSTRUCTION]);
+    ).toEqual([]);
   });
 
   it("adds a shallow workspace awareness section when authored project files are mounted", () => {
@@ -68,12 +61,11 @@ describe("composeRuntimeBasePrompt", () => {
         "- Use the `bash` tool with `ls`, `find`, and `rg` to inspect deeper contents when needed.",
         "- Do not claim these files are unavailable unless a workspace or tool call actually fails.",
       ].join("\n"),
-      CONDITIONAL_DELIVERY_INSTRUCTION,
     ]);
   });
 
-  it("always explains conditional empty delivery without injecting sandbox guidance", () => {
-    expect(composeRuntimeBasePrompt({})).toEqual([CONDITIONAL_DELIVERY_INSTRUCTION]);
+  it("does not inject runtime-owned delivery or sandbox guidance", () => {
+    expect(composeRuntimeBasePrompt({})).toEqual([]);
   });
 
   it("orders workspace and tool execution sections predictably", () => {
@@ -99,7 +91,6 @@ describe("composeRuntimeBasePrompt", () => {
         "Tool execution",
         "A single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
       ].join("\n"),
-      CONDITIONAL_DELIVERY_INSTRUCTION,
     ]);
   });
 });

--- a/packages/eve/test/runtime-prompt-compose.test.ts
+++ b/packages/eve/test/runtime-prompt-compose.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { composeRuntimeBasePrompt } from "../src/runtime/prompt/compose.js";
+import {
+  composeRuntimeBasePrompt,
+  CONDITIONAL_DELIVERY_INSTRUCTION,
+} from "../src/runtime/prompt/compose.js";
 
 describe("composeRuntimeBasePrompt", () => {
   it("composes the authored instructions prompt into one runtime instruction block", () => {
@@ -13,7 +16,10 @@ describe("composeRuntimeBasePrompt", () => {
           sourceKind: "markdown",
         },
       }),
-    ).toEqual(["Instructions (instructions)\nYou are a weather assistant."]);
+    ).toEqual([
+      "Instructions (instructions)\nYou are a weather assistant.",
+      CONDITIONAL_DELIVERY_INSTRUCTION,
+    ]);
   });
 
   it("adds a parallel tool execution instruction when tools are available", () => {
@@ -26,6 +32,7 @@ describe("composeRuntimeBasePrompt", () => {
         "Tool execution",
         "A single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
       ].join("\n"),
+      CONDITIONAL_DELIVERY_INSTRUCTION,
     ]);
   });
 
@@ -40,7 +47,7 @@ describe("composeRuntimeBasePrompt", () => {
           sourceKind: "markdown",
         },
       }),
-    ).toEqual([]);
+    ).toEqual([CONDITIONAL_DELIVERY_INSTRUCTION]);
   });
 
   it("adds a shallow workspace awareness section when authored project files are mounted", () => {
@@ -61,11 +68,12 @@ describe("composeRuntimeBasePrompt", () => {
         "- Use the `bash` tool with `ls`, `find`, and `rg` to inspect deeper contents when needed.",
         "- Do not claim these files are unavailable unless a workspace or tool call actually fails.",
       ].join("\n"),
+      CONDITIONAL_DELIVERY_INSTRUCTION,
     ]);
   });
 
-  it("does not inject sandbox routing guidance — sandboxes are no longer auto-exposed", () => {
-    expect(composeRuntimeBasePrompt({})).toEqual([]);
+  it("always explains conditional empty delivery without injecting sandbox guidance", () => {
+    expect(composeRuntimeBasePrompt({})).toEqual([CONDITIONAL_DELIVERY_INSTRUCTION]);
   });
 
   it("orders workspace and tool execution sections predictably", () => {
@@ -91,6 +99,7 @@ describe("composeRuntimeBasePrompt", () => {
         "Tool execution",
         "A single tool or subagent call runs as one serial action. If you call multiple independent tools or subagents in one response, eve treats that batch as parallel work. Only batch work that is independent and does not rely on another call in the same response.",
       ].join("\n"),
+      CONDITIONAL_DELIVERY_INSTRUCTION,
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- teach agents to use <eve-empty-delivery/> only when a prompt makes delivery conditional and there is nothing to report
- convert any terminal response containing the marker into message.completed with message: null, then remove it from history and task output
- retry genuine blank responses so HITL replies cannot be mistaken for intentional silence
- prove channel-level no-delivery with the scheduled fixture and clear Slack typing state without posting

## Why

Frequent scheduled checks usually have nothing to report. Authors should express that in the prompt without a delivery flag or filtering API. A reserved internal marker distinguishes intentional no-delivery from an accidental empty model response.

## Impact

A schedule can say report only when there are alerts. When there are none, eve instructs the model to return the internal marker and suppresses the terminal delivery for every channel through the shared message.completed event. Existing tasks that produce messages keep their current behavior.

## Validation

- pnpm test:unit — 3,894 passed
- pnpm test:integration — 368 passed
- pnpm test:scenario — 260 passed, 15 skipped
- pnpm typecheck
- pnpm lint
- pnpm fmt
- pnpm build
- pnpm docs:check
- pnpm guard:invariants
- focused sentinel, tool-loop, HITL, prompt, emission, and Slack suites — 198 passed
- agent-schedules fixture build and typecheck

The live agent-schedules eval cannot run locally because AI_GATEWAY_API_KEY is unset; the credentialed GitHub e2e jobs provide that verification.