### PR TITLE
fix(eve): workflows - fence replayed turn children

### DIFF
--- a/.changeset/quiet-turn-replays.md
+++ b/.changeset/quiet-turn-replays.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fence replayed turn child workflows so only the inbox owner durably selected by the session driver can execute the turn.

--- a/packages/eve/src/execution/activate-turn-step.test.ts
+++ b/packages/eve/src/execution/activate-turn-step.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { activateTurnStep } from "#execution/activate-turn-step.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({
+  resumeHook: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("activateTurnStep", () => {
+  it("sends the committed owner identity to the shared inbox", async () => {
+    await activateTurnStep({ expectedRunId: "wrun_owner", inboxToken: "turn-inbox" });
+
+    expect(resumeHook).toHaveBeenCalledWith("turn-inbox", {
+      expectedRunId: "wrun_owner",
+      kind: "turn-activation",
+    });
+  });
+
+  it("accepts a replay after the activated child disposed its inbox", async () => {
+    vi.mocked(resumeHook).mockRejectedValueOnce(
+      Object.assign(new Error("missing"), { name: "HookNotFoundError" }),
+    );
+
+    await expect(
+      activateTurnStep({ expectedRunId: "wrun_owner", inboxToken: "turn-inbox" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/eve/src/execution/activate-turn-step.ts
+++ b/packages/eve/src/execution/activate-turn-step.ts
@@ -1,0 +1,22 @@
+import { isHookNotFoundError } from "#execution/hook-ownership.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+
+/** Activates the turn child whose inbox ownership was committed by the dispatch step. */
+export async function activateTurnStep(input: {
+  readonly expectedRunId: string;
+  readonly inboxToken: string;
+}): Promise<void> {
+  "use step";
+
+  try {
+    await resumeHook(input.inboxToken, {
+      expectedRunId: input.expectedRunId,
+      kind: "turn-activation",
+    });
+  } catch (error) {
+    // A replay can arrive after the activated child disposed its inbox. The
+    // committed owner cannot be replaced here without activating a different run.
+    if (isHookNotFoundError(error)) return;
+    throw error;
+  }
+}

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.test.ts
@@ -62,6 +62,22 @@ describe("turn workflow wire migrations", () => {
     });
   });
 
+  it("advertises activation when dispatch provides a stable inbox", () => {
+    const input = createTurnWorkflowInput({
+      capabilities: undefined,
+      completionToken: "turn-token",
+      delivery: createDelivery(),
+      inboxToken: "turn-token:inbox:step_dispatch",
+      mode: "conversation",
+      parentWritable: new WritableStream<Uint8Array>(),
+      serializedContext: {},
+      sessionState: createSessionState(),
+    });
+
+    expect(input.driverCapabilities).toEqual({ turnActivation: true, turnInbox: true });
+    expect(input.inboxToken).toBe("turn-token:inbox:step_dispatch");
+  });
+
   it("migrates pre-version (unversioned) workflow input into the current shape", () => {
     const delivery = createDelivery();
     const parentWritable = new WritableStream<Uint8Array>();

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -35,8 +35,11 @@ export interface TurnWorkflowInput {
    * which keeps runtime-action orchestration on the legacy entry-owned path.
    */
   readonly driverCapabilities?: {
+    readonly turnActivation?: true;
     readonly turnInbox?: true;
   };
+  /** Stable inbox shared by every child started by one dispatch step. */
+  readonly inboxToken?: string;
   readonly mode: RunMode;
   readonly stepInput: TurnStepInput;
 }
@@ -45,6 +48,7 @@ export interface TurnWorkflowDispatchInput {
   readonly capabilities: SessionCapabilities | undefined;
   readonly completionToken: string;
   readonly delivery: HookPayload;
+  readonly inboxToken?: string;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
@@ -54,10 +58,13 @@ export interface TurnWorkflowDispatchInput {
 const turnWorkflowInputMigrations: readonly VersionMigration[] = [turnWorkflowInputV0ToV1];
 
 export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnWorkflowInput {
-  return {
+  const workflowInput: TurnWorkflowInput = {
     capabilities: input.capabilities,
     completionToken: input.completionToken,
-    driverCapabilities: { turnInbox: true },
+    driverCapabilities:
+      input.inboxToken === undefined
+        ? { turnInbox: true }
+        : { turnActivation: true, turnInbox: true },
     mode: input.mode,
     stepInput: {
       input: input.delivery,
@@ -67,6 +74,9 @@ export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnW
     },
     version: TURN_WORKFLOW_INPUT_VERSION,
   };
+
+  if (input.inboxToken === undefined) return workflowInput;
+  return { ...workflowInput, inboxToken: input.inboxToken };
 }
 
 export function migrateTurnWorkflowInput(value: unknown): TurnWorkflowInput {

--- a/packages/eve/src/execution/hook-ownership.ts
+++ b/packages/eve/src/execution/hook-ownership.ts
@@ -70,6 +70,18 @@ export function isHookConflictError(error: unknown): error is {
   );
 }
 
+/** Recognizes missing hooks across Workflow package identities. */
+export function isHookNotFoundError(
+  error: unknown,
+): error is { readonly name: "HookNotFoundError" } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "HookNotFoundError"
+  );
+}
+
 function createHookConflictError(
   token: string,
   conflictingRunId?: string,

--- a/packages/eve/src/execution/turn-control-protocol.ts
+++ b/packages/eve/src/execution/turn-control-protocol.ts
@@ -6,6 +6,10 @@ import { resumeHook } from "#internal/workflow/runtime.js";
 export type TurnInboxPayload =
   | Exclude<HookPayload, DeliverHookPayload>
   | {
+      readonly expectedRunId: string;
+      readonly kind: "turn-activation";
+    }
+  | {
       readonly delivery: DeliverHookPayload;
       readonly kind: "driver-delivery";
       readonly requestId: string;

--- a/packages/eve/src/execution/turn-dispatch.test.ts
+++ b/packages/eve/src/execution/turn-dispatch.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
+import { activateTurnStep } from "#execution/activate-turn-step.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.js";
 import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
@@ -14,7 +15,14 @@ vi.mock("#compiled/@workflow/core/index.js", () => ({
 }));
 
 vi.mock("./workflow-steps.js", () => ({
-  dispatchTurnStep: vi.fn(async () => ({ runId: "turn-run" })),
+  dispatchTurnStep: vi.fn(async () => ({
+    inboxToken: "turn-inbox",
+    ownerRunId: "turn-owner",
+  })),
+}));
+
+vi.mock("./activate-turn-step.js", () => ({
+  activateTurnStep: vi.fn(),
 }));
 
 vi.mock("./forward-turn-delivery-step.js", () => ({
@@ -51,6 +59,10 @@ describe("dispatchAndAwaitTurn", () => {
     });
 
     expect(rekeyHook).toHaveBeenCalledWith("slack:C1:T1");
+    expect(activateTurnStep).toHaveBeenCalledWith({
+      expectedRunId: "turn-owner",
+      inboxToken: "turn-inbox",
+    });
   });
 
   it("rekeys while a turn delivery request is already waiting", async () => {

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -1,4 +1,5 @@
 import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
+import { activateTurnStep } from "#execution/activate-turn-step.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
@@ -25,7 +26,7 @@ export async function dispatchAndAwaitTurn(input: {
   });
 
   try {
-    await dispatchTurnStep({
+    const dispatched = await dispatchTurnStep({
       capabilities: input.capabilities,
       completionToken: control.token,
       delivery: input.delivery,
@@ -33,6 +34,11 @@ export async function dispatchAndAwaitTurn(input: {
       parentWritable: input.parentWritable,
       serializedContext: input.serializedContext,
       sessionState: input.sessionState,
+    });
+
+    await activateTurnStep({
+      expectedRunId: dispatched.ownerRunId,
+      inboxToken: dispatched.inboxToken,
     });
 
     return await control.waitForAction();

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -17,7 +17,10 @@ const createHookMock = vi.fn();
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: (...args: unknown[]) => createHookMock(...args),
-  getWorkflowMetadata: vi.fn(() => ({ url: "https://eve.example.com" })),
+  getWorkflowMetadata: vi.fn(() => ({
+    url: "https://eve.example.com",
+    workflowRunId: "wrun_owner",
+  })),
 }));
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
@@ -250,7 +253,7 @@ describe("turnWorkflow", () => {
 
   it("deduplicates concurrent turn workflows through inbox ownership", async () => {
     const sessionState = createSessionState();
-    const ownerInbox = createInboxMock([]);
+    const ownerInbox = createInboxMock([{ expectedRunId: "wrun_owner", kind: "turn-activation" }]);
     const duplicateInbox = createInboxMock([], {
       conflict: { runId: "wrun_owner" },
     });
@@ -263,7 +266,8 @@ describe("turnWorkflow", () => {
     });
 
     const { input } = createInput({
-      driverCapabilities: { turnInbox: true },
+      driverCapabilities: { turnActivation: true, turnInbox: true },
+      inboxToken: "turn-token:inbox",
       sessionState,
     });
     await Promise.all([turnWorkflow(input), turnWorkflow(input)]);
@@ -277,6 +281,20 @@ describe("turnWorkflow", () => {
     expect(duplicateInbox.dispose).toHaveBeenCalledOnce();
     expect(ownerInbox.createIterator).toHaveBeenCalledOnce();
     expect(duplicateInbox.createIterator).toHaveBeenCalledOnce();
+  });
+
+  it("does not execute when activation names a different inbox owner", async () => {
+    const inbox = installInbox([{ expectedRunId: "wrun_previous_owner", kind: "turn-activation" }]);
+    const { input } = createInput({
+      driverCapabilities: { turnActivation: true, turnInbox: true },
+      inboxToken: "turn-token:inbox",
+    });
+
+    await turnWorkflow(input);
+
+    expect(turnStep).not.toHaveBeenCalled();
+    expect(resumeHookMock).not.toHaveBeenCalled();
+    expect(inbox.dispose).toHaveBeenCalledOnce();
   });
 
   it("deduplicates a cross-realm inbox conflict rejection", async () => {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -42,7 +42,9 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
 }
 
 async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
-  const inbox = createHook<TurnInboxPayload>({ token: `${input.completionToken}:inbox` });
+  const inbox = createHook<TurnInboxPayload>({
+    token: input.inboxToken ?? `${input.completionToken}:inbox`,
+  });
   // Hook promises and iterators share one durable cursor. Create the iterator before
   // claiming so conflict replay is consumed by getConflict(), not a later iterator read.
   const iterator = inbox[Symbol.asyncIterator]();
@@ -69,6 +71,17 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
     } catch (error) {
       if (isHookConflictError(error)) return;
       throw error;
+    }
+
+    if (input.driverCapabilities?.turnActivation === true) {
+      const activation = await iterator.next();
+      if (
+        activation.done ||
+        activation.value.kind !== "turn-activation" ||
+        activation.value.expectedRunId !== getWorkflowMetadata().workflowRunId
+      ) {
+        return;
+      }
     }
 
     while (true) {

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -45,8 +45,14 @@ vi.mock("./route-child-delivery.js", () => ({
 }));
 
 vi.mock("./workflow-steps.js", () => ({
-  dispatchTurnStep: vi.fn().mockImplementation(async () => ({ runId: "turn-run" })),
+  dispatchTurnStep: vi
+    .fn()
+    .mockImplementation(async () => ({ inboxToken: "turn-inbox", ownerRunId: "turn-owner" })),
   emitTerminalSessionFailureStep: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./activate-turn-step.js", () => ({
+  activateTurnStep: vi.fn(),
 }));
 
 function createSessionStateForMock(

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
 import type { DeliverPayload, SubagentInputRequestHookPayload } from "#channel/types.js";
@@ -82,6 +82,7 @@ function createStubSessionState(overrides: Partial<DurableSessionState> = {}): D
 
 const DEFAULT_WORKFLOW_STREAM_NAMESPACE = "__default__";
 const getRunMock = vi.fn();
+const getHookByTokenMock = vi.fn();
 const startMock = vi.fn();
 const workflowWritesByNamespace = new Map<string, unknown[]>();
 
@@ -106,9 +107,14 @@ vi.mock("../runtime/sessions/compiled-agent-cache.js", () => ({
 }));
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
+  getHookByToken: (...args: unknown[]) => getHookByTokenMock(...args),
   getRun: (...args: unknown[]) => getRunMock(...args),
   resumeHook: vi.fn(),
   start: (...args: unknown[]) => startMock(...args),
+}));
+
+vi.mock("#compiled/@workflow/core/index.js", () => ({
+  getStepMetadata: vi.fn(() => ({ stepId: "step_dispatch" })),
 }));
 
 const ThreadKey = new ContextKey<string>("test.workflow.thread");
@@ -175,12 +181,17 @@ function createSerializedContext(): Record<string, unknown> {
 }
 
 afterEach(() => {
+  getHookByTokenMock.mockReset();
   getRunMock.mockReset();
   startMock.mockReset();
   workflowWritesByNamespace.clear();
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  getHookByTokenMock.mockResolvedValue({ runId: "turn-owner" });
 });
 
 describe("dispatchTurnStep", () => {
@@ -208,11 +219,19 @@ describe("dispatchTurnStep", () => {
     const input = createTurnInput();
     startMock.mockResolvedValue({ runId: "turn-run" });
 
-    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+    await expect(dispatchTurnStep(input)).resolves.toEqual({
+      inboxToken: "turn-control:inbox:step_dispatch",
+      ownerRunId: "turn-owner",
+    });
 
     expect(startMock).toHaveBeenCalledWith(
       turnWorkflowReference,
-      [createTurnWorkflowInput(input)],
+      [
+        createTurnWorkflowInput({
+          ...input,
+          inboxToken: "turn-control:inbox:step_dispatch",
+        }),
+      ],
       {
         allowReservedAttributes: true,
         attributes: {
@@ -231,12 +250,20 @@ describe("dispatchTurnStep", () => {
     const input = createTurnInput();
     startMock.mockResolvedValue({ runId: "turn-run" });
 
-    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+    await expect(dispatchTurnStep(input)).resolves.toEqual({
+      inboxToken: "turn-control:inbox:step_dispatch",
+      ownerRunId: "turn-owner",
+    });
 
     expect(startMock).toHaveBeenCalledTimes(1);
     expect(startMock).toHaveBeenCalledWith(
       turnWorkflowReference,
-      [createTurnWorkflowInput(input)],
+      [
+        createTurnWorkflowInput({
+          ...input,
+          inboxToken: "turn-control:inbox:step_dispatch",
+        }),
+      ],
       {
         allowReservedAttributes: true,
         attributes: {
@@ -249,6 +276,23 @@ describe("dispatchTurnStep", () => {
     );
   });
 
+  it("waits for the child to register its inbox", async () => {
+    const input = createTurnInput();
+    startMock.mockResolvedValue({ runId: "turn-run" });
+    getHookByTokenMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error("not registered"), { name: "HookNotFoundError" }),
+      )
+      .mockResolvedValueOnce({ runId: "turn-owner" });
+
+    await expect(dispatchTurnStep(input)).resolves.toEqual({
+      inboxToken: "turn-control:inbox:step_dispatch",
+      ownerRunId: "turn-owner",
+    });
+
+    expect(getHookByTokenMock).toHaveBeenCalledTimes(2);
+  });
+
   it("falls back to the current deployment when latest is unsupported", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const input = createTurnInput();
@@ -256,9 +300,15 @@ describe("dispatchTurnStep", () => {
       .mockRejectedValueOnce(new Error(LATEST_DEPLOYMENT_UNSUPPORTED_MESSAGE))
       .mockResolvedValueOnce({ runId: "turn-run" });
 
-    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+    await expect(dispatchTurnStep(input)).resolves.toEqual({
+      inboxToken: "turn-control:inbox:step_dispatch",
+      ownerRunId: "turn-owner",
+    });
 
-    const wireInput = createTurnWorkflowInput(input);
+    const wireInput = createTurnWorkflowInput({
+      ...input,
+      inboxToken: "turn-control:inbox:step_dispatch",
+    });
     expect(startMock).toHaveBeenNthCalledWith(1, turnWorkflowReference, [wireInput], {
       allowReservedAttributes: true,
       attributes: {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -5,6 +5,7 @@ import type {
   SessionAuthContext,
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
+import { getStepMetadata } from "#compiled/@workflow/core/index.js";
 import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
 import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-lifecycle.js";
 import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
@@ -60,13 +61,14 @@ import { createExecutionNodeStep } from "#execution/node-step.js";
 import { emitProxiedInputRequest, routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
 import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
+import { isHookNotFoundError } from "#execution/hook-ownership.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
 import {
   createWorkflowRuntime,
   startWorkflowPreferLatest,
   turnWorkflowReference,
 } from "#execution/workflow-runtime.js";
-import { resumeHook } from "#internal/workflow/runtime.js";
+import { getHookByToken, resumeHook } from "#internal/workflow/runtime.js";
 
 /**
  * Result of one durable harness step, consumed by the turn workflow.
@@ -640,12 +642,14 @@ export async function routeProxiedDeliverStep(input: {
 /** Starts a per-turn child workflow for the current driver session. */
 export async function dispatchTurnStep(
   input: TurnWorkflowDispatchInput,
-): Promise<{ readonly runId: string }> {
+): Promise<{ readonly inboxToken: string; readonly ownerRunId: string }> {
   "use step";
 
-  const run = await startWorkflowPreferLatest(
+  const inboxToken = `${input.completionToken}:inbox:${getStepMetadata().stepId}`;
+
+  await startWorkflowPreferLatest(
     turnWorkflowReference,
-    [createTurnWorkflowInput(input)],
+    [createTurnWorkflowInput({ ...input, inboxToken })],
     {
       allowReservedAttributes: true,
       attributes: normalizeEveAttributes(
@@ -658,5 +662,22 @@ export async function dispatchTurnStep(
     },
   );
 
-  return { runId: run.runId };
+  return { inboxToken, ownerRunId: await waitForTurnInboxOwner(inboxToken) };
+}
+
+async function waitForTurnInboxOwner(inboxToken: string): Promise<string> {
+  let notFound: unknown;
+
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    try {
+      return (await getHookByToken(inboxToken)).runId;
+    } catch (error) {
+      if (!isHookNotFoundError(error)) throw error;
+      notFound = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw notFound;
 }


### PR DESCRIPTION
## Summary

- derive each turn inbox token from the durable `dispatchTurnStep` step ID
- resolve the inbox's actual owning workflow run after starting a latest-deployment child
- require a separate, post-commit activation addressed to that owner before `turnStep` can execute
- keep the wire additive so children started by older pinned drivers retain the existing behavior

This closes the window where a turn child could finish and release its conflict hook before the dispatch step committed, allowing a replay or late concurrent dispatch attempt to start and execute another child. A late claimant may receive an old activation, but the expected run ID fences it from doing turn work.

This is intentionally narrower than, and intended to supersede, #335. It does not filter client events or claim to make individual step effects exactly-once. Concurrent attempts of the same `turnStep` still require effect-level idempotency.

## Testing

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm typecheck`
- `pnpm test:unit` (4,145 passed, 1 skipped)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/workflow-entry.integration.test.ts` (8 passed)
