### PR TITLE
feat(eve): add subagent runtime limits

### DIFF
--- a/.changeset/runtime-delegation-limits.md
+++ b/.changeset/runtime-delegation-limits.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add default runtime limits and agent config overrides for subagent depth and per-step child-agent fan-out.

--- a/e2e/fixtures/agent-subagent-limits/.gitignore
+++ b/e2e/fixtures/agent-subagent-limits/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env*
+.eve
+.vercel
+.workflow-data
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-subagent-limits/.vercelignore
+++ b/e2e/fixtures/agent-subagent-limits/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-subagent-limits/agent/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/agent.ts
@@ -1,0 +1,63 @@
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest } from "eve/evals";
+
+const DEPTH_PROMPT_MARKER = "depth guardrail e2e";
+const FANOUT_PROMPT_MARKER = "fanout guardrail e2e";
+const DEPTH_RESULT_MARKER = "SUBAGENT_DEPTH_LIMIT_E2E_OK";
+const FANOUT_RESULT_MARKER = "SUBAGENT_FANOUT_LIMIT_E2E_OK";
+
+export default defineAgent({
+  limits: {
+    subagents: {
+      maxCallsPerStep: 1,
+      maxDepth: 1,
+    },
+  },
+  model: mockModel(handleRootRequest),
+  modelContextWindowTokens: 1_000_000,
+});
+
+function handleRootRequest(request: MockModelRequest) {
+  const prompt = request.lastUserMessage ?? "";
+
+  if (prompt.includes(DEPTH_PROMPT_MARKER)) {
+    const result = request.toolResults.find((entry) => entry.name === "depth-prober");
+    if (result !== undefined) {
+      return `${DEPTH_RESULT_MARKER}: ${JSON.stringify(result.output)}`;
+    }
+
+    return {
+      toolCalls: [
+        {
+          id: "depth-prober-call",
+          input: { message: "try one nested self-delegation" },
+          name: "depth-prober",
+        },
+      ],
+    };
+  }
+
+  if (prompt.includes(FANOUT_PROMPT_MARKER)) {
+    const results = request.toolResults.filter((entry) => entry.name === "echo-marker");
+    if (results.length > 0) {
+      return `${FANOUT_RESULT_MARKER}: ${JSON.stringify(results.map((entry) => entry.output))}`;
+    }
+
+    return {
+      toolCalls: [
+        {
+          id: "fanout-accepted-call",
+          input: { message: "accepted fanout child" },
+          name: "echo-marker",
+        },
+        {
+          id: "fanout-rejected-call",
+          input: { message: "rejected fanout child" },
+          name: "echo-marker",
+        },
+      ],
+    };
+  }
+
+  return "Unknown subagent limit eval prompt.";
+}

--- a/e2e/fixtures/agent-subagent-limits/agent/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e fixture for subagent runtime limits.

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/agent.ts
@@ -1,7 +1,8 @@
 import { defineAgent } from "eve";
 import { mockModel, type MockModelRequest } from "eve/evals";
 
-const DEPTH_PROBER_MARKER = "DEPTH_PROBER_LIMIT_OBSERVED";
+export const DEPTH_PROBER_TOOL_HIDDEN_MARKER = "DEPTH_PROBER_SUBAGENT_TOOL_HIDDEN";
+const DEPTH_PROBER_LIMIT_MARKER = "DEPTH_PROBER_LIMIT_OBSERVED";
 
 export default defineAgent({
   description:
@@ -14,7 +15,11 @@ function handleDepthProbeRequest(request: MockModelRequest) {
   const result = request.toolResults.find((entry) => entry.name === "agent");
 
   if (result !== undefined) {
-    return `${DEPTH_PROBER_MARKER}: ${JSON.stringify(result.output)}`;
+    return `${DEPTH_PROBER_LIMIT_MARKER}: ${JSON.stringify(result.output)}`;
+  }
+
+  if (!request.tools.some((tool) => tool.name === "agent")) {
+    return `${DEPTH_PROBER_TOOL_HIDDEN_MARKER}: nested subagent tool is not advertised`;
   }
 
   return {

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/agent.ts
@@ -1,0 +1,29 @@
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest } from "eve/evals";
+
+const DEPTH_PROBER_MARKER = "DEPTH_PROBER_LIMIT_OBSERVED";
+
+export default defineAgent({
+  description:
+    "Deterministic depth-limit probe. It attempts one nested self-subagent call, then reports the tool result it received.",
+  model: mockModel(handleDepthProbeRequest),
+  modelContextWindowTokens: 1_000_000,
+});
+
+function handleDepthProbeRequest(request: MockModelRequest) {
+  const result = request.toolResults.find((entry) => entry.name === "agent");
+
+  if (result !== undefined) {
+    return `${DEPTH_PROBER_MARKER}: ${JSON.stringify(result.output)}`;
+  }
+
+  return {
+    toolCalls: [
+      {
+        id: "depth-prober-self-call",
+        input: { message: "this nested self-delegation should hit maxDepth" },
+        name: "agent",
+      },
+    ],
+  };
+}

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e subagent that probes nested subagent depth limits.

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/agent.ts
@@ -1,0 +1,11 @@
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export const ECHO_LIMIT_TOKEN = "SUBAGENT_LIMIT_ECHO_CHILD_OK";
+
+export default defineAgent({
+  description:
+    "Deterministic echo subagent for subagent limit e2e coverage. It returns a fixed marker.",
+  model: mockModel(ECHO_LIMIT_TOKEN),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e subagent that returns a fixed marker.

--- a/e2e/fixtures/agent-subagent-limits/evals/depth-limit.eval.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/depth-limit.eval.ts
@@ -1,0 +1,23 @@
+import { defineEval } from "eve/evals";
+
+const DEPTH_LIMIT_CODE = "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED";
+const DEPTH_RESULT_MARKER = "SUBAGENT_DEPTH_LIMIT_E2E_OK";
+
+export default defineEval({
+  description:
+    "Subagent limits e2e: a child subagent cannot start a nested subagent after maxDepth is reached.",
+  tags: ["subagents", "limits", "depth"],
+
+  async test(t) {
+    await t.send("depth guardrail e2e: ask the depth-prober subagent to attempt one nested call.");
+
+    t.succeeded();
+    t.calledSubagent("depth-prober", {
+      output: new RegExp(DEPTH_LIMIT_CODE),
+      count: 1,
+    });
+    t.messageIncludes(DEPTH_RESULT_MARKER);
+    t.messageIncludes(DEPTH_LIMIT_CODE);
+    t.messageIncludes(/Do not retry this subagent call/);
+  },
+});

--- a/e2e/fixtures/agent-subagent-limits/evals/depth-limit.eval.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/depth-limit.eval.ts
@@ -1,11 +1,12 @@
 import { defineEval } from "eve/evals";
 
-const DEPTH_LIMIT_CODE = "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED";
+import { DEPTH_PROBER_TOOL_HIDDEN_MARKER } from "../agent/subagents/depth-prober/agent.js";
+
 const DEPTH_RESULT_MARKER = "SUBAGENT_DEPTH_LIMIT_E2E_OK";
 
 export default defineEval({
   description:
-    "Subagent limits e2e: a child subagent cannot start a nested subagent after maxDepth is reached.",
+    "Subagent limits e2e: a child subagent does not see nested subagent tools after maxDepth is reached.",
   tags: ["subagents", "limits", "depth"],
 
   async test(t) {
@@ -13,11 +14,10 @@ export default defineEval({
 
     t.succeeded();
     t.calledSubagent("depth-prober", {
-      output: new RegExp(DEPTH_LIMIT_CODE),
+      output: new RegExp(DEPTH_PROBER_TOOL_HIDDEN_MARKER),
       count: 1,
     });
     t.messageIncludes(DEPTH_RESULT_MARKER);
-    t.messageIncludes(DEPTH_LIMIT_CODE);
-    t.messageIncludes(/Do not retry this subagent call/);
+    t.messageIncludes(DEPTH_PROBER_TOOL_HIDDEN_MARKER);
   },
 });

--- a/e2e/fixtures/agent-subagent-limits/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/evals.config.ts
@@ -1,0 +1,3 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({});

--- a/e2e/fixtures/agent-subagent-limits/evals/fanout-limit.eval.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/fanout-limit.eval.ts
@@ -1,0 +1,39 @@
+import { defineEval } from "eve/evals";
+
+import { ECHO_LIMIT_TOKEN } from "../agent/subagents/echo-marker/agent.js";
+
+const FANOUT_LIMIT_CODE = "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED";
+const FANOUT_RESULT_MARKER = "SUBAGENT_FANOUT_LIMIT_E2E_OK";
+
+export default defineEval({
+  description:
+    "Subagent limits e2e: per-step fan-out overflow starts the first child and rejects the rest.",
+  tags: ["subagents", "limits", "fanout"],
+
+  async test(t) {
+    await t.send("fanout guardrail e2e: request two echo-marker subagents in one model step.");
+
+    t.succeeded();
+    t.calledSubagent("echo-marker", {
+      output: ECHO_LIMIT_TOKEN,
+      count: 1,
+    });
+    t.event("action.result", {
+      data: {
+        result: {
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: FANOUT_LIMIT_CODE,
+            message: /This step requested 2 subagent calls, but eve allows 1/,
+          },
+          subagentName: "echo-marker",
+        },
+        status: "failed",
+      },
+      count: 1,
+    });
+    t.messageIncludes(FANOUT_RESULT_MARKER);
+    t.messageIncludes(FANOUT_LIMIT_CODE);
+  },
+});

--- a/e2e/fixtures/agent-subagent-limits/package.json
+++ b/e2e/fixtures/agent-subagent-limits/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agent-subagent-limits",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "2.6.1",
+    "@opentelemetry/sdk-trace-base": "2.6.1",
+    "@vercel/otel": "2.1.2",
+    "ai": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-subagent-limits/tsconfig.json
+++ b/e2e/fixtures/agent-subagent-limits/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts", ".eve/**/*.d.ts"]
+}

--- a/packages/eve/README.md
+++ b/packages/eve/README.md
@@ -116,6 +116,22 @@ export default defineAgent({
 });
 ```
 
+eve applies default subagent guardrails to the built-in `agent` tool, authored
+subagents, remote agents, and Workflow-launched subagent calls. Raise them
+explicitly when an agent needs broader delegation:
+
+```ts
+export default defineAgent({
+  model: "openai/gpt-5.4-mini",
+  limits: {
+    subagents: {
+      maxCallsPerStep: 8,
+      maxDepth: 6,
+    },
+  },
+});
+```
+
 ## Quick Start
 
 ```bash

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -6,6 +6,7 @@ import type { RuntimeActionResult } from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
 import type { JsonObject } from "#shared/json.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 
 export type { ContextAccessor } from "#context/key.js";
 export type { ChannelInstrumentationProjection } from "#channel/instrumentation.js";
@@ -44,6 +45,12 @@ export interface SessionParent {
   readonly callId: string;
   readonly rootSessionId: string;
   readonly sessionId: string;
+  /**
+   * Depth of this child in the delegated subagent tree. Root sessions have
+   * depth 0 and omit this field; first-level children set it to 1.
+   */
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
   readonly turn: SessionTurn;
 }
 

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -40,4 +40,28 @@ describe("compiledAgentManifestSchema", () => {
     expect(parsed.success).toBe(true);
     expect(manifest.config.experimental?.workflow).toEqual({ world: "@acme/eve-world" });
   });
+
+  it("preserves subagent limit configuration", () => {
+    const manifest = createCompiledAgentManifest({
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      config: {
+        limits: {
+          subagents: {
+            maxCallsPerStep: 8,
+            maxDepth: 6,
+          },
+        },
+        model: { id: "openai/gpt-5.5", routing: classifyModelRouting("openai/gpt-5.5") },
+        name: "app",
+      },
+    });
+
+    const parsed = compiledAgentManifestSchema.parse(manifest);
+
+    expect(parsed.config.limits?.subagents).toEqual({
+      maxCallsPerStep: 8,
+      maxDepth: 6,
+    });
+  });
 });

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -23,6 +23,7 @@ import type {
   InternalAgentModelDefinition,
   InternalAgentCompactionDefinition,
   AgentBuildDefinition,
+  AgentLimitsDefinition,
   ModelRouting,
 } from "#shared/agent-definition.js";
 import type { InternalToolDefinition } from "#shared/tool-definition.js";
@@ -112,12 +113,15 @@ type CompiledAgentCompactionDefinition = Omit<InternalAgentCompactionDefinition,
   model?: CompiledRuntimeModelReference;
 };
 
+type CompiledAgentLimitsDefinition = AgentLimitsDefinition;
+
 /**
  * Normalized additive agent configuration preserved in the compiled manifest.
  */
 export type CompiledAgentDefinition = Omit<InternalAgentDefinition, "model" | "compaction"> & {
   model: CompiledRuntimeModelReference;
   compaction?: CompiledAgentCompactionDefinition;
+  limits?: CompiledAgentLimitsDefinition;
 };
 
 /**
@@ -357,6 +361,18 @@ const compiledAgentCompactionDefinitionSchema: z.ZodType<CompiledAgentCompaction
   })
   .strict();
 
+const compiledAgentLimitsDefinitionSchema: z.ZodType<CompiledAgentLimitsDefinition> = z
+  .object({
+    subagents: z
+      .object({
+        maxCallsPerStep: z.number().int().min(1).optional(),
+        maxDepth: z.number().int().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
   .object({
     build: compiledAgentBuildDefinitionSchema.optional(),
@@ -368,6 +384,7 @@ const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
       })
       .strict()
       .optional(),
+    limits: compiledAgentLimitsDefinitionSchema.optional(),
     model: compiledRuntimeModelReferenceSchema,
     name: z.string(),
     outputSchema: jsonObjectSchema.optional(),
@@ -713,6 +730,7 @@ export function createCompiledAgentNodeManifest(input: {
                       world: input.config.experimental.workflow.world,
                     },
             },
+      limits: cloneCompiledAgentLimits(input.config.limits),
       model: cloneCompiledRuntimeModelReference(input.config.model),
       name: input.config.name,
       outputSchema: input.config.outputSchema,
@@ -754,6 +772,24 @@ export function createCompiledAgentNodeManifest(input: {
   }
 
   return node;
+}
+
+function cloneCompiledAgentLimits(
+  limits: CompiledAgentLimitsDefinition | undefined,
+): CompiledAgentLimitsDefinition | undefined {
+  if (limits === undefined) {
+    return undefined;
+  }
+
+  return {
+    subagents:
+      limits.subagents === undefined
+        ? undefined
+        : {
+            maxCallsPerStep: limits.subagents.maxCallsPerStep,
+            maxDepth: limits.subagents.maxDepth,
+          },
+  };
 }
 
 /**

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -66,6 +66,7 @@ export async function compileAgentConfig(
     };
     description?: string;
     experimental?: CompiledAgentDefinition["experimental"];
+    limits?: CompiledAgentDefinition["limits"];
     model: CompiledRuntimeModelReference;
     name: string;
     outputSchema?: JsonObject;
@@ -93,6 +94,10 @@ export async function compileAgentConfig(
           ? undefined
           : [...definition.build.externalDependencies],
     };
+  }
+
+  if (definition.limits !== undefined) {
+    compiledConfig.limits = normalizeLimitsDefinition(definition.limits);
   }
 
   if (definition.outputSchema !== undefined) {
@@ -129,6 +134,24 @@ export async function compileAgentConfig(
   }
 
   return compiledConfig;
+}
+
+function normalizeLimitsDefinition(
+  limits: CompiledAgentDefinition["limits"],
+): CompiledAgentDefinition["limits"] {
+  if (limits === undefined) {
+    return undefined;
+  }
+
+  return {
+    subagents:
+      limits.subagents === undefined
+        ? undefined
+        : {
+            maxCallsPerStep: limits.subagents.maxCallsPerStep,
+            maxDepth: limits.subagents.maxDepth,
+          },
+  };
 }
 
 function normalizeExperimentalDefinition(

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -5,6 +5,7 @@ import {
   type DurableSessionState,
 } from "#execution/durable-session-store.js";
 import { createSession } from "#execution/session.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 import type { JsonObject } from "#shared/json.js";
 
 /**
@@ -30,6 +31,8 @@ export async function createSessionStep(input: {
   readonly nodeId?: string;
   readonly rootSessionId?: string;
   readonly sessionId: string;
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
 }): Promise<CreateSessionStepResult> {
   "use step";
 
@@ -46,6 +49,8 @@ export async function createSessionStep(input: {
     outputSchema: input.outputSchema,
     rootSessionId: input.rootSessionId,
     sessionId: input.sessionId,
+    subagentDepth: input.subagentDepth,
+    subagentLimits: input.subagentLimits,
     turnAgent: bundle.turnAgent,
   });
 

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -64,7 +64,7 @@ export async function dispatchRuntimeActionsStep(input: {
   const durableSession = await readDurableSession(input.sessionState);
   const batch = getPendingRuntimeActionBatch(durableSession.state);
 
-  if (batch === undefined || batch.actions.length === 0) {
+  if (batch === undefined) {
     return { results: [], sessionState: input.sessionState };
   }
 
@@ -86,9 +86,25 @@ export async function dispatchRuntimeActionsStep(input: {
 
   const adapterCtx = buildAdapterContext(adapter, ctx);
 
-  let nextSession = session;
-  const results: RuntimeSubagentResultActionResult[] = [];
-  const limitedBatch = applySubagentLimits({ actions: batch.actions, session });
+  const prefiltered = batch.dispatchActions !== undefined;
+  const dispatchActions = batch.dispatchActions ?? batch.actions;
+  const results: RuntimeSubagentResultActionResult[] = [
+    ...(batch.prefilledResults ?? []).filter(
+      (result): result is RuntimeSubagentResultActionResult => result.kind === "subagent-result",
+    ),
+  ];
+  const limitedBatch = prefiltered
+    ? { actions: dispatchActions, rejectedResults: [], session }
+    : applySubagentLimits({
+        actions: dispatchActions,
+        session,
+        step: {
+          stepIndex: batch.event.stepIndex,
+          turnId: batch.event.turnId,
+        },
+      });
+  let nextSession = limitedBatch.session;
+
   results.push(...limitedBatch.rejectedResults);
 
   try {

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -42,6 +42,7 @@ import {
 import { hydrateDurableSession } from "#execution/session.js";
 import { buildSubagentRunInput, type SubagentInputSource } from "#execution/subagent-tool.js";
 import { createWorkflowRuntime, workflowEntryReference } from "#execution/workflow-runtime.js";
+import { applySubagentLimits } from "#harness/subagent-limits.js";
 import { createLogger, logError } from "#internal/logging.js";
 import { toErrorMessage } from "#shared/errors.js";
 
@@ -87,9 +88,11 @@ export async function dispatchRuntimeActionsStep(input: {
 
   let nextSession = session;
   const results: RuntimeSubagentResultActionResult[] = [];
+  const limitedBatch = applySubagentLimits({ actions: batch.actions, session });
+  results.push(...limitedBatch.rejectedResults);
 
   try {
-    for (const action of batch.actions) {
+    for (const action of limitedBatch.actions) {
       let childSessionId: string;
       let name: string;
       let remote: { readonly url: string } | undefined;

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -27,6 +27,7 @@
 
 import { ChannelRequestIdKey } from "#context/keys.js";
 import type { EveAttributeValue } from "#runtime/attributes/normalize.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 import { isNonEmptyString } from "#shared/guards.js";
 
 /**
@@ -51,6 +52,8 @@ interface SerializedSessionParent {
   readonly callId?: unknown;
   readonly sessionId?: unknown;
   readonly rootSessionId?: unknown;
+  readonly subagentDepth?: unknown;
+  readonly subagentLimits?: unknown;
   readonly turn?: {
     readonly id?: unknown;
   };
@@ -63,6 +66,8 @@ export interface SessionParentLineage {
   readonly callId?: string;
   readonly rootSessionId?: string;
   readonly sessionId?: string;
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
   readonly turnId?: string;
 }
 
@@ -88,13 +93,40 @@ export function readParentLineage(
   const callId = parent?.callId;
   const rootSessionId = parent?.rootSessionId;
   const sessionId = parent?.sessionId;
+  const subagentDepth = parent?.subagentDepth;
+  const subagentLimits = parent?.subagentLimits;
   const turnId = parent?.turn?.id;
   return {
     callId: isNonEmptyString(callId) ? callId : undefined,
     rootSessionId: isNonEmptyString(rootSessionId) ? rootSessionId : undefined,
     sessionId: isNonEmptyString(sessionId) ? sessionId : undefined,
+    subagentDepth:
+      typeof subagentDepth === "number" && Number.isInteger(subagentDepth) && subagentDepth >= 0
+        ? subagentDepth
+        : undefined,
+    subagentLimits: parseSubagentLimits(subagentLimits),
     turnId: isNonEmptyString(turnId) ? turnId : undefined,
   };
+}
+
+function parseSubagentLimits(value: unknown): AgentSubagentLimitsDefinition | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as { readonly maxCallsPerStep?: unknown; readonly maxDepth?: unknown };
+  const maxDepth = parsePositiveInteger(record.maxDepth);
+  const maxCallsPerStep = parsePositiveInteger(record.maxCallsPerStep);
+
+  if (maxDepth === undefined && maxCallsPerStep === undefined) {
+    return undefined;
+  }
+
+  return { maxCallsPerStep, maxDepth };
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
 /**

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -9,6 +9,7 @@ import {
   projectToDurableSession,
   refreshSessionFromTurnAgent,
 } from "#execution/session.js";
+import { getEffectiveSubagentLimits } from "#harness/subagent-limits.js";
 
 function createTestTurnAgent(overrides?: Partial<RuntimeTurnAgent>): RuntimeTurnAgent {
   return {
@@ -224,6 +225,50 @@ describe("createSession", () => {
 
     expect(durable.agent).toEqual({ system: session.agent.system });
     expect(hydrated.agent.reasoning).toBe("high");
+  });
+
+  it("stores authored subagent limit overrides on new sessions", () => {
+    const session = createSession({
+      continuationToken: "root-token",
+      sessionId: "sess-root",
+      turnAgent: createTestTurnAgent({
+        limits: {
+          subagents: {
+            maxCallsPerStep: 8,
+            maxDepth: 6,
+          },
+        },
+      }),
+    });
+
+    expect(getEffectiveSubagentLimits(session.state)).toEqual({
+      maxCallsPerStep: 8,
+      maxDepth: 6,
+    });
+  });
+
+  it("inherits parent subagent limits unless the child tightens them", () => {
+    const session = createSession({
+      continuationToken: "child-token",
+      sessionId: "sess-child",
+      subagentLimits: {
+        maxCallsPerStep: 8,
+        maxDepth: 6,
+      },
+      turnAgent: createTestTurnAgent({
+        limits: {
+          subagents: {
+            maxCallsPerStep: 5,
+            maxDepth: 10,
+          },
+        },
+      }),
+    });
+
+    expect(getEffectiveSubagentLimits(session.state)).toEqual({
+      maxCallsPerStep: 5,
+      maxDepth: 6,
+    });
   });
 });
 

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -1,6 +1,8 @@
 import type { DurableSession } from "#execution/durable-session-store.js";
 import type { HarnessSession, SessionToolDefinition } from "#harness/types.js";
 import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
+import { resolveEffectiveSubagentLimits, setSubagentLimitState } from "#harness/subagent-limits.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 
 const DEFAULT_COMPACTION_RECENT_WINDOW_SIZE = 10;
 const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 0.9;
@@ -51,6 +53,8 @@ export interface CreateSessionInput {
    */
   readonly rootSessionId?: string;
   readonly sessionId: string;
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
   readonly turnAgent: RuntimeTurnAgent;
   readonly outputSchema?: HarnessSession["outputSchema"];
 }
@@ -86,7 +90,14 @@ export function createSession(input: CreateSessionInput): HarnessSession {
     session.outputSchema = input.outputSchema;
   }
 
-  return session;
+  return setSubagentLimitState({
+    depth: input.subagentDepth,
+    limits: resolveEffectiveSubagentLimits({
+      authored: turnAgent.limits?.subagents,
+      inherited: input.subagentLimits,
+    }),
+    session,
+  });
 }
 
 /**

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -10,6 +10,7 @@ import type { HarnessSession } from "#harness/types.js";
 import type { JsonObject } from "#shared/json.js";
 import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
 import { mintSubagentContinuationToken } from "#execution/session.js";
+import { getChildSubagentDepth, getEffectiveSubagentLimits } from "#harness/subagent-limits.js";
 
 /**
  * Pending runtime-action batch event metadata needed for child run lineage.
@@ -111,6 +112,8 @@ export function buildSubagentRunInput(input: {
       callId: action.callId,
       rootSessionId,
       sessionId: session.sessionId,
+      subagentDepth: getChildSubagentDepth(session),
+      subagentLimits: getEffectiveSubagentLimits(session.state),
       turn: {
         id: batchEvent.turnId,
         sequence: batchEvent.sequence,

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -8,7 +8,7 @@ import type {
   SessionCapabilities,
 } from "#channel/types.js";
 import { coalesceDeliveries } from "#harness/messages.js";
-import { readChannelRequestId, readRootSessionId } from "#execution/eve-workflow-attributes.js";
+import { readChannelRequestId, readParentLineage } from "#execution/eve-workflow-attributes.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { notifyDelegatedParentStep } from "#execution/delegated-parent-notification.js";
@@ -85,15 +85,17 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
   try {
     // Derived once and reused for createSession + tag emission so the
     // chain-root id can never drift between persisted session and tags.
-    const rootSessionIdFromParent = readRootSessionId(input.serializedContext);
+    const parentLineage = readParentLineage(input.serializedContext);
 
     const { state: sessionState } = await createSessionStep({
       compiledArtifactsSource: serializedBundle.source,
       continuationToken,
       nodeId: serializedBundle.nodeId,
       outputSchema: input.input.outputSchema,
-      rootSessionId: rootSessionIdFromParent,
+      rootSessionId: parentLineage.rootSessionId,
       sessionId,
+      subagentDepth: parentLineage.subagentDepth,
+      subagentLimits: parentLineage.subagentLimits,
     });
 
     return await runDriverLoop({

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -9,6 +9,7 @@ import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js
 import { serializeContext } from "#context/serialize.js";
 import { setPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
+import { DEFAULT_MAX_SUBAGENT_DEPTH, setSubagentDepth } from "#harness/subagent-limits.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
 import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
@@ -282,6 +283,167 @@ describe("dispatchTurnStep", () => {
 });
 
 describe("dispatchRuntimeActionsStep", () => {
+  it("rejects subagent calls at the default maximum depth", async () => {
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {},
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {
+        subagentsByNodeId: new Map(),
+      },
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+
+    const session = setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "call-1",
+          description: "Launch another copy.",
+          input: { message: "keep going" },
+          kind: "subagent-call",
+          name: "agent",
+          nodeId: "__root__",
+          subagentName: "agent",
+        },
+      ],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      responseMessages: [],
+      session: setSubagentDepth({
+        depth: DEFAULT_MAX_SUBAGENT_DEPTH,
+        session: createStubSession({
+          continuationToken: "http:parent",
+          sessionId: "parent-session",
+        }),
+      }),
+    });
+    installSessionStoreMocks([session]);
+
+    const sessionState = createStubSessionState({
+      continuationToken: "http:parent",
+      sessionId: "parent-session",
+    });
+
+    await expect(
+      dispatchRuntimeActionsStep({
+        parentContinuationToken: "turn-inbox",
+        parentWritable: createTestWritable(),
+        serializedContext: createSerializedContext(),
+        sessionState,
+      }),
+    ).resolves.toEqual({
+      results: [
+        {
+          callId: "call-1",
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED",
+            message:
+              "Maximum subagent depth reached. Do not retry this subagent call; complete the work in this session or return a partial result.",
+          },
+          subagentName: "agent",
+        },
+      ],
+      sessionState,
+    });
+    expect(startMock).not.toHaveBeenCalled();
+    expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE)).toBeUndefined();
+  });
+
+  it("starts only the first four subagent calls from one dispatch batch", async () => {
+    const compiledArtifactsSource = {} as never;
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      hookRegistry: createEmptyHookRegistry(),
+      nodeId: "__root__",
+      resolvedAgent: { config: {} },
+      subagentRegistry: {
+        subagentsByNodeId: new Map(),
+      },
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    startMock.mockResolvedValue({ runId: "child-run" });
+    getRunMock.mockReturnValue({
+      getReadable: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+    });
+
+    const session = setPendingRuntimeActionBatch({
+      actions: Array.from({ length: 5 }, (_, index) => ({
+        callId: `call-${index + 1}`,
+        description: "Launch another copy.",
+        input: { message: `work item ${index + 1}` },
+        kind: "subagent-call" as const,
+        name: "agent",
+        nodeId: "__root__",
+        subagentName: "agent",
+      })),
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      responseMessages: [],
+      session: createStubSession({
+        continuationToken: "http:parent",
+        sessionId: "parent-session",
+      }),
+    });
+    installSessionStoreMocks([session]);
+
+    const sessionState = createStubSessionState({
+      continuationToken: "http:parent",
+      sessionId: "parent-session",
+    });
+
+    const result = await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
+      sessionState,
+    });
+
+    expect(startMock).toHaveBeenCalledTimes(4);
+    expect(result.results).toEqual([
+      {
+        callId: "call-5",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+          message:
+            "This step requested 5 subagent calls, but eve allows 4. The first 4 were started. Retry the remaining work in a later step with at most 4 subagent calls.",
+        },
+        subagentName: "agent",
+      },
+    ]);
+    expect(result.sessionState).toEqual(expect.any(Object));
+  });
+
   it("starts subagent child drivers on the latest deployment", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as never;
@@ -371,6 +533,9 @@ describe("dispatchRuntimeActionsStep", () => {
             "eve.channel": expect.objectContaining({
               kind: "subagent",
               state: expect.objectContaining({ parentContinuationToken: "turn-inbox" }),
+            }),
+            "eve.parentSession": expect.objectContaining({
+              subagentDepth: 1,
             }),
           }),
         }),

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -634,31 +634,48 @@ describe("dispatchRuntimeActionsStep", () => {
       sessionId: "parent-session",
     });
 
-    await expect(
-      dispatchRuntimeActionsStep({
-        callbackBaseUrl: "https://caller.example.com",
-        parentContinuationToken: "turn-inbox",
-        parentWritable: createTestWritable(),
-        serializedContext: createSerializedContext(),
-        sessionState,
-      }),
-    ).resolves.toEqual({
-      results: [
-        {
-          callId: "call-1",
-          isError: true,
-          kind: "subagent-result",
-          output: {
-            code: "REMOTE_AGENT_START_FAILED",
-            message: 'Remote agent "research" create-session request failed with HTTP 503.',
-          },
-          subagentName: "research",
-        },
-      ],
-      // A remote-agent dispatch failure does not mutate the session,
-      // so the step returns the input sessionState unchanged.
+    const result = await dispatchRuntimeActionsStep({
+      callbackBaseUrl: "https://caller.example.com",
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
       sessionState,
     });
+
+    expect(result.results).toEqual([
+      {
+        callId: "call-1",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "REMOTE_AGENT_START_FAILED",
+          message: 'Remote agent "research" create-session request failed with HTTP 503.',
+        },
+        subagentName: "research",
+      },
+    ]);
+    expect(result.sessionState).toMatchObject({
+      snapshot: {
+        session: {
+          state: {
+            "eve.runtime.subagentLimits": {
+              stepCalls: {
+                acceptedCalls: 1,
+                requestedCalls: 1,
+                stepIndex: 0,
+                turnId: "turn_0",
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(result.sessionState).toEqual(
+      expect.objectContaining({
+        hasProxyInputRequests: false,
+        sessionId: "parent-session",
+      }),
+    );
     expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string).callback.token).toBe(
       "turn-inbox",
     );

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -40,7 +40,9 @@ interface PendingRuntimeActionEventMetadata {
 interface PendingRuntimeActionBatch {
   readonly actions: readonly RuntimeActionRequest[];
   readonly childContinuationTokens?: Readonly<Record<string, string>>;
+  readonly dispatchActions?: readonly RuntimeActionRequest[];
   readonly event: PendingRuntimeActionEventMetadata;
+  readonly prefilledResults?: readonly RuntimeActionResult[];
   readonly responseMessages: readonly ModelMessage[];
 }
 
@@ -67,6 +69,8 @@ export function getPendingRuntimeActionBatch(
 
   if (
     !Array.isArray(batch.actions) ||
+    (batch.dispatchActions !== undefined && !Array.isArray(batch.dispatchActions)) ||
+    (batch.prefilledResults !== undefined && !Array.isArray(batch.prefilledResults)) ||
     !Array.isArray(batch.responseMessages) ||
     typeof batch.event !== "object" ||
     batch.event === null
@@ -98,14 +102,20 @@ export function clearPendingRuntimeActionBatch(session: HarnessSession): Harness
  */
 export function setPendingRuntimeActionBatch(input: {
   readonly actions: readonly RuntimeActionRequest[];
+  readonly dispatchActions?: readonly RuntimeActionRequest[];
   readonly event: PendingRuntimeActionEventMetadata;
+  readonly prefilledResults?: readonly RuntimeActionResult[];
   readonly responseMessages: readonly ModelMessage[];
   readonly session: HarnessSession;
 }): HarnessSession {
   const state = { ...input.session.state };
   state[PENDING_RUNTIME_ACTION_BATCH_KEY] = {
     actions: [...input.actions],
+    ...(input.dispatchActions === undefined ? {} : { dispatchActions: [...input.dispatchActions] }),
     event: input.event,
+    ...(input.prefilledResults === undefined || input.prefilledResults.length === 0
+      ? {}
+      : { prefilledResults: [...input.prefilledResults] }),
     responseMessages: [...input.responseMessages],
   } satisfies PendingRuntimeActionBatch;
 

--- a/packages/eve/src/harness/subagent-limits.test.ts
+++ b/packages/eve/src/harness/subagent-limits.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applySubagentLimits,
+  DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
+  DEFAULT_MAX_SUBAGENT_DEPTH,
+  resolveEffectiveSubagentLimits,
+  setSubagentLimitState,
+} from "#harness/subagent-limits.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
+
+function createSession(state?: HarnessSession["state"]): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "test-token",
+    history: [],
+    sessionId: "sess-test",
+    state,
+  };
+}
+
+function createSubagentAction(index: number): RuntimeSubagentCallActionRequest {
+  return {
+    callId: `call-${index}`,
+    description: "Launch another copy.",
+    input: { message: `work item ${index}` },
+    kind: "subagent-call",
+    name: "agent",
+    nodeId: "__root__",
+    subagentName: "agent",
+  };
+}
+
+describe("resolveEffectiveSubagentLimits", () => {
+  it("uses eve defaults when no limits are authored or inherited", () => {
+    expect(resolveEffectiveSubagentLimits({})).toEqual({
+      maxCallsPerStep: DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
+      maxDepth: DEFAULT_MAX_SUBAGENT_DEPTH,
+    });
+  });
+
+  it("allows root agents to raise default limits explicitly", () => {
+    expect(
+      resolveEffectiveSubagentLimits({
+        authored: {
+          maxCallsPerStep: 8,
+          maxDepth: 6,
+        },
+      }),
+    ).toEqual({
+      maxCallsPerStep: 8,
+      maxDepth: 6,
+    });
+  });
+
+  it("inherits parent limits when a child does not author overrides", () => {
+    expect(
+      resolveEffectiveSubagentLimits({
+        inherited: {
+          maxCallsPerStep: 8,
+          maxDepth: 6,
+        },
+      }),
+    ).toEqual({
+      maxCallsPerStep: 8,
+      maxDepth: 6,
+    });
+  });
+
+  it("lets child agents tighten inherited limits but not loosen them", () => {
+    expect(
+      resolveEffectiveSubagentLimits({
+        authored: {
+          maxCallsPerStep: 5,
+          maxDepth: 10,
+        },
+        inherited: {
+          maxCallsPerStep: 8,
+          maxDepth: 6,
+        },
+      }),
+    ).toEqual({
+      maxCallsPerStep: 5,
+      maxDepth: 6,
+    });
+  });
+});
+
+describe("applySubagentLimits", () => {
+  it("uses configured per-step fan-out limits from session state", () => {
+    const session = setSubagentLimitState({
+      depth: undefined,
+      limits: {
+        maxCallsPerStep: 2,
+        maxDepth: 4,
+      },
+      session: createSession(),
+    });
+
+    const result = applySubagentLimits({
+      actions: [createSubagentAction(1), createSubagentAction(2), createSubagentAction(3)],
+      session,
+    });
+
+    expect(result.actions.map((action) => action.callId)).toEqual(["call-1", "call-2"]);
+    expect(result.rejectedResults).toEqual([
+      {
+        callId: "call-3",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+          message:
+            "This step requested 3 subagent calls, but eve allows 2. The first 2 were started. Retry the remaining work in a later step with at most 2 subagent calls.",
+        },
+        subagentName: "agent",
+      },
+    ]);
+  });
+});

--- a/packages/eve/src/harness/subagent-limits.test.ts
+++ b/packages/eve/src/harness/subagent-limits.test.ts
@@ -119,4 +119,52 @@ describe("applySubagentLimits", () => {
       },
     ]);
   });
+
+  it("shares the per-step fan-out limit across split runtime action batches", () => {
+    const session = setSubagentLimitState({
+      depth: undefined,
+      limits: {
+        maxCallsPerStep: 1,
+        maxDepth: 4,
+      },
+      session: createSession(),
+    });
+
+    const first = applySubagentLimits({
+      actions: [createSubagentAction(1)],
+      session,
+      step: { stepIndex: 0, turnId: "turn_0" },
+    });
+
+    const second = applySubagentLimits({
+      actions: [createSubagentAction(2)],
+      session: first.session,
+      step: { stepIndex: 0, turnId: "turn_0" },
+    });
+
+    const nextStep = applySubagentLimits({
+      actions: [createSubagentAction(3)],
+      session: second.session,
+      step: { stepIndex: 1, turnId: "turn_0" },
+    });
+
+    expect(first.actions.map((action) => action.callId)).toEqual(["call-1"]);
+    expect(first.rejectedResults).toEqual([]);
+    expect(second.actions).toEqual([]);
+    expect(second.rejectedResults).toEqual([
+      {
+        callId: "call-2",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+          message:
+            "This step requested 2 subagent calls, but eve allows 1. The first 1 were started. Retry the remaining work in a later step with at most 1 subagent calls.",
+        },
+        subagentName: "agent",
+      },
+    ]);
+    expect(nextStep.actions.map((action) => action.callId)).toEqual(["call-3"]);
+    expect(nextStep.rejectedResults).toEqual([]);
+  });
 });

--- a/packages/eve/src/harness/subagent-limits.test.ts
+++ b/packages/eve/src/harness/subagent-limits.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { jsonSchema } from "ai";
 
 import {
   applySubagentLimits,
   DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
   DEFAULT_MAX_SUBAGENT_DEPTH,
+  filterAdvertisedSubagentTools,
   resolveEffectiveSubagentLimits,
   setSubagentLimitState,
 } from "#harness/subagent-limits.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
 
@@ -166,5 +169,75 @@ describe("applySubagentLimits", () => {
     ]);
     expect(nextStep.actions.map((action) => action.callId)).toEqual(["call-3"]);
     expect(nextStep.rejectedResults).toEqual([]);
+  });
+});
+
+describe("filterAdvertisedSubagentTools", () => {
+  const tools = new Map<string, HarnessToolDefinition>([
+    [
+      "search",
+      {
+        description: "Search locally.",
+        execute: () => "result",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "search",
+      },
+    ],
+    [
+      "delegate",
+      {
+        description: "Delegate to a subagent.",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "delegate",
+        runtimeAction: {
+          kind: "subagent-call",
+          nodeId: "worker",
+          subagentName: "worker",
+        },
+      },
+    ],
+    [
+      "remote_reviewer",
+      {
+        description: "Delegate to a remote agent.",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "remote_reviewer",
+        runtimeAction: {
+          kind: "remote-agent-call",
+          nodeId: "remote",
+          remoteAgentName: "reviewer",
+          subagentName: "reviewer",
+        },
+      },
+    ],
+  ]);
+
+  it("keeps subagent tools advertised while depth remains below the cap", () => {
+    const session = setSubagentLimitState({
+      depth: 1,
+      limits: {
+        maxCallsPerStep: 4,
+        maxDepth: 2,
+      },
+      session: createSession(),
+    });
+
+    expect(filterAdvertisedSubagentTools({ session, tools })).toBe(tools);
+  });
+
+  it("hides subagent tools from the model once the depth cap is reached", () => {
+    const session = setSubagentLimitState({
+      depth: 2,
+      limits: {
+        maxCallsPerStep: 4,
+        maxDepth: 2,
+      },
+      session: createSession(),
+    });
+
+    const filtered = filterAdvertisedSubagentTools({ session, tools });
+
+    expect([...filtered.keys()]).toEqual(["search"]);
+    expect(filtered).not.toBe(tools);
   });
 });

--- a/packages/eve/src/harness/subagent-limits.ts
+++ b/packages/eve/src/harness/subagent-limits.ts
@@ -16,11 +16,19 @@ interface SubagentLimitState {
   readonly depth?: number;
   readonly maxCallsPerStep?: number;
   readonly maxDepth?: number;
+  readonly stepCalls?: SubagentStepCallState;
 }
 
 type DelegationAction = RuntimeRemoteAgentCallActionRequest | RuntimeSubagentCallActionRequest;
 
 type SubagentLimitCode = "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED" | "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED";
+
+interface SubagentStepCallState {
+  readonly acceptedCalls: number;
+  readonly requestedCalls: number;
+  readonly stepIndex: number;
+  readonly turnId: string;
+}
 
 interface SubagentLimitRejection {
   readonly action: DelegationAction;
@@ -31,6 +39,7 @@ interface SubagentLimitRejection {
 export interface ApplySubagentLimitsResult {
   readonly actions: readonly RuntimeActionRequest[];
   readonly rejectedResults: readonly RuntimeSubagentResultActionResult[];
+  readonly session: HarnessSession;
 }
 
 export interface EffectiveSubagentLimits {
@@ -41,13 +50,23 @@ export interface EffectiveSubagentLimits {
 export function applySubagentLimits(input: {
   readonly actions: readonly RuntimeActionRequest[];
   readonly session: HarnessSession;
+  readonly step?: {
+    readonly stepIndex: number;
+    readonly turnId: string;
+  };
 }): ApplySubagentLimitsResult {
   const depth = getSubagentDepth(input.session.state);
   const limits = getEffectiveSubagentLimits(input.session.state);
   const requestedDelegationCalls = input.actions.filter(isDelegationAction).length;
+  const priorStepCalls = resolveStepCallState({
+    session: input.session,
+    step: input.step,
+  });
   const actions: RuntimeActionRequest[] = [];
   const rejections: SubagentLimitRejection[] = [];
-  let acceptedDelegationCalls = 0;
+  let acceptedDelegationCalls = priorStepCalls?.acceptedCalls ?? 0;
+  const totalRequestedDelegationCalls =
+    (priorStepCalls?.requestedCalls ?? 0) + requestedDelegationCalls;
 
   for (const action of input.actions) {
     if (!isDelegationAction(action)) {
@@ -69,7 +88,7 @@ export function applySubagentLimits(input: {
       rejections.push({
         action,
         code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
-        message: `This step requested ${requestedDelegationCalls} subagent calls, but eve allows ${limits.maxCallsPerStep}. The first ${limits.maxCallsPerStep} were started. Retry the remaining work in a later step with at most ${limits.maxCallsPerStep} subagent calls.`,
+        message: `This step requested ${totalRequestedDelegationCalls} subagent calls, but eve allows ${limits.maxCallsPerStep}. The first ${limits.maxCallsPerStep} were started. Retry the remaining work in a later step with at most ${limits.maxCallsPerStep} subagent calls.`,
       });
       continue;
     }
@@ -81,6 +100,12 @@ export function applySubagentLimits(input: {
   return {
     actions,
     rejectedResults: rejections.map(createSubagentLimitResult),
+    session: setStepCallState({
+      acceptedCalls: acceptedDelegationCalls,
+      requestedCalls: totalRequestedDelegationCalls,
+      session: input.session,
+      step: input.step,
+    }),
   };
 }
 
@@ -203,6 +228,58 @@ function normalizeEffectiveSubagentLimits(
       normalizePositiveInteger(limits.maxCallsPerStep) ?? DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
     maxDepth: normalizePositiveInteger(limits.maxDepth) ?? DEFAULT_MAX_SUBAGENT_DEPTH,
   };
+}
+
+function resolveStepCallState(input: {
+  readonly session: HarnessSession;
+  readonly step: { readonly stepIndex: number; readonly turnId: string } | undefined;
+}): SubagentStepCallState | undefined {
+  if (input.step === undefined) return undefined;
+  const value = input.session.state?.[SUBAGENT_LIMIT_STATE_KEY];
+  if (typeof value !== "object" || value === null) return undefined;
+  const stepCalls = (value as SubagentLimitState).stepCalls;
+  if (stepCalls === undefined) return undefined;
+  if (stepCalls.turnId !== input.step.turnId || stepCalls.stepIndex !== input.step.stepIndex) {
+    return undefined;
+  }
+  if (
+    !Number.isInteger(stepCalls.acceptedCalls) ||
+    stepCalls.acceptedCalls < 0 ||
+    !Number.isInteger(stepCalls.requestedCalls) ||
+    stepCalls.requestedCalls < 0
+  ) {
+    return undefined;
+  }
+  return stepCalls;
+}
+
+function setStepCallState(input: {
+  readonly acceptedCalls: number;
+  readonly requestedCalls: number;
+  readonly session: HarnessSession;
+  readonly step: { readonly stepIndex: number; readonly turnId: string } | undefined;
+}): HarnessSession {
+  if (input.step === undefined || input.requestedCalls === 0) return input.session;
+
+  const existing = input.session.state?.[SUBAGENT_LIMIT_STATE_KEY];
+  const current =
+    typeof existing === "object" && existing !== null ? (existing as SubagentLimitState) : {};
+
+  if (input.acceptedCalls === 0 && current.stepCalls === undefined) {
+    return input.session;
+  }
+
+  const state = { ...input.session.state };
+  state[SUBAGENT_LIMIT_STATE_KEY] = {
+    ...current,
+    stepCalls: {
+      acceptedCalls: input.acceptedCalls,
+      requestedCalls: input.requestedCalls,
+      stepIndex: input.step.stepIndex,
+      turnId: input.step.turnId,
+    },
+  } satisfies SubagentLimitState;
+  return { ...input.session, state };
 }
 
 function normalizePositiveInteger(value: number | undefined): number | undefined {

--- a/packages/eve/src/harness/subagent-limits.ts
+++ b/packages/eve/src/harness/subagent-limits.ts
@@ -1,0 +1,217 @@
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+import type {
+  RuntimeActionRequest,
+  RuntimeRemoteAgentCallActionRequest,
+  RuntimeSubagentCallActionRequest,
+  RuntimeSubagentResultActionResult,
+} from "#runtime/actions/types.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
+
+export const DEFAULT_MAX_SUBAGENT_DEPTH = 4;
+export const DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP = 4;
+
+const SUBAGENT_LIMIT_STATE_KEY = "eve.runtime.subagentLimits";
+
+interface SubagentLimitState {
+  readonly depth?: number;
+  readonly maxCallsPerStep?: number;
+  readonly maxDepth?: number;
+}
+
+type DelegationAction = RuntimeRemoteAgentCallActionRequest | RuntimeSubagentCallActionRequest;
+
+type SubagentLimitCode = "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED" | "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED";
+
+interface SubagentLimitRejection {
+  readonly action: DelegationAction;
+  readonly code: SubagentLimitCode;
+  readonly message: string;
+}
+
+export interface ApplySubagentLimitsResult {
+  readonly actions: readonly RuntimeActionRequest[];
+  readonly rejectedResults: readonly RuntimeSubagentResultActionResult[];
+}
+
+export interface EffectiveSubagentLimits {
+  readonly maxCallsPerStep: number;
+  readonly maxDepth: number;
+}
+
+export function applySubagentLimits(input: {
+  readonly actions: readonly RuntimeActionRequest[];
+  readonly session: HarnessSession;
+}): ApplySubagentLimitsResult {
+  const depth = getSubagentDepth(input.session.state);
+  const limits = getEffectiveSubagentLimits(input.session.state);
+  const requestedDelegationCalls = input.actions.filter(isDelegationAction).length;
+  const actions: RuntimeActionRequest[] = [];
+  const rejections: SubagentLimitRejection[] = [];
+  let acceptedDelegationCalls = 0;
+
+  for (const action of input.actions) {
+    if (!isDelegationAction(action)) {
+      actions.push(action);
+      continue;
+    }
+
+    if (depth >= limits.maxDepth) {
+      rejections.push({
+        action,
+        code: "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED",
+        message:
+          "Maximum subagent depth reached. Do not retry this subagent call; complete the work in this session or return a partial result.",
+      });
+      continue;
+    }
+
+    if (acceptedDelegationCalls >= limits.maxCallsPerStep) {
+      rejections.push({
+        action,
+        code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+        message: `This step requested ${requestedDelegationCalls} subagent calls, but eve allows ${limits.maxCallsPerStep}. The first ${limits.maxCallsPerStep} were started. Retry the remaining work in a later step with at most ${limits.maxCallsPerStep} subagent calls.`,
+      });
+      continue;
+    }
+
+    acceptedDelegationCalls++;
+    actions.push(action);
+  }
+
+  return {
+    actions,
+    rejectedResults: rejections.map(createSubagentLimitResult),
+  };
+}
+
+export function getChildSubagentDepth(session: HarnessSession): number {
+  return getSubagentDepth(session.state) + 1;
+}
+
+export function resolveEffectiveSubagentLimits(input: {
+  readonly authored?: AgentSubagentLimitsDefinition;
+  readonly inherited?: AgentSubagentLimitsDefinition;
+}): EffectiveSubagentLimits {
+  if (input.inherited === undefined) {
+    return {
+      maxCallsPerStep:
+        normalizePositiveInteger(input.authored?.maxCallsPerStep) ??
+        DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
+      maxDepth: normalizePositiveInteger(input.authored?.maxDepth) ?? DEFAULT_MAX_SUBAGENT_DEPTH,
+    };
+  }
+
+  const inherited = normalizeEffectiveSubagentLimits(input.inherited);
+  return {
+    maxCallsPerStep:
+      input.authored?.maxCallsPerStep === undefined
+        ? inherited.maxCallsPerStep
+        : Math.min(inherited.maxCallsPerStep, input.authored.maxCallsPerStep),
+    maxDepth:
+      input.authored?.maxDepth === undefined
+        ? inherited.maxDepth
+        : Math.min(inherited.maxDepth, input.authored.maxDepth),
+  };
+}
+
+export function getEffectiveSubagentLimits(
+  state: SessionStateMap | undefined,
+): EffectiveSubagentLimits {
+  const value = state?.[SUBAGENT_LIMIT_STATE_KEY];
+  if (typeof value !== "object" || value === null) return DEFAULT_SUBAGENT_LIMITS;
+  return normalizeEffectiveSubagentLimits(value as AgentSubagentLimitsDefinition);
+}
+
+export function setSubagentLimitState(input: {
+  readonly depth: number | undefined;
+  readonly limits: EffectiveSubagentLimits;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const depth = normalizeDepth(input.depth);
+  if (depth === 0 && isDefaultSubagentLimits(input.limits)) return input.session;
+
+  const state = { ...input.session.state };
+  state[SUBAGENT_LIMIT_STATE_KEY] = {
+    depth: depth === 0 ? undefined : depth,
+    maxCallsPerStep: input.limits.maxCallsPerStep,
+    maxDepth: input.limits.maxDepth,
+  } satisfies SubagentLimitState;
+  return { ...input.session, state };
+}
+
+export function setSubagentDepth(input: {
+  readonly depth: number | undefined;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const depth = normalizeDepth(input.depth);
+  if (depth === 0) return input.session;
+
+  const limits = getEffectiveSubagentLimits(input.session.state);
+  const state = { ...input.session.state };
+  state[SUBAGENT_LIMIT_STATE_KEY] = {
+    depth,
+    maxCallsPerStep: limits.maxCallsPerStep,
+    maxDepth: limits.maxDepth,
+  } satisfies SubagentLimitState;
+  return { ...input.session, state };
+}
+
+export function getSubagentDepth(state: SessionStateMap | undefined): number {
+  const value = state?.[SUBAGENT_LIMIT_STATE_KEY];
+  if (typeof value !== "object" || value === null) return 0;
+  return normalizeDepth((value as SubagentLimitState).depth);
+}
+
+function createSubagentLimitResult(
+  rejection: SubagentLimitRejection,
+): RuntimeSubagentResultActionResult {
+  return {
+    callId: rejection.action.callId,
+    isError: true,
+    kind: "subagent-result",
+    output: {
+      code: rejection.code,
+      message: rejection.message,
+    },
+    subagentName: getDelegationActionName(rejection.action),
+  };
+}
+
+function getDelegationActionName(action: DelegationAction): string {
+  return action.kind === "remote-agent-call" ? action.remoteAgentName : action.subagentName;
+}
+
+function isDelegationAction(action: RuntimeActionRequest): action is DelegationAction {
+  return action.kind === "remote-agent-call" || action.kind === "subagent-call";
+}
+
+function normalizeDepth(depth: number | undefined): number {
+  if (depth === undefined || !Number.isInteger(depth) || depth < 0) return 0;
+  return depth;
+}
+
+const DEFAULT_SUBAGENT_LIMITS: EffectiveSubagentLimits = {
+  maxCallsPerStep: DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
+  maxDepth: DEFAULT_MAX_SUBAGENT_DEPTH,
+};
+
+function normalizeEffectiveSubagentLimits(
+  limits: AgentSubagentLimitsDefinition,
+): EffectiveSubagentLimits {
+  return {
+    maxCallsPerStep:
+      normalizePositiveInteger(limits.maxCallsPerStep) ?? DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP,
+    maxDepth: normalizePositiveInteger(limits.maxDepth) ?? DEFAULT_MAX_SUBAGENT_DEPTH,
+  };
+}
+
+function normalizePositiveInteger(value: number | undefined): number | undefined {
+  return value === undefined || !Number.isInteger(value) || value <= 0 ? undefined : value;
+}
+
+function isDefaultSubagentLimits(limits: EffectiveSubagentLimits): boolean {
+  return (
+    limits.maxCallsPerStep === DEFAULT_MAX_SUBAGENT_CALLS_PER_STEP &&
+    limits.maxDepth === DEFAULT_MAX_SUBAGENT_DEPTH
+  );
+}

--- a/packages/eve/src/harness/subagent-limits.ts
+++ b/packages/eve/src/harness/subagent-limits.ts
@@ -1,4 +1,4 @@
-import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+import type { HarnessSession, HarnessToolMap, SessionStateMap } from "#harness/types.js";
 import type {
   RuntimeActionRequest,
   RuntimeRemoteAgentCallActionRequest,
@@ -45,6 +45,28 @@ export interface ApplySubagentLimitsResult {
 export interface EffectiveSubagentLimits {
   readonly maxCallsPerStep: number;
   readonly maxDepth: number;
+}
+
+export function filterAdvertisedSubagentTools(input: {
+  readonly session: HarnessSession;
+  readonly tools: HarnessToolMap;
+}): HarnessToolMap {
+  const depth = getSubagentDepth(input.session.state);
+  const limits = getEffectiveSubagentLimits(input.session.state);
+
+  if (depth < limits.maxDepth) {
+    return input.tools;
+  }
+
+  const tools = new Map(input.tools);
+
+  for (const [name, definition] of input.tools) {
+    if (definition.runtimeAction !== undefined) {
+      tools.delete(name);
+    }
+  }
+
+  return tools;
 }
 
 export function applySubagentLimits(input: {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -35,6 +35,7 @@ import {
 } from "#harness/authorization.js";
 import { hasDeferredStepInput, setPendingInputBatch } from "#harness/input-requests.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
+import { setSubagentLimitState } from "#harness/subagent-limits.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 import {
@@ -590,6 +591,75 @@ describe("createToolLoopHarness", () => {
     const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
     expect(agentCall).toBeDefined();
     expect(agentCall!.tools).toHaveProperty("add");
+    expect(agentCall!.tools).not.toHaveProperty("Workflow");
+  });
+
+  it("hides subagent tools from the model once the depth cap is reached", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Done.", role: "assistant" }] },
+      text: "Done.",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const config = createTestConfig("conversation", undefined, {
+      tools: new Map([
+        [
+          "add",
+          {
+            description: "Adds numbers",
+            execute: vi.fn().mockResolvedValue("42"),
+            inputSchema: jsonSchema({ type: "object" }),
+            name: "add",
+          },
+        ],
+        [
+          "delegate",
+          {
+            description: "Delegate to a local subagent.",
+            inputSchema: jsonSchema({ type: "object" }),
+            name: "delegate",
+            runtimeAction: {
+              kind: "subagent-call",
+              nodeId: "workers",
+              subagentName: "worker",
+            },
+          },
+        ],
+        [
+          "remote_reviewer",
+          {
+            description: "Delegate to a remote subagent.",
+            inputSchema: jsonSchema({ type: "object" }),
+            name: "remote_reviewer",
+            runtimeAction: {
+              kind: "remote-agent-call",
+              nodeId: "remote-reviewer",
+              remoteAgentName: "reviewer",
+              subagentName: "reviewer",
+            },
+          },
+        ],
+      ]),
+      workflow: true,
+    });
+    const session = setSubagentLimitState({
+      depth: 1,
+      limits: {
+        maxCallsPerStep: 4,
+        maxDepth: 1,
+      },
+      session: createTestSession(),
+    });
+
+    await createToolLoopHarness(config)(session, { message: "Hi" });
+
+    const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
+    expect(agentCall).toBeDefined();
+    expect(agentCall!.tools).toHaveProperty("add");
+    expect(agentCall!.tools).not.toHaveProperty("delegate");
+    expect(agentCall!.tools).not.toHaveProperty("remote_reviewer");
     expect(agentCall!.tools).not.toHaveProperty("Workflow");
   });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -33,6 +33,7 @@ import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js
 import { toErrorMessage } from "#shared/errors.js";
 import {
   createActionResultEvent,
+  createActionsRequestedEvent,
   createCompactionCompletedEvent,
   createCompactionRequestedEvent,
   createInputRequestedEvent,
@@ -136,6 +137,7 @@ import {
   resolvePendingRuntimeActions,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
+import { applySubagentLimits } from "#harness/subagent-limits.js";
 import {
   buildStepHooks,
   emitStepActions,
@@ -725,7 +727,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       const executeModelCall = async (): Promise<HarnessStepResult> => {
         if (emit) {
-          const excludedActionToolNames = new Set([ASK_QUESTION_TOOL_NAME, FINAL_OUTPUT_TOOL_NAME]);
+          const excludedActionToolNames = getHarnessOnlyToolNames(config.tools);
           const streamResult = await agent.stream({ messages: callMessages });
           const {
             emittedActionCallIds,
@@ -1345,6 +1347,18 @@ function buildEmptyResponseNudge(emptyDeliveryEnabled: boolean): string {
   return `${EMPTY_RESPONSE_NUDGE} If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
 }
 
+function getHarnessOnlyToolNames(tools: HarnessToolMap): ReadonlySet<string> {
+  const excluded = new Set<string>([ASK_QUESTION_TOOL_NAME, FINAL_OUTPUT_TOOL_NAME]);
+
+  for (const [toolName, definition] of tools) {
+    if (definition.runtimeAction !== undefined) {
+      excluded.add(toolName);
+    }
+  }
+
+  return excluded;
+}
+
 /**
  * Recovers a model call that completed without content (see
  * {@link EmptyModelResponseError}) by reissuing the same call once, with
@@ -1474,6 +1488,27 @@ async function handleStepResult(input: {
     );
 
   if (pendingRuntimeActions.length > 0) {
+    const pendingSession: HarnessSession = { ...baseSession, history: [...promptMessages] };
+    const limitedRuntimeActions = applySubagentLimits({
+      actions: pendingRuntimeActions,
+      session: pendingSession,
+      step: {
+        stepIndex: emissionState.stepIndex,
+        turnId: emissionState.turnId,
+      },
+    });
+
+    if (emit !== undefined && limitedRuntimeActions.actions.length > 0) {
+      await emit(
+        createActionsRequestedEvent({
+          actions: limitedRuntimeActions.actions,
+          sequence: emissionState.sequence,
+          stepIndex: emissionState.stepIndex,
+          turnId: emissionState.turnId,
+        }),
+      );
+    }
+
     // Stamp the live emission state onto the parked session so the
     // resume turn is classified as a continuation (turnId set), not a
     // fresh turn. Every other park path does this; without it the
@@ -1485,13 +1520,15 @@ async function handleStepResult(input: {
       session: setHarnessEmissionState(
         setPendingRuntimeActionBatch({
           actions: pendingRuntimeActions,
+          dispatchActions: limitedRuntimeActions.actions,
           event: {
             sequence: emissionState.sequence,
             stepIndex: emissionState.stepIndex,
             turnId: emissionState.turnId,
           },
+          prefilledResults: limitedRuntimeActions.rejectedResults,
           responseMessages,
-          session: { ...baseSession, history: [...promptMessages] },
+          session: limitedRuntimeActions.session,
         }),
         emissionState,
       ),

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -137,7 +137,7 @@ import {
   resolvePendingRuntimeActions,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
-import { applySubagentLimits } from "#harness/subagent-limits.js";
+import { applySubagentLimits, filterAdvertisedSubagentTools } from "#harness/subagent-limits.js";
 import {
   buildStepHooks,
   emitStepActions,
@@ -642,12 +642,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         ? [...modelMessages, { role: "user" as const, content: opts.trailingUserNote }]
         : modelMessages;
 
+      const advertisedTools = filterAdvertisedSubagentTools({
+        session,
+        tools: config.tools,
+      });
       const flatTools = await buildToolSetWithProviderTools({
         approvedTools,
         capabilities: config.capabilities,
         disabledProviderTools: opts.disabledProviderTools,
         modelReference: session.agent.modelReference,
-        tools: config.tools,
+        tools: advertisedTools,
       });
 
       if (ctx !== undefined) {
@@ -673,13 +677,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           ? (
               await applyWorkflowTool({
                 continuationSecurity: getWorkflowContinuationSecurity(session),
-                harnessTools: config.tools,
+                harnessTools: advertisedTools,
                 lifecycle:
                   emit !== undefined
                     ? createWorkflowLifecycle({
                         emit,
                         emissionState,
-                        tools: config.tools,
+                        tools: advertisedTools,
                       })
                     : undefined,
                 tools: flatTools,

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -81,6 +81,42 @@ describe("normalizeAgentDefinition", () => {
       ),
     ).toThrow('"experimental.workflow.world" must be a non-empty package name');
   });
+
+  it("accepts subagent limit overrides", () => {
+    const definition = normalizeAgentDefinition(
+      {
+        model: "openai/gpt-5.5",
+        limits: {
+          subagents: {
+            maxCallsPerStep: 8,
+            maxDepth: 6,
+          },
+        },
+      },
+      FAILURE_MESSAGE,
+    );
+
+    expect(definition.limits?.subagents).toEqual({
+      maxCallsPerStep: 8,
+      maxDepth: 6,
+    });
+  });
+
+  it("rejects invalid subagent limit overrides", () => {
+    expect(() =>
+      normalizeAgentDefinition(
+        {
+          model: "openai/gpt-5.5",
+          limits: {
+            subagents: {
+              maxCallsPerStep: 0,
+            },
+          },
+        },
+        FAILURE_MESSAGE,
+      ),
+    ).toThrow(FAILURE_MESSAGE);
+  });
 });
 
 describe("normalizeScheduleDefinition", () => {

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -41,6 +41,7 @@ export function normalizeAgentDefinition(
       "compaction",
       "description",
       "experimental",
+      "limits",
       "model",
       "modelContextWindowTokens",
       "modelOptions",
@@ -71,6 +72,10 @@ export function normalizeAgentDefinition(
 
   if (record.experimental !== undefined) {
     definition.experimental = normalizeAgentExperimentalDefinition(record.experimental, message);
+  }
+
+  if (record.limits !== undefined) {
+    definition.limits = normalizeAgentLimitsDefinition(record.limits, message);
   }
 
   if (record.modelOptions !== undefined) {
@@ -121,6 +126,45 @@ function expectPositiveInteger(value: unknown, message: string): number {
   }
 
   return value;
+}
+
+function normalizeAgentLimitsDefinition(
+  value: unknown,
+  message: string,
+): NonNullable<NormalizedAgentDefinition["limits"]> {
+  const record = expectObjectRecord(value, message);
+  expectOnlyKnownKeys(record, ["subagents"], message);
+  const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["limits"]>> = {};
+
+  if (record.subagents !== undefined) {
+    normalizedDefinition.subagents = normalizeAgentSubagentLimitsDefinition(
+      record.subagents,
+      message,
+    );
+  }
+
+  return normalizedDefinition;
+}
+
+function normalizeAgentSubagentLimitsDefinition(
+  value: unknown,
+  message: string,
+): NonNullable<NonNullable<NormalizedAgentDefinition["limits"]>["subagents"]> {
+  const record = expectObjectRecord(value, message);
+  expectOnlyKnownKeys(record, ["maxCallsPerStep", "maxDepth"], message);
+  const normalizedDefinition: Mutable<
+    NonNullable<NonNullable<NormalizedAgentDefinition["limits"]>["subagents"]>
+  > = {};
+
+  if (record.maxDepth !== undefined) {
+    normalizedDefinition.maxDepth = expectPositiveInteger(record.maxDepth, message);
+  }
+
+  if (record.maxCallsPerStep !== undefined) {
+    normalizedDefinition.maxCallsPerStep = expectPositiveInteger(record.maxCallsPerStep, message);
+  }
+
+  return normalizedDefinition;
 }
 
 function normalizeAgentBuildDefinition(

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -6,6 +6,8 @@ export type {
   AgentReasoningDefinition,
   AgentBuildDefinition,
   AgentExperimentalDefinition,
+  AgentLimitsDefinition,
+  AgentSubagentLimitsDefinition,
   AgentWorkflowDefinition,
   AgentWorkflowWorldDefinition,
   PublicAgentModelDefinition as AgentModelDefinition,

--- a/packages/eve/src/runtime/agent/bootstrap.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.ts
@@ -2,7 +2,10 @@ import { composeRuntimeBasePrompt } from "#runtime/prompt/compose.js";
 import type { PreparedRuntimeTool } from "#runtime/sessions/turn.js";
 import type { ResolvedAgent } from "#runtime/types.js";
 import type { WorkspaceRuntimeSpec } from "#runtime/workspace/types.js";
-import type { InternalAgentModelDefinition } from "#shared/agent-definition.js";
+import type {
+  AgentLimitsDefinition,
+  InternalAgentModelDefinition,
+} from "#shared/agent-definition.js";
 
 /**
  * Fixed internal model reference used only by the framework-owned bootstrap
@@ -21,6 +24,7 @@ export type RuntimeModelReference = Readonly<InternalAgentModelDefinition>;
 export interface RuntimeTurnAgent {
   readonly id: string;
   readonly instructions: readonly string[];
+  readonly limits?: AgentLimitsDefinition;
   /**
    * Optional model used only for compaction summaries.
    *
@@ -60,6 +64,7 @@ export function createResolvedRuntimeTurnAgent(input: {
       toolsAvailable: input.tools.length > 0,
       workspaceSpec: agent.workspaceSpec,
     }),
+    limits: cloneAgentLimits(agent.config.limits),
     compactionModel: agent.config.compaction?.model,
     model: agent.config.model,
     nodeId: input.nodeId,
@@ -67,5 +72,23 @@ export function createResolvedRuntimeTurnAgent(input: {
     reasoning: agent.config.reasoning,
     tools: [...input.tools],
     workspaceSpec: agent.workspaceSpec,
+  };
+}
+
+function cloneAgentLimits(
+  limits: AgentLimitsDefinition | undefined,
+): AgentLimitsDefinition | undefined {
+  if (limits === undefined) {
+    return undefined;
+  }
+
+  return {
+    subagents:
+      limits.subagents === undefined
+        ? undefined
+        : {
+            maxCallsPerStep: limits.subagents.maxCallsPerStep,
+            maxDepth: limits.subagents.maxDepth,
+          },
   };
 }

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -148,6 +148,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
   const config: {
     compaction?: ResolvedAgent["config"]["compaction"];
     experimental?: ResolvedAgent["config"]["experimental"];
+    limits?: ResolvedAgent["config"]["limits"];
     model: ResolvedAgent["config"]["model"];
     name: string;
     outputSchema?: ResolvedAgent["config"]["outputSchema"];
@@ -215,6 +216,18 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
         manifest.config.experimental.workflow === undefined
           ? undefined
           : { world: manifest.config.experimental.workflow.world },
+    };
+  }
+
+  if (manifest.config.limits !== undefined) {
+    config.limits = {
+      subagents:
+        manifest.config.limits.subagents === undefined
+          ? undefined
+          : {
+              maxCallsPerStep: manifest.config.limits.subagents.maxCallsPerStep,
+              maxDepth: manifest.config.limits.subagents.maxDepth,
+            },
     };
   }
 

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -97,6 +97,29 @@ export interface PublicAgentCompactionDefinition {
 }
 
 /**
+ * Limits for agent-to-agent delegation. These apply to the built-in `agent`
+ * tool, authored subagents, remote agents, and subagent calls launched by
+ * Workflow.
+ */
+export interface AgentSubagentLimitsDefinition {
+  /**
+   * Maximum depth for nested subagent calls. Root sessions are depth 0.
+   */
+  readonly maxDepth?: number;
+  /**
+   * Maximum number of subagent calls a single model step may dispatch.
+   */
+  readonly maxCallsPerStep?: number;
+}
+
+/**
+ * Runtime safety limits authored in `agent.ts`.
+ */
+export interface AgentLimitsDefinition {
+  readonly subagents?: AgentSubagentLimitsDefinition;
+}
+
+/**
  * Experimental, opt-in agent capabilities authored in `agent.ts`.
  *
  * These options are unstable and may change or be removed in any release.
@@ -158,6 +181,7 @@ export type InternalAgentDefinition = {
   build?: AgentBuildDefinition;
   compaction?: InternalAgentCompactionDefinition;
   experimental?: AgentExperimentalDefinition;
+  limits?: AgentLimitsDefinition;
   model: InternalAgentModelDefinition;
   outputSchema?: JsonObject;
   reasoning?: AgentReasoningDefinition;
@@ -190,6 +214,10 @@ export type PublicAgentDefinition = {
    * AI SDK-compatible language model.
    */
   readonly model: PublicAgentModelDefinition;
+  /**
+   * Runtime safety limits. Omit to use eve's default guardrails.
+   */
+  readonly limits?: AgentLimitsDefinition;
   /**
    * Optional override for the primary model's context window size, in tokens.
    *

--- a/packages/eve/test/resolve-agent.test.ts
+++ b/packages/eve/test/resolve-agent.test.ts
@@ -26,6 +26,12 @@ describe("resolveAgent", () => {
       appRoot: "/app",
       channels: [slackChannelDefinition],
       config: {
+        limits: {
+          subagents: {
+            maxCallsPerStep: 8,
+            maxDepth: 6,
+          },
+        },
         model: {
           id: "anthropic/claude-sonnet-4.5",
           routing: { kind: "gateway", target: "anthropic" },
@@ -169,6 +175,12 @@ describe("resolveAgent", () => {
     expect(resolved.config.name).toBe("weather-agent");
     expect(resolved.config).toEqual({
       compaction: {},
+      limits: {
+        subagents: {
+          maxCallsPerStep: 8,
+          maxDepth: 6,
+        },
+      },
       model: {
         id: "anthropic/claude-sonnet-4.5",
       },

--- a/packages/eve/test/runtime-agent-graph.test.ts
+++ b/packages/eve/test/runtime-agent-graph.test.ts
@@ -37,6 +37,12 @@ describe("resolveRuntimeAgentGraph", () => {
       agentRoot: "/app/agent",
       appRoot: "/app",
       config: {
+        limits: {
+          subagents: {
+            maxCallsPerStep: 8,
+            maxDepth: 6,
+          },
+        },
         model: {
           id: TEST_DEFAULT_MODEL_ID,
           routing: { kind: "gateway", target: "openai" },
@@ -109,6 +115,12 @@ describe("resolveRuntimeAgentGraph", () => {
     });
 
     expect(graph.root.sandboxRegistry.sandbox?.definition.backend.name).toBe("vercel");
+    expect(graph.root.turnAgent.limits).toEqual({
+      subagents: {
+        maxCallsPerStep: 8,
+        maxDepth: 6,
+      },
+    });
     expect(
       graph.nodesByNodeId.get("subagents/researcher")?.sandboxRegistry.sandbox?.definition.backend
         .name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,31 @@ importers:
         specifier: 'catalog:'
         version: 7.0.1-rc
 
+  e2e/fixtures/agent-subagent-limits:
+    dependencies:
+      '@opentelemetry/core':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@vercel/otel':
+        specifier: 2.1.2
+        version: 2.1.2(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.0(zod@4.4.3)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.1-rc
+
   e2e/fixtures/agent-subagents:
     dependencies:
       '@opentelemetry/core':


### PR DESCRIPTION
## Summary

Adds default runtime guardrails for subagent delegation:

- caps nested subagent depth at 4 by default
- caps subagent calls from a single model step at 4 by default
- returns failed `subagent-result` action results when calls are rejected
- adds `defineAgent({ limits: { subagents: { maxDepth, maxCallsPerStep } } })` overrides
- persists effective subagent limits in session state and propagates them through parent lineage so children inherit the root policy and can only tighten it

The limits apply to the built-in `agent` tool, authored subagents, remote agents, and Workflow-launched subagent calls because enforcement happens at runtime-action dispatch.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/subagent-limits.test.ts src/internal/authored-definition/core.test.ts src/compiler/manifest.test.ts src/execution/session.test.ts src/execution/workflow-steps.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve run build`
- `test-agent`: `npm install --no-save --package-lock=false ../eve-runtime-limits/packages/eve`
- `test-agent`: confirmed `node_modules/eve` resolves to `/Users/allenzhou/Desktop/code/eve/eve-runtime-limits/packages/eve`
- `test-agent`: `npm run typecheck`
- `test-agent`: `npm run build`
- `test-agent`: `npm run start -- --host 127.0.0.1 --port 2117`, then `curl -fsS http://127.0.0.1:2117/eve/v1/info`
