### PR TITLE
chore(e2e): stress - reduce sequential turns

### DIFF
--- a/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
@@ -1,10 +1,10 @@
 import { defineEval } from "eve/evals";
 import { equals } from "eve/evals/expect";
 
-const TURN_COUNT = 100;
+const TURN_COUNT = 20;
 
 export default defineEval({
-  description: "Workflow stress: one durable session completes 100 sequential turns.",
+  description: "Workflow stress: one durable session completes 20 sequential turns.",
   tags: ["stress", "workflow", "sequential"],
 
   async test(t) {


### PR DESCRIPTION
## Summary

- reduce the sequential workflow stress eval from 100 turns to 20
- keep the eval description aligned with the configured turn count

## Impact

The serial stress test will use fewer model turns while continuing to exercise durable sequential session behavior.

## Validation

- `git diff --check`
- pre-commit formatting hook
- E2E eval execution deferred to CI, as required by the repository workflow
