### PR TITLE
fix(eve): keep Workflow root-only

### DIFF
--- a/.changeset/limit-workflow-runtime-subagents.md
+++ b/.changeset/limit-workflow-runtime-subagents.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep the `Workflow` orchestration tool root-only. Delegated subagent sessions can still call visible subagent tools directly until the configured depth cap, but eve no longer advertises `Workflow` from those child sessions.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -94,6 +94,8 @@ at depths 1 through 4; a session already at depth 4 cannot delegate again.
 
 At the configured depth, eve stops advertising subagent tools, including declared local subagents, remote-agent tools, the built-in `agent` tool, and the `Workflow` orchestration tool when it would only expose subagents. If a stale or forced subagent call still reaches execution, eve blocks it and returns an error tool result instead of starting another child session.
 
+`Workflow` is root-only. Delegated subagent sessions can still call their own visible subagent tools until the depth cap, but they do not receive the `Workflow` orchestration wrapper.
+
 A declared subagent's tool name is the bare path-derived name, with no prefix. `agent/subagents/researcher/` registers as the tool `researcher`. Unlike connection tools (`<connection>__<tool>`), it carries no namespace, so the model, approvals, logs, and evals all reference it by that name. Its input schema is:
 
 ```ts

--- a/e2e/fixtures/agent-subagents/evals/runtime-subagent-workflow.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/runtime-subagent-workflow.eval.ts
@@ -1,0 +1,29 @@
+import { defineEval } from "eve/evals";
+
+const CHILD_TOKEN = "CHILD_WORKFLOW_TOOL_NOT_AVAILABLE";
+
+/**
+ * Runtime subagent Workflow visibility: the root delegates to the built-in
+ * `agent` child, which should not receive the root-only `Workflow` wrapper.
+ */
+export default defineEval({
+  description: "Runtime subagent sessions do not receive the root-only Workflow tool.",
+  async test(t) {
+    await t.send(
+      [
+        "Use the built-in agent subagent exactly once.",
+        "Give the child this task:",
+        "If a Workflow tool is visible, use Workflow exactly once to call echo-marker with message 'subagent workflow probe', then return WORKFLOW_WAS_VISIBLE.",
+        `If no Workflow tool is visible, do not call echo-marker or any other subagent. Return exactly ${CHILD_TOKEN}.`,
+        `After the child returns, reply with its exact output and no other token.`,
+      ].join(" "),
+    );
+
+    t.succeeded();
+    t.calledSubagent("agent", { count: 1 });
+    t.notCalledTool("Workflow");
+    t.notEvent("subagent.called", { data: { name: "echo-marker" } });
+    t.messageIncludes(CHILD_TOKEN);
+    t.noFailedActions();
+  },
+});

--- a/packages/eve/src/evals/assertions/run.test.ts
+++ b/packages/eve/src/evals/assertions/run.test.ts
@@ -76,6 +76,33 @@ function actionResult(callId: string, toolName: string): HandleMessageStreamEven
   };
 }
 
+function failedSubagentResult(input: {
+  callId: string;
+  output: unknown;
+  subagentName: string;
+}): HandleMessageStreamEvent {
+  return {
+    type: "action.result",
+    data: {
+      error: {
+        code: "SUBAGENT_DEPTH_LIMIT",
+        message: "Subagent depth limit reached",
+      },
+      result: {
+        callId: input.callId,
+        isError: true,
+        kind: "subagent-result",
+        output: input.output as never,
+        subagentName: input.subagentName,
+      },
+      sequence: 2,
+      status: "failed",
+      stepIndex: 0,
+      turnId: "t1",
+    },
+  };
+}
+
 describe("run assertions", () => {
   it("succeeded passes a clean run and fails a failed or parked run", async () => {
     expect((await Run.succeeded().evaluate(makeResult({ status: "completed" }))).score).toBe(1);
@@ -212,6 +239,27 @@ describe("run assertions", () => {
     });
 
     expect((await Run.toolOrder(["step-a"]).evaluate(result)).score).toBe(0);
+  });
+
+  it("noFailedActions includes failed action details", async () => {
+    const outcome = await Run.noFailedActions().evaluate(
+      makeResult({
+        events: [
+          failedSubagentResult({
+            callId: "call-a",
+            output: "Subagent recursion stopped before LEVEL_4_REACHED",
+            subagentName: "agent",
+          }),
+        ],
+      }),
+    );
+
+    expect(outcome.score).toBe(0);
+    expect(outcome.message).toContain("subagent-result");
+    expect(outcome.message).toContain("agent");
+    expect(outcome.message).toContain("call-a");
+    expect(outcome.message).toContain("Subagent depth limit reached");
+    expect(outcome.message).toContain("Subagent recursion stopped");
   });
 
   it("matches typed event counts and ordered event groups", async () => {

--- a/packages/eve/src/evals/assertions/run.ts
+++ b/packages/eve/src/evals/assertions/run.ts
@@ -204,10 +204,16 @@ export function noFailedActions(): RunAssertion {
           (evt.data.status === "failed" || evt.data.result.isError === true),
       );
       if (failed.length === 0) return PASS;
-      const names = failed.map((evt) =>
-        evt.data.result.kind === "tool-result" ? evt.data.result.toolName : evt.data.result.kind,
-      );
-      return fail(`${failed.length} failed action(s): ${names.join(", ")}`);
+      const details = failed.map(formatFailedActionResult);
+      return fail(`${failed.length} failed action(s): ${details.join("; ")}`, {
+        failedActions: failed.map((evt) => ({
+          callId: evt.data.result.callId,
+          error: evt.data.error,
+          kind: evt.data.result.kind,
+          output: evt.data.result.output,
+          status: evt.data.status,
+        })),
+      });
     },
   };
 }
@@ -371,6 +377,34 @@ function failureDetail(prefix: string, code: string | undefined): string {
   return code === undefined ? prefix : `${prefix} (code: ${code})`;
 }
 
+function formatFailedActionResult(
+  event: Extract<HandleMessageStreamEvent, { type: "action.result" }>,
+): string {
+  const { result, status } = event.data;
+  const parts = [
+    actionResultLabel(result),
+    `callId=${result.callId}`,
+    `status=${status}`,
+    result.isError === true ? "isError=true" : undefined,
+    event.data.error?.message === undefined ? undefined : `error=${event.data.error.message}`,
+    `output=${truncate(formatUnknown(result.output))}`,
+  ];
+  return parts.filter((part) => part !== undefined).join(" ");
+}
+
+function actionResultLabel(
+  result: Extract<HandleMessageStreamEvent, { type: "action.result" }>["data"]["result"],
+): string {
+  switch (result.kind) {
+    case "tool-result":
+      return `tool-result:${result.toolName}`;
+    case "subagent-result":
+      return `subagent-result:${result.subagentName}`;
+    case "load-skill-result":
+      return result.name === undefined ? "load-skill-result" : `load-skill-result:${result.name}`;
+  }
+}
+
 function runFailure(result: EveEvalAssertionSubject): AssertionOutcome | undefined {
   if (result.status === "failed") {
     return fail(failureDetail("run failed", result.derived.failureCode));
@@ -387,6 +421,16 @@ function runFailure(result: EveEvalAssertionSubject): AssertionOutcome | undefin
 function truncate(text: string | undefined, max = 200): string {
   if (text === undefined) return "undefined";
   return text.length <= max ? text : `${text.slice(0, max)}…`;
+}
+
+function formatUnknown(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function validateCount(count: number | undefined): void {

--- a/packages/eve/src/harness/advertised-tools.test.ts
+++ b/packages/eve/src/harness/advertised-tools.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
 import { DEFAULT_SUBAGENT_MAX_DEPTH } from "#harness/subagent-depth.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
-import type { HarnessToolMap } from "#harness/types.js";
+import type { HarnessSession, HarnessToolMap } from "#harness/types.js";
+import { buildToolSet } from "#harness/tools.js";
+import { WORKFLOW_TOOL_NAME } from "#shared/workflow-sandbox.js";
 
 describe("getAdvertisedTools", () => {
   it("keeps subagent tools below the subagent depth limit", () => {
@@ -68,6 +70,51 @@ describe("getAdvertisedTools", () => {
     expect([...belowCustomLimit.keys()]).toEqual(["add", "delegate"]);
     expect([...atCustomLimit.keys()]).toEqual(["add"]);
   });
+
+  it("keeps direct subagent tools in runtime subagent sessions below the depth limit", () => {
+    const tools = new Map([
+      ["add", createTool("add")],
+      ["delegate", createSubagentTool("delegate")],
+    ]) satisfies HarnessToolMap;
+
+    const advertisedTools = getAdvertisedTools({
+      session: { rootSessionId: "root-session", subagentDepth: 1 },
+      tools,
+    });
+
+    expect([...advertisedTools.keys()]).toEqual(["add", "delegate"]);
+  });
+
+  it("does not add Workflow in runtime subagent sessions", async () => {
+    const tools = new Map([["delegate", createSubagentTool("delegate")]]) satisfies HarnessToolMap;
+
+    const advertisedTools = await getAdvertisedTools({
+      modelTools: buildToolSet({ tools }),
+      session: createSession({ rootSessionId: "root-session", subagentDepth: 1 }),
+      tools,
+      workflow: {},
+    });
+
+    expect(Object.keys(advertisedTools.modelTools)).toEqual(["delegate"]);
+    expect(advertisedTools.modelTools[WORKFLOW_TOOL_NAME]).toBeUndefined();
+  });
+
+  it("adds Workflow in root sessions below the depth limit", async () => {
+    const tools = new Map([
+      ["add", createTool("add")],
+      ["delegate", createSubagentTool("delegate")],
+    ]) satisfies HarnessToolMap;
+
+    const advertisedTools = await getAdvertisedTools({
+      modelTools: buildToolSet({ tools }),
+      session: createSession(),
+      tools,
+      workflow: {},
+    });
+
+    expect([...advertisedTools.harnessTools.keys()]).toEqual(["add", "delegate"]);
+    expect(advertisedTools.modelTools[WORKFLOW_TOOL_NAME]).toBeDefined();
+  });
 });
 
 describe("getAdvertisedTools for definition arrays", () => {
@@ -97,5 +144,20 @@ function createSubagentTool(name: string): HarnessToolDefinition {
       nodeId: "workers",
       subagentName: name,
     },
+  };
+}
+
+function createSession(overrides: Partial<HarnessSession> = {}): HarnessSession {
+  return {
+    agent: {
+      modelReference: { id: "test-model" },
+      system: "",
+      tools: [],
+    },
+    compaction: { recentWindowSize: 4, threshold: 1_000_000 },
+    continuationToken: "test-token",
+    history: [],
+    sessionId: "test-session",
+    ...overrides,
   };
 }

--- a/packages/eve/src/harness/advertised-tools.ts
+++ b/packages/eve/src/harness/advertised-tools.ts
@@ -1,18 +1,53 @@
+import type { ToolSet } from "ai";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { resolveSubagentDelegationLimit } from "#harness/subagent-depth.js";
+import {
+  ensureWorkflowContinuationSecurity,
+  getWorkflowContinuationSecurity,
+} from "#harness/workflow-continuation-security.js";
+import { applyWorkflowTool } from "#harness/workflow-sandbox.js";
 import type { HarnessSession, HarnessToolMap } from "#harness/types.js";
+import type { WorkflowSandboxLifecycle } from "#shared/workflow-sandbox.js";
+
+type AdvertisedToolSession = Pick<
+  HarnessSession,
+  "rootSessionId" | "subagentDepth" | "subagentMaxDepth"
+>;
 
 type AdvertisedToolMapInput = {
-  readonly session: Pick<HarnessSession, "subagentDepth" | "subagentMaxDepth">;
+  readonly session: AdvertisedToolSession;
   readonly tools: HarnessToolMap;
 };
 
 type AdvertisedToolDefinitionsInput = {
-  readonly session: Pick<HarnessSession, "subagentDepth" | "subagentMaxDepth">;
+  readonly session: AdvertisedToolSession;
   readonly tools: readonly HarnessToolDefinition[];
 };
 
-type AdvertisedToolsInput = AdvertisedToolMapInput | AdvertisedToolDefinitionsInput;
+type AdvertisedModelToolsInput = {
+  readonly modelTools: ToolSet;
+  readonly session: HarnessSession;
+  readonly tools: HarnessToolMap;
+  readonly workflow?: {
+    readonly lifecycle?: (input: {
+      readonly session: HarnessSession;
+      readonly tools: HarnessToolMap;
+    }) => WorkflowSandboxLifecycle | undefined;
+  };
+};
+
+type AdvertisedModelTools = {
+  readonly harnessTools: HarnessToolMap;
+  readonly modelTools: ToolSet;
+  readonly session: HarnessSession;
+};
+
+type AdvertisedToolsInput =
+  | AdvertisedModelToolsInput
+  | AdvertisedToolMapInput
+  | AdvertisedToolDefinitionsInput;
+
+export function getAdvertisedTools(input: AdvertisedModelToolsInput): Promise<AdvertisedModelTools>;
 
 export function getAdvertisedTools(input: AdvertisedToolMapInput): HarnessToolMap;
 export function getAdvertisedTools(
@@ -20,7 +55,11 @@ export function getAdvertisedTools(
 ): readonly HarnessToolDefinition[];
 export function getAdvertisedTools(
   input: AdvertisedToolsInput,
-): HarnessToolMap | readonly HarnessToolDefinition[] {
+): HarnessToolMap | Promise<AdvertisedModelTools> | readonly HarnessToolDefinition[] {
+  if ("modelTools" in input) {
+    return getAdvertisedModelTools(input);
+  }
+
   if (isToolDefinitionList(input.tools)) {
     return filterSubagentToolDefinitionsAtDepthLimit(input.tools, input.session);
   }
@@ -28,9 +67,45 @@ export function getAdvertisedTools(
   return filterSubagentToolMapAtDepthLimit(input.tools, input.session);
 }
 
+async function getAdvertisedModelTools(
+  input: AdvertisedModelToolsInput,
+): Promise<AdvertisedModelTools> {
+  const tools = filterSubagentToolMapAtDepthLimit(input.tools, input.session);
+  if (input.workflow === undefined) {
+    return {
+      harnessTools: tools,
+      modelTools: input.modelTools,
+      session: input.session,
+    };
+  }
+
+  const workflowHostTools = filterWorkflowHostToolsForRootSession(tools, input.session);
+  if (workflowHostTools.size === 0) {
+    return {
+      harnessTools: tools,
+      modelTools: input.modelTools,
+      session: input.session,
+    };
+  }
+
+  const session = ensureWorkflowContinuationSecurity(input.session);
+  const { modelTools } = await applyWorkflowTool({
+    continuationSecurity: getWorkflowContinuationSecurity(session),
+    harnessTools: workflowHostTools,
+    lifecycle: input.workflow.lifecycle?.({ session, tools: workflowHostTools }),
+    tools: input.modelTools,
+  });
+
+  return {
+    harnessTools: tools,
+    modelTools,
+    session,
+  };
+}
+
 function filterSubagentToolDefinitionsAtDepthLimit(
   tools: readonly HarnessToolDefinition[],
-  session: Pick<HarnessSession, "subagentDepth" | "subagentMaxDepth">,
+  session: AdvertisedToolSession,
 ): readonly HarnessToolDefinition[] {
   const delegationLimit = resolveSubagentDelegationLimit(session);
   const filteredTools: HarnessToolDefinition[] = [];
@@ -46,7 +121,7 @@ function filterSubagentToolDefinitionsAtDepthLimit(
 
 function filterSubagentToolMapAtDepthLimit(
   tools: HarnessToolMap,
-  session: Pick<HarnessSession, "subagentDepth" | "subagentMaxDepth">,
+  session: AdvertisedToolSession,
 ): HarnessToolMap {
   const delegationLimit = resolveSubagentDelegationLimit(session);
   const filteredTools = new Map<string, HarnessToolDefinition>();
@@ -56,6 +131,25 @@ function filterSubagentToolMapAtDepthLimit(
       continue;
     }
     filteredTools.set(name, tool);
+  }
+  return filteredTools;
+}
+
+function filterWorkflowHostToolsForRootSession(
+  tools: HarnessToolMap,
+  session: AdvertisedToolSession,
+): HarnessToolMap {
+  const filteredTools = new Map<string, HarnessToolDefinition>();
+  const delegationLimit = resolveSubagentDelegationLimit(session);
+
+  if (session.rootSessionId !== undefined || delegationLimit.currentDepth > 0) {
+    return filteredTools;
+  }
+
+  for (const [name, tool] of tools) {
+    if (isDelegatedRuntimeActionTool(tool)) {
+      filteredTools.set(name, tool);
+    }
   }
   return filteredTools;
 }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -803,6 +803,35 @@ describe("createToolLoopHarness", () => {
     expect(agentCall!.tools).not.toHaveProperty("Workflow");
   });
 
+  it("omits Workflow from runtime subagent sessions", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Hello!", role: "assistant" }] },
+      text: "Hello!",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const config = createTestConfig("conversation", undefined, {
+      workflow: true,
+      tools: createDelegationToolMap(),
+    });
+    const runStep = createToolLoopHarness(config);
+
+    await runStep(
+      createTestSession({
+        rootSessionId: "root-session",
+        subagentDepth: 1,
+      }),
+      { message: "Hi" },
+    );
+
+    const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
+    expect(agentCall).toBeDefined();
+    expect(agentCall!.tools).toHaveProperty("delegate");
+    expect(agentCall!.tools).not.toHaveProperty("Workflow");
+  });
+
   it("forwards the agent reasoning effort to the model call", async () => {
     setupMockAgent({
       finishReason: "stop",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -49,10 +49,10 @@ import {
   hydrateSandboxAttachments,
   stageAttachmentsToSandbox,
 } from "#harness/attachment-staging.js";
-import { applyWorkflowTool, buildWorkflowHostTools } from "#harness/workflow-sandbox.js";
+import { buildWorkflowHostTools } from "#harness/workflow-sandbox.js";
 import {
-  ensureWorkflowContinuationSecurity,
   getWorkflowContinuationSecurity,
+  readWorkflowContinuationSecurity,
 } from "#harness/workflow-continuation-security.js";
 import { createWorkflowLifecycle } from "#harness/workflow-lifecycle.js";
 import {
@@ -480,9 +480,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     }
 
     session = pending.session;
-    if (config.workflow === true) {
-      session = ensureWorkflowContinuationSecurity(session);
-    }
     let messages: ModelMessage[] = pending.messages;
 
     if (stepInput.input?.context !== undefined) {
@@ -674,24 +671,26 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         flatTools[FINAL_OUTPUT_TOOL_NAME] = buildFinalOutputTool(session.outputSchema);
       }
 
-      const modelTools =
-        config.workflow === true
-          ? (
-              await applyWorkflowTool({
-                continuationSecurity: getWorkflowContinuationSecurity(session),
-                harnessTools: advertisedHarnessTools,
-                lifecycle:
-                  emit !== undefined
-                    ? createWorkflowLifecycle({
-                        emit,
-                        emissionState,
-                        tools: advertisedHarnessTools,
-                      })
-                    : undefined,
-                tools: flatTools,
+      const workflowLifecycle =
+        emit !== undefined
+          ? ({ tools }: { readonly tools: HarnessToolMap }) =>
+              createWorkflowLifecycle({
+                emit,
+                emissionState,
+                tools,
               })
-            ).modelTools
-          : flatTools;
+          : undefined;
+      const workflowConfig =
+        config.workflow === true ? { lifecycle: workflowLifecycle } : undefined;
+
+      const advertisedModelTools = await getAdvertisedTools({
+        modelTools: flatTools,
+        session,
+        tools: advertisedHarnessTools,
+        workflow: workflowConfig,
+      });
+      session = advertisedModelTools.session;
+      const modelTools = advertisedModelTools.modelTools;
 
       const effectiveTools = marker ? applyLastToolCacheBreakpoint(modelTools, marker) : modelTools;
 
@@ -1457,9 +1456,14 @@ async function handleStepResult(input: {
     compaction: createNextCompactionConfig(session.compaction, promptMessages, result),
   };
 
-  if (config.workflow === true) {
-    const continuationSecurity = getWorkflowContinuationSecurity(baseSession);
-    const workflowInterrupt = await getWorkflowSandboxInterrupt(result, continuationSecurity);
+  const workflowContinuationSecurity =
+    config.workflow === true ? readWorkflowContinuationSecurity(baseSession) : undefined;
+
+  if (workflowContinuationSecurity !== undefined) {
+    const workflowInterrupt = await getWorkflowSandboxInterrupt(
+      result,
+      workflowContinuationSecurity,
+    );
     if (workflowInterrupt !== undefined) {
       if (!isWorkflowRuntimeActionInterrupt(workflowInterrupt)) {
         throw new Error(`Unsupported Workflow interrupt kind "${workflowInterrupt.payload.kind}".`);

--- a/packages/eve/src/harness/workflow-continuation-security.test.ts
+++ b/packages/eve/src/harness/workflow-continuation-security.test.ts
@@ -4,6 +4,7 @@ import type { HarnessSession } from "#harness/types.js";
 import {
   ensureWorkflowContinuationSecurity,
   getWorkflowContinuationSecurity,
+  readWorkflowContinuationSecurity,
 } from "#harness/workflow-continuation-security.js";
 
 function makeSession(state?: HarnessSession["state"]): HarnessSession {
@@ -34,6 +35,7 @@ describe("workflow continuation security", () => {
     expect(security.maxAgeMs).toBe(365 * 24 * 60 * 60 * 1000);
     expect(ensureWorkflowContinuationSecurity(secured)).toBe(secured);
     expect(getWorkflowContinuationSecurity(secured)).toEqual(security);
+    expect(readWorkflowContinuationSecurity(secured)).toEqual(security);
   });
 
   it("rejects malformed persisted security state", () => {
@@ -47,5 +49,9 @@ describe("workflow continuation security", () => {
     expect(() => ensureWorkflowContinuationSecurity(session)).toThrow(
       "Workflow continuation security state is missing or invalid.",
     );
+    expect(() => getWorkflowContinuationSecurity(session)).toThrow(
+      "Workflow continuation security state is missing or invalid.",
+    );
+    expect(readWorkflowContinuationSecurity(session)).toBeUndefined();
   });
 });

--- a/packages/eve/src/harness/workflow-continuation-security.ts
+++ b/packages/eve/src/harness/workflow-continuation-security.ts
@@ -29,9 +29,9 @@ export function ensureWorkflowContinuationSecurity(session: HarnessSession): Har
   };
 }
 
-export function getWorkflowContinuationSecurity(
+export function readWorkflowContinuationSecurity(
   session: HarnessSession,
-): WorkflowSandboxContinuationSecurity {
+): WorkflowSandboxContinuationSecurity | undefined {
   const stored = session.state?.[WORKFLOW_CONTINUATION_SECURITY_KEY];
   if (
     typeof stored !== "object" ||
@@ -40,7 +40,7 @@ export function getWorkflowContinuationSecurity(
     typeof (stored as { signingKey?: unknown }).signingKey !== "string" ||
     !/^[A-Za-z0-9_-]{43}$/.test((stored as { signingKey: string }).signingKey)
   ) {
-    throw new Error("Workflow continuation security state is missing or invalid.");
+    return undefined;
   }
 
   return {
@@ -48,4 +48,14 @@ export function getWorkflowContinuationSecurity(
     // A parked workflow can legitimately wait far beyond code mode's one-hour default.
     maxAgeMs: WORKFLOW_CONTINUATION_MAX_AGE_MS,
   };
+}
+
+export function getWorkflowContinuationSecurity(
+  session: HarnessSession,
+): WorkflowSandboxContinuationSecurity {
+  const security = readWorkflowContinuationSecurity(session);
+  if (security === undefined) {
+    throw new Error("Workflow continuation security state is missing or invalid.");
+  }
+  return security;
 }


### PR DESCRIPTION
## What

- Keep `getAdvertisedTools` as the normal model-visible filter for direct tools.
- Add `getAdvertisedWorkflowHostTools` for the Workflow host subset. It first applies the same subagent-depth filter, then returns only root-session delegated runtime-action tools.
- Gate `Workflow` setup, provider advertising, and interrupt extraction from that Workflow-host tool map.
- Document the root-only `Workflow` rule and add a patch changeset.

## Why

`Workflow` is synthesized after ordinary harness tools are advertised, so it cannot be removed as a normal `HarnessToolDefinition`. The policy still belongs with advertised-tool filtering. The code now uses collection-level filters: take a tool map plus session, return the filtered tool map.

Root sessions keep Workflow only when the advertised host map has delegated runtime-action tools. Delegated subagent sessions keep their direct subagent tools until the depth cap, but `getAdvertisedWorkflowHostTools` returns an empty map for them, so `Workflow` is not added.

## Stack

Base: #409, `rui/fix-subagent-child-prompt`.
