### PR TITLE
fix(eve): add direct eve scripts to web template

### DIFF
--- a/.changeset/web-template-eve-scripts.md
+++ b/.changeset/web-template-eve-scripts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add explicit `dev:eve`, `build:eve`, and `start:eve` scripts to generated Web Chat projects so users can run the embedded eve app directly when needed.

--- a/apps/templates/web-chat-next/package.json
+++ b/apps/templates/web-chat-next/package.json
@@ -4,8 +4,11 @@
   "type": "module",
   "scripts": {
     "build": "next build",
+    "build:eve": "eve build",
     "dev": "next dev",
+    "dev:eve": "eve dev",
     "start": "next start",
+    "start:eve": "eve start",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/eve/src/setup/scaffold/create/web-template.ts
+++ b/packages/eve/src/setup/scaffold/create/web-template.ts
@@ -78,8 +78,11 @@ export const WEB_APP_TEMPLATE_FILES = {
 export const WEB_APP_TEMPLATE_PACKAGE_JSON = {
   scripts: {
     build: "next build",
+    "build:eve": "eve build",
     dev: "next dev",
+    "dev:eve": "eve dev",
     start: "next start",
+    "start:eve": "eve start",
     typecheck: "tsc --noEmit -p tsconfig.json",
   },
   dependencies: {

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -158,7 +158,15 @@ describe("ensureChannel", () => {
         path: join(projectRoot, "package.json"),
         dependencies: expect.arrayContaining(["eve", "next", "react", "react-dom"]),
         devDependencies: expect.arrayContaining(["typescript", "@types/react"]),
-        scripts: expect.arrayContaining(["build", "dev", "start", "typecheck"]),
+        scripts: expect.arrayContaining([
+          "build",
+          "build:eve",
+          "dev",
+          "dev:eve",
+          "start",
+          "start:eve",
+          "typecheck",
+        ]),
       }),
     ]);
     await expect(readFile(join(projectRoot, "agent/channels/eve.ts"), "utf8")).resolves.toBe(
@@ -189,7 +197,10 @@ describe("ensureChannel", () => {
     );
     const packageJson = await readFile(join(projectRoot, "package.json"), "utf8");
     expect(packageJson).toContain('"next": "16.2.6"');
+    expect(packageJson).toContain('"build:eve": "eve build"');
     expect(packageJson).toContain('"dev": "next dev"');
+    expect(packageJson).toContain('"dev:eve": "eve dev"');
+    expect(packageJson).toContain('"start:eve": "eve start"');
     expect(JSON.parse(packageJson)).toMatchObject({ engines: { node: "24.x" } });
     await expect(readFile(join(projectRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
       PNPM_WORKSPACE_CONTENT,


### PR DESCRIPTION
Closes #29.

What changed:
- Added `build:eve`, `dev:eve`, and `start:eve` to generated Web Chat projects.
- Regenerated the scaffold module from `apps/templates/web-chat-next`.
- Extended the scaffold integration test and added a patch changeset.

The Web Chat template still keeps `dev`, `build`, and `start` on the Next.js entrypoints. These new scripts give users a direct way to run the embedded eve app when they need the TUI, a standalone build, or a local `eve start` smoke.

Checked generated-template drift and the Web Chat scaffold integration case.