### PR TITLE
fix(eve): e2e - stabilize delegated HITL smoke

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -83,5 +83,6 @@ jobs:
             .junit
             e2e/fixtures/*/.eve/evals
             apps/fixtures/*/.eve/evals
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -110,5 +110,6 @@ jobs:
             .junit
             e2e/fixtures/*/.eve/evals
             apps/fixtures/*/.eve/evals
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7

--- a/e2e/fixtures/agent-subagents-hitl/agent/instructions.md
+++ b/e2e/fixtures/agent-subagents-hitl/agent/instructions.md
@@ -1,4 +1,6 @@
 # Identity
 
 You are a helpful assistant. When the user explicitly asks you to use a named
-subagent, call that subagent and include its result in your final reply.
+subagent, call that subagent exactly once. After it returns, include its result
+in your final reply without calling any subagent again unless the user explicitly
+requested multiple calls.

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/instructions.md
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/instructions.md
@@ -1,1 +1,3 @@
-You are a stock price lookup agent. When given a ticker symbol, use your tools to look up the current price and return a concise summary.
+You are a stock price lookup agent. When given a ticker symbol, call the
+get_stock_price tool exactly once, then return a concise summary without calling
+any tool again.

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/tools/get_stock_price.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/tools/get_stock_price.ts
@@ -1,4 +1,5 @@
 import { defineTool } from "eve/tools";
+import { once } from "eve/tools/approval";
 import { z } from "zod";
 
 const MOCK_PRICES: Record<string, { price: number; change: number }> = {
@@ -15,7 +16,7 @@ export default defineTool({
   inputSchema: z.object({
     ticker: z.string().describe("Stock ticker symbol"),
   }),
-  approval: () => "user-approval",
+  approval: once(),
   async execute(input) {
     const ticker = input.ticker.toUpperCase();
     const data = MOCK_PRICES[ticker];

--- a/e2e/fixtures/agent-subagents-hitl/evals/hitl.eval.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/hitl.eval.ts
@@ -39,13 +39,35 @@ export default defineEval({
     const resumed = await t.respondAll("approve");
     resumed.expectOk();
 
-    const outputs = subagentOutputs(t.events);
-    if (!outputs.some((output) => output.includes(GOOG_PRICE))) {
+    if (resumed.inputRequests.length > 0) {
+      const requests = resumed.inputRequests.map((request) => ({
+        requestId: request.requestId,
+        toolName: request.action.kind === "tool-call" ? request.action.toolName : undefined,
+      }));
       throw new Error(
-        `No subagent.completed output contained the GOOG price; got [${outputs.join(", ")}].`,
+        `Subagent re-parked after approval with input requests: ${JSON.stringify(requests)}.`,
       );
     }
 
+    const outputs = subagentOutputs(t.events);
+    if (!outputs.some((output) => output.includes(GOOG_PRICE))) {
+      const failedActions = t.events.flatMap((event) => {
+        if (event.type !== "action.result") return [];
+        if (event.data.status !== "failed" && event.data.result.isError !== true) return [];
+        return [event.data.result];
+      });
+      const recentEventTypes = t.events.slice(-20).map((event) => event.type);
+      throw new Error(
+        [
+          `No subagent.completed output contained the GOOG price; got [${outputs.join(", ")}].`,
+          `Resumed turn status: ${resumed.status}.`,
+          `Failed actions: ${JSON.stringify(failedActions)}.`,
+          `Recent events: [${recentEventTypes.join(", ")}].`,
+        ].join(" "),
+      );
+    }
+
+    t.noFailedActions();
     t.didNotFail();
     t.completed();
     t.messageIncludes(GOOG_PRICE);

--- a/e2e/fixtures/agent-subagents-hitl/evals/hitl.eval.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/hitl.eval.ts
@@ -19,7 +19,7 @@ function subagentOutputs(events: readonly HandleMessageStreamEvent[]): string[] 
 
 /**
  * Parent/child HITL proxying: the stock-price subagent's tool approval
- * (`approval: () => "user-approval"`) surfaces on the parent stream, the approval
+ * (`approval: once()`) surfaces on the parent stream, the approval
  * routes back down, and the child's result splices into the parent reply.
  * Parking is server-side.
  */
@@ -28,7 +28,7 @@ export default defineEval({
 
   async test(t) {
     await t.send(
-      `Call the stock-price subagent exactly once with message 'Call the get_stock_price tool with ticker "GOOG".'. After that single call finishes, do not call any subagent or tool again; include the exact stock price in your final reply.`,
+      `Call the stock-price subagent exactly once with message 'Call the get_stock_price tool exactly once with ticker "GOOG". After it returns, do not call any tool again; return the result.'. After that single subagent call finishes, do not call any subagent or tool again; include the exact stock price in your final reply.`,
     );
 
     // The child's approval request must surface on the parent stream.

--- a/e2e/fixtures/agent-subagents-hitl/evals/hitl.eval.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/hitl.eval.ts
@@ -28,7 +28,7 @@ export default defineEval({
 
   async test(t) {
     await t.send(
-      `Use the stock-price subagent with message 'Call the get_stock_price tool with ticker "GOOG".'. When it finishes, include the exact stock price in your reply.`,
+      `Call the stock-price subagent exactly once with message 'Call the get_stock_price tool with ticker "GOOG".'. After that single call finishes, do not call any subagent or tool again; include the exact stock price in your final reply.`,
     );
 
     // The child's approval request must surface on the parent stream.
@@ -38,6 +38,13 @@ export default defineEval({
 
     const resumed = await t.respondAll("approve");
     resumed.expectOk();
+    t.event(
+      (events) =>
+        events.filter(
+          (event) => event.type === "subagent.called" && event.data.name === "stock-price",
+        ).length === 1,
+      "stock-price subagent was called exactly once",
+    );
 
     if (resumed.inputRequests.length > 0) {
       const requests = resumed.inputRequests.map((request) => ({

--- a/packages/eve/test/tui-client/tui-subagents-weather.ts
+++ b/packages/eve/test/tui-client/tui-subagents-weather.ts
@@ -11,7 +11,7 @@ import { theme } from "./lib/theme.ts";
  * Multi-message subagent smoke driving `e2e/fixtures/agent-subagents-hitl` and its
  * `stock-price` subagent. The subagent emits a pre-tool message
  * ("I'll look up..."), calls `get_stock_price` (which has
- * `needsApproval: () => true`), and then emits a post-tool message
+ * `approval: once()`), and then emits a post-tool message
  * with the result. This is the real-world flow that broke the earlier
  * stepIndex-keyed implementation, both pre and post messages were
  * landing under `stepIndex: 0` and collapsing into one box.
@@ -60,7 +60,7 @@ run({ app: "agent-subagents-hitl", kind: "local-build" }, async (target) => {
   // delegating. Explicitly limiting the request to one delegation also keeps
   // the model from re-checking the fixed fixture result with a second child.
   input.type(
-    `Call the stock-price subagent exactly once with message 'Call the get_stock_price tool with ticker "${TICKER}".'. After that single call finishes, do not call any subagent or tool again; include the exact stock price in your final reply.`,
+    `Call the stock-price subagent exactly once with message 'Call the get_stock_price tool exactly once with ticker "${TICKER}". After it returns, do not call any tool again; return the result.'. After that single subagent call finishes, do not call any subagent or tool again; include the exact stock price in your final reply.`,
   );
   input.enter();
 

--- a/packages/eve/test/tui-client/tui-subagents-weather.ts
+++ b/packages/eve/test/tui-client/tui-subagents-weather.ts
@@ -57,10 +57,10 @@ run({ app: "agent-subagents-hitl", kind: "local-build" }, async (target) => {
 
   // Delegate explicitly. An implicit prompt ("what is the value of GOOG?")
   // leaves the choice to the model, which may answer directly instead of
-  // delegating; naming the subagent keeps the flow this smoke exercises
-  // deterministic. The price itself is fixed by the subagent's fixture tool.
+  // delegating. Explicitly limiting the request to one delegation also keeps
+  // the model from re-checking the fixed fixture result with a second child.
   input.type(
-    `Use the stock-price subagent with message 'Call the get_stock_price tool with ticker "${TICKER}".'. When it finishes, include the exact stock price in your reply.`,
+    `Call the stock-price subagent exactly once with message 'Call the get_stock_price tool with ticker "${TICKER}".'. After that single call finishes, do not call any subagent or tool again; include the exact stock price in your final reply.`,
   );
   input.enter();
 


### PR DESCRIPTION
## Summary

- make the delegated HITL fixture request exactly one parent delegation and one child tool call
- use `once()` approval so a repeated model tool call cannot create another human gate in the same child session
- assert that the eval dispatched the stock-price subagent exactly once
- upload hidden JUnit and eval artifacts when E2E jobs fail
- report re-parking, failed actions, resumed status, and recent event types

## Root cause

The first CI run on this PR reproduced the symptom in the equivalent TUI smoke. The approved child call returned the correct `178.92` fixture result, then the model requested `get_stock_price` again instead of producing the final parent reply. The run timed out on a second approval prompt.

This demonstrates model-level repeated delegation/tool use rather than a lost workflow hook delivery. The fixture prompt previously requested a named subagent and tool but did not explicitly limit either to one call. This change makes that test contract explicit and keeps the approval gate one-time within the child session. Production workflow scheduling remains unchanged.

## Validation

- `pnpm exec oxfmt --check` on all changed files
- `pnpm exec oxlint` on all changed TypeScript files
- `pnpm --filter eve build:compiled`
- `pnpm --filter agent-subagents-hitl typecheck`
- `pnpm --filter eve exec tsc -p tsconfig.tui.json --noEmit`
- `pnpm guard:invariants`

The initial PR run passed the complete local and Vercel E2E matrices; its TUI failure supplied the root-cause trace above. A new run with the deterministic fixture changes is in progress.
