### PR TITLE
fix(eve): github channel - infer headerless webhooks

### DIFF
--- a/.changeset/github-connect-webhook-headers.md
+++ b/.changeset/github-connect-webhook-headers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The GitHub channel now accepts Vercel Connect-forwarded webhook payloads that omit `x-github-event` and `x-github-delivery` by inferring the supported event type from the payload shape. Headerless forwarded payloads now emit a warning with the inferred metadata instead of being silently acknowledged and ignored.

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -112,6 +112,18 @@ function signedRequest(event: string, payload: Record<string, unknown>): Request
   });
 }
 
+function signedRequestWithoutGitHubHeaders(payload: Record<string, unknown>): Request {
+  const body = JSON.stringify(payload);
+  return new Request("https://example.com/eve/v1/github", {
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-hub-signature-256": signGitHubWebhookBody(body, SECRET),
+    },
+    method: "POST",
+  });
+}
+
 /** Builds a webhook request carrying a deliberately invalid HMAC signature. */
 function badlySignedRequest(event: string, payload: Record<string, unknown>): Request {
   const body = JSON.stringify(payload);
@@ -242,6 +254,51 @@ describe("githubChannel", () => {
         triggeringCommentId: 10,
       },
     });
+  });
+
+  it("dispatches Connect-forwarded issue comments without GitHub event headers", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const channel = githubChannel({
+      botName: "testbot",
+      credentials: { webhookSecret: SECRET },
+    });
+    const { send } = await firePost(
+      channel,
+      signedRequestWithoutGitHubHeaders(
+        basePayload({
+          action: "created",
+          comment: {
+            body: "@testbot help me",
+            html_url: "https://github.test/vercel/eve/issues/5#issuecomment-10",
+            id: 10,
+            user: { id: 1, login: "octocat", type: "User" },
+          },
+          issue: { number: 5 },
+        }),
+      ),
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [payload, options] = send.mock.calls[0]!;
+    expect(payload.message).toContain("delivery_id: inferred:issue_comment:10:created");
+    expect(payload.message).toContain("help me");
+    expect(options).toMatchObject({
+      auth: {
+        attributes: {
+          delivery_id: "inferred:issue_comment:10:created",
+        },
+      },
+      continuationToken: "repo:123:issue:5",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "[eve:github.channel] GitHub webhook missing standard headers; inferred metadata from payload",
+      expect.objectContaining({
+        deliveryId: "inferred:issue_comment:10:created",
+        event: "issue_comment",
+        missingHeaders: ["x-github-event", "x-github-delivery"],
+        repository: "vercel/eve",
+      }),
+    );
   });
 
   it("verifies inbound webhooks via webhookVerifier instead of HMAC when supplied", async () => {

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -240,6 +240,7 @@ export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
         async (req, { send, waitUntil }) => {
           const body = await verifyInbound(req, config.credentials);
           if (body === null) return new Response("unauthorized", { status: 401 });
+          const missingHeaders = missingGitHubWebhookHeaders(req.headers);
 
           let event: GitHubInboundEvent | null;
           try {
@@ -253,7 +254,22 @@ export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
             return jsonOk({ ignored: true, ok: true });
           }
 
-          if (event === null) return jsonOk({ ignored: true, ok: true });
+          if (event === null) {
+            if (missingHeaders.length > 0) {
+              log.warn("GitHub webhook ignored because standard headers were missing", {
+                missingHeaders,
+              });
+            }
+            return jsonOk({ ignored: true, ok: true });
+          }
+          if (missingHeaders.length > 0) {
+            log.warn("GitHub webhook missing standard headers; inferred metadata from payload", {
+              deliveryId: event.delivery.id,
+              event: event.delivery.event,
+              missingHeaders,
+              repository: event.repository.fullName,
+            });
+          }
           if (event.kind === "ping") return jsonOk({ ok: true });
 
           if (event.kind === "issue_comment" && event.action === "created") {
@@ -438,6 +454,13 @@ async function verifyInbound(
 
 function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function missingGitHubWebhookHeaders(headers: Headers): readonly string[] {
+  return ["x-github-event", "x-github-delivery"].filter((name) => {
+    const value = headers.get(name);
+    return value === null || value.trim().length === 0;
+  });
 }
 
 function jsonOk(body: Record<string, unknown>): Response {

--- a/packages/eve/src/public/channels/github/inbound-types.ts
+++ b/packages/eve/src/public/channels/github/inbound-types.ts
@@ -1,0 +1,248 @@
+import type { JsonObject } from "#shared/json.js";
+
+/** GitHub conversation kinds represented by the channel state. */
+export type GitHubConversationKind = "issue" | "pull_request" | "review_thread";
+
+/** Stable repository identity normalized from webhook payloads. */
+export interface GitHubRepositoryRef {
+  readonly fullName: string;
+  readonly id: number;
+  readonly name: string;
+  readonly owner: string;
+  readonly private: boolean;
+}
+
+/** GitHub actor metadata normalized from webhook payloads. */
+export interface GitHubUser {
+  readonly htmlUrl: string | undefined;
+  readonly id: number;
+  readonly login: string;
+  readonly type: string;
+  readonly url: string | undefined;
+}
+
+/** GitHub webhook delivery metadata. */
+export interface GitHubDelivery {
+  readonly event: string;
+  readonly hookId: string | undefined;
+  readonly id: string;
+}
+
+/** Channel-local conversation reference. */
+export interface GitHubConversationRef {
+  readonly issueNumber: number | null;
+  readonly kind: GitHubConversationKind;
+  readonly pullRequestNumber: number | null;
+}
+
+/**
+ * Normalized GitHub comment handed to the `onComment` hook. Covers issue and PR
+ * timeline comments and inline review comments alike; `ctx.conversation.kind`
+ * distinguishes them.
+ */
+export interface GitHubComment {
+  readonly author: GitHubUser | undefined;
+  readonly body: string;
+  readonly htmlUrl: string | undefined;
+  readonly id: number;
+  readonly raw: JsonObject;
+  readonly url: string | undefined;
+}
+
+/** Normalized issue/PR timeline comment. */
+export interface GitHubIssueComment {
+  readonly author: GitHubUser | undefined;
+  readonly body: string;
+  readonly htmlUrl: string | undefined;
+  readonly id: number;
+  readonly issueNumber: number;
+  readonly pullRequestNumber: number | null;
+  readonly raw: JsonObject;
+  readonly url: string | undefined;
+}
+
+/** Normalized inline pull-request review comment. */
+export interface GitHubPullRequestReviewComment {
+  readonly author: GitHubUser | undefined;
+  readonly body: string;
+  readonly htmlUrl: string | undefined;
+  readonly id: number;
+  readonly inReplyToId: number | null;
+  readonly pullRequestNumber: number;
+  readonly raw: JsonObject;
+  readonly reviewThreadRootCommentId: number;
+  readonly url: string | undefined;
+}
+
+/**
+ * Common `issues` webhook actions, kept open to any action GitHub sends so
+ * authors get autocomplete without losing forward compatibility.
+ */
+export type GitHubIssueAction =
+  | "assigned"
+  | "closed"
+  | "edited"
+  | "labeled"
+  | "opened"
+  | "reopened"
+  | "unassigned"
+  | "unlabeled"
+  | (string & {});
+
+/** Common `pull_request` webhook actions, kept open to any action GitHub sends. */
+export type GitHubPullRequestAction =
+  | "closed"
+  | "edited"
+  | "labeled"
+  | "opened"
+  | "ready_for_review"
+  | "reopened"
+  | "synchronize"
+  | "unlabeled"
+  | (string & {});
+
+/** Normalized issue event payload. */
+export interface GitHubIssueEvent {
+  readonly action: GitHubIssueAction;
+  readonly issueNumber: number;
+  readonly raw: JsonObject;
+}
+
+/** Normalized pull-request event payload. */
+export interface GitHubPullRequestEvent {
+  readonly action: GitHubPullRequestAction;
+  readonly headSha: string | null;
+  readonly pullRequestNumber: number;
+  readonly raw: JsonObject;
+}
+
+/** GitHub App identity attached to CI webhook payloads. */
+export interface GitHubAppRef {
+  readonly slug: string | null;
+}
+
+/** Common fields normalized from GitHub CI webhook payloads. */
+export interface GitHubCiEvent {
+  readonly action: string;
+  readonly app: GitHubAppRef;
+  readonly conclusion: string | null;
+  readonly headSha: string | null;
+  readonly pullRequests: readonly number[];
+  readonly raw: JsonObject;
+  readonly status: string | null;
+}
+
+/** Normalized `check_suite` webhook payload. */
+export interface GitHubCheckSuiteEvent extends GitHubCiEvent {
+  readonly checkSuiteId: number;
+}
+
+/** Normalized `check_run` webhook payload. */
+export interface GitHubCheckRunEvent extends GitHubCiEvent {
+  readonly checkRunId: number;
+}
+
+/** Normalized `workflow_run` webhook payload. */
+export interface GitHubWorkflowRunEvent extends GitHubCiEvent {
+  readonly workflowRunId: number;
+}
+
+/** Normalized payload accepted by one of the GitHub CI event hooks. */
+export type GitHubCiPayload = GitHubCheckRunEvent | GitHubCheckSuiteEvent | GitHubWorkflowRunEvent;
+
+export interface GitHubInboundEventBase {
+  readonly delivery: GitHubDelivery;
+  readonly installationId: number | undefined;
+  readonly raw: JsonObject;
+  readonly repository: GitHubRepositoryRef;
+  readonly sender: GitHubUser;
+}
+
+export interface GitHubPingEvent extends GitHubInboundEventBase {
+  readonly kind: "ping";
+}
+
+export interface GitHubIssueCommentEvent extends GitHubInboundEventBase {
+  readonly action: string;
+  readonly baseRef: string | null;
+  readonly baseSha: string | null;
+  readonly comment: GitHubIssueComment;
+  readonly conversation: GitHubConversationRef;
+  readonly defaultBranch: string | null;
+  readonly headRef: string | null;
+  readonly headSha: string | null;
+  readonly kind: "issue_comment";
+}
+
+export interface GitHubPullRequestReviewCommentEvent extends GitHubInboundEventBase {
+  readonly action: string;
+  readonly baseRef: string | null;
+  readonly baseSha: string | null;
+  readonly comment: GitHubPullRequestReviewComment;
+  readonly conversation: GitHubConversationRef;
+  readonly defaultBranch: string | null;
+  readonly headRef: string | null;
+  readonly headSha: string | null;
+  readonly kind: "pull_request_review_comment";
+}
+
+export interface GitHubIssueWebhookEvent extends GitHubInboundEventBase {
+  readonly action: string;
+  readonly conversation: GitHubConversationRef;
+  readonly issue: GitHubIssueEvent;
+  readonly kind: "issues";
+}
+
+export interface GitHubPullRequestWebhookEvent extends GitHubInboundEventBase {
+  readonly action: string;
+  readonly baseRef: string | null;
+  readonly baseSha: string | null;
+  readonly conversation: GitHubConversationRef;
+  readonly defaultBranch: string | null;
+  readonly headRef: string | null;
+  readonly headSha: string | null;
+  readonly kind: "pull_request";
+  readonly pullRequest: GitHubPullRequestEvent;
+}
+
+export interface GitHubCheckSuiteWebhookEvent extends GitHubInboundEventBase {
+  readonly checkSuite: GitHubCheckSuiteEvent;
+  readonly conversation: GitHubConversationRef;
+  readonly kind: "check_suite";
+}
+
+export interface GitHubCheckRunWebhookEvent extends GitHubInboundEventBase {
+  readonly checkRun: GitHubCheckRunEvent;
+  readonly conversation: GitHubConversationRef;
+  readonly kind: "check_run";
+}
+
+export interface GitHubWorkflowRunWebhookEvent extends GitHubInboundEventBase {
+  readonly conversation: GitHubConversationRef;
+  readonly kind: "workflow_run";
+  readonly workflowRun: GitHubWorkflowRunEvent;
+}
+
+/** Parsed CI webhook envelopes consumed by the GitHub channel. */
+export type GitHubCiWebhookEvent =
+  | GitHubCheckRunWebhookEvent
+  | GitHubCheckSuiteWebhookEvent
+  | GitHubWorkflowRunWebhookEvent;
+
+/** Parsed GitHub webhook event shape consumed by the channel. */
+export type GitHubInboundEvent =
+  | GitHubCheckRunWebhookEvent
+  | GitHubCheckSuiteWebhookEvent
+  | GitHubIssueCommentEvent
+  | GitHubIssueWebhookEvent
+  | GitHubPingEvent
+  | GitHubPullRequestReviewCommentEvent
+  | GitHubPullRequestWebhookEvent
+  | GitHubWorkflowRunWebhookEvent;
+
+/** Parsed mention trigger for a bot-directed GitHub comment. */
+export interface GitHubCommentTrigger {
+  readonly kind: "mention";
+  readonly message: string;
+  readonly token: string;
+}

--- a/packages/eve/src/public/channels/github/inbound.test.ts
+++ b/packages/eve/src/public/channels/github/inbound.test.ts
@@ -43,6 +43,14 @@ function parse(event: string, payload: Record<string, unknown>, contentType = "a
   });
 }
 
+function parseWithoutGitHubHeaders(payload: Record<string, unknown>) {
+  return parseGitHubWebhookEvent({
+    body: JSON.stringify(payload),
+    contentType: "application/json",
+    headers: new Headers(),
+  });
+}
+
 describe("GitHub inbound parsing", () => {
   it("detects issue comments versus PR timeline comments", () => {
     const issue = parse(
@@ -71,6 +79,59 @@ describe("GitHub inbound parsing", () => {
       comment: { issueNumber: 7, pullRequestNumber: 7 },
       conversation: { kind: "pull_request" },
       kind: "issue_comment",
+    });
+  });
+
+  it("infers issue comment events when forwarded without GitHub headers", () => {
+    const event = parseWithoutGitHubHeaders(
+      basePayload({
+        action: "created",
+        comment: { body: "@testbot hello", id: 10, user: { id: 1, login: "octocat" } },
+        issue: { number: 5 },
+      }),
+    );
+
+    expect(event).toMatchObject({
+      comment: { issueNumber: 5, pullRequestNumber: null },
+      conversation: { kind: "issue", issueNumber: 5 },
+      delivery: {
+        event: "issue_comment",
+        id: "inferred:issue_comment:10:created",
+      },
+      kind: "issue_comment",
+    });
+  });
+
+  it("infers pull request and review comment events when forwarded without GitHub headers", () => {
+    const pullRequest = parseWithoutGitHubHeaders(
+      basePayload({
+        action: "opened",
+        pull_request: {
+          id: 777,
+          number: 7,
+        },
+      }),
+    );
+    const reviewComment = parseWithoutGitHubHeaders(
+      basePayload({
+        action: "created",
+        comment: { body: "@testbot simplify", id: 101, user: { id: 1, login: "octocat" } },
+        pull_request: { number: 7 },
+      }),
+    );
+
+    expect(pullRequest).toMatchObject({
+      delivery: { event: "pull_request", id: "inferred:pull_request:777:opened" },
+      kind: "pull_request",
+      pullRequest: { pullRequestNumber: 7 },
+    });
+    expect(reviewComment).toMatchObject({
+      comment: { id: 101, pullRequestNumber: 7 },
+      delivery: {
+        event: "pull_request_review_comment",
+        id: "inferred:pull_request_review_comment:101:created",
+      },
+      kind: "pull_request_review_comment",
     });
   });
 

--- a/packages/eve/src/public/channels/github/inbound.ts
+++ b/packages/eve/src/public/channels/github/inbound.ts
@@ -2,253 +2,56 @@ import type { TextPart, UserContent } from "ai";
 
 import { isObject } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
-
-/** GitHub conversation kinds represented by the channel state. */
-export type GitHubConversationKind = "issue" | "pull_request" | "review_thread";
-
-/** Stable repository identity normalized from webhook payloads. */
-export interface GitHubRepositoryRef {
-  readonly fullName: string;
-  readonly id: number;
-  readonly name: string;
-  readonly owner: string;
-  readonly private: boolean;
-}
-
-/** GitHub actor metadata normalized from webhook payloads. */
-export interface GitHubUser {
-  readonly htmlUrl: string | undefined;
-  readonly id: number;
-  readonly login: string;
-  readonly type: string;
-  readonly url: string | undefined;
-}
-
-/** Verified GitHub webhook delivery headers. */
-export interface GitHubDelivery {
-  readonly event: string;
-  readonly hookId: string | undefined;
-  readonly id: string;
-}
-
-/** Channel-local conversation reference. */
-export interface GitHubConversationRef {
-  readonly issueNumber: number | null;
-  readonly kind: GitHubConversationKind;
-  readonly pullRequestNumber: number | null;
-}
-
-/**
- * Normalized GitHub comment handed to the `onComment` hook. Covers issue and PR
- * timeline comments and inline review comments alike; `ctx.conversation.kind`
- * distinguishes them.
- */
-export interface GitHubComment {
-  readonly author: GitHubUser | undefined;
-  readonly body: string;
-  readonly htmlUrl: string | undefined;
-  readonly id: number;
-  readonly raw: JsonObject;
-  readonly url: string | undefined;
-}
-
-/** Normalized issue/PR timeline comment. */
-export interface GitHubIssueComment {
-  readonly author: GitHubUser | undefined;
-  readonly body: string;
-  readonly htmlUrl: string | undefined;
-  readonly id: number;
-  readonly issueNumber: number;
-  readonly pullRequestNumber: number | null;
-  readonly raw: JsonObject;
-  readonly url: string | undefined;
-}
-
-/** Normalized inline pull-request review comment. */
-export interface GitHubPullRequestReviewComment {
-  readonly author: GitHubUser | undefined;
-  readonly body: string;
-  readonly htmlUrl: string | undefined;
-  readonly id: number;
-  readonly inReplyToId: number | null;
-  readonly pullRequestNumber: number;
-  readonly raw: JsonObject;
-  readonly reviewThreadRootCommentId: number;
-  readonly url: string | undefined;
-}
-
-/**
- * Common `issues` webhook actions, kept open to any action GitHub sends so
- * authors get autocomplete without losing forward compatibility.
- */
-export type GitHubIssueAction =
-  | "assigned"
-  | "closed"
-  | "edited"
-  | "labeled"
-  | "opened"
-  | "reopened"
-  | "unassigned"
-  | "unlabeled"
-  | (string & {});
-
-/** Common `pull_request` webhook actions, kept open to any action GitHub sends. */
-export type GitHubPullRequestAction =
-  | "closed"
-  | "edited"
-  | "labeled"
-  | "opened"
-  | "ready_for_review"
-  | "reopened"
-  | "synchronize"
-  | "unlabeled"
-  | (string & {});
-
-/** Normalized issue event payload. */
-export interface GitHubIssueEvent {
-  readonly action: GitHubIssueAction;
-  readonly issueNumber: number;
-  readonly raw: JsonObject;
-}
-
-/** Normalized pull-request event payload. */
-export interface GitHubPullRequestEvent {
-  readonly action: GitHubPullRequestAction;
-  readonly headSha: string | null;
-  readonly pullRequestNumber: number;
-  readonly raw: JsonObject;
-}
-
-/** GitHub App identity attached to CI webhook payloads. */
-export interface GitHubAppRef {
-  readonly slug: string | null;
-}
-
-/** Common fields normalized from GitHub CI webhook payloads. */
-export interface GitHubCiEvent {
-  readonly action: string;
-  readonly app: GitHubAppRef;
-  readonly conclusion: string | null;
-  readonly headSha: string | null;
-  readonly pullRequests: readonly number[];
-  readonly raw: JsonObject;
-  readonly status: string | null;
-}
-
-/** Normalized `check_suite` webhook payload. */
-export interface GitHubCheckSuiteEvent extends GitHubCiEvent {
-  readonly checkSuiteId: number;
-}
-
-/** Normalized `check_run` webhook payload. */
-export interface GitHubCheckRunEvent extends GitHubCiEvent {
-  readonly checkRunId: number;
-}
-
-/** Normalized `workflow_run` webhook payload. */
-export interface GitHubWorkflowRunEvent extends GitHubCiEvent {
-  readonly workflowRunId: number;
-}
-
-/** Normalized payload accepted by one of the GitHub CI event hooks. */
-export type GitHubCiPayload = GitHubCheckRunEvent | GitHubCheckSuiteEvent | GitHubWorkflowRunEvent;
-
-export interface GitHubPingEvent extends GitHubInboundEventBase {
-  readonly kind: "ping";
-}
-
-export interface GitHubIssueCommentEvent extends GitHubInboundEventBase {
-  readonly action: string;
-  readonly baseRef: string | null;
-  readonly baseSha: string | null;
-  readonly comment: GitHubIssueComment;
-  readonly conversation: GitHubConversationRef;
-  readonly defaultBranch: string | null;
-  readonly headRef: string | null;
-  readonly headSha: string | null;
-  readonly kind: "issue_comment";
-}
-
-export interface GitHubPullRequestReviewCommentEvent extends GitHubInboundEventBase {
-  readonly action: string;
-  readonly baseRef: string | null;
-  readonly baseSha: string | null;
-  readonly comment: GitHubPullRequestReviewComment;
-  readonly conversation: GitHubConversationRef;
-  readonly defaultBranch: string | null;
-  readonly headRef: string | null;
-  readonly headSha: string | null;
-  readonly kind: "pull_request_review_comment";
-}
-
-export interface GitHubIssueWebhookEvent extends GitHubInboundEventBase {
-  readonly action: string;
-  readonly conversation: GitHubConversationRef;
-  readonly issue: GitHubIssueEvent;
-  readonly kind: "issues";
-}
-
-export interface GitHubPullRequestWebhookEvent extends GitHubInboundEventBase {
-  readonly action: string;
-  readonly baseRef: string | null;
-  readonly baseSha: string | null;
-  readonly conversation: GitHubConversationRef;
-  readonly defaultBranch: string | null;
-  readonly headRef: string | null;
-  readonly headSha: string | null;
-  readonly kind: "pull_request";
-  readonly pullRequest: GitHubPullRequestEvent;
-}
-
-export interface GitHubCheckSuiteWebhookEvent extends GitHubInboundEventBase {
-  readonly checkSuite: GitHubCheckSuiteEvent;
-  readonly conversation: GitHubConversationRef;
-  readonly kind: "check_suite";
-}
-
-export interface GitHubCheckRunWebhookEvent extends GitHubInboundEventBase {
-  readonly checkRun: GitHubCheckRunEvent;
-  readonly conversation: GitHubConversationRef;
-  readonly kind: "check_run";
-}
-
-export interface GitHubWorkflowRunWebhookEvent extends GitHubInboundEventBase {
-  readonly conversation: GitHubConversationRef;
-  readonly kind: "workflow_run";
-  readonly workflowRun: GitHubWorkflowRunEvent;
-}
-
-/** Parsed CI webhook envelopes consumed by the GitHub channel. */
-export type GitHubCiWebhookEvent =
-  | GitHubCheckRunWebhookEvent
-  | GitHubCheckSuiteWebhookEvent
-  | GitHubWorkflowRunWebhookEvent;
-
-interface GitHubInboundEventBase {
-  readonly delivery: GitHubDelivery;
-  readonly installationId: number | undefined;
-  readonly raw: JsonObject;
-  readonly repository: GitHubRepositoryRef;
-  readonly sender: GitHubUser;
-}
-
-/** Parsed GitHub webhook event shape consumed by the channel. */
-export type GitHubInboundEvent =
-  | GitHubCheckRunWebhookEvent
-  | GitHubCheckSuiteWebhookEvent
-  | GitHubIssueCommentEvent
-  | GitHubIssueWebhookEvent
-  | GitHubPingEvent
-  | GitHubPullRequestReviewCommentEvent
-  | GitHubPullRequestWebhookEvent
-  | GitHubWorkflowRunWebhookEvent;
-
-/** Parsed mention trigger for a bot-directed GitHub comment. */
-export interface GitHubCommentTrigger {
-  readonly kind: "mention";
-  readonly message: string;
-  readonly token: string;
-}
+import type {
+  GitHubAppRef,
+  GitHubCheckRunWebhookEvent,
+  GitHubCheckSuiteWebhookEvent,
+  GitHubCiEvent,
+  GitHubCommentTrigger,
+  GitHubConversationKind,
+  GitHubConversationRef,
+  GitHubInboundEvent,
+  GitHubInboundEventBase,
+  GitHubIssueComment,
+  GitHubIssueCommentEvent,
+  GitHubIssueWebhookEvent,
+  GitHubPullRequestReviewComment,
+  GitHubPullRequestReviewCommentEvent,
+  GitHubPullRequestWebhookEvent,
+  GitHubRepositoryRef,
+  GitHubUser,
+  GitHubWorkflowRunWebhookEvent,
+} from "#public/channels/github/inbound-types.js";
+export type {
+  GitHubAppRef,
+  GitHubCheckRunEvent,
+  GitHubCheckRunWebhookEvent,
+  GitHubCheckSuiteEvent,
+  GitHubCheckSuiteWebhookEvent,
+  GitHubCiEvent,
+  GitHubCiPayload,
+  GitHubCiWebhookEvent,
+  GitHubComment,
+  GitHubCommentTrigger,
+  GitHubConversationKind,
+  GitHubConversationRef,
+  GitHubDelivery,
+  GitHubInboundEvent,
+  GitHubIssueAction,
+  GitHubIssueComment,
+  GitHubIssueCommentEvent,
+  GitHubIssueEvent,
+  GitHubIssueWebhookEvent,
+  GitHubPullRequestAction,
+  GitHubPullRequestEvent,
+  GitHubPullRequestReviewComment,
+  GitHubPullRequestReviewCommentEvent,
+  GitHubPullRequestWebhookEvent,
+  GitHubRepositoryRef,
+  GitHubUser,
+  GitHubWorkflowRunEvent,
+  GitHubWorkflowRunWebhookEvent,
+} from "#public/channels/github/inbound-types.js";
 
 /** Builds the channel-local continuation token for a GitHub conversation. */
 export function githubContinuationToken(input: {
@@ -309,11 +112,10 @@ export function parseGitHubWebhookEvent(input: {
   readonly contentType?: string;
   readonly headers: Headers;
 }): GitHubInboundEvent | null {
-  const eventName = input.headers.get("x-github-event") ?? "";
-  const deliveryId = input.headers.get("x-github-delivery") ?? "";
-  if (!eventName || !deliveryId) return null;
-
   const raw = decodePayload(input.body, input.contentType);
+  const eventName = readHeader(input.headers, "x-github-event") ?? inferGitHubWebhookEventName(raw);
+  if (eventName === null) return null;
+
   const repository = normalizeRepository(raw.repository);
   const sender = normalizeUser(raw.sender);
   if (repository === null || sender === undefined) return null;
@@ -321,8 +123,8 @@ export function parseGitHubWebhookEvent(input: {
   const base = {
     delivery: {
       event: eventName,
-      hookId: input.headers.get("x-github-hook-id") ?? undefined,
-      id: deliveryId,
+      hookId: readHeader(input.headers, "x-github-hook-id") ?? readGitHubHookId(raw),
+      id: readHeader(input.headers, "x-github-delivery") ?? inferGitHubDeliveryId(eventName, raw),
     },
     installationId: readInstallationId(raw.installation),
     raw,
@@ -341,6 +143,41 @@ export function parseGitHubWebhookEvent(input: {
   if (eventName === "check_run") return parseCheckRunEvent(base);
   if (eventName === "workflow_run") return parseWorkflowRunEvent(base);
   return null;
+}
+
+function inferGitHubWebhookEventName(raw: JsonObject): string | null {
+  if (isObject(raw.hook) && typeof raw.zen === "string") return "ping";
+  if (isObject(raw.comment) && isObject(raw.issue)) return "issue_comment";
+  if (isObject(raw.comment) && isObject(raw.pull_request)) {
+    return "pull_request_review_comment";
+  }
+  if (isObject(raw.check_suite)) return "check_suite";
+  if (isObject(raw.check_run)) return "check_run";
+  if (isObject(raw.workflow_run)) return "workflow_run";
+  if (isObject(raw.issue)) return "issues";
+  if (isObject(raw.pull_request) && !isObject(raw.review)) return "pull_request";
+  return null;
+}
+
+function inferGitHubDeliveryId(eventName: string, raw: JsonObject): string {
+  const id =
+    readObjectNumber(raw.comment, "id") ??
+    readObjectNumber(raw.issue, "id") ??
+    readObjectNumber(raw.issue, "number") ??
+    readObjectNumber(raw.pull_request, "id") ??
+    readObjectNumber(raw.pull_request, "number") ??
+    readObjectNumber(raw.check_suite, "id") ??
+    readObjectNumber(raw.check_run, "id") ??
+    readObjectNumber(raw.workflow_run, "id") ??
+    readObjectNumber(raw.hook, "id") ??
+    "unknown";
+  const action = readAction(raw) || "unknown";
+  return `inferred:${eventName}:${id}:${action}`;
+}
+
+function readHeader(headers: Headers, name: string): string | undefined {
+  const value = headers.get(name)?.trim();
+  return value && value.length > 0 ? value : undefined;
 }
 
 /** Renders deterministic GitHub metadata for the model-visible turn. */
@@ -573,6 +410,10 @@ function readId(value: JsonObject): number | null {
   return typeof value.id === "number" ? value.id : null;
 }
 
+function readObjectNumber(value: unknown, key: string): number | null {
+  return isObject(value) && typeof value[key] === "number" ? value[key] : null;
+}
+
 function normalizeApp(value: unknown): GitHubAppRef {
   return {
     slug: isObject(value) && typeof value.slug === "string" ? value.slug : null,
@@ -640,6 +481,13 @@ function normalizeUser(value: unknown): GitHubUser | undefined {
 function readInstallationId(value: unknown): number | undefined {
   if (!isObject(value)) return undefined;
   return typeof value.id === "number" ? value.id : undefined;
+}
+
+function readGitHubHookId(raw: JsonObject): string | undefined {
+  if (typeof raw.hook_id === "number") return String(raw.hook_id);
+  if (typeof raw.hook_id === "string" && raw.hook_id.length > 0) return raw.hook_id;
+  const hookId = readObjectNumber(raw.hook, "id");
+  return hookId === null ? undefined : String(hookId);
 }
 
 function readAction(raw: JsonObject): string {


### PR DESCRIPTION
## Summary

Fixes #366.

The GitHub channel now accepts Vercel Connect-forwarded GitHub webhook payloads that omit the standard `x-github-event` and `x-github-delivery` headers. When those headers are absent, eve infers the supported webhook event type from the payload shape and synthesizes deterministic fallback delivery metadata.

## Root Cause

`githubChannel` previously parsed the event discriminator exclusively from GitHub webhook headers. Vercel Connect can forward the verified payload JSON without those headers, so the route returned `200` while `parseGitHubWebhookEvent` returned `null` and no session was dispatched.

## Impact

Headerless forwarded issue comments, PR review comments, PR events, issue events, and supported CI events can now reach their existing dispatch paths. The channel also logs a warning when it has to infer metadata, and logs when a headerless payload still cannot be classified.

## Validation

- `pnpm fmt`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/github/inbound.test.ts src/public/channels/github/githubChannel.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
