### PR TITLE
Preserve Vercel git config for eve builds

### DIFF
--- a/.changeset/quiet-eve-vercel-git.md
+++ b/.changeset/quiet-eve-vercel-git.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve authored Vercel Git deployment policy when building eve apps on Vercel. Static `vercel.json` and `vercel.ts` configs with `git.deploymentEnabled` are copied into the generated framework output so Vercel can honor disabled preview branches for eve projects.

--- a/packages/eve/src/internal/nitro/host/authored-vercel-config.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/authored-vercel-config.integration.test.ts
@@ -1,0 +1,115 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { mergeAuthoredVercelGitConfigIntoBuildOutput } from "./authored-vercel-config.js";
+
+const temporaryRoots: string[] = [];
+
+async function createTempRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+async function writeOutputConfig(
+  outputDir: string,
+  config: Record<string, unknown> = { routes: [{ handle: "filesystem" }], version: 3 },
+): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(join(outputDir, "config.json"), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+async function readOutputConfig(outputDir: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(outputDir, "config.json"), "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("mergeAuthoredVercelGitConfigIntoBuildOutput", () => {
+  afterEach(async () => {
+    await Promise.all(
+      temporaryRoots.splice(0).map(async (root) => {
+        await rm(root, { force: true, recursive: true });
+      }),
+    );
+  });
+
+  it("preserves git deployment policy from vercel.json", async () => {
+    const appRoot = await createTempRoot("eve-authored-vercel-json-");
+    const outputDir = join(appRoot, ".vercel", "output");
+
+    await writeFile(
+      join(appRoot, "vercel.json"),
+      `${JSON.stringify({ git: { deploymentEnabled: { "*": false, master: true } } }, null, 2)}\n`,
+    );
+    await writeOutputConfig(outputDir);
+
+    await mergeAuthoredVercelGitConfigIntoBuildOutput({ appRoot, outputDir });
+
+    await expect(readOutputConfig(outputDir)).resolves.toEqual({
+      git: {
+        deploymentEnabled: {
+          "*": false,
+          master: true,
+        },
+      },
+      routes: [{ handle: "filesystem" }],
+      version: 3,
+    });
+  });
+
+  it("preserves git deployment policy from vercel.ts", async () => {
+    const appRoot = await createTempRoot("eve-authored-vercel-ts-");
+    const outputDir = join(appRoot, ".vercel", "output");
+
+    await writeFile(
+      join(appRoot, "vercel.ts"),
+      [
+        'import type { VercelConfig } from "@vercel/config/v1";',
+        "export const config: VercelConfig = {",
+        "  git: {",
+        '    deploymentEnabled: { "*": false, master: true },',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeOutputConfig(outputDir);
+
+    await mergeAuthoredVercelGitConfigIntoBuildOutput({ appRoot, outputDir });
+
+    await expect(readOutputConfig(outputDir)).resolves.toMatchObject({
+      git: {
+        deploymentEnabled: {
+          "*": false,
+          master: true,
+        },
+      },
+    });
+  });
+
+  it("does not replace git config already emitted in Build Output", async () => {
+    const appRoot = await createTempRoot("eve-authored-vercel-existing-");
+    const outputDir = join(appRoot, ".vercel", "output");
+
+    await writeFile(
+      join(appRoot, "vercel.json"),
+      `${JSON.stringify({ git: { deploymentEnabled: { "*": false } } }, null, 2)}\n`,
+    );
+    await writeOutputConfig(outputDir, {
+      git: { deploymentEnabled: { main: true } },
+      version: 3,
+    });
+
+    await mergeAuthoredVercelGitConfigIntoBuildOutput({ appRoot, outputDir });
+
+    await expect(readOutputConfig(outputDir)).resolves.toEqual({
+      git: { deploymentEnabled: { main: true } },
+      version: 3,
+    });
+  });
+});

--- a/packages/eve/src/internal/nitro/host/authored-vercel-config.ts
+++ b/packages/eve/src/internal/nitro/host/authored-vercel-config.ts
@@ -1,0 +1,106 @@
+import { access, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const VERCEL_CONFIG_FILENAMES = ["vercel.json", "vercel.ts", "vercel.mts"] as const;
+
+interface AuthoredVercelConfig {
+  readonly git?: unknown;
+}
+
+type VercelBuildOutputConfig = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function findAuthoredVercelConfigPath(appRoot: string): Promise<string | undefined> {
+  for (const filename of VERCEL_CONFIG_FILENAMES) {
+    const path = join(appRoot, filename);
+
+    if (await pathExists(path)) {
+      return path;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeAuthoredVercelConfig(value: unknown, configPath: string): AuthoredVercelConfig {
+  if (!isRecord(value)) {
+    throw new Error(`${configPath} must export a Vercel config object.`);
+  }
+
+  return value;
+}
+
+async function loadAuthoredVercelConfig(
+  configPath: string,
+): Promise<AuthoredVercelConfig | undefined> {
+  if (configPath.endsWith(".json")) {
+    return normalizeAuthoredVercelConfig(
+      JSON.parse(await readFile(configPath, "utf8")) as unknown,
+      configPath,
+    );
+  }
+
+  const module = (await import(pathToFileURL(configPath).href)) as Record<string, unknown>;
+  const config = module.config ?? module.default;
+
+  if (config === undefined) {
+    return undefined;
+  }
+
+  return normalizeAuthoredVercelConfig(config, configPath);
+}
+
+/**
+ * Nitro owns Build Output routing and function config, but authored Vercel Git
+ * policy is project-level deployment behavior. Preserve it so Vercel can honor
+ * settings such as `git.deploymentEnabled` for eve framework output.
+ */
+export async function mergeAuthoredVercelGitConfigIntoBuildOutput(input: {
+  readonly appRoot: string;
+  readonly outputDir: string;
+}): Promise<void> {
+  const configPath = await findAuthoredVercelConfigPath(input.appRoot);
+
+  if (configPath === undefined) {
+    return;
+  }
+
+  const authoredConfig = await loadAuthoredVercelConfig(configPath);
+
+  if (authoredConfig?.git === undefined) {
+    return;
+  }
+
+  const outputConfigPath = join(input.outputDir, "config.json");
+  const outputConfig = JSON.parse(await readFile(outputConfigPath, "utf8")) as unknown;
+
+  if (!isRecord(outputConfig)) {
+    throw new Error(`${outputConfigPath} must contain a JSON object.`);
+  }
+
+  const nextConfig: VercelBuildOutputConfig = {
+    ...outputConfig,
+    git: outputConfig.git ?? authoredConfig.git,
+  };
+
+  if (JSON.stringify(outputConfig) !== JSON.stringify(nextConfig)) {
+    await writeFile(outputConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`);
+  }
+}

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -13,6 +13,7 @@ import { resolveNitroSurfaceOutputDirectory } from "#internal/application/paths.
 import { WorkflowBundleBuilder } from "#internal/workflow-bundle/builder.js";
 import { normalizeEveVercelFunctionOutput } from "#internal/workflow-bundle/vercel-workflow-output.js";
 import { createApplicationNitro } from "#internal/nitro/host/create-application-nitro.js";
+import { mergeAuthoredVercelGitConfigIntoBuildOutput } from "#internal/nitro/host/authored-vercel-config.js";
 import { emitVercelAgentSummary } from "#internal/nitro/host/build-vercel-agent-summary.js";
 import { prepareApplicationHost } from "#internal/nitro/host/prepare-application-host.js";
 import { runVercelBuildPrewarm } from "#internal/nitro/host/vercel-build-prewarm.js";
@@ -256,6 +257,10 @@ export async function buildApplication(rootDir: string): Promise<string> {
 
   try {
     const outputDirectory = await buildNitroOutput(nitro);
+    await mergeAuthoredVercelGitConfigIntoBuildOutput({
+      appRoot: preparedHost.appRoot,
+      outputDir: outputDirectory,
+    });
     // Run sandbox prewarm before emitting the workflow functions so a
     // prewarm failure aborts the build before we spend time bundling
     // function output that we would never deploy.


### PR DESCRIPTION
## Summary
- copy authored Vercel `git` config into generated eve Build Output config
- preserve `git.deploymentEnabled` from `vercel.json` and static `vercel.ts` configs
- add integration coverage for the merge behavior

## Test
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/host/authored-vercel-config.integration.test.ts`

Fixes #438