### PR TITLE
feat(eve): github channel - dispatch CI webhook events

### DIFF
--- a/.changeset/curvy-checks-dispatch.md
+++ b/.changeset/curvy-checks-dispatch.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add opt-in GitHub channel hooks for check suite, check run, and workflow run webhooks, with normalized CI metadata and pull request dispatch.

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -32,7 +32,7 @@ GITHUB_APP_SLUG=...          # supplies botName when it is not set in config
 
 `appId`/`privateKey`/`webhookSecret` also take a lazy resolver function if you'd rather fetch them on demand.
 
-Point the GitHub App webhook URL at `https://<deployment>/eve/v1/github`. For mention-driven turns, subscribe to `issue_comment` and `pull_request_review_comment`; add `issues` / `pull_request` if you wire up their opt-in hooks. A comment that `@mention`s `botName` starts a turn.
+Point the GitHub App webhook URL at `https://<deployment>/eve/v1/github`. For mention-driven turns, subscribe to `issue_comment` and `pull_request_review_comment`; add `issues`, `pull_request`, `check_suite`, `check_run`, or `workflow_run` if you wire up their opt-in hooks. A comment that `@mention`s `botName` starts a turn.
 
 ## How the channel handles messages
 
@@ -50,8 +50,20 @@ export default githubChannel({
   // Opt in; no default dispatch on these events.
   onIssue: (ctx, issue) => (issue.action === "opened" ? { auth: defaultGitHubAuth(ctx) } : null),
   onPullRequest: (ctx, pr) => (pr.action === "opened" ? { auth: defaultGitHubAuth(ctx) } : null),
+  onCheckSuite: (ctx, suite) =>
+    suite.action === "completed" &&
+    suite.conclusion === "failure" &&
+    suite.app.slug === "github-actions" &&
+    suite.pullRequests.length > 0
+      ? {
+          auth: defaultGitHubAuth(ctx),
+          context: [`Triage failed check suite ${suite.checkSuiteId} at ${suite.headSha}.`],
+        }
+      : null,
 });
 ```
+
+The CI hooks expose normalized `action`, `status`, `conclusion`, `app.slug`, `headSha`, and `pullRequests` fields, plus `checkSuiteId`, `checkRunId`, or `workflowRunId`. `workflow_run` is a GitHub Actions-only event, so its normalized `app.slug` is `"github-actions"`. A dispatched CI turn is anchored to the first number in `pullRequests`; the hook still runs when the array is empty, but it must return `null` because there is no issue or PR thread for the session.
 
 ### Delivery
 

--- a/packages/eve/src/internal/testing/scenario-apps/github-route-portability.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/github-route-portability.ts
@@ -2,10 +2,20 @@ import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
 
 export const GITHUB_ROUTE_PORTABILITY_DESCRIPTOR: ScenarioAppDescriptor = {
   files: {
-    "agent/channels/github.ts": `import { githubChannel } from "eve/channels/github";
+    "agent/channels/github.ts": `import {
+  githubChannel,
+  type GitHubCheckRunEvent,
+  type GitHubCheckSuiteEvent,
+  type GitHubWorkflowRunEvent,
+} from "eve/channels/github";
+
+const ignore = <T>(_event: T): null => null;
 
 export default githubChannel({
   botName: "testbot",
+  onCheckRun: (_ctx, checkRun) => ignore<GitHubCheckRunEvent>(checkRun),
+  onCheckSuite: (_ctx, checkSuite) => ignore<GitHubCheckSuiteEvent>(checkSuite),
+  onWorkflowRun: (_ctx, workflowRun) => ignore<GitHubWorkflowRunEvent>(workflowRun),
 });
 `,
   },

--- a/packages/eve/src/public/channels/github/dispatch.ts
+++ b/packages/eve/src/public/channels/github/dispatch.ts
@@ -6,6 +6,10 @@ import {
   extractGitHubCommentTrigger,
   formatGitHubContextBlock,
   prependGitHubContext,
+  type GitHubCheckRunWebhookEvent,
+  type GitHubCheckSuiteWebhookEvent,
+  type GitHubCiPayload,
+  type GitHubCiWebhookEvent,
   type GitHubComment,
   type GitHubIssueComment,
   type GitHubIssueCommentEvent,
@@ -14,6 +18,7 @@ import {
   type GitHubPullRequestReviewCommentEvent,
   type GitHubPullRequestWebhookEvent,
   type GitHubUser,
+  type GitHubWorkflowRunWebhookEvent,
 } from "#public/channels/github/inbound.js";
 import {
   buildGitHubPullRequestContext,
@@ -21,6 +26,7 @@ import {
 } from "#public/channels/github/pr-context.js";
 import {
   continuationTokenFromState,
+  stateFromCiEvent,
   stateFromIssueCommentEvent,
   stateFromIssueEvent,
   stateFromPullRequestEvent,
@@ -38,6 +44,7 @@ import type { SendFn } from "#public/definitions/defineChannel.js";
 const log = createLogger("github.dispatch");
 
 type GitHubTurnEvent =
+  | GitHubCiWebhookEvent
   | GitHubIssueCommentEvent
   | GitHubIssueWebhookEvent
   | GitHubPullRequestReviewCommentEvent
@@ -131,9 +138,88 @@ export async function dispatchPullRequest(input: {
   });
 }
 
+/** Dispatches an opt-in check-suite webhook event into the runtime. */
+export async function dispatchCheckSuite(input: {
+  readonly config: GitHubChannelConfig;
+  readonly event: GitHubCheckSuiteWebhookEvent;
+  readonly handler: NonNullable<GitHubChannelConfig["onCheckSuite"]>;
+  readonly send: SendFn<GitHubChannelState>;
+}): Promise<void> {
+  await dispatchCiEvent({
+    ...input,
+    ci: input.event.checkSuite,
+    handlerResult: (ctx) => input.handler(ctx, input.event.checkSuite),
+    label: "Check suite",
+  });
+}
+
+/** Dispatches an opt-in check-run webhook event into the runtime. */
+export async function dispatchCheckRun(input: {
+  readonly config: GitHubChannelConfig;
+  readonly event: GitHubCheckRunWebhookEvent;
+  readonly handler: NonNullable<GitHubChannelConfig["onCheckRun"]>;
+  readonly send: SendFn<GitHubChannelState>;
+}): Promise<void> {
+  await dispatchCiEvent({
+    ...input,
+    ci: input.event.checkRun,
+    handlerResult: (ctx) => input.handler(ctx, input.event.checkRun),
+    label: "Check run",
+  });
+}
+
+/** Dispatches an opt-in workflow-run webhook event into the runtime. */
+export async function dispatchWorkflowRun(input: {
+  readonly config: GitHubChannelConfig;
+  readonly event: GitHubWorkflowRunWebhookEvent;
+  readonly handler: NonNullable<GitHubChannelConfig["onWorkflowRun"]>;
+  readonly send: SendFn<GitHubChannelState>;
+}): Promise<void> {
+  await dispatchCiEvent({
+    ...input,
+    ci: input.event.workflowRun,
+    handlerResult: (ctx) => input.handler(ctx, input.event.workflowRun),
+    label: "Workflow run",
+  });
+}
+
+async function dispatchCiEvent(input: {
+  readonly ci: GitHubCiPayload;
+  readonly config: GitHubChannelConfig;
+  readonly event: GitHubCiWebhookEvent;
+  readonly handlerResult: (ctx: GitHubInboundContext) => GitHubInboundResultOrPromise;
+  readonly label: string;
+  readonly send: SendFn<GitHubChannelState>;
+}): Promise<void> {
+  const state = stateFromCiEvent(input.event);
+  const ctx = buildInboundContext(input.config, input.event);
+  if (state.pullRequestNumber === null) {
+    const result = await runInboundHandler({
+      event: input.event,
+      handlerResult: () => input.handlerResult(ctx),
+    });
+    if (result !== null && result !== undefined) {
+      log.warn("GitHub CI event cannot dispatch without an associated pull request", {
+        deliveryId: input.event.delivery.id,
+        event: input.event.kind,
+      });
+    }
+    return;
+  }
+
+  await dispatchWebhookEventTurn({
+    config: input.config,
+    event: input.event,
+    handlerResult: () => input.handlerResult(ctx),
+    message: formatCiEventMessage(input.label, input.ci),
+    send: input.send,
+    state,
+  });
+}
+
 async function dispatchWebhookEventTurn(input: {
   readonly config: GitHubChannelConfig;
-  readonly event: GitHubIssueWebhookEvent | GitHubPullRequestWebhookEvent;
+  readonly event: GitHubCiWebhookEvent | GitHubIssueWebhookEvent | GitHubPullRequestWebhookEvent;
   readonly handlerResult: () => GitHubInboundResultOrPromise;
   readonly message: string;
   readonly send: SendFn<GitHubChannelState>;
@@ -274,19 +360,22 @@ async function buildPullRequestContext(
 function buildInboundContext(
   config: GitHubChannelConfig,
   event:
+    | GitHubCiWebhookEvent
     | GitHubIssueCommentEvent
     | GitHubIssueWebhookEvent
     | GitHubPullRequestWebhookEvent
     | GitHubPullRequestReviewCommentEvent,
 ): GitHubInboundContext {
   const state =
-    event.kind === "issue_comment"
-      ? stateFromIssueCommentEvent(event)
-      : event.kind === "issues"
-        ? stateFromIssueEvent(event)
-        : event.kind === "pull_request"
-          ? stateFromPullRequestEvent(event)
-          : stateFromPullRequestReviewCommentEvent(event);
+    event.kind === "check_suite" || event.kind === "check_run" || event.kind === "workflow_run"
+      ? stateFromCiEvent(event)
+      : event.kind === "issue_comment"
+        ? stateFromIssueCommentEvent(event)
+        : event.kind === "issues"
+          ? stateFromIssueEvent(event)
+          : event.kind === "pull_request"
+            ? stateFromPullRequestEvent(event)
+            : stateFromPullRequestReviewCommentEvent(event);
   const binding = buildGitHubBinding({ config, state });
   return {
     conversation: event.conversation,
@@ -321,6 +410,17 @@ function formatPullRequestEventMessage(event: GitHubPullRequestWebhookEvent): st
   return `Pull request ${event.pullRequest.action}: #${event.pullRequest.pullRequestNumber}${
     title ? ` ${title}` : ""
   }`;
+}
+
+function formatCiEventMessage(label: string, event: GitHubCiPayload): string {
+  const outcome = event.conclusion ?? event.status;
+  return `${label} ${event.action}: ${ciEventId(event)}${outcome ? ` (${outcome})` : ""}`;
+}
+
+function ciEventId(event: GitHubCiPayload): number {
+  if ("checkSuiteId" in event) return event.checkSuiteId;
+  if ("checkRunId" in event) return event.checkRunId;
+  return event.workflowRunId;
 }
 
 function isIgnoredInboundComment(

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -504,7 +504,124 @@ describe("githubChannel", () => {
     });
   });
 
-  it("ignores issue and pull request webhooks without opt-in hooks", async () => {
+  it.each([
+    { event: "check_suite", label: "Check suite", object: "check_suite" },
+    { event: "check_run", label: "Check run", object: "check_run" },
+    { event: "workflow_run", label: "Workflow run", object: "workflow_run" },
+  ])("dispatches opt-in $event webhook hooks on the first associated PR", async (testCase) => {
+    const hook = vi.fn();
+    const commonConfig = {
+      api: { apiBaseUrl: "https://github.test", fetch: prContextFetch() },
+      credentials: { appId: "test-app", webhookSecret: SECRET },
+    };
+    const channel =
+      testCase.event === "check_suite"
+        ? githubChannel({
+            ...commonConfig,
+            onCheckSuite(ctx, checkSuite) {
+              hook(ctx.conversation, checkSuite);
+              return { auth: defaultGitHubAuth(ctx) };
+            },
+          })
+        : testCase.event === "check_run"
+          ? githubChannel({
+              ...commonConfig,
+              onCheckRun(ctx, checkRun) {
+                hook(ctx.conversation, checkRun);
+                return { auth: defaultGitHubAuth(ctx) };
+              },
+            })
+          : githubChannel({
+              ...commonConfig,
+              onWorkflowRun(ctx, workflowRun) {
+                hook(ctx.conversation, workflowRun);
+                return { auth: defaultGitHubAuth(ctx) };
+              },
+            });
+    const headSha = "c".repeat(40);
+    const ciPayload: Record<string, unknown> = {
+      conclusion: "failure",
+      head_sha: headSha,
+      id: 9001,
+      pull_requests: [{ number: 7 }, { number: 9 }],
+      status: "completed",
+    };
+    if (testCase.event !== "workflow_run") {
+      ciPayload.app = { slug: "github-actions" };
+    }
+
+    const { send } = await firePost(
+      channel,
+      signedRequest(
+        testCase.event,
+        basePayload({
+          action: "completed",
+          [testCase.object]: ciPayload,
+        }),
+      ),
+    );
+
+    expect(hook).toHaveBeenCalledWith(
+      { issueNumber: null, kind: "pull_request", pullRequestNumber: 7 },
+      expect.objectContaining({
+        action: "completed",
+        app: { slug: "github-actions" },
+        conclusion: "failure",
+        headSha,
+        pullRequests: [7, 9],
+        status: "completed",
+      }),
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+    const [payload, options] = send.mock.calls[0]!;
+    expect(payload.message).toContain(`${testCase.label} completed: 9001 (failure)`);
+    expect(options).toMatchObject({
+      continuationToken: "repo:123:pull:7",
+      state: {
+        conversationKind: "pull_request",
+        headSha,
+        issueNumber: 7,
+        pullRequestNumber: 7,
+      },
+    });
+  });
+
+  it("invokes CI hooks without dispatching when no pull request is associated", async () => {
+    const hook = vi.fn();
+    const channel = githubChannel({
+      credentials: { webhookSecret: SECRET },
+      onCheckSuite(ctx, checkSuite) {
+        hook(ctx.conversation, checkSuite.pullRequests);
+        return { auth: defaultGitHubAuth(ctx) };
+      },
+    });
+
+    const { send } = await firePost(
+      channel,
+      signedRequest(
+        "check_suite",
+        basePayload({
+          action: "completed",
+          check_suite: {
+            app: { slug: "github-actions" },
+            conclusion: "failure",
+            head_sha: "abc123",
+            id: 9001,
+            pull_requests: [],
+            status: "completed",
+          },
+        }),
+      ),
+    );
+
+    expect(hook).toHaveBeenCalledWith(
+      { issueNumber: null, kind: "pull_request", pullRequestNumber: null },
+      [],
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("ignores issue, pull request, and CI webhooks without opt-in hooks", async () => {
     const channel = githubChannel({
       credentials: { webhookSecret: SECRET },
     });
@@ -529,9 +646,31 @@ describe("githubChannel", () => {
         }),
       ),
     );
+    const ciEvents = await Promise.all(
+      ["check_suite", "check_run", "workflow_run"].map((event) =>
+        firePost(
+          channel,
+          signedRequest(
+            event,
+            basePayload({
+              action: "completed",
+              [event]: {
+                app: { slug: "github-actions" },
+                conclusion: "failure",
+                head_sha: "abc123",
+                id: 9001,
+                pull_requests: [{ number: 7 }],
+                status: "completed",
+              },
+            }),
+          ),
+        ),
+      ),
+    );
 
     expect(issue.send).not.toHaveBeenCalled();
     expect(pullRequest.send).not.toHaveBeenCalled();
+    for (const ciEvent of ciEvents) expect(ciEvent.send).not.toHaveBeenCalled();
   });
 
   it("posts final messages through the issue comments API", async () => {

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -16,6 +16,8 @@ import { GITHUB_CHANNEL_DEFAULT_ROUTE } from "#public/channels/github/constants.
 import { createDefaultEvents, defaultOnComment } from "#public/channels/github/defaults.js";
 import {
   parseGitHubWebhookEvent,
+  type GitHubCheckRunEvent,
+  type GitHubCheckSuiteEvent,
   type GitHubComment,
   type GitHubConversationRef,
   type GitHubDelivery,
@@ -24,12 +26,16 @@ import {
   type GitHubPullRequestEvent,
   type GitHubRepositoryRef,
   type GitHubUser,
+  type GitHubWorkflowRunEvent,
 } from "#public/channels/github/inbound.js";
 import {
+  dispatchCheckRun,
+  dispatchCheckSuite,
   dispatchIssue,
   dispatchIssueComment,
   dispatchPullRequest,
   dispatchPullRequestReviewComment,
+  dispatchWorkflowRun,
 } from "#public/channels/github/dispatch.js";
 import {
   continuationTokenFromState,
@@ -101,8 +107,8 @@ export type GitHubInboundResult = {
 } | null;
 
 /**
- * Return type of the `onComment`/`onIssue`/`onPullRequest` hooks: a
- * {@link GitHubInboundResult} or a promise for one.
+ * Return type of GitHub inbound hooks: a {@link GitHubInboundResult} or a
+ * promise for one.
  */
 export type GitHubInboundResultOrPromise = GitHubInboundResult | Promise<GitHubInboundResult>;
 
@@ -159,6 +165,26 @@ export interface GitHubChannelConfig {
   onComment?(ctx: GitHubInboundContext, comment: GitHubComment): GitHubInboundResultOrPromise;
 
   /**
+   * Opt-in handler for `check_suite` webhook events. There is no default
+   * dispatch. A dispatched turn is anchored to the first associated pull
+   * request.
+   */
+  onCheckSuite?(
+    ctx: GitHubInboundContext,
+    checkSuite: GitHubCheckSuiteEvent,
+  ): GitHubInboundResultOrPromise;
+
+  /**
+   * Opt-in handler for `check_run` webhook events. There is no default
+   * dispatch. A dispatched turn is anchored to the first associated pull
+   * request.
+   */
+  onCheckRun?(
+    ctx: GitHubInboundContext,
+    checkRun: GitHubCheckRunEvent,
+  ): GitHubInboundResultOrPromise;
+
+  /**
    * Opt-in handler for `issues` webhook events. There is no default dispatch;
    * define this to act on issues (e.g. `issue.action === "opened"`).
    */
@@ -171,6 +197,16 @@ export interface GitHubChannelConfig {
   onPullRequest?(
     ctx: GitHubInboundContext,
     pullRequest: GitHubPullRequestEvent,
+  ): GitHubInboundResultOrPromise;
+
+  /**
+   * Opt-in handler for `workflow_run` webhook events. There is no default
+   * dispatch. A dispatched turn is anchored to the first associated pull
+   * request.
+   */
+  onWorkflowRun?(
+    ctx: GitHubInboundContext,
+    workflowRun: GitHubWorkflowRunEvent,
   ): GitHubInboundResultOrPromise;
 }
 
@@ -268,6 +304,42 @@ export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
                 config,
                 event,
                 handler: config.onPullRequest,
+                send,
+              }),
+            );
+            return jsonOk({ ok: true });
+          }
+
+          if (event.kind === "check_suite" && config.onCheckSuite !== undefined) {
+            waitUntil(
+              dispatchCheckSuite({
+                config,
+                event,
+                handler: config.onCheckSuite,
+                send,
+              }),
+            );
+            return jsonOk({ ok: true });
+          }
+
+          if (event.kind === "check_run" && config.onCheckRun !== undefined) {
+            waitUntil(
+              dispatchCheckRun({
+                config,
+                event,
+                handler: config.onCheckRun,
+                send,
+              }),
+            );
+            return jsonOk({ ok: true });
+          }
+
+          if (event.kind === "workflow_run" && config.onWorkflowRun !== undefined) {
+            waitUntil(
+              dispatchWorkflowRun({
+                config,
+                event,
+                handler: config.onWorkflowRun,
                 send,
               }),
             );

--- a/packages/eve/src/public/channels/github/inbound.test.ts
+++ b/packages/eve/src/public/channels/github/inbound.test.ts
@@ -138,6 +138,78 @@ describe("GitHub inbound parsing", () => {
     });
   });
 
+  it.each([
+    {
+      event: "check_suite",
+      idField: "checkSuiteId",
+      object: "check_suite",
+    },
+    {
+      event: "check_run",
+      idField: "checkRunId",
+      object: "check_run",
+    },
+  ])("normalizes $event webhook payloads", ({ event, idField, object }) => {
+    const parsed = parse(
+      event,
+      basePayload({
+        action: "completed",
+        [object]: {
+          app: { slug: "github-actions" },
+          conclusion: "failure",
+          head_sha: "abc123",
+          id: 9001,
+          pull_requests: [{ number: 7 }, { number: 9 }],
+          status: "completed",
+        },
+      }),
+    );
+
+    expect(parsed).toMatchObject({
+      [object === "check_suite" ? "checkSuite" : "checkRun"]: {
+        action: "completed",
+        app: { slug: "github-actions" },
+        conclusion: "failure",
+        headSha: "abc123",
+        [idField]: 9001,
+        pullRequests: [7, 9],
+        status: "completed",
+      },
+      conversation: { kind: "pull_request", pullRequestNumber: 7 },
+      kind: event,
+    });
+  });
+
+  it("normalizes workflow_run payloads with the GitHub Actions app identity", () => {
+    const event = parse(
+      "workflow_run",
+      basePayload({
+        action: "completed",
+        workflow_run: {
+          conclusion: "failure",
+          head_sha: "abc123",
+          id: 9001,
+          pull_requests: [{ number: 7 }],
+          status: "completed",
+        },
+      }),
+    );
+
+    expect(event).toMatchObject({
+      conversation: { kind: "pull_request", pullRequestNumber: 7 },
+      kind: "workflow_run",
+      workflowRun: {
+        action: "completed",
+        app: { slug: "github-actions" },
+        conclusion: "failure",
+        headSha: "abc123",
+        pullRequests: [7],
+        status: "completed",
+        workflowRunId: 9001,
+      },
+    });
+  });
+
   it("extracts and strips the bot mention from a comment body", () => {
     expect(
       extractGitHubCommentTrigger({

--- a/packages/eve/src/public/channels/github/inbound.ts
+++ b/packages/eve/src/public/channels/github/inbound.ts
@@ -119,6 +119,40 @@ export interface GitHubPullRequestEvent {
   readonly raw: JsonObject;
 }
 
+/** GitHub App identity attached to CI webhook payloads. */
+export interface GitHubAppRef {
+  readonly slug: string | null;
+}
+
+/** Common fields normalized from GitHub CI webhook payloads. */
+export interface GitHubCiEvent {
+  readonly action: string;
+  readonly app: GitHubAppRef;
+  readonly conclusion: string | null;
+  readonly headSha: string | null;
+  readonly pullRequests: readonly number[];
+  readonly raw: JsonObject;
+  readonly status: string | null;
+}
+
+/** Normalized `check_suite` webhook payload. */
+export interface GitHubCheckSuiteEvent extends GitHubCiEvent {
+  readonly checkSuiteId: number;
+}
+
+/** Normalized `check_run` webhook payload. */
+export interface GitHubCheckRunEvent extends GitHubCiEvent {
+  readonly checkRunId: number;
+}
+
+/** Normalized `workflow_run` webhook payload. */
+export interface GitHubWorkflowRunEvent extends GitHubCiEvent {
+  readonly workflowRunId: number;
+}
+
+/** Normalized payload accepted by one of the GitHub CI event hooks. */
+export type GitHubCiPayload = GitHubCheckRunEvent | GitHubCheckSuiteEvent | GitHubWorkflowRunEvent;
+
 export interface GitHubPingEvent extends GitHubInboundEventBase {
   readonly kind: "ping";
 }
@@ -166,6 +200,30 @@ export interface GitHubPullRequestWebhookEvent extends GitHubInboundEventBase {
   readonly pullRequest: GitHubPullRequestEvent;
 }
 
+export interface GitHubCheckSuiteWebhookEvent extends GitHubInboundEventBase {
+  readonly checkSuite: GitHubCheckSuiteEvent;
+  readonly conversation: GitHubConversationRef;
+  readonly kind: "check_suite";
+}
+
+export interface GitHubCheckRunWebhookEvent extends GitHubInboundEventBase {
+  readonly checkRun: GitHubCheckRunEvent;
+  readonly conversation: GitHubConversationRef;
+  readonly kind: "check_run";
+}
+
+export interface GitHubWorkflowRunWebhookEvent extends GitHubInboundEventBase {
+  readonly conversation: GitHubConversationRef;
+  readonly kind: "workflow_run";
+  readonly workflowRun: GitHubWorkflowRunEvent;
+}
+
+/** Parsed CI webhook envelopes consumed by the GitHub channel. */
+export type GitHubCiWebhookEvent =
+  | GitHubCheckRunWebhookEvent
+  | GitHubCheckSuiteWebhookEvent
+  | GitHubWorkflowRunWebhookEvent;
+
 interface GitHubInboundEventBase {
   readonly delivery: GitHubDelivery;
   readonly installationId: number | undefined;
@@ -176,11 +234,14 @@ interface GitHubInboundEventBase {
 
 /** Parsed GitHub webhook event shape consumed by the channel. */
 export type GitHubInboundEvent =
+  | GitHubCheckRunWebhookEvent
+  | GitHubCheckSuiteWebhookEvent
   | GitHubIssueCommentEvent
   | GitHubIssueWebhookEvent
   | GitHubPingEvent
   | GitHubPullRequestReviewCommentEvent
-  | GitHubPullRequestWebhookEvent;
+  | GitHubPullRequestWebhookEvent
+  | GitHubWorkflowRunWebhookEvent;
 
 /** Parsed mention trigger for a bot-directed GitHub comment. */
 export interface GitHubCommentTrigger {
@@ -276,6 +337,9 @@ export function parseGitHubWebhookEvent(input: {
   }
   if (eventName === "issues") return parseIssueEvent(base);
   if (eventName === "pull_request") return parsePullRequestEvent(base);
+  if (eventName === "check_suite") return parseCheckSuiteEvent(base);
+  if (eventName === "check_run") return parseCheckRunEvent(base);
+  if (eventName === "workflow_run") return parseWorkflowRunEvent(base);
   return null;
 }
 
@@ -444,6 +508,93 @@ function parsePullRequestEvent(base: GitHubInboundEventBase): GitHubPullRequestW
       pullRequestNumber,
       raw: parseJsonObject(pullRequest),
     },
+  };
+}
+
+function parseCheckSuiteEvent(base: GitHubInboundEventBase): GitHubCheckSuiteWebhookEvent | null {
+  const rawCheckSuite = readEventObject(base.raw.check_suite);
+  if (rawCheckSuite === null) return null;
+  const checkSuiteId = readId(rawCheckSuite);
+  if (checkSuiteId === null) return null;
+  const checkSuite = normalizeCiEvent(base.raw, rawCheckSuite, normalizeApp(rawCheckSuite.app));
+  return {
+    ...base,
+    checkSuite: { ...checkSuite, checkSuiteId },
+    conversation: ciConversation(checkSuite.pullRequests),
+    kind: "check_suite",
+  };
+}
+
+function parseCheckRunEvent(base: GitHubInboundEventBase): GitHubCheckRunWebhookEvent | null {
+  const rawCheckRun = readEventObject(base.raw.check_run);
+  if (rawCheckRun === null) return null;
+  const checkRunId = readId(rawCheckRun);
+  if (checkRunId === null) return null;
+  const checkRun = normalizeCiEvent(base.raw, rawCheckRun, normalizeApp(rawCheckRun.app));
+  return {
+    ...base,
+    checkRun: { ...checkRun, checkRunId },
+    conversation: ciConversation(checkRun.pullRequests),
+    kind: "check_run",
+  };
+}
+
+function parseWorkflowRunEvent(base: GitHubInboundEventBase): GitHubWorkflowRunWebhookEvent | null {
+  const rawWorkflowRun = readEventObject(base.raw.workflow_run);
+  if (rawWorkflowRun === null) return null;
+  const workflowRunId = readId(rawWorkflowRun);
+  if (workflowRunId === null) return null;
+  const workflowRun = normalizeCiEvent(base.raw, rawWorkflowRun, { slug: "github-actions" });
+  return {
+    ...base,
+    conversation: ciConversation(workflowRun.pullRequests),
+    kind: "workflow_run",
+    workflowRun: { ...workflowRun, workflowRunId },
+  };
+}
+
+function normalizeCiEvent(webhook: JsonObject, raw: JsonObject, app: GitHubAppRef): GitHubCiEvent {
+  return {
+    action: readAction(webhook),
+    app,
+    conclusion: readNullableString(raw.conclusion),
+    headSha: readNullableString(raw.head_sha),
+    pullRequests: readPullRequestNumbers(raw.pull_requests),
+    raw,
+    status: readNullableString(raw.status),
+  };
+}
+
+function readEventObject(value: unknown): JsonObject | null {
+  return isObject(value) ? parseJsonObject(value) : null;
+}
+
+function readId(value: JsonObject): number | null {
+  return typeof value.id === "number" ? value.id : null;
+}
+
+function normalizeApp(value: unknown): GitHubAppRef {
+  return {
+    slug: isObject(value) && typeof value.slug === "string" ? value.slug : null,
+  };
+}
+
+function readNullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readPullRequestNumbers(value: unknown): readonly number[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((pullRequest) =>
+    isObject(pullRequest) && typeof pullRequest.number === "number" ? [pullRequest.number] : [],
+  );
+}
+
+function ciConversation(pullRequests: readonly number[]): GitHubConversationRef {
+  return {
+    issueNumber: null,
+    kind: "pull_request",
+    pullRequestNumber: pullRequests[0] ?? null,
   };
 }
 

--- a/packages/eve/src/public/channels/github/index.ts
+++ b/packages/eve/src/public/channels/github/index.ts
@@ -17,6 +17,11 @@ export {
 } from "#public/channels/github/auth.js";
 export { defaultGitHubAuth } from "#public/channels/github/defaults.js";
 export {
+  type GitHubAppRef,
+  type GitHubCheckRunEvent,
+  type GitHubCheckSuiteEvent,
+  type GitHubCiEvent,
+  type GitHubCiPayload,
   type GitHubComment,
   type GitHubConversationKind,
   type GitHubConversationRef,
@@ -27,6 +32,7 @@ export {
   type GitHubPullRequestEvent,
   type GitHubRepositoryRef,
   type GitHubUser,
+  type GitHubWorkflowRunEvent,
 } from "#public/channels/github/inbound.js";
 export {
   githubChannel,

--- a/packages/eve/src/public/channels/github/state.ts
+++ b/packages/eve/src/public/channels/github/state.ts
@@ -1,5 +1,7 @@
 import {
   githubContinuationToken,
+  type GitHubCiEvent,
+  type GitHubCiWebhookEvent,
   type GitHubConversationKind,
   type GitHubConversationRef,
   type GitHubIssueCommentEvent,
@@ -152,6 +154,24 @@ export function stateFromPullRequestEvent(
   };
 }
 
+/** Builds pull-request state for a CI event hook dispatch. */
+export function stateFromCiEvent(event: GitHubCiWebhookEvent): GitHubChannelState {
+  const ci = ciPayload(event);
+  const pullRequestNumber = ci.pullRequests[0] ?? null;
+  return {
+    ...initialGitHubState(),
+    conversationKind: "pull_request",
+    headSha: ci.headSha,
+    installationId: event.installationId ?? null,
+    issueNumber: pullRequestNumber,
+    owner: event.repository.owner,
+    pullRequestNumber,
+    repo: event.repository.name,
+    repositoryId: event.repository.id,
+    triggeringUserLogin: event.sender.login,
+  };
+}
+
 /** Builds state for proactive `receive()` calls. */
 export function stateFromReceiveTarget(input: {
   readonly target: GitHubReceiveStateTarget;
@@ -195,4 +215,10 @@ export function continuationTokenFromState(state: GitHubChannelState): string {
     repositoryId: state.repositoryId,
     reviewThreadRootCommentId: state.reviewThreadRootCommentId,
   });
+}
+
+function ciPayload(event: GitHubCiWebhookEvent): GitHubCiEvent {
+  if (event.kind === "check_suite") return event.checkSuite;
+  if (event.kind === "check_run") return event.checkRun;
+  return event.workflowRun;
 }


### PR DESCRIPTION
## Summary

- parse `check_suite`, `check_run`, and `workflow_run` deliveries into eve-owned payloads
- add opt-in `onCheckSuite`, `onCheckRun`, and `onWorkflowRun` hooks on the GitHub channel
- anchor dispatched CI turns to the first associated pull request while preserving no-op behavior when hooks are unset
- document the normalized payload contract and add a patch changeset

## Why

A GitHub App has one webhook URL, and the eve GitHub channel owns that route. CI deliveries previously parsed to `null`, so agents could not react to CI outcomes without forking the channel or configuring a separate repository webhook.

## Impact

The new hooks expose the action, status, conclusion, app slug, head SHA, associated pull request numbers, raw payload, and run or suite ID. Existing applications are unchanged unless they configure one of the hooks.

## Validation

- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` — 3,923 passed
- `pnpm test:integration` — 369 passed
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts --maxWorkers=1` — 262 passed, 15 skipped
- focused GitHub unit and public API scenario tests

The default parallel scenario command was also attempted; scenario files raced while rebuilding the shared `packages/eve/dist` directory and produced varying missing-module failures. The complete serial run passed.
