### PR TITLE
feat(setup): honor `AI_GATEWAY_BASE_URL` when validating the gateway key

### DIFF
--- a/.changeset/gateway-base-url-env.md
+++ b/.changeset/gateway-base-url-env.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`validateGatewayApiKey` now honors the `AI_GATEWAY_BASE_URL` environment variable when constructing the gateway provider, so the `AI_GATEWAY_API_KEY` check can be pointed at a self-hosted or proxied AI Gateway instead of always hitting `ai-gateway.vercel.sh`.

--- a/packages/eve/src/setup/validate-gateway-key.ts
+++ b/packages/eve/src/setup/validate-gateway-key.ts
@@ -54,6 +54,7 @@ export async function validateGatewayApiKey(
   try {
     const provider = createGateway({
       apiKey,
+      baseURL: process.env.AI_GATEWAY_BASE_URL,
       fetch: (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
         globalThis.fetch(url, { ...init, signal: effectiveSignal }),
     });


### PR DESCRIPTION
## Summary

`validateGatewayApiKey` constructs an `@ai-sdk/gateway` provider with no `baseURL`, so the `AI_GATEWAY_API_KEY` check always runs against `ai-gateway.vercel.sh`. This forwards the `AI_GATEWAY_BASE_URL` environment variable to `createGateway`, so anyone running eve against a self-hosted or proxied AI Gateway can validate their key against the same endpoint they actually use.

```ts
const provider = createGateway({
  apiKey,
  baseURL: process.env.AI_GATEWAY_BASE_URL,
  fetch: ...,
});
```

`createGateway` already treats an `undefined`/empty `baseURL` as "use the default", so there is no behavior change when the variable is unset.

## Notes

- Pairs with vercel/ai#16401, which adds the same `AI_GATEWAY_BASE_URL` fallback inside `@ai-sdk/gateway` itself (covering the default/global provider used for runtime inference). This makes eve's own `createGateway` call honor it directly, without waiting on that release.
- The setup-time model-listing endpoints (`gateway-models.ts` / `model-catalog.ts`) go through `vercel curl` against the `/v1/models` API — a separate code path and endpoint — so they're intentionally left out of this change. Happy to follow up on those if desired.
