### PR TITLE
feat(slack): add mention free thread follow ups

### DIFF
--- a/.changeset/slack-mention-free-thread-follow-ups.md
+++ b/.changeset/slack-mention-free-thread-follow-ups.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Add an opt-in `followUps` option to the Slack channel so the agent keeps answering plain (non-mention) replies in threads it is already part of, without a re-`@mention`. Pass `followUps: true` for the built-in "answer in threads I'm part of" rule, or `followUps: { decide }` to layer an agent-specific check on top.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -70,6 +70,55 @@ export default slackChannel({
 
 `threadContext` performs one `conversations.replies` request for each triggering thread reply and requires the matching Slack history scope. Omit it when the agent should see only direct mentions. `loadThreadContextMessages` remains available when you need custom filtering or non-model processing of the raw thread messages.
 
+### Mention-free follow-ups
+
+By default, agents only respond to messages that `@mention` them. Set `followUps: true` to continue responding to new messages in threads the agent is already participating in, without requiring additional mentions.
+
+```ts
+import { slackChannel } from "eve/channels/slack";
+import { connectSlackCredentials } from "@vercel/connect/eve";
+
+export default slackChannel({
+  credentials: connectSlackCredentials("slack/my-agent"),
+  followUps: true,
+});
+```
+
+Follow-ups are only enabled for threads the agent is already part of, either because it was mentioned or has previously replied. The agent never joins unrelated threads automatically.
+
+To enable follow-ups, configure your Slack app to receive channel messages in addition to mentions:
+
+- Subscribe to the `message.channels` event (`message.groups` for private channels).
+- Add the `channels:history` scope (`groups:history` for private channels).
+
+#### Filtering follow-ups
+
+Set `followUps` to an object with a `decide` callback to determine whether the agent should respond to each follow-up message.
+
+The callback runs after Eve's built-in checks and receives the incoming message. Return `true` to reply or `false` to skip it. Messages are always added to the conversation context, regardless of the return value.
+
+```ts
+import { generateText } from "ai";
+import { slackChannel } from "eve/channels/slack";
+import { connectSlackCredentials } from "@vercel/connect/eve";
+
+export default slackChannel({
+  credentials: connectSlackCredentials("slack/my-agent"),
+  followUps: {
+    async decide(message) {
+      const { text } = await generateText({
+        model: "openai/gpt-5.5",
+        prompt: `In a Slack thread an assistant is part of, decide if this message is addressed to the assistant (vs. talk between other people). Answer "yes" or "no".\n\nMessage: ${message.text}`,
+      });
+
+      return text.trim().toLowerCase().startsWith("y");
+    },
+  },
+});
+```
+
+`decide` is optional. If provided, Eve calls it for every follow-up message after its built-in checks. Implement it using a model, keyword matching, custom routing logic, or any other approach appropriate for your application.
+
 ### Delivery
 
 The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets build progressively: extensions of at least four characters appear immediately, while smaller streamed deltas use the five-second refresh interval to avoid one Slack request per token. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -114,7 +114,11 @@ export async function resolveBotUserId(
   if (!cached) {
     cached = callSlackApi({ botToken: token, operation: "auth.test", body: {} })
       .then((r) => (r.ok && typeof r.user_id === "string" ? r.user_id : undefined))
-      .catch(() => undefined);
+      .catch(() => undefined)
+      .then((userId) => {
+        if (userId === undefined) botUserIdCache.delete(token);
+        return userId;
+      });
     botUserIdCache.set(token, cached);
   }
   return cached;

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -92,6 +92,34 @@ export async function callSlackApi(input: {
   return response.json() as Promise<SlackApiResponse>;
 }
 
+const botUserIdCache = new Map<string, Promise<string | undefined>>();
+
+/**
+ * Resolves the bot's own Slack user id via `auth.test`, cached per resolved bot
+ * token for the lifetime of the process. Used by the `followUps` dispatch path
+ * to (a) skip follow-ups that @mention the bot — those also arrive as
+ * `app_mention` — and (b) recognise the bot's presence in a thread. Returns
+ * `undefined` when the call fails so callers can degrade gracefully.
+ */
+export async function resolveBotUserId(
+  botToken: SlackBotToken | undefined,
+): Promise<string | undefined> {
+  let token: string;
+  try {
+    token = await resolveSlackBotToken(botToken);
+  } catch {
+    return undefined;
+  }
+  let cached = botUserIdCache.get(token);
+  if (!cached) {
+    cached = callSlackApi({ botToken: token, operation: "auth.test", body: {} })
+      .then((r) => (r.ok && typeof r.user_id === "string" ? r.user_id : undefined))
+      .catch(() => undefined);
+    botUserIdCache.set(token, cached);
+  }
+  return cached;
+}
+
 /**
  * Builds the `request(op, body)` Slack API caller installed on every
  * {@link SlackHandle}. Resolves the bot token at call time so rotated

--- a/packages/eve/src/public/channels/slack/inbound.test.ts
+++ b/packages/eve/src/public/channels/slack/inbound.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { parseAppMentionEvent, parseDirectMessageEvent } from "#public/channels/slack/inbound.js";
+import {
+  parseAppMentionEvent,
+  parseDirectMessageEvent,
+  parseThreadFollowUpEvent,
+} from "#public/channels/slack/inbound.js";
 
 describe("parseAppMentionEvent", () => {
   it("returns a SlackMessage with mrkdwn re-rendered as GFM", () => {
@@ -260,5 +264,62 @@ describe("parseDirectMessageEvent", () => {
       event: { type: "message", channel_type: "im", user: "U01" },
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("parseThreadFollowUpEvent", () => {
+  const reply = (overrides: Record<string, unknown> = {}) => ({
+    type: "event_callback" as const,
+    team_id: "T01",
+    event: {
+      type: "message",
+      channel_type: "channel",
+      user: "U01",
+      text: "now do bachelorette content",
+      channel: "C01",
+      ts: "1700000000.000200",
+      thread_ts: "1700000000.000100",
+      ...overrides,
+    },
+  });
+
+  it("parses a non-mention reply inside a channel thread", () => {
+    const message = parseThreadFollowUpEvent(reply());
+    expect(message).not.toBeNull();
+    expect(message?.channelId).toBe("C01");
+    expect(message?.threadTs).toBe("1700000000.000100");
+    expect(message?.author?.userId).toBe("U01");
+  });
+
+  it("returns null for a top-level message (no thread_ts)", () => {
+    expect(parseThreadFollowUpEvent(reply({ thread_ts: undefined }))).toBeNull();
+  });
+
+  it("returns null for a thread root (thread_ts === ts)", () => {
+    expect(
+      parseThreadFollowUpEvent(reply({ thread_ts: "1700000000.000200" })),
+    ).toBeNull();
+  });
+
+  it("returns null for DMs (handled by parseDirectMessageEvent)", () => {
+    expect(parseThreadFollowUpEvent(reply({ channel_type: "im" }))).toBeNull();
+  });
+
+  it("returns null for bot messages (avoids self-trigger loops)", () => {
+    expect(parseThreadFollowUpEvent(reply({ bot_id: "B01" }))).toBeNull();
+  });
+
+  it("returns null for system subtypes but allows file_share", () => {
+    expect(parseThreadFollowUpEvent(reply({ subtype: "channel_join" }))).toBeNull();
+    expect(parseThreadFollowUpEvent(reply({ subtype: "file_share" }))).not.toBeNull();
+  });
+
+  it("returns null for non-message events", () => {
+    expect(
+      parseThreadFollowUpEvent({
+        type: "event_callback",
+        event: { type: "app_mention", channel: "C01", ts: "1.0", thread_ts: "0.9" },
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/eve/src/public/channels/slack/inbound.ts
+++ b/packages/eve/src/public/channels/slack/inbound.ts
@@ -165,6 +165,48 @@ export function parseDirectMessageEvent(envelope: SlackEventCallback): SlackMess
   return buildSlackMessage(message, envelope.team_id);
 }
 
+/**
+ * Parses a Slack `message` event that is a non-mention reply inside a
+ * channel/group thread into a {@link SlackMessage}. Powers
+ * `SlackChannelConfig.followUps`: continuing a conversation in a thread the bot
+ * is already part of without a re-mention.
+ *
+ * Returns `null` when:
+ * - the envelope is not a `message` event,
+ * - it is a DM (`channel_type: "im"`) — handled by {@link parseDirectMessageEvent},
+ * - it is not a threaded reply (no `thread_ts`, or `thread_ts === ts`, i.e. a
+ *   top-level message — the bot only follows up inside threads),
+ * - the message carries a system `subtype` (edits, deletes, joins, etc.) other
+ *   than `file_share`, or
+ * - the message was posted by a bot (`bot_id` set) — prevents the bot's own
+ *   thread replies from re-triggering the handler.
+ *
+ * Messages that mention the bot also arrive as `app_mention`; the channel skips
+ * follow-ups that mention the bot so the mention path owns them (no double reply).
+ */
+export function parseThreadFollowUpEvent(envelope: SlackEventCallback): SlackMessage | null {
+  if (envelope.type !== "event_callback") return null;
+  const event = envelope.event;
+  if (!event || event.type !== "message") return null;
+
+  const message = event as SlackMessageEvent;
+  if (message.channel_type === "im") return null;
+  if (
+    typeof message.subtype === "string" &&
+    message.subtype.length > 0 &&
+    message.subtype !== "file_share"
+  ) {
+    return null;
+  }
+  if (typeof message.bot_id === "string" && message.bot_id.length > 0) return null;
+
+  const threadTs = typeof message.thread_ts === "string" ? message.thread_ts : "";
+  const ts = typeof message.ts === "string" ? message.ts : "";
+  if (!threadTs || threadTs === ts) return null;
+
+  return buildSlackMessage(message, envelope.team_id);
+}
+
 function buildSlackMessage(
   event: SlackAppMentionEvent | SlackMessageEvent,
   envelopeTeamId: string | undefined,

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -19,6 +19,7 @@ export {
   type SlackChannelState,
   type SlackContext,
   type SlackEventContext,
+  type SlackFollowUpsOptions,
   type SlackHandle,
   type SlackInboundResult,
   type SlackInboundResultOrPromise,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1900,3 +1900,151 @@ describe("constrainAuthorizationRequired", () => {
     expect(handler.mock.calls[0]?.[2]).toBe(sessionCtx);
   });
 });
+
+describe("slackChannel() followUps", () => {
+  const BOT = "UBOT";
+
+  // Routes outbound Slack calls a follow-up makes: auth.test (bot identity) and
+  // conversations.replies (the thread membership gate).
+  function routeFetch(threadMessages: Record<string, unknown>[]): ReturnType<typeof vi.fn> {
+    return vi.fn().mockImplementation((url: string | URL) => {
+      const u = String(url);
+      const payload = u.endsWith("/auth.test")
+        ? { ok: true, user_id: BOT }
+        : u.endsWith("/conversations.replies")
+          ? { ok: true, messages: threadMessages }
+          : { ok: true, ts: "1700000001.000001" };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    });
+  }
+
+  function threadReplyBody(overrides?: { text?: string }): string {
+    return JSON.stringify({
+      type: "event_callback",
+      team_id: "T01",
+      event_id: `EvFU${Math.random()}`,
+      event: {
+        type: "message",
+        channel_type: "channel",
+        user: "U01",
+        text: overrides?.text ?? "now do bachelorette content",
+        channel: "C01",
+        ts: "1700000000.000200",
+        thread_ts: "1700000000.000100",
+      },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("dispatches a non-mention thread reply when the bot is in the thread", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: BOT, bot_id: "B01", text: "earlier reply" }]));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-in", signingSecret: SIGNING_SECRET },
+      followUps: true,
+    });
+    const { send } = await firePost(channel, buildSignedRequest({ body: threadReplyBody() }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[1]?.continuationToken).toBe("C01:1700000000.000100");
+  });
+
+  it("ignores a non-mention thread reply when the bot is not in the thread", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: "U01", text: "hi" }, { user: "U02", text: "yo" }]));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-out", signingSecret: SIGNING_SECRET },
+      followUps: true,
+    });
+    const { send } = await firePost(channel, buildSignedRequest({ body: threadReplyBody() }));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("defers follow-ups that mention the bot to the app_mention path", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: BOT, bot_id: "B01", text: "earlier reply" }]));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-mention", signingSecret: SIGNING_SECRET },
+      followUps: true,
+    });
+    const { send } = await firePost(
+      channel,
+      buildSignedRequest({ body: threadReplyBody({ text: `<@${BOT}> keep going` }) }),
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("defers follow-ups that mention the bot in the labeled `<@U|name>` form", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: BOT, bot_id: "B01", text: "earlier reply" }]));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-label", signingSecret: SIGNING_SECRET },
+      followUps: true,
+    });
+    const { send } = await firePost(
+      channel,
+      buildSignedRequest({ body: threadReplyBody({ text: `<@${BOT}|outpost> keep going` }) }),
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for thread replies when followUps is disabled (default)", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: BOT, bot_id: "B01", text: "earlier reply" }]));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-off", signingSecret: SIGNING_SECRET },
+    });
+    const { send } = await firePost(channel, buildSignedRequest({ body: threadReplyBody() }));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("ignores a thread touched only by a different (foreign) bot", async () => {
+    // A thread where an unrelated bot (e.g. CI) posted, but this bot never did
+    // and was never mentioned. `isMe` is true for any bot, so the gate must
+    // match this bot's user id specifically — otherwise it barges in.
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([{ user: "UFOREIGN", bot_id: "B99", text: "build passed ✅" }]),
+    );
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-foreign", signingSecret: SIGNING_SECRET },
+      followUps: true,
+    });
+    const { send } = await firePost(channel, buildSignedRequest({ body: threadReplyBody() }));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("runs the decide hook and stays silent when it returns false", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: BOT, bot_id: "B01", text: "earlier reply" }]));
+    const decide = vi.fn().mockResolvedValue(false);
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-decide-no", signingSecret: SIGNING_SECRET },
+      followUps: { decide },
+    });
+    const { send } = await firePost(channel, buildSignedRequest({ body: threadReplyBody() }));
+
+    expect(decide).toHaveBeenCalledTimes(1);
+    expect(decide.mock.calls[0]?.[0]?.text).toContain("bachelorette");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("runs the decide hook and dispatches when it returns true", async () => {
+    vi.stubGlobal("fetch", routeFetch([{ user: BOT, bot_id: "B01", text: "earlier reply" }]));
+    const decide = vi.fn().mockReturnValue(true);
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-followups-decide-yes", signingSecret: SIGNING_SECRET },
+      followUps: { decide },
+    });
+    const { send } = await firePost(channel, buildSignedRequest({ body: threadReplyBody() }));
+
+    expect(decide).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -8,6 +8,7 @@ import { createLogger, logError } from "#internal/logging.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import {
   buildSlackBinding,
+  resolveBotUserId,
   slackContinuationToken,
   type SlackBotToken,
   type SlackHandle,
@@ -27,6 +28,7 @@ import {
 import {
   parseAppMentionEvent,
   parseDirectMessageEvent,
+  parseThreadFollowUpEvent,
   type SlackEventCallback,
   type SlackInboundContext,
   type SlackMessage,
@@ -365,6 +367,30 @@ export interface SlackChannelInternalEvents extends Omit<
   readonly "authorization.required"?: SlackEventHandler<"authorization.required">;
 }
 
+/**
+ * Options form of {@link SlackChannelConfig.followUps}. Use it to layer an
+ * agent-specific decision on top of the built-in "answer in threads I'm part
+ * of" rule.
+ */
+export interface SlackFollowUpsOptions {
+  /**
+   * Decide whether a candidate follow-up should be answered. Runs only after
+   * the built-in checks pass (the message is a non-mention reply in a thread
+   * this bot is already part of), so it sees just the messages that are
+   * plausibly for the bot. Return `false` to stay silent — the message is still
+   * readable as thread context on the next turn.
+   *
+   * This is the place for intent checks a deterministic rule can't make, such
+   * as a fast model classification of whether a message in a busy multi-user
+   * thread is actually addressed to the bot. `ctx` exposes the thread and raw
+   * Slack handles. A throw is treated as `false`.
+   */
+  readonly decide?: (
+    message: SlackMessage,
+    ctx: SlackContext,
+  ) => boolean | Promise<boolean>;
+}
+
 export interface SlackChannelConfig {
   readonly credentials?: SlackChannelCredentials;
   readonly botName?: string;
@@ -388,6 +414,27 @@ export interface SlackChannelConfig {
    * option to avoid fetching thread history.
    */
   readonly threadContext?: LoadThreadContextMessagesOptions;
+
+  /**
+   * Keep answering messages in a thread the bot is already in, without a
+   * re-`@mention`. Once the bot has been mentioned in a thread (or has replied
+   * there), it picks up follow-up messages in that thread automatically.
+   *
+   * The bot only follows up in threads it's part of, it stays out of every
+   * other thread, so it never jumps into conversations that aren't for it. DMs
+   * are already mention-free and don't need this.
+   *
+   * `true` uses the built-in rule above. Pass `{ decide }` to add an
+   * agent-specific check — e.g. a quick model classification of whether a
+   * message in a shared thread is actually addressed to the bot — on top of it.
+   *
+   * Requires the Slack app to subscribe to `message.channels` (and
+   * `message.groups` for private channels) with the `channels:history` /
+   * `groups:history` scope, alongside the usual `app_mention` setup.
+   *
+   * Default: `false`.
+   */
+  readonly followUps?: boolean | SlackFollowUpsOptions;
 
   /**
    * Invoked when a Slack `app_mention` event arrives (only `app_mention`;
@@ -490,6 +537,9 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
   const uploadPolicy = mergeUploadPolicy(config.uploadPolicy);
   const slackFetchFile = createSlackFetchFile({ botToken: config.credentials?.botToken });
   const onAppMention = config.onAppMention ?? defaultOnAppMention;
+  const followUpsEnabled = config.followUps !== undefined && config.followUps !== false;
+  const followUpsDecide =
+    typeof config.followUps === "object" ? config.followUps.decide : undefined;
   const onDirectMessage = config.onDirectMessage ?? defaultOnDirectMessage;
   const authorizationRequiredOverride = config.events?.["authorization.required"];
   const turnStartedHandler = config.events?.["turn.started"] ?? defaultEvents["turn.started"]!;
@@ -568,6 +618,8 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
             onDirectMessage,
             uploadPolicy,
             threadContext: config.threadContext,
+            followUps: followUpsEnabled,
+            followUpsDecide,
             handledEvents,
             headers: req.headers,
             credentials: config.credentials,
@@ -674,6 +726,8 @@ async function handleEventPost(input: {
   readonly onDirectMessage: NonNullable<SlackChannelConfig["onDirectMessage"]>;
   readonly uploadPolicy: UploadPolicy;
   readonly threadContext: LoadThreadContextMessagesOptions | undefined;
+  readonly followUps: boolean;
+  readonly followUpsDecide: SlackFollowUpsOptions["decide"] | undefined;
   readonly credentials: SlackChannelCredentials | undefined;
   readonly handledEvents: Set<string>;
 }): Promise<Response> {
@@ -737,6 +791,25 @@ async function handleEventPost(input: {
     return new Response("ok");
   }
 
+  if (input.followUps) {
+    const followUp = parseThreadFollowUpEvent(envelope);
+    if (followUp) {
+      input.waitUntil(
+        dispatchInboundMessage({
+          kind: "thread_follow_up",
+          message: followUp,
+          handler: input.onAppMention,
+          send: input.send,
+          uploadPolicy: input.uploadPolicy,
+          threadContext: input.threadContext,
+          credentials: input.credentials,
+          decide: input.followUpsDecide,
+        }),
+      );
+      return new Response("ok");
+    }
+  }
+
   return new Response("ok");
 }
 
@@ -769,7 +842,7 @@ async function verifyInbound(
  * handler never crashes the webhook ACK.
  */
 async function dispatchInboundMessage(input: {
-  readonly kind: "app_mention" | "direct_message";
+  readonly kind: "app_mention" | "direct_message" | "thread_follow_up";
   readonly message: SlackMessage;
   readonly handler:
     | NonNullable<SlackChannelConfig["onAppMention"]>
@@ -778,6 +851,7 @@ async function dispatchInboundMessage(input: {
   readonly uploadPolicy: UploadPolicy;
   readonly threadContext: LoadThreadContextMessagesOptions | undefined;
   readonly credentials: SlackChannelCredentials | undefined;
+  readonly decide?: SlackFollowUpsOptions["decide"];
 }): Promise<void> {
   const { message, kind } = input;
   const { thread, slack } = buildSlackBinding({
@@ -787,6 +861,52 @@ async function dispatchInboundMessage(input: {
     teamId: message.teamId,
   });
   const slackCtx: SlackContext = { thread, slack };
+
+  // A mention-free thread reply only continues a conversation the bot is
+  // already part of. Resolve the bot's user id to (a) defer messages that
+  // mention it to the `app_mention` path, and (b) detect its presence in the
+  // thread (it posted, or was mentioned). A thread with neither is left alone.
+  if (kind === "thread_follow_up") {
+    const botUserId = await resolveBotUserId(input.credentials?.botToken);
+    const mention = botUserId ? `<@${botUserId}` : null;
+    if (mention !== null && message.text.includes(mention)) return;
+    try {
+      await thread.refresh();
+    } catch (error) {
+      logError(log, "thread_follow_up refresh failed", error, {
+        channelId: message.channelId,
+      });
+      return;
+    }
+
+    // Match this bot specifically by user id — not `isMe`, which is true for any
+    // bot-authored message and would treat a thread touched only by an unrelated
+    // bot (CI, another app) as one we belong to. Fall back to `isMe` only when the
+    // bot's id can't be resolved.
+    const botInThread = thread.recentMessages.some((m) =>
+      botUserId
+        ? m.user === botUserId || (mention !== null && m.text.includes(mention))
+        : m.isMe,
+    );
+    if (!botInThread) return;
+
+    // Optional agent-specific decision: only this bot's threads reach here, so a
+    // `decide` hook can apply intent checks (e.g. "is this message for me?")
+    // before committing to a full turn. Returning false stays silent; the
+    // message is still readable as thread context next turn.
+    if (input.decide) {
+      let proceed: boolean;
+      try {
+        proceed = await input.decide(message, slackCtx);
+      } catch (error) {
+        logError(log, "thread_follow_up decide threw — dropping", error, {
+          channelId: message.channelId,
+        });
+        return;
+      }
+      if (!proceed) return;
+    }
+  }
 
   let result;
   try {


### PR DESCRIPTION
### Description

Adds an opt-in `followUps` option to the Slack channel so the agent keeps
answering plain messages in a thread it's already part of, without a
re-mention on every turn. 

With `followUps` enabled, once the bot has been pulled into a thread (was
mentioned there, or has already replied), it picks up subsequent non-mention
replies in that same thread and continues the conversation on the existing
session. 

Also has the option to pass a custom `decide` hook. It runs **only after** the built-in
checks pass and reads the message into it's thread context even if it returns `false`. 

```ts
slackChannel({
  credentials,
  followUps: {
    async decide(message, ctx) {
      // e.g. a fast model classification of "is this addressed to me?"
      return isForTheBot(message.text);
    },
  },
});
```


https://github.com/user-attachments/assets/7309db0b-aea9-478d-ad10-ad4d58e2b68f

Relevant issues: #223 and a batteries-included option for the proposed shape of #235.

### How did you test your changes?

Tested end-to-end manually and added tests.

```bash
pnpm --filter eve build:types   # typecheck — pass
pnpm --filter eve test:unit     # 4250 passed, 1 skipped (411 files)
pnpm lint                       # oxlint — clean
pnpm run docs:check             # docs + snippets compile
```

### PR Checklist

- [X] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
