### PR TITLE
fix(eve): answer HEAD requests on the health endpoint

### DIFF
--- a/.changeset/eve-health-head.md
+++ b/.changeset/eve-health-head.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+eve's health endpoint (`/eve/v1/health`) now responds to `HEAD` requests, not just `GET`, so load balancers and uptime monitors that probe with `HEAD` (UptimeRobot, Kubernetes probes, and others) no longer report a healthy deployment as down.

--- a/packages/eve/src/internal/nitro/host/configure-nitro-routes.test.ts
+++ b/packages/eve/src/internal/nitro/host/configure-nitro-routes.test.ts
@@ -142,7 +142,7 @@ describe("configureNitroRoutes", () => {
     });
 
     const healthHandler = nitro.options.handlers.find(
-      (handler) => handler.route === EVE_HEALTH_ROUTE_PATH,
+      (handler) => handler.route === EVE_HEALTH_ROUTE_PATH && handler.method === "GET",
     );
     expect(healthHandler?.handler).toBe(`#eve-route-handler/GET ${EVE_HEALTH_ROUTE_PATH}`);
 
@@ -151,6 +151,30 @@ describe("configureNitroRoutes", () => {
       'import handler from "file:///G:/projects/test-eve/node_modules/.pnpm/eve@0.3.0/node_modules/eve/dist/src/internal/nitro/routes/health.js";',
     );
     expect(virtualSource).not.toContain('"G:\\');
+  });
+
+  it("registers the health route for HEAD so load balancers probing with HEAD see 200", async () => {
+    const nitro = createNitroStub();
+
+    await configureNitroRoutes(nitro, createPreparedHost(), {
+      surface: "app",
+    });
+
+    const healthMethods = nitro.options.handlers
+      .filter((handler) => handler.route === EVE_HEALTH_ROUTE_PATH)
+      .map((handler) => handler.method);
+    expect(healthMethods).toContain("GET");
+    expect(healthMethods).toContain("HEAD");
+
+    const headHandler = nitro.options.handlers.find(
+      (handler) => handler.route === EVE_HEALTH_ROUTE_PATH && handler.method === "HEAD",
+    );
+    expect(headHandler?.handler).toBe(`#eve-route-handler/HEAD ${EVE_HEALTH_ROUTE_PATH}`);
+
+    const virtualSource = nitro.options.virtual[headHandler?.handler ?? ""];
+    expect(virtualSource).toContain(
+      'import handler from "file:///G:/projects/test-eve/node_modules/.pnpm/eve@0.3.0/node_modules/eve/dist/src/internal/nitro/routes/health.js";',
+    );
   });
 
   it("registers workflow routes through physical handlers with relative bundle imports", async () => {

--- a/packages/eve/src/internal/nitro/host/configure-nitro-routes.ts
+++ b/packages/eve/src/internal/nitro/host/configure-nitro-routes.ts
@@ -46,7 +46,7 @@ function registerHandler(
   nitro: Nitro,
   options: {
     handlerPath: string;
-    method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+    method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
     route: string;
   },
 ): void {
@@ -327,11 +327,17 @@ export async function configureNitroRoutes(
       method: "GET",
       route: "/",
     });
-    registerHandler(nitro, {
-      handlerPath: resolvePackageSourceFilePath("src/internal/nitro/routes/health.ts"),
-      method: "GET",
-      route: EVE_HEALTH_ROUTE_PATH,
-    });
+    // Register health for GET and HEAD: each (method, route) pair is a
+    // distinct Nitro handler, so HEAD must be registered explicitly or load
+    // balancers and uptime monitors that probe with HEAD get a 404. Nitro
+    // runs the handler for HEAD and omits the body, leaving GET unchanged.
+    for (const method of ["GET", "HEAD"] as const) {
+      registerHandler(nitro, {
+        handlerPath: resolvePackageSourceFilePath("src/internal/nitro/routes/health.ts"),
+        method,
+        route: EVE_HEALTH_ROUTE_PATH,
+      });
+    }
 
     // The agent info endpoint needs `appRoot` baked at build time (used by
     // the disk-source fallback in dev) and runs request-time auth, so it


### PR DESCRIPTION
## The bug

eve's health endpoint `/eve/v1/health` returns `200 {"ok":true,"status":"ready",...}` for `GET`, but returned **404 for HTTP `HEAD`** requests. Many load balancers and uptime monitors (UptimeRobot, Kubernetes probes, etc.) default to `HEAD`, so they saw a healthy deployment as "down." This was hit in a real self-hosting writeup.

### Root cause

In `packages/eve/src/internal/nitro/host/configure-nitro-routes.ts`, the health route was registered GET-only. Nitro/H3 v2 keys route lookup on the request method with no GET→HEAD fallback, so a `HEAD` request matched no registered handler and fell through to 404. This mirrors the existing `(method, urlPath)`-per-route model already documented in `runtime/connections/callback-route.ts` ("sharing one URL pattern across multiple methods is not supported").

## The fix

Register the health route for both `GET` and `HEAD`, and add `"HEAD"` to the `registerHandler` `method` union. H3 v2 runs the matched handler for `HEAD` and strips the response body (`nullBody`) while keeping `status` 200 and headers, so `GET` behavior is unchanged. The change is scoped to the health route only — the home `/` route and all other routes are untouched.

## Tests

- Added a unit test in `configure-nitro-routes.test.ts`: `registers the health route for HEAD so load balancers probing with HEAD see 200`, asserting the health route is registered for both `GET` and `HEAD` and that the `HEAD` handler resolves the same `health.ts` source. The existing health-GET assertion was tightened to match on method so it keeps asserting GET specifically.
- No existing scenario/integration test boots a real Nitro HTTP server to probe `/eve/v1/health` (the nitro-host scenario tests mock the Nitro builder and assert on build config/output), so there was no suitable live-server test to extend with a `HEAD → 200` HTTP assertion.

## Validation

- `pnpm --filter eve typecheck` — pass
- `pnpm lint` (oxlint) — pass
- Unit: `vitest run --config vitest.unit.config.ts src/internal/nitro/host/configure-nitro-routes.test.ts` — 7/7 pass

A changeset (`patch`) is included.

## Notes

Stems from the same self-hosting writeup as #306/#308, and touches the same file as #308 (`configure-nitro-routes.ts`) but a different region (health route registration vs. the `registerHandler` method union edit is small/localized), so a trivial rebase may be needed depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)