### PR TITLE
fix(eve): connections - use local callback URL

### DIFF
--- a/.changeset/calm-callback-ports.md
+++ b/.changeset/calm-callback-ports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use the active eve development server URL for connection authorization callbacks. Local Vercel Connect flows now return to eve's actual port instead of Workflow's port 3000 fallback.

--- a/packages/eve/src/execution/workflow-callback-url.test.ts
+++ b/packages/eve/src/execution/workflow-callback-url.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createWorkflowCallbackUrl,
   resolveVercelProductionCallbackBaseUrl,
+  resolveWorkflowCallbackBaseUrl,
 } from "#execution/workflow-callback-url.js";
 
 describe("resolveVercelProductionCallbackBaseUrl", () => {
@@ -44,6 +45,36 @@ describe("resolveVercelProductionCallbackBaseUrl", () => {
       ),
     ).toBe(
       "https://agent.example.com/eve/v1/connections/linear/callback/tok123?code=abc&x-vercel-protection-bypass=secret",
+    );
+  });
+});
+
+describe("resolveWorkflowCallbackBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses workflow metadata when no callback override is configured", () => {
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("WORKFLOW_LOCAL_BASE_URL", "");
+
+    expect(resolveWorkflowCallbackBaseUrl("http://localhost:3000/")).toBe("http://localhost:3000");
+  });
+
+  it("prefers the active local world base URL and removes its trailing slash", () => {
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("WORKFLOW_LOCAL_BASE_URL", "http://127.0.0.1:2000/");
+
+    expect(resolveWorkflowCallbackBaseUrl("http://localhost:3000")).toBe("http://127.0.0.1:2000");
+  });
+
+  it("prefers the stable Vercel production URL over a local world override", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("VERCEL_PROJECT_PRODUCTION_URL", "agent.example.com");
+    vi.stubEnv("WORKFLOW_LOCAL_BASE_URL", "http://127.0.0.1:2000");
+
+    expect(resolveWorkflowCallbackBaseUrl("https://deployment.example.com")).toBe(
+      "https://agent.example.com",
     );
   });
 });

--- a/packages/eve/src/execution/workflow-callback-url.ts
+++ b/packages/eve/src/execution/workflow-callback-url.ts
@@ -1,5 +1,6 @@
 const PRODUCTION_ENVIRONMENT = "production";
 const VERCEL_PROTECTION_BYPASS_QUERY = "x-vercel-protection-bypass";
+const WORKFLOW_LOCAL_BASE_URL_ENV = "WORKFLOW_LOCAL_BASE_URL";
 
 /**
  * Workflow metadata is deployment-specific, so on Vercel it can point at
@@ -18,6 +19,20 @@ export function resolveVercelProductionCallbackBaseUrl(): string | null {
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
   }
   return null;
+}
+
+/**
+ * Resolves the origin used for framework-owned workflow callbacks.
+ *
+ * Workflow metadata falls back to port 3000 when its optional local port
+ * discovery is unavailable. eve already configures the local world with the
+ * active dev-server origin, so prefer that value before the metadata fallback.
+ */
+export function resolveWorkflowCallbackBaseUrl(metadataUrl: string): string {
+  const configuredLocalBaseUrl = process.env[WORKFLOW_LOCAL_BASE_URL_ENV]?.trim();
+  const localBaseUrl = configuredLocalBaseUrl ? configuredLocalBaseUrl : undefined;
+  const resolved = resolveVercelProductionCallbackBaseUrl() ?? localBaseUrl ?? metadataUrl;
+  return resolved.replace(/\/$/, "");
 }
 
 /**

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -31,7 +31,7 @@ import {
   normalizeSerializableError,
   rebuildSerializableError,
 } from "#execution/workflow-errors.js";
-import { resolveVercelProductionCallbackBaseUrl } from "#execution/workflow-callback-url.js";
+import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import { createSessionStep } from "#execution/create-session-step.js";
 import { dispatchWorkflowRuntimeActionsStep } from "#execution/dispatch-workflow-runtime-actions-step.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
@@ -297,7 +297,7 @@ async function runDriverLoop(input: {
               : dispatchRuntimeActionsStep;
 
           const dispatchResult = await dispatchStep({
-            callbackBaseUrl: resolveVercelProductionCallbackBaseUrl() ?? getWorkflowMetadata().url,
+            callbackBaseUrl: resolveWorkflowCallbackBaseUrl(getWorkflowMetadata().url),
             parentWritable: input.driverWritable,
             serializedContext: action.serializedContext,
             sessionState: action.sessionState,

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -43,6 +43,7 @@ import {
   PendingAuthorizationResultKey,
   type AuthorizationResult,
 } from "#harness/authorization.js";
+import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import type { ConnectionAuthorizationChallenge } from "#public/connections/errors.js";
 import type { AuthorizationCallback } from "#runtime/connections/types.js";
 import {
@@ -111,13 +112,13 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const adapter = ctx.require(ChannelKey);
   const bundle = ctx.require(BundleKey);
 
-  // Populate the callback base URL so getHookUrl() works during
-  // tool execution. Reads from workflow metadata (available in steps).
+  // Populate the callback base URL so getHookUrl() works during tool
+  // execution, preferring eve's active local origin over metadata fallback.
   try {
     const { getWorkflowMetadata } = await import("#compiled/@workflow/core/index.js");
     const metadata = getWorkflowMetadata();
     if (typeof metadata.url === "string") {
-      ctx.set(CallbackBaseUrlKey, metadata.url.replace(/\/$/, ""));
+      ctx.set(CallbackBaseUrlKey, resolveWorkflowCallbackBaseUrl(metadata.url));
     }
   } catch {
     // Outside a workflow context (e.g. tests) — getHookUrl will return undefined.


### PR DESCRIPTION
## Summary

- prefer `WORKFLOW_LOCAL_BASE_URL` when eve constructs framework-owned callback URLs
- preserve the stable Vercel production URL override and Workflow metadata fallback
- add regression coverage and a patch changeset

## Why

Workflow metadata falls back to `http://localhost:3000` when its optional local port discovery is unavailable. Packaged eve applications do not expose that optional module at runtime, while `eve dev` listens on port 2000 by default. Vercel Connect authorization therefore succeeded but redirected the browser to the wrong local port.

With this change, connection authorization callbacks use the active eve development server origin, including an explicitly configured or automatically selected port. No local user configuration is required.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/workflow-callback-url.test.ts src/execution/workflow-entry.test.ts src/execution/workflow-steps.test.ts`
- `pnpm --filter eve typecheck`
- focused `oxlint` and `oxfmt` checks
- `pnpm guard:invariants`