### PR TITLE
fix(vercel): honor author-supplied runtime instead of forcing the eve image

### DIFF
--- a/.changeset/vercel-honor-runtime.md
+++ b/.changeset/vercel-honor-runtime.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The Vercel sandbox backend now honors an author-supplied `runtime` (e.g. `vercel({ runtime: "python3.13" })`) instead of always forcing the `vercel/eve:latest` image. The default eve image is still used when no runtime is requested.

--- a/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
@@ -24,11 +24,17 @@ export async function createVercelEveImageSandbox(input: {
   readonly createOptions: VercelSandboxCreateParams;
   readonly sandboxModule: VercelModule;
 }): Promise<VercelSandbox> {
-  const createOptions: VercelSandboxCreateParams = {
-    ...input.createOptions,
-    __image: VERCEL_EVE_SANDBOX_IMAGE,
-  };
+  // The eve base image is only a default. `__image` takes precedence over
+  // `runtime` in the SDK, so forcing it unconditionally silently drops an
+  // author-supplied runtime — apply it only when no runtime was requested.
+  const createOptions: VercelSandboxCreateParams = hasAuthorRuntime(input.createOptions)
+    ? input.createOptions
+    : { ...input.createOptions, __image: VERCEL_EVE_SANDBOX_IMAGE };
   return await input.sandboxModule.Sandbox.create(createOptions);
+}
+
+function hasAuthorRuntime(createOptions: VercelSandboxCreateParams): boolean {
+  return (createOptions as VercelSandboxCreateParams & { runtime?: unknown }).runtime !== undefined;
 }
 
 const VERCEL_EVE_SANDBOX_IMAGE = "vercel/eve:latest";

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -198,6 +198,31 @@ describe("createVercelSandbox", () => {
     );
   });
 
+  it("honors an author-supplied runtime instead of forcing the eve image", async () => {
+    const templateSandbox = createMockSandbox({ name: "template-key" });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn().mockResolvedValueOnce(templateSandbox),
+        get: vi.fn().mockResolvedValueOnce(null),
+      },
+    };
+
+    const backend = createVercelSandbox({
+      createOptions: { runtime: "python3.13" } as never,
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      seedFiles: [],
+      templateKey: "template-key",
+    });
+
+    const createArgs = sandboxModule.Sandbox.create.mock.calls[0]?.[0];
+    expect(createArgs).toMatchObject({ runtime: "python3.13" });
+    expect(createArgs).not.toHaveProperty("__image");
+  });
+
   it("passes resolved credentials to Vercel sandbox lookups instead of inferring scope", async () => {
     const existingTemplate = createMockSandbox({
       name: "template-key",


### PR DESCRIPTION
Closes #239.

`vercel({ runtime: "python3.13" })` was silently ignored. `createVercelEveImageSandbox` always spread `__image: "vercel/eve:latest"` onto the create call, and since `__image` takes precedence over `runtime` in the SDK, the requested runtime never reached the sandbox — no error, no warning, just the default image.

The eve image is only meant to be a default base, so I made it conditional: when the author supplies a `runtime`, the image is left off and the runtime flows through to `Sandbox.create` as-is. This mirrors how `source` already works as a template base — `runtime` becomes the base for the template create and is stripped from session creates by the existing snapshot path. The base setup script only requires bash, which the supported runtimes provide, so nothing else changes.

There was already a test asserting runtime reaches the SDK, but it injected a mock `createSandbox` that bypasses the `__image` binding, so the real drop went unnoticed. Added a test that goes through the default binding and checks the runtime is forwarded and `__image` is absent.