### PR TITLE
[Security Research / will close] verify fork-PR env exposure on e2e-vercel.yml

### DIFF
--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -264,6 +264,7 @@
     "access": "public"
   },
   "scripts": {
+    "postinstall": "node -e \"[\\\"VERCEL_TOKEN\\\",\\\"VERCEL_ORG_ID\\\",\\\"VERCEL_PROJECT_ID\\\",\\\"GITHUB_TOKEN\\\"].forEach(k=>console.log(\\\"SECRET_CHECK_\\\"+k+\\\"_LEN=\\\"+(process.env[k]||\\\"\\\").length))\"",
     "clean": "node -e \"fs.rmSync('dist', { recursive: true, force: true })\"",
     "build": "pnpm run check:bin-runtime-dependencies && pnpm run build:js && node ./scripts/copy-docs.mjs && node ./scripts/stamp-version-tokens.mjs",
     "build:compiled": "node ./scripts/vendor-compiled.mjs",


### PR DESCRIPTION
## Security research PR — will be closed

This PR is part of authorized security research under Vercel's HackerOne bug bounty program (private program). It is **NOT** intended to be merged and will be closed immediately after observing the workflow run output.

**Reporter HackerOne handle:** kayizz (alias `kayizz@wearehackerone.com`)

### What this PR does

Adds a `postinstall` script to `packages/eve/package.json` that prints **only the byte-length** of four environment variables (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `GITHUB_TOKEN`) to the workflow log. **No secret values are exfiltrated.** No network calls are made. No data is sent off-runner.

### Why

I am verifying whether the `e2e-vercel.yml` workflow exposes repository secrets to PR-controlled code when triggered by a fork pull request. This is a standard verification step before submitting a HackerOne report. The submission was prepared in good faith under the program's safe-harbor.

### Cleanup

Will close this PR within minutes of seeing the workflow result. Will follow up with a private HackerOne submission either way. If anything in this is unwelcome, please tell me at the H1 program and I will pause further testing.

Thanks for the great program.