### PR TITLE
fix(eve): slack schedules - prevent proactive hook conflicts

### DIFF
--- a/.changeset/unique-slack-hook-tokens.md
+++ b/.changeset/unique-slack-hook-tokens.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Give each threadless proactive Slack session a unique temporary continuation token so overlapping scheduled runs targeting the same channel do not conflict before they anchor to a Slack thread.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -80,7 +80,7 @@ export default slackChannel({
 
 The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets build progressively: extensions of at least four characters appear immediately, while smaller streamed deltas use the five-second refresh interval to avoid one Slack request per token. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
 
-When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), it anchors on the first agent post, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
+When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), eve gives it a unique temporary continuation token. The first agent post anchors the session to the Slack message timestamp, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 
 The example below overrides `onAppMention` to gate on an authored message and posts the completed reply to the thread. Event handlers receive `(eventData, channel, ctx)`, with Slack platform handles on `channel.thread` and `channel.slack`:
 

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -123,7 +123,9 @@ describe("ScheduleDispatcher", () => {
         expect(runtime.run).toHaveBeenCalledTimes(1);
 
         const runInput = vi.mocked(runtime.run).mock.calls[0]![0];
-        expect(runInput.continuationToken).toBe("slack:C0123ABC:");
+        expect(runInput.continuationToken).toMatch(
+          /^slack:C0123ABC:[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/,
+        );
         expect(runInput.auth).toEqual(SCHEDULE_APP_AUTH);
       } finally {
         vi.unstubAllEnvs();

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1471,6 +1471,34 @@ describe("slackChannel().receive", () => {
     expect(options.auth.principalId).toBe("p");
   });
 
+  it("gives each threadless proactive session a unique temporary continuation token", async () => {
+    const randomUUID = vi
+      .spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000002");
+    const send = vi.fn().mockResolvedValue({ id: "s", continuationToken: "ct" });
+
+    try {
+      const receive = buildReceive();
+      const input = {
+        message: "run the check",
+        target: { channelId: "C123" },
+        auth: null,
+      };
+
+      await receive(input, { send });
+      await receive(input, { send });
+
+      expect(send.mock.calls.map(([, options]) => options.continuationToken)).toEqual([
+        "C123:00000000-0000-4000-8000-000000000001",
+        "C123:00000000-0000-4000-8000-000000000002",
+      ]);
+      expect(send.mock.calls.map(([, options]) => options.state.threadTs)).toEqual([null, null]);
+    } finally {
+      randomUUID.mockRestore();
+    }
+  });
+
   it("requires channelId", async () => {
     const send = vi.fn();
     await expect(

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -584,9 +584,13 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
         threadTs = posted.id;
       }
 
+      // Threadless proactive runs need distinct identities until their first
+      // Slack post supplies the real thread timestamp and re-keys the session.
+      const continuationThreadTs = threadTs || crypto.randomUUID();
+
       return send(input.message, {
         auth: input.auth,
-        continuationToken: slackContinuationToken(channelId, threadTs),
+        continuationToken: slackContinuationToken(channelId, continuationThreadTs),
         state: {
           channelId,
           threadTs: threadTs || null,


### PR DESCRIPTION
## Summary

- give every threadless proactive Slack session a unique temporary continuation token
- preserve the existing first-post re-key to the real Slack thread timestamp
- add schedule and Slack receive regression coverage, documentation, and a patch changeset

## Root cause

Scheduled Slack runs without a known thread timestamp all started with `slack:<channelId>:`. The new `getConflict()` ownership check correctly rejected a second active workflow before either run could post and re-key. Empty scheduled deliveries can intentionally remain parked, so the shared placeholder could also outlive the schedule invocation.

The existing re-key path already claims the replacement hook and disposes the old hook. This change fixes the colliding provisional identity rather than changing hook disposal.

## Impact

Overlapping or repeated scheduled Slack runs targeting the same channel no longer conflict before anchoring. Sessions with an explicit `threadTs` or `initialMessage` keep their existing deterministic token behavior.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` (3,998 passed)
- `pnpm test:integration` (369 passed)
- scenario suite assertions passed across a serialized run and isolated retry; the initial parallel run exposed unrelated shared `dist`/temporary tarball races

The `agent-schedules` real-model eval was attempted but could not run because this environment has no `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`.
