### PR TITLE
fix(eve): render Slack status text plainly

### DIFF
--- a/.changeset/neat-terms-sparkle.md
+++ b/.changeset/neat-terms-sparkle.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack assistant-thread status text now strips lightweight Markdown before calling Slack, so model progress updates like `**Considering turbo tasks**` display without literal formatting markers.

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -560,6 +560,25 @@ describe("auto-anchor on first post", () => {
     expect((setStatus!.body as { thread_ts: string }).thread_ts).toBe("1700000001.000001");
   });
 
+  it("sends assistant status as plain text", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.startTyping("**Considering turbo tasks**");
+
+    const setStatus = mock.calls.find(
+      (c) => c.url === "https://slack.com/api/assistant.threads.setStatus",
+    );
+    expect(setStatus?.body).toMatchObject({
+      status: "Considering turbo tasks",
+      loading_messages: ["Considering turbo tasks"],
+    });
+  });
+
   it("invokes onThreadTsChanged exactly once even on concurrent first-posts", async () => {
     const anchors: string[] = [];
     const { thread } = buildSlackBinding({

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -20,6 +20,7 @@ import { isCardElement, type CardElement, type FileUpload } from "#compiled/chat
 import { createLogger, logError } from "#internal/logging.js";
 import { encodeSlackApiBody } from "#public/channels/slack/api-encoding.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
+import { truncateTypingStatus } from "#public/channels/slack/limits.js";
 import {
   gfmToSlackMrkdwn,
   rewriteBareMentions,
@@ -481,13 +482,14 @@ export function buildSlackBinding(input: {
     async startTyping(status) {
       if (!input.channelId || !currentThreadTs) return;
       try {
+        const normalizedStatus = status === undefined ? "" : truncateTypingStatus(status);
         const body: Record<string, unknown> = {
           channel_id: input.channelId,
           thread_ts: currentThreadTs,
-          status: status ?? "",
+          status: normalizedStatus,
         };
-        if (status !== undefined && status.length > 0) {
-          body.loading_messages = [status];
+        if (normalizedStatus.length > 0) {
+          body.loading_messages = [normalizedStatus];
         }
         const response = await request("assistant.threads.setStatus", body);
         if (response.ok !== true) {

--- a/packages/eve/src/public/channels/slack/limits.test.ts
+++ b/packages/eve/src/public/channels/slack/limits.test.ts
@@ -22,6 +22,13 @@ describe("truncateTypingStatus", () => {
     expect(truncateTypingStatus("   Running   foo,   bar  ")).toBe("Running foo, bar");
   });
 
+  it("strips Markdown formatting that assistant status renders literally", () => {
+    expect(truncateTypingStatus("**Considering turbo tasks**")).toBe("Considering turbo tasks");
+    expect(truncateTypingStatus("Running `turbo` for [eve](https://github.com/vercel/eve)")).toBe(
+      "Running turbo for eve",
+    );
+  });
+
   it("caps at the typing-status limit with a trailing ellipsis", () => {
     const long = "a".repeat(SLACK_TYPING_STATUS_MAX_LENGTH + 20);
     const result = truncateTypingStatus(long);

--- a/packages/eve/src/public/channels/slack/limits.ts
+++ b/packages/eve/src/public/channels/slack/limits.ts
@@ -40,12 +40,14 @@ export const SLACK_MESSAGE_TEXT_MAX_LENGTH = 40000;
 export const SLACK_MODAL_TITLE_MAX_LENGTH = 24;
 
 /**
- * Normalizes a typing status: trims, collapses runs of whitespace into a
- * single space, then truncates to {@link SLACK_TYPING_STATUS_MAX_LENGTH}
- * with a trailing ellipsis when needed.
+ * Normalizes a typing status: strips lightweight Markdown that Slack
+ * assistant-thread status does not render, trims, collapses runs of
+ * whitespace into a single space, then truncates to
+ * {@link SLACK_TYPING_STATUS_MAX_LENGTH} with a trailing ellipsis when
+ * needed.
  */
 export function truncateTypingStatus(status: string): string {
-  const normalized = status.trim().replace(/\s+/gu, " ");
+  const normalized = stripTypingStatusMarkdown(status).trim().replace(/\s+/gu, " ");
   return truncateWithEllipsis(normalized, SLACK_TYPING_STATUS_MAX_LENGTH);
 }
 
@@ -88,4 +90,13 @@ function truncateWithEllipsis(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   const sliceLength = Math.max(0, maxLength - 3);
   return `${value.slice(0, sliceLength).trimEnd()}...`;
+}
+
+function stripTypingStatusMarkdown(status: string): string {
+  return status
+    .replace(/\[([^\]]+)\]\([^)]+\)/gu, "$1")
+    .replace(/`([^`]+)`/gu, "$1")
+    .replace(/~~([^~]+)~~/gu, "$1")
+    .replace(/(\*\*|__)([^*_]+)\1/gu, "$2")
+    .replace(/(^|[^\p{L}\p{N}])([*_])([^*_]+)\2(?=$|[^\p{L}\p{N}])/gu, "$1$3");
 }


### PR DESCRIPTION
### Description

Slack assistant-thread status text is rendered as plain text, so GFM-style model updates like `**Considering turbo tasks**` were showing literal asterisks in Slack.

This normalizes status text through the Slack typing-status helper before calling `assistant.threads.setStatus`, stripping lightweight Markdown while leaving normal Slack message formatting untouched.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/limits.test.ts src/public/channels/slack/api.test.ts`
- `pnpm --filter eve run test:unit`
- `pnpm --filter eve run typecheck`
- `pnpm exec oxlint packages/eve/src/public/channels/slack/limits.ts packages/eve/src/public/channels/slack/api.ts packages/eve/src/public/channels/slack/limits.test.ts packages/eve/src/public/channels/slack/api.test.ts`
- `git diff --check`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
