### PR TITLE
docs(eve): document self-hosted workflow world version pin and reverse-proxy routes

### DIFF
--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -96,11 +96,21 @@ export default defineAgent({
 ```
 
 Install that package in your app. It should export a default factory or
-`createWorld()` function.
+`createWorld()` function. Pin a version built against the same `@workflow/*`
+line as your eve release (currently the `5.0.0-beta` line):
+
+```bash
+pnpm add @workflow/world-postgres@5.0.0-beta.x
+```
+
+The npm `latest` tag can lag behind that line, so an unpinned install may pull
+an incompatible major that fails with `ZodError: invalid_union` at run replay.
 
 Put credentials and host-specific options in runtime environment variables read
-by the world package, not in `agent.ts`. If the installed package must stay
-external in hosted output, list it in `build.externalDependencies`.
+by the world package, not in `agent.ts`. For the Postgres world, that means
+putting the connection string or credentials in the env vars it reads. If the
+installed package must stay external in hosted output, list it in
+`build.externalDependencies`.
 
 ## Other defineAgent fields
 

--- a/docs/concepts/execution-model-and-durability.md
+++ b/docs/concepts/execution-model-and-durability.md
@@ -36,7 +36,7 @@ export default defineAgent({
 });
 ```
 
-The world package backs workflow state, queues, hooks, and streams. Keep secrets and deployment-specific options in runtime environment variables read by that package, not in `agent.ts`. See [agent.ts](../agent-config#workflow-world) and [Workflow Worlds](https://workflow-sdk.dev/worlds).
+The world package backs workflow state, queues, hooks, and streams. Keep secrets and deployment-specific options in runtime environment variables read by that package, not in `agent.ts`. The selected world must match eve's bundled `@workflow/*` line (currently the `5.0.0-beta` line); pin it explicitly, since a mismatched world fails with a `ZodError: invalid_union` during run replay. See the [deployment guide](../guides/deployment#8-deploy-without-vercel) for the install command, plus [agent.ts](../agent-config#workflow-world) and [Workflow Worlds](https://workflow-sdk.dev/worlds).
 
 ## Resuming after a crash
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -140,7 +140,8 @@ Eve writes the standard Nitro output under `.output/` instead of Vercel Build Ou
 
 Self-deployed agents should make the Vercel-specific choices explicit:
 
-- Let the Workflow SDK use its default local world, which stores workflow state under `.workflow-data`, configure your host so that directory is on persistent storage, or select another world with `experimental.workflow.world` in the root `agent.ts`.
+- Let the Workflow SDK use its default local world, which stores workflow state under `.workflow-data`, configure your host so that directory is on persistent storage, or select another world with `experimental.workflow.world` in the root `agent.ts`. When you select a custom world, install a world package built against the same `@workflow/*` line as your eve release (currently the `5.0.0-beta` line). The npm `latest` tag may lag, so pin the version explicitly, for example `pnpm add @workflow/world-postgres@5.0.0-beta.x`. A mismatched world (such as a `4.x` package against a `5.x` core) fails with a `ZodError: invalid_union` during run replay.
+- If you put a reverse proxy or ingress in front of eve, forward **both** `/eve/` and `/.well-known/workflow/`. The workflow world delivers run callbacks to `/.well-known/workflow/v1/flow`; a proxy restricted to `/eve/` lets sessions start but silently stalls runs forever, because the callbacks never reach eve.
 - Install the AI SDK package for your provider, then use a direct provider model object and `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` when you want no Gateway dependency.
 - Use `AI_GATEWAY_API_KEY` if you still want Gateway routing from a non-Vercel host.
 - Replace `vercelOidc()` with auth that your host can verify.
@@ -148,7 +149,7 @@ Self-deployed agents should make the Vercel-specific choices explicit:
 - If the agent defines schedules, the default `eve build && eve start` path starts Nitro's schedule runner, and Vercel wires schedules to Vercel Cron automatically. If you adapt the output to a custom HTTP-only host or preset, make sure it also runs Nitro scheduled tasks, or trigger the same work from your own scheduler.
 - Treat Vercel Cron, Vercel Sandbox prewarm, Vercel Deployment Protection bypass, and the Agent Runs dashboard as Vercel-only conveniences.
 
-The HTTP contract is unchanged: health, session creation, streaming, channels, tools, and subagents use the same routes. Any client that can reach and authenticate to those routes can talk to the agent.
+The HTTP contract is unchanged: health, session creation, streaming, channels, tools, and subagents use the same routes under `/eve/`, and the workflow dispatch route lives under `/.well-known/workflow/`. A reverse proxy must preserve both prefixes. Any client that can reach and authenticate to those routes can talk to the agent.
 
 ## 9. Verify the deployment
 


### PR DESCRIPTION
## Summary

Documents two undocumented gotchas that tripped up a self-hoster wiring up the Postgres-backed workflow world for self-hosting. Both stem from a self-hosting writeup.

### 1. Reverse-proxy gap (`/.well-known/workflow/`)

eve serves an internal workflow dispatch route at `/.well-known/workflow/v1/flow` that the workflow world uses for run callbacks. A reverse proxy that forwards only `/eve/*` (the natural instinct) lets sessions **start** but makes runs **silently stall forever** — the callbacks never reach eve. The code already treats `eve/` and `.well-known/workflow/` as co-equal required prefixes (`EVE_VERCEL_FUNCTION_PREFIXES`), but the docs never told self-hosters this. Now they do: a proxy/ingress in front of eve must forward **both** `/eve/` and `/.well-known/workflow/`.

### 2. World version trap (version pin)

The docs referenced `experimental.workflow.world: "@workflow/world-postgres"` with no install command and no version guidance. `pnpm add @workflow/world-postgres` resolves the npm `latest` tag, which can be **incompatible** with the `@workflow/*` line this eve release bundles (currently the `5.0.0-beta` line). A mismatched world (e.g. a `4.x` world against a `5.x` core) throws a cryptic `ZodError: invalid_union` during run replay. The docs now give a concrete install command with an explicit pin (`pnpm add @workflow/world-postgres@5.0.0-beta.x`), warn that `latest` can lag, and make the Postgres credentials-in-env guidance concrete.

## Changes

- `docs/guides/deployment.md` (§8 "Deploy without Vercel"): expanded the custom-world bullet with the version-pin guidance, added a reverse-proxy bullet, and updated the closing HTTP-contract sentence to name the `/.well-known/workflow/` dispatch route.
- `docs/agent-config.md` ("Workflow world"): added the install block with the explicit pin, the `latest`-tag warning, and concrete Postgres credentials guidance.
- `docs/concepts/execution-model-and-durability.md` ("Selecting custom workflow world packages"): added a short compatibility note cross-linking to the deployment guide for the install command.

## Notes

- Docs-only change; no changeset.
- `pnpm docs:check` passes (69 files validated, snippets resolve, MDX compiles).
- Pairs with a sibling runtime PR (branch `pgp/eve-self-host-workflow-runtime`) that makes `eve start` work with a custom world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)