### PR TITLE
feat(eve): web search - use Parallel for gateway models

### DIFF
--- a/.changeset/parallel-gateway-search.md
+++ b/.changeset/parallel-gateway-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use Parallel through AI Gateway for the built-in `web_search` tool with every string model. Gateway requests no longer select native provider search tools or pin routing to a model provider.

--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
@@ -10,8 +10,9 @@ export default defineEval({
     t.completed();
     t.calledTool("web_search", { isError: false });
     t.noFailedActions();
+    t.messageIncludes(/New York Knicks/iu);
     t.judge.autoevals
-      .closedQA("The reply says that the New York Knicks won the 2026 NBA Finals.", {
+      .factuality("The New York Knicks won the 2026 NBA Finals.", {
         on: turn.message,
       })
       .atLeast(0.5);

--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
@@ -1,0 +1,19 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "Provider tools smoke: gateway web search answers a current-events question.",
+  async test(t) {
+    const turn = await t.send("Who won the 2026 NBA finals");
+    turn.expectOk();
+
+    t.didNotFail();
+    t.completed();
+    t.calledTool("web_search", { isError: false });
+    t.noFailedActions();
+    t.judge.autoevals
+      .closedQA("The reply says that the New York Knicks won the 2026 NBA Finals.", {
+        on: turn.message,
+      })
+      .atLeast(0.5);
+  },
+});

--- a/packages/eve/src/harness/provider-tools.test.ts
+++ b/packages/eve/src/harness/provider-tools.test.ts
@@ -3,14 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import {
   WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA,
-  WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA,
   WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA,
   WEB_SEARCH_OPENAI_OUTPUT_SCHEMA,
+  WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA,
 } from "#runtime/framework-tools/web-search.js";
 import {
-  mergeGatewayProviderPin,
   resolveFrameworkToolFromUpstreamType,
-  resolveGatewayPinForWebSearchBackend,
   resolveWebSearchBackend,
   resolveWebSearchOutputSchema,
   resolveWebSearchProviderTool,
@@ -19,7 +17,7 @@ import {
 const {
   anthropicWebSearch_20250305,
   anthropicWebSearch_20260209,
-  gatewayPerplexitySearch,
+  gatewayParallelSearch,
   googleSearch,
   openaiWebSearch,
 } = vi.hoisted(() => ({
@@ -29,7 +27,7 @@ const {
   anthropicWebSearch_20260209: vi.fn(() => ({
     providerTool: "anthropic.webSearch_20260209",
   })),
-  gatewayPerplexitySearch: vi.fn(() => ({ providerTool: "gateway.perplexitySearch" })),
+  gatewayParallelSearch: vi.fn(() => ({ providerTool: "gateway.parallelSearch" })),
   googleSearch: vi.fn(() => ({ providerTool: "google.googleSearch" })),
   openaiWebSearch: vi.fn(() => ({ providerTool: "openai.webSearch" })),
 }));
@@ -65,7 +63,7 @@ vi.mock("ai", async () => {
     ...actual,
     gateway: {
       tools: {
-        perplexitySearch: gatewayPerplexitySearch,
+        parallelSearch: gatewayParallelSearch,
       },
     },
   };
@@ -79,14 +77,14 @@ describe("resolveWebSearchBackend", () => {
   beforeEach(() => {
     anthropicWebSearch_20250305.mockClear();
     anthropicWebSearch_20260209.mockClear();
-    gatewayPerplexitySearch.mockClear();
+    gatewayParallelSearch.mockClear();
     googleSearch.mockClear();
     openaiWebSearch.mockClear();
   });
 
-  it("returns 'openai' for an OpenAI gateway model", () => {
+  it("returns 'parallel' for an OpenAI gateway model", () => {
     const ref: RuntimeModelReference = { id: "openai/gpt-5.4" };
-    expect(resolveWebSearchBackend(ref)).toBe("openai");
+    expect(resolveWebSearchBackend(ref)).toBe("parallel");
   });
 
   it("returns 'openai' for a BYO OpenAI model", () => {
@@ -102,9 +100,9 @@ describe("resolveWebSearchBackend", () => {
     expect(resolveWebSearchBackend(ref)).toBe("openai");
   });
 
-  it("returns 'anthropic' for an Anthropic gateway model", () => {
+  it("returns 'parallel' for an Anthropic gateway model", () => {
     const ref: RuntimeModelReference = { id: "anthropic/claude-opus-4.6" };
-    expect(resolveWebSearchBackend(ref)).toBe("anthropic");
+    expect(resolveWebSearchBackend(ref)).toBe("parallel");
   });
 
   it("returns 'anthropic' for a BYO Anthropic model", () => {
@@ -133,14 +131,14 @@ describe("resolveWebSearchBackend", () => {
     expect(resolveWebSearchBackend(ref)).toBe("google");
   });
 
-  it("returns 'gateway' for a Google model on AI Gateway", () => {
+  it("returns 'parallel' for a Google model on AI Gateway", () => {
     const ref: RuntimeModelReference = { id: "google/gemini-3.1-pro" };
-    expect(resolveWebSearchBackend(ref)).toBe("gateway");
+    expect(resolveWebSearchBackend(ref)).toBe("parallel");
   });
 
-  it("returns 'gateway' for a non-OpenAI/Anthropic/Google gateway model", () => {
+  it("returns 'parallel' for any other AI Gateway model", () => {
     const ref: RuntimeModelReference = { id: "mistral/mistral-large" };
-    expect(resolveWebSearchBackend(ref)).toBe("gateway");
+    expect(resolveWebSearchBackend(ref)).toBe("parallel");
   });
 
   it("returns null for a BYO non-OpenAI/Anthropic/Google model", () => {
@@ -181,19 +179,19 @@ describe("resolveWebSearchBackend", () => {
     expect(getOutputJsonSchema(tool)).toEqual(WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA);
   });
 
-  it("uses gateway perplexitySearch for the gateway fallback backend", async () => {
-    const tool = await resolveWebSearchProviderTool("gateway");
+  it("uses gateway parallelSearch for the Parallel backend", async () => {
+    const tool = await resolveWebSearchProviderTool("parallel");
 
-    expect(gatewayPerplexitySearch).toHaveBeenCalledTimes(1);
-    expect(tool).toMatchObject({ providerTool: "gateway.perplexitySearch" });
-    expect(getOutputJsonSchema(tool)).toEqual(WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA);
+    expect(gatewayParallelSearch).toHaveBeenCalledTimes(1);
+    expect(tool).toMatchObject({ providerTool: "gateway.parallelSearch" });
+    expect(getOutputJsonSchema(tool)).toEqual(WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA);
   });
 
   it("resolves output schemas per selected backend", () => {
     expect(resolveWebSearchOutputSchema("anthropic")).toBe(WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA);
-    expect(resolveWebSearchOutputSchema("gateway")).toBe(WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA);
     expect(resolveWebSearchOutputSchema("google")).toBe(WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA);
     expect(resolveWebSearchOutputSchema("openai")).toBe(WEB_SEARCH_OPENAI_OUTPUT_SCHEMA);
+    expect(resolveWebSearchOutputSchema("parallel")).toBe(WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA);
   });
 });
 
@@ -205,55 +203,5 @@ describe("resolveFrameworkToolFromUpstreamType", () => {
   it("returns null for unknown upstream tool types", () => {
     expect(resolveFrameworkToolFromUpstreamType("computer_20251022")).toBeNull();
     expect(resolveFrameworkToolFromUpstreamType("some.future.tool")).toBeNull();
-  });
-});
-
-describe("resolveGatewayPinForWebSearchBackend", () => {
-  it("pins to the matching provider for direct provider backends", () => {
-    expect(resolveGatewayPinForWebSearchBackend("anthropic")).toBe("anthropic");
-    expect(resolveGatewayPinForWebSearchBackend("openai")).toBe("openai");
-    expect(resolveGatewayPinForWebSearchBackend("google")).toBe("google");
-  });
-
-  it("returns null for the gateway-native Perplexity backend", () => {
-    expect(resolveGatewayPinForWebSearchBackend("gateway")).toBeNull();
-  });
-});
-
-describe("mergeGatewayProviderPin", () => {
-  it("adds gateway.only when the base has no gateway section", () => {
-    expect(mergeGatewayProviderPin(undefined, "anthropic")).toEqual({
-      gateway: { only: ["anthropic"] },
-    });
-  });
-
-  it("preserves other gateway fields while adding only", () => {
-    expect(mergeGatewayProviderPin({ gateway: { caching: "auto" } }, "anthropic")).toEqual({
-      gateway: { caching: "auto", only: ["anthropic"] },
-    });
-  });
-
-  it("preserves unrelated providerOptions keys", () => {
-    expect(
-      mergeGatewayProviderPin(
-        { anthropic: { thinking: { type: "adaptive" } }, gateway: { caching: "auto" } },
-        "anthropic",
-      ),
-    ).toEqual({
-      anthropic: { thinking: { type: "adaptive" } },
-      gateway: { caching: "auto", only: ["anthropic"] },
-    });
-  });
-
-  it("does not overwrite an author-supplied gateway.only", () => {
-    expect(mergeGatewayProviderPin({ gateway: { only: ["bedrock"] } }, "anthropic")).toEqual({
-      gateway: { only: ["bedrock"] },
-    });
-  });
-
-  it("does not overwrite an author-supplied gateway.order", () => {
-    expect(
-      mergeGatewayProviderPin({ gateway: { order: ["anthropic", "bedrock"] } }, "anthropic"),
-    ).toEqual({ gateway: { order: ["anthropic", "bedrock"] } });
   });
 });

--- a/packages/eve/src/harness/provider-tools.ts
+++ b/packages/eve/src/harness/provider-tools.ts
@@ -3,18 +3,17 @@ import { jsonSchema, type JSONSchema7, type ToolSet } from "ai";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import {
   WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA,
-  WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA,
   WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA,
   WEB_SEARCH_OPENAI_OUTPUT_SCHEMA,
+  WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA,
   WEB_SEARCH_TOOL_DEFINITION,
 } from "#runtime/framework-tools/web-search.js";
-import { isObject } from "#shared/guards.js";
 import type { JsonObject } from "#shared/json.js";
 
 /**
  * The provider backend resolved for one web search tool invocation.
  */
-export type WebSearchBackend = "anthropic" | "gateway" | "google" | "openai";
+export type WebSearchBackend = "anthropic" | "google" | "openai" | "parallel";
 
 /**
  * Maps an upstream provider tool type (the literal `type` string the AI SDK
@@ -49,26 +48,6 @@ export function resolveFrameworkToolFromUpstreamType(type: string): string | nul
 }
 
 /**
- * Maps a {@link WebSearchBackend} to the gateway provider slug used in
- * `providerOptions.gateway.only` to pin routing to that provider.
- *
- * Returns `null` for the `"gateway"` backend (Perplexity via AI Gateway),
- * which is served by the gateway directly and does not need pinning.
- */
-export function resolveGatewayPinForWebSearchBackend(backend: WebSearchBackend): string | null {
-  switch (backend) {
-    case "anthropic":
-      return "anthropic";
-    case "openai":
-      return "openai";
-    case "google":
-      return "google";
-    case "gateway":
-      return null;
-  }
-}
-
-/**
  * Returns the output schema for the provider-managed web search tool that
  * will be injected for `backend`.
  */
@@ -76,62 +55,29 @@ export function resolveWebSearchOutputSchema(backend: WebSearchBackend): JsonObj
   switch (backend) {
     case "anthropic":
       return WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA;
-    case "gateway":
-      return WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA;
     case "google":
       return WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA;
     case "openai":
       return WEB_SEARCH_OPENAI_OUTPUT_SCHEMA;
+    case "parallel":
+      return WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA;
   }
-}
-
-/**
- * Returns a new `providerOptions` object with
- * `gateway.only = [provider]` merged into the existing `gateway`
- * sub-object so the AI Gateway only attempts the given provider.
- *
- * Used by the harness to pin routing when a provider-specific tool
- * (e.g. Anthropic's `web_search_20250305`) is in the per-step toolset,
- * so a transient primary outage produces a clean retryable 503 instead
- * of a fallback-to-incompatible-provider 400.
- *
- * Author overrides win — if `base.gateway.only` or `base.gateway.order`
- * is already set, the input is returned unchanged so explicit routing
- * preferences are never silently overwritten.
- */
-export function mergeGatewayProviderPin(
-  base: Readonly<Record<string, unknown>> | undefined,
-  provider: string,
-): Record<string, unknown> {
-  const baseGateway = isObject(base?.gateway)
-    ? (base.gateway as Record<string, unknown>)
-    : undefined;
-
-  if (baseGateway?.only !== undefined || baseGateway?.order !== undefined) {
-    return { ...base };
-  }
-
-  const mergedGateway: Record<string, unknown> = {
-    ...baseGateway,
-    only: [provider],
-  };
-
-  return {
-    ...base,
-    gateway: mergedGateway,
-  };
 }
 
 /**
  * Determines the web search backend for a model reference.
  *
- * - OpenAI models (gateway or BYO): native OpenAI search
- * - Anthropic models (gateway or BYO): native Anthropic search
+ * - All AI Gateway models: Parallel search via gateway
+ * - Direct/BYO OpenAI models: native OpenAI search
+ * - Direct/BYO Anthropic models: native Anthropic search
  * - Direct/BYO Google models: native Google search grounding
- * - Other models on AI Gateway (including `google/...`): Perplexity search via gateway
  * - Other BYO models: not available (returns `null`)
  */
 export function resolveWebSearchBackend(modelRef: RuntimeModelReference): WebSearchBackend | null {
+  if (modelRef.source === undefined) {
+    return "parallel";
+  }
+
   const providerId = modelRef.id.split("/")[0] ?? "";
 
   if (providerId === "openai" || providerId.startsWith("openai.")) {
@@ -144,10 +90,6 @@ export function resolveWebSearchBackend(modelRef: RuntimeModelReference): WebSea
 
   if (providerId.startsWith("google.")) {
     return "google";
-  }
-
-  if (modelRef.source === undefined) {
-    return "gateway";
   }
 
   return null;
@@ -183,10 +125,10 @@ export async function resolveWebSearchProviderTool(
       const { google } = await import("#compiled/@ai-sdk/google/index.js");
       return attachWebSearchOutputSchema(google.tools.googleSearch({}) as ToolSet[string], backend);
     }
-    case "gateway": {
+    case "parallel": {
       const { gateway } = await import("ai");
       return attachWebSearchOutputSchema(
-        gateway.tools.perplexitySearch() as ToolSet[string],
+        gateway.tools.parallelSearch() as ToolSet[string],
         backend,
       );
     }

--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -27,7 +27,6 @@ import {
   mergeGatewayAutoCaching,
   type PromptCachePath,
 } from "#harness/prompt-cache.js";
-import { mergeGatewayProviderPin } from "#harness/provider-tools.js";
 import { createRuntimeActionRequestFromToolCall } from "#harness/runtime-actions.js";
 import type { RuntimeToolResultActionResult } from "#runtime/actions/types.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
@@ -69,19 +68,6 @@ interface StepHooksInput {
    * Defaults to `true`.
    */
   readonly emitStepStarted?: boolean;
-  /**
-   * When set on the `gateway-auto` cache path, merges
-   * `providerOptions.gateway.only = [gatewayPinProvider]` so the AI
-   * Gateway only routes to the given provider. Used to keep
-   * provider-specific tools (e.g. Anthropic's `web_search_20250305`)
-   * on a provider that can serve them, converting a transient outage
-   * into a clean retryable 503 rather than a fallback-to-incompatible
-   * provider 400.
-   *
-   * Ignored when the author already set `gateway.only` or
-   * `gateway.order` on the model reference's provider options.
-   */
-  readonly gatewayPinProvider?: string;
   readonly marker: AnthropicCacheMarker | undefined;
   readonly session: HarnessSession;
 }
@@ -171,13 +157,9 @@ export function buildStepHooks(input: StepHooksInput): StepHooks {
     };
 
     if (input.cachePath.kind === "gateway-auto") {
-      let providerOptions = mergeGatewayAutoCaching(session.agent.modelReference.providerOptions);
-      if (input.gatewayPinProvider !== undefined) {
-        providerOptions = mergeGatewayProviderPin(providerOptions, input.gatewayPinProvider);
-      }
-      stepResult.providerOptions = providerOptions as NonNullable<
-        typeof stepResult.providerOptions
-      >;
+      stepResult.providerOptions = mergeGatewayAutoCaching(
+        session.agent.modelReference.providerOptions,
+      ) as NonNullable<typeof stepResult.providerOptions>;
     }
 
     return stepResult;

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -33,6 +33,11 @@ declare module "#public/channels/index.js" {
 
 vi.mock("ai", () => ({
   ToolLoopAgent: vi.fn(),
+  gateway: {
+    tools: {
+      parallelSearch: vi.fn(() => ({})),
+    },
+  },
   jsonSchema: vi.fn((s: unknown) => s),
   isStepCount: vi.fn((n: number) => n),
   tool: vi.fn((t: unknown) => t),
@@ -2923,147 +2928,50 @@ describe("createToolLoopHarness", () => {
     });
   });
 
-  describe("gateway provider tool routing pin", () => {
-    function setupStopResult(): void {
-      setupMockAgent({
-        finishReason: "stop",
-        response: { messages: [{ content: "ok", role: "assistant" }] },
-        text: "ok",
-        toolCalls: [],
-        toolResults: [],
-      });
-    }
-
-    it("pins providerOptions.gateway.only to the web_search backend for gateway models", async () => {
-      setupStopResult();
-      const session = createTestSession({
-        agent: {
-          modelReference: { id: "anthropic/claude-opus-4.7" },
-          system: "",
-          tools: [{ description: "Web search.", name: "web_search", inputSchema: null }],
-        },
-      });
-      const config: ToolLoopHarnessConfig = {
-        mode: "conversation",
-        resolveModel: vi.fn().mockResolvedValue("anthropic/claude-opus-4.7"),
-        tools: new Map([
-          [
-            "web_search",
-            {
-              description: "Web search.",
-              inputSchema: jsonSchema({}),
-              name: "web_search",
-            },
-          ],
-        ]),
-      };
-      const runStep = createToolLoopHarness(config);
-      await runStep(session, { message: "hi" });
-
-      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
-      const prepareStep = getPrepareStep<unknown[], { providerOptions?: unknown }>(
-        agentCall?.prepareStep,
-      );
-      const stepResult = await prepareStep({
-        messages: [],
-        stepNumber: 0,
-        steps: [],
-        model: null,
-        context: undefined,
-      });
-      expect(stepResult.providerOptions).toEqual({
-        gateway: { caching: "auto", only: ["anthropic"] },
-      });
+  it("does not pin gateway routing when web_search is enabled", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "ok", role: "assistant" }] },
+      text: "ok",
+      toolCalls: [],
+      toolResults: [],
     });
-
-    it("does not pin when the step has no provider-specific tool in play", async () => {
-      setupStopResult();
-      const session = createTestSession({
-        agent: {
-          modelReference: { id: "anthropic/claude-opus-4.7" },
-          system: "",
-          tools: [{ description: "Adds numbers", name: "add", inputSchema: { type: "object" } }],
-        },
-      });
-      const config: ToolLoopHarnessConfig = {
-        mode: "conversation",
-        resolveModel: vi.fn().mockResolvedValue("anthropic/claude-opus-4.7"),
-        tools: new Map([
-          [
-            "add",
-            {
-              description: "Adds numbers",
-              execute: vi.fn(),
-              inputSchema: jsonSchema({ type: "object" }),
-              name: "add",
-            },
-          ],
-        ]),
-      };
-      const runStep = createToolLoopHarness(config);
-      await runStep(session, { message: "hi" });
-
-      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
-      const prepareStep = getPrepareStep<unknown[], { providerOptions?: unknown }>(
-        agentCall?.prepareStep,
-      );
-      const stepResult = await prepareStep({
-        messages: [],
-        stepNumber: 0,
-        steps: [],
-        model: null,
-        context: undefined,
-      });
-      // Caching hint stays; no `only` pin because no provider-specific
-      // tool is in play.
-      expect(stepResult.providerOptions).toEqual({ gateway: { caching: "auto" } });
+    const session = createTestSession({
+      agent: {
+        modelReference: { id: "anthropic/claude-opus-4.7" },
+        system: "",
+        tools: [{ description: "Web search.", name: "web_search", inputSchema: null }],
+      },
     });
-
-    it("respects an author-supplied gateway.order over the auto pin", async () => {
-      setupStopResult();
-      const session = createTestSession({
-        agent: {
-          modelReference: {
-            id: "anthropic/claude-opus-4.7",
-            providerOptions: { gateway: { order: ["anthropic", "bedrock"] } },
+    const config: ToolLoopHarnessConfig = {
+      mode: "conversation",
+      resolveModel: vi.fn().mockResolvedValue("anthropic/claude-opus-4.7"),
+      tools: new Map([
+        [
+          "web_search",
+          {
+            description: "Web search.",
+            inputSchema: jsonSchema({}),
+            name: "web_search",
           },
-          system: "",
-          tools: [{ description: "Web search.", name: "web_search", inputSchema: null }],
-        },
-      });
-      const config: ToolLoopHarnessConfig = {
-        mode: "conversation",
-        resolveModel: vi.fn().mockResolvedValue("anthropic/claude-opus-4.7"),
-        tools: new Map([
-          [
-            "web_search",
-            {
-              description: "Web search.",
-              inputSchema: jsonSchema({}),
-              name: "web_search",
-            },
-          ],
-        ]),
-      };
-      const runStep = createToolLoopHarness(config);
-      await runStep(session, { message: "hi" });
+        ],
+      ]),
+    };
+    const runStep = createToolLoopHarness(config);
+    await runStep(session, { message: "hi" });
 
-      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
-      const prepareStep = getPrepareStep<unknown[], { providerOptions?: unknown }>(
-        agentCall?.prepareStep,
-      );
-      const stepResult = await prepareStep({
-        messages: [],
-        stepNumber: 0,
-        steps: [],
-        model: null,
-        context: undefined,
-      });
-      // `order` was preserved; no `only` was added.
-      expect(stepResult.providerOptions).toEqual({
-        gateway: { caching: "auto", order: ["anthropic", "bedrock"] },
-      });
+    const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
+    const prepareStep = getPrepareStep<unknown[], { providerOptions?: unknown }>(
+      agentCall?.prepareStep,
+    );
+    const stepResult = await prepareStep({
+      messages: [],
+      stepNumber: 0,
+      steps: [],
+      model: null,
+      context: undefined,
     });
+    expect(stepResult.providerOptions).toEqual({ gateway: { caching: "auto" } });
   });
 
   it("emits assistant/tool events in response order when a step completes after tool work", async () => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3923,6 +3923,7 @@ describe("createToolLoopHarness", () => {
             content: [
               {
                 input: { objective: "Search the web." },
+                providerExecuted: true,
                 toolCallId,
                 toolName: "web_search",
                 type: "tool-call",
@@ -3966,24 +3967,31 @@ describe("createToolLoopHarness", () => {
     );
 
     expect(typeof result.next).toBe("function");
-    expect(result.session.history.at(-1)).toEqual({
-      content: [
-        {
-          input: { objective: "Search the web." },
-          providerExecuted: true,
-          toolCallId,
-          toolName: "web_search",
-          type: "tool-call",
-        },
-        {
-          output: { type: "json", value: { results: [], searchId: "search-1" } },
-          toolCallId,
-          toolName: "web_search",
-          type: "tool-result",
-        },
-      ],
-      role: "assistant",
-    });
+    expect(result.session.history.slice(-2)).toEqual([
+      {
+        content: [
+          {
+            input: { objective: "Search the web." },
+            providerExecuted: false,
+            toolCallId,
+            toolName: "web_search",
+            type: "tool-call",
+          },
+        ],
+        role: "assistant",
+      },
+      {
+        content: [
+          {
+            output: { type: "json", value: { results: [], searchId: "search-1" } },
+            toolCallId,
+            toolName: "web_search",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+    ]);
   });
 
   it("emits provider-executed web_search errors through normal failed action results", async () => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3904,6 +3904,65 @@ describe("createToolLoopHarness", () => {
     ).toEqual([]);
   });
 
+  it("continues after a provider-executed web_search returns without assistant text", async () => {
+    const toolCallId = "parallel_search_1";
+    setupMockAgent({
+      content: [
+        {
+          output: { results: [], searchId: "search-1" },
+          providerExecuted: true,
+          toolCallId,
+          toolName: "web_search",
+          type: "tool-result",
+        },
+      ],
+      finishReason: "stop",
+      response: {
+        messages: [
+          {
+            content: [
+              {
+                output: { type: "json", value: { results: [], searchId: "search-1" } },
+                toolCallId,
+                toolName: "web_search",
+                type: "tool-result",
+              },
+            ],
+            role: "assistant",
+          },
+        ],
+      },
+      text: "",
+      toolCalls: [],
+      toolResults: [
+        {
+          output: { results: [], searchId: "search-1" },
+          providerExecuted: true,
+          toolCallId,
+          toolName: "web_search",
+          type: "tool-result",
+        },
+      ],
+    });
+
+    const harness = createToolLoopHarness(
+      createTestConfig("conversation", undefined, { tools: new Map() }),
+    );
+    const result = await harness(
+      createTestSession({
+        agent: {
+          modelReference: { id: "openai/gpt-5.5" },
+          system: "You are a test assistant.",
+          tools: [{ description: "Search the web", name: "web_search", inputSchema: null }],
+        },
+      }),
+      { message: "Search the web." },
+    );
+
+    expect(typeof result.next).toBe("function");
+    expect(result.session.history.at(-1)?.role).toBe("assistant");
+  });
+
   it("emits provider-executed web_search errors through normal failed action results", async () => {
     const toolCallId = "srvtoolu_error";
     setupMockAgent({

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3922,10 +3922,10 @@ describe("createToolLoopHarness", () => {
           {
             content: [
               {
-                output: { type: "json", value: { results: [], searchId: "search-1" } },
+                input: { objective: "Search the web." },
                 toolCallId,
                 toolName: "web_search",
-                type: "tool-result",
+                type: "tool-call",
               },
             ],
             role: "assistant",
@@ -3960,7 +3960,7 @@ describe("createToolLoopHarness", () => {
     );
 
     expect(typeof result.next).toBe("function");
-    expect(result.session.history.at(-1)?.role).toBe("assistant");
+    expect(result.session.history.at(-1)?.role).toBe("tool");
   });
 
   it("emits provider-executed web_search errors through normal failed action results", async () => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3927,6 +3927,12 @@ describe("createToolLoopHarness", () => {
                 toolName: "web_search",
                 type: "tool-call",
               },
+              {
+                output: { type: "json", value: { results: [], searchId: "search-1" } },
+                toolCallId,
+                toolName: "web_search",
+                type: "tool-result",
+              },
             ],
             role: "assistant",
           },
@@ -3960,7 +3966,24 @@ describe("createToolLoopHarness", () => {
     );
 
     expect(typeof result.next).toBe("function");
-    expect(result.session.history.at(-1)?.role).toBe("tool");
+    expect(result.session.history.at(-1)).toEqual({
+      content: [
+        {
+          input: { objective: "Search the web." },
+          providerExecuted: true,
+          toolCallId,
+          toolName: "web_search",
+          type: "tool-call",
+        },
+        {
+          output: { type: "json", value: { results: [], searchId: "search-1" } },
+          toolCallId,
+          toolName: "web_search",
+          type: "tool-result",
+        },
+      ],
+      role: "assistant",
+    });
   });
 
   it("emits provider-executed web_search errors through normal failed action results", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -41,7 +41,6 @@ import type { InstrumentationDefinition } from "#public/instrumentation/index.js
 import { ASK_QUESTION_TOOL_NAME } from "#runtime/framework-tools/ask-question.js";
 import { isCodeModeRuntimeActionInterrupt } from "#harness/code-mode-runtime-action-state.js";
 import { isCodeModeConnectionAuthInterrupt } from "#runtime/framework-tools/code-mode-connection-auth.js";
-import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
 import type { InputRequest } from "#runtime/input/types.js";
 import {
   hydrateSandboxAttachments,
@@ -123,13 +122,8 @@ import {
   applySystemCacheBreakpoint,
   detectPromptCachePath,
   getAnthropicCacheMarker,
-  type PromptCachePath,
 } from "#harness/prompt-cache.js";
-import {
-  resolveFrameworkToolFromUpstreamType,
-  resolveGatewayPinForWebSearchBackend,
-  resolveWebSearchBackend,
-} from "#harness/provider-tools.js";
+import { resolveFrameworkToolFromUpstreamType } from "#harness/provider-tools.js";
 import {
   createRuntimeActionRequestFromToolCall,
   resolvePendingRuntimeActions,
@@ -237,41 +231,6 @@ function enrichTelemetry(
     recordInputs: authored.recordInputs ?? true,
     recordOutputs: authored.recordOutputs ?? true,
   };
-}
-
-/**
- * Resolves the gateway provider slug to pin via
- * `providerOptions.gateway.only` for one harness step, or `undefined`
- * when no pin is needed.
- *
- * A pin is added when all of:
- * 1. The model is gateway-routed (the `gateway-auto` cache path —
- *    matches the existing `gateway.caching` hint condition).
- * 2. The effective toolset includes a framework provider tool whose
- *    backend pins to one provider (e.g. `web_search` on Anthropic).
- *
- * The author keeps the final say via `providerOptions.gateway.only` or
- * `.order` on their model reference — those overrides flow through
- * {@link mergeGatewayProviderPin} which is a no-op when either field is
- * already set.
- */
-function resolveGatewayPinForStep(input: {
-  readonly cachePath: PromptCachePath;
-  readonly modelReference: HarnessSession["agent"]["modelReference"];
-  readonly tools: ToolSet;
-}): string | undefined {
-  if (input.cachePath.kind !== "gateway-auto") {
-    return undefined;
-  }
-  if (input.tools[WEB_SEARCH_TOOL_DEFINITION.name] === undefined) {
-    return undefined;
-  }
-  const backend = resolveWebSearchBackend(input.modelReference);
-  if (backend === null) {
-    return undefined;
-  }
-  const pin = resolveGatewayPinForWebSearchBackend(backend);
-  return pin ?? undefined;
 }
 
 /**
@@ -688,24 +647,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       const effectiveTools = marker ? applyLastToolCacheBreakpoint(modelTools, marker) : modelTools;
 
-      // Pin gateway routing to the provider that owns any
-      // provider-specific tool in this step's toolset. Converts a
-      // transient primary outage into a retryable 503 instead of
-      // routing to an incompatible fallback provider. Skipped on the
-      // recovery retry because the offending tool was dropped — any
-      // provider can serve the request now.
-      const gatewayPinProvider = resolveGatewayPinForStep({
-        cachePath,
-        modelReference: session.agent.modelReference,
-        tools: effectiveTools,
-      });
-
       const hooks = buildStepHooks({
         cachePath,
         emit,
         emissionState,
         emitStepStarted: opts.suppressStepStartedEmission !== true,
-        gatewayPinProvider,
         marker,
         session,
       });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1514,10 +1514,15 @@ async function handleStepResult(input: {
   // dangling tool_use the next provider call rejects, and drop the result.
   const calledFinalOutput =
     nextSession.outputSchema !== undefined && extractFinalOutput(result) !== undefined;
+  const hasProviderExecutedToolResult = (result.toolResults ?? []).some(
+    (toolResult) => toolResult.providerExecuted === true,
+  );
 
   const continueLoop =
     !calledFinalOutput &&
-    (responseMessages.at(-1)?.role === "tool" || hasDeferredStepInput(nextSession));
+    (responseMessages.at(-1)?.role === "tool" ||
+      hasDeferredStepInput(nextSession) ||
+      (stepOutput === null && hasProviderExecutedToolResult));
   if (continueLoop) {
     if (emit) {
       emissionState = advanceStep(emissionState);

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1506,23 +1506,23 @@ async function handleStepResult(input: {
   // so the prompt prefix stays stable and the provider's prompt cache keeps
   // hitting across steps. Compaction is the sole mechanism that ever rewrites
   // history, and it runs before the model call (see `maybeCompact`).
-  const hasProviderExecutedToolResult = (result.toolResults ?? []).some(
-    (toolResult) => toolResult.providerExecuted === true,
+  const providerExecutedToolCallIds = new Set(
+    (result.toolResults ?? [])
+      .filter((toolResult) => toolResult.providerExecuted === true)
+      .map((toolResult) => toolResult.toolCallId),
   );
-  const continuationMessages: ModelMessage[] = [...responseMessages];
-  if (stepOutput === null && hasProviderExecutedToolResult) {
-    continuationMessages.push({
-      role: "tool",
-      content: (result.toolResults ?? [])
-        .filter((toolResult) => toolResult.providerExecuted === true)
-        .map((toolResult) => ({
-          type: "tool-result" as const,
-          toolCallId: toolResult.toolCallId,
-          toolName: toolResult.toolName,
-          output: { type: "json" as const, value: toolResult.output },
-        })),
-    });
-  }
+  const continuationMessages: ModelMessage[] = responseMessages.map((message) =>
+    message.role === "assistant" && Array.isArray(message.content)
+      ? {
+          ...message,
+          content: message.content.map((part) =>
+            part.type === "tool-call" && providerExecutedToolCallIds.has(part.toolCallId)
+              ? { ...part, providerExecuted: true }
+              : part,
+          ),
+        }
+      : message,
+  );
   const updatedHistory: ModelMessage[] = [...promptMessages, ...continuationMessages];
   let nextSession: HarnessSession = { ...baseSession, history: updatedHistory };
 
@@ -1534,7 +1534,9 @@ async function handleStepResult(input: {
 
   const continueLoop =
     !calledFinalOutput &&
-    (continuationMessages.at(-1)?.role === "tool" || hasDeferredStepInput(nextSession));
+    (continuationMessages.at(-1)?.role === "tool" ||
+      hasDeferredStepInput(nextSession) ||
+      (stepOutput === null && providerExecutedToolCallIds.size > 0));
   if (continueLoop) {
     if (emit) {
       emissionState = advanceStep(emissionState);

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1506,7 +1506,24 @@ async function handleStepResult(input: {
   // so the prompt prefix stays stable and the provider's prompt cache keeps
   // hitting across steps. Compaction is the sole mechanism that ever rewrites
   // history, and it runs before the model call (see `maybeCompact`).
-  const updatedHistory: ModelMessage[] = [...promptMessages, ...responseMessages];
+  const hasProviderExecutedToolResult = (result.toolResults ?? []).some(
+    (toolResult) => toolResult.providerExecuted === true,
+  );
+  const continuationMessages: ModelMessage[] = [...responseMessages];
+  if (stepOutput === null && hasProviderExecutedToolResult) {
+    continuationMessages.push({
+      role: "tool",
+      content: (result.toolResults ?? [])
+        .filter((toolResult) => toolResult.providerExecuted === true)
+        .map((toolResult) => ({
+          type: "tool-result" as const,
+          toolCallId: toolResult.toolCallId,
+          toolName: toolResult.toolName,
+          output: { type: "json" as const, value: toolResult.output },
+        })),
+    });
+  }
+  const updatedHistory: ModelMessage[] = [...promptMessages, ...continuationMessages];
   let nextSession: HarnessSession = { ...baseSession, history: updatedHistory };
 
   // A `final_output` call is terminal even when the model emits it alongside
@@ -1514,15 +1531,10 @@ async function handleStepResult(input: {
   // dangling tool_use the next provider call rejects, and drop the result.
   const calledFinalOutput =
     nextSession.outputSchema !== undefined && extractFinalOutput(result) !== undefined;
-  const hasProviderExecutedToolResult = (result.toolResults ?? []).some(
-    (toolResult) => toolResult.providerExecuted === true,
-  );
 
   const continueLoop =
     !calledFinalOutput &&
-    (responseMessages.at(-1)?.role === "tool" ||
-      hasDeferredStepInput(nextSession) ||
-      (stepOutput === null && hasProviderExecutedToolResult));
+    (continuationMessages.at(-1)?.role === "tool" || hasDeferredStepInput(nextSession));
   if (continueLoop) {
     if (emit) {
       emissionState = advanceStep(emissionState);

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -10,6 +10,7 @@ import {
   type ModelMessage,
   type SystemModelMessage,
   type TelemetryOptions,
+  type ToolModelMessage,
   ToolLoopAgent,
   type ToolSet,
   type TypedToolCall,
@@ -1507,22 +1508,32 @@ async function handleStepResult(input: {
   // hitting across steps. Compaction is the sole mechanism that ever rewrites
   // history, and it runs before the model call (see `maybeCompact`).
   const providerExecutedToolCallIds = new Set(
-    (result.toolResults ?? [])
+    (stepOutput === null ? (result.toolResults ?? []) : [])
       .filter((toolResult) => toolResult.providerExecuted === true)
       .map((toolResult) => toolResult.toolCallId),
   );
+  const providerExecutedToolResults: ToolModelMessage["content"] = [];
   const continuationMessages: ModelMessage[] = responseMessages.map((message) =>
     message.role === "assistant" && Array.isArray(message.content)
       ? {
           ...message,
-          content: message.content.map((part) =>
-            part.type === "tool-call" && providerExecutedToolCallIds.has(part.toolCallId)
-              ? { ...part, providerExecuted: true }
-              : part,
-          ),
+          content: message.content.flatMap((part) => {
+            if (part.type === "tool-result" && providerExecutedToolCallIds.has(part.toolCallId)) {
+              providerExecutedToolResults.push(part);
+              return [];
+            }
+            return [
+              part.type === "tool-call" && providerExecutedToolCallIds.has(part.toolCallId)
+                ? { ...part, providerExecuted: false }
+                : part,
+            ];
+          }),
         }
       : message,
   );
+  if (providerExecutedToolResults.length > 0) {
+    continuationMessages.push({ role: "tool", content: providerExecutedToolResults });
+  }
   const updatedHistory: ModelMessage[] = [...promptMessages, ...continuationMessages];
   let nextSession: HarnessSession = { ...baseSession, history: updatedHistory };
 
@@ -1534,9 +1545,7 @@ async function handleStepResult(input: {
 
   const continueLoop =
     !calledFinalOutput &&
-    (continuationMessages.at(-1)?.role === "tool" ||
-      hasDeferredStepInput(nextSession) ||
-      (stepOutput === null && providerExecutedToolCallIds.size > 0));
+    (continuationMessages.at(-1)?.role === "tool" || hasDeferredStepInput(nextSession));
   if (continueLoop) {
     if (emit) {
       emissionState = advanceStep(emissionState);

--- a/packages/eve/src/harness/tools.test.ts
+++ b/packages/eve/src/harness/tools.test.ts
@@ -5,9 +5,9 @@ import { always, never, once } from "#public/tools/approval/approval-helpers.js"
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import {
   WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA,
-  WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA,
   WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA,
   WEB_SEARCH_OPENAI_OUTPUT_SCHEMA,
+  WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA,
 } from "#runtime/framework-tools/web-search.js";
 import type { JsonObject } from "#shared/json.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
@@ -126,8 +126,32 @@ describe("buildToolSet", () => {
   });
 
   it.each([
-    [{ id: "openai/gpt-5.4" }, WEB_SEARCH_OPENAI_OUTPUT_SCHEMA],
-    [{ id: "anthropic/claude-opus-4.6" }, WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA],
+    [{ id: "openai/gpt-5.4" }, WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA],
+    [{ id: "anthropic/claude-opus-4.6" }, WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA],
+    [
+      {
+        id: "openai.chat/gpt-5.4",
+        source: {
+          exportName: "model",
+          logicalPath: "agent.ts",
+          sourceId: "agent.ts",
+          sourceKind: "module",
+        },
+      },
+      WEB_SEARCH_OPENAI_OUTPUT_SCHEMA,
+    ],
+    [
+      {
+        id: "anthropic.messages/claude-opus-4.6",
+        source: {
+          exportName: "model",
+          logicalPath: "agent.ts",
+          sourceId: "agent.ts",
+          sourceKind: "module",
+        },
+      },
+      WEB_SEARCH_ANTHROPIC_OUTPUT_SCHEMA,
+    ],
     [
       {
         id: "google.generative-ai/gemini-3.1-pro",
@@ -140,7 +164,7 @@ describe("buildToolSet", () => {
       },
       WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA,
     ],
-    [{ id: "mistral/mistral-large" }, WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA],
+    [{ id: "mistral/mistral-large" }, WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA],
   ] satisfies Array<readonly [RuntimeModelReference, JsonObject]>)(
     "injects the selected web_search provider output schema",
     async (modelReference, expectedOutputSchema) => {

--- a/packages/eve/src/runtime/framework-tools/web-search.ts
+++ b/packages/eve/src/runtime/framework-tools/web-search.ts
@@ -132,39 +132,48 @@ export const WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA: JsonObject = {
 };
 
 /**
- * Output schema for AI Gateway's provider-managed `perplexitySearch` tool.
+ * Output schema for AI Gateway's provider-managed `parallelSearch` tool.
  */
-export const WEB_SEARCH_GATEWAY_OUTPUT_SCHEMA: JsonObject = {
+export const WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA: JsonObject = {
   $schema: "http://json-schema.org/draft-07/schema#",
   anyOf: [
     {
       additionalProperties: false,
       properties: {
-        id: { type: "string" },
         results: {
           items: {
             additionalProperties: false,
             properties: {
-              date: { type: "string" },
-              lastUpdated: { type: "string" },
-              snippet: { type: "string" },
+              excerpt: { type: "string" },
+              publishDate: {
+                anyOf: [{ type: "string" }, { type: "null" }],
+              },
+              relevanceScore: { type: "number" },
               title: { type: "string" },
               url: { type: "string" },
             },
-            required: ["title", "url", "snippet"],
+            required: ["url", "title", "excerpt"],
             type: "object",
           },
           type: "array",
         },
+        searchId: { type: "string" },
       },
-      required: ["results", "id"],
+      required: ["searchId", "results"],
       type: "object",
     },
     {
       additionalProperties: false,
       properties: {
         error: {
-          enum: ["api_error", "rate_limit", "timeout", "invalid_input", "unknown"],
+          enum: [
+            "api_error",
+            "rate_limit",
+            "timeout",
+            "invalid_input",
+            "configuration_error",
+            "unknown",
+          ],
           type: "string",
         },
         message: { type: "string" },


### PR DESCRIPTION
## Summary

- route the built-in `web_search` tool through Parallel for every Vercel AI Gateway string model
- remove automatic gateway provider pinning for provider-specific search tools
- add a CI eval that asks “Who won the 2026 NBA finals” and judges the response against the New York Knicks

## Validation

- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:scenario`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `pnpm guard:invariants`
- `pnpm build`
- `pnpm --dir e2e/fixtures/agent-tools exec tsc`

The final eval was not run locally; it is intentionally left for CI with the required gateway credentials.