### PR TITLE
fix(sandbox): reclaim orphaned prewarm lock via pid-liveness check

### DIFF
--- a/packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts
@@ -1,0 +1,144 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { waitForSandboxTemplatePrewarmLock } from "#execution/sandbox/template-prewarm-lock.js";
+
+const BACKEND_NAME = "docker";
+const TEMPLATE_KEY = "template-abc";
+
+let appRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(appRoots.map((root) => rm(root, { force: true, recursive: true })));
+  appRoots = [];
+});
+
+async function createAppRoot(): Promise<string> {
+  const appRoot = await mkdtemp(join(tmpdir(), "eve-prewarm-lock-"));
+  appRoots.push(appRoot);
+  return appRoot;
+}
+
+function resolveLockPath(appRoot: string): string {
+  // Mirrors the private resolveSandboxTemplatePrewarmLockPath layout.
+  return join(
+    appRoot,
+    ".eve",
+    "sandbox-cache",
+    "template-locks",
+    BACKEND_NAME,
+    `${TEMPLATE_KEY}.lock`,
+  );
+}
+
+async function writeLock(
+  appRoot: string,
+  owner: Record<string, unknown>,
+  options: { mtimeMs?: number } = {},
+): Promise<string> {
+  const lockPath = resolveLockPath(appRoot);
+  await mkdir(lockPath, { recursive: true });
+  await writeFile(join(lockPath, "owner.json"), `${JSON.stringify(owner)}\n`);
+  if (options.mtimeMs !== undefined) {
+    // Backdate after the write, which itself bumps the dir's mtime.
+    const seconds = options.mtimeMs / 1000;
+    await utimes(lockPath, seconds, seconds);
+  }
+  return lockPath;
+}
+
+async function spawnDeadPid(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], {
+    stdio: "ignore",
+  });
+  const pid = child.pid;
+  if (pid === undefined) {
+    throw new Error("failed to spawn child process");
+  }
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+    child.kill("SIGKILL");
+  });
+  return pid;
+}
+
+function waitFor(appRoot: string): Promise<void> {
+  return waitForSandboxTemplatePrewarmLock({
+    appRoot,
+    backendName: BACKEND_NAME,
+    templateKey: TEMPLATE_KEY,
+  });
+}
+
+const PENDING = Symbol("pending");
+
+async function settlesWithin(promise: Promise<unknown>, ms: number): Promise<boolean> {
+  const result = await Promise.race([
+    promise.then(() => true),
+    new Promise<typeof PENDING>((resolve) => setTimeout(() => resolve(PENDING), ms)),
+  ]);
+  return result !== PENDING;
+}
+
+describe("waitForSandboxTemplatePrewarmLock", () => {
+  it("reclaims a fresh lock whose same-host owner pid is dead", async () => {
+    const appRoot = await createAppRoot();
+    const pid = await spawnDeadPid();
+    const lockPath = await writeLock(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid,
+    });
+
+    const startedAt = Date.now();
+    await waitFor(appRoot);
+
+    // Reclaimed via pid-liveness, not by waiting out the mtime stale window.
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("respects a same-host owner that is still alive even when its mtime is stale", async () => {
+    const appRoot = await createAppRoot();
+    // Owner is this process (definitely alive, same host). Backdate the mtime
+    // well past STALE_LOCK_MS (10 min) to prove the live holder is NOT reclaimed
+    // by the mtime window — a long-running prewarm must keep its lock.
+    await writeLock(
+      appRoot,
+      {
+        createdAt: new Date().toISOString(),
+        hostname: hostname(),
+        pid: process.pid,
+      },
+      { mtimeMs: Date.now() - 20 * 60 * 1000 },
+    );
+
+    const pending = waitFor(appRoot);
+    expect(await settlesWithin(pending, 1000)).toBe(false);
+
+    // Release so the waiter resolves and no handle dangles into the next test.
+    await rm(resolveLockPath(appRoot), { force: true, recursive: true });
+    await pending;
+  });
+
+  it("falls back to the mtime window for a dead owner recorded without a hostname", async () => {
+    const appRoot = await createAppRoot();
+    const pid = await spawnDeadPid();
+    // Pre-hostname owner record: a dead pid must NOT be reclaimed via the pid
+    // path, because there is no hostname to confirm it was a same-host owner.
+    await writeLock(appRoot, {
+      createdAt: new Date().toISOString(),
+      pid,
+    });
+
+    const pending = waitFor(appRoot);
+    expect(await settlesWithin(pending, 1000)).toBe(false);
+
+    await rm(resolveLockPath(appRoot), { force: true, recursive: true });
+    await pending;
+  });
+});

--- a/packages/eve/src/execution/sandbox/template-prewarm-lock.ts
+++ b/packages/eve/src/execution/sandbox/template-prewarm-lock.ts
@@ -1,11 +1,23 @@
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 
 import { resolveSandboxCacheDirectory } from "#internal/application/paths.js";
 
 const LOCK_POLL_MS = 250;
 const LOCK_TIMEOUT_MS = 15 * 60 * 1000;
-const STALE_LOCK_MS = 30 * 60 * 1000;
+// Must stay strictly below LOCK_TIMEOUT_MS so a fresh orphan lock (recent mtime)
+// is reclaimed by the mtime fallback before any waiter gives up and throws.
+// Same-host dead holders are reclaimed immediately by the pid-liveness check
+// below, regardless of this window; this only bounds the hostname-less /
+// cross-host fallback case.
+const STALE_LOCK_MS = 10 * 60 * 1000;
+
+interface PrewarmLockOwner {
+  readonly createdAt: string;
+  readonly hostname?: string;
+  readonly pid?: number;
+}
 
 export interface SandboxTemplatePrewarmLockInput {
   readonly appRoot: string;
@@ -50,7 +62,11 @@ async function acquireLock(lockPath: string): Promise<void> {
       await mkdir(lockPath);
       await writeFile(
         join(lockPath, "owner.json"),
-        `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
+        `${JSON.stringify({
+          createdAt: new Date().toISOString(),
+          hostname: hostname(),
+          pid: process.pid,
+        } satisfies PrewarmLockOwner)}\n`,
       );
       return;
     } catch (error) {
@@ -106,12 +122,40 @@ async function waitForExistingLock(
     return;
   }
 
-  const lockAgeMs = Date.now() - lockStat.mtimeMs;
-  if (lockAgeMs > STALE_LOCK_MS) {
-    log?.("removing stale sandbox template prewarm lock");
+  // Decide what to do based on the recorded owner's liveness. The prewarm holder
+  // always runs on the same host as the waiter for the local/docker/microsandbox
+  // backends, so a same-host pid-liveness check is sound. We only trust it when
+  // owner.json records a matching hostname; older locks without a hostname (or
+  // genuine cross-host holders) report "unknown" and fall back to the mtime
+  // window below.
+  const liveness = await getPrewarmLockHolderLiveness(lockPath);
+
+  if (liveness === "dead") {
+    // Holder process is gone -> reclaim immediately rather than waiting out the
+    // mtime stale window.
+    log?.("removing sandbox template prewarm lock held by a dead process");
     await rm(lockPath, { force: true, recursive: true }).catch(() => {});
     return;
   }
+
+  if (liveness === "unknown") {
+    // No trustworthy pid signal: fall back to the mtime window. The lock's mtime
+    // is set once at acquire time and never refreshed, so this also reclaims a
+    // hostname-less orphan whose recent mtime would otherwise block. (A genuine
+    // long-running hostname-less holder is the only false-positive case; such
+    // locks are transient after an upgrade adds the hostname field.)
+    const lockAgeMs = Date.now() - lockStat.mtimeMs;
+    if (lockAgeMs > STALE_LOCK_MS) {
+      log?.("removing stale sandbox template prewarm lock");
+      await rm(lockPath, { force: true, recursive: true }).catch(() => {});
+      return;
+    }
+  }
+
+  // liveness === "alive": respect the live holder and keep polling. Do NOT apply
+  // the mtime window — the holder may legitimately run longer than STALE_LOCK_MS,
+  // and reclaiming it would let two prewarms of the same template race. Overall
+  // waiting is still bounded by LOCK_TIMEOUT_MS below.
 
   const elapsedMs = Date.now() - startedAt;
   if (elapsedMs > LOCK_TIMEOUT_MS) {
@@ -121,6 +165,56 @@ async function waitForExistingLock(
   }
 
   await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+}
+
+type PrewarmLockLiveness = "alive" | "dead" | "unknown";
+
+/**
+ * Classifies the recorded lock owner's liveness:
+ *   "dead"    - same-host owner (hostname matches), valid pid, process gone (ESRCH)
+ *   "alive"   - same-host owner, valid pid, process exists (kill(0) ok, or EPERM)
+ *   "unknown" - no owner / no hostname / hostname mismatch / non-positive pid /
+ *               unreadable record. A pid is only meaningful on the host that
+ *               recorded it, so anything we can't verify falls back to the mtime
+ *               window in the caller.
+ */
+async function getPrewarmLockHolderLiveness(lockPath: string): Promise<PrewarmLockLiveness> {
+  const owner = await readPrewarmLockOwner(lockPath);
+  if (owner === null) {
+    return "unknown";
+  }
+  if (owner.hostname === undefined || owner.hostname !== hostname()) {
+    return "unknown";
+  }
+  if (typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid <= 0) {
+    return "unknown";
+  }
+  try {
+    // Signal 0 performs error checking without sending a signal.
+    process.kill(owner.pid, 0);
+    return "alive";
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error) {
+      // ESRCH: no such process -> the holder is gone. EPERM: the process exists
+      // but is owned by another user -> treat as alive.
+      return error.code === "ESRCH" ? "dead" : "alive";
+    }
+    // Unexpected error shape: don't assume dead.
+    return "alive";
+  }
+}
+
+async function readPrewarmLockOwner(lockPath: string): Promise<PrewarmLockOwner | null> {
+  try {
+    const contents = await readFile(join(lockPath, "owner.json"), "utf8");
+    const parsed: unknown = JSON.parse(contents);
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+    return parsed as PrewarmLockOwner;
+  } catch {
+    return null;
+  }
 }
 
 function isFileExistsError(error: unknown): boolean {


### PR DESCRIPTION
## The bug

The cross-process sandbox-template prewarm lock (`withSandboxTemplatePrewarmLock` / `waitForSandboxTemplatePrewarmLock` in `src/execution/sandbox/template-prewarm-lock.ts`) is a filesystem `mkdir` lock released only in a `finally`. If the lock-holding process is killed (SIGINT/SIGKILL, OOM, crash) the `finally` never runs and the lock directory is orphaned. The next process that needs that template then blocks — emitting `waiting for sandbox template prewarm to finish (Ns elapsed)` with zero sandbox activity.

Two defects compounded this:

1. **`owner.json` records the holder `pid`, but liveness was never checked** — a dead owner was indistinguishable from a live one for up to the full stale window.
2. **`LOCK_TIMEOUT_MS` (15 min) was shorter than `STALE_LOCK_MS` (30 min)** — a *fresh* orphan (recent mtime) made a waiter throw at 15 min before the 30-min stale-removal could heal it.

## The fix

**1. Tri-state PID-liveness.** When waiting on a held lock, read `owner.json` and classify the recorded holder as `dead` / `alive` / `unknown`, probing with `process.kill(pid, 0)` (`ESRCH` → dead; success or `EPERM` → alive):

- `dead` → reclaim the lock immediately rather than waiting out the stale window.
- `alive` → respect the lock and keep polling; the mtime-stale reclaim is **not** applied (a legitimate prewarm may run longer than the stale window, and reclaiming it would let two prewarms of the same template race). Overall waiting is still bounded by `LOCK_TIMEOUT_MS`.
- `unknown` → fall back to the existing mtime-stale window.

**Same-host safety.** A pid check is only valid when the holder is on the same host. `owner.json` did not previously record a hostname, so this PR adds a `hostname` field at acquire time and only treats liveness as `dead`/`alive` when the recorded hostname matches `os.hostname()`. The prewarm always runs on the same host as the waiter for the local/docker/microsandbox backends, so same-host pid-liveness is sound (stated in a code comment). Anything we can't verify — missing/unreadable `owner.json`, missing or mismatched hostname, non-positive pid — is `unknown` and falls back to mtime, so **older locks written without a hostname remain fully backward-compatible**. (The one residual false-positive — a *live* hostname-less local holder running past the stale window — only applies to locks predating the upgrade and is transient.)

**2. Timeout/stale asymmetry.** `STALE_LOCK_MS` is lowered to 10 min, strictly below `LOCK_TIMEOUT_MS` (15 min), with a documented invariant. Because a waiter only ever waits on a lock that already exists (so the lock's mtime is at-or-before the waiter's start), `STALE_LOCK_MS < LOCK_TIMEOUT_MS` guarantees a fresh `unknown` orphan self-heals via the mtime path before any waiter throws. This window is now correctly scoped to the `unknown`-liveness case only — same-host dead holders are reclaimed immediately by the pid check, and same-host live holders are never reclaimed by mtime.

The change is surgical and backward-compatible; no unrelated code was reformatted.

## Test

Added `packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts` (vitest). It covers:

- a fresh lock whose same-host owner pid is **dead** is reclaimed quickly (asserts the waiter returns in < 5 s and the lock dir is gone — it does **not** block to the stale window);
- a same-host owner that is **alive** is respected **even when its mtime is stale** (owner = `process.pid`, mtime backdated 20 min > the 10-min stale window; waiter stays pending) — this guards the live-holder regression where a long-running prewarm's lock would otherwise be yanked;
- **backward-compat**: a dead owner recorded **without** a hostname is *not* reclaimed via the pid path and falls back to the mtime window (waiter stays pending).

The dead pid is produced by spawning a child, `SIGKILL`-ing it, and awaiting its `exit` before using its pid. Hostname uses `os.hostname()`.

**Note on test tier:** the lock is inherently filesystem-and-process based, so the test cannot run in eve's hermetic Tier-0 unit tier (the unit guard blocks real `fs/promises`). It is therefore an `*.integration.test.ts`, matching where the repo already puts real-`mkdtemp` tests.

### Validation
- Test: `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/sandbox/template-prewarm-lock.integration.test.ts` → **3 passed**.
- Typecheck: `pnpm --filter eve run typecheck` → **clean**.

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
