### PR TITLE
fix(eve): cap subagent recursion depth

### DIFF
--- a/.changeset/runtime-delegation-limits.md
+++ b/.changeset/runtime-delegation-limits.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add default runtime limits and agent config overrides for nested subagent depth.

--- a/e2e/fixtures/agent-subagent-limits/.gitignore
+++ b/e2e/fixtures/agent-subagent-limits/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env*
+.eve
+.vercel
+.workflow-data
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-subagent-limits/.vercelignore
+++ b/e2e/fixtures/agent-subagent-limits/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-subagent-limits/agent/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/agent.ts
@@ -1,0 +1,38 @@
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest } from "eve/evals";
+
+const DEPTH_PROMPT_MARKER = "depth guardrail e2e";
+const DEPTH_RESULT_MARKER = "SUBAGENT_DEPTH_LIMIT_E2E_OK";
+
+export default defineAgent({
+  limits: {
+    subagents: {
+      maxDepth: 1,
+    },
+  },
+  model: mockModel(handleRootRequest),
+  modelContextWindowTokens: 1_000_000,
+});
+
+function handleRootRequest(request: MockModelRequest) {
+  const prompt = request.lastUserMessage ?? "";
+
+  if (prompt.includes(DEPTH_PROMPT_MARKER)) {
+    const result = request.toolResults.find((entry) => entry.name === "depth-prober");
+    if (result !== undefined) {
+      return `${DEPTH_RESULT_MARKER}: ${JSON.stringify(result.output)}`;
+    }
+
+    return {
+      toolCalls: [
+        {
+          id: "depth-prober-call",
+          input: { message: "try one nested self-delegation" },
+          name: "depth-prober",
+        },
+      ],
+    };
+  }
+
+  return "Unknown subagent limit eval prompt.";
+}

--- a/e2e/fixtures/agent-subagent-limits/agent/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e fixture for subagent runtime limits.

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/agent.ts
@@ -1,0 +1,34 @@
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest } from "eve/evals";
+
+export const DEPTH_PROBER_TOOL_HIDDEN_MARKER = "DEPTH_PROBER_SUBAGENT_TOOL_HIDDEN";
+const DEPTH_PROBER_LIMIT_MARKER = "DEPTH_PROBER_LIMIT_OBSERVED";
+
+export default defineAgent({
+  description:
+    "Deterministic depth-limit probe. It attempts one nested self-subagent call, then reports the tool result it received.",
+  model: mockModel(handleDepthProbeRequest),
+  modelContextWindowTokens: 1_000_000,
+});
+
+function handleDepthProbeRequest(request: MockModelRequest) {
+  const result = request.toolResults.find((entry) => entry.name === "agent");
+
+  if (result !== undefined) {
+    return `${DEPTH_PROBER_LIMIT_MARKER}: ${JSON.stringify(result.output)}`;
+  }
+
+  if (!request.tools.some((tool) => tool.name === "agent")) {
+    return `${DEPTH_PROBER_TOOL_HIDDEN_MARKER}: nested subagent tool is not advertised`;
+  }
+
+  return {
+    toolCalls: [
+      {
+        id: "depth-prober-self-call",
+        input: { message: "this nested self-delegation should hit maxDepth" },
+        name: "agent",
+      },
+    ],
+  };
+}

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/depth-prober/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e subagent that probes nested subagent depth limits.

--- a/e2e/fixtures/agent-subagent-limits/evals/depth-limit.eval.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/depth-limit.eval.ts
@@ -1,0 +1,23 @@
+import { defineEval } from "eve/evals";
+
+import { DEPTH_PROBER_TOOL_HIDDEN_MARKER } from "../agent/subagents/depth-prober/agent.js";
+
+const DEPTH_RESULT_MARKER = "SUBAGENT_DEPTH_LIMIT_E2E_OK";
+
+export default defineEval({
+  description:
+    "Subagent limits e2e: a child subagent does not see nested subagent tools after maxDepth is reached.",
+  tags: ["subagents", "limits", "depth"],
+
+  async test(t) {
+    await t.send("depth guardrail e2e: ask the depth-prober subagent to attempt one nested call.");
+
+    t.succeeded();
+    t.calledSubagent("depth-prober", {
+      output: new RegExp(DEPTH_PROBER_TOOL_HIDDEN_MARKER),
+      count: 1,
+    });
+    t.messageIncludes(DEPTH_RESULT_MARKER);
+    t.messageIncludes(DEPTH_PROBER_TOOL_HIDDEN_MARKER);
+  },
+});

--- a/e2e/fixtures/agent-subagent-limits/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/evals.config.ts
@@ -1,0 +1,3 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({});

--- a/e2e/fixtures/agent-subagent-limits/package.json
+++ b/e2e/fixtures/agent-subagent-limits/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agent-subagent-limits",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "2.6.1",
+    "@opentelemetry/sdk-trace-base": "2.6.1",
+    "@vercel/otel": "2.1.2",
+    "ai": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-subagent-limits/tsconfig.json
+++ b/e2e/fixtures/agent-subagent-limits/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts", ".eve/**/*.d.ts"]
+}

--- a/packages/eve/README.md
+++ b/packages/eve/README.md
@@ -116,6 +116,21 @@ export default defineAgent({
 });
 ```
 
+eve applies default subagent guardrails to the built-in `agent` tool, authored
+subagents, remote agents, and Workflow-launched subagent calls. Raise the
+maximum depth explicitly when an agent needs broader delegation:
+
+```ts
+export default defineAgent({
+  model: "openai/gpt-5.4-mini",
+  limits: {
+    subagents: {
+      maxDepth: 6,
+    },
+  },
+});
+```
+
 ## Quick Start
 
 ```bash

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -6,6 +6,7 @@ import type { RuntimeActionResult } from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
 import type { JsonObject } from "#shared/json.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 
 export type { ContextAccessor } from "#context/key.js";
 export type { ChannelInstrumentationProjection } from "#channel/instrumentation.js";
@@ -44,6 +45,12 @@ export interface SessionParent {
   readonly callId: string;
   readonly rootSessionId: string;
   readonly sessionId: string;
+  /**
+   * Depth of this child in the delegated subagent tree. Root sessions have
+   * depth 0 and omit this field; first-level children set it to 1.
+   */
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
   readonly turn: SessionTurn;
 }
 

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -40,4 +40,26 @@ describe("compiledAgentManifestSchema", () => {
     expect(parsed.success).toBe(true);
     expect(manifest.config.experimental?.workflow).toEqual({ world: "@acme/eve-world" });
   });
+
+  it("preserves subagent limit configuration", () => {
+    const manifest = createCompiledAgentManifest({
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      config: {
+        limits: {
+          subagents: {
+            maxDepth: 6,
+          },
+        },
+        model: { id: "openai/gpt-5.5", routing: classifyModelRouting("openai/gpt-5.5") },
+        name: "app",
+      },
+    });
+
+    const parsed = compiledAgentManifestSchema.parse(manifest);
+
+    expect(parsed.config.limits?.subagents).toEqual({
+      maxDepth: 6,
+    });
+  });
 });

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -23,6 +23,7 @@ import type {
   InternalAgentModelDefinition,
   InternalAgentCompactionDefinition,
   AgentBuildDefinition,
+  AgentLimitsDefinition,
   ModelRouting,
 } from "#shared/agent-definition.js";
 import type { InternalToolDefinition } from "#shared/tool-definition.js";
@@ -112,12 +113,15 @@ type CompiledAgentCompactionDefinition = Omit<InternalAgentCompactionDefinition,
   model?: CompiledRuntimeModelReference;
 };
 
+type CompiledAgentLimitsDefinition = AgentLimitsDefinition;
+
 /**
  * Normalized additive agent configuration preserved in the compiled manifest.
  */
 export type CompiledAgentDefinition = Omit<InternalAgentDefinition, "model" | "compaction"> & {
   model: CompiledRuntimeModelReference;
   compaction?: CompiledAgentCompactionDefinition;
+  limits?: CompiledAgentLimitsDefinition;
 };
 
 /**
@@ -357,6 +361,17 @@ const compiledAgentCompactionDefinitionSchema: z.ZodType<CompiledAgentCompaction
   })
   .strict();
 
+const compiledAgentLimitsDefinitionSchema: z.ZodType<CompiledAgentLimitsDefinition> = z
+  .object({
+    subagents: z
+      .object({
+        maxDepth: z.number().int().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
   .object({
     build: compiledAgentBuildDefinitionSchema.optional(),
@@ -368,6 +383,7 @@ const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
       })
       .strict()
       .optional(),
+    limits: compiledAgentLimitsDefinitionSchema.optional(),
     model: compiledRuntimeModelReferenceSchema,
     name: z.string(),
     outputSchema: jsonObjectSchema.optional(),
@@ -713,6 +729,7 @@ export function createCompiledAgentNodeManifest(input: {
                       world: input.config.experimental.workflow.world,
                     },
             },
+      limits: cloneCompiledAgentLimits(input.config.limits),
       model: cloneCompiledRuntimeModelReference(input.config.model),
       name: input.config.name,
       outputSchema: input.config.outputSchema,
@@ -754,6 +771,23 @@ export function createCompiledAgentNodeManifest(input: {
   }
 
   return node;
+}
+
+function cloneCompiledAgentLimits(
+  limits: CompiledAgentLimitsDefinition | undefined,
+): CompiledAgentLimitsDefinition | undefined {
+  if (limits === undefined) {
+    return undefined;
+  }
+
+  return {
+    subagents:
+      limits.subagents === undefined
+        ? undefined
+        : {
+            maxDepth: limits.subagents.maxDepth,
+          },
+  };
 }
 
 /**

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -66,6 +66,7 @@ export async function compileAgentConfig(
     };
     description?: string;
     experimental?: CompiledAgentDefinition["experimental"];
+    limits?: CompiledAgentDefinition["limits"];
     model: CompiledRuntimeModelReference;
     name: string;
     outputSchema?: JsonObject;
@@ -93,6 +94,10 @@ export async function compileAgentConfig(
           ? undefined
           : [...definition.build.externalDependencies],
     };
+  }
+
+  if (definition.limits !== undefined) {
+    compiledConfig.limits = normalizeLimitsDefinition(definition.limits);
   }
 
   if (definition.outputSchema !== undefined) {
@@ -129,6 +134,23 @@ export async function compileAgentConfig(
   }
 
   return compiledConfig;
+}
+
+function normalizeLimitsDefinition(
+  limits: CompiledAgentDefinition["limits"],
+): CompiledAgentDefinition["limits"] {
+  if (limits === undefined) {
+    return undefined;
+  }
+
+  return {
+    subagents:
+      limits.subagents === undefined
+        ? undefined
+        : {
+            maxDepth: limits.subagents.maxDepth,
+          },
+  };
 }
 
 function normalizeExperimentalDefinition(

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -5,6 +5,7 @@ import {
   type DurableSessionState,
 } from "#execution/durable-session-store.js";
 import { createSession } from "#execution/session.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 import type { JsonObject } from "#shared/json.js";
 
 /**
@@ -30,6 +31,8 @@ export async function createSessionStep(input: {
   readonly nodeId?: string;
   readonly rootSessionId?: string;
   readonly sessionId: string;
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
 }): Promise<CreateSessionStepResult> {
   "use step";
 
@@ -46,6 +49,8 @@ export async function createSessionStep(input: {
     outputSchema: input.outputSchema,
     rootSessionId: input.rootSessionId,
     sessionId: input.sessionId,
+    subagentDepth: input.subagentDepth,
+    subagentLimits: input.subagentLimits,
     turnAgent: bundle.turnAgent,
   });
 

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -42,6 +42,7 @@ import {
 import { hydrateDurableSession } from "#execution/session.js";
 import { buildSubagentRunInput, type SubagentInputSource } from "#execution/subagent-tool.js";
 import { createWorkflowRuntime, workflowEntryReference } from "#execution/workflow-runtime.js";
+import { applySubagentLimits } from "#harness/subagent-limits.js";
 import { createLogger, logError } from "#internal/logging.js";
 import { toErrorMessage } from "#shared/errors.js";
 
@@ -63,7 +64,7 @@ export async function dispatchRuntimeActionsStep(input: {
   const durableSession = await readDurableSession(input.sessionState);
   const batch = getPendingRuntimeActionBatch(durableSession.state);
 
-  if (batch === undefined || batch.actions.length === 0) {
+  if (batch === undefined) {
     return { results: [], sessionState: input.sessionState };
   }
 
@@ -85,11 +86,29 @@ export async function dispatchRuntimeActionsStep(input: {
 
   const adapterCtx = buildAdapterContext(adapter, ctx);
 
-  let nextSession = session;
-  const results: RuntimeSubagentResultActionResult[] = [];
+  const prefiltered = batch.dispatchActions !== undefined;
+  const dispatchActions = batch.dispatchActions ?? batch.actions;
+  const results: RuntimeSubagentResultActionResult[] = [
+    ...(batch.prefilledResults ?? []).filter(
+      (result): result is RuntimeSubagentResultActionResult => result.kind === "subagent-result",
+    ),
+  ];
+  const limitedBatch = prefiltered
+    ? { actions: dispatchActions, rejectedResults: [], session }
+    : applySubagentLimits({
+        actions: dispatchActions,
+        session,
+        step: {
+          stepIndex: batch.event.stepIndex,
+          turnId: batch.event.turnId,
+        },
+      });
+  let nextSession = limitedBatch.session;
+
+  results.push(...limitedBatch.rejectedResults);
 
   try {
-    for (const action of batch.actions) {
+    for (const action of limitedBatch.actions) {
       let childSessionId: string;
       let name: string;
       let remote: { readonly url: string } | undefined;

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -27,6 +27,7 @@
 
 import { ChannelRequestIdKey } from "#context/keys.js";
 import type { EveAttributeValue } from "#runtime/attributes/normalize.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 import { isNonEmptyString } from "#shared/guards.js";
 
 /**
@@ -51,6 +52,8 @@ interface SerializedSessionParent {
   readonly callId?: unknown;
   readonly sessionId?: unknown;
   readonly rootSessionId?: unknown;
+  readonly subagentDepth?: unknown;
+  readonly subagentLimits?: unknown;
   readonly turn?: {
     readonly id?: unknown;
   };
@@ -63,6 +66,8 @@ export interface SessionParentLineage {
   readonly callId?: string;
   readonly rootSessionId?: string;
   readonly sessionId?: string;
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
   readonly turnId?: string;
 }
 
@@ -88,13 +93,39 @@ export function readParentLineage(
   const callId = parent?.callId;
   const rootSessionId = parent?.rootSessionId;
   const sessionId = parent?.sessionId;
+  const subagentDepth = parent?.subagentDepth;
+  const subagentLimits = parent?.subagentLimits;
   const turnId = parent?.turn?.id;
   return {
     callId: isNonEmptyString(callId) ? callId : undefined,
     rootSessionId: isNonEmptyString(rootSessionId) ? rootSessionId : undefined,
     sessionId: isNonEmptyString(sessionId) ? sessionId : undefined,
+    subagentDepth:
+      typeof subagentDepth === "number" && Number.isInteger(subagentDepth) && subagentDepth >= 0
+        ? subagentDepth
+        : undefined,
+    subagentLimits: parseSubagentLimits(subagentLimits),
     turnId: isNonEmptyString(turnId) ? turnId : undefined,
   };
+}
+
+function parseSubagentLimits(value: unknown): AgentSubagentLimitsDefinition | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as { readonly maxDepth?: unknown };
+  const maxDepth = parsePositiveInteger(record.maxDepth);
+
+  if (maxDepth === undefined) {
+    return undefined;
+  }
+
+  return { maxDepth };
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
 /**

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -371,6 +371,17 @@ describe("createExecutionNodeStep", () => {
           subagentName: "child-agent",
         },
       ],
+      dispatchActions: [
+        {
+          callId: "call-subagent-1",
+          description: "Delegate work to the child agent.",
+          input: { task: "Delegate this." },
+          kind: "subagent-call",
+          name: "child-agent",
+          nodeId: "child-node",
+          subagentName: "child-agent",
+        },
+      ],
       event: {
         sequence: 0,
         stepIndex: 0,

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -9,6 +9,7 @@ import {
   projectToDurableSession,
   refreshSessionFromTurnAgent,
 } from "#execution/session.js";
+import { getEffectiveSubagentLimits } from "#harness/subagent-limits.js";
 
 function createTestTurnAgent(overrides?: Partial<RuntimeTurnAgent>): RuntimeTurnAgent {
   return {
@@ -224,6 +225,45 @@ describe("createSession", () => {
 
     expect(durable.agent).toEqual({ system: session.agent.system });
     expect(hydrated.agent.reasoning).toBe("high");
+  });
+
+  it("stores authored subagent limit overrides on new sessions", () => {
+    const session = createSession({
+      continuationToken: "root-token",
+      sessionId: "sess-root",
+      turnAgent: createTestTurnAgent({
+        limits: {
+          subagents: {
+            maxDepth: 6,
+          },
+        },
+      }),
+    });
+
+    expect(getEffectiveSubagentLimits(session.state)).toEqual({
+      maxDepth: 6,
+    });
+  });
+
+  it("inherits parent subagent limits unless the child tightens them", () => {
+    const session = createSession({
+      continuationToken: "child-token",
+      sessionId: "sess-child",
+      subagentLimits: {
+        maxDepth: 6,
+      },
+      turnAgent: createTestTurnAgent({
+        limits: {
+          subagents: {
+            maxDepth: 10,
+          },
+        },
+      }),
+    });
+
+    expect(getEffectiveSubagentLimits(session.state)).toEqual({
+      maxDepth: 6,
+    });
   });
 });
 

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -1,6 +1,8 @@
 import type { DurableSession } from "#execution/durable-session-store.js";
 import type { HarnessSession, SessionToolDefinition } from "#harness/types.js";
 import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
+import { resolveEffectiveSubagentLimits, setSubagentLimitState } from "#harness/subagent-limits.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
 
 const DEFAULT_COMPACTION_RECENT_WINDOW_SIZE = 10;
 const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 0.9;
@@ -51,6 +53,8 @@ export interface CreateSessionInput {
    */
   readonly rootSessionId?: string;
   readonly sessionId: string;
+  readonly subagentDepth?: number;
+  readonly subagentLimits?: AgentSubagentLimitsDefinition;
   readonly turnAgent: RuntimeTurnAgent;
   readonly outputSchema?: HarnessSession["outputSchema"];
 }
@@ -86,7 +90,14 @@ export function createSession(input: CreateSessionInput): HarnessSession {
     session.outputSchema = input.outputSchema;
   }
 
-  return session;
+  return setSubagentLimitState({
+    depth: input.subagentDepth,
+    limits: resolveEffectiveSubagentLimits({
+      authored: turnAgent.limits?.subagents,
+      inherited: input.subagentLimits,
+    }),
+    session,
+  });
 }
 
 /**

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -85,6 +85,10 @@ describe("buildSubagentRunInput", () => {
       callId: "call-1",
       rootSessionId: "parent-session",
       sessionId: "parent-session",
+      subagentDepth: 1,
+      subagentLimits: {
+        maxDepth: 4,
+      },
       turn: { id: "turn-17", sequence: 5 },
     });
     expect(runInput.continuationToken).toBe(childContinuationToken);
@@ -153,6 +157,10 @@ describe("buildSubagentRunInput", () => {
       callId: "call-1",
       rootSessionId: "root-session-from-top",
       sessionId: "intermediate-session",
+      subagentDepth: 1,
+      subagentLimits: {
+        maxDepth: 4,
+      },
       turn: { id: "turn-99", sequence: 1 },
     });
   });

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -10,6 +10,7 @@ import type { HarnessSession } from "#harness/types.js";
 import type { JsonObject } from "#shared/json.js";
 import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
 import { mintSubagentContinuationToken } from "#execution/session.js";
+import { getChildSubagentDepth, getEffectiveSubagentLimits } from "#harness/subagent-limits.js";
 
 /**
  * Pending runtime-action batch event metadata needed for child run lineage.
@@ -111,6 +112,8 @@ export function buildSubagentRunInput(input: {
       callId: action.callId,
       rootSessionId,
       sessionId: session.sessionId,
+      subagentDepth: getChildSubagentDepth(session),
+      subagentLimits: getEffectiveSubagentLimits(session.state),
       turn: {
         id: batchEvent.turnId,
         sequence: batchEvent.sequence,

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -8,7 +8,7 @@ import type {
   SessionCapabilities,
 } from "#channel/types.js";
 import { coalesceDeliveries } from "#harness/messages.js";
-import { readChannelRequestId, readRootSessionId } from "#execution/eve-workflow-attributes.js";
+import { readChannelRequestId, readParentLineage } from "#execution/eve-workflow-attributes.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { notifyDelegatedParentStep } from "#execution/delegated-parent-notification.js";
@@ -85,15 +85,17 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
   try {
     // Derived once and reused for createSession + tag emission so the
     // chain-root id can never drift between persisted session and tags.
-    const rootSessionIdFromParent = readRootSessionId(input.serializedContext);
+    const parentLineage = readParentLineage(input.serializedContext);
 
     const { state: sessionState } = await createSessionStep({
       compiledArtifactsSource: serializedBundle.source,
       continuationToken,
       nodeId: serializedBundle.nodeId,
       outputSchema: input.input.outputSchema,
-      rootSessionId: rootSessionIdFromParent,
+      rootSessionId: parentLineage.rootSessionId,
       sessionId,
+      subagentDepth: parentLineage.subagentDepth,
+      subagentLimits: parentLineage.subagentLimits,
     });
 
     return await runDriverLoop({

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -9,6 +9,7 @@ import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js
 import { serializeContext } from "#context/serialize.js";
 import { setPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
+import { DEFAULT_MAX_SUBAGENT_DEPTH, setSubagentDepth } from "#harness/subagent-limits.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
 import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
@@ -282,6 +283,85 @@ describe("dispatchTurnStep", () => {
 });
 
 describe("dispatchRuntimeActionsStep", () => {
+  it("rejects subagent calls at the default maximum depth", async () => {
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {},
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {
+        subagentsByNodeId: new Map(),
+      },
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+
+    const session = setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "call-1",
+          description: "Launch another copy.",
+          input: { message: "keep going" },
+          kind: "subagent-call",
+          name: "agent",
+          nodeId: "__root__",
+          subagentName: "agent",
+        },
+      ],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      responseMessages: [],
+      session: setSubagentDepth({
+        depth: DEFAULT_MAX_SUBAGENT_DEPTH,
+        session: createStubSession({
+          continuationToken: "http:parent",
+          sessionId: "parent-session",
+        }),
+      }),
+    });
+    installSessionStoreMocks([session]);
+
+    const sessionState = createStubSessionState({
+      continuationToken: "http:parent",
+      sessionId: "parent-session",
+    });
+
+    await expect(
+      dispatchRuntimeActionsStep({
+        parentContinuationToken: "turn-inbox",
+        parentWritable: createTestWritable(),
+        serializedContext: createSerializedContext(),
+        sessionState,
+      }),
+    ).resolves.toEqual({
+      results: [
+        {
+          callId: "call-1",
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED",
+            message:
+              "Maximum subagent depth reached. Do not retry this subagent call; complete the work in this session or return a partial result.",
+          },
+          subagentName: "agent",
+        },
+      ],
+      sessionState,
+    });
+    expect(startMock).not.toHaveBeenCalled();
+    expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE)).toBeUndefined();
+  });
+
   it("starts subagent child drivers on the latest deployment", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as never;
@@ -371,6 +451,9 @@ describe("dispatchRuntimeActionsStep", () => {
             "eve.channel": expect.objectContaining({
               kind: "subagent",
               state: expect.objectContaining({ parentContinuationToken: "turn-inbox" }),
+            }),
+            "eve.parentSession": expect.objectContaining({
+              subagentDepth: 1,
             }),
           }),
         }),
@@ -469,31 +552,32 @@ describe("dispatchRuntimeActionsStep", () => {
       sessionId: "parent-session",
     });
 
-    await expect(
-      dispatchRuntimeActionsStep({
-        callbackBaseUrl: "https://caller.example.com",
-        parentContinuationToken: "turn-inbox",
-        parentWritable: createTestWritable(),
-        serializedContext: createSerializedContext(),
-        sessionState,
-      }),
-    ).resolves.toEqual({
-      results: [
-        {
-          callId: "call-1",
-          isError: true,
-          kind: "subagent-result",
-          output: {
-            code: "REMOTE_AGENT_START_FAILED",
-            message: 'Remote agent "research" create-session request failed with HTTP 503.',
-          },
-          subagentName: "research",
-        },
-      ],
-      // A remote-agent dispatch failure does not mutate the session,
-      // so the step returns the input sessionState unchanged.
+    const result = await dispatchRuntimeActionsStep({
+      callbackBaseUrl: "https://caller.example.com",
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
       sessionState,
     });
+
+    expect(result.results).toEqual([
+      {
+        callId: "call-1",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "REMOTE_AGENT_START_FAILED",
+          message: 'Remote agent "research" create-session request failed with HTTP 503.',
+        },
+        subagentName: "research",
+      },
+    ]);
+    expect(result.sessionState).toEqual(
+      expect.objectContaining({
+        hasProxyInputRequests: false,
+        sessionId: "parent-session",
+      }),
+    );
     expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string).callback.token).toBe(
       "turn-inbox",
     );

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -40,9 +40,15 @@ interface PendingRuntimeActionEventMetadata {
 interface PendingRuntimeActionBatch {
   readonly actions: readonly RuntimeActionRequest[];
   readonly childContinuationTokens?: Readonly<Record<string, string>>;
+  readonly dispatchActions?: readonly RuntimeActionRequest[];
   readonly event: PendingRuntimeActionEventMetadata;
+  readonly prefilledResults?: readonly RuntimeActionResult[];
   readonly responseMessages: readonly ModelMessage[];
 }
+
+type MutablePendingRuntimeActionBatch = {
+  -readonly [Key in keyof PendingRuntimeActionBatch]: PendingRuntimeActionBatch[Key];
+};
 
 /**
  * Outcome of resolving a pending runtime-action batch.
@@ -67,6 +73,8 @@ export function getPendingRuntimeActionBatch(
 
   if (
     !Array.isArray(batch.actions) ||
+    (batch.dispatchActions !== undefined && !Array.isArray(batch.dispatchActions)) ||
+    (batch.prefilledResults !== undefined && !Array.isArray(batch.prefilledResults)) ||
     !Array.isArray(batch.responseMessages) ||
     typeof batch.event !== "object" ||
     batch.event === null
@@ -98,16 +106,28 @@ export function clearPendingRuntimeActionBatch(session: HarnessSession): Harness
  */
 export function setPendingRuntimeActionBatch(input: {
   readonly actions: readonly RuntimeActionRequest[];
+  readonly dispatchActions?: readonly RuntimeActionRequest[];
   readonly event: PendingRuntimeActionEventMetadata;
+  readonly prefilledResults?: readonly RuntimeActionResult[];
   readonly responseMessages: readonly ModelMessage[];
   readonly session: HarnessSession;
 }): HarnessSession {
   const state = { ...input.session.state };
-  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = {
+  const batch: MutablePendingRuntimeActionBatch = {
     actions: [...input.actions],
     event: input.event,
     responseMessages: [...input.responseMessages],
   } satisfies PendingRuntimeActionBatch;
+
+  if (input.dispatchActions !== undefined) {
+    batch.dispatchActions = [...input.dispatchActions];
+  }
+
+  if (input.prefilledResults !== undefined && input.prefilledResults.length > 0) {
+    batch.prefilledResults = [...input.prefilledResults];
+  }
+
+  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = batch satisfies PendingRuntimeActionBatch;
 
   return { ...input.session, state };
 }

--- a/packages/eve/src/harness/subagent-limits.test.ts
+++ b/packages/eve/src/harness/subagent-limits.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { jsonSchema } from "ai";
+
+import {
+  applySubagentLimits,
+  DEFAULT_MAX_SUBAGENT_DEPTH,
+  filterAdvertisedSubagentTools,
+  resolveEffectiveSubagentLimits,
+  setSubagentLimitState,
+} from "#harness/subagent-limits.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
+
+function createSession(state?: HarnessSession["state"]): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "test-token",
+    history: [],
+    sessionId: "sess-test",
+    state,
+  };
+}
+
+function createSubagentAction(index: number): RuntimeSubagentCallActionRequest {
+  return {
+    callId: `call-${index}`,
+    description: "Launch another copy.",
+    input: { message: `work item ${index}` },
+    kind: "subagent-call",
+    name: "agent",
+    nodeId: "__root__",
+    subagentName: "agent",
+  };
+}
+
+describe("resolveEffectiveSubagentLimits", () => {
+  it("uses eve defaults when no limits are authored or inherited", () => {
+    expect(resolveEffectiveSubagentLimits({})).toEqual({
+      maxDepth: DEFAULT_MAX_SUBAGENT_DEPTH,
+    });
+  });
+
+  it("allows root agents to raise default limits explicitly", () => {
+    expect(
+      resolveEffectiveSubagentLimits({
+        authored: {
+          maxDepth: 6,
+        },
+      }),
+    ).toEqual({
+      maxDepth: 6,
+    });
+  });
+
+  it("inherits parent limits when a child does not author overrides", () => {
+    expect(
+      resolveEffectiveSubagentLimits({
+        inherited: {
+          maxDepth: 6,
+        },
+      }),
+    ).toEqual({
+      maxDepth: 6,
+    });
+  });
+
+  it("lets child agents tighten inherited limits but not loosen them", () => {
+    expect(
+      resolveEffectiveSubagentLimits({
+        authored: {
+          maxDepth: 10,
+        },
+        inherited: {
+          maxDepth: 6,
+        },
+      }),
+    ).toEqual({
+      maxDepth: 6,
+    });
+  });
+});
+
+describe("applySubagentLimits", () => {
+  it("rejects stale subagent calls once depth reaches the configured maximum", () => {
+    const session = setSubagentLimitState({
+      depth: 2,
+      limits: {
+        maxDepth: 2,
+      },
+      session: createSession(),
+    });
+
+    const result = applySubagentLimits({
+      actions: [createSubagentAction(1)],
+      session,
+    });
+
+    expect(result.actions).toEqual([]);
+    expect(result.rejectedResults).toEqual([
+      {
+        callId: "call-1",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED",
+          message:
+            "Maximum subagent depth reached. Do not retry this subagent call; complete the work in this session or return a partial result.",
+        },
+        subagentName: "agent",
+      },
+    ]);
+  });
+
+  it("allows subagent calls while depth remains below the configured maximum", () => {
+    const session = setSubagentLimitState({
+      depth: 1,
+      limits: {
+        maxDepth: 2,
+      },
+      session: createSession(),
+    });
+
+    const result = applySubagentLimits({
+      actions: [createSubagentAction(1)],
+      session,
+    });
+
+    expect(result.actions.map((action) => action.callId)).toEqual(["call-1"]);
+    expect(result.rejectedResults).toEqual([]);
+  });
+});
+
+describe("filterAdvertisedSubagentTools", () => {
+  const tools = new Map<string, HarnessToolDefinition>([
+    [
+      "search",
+      {
+        description: "Search locally.",
+        execute: () => "result",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "search",
+      },
+    ],
+    [
+      "delegate",
+      {
+        description: "Delegate to a subagent.",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "delegate",
+        runtimeAction: {
+          kind: "subagent-call",
+          nodeId: "worker",
+          subagentName: "worker",
+        },
+      },
+    ],
+    [
+      "remote_reviewer",
+      {
+        description: "Delegate to a remote agent.",
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "remote_reviewer",
+        runtimeAction: {
+          kind: "remote-agent-call",
+          nodeId: "remote",
+          remoteAgentName: "reviewer",
+          subagentName: "reviewer",
+        },
+      },
+    ],
+  ]);
+
+  it("keeps subagent tools advertised while depth remains below the cap", () => {
+    const session = setSubagentLimitState({
+      depth: 1,
+      limits: {
+        maxDepth: 2,
+      },
+      session: createSession(),
+    });
+
+    expect(filterAdvertisedSubagentTools({ session, tools })).toBe(tools);
+  });
+
+  it("hides subagent tools from the model once the depth cap is reached", () => {
+    const toolsWithFutureRuntimeAction = new Map(tools);
+    const futureRuntimeTool: HarnessToolDefinition = {
+      description: "Start a durable workflow job.",
+      inputSchema: jsonSchema({ type: "object" }),
+      name: "workflow_job",
+    };
+    (
+      futureRuntimeTool as {
+        runtimeAction?: {
+          readonly kind: string;
+          readonly nodeId: string;
+          readonly subagentName: string;
+        };
+      }
+    ).runtimeAction = {
+      kind: "workflow-job",
+      nodeId: "workflow",
+      subagentName: "workflow",
+    };
+    toolsWithFutureRuntimeAction.set("workflow_job", futureRuntimeTool);
+
+    const session = setSubagentLimitState({
+      depth: 2,
+      limits: {
+        maxDepth: 2,
+      },
+      session: createSession(),
+    });
+
+    const filtered = filterAdvertisedSubagentTools({
+      session,
+      tools: toolsWithFutureRuntimeAction,
+    });
+
+    expect([...filtered.keys()]).toEqual(["search", "workflow_job"]);
+    expect(filtered).not.toBe(toolsWithFutureRuntimeAction);
+  });
+});

--- a/packages/eve/src/harness/subagent-limits.ts
+++ b/packages/eve/src/harness/subagent-limits.ts
@@ -1,0 +1,223 @@
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { HarnessSession, HarnessToolMap, SessionStateMap } from "#harness/types.js";
+import type {
+  RuntimeActionRequest,
+  RuntimeRemoteAgentCallActionRequest,
+  RuntimeSubagentCallActionRequest,
+  RuntimeSubagentResultActionResult,
+} from "#runtime/actions/types.js";
+import type { AgentSubagentLimitsDefinition } from "#shared/agent-definition.js";
+
+export const DEFAULT_MAX_SUBAGENT_DEPTH = 4;
+
+const SUBAGENT_LIMIT_STATE_KEY = "eve.runtime.subagentLimits";
+
+interface SubagentLimitState {
+  readonly depth?: number;
+  readonly maxDepth?: number;
+}
+
+type DelegationAction = RuntimeRemoteAgentCallActionRequest | RuntimeSubagentCallActionRequest;
+
+interface SubagentLimitRejection {
+  readonly action: DelegationAction;
+  readonly message: string;
+}
+
+export interface ApplySubagentLimitsResult {
+  readonly actions: readonly RuntimeActionRequest[];
+  readonly rejectedResults: readonly RuntimeSubagentResultActionResult[];
+  readonly session: HarnessSession;
+}
+
+export interface EffectiveSubagentLimits {
+  readonly maxDepth: number;
+}
+
+export function filterAdvertisedSubagentTools(input: {
+  readonly session: HarnessSession;
+  readonly tools: HarnessToolMap;
+}): HarnessToolMap {
+  const depth = getSubagentDepth(input.session.state);
+  const limits = getEffectiveSubagentLimits(input.session.state);
+
+  if (depth < limits.maxDepth) {
+    return input.tools;
+  }
+
+  const tools = new Map(input.tools);
+
+  for (const [name, definition] of input.tools) {
+    if (isSubagentRuntimeAction(definition)) {
+      tools.delete(name);
+    }
+  }
+
+  return tools;
+}
+
+export function applySubagentLimits(input: {
+  readonly actions: readonly RuntimeActionRequest[];
+  readonly session: HarnessSession;
+  readonly step?: {
+    readonly stepIndex: number;
+    readonly turnId: string;
+  };
+}): ApplySubagentLimitsResult {
+  const depth = getSubagentDepth(input.session.state);
+  const limits = getEffectiveSubagentLimits(input.session.state);
+
+  if (depth < limits.maxDepth) {
+    return {
+      actions: input.actions,
+      rejectedResults: [],
+      session: input.session,
+    };
+  }
+
+  const actions: RuntimeActionRequest[] = [];
+  const rejections: SubagentLimitRejection[] = [];
+
+  for (const action of input.actions) {
+    if (!isDelegationAction(action)) {
+      actions.push(action);
+      continue;
+    }
+
+    rejections.push({
+      action,
+      message:
+        "Maximum subagent depth reached. Do not retry this subagent call; complete the work in this session or return a partial result.",
+    });
+  }
+
+  return {
+    actions,
+    rejectedResults: rejections.map(createSubagentLimitResult),
+    session: input.session,
+  };
+}
+
+export function getChildSubagentDepth(session: HarnessSession): number {
+  return getSubagentDepth(session.state) + 1;
+}
+
+export function resolveEffectiveSubagentLimits(input: {
+  readonly authored?: AgentSubagentLimitsDefinition;
+  readonly inherited?: AgentSubagentLimitsDefinition;
+}): EffectiveSubagentLimits {
+  if (input.inherited === undefined) {
+    return {
+      maxDepth: normalizePositiveInteger(input.authored?.maxDepth) ?? DEFAULT_MAX_SUBAGENT_DEPTH,
+    };
+  }
+
+  const inherited = normalizeEffectiveSubagentLimits(input.inherited);
+  return {
+    maxDepth:
+      input.authored?.maxDepth === undefined
+        ? inherited.maxDepth
+        : Math.min(inherited.maxDepth, input.authored.maxDepth),
+  };
+}
+
+export function getEffectiveSubagentLimits(
+  state: SessionStateMap | undefined,
+): EffectiveSubagentLimits {
+  const value = state?.[SUBAGENT_LIMIT_STATE_KEY];
+  if (typeof value !== "object" || value === null) return DEFAULT_SUBAGENT_LIMITS;
+  return normalizeEffectiveSubagentLimits(value as AgentSubagentLimitsDefinition);
+}
+
+export function setSubagentLimitState(input: {
+  readonly depth: number | undefined;
+  readonly limits: EffectiveSubagentLimits;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const depth = normalizeDepth(input.depth);
+  if (depth === 0 && isDefaultSubagentLimits(input.limits)) return input.session;
+
+  const state = { ...input.session.state };
+  state[SUBAGENT_LIMIT_STATE_KEY] = {
+    depth: depth === 0 ? undefined : depth,
+    maxDepth: input.limits.maxDepth,
+  } satisfies SubagentLimitState;
+  return { ...input.session, state };
+}
+
+export function setSubagentDepth(input: {
+  readonly depth: number | undefined;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const depth = normalizeDepth(input.depth);
+  if (depth === 0) return input.session;
+
+  const limits = getEffectiveSubagentLimits(input.session.state);
+  const state = { ...input.session.state };
+  state[SUBAGENT_LIMIT_STATE_KEY] = {
+    depth,
+    maxDepth: limits.maxDepth,
+  } satisfies SubagentLimitState;
+  return { ...input.session, state };
+}
+
+export function getSubagentDepth(state: SessionStateMap | undefined): number {
+  const value = state?.[SUBAGENT_LIMIT_STATE_KEY];
+  if (typeof value !== "object" || value === null) return 0;
+  return normalizeDepth((value as SubagentLimitState).depth);
+}
+
+function createSubagentLimitResult(
+  rejection: SubagentLimitRejection,
+): RuntimeSubagentResultActionResult {
+  return {
+    callId: rejection.action.callId,
+    isError: true,
+    kind: "subagent-result",
+    output: {
+      code: "EVE_SUBAGENT_DEPTH_LIMIT_EXCEEDED",
+      message: rejection.message,
+    },
+    subagentName: getDelegationActionName(rejection.action),
+  };
+}
+
+function getDelegationActionName(action: DelegationAction): string {
+  return action.kind === "remote-agent-call" ? action.remoteAgentName : action.subagentName;
+}
+
+function isDelegationAction(action: RuntimeActionRequest): action is DelegationAction {
+  return action.kind === "remote-agent-call" || action.kind === "subagent-call";
+}
+
+function isSubagentRuntimeAction(definition: HarnessToolDefinition): boolean {
+  return (
+    definition.runtimeAction?.kind === "remote-agent-call" ||
+    definition.runtimeAction?.kind === "subagent-call"
+  );
+}
+
+function normalizeDepth(depth: number | undefined): number {
+  if (depth === undefined || !Number.isInteger(depth) || depth < 0) return 0;
+  return depth;
+}
+
+const DEFAULT_SUBAGENT_LIMITS: EffectiveSubagentLimits = {
+  maxDepth: DEFAULT_MAX_SUBAGENT_DEPTH,
+};
+
+function normalizeEffectiveSubagentLimits(
+  limits: AgentSubagentLimitsDefinition,
+): EffectiveSubagentLimits {
+  return {
+    maxDepth: normalizePositiveInteger(limits.maxDepth) ?? DEFAULT_MAX_SUBAGENT_DEPTH,
+  };
+}
+
+function normalizePositiveInteger(value: number | undefined): number | undefined {
+  return value === undefined || !Number.isInteger(value) || value <= 0 ? undefined : value;
+}
+
+function isDefaultSubagentLimits(limits: EffectiveSubagentLimits): boolean {
+  return limits.maxDepth === DEFAULT_MAX_SUBAGENT_DEPTH;
+}

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -35,6 +35,7 @@ import {
 } from "#harness/authorization.js";
 import { hasDeferredStepInput, setPendingInputBatch } from "#harness/input-requests.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
+import { setSubagentLimitState } from "#harness/subagent-limits.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 import {
@@ -590,6 +591,74 @@ describe("createToolLoopHarness", () => {
     const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
     expect(agentCall).toBeDefined();
     expect(agentCall!.tools).toHaveProperty("add");
+    expect(agentCall!.tools).not.toHaveProperty("Workflow");
+  });
+
+  it("hides subagent tools from the model once the depth cap is reached", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Done.", role: "assistant" }] },
+      text: "Done.",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const config = createTestConfig("conversation", undefined, {
+      tools: new Map([
+        [
+          "add",
+          {
+            description: "Adds numbers",
+            execute: vi.fn().mockResolvedValue("42"),
+            inputSchema: jsonSchema({ type: "object" }),
+            name: "add",
+          },
+        ],
+        [
+          "delegate",
+          {
+            description: "Delegate to a local subagent.",
+            inputSchema: jsonSchema({ type: "object" }),
+            name: "delegate",
+            runtimeAction: {
+              kind: "subagent-call",
+              nodeId: "workers",
+              subagentName: "worker",
+            },
+          },
+        ],
+        [
+          "remote_reviewer",
+          {
+            description: "Delegate to a remote subagent.",
+            inputSchema: jsonSchema({ type: "object" }),
+            name: "remote_reviewer",
+            runtimeAction: {
+              kind: "remote-agent-call",
+              nodeId: "remote-reviewer",
+              remoteAgentName: "reviewer",
+              subagentName: "reviewer",
+            },
+          },
+        ],
+      ]),
+      workflow: true,
+    });
+    const session = setSubagentLimitState({
+      depth: 1,
+      limits: {
+        maxDepth: 1,
+      },
+      session: createTestSession(),
+    });
+
+    await createToolLoopHarness(config)(session, { message: "Hi" });
+
+    const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
+    expect(agentCall).toBeDefined();
+    expect(agentCall!.tools).toHaveProperty("add");
+    expect(agentCall!.tools).not.toHaveProperty("delegate");
+    expect(agentCall!.tools).not.toHaveProperty("remote_reviewer");
     expect(agentCall!.tools).not.toHaveProperty("Workflow");
   });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -33,6 +33,7 @@ import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js
 import { toErrorMessage } from "#shared/errors.js";
 import {
   createActionResultEvent,
+  createActionsRequestedEvent,
   createCompactionCompletedEvent,
   createCompactionRequestedEvent,
   createInputRequestedEvent,
@@ -136,6 +137,7 @@ import {
   resolvePendingRuntimeActions,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
+import { applySubagentLimits, filterAdvertisedSubagentTools } from "#harness/subagent-limits.js";
 import {
   buildStepHooks,
   emitStepActions,
@@ -640,12 +642,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         ? [...modelMessages, { role: "user" as const, content: opts.trailingUserNote }]
         : modelMessages;
 
+      const advertisedTools = filterAdvertisedSubagentTools({
+        session,
+        tools: config.tools,
+      });
       const flatTools = await buildToolSetWithProviderTools({
         approvedTools,
         capabilities: config.capabilities,
         disabledProviderTools: opts.disabledProviderTools,
         modelReference: session.agent.modelReference,
-        tools: config.tools,
+        tools: advertisedTools,
       });
 
       if (ctx !== undefined) {
@@ -671,13 +677,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           ? (
               await applyWorkflowTool({
                 continuationSecurity: getWorkflowContinuationSecurity(session),
-                harnessTools: config.tools,
+                harnessTools: advertisedTools,
                 lifecycle:
                   emit !== undefined
                     ? createWorkflowLifecycle({
                         emit,
                         emissionState,
-                        tools: config.tools,
+                        tools: advertisedTools,
                       })
                     : undefined,
                 tools: flatTools,
@@ -725,7 +731,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       const executeModelCall = async (): Promise<HarnessStepResult> => {
         if (emit) {
-          const excludedActionToolNames = new Set([ASK_QUESTION_TOOL_NAME, FINAL_OUTPUT_TOOL_NAME]);
+          const excludedActionToolNames = getHarnessOnlyToolNames(config.tools);
           const streamResult = await agent.stream({ messages: callMessages });
           const {
             emittedActionCallIds,
@@ -1345,6 +1351,18 @@ function buildEmptyResponseNudge(emptyDeliveryEnabled: boolean): string {
   return `${EMPTY_RESPONSE_NUDGE} If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
 }
 
+function getHarnessOnlyToolNames(tools: HarnessToolMap): ReadonlySet<string> {
+  const excluded = new Set<string>([ASK_QUESTION_TOOL_NAME, FINAL_OUTPUT_TOOL_NAME]);
+
+  for (const [toolName, definition] of tools) {
+    if (definition.runtimeAction !== undefined) {
+      excluded.add(toolName);
+    }
+  }
+
+  return excluded;
+}
+
 /**
  * Recovers a model call that completed without content (see
  * {@link EmptyModelResponseError}) by reissuing the same call once, with
@@ -1474,6 +1492,27 @@ async function handleStepResult(input: {
     );
 
   if (pendingRuntimeActions.length > 0) {
+    const pendingSession: HarnessSession = { ...baseSession, history: [...promptMessages] };
+    const limitedRuntimeActions = applySubagentLimits({
+      actions: pendingRuntimeActions,
+      session: pendingSession,
+      step: {
+        stepIndex: emissionState.stepIndex,
+        turnId: emissionState.turnId,
+      },
+    });
+
+    if (emit !== undefined && limitedRuntimeActions.actions.length > 0) {
+      await emit(
+        createActionsRequestedEvent({
+          actions: limitedRuntimeActions.actions,
+          sequence: emissionState.sequence,
+          stepIndex: emissionState.stepIndex,
+          turnId: emissionState.turnId,
+        }),
+      );
+    }
+
     // Stamp the live emission state onto the parked session so the
     // resume turn is classified as a continuation (turnId set), not a
     // fresh turn. Every other park path does this; without it the
@@ -1485,13 +1524,15 @@ async function handleStepResult(input: {
       session: setHarnessEmissionState(
         setPendingRuntimeActionBatch({
           actions: pendingRuntimeActions,
+          dispatchActions: limitedRuntimeActions.actions,
           event: {
             sequence: emissionState.sequence,
             stepIndex: emissionState.stepIndex,
             turnId: emissionState.turnId,
           },
+          prefilledResults: limitedRuntimeActions.rejectedResults,
           responseMessages,
-          session: { ...baseSession, history: [...promptMessages] },
+          session: limitedRuntimeActions.session,
         }),
         emissionState,
       ),

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -81,6 +81,40 @@ describe("normalizeAgentDefinition", () => {
       ),
     ).toThrow('"experimental.workflow.world" must be a non-empty package name');
   });
+
+  it("accepts subagent limit overrides", () => {
+    const definition = normalizeAgentDefinition(
+      {
+        model: "openai/gpt-5.5",
+        limits: {
+          subagents: {
+            maxDepth: 6,
+          },
+        },
+      },
+      FAILURE_MESSAGE,
+    );
+
+    expect(definition.limits?.subagents).toEqual({
+      maxDepth: 6,
+    });
+  });
+
+  it("rejects invalid subagent limit overrides", () => {
+    expect(() =>
+      normalizeAgentDefinition(
+        {
+          model: "openai/gpt-5.5",
+          limits: {
+            subagents: {
+              maxDepth: 0,
+            },
+          },
+        },
+        FAILURE_MESSAGE,
+      ),
+    ).toThrow(FAILURE_MESSAGE);
+  });
 });
 
 describe("normalizeScheduleDefinition", () => {

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -41,6 +41,7 @@ export function normalizeAgentDefinition(
       "compaction",
       "description",
       "experimental",
+      "limits",
       "model",
       "modelContextWindowTokens",
       "modelOptions",
@@ -71,6 +72,10 @@ export function normalizeAgentDefinition(
 
   if (record.experimental !== undefined) {
     definition.experimental = normalizeAgentExperimentalDefinition(record.experimental, message);
+  }
+
+  if (record.limits !== undefined) {
+    definition.limits = normalizeAgentLimitsDefinition(record.limits, message);
   }
 
   if (record.modelOptions !== undefined) {
@@ -121,6 +126,41 @@ function expectPositiveInteger(value: unknown, message: string): number {
   }
 
   return value;
+}
+
+function normalizeAgentLimitsDefinition(
+  value: unknown,
+  message: string,
+): NonNullable<NormalizedAgentDefinition["limits"]> {
+  const record = expectObjectRecord(value, message);
+  expectOnlyKnownKeys(record, ["subagents"], message);
+  const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["limits"]>> = {};
+
+  if (record.subagents !== undefined) {
+    normalizedDefinition.subagents = normalizeAgentSubagentLimitsDefinition(
+      record.subagents,
+      message,
+    );
+  }
+
+  return normalizedDefinition;
+}
+
+function normalizeAgentSubagentLimitsDefinition(
+  value: unknown,
+  message: string,
+): NonNullable<NonNullable<NormalizedAgentDefinition["limits"]>["subagents"]> {
+  const record = expectObjectRecord(value, message);
+  expectOnlyKnownKeys(record, ["maxDepth"], message);
+  const normalizedDefinition: Mutable<
+    NonNullable<NonNullable<NormalizedAgentDefinition["limits"]>["subagents"]>
+  > = {};
+
+  if (record.maxDepth !== undefined) {
+    normalizedDefinition.maxDepth = expectPositiveInteger(record.maxDepth, message);
+  }
+
+  return normalizedDefinition;
 }
 
 function normalizeAgentBuildDefinition(

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -6,6 +6,8 @@ export type {
   AgentReasoningDefinition,
   AgentBuildDefinition,
   AgentExperimentalDefinition,
+  AgentLimitsDefinition,
+  AgentSubagentLimitsDefinition,
   AgentWorkflowDefinition,
   AgentWorkflowWorldDefinition,
   PublicAgentModelDefinition as AgentModelDefinition,

--- a/packages/eve/src/runtime/agent/bootstrap.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.ts
@@ -2,7 +2,10 @@ import { composeRuntimeBasePrompt } from "#runtime/prompt/compose.js";
 import type { PreparedRuntimeTool } from "#runtime/sessions/turn.js";
 import type { ResolvedAgent } from "#runtime/types.js";
 import type { WorkspaceRuntimeSpec } from "#runtime/workspace/types.js";
-import type { InternalAgentModelDefinition } from "#shared/agent-definition.js";
+import type {
+  AgentLimitsDefinition,
+  InternalAgentModelDefinition,
+} from "#shared/agent-definition.js";
 
 /**
  * Fixed internal model reference used only by the framework-owned bootstrap
@@ -21,6 +24,7 @@ export type RuntimeModelReference = Readonly<InternalAgentModelDefinition>;
 export interface RuntimeTurnAgent {
   readonly id: string;
   readonly instructions: readonly string[];
+  readonly limits?: AgentLimitsDefinition;
   /**
    * Optional model used only for compaction summaries.
    *
@@ -60,6 +64,7 @@ export function createResolvedRuntimeTurnAgent(input: {
       toolsAvailable: input.tools.length > 0,
       workspaceSpec: agent.workspaceSpec,
     }),
+    limits: cloneAgentLimits(agent.config.limits),
     compactionModel: agent.config.compaction?.model,
     model: agent.config.model,
     nodeId: input.nodeId,
@@ -67,5 +72,22 @@ export function createResolvedRuntimeTurnAgent(input: {
     reasoning: agent.config.reasoning,
     tools: [...input.tools],
     workspaceSpec: agent.workspaceSpec,
+  };
+}
+
+function cloneAgentLimits(
+  limits: AgentLimitsDefinition | undefined,
+): AgentLimitsDefinition | undefined {
+  if (limits === undefined) {
+    return undefined;
+  }
+
+  return {
+    subagents:
+      limits.subagents === undefined
+        ? undefined
+        : {
+            maxDepth: limits.subagents.maxDepth,
+          },
   };
 }

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -148,6 +148,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
   const config: {
     compaction?: ResolvedAgent["config"]["compaction"];
     experimental?: ResolvedAgent["config"]["experimental"];
+    limits?: ResolvedAgent["config"]["limits"];
     model: ResolvedAgent["config"]["model"];
     name: string;
     outputSchema?: ResolvedAgent["config"]["outputSchema"];
@@ -215,6 +216,17 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
         manifest.config.experimental.workflow === undefined
           ? undefined
           : { world: manifest.config.experimental.workflow.world },
+    };
+  }
+
+  if (manifest.config.limits !== undefined) {
+    config.limits = {
+      subagents:
+        manifest.config.limits.subagents === undefined
+          ? undefined
+          : {
+              maxDepth: manifest.config.limits.subagents.maxDepth,
+            },
     };
   }
 

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -97,6 +97,25 @@ export interface PublicAgentCompactionDefinition {
 }
 
 /**
+ * Limits for agent-to-agent delegation. These apply to the built-in `agent`
+ * tool, authored subagents, remote agents, and subagent calls launched by
+ * Workflow.
+ */
+export interface AgentSubagentLimitsDefinition {
+  /**
+   * Maximum depth for nested subagent calls. Root sessions are depth 0.
+   */
+  readonly maxDepth?: number;
+}
+
+/**
+ * Runtime safety limits authored in `agent.ts`.
+ */
+export interface AgentLimitsDefinition {
+  readonly subagents?: AgentSubagentLimitsDefinition;
+}
+
+/**
  * Experimental, opt-in agent capabilities authored in `agent.ts`.
  *
  * These options are unstable and may change or be removed in any release.
@@ -158,6 +177,7 @@ export type InternalAgentDefinition = {
   build?: AgentBuildDefinition;
   compaction?: InternalAgentCompactionDefinition;
   experimental?: AgentExperimentalDefinition;
+  limits?: AgentLimitsDefinition;
   model: InternalAgentModelDefinition;
   outputSchema?: JsonObject;
   reasoning?: AgentReasoningDefinition;
@@ -190,6 +210,10 @@ export type PublicAgentDefinition = {
    * AI SDK-compatible language model.
    */
   readonly model: PublicAgentModelDefinition;
+  /**
+   * Runtime safety limits. Omit to use eve's default guardrails.
+   */
+  readonly limits?: AgentLimitsDefinition;
   /**
    * Optional override for the primary model's context window size, in tokens.
    *

--- a/packages/eve/test/resolve-agent.test.ts
+++ b/packages/eve/test/resolve-agent.test.ts
@@ -26,6 +26,11 @@ describe("resolveAgent", () => {
       appRoot: "/app",
       channels: [slackChannelDefinition],
       config: {
+        limits: {
+          subagents: {
+            maxDepth: 6,
+          },
+        },
         model: {
           id: "anthropic/claude-sonnet-4.5",
           routing: { kind: "gateway", target: "anthropic" },
@@ -169,6 +174,11 @@ describe("resolveAgent", () => {
     expect(resolved.config.name).toBe("weather-agent");
     expect(resolved.config).toEqual({
       compaction: {},
+      limits: {
+        subagents: {
+          maxDepth: 6,
+        },
+      },
       model: {
         id: "anthropic/claude-sonnet-4.5",
       },

--- a/packages/eve/test/runtime-agent-graph.test.ts
+++ b/packages/eve/test/runtime-agent-graph.test.ts
@@ -37,6 +37,11 @@ describe("resolveRuntimeAgentGraph", () => {
       agentRoot: "/app/agent",
       appRoot: "/app",
       config: {
+        limits: {
+          subagents: {
+            maxDepth: 6,
+          },
+        },
         model: {
           id: TEST_DEFAULT_MODEL_ID,
           routing: { kind: "gateway", target: "openai" },
@@ -109,6 +114,11 @@ describe("resolveRuntimeAgentGraph", () => {
     });
 
     expect(graph.root.sandboxRegistry.sandbox?.definition.backend.name).toBe("vercel");
+    expect(graph.root.turnAgent.limits).toEqual({
+      subagents: {
+        maxDepth: 6,
+      },
+    });
     expect(
       graph.nodesByNodeId.get("subagents/researcher")?.sandboxRegistry.sandbox?.definition.backend
         .name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,31 @@ importers:
         specifier: 'catalog:'
         version: 7.0.1-rc
 
+  e2e/fixtures/agent-subagent-limits:
+    dependencies:
+      '@opentelemetry/core':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@vercel/otel':
+        specifier: 2.1.2
+        version: 2.1.2(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.0(zod@4.4.3)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.1-rc
+
   e2e/fixtures/agent-subagents:
     dependencies:
       '@opentelemetry/core':


### PR DESCRIPTION
## Summary

Depth-only subagent recursion guardrail.

- adds `limits.subagents.maxDepth` with a default of 4
- propagates effective depth limits through child subagent sessions, remote agents, and Workflow-launched subagent calls
- lets children tighten inherited depth but not loosen the parent/root policy
- hides subagent/remote-agent tools from the model once the depth cap is reached
- keeps dispatch-time rejection as a stale-call backstop with a non-retryable depth-limit message
- adds a deterministic e2e fixture proving capped children do not see nested subagent tools

This is the base PR for the stacked fan-out guardrail follow-up.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/subagent-limits.test.ts src/harness/tool-loop.test.ts src/internal/authored-definition/core.test.ts src/compiler/manifest.test.ts src/execution/session.test.ts src/execution/workflow-steps.test.ts test/resolve-agent.test.ts test/runtime-agent-graph.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve run build`
- `pnpm --filter agent-subagent-limits run typecheck`
- `pnpm --filter agent-subagent-limits run test:e2e`
