### PR TITLE
fix(eve): improve Connect-backed connection auth error messaging and evict support

### DIFF
--- a/.changeset/allow-connection-auth-evict.md
+++ b/.changeset/allow-connection-auth-evict.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow authored connection auth definitions to include the `evict` hook emitted by Vercel Connect helpers, so `eve build` accepts cache-eviction-aware providers.

--- a/.changeset/allow-connection-auth-evict.md
+++ b/.changeset/allow-connection-auth-evict.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow authored connection auth definitions to include the `evict` hook emitted by Vercel Connect helpers, so `eve build` accepts cache-eviction-aware providers.
+Improve Vercel Connect-backed connection auth by allowing authored definitions to include the `evict` hook and clarifying `principal_required` guidance when user-scoped connections run without an authenticated user principal.

--- a/.changeset/connect-principal-required-guidance.md
+++ b/.changeset/connect-principal-required-guidance.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Clarify the `principal_required` error for user-scoped connections that run without an authenticated user principal.

--- a/.changeset/connect-principal-required-guidance.md
+++ b/.changeset/connect-principal-required-guidance.md
@@ -1,5 +1,0 @@
----
-"eve": patch
----
-
-Clarify the `principal_required` error for user-scoped connections that run without an authenticated user principal.

--- a/packages/eve/src/internal/authored-definition/connection.test.ts
+++ b/packages/eve/src/internal/authored-definition/connection.test.ts
@@ -101,6 +101,22 @@ describe("normalizeMcpClientConnectionDefinition", () => {
       });
     });
 
+    it("preserves the optional auth evict hook", () => {
+      const evict = async () => {};
+      const result = normalizeMcpClientConnectionDefinition(
+        validInput({
+          auth: {
+            evict,
+            getToken: async () => ({ token: "x" }),
+            principalType: "app",
+          },
+        }),
+        MSG,
+      );
+
+      expect((result.auth as Record<string, unknown>).evict).toBe(evict);
+    });
+
     it("drops a malformed vercelConnect marker without throwing", () => {
       // A misbehaving auth provider could attach a malformed marker; the
       // normalizer treats it as absent rather than failing the whole

--- a/packages/eve/src/internal/authored-definition/connection.ts
+++ b/packages/eve/src/internal/authored-definition/connection.ts
@@ -27,6 +27,7 @@ const KNOWN_OPENAPI_TOP_LEVEL_KEYS = [
 ] as const;
 const KNOWN_AUTHORIZATION_KEYS = [
   "completeAuthorization",
+  "evict",
   "getToken",
   "principalType",
   "startAuthorization",

--- a/packages/eve/src/runtime/connections/principal.test.ts
+++ b/packages/eve/src/runtime/connections/principal.test.ts
@@ -104,7 +104,7 @@ describe("resolveConnectionPrincipal", () => {
   it("throws principal_required (non-retryable) when AuthKey is null", () => {
     const ctx = ctxWithAuth(null);
 
-    expect.assertions(4);
+    expect.assertions(5);
     try {
       contextStorage.run(ctx, () => resolveConnectionPrincipal("linear", userAuthDef));
     } catch (error) {
@@ -113,6 +113,7 @@ describe("resolveConnectionPrincipal", () => {
       expect(err.reason).toBe("principal_required");
       expect(err.retryable).toBe(false);
       expect(err.connectionName).toBe("linear");
+      expect(err.message).toContain("route auth that resolves an authenticated user");
     }
   });
 
@@ -126,7 +127,7 @@ describe("resolveConnectionPrincipal", () => {
 
     expect(() =>
       contextStorage.run(ctx, () => resolveConnectionPrincipal("linear", userAuthDef)),
-    ).toThrow(/principalType "user"/);
+    ).toThrow(/active session is scoped to "service"/);
   });
 
   it("accepts an explicit ctx argument and bypasses AsyncLocalStorage", () => {
@@ -168,7 +169,7 @@ describe("resolveConnectionPrincipal", () => {
   });
 
   it("throws principal_required for user-typed connections when no context is active", () => {
-    expect.assertions(4);
+    expect.assertions(5);
     try {
       resolveConnectionPrincipal("linear", userAuthDef);
     } catch (error) {
@@ -177,6 +178,7 @@ describe("resolveConnectionPrincipal", () => {
       expect(err.reason).toBe("principal_required");
       expect(err.retryable).toBe(false);
       expect(err.message).toMatch(/outside an eve context/);
+      expect(err.message).toContain("credentials shared by the agent");
     }
   });
 });

--- a/packages/eve/src/runtime/connections/principal.ts
+++ b/packages/eve/src/runtime/connections/principal.ts
@@ -85,12 +85,7 @@ export function resolveConnectionPrincipal(
   const current = ctx?.get(AuthKey);
   if (current === null || current === undefined || current.principalType !== "user") {
     throw new ConnectionAuthorizationFailedError(connectionName, {
-      message:
-        ctx === undefined
-          ? `Connection "${connectionName}" declares principalType "user" ` +
-            `but was invoked outside an eve context, so no user principal can be resolved.`
-          : `Connection "${connectionName}" declares principalType "user" ` +
-            `but the active session has no authenticated user principal.`,
+      message: buildUserPrincipalRequiredMessage(connectionName, ctx, current?.principalType),
       reason: "principal_required",
       retryable: false,
     });
@@ -102,4 +97,25 @@ export function resolveConnectionPrincipal(
     issuer: current.issuer ?? current.authenticator,
     type: "user",
   };
+}
+
+function buildUserPrincipalRequiredMessage(
+  connectionName: string,
+  ctx: AlsContext | undefined,
+  currentPrincipalType: string | undefined,
+): string {
+  let detail: string;
+  if (ctx === undefined) {
+    detail = "it was invoked outside an eve context, so no authenticated user can be resolved.";
+  } else if (currentPrincipalType === undefined) {
+    detail = "the active session has no authenticated user.";
+  } else {
+    detail = `the active session is scoped to "${currentPrincipalType}", not an authenticated user.`;
+  }
+
+  return (
+    `Connection "${connectionName}" is user-scoped, but ${detail} ` +
+    `User-scoped connections require route auth that resolves an authenticated user. ` +
+    `If this connection should use credentials shared by the agent instead, configure it as an app-scoped connection.`
+  );
 }


### PR DESCRIPTION
## Summary
- allow authored connection auth definitions to include the optional `evict` hook emitted by Vercel Connect helpers
- add a regression test that preserves `auth.evict` through the build-time normalizer
- clarify `principal_required` guidance for user-scoped connections vs credentials shared by the agent
- add one patch changeset for the combined eve auth fixes

## Verification
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/authored-definition/connection.test.ts src/runtime/connections/principal.test.ts`
- `pnpm exec oxfmt --check packages/eve/src/internal/authored-definition/connection.ts packages/eve/src/internal/authored-definition/connection.test.ts packages/eve/src/runtime/connections/principal.ts packages/eve/src/runtime/connections/principal.test.ts .changeset/allow-connection-auth-evict.md`
- `git diff --check`

## Notes
- Combines the previous standalone principal-guidance PR (#263) into this branch.
- Full `pnpm --filter eve typecheck` remains blocked in this local worktree before TypeScript by `packages/eve/scripts/vendor-compiled.mjs` failing under the current install graph with `Error: Value is non of these types Promise, UnknownReturnValue`; the focused regression suites pass.