### PR TITLE
chore(eve): cancellation - add coverage and evals

### DIFF
--- a/e2e/fixtures/agent-cancellation/.gitignore
+++ b/e2e/fixtures/agent-cancellation/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env*
+.eve
+.vercel
+.workflow-data
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-cancellation/.vercelignore
+++ b/e2e/fixtures/agent-cancellation/.vercelignore
@@ -1,0 +1,6 @@
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-cancellation/agent/agent.ts
+++ b/e2e/fixtures/agent-cancellation/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "openai/gpt-5.5",
+});

--- a/e2e/fixtures/agent-cancellation/agent/instructions.md
+++ b/e2e/fixtures/agent-cancellation/agent/instructions.md
@@ -1,0 +1,3 @@
+# Assistant
+
+Follow the user's requested content, format, and level of detail.

--- a/e2e/fixtures/agent-cancellation/evals/cancellation/session.eval.ts
+++ b/e2e/fixtures/agent-cancellation/evals/cancellation/session.eval.ts
@@ -1,0 +1,33 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "Cancelling an active session makes the next message start a new session.",
+  async test(t) {
+    const active = await t.start(
+      "Draft a complete post-incident review for a multi-region payments outage. Include the timeline, customer impact, contributing factors, detection gaps, remediation, follow-up owners, and prevention work.",
+    );
+    const cancelledResult = active.result();
+
+    await t.sleep(2_000);
+    await t.cancel();
+
+    const cancelled = await cancelledResult;
+    if (cancelled.status !== "cancelled") {
+      throw new Error(`Expected a cancelled turn, received ${cancelled.status}.`);
+    }
+    if (!cancelled.events.some((event) => event.type === "turn.cancelled")) {
+      throw new Error("The cancelled session did not emit turn.cancelled.");
+    }
+    if (!cancelled.events.some((event) => event.type === "session.cancelled")) {
+      throw new Error("The cancelled session did not emit session.cancelled.");
+    }
+
+    const restarted = await t.send("Reply with exactly: new session started");
+    restarted.expectOk();
+    if (t.sessionId === active.sessionId) {
+      throw new Error("The next message reused the cancelled session.");
+    }
+
+    t.didNotFail();
+  },
+});

--- a/e2e/fixtures/agent-cancellation/evals/cancellation/turn.eval.ts
+++ b/e2e/fixtures/agent-cancellation/evals/cancellation/turn.eval.ts
@@ -1,0 +1,33 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "Cancelling an active turn preserves its session for the next message.",
+  async test(t) {
+    const active = await t.start(
+      "Prepare a production migration plan for moving a high-traffic payments service from a monolith to an event-driven architecture. Include the target design, data migration, rollout phases, observability, failure modes, rollback, security, staffing, and timeline.",
+    );
+    const cancelledResult = active.result();
+
+    await t.sleep(2_000);
+    await active.cancel();
+
+    const cancelled = await cancelledResult;
+    if (cancelled.status !== "cancelled") {
+      throw new Error(`Expected a cancelled turn, received ${cancelled.status}.`);
+    }
+    if (!cancelled.events.some((event) => event.type === "turn.cancelled")) {
+      throw new Error("The cancelled turn did not emit turn.cancelled.");
+    }
+    if (!cancelled.events.some((event) => event.type === "session.waiting")) {
+      throw new Error("Turn cancellation did not leave the session waiting.");
+    }
+
+    const followUp = await t.send("Reply with exactly: session continued");
+    followUp.expectOk();
+    if (t.sessionId !== active.sessionId) {
+      throw new Error("The follow-up did not reuse the turn-cancelled session.");
+    }
+
+    t.didNotFail();
+  },
+});

--- a/e2e/fixtures/agent-cancellation/evals/evals.config.ts
+++ b/e2e/fixtures/agent-cancellation/evals/evals.config.ts
@@ -1,0 +1,5 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({
+  judge: { model: "openai/gpt-5.5" },
+});

--- a/e2e/fixtures/agent-cancellation/package.json
+++ b/e2e/fixtures/agent-cancellation/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agent-cancellation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-cancellation/tsconfig.json
+++ b/e2e/fixtures/agent-cancellation/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts", ".eve/**/*.d.ts"]
+}

--- a/packages/eve/src/client/session-utils.test.ts
+++ b/packages/eve/src/client/session-utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { advanceSession, deriveResultStatus } from "#client/session-utils.js";
+import {
+  createSessionCancelledEvent,
+  createSessionWaitingEvent,
+  createTurnCancelledEvent,
+} from "#protocol/message.js";
+
+describe("client cancellation boundaries", () => {
+  it("reports turn cancellation while preserving the waiting session cursor", () => {
+    const events = [
+      createTurnCancelledEvent({ sequence: 1, turnId: "turn-1" }),
+      createSessionWaitingEvent(),
+    ];
+
+    expect(deriveResultStatus(events)).toBe("cancelled");
+    expect(
+      advanceSession({
+        continuationToken: "eve:session-1",
+        events,
+        session: { sessionId: "session-1", streamIndex: 4 },
+        sessionId: "session-1",
+      }),
+    ).toEqual({
+      continuationToken: "eve:session-1",
+      sessionId: "session-1",
+      streamIndex: 6,
+    });
+  });
+
+  it("reports session cancellation and clears the resumable cursor", () => {
+    const events = [createSessionCancelledEvent("session-1")];
+
+    expect(deriveResultStatus(events)).toBe("cancelled");
+    expect(
+      advanceSession({
+        continuationToken: "eve:session-1",
+        events,
+        session: { sessionId: "session-1", streamIndex: 4 },
+        sessionId: "session-1",
+      }),
+    ).toEqual({ streamIndex: 0 });
+  });
+});

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -49,6 +49,58 @@ function createStreamResponse(events: readonly unknown[]) {
 }
 
 describe("ClientSession", () => {
+  it("cancels only the turn represented by a message response", async () => {
+    const requests: Array<{ body: unknown; url: string }> = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      const url = String(request);
+      requests.push({ body: JSON.parse(String(init?.body)), url });
+      return requests.length === 1
+        ? createAcceptedResponse()
+        : Response.json({ ok: true }, { status: 202 });
+    });
+    const session = createSession();
+
+    const response = await session.send("start work");
+    await response.cancel();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new URL(requests[1]!.url).pathname).toBe("/eve/v1/session/session_1/cancel");
+    expect(requests[1]!.body).toEqual({ scope: "turn" });
+  });
+
+  it("cancels the active entry session and clears its resumable cursor", async () => {
+    const requests: Array<{ body: unknown; url: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      requests.push({ body: JSON.parse(String(init?.body)), url: String(request) });
+      return requests.length === 1
+        ? createAcceptedResponse()
+        : Response.json({ ok: true }, { status: 202 });
+    });
+    const session = createSession();
+
+    await session.send("start work");
+    await session.cancel();
+
+    expect(requests[1]!.body).toEqual({ scope: "session" });
+    expect(session.state).toEqual({ streamIndex: 0 });
+  });
+
+  it("does not restore a cancelled cursor when an earlier response settles later", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(createAcceptedResponse())
+      .mockResolvedValueOnce(Response.json({ ok: true }, { status: 202 }))
+      .mockResolvedValueOnce(
+        createStreamResponse([{ type: "session.waiting", data: { wait: "next-user-message" } }]),
+      );
+    const session = createSession();
+
+    const response = await session.send("start work");
+    await session.cancel();
+    await response.result();
+
+    expect(session.state).toEqual({ streamIndex: 0 });
+  });
+
   it("serializes clientContext when sending a create-session message", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(createAcceptedResponse());
     const session = createSession();

--- a/packages/eve/src/evals/session.test.ts
+++ b/packages/eve/src/evals/session.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MessageResponse } from "#client/message-response.js";
+import { ClientSession } from "#client/session.js";
+import type { SessionState } from "#client/types.js";
+import { EvalSessionDriver } from "#evals/session.js";
+import { createSessionWaitingEvent, createTurnCancelledEvent } from "#protocol/message.js";
+
+function createClientSession(state: SessionState): ClientSession {
+  return new ClientSession(
+    {
+      host: "https://example.com",
+      maxReconnectAttempts: 0,
+      preserveCompletedSessions: false,
+      resolveHeaders: async () => new Headers(),
+    },
+    state,
+  );
+}
+
+describe("EvalSessionDriver cancellation", () => {
+  it("retains a cancellable active turn and records its cancellation boundary", async () => {
+    const cancelTurn = vi.fn().mockResolvedValue(undefined);
+    const events = [
+      createTurnCancelledEvent({ sequence: 0, turnId: "turn-0" }),
+      createSessionWaitingEvent(),
+    ];
+    const session = createClientSession({
+      continuationToken: "eve:session-1",
+      sessionId: "session-1",
+      streamIndex: 0,
+    });
+    vi.spyOn(session, "send").mockResolvedValue(
+      new MessageResponse({
+        cancel: cancelTurn,
+        continuationToken: "eve:session-1",
+        createStream: async function* () {
+          yield* events;
+        },
+        sessionId: "session-1",
+      }),
+    );
+    const driver = new EvalSessionDriver({ session });
+
+    const active = await driver.start("slow work");
+    await active.cancel();
+    const turn = await active.result();
+
+    expect(cancelTurn).toHaveBeenCalledTimes(1);
+    expect(turn.status).toBe("cancelled");
+    expect(turn.expectOk()).toBe(turn);
+    expect(driver.events).toEqual(events);
+  });
+
+  it("delegates whole-session cancellation to the TypeScript client", async () => {
+    const cancelSession = vi.fn().mockResolvedValue(undefined);
+    const session = createClientSession({
+      continuationToken: "eve:session-1",
+      sessionId: "session-1",
+      streamIndex: 0,
+    });
+    vi.spyOn(session, "cancel").mockImplementation(cancelSession);
+
+    await new EvalSessionDriver({ session }).cancel();
+
+    expect(cancelSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eve/src/execution/cancel-descendants-step.test.ts
+++ b/packages/eve/src/execution/cancel-descendants-step.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { cancelDescendantsStep } from "#execution/cancel-descendants-step.js";
+import {
+  recordPendingRuntimeActionChild,
+  setPendingRuntimeActionBatch,
+} from "#harness/runtime-actions.js";
+import type { HarnessSession } from "#harness/types.js";
+
+const getHookByTokenMock = vi.fn();
+const readDurableSessionMock = vi.fn();
+const resumeHookMock = vi.fn();
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({
+  getHookByToken: (...args: unknown[]) => getHookByTokenMock(...args),
+  resumeHook: (...args: unknown[]) => resumeHookMock(...args),
+}));
+
+vi.mock("./durable-session-store.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./durable-session-store.js")>()),
+  readDurableSession: (...args: unknown[]) => readDurableSessionMock(...args),
+}));
+
+vi.mock("#context/serialize.js", () => ({
+  deserializeContext: vi.fn().mockResolvedValue({
+    require: () => ({
+      subagentRegistry: { subagentsByNodeId: new Map() },
+    }),
+  }),
+}));
+
+describe("cancelDescendantsStep", () => {
+  beforeEach(() => {
+    getHookByTokenMock.mockReset().mockResolvedValue({ runId: "child-session" });
+    resumeHookMock.mockReset().mockResolvedValue(undefined);
+    readDurableSessionMock.mockReset();
+  });
+
+  it("returns after every recorded local child accepts cancellation", async () => {
+    readDurableSessionMock.mockResolvedValue(createSessionWithChild());
+
+    await cancelDescendantsStep({
+      serializedContext: {},
+      sessionState: {} as DurableSessionState,
+    });
+
+    expect(getHookByTokenMock).toHaveBeenCalledWith("subagent:parent:call-1");
+    expect(resumeHookMock).toHaveBeenCalledWith("child-session:cancel-session", undefined);
+  });
+
+  it("ignores a child whose cancellation hook is unavailable", async () => {
+    const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
+    getHookByTokenMock.mockRejectedValue(new HookNotFoundError("subagent:parent:call-1"));
+    readDurableSessionMock.mockResolvedValue(createSessionWithChild());
+
+    await cancelDescendantsStep({
+      serializedContext: {},
+      sessionState: {} as DurableSessionState,
+    });
+
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps parent cancellation non-fatal when a descendant request fails", async () => {
+    resumeHookMock.mockRejectedValue(new Error("child unavailable"));
+    readDurableSessionMock.mockResolvedValue(createSessionWithChild());
+
+    await expect(
+      cancelDescendantsStep({
+        serializedContext: {},
+        sessionState: {} as DurableSessionState,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+function createSessionWithChild(): HarnessSession {
+  return recordPendingRuntimeActionChild({
+    callId: "call-1",
+    child: {
+      continuationToken: "subagent:parent:call-1",
+      sessionId: "child-session",
+    },
+    session: setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "call-1",
+          description: "Slow child",
+          input: { message: "work" },
+          kind: "subagent-call",
+          name: "child",
+          nodeId: "subagents/child.ts",
+          subagentName: "child",
+        },
+      ],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn-0" },
+      responseMessages: [],
+      session: createSession(),
+    }),
+  });
+}
+
+function createSession(): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "eve:parent",
+    history: [],
+    sessionId: "parent-session",
+  };
+}

--- a/packages/eve/src/execution/cancellation-step.integration.test.ts
+++ b/packages/eve/src/execution/cancellation-step.integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { finalizeCancellationStep } from "#execution/cancellation-step.js";
+import { createDurableSessionState } from "#execution/durable-session-store.js";
+import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+
+describe("finalizeCancellationStep integration", () => {
+  it("cancels a parked session without emitting a phantom turn boundary", async () => {
+    const app = createTestRuntime({ agent: { name: "parked-session-cancellation" } });
+
+    await app.run(async () => {
+      const continuationToken = "http:parked-session-cancellation";
+      const compiledArtifactsSource = createBundledRuntimeCompiledArtifactsSource();
+      const serializedContext = {
+        "eve.auth": null,
+        "eve.bundle": { source: compiledArtifactsSource },
+        "eve.channel": { kind: "http", state: {} },
+        "eve.continuationToken": continuationToken,
+        "eve.mode": "conversation",
+        "eve.sessionId": "session-1",
+      };
+      const state = createDurableSessionState({
+        session: {
+          agent: { modelReference: { id: "test" }, system: "", tools: [] },
+          compaction: { recentWindowSize: 10, threshold: 100_000 },
+          history: [],
+          sessionId: "session-1",
+          continuationToken,
+        },
+      });
+      const chunks: Uint8Array[] = [];
+
+      await finalizeCancellationStep({
+        parentWritable: new WritableStream<Uint8Array>({
+          write(chunk) {
+            chunks.push(chunk);
+          },
+        }),
+        scope: "session",
+        serializedContext,
+        sessionState: state,
+      });
+
+      const events = new TextDecoder()
+        .decode(concatChunks(chunks))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { type: string });
+      expect(events.map((event) => event.type)).toEqual(["session.cancelled"]);
+    });
+  });
+});
+
+function concatChunks(chunks: readonly Uint8Array[]): Uint8Array {
+  const length = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}

--- a/packages/eve/src/execution/cancellation-step.test.ts
+++ b/packages/eve/src/execution/cancellation-step.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChannelAdapter } from "#channel/adapter.js";
+import type { HarnessSession } from "#harness/types.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { finalizeCancellationStep } from "#execution/cancellation-step.js";
+
+const dispatchStreamEventHooksMock = vi.fn();
+const readDurableSessionMock = vi.fn();
+const serializeContextMock = vi.fn();
+const withContextScopeMock = vi.fn();
+
+vi.mock("#context/hook-lifecycle.js", () => ({
+  dispatchStreamEventHooks: (...args: unknown[]) => dispatchStreamEventHooksMock(...args),
+}));
+
+vi.mock("#context/run-step.js", () => ({
+  withContextScope: (...args: unknown[]) => withContextScopeMock(...args),
+}));
+
+vi.mock("#context/serialize.js", () => ({
+  deserializeContext: vi.fn(),
+  serializeContext: (...args: unknown[]) => serializeContextMock(...args),
+}));
+
+vi.mock("#execution/durable-session-store.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#execution/durable-session-store.js")>()),
+  createDurableSessionState: vi.fn(({ session }) => ({ session })),
+  readDurableSession: (...args: unknown[]) => readDurableSessionMock(...args),
+}));
+
+vi.mock("#execution/session.js", () => ({
+  hydrateDurableSession: ({ durable }: { durable: HarnessSession }) => durable,
+}));
+
+describe("finalizeCancellationStep", () => {
+  beforeEach(async () => {
+    dispatchStreamEventHooksMock.mockReset().mockResolvedValue(undefined);
+    readDurableSessionMock.mockReset().mockResolvedValue(createSession());
+    serializeContextMock.mockReset().mockReturnValue({ serialized: true });
+    withContextScopeMock
+      .mockReset()
+      .mockImplementation(async (_ctx, session, callback) => callback(session));
+
+    const { deserializeContext } = await import("#context/serialize.js");
+    vi.mocked(deserializeContext).mockReset();
+  });
+
+  it("dispatches cancellation boundaries through channel handlers and authored hooks", async () => {
+    const turnCancelled = vi.fn();
+    const sessionWaiting = vi.fn();
+    const adapter: ChannelAdapter = {
+      kind: "test",
+      "session.waiting": sessionWaiting,
+      "turn.cancelled": turnCancelled,
+    };
+    const hookRegistry = { id: "hooks" };
+    const bundle = {
+      hookRegistry,
+      resolvedAgent: { config: {} },
+      turnAgent: {},
+    };
+    const ctx = {
+      get: vi.fn(),
+      require(key: unknown) {
+        if (key === BundleKey) return bundle;
+        if (key === ChannelKey) return adapter;
+        throw new Error("Unexpected context key.");
+      },
+    };
+    const { deserializeContext } = await import("#context/serialize.js");
+    vi.mocked(deserializeContext).mockResolvedValue(ctx as never);
+
+    const result = await finalizeCancellationStep({
+      parentWritable: new WritableStream<Uint8Array>(),
+      scope: "turn",
+      serializedContext: {},
+      sessionState: {
+        continuationToken: "test:session",
+        emissionState: {
+          sequence: 2,
+          sessionStarted: true,
+          stepIndex: 1,
+          turnId: "turn_2",
+        },
+        hasProxyInputRequests: false,
+        sessionId: "session-1",
+        version: 1,
+      },
+    });
+
+    expect(turnCancelled).toHaveBeenCalledOnce();
+    expect(sessionWaiting).toHaveBeenCalledOnce();
+    expect(dispatchStreamEventHooksMock.mock.calls.map(([input]) => input.event.type)).toEqual([
+      "turn.cancelled",
+      "session.waiting",
+    ]);
+    expect(dispatchStreamEventHooksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ctx, registry: hookRegistry }),
+    );
+    expect(withContextScopeMock.mock.calls[0]?.[3].abortSignal.aborted).toBe(true);
+    expect(result.serializedContext).toEqual({ serialized: true });
+  });
+});
+
+function createSession(): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "test:session",
+    history: [],
+    sessionId: "session-1",
+  };
+}

--- a/packages/eve/src/execution/cancellation-step.test.ts
+++ b/packages/eve/src/execution/cancellation-step.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
+import { setHarnessEmissionState } from "#harness/emission.js";
 import type { HarnessSession } from "#harness/types.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { finalizeCancellationStep } from "#execution/cancellation-step.js";
@@ -36,7 +37,14 @@ vi.mock("#execution/session.js", () => ({
 describe("finalizeCancellationStep", () => {
   beforeEach(async () => {
     dispatchStreamEventHooksMock.mockReset().mockResolvedValue(undefined);
-    readDurableSessionMock.mockReset().mockResolvedValue(createSession());
+    readDurableSessionMock.mockReset().mockResolvedValue(
+      setHarnessEmissionState(createSession(), {
+        sequence: 2,
+        sessionStarted: true,
+        stepIndex: 1,
+        turnId: "turn_2",
+      }),
+    );
     serializeContextMock.mockReset().mockReturnValue({ serialized: true });
     withContextScopeMock
       .mockReset()
@@ -100,6 +108,58 @@ describe("finalizeCancellationStep", () => {
     );
     expect(withContextScopeMock.mock.calls[0]?.[3].abortSignal.aborted).toBe(true);
     expect(result.serializedContext).toEqual({ serialized: true });
+  });
+
+  it("does not emit a turn boundary when cancelling a parked session", async () => {
+    readDurableSessionMock.mockResolvedValue(createSession());
+    const turnCancelled = vi.fn();
+    const sessionCancelled = vi.fn();
+    const adapter: ChannelAdapter = {
+      kind: "test",
+      "session.cancelled": sessionCancelled,
+      "turn.cancelled": turnCancelled,
+    };
+    const hookRegistry = { id: "hooks" };
+    const ctx = {
+      get: vi.fn(),
+      require(key: unknown) {
+        if (key === BundleKey) {
+          return {
+            hookRegistry,
+            resolvedAgent: { config: {} },
+            turnAgent: {},
+          };
+        }
+        if (key === ChannelKey) return adapter;
+        throw new Error("Unexpected context key.");
+      },
+    };
+    const { deserializeContext } = await import("#context/serialize.js");
+    vi.mocked(deserializeContext).mockResolvedValue(ctx as never);
+
+    await finalizeCancellationStep({
+      parentWritable: new WritableStream<Uint8Array>(),
+      scope: "session",
+      serializedContext: {},
+      sessionState: {
+        continuationToken: "test:session",
+        emissionState: {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: "",
+        },
+        hasProxyInputRequests: false,
+        sessionId: "session-1",
+        version: 1,
+      },
+    });
+
+    expect(turnCancelled).not.toHaveBeenCalled();
+    expect(sessionCancelled).toHaveBeenCalledOnce();
+    expect(dispatchStreamEventHooksMock.mock.calls.map(([input]) => input.event.type)).toEqual([
+      "session.cancelled",
+    ]);
   });
 });
 

--- a/packages/eve/src/execution/context.test.ts
+++ b/packages/eve/src/execution/context.test.ts
@@ -14,6 +14,8 @@ import {
 } from "#context/keys.js";
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
+import { buildCallbackContext } from "#context/build-callback-context.js";
+import { createCancellationReason } from "#execution/cancellation.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import type { HarnessEmissionState } from "#harness/emission.js";
 import type { HarnessSession } from "#harness/types.js";
@@ -79,6 +81,36 @@ function createSeedContext(overrides?: {
 }
 
 describe("runStep with sessionProvider", () => {
+  it("exposes the active abort signal and exits authored code on cancellation", async () => {
+    const ctx = createSeedContext();
+    const session = createStubSession();
+    const controller = new AbortController();
+    const reason = createCancellationReason("session");
+    expect(reason).toMatchObject({ name: "AbortError", scope: "session" });
+
+    const run = runStep(
+      ctx,
+      session,
+      async (): Promise<never> => {
+        const callback = buildCallbackContext();
+        expect(callback.abortSignal).toBe(controller.signal);
+        return callback.cancel({ scope: "session" });
+      },
+      {
+        abortSignal: controller.signal,
+        cancel({ scope }): never {
+          expect(scope).toBe("session");
+          controller.abort(reason);
+          throw reason;
+        },
+      },
+    );
+
+    await expect(run).rejects.toEqual(reason);
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toEqual(reason);
+  });
+
   it("builds a session with auth from durable context", async () => {
     const auth: SessionAuthContext = {
       attributes: { role: "admin" },

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { startRemoteAgentSession } from "#execution/remote-agent-dispatch.js";
+import {
+  cancelRemoteAgentSession,
+  startRemoteAgentSession,
+} from "#execution/remote-agent-dispatch.js";
 import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types.js";
 import type { ResolvedRuntimeRemoteAgentNode } from "#runtime/types.js";
 
@@ -162,6 +165,31 @@ describe("startRemoteAgentSession", () => {
           url: "https://caller.example.com/eve/v1/callback/eve%3Aparent-token?x-vercel-protection-bypass=remote+callback+secret",
         }),
       }),
+    );
+  });
+
+  it("cancels a remote child through its public scoped endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ ok: true }, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await cancelRemoteAgentSession({
+      remote: createRemoteAgent(),
+      sessionId: "remote-session",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://remote.example.com/eve/v1/session/remote-session/cancel",
+      {
+        body: JSON.stringify({
+          scope: "session",
+        }),
+        headers: {
+          authorization: "Bearer remote-token",
+          "content-type": "application/json",
+          "x-static": "yes",
+        },
+        method: "POST",
+      },
     );
   });
 });

--- a/packages/eve/src/execution/session-callback-step.test.ts
+++ b/packages/eve/src/execution/session-callback-step.test.ts
@@ -122,6 +122,34 @@ describe("fireSessionCallbackStep", () => {
     });
   });
 
+  it("posts intentional session cancellation without a failure payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fireSessionCallbackStep({
+      serializedContext: createSerializedContext(),
+      status: "cancelled",
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
+      callId: "call-1",
+      kind: "session.cancelled",
+      sessionId: "remote-session",
+      subagentName: "research",
+    });
+  });
+
+  it("accepts a missing parent callback after cancellation", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+
+    await expect(
+      fireSessionCallbackStep({
+        serializedContext: createSerializedContext(),
+        status: "cancelled",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it.each([
     ["null", null],
     ["array", []],

--- a/packages/eve/src/execution/turn-cancellation-step.test.ts
+++ b/packages/eve/src/execution/turn-cancellation-step.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HookNotFoundError } from "#compiled/@workflow/errors/index.js";
+import { cancelTurnSegmentStep } from "#execution/turn-cancellation-step.js";
+
+const resumeHookMock = vi.fn();
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({
+  resumeHook: (...args: unknown[]) => resumeHookMock(...args),
+}));
+
+describe("cancelTurnSegmentStep", () => {
+  beforeEach(() => {
+    resumeHookMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("resumes the cooperative cancellation hook once", async () => {
+    await expect(cancelTurnSegmentStep({ hookId: "turn:child" })).resolves.toBeUndefined();
+
+    expect(resumeHookMock).toHaveBeenCalledOnce();
+  });
+
+  it("ignores an unavailable cooperative cancellation hook", async () => {
+    resumeHookMock.mockRejectedValue(new HookNotFoundError("turn:child"));
+
+    await expect(cancelTurnSegmentStep({ hookId: "turn:child" })).resolves.toBeUndefined();
+
+    expect(resumeHookMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHook } from "#compiled/@workflow/core/index.js";
 import type { HookPayload } from "#channel/types.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
-import { turnWorkflow } from "#execution/turn-workflow.js";
+import { notifyDriverStep, turnWorkflow } from "#execution/turn-workflow.js";
+import { HookNotFoundError } from "#compiled/@workflow/errors/index.js";
 import {
   TURN_WORKFLOW_INPUT_VERSION,
   type TurnWorkflowInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { turnStep } from "#execution/workflow-steps.js";
+import { createCancellationReason } from "#execution/cancellation.js";
 
 const resumeHookMock = vi.fn();
 const disposeHookMock = vi.fn();
@@ -83,6 +85,66 @@ describe("turnWorkflow", () => {
         sessionState,
       },
       kind: "turn-result",
+    });
+  });
+
+  it("aborts the active turn step when the private cancellation hook resumes", async () => {
+    let cancel: ((result: IteratorResult<void>) => void) | undefined;
+    vi.mocked(createHook).mockImplementationOnce(
+      (options?: { readonly token?: string }) =>
+        ({
+          [Symbol.asyncIterator]() {
+            return {
+              next: () =>
+                new Promise<IteratorResult<void>>((resolve) => {
+                  cancel = resolve;
+                }),
+            };
+          },
+          dispose: disposeHookMock,
+          getConflict: vi.fn().mockResolvedValue(null),
+          token: options?.token ?? "cancel-token",
+        }) as never,
+    );
+    vi.mocked(turnStep).mockImplementationOnce(
+      async ({ abortController }) =>
+        await new Promise((_, reject) => {
+          abortController?.signal.addEventListener(
+            "abort",
+            () => reject(abortController.signal.reason),
+            {
+              once: true,
+            },
+          );
+        }),
+    );
+
+    const { input } = createInput();
+    const running = turnWorkflow(input);
+    await vi.waitFor(() => expect(cancel).toBeTypeOf("function"));
+    cancel?.({ done: false, value: undefined });
+    await running;
+
+    const controller = vi.mocked(turnStep).mock.calls[0]?.[0].abortController;
+    expect(controller?.signal.aborted).toBe(true);
+    expect(resumeHookMock).toHaveBeenCalledWith("turn-token", {
+      kind: "turn-cancelled",
+      scope: "turn",
+    });
+  });
+
+  it("reports session scope when authored code cancels from inside the step", async () => {
+    vi.mocked(turnStep).mockImplementationOnce(async ({ abortController }) => {
+      const reason = createCancellationReason("session");
+      abortController?.abort(reason);
+      throw reason;
+    });
+
+    await turnWorkflow(createInput().input);
+
+    expect(resumeHookMock).toHaveBeenCalledWith("turn-token", {
+      kind: "turn-cancelled",
+      scope: "session",
     });
   });
 
@@ -254,6 +316,19 @@ describe("turnWorkflow", () => {
     expect(resumeHookMock.mock.calls[0]?.[1]).toMatchObject({
       kind: "turn-error",
     });
+  });
+});
+
+describe("notifyDriverStep", () => {
+  it("ignores a late result after the parent completion hook is retired", async () => {
+    resumeHookMock.mockRejectedValueOnce(new HookNotFoundError("turn-token"));
+
+    await expect(
+      notifyDriverStep({
+        completionToken: "turn-token",
+        payload: { kind: "turn-cancelled", scope: "turn" },
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/eve/src/execution/workflow-entry-helpers.test.ts
+++ b/packages/eve/src/execution/workflow-entry-helpers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { waitForPendingRuntimeActionResults } from "#execution/workflow-entry-helpers.js";
+
+describe("waitForPendingRuntimeActionResults", () => {
+  it("returns cancellation as an interruption value", async () => {
+    const sessionState: DurableSessionState = {
+      continuationToken: "http:test",
+      emissionState: {
+        sequence: 1,
+        sessionStarted: true,
+        stepIndex: 1,
+        turnId: "turn_1",
+      },
+      hasProxyInputRequests: false,
+      sessionId: "session-1",
+      version: 1,
+    };
+    const consumeNext = vi.fn();
+    const rekeyHook = vi.fn();
+
+    await expect(
+      waitForPendingRuntimeActionResults({
+        bufferedDeliveries: [],
+        cancellation: async () => ({ kind: "cancelled", scope: "session" }),
+        consumeNext,
+        getNextPromise: () => new Promise(() => undefined),
+        parentWritable: new WritableStream<Uint8Array>(),
+        pendingActionKeys: ["subagent:call-1"],
+        rekeyHook,
+        serializedContext: { context: true },
+        sessionState,
+      }),
+    ).resolves.toEqual({
+      kind: "cancelled",
+      scope: "session",
+      serializedContext: { context: true },
+      sessionState,
+    });
+    expect(consumeNext).not.toHaveBeenCalled();
+    expect(rekeyHook).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { getWorld, resumeHook, start } from "#compiled/@workflow/core/runtime.js";
 
+import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { captureTurnEvents, filterEventsByType } from "#internal/testing/events.js";
 import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { mockTool } from "#internal/testing/mocks/mock-tool.js";
 import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { workflowEntry } from "#execution/workflow-entry.js";
@@ -35,6 +37,178 @@ function buildSerializedContext(overrides: {
 }
 
 describe("workflowEntry integration", () => {
+  it("cancels one active turn and resumes the same entry session", async () => {
+    const blocking = createBlockingCancellationTool();
+    const app = createTestRuntime({
+      agent: { name: "workflow-entry-turn-cancellation" },
+      tools: [blocking.tool],
+    });
+    const continuationToken = "http:workflow-entry-turn-cancellation";
+
+    await app.run(async () => {
+      const compiledArtifactsSource = createBundledRuntimeCompiledArtifactsSource();
+      const runtime = createWorkflowRuntime({
+        compiledArtifactsSource,
+      });
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "call wait_for_cancellation" },
+          serializedContext: buildSerializedContext({
+            channelKind: "http",
+            continuationToken,
+            mode: "conversation",
+          }),
+        },
+      ]);
+      await blocking.started;
+      const stream = captureTurnEvents(run);
+
+      try {
+        await runtime.cancelTurn({ sessionId: run.runId });
+        await blocking.aborted;
+
+        const cancelledTurn = await stream.nextTurn();
+        expect(cancelledTurn.map((event) => event.type)).toContain("turn.cancelled");
+        expect(cancelledTurn.at(-1)?.type).toBe("session.waiting");
+
+        await expect(runtime.cancelTurn({ sessionId: run.runId })).resolves.toBeUndefined();
+
+        const followUp = await runtime.deliver({
+          auth: null,
+          continuationToken,
+          payload: { message: "continue after cancellation" },
+        });
+        expect(followUp.sessionId).toBe(run.runId);
+
+        let resumedTurn = await stream.nextTurn();
+        while (isCancellationBoundary(resumedTurn)) {
+          resumedTurn = await stream.nextTurn();
+        }
+        expect(resumedTurn.at(-1)?.type).toBe("session.waiting");
+        expect(
+          resumedTurn.some(
+            (event) =>
+              event.type === "message.completed" &&
+              event.data.message?.includes("continue after cancellation") === true,
+          ),
+        ).toBe(true);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  });
+
+  it("cancels an entry session and eventually releases its continuation", async () => {
+    const blocking = createBlockingCancellationTool();
+    const app = createTestRuntime({
+      agent: { name: "workflow-entry-session-cancellation" },
+      tools: [blocking.tool],
+    });
+    const continuationToken = "http:workflow-entry-session-cancellation";
+
+    await app.run(async () => {
+      const compiledArtifactsSource = createBundledRuntimeCompiledArtifactsSource();
+      const runtime = createWorkflowRuntime({
+        compiledArtifactsSource,
+      });
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "call wait_for_cancellation" },
+          serializedContext: buildSerializedContext({
+            channelKind: "http",
+            continuationToken,
+            mode: "conversation",
+          }),
+        },
+      ]);
+      await blocking.started;
+      const stream = captureTurnEvents(run);
+
+      try {
+        await runtime.cancelSession({ sessionId: run.runId });
+        await blocking.aborted;
+
+        const cancelledSession = await stream.nextTurn();
+        expect(cancelledSession.map((event) => event.type)).toContain("turn.cancelled");
+        expect(cancelledSession.at(-1)?.type).toBe("session.cancelled");
+        await expect(run.returnValue).resolves.toEqual({ output: "" });
+
+        const replacementRun = await start(workflowEntry, [
+          {
+            input: { message: "fresh session" },
+            serializedContext: buildSerializedContext({
+              channelKind: "http",
+              continuationToken,
+              mode: "conversation",
+            }),
+          },
+        ]);
+        const replacementStream = captureTurnEvents(replacementRun);
+
+        try {
+          expect(replacementRun.runId).not.toBe(run.runId);
+
+          const freshTurn = await replacementStream.nextTurn();
+          expect(freshTurn.at(-1)?.type).toBe("session.waiting");
+          expect(
+            freshTurn.some(
+              (event) =>
+                event.type === "message.completed" &&
+                event.data.message?.includes("fresh session") === true,
+            ),
+          ).toBe(true);
+        } finally {
+          replacementStream.dispose();
+          await replacementRun.cancel();
+        }
+      } finally {
+        stream.dispose();
+        if ((await run.status) === "running") await run.cancel();
+      }
+    });
+  });
+
+  it("treats authored session cancellation as non-retryable control flow", async () => {
+    let executions = 0;
+    const tool = mockTool({
+      name: "cancel_session",
+      execute(_input, ctx): never {
+        executions += 1;
+        return ctx.cancel({ scope: "session" });
+      },
+    });
+    const app = createTestRuntime({
+      agent: { name: "workflow-entry-authored-session-cancellation" },
+      tools: [tool],
+    });
+
+    await app.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "call cancel_session" },
+          serializedContext: buildSerializedContext({
+            channelKind: "http",
+            continuationToken: "http:workflow-entry-authored-session-cancellation",
+            mode: "conversation",
+          }),
+        },
+      ]);
+      const stream = captureTurnEvents(run);
+
+      try {
+        const events = await stream.nextTurn();
+        expect(events.map((event) => event.type)).toContain("turn.cancelled");
+        expect(events.at(-1)?.type).toBe("session.cancelled");
+        expect(executions).toBe(1);
+        await expect(run.returnValue).resolves.toEqual({ output: "" });
+      } finally {
+        stream.dispose();
+        if ((await run.status) === "running") await run.cancel();
+      }
+    });
+  });
+
   it("parks in conversation mode and resumes via the workflow hook", async () => {
     const runtime = createTestRuntime({ agent: { name: "workflow-entry-conversation" } });
     const continuationToken = "http:workflow-entry-conversation";
@@ -287,3 +461,40 @@ describe("workflowEntry integration", () => {
     });
   });
 });
+
+function createBlockingCancellationTool() {
+  let markStarted: () => void = () => undefined;
+  let markAborted: () => void = () => undefined;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const aborted = new Promise<void>((resolve) => {
+    markAborted = resolve;
+  });
+
+  const tool = mockTool({
+    name: "wait_for_cancellation",
+    execute(_input, ctx) {
+      markStarted();
+      return new Promise<never>((_resolve, reject) => {
+        const onAbort = () => {
+          markAborted();
+          reject(ctx.abortSignal.reason);
+        };
+        if (ctx.abortSignal.aborted) {
+          onAbort();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  });
+
+  return { aborted, started, tool };
+}
+
+function isCancellationBoundary(
+  events: readonly import("#protocol/message.js").HandleMessageStreamEvent[],
+): boolean {
+  return events.some((event) => event.type === "turn.cancelled");
+}

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -80,10 +80,8 @@ describe("workflowEntry integration", () => {
         });
         expect(followUp.sessionId).toBe(run.runId);
 
-        let resumedTurn = await stream.nextTurn();
-        while (isCancellationBoundary(resumedTurn)) {
-          resumedTurn = await stream.nextTurn();
-        }
+        const resumedTurn = await stream.nextTurn();
+        expect(resumedTurn.map((event) => event.type)).not.toContain("turn.cancelled");
         expect(resumedTurn.at(-1)?.type).toBe("session.waiting");
         expect(
           resumedTurn.some(
@@ -563,10 +561,4 @@ function createBlockingCancellationTool() {
   });
 
   return { aborted, started, tool };
-}
-
-function isCancellationBoundary(
-  events: readonly import("#protocol/message.js").HandleMessageStreamEvent[],
-): boolean {
-  return events.some((event) => event.type === "turn.cancelled");
 }

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -14,6 +14,10 @@ import {
   routeProxiedDeliverStep,
   runProxyInputRequestStep,
 } from "#execution/workflow-steps.js";
+import { cancelTurnSegmentStep } from "#execution/turn-cancellation-step.js";
+import { finalizeCancellationStep } from "#execution/cancellation-step.js";
+import { cancelDescendantsStep } from "#execution/cancel-descendants-step.js";
+import { fireSessionCallbackStep } from "#execution/session-callback-step.js";
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: vi.fn(),
@@ -67,6 +71,10 @@ vi.mock("./workflow-steps.js", () => ({
     })),
 }));
 
+vi.mock("./turn-cancellation-step.js", () => ({
+  cancelTurnSegmentStep: vi.fn().mockResolvedValue(undefined),
+}));
+
 function createSessionStateForMock(
   overrides: Partial<DurableSessionState> = {},
 ): DurableSessionState {
@@ -89,6 +97,17 @@ function createSessionStepResultForMock(state: DurableSessionState) {
 
 vi.mock("./session-callback-step.js", () => ({
   fireSessionCallbackStep: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./cancel-descendants-step.js", () => ({
+  cancelDescendantsStep: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./cancellation-step.js", () => ({
+  finalizeCancellationStep: vi.fn().mockImplementation(async (input) => ({
+    serializedContext: input.serializedContext,
+    sessionState: input.sessionState,
+  })),
 }));
 
 interface ParkHookConfig {
@@ -154,6 +173,55 @@ describe("workflowEntry", () => {
         }),
         sessionState,
       }),
+    );
+  });
+
+  it("cancels one logical turn and leaves the entry session parked", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      cancellationScope: "turn",
+      parkHooks: [{ token: "http:test", values: [] }],
+      turnCompletions: [turnResult({ action: "done", output: "late completion", sessionState })],
+    });
+
+    await expect(
+      workflowEntry({
+        input: { message: "cancel me" },
+        serializedContext: createSerializedContext(),
+      }),
+    ).resolves.toEqual({ output: "" });
+
+    expect(cancelTurnSegmentStep).toHaveBeenCalledWith({
+      hookId: "wrun_test_123:turn-completion:0:cancel",
+    });
+    expect(cancelDescendantsStep).toHaveBeenCalledTimes(1);
+    expect(finalizeCancellationStep).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "turn" }),
+    );
+  });
+
+  it("releases and terminally cancels the entry session", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      cancellationScope: "session",
+      parkHooks: [{ token: "http:test", values: [] }],
+      turnCompletions: [{ kind: "turn-cancelled", scope: "turn" }],
+    });
+
+    await expect(
+      workflowEntry({
+        input: { message: "cancel session" },
+        serializedContext: createSerializedContext(),
+      }),
+    ).resolves.toEqual({ output: "" });
+
+    expect(finalizeCancellationStep).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "session" }),
+    );
+    expect(fireSessionCallbackStep).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "cancelled" }),
     );
   });
 
@@ -901,6 +969,7 @@ function turnResult(input: {
 }
 
 function installHookMocks(input: {
+  readonly cancellationScope?: "session" | "turn";
   readonly parkHooks?: readonly ParkHookConfig[];
   readonly symbolDispose?: () => void;
   readonly turnCompletions: readonly TurnCompletionPayload[];
@@ -924,8 +993,13 @@ function installHookMocks(input: {
     }
 
     if (token.endsWith(":cancel-session") || token.endsWith(":cancel-turn")) {
+      const signaled =
+        (token.endsWith(":cancel-session") && input.cancellationScope === "session") ||
+        (token.endsWith(":cancel-turn") && input.cancellationScope === "turn");
       return createMockHook({
-        next: () => new Promise<IteratorResult<void>>(() => {}),
+        next: signaled
+          ? async () => ({ done: false, value: undefined })
+          : () => new Promise<IteratorResult<void>>(() => {}),
         token,
         values: [],
       }) as never;

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -8,7 +8,10 @@ import {
   turnWorkflowReference,
   workflowEntryReference,
 } from "#execution/workflow-runtime.js";
-import { isRuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
+import {
+  isRuntimeCancellationConflictError,
+  isRuntimeNoActiveSessionError,
+} from "#execution/runtime-errors.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 
@@ -16,6 +19,13 @@ const getHookByTokenMock = vi.fn();
 const getRunMock = vi.fn();
 const resumeHookMock = vi.fn();
 const startMock = vi.fn();
+
+function createStartedRun(runId: string) {
+  return {
+    returnValue: new Promise<never>(() => undefined),
+    runId,
+  };
+}
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   getHookByToken: (...args: unknown[]) => getHookByTokenMock(...args),
@@ -62,6 +72,22 @@ describe("createWorkflowRuntime#deliver", () => {
     return createWorkflowRuntime({ compiledArtifactsSource });
   }
 
+  it("returns after the delivery hook accepts the turn", async () => {
+    getHookByTokenMock.mockResolvedValue({ runId: "driver-run" });
+
+    const result = await buildRuntime().deliver({
+      auth: null,
+      continuationToken: "eve:session-1",
+      payload: { message: "continue" },
+    });
+
+    expect(result).toEqual({
+      sessionId: "driver-run",
+    });
+    expect(resumeHookMock).toHaveBeenCalledOnce();
+    expect(getRunMock).not.toHaveBeenCalled();
+  });
+
   it("normalizes `HookNotFoundError` into `RuntimeNoActiveSessionError`", async () => {
     const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
     getHookByTokenMock.mockRejectedValue(new HookNotFoundError(NOT_FOUND_TOKEN));
@@ -93,6 +119,47 @@ describe("createWorkflowRuntime#deliver", () => {
   });
 });
 
+describe("createWorkflowRuntime cancellation", () => {
+  function buildRuntime() {
+    return createWorkflowRuntime({ compiledArtifactsSource: {} as RuntimeCompiledArtifactsSource });
+  }
+
+  it("resumes the active turn hook only when it belongs to the requested session", async () => {
+    getHookByTokenMock.mockResolvedValue({ runId: "session-1" });
+
+    await buildRuntime().cancelTurn({ sessionId: "session-1" });
+
+    expect(resumeHookMock).toHaveBeenCalledWith("session-1:cancel-turn", undefined);
+  });
+
+  it("rejects an active turn hook owned by a different session", async () => {
+    getHookByTokenMock.mockResolvedValue({ runId: "session-2" });
+
+    await expect(buildRuntime().cancelTurn({ sessionId: "session-1" })).rejects.toSatisfy(
+      isRuntimeCancellationConflictError,
+    );
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts session cancellation by session id", async () => {
+    getHookByTokenMock.mockResolvedValue({ runId: "session-1" });
+
+    await buildRuntime().cancelSession({ sessionId: "session-1" });
+
+    expect(resumeHookMock).toHaveBeenCalledWith("session-1:cancel-session", undefined);
+    expect(getHookByTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes stale cancellation capabilities to a conflict", async () => {
+    const { HookNotFoundError } = await import("#compiled/@workflow/errors/index.js");
+    getHookByTokenMock.mockRejectedValue(new HookNotFoundError("stale"));
+
+    await expect(buildRuntime().cancelTurn({ sessionId: "session-1" })).rejects.toSatisfy(
+      isRuntimeCancellationConflictError,
+    );
+  });
+});
+
 describe("createWorkflowRuntime#run", () => {
   const adapter: ChannelAdapter = { kind: "http" };
 
@@ -104,21 +171,14 @@ describe("createWorkflowRuntime#run", () => {
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
       compiledArtifactsSource,
     } as never);
-    getRunMock.mockReturnValue({
-      getReadable: () =>
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.close();
-          },
-        }),
-    });
+    getHookByTokenMock.mockResolvedValue({ runId: "driver-run" });
   }
 
   it("starts workflowEntry on the latest deployment in Vercel production", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
     mockBundleAndRun(compiledArtifactsSource);
-    startMock.mockResolvedValue({ runId: "driver-run" });
+    startMock.mockResolvedValue(createStartedRun("driver-run"));
 
     await buildRuntime(compiledArtifactsSource).run({
       adapter,
@@ -149,7 +209,7 @@ describe("createWorkflowRuntime#run", () => {
     mockBundleAndRun(compiledArtifactsSource);
     startMock
       .mockRejectedValueOnce(new Error(LATEST_DEPLOYMENT_UNSUPPORTED_MESSAGE))
-      .mockResolvedValueOnce({ runId: "driver-run" });
+      .mockResolvedValueOnce(createStartedRun("driver-run"));
 
     await buildRuntime(compiledArtifactsSource).run({
       adapter,
@@ -178,7 +238,7 @@ describe("createWorkflowRuntime#run", () => {
       }
       const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
       mockBundleAndRun(compiledArtifactsSource);
-      startMock.mockResolvedValue({ runId: "driver-run" });
+      startMock.mockResolvedValue(createStartedRun("driver-run"));
 
       await buildRuntime(compiledArtifactsSource).run({
         adapter,
@@ -198,17 +258,17 @@ describe("createWorkflowRuntime#run", () => {
       compiledArtifactsSource,
     } as never);
     const bytes = new TextEncoder().encode('{"type":"test.event"}\n');
-    const getReadable = vi.fn(
-      () =>
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(bytes);
-            controller.close();
-          },
-        }),
-    );
+    const getReadable = vi.fn(() => {
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      });
+    });
     getRunMock.mockReturnValue({ getReadable });
-    startMock.mockResolvedValue({ runId: "driver-run" });
+    getHookByTokenMock.mockResolvedValue({ runId: "driver-run" });
+    startMock.mockResolvedValue(createStartedRun("driver-run"));
 
     const handle = await buildRuntime(compiledArtifactsSource).run({
       adapter,
@@ -226,6 +286,6 @@ describe("createWorkflowRuntime#run", () => {
 
     expect(event.value).toEqual({ type: "test.event" });
     expect(getRunMock).toHaveBeenCalledWith("driver-run");
-    expect(getReadable).toHaveBeenCalledTimes(1);
+    expect(getReadable).toHaveBeenCalledOnce();
   });
 });

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -52,6 +52,43 @@ function createEvent(input?: {
 }
 
 describe("dispatchChannelRequest", () => {
+  it("exposes channel-local session and turn cancellation operations", async () => {
+    const cancelSession = vi.fn().mockResolvedValue(undefined);
+    const cancelTurn = vi.fn().mockResolvedValue(undefined);
+    const cancellationRuntime: Runtime = {
+      cancelSession,
+      cancelTurn,
+      deliver: vi.fn(),
+      getEventStream: vi.fn(),
+      run: vi.fn(),
+    };
+    mockedResolveNitroChannelRuntimeBundle.mockResolvedValue({
+      channels: [
+        {
+          handler: async (_request, args) => {
+            await args.cancelSession({ sessionId: "session-1" });
+            await args.cancelTurn({ sessionId: "session-1" });
+            return new Response("ok");
+          },
+          fetch: async () => new Response("ok"),
+          adapter: { kind: "channel:webhook" },
+          logicalPath: "agent/channels/webhook.ts",
+          method: "POST",
+          name: "webhook",
+          sourceId: "channel-webhook",
+          sourceKind: "module",
+          urlPath: "/webhook",
+        } satisfies ResolvedChannelDefinition,
+      ],
+      runtime: cancellationRuntime,
+    });
+
+    await dispatchChannelRequest(createEvent({ waitUntil: vi.fn() }), "POST /webhook", {} as never);
+
+    expect(cancelSession).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(cancelTurn).toHaveBeenCalledWith({ sessionId: "session-1" });
+  });
+
   it("returns the response before background work settles when Nitro provides waitUntil", async () => {
     const deferred = createDeferred<void>();
     const waitUntil = vi.fn<(task: Promise<unknown>) => void>();

--- a/packages/eve/src/internal/testing/app-harness.ts
+++ b/packages/eve/src/internal/testing/app-harness.ts
@@ -1,7 +1,11 @@
 import type { JsonObject } from "#shared/json.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
 import { compileFromMemory } from "#compiler/compile-from-memory.js";
-import type { CompiledAgentManifest, CompiledSkillDefinition } from "#compiler/manifest.js";
+import {
+  ROOT_COMPILED_AGENT_NODE_ID,
+  type CompiledAgentManifest,
+  type CompiledSkillDefinition,
+} from "#compiler/manifest.js";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
 import type { SessionParent, SessionTurn } from "#context/keys.js";
 import { installBundledCompiledArtifacts } from "#runtime/loaders/bundled-artifacts.js";
@@ -175,6 +179,15 @@ export function createTestRuntime(descriptor: TestAppDescriptor = {}): TestRunti
   const session = createRuntimeSession(descriptor.agent?.name ?? DEFAULT_AGENT_NAME);
   const tools = descriptor.tools ?? [];
   const skills = descriptor.skills ?? [];
+
+  const rootModules = moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules;
+  if (rootModules === undefined) {
+    throw new Error("In-memory app is missing its root module scope.");
+  }
+  for (const tool of tools) {
+    const definition = manifest.tools.find((entry) => entry.name === tool.name);
+    if (definition !== undefined) rootModules[definition.sourceId] = { default: tool };
+  }
 
   function install(): void {
     installBundledCompiledArtifacts({ manifest, moduleMap });

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -5,9 +5,12 @@ import {
   createActionResultEvent,
   createAuthorizationCompletedEvent,
   createAuthorizationRequiredEvent,
+  createSessionCancelledEvent,
   createResultCompletedEvent,
   createStepStartedEvent,
+  createTurnCancelledEvent,
   encodeMessageStreamEvent,
+  isCurrentTurnBoundaryEvent,
   timestampHandleMessageStreamEvent,
 } from "#protocol/message.js";
 import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
@@ -15,6 +18,19 @@ import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 describe("message stream protocol", () => {
   it("pins the stream version for timed session events", () => {
     expect(EVE_MESSAGE_STREAM_VERSION).toBe("17");
+  });
+
+  it("creates cancellation events with the expected turn and session boundaries", () => {
+    expect(createTurnCancelledEvent({ sequence: 2, turnId: "turn_2" })).toEqual({
+      data: { sequence: 2, turnId: "turn_2" },
+      type: "turn.cancelled",
+    });
+    const session = createSessionCancelledEvent("session-1");
+    expect(session).toEqual({
+      data: { sessionId: "session-1" },
+      type: "session.cancelled",
+    });
+    expect(isCurrentTurnBoundaryEvent(session)).toBe(true);
   });
 
   it("creates result.completed events", () => {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -9,7 +9,7 @@ import { type AuthFn, none } from "#public/channels/auth.js";
 import { eveChannel, defaultEveAuth, type EveChannelInput } from "#public/channels/eve.js";
 import type { SessionAuthContext } from "#channel/types.js";
 import type { RouteHandlerArgs, SendFn, SendOptions, SendPayload } from "#channel/routes.js";
-import type { Session as ChannelSession } from "#channel/session.js";
+import type { Session } from "#channel/session.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
 import type { ContextAccessor } from "#context/key.js";
 import {
@@ -19,6 +19,7 @@ import {
   type Session as RuntimeSession,
 } from "#context/keys.js";
 import { createMessageCompletedEvent } from "#protocol/message.js";
+import { RuntimeCancellationConflictError } from "#execution/runtime-errors.js";
 
 /**
  * Unit coverage for the inbound HTTP route's message-body parser and
@@ -57,13 +58,14 @@ function createEveCreateHandler(input: EveChannelInput) {
   );
   if (!createRoute) throw new Error("No create POST route found");
 
-  const mockSend = vi.fn<SendFn>().mockResolvedValue({
+  const mockSession = {
     id: "test-session-id",
     continuationToken: "eve:test",
     async getEventStream() {
       return new ReadableStream();
     },
-  } satisfies ChannelSession);
+  } satisfies Session;
+  const mockSend = vi.fn<SendFn>().mockResolvedValue(mockSession);
 
   return {
     send: mockSend,
@@ -94,7 +96,7 @@ function createEveContinueHandler(input: EveChannelInput) {
   );
   if (!continueRoute) throw new Error("No continue POST route found");
 
-  const mockSession: ChannelSession = {
+  const mockSession: Session = {
     id: "test-session-id",
     continuationToken: "eve:test",
     async getEventStream() {
@@ -1073,5 +1075,95 @@ describe("eveChannel — auth array shape", () => {
     expect(response.status).toBe(200);
     const options = handler.send.mock.calls[0]?.[1] as SendOptions;
     expect(options.auth).toEqual(ACCEPTED);
+  });
+});
+
+describe("eveChannel — cancellation", () => {
+  function createHandler(
+    auth: EveChannelInput["auth"] = none(),
+    overrides: Partial<Pick<RouteHandlerArgs, "cancelSession" | "cancelTurn">> = {},
+  ) {
+    const channel = eveChannel({ auth });
+    const route = channel.routes.find(
+      (candidate) =>
+        candidate.method === "POST" && candidate.path === "/eve/v1/session/:sessionId/cancel",
+    );
+    if (route === undefined) throw new Error("No cancellation route found.");
+
+    const operations = {
+      cancelSession: vi.fn(),
+      cancelTurn: vi.fn(),
+      ...overrides,
+    };
+    const args: RouteHandlerArgs = {
+      ...operations,
+      getSession: vi.fn(),
+      params: { sessionId: "session-1" },
+      receive: vi.fn() as any,
+      requestIp: "127.0.0.1",
+      send: vi.fn(),
+      waitUntil: () => undefined,
+    };
+
+    return {
+      operations,
+      fetch: (request: Request) => (route as any).handler(request, args) as Promise<Response>,
+    };
+  }
+
+  it("authenticates before parsing the cancellation body", async () => {
+    const handler = createHandler([]);
+    const response = await handler.fetch(
+      new Request("https://eve.test/eve/v1/session/session-1/cancel", {
+        body: "not json",
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(handler.operations.cancelTurn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {},
+    { scope: "turn", extra: true },
+    { continuationToken: "eve:1", scope: "turn" },
+    { continuationToken: "eve:1", scope: "session" },
+  ])("rejects malformed scoped cancellation payloads", async (body) => {
+    const handler = createHandler();
+    const response = await handler.fetch(createJsonMessageRequest(body));
+
+    expect(response.status).toBe(400);
+    expect(handler.operations.cancelSession).not.toHaveBeenCalled();
+    expect(handler.operations.cancelTurn).not.toHaveBeenCalled();
+  });
+
+  it("cancels the currently running turn", async () => {
+    const handler = createHandler();
+    const response = await handler.fetch(createJsonMessageRequest({ scope: "turn" }));
+
+    expect(response.status).toBe(202);
+    expect(handler.operations.cancelTurn).toHaveBeenCalledWith({
+      sessionId: "session-1",
+    });
+  });
+
+  it("cancels the session in the request path", async () => {
+    const handler = createHandler();
+    const response = await handler.fetch(createJsonMessageRequest({ scope: "session" }));
+
+    expect(response.status).toBe(202);
+    expect(handler.operations.cancelSession).toHaveBeenCalledWith({
+      sessionId: "session-1",
+    });
+  });
+
+  it("maps stale and mismatched capabilities to one conflict response", async () => {
+    const handler = createHandler(none(), {
+      cancelTurn: vi.fn().mockRejectedValue(new RuntimeCancellationConflictError()),
+    });
+    const response = await handler.fetch(createJsonMessageRequest({ scope: "turn" }));
+
+    expect(response.status).toBe(409);
   });
 });

--- a/packages/eve/src/public/definitions/defineChannel.test.ts
+++ b/packages/eve/src/public/definitions/defineChannel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { buildAdapterContext } from "#channel/adapter-context.js";
 import { callAdapterEventHandler, type ChannelAdapter } from "#channel/adapter.js";
@@ -372,6 +372,49 @@ describe("defineChannel", () => {
     expect(capturedCtx.session.turn).toEqual({ id: "turn-1", sequence: 0 });
     expect(typeof capturedChannel.continuationToken).toBe("string");
     expect(typeof capturedChannel.setContinuationToken).toBe("function");
+  });
+
+  it("registers turn and session cancellation event handlers", async () => {
+    const turnCancelled = vi.fn();
+    const sessionCancelled = vi.fn();
+    const channel = defineChannel({
+      routes: [POST("/x", async () => new Response("ok"))],
+      events: {
+        "session.cancelled": sessionCancelled,
+        "turn.cancelled": turnCancelled,
+      },
+    });
+    const adapter = getAdapter(channel);
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "session-1",
+      turn: { id: "turn-1", sequence: 0 },
+    });
+    const accessor: ContextAccessor = {
+      ensure: (key, create) => ctx.ensure(key as any, create),
+      get: (key) => ctx.get(key as any),
+      has: (key) => ctx.has(key as any),
+      require: (key) => ctx.require(key as any),
+      set: (key, value) => ctx.set(key as any, value),
+    };
+    const adapterCtx = buildAdapterContext(adapter, accessor);
+
+    await contextStorage.run(ctx, async () => {
+      await callAdapterEventHandler(
+        adapter,
+        { data: { sequence: 0, turnId: "turn-1" }, type: "turn.cancelled" } as any,
+        adapterCtx,
+      );
+      await callAdapterEventHandler(
+        adapter,
+        { data: { sessionId: "session-1" }, type: "session.cancelled" } as any,
+        adapterCtx,
+      );
+    });
+
+    expect(turnCancelled).toHaveBeenCalledOnce();
+    expect(sessionCancelled).toHaveBeenCalledOnce();
   });
 
   it("registers reasoning event handlers with channel and session context", async () => {

--- a/packages/eve/src/runtime/session-callback-route.test.ts
+++ b/packages/eve/src/runtime/session-callback-route.test.ts
@@ -66,6 +66,40 @@ describe("session callback route", () => {
       ],
     });
   });
+
+  it("resumes a cancelled remote-agent result as an intentional action error", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          callId: "call-1",
+          kind: "session.cancelled",
+          sessionId: "remote-session",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).toHaveBeenCalledWith("tok123", {
+      kind: "runtime-action-result",
+      results: [
+        {
+          callId: "call-1",
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: "REMOTE_AGENT_CANCELLED",
+            message: "Remote agent session was cancelled.",
+          },
+          subagentName: "research",
+        },
+      ],
+    });
+  });
 });
 
 function createRouteContext(params: Record<string, string>): RouteContext {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,19 @@ importers:
         specifier: 'catalog:'
         version: 7.0.1-rc
 
+  e2e/fixtures/agent-cancellation:
+    dependencies:
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.1-rc
+
   e2e/fixtures/agent-channels:
     dependencies:
       '@opentelemetry/core':


### PR DESCRIPTION
## Summary

- add new unit and integration coverage for the cancellation implementation in #230
- add the cancellation E2E fixture and turn/session cancellation evals
- keep compatibility-only migrations for existing tests in #230 so the parent passes standalone CI

## Stack

- Base: #230 (`barba/session-reset-api`)
- This PR contains only new tests, cancellation-specific test support, fixture files, eval cases, and the fixture lockfile importer

## Why

The cancellation implementation spans channels, clients, workflow execution, runtime actions, subagents, and the harness. Keeping new coverage in a separate stacked PR makes the implementation diff reviewable independently without leaving the parent branch unable to typecheck or run its existing suite.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` — 3,931 tests
- `pnpm test:integration` — 371 tests
- full serial scenario suite — 261 passed, 15 skipped

The default parallel local scenario run exposed pre-existing shared-`dist/` races; every affected file and the complete suite pass with one worker.
