### PR TITLE
chore(e2e): fixtures - use zai/glm-5.2

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -39,7 +39,7 @@ One-time project setup:
 
 - Configure the shared Vercel project for Node.js 24.
 - Provide the model-provider credentials the fixtures need (the agents and
-  judges run against `openai/gpt-5.5`) in the project's Preview environment.
+  judges run against `zai/glm-5.2`) in the project's Preview environment.
 - Provide `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` in CI.
 
 Run a fixture against Vercel from its directory:
@@ -59,7 +59,7 @@ Do not set `VERCEL_TEAM_ID` at build: sandbox template keys must derive
 identically at build and runtime, and Vercel has no team variable at runtime.
 
 Both local and deployed evals run the fixture agents and judges against real
-models (`openai/gpt-5.5`), so the environment must provide the corresponding
+models (`zai/glm-5.2`), so the environment must provide the corresponding
 model-provider credentials.
 
 ## Fixtures

--- a/e2e/fixtures/agent-basic-runtime/agent/agent.ts
+++ b/e2e/fixtures/agent-basic-runtime/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-basic-runtime/evals/evals.config.ts
+++ b/e2e/fixtures/agent-basic-runtime/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-channels/agent/agent.ts
+++ b/e2e/fixtures/agent-channels/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-channels/evals/evals.config.ts
+++ b/e2e/fixtures/agent-channels/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-openapi-swagger/agent/agent.ts
+++ b/e2e/fixtures/agent-openapi-swagger/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-openapi-swagger/evals/evals.config.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-schedules/agent/agent.ts
+++ b/e2e/fixtures/agent-schedules/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-schedules/evals/evals.config.ts
+++ b/e2e/fixtures/agent-schedules/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-skills/agent/agent.ts
+++ b/e2e/fixtures/agent-skills/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-skills/evals/evals.config.ts
+++ b/e2e/fixtures/agent-skills/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/agent.ts
@@ -3,5 +3,5 @@ import { defineAgent } from "eve";
 export default defineAgent({
   description:
     'Look up the current stock price for a given ticker symbol. Pass the ticker symbol you want to look up in the message (e.g. "AAPL", "GOOG", or "TSLA").',
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-subagents-hitl/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-subagents/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-subagents/agent/subagents/echo-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/echo-marker/agent.ts
@@ -12,5 +12,5 @@ import { defineAgent } from "eve";
 export default defineAgent({
   description:
     "Smoke-test echo subagent. Call this whenever the user mentions the phrase 'echo marker subagent'. Pass any short text as the input; the subagent replies with a fixed marker token.",
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-subagents/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagents/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-tools-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-tools-hitl/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-tools-sandbox/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-tools-sandbox/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });

--- a/e2e/fixtures/agent-tools/agent/agent.ts
+++ b/e2e/fixtures/agent-tools/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
 });

--- a/e2e/fixtures/agent-tools/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: "zai/glm-5.2" },
 });


### PR DESCRIPTION
## Summary

- switch every e2e fixture agent and subagent to `zai/glm-5.2`
- switch every e2e judge configuration to `zai/glm-5.2`
- update the e2e documentation to identify the required model credentials

## Impact

All local and deployed fixture evals now use the same Z.ai GLM 5.2 model for both agent execution and model-based judging.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:unit` (3,991 tests)
- `pnpm test:integration` (369 tests)

Live e2e evals were not run because model-provider credentials are unavailable in the local environment.
