### PR TITLE
fix(next): run eve dev server with node under bun

### DIFF
--- a/.changeset/next-bun-dev-server-node.md
+++ b/.changeset/next-bun-dev-server-node.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Start the `withEve` local dev server with Node when Next.js itself is running under Bun, avoiding Bun-only runtime globals leaking into the eve Nitro worker.

--- a/packages/eve/src/public/next/server.integration.test.ts
+++ b/packages/eve/src/public/next/server.integration.test.ts
@@ -40,6 +40,8 @@ describe("resolveEveDestinationPrefix", () => {
   afterEach(async () => {
     spawnMock.mockReset();
     vi.unstubAllEnvs();
+    delete process.env.EVE_BASE_URL;
+    Reflect.deleteProperty(globalThis, "Bun");
     await Promise.all(
       tempRoots.splice(0).map((root) =>
         rm(root, {
@@ -74,6 +76,32 @@ describe("resolveEveDestinationPrefix", () => {
 
     await expect(destination).resolves.toBe("http://127.0.0.1:33449");
     await expect(readRegisteredOrigin(appRoot)).resolves.toBe("http://127.0.0.1:33449");
+  });
+
+  it("starts the dev server with node when Next.js is running under Bun", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    Reflect.set(globalThis, "Bun", {});
+    const appRoot = await createTempAppRoot();
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const destination = resolveEveDestinationPrefix({
+      appRoot,
+      phase: "phase-development-server",
+      productionDestinationPrefix: "/internal/eve",
+    });
+
+    await vi.waitFor(() => {
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+    expect(spawnMock).toHaveBeenCalledWith(
+      "node",
+      expect.arrayContaining(["dev", "--no-ui", "--port", "0"]),
+      expect.objectContaining({ cwd: appRoot }),
+    );
+
+    child.stdout.emit("data", Buffer.from("dev server listening at http://127.0.0.1:33449\n"));
+    await expect(destination).resolves.toBe("http://127.0.0.1:33449");
   });
 });
 

--- a/packages/eve/src/public/next/server.ts
+++ b/packages/eve/src/public/next/server.ts
@@ -246,6 +246,17 @@ function createEveBinaryPath(): string {
   return join(resolvePackageRoot(), "bin", "eve.js");
 }
 
+function isBunRuntime(): boolean {
+  return (
+    typeof (process.versions as Record<string, string | undefined>).bun === "string" ||
+    "Bun" in globalThis
+  );
+}
+
+function resolveNodeCommand(): string {
+  return isBunRuntime() ? "node" : process.execPath;
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   return (
     hostname === "localhost" ||
@@ -377,7 +388,7 @@ function installProcessShutdown(handle: EveProcessHandle): EveProcessHandle {
 function startEveDevServer(appRoot: string, timeoutMs: number): Promise<EveProcessHandle> {
   return startServerProcess({
     args: [createEveBinaryPath(), "dev", "--no-ui", "--port", "0"],
-    command: process.execPath,
+    command: resolveNodeCommand(),
     cwd: appRoot,
     timeoutMs,
   }).then((handle) => {


### PR DESCRIPTION
## Summary

- start the `withEve` sidecar dev server with Node when the host Next.js process is running under Bun
- add regression coverage for Bun-hosted Next.js dev startup
- add a patch changeset

## Why

When a Next.js app is launched with `bun --bun next dev`, `process.execPath` points at Bun. `withEve` used that executable to spawn the local `eve dev --no-ui --port 0` server, which let Bun runtime globals leak into the Nitro worker and caused crossws to reject the Node adapter.

## Verification

- `corepack pnpm --filter eve run build:js`
- `corepack pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/public/next/server.integration.test.ts`
- `corepack pnpm --filter eve run typecheck`
- `corepack pnpm exec oxlint packages/eve/src/public/next/server.ts packages/eve/src/public/next/server.integration.test.ts`
- `git diff --check`

Closes #101
