### PR TITLE
chore(eve): workflow runtime - route types through boundary

### DIFF
--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -16,7 +16,15 @@ import {
 } from "#execution/eve-workflow-attributes.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { createLogger, logError } from "#internal/logging.js";
-import { getRun, resumeHook, start, type Run } from "#internal/workflow/runtime.js";
+import {
+  getRun,
+  resumeHook,
+  start,
+  type Run,
+  type StartOptionsWithoutDeploymentId,
+  type WorkflowFunction,
+  type WorkflowMetadata,
+} from "#internal/workflow/runtime.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
@@ -29,17 +37,6 @@ import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 const WORKFLOW_ENTRY_NAME = "workflowEntry";
 const TURN_WORKFLOW_NAME = "turnWorkflow";
 const EVE_PACKAGE_INFO = resolveInstalledPackageInfo();
-
-type WorkflowFunction<TArgs extends unknown[], TResult> = (...args: TArgs) => Promise<TResult>;
-
-interface WorkflowMetadata {
-  readonly workflowId: string;
-}
-
-interface WorkflowStartOptions {
-  readonly allowReservedAttributes?: boolean;
-  readonly attributes?: Record<string, string>;
-}
 
 export const LATEST_DEPLOYMENT_UNSUPPORTED_MESSAGE =
   "deploymentId 'latest' requires a World that implements resolveLatestDeploymentId()";
@@ -200,7 +197,7 @@ export function createWorkflowRuntime(config: {
 export async function startWorkflowPreferLatest<TArgs extends unknown[], TResult>(
   workflow: WorkflowFunction<TArgs, TResult> | WorkflowMetadata,
   args: TArgs,
-  options?: WorkflowStartOptions,
+  options?: StartOptionsWithoutDeploymentId,
 ): Promise<Run<unknown> | Run<TResult>> {
   if (!shouldRouteToLatestDeployment()) {
     return options === undefined

--- a/packages/eve/src/internal/workflow/runtime.ts
+++ b/packages/eve/src/internal/workflow/runtime.ts
@@ -2,6 +2,11 @@ import "#internal/workflow/queue-namespace.js";
 import * as workflowRuntime from "#compiled/@workflow/core/runtime.js";
 
 export * from "#compiled/@workflow/core/runtime.js";
+export type {
+  StartOptionsWithoutDeploymentId,
+  WorkflowFunction,
+  WorkflowMetadata,
+} from "#compiled/@workflow/core/runtime/start.js";
 
 /** Installs a World across source and vendored Workflow package identities. */
 export function setWorld(world: unknown): void {


### PR DESCRIPTION
## Summary

- re-export Workflow's start types through eve's internal runtime boundary
- replace the local structural stand-ins with the vendored SDK types
- preserve runtime behavior and generated vendor output unchanged

## Verification

- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`

No tests added or run; this is a type-only cleanup following #278.
