### PR TITLE
chore(e2e): fixture evals - use zai GLM-5.2

### DIFF
--- a/e2e/fixtures/agent-basic-runtime/agent/agent.ts
+++ b/e2e/fixtures/agent-basic-runtime/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-basic-runtime/evals/evals.config.ts
+++ b/e2e/fixtures/agent-basic-runtime/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-channels/agent/agent.ts
+++ b/e2e/fixtures/agent-channels/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-channels/evals/evals.config.ts
+++ b/e2e/fixtures/agent-channels/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-openapi-swagger/agent/agent.ts
+++ b/e2e/fixtures/agent-openapi-swagger/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-openapi-swagger/evals/evals.config.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-schedules/agent/agent.ts
+++ b/e2e/fixtures/agent-schedules/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-schedules/evals/evals.config.ts
+++ b/e2e/fixtures/agent-schedules/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-skills/agent/agent.ts
+++ b/e2e/fixtures/agent-skills/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-skills/evals/evals.config.ts
+++ b/e2e/fixtures/agent-skills/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/agent.ts
@@ -3,6 +3,11 @@ import { defineAgent } from "eve";
 export default defineAgent({
   description:
     'Look up the current stock price for a given ticker symbol. Pass the ticker symbol you want to look up in the message (e.g. "AAPL", "GOOG", or "TSLA").',
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents-hitl/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-subagents/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents/agent/subagents/echo-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/echo-marker/agent.ts
@@ -12,6 +12,11 @@ import { defineAgent } from "eve";
 export default defineAgent({
   description:
     "Smoke-test echo subagent. Call this whenever the user mentions the phrase 'echo marker subagent'. Pass any short text as the input; the subagent replies with a fixed marker token.",
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagents/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-tools-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools-hitl/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-tools-sandbox/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools-sandbox/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });

--- a/e2e/fixtures/agent-tools/agent/agent.ts
+++ b/e2e/fixtures/agent-tools/agent/agent.ts
@@ -1,6 +1,11 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: "zai/glm-5.2",
+  modelOptions: {
+    providerOptions: {
+      gateway: { only: ["zai"] },
+    },
+  },
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools/evals/evals.config.ts
@@ -2,5 +2,12 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: {
+    model: "zai/glm-5.2",
+    modelOptions: {
+      providerOptions: {
+        gateway: { only: ["zai"] },
+      },
+    },
+  },
 });


### PR DESCRIPTION
### Description

Switch all e2e fixture agents, subagents, and judge configs to `zai/glm-5.2`. Restrict every request to the `zai` provider through AI Gateway so the suite specifically validates the ZAI execution path.

### How did you test your changes?

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- Verified all 22 model configurations include `gateway.only: ["zai"]`

The fixture-owned e2e suite runs in CI only.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not applicable; fixture-only change)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
