### PR TITLE
chore(eve): bump @ai-sdk/mcp to 2.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^4.0.0
       version: 4.0.0
     '@ai-sdk/mcp':
-      specifier: ^2.0.0
-      version: 2.0.0
+      specifier: ^2.0.1
+      version: 2.0.1
     '@ai-sdk/openai':
       specifier: ^4.0.0
       version: 4.0.0
@@ -297,7 +297,7 @@ importers:
         version: 0.41.2
       '@vercel/connect':
         specifier: 'catalog:'
-        version: 0.2.2(@ai-sdk/mcp@2.0.0(zod@4.4.3))(@auth/core@0.41.2)(ai@7.0.0(zod@4.4.3))(eve@packages+eve)
+        version: 0.2.2(@ai-sdk/mcp@2.0.1(zod@4.4.3))(@auth/core@0.41.2)(ai@7.0.0(zod@4.4.3))(eve@packages+eve)
       '@vercel/oidc':
         specifier: 3.4.1
         version: 3.4.1
@@ -784,7 +784,7 @@ importers:
         version: 4.0.0(zod@4.4.3)
       '@ai-sdk/mcp':
         specifier: 'catalog:'
-        version: 2.0.0(zod@4.4.3)
+        version: 2.0.1(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 'catalog:'
         version: 4.0.0(zod@4.4.3)
@@ -962,8 +962,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@2.0.0':
-    resolution: {integrity: sha512-+N6gJ1AbcDk3+6asoEsdIojVmgEReKNcvWIT716pDL3AepGI6j7RJVdaRyhQLltwzTj0arwpwU4BBzvhOiCd/g==}
+  '@ai-sdk/mcp@2.0.1':
+    resolution: {integrity: sha512-tsk+FAX7TN8BsA3eqwR7jf33PiYaGh+w/rHofk7hj13mFvicAhrdITgSOvncULUReUZcDoS0axHEXv1y1/yR8Q==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -12874,7 +12874,7 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/mcp@2.0.0(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.1(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.0
       '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
@@ -18254,11 +18254,11 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.2.2(@ai-sdk/mcp@2.0.0(zod@4.4.3))(@auth/core@0.41.2)(ai@7.0.0(zod@4.4.3))(eve@packages+eve)':
+  '@vercel/connect@0.2.2(@ai-sdk/mcp@2.0.1(zod@4.4.3))(@auth/core@0.41.2)(ai@7.0.0(zod@4.4.3))(eve@packages+eve)':
     dependencies:
       '@vercel/oidc': 3.6.1
     optionalDependencies:
-      '@ai-sdk/mcp': 2.0.0(zod@4.4.3)
+      '@ai-sdk/mcp': 2.0.1(zod@4.4.3)
       '@auth/core': 0.41.2
       ai: 7.0.0(zod@4.4.3)
       eve: link:packages/eve

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ allowBuilds:
 catalog:
   "@ai-sdk/anthropic": "^4.0.0"
   "@ai-sdk/google": "^4.0.0"
-  "@ai-sdk/mcp": "^2.0.0"
+  "@ai-sdk/mcp": "^2.0.1"
   "@ai-sdk/openai": "^4.0.0"
   "@ai-sdk/otel": "^1.0.0"
   "@ai-sdk/provider": "^4.0.0"


### PR DESCRIPTION
## Summary

- Bump the workspace catalog entry for `@ai-sdk/mcp` to `^2.0.1`.
- Refresh `pnpm-lock.yaml` so eve and `@vercel/connect` resolve `@ai-sdk/mcp@2.0.1`.
- Verified the generated `#compiled/@ai-sdk/mcp` output now includes the MCP HTTP session hooks from `@ai-sdk/mcp@2.0.1` (`initialSessionId`, `initialProtocolVersion`, `onSessionIdChange`, `onSessionExpired`, `terminateSessionOnClose`, and `initialInitializeResult`).

No changeset: `pnpm changeset status --since=origin/main` reports no packages to bump for this dependency-only change.

## Testing

- `pnpm install`
- `pnpm --filter eve run build:compiled`
- `pnpm --filter eve run typecheck`
- `pnpm changeset status --since=origin/main`
- `git diff --check`
