### PR TITLE
fix(eve): slack - acknowledge view submissions with empty body

### DIFF
--- a/.changeset/slack-view-submission-empty-ack.md
+++ b/.changeset/slack-view-submission-empty-ack.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Acknowledge Slack view submissions with an empty response body so submitted modals close without an error.

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -331,7 +331,8 @@ async function handleViewSubmission(
   },
   _deps: InteractionHandlerDeps,
 ): Promise<Response> {
-  const ack = new Response("ok", { status: 200 });
+  // Slack view submissions require an empty 200 body to close the modal.
+  const ack = new Response(null, { status: 200 });
   const view = payload.view as
     | {
         callback_id?: string;


### PR DESCRIPTION
### Description

Reopens the fix from #271 under a branch in this repository. Slack view submissions now acknowledge with an empty 200 response body so submitted modals can close without showing a generic Slack error.

The commit includes `Co-authored-by: Yasuyuki Matsumoto <sy12250@gmail.com>` for the original contributor.

### Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`