### PR TITLE
fix(eve): limit subagent fan-out per step

### DIFF
--- a/.changeset/runtime-delegation-limits.md
+++ b/.changeset/runtime-delegation-limits.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a default per-step fan-out limit for subagent calls and an agent config override.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -94,6 +94,23 @@ at depths 1 through 4; a session already at depth 4 cannot delegate again.
 
 At the configured depth, eve stops advertising subagent tools, including declared local subagents, remote-agent tools, the built-in `agent` tool, and the `Workflow` orchestration tool when it would only expose subagents. If a stale or forced subagent call still reaches execution, eve blocks it and returns an error tool result instead of starting another child session.
 
+eve also caps subagent fan-out from a single model step. By default, one step
+may start up to four subagent calls. Increase or lower that limit with
+`limits.maxSubagentCallsPerStep`:
+
+```ts title="agent/agent.ts"
+export default defineAgent({
+  model: "anthropic/claude-sonnet-5",
+  limits: {
+    maxSubagentCallsPerStep: 8,
+  },
+});
+```
+
+If a model requests more subagent calls than the configured step limit, eve
+starts the first allowed calls and returns error tool results for the overflow
+calls so the agent can retry the remaining work in a later step.
+
 `Workflow` is root-only. Delegated subagent sessions can still call their own visible subagent tools until the depth cap, but they do not receive the `Workflow` orchestration wrapper.
 
 A declared subagent's tool name is the bare path-derived name, with no prefix. `agent/subagents/researcher/` registers as the tool `researcher`. Unlike connection tools (`<connection>__<tool>`), it carries no namespace, so the model, approvals, logs, and evals all reference it by that name. Its input schema is:

--- a/e2e/fixtures/agent-subagent-limits/.gitignore
+++ b/e2e/fixtures/agent-subagent-limits/.gitignore
@@ -1,0 +1,4 @@
+.eve
+.output
+.workflow-data
+node_modules

--- a/e2e/fixtures/agent-subagent-limits/.vercelignore
+++ b/e2e/fixtures/agent-subagent-limits/.vercelignore
@@ -1,0 +1,4 @@
+.eve
+.output
+.workflow-data
+node_modules

--- a/e2e/fixtures/agent-subagent-limits/agent/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/agent.ts
@@ -1,0 +1,41 @@
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest } from "eve/evals";
+
+const FANOUT_PROMPT_MARKER = "fanout guardrail e2e";
+const FANOUT_RESULT_MARKER = "SUBAGENT_FANOUT_LIMIT_E2E_OK";
+
+export default defineAgent({
+  limits: {
+    maxSubagentCallsPerStep: 1,
+  },
+  model: mockModel(handleRootRequest),
+  modelContextWindowTokens: 1_000_000,
+});
+
+function handleRootRequest(request: MockModelRequest) {
+  const prompt = request.lastUserMessage ?? "";
+
+  if (prompt.includes(FANOUT_PROMPT_MARKER)) {
+    const results = request.toolResults.filter((entry) => entry.name === "echo-marker");
+    if (results.length > 0) {
+      return `${FANOUT_RESULT_MARKER}: ${JSON.stringify(results.map((entry) => entry.output))}`;
+    }
+
+    return {
+      toolCalls: [
+        {
+          id: "fanout-accepted-call",
+          input: { message: "accepted fanout child" },
+          name: "echo-marker",
+        },
+        {
+          id: "fanout-rejected-call",
+          input: { message: "rejected fanout child" },
+          name: "echo-marker",
+        },
+      ],
+    };
+  }
+
+  return "Unknown subagent fan-out eval prompt.";
+}

--- a/e2e/fixtures/agent-subagent-limits/agent/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e root agent for subagent limit coverage.

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/agent.ts
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/agent.ts
@@ -1,0 +1,11 @@
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export const ECHO_LIMIT_TOKEN = "SUBAGENT_LIMIT_ECHO_CHILD_OK";
+
+export default defineAgent({
+  description:
+    "Deterministic echo subagent for subagent limit e2e coverage. It returns a fixed marker.",
+  model: mockModel(ECHO_LIMIT_TOKEN),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/instructions.md
+++ b/e2e/fixtures/agent-subagent-limits/agent/subagents/echo-marker/instructions.md
@@ -1,0 +1,1 @@
+You are a deterministic e2e subagent that returns a fixed marker.

--- a/e2e/fixtures/agent-subagent-limits/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/evals.config.ts
@@ -1,0 +1,3 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({});

--- a/e2e/fixtures/agent-subagent-limits/evals/fanout-limit.eval.ts
+++ b/e2e/fixtures/agent-subagent-limits/evals/fanout-limit.eval.ts
@@ -1,0 +1,39 @@
+import { defineEval } from "eve/evals";
+
+import { ECHO_LIMIT_TOKEN } from "../agent/subagents/echo-marker/agent.js";
+
+const FANOUT_LIMIT_CODE = "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED";
+const FANOUT_RESULT_MARKER = "SUBAGENT_FANOUT_LIMIT_E2E_OK";
+
+export default defineEval({
+  description:
+    "Subagent limits e2e: per-step fan-out overflow starts the first child and rejects the rest.",
+  tags: ["subagents", "limits", "fanout"],
+
+  async test(t) {
+    await t.send("fanout guardrail e2e: request two echo-marker subagents in one model step.");
+
+    t.succeeded();
+    t.calledSubagent("echo-marker", {
+      output: ECHO_LIMIT_TOKEN,
+      count: 1,
+    });
+    t.event("action.result", {
+      data: {
+        result: {
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: FANOUT_LIMIT_CODE,
+            message: /This step requested 2 subagent calls, but eve allows 1/,
+          },
+          subagentName: "echo-marker",
+        },
+        status: "failed",
+      },
+      count: 1,
+    });
+    t.messageIncludes(FANOUT_RESULT_MARKER);
+    t.messageIncludes(FANOUT_LIMIT_CODE);
+  },
+});

--- a/e2e/fixtures/agent-subagent-limits/package.json
+++ b/e2e/fixtures/agent-subagent-limits/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agent-subagent-limits",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-subagent-limits/tsconfig.json
+++ b/e2e/fixtures/agent-subagent-limits/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts", ".eve/**/*.d.ts"]
+}

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -279,6 +279,11 @@ export interface RunInput {
    */
   readonly subagentDepth?: number;
   /**
+   * Optional maximum delegated subagent calls allowed from one model step.
+   * Inherited by delegated child runs.
+   */
+  readonly subagentMaxCallsPerStep?: number;
+  /**
    * Optional maximum delegated subagent depth inherited by this run. When
    * omitted, the session uses its resolved agent config or eve's default.
    */

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -28,6 +28,7 @@ describe("compiledAgentManifestSchema", () => {
         limits: {
           maxInputTokensPerSession: 200_000,
           maxOutputTokensPerSession: 20_000,
+          maxSubagentCallsPerStep: 6,
           maxSubagentDepth: 4,
         },
         model: { id: "openai/gpt-5.5", routing: classifyModelRouting("openai/gpt-5.5") },
@@ -40,6 +41,7 @@ describe("compiledAgentManifestSchema", () => {
     expect(parsed.config.limits).toEqual({
       maxInputTokensPerSession: 200_000,
       maxOutputTokensPerSession: 20_000,
+      maxSubagentCallsPerStep: 6,
       maxSubagentDepth: 4,
     });
   });

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -359,6 +359,7 @@ const compiledAgentCompactionDefinitionSchema: z.ZodType<CompiledAgentCompaction
 
 const compiledAgentLimitsDefinitionSchema = z
   .object({
+    maxSubagentCallsPerStep: z.number().int().positive().optional(),
     maxSubagentDepth: z.number().int().positive().optional(),
     maxInputTokensPerSession: z.number().int().positive().optional(),
     maxOutputTokensPerSession: z.number().int().positive().optional(),
@@ -730,6 +731,7 @@ export function createCompiledAgentNodeManifest(input: {
         input.config.limits === undefined
           ? undefined
           : {
+              maxSubagentCallsPerStep: input.config.limits.maxSubagentCallsPerStep,
               maxInputTokensPerSession: input.config.limits.maxInputTokensPerSession,
               maxOutputTokensPerSession: input.config.limits.maxOutputTokensPerSession,
               maxSubagentDepth: input.config.limits.maxSubagentDepth,

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -106,6 +106,7 @@ export async function compileAgentConfig(
 
   if (definition.limits !== undefined) {
     compiledConfig.limits = {
+      maxSubagentCallsPerStep: definition.limits.maxSubagentCallsPerStep,
       maxSubagentDepth: definition.limits.maxSubagentDepth,
       maxInputTokensPerSession: definition.limits.maxInputTokensPerSession,
       maxOutputTokensPerSession: definition.limits.maxOutputTokensPerSession,

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -67,6 +67,7 @@ export const ChannelInstrumentationKey = new ContextKey<ChannelInstrumentationPr
 export const ModeKey = new ContextKey<RunMode>("eve.mode");
 export const ParentSessionKey = new ContextKey<SessionParent>("eve.parentSession");
 export const SubagentDepthKey = new ContextKey<number>("eve.subagentDepth");
+export const SubagentMaxCallsPerStepKey = new ContextKey<number>("eve.subagentMaxCallsPerStep");
 export const SubagentMaxDepthKey = new ContextKey<number>("eve.subagentMaxDepth");
 
 /**

--- a/packages/eve/src/execution/create-session-step.test.ts
+++ b/packages/eve/src/execution/create-session-step.test.ts
@@ -104,6 +104,25 @@ describe("createSessionStep", () => {
     expect(state.snapshot?.session.subagentMaxDepth).toBe(4);
   });
 
+  it("seeds subagent max calls per step from resolved agent config", async () => {
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      resolvedAgent: {
+        config: {
+          limits: { maxSubagentCallsPerStep: 6 },
+        },
+      },
+      turnAgent: TestTurnAgent,
+    } as never);
+
+    const { state } = await createSessionStep({
+      compiledArtifactsSource: { kind: "bundled" },
+      continuationToken: "http:test",
+      sessionId: "sess-root",
+    });
+
+    expect(state.snapshot?.session.subagentMaxCallsPerStep).toBe(6);
+  });
+
   it("keeps inherited subagent max depth when one is provided", async () => {
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
       resolvedAgent: {
@@ -122,5 +141,25 @@ describe("createSessionStep", () => {
     });
 
     expect(state.snapshot?.session.subagentMaxDepth).toBe(4);
+  });
+
+  it("keeps inherited subagent max calls per step when one is provided", async () => {
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      resolvedAgent: {
+        config: {
+          limits: { maxSubagentCallsPerStep: 2 },
+        },
+      },
+      turnAgent: TestTurnAgent,
+    } as never);
+
+    const { state } = await createSessionStep({
+      compiledArtifactsSource: { kind: "bundled" },
+      continuationToken: "subagent:test",
+      sessionId: "sess-child",
+      subagentMaxCallsPerStep: 6,
+    });
+
+    expect(state.snapshot?.session.subagentMaxCallsPerStep).toBe(6);
   });
 });

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -31,6 +31,7 @@ export async function createSessionStep(input: {
   readonly rootSessionId?: string;
   readonly sessionId: string;
   readonly subagentDepth?: number;
+  readonly subagentMaxCallsPerStep?: number;
   readonly subagentMaxDepth?: number;
 }): Promise<CreateSessionStepResult> {
   "use step";
@@ -53,6 +54,8 @@ export async function createSessionStep(input: {
     rootSessionId: input.rootSessionId,
     sessionId: input.sessionId,
     subagentDepth: input.subagentDepth,
+    subagentMaxCallsPerStep:
+      input.subagentMaxCallsPerStep ?? bundle.resolvedAgent.config.limits?.maxSubagentCallsPerStep,
     subagentMaxDepth:
       input.subagentMaxDepth ?? bundle.resolvedAgent.config.limits?.maxSubagentDepth,
     turnAgent: bundle.turnAgent,

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -92,12 +92,17 @@ export async function dispatchRuntimeActionsStep(input: {
 
   const adapterCtx = buildAdapterContext(adapter, ctx);
   const delegationLimit = resolveSubagentDelegationLimit(session);
+  const dispatchActions = batch.dispatchActions ?? batch.actions;
 
   let nextSession = session;
-  const results: RuntimeSubagentResultActionResult[] = [];
+  const results: RuntimeSubagentResultActionResult[] = [
+    ...(batch.prefilledResults ?? []).filter(
+      (result): result is RuntimeSubagentResultActionResult => result.kind === "subagent-result",
+    ),
+  ];
 
   try {
-    for (const action of batch.actions) {
+    for (const action of dispatchActions) {
       if (delegationLimit.reached && isSubagentDelegationAction(action)) {
         log.warn("subagent depth limit reached; blocking delegated call", {
           callId: action.callId,

--- a/packages/eve/src/execution/durable-session-store.ts
+++ b/packages/eve/src/execution/durable-session-store.ts
@@ -86,6 +86,7 @@ export interface DurableSession {
   readonly state?: SessionStateMap;
   readonly sandboxState?: SandboxState;
   readonly subagentDepth?: number;
+  readonly subagentMaxCallsPerStep?: number;
   readonly subagentMaxDepth?: number;
   readonly agent: {
     readonly system: string;

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -371,6 +371,17 @@ describe("createExecutionNodeStep", () => {
           subagentName: "child-agent",
         },
       ],
+      dispatchActions: [
+        {
+          callId: "call-subagent-1",
+          description: "Delegate work to the child agent.",
+          input: { task: "Delegate this." },
+          kind: "subagent-call",
+          name: "child-agent",
+          nodeId: "child-node",
+          subagentName: "child-agent",
+        },
+      ],
       event: {
         sequence: 0,
         stepIndex: 0,

--- a/packages/eve/src/execution/runtime-context.test.ts
+++ b/packages/eve/src/execution/runtime-context.test.ts
@@ -7,6 +7,7 @@ import {
   type SessionAuthContext,
   SessionIdKey,
   SessionKey,
+  SubagentMaxCallsPerStepKey,
   SubagentMaxDepthKey,
 } from "#context/keys.js";
 import { buildRunContext } from "#execution/runtime-context.js";
@@ -262,5 +263,21 @@ describe("buildRunContext", () => {
     });
 
     expect(ctx.require(SubagentMaxDepthKey)).toBe(4);
+  });
+
+  it("seeds inherited subagent max calls per step from the run input", () => {
+    const ctx = buildRunContext({
+      bundle: createMinimalBundle(),
+      run: {
+        auth: null,
+        adapter: { kind: "subagent" },
+        continuationToken: "t",
+        input: { message: "hi" },
+        mode: "task",
+        subagentMaxCallsPerStep: 6,
+      },
+    });
+
+    expect(ctx.require(SubagentMaxCallsPerStepKey)).toBe(6);
   });
 });

--- a/packages/eve/src/execution/runtime-context.ts
+++ b/packages/eve/src/execution/runtime-context.ts
@@ -12,6 +12,7 @@ import {
   ParentSessionKey,
   SessionCallbackKey,
   SubagentDepthKey,
+  SubagentMaxCallsPerStepKey,
   SubagentMaxDepthKey,
 } from "#context/keys.js";
 import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
@@ -61,6 +62,10 @@ export function buildRunContext(input: {
 
   if (run.subagentDepth !== undefined) {
     ctx.set(SubagentDepthKey, run.subagentDepth);
+  }
+
+  if (run.subagentMaxCallsPerStep !== undefined) {
+    ctx.set(SubagentMaxCallsPerStepKey, run.subagentMaxCallsPerStep);
   }
 
   if (run.subagentMaxDepth !== undefined) {

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -274,6 +274,7 @@ describe("createSession", () => {
       continuationToken: "root-token",
       sessionId: "sess-root",
       subagentDepth: 2,
+      subagentMaxCallsPerStep: 6,
       subagentMaxDepth: 4,
       turnAgent: createTestTurnAgent(),
     });
@@ -285,8 +286,10 @@ describe("createSession", () => {
     });
 
     expect(durable.subagentDepth).toBe(2);
+    expect(durable.subagentMaxCallsPerStep).toBe(6);
     expect(durable.subagentMaxDepth).toBe(4);
     expect(hydrated.subagentDepth).toBe(2);
+    expect(hydrated.subagentMaxCallsPerStep).toBe(6);
     expect(hydrated.subagentMaxDepth).toBe(4);
   });
 

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -57,6 +57,7 @@ export interface CreateSessionInput {
   readonly limits?: SessionLimits;
   readonly outputSchema?: HarnessSession["outputSchema"];
   readonly subagentDepth?: number;
+  readonly subagentMaxCallsPerStep?: number;
   readonly subagentMaxDepth?: number;
 }
 
@@ -93,6 +94,9 @@ export function createSession(input: CreateSessionInput): HarnessSession {
   }
   if (input.subagentDepth !== undefined) {
     session.subagentDepth = input.subagentDepth;
+  }
+  if (input.subagentMaxCallsPerStep !== undefined) {
+    session.subagentMaxCallsPerStep = input.subagentMaxCallsPerStep;
   }
   if (input.subagentMaxDepth !== undefined) {
     session.subagentMaxDepth = input.subagentMaxDepth;
@@ -163,6 +167,7 @@ export function projectToDurableSession(session: HarnessSession): DurableSession
     sessionId: string;
     state?: HarnessSession["state"];
     subagentDepth?: number;
+    subagentMaxCallsPerStep?: number;
     subagentMaxDepth?: number;
   } = {
     agent: { system: session.agent.system },
@@ -197,6 +202,9 @@ export function projectToDurableSession(session: HarnessSession): DurableSession
   }
   if (session.subagentDepth !== undefined) {
     durable.subagentDepth = session.subagentDepth;
+  }
+  if (session.subagentMaxCallsPerStep !== undefined) {
+    durable.subagentMaxCallsPerStep = session.subagentMaxCallsPerStep;
   }
   if (session.subagentMaxDepth !== undefined) {
     durable.subagentMaxDepth = session.subagentMaxDepth;
@@ -255,6 +263,9 @@ export function hydrateDurableSession(input: {
   }
   if (durable.subagentDepth !== undefined) {
     session.subagentDepth = durable.subagentDepth;
+  }
+  if (durable.subagentMaxCallsPerStep !== undefined) {
+    session.subagentMaxCallsPerStep = durable.subagentMaxCallsPerStep;
   }
   if (durable.subagentMaxDepth !== undefined) {
     session.subagentMaxDepth = durable.subagentMaxDepth;

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -162,6 +162,7 @@ describe("buildSubagentRunInput", () => {
       ...makeSession(),
       sessionId: "intermediate-session",
       subagentDepth: 2,
+      subagentMaxCallsPerStep: 6,
       subagentMaxDepth: 4,
     };
     const { runInput } = buildRuntimeSubagentRunInput({
@@ -173,6 +174,7 @@ describe("buildSubagentRunInput", () => {
     });
 
     expect(runInput.subagentDepth).toBe(3);
+    expect(runInput.subagentMaxCallsPerStep).toBe(6);
     expect(runInput.subagentMaxDepth).toBe(4);
   });
 

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -119,6 +119,7 @@ export function buildSubagentRunInput(input: {
       },
     },
     subagentDepth: delegationLimit.nextChildDepth,
+    subagentMaxCallsPerStep: session.subagentMaxCallsPerStep,
     subagentMaxDepth: session.subagentMaxDepth,
   };
 

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -3,7 +3,12 @@ import { createHook } from "#compiled/@workflow/core/index.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 
 import type { HookPayload } from "#channel/types.js";
-import { ChannelRequestIdKey, SubagentDepthKey, SubagentMaxDepthKey } from "#context/keys.js";
+import {
+  ChannelRequestIdKey,
+  SubagentDepthKey,
+  SubagentMaxCallsPerStepKey,
+  SubagentMaxDepthKey,
+} from "#context/keys.js";
 import { createSessionStep } from "#execution/create-session-step.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
@@ -240,6 +245,7 @@ describe("workflowEntry", () => {
       input: { message: "hello there" },
       serializedContext: createSerializedContext({
         [SubagentDepthKey.name]: 3,
+        [SubagentMaxCallsPerStepKey.name]: 6,
         [SubagentMaxDepthKey.name]: 4,
       }),
     });
@@ -247,6 +253,7 @@ describe("workflowEntry", () => {
     expect(createSessionStep).toHaveBeenCalledWith(
       expect.objectContaining({
         subagentDepth: 3,
+        subagentMaxCallsPerStep: 6,
         subagentMaxDepth: 4,
       }),
     );

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -30,6 +30,7 @@ import {
   type SessionDeliveryHook,
 } from "#execution/session-delivery-hook.js";
 import { readSerializedSubagentSessionDepth } from "#harness/subagent-depth.js";
+import { readSerializedSubagentMaxCallsPerStep } from "#harness/subagent-fanout.js";
 
 // workflow-entry.ts is the durable workflow body — the bundler rejects
 // node built-ins here, so `internal/logging.ts` cannot be imported.
@@ -90,6 +91,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
     const { subagentDepth, subagentMaxDepth } = readSerializedSubagentSessionDepth(
       input.serializedContext,
     );
+    const subagentMaxCallsPerStep = readSerializedSubagentMaxCallsPerStep(input.serializedContext);
 
     const { state: sessionState } = await createSessionStep({
       compiledArtifactsSource: serializedBundle.source,
@@ -99,6 +101,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       rootSessionId: rootSessionIdFromParent,
       sessionId,
       subagentDepth,
+      subagentMaxCallsPerStep,
       subagentMaxDepth,
     });
 

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -410,6 +410,97 @@ describe("dispatchRuntimeActionsStep", () => {
     );
   });
 
+  it("starts only dispatch actions and returns prefilled subagent results", async () => {
+    const compiledArtifactsSource = {} as never;
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {
+        subagentsByNodeId: new Map(),
+      },
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    startMock.mockResolvedValue({ runId: "child-run" });
+    getRunMock.mockReturnValue({
+      getReadable: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+    });
+
+    const acceptedAction = {
+      callId: "call-1",
+      description: "Launch another copy.",
+      input: { message: "accepted" },
+      kind: "subagent-call" as const,
+      name: "agent",
+      nodeId: "__root__",
+      subagentName: "agent",
+    };
+    const rejectedResult = {
+      callId: "call-2",
+      isError: true,
+      kind: "subagent-result" as const,
+      output: {
+        code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+        message:
+          "This step requested 2 subagent calls, but eve allows 1. The first 1 were started. Retry the remaining work in a later step with at most 1 subagent calls.",
+      },
+      subagentName: "agent",
+    };
+    const session = setPendingRuntimeActionBatch({
+      actions: [
+        acceptedAction,
+        {
+          callId: "call-2",
+          description: "Launch another copy.",
+          input: { message: "rejected" },
+          kind: "subagent-call" as const,
+          name: "agent",
+          nodeId: "__root__",
+          subagentName: "agent",
+        },
+      ],
+      dispatchActions: [acceptedAction],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      prefilledResults: [rejectedResult],
+      responseMessages: [],
+      session: createStubSession({
+        continuationToken: "http:parent",
+        sessionId: "parent-session",
+      }),
+    });
+    installSessionStoreMocks([session]);
+
+    const result = await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
+      sessionState: createStubSessionState({
+        continuationToken: "http:parent",
+        sessionId: "parent-session",
+      }),
+    });
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(result.results).toEqual([rejectedResult]);
+  });
+
   it("returns a failed subagent result when remote session creation fails", async () => {
     const remote = {
       definition: {

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -40,9 +40,15 @@ interface PendingRuntimeActionEventMetadata {
 interface PendingRuntimeActionBatch {
   readonly actions: readonly RuntimeActionRequest[];
   readonly childContinuationTokens?: Readonly<Record<string, string>>;
+  readonly dispatchActions?: readonly RuntimeActionRequest[];
   readonly event: PendingRuntimeActionEventMetadata;
+  readonly prefilledResults?: readonly RuntimeActionResult[];
   readonly responseMessages: readonly ModelMessage[];
 }
+
+type MutablePendingRuntimeActionBatch = {
+  -readonly [Key in keyof PendingRuntimeActionBatch]: PendingRuntimeActionBatch[Key];
+};
 
 /**
  * Outcome of resolving a pending runtime-action batch.
@@ -67,6 +73,8 @@ export function getPendingRuntimeActionBatch(
 
   if (
     !Array.isArray(batch.actions) ||
+    (batch.dispatchActions !== undefined && !Array.isArray(batch.dispatchActions)) ||
+    (batch.prefilledResults !== undefined && !Array.isArray(batch.prefilledResults)) ||
     !Array.isArray(batch.responseMessages) ||
     typeof batch.event !== "object" ||
     batch.event === null
@@ -98,16 +106,28 @@ export function clearPendingRuntimeActionBatch(session: HarnessSession): Harness
  */
 export function setPendingRuntimeActionBatch(input: {
   readonly actions: readonly RuntimeActionRequest[];
+  readonly dispatchActions?: readonly RuntimeActionRequest[];
   readonly event: PendingRuntimeActionEventMetadata;
+  readonly prefilledResults?: readonly RuntimeActionResult[];
   readonly responseMessages: readonly ModelMessage[];
   readonly session: HarnessSession;
 }): HarnessSession {
   const state = { ...input.session.state };
-  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = {
+  const batch: MutablePendingRuntimeActionBatch = {
     actions: [...input.actions],
     event: input.event,
     responseMessages: [...input.responseMessages],
   } satisfies PendingRuntimeActionBatch;
+
+  if (input.dispatchActions !== undefined) {
+    batch.dispatchActions = [...input.dispatchActions];
+  }
+
+  if (input.prefilledResults !== undefined && input.prefilledResults.length > 0) {
+    batch.prefilledResults = [...input.prefilledResults];
+  }
+
+  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = batch satisfies PendingRuntimeActionBatch;
 
   return { ...input.session, state };
 }

--- a/packages/eve/src/harness/subagent-fanout.test.ts
+++ b/packages/eve/src/harness/subagent-fanout.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applySubagentFanoutLimit,
+  DEFAULT_SUBAGENT_MAX_CALLS_PER_STEP,
+  resolveSubagentMaxCallsPerStep,
+} from "#harness/subagent-fanout.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
+
+function createSession(overrides: Partial<HarnessSession> = {}): HarnessSession {
+  return {
+    agent: {
+      modelReference: { id: "test-model" },
+      system: "",
+      tools: [],
+    },
+    compaction: { recentWindowSize: 4, threshold: 1_000_000 },
+    continuationToken: "test-token",
+    history: [],
+    sessionId: "test-session",
+    ...overrides,
+  };
+}
+
+function createSubagentAction(index: number): RuntimeSubagentCallActionRequest {
+  return {
+    callId: `call-${index}`,
+    description: "Launch another copy.",
+    input: { message: `work item ${index}` },
+    kind: "subagent-call",
+    name: "agent",
+    nodeId: "__root__",
+    subagentName: "agent",
+  };
+}
+
+describe("resolveSubagentMaxCallsPerStep", () => {
+  it("uses eve's default when the session has no override", () => {
+    expect(resolveSubagentMaxCallsPerStep(createSession())).toBe(
+      DEFAULT_SUBAGENT_MAX_CALLS_PER_STEP,
+    );
+  });
+
+  it("uses a positive session override", () => {
+    expect(resolveSubagentMaxCallsPerStep(createSession({ subagentMaxCallsPerStep: 8 }))).toBe(8);
+  });
+});
+
+describe("applySubagentFanoutLimit", () => {
+  it("uses configured per-step fan-out limits from the session", () => {
+    const result = applySubagentFanoutLimit({
+      actions: [createSubagentAction(1), createSubagentAction(2), createSubagentAction(3)],
+      session: createSession({ subagentMaxCallsPerStep: 2 }),
+    });
+
+    expect(result.actions.map((action) => action.callId)).toEqual(["call-1", "call-2"]);
+    expect(result.rejectedResults).toEqual([
+      {
+        callId: "call-3",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+          message:
+            "This step requested 3 subagent calls, but eve allows 2. The first 2 were started. Retry the remaining work in a later step with at most 2 subagent calls.",
+        },
+        subagentName: "agent",
+      },
+    ]);
+  });
+
+  it("shares the per-step fan-out limit across split runtime action batches", () => {
+    const session = createSession({ subagentMaxCallsPerStep: 1 });
+
+    const first = applySubagentFanoutLimit({
+      actions: [createSubagentAction(1)],
+      session,
+      step: { stepIndex: 0, turnId: "turn_0" },
+    });
+
+    const second = applySubagentFanoutLimit({
+      actions: [createSubagentAction(2)],
+      session: first.session,
+      step: { stepIndex: 0, turnId: "turn_0" },
+    });
+
+    const nextStep = applySubagentFanoutLimit({
+      actions: [createSubagentAction(3)],
+      session: second.session,
+      step: { stepIndex: 1, turnId: "turn_0" },
+    });
+
+    expect(first.actions.map((action) => action.callId)).toEqual(["call-1"]);
+    expect(first.rejectedResults).toEqual([]);
+    expect(second.actions).toEqual([]);
+    expect(second.rejectedResults).toEqual([
+      {
+        callId: "call-2",
+        isError: true,
+        kind: "subagent-result",
+        output: {
+          code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+          message:
+            "This step requested 2 subagent calls, but eve allows 1. The first 1 were started. Retry the remaining work in a later step with at most 1 subagent calls.",
+        },
+        subagentName: "agent",
+      },
+    ]);
+    expect(nextStep.actions.map((action) => action.callId)).toEqual(["call-3"]);
+    expect(nextStep.rejectedResults).toEqual([]);
+  });
+});

--- a/packages/eve/src/harness/subagent-fanout.ts
+++ b/packages/eve/src/harness/subagent-fanout.ts
@@ -1,0 +1,158 @@
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+import { SubagentMaxCallsPerStepKey } from "#context/keys.js";
+import {
+  getSubagentDelegationName,
+  isSubagentDelegationAction,
+  type DelegatedRuntimeActionRequest,
+} from "#harness/subagent-depth.js";
+import type {
+  RuntimeActionRequest,
+  RuntimeSubagentResultActionResult,
+} from "#runtime/actions/types.js";
+
+export const DEFAULT_SUBAGENT_MAX_CALLS_PER_STEP = 4;
+
+const SUBAGENT_STEP_CALLS_STATE_KEY = "eve.runtime.subagentStepCalls";
+
+interface SubagentStepCallState {
+  readonly acceptedCalls: number;
+  readonly requestedCalls: number;
+  readonly stepIndex: number;
+  readonly turnId: string;
+}
+
+interface SubagentFanoutRejection {
+  readonly action: DelegatedRuntimeActionRequest;
+  readonly message: string;
+}
+
+export interface ApplySubagentFanoutLimitResult {
+  readonly actions: readonly RuntimeActionRequest[];
+  readonly rejectedResults: readonly RuntimeSubagentResultActionResult[];
+  readonly session: HarnessSession;
+}
+
+export function resolveSubagentMaxCallsPerStep(
+  session: Pick<HarnessSession, "subagentMaxCallsPerStep">,
+): number {
+  return (
+    parsePositiveInteger(session.subagentMaxCallsPerStep) ?? DEFAULT_SUBAGENT_MAX_CALLS_PER_STEP
+  );
+}
+
+export function readSerializedSubagentMaxCallsPerStep(
+  serializedContext: Readonly<Record<string, unknown>>,
+): number | undefined {
+  return parsePositiveInteger(serializedContext[SubagentMaxCallsPerStepKey.name]);
+}
+
+export function applySubagentFanoutLimit(input: {
+  readonly actions: readonly RuntimeActionRequest[];
+  readonly session: HarnessSession;
+  readonly step?: {
+    readonly stepIndex: number;
+    readonly turnId: string;
+  };
+}): ApplySubagentFanoutLimitResult {
+  const maxCallsPerStep = resolveSubagentMaxCallsPerStep(input.session);
+  const requestedDelegationCalls = input.actions.filter(isSubagentDelegationAction).length;
+  const priorStepCalls = resolveStepCallState({
+    session: input.session,
+    step: input.step,
+  });
+  const actions: RuntimeActionRequest[] = [];
+  const rejections: SubagentFanoutRejection[] = [];
+  let acceptedDelegationCalls = priorStepCalls?.acceptedCalls ?? 0;
+  const totalRequestedDelegationCalls =
+    (priorStepCalls?.requestedCalls ?? 0) + requestedDelegationCalls;
+
+  for (const action of input.actions) {
+    if (!isSubagentDelegationAction(action)) {
+      actions.push(action);
+      continue;
+    }
+
+    if (acceptedDelegationCalls >= maxCallsPerStep) {
+      rejections.push({
+        action,
+        message: `This step requested ${totalRequestedDelegationCalls} subagent calls, but eve allows ${maxCallsPerStep}. The first ${maxCallsPerStep} were started. Retry the remaining work in a later step with at most ${maxCallsPerStep} subagent calls.`,
+      });
+      continue;
+    }
+
+    acceptedDelegationCalls++;
+    actions.push(action);
+  }
+
+  return {
+    actions,
+    rejectedResults: rejections.map(createSubagentFanoutLimitResult),
+    session: setStepCallState({
+      acceptedCalls: acceptedDelegationCalls,
+      requestedCalls: totalRequestedDelegationCalls,
+      session: input.session,
+      step: input.step,
+    }),
+  };
+}
+
+function createSubagentFanoutLimitResult(
+  rejection: SubagentFanoutRejection,
+): RuntimeSubagentResultActionResult {
+  return {
+    callId: rejection.action.callId,
+    isError: true,
+    kind: "subagent-result",
+    output: {
+      code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+      message: rejection.message,
+    },
+    subagentName: getSubagentDelegationName(rejection.action),
+  };
+}
+
+function resolveStepCallState(input: {
+  readonly session: HarnessSession;
+  readonly step: { readonly stepIndex: number; readonly turnId: string } | undefined;
+}): SubagentStepCallState | undefined {
+  if (input.step === undefined) return undefined;
+  const value = input.session.state?.[SUBAGENT_STEP_CALLS_STATE_KEY];
+  if (typeof value !== "object" || value === null) return undefined;
+  const stepCalls = value as SubagentStepCallState;
+  if (stepCalls.turnId !== input.step.turnId || stepCalls.stepIndex !== input.step.stepIndex) {
+    return undefined;
+  }
+  if (
+    !Number.isInteger(stepCalls.acceptedCalls) ||
+    stepCalls.acceptedCalls < 0 ||
+    !Number.isInteger(stepCalls.requestedCalls) ||
+    stepCalls.requestedCalls < 0
+  ) {
+    return undefined;
+  }
+  return stepCalls;
+}
+
+function setStepCallState(input: {
+  readonly acceptedCalls: number;
+  readonly requestedCalls: number;
+  readonly session: HarnessSession;
+  readonly step: { readonly stepIndex: number; readonly turnId: string } | undefined;
+}): HarnessSession {
+  if (input.step === undefined || input.requestedCalls === 0) return input.session;
+
+  const state: SessionStateMap = {
+    ...input.session.state,
+    [SUBAGENT_STEP_CALLS_STATE_KEY]: {
+      acceptedCalls: input.acceptedCalls,
+      requestedCalls: input.requestedCalls,
+      stepIndex: input.step.stepIndex,
+      turnId: input.step.turnId,
+    } satisfies SubagentStepCallState,
+  };
+  return { ...input.session, state };
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -713,6 +713,91 @@ describe("createToolLoopHarness", () => {
     ]);
   });
 
+  it("publishes only accepted subagent calls when the step fan-out limit is exceeded", async () => {
+    setupMockAgent({
+      finishReason: "tool-calls",
+      response: {
+        messages: [
+          {
+            content: [
+              {
+                input: { message: "first" },
+                toolCallId: "call-1",
+                toolName: "delegate",
+                type: "tool-call",
+              },
+              {
+                input: { message: "second" },
+                toolCallId: "call-2",
+                toolName: "delegate",
+                type: "tool-call",
+              },
+            ],
+            role: "assistant",
+          },
+        ],
+      },
+      text: "",
+      toolCalls: [
+        {
+          input: { message: "first" },
+          toolCallId: "call-1",
+          toolName: "delegate",
+          type: "tool-call",
+        },
+        {
+          input: { message: "second" },
+          toolCallId: "call-2",
+          toolName: "delegate",
+          type: "tool-call",
+        },
+      ],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, { tools: createDelegationToolMap() }),
+    );
+
+    const result = await runStep(createTestSession({ subagentMaxCallsPerStep: 1 }), {
+      message: "Hi",
+    });
+
+    expect(events.find((event) => event.type === "actions.requested")?.data.actions).toEqual([
+      {
+        callId: "call-1",
+        description: "Delegate to a subagent.",
+        input: { message: "first" },
+        kind: "subagent-call",
+        name: "delegate",
+        nodeId: "workers",
+        subagentName: "worker",
+      },
+    ]);
+    expect(getPendingRuntimeActionBatch(result.session.state)).toMatchObject({
+      dispatchActions: [
+        {
+          callId: "call-1",
+          kind: "subagent-call",
+        },
+      ],
+      prefilledResults: [
+        {
+          callId: "call-2",
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: "EVE_SUBAGENT_STEP_LIMIT_EXCEEDED",
+            message:
+              "This step requested 2 subagent calls, but eve allows 1. The first 1 were started. Retry the remaining work in a later step with at most 1 subagent calls.",
+          },
+          subagentName: "worker",
+        },
+      ],
+    });
+  });
+
   it("does not publish subagent calls from the current run at the depth limit", async () => {
     setupMockAgent({
       finishReason: "tool-calls",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -33,6 +33,7 @@ import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js
 import { toErrorMessage } from "#shared/errors.js";
 import {
   createActionResultEvent,
+  createActionsRequestedEvent,
   createCompactionCompletedEvent,
   createCompactionRequestedEvent,
   createInputRequestedEvent,
@@ -129,6 +130,7 @@ import {
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
 import { ensureOtelIntegration } from "#harness/otel-integration.js";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
+import { applySubagentFanoutLimit } from "#harness/subagent-fanout.js";
 import {
   applyLastToolCacheBreakpoint,
   applySystemCacheBreakpoint,
@@ -736,16 +738,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       const executeModelCall = async (): Promise<HarnessStepResult> => {
         if (emit) {
-          const hiddenRuntimeActionToolNames = [...config.tools]
-            .filter(
-              ([name, tool]) =>
-                tool.runtimeAction !== undefined && advertisedHarnessTools.get(name) === undefined,
-            )
-            .map(([name]) => name);
           const excludedActionToolNames = new Set([
             ASK_QUESTION_TOOL_NAME,
             FINAL_OUTPUT_TOOL_NAME,
-            ...hiddenRuntimeActionToolNames,
+            ...getRuntimeActionToolNames(config.tools),
           ]);
           const streamResult = await agent.stream({ messages: callMessages });
           const {
@@ -1434,6 +1430,18 @@ function buildEmptyResponseNudge(emptyDeliveryEnabled: boolean): string {
   return `${EMPTY_RESPONSE_NUDGE} If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
 }
 
+function getRuntimeActionToolNames(tools: HarnessToolMap): readonly string[] {
+  const names: string[] = [];
+
+  for (const [name, definition] of tools) {
+    if (definition.runtimeAction !== undefined) {
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
 /**
  * Recovers a model call that completed without content (see
  * {@link EmptyModelResponseError}) by reissuing the same call once, with
@@ -1583,6 +1591,27 @@ async function handleStepResult(input: {
     );
 
   if (pendingRuntimeActions.length > 0) {
+    const pendingSession: HarnessSession = { ...baseSession, history: [...promptMessages] };
+    const limitedRuntimeActions = applySubagentFanoutLimit({
+      actions: pendingRuntimeActions,
+      session: pendingSession,
+      step: {
+        stepIndex: emissionState.stepIndex,
+        turnId: emissionState.turnId,
+      },
+    });
+
+    if (emit !== undefined && limitedRuntimeActions.actions.length > 0) {
+      await emit(
+        createActionsRequestedEvent({
+          actions: limitedRuntimeActions.actions,
+          sequence: emissionState.sequence,
+          stepIndex: emissionState.stepIndex,
+          turnId: emissionState.turnId,
+        }),
+      );
+    }
+
     // Stamp the live emission state onto the parked session so the
     // resume turn is classified as a continuation (turnId set), not a
     // fresh turn. Every other park path does this; without it the
@@ -1594,13 +1623,15 @@ async function handleStepResult(input: {
       session: setHarnessEmissionState(
         setPendingRuntimeActionBatch({
           actions: pendingRuntimeActions,
+          dispatchActions: limitedRuntimeActions.actions,
           event: {
             sequence: emissionState.sequence,
             stepIndex: emissionState.stepIndex,
             turnId: emissionState.turnId,
           },
+          prefilledResults: limitedRuntimeActions.rejectedResults,
           responseMessages,
-          session: { ...baseSession, history: [...promptMessages] },
+          session: limitedRuntimeActions.session,
         }),
         emissionState,
       ),

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -81,6 +81,11 @@ export interface HarnessSession {
    */
   readonly subagentDepth?: number;
   /**
+   * Maximum delegated subagent calls allowed from one model step. When omitted,
+   * the harness uses the framework default.
+   */
+  readonly subagentMaxCallsPerStep?: number;
+  /**
    * Maximum delegated child-session depth for this session. When omitted, the
    * harness uses the framework default.
    */

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -39,6 +39,7 @@ describe("normalizeAgentDefinition", () => {
         limits: {
           maxInputTokensPerSession: 200_000,
           maxOutputTokensPerSession: 20_000,
+          maxSubagentCallsPerStep: 6,
           maxSubagentDepth: 4,
         },
       },
@@ -48,9 +49,25 @@ describe("normalizeAgentDefinition", () => {
     expect(definition.limits).toEqual({
       maxInputTokensPerSession: 200_000,
       maxOutputTokensPerSession: 20_000,
+      maxSubagentCallsPerStep: 6,
       maxSubagentDepth: 4,
     });
   });
+
+  it.each([0, 1.5, -1, "4"])(
+    "rejects invalid subagent max calls per step %j",
+    (maxSubagentCallsPerStep) => {
+      expect(() =>
+        normalizeAgentDefinition(
+          {
+            model: "openai/gpt-5.5",
+            limits: { maxSubagentCallsPerStep },
+          },
+          FAILURE_MESSAGE,
+        ),
+      ).toThrow(FAILURE_MESSAGE);
+    },
+  );
 
   it.each([0, 1.5, -1, "4"])("rejects invalid subagent max depth %j", (maxSubagentDepth) => {
     expect(() =>

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -135,11 +135,22 @@ function normalizeAgentLimitsDefinition(
   const record = expectObjectRecord(value, message);
   expectOnlyKnownKeys(
     record,
-    ["maxInputTokensPerSession", "maxOutputTokensPerSession", "maxSubagentDepth"],
+    [
+      "maxInputTokensPerSession",
+      "maxOutputTokensPerSession",
+      "maxSubagentCallsPerStep",
+      "maxSubagentDepth",
+    ],
     message,
   );
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["limits"]>> = {};
 
+  if (record.maxSubagentCallsPerStep !== undefined) {
+    normalizedDefinition.maxSubagentCallsPerStep = expectPositiveInteger(
+      record.maxSubagentCallsPerStep,
+      message,
+    );
+  }
   if (record.maxInputTokensPerSession !== undefined) {
     normalizedDefinition.maxInputTokensPerSession = expectPositiveInteger(
       record.maxInputTokensPerSession,

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -19,6 +19,7 @@ describe("definition helper exact inputs", () => {
       limits: {
         maxInputTokensPerSession: 200_000,
         maxOutputTokensPerSession: 20_000,
+        maxSubagentCallsPerStep: 6,
         maxSubagentDepth: 4,
       },
       model: "anthropic/claude-sonnet-5",
@@ -32,6 +33,7 @@ describe("definition helper exact inputs", () => {
     expect(agent.description).toBe("type-test");
     expect(agent.limits.maxInputTokensPerSession).toBe(200_000);
     expect(agent.limits.maxOutputTokensPerSession).toBe(20_000);
+    expect(agent.limits.maxSubagentCallsPerStep).toBe(6);
     expect(agent.limits.maxSubagentDepth).toBe(4);
     expect(schedule.cron).toBe("0 9 * * *");
   });

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -233,6 +233,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
 
   if (manifest.config.limits !== undefined) {
     config.limits = {
+      maxSubagentCallsPerStep: manifest.config.limits.maxSubagentCallsPerStep,
       maxSubagentDepth: manifest.config.limits.maxSubagentDepth,
       maxInputTokensPerSession: manifest.config.limits.maxInputTokensPerSession,
       maxOutputTokensPerSession: manifest.config.limits.maxOutputTokensPerSession,

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -101,6 +101,15 @@ export interface PublicAgentCompactionDefinition {
  */
 export interface AgentLimitsDefinition {
   /**
+   * Maximum number of subagent calls one model step may dispatch.
+   *
+   * Applies to the built-in `agent` tool, authored subagents, remote agents,
+   * and subagent calls launched by Workflow.
+   *
+   * @default 4
+   */
+  readonly maxSubagentCallsPerStep?: number;
+  /**
    * Maximum number of delegated child-session levels from the root session.
    *
    * Root sessions are depth 0. A `maxSubagentDepth` of 3 allows child sessions at

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,6 +644,19 @@ importers:
         specifier: 'catalog:'
         version: 7.0.1-rc
 
+  e2e/fixtures/agent-subagent-limits:
+    dependencies:
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.1-rc
+
   e2e/fixtures/agent-subagents:
     dependencies:
       '@opentelemetry/core':


### PR DESCRIPTION
## Summary

Stacked on the subagent depth guardrail PR. Adds the width/fan-out limit separately from recursion depth.

- adds `limits.subagents.maxCallsPerStep` with a default of 4
- starts only the allowed subagent calls from a single model step
- returns `EVE_SUBAGENT_STEP_LIMIT_EXCEEDED` subagent results for overflow calls instead of dispatching them
- tracks accepted/requested calls across split runtime-action batches for the same model step
- extends the deterministic e2e fixture with a fan-out overflow eval

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/subagent-limits.test.ts src/harness/tool-loop.test.ts src/internal/authored-definition/core.test.ts src/compiler/manifest.test.ts src/execution/session.test.ts src/execution/workflow-steps.test.ts test/resolve-agent.test.ts test/runtime-agent-graph.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve run build`
- `pnpm --filter agent-subagent-limits run typecheck`
- `pnpm --filter agent-subagent-limits run test:e2e`
