### PR TITLE
docs: fix Edit-on-GitHub link to /blob/main/docs path

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -1,6 +1,7 @@
 import { MobileDocsBar } from "@vercel/geistdocs/mobile-docs-bar";
-import { createDocsPage } from "@vercel/geistdocs/pages/docs";
+import { createDocsPage, createPageActions } from "@vercel/geistdocs/pages/docs";
 import type { MDXComponents } from "mdx/types";
+import { EditOnGithubAction } from "@/components/geistdocs/edit-on-github";
 import { getMDXComponents } from "@/components/geistdocs/mdx-components";
 import { config } from "@/lib/geistdocs/config";
 import { staticOgImage } from "@/lib/geistdocs/og";
@@ -9,6 +10,11 @@ import { getSiteOrigin } from "@/lib/geistdocs/url";
 
 const docsPage = createDocsPage({
   config,
+  pageActions: createPageActions({
+    config,
+    getExtraActions: ({ page }) =>
+      page.path ? [<EditOnGithubAction key="edit-source" path={page.path} />] : [],
+  }),
   mdx: ({ link }) => {
     const components: MDXComponents = link ? { a: link } : {};
     return getMDXComponents(components);

--- a/apps/docs/components/geistdocs/edit-on-github.tsx
+++ b/apps/docs/components/geistdocs/edit-on-github.tsx
@@ -1,0 +1,42 @@
+import { SiGithub } from "@icons-pack/react-simple-icons";
+import { github } from "@/geistdocs";
+
+// geistdocs' built-in EditSourceAction hardcodes a `/edit/` GitHub URL and a
+// `content/docs/` path prefix, and exports neither the URL builder nor its
+// styling. We disable it (`pageActions.editSource: false`) and render this
+// `/blob/` link to the real source file instead. The class list mirrors the
+// internal action style (layout/focus) so this entry matches its siblings.
+const actionClassName =
+  "group flex min-h-7 w-full min-w-0 items-center gap-2 rounded-md text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-600 focus-visible:ring-offset-2 focus-visible:ring-offset-background-100 [&_svg]:size-3.5 [&_svg]:shrink-0 [&_span]:min-w-0 [&_span]:truncate";
+
+// Set the color inline (rather than via a `text-*` utility) so it wins over
+// the docs layout's global anchor color, which otherwise overrides it on this
+// lone `<a>`. The icon is `fill="currentColor"`, so it inherits this too.
+const color = "var(--ds-gray-800)";
+
+const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "");
+
+/**
+ * Footer action linking to a docs page's source file on GitHub.
+ *
+ * `path` is the page's source path relative to the docs content directory
+ * (e.g. `connections/mcp.mdx`), which is the repo-root `docs/` directory — so
+ * the GitHub path is `docs/${path}`.
+ */
+export const EditOnGithubAction = ({ path }: { path: string }) => {
+  const branch = github.branch ?? "main";
+  const filePath = `docs/${trimSlashes(path)}`;
+  const url = `https://github.com/${github.owner}/${github.repo}/blob/${branch}/${filePath}`;
+  return (
+    <a
+      className={actionClassName}
+      href={url}
+      rel="noopener noreferrer"
+      style={{ color }}
+      target="_blank"
+    >
+      <SiGithub className="size-3.5" style={{ color }} />
+      <span>Edit this page on GitHub</span>
+    </a>
+  );
+};

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -1,8 +1,9 @@
 import { LogoEve } from "@vercel/geistdocs/assets/logos/logo-eve";
+import type { GeistdocsGithubConfig } from "@vercel/geistdocs/config";
 
 export const Logo = () => <LogoEve height={15} />;
 
-export const github = {
+export const github: GeistdocsGithubConfig = {
   owner: "vercel",
   repo: "eve",
 };

--- a/apps/docs/lib/geistdocs/config.tsx
+++ b/apps/docs/lib/geistdocs/config.tsx
@@ -36,6 +36,9 @@ export const config = defineConfig({
   basePath,
   siteId,
   translations,
+  // Built-in edit link hardcodes `/edit/` and a `content/docs/` prefix; we
+  // render our own `/blob/` link instead (see EditOnGithubAction).
+  pageActions: { editSource: false },
   content: [{ id: "docs", label: "Docs", dir: "docs", route: "/docs" }],
   ai: {
     prompt,


### PR DESCRIPTION
## Problem

On the docs site, the **Edit this page on GitHub** link is wrong. On `/docs/introduction` it points to:

```
https://github.com/vercel/eve/edit/main/content/docs/introduction.mdx
```

`content/docs/` doesn't exist in the repo (sources live at repo-root `docs/`), so the link 404s.

## Cause

`@vercel/geistdocs` builds the link as `/edit/{branch}/{editPath}`, with `editPath` defaulting to `content/docs/{path}`. The prefix is configurable via `github.editPath`, but `/edit/` is hardcoded — there is no config option for `/blob/`.

## Fix

Disable the built-in `editSource` action and render a custom one linking to the real source file:

```
https://github.com/vercel/eve/blob/main/docs/${page.path}
```

`page.path` is each page's real source path (including its real extension, since `docs/` mixes `.md` and `.mdx`), so links never 404.

- `lib/geistdocs/config.tsx` — `pageActions: { editSource: false }`
- `components/geistdocs/edit-on-github.tsx` (new) — custom `/blob/` action, styled to match siblings
- `app/[lang]/docs/[[...slug]]/page.tsx` — wires it via `createPageActions({ config, getExtraActions })`
- `geistdocs.tsx` — typed `github` as `GeistdocsGithubConfig` for safe `branch` access

## Validation

- `/docs/introduction` → `…/blob/main/docs/introduction.md`
- `/docs/connections/mcp` → `…/blob/main/docs/connections/mcp.mdx`

## Note

geistdocs renders custom actions after its built-ins, so the edit link now sits **last** in the page-actions list (was first).

## Verification

`oxlint`, `oxfmt`, and a full `next build` (239/239 docs pages prerendered, TypeScript clean) all pass.