### PR TITLE
Clarify bundled docs location guidance

### DIFF
--- a/.changeset/eve-docs-location-guidance.md
+++ b/.changeset/eve-docs-location-guidance.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Clarify scaffolded guidance for locating bundled eve package docs in workspaces and local installs.

--- a/packages/eve/src/cli/commands/agent-instructions.test.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.test.ts
@@ -25,7 +25,9 @@ describe("initAgentInstructions", () => {
     // pre-scaffold guide renders the universal `npx eve dev` through the shared
     // prompt renderer rather than a launcher-specific command.
     expect(instructions).toContain("npx eve@latest init <name>");
+    expect(instructions).toContain("full docs are bundled");
     expect(instructions).toContain("node_modules/eve/docs/");
+    expect(instructions).toContain("resolve\nthe installed `eve` package location");
     expect(instructions).toContain("npx eve dev --no-ui");
     expect(instructions).not.toContain("npm run dev");
     expect(instructions).not.toContain("starts the dev server");
@@ -56,7 +58,9 @@ describe("initAgentDevHandoff", () => {
     // The intro names the scaffolded project; the shared sections then reference
     // paths relative to it rather than interpolating the working directory.
     expect(handoff).toContain("The project at `/tmp/triage-bot` is already scaffolded");
+    expect(handoff).toContain("full docs are bundled");
     expect(handoff).toContain("node_modules/eve/docs/");
+    expect(handoff).toContain("resolve\nthe installed `eve` package location");
     expect(handoff).toContain("agent/instructions.md");
     expect(handoff).not.toContain("/tmp/triage-bot/");
 

--- a/packages/eve/src/cli/commands/agent-prompt/build-and-verify.md
+++ b/packages/eve/src/cli/commands/agent-prompt/build-and-verify.md
@@ -1,10 +1,13 @@
 ## Build it out, then verify
 
 Work from the project directory. Once eve is installed, the full docs are bundled
-at `node_modules/eve/docs/` and match the installed version exactly. Read
-`README.md` there first, then the guide for what you're adding, such as
-`connections`, `channels/slack`, or `guides/auth-and-route-protection` for the
-Vercel Connect flow.
+with the installed package and match its version exactly. In most installs, they
+are at `node_modules/eve/docs/`. In workspaces or local package installs, resolve
+the installed `eve` package location first and read its `docs/` directory. If
+package docs are unavailable, use https://eve.dev/docs as a fallback. Read
+`README.md` in the package docs first, then the guide for what you're adding,
+such as `connections`, `channels/slack`, or `guides/auth-and-route-protection`
+for the Vercel Connect flow.
 
 - Put the purpose in `agent/instructions.md` (the always-on system prompt),
   replacing the scaffold's placeholder with what the user said the agent should

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -245,7 +245,11 @@ dist
 `,
   "AGENTS.md": `# eve Agent App
 
-This project uses the eve framework. Before writing code, always read the relevant guide in \`node_modules/eve/docs/\`.
+This project uses the eve framework. Before writing code, read the relevant guide
+from the installed eve package docs. In most installs, those docs are at
+\`node_modules/eve/docs/\`. In workspaces or local package installs, resolve the
+installed \`eve\` package location first and read its \`docs/\` directory. If
+package docs are unavailable, use https://eve.dev/docs as a fallback.
 `,
   "CLAUDE.md": `@AGENTS.md
 `,

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -730,9 +730,10 @@ describe("scaffoldBaseProject", () => {
     await expect(readFile(join(projectRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
       PNPM_WORKSPACE_CONTENT,
     );
-    await expect(readFile(join(projectRoot, "AGENTS.md"), "utf8")).resolves.toContain(
-      "node_modules/eve/docs/",
-    );
+    const agentsMd = await readFile(join(projectRoot, "AGENTS.md"), "utf8");
+    expect(agentsMd).toContain("installed eve package docs");
+    expect(agentsMd).toContain("node_modules/eve/docs/");
+    expect(agentsMd).toContain("resolve the\ninstalled `eve` package location");
     // `vercel deploy` uploads everything a .vercelignore doesn't exclude, and
     // the platform default-ignores only the .env.local variants — eve's dev
     // artifacts and a bare .env must be excluded here or a source deploy


### PR DESCRIPTION
## Summary

- clarify scaffolded AGENTS.md so agents read docs from the installed eve package, usually `node_modules/eve/docs/`
- add workspace/local-install guidance to resolve the installed package location first
- add `https://eve.dev/docs` as a fallback when package docs are unavailable
- mirror the same guidance in the init/handoff build prompt and update tests

## Context

The published package does include docs, but `packages/eve/docs/` is generated during build/prepack rather than tracked in source. A workspace or local package install can therefore make the literal `node_modules/eve/docs/` instruction misleading if the agent is looking at the wrong resolved package location or at a source checkout before docs are copied.

## Testing

- `git diff --check`
- `../../node_modules/.bin/vitest run --config vitest.unit.config.ts src/cli/commands/agent-instructions.test.ts`

Note: `src/setup/scaffold/index.integration.test.ts` could not be run in this auxiliary worktree because the borrowed install makes Vitest write `.vite-temp` under the source checkout and package imports fail to resolve `#internal/workflow-bundle/workflow-builders.js`. CI should run it with a normal workspace install.
