### PR TITLE
fix(eve): retry transient agent info probes

### DIFF
--- a/.changeset/resilient-agent-info-probe.md
+++ b/.changeset/resilient-agent-info-probe.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The `eve dev` TUI retries one transient agent-inspection failure before treating a local or remote agent as unavailable.

--- a/packages/eve/src/cli/dev/tui/agent-info-probe.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-info-probe.test.ts
@@ -41,39 +41,70 @@ const AGENT_INFO = {
   workspace: { resourceRoot: null, rootEntries: [] },
 } satisfies AgentInfoResult;
 
+async function advanceRetry(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(100);
+}
+
 describe("probeAgentInfo", () => {
   it("retries a transient server failure and returns inspection once the server is ready", async () => {
-    const info = vi
-      .fn<() => Promise<AgentInfoResult>>()
-      .mockRejectedValueOnce(new ClientError(500, "Runner did not become ready in time"))
-      .mockResolvedValueOnce(AGENT_INFO);
-    const client = { info } satisfies Pick<Client, "info">;
+    vi.useFakeTimers();
+    try {
+      const info = vi
+        .fn<() => Promise<AgentInfoResult>>()
+        .mockRejectedValueOnce(new ClientError(500, "Runner did not become ready in time"))
+        .mockResolvedValueOnce(AGENT_INFO);
+      const client = { info } satisfies Pick<Client, "info">;
 
-    await expect(
-      probeAgentInfo({
-        client,
-        retryDelaysMs: [1],
-        wait: async () => {},
-      }),
-    ).resolves.toEqual({ kind: "ready", info: AGENT_INFO });
-    expect(info).toHaveBeenCalledTimes(2);
+      const probe = probeAgentInfo({ client });
+      await advanceRetry();
+
+      await expect(probe).resolves.toEqual({ kind: "ready", info: AGENT_INFO });
+      expect(info).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retries a network failure", async () => {
-    const info = vi
-      .fn<() => Promise<AgentInfoResult>>()
-      .mockRejectedValueOnce(new TypeError("fetch failed"))
-      .mockResolvedValueOnce(AGENT_INFO);
-    const client = { info } satisfies Pick<Client, "info">;
+    vi.useFakeTimers();
+    try {
+      const info = vi
+        .fn<() => Promise<AgentInfoResult>>()
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce(AGENT_INFO);
+      const client = { info } satisfies Pick<Client, "info">;
 
-    await expect(
-      probeAgentInfo({
-        client,
-        retryDelaysMs: [1],
-        wait: async () => {},
-      }),
-    ).resolves.toEqual({ kind: "ready", info: AGENT_INFO });
-    expect(info).toHaveBeenCalledTimes(2);
+      const probe = probeAgentInfo({ client });
+      await advanceRetry();
+
+      await expect(probe).resolves.toEqual({ kind: "ready", info: AGENT_INFO });
+      expect(info).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops after one retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstFailure = new ClientError(500, "Runner did not become ready in time");
+      const secondFailure = new ClientError(500, "Still unavailable");
+      const info = vi
+        .fn<() => Promise<AgentInfoResult>>()
+        .mockRejectedValueOnce(firstFailure)
+        .mockRejectedValueOnce(secondFailure);
+      const client = { info } satisfies Pick<Client, "info">;
+
+      const probe = probeAgentInfo({ client });
+      await advanceRetry();
+
+      await expect(probe).resolves.toEqual({ kind: "unavailable", error: secondFailure });
+      expect(info).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([
@@ -84,13 +115,7 @@ describe("probeAgentInfo", () => {
     const info = vi.fn<() => Promise<AgentInfoResult>>().mockRejectedValueOnce(error);
     const client = { info } satisfies Pick<Client, "info">;
 
-    await expect(
-      probeAgentInfo({
-        client,
-        retryDelaysMs: [1],
-        wait: async () => {},
-      }),
-    ).resolves.toEqual({ kind: "unavailable", error });
+    await expect(probeAgentInfo({ client })).resolves.toEqual({ kind: "unavailable", error });
     expect(info).toHaveBeenCalledOnce();
   });
 });

--- a/packages/eve/src/cli/dev/tui/agent-info-probe.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-info-probe.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AgentInfoResponseError,
+  ClientError,
+  type AgentInfoResult,
+  type Client,
+} from "#client/index.js";
+
+import { probeAgentInfo } from "./agent-info-probe.js";
+
+const AGENT_INFO = {
+  agent: {
+    agentRoot: "/tmp/weather-agent/agent",
+    appRoot: "/tmp/weather-agent",
+    model: { id: "gpt-5" },
+    name: "Weather Agent",
+  },
+  capabilities: { devRoutes: true },
+  channels: { authored: [], available: [], disabledFramework: [], framework: [] },
+  connections: [],
+  diagnostics: { discoveryErrors: 0, discoveryWarnings: 0 },
+  hooks: [],
+  instructions: { dynamic: [], static: null },
+  kind: "eve-agent-info",
+  mode: "development",
+  sandbox: null,
+  schedules: [],
+  skills: { dynamic: [], static: [] },
+  subagents: { local: [], total: 0 },
+  tools: {
+    authored: [],
+    available: [],
+    disabledFramework: [],
+    dynamic: [],
+    framework: [],
+    reserved: [],
+  },
+  version: 1,
+  workflow: { enabled: false, toolName: "Workflow" },
+  workspace: { resourceRoot: null, rootEntries: [] },
+} satisfies AgentInfoResult;
+
+describe("probeAgentInfo", () => {
+  it("retries a transient server failure and returns inspection once the server is ready", async () => {
+    const info = vi
+      .fn<() => Promise<AgentInfoResult>>()
+      .mockRejectedValueOnce(new ClientError(500, "Runner did not become ready in time"))
+      .mockResolvedValueOnce(AGENT_INFO);
+    const client = { info } satisfies Pick<Client, "info">;
+
+    await expect(
+      probeAgentInfo({
+        client,
+        retryDelaysMs: [1],
+        wait: async () => {},
+      }),
+    ).resolves.toEqual({ kind: "ready", info: AGENT_INFO });
+    expect(info).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a network failure", async () => {
+    const info = vi
+      .fn<() => Promise<AgentInfoResult>>()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(AGENT_INFO);
+    const client = { info } satisfies Pick<Client, "info">;
+
+    await expect(
+      probeAgentInfo({
+        client,
+        retryDelaysMs: [1],
+        wait: async () => {},
+      }),
+    ).resolves.toEqual({ kind: "ready", info: AGENT_INFO });
+    expect(info).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["authorization failures", new ClientError(401, "Unauthorized")],
+    ["unrecognized inspection payloads", new AgentInfoResponseError(["version: Required"])],
+    ["unexpected client failures", new Error("unexpected")],
+  ])("does not retry %s", async (_name, error) => {
+    const info = vi.fn<() => Promise<AgentInfoResult>>().mockRejectedValueOnce(error);
+    const client = { info } satisfies Pick<Client, "info">;
+
+    await expect(
+      probeAgentInfo({
+        client,
+        retryDelaysMs: [1],
+        wait: async () => {},
+      }),
+    ).resolves.toEqual({ kind: "unavailable", error });
+    expect(info).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/cli/dev/tui/agent-info-probe.ts
+++ b/packages/eve/src/cli/dev/tui/agent-info-probe.ts
@@ -1,0 +1,48 @@
+import {
+  AgentInfoResponseError,
+  ClientError,
+  type AgentInfoResult,
+  type Client,
+} from "#client/index.js";
+
+const defaultRetryDelaysMs = [100] as const;
+
+export type AgentInfoProbeResult =
+  | { readonly kind: "ready"; readonly info: AgentInfoResult }
+  | { readonly kind: "unavailable"; readonly error: unknown };
+
+function isRetryableAgentInfoFailure(error: unknown): boolean {
+  if (error instanceof AgentInfoResponseError) return false;
+  if (error instanceof ClientError) return error.status >= 500;
+  return error instanceof TypeError;
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+/**
+ * Reads best-effort inspection data from a server whose lifecycle belongs to
+ * another process. Transient transport and server failures can occur while
+ * that process reloads, but auth and schema failures cannot be fixed by retry.
+ */
+export async function probeAgentInfo(input: {
+  readonly client: Pick<Client, "info">;
+  readonly retryDelaysMs?: readonly number[];
+  readonly wait?: (delayMs: number) => Promise<void>;
+}): Promise<AgentInfoProbeResult> {
+  const retryDelaysMs = input.retryDelaysMs ?? defaultRetryDelaysMs;
+  const wait = input.wait ?? sleep;
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return { kind: "ready", info: await input.client.info() };
+    } catch (error) {
+      const delayMs = retryDelaysMs[attempt];
+      if (!isRetryableAgentInfoFailure(error) || delayMs === undefined) {
+        return { kind: "unavailable", error };
+      }
+      await wait(delayMs);
+    }
+  }
+}

--- a/packages/eve/src/cli/dev/tui/agent-info-probe.ts
+++ b/packages/eve/src/cli/dev/tui/agent-info-probe.ts
@@ -5,7 +5,7 @@ import {
   type Client,
 } from "#client/index.js";
 
-const defaultRetryDelaysMs = [100] as const;
+const RETRY_DELAY_MS = 100;
 
 export type AgentInfoProbeResult =
   | { readonly kind: "ready"; readonly info: AgentInfoResult }
@@ -28,21 +28,18 @@ function sleep(delayMs: number): Promise<void> {
  */
 export async function probeAgentInfo(input: {
   readonly client: Pick<Client, "info">;
-  readonly retryDelaysMs?: readonly number[];
-  readonly wait?: (delayMs: number) => Promise<void>;
 }): Promise<AgentInfoProbeResult> {
-  const retryDelaysMs = input.retryDelaysMs ?? defaultRetryDelaysMs;
-  const wait = input.wait ?? sleep;
+  try {
+    return { kind: "ready", info: await input.client.info() };
+  } catch (error) {
+    if (!isRetryableAgentInfoFailure(error)) return { kind: "unavailable", error };
+  }
 
-  for (let attempt = 0; ; attempt += 1) {
-    try {
-      return { kind: "ready", info: await input.client.info() };
-    } catch (error) {
-      const delayMs = retryDelaysMs[attempt];
-      if (!isRetryableAgentInfoFailure(error) || delayMs === undefined) {
-        return { kind: "unavailable", error };
-      }
-      await wait(delayMs);
-    }
+  await sleep(RETRY_DELAY_MS);
+
+  try {
+    return { kind: "ready", info: await input.client.info() };
+  } catch (error) {
+    return { kind: "unavailable", error };
   }
 }

--- a/packages/eve/src/cli/dev/tui/remote-connection-probe.ts
+++ b/packages/eve/src/cli/dev/tui/remote-connection-probe.ts
@@ -7,6 +7,7 @@ import {
 import { toErrorMessage } from "#shared/errors.js";
 import { isObject } from "#shared/guards.js";
 
+import { probeAgentInfo } from "./agent-info-probe.js";
 import type { RemoteConnectionState } from "./remote-connection-types.js";
 
 export type RemoteProbeResult = Extract<
@@ -88,20 +89,20 @@ export async function probeRemoteInfo(input: {
   readonly client: Client;
   readonly phase: RemoteProbePhase;
 }): Promise<RemoteProbeResult> {
-  try {
-    return { state: "ready", info: await input.client.info() };
-  } catch (error) {
-    // Inspection is best-effort: an authorized response we cannot use must not
-    // block the connection, since the conversation transport does not depend on
-    // `/eve/v1/info`.
-    if (
-      error instanceof AgentInfoResponseError ||
-      (error instanceof ClientError && error.status === 404)
-    ) {
-      // The info route can be missing or use an older payload shape. Only call
-      // the target ready once the public health route confirms a live Eve server.
-      if (await probeDeploymentHealth(input.client)) return { state: "ready" };
-    }
-    return classifyRemoteError(error, input.phase);
+  const probe = await probeAgentInfo({ client: input.client });
+  if (probe.kind === "ready") return { state: "ready", info: probe.info };
+
+  const { error } = probe;
+  // Inspection is best-effort: an authorized response we cannot use must not
+  // block the connection, since the conversation transport does not depend on
+  // `/eve/v1/info`.
+  if (
+    error instanceof AgentInfoResponseError ||
+    (error instanceof ClientError && error.status === 404)
+  ) {
+    // The info route can be missing or use an older payload shape. Only call
+    // the target ready once the public health route confirms a live Eve server.
+    if (await probeDeploymentHealth(input.client)) return { state: "ready" };
   }
+  return classifyRemoteError(error, input.phase);
 }

--- a/packages/eve/src/cli/dev/tui/remote-connection.test.ts
+++ b/packages/eve/src/cli/dev/tui/remote-connection.test.ts
@@ -197,6 +197,28 @@ describe("createRemoteConnectionController", () => {
     await expect(checkFailure(error)).resolves.toMatchObject(expected);
   });
 
+  it("retries a transient info failure before declaring the remote unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      const { controller, info } = createHarness({
+        info: vi
+          .fn<() => Promise<AgentInfoResult>>()
+          .mockRejectedValueOnce(new ClientError(500, "Runner did not become ready in time"))
+          .mockResolvedValueOnce(INFO),
+      });
+
+      const check = controller.check();
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(check).resolves.toEqual({ state: "ready", info: INFO });
+      expect(info).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stays ready after an unusable info payload when health confirms Eve", async () => {
     const harness = createHarness({
       info: async () => {

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -386,7 +386,7 @@ describe("EveTUIRunner agent header", () => {
     expect(session.send).toHaveBeenCalledTimes(2);
   });
 
-  it("refreshes the agent header while waiting for prompt input", async () => {
+  it("retries a transient info failure while refreshing the agent header", async () => {
     vi.useFakeTimers();
     const headers: AgentTUIAgentHeader[] = [];
     const prompt = createDeferred<string | undefined>();
@@ -400,7 +400,10 @@ describe("EveTUIRunner agent header", () => {
       },
     };
     const client = stubClient();
-    vi.spyOn(client, "info").mockResolvedValueOnce(AGENT_INFO).mockResolvedValueOnce(nextInfo);
+    vi.spyOn(client, "info")
+      .mockResolvedValueOnce(AGENT_INFO)
+      .mockRejectedValueOnce(new ClientError(500, "Runner did not become ready in time"))
+      .mockResolvedValueOnce(nextInfo);
     const revisions = ["snapshot-a", "snapshot-b"];
     const fetchMock = vi.fn(async () =>
       Response.json({ revision: revisions.shift() ?? "snapshot-b" }),
@@ -429,9 +432,12 @@ describe("EveTUIRunner agent header", () => {
 
     await vi.advanceTimersByTimeAsync(500);
     await settleAsyncWork();
+    await vi.advanceTimersByTimeAsync(100);
+    await settleAsyncWork();
 
     expect(headers).toHaveLength(2);
     expect(headers[1]?.info?.agent.model.id).toBe("anthropic/claude-sonnet-4.6");
+    expect(client.info).toHaveBeenCalledTimes(3);
     expect(session.send).not.toHaveBeenCalled();
 
     prompt.resolve(undefined);

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -303,6 +303,39 @@ describe("EveTUIRunner agent header", () => {
     expect(headers[0]?.name).toBe("Weather Agent");
   });
 
+  it("retries a transient info failure before rendering the startup header", async () => {
+    vi.useFakeTimers();
+    const headers: AgentTUIAgentHeader[] = [];
+    const renderer = fakeRenderer({
+      renderAgentHeader: (header) => headers.push(header),
+    });
+    const client = stubClient();
+    vi.spyOn(client, "info")
+      .mockRejectedValueOnce(new ClientError(500, "Runner did not become ready in time"))
+      .mockResolvedValueOnce(AGENT_INFO);
+    const runner = new EveTUIRunner({
+      session: stubSession(),
+      client,
+      renderer,
+      serverUrl: "http://localhost:3000",
+      name: "Weather Agent",
+    });
+
+    const running = runner.run();
+    await settleAsyncWork();
+    await vi.advanceTimersByTimeAsync(100);
+    await running;
+
+    expect(client.info).toHaveBeenCalledTimes(2);
+    expect(headers).toEqual([
+      {
+        name: "Weather Agent",
+        serverUrl: "http://localhost:3000",
+        info: AGENT_INFO,
+      },
+    ]);
+  });
+
   it("refreshes the agent header when a dev artifact refresh changes the model", async () => {
     const headers: AgentTUIAgentHeader[] = [];
     const prompts: Array<string | undefined> = ["first", "second", undefined];

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -1318,11 +1318,11 @@ export class EveTUIRunner {
   }
 
   async #readAgentInfo(): Promise<AgentInfoResult | undefined> {
-    try {
-      return await this.#client?.info();
-    } catch {
-      return undefined;
-    }
+    const client = this.#client;
+    if (client === undefined) return;
+
+    const probe = await probeAgentInfo({ client });
+    return probe.kind === "ready" ? probe.info : undefined;
   }
 
   async #handleRuntimeArtifactsChanged(): Promise<void> {

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -41,6 +41,7 @@ import {
 } from "./errors.js";
 
 import { pickAgentHeaderTip } from "./agent-header.js";
+import { probeAgentInfo } from "./agent-info-probe.js";
 import { parseLogDisplayMode } from "./log-display-mode.js";
 import {
   formatPromptCommandHelp,
@@ -550,14 +551,18 @@ export class EveTUIRunner {
       const connection = await this.#remoteConnection.check();
       if (connection.state === "ready") info = connection.info;
     } else {
-      try {
-        info = await devBootPhase(
-          "connecting to agent",
-          () => (this.#client ? this.#client.info() : Promise.resolve(undefined)),
-          this.#onBootProgress,
-        );
-      } catch {
-        info = undefined;
+      const client = this.#client;
+      if (client !== undefined) {
+        try {
+          const probe = await devBootPhase(
+            "connecting to agent",
+            () => probeAgentInfo({ client }),
+            this.#onBootProgress,
+          );
+          if (probe.kind === "ready") info = probe.info;
+        } catch {
+          info = undefined;
+        }
       }
     }
     this.#reportBeforeFirstPaint();


### PR DESCRIPTION
## What

- Retry `GET /eve/v1/info` once after a transient 5xx or network failure.
- Apply that probe to both local startup and remote connection checks.
- Keep authorization failures, missing routes, and incompatible inspection payloads as immediate outcomes.

`env-runner` can answer `GET /eve/v1/info` with `Runner did not become ready in time` while a dev worker reloads. The TUI previously treated that one inspection failure as final, although the server can be owned by another process and become ready moments later.

The retry belongs in the TUI probe, not `Client.info()` or the dev server. `Client.info()` remains strict for callers that need the actual error; the TUI gets one bounded retry before it omits optional inspection data. This does not change server readiness, routing, or authentication behavior.
