### PR TITLE
fix(sandbox): strip `runtime` param from Sandbox

### DIFF
--- a/.changeset/vercel-sandbox-image-no-runtime.md
+++ b/.changeset/vercel-sandbox-image-no-runtime.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Vercel sandbox: drop the `runtime` option. eve now always boots its hosted sandboxes from the published eve image.

--- a/.changeset/vercel-sandbox-image-no-runtime.md
+++ b/.changeset/vercel-sandbox-image-no-runtime.md
@@ -1,5 +1,5 @@
 ---
-"eve": minor
+"eve": patch
 ---
 
 Vercel sandbox: drop the `runtime` option. eve now always boots its hosted sandboxes from the published eve image.

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -96,7 +96,7 @@ import { defineSandbox } from "eve/sandbox";
 import { vercel } from "eve/sandbox/vercel";
 
 export default defineSandbox({
-  backend: vercel({ runtime: "node24", resources: { vcpus: 2 } }),
+  backend: vercel({ resources: { vcpus: 2 } }),
   revalidationKey: () => "repo-bootstrap-v1",
   async bootstrap({ use }) {
     const sandbox = await use();

--- a/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
@@ -26,7 +26,7 @@ export async function createVercelEveImageSandbox(input: {
 }): Promise<VercelSandbox> {
   const createOptions: VercelSandboxCreateParams = {
     ...input.createOptions,
-    __image: VERCEL_EVE_SANDBOX_IMAGE,
+    image: VERCEL_EVE_SANDBOX_IMAGE,
   };
   return await input.sandboxModule.Sandbox.create(createOptions);
 }

--- a/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
@@ -24,11 +24,23 @@ export async function createVercelEveImageSandbox(input: {
   readonly createOptions: VercelSandboxCreateParams;
   readonly sandboxModule: VercelModule;
 }): Promise<VercelSandbox> {
-  const createOptions: VercelSandboxCreateParams = {
-    ...input.createOptions,
+  const { image: _image, runtime: _runtime, source, ...createOptions } = input.createOptions;
+
+  /*
+   * `runtime`, `image`, and a snapshot source are mutually exclusive in the
+   * SDK.
+   */
+  if (source?.type === "snapshot") {
+    return await input.sandboxModule.Sandbox.create({
+      ...createOptions,
+      source,
+    });
+  }
+  return await input.sandboxModule.Sandbox.create({
+    ...createOptions,
+    source,
     image: VERCEL_EVE_SANDBOX_IMAGE,
-  };
-  return await input.sandboxModule.Sandbox.create(createOptions);
+  });
 }
 
 const VERCEL_EVE_SANDBOX_IMAGE = "vercel/eve:latest";

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -156,7 +156,7 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledTimes(1);
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        __image: "vercel/eve:latest",
+        image: "vercel/eve:latest",
         name: "template-key",
         networkPolicy: "allow-all",
         persistent: false,
@@ -193,7 +193,7 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledWith(
       expect.objectContaining({
         __experimentalFlag: "enabled",
-        __image: "vercel/eve:latest",
+        image: "vercel/eve:latest",
       }),
     );
   });

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -581,7 +581,7 @@ describe("createVercelSandbox", () => {
 
     const backend = createTestVercelSandbox({
       createOptions: {
-        runtime: "node22",
+        ports: [3000],
         source: { snapshotId: "author-snap", type: "snapshot" },
       },
       loadSandboxModule: async () => sandboxModule as never,
@@ -596,7 +596,7 @@ describe("createVercelSandbox", () => {
     expect(create.mock.calls[0]?.[0]).toMatchObject({
       name: "session-key",
       persistent: true,
-      runtime: "node22",
+      ports: [3000],
       source: { snapshotId: "author-snap", type: "snapshot" },
     });
     expect(sessionSandbox.snapshot).not.toHaveBeenCalled();
@@ -658,43 +658,6 @@ describe("createVercelSandbox", () => {
       timeout: 600_000,
     });
     expect(templateSandbox.update).toHaveBeenCalledWith({ networkPolicy: "deny-all" });
-  });
-
-  it("forwards runtime to template create but strips it from session create", async () => {
-    const templateSandbox = createMockSandbox({ name: "template" });
-    const sessionSandbox = createMockSandbox({ name: "session" });
-    const create = vi
-      .fn()
-      .mockResolvedValueOnce(templateSandbox)
-      .mockResolvedValueOnce(sessionSandbox);
-    const sandboxModule = {
-      Sandbox: {
-        create,
-        get: vi.fn().mockResolvedValue(null),
-      },
-    };
-
-    const backend = createTestVercelSandbox({
-      createOptions: { runtime: "node22" },
-      loadSandboxModule: async () => sandboxModule as never,
-    });
-
-    await backend.prewarm({
-      runtimeContext: { appRoot: "/tmp/test-app-root" },
-      seedFiles: [],
-      templateKey: "template-key",
-    });
-
-    await backend.create({
-      runtimeContext: { appRoot: "/tmp/test-app-root" },
-      sessionKey: "session-key",
-      templateKey: "template-key",
-    });
-
-    expect(create).toHaveBeenCalledTimes(2);
-    const [templateArgs, sessionArgs] = create.mock.calls;
-    expect(templateArgs?.[0]).toMatchObject({ runtime: "node22" });
-    expect(sessionArgs?.[0]).not.toHaveProperty("runtime");
   });
 
   it("forwards author source to template create as the base layer", async () => {

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -408,15 +408,18 @@ function createSessionCreateParams(
   }
 
   /*
-   * Strip both `source` and `runtime` from author-supplied create options for the
-   * template-backed session path. The framework owns the source there, and the SDK
-   * rejects `runtime` for a snapshot because its runtime is already baked into it.
+   * Strip `source`, `runtime`, and `image` from author-supplied create options
+   * for the template-backed session path. The framework owns the source there,
+   * and a snapshot source is mutually exclusive with both `runtime` and `image`
+   * (the template snapshot already has the eve image baked in).
    */
   const {
+    image: _image,
     runtime: _runtime,
     source: _source,
     ...sessionCreateOptions
-  } = input.createOptions as VercelCreateOptions & Partial<Record<"runtime" | "source", unknown>>;
+  } = input.createOptions as VercelCreateOptions &
+    Partial<Record<"image" | "runtime" | "source", unknown>>;
 
   return {
     ...sessionCreateOptions,

--- a/packages/eve/src/public/sandbox/vercel-sandbox.ts
+++ b/packages/eve/src/public/sandbox/vercel-sandbox.ts
@@ -9,7 +9,8 @@ type VercelSandboxInternalCreateOptions = {
 };
 
 type VercelSandboxAuthorCreateOptions<T> = T extends unknown
-  ? Omit<T, "name" | "onResume" | "persistent" | "signal"> & VercelSandboxInternalCreateOptions
+  ? Omit<T, "name" | "onResume" | "persistent" | "runtime" | "signal"> &
+      VercelSandboxInternalCreateOptions
   : never;
 
 /**
@@ -27,6 +28,9 @@ type VercelSandboxAuthorCreateOptions<T> = T extends unknown
  * Framework-injected fields (`name`, `onResume`, `persistent`, `signal`)
  * are excluded: the framework owns those and overrides any
  * author-supplied values.
+ *
+ * `runtime` is excluded as well: eve always boots its sandboxes from the
+ * published eve image, which is mutually exclusive with a stock runtime.
  *
  * `source` is honored only on the template create at prewarm time, so
  * an author-supplied snapshot, git revision, or tarball becomes the

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -52,7 +52,7 @@ const fallback = defaultBackend({
   docker: { image: "ghcr.io/vercel/eve:latest" },
   justBash: {},
   microsandbox: {},
-  vercel: { runtime: "node24" },
+  vercel: { resources: { vcpus: 2 } },
 });
 
 void docker;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 0.2.2
       version: 0.2.2
     '@vercel/sandbox':
-      specifier: 2.2.1
-      version: 2.2.1
+      specifier: 2.3.0
+      version: 2.3.0
     ai:
       specifier: ^7.0.0
       version: 7.0.0
@@ -859,7 +859,7 @@ importers:
         version: 3.5.0
       '@vercel/sandbox':
         specifier: 'catalog:'
-        version: 2.2.1
+        version: 2.3.0
       '@vercel/sdk':
         specifier: 1.28.1
         version: 1.28.1
@@ -6736,8 +6736,8 @@ packages:
   '@vercel/sandbox@2.1.1':
     resolution: {integrity: sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==}
 
-  '@vercel/sandbox@2.2.1':
-    resolution: {integrity: sha512-IqFYVEsPilXb28VbpTtrP5UkMgVAyQlp77zcLJUgCUo1yEbjJiClGS6sEqGjkAukhbLGS+T2vG3ZOgzSzUTyZg==}
+  '@vercel/sandbox@2.3.0':
+    resolution: {integrity: sha512-KLhc/sj2JuftgWEivPmmDq3iFLIoYU0XIv+44paTyhk5eGGaqNl6dQdxXSqOf+N31jh55m4UWY7i8oJy8oJRrQ==}
 
   '@vercel/sdk@1.28.1':
     resolution: {integrity: sha512-QYAX0QStBQak4c9PXunGVERL68cp8r1JcVuQd+SwXGThuZkEHRMpSStnvrO1Ny2nWg9wOeRnS0GEp+md42IVfg==}
@@ -18677,7 +18677,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/sandbox@2.2.1':
+  '@vercel/sandbox@2.3.0':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ catalog:
   "@types/react": "19.2.15"
   "@types/react-dom": "19.2.3"
   "@vercel/connect": "0.2.2"
-  "@vercel/sandbox": "2.2.1"
+  "@vercel/sandbox": "2.3.0"
   ai: "^7.0.0"
   next: "16.2.6"
   picocolors: "1.1.1"
@@ -61,4 +61,3 @@ minimumReleaseAgeExclude:
   - typescript
   - vercel
   - workflow
-


### PR DESCRIPTION
Sandbox package has been updated to a new version that requires a few changes:

- `__image` is now `image
- `runtime` and `image` are mutually exclusive
- `image` and `snapshot` are mutually exclusive

`runtime` is passed through in eve but is unused hence the param being removed here.