### PR TITLE
docs: use port 2000 in local HTTP curl examples

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -137,7 +137,7 @@ The same CLI can point at a deployment. `npx eve dev https://your-app.vercel.app
 Every eve app exposes the same stable HTTP API. Start a durable session:
 
 ```bash
-curl -X POST http://127.0.0.1:3000/eve/v1/session \
+curl -X POST http://127.0.0.1:2000/eve/v1/session \
   -H 'content-type: application/json' \
   -d '{"message":"What is the weather in Brooklyn?"}'
 ```
@@ -152,7 +152,7 @@ The response comes back with two things you'll reuse:
 Attach to the session stream:
 
 ```bash
-curl http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream
+curl http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream
 ```
 
 The stream is NDJSON, served as `application/x-ndjson; charset=utf-8`. For this run you'll see a handful of lifecycle events:
@@ -174,7 +174,7 @@ The full set covers more lifecycle, human-in-the-loop, and authorization events,
 When the session is waiting for the next user message, post a follow-up with the token:
 
 ```bash
-curl -X POST http://127.0.0.1:3000/eve/v1/session/<sessionId> \
+curl -X POST http://127.0.0.1:2000/eve/v1/session/<sessionId> \
   -H 'content-type: application/json' \
   -d '{"continuationToken":"<token>","message":"Now do Queens."}'
 ```


### PR DESCRIPTION


### Description

`eve dev` binds to 2000 by default, not 3000. Wrong ports in Getting Started and the sessions doc were causing coding agents to curl the wrong host when following the docs, causing thrash as the agents would think something wasn't set up correctly.
### How did you test your changes?

Its just documentation
### PR Checklist

- [NA] I linked an issue with prior discussion confirming this change is wanted
- [X] I ran the relevant checks from `CONTRIBUTING.md`
- [X] I added tests and documentation where relevant
- [NA] I added a changeset if this touches the published `eve` package
- [X] DCO sign-off passes for every commit (`git commit --signoff`)
