### PR TITLE
chore(e2e): stress fixture - log sequential turn timings

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           mkdir -p "$EVE_EVAL_JUNIT_DIR"
           cd "${{ matrix.dir }}"
-          pnpm exec eve eval --strict --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
+          pnpm exec eve eval --strict --verbose --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
 
       - name: Upload eval artifacts
         if: failure()

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -99,7 +99,7 @@ jobs:
             pnpm exec eve build
           DEPLOYMENT_URL="$(pnpm exec vc deploy --prebuilt --yes --target=preview "${token_args[@]}" | tail -n 1)"
 
-          npx eve eval --strict --url "$DEPLOYMENT_URL" --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
+          npx eve eval --strict --verbose --url "$DEPLOYMENT_URL" --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
 
       - name: Upload eval artifacts
         if: failure()

--- a/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
@@ -12,7 +12,15 @@ export default defineEval({
 
     for (let turnNumber = 1; turnNumber <= TURN_COUNT; turnNumber += 1) {
       const marker = `sequential-turn-${String(turnNumber).padStart(3, "0")}`;
-      const turn = (await t.send(marker)).expectOk();
+      const startedAt = performance.now();
+      const result = await t.send(marker);
+      const elapsedSeconds = (performance.now() - startedAt) / 1_000;
+
+      t.log(
+        `turn ${String(turnNumber).padStart(3, "0")}/${TURN_COUNT} completed in ${elapsedSeconds.toFixed(3)}s`,
+      );
+
+      const turn = result.expectOk();
 
       sessionId ??= turn.sessionId;
       await t.require(turn.sessionId, equals(sessionId));


### PR DESCRIPTION
## Summary

- measure and record the elapsed time for every turn in the 100-turn sequential workflow stress eval
- stream eval timing logs in the local and Vercel e2e workflows with `--verbose`

## Why

The sequential stress fixture is taking unexpectedly long against Vercel, but the existing output only reports the duration of the complete eval. Per-turn timing makes it possible to identify whether latency grows as the durable session accumulates history and to spot individual outliers.

## Validation

- `pnpm --filter eve build`
- `pnpm --filter agent-workflow-stress typecheck`
- `pnpm lint`
- `pnpm exec eve eval sequential-workflow-turns --strict --verbose` (205/205 gates passed; 100 timing lines emitted)
