### PR TITLE
fix(eve): scope scaffold peer metadata to package manager

### DIFF
--- a/.changeset/gentle-geese-build.md
+++ b/.changeset/gentle-geese-build.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Generated projects now emit peer-resolution metadata only for their selected package manager. pnpm scaffolds no longer include npm or Yarn fields that can make frozen Vercel installs fail.

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -153,15 +153,10 @@ describe("runInitCommand", () => {
     );
     const manifest = await readFile(join(projectPath, "package.json"), "utf8");
     expect(manifest).toContain('"eve": "^0.6.0"');
-    // `@vercel/connect`'s optional `ai` peer rejects prereleases, so npm/yarn
-    // need `ai` forced to the pinned prerelease or the install fails (ERESOLVE).
-    const packageJson = JSON.parse(manifest) as {
-      dependencies: Record<string, string>;
-      overrides: Record<string, string>;
-      resolutions: Record<string, string>;
-    };
-    expect(packageJson.overrides.ai).toBe(packageJson.dependencies.ai);
-    expect(packageJson.resolutions.ai).toBe(packageJson.dependencies.ai);
+    // pnpm accepts the optional prerelease peer without a manager-specific pin.
+    const packageJson: unknown = JSON.parse(manifest);
+    expect(packageJson).not.toHaveProperty("overrides");
+    expect(packageJson).not.toHaveProperty("resolutions");
     await expect(pathExists(join(projectPath, "app"))).resolves.toBe(false);
     await expect(pathExists(join(projectPath, ".vercel"))).resolves.toBe(false);
     await expect(pathExists(join(projectPath, "vercel.json"))).resolves.toBe(false);
@@ -305,12 +300,12 @@ describe("runInitCommand", () => {
   );
 
   it.each([
-    ["npm", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", ["eve", "dev", "--input", "/model"]],
-    ["bun", ["x", "eve", "dev", "--input", "/model"]],
+    ["npm", "overrides", ["exec", "--", "eve", "dev", "--input", "/model"]],
+    ["yarn", "resolutions", ["eve", "dev", "--input", "/model"]],
+    ["bun", "overrides", ["x", "eve", "dev", "--input", "/model"]],
   ] as const)(
     "scaffolds a fresh project owned by the invoking manager %s without pnpm policy",
-    async (kind, devArguments) => {
+    async (kind, aiPinField, devArguments) => {
       const parentDirectory = await mkdtemp(join(tmpdir(), `eve-init-agent-${kind}-`));
       const output = logger();
       const deps = dependencies();
@@ -325,6 +320,13 @@ describe("runInitCommand", () => {
       // The workspace policy is pnpm configuration; a scaffold owned by
       // another manager must not receive it.
       await expect(pathExists(join(projectPath, "pnpm-workspace.yaml"))).resolves.toBe(false);
+      const packageJson: unknown = JSON.parse(
+        await readFile(join(projectPath, "package.json"), "utf8"),
+      );
+      expect(packageJson).toHaveProperty(aiPinField);
+      expect(packageJson).not.toHaveProperty(
+        aiPinField === "overrides" ? "resolutions" : "overrides",
+      );
       expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
         kind,
         projectPath,

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -153,11 +153,37 @@ export default defineAgent({
 `;
 
 // `@vercel/connect`'s optional `ai` peer (`^6 || ^7`) excludes prereleases, so
-// npm and yarn refuse to fill it from the prerelease `ai` the eve runtime pins
-// and abort the install (ERESOLVE). Forcing `ai` through `overrides` (npm/bun)
-// and `resolutions` (yarn) keeps the whole tree on that exact version; pnpm
-// already tolerates the unmet optional peer and ignores both fields.
-function packageJsonTemplate(includeRootOnlyFields: boolean): string {
+// npm, Bun, and Yarn need a manager-specific pin for the runtime's prerelease
+// `ai` version. pnpm tolerates the unmet optional peer without either field.
+function packageManagerAiPinTemplateSuffix(packageManager: PackageManagerKind): string {
+  switch (packageManager) {
+    case "bun":
+    case "npm":
+      return `,
+  "overrides": {
+    "ai": "__EVE_INIT_AI_SDK_VERSION__"
+  }`;
+    case "yarn":
+      return `,
+  "resolutions": {
+    "ai": "__EVE_INIT_AI_SDK_VERSION__"
+  }`;
+    case "pnpm":
+      return "";
+    default: {
+      const exhaustive: never = packageManager;
+      return exhaustive;
+    }
+  }
+}
+
+function packageJsonTemplate(input: {
+  includeRootOnlyFields: boolean;
+  packageManager: PackageManagerKind;
+}): string {
+  const rootOnlyFields = input.includeRootOnlyFields
+    ? `${packageManagerAiPinTemplateSuffix(input.packageManager)}${ROOT_ONLY_PACKAGE_JSON_TEMPLATE_SUFFIX}`
+    : "";
   return `{
   "name": "__EVE_INIT_APP_NAME__",
   "version": "0.0.0",
@@ -181,18 +207,12 @@ function packageJsonTemplate(includeRootOnlyFields: boolean): string {
   "devDependencies": {
     "@types/node": "__EVE_INIT_TYPES_NODE_VERSION__",
     "typescript": "__EVE_INIT_TYPESCRIPT_VERSION__"
-  }${includeRootOnlyFields ? ROOT_ONLY_PACKAGE_JSON_TEMPLATE_SUFFIX : ""}
+  }${rootOnlyFields}
 }
 `;
 }
 
 const ROOT_ONLY_PACKAGE_JSON_TEMPLATE_SUFFIX = `,
-  "overrides": {
-    "ai": "__EVE_INIT_AI_SDK_VERSION__"
-  },
-  "resolutions": {
-    "ai": "__EVE_INIT_AI_SDK_VERSION__"
-  },
   "engines": {
     "node": "__EVE_INIT_NODE_ENGINE__"
   }
@@ -255,14 +275,18 @@ package docs are unavailable, use https://eve.dev/docs as a fallback.
 `,
 };
 
-function templateFiles(
-  byokProvider: boolean,
-  includeRootOnlyPackageJsonFields: boolean,
-): Record<string, string> {
+function templateFiles(input: {
+  byokProvider: boolean;
+  includeRootOnlyPackageJsonFields: boolean;
+  packageManager: PackageManagerKind;
+}): Record<string, string> {
   return {
-    "agent/agent.ts": byokProvider ? BYOK_AGENT_TEMPLATE : BASE_AGENT_TEMPLATE,
+    "agent/agent.ts": input.byokProvider ? BYOK_AGENT_TEMPLATE : BASE_AGENT_TEMPLATE,
     ...SHARED_TEMPLATE_FILES,
-    "package.json": packageJsonTemplate(includeRootOnlyPackageJsonFields),
+    "package.json": packageJsonTemplate({
+      includeRootOnlyFields: input.includeRootOnlyPackageJsonFields,
+      packageManager: input.packageManager,
+    }),
   };
 }
 
@@ -363,7 +387,13 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
 
   await mkdir(targetRoot, { recursive: true });
 
-  for (const [relPath, content] of Object.entries(templateFiles(byokProvider, !workspaceMember))) {
+  for (const [relPath, content] of Object.entries(
+    templateFiles({
+      byokProvider,
+      includeRootOnlyPackageJsonFields: !workspaceMember,
+      packageManager,
+    }),
+  )) {
     const filePath = `${targetRoot}/${relPath}`;
     const existed = await pathExists(filePath);
     await writeTextFile(filePath, renderTemplate(content, ctx), {

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -746,9 +746,14 @@ describe("scaffoldBaseProject", () => {
     }
   });
 
-  test.each(["npm", "yarn", "bun"] as const)(
-    "omits the pnpm workspace policy from a scaffold owned by %s",
-    async (packageManager) => {
+  test.each([
+    ["pnpm", undefined],
+    ["npm", "overrides"],
+    ["yarn", "resolutions"],
+    ["bun", "overrides"],
+  ] as const)(
+    "scaffolds a standalone %s project with its own package-manager metadata",
+    async (packageManager, aiPinField) => {
       const targetDirectory = await createTempDir();
       const projectRoot = await scaffoldBaseProject({
         projectName: "demo-agent",
@@ -764,7 +769,21 @@ describe("scaffoldBaseProject", () => {
       await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
         '"eve": "^0.25.0"',
       );
-      await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
+      await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(
+        packageManager === "pnpm",
+      );
+      const packageJson: unknown = JSON.parse(
+        await readFile(join(projectRoot, "package.json"), "utf8"),
+      );
+      if (aiPinField === undefined) {
+        expect(packageJson).not.toHaveProperty("overrides");
+        expect(packageJson).not.toHaveProperty("resolutions");
+      } else {
+        expect(packageJson).toHaveProperty(`${aiPinField}.ai`, "7.0.0");
+        expect(packageJson).not.toHaveProperty(
+          aiPinField === "overrides" ? "resolutions" : "overrides",
+        );
+      }
     },
   );
 


### PR DESCRIPTION
## What

- Write `overrides` only for npm and Bun, `resolutions` only for Yarn, and neither for pnpm.
- Cover standalone scaffolds and `eve init` for each manager.

Vercel's pnpm 10 frozen install failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because a pnpm project received npm's `overrides` field. The init flow already selected a package manager, but the `package.json` template ignored it.

The peer pin stays for npm, Bun, and Yarn. Removing it everywhere would bring back their prerelease peer install failures. Existing projects are not migrated and still need any mixed lockfiles cleaned up separately.
