### PR TITLE
refactor(slack): use chat sdk format primitives

### DIFF
--- a/.changeset/forty-pears-act.md
+++ b/.changeset/forty-pears-act.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+use Chat SDK Slack format primitives for Slack mrkdwn conversion

--- a/packages/eve/scripts/vendor-compiled/@chat-adapter/slack.mjs
+++ b/packages/eve/scripts/vendor-compiled/@chat-adapter/slack.mjs
@@ -78,6 +78,10 @@ export default {
       input: "@chat-adapter/slack/webhook",
       outputPath: "webhook",
     },
+    {
+      input: "@chat-adapter/slack/format",
+      outputPath: "format",
+    },
   ],
   plugins: [createOptionalNativeStubPlugin(["bufferutil", "utf-8-validate"])],
   copyDeclarations: createDeclarationCopier({
@@ -87,6 +91,7 @@ export default {
       { source: "index.d.ts", output: "index.d.ts" },
       { source: "blocks.d.ts", output: "blocks.d.ts" },
       { source: "webhook.d.ts", output: "webhook.d.ts" },
+      { source: "format.d.ts", output: "format.d.ts" },
     ],
     rewrites: {
       chat: { kind: "vendored", compiledPath: "chat" },

--- a/packages/eve/src/public/channels/slack/mrkdwn.test.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.test.ts
@@ -43,6 +43,12 @@ describe("gfmToSlackMrkdwn", () => {
     );
   });
 
+  it("leaves links with Slack control characters in the URL unchanged", () => {
+    expect(gfmToSlackMrkdwn("see [bad](https://x.dev/a|b)")).toBe(
+      "see [bad](https://x.dev/a|b)",
+    );
+  });
+
   it("leaves fenced code blocks untouched", () => {
     const fenced = "before\n```\n**not bold**\n```\nafter";
     expect(gfmToSlackMrkdwn(fenced)).toBe(fenced);

--- a/packages/eve/src/public/channels/slack/mrkdwn.test.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.test.ts
@@ -37,6 +37,12 @@ describe("gfmToSlackMrkdwn", () => {
     expect(gfmToSlackMrkdwn("see [docs](https://x.dev)")).toBe("see <https://x.dev|docs>");
   });
 
+  it("escapes Slack control characters in link labels", () => {
+    expect(gfmToSlackMrkdwn("see [a < b](https://x.dev?a=1&b=2)")).toBe(
+      "see <https://x.dev?a=1&b=2|a &lt; b>",
+    );
+  });
+
   it("leaves fenced code blocks untouched", () => {
     const fenced = "before\n```\n**not bold**\n```\nafter";
     expect(gfmToSlackMrkdwn(fenced)).toBe(fenced);
@@ -68,6 +74,11 @@ describe("slackMrkdwnToGfm", () => {
 
   it("upgrades paired *bold* and ~strike~ to GFM", () => {
     expect(slackMrkdwnToGfm("a *b* c ~d~")).toBe("a **b** c ~~d~~");
+  });
+
+  it("unescapes Slack control entities outside code", () => {
+    expect(slackMrkdwnToGfm("a &lt; b &amp; c")).toBe("a < b & c");
+    expect(slackMrkdwnToGfm("call `a &lt; b` here")).toBe("call `a &lt; b` here");
   });
 
   it("leaves fenced and inline code untouched", () => {

--- a/packages/eve/src/public/channels/slack/mrkdwn.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.ts
@@ -52,12 +52,24 @@ function markdownToSlack(input: string): string {
   let output = markdownBoldToSlackMrkdwn(input);
   output = output.replace(/__([^_\n]+)__/gu, "*$1*");
   output = output.replace(/~~([^~\n]+)~~/gu, "~$1~");
-  output = output.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/gu, (_, label: string, url: string) =>
-    formatSlackLink(url, label),
+  output = output.replace(
+    /\[([^\]\n]+)\]\(([^)\s]+)\)/gu,
+    (match: string, label: string, url: string) => formatMarkdownLink(match, label, url),
   );
   return output;
 }
 
 function slackToMarkdown(input: string): string {
   return slackMrkdwnToMarkdown(input.replace(/<!(channel|here|everyone)>/gu, "@$1"));
+}
+
+function formatMarkdownLink(match: string, label: string, url: string): string {
+  try {
+    return formatSlackLink(url, label);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return match;
+    }
+    throw error;
+  }
 }

--- a/packages/eve/src/public/channels/slack/mrkdwn.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.ts
@@ -1,56 +1,30 @@
-/**
- * Slack mrkdwn ↔ GitHub-flavored markdown converters and the bare
- * `@mention` rewriter used by the outbound post pipeline. These are
- * pure string utilities — no Slack API I/O, no I/O at all — so they
- * live separately from the binding constructor and request shape code
- * in {@link ./api.ts}.
- */
+import {
+  formatSlackLink,
+  linkBareSlackMentions,
+  markdownBoldToSlackMrkdwn,
+  slackMrkdwnToMarkdown,
+} from "#compiled/@chat-adapter/slack/format.js";
 
 const BARE_MENTION_RE = /(?<![<\w])@(\w+)/gu;
 
-/**
- * Rewrites bare `@USER_ID` tokens (the form Slack apps and humans tend
- * to type) into the `<@USER_ID>` mention syntax Slack actually renders.
- * Anything already wrapped in `<...>` is left untouched.
- */
+/** Rewrites bare Slack mention tokens into Slack's linked mention syntax. */
 export function rewriteBareMentions(text: string): string {
-  return text.replace(BARE_MENTION_RE, "<@$1>");
+  return linkBareSlackMentions(text).replace(BARE_MENTION_RE, "<@$1>");
 }
 
-/**
- * Best-effort GFM → Slack mrkdwn converter used only in contexts that
- * do not support `markdown_text` (e.g. `files.completeUploadExternal`'s
- * `initial_comment` field).
- *
- * The main `{ markdown }` post path sends `markdown_text` directly
- * to `chat.postMessage` and does not go through this converter.
- */
+/** Converts markdown into Slack mrkdwn for legacy Slack text surfaces. */
 export function gfmToSlackMrkdwn(input: string): string {
   const segments = splitCodeFences(input);
   return segments
-    .map((segment) => (segment.kind === "code" ? segment.text : convertInline(segment.text)))
+    .map((segment) => (segment.kind === "code" ? segment.text : markdownToSlack(segment.text)))
     .join("");
 }
 
-/**
- * Best-effort Slack mrkdwn → GFM converter applied to the text of
- * every inbound Slack message before the harness sees it.
- *
- * - `<@U123>`              → `@U123`
- * - `<#C123|name>`         → `#name` (or `#C123` when no name)
- * - `<!channel>` etc.      → `@channel`
- * - `<https://x|label>`    → `[label](https://x)`
- * - `<https://x>`          → `https://x`
- * - `*bold*` (paired)      → `**bold**`
- * - `~strike~` (paired)    → `~~strike~~`
- *
- * Inline `_italic_` and code spans pass through unchanged because both
- * formats render them identically.
- */
+/** Converts inbound Slack mrkdwn into markdown while preserving code spans and fences. */
 export function slackMrkdwnToGfm(input: string): string {
   const segments = splitCodeFences(input);
   return segments
-    .map((segment) => (segment.kind === "code" ? segment.text : decodeInline(segment.text)))
+    .map((segment) => (segment.kind === "code" ? segment.text : slackToMarkdown(segment.text)))
     .join("");
 }
 
@@ -74,25 +48,16 @@ function splitCodeFences(input: string): Segment[] {
   return segments;
 }
 
-function convertInline(input: string): string {
-  let out = input;
-  out = out.replace(/\*\*([^*\n]+)\*\*/gu, "*$1*");
-  out = out.replace(/__([^_\n]+)__/gu, "*$1*");
-  out = out.replace(/~~([^~\n]+)~~/gu, "~$1~");
-  out = out.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/gu, "<$2|$1>");
-  return out;
+function markdownToSlack(input: string): string {
+  let output = markdownBoldToSlackMrkdwn(input);
+  output = output.replace(/__([^_\n]+)__/gu, "*$1*");
+  output = output.replace(/~~([^~\n]+)~~/gu, "~$1~");
+  output = output.replace(/\[([^\]\n]+)\]\(([^)\s]+)\)/gu, (_, label: string, url: string) =>
+    formatSlackLink(url, label),
+  );
+  return output;
 }
 
-function decodeInline(input: string): string {
-  let out = input;
-  out = out.replace(/<!(channel|here|everyone)>/gu, "@$1");
-  out = out.replace(/<@([A-Z0-9]+)\|([^>]+)>/gu, "@$2");
-  out = out.replace(/<@([A-Z0-9]+)>/gu, "@$1");
-  out = out.replace(/<#([A-Z0-9]+)\|([^>]+)>/gu, "#$2");
-  out = out.replace(/<#([A-Z0-9]+)>/gu, "#$1");
-  out = out.replace(/<(https?:\/\/[^|>\s]+)\|([^>]+)>/gu, "[$2]($1)");
-  out = out.replace(/<(https?:\/\/[^>\s]+)>/gu, "$1");
-  out = out.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/gu, "$1**$2**");
-  out = out.replace(/(^|[^~])~([^~\n]+)~(?!~)/gu, "$1~~$2~~");
-  return out;
+function slackToMarkdown(input: string): string {
+  return slackMrkdwnToMarkdown(input.replace(/<!(channel|here|everyone)>/gu, "@$1"));
 }


### PR DESCRIPTION
## summary

updates Eve's Slack mrkdwn converter to use the runtime-free Chat SDK Slack format primitives

keeps Eve's existing public API and broad bare mention behavior, while sharing Slack link formatting, mrkdwn normalization, and control-character escaping with Chat SDK

also vendors the `@chat-adapter/slack/format` entrypoint with copied declarations and adds focused coverage for Slack link label escaping and inbound entity unescaping