### PR TITLE
fix(eve): channels - simplify CORS opt-in

### DIFF
--- a/.changeset/eve-channel-cors.md
+++ b/.changeset/eve-channel-cors.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-The eve HTTP channel now enables permissive browser CORS by default, including preflight handling for session routes. Custom channels can opt into CORS with `defineChannel({ cors })`, and `eveChannel({ cors })` can disable or narrow the default policy.
+HTTP channels can now opt into browser CORS with preflight handling. Use `defineChannel({ cors })` for custom channels or `eveChannel({ cors: true | options })` for the eve channel; omitted CORS remains disabled.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -47,12 +47,12 @@ See [Sessions, runs & streaming](../concepts/sessions-runs-and-streaming) for th
 
 ## CORS
 
-The eve channel enables permissive browser CORS by default. Its session routes
-respond to preflight requests and emit wildcard CORS headers, so browser
-frontends can call the channel without extra deployment configuration. Route
-auth still runs on the actual session requests.
+The eve channel leaves CORS untouched by default. Pass `cors: true` to enable
+permissive browser CORS with preflight handling, or pass an options object to
+narrow origins, methods, and headers. Route auth still runs on the actual
+session requests.
 
-Disable or narrow CORS only when another layer owns it:
+Enable or narrow CORS only when browser clients call the channel directly:
 
 ```ts title="agent/channels/eve.ts"
 import { eveChannel } from "eve/channels/eve";

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -162,8 +162,17 @@ function contextAccessorFor(ctx: ContextContainer): ContextAccessor {
 }
 
 describe("eveChannel — events", () => {
-  it("defaults to permissive CORS", () => {
+  it("leaves CORS disabled by default", () => {
     const channel = eveChannel({ auth: none() });
+    if (!isCompiledChannel(channel)) {
+      throw new Error("Expected eveChannel() to return a compiled channel.");
+    }
+
+    expect(channel.cors).toBeUndefined();
+  });
+
+  it("accepts true for explicit permissive CORS", () => {
+    const channel = eveChannel({ auth: none(), cors: true });
     if (!isCompiledChannel(channel)) {
       throw new Error("Expected eveChannel() to return a compiled channel.");
     }
@@ -205,6 +214,28 @@ describe("eveChannel — events", () => {
       methods: ["POST", "GET"],
       origin: ["https://app.example.com"],
       preflight: { statusCode: 200 },
+    });
+  });
+
+  it("passes wildcard values through inside CORS options", () => {
+    const channel = eveChannel({
+      auth: none(),
+      cors: {
+        allowedHeaders: "*",
+        exposedHeaders: "*",
+        methods: "*",
+        origin: "*",
+      },
+    });
+    if (!isCompiledChannel(channel)) {
+      throw new Error("Expected eveChannel() to return a compiled channel.");
+    }
+
+    expect(channel.cors).toEqual({
+      allowHeaders: "*",
+      exposeHeaders: "*",
+      methods: "*",
+      origin: "*",
     });
   });
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -66,10 +66,10 @@ export interface EveChannelCorsOptions {
 }
 
 /**
- * Higher-level CORS policy for the default eve HTTP channel. Omit or pass `"*"`
- * / `true` for fully permissive browser access; pass `false` to disable CORS.
+ * Higher-level CORS policy for the default eve HTTP channel. Pass `true` for
+ * fully permissive browser access, or pass an options object to narrow it.
  */
-export type EveChannelCors = "*" | boolean | EveChannelCorsOptions;
+export type EveChannelCors = boolean | EveChannelCorsOptions;
 
 /** Low-level eve HTTP handle exposed to `eveChannel({ onMessage })`. */
 export interface EveHandle {
@@ -122,8 +122,9 @@ export interface EveChannelInput {
    */
   readonly uploadPolicy?: UploadPolicyInput;
   /**
-   * Browser CORS policy for the eve HTTP routes. Omit for fully permissive
-   * CORS (`"*"`). Pass `false` only when another layer owns CORS.
+   * Browser CORS policy for the eve HTTP routes. Omit or pass `false` to leave
+   * CORS untouched, pass `true` for fully permissive CORS, or pass an options
+   * object to narrow the policy.
    */
   readonly cors?: EveChannelCors;
   /**
@@ -335,11 +336,11 @@ export function eveChannel(input: EveChannelInput): EveChannel {
 }
 
 function normalizeEveCors(cors: EveChannelCors | undefined): ChannelCors {
-  if (cors === undefined || cors === "*" || cors === true) {
-    return true;
-  }
-  if (cors === false) {
+  if (cors === undefined || cors === false) {
     return false;
+  }
+  if (cors === true) {
+    return true;
   }
 
   const result: {


### PR DESCRIPTION
## Summary
- remove the top-level `eveChannel({ cors: "*" })` shorthand
- restore omitted `eveChannel({ cors })` to no CORS handling
- keep wildcard values available inside the CORS options object, e.g. `origin: "*"`

## Validation
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/eve.test.ts src/public/definitions/exact.test.ts src/public/definitions/defineChannel.test.ts src/internal/nitro/host/channel-routes.test.ts src/runtime/framework-channels/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm docs:check`
- `pnpm guard:invariants`