### PR TITLE
docs: align dev server examples with default port

### DIFF
--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -19,7 +19,7 @@ React, Vue, and Svelte apps reach for [`useEveAgent()`](../guides/frontend/overv
 ## Start a session
 
 ```bash
-curl -X POST http://127.0.0.1:3000/eve/v1/session \
+curl -X POST http://127.0.0.1:2000/eve/v1/session \
   -H 'content-type: application/json' \
   -d '{"message":"Summarize the latest forecast."}'
 ```
@@ -29,7 +29,7 @@ eve responds right away. The JSON body carries a `sessionId` and a `continuation
 ## Stream a session
 
 ```bash
-curl http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream
+curl http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream
 ```
 
 The stream is newline-delimited JSON (NDJSON), one event per line:
@@ -77,7 +77,7 @@ A delegated subagent publishes progress on its own child-session stream. The par
 Once the session is waiting (you'll see `session.waiting`), POST your follow-up to the session endpoint with the stored continuation token:
 
 ```bash
-curl -X POST http://127.0.0.1:3000/eve/v1/session/<sessionId> \
+curl -X POST http://127.0.0.1:2000/eve/v1/session/<sessionId> \
   -H 'content-type: application/json' \
   -d '{"continuationToken":"<token>","message":"Now send the short version."}'
 ```
@@ -93,7 +93,7 @@ For deterministic ordering, send one follow-up at a time and wait for the next `
 The stream is durable. Every event is recorded before a step completes, so the whole stream is replayable. Pass `startIndex` to reconnect by event count and pick up where you dropped off, or rewind to the start:
 
 ```bash
-curl "http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream?startIndex=<count>"
+curl "http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream?startIndex=<count>"
 ```
 
 ## Use the client from TypeScript
@@ -107,7 +107,7 @@ Start with the [TypeScript SDK](../guides/client/overview) guide. It covers basi
 `GET /eve/v1/info` returns a JSON inspection snapshot for the running agent: model, instructions, authored and framework tools, skills, channels, schedules, subagents, sandbox, connections, hooks, workflow, and workspace metadata. Local development accepts loopback requests; deployed Vercel targets require the route's OIDC auth.
 
 ```bash
-curl http://127.0.0.1:3000/eve/v1/info
+curl http://127.0.0.1:2000/eve/v1/info
 ```
 
 The route uses the same default auth chain as the eve channel (`[vercelOidc(), localDev()]`). A local Vercel OIDC bearer takes precedence; other local requests fall back to development access. A deployed Vercel target requires a valid OIDC bearer, with a same-project bypass for in-deployment callers. See [auth & route protection](../guides/auth-and-route-protection).

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -137,7 +137,7 @@ The same CLI can point at a deployment. `npx eve dev https://your-app.vercel.app
 Every eve app exposes the same stable HTTP API. Start a durable session:
 
 ```bash
-curl -X POST http://127.0.0.1:3000/eve/v1/session \
+curl -X POST http://127.0.0.1:2000/eve/v1/session \
   -H 'content-type: application/json' \
   -d '{"message":"What is the weather in Brooklyn?"}'
 ```
@@ -152,7 +152,7 @@ The response comes back with two things you'll reuse:
 Attach to the session stream:
 
 ```bash
-curl http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream
+curl http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream
 ```
 
 The stream is NDJSON, served as `application/x-ndjson; charset=utf-8`. For this run you'll see a handful of lifecycle events:
@@ -174,7 +174,7 @@ The full set covers more lifecycle, human-in-the-loop, and authorization events,
 When the session is waiting for the next user message, post a follow-up with the token:
 
 ```bash
-curl -X POST http://127.0.0.1:3000/eve/v1/session/<sessionId> \
+curl -X POST http://127.0.0.1:2000/eve/v1/session/<sessionId> \
   -H 'content-type: application/json' \
   -d '{"continuationToken":"<token>","message":"Now do Queens."}'
 ```

--- a/docs/guides/client/messages.mdx
+++ b/docs/guides/client/messages.mdx
@@ -12,7 +12,7 @@ Pass a string to `send()` for plain text:
 ```ts
 import { Client } from "eve/client";
 
-const client = new Client({ host: "http://127.0.0.1:3000" });
+const client = new Client({ host: "http://127.0.0.1:2000" });
 const session = client.session();
 
 const response = await session.send("What is the weather in Brooklyn?");

--- a/docs/guides/client/output-schema.mdx
+++ b/docs/guides/client/output-schema.mdx
@@ -26,7 +26,7 @@ const outputSchema = {
   required: ["title", "count"],
 } as const;
 
-const client = new Client({ host: "http://127.0.0.1:3000" });
+const client = new Client({ host: "http://127.0.0.1:2000" });
 const session = client.session();
 
 const response = await session.send<Summary>({

--- a/docs/guides/client/overview.mdx
+++ b/docs/guides/client/overview.mdx
@@ -15,7 +15,7 @@ A `Client` binds one host, auth policy, header policy, and stream reconnection b
 import { Client } from "eve/client";
 
 const client = new Client({
-  host: "http://127.0.0.1:3000",
+  host: "http://127.0.0.1:2000",
 });
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -96,7 +96,7 @@ Pass a bare URL as the only argument and the UI connects to that server instead 
 | Flag                                | Type   | Default            | Description                                                                               |
 | ----------------------------------- | ------ | ------------------ | ----------------------------------------------------------------------------------------- |
 | `--host <host>`                     | string | all interfaces     | Host interface to bind                                                                    |
-| `--port <port>`                     | number | `$PORT`, then 3000 | Port to listen on                                                                         |
+| `--port <port>`                     | number | `$PORT`, then 2000 | Port to listen on                                                                         |
 | `-u, --url <url>`                   | string | none               | Connect to an existing server URL instead of starting one                                 |
 | `--no-ui`                           | flag   | UI on              | Start the server without an interactive UI                                                |
 | `--name <name>`                     | string | app folder name    | Title shown in the terminal UI                                                            |

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -90,7 +90,7 @@ A handler-form session runs on the same durable runtime engine as any other sess
 The dev server mounts a one-shot dispatch route that fires a schedule by name, out of band, exactly once. Since `eve dev` never runs schedules on their cron cadence, this is how you trigger one without waiting for the next production tick.
 
 ```sh
-curl -X POST http://localhost:3000/eve/v1/dev/schedules/heartbeat
+curl -X POST http://localhost:2000/eve/v1/dev/schedules/heartbeat
 # -> { "scheduleId": "heartbeat", "sessionIds": ["..."] }
 ```
 


### PR DESCRIPTION
### Description

Fixes #388. The local development docs used port `3000` in HTTP examples, but `eve dev` defaults to `$PORT`, then `2000`. This updates the local `eve dev` examples to use `2000` and fixes the CLI reference for the `eve dev --port` default, while leaving the `eve start` production default at `3000`.

### How did you test your changes?

Tested locally with `rg` to confirm local `eve dev` examples now use `2000` and that the remaining `3000` reference is for `eve start`.

### PR Checklist

* [x] I linked an issue with prior discussion confirming this change is wanted.
* [ ] I ran the relevant checks from `CONTRIBUTING.md`.
* [x] I added tests and documentation where relevant.
* [ ] I added a changeset if this touches the published `eve` package.
* [x] DCO sign-off passes for every commit (`git commit --signoff`).
