### PR TITLE
fix(eve): route info auth through eve channel

### DIFF
--- a/.changeset/remote-info-auth.md
+++ b/.changeset/remote-info-auth.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use authored `eveChannel()` auth for `GET /eve/v1/info` so remote `eve dev` can authenticate with the same policy as the session routes.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -18,9 +18,10 @@ export default eveChannel({
 
 ## Routes
 
-The channel exposes routes that create sessions, send follow-ups, and stream events:
+The application exposes a health route plus eve channel routes that inspect the agent, create sessions, send follow-ups, and stream events:
 
 - `GET /eve/v1/health`
+- `GET /eve/v1/info`
 - `POST /eve/v1/session` (start a session)
 - `POST /eve/v1/session/:sessionId` (send a follow-up)
 - `GET /eve/v1/session/:sessionId/stream` (stream events, NDJSON)
@@ -70,7 +71,7 @@ export default eveChannel({
 
 ## Authentication
 
-The `auth` option decides who can call these routes. The built-in helpers cover development and trusted infrastructure:
+The `auth` option decides who can call `/eve/v1/info` and the session routes. The built-in helpers cover development and trusted infrastructure:
 
 - `localDev()` accepts requests during local development.
 - `vercelOidc()` lets the local CLI reach a deployed agent, and lets other internal deployments from your team call it.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -104,13 +104,13 @@ Start with the [TypeScript SDK](../guides/client/overview) guide. It covers basi
 
 ## Inspect the agent over HTTP
 
-`GET /eve/v1/info` returns a JSON inspection snapshot for the running agent: model, instructions, authored and framework tools, skills, channels, schedules, subagents, sandbox, connections, hooks, workflow, and workspace metadata. Local development accepts loopback requests; deployed Vercel targets require the route's OIDC auth.
+`GET /eve/v1/info` returns a JSON inspection snapshot for the running agent: model, instructions, authored and framework tools, skills, channels, schedules, subagents, sandbox, connections, hooks, workflow, and workspace metadata. It uses the resolved `eveChannel()` route auth when `agent/channels/eve.ts` authors one; otherwise it falls back to the framework default of Vercel OIDC plus local development access.
 
 ```bash
 curl http://127.0.0.1:3000/eve/v1/info
 ```
 
-The route uses the same default auth chain as the eve channel (`[vercelOidc(), localDev()]`). A local Vercel OIDC bearer takes precedence; other local requests fall back to development access. A deployed Vercel target requires a valid OIDC bearer, with a same-project bypass for in-deployment callers. See [auth & route protection](../guides/auth-and-route-protection).
+With the default auth chain (`[vercelOidc(), localDev()]`), a local Vercel OIDC bearer takes precedence and other local requests fall back to development access. A deployed Vercel target requires a valid OIDC bearer, with a same-project bypass for in-deployment callers. See [auth & route protection](../guides/auth-and-route-protection).
 
 ## Dispatch order
 

--- a/packages/eve/src/internal/nitro/host/configure-nitro-routes.test.ts
+++ b/packages/eve/src/internal/nitro/host/configure-nitro-routes.test.ts
@@ -299,21 +299,29 @@ describe("configureNitroRoutes", () => {
     });
 
     expect(devNitro.options.handlers).toContainEqual({
-      handler: `#eve-route${EVE_INFO_ROUTE_PATH}`,
+      handler: `#nitro/virtual/eve-channel/GET ${EVE_INFO_ROUTE_PATH}`,
       method: "GET",
       route: EVE_INFO_ROUTE_PATH,
     });
     expect(prodNitro.options.handlers).toContainEqual({
-      handler: `#eve-route${EVE_INFO_ROUTE_PATH}`,
+      handler: `#nitro/virtual/eve-channel/GET ${EVE_INFO_ROUTE_PATH}`,
       method: "GET",
       route: EVE_INFO_ROUTE_PATH,
     });
-    expect(devNitro.options.virtual[`#eve-route${EVE_INFO_ROUTE_PATH}`]).toContain(
-      '"mode":"development"',
-    );
-    expect(prodNitro.options.virtual[`#eve-route${EVE_INFO_ROUTE_PATH}`]).toContain(
-      '"mode":"production"',
-    );
+    expect(
+      devNitro.options.virtual[`#nitro/virtual/eve-channel/GET ${EVE_INFO_ROUTE_PATH}`],
+    ).toContain('"dev":true');
+    expect(
+      prodNitro.options.virtual[`#nitro/virtual/eve-channel/GET ${EVE_INFO_ROUTE_PATH}`],
+    ).toContain('"dev":false');
+    expect(
+      devNitro.options.virtual[`#nitro/virtual/eve-channel/GET ${EVE_INFO_ROUTE_PATH}`],
+    ).toContain("dispatchChannelRequest");
+    expect(
+      prodNitro.options.virtual[`#nitro/virtual/eve-channel/GET ${EVE_INFO_ROUTE_PATH}`],
+    ).toContain("dispatchChannelRequest");
+    expect(devNitro.options.virtual[`#eve-route${EVE_INFO_ROUTE_PATH}`]).toBeUndefined();
+    expect(prodNitro.options.virtual[`#eve-route${EVE_INFO_ROUTE_PATH}`]).toBeUndefined();
   });
 
   it("does not register direct workflow queue handlers for Vercel production builds", async () => {

--- a/packages/eve/src/internal/nitro/host/configure-nitro-routes.ts
+++ b/packages/eve/src/internal/nitro/host/configure-nitro-routes.ts
@@ -6,7 +6,6 @@ import {
   EVE_DEV_DISPATCH_SCHEDULE_ROUTE_PATTERN,
   EVE_DEV_RUNTIME_ARTIFACTS_ROUTE_PATH,
   EVE_HEALTH_ROUTE_PATH,
-  EVE_INFO_ROUTE_PATH,
 } from "#protocol/routes.js";
 import {
   normalizeEsmImportSpecifier,
@@ -339,20 +338,6 @@ export async function configureNitroRoutes(
         route: EVE_HEALTH_ROUTE_PATH,
       });
     }
-
-    // The agent info endpoint needs `appRoot` baked at build time (used by
-    // the disk-source fallback in dev) and runs request-time auth, so it
-    // stays a virtual handler.
-    addFrameworkVirtualHandler(nitro, {
-      args: JSON.stringify({
-        ...artifactsConfig,
-        mode: nitro.options.dev ? "development" : "production",
-      }),
-      handlerExport: "handleAgentInfoRequest",
-      method: "GET",
-      modulePath: resolvePackageSourceFilePath("src/internal/nitro/routes/info.ts"),
-      route: EVE_INFO_ROUTE_PATH,
-    });
 
     // Per-channel mounting: one virtual Nitro handler per (method, urlPath) in
     // the merged channel set. Each handler bakes in its route key and artifacts

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
@@ -9,9 +9,10 @@ import type { RouteHandlerArgs, WebSocketRouteHooks } from "#channel/routes.js";
 import { createSendFn } from "#channel/send.js";
 import { createGetSessionFn } from "#channel/session.js";
 import { createLogger, logError } from "#internal/logging.js";
-import { readVercelProjectLink } from "#internal/vercel/project-link.js";
+import { attachAgentInfoRouteResponse } from "#internal/nitro/routes/channel-route-context.js";
 import type { NitroArtifactsConfig } from "#internal/nitro/routes/runtime-artifacts.js";
 import { resolveNitroChannelRuntimeBundle } from "#internal/nitro/routes/runtime-stack.js";
+import { readVercelProjectLink } from "#internal/vercel/project-link.js";
 import { withVercelOidcProjectResolver } from "#runtime/governance/auth/vercel-oidc-project.js";
 
 const log = createLogger("channel.dispatch");
@@ -57,7 +58,7 @@ export async function dispatchChannelRequest(
     );
   }
 
-  const routeArgs = buildRouteArgs(event, bundle, matchedChannel.name);
+  const routeArgs = buildRouteArgs(event, bundle, matchedChannel.name, config);
 
   let response: Response;
 
@@ -113,7 +114,7 @@ export async function dispatchChannelWebSocketRequest(
   }
 
   const websocket = matchedChannel.websocket;
-  const routeArgs = buildRouteArgs(event, bundle, matchedChannel.name);
+  const routeArgs = buildRouteArgs(event, bundle, matchedChannel.name, config);
 
   try {
     const hooks = await withDevelopmentVercelOidcContext(
@@ -164,6 +165,7 @@ function buildRouteArgs(
   event: H3Event,
   bundle: Awaited<ReturnType<typeof resolveNitroChannelRuntimeBundle>>,
   channelName: string,
+  config: NitroArtifactsConfig,
 ): BuiltRouteArgs {
   const requestId = readVercelRequestId(event.req.headers);
   const requestIp = extractSocketIp(event);
@@ -187,9 +189,8 @@ function buildRouteArgs(
     toCrossChannelTargets(bundle.channels),
   );
 
-  return {
-    agent,
-    args: {
+  const args = attachAgentInfoRouteResponse(
+    {
       send,
       getSession,
       receive,
@@ -197,6 +198,15 @@ function buildRouteArgs(
       waitUntil,
       requestIp,
     },
+    async () => {
+      const { handleAgentInfoRequest } = await import("#internal/nitro/routes/info.js");
+      return await handleAgentInfoRequest(config);
+    },
+  );
+
+  return {
+    agent,
+    args,
     backgroundTasks,
   };
 }

--- a/packages/eve/src/internal/nitro/routes/channel-route-context.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-route-context.ts
@@ -1,0 +1,25 @@
+import type { RouteHandlerArgs } from "#channel/routes.js";
+
+type AgentInfoRouteResponse = () => Promise<Response>;
+
+const agentInfoRouteResponseKey = "__eveAgentInfoRouteResponse";
+
+type AgentInfoRouteArgs = RouteHandlerArgs & {
+  [agentInfoRouteResponseKey]?: AgentInfoRouteResponse;
+};
+
+export function attachAgentInfoRouteResponse<TArgs extends RouteHandlerArgs>(
+  args: TArgs,
+  respond: AgentInfoRouteResponse,
+): TArgs {
+  const routeArgs: AgentInfoRouteArgs = args;
+  routeArgs[agentInfoRouteResponseKey] = respond;
+  return args;
+}
+
+export function readAgentInfoRouteResponse(
+  args: RouteHandlerArgs,
+): AgentInfoRouteResponse | undefined {
+  const routeArgs: AgentInfoRouteArgs = args;
+  return routeArgs[agentInfoRouteResponseKey];
+}

--- a/packages/eve/src/internal/nitro/routes/index.ts
+++ b/packages/eve/src/internal/nitro/routes/index.ts
@@ -17,8 +17,8 @@ const DEPLOYMENT_URL_PLACEHOLDER = "{{DEPLOYMENT_URL}}";
  * This is intentional: the root URL of a deployment is reachable by
  * anyone on the public internet, and the deployment must not advertise
  * its agent's configuration to unauthenticated callers. Inspection JSON
- * (model id, instructions, tools, skills, etc.) lives behind the default
- * local-dev / Vercel OIDC auth chain at `/eve/v1/info`.
+ * (model id, instructions, tools, skills, etc.) lives behind the resolved
+ * eve channel auth policy at `/eve/v1/info`.
  *
  * The page also loads zero external assets — no fonts, no scripts, no
  * images, no analytics beacons — so it cannot leak the deployment's

--- a/packages/eve/src/internal/nitro/routes/info.test.ts
+++ b/packages/eve/src/internal/nitro/routes/info.test.ts
@@ -13,13 +13,10 @@ const mocks = vi.hoisted(() => ({
     },
     schedules: [],
   })),
-  localDev: vi.fn(() => "local-dev-auth"),
   resolveAgentInfoCompiledArtifactsSource: vi.fn(() => ({
     appRoot: "/tmp/app/.eve/dev-runtime/snapshots/current/app",
     kind: "disk" as const,
   })),
-  routeAuth: vi.fn(async () => ({ principal: "local-dev" })),
-  vercelOidc: vi.fn(() => "vercel-oidc-auth"),
 }));
 
 vi.mock("#compiled/@vercel/oidc/index.js", () => ({
@@ -33,12 +30,6 @@ vi.mock("#internal/nitro/routes/agent-info/build-agent-info-response-from-manife
 vi.mock("#internal/nitro/routes/agent-info/load-agent-info-data.js", () => ({
   loadAgentInfoManifestData: mocks.loadAgentInfoManifestData,
   resolveAgentInfoCompiledArtifactsSource: mocks.resolveAgentInfoCompiledArtifactsSource,
-}));
-
-vi.mock("#public/channels/auth.js", () => ({
-  localDev: mocks.localDev,
-  routeAuth: mocks.routeAuth,
-  vercelOidc: mocks.vercelOidc,
 }));
 
 const ROUTE_INPUT = {
@@ -63,7 +54,7 @@ const GATEWAY_MANIFEST_DATA = {
 async function requestAgentInfo(): Promise<Response> {
   const { handleAgentInfoRequest } = await import("#internal/nitro/routes/info.js");
 
-  return await handleAgentInfoRequest(ROUTE_INPUT, new Request("http://127.0.0.1/eve/v1/info"));
+  return await handleAgentInfoRequest(ROUTE_INPUT);
 }
 
 describe("handleAgentInfoRequest", () => {

--- a/packages/eve/src/internal/nitro/routes/info.ts
+++ b/packages/eve/src/internal/nitro/routes/info.ts
@@ -6,12 +6,11 @@ import {
 } from "#internal/nitro/routes/agent-info/load-agent-info-data.js";
 import type { GatewayCredentialPresence } from "#internal/resolve-model-endpoint-status.js";
 import type { NitroArtifactsConfig } from "#internal/nitro/routes/runtime-artifacts.js";
-import { localDev, routeAuth, vercelOidc } from "#public/channels/auth.js";
 import type { ModelRouting } from "#shared/agent-definition.js";
 
 type AgentInfoRouteMode = "development" | "production";
 
-interface AgentInfoRouteInput extends NitroArtifactsConfig {
+export interface AgentInfoRouteInput extends NitroArtifactsConfig {
   readonly mode?: AgentInfoRouteMode;
 }
 
@@ -21,7 +20,7 @@ async function createAgentInfoPayload(input: AgentInfoRouteInput) {
   });
 
   return buildAgentInfoResponseFromManifest(data, {
-    mode: input.mode ?? "development",
+    mode: input.mode ?? (input.dev === false ? "production" : "development"),
     gatewayCredentials: await resolveGatewayCredentialPresence(data.manifest.config.model.routing),
   });
 }
@@ -54,18 +53,8 @@ async function resolveGatewayCredentialPresence(
 
 /**
  * Builds the package-owned JSON inspection response for the current agent.
- *
- * The route keeps the same default auth chain as the eve channel:
- * local development requests are accepted by hostname, while deployed
- * Vercel targets require a valid OIDC bearer.
  */
-export async function handleAgentInfoRequest(
-  input: AgentInfoRouteInput,
-  request: Request,
-): Promise<Response> {
-  const authResult = await routeAuth(request, [vercelOidc(), localDev()]);
-  if (authResult instanceof Response) return authResult;
-
+export async function handleAgentInfoRequest(input: AgentInfoRouteInput): Promise<Response> {
   return new Response(JSON.stringify(await createAgentInfoPayload(input)), {
     headers: {
       "cache-control": "no-store",

--- a/packages/eve/src/protocol/routes.ts
+++ b/packages/eve/src/protocol/routes.ts
@@ -11,10 +11,8 @@ export const EVE_HEALTH_ROUTE_PATH = `${EVE_ROUTE_PREFIX}/health`;
 
 /**
  * Stable framework-owned route exposing the JSON inspection payload for
- * the current agent. Nitro registers this route with the application
- * surface, and the handler uses the same default auth chain as the eve
- * channel: local development accepts loopback requests, while deployed
- * Vercel targets require OIDC.
+ * the current agent. The eve channel registers and authenticates this route
+ * with the same `auth` input as its session routes.
  */
 export const EVE_INFO_ROUTE_PATH = `${EVE_ROUTE_PREFIX}/info`;
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -4,6 +4,7 @@ import type { SessionAuthContext, SessionCallback } from "#channel/types.js";
 import { parseSessionCallback } from "#channel/session-callback.js";
 import { hasInternalRefScheme } from "#internal/attachments/url-refs.js";
 import { createLogger, logError } from "#internal/logging.js";
+import { readAgentInfoRouteResponse } from "#internal/nitro/routes/channel-route-context.js";
 import {
   EVE_MESSAGE_STREAM_CONTENT_TYPE,
   EVE_MESSAGE_STREAM_FORMAT,
@@ -12,6 +13,7 @@ import {
   EVE_STREAM_FORMAT_HEADER,
   EVE_STREAM_VERSION_HEADER,
 } from "#protocol/message.js";
+import { EVE_INFO_ROUTE_PATH } from "#protocol/routes.js";
 import { type InputResponse, isInputResponse } from "#runtime/input/types.js";
 import { type AuthFn, routeAuth } from "#public/channels/auth.js";
 import {
@@ -151,10 +153,11 @@ export interface EveChannel extends Channel {}
 
 /**
  * Builds the default eve HTTP channel: a {@link defineChannel} instance serving the
- * built-in `/eve/v1` routes (POST creates a session, POST delivers a follow-up, GET
- * streams a session's NDJSON event feed). Every route runs {@link EveChannelInput.auth}
- * via {@link routeAuth} before dispatching. Default-export the result as your
- * `agent/channels/eve.ts` channel; reach for {@link defineChannel} directly only for a custom transport.
+ * built-in `/eve/v1` routes (GET inspects the agent, POST creates a session, POST
+ * delivers a follow-up, GET streams a session's NDJSON event feed). Every route
+ * runs {@link EveChannelInput.auth} via {@link routeAuth} before dispatching.
+ * Default-export the result as your `agent/channels/eve.ts` channel; reach for
+ * {@link defineChannel} directly only for a custom transport.
  */
 export function eveChannel(input: EveChannelInput): EveChannel {
   const uploadPolicy = mergeUploadPolicy(input.uploadPolicy);
@@ -162,6 +165,21 @@ export function eveChannel(input: EveChannelInput): EveChannel {
   return defineChannel<undefined, EveEventContext>({
     cors: normalizeEveCors(input.cors),
     routes: [
+      GET(EVE_INFO_ROUTE_PATH, async (req, args) => {
+        const authResult = await routeAuth(req, input.auth);
+        if (authResult instanceof Response) return authResult;
+
+        const respond = readAgentInfoRouteResponse(args);
+        if (respond === undefined) {
+          return Response.json(
+            { error: "Agent info route requires internal channel dispatch context.", ok: false },
+            { status: 500 },
+          );
+        }
+
+        return await respond();
+      }),
+
       POST("/eve/v1/session", async (req, { send }) => {
         const authResult = await routeAuth(req, input.auth);
         if (authResult instanceof Response) return authResult;

--- a/packages/eve/test/eve-run-stream-channel.test.ts
+++ b/packages/eve/test/eve-run-stream-channel.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { HandleMessageStreamEvent } from "../src/protocol/message.js";
 import type { RouteHandlerArgs, GetSessionFn } from "../src/channel/routes.js";
 import type { Session } from "../src/channel/session.js";
+import { EVE_MESSAGE_STREAM_ROUTE_PATTERN } from "../src/protocol/routes.js";
 import { none } from "../src/public/channels/auth.js";
 import { eveChannel } from "../src/public/channels/eve.js";
 
@@ -19,8 +20,10 @@ import { eveChannel } from "../src/public/channels/eve.js";
 
 function createGetHandler() {
   const channel = eveChannel({ auth: none() });
-  const getRoute = channel.routes.find((r) => r.method === "GET");
-  if (!getRoute) throw new Error("No GET route found");
+  const getRoute = channel.routes.find(
+    (r) => r.method === "GET" && r.path === EVE_MESSAGE_STREAM_ROUTE_PATTERN,
+  );
+  if (!getRoute) throw new Error("No stream GET route found");
   return getRoute;
 }
 

--- a/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
+++ b/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
@@ -1,17 +1,21 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import type { H3Event } from "nitro";
 import { describe, expect, it } from "vitest";
 
 import { compileAgent } from "../../src/compiler/compile-agent.js";
+import { createNitroArtifactsConfig } from "../../src/internal/nitro/host/artifacts-config.js";
 import type { AgentInfoResponse } from "../../src/internal/nitro/routes/agent-info/build-agent-info-response.js";
-import { handleAgentInfoRequest } from "../../src/internal/nitro/routes/info.js";
-import { EVE_CREATE_SESSION_ROUTE_PATH } from "../../src/protocol/routes.js";
+import { dispatchChannelRequest } from "../../src/internal/nitro/routes/channel-dispatch.js";
+import { EVE_CREATE_SESSION_ROUTE_PATH, EVE_INFO_ROUTE_PATH } from "../../src/protocol/routes.js";
 import { useTemporaryAppRoots } from "../../src/internal/testing/use-temporary-app-roots.js";
 
 const createAppRoot = useTemporaryAppRoots();
 
 const APP_ROOT_OPTIONS = { packageName: "agent-info-route-test-agent" } as const;
+const EVE_CHANNEL_IMPORT_URL = new URL("../../dist/src/public/channels/eve.js", import.meta.url);
+const INFO_ROUTE_KEY = `GET ${EVE_INFO_ROUTE_PATH}`;
 
 // Loopback request — `localDev()` authenticates this one. Models a
 // developer hitting `eve start` or `vercel dev` on their machine.
@@ -22,8 +26,58 @@ const LOOPBACK_REQUEST = new Request("http://localhost/eve/v1/info");
 // request was not addressed to a loopback hostname, so the walk falls
 // through to `vercelOidc()`.
 const DEPLOYED_REQUEST = new Request("https://weather-agent.vercel.app/eve/v1/info");
+const AUTHORIZED_DEPLOYED_REQUEST = new Request("https://weather-agent.vercel.app/eve/v1/info", {
+  headers: {
+    "x-eve-info-token": "issue-389",
+  },
+});
 
-describe("handleAgentInfoRequest", () => {
+type MinimalAgentInfoH3Event = Pick<H3Event, "context" | "waitUntil"> & {
+  readonly req: Request;
+};
+
+async function installEveChannelShim(appRoot: string): Promise<void> {
+  const packageRoot = join(appRoot, "node_modules", "eve");
+  await mkdir(join(packageRoot, "channels"), { recursive: true });
+  await writeFile(
+    join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "eve",
+        type: "module",
+        exports: {
+          "./channels/eve": "./channels/eve.js",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(packageRoot, "channels", "eve.js"),
+    `export { eveChannel } from ${JSON.stringify(EVE_CHANNEL_IMPORT_URL.href)};\n`,
+  );
+}
+
+function createInfoEvent(request: Request): H3Event {
+  Object.assign(request, { ip: "127.0.0.1" });
+  const event: MinimalAgentInfoH3Event = {
+    context: { params: {} },
+    req: request,
+    waitUntil() {},
+  };
+  return event as H3Event;
+}
+
+async function requestAgentInfo(appRoot: string, request: Request): Promise<Response> {
+  return await dispatchChannelRequest(
+    createInfoEvent(request),
+    INFO_ROUTE_KEY,
+    createNitroArtifactsConfig({ appRoot, dev: true }),
+  );
+}
+
+describe("eve agent info route", () => {
   it("returns inspection JSON when the request is addressed to a loopback hostname", async () => {
     const { agentRoot, appRoot } = await createAppRoot("eve-agent-info-route-", APP_ROOT_OPTIONS);
 
@@ -39,7 +93,7 @@ describe("handleAgentInfoRequest", () => {
       startPath: appRoot,
     });
 
-    const response = await handleAgentInfoRequest({ appRoot }, LOOPBACK_REQUEST);
+    const response = await requestAgentInfo(appRoot, LOOPBACK_REQUEST);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
@@ -87,7 +141,7 @@ describe("handleAgentInfoRequest", () => {
       startPath: appRoot,
     });
 
-    const response = await handleAgentInfoRequest({ appRoot }, DEPLOYED_REQUEST);
+    const response = await requestAgentInfo(appRoot, DEPLOYED_REQUEST);
 
     expect(response.status).toBe(401);
     expect(response.headers.get("www-authenticate")).toContain("Bearer");
@@ -95,5 +149,50 @@ describe("handleAgentInfoRequest", () => {
     const body = await response.text();
     expect(body).not.toMatch(/openai|gpt-5|gpt5/i);
     expect(body).not.toMatch(/precise assistant/i);
+  });
+
+  it("uses authored eve channel auth for public-hostname info requests", async () => {
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-agent-info-route-authored-auth-",
+      APP_ROOT_OPTIONS,
+    );
+
+    await mkdir(join(agentRoot, "channels"), { recursive: true });
+    await installEveChannelShim(appRoot);
+    await writeFile(join(agentRoot, "agent.mjs"), 'export default { model: "openai/gpt-5.4" };\n');
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+    await writeFile(
+      join(agentRoot, "channels", "eve.mjs"),
+      `import { eveChannel } from "eve/channels/eve";
+
+function issue389Auth(request) {
+  if (request.headers.get("x-eve-info-token") !== "issue-389") {
+    return null;
+  }
+  return {
+    attributes: { source: "agent/channels/eve.mjs" },
+    authenticator: "issue-389",
+    principalId: "issue-389-user",
+    principalType: "user",
+  };
+}
+
+export default eveChannel({ auth: issue389Auth });
+`,
+    );
+
+    await compileAgent({
+      startPath: appRoot,
+    });
+
+    const rejected = await requestAgentInfo(appRoot, DEPLOYED_REQUEST);
+    expect(rejected.status).toBe(401);
+
+    const accepted = await requestAgentInfo(appRoot, AUTHORIZED_DEPLOYED_REQUEST);
+    expect(accepted.status).toBe(200);
+
+    const payload = (await accepted.json()) as AgentInfoResponse;
+    expect(payload.kind).toBe("eve-agent-info");
+    expect(payload.agent.model.id).toBe("openai/gpt-5.4");
   });
 });


### PR DESCRIPTION
Fixes #389.

## What

- Moves `GET /eve/v1/info` into the `eveChannel()` route table, so it authenticates with `input.auth` like the session routes.
- Removes auth from the info payload builder. It only builds the inspection response after the channel route accepts the request.
- Keeps info response generation on the Nitro dispatch side. The public eve channel authenticates the request, then calls the internal response callback carried on route args.
- Updates the docs, changeset, route registration assertions, stream-route unit coverage, and scenario coverage for authored eve channel auth.

## Why this shape

The old `/info` route was a standalone virtual Nitro handler. That handler only received JSON-serialized artifact config, so it could not call the authored `auth` function from `agent/channels/eve.ts`. It fell back to `[vercelOidc(), localDev()]`, while `POST /eve/v1/session` used the authored channel auth.

Mounting `/info` as an eve channel route puts the auth decision at the same boundary as the other eve HTTP routes:

```ts
const authResult = await routeAuth(req, input.auth);
```

The info payload still belongs to Nitro because it reads compiled artifacts. Dispatch attaches a small internal response callback to the route args object, and the eve channel calls it after auth passes. That keeps Nitro-only imports out of authored channel bundles.
