### PR TITLE
chore: ignore codex directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ bun-error.log*
 Thumbs.db
 
 # IDE/editor
+.codex/
 .vscode/
 .idea/
 


### PR DESCRIPTION
ignore codex directory