### PR TITLE
fix(eve): workflow - disable turbo mode

### DIFF
--- a/.changeset/disable-workflow-turbo.md
+++ b/.changeset/disable-workflow-turbo.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Disable the Workflow SDK turbo first-delivery path for eve. Workflow runs now stay on the fully ordered runtime path instead of the beta turbo mode.

--- a/packages/eve/src/internal/workflow/runtime.ts
+++ b/packages/eve/src/internal/workflow/runtime.ts
@@ -1,5 +1,9 @@
 import * as workflowRuntime from "#compiled/@workflow/core/runtime.js";
 
+// Workflow turbo backgrounds run_started and forces optimistic inline start.
+// Keep eve on the fully ordered runtime path until that beta behavior is safe.
+process.env.WORKFLOW_TURBO = "0";
+
 export * from "#compiled/@workflow/core/runtime.js";
 export type {
   StartOptionsWithoutDeploymentId,


### PR DESCRIPTION
## Summary

- Disable the Workflow SDK turbo first-delivery path for eve by forcing `WORKFLOW_TURBO=0` in the eve Workflow runtime facade.
- Add a patch changeset for the published `eve` package.

## Why

The latest Workflow beta enables turbo mode by default. That path backgrounds `run_started`, skips the first event-log load, and forces optimistic inline start. eve should remain on the fully ordered runtime path until that beta behavior is safe for the framework.

## Validation

- `pnpm --filter eve typecheck`
