### PR TITLE
fix(slack): ack view_submission with an empty 200 body so the modal closes

### DIFF
--- a/.changeset/slack-view-submission-empty-ack.md
+++ b/.changeset/slack-view-submission-empty-ack.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Acknowledge Slack `view_submission` (the free-form HITL input modal) with an empty 200 body instead of `"ok"`. A non-empty body is invalid for a view submission, so Slack showed a generic error and left the modal open even though the submitted value was accepted and delivered. Returning an empty body dismisses the modal. Block Actions acks are unchanged (they ignore the response body).

--- a/packages/eve/src/public/channels/slack/interactions.test.ts
+++ b/packages/eve/src/public/channels/slack/interactions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { parseBlockActionsPayload } from "#public/channels/slack/interactions.js";
+import {
+  handleInteractionPost,
+  parseBlockActionsPayload,
+} from "#public/channels/slack/interactions.js";
 
 function makePayload(overrides: Record<string, unknown>): Record<string, unknown> {
   return {
@@ -36,5 +39,27 @@ describe("parseBlockActionsPayload", () => {
         name: "jane.doe",
       });
     }
+  });
+});
+
+describe("handleInteractionPost", () => {
+  it("acknowledges a view_submission with an empty 200 body so Slack dismisses the modal", async () => {
+    const payload = JSON.stringify({
+      type: "view_submission",
+      view: { callback_id: "some_other_modal" },
+    });
+    const rawBody = `payload=${encodeURIComponent(payload)}`;
+    const ctx = {
+      send: async () => undefined,
+      waitUntil: () => {},
+    } as unknown as Parameters<typeof handleInteractionPost>[1];
+    const deps = {} as unknown as Parameters<typeof handleInteractionPost>[2];
+
+    const res = await handleInteractionPost(rawBody, ctx, deps);
+
+    expect(res.status).toBe(200);
+    // A non-empty body (e.g. "ok") makes Slack reject the view_submission and
+    // leave the modal open; the ack body must be empty to dismiss the modal.
+    expect(await res.text()).toBe("");
   });
 });

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -331,7 +331,12 @@ async function handleViewSubmission(
   },
   _deps: InteractionHandlerDeps,
 ): Promise<Response> {
-  const ack = new Response("ok", { status: 200 });
+  // A `view_submission` must be acknowledged with an empty 200 body (or a
+  // `response_action` JSON). A non-empty body like "ok" is invalid here, so
+  // Slack shows a generic error and leaves the modal open even though the
+  // submission was accepted. (Block Actions ignore the body, so the "ok" ack
+  // elsewhere is fine — only modal submissions need an empty body.)
+  const ack = new Response(null, { status: 200 });
   const view = payload.view as
     | {
         callback_id?: string;


### PR DESCRIPTION
### Description

Free-form HITL input in Slack (an `ask_question`/input request with no options) renders a modal. When the user submits it, `handleViewSubmission` accepts the value and delivers it to the session via `ctx.send({ inputResponses: [...] })`, **but acknowledges the `view_submission` with a 200 whose body is `"ok"`**.

A `view_submission` must be acknowledged with an **empty 200 body** (or a `response_action` JSON). A non-empty body like `"ok"` is invalid, so Slack shows a generic error and **leaves the modal open** — even though the submission was accepted and the answer was already delivered to the agent. From the user's side it looks like the value went through but the form errored / the modal won't close.

**Fix:** return an empty body (`new Response(null, { status: 200 })`) from `handleViewSubmission`. Block Actions ignore the response body, so the `"ok"` ack in `handleInteractionPost` is intentionally left unchanged.

Repro: trigger a free-form HITL question over Slack, type a value, submit → value reaches the agent but the modal shows an error and stays open. Still reproduces on the latest release (0.13.6).

### How did you test your changes?

- Added a unit test asserting `handleInteractionPost` acks a `view_submission` with `status 200` and an **empty** body.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/interactions.test.ts` → 2 passed.
- `pnpm --filter eve run typecheck` → passes. `pnpm fmt` / `pnpm lint` clean.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

> Note: no prior issue — happy to open one if you'd prefer. This is a small, self-contained correctness fix with the repro above.