### PR TITLE
fix(eve): tests - isolate workflow data by Vitest pool

### DIFF
--- a/packages/eve/test/setup/workflow-setup.ts
+++ b/packages/eve/test/setup/workflow-setup.ts
@@ -19,7 +19,7 @@ const outDir = resolveWorkflowTestOutputDirectory(packageRoot);
 const poolId = process.env.VITEST_POOL_ID ?? "0";
 installEveWorkflowQueueNamespace(WORKFLOW_TEST_AGENT_NAME);
 const world = createLocalWorld({
-  dataDir: join(packageRoot, ".workflow-data"),
+  dataDir: join(packageRoot, ".workflow-data", `vitest-${poolId}`),
   tag: `vitest-${poolId}`,
 });
 


### PR DESCRIPTION
## Summary

- isolate local Workflow data directories by Vitest pool
- prevent parallel Windows workers from sharing Workflow's writability probe file

## Root cause

Every integration-test worker used the same `.workflow-data` directory. `@workflow/world-local` names its writability probe with `Date.now()`, so workers starting in the same millisecond can collide. Windows rejects one worker's cleanup with `EPERM` while another worker still has the probe open.

The existing per-pool tag isolates stored entities but not this directory-level probe. Giving each pool its own directory removes the collision without changing test behavior.

## Validation

- `pnpm --filter eve test:integration` — 48 files and 369 tests passed
