### PR TITLE
fix(sandbox): add idle-timeout backstop to microsandbox exec stream

### DIFF
--- a/.changeset/microsandbox-exec-idle-timeout.md
+++ b/.changeset/microsandbox-exec-idle-timeout.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add an idle-timeout backstop to the microsandbox exec stream so a stalled command can no longer hang the agent turn forever. If the exec iterator stops yielding output and never delivers an `exited` event, eve now kills the command and surfaces a failure once the stream has been idle past a configurable ceiling (default 5 minutes; reset on any output, overridable via `EVE_MICROSANDBOX_EXEC_IDLE_TIMEOUT_MS`).

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-process.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-process.test.ts
@@ -1,0 +1,91 @@
+import type { ExecHandle as MicrosandboxExecHandle } from "microsandbox";
+import { describe, expect, it, vi } from "vitest";
+
+import { adaptMicrosandboxExecToSandboxProcess } from "#execution/sandbox/bindings/microsandbox-process.js";
+import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
+
+type ExecEvent =
+  | { readonly kind: "stdout" | "stderr"; readonly data: Uint8Array }
+  | { readonly kind: "exited"; readonly code: number };
+
+/**
+ * Builds a fake microsandbox exec handle. After the scripted `events` are
+ * exhausted the iterator either stalls forever (`tail: "stall"`, the wedged-exec
+ * case the idle backstop guards against) or reports the stream as ended
+ * (`tail: "done"`).
+ */
+function createFakeExecHandle(
+  events: ExecEvent[],
+  tail: "stall" | "done",
+): MicrosandboxExecHandle & { kill: ReturnType<typeof vi.fn> } {
+  const queue = [...events];
+  const kill = vi.fn(async () => {});
+  return {
+    kill,
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          const event = queue.shift();
+          if (event !== undefined) {
+            return { done: false, value: event };
+          }
+          if (tail === "done") {
+            return { done: true, value: undefined };
+          }
+          // Stall: never resolve, never close.
+          return new Promise<IteratorResult<ExecEvent>>(() => {});
+        },
+      };
+    },
+  } as unknown as MicrosandboxExecHandle & { kill: ReturnType<typeof vi.fn> };
+}
+
+describe("adaptMicrosandboxExecToSandboxProcess", () => {
+  it("resolves with the exit code and delivers stdout on a clean exit", async () => {
+    const handle = createFakeExecHandle(
+      [
+        { data: Buffer.from("hello\n"), kind: "stdout" },
+        { code: 0, kind: "exited" },
+      ],
+      "done",
+    );
+
+    const process = adaptMicrosandboxExecToSandboxProcess(handle, { idleTimeoutMs: 1000 });
+    const [stdout, status] = await Promise.all([streamToBuffer(process.stdout), process.wait()]);
+
+    expect(stdout.toString()).toBe("hello\n");
+    expect(status).toEqual({ exitCode: 0 });
+    expect(handle.kill).not.toHaveBeenCalled();
+  });
+
+  it("kills the command and rejects when the stream stalls without an exit event", async () => {
+    const handle = createFakeExecHandle(
+      [{ data: Buffer.from("partial\n"), kind: "stdout" }],
+      "stall",
+    );
+
+    const process = adaptMicrosandboxExecToSandboxProcess(handle, { idleTimeoutMs: 50 });
+    // Drain stdout so its errored stream does not surface as an unhandled rejection.
+    void streamToBuffer(process.stdout).catch(() => {});
+
+    await expect(process.wait()).rejects.toThrow(
+      "Microsandbox command exceeded idle timeout (50ms with no output or exit event).",
+    );
+    expect(handle.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects with the ended-without-exit error when the stream closes before exiting", async () => {
+    const handle = createFakeExecHandle(
+      [{ data: Buffer.from("partial\n"), kind: "stdout" }],
+      "done",
+    );
+
+    const process = adaptMicrosandboxExecToSandboxProcess(handle, { idleTimeoutMs: 1000 });
+    void streamToBuffer(process.stdout).catch(() => {});
+
+    await expect(process.wait()).rejects.toThrow(
+      "Microsandbox command ended without an exit event.",
+    );
+    expect(handle.kill).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-process.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-process.ts
@@ -3,9 +3,53 @@ import type { ExecHandle as MicrosandboxExecHandle } from "microsandbox";
 
 const MICROSANDBOX_EXEC_POST_EXIT_DRAIN_MS = 100;
 
+/**
+ * Idle backstop for the exec stream. The microsandbox SDK exec iterator wraps a
+ * native NAPI binding with no timeout of its own, so a stalled exec — an in-guest
+ * process that never exits, or a dropped/lost native `exited` event — would block
+ * the completion loop (and the `wait()` promise behind it) forever. We bound that
+ * by killing the command and surfacing a failure once the stream has produced no
+ * activity for this long.
+ *
+ * This is an IDLE timeout, not a wall-clock one: the deadline resets on every
+ * stdout/stderr/exit event (each loop iteration starts a fresh race), so a long
+ * command that keeps emitting output is never killed. The only thing that trips
+ * it is total silence. The tradeoff: a legitimate long compute that emits NOTHING
+ * for the full window (e.g. `sleep 600`, a silent heavy calculation) would be
+ * killed. We bias generous so realistic tool commands are never affected — output
+ * resets the clock, so this is purely a ceiling on dead air — and expose an
+ * override (constructor option or `EVE_MICROSANDBOX_EXEC_IDLE_TIMEOUT_MS`) so the
+ * window can be tuned per environment.
+ */
+const MICROSANDBOX_EXEC_DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const MICROSANDBOX_EXEC_IDLE_TIMEOUT_ENV = "EVE_MICROSANDBOX_EXEC_IDLE_TIMEOUT_MS";
+
+interface AdaptMicrosandboxExecOptions {
+  /**
+   * Override for the idle timeout (ms) applied while waiting for an exit event.
+   * Falls back to {@link MICROSANDBOX_EXEC_IDLE_TIMEOUT_ENV}, then to
+   * {@link MICROSANDBOX_EXEC_DEFAULT_IDLE_TIMEOUT_MS}.
+   */
+  readonly idleTimeoutMs?: number;
+}
+
+function resolveIdleTimeoutMs(options: AdaptMicrosandboxExecOptions): number {
+  if (options.idleTimeoutMs !== undefined) {
+    return options.idleTimeoutMs;
+  }
+  const fromEnv = Number(process.env[MICROSANDBOX_EXEC_IDLE_TIMEOUT_ENV]);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return MICROSANDBOX_EXEC_DEFAULT_IDLE_TIMEOUT_MS;
+}
+
 export function adaptMicrosandboxExecToSandboxProcess(
   command: MicrosandboxExecHandle,
+  options: AdaptMicrosandboxExecOptions = {},
 ): SandboxProcess {
+  const idleTimeoutMs = resolveIdleTimeoutMs(options);
   let stdoutController: ReadableStreamDefaultController<Uint8Array> | undefined;
   let stderrController: ReadableStreamDefaultController<Uint8Array> | undefined;
   let exitCode: number | undefined;
@@ -29,13 +73,32 @@ export function adaptMicrosandboxExecToSandboxProcess(
 
   void (async () => {
     const iterator = command[Symbol.asyncIterator]();
+    let terminalError: unknown;
     try {
       for (;;) {
-        const result =
-          exitCode === undefined
-            ? await iterator.next()
-            : await nextWithTimeout(iterator, MICROSANDBOX_EXEC_POST_EXIT_DRAIN_MS);
-        if (result === "timeout" || result.done === true) {
+        // Before an exit event arrives, bound the wait by the idle timeout; after
+        // it, fall back to the short post-exit drain so trailing output flushes.
+        // Either way each iteration starts a fresh race, so any event resets the
+        // idle deadline.
+        const awaitingExit = exitCode === undefined;
+        const result = await nextWithTimeout(
+          iterator,
+          awaitingExit ? idleTimeoutMs : MICROSANDBOX_EXEC_POST_EXIT_DRAIN_MS,
+        );
+        if (result === "timeout") {
+          if (awaitingExit) {
+            // The stream stalled open with no output and no exit event. Kill the
+            // command (fire-and-forget — the native binding that stalled also
+            // backs kill(), so awaiting it could wedge again) and surface the
+            // failure instead of hanging forever.
+            void command.kill().catch(() => {});
+            terminalError = new Error(
+              `Microsandbox command exceeded idle timeout (${idleTimeoutMs}ms with no output or exit event).`,
+            );
+          }
+          break;
+        }
+        if (result.done === true) {
           break;
         }
 
@@ -49,12 +112,14 @@ export function adaptMicrosandboxExecToSandboxProcess(
         }
       }
     } catch (error) {
-      stdoutController?.error(error);
-      stderrController?.error(error);
-      rejectFinished?.(error);
+      terminalError = error;
     } finally {
       void iterator.return?.().catch(() => {});
-      if (exitCode === undefined) {
+      if (terminalError !== undefined) {
+        stdoutController?.error(terminalError);
+        stderrController?.error(terminalError);
+        rejectFinished?.(terminalError);
+      } else if (exitCode === undefined) {
         const error = new Error("Microsandbox command ended without an exit event.");
         stdoutController?.error(error);
         stderrController?.error(error);


### PR DESCRIPTION
## Problem

A microsandbox sandbox command can hang **indefinitely**. In
`adaptMicrosandboxExecToSandboxProcess`
(`packages/eve/src/execution/sandbox/bindings/microsandbox-process.ts`) the
completion loop consumes the SDK exec async-iterator:

```ts
const result =
  exitCode === undefined
    ? await iterator.next()                                   // no timeout
    : await nextWithTimeout(iterator, MICROSANDBOX_EXEC_POST_EXIT_DRAIN_MS);
```

While no `exited` event has arrived (`exitCode === undefined`), it does a plain
`await iterator.next()` with **no timeout**. The 100 ms `nextWithTimeout` only
applies *after* an exit event, to drain trailing output. There is a guard for the
stream *ending* without an exit (`"Microsandbox command ended without an exit
event."`) but **none for the stream stalling open** — if the iterator never yields
`exited` and never closes, this `await` (and the `finished` promise behind
`wait()`) blocks forever. The microsandbox SDK exec layer wraps a native NAPI
binding with no timeout of its own, so there is no timeout anywhere in the JS
stack and a stalled exec becomes an infinite hang of the agent turn / `eve eval`.

Closes #440.

## Fix (self-contained backstop)

This is the graduated fix #1 from the issue: an **idle timeout** on the no-exit
branch, with **no public-API change**.

- The pre-exit `await iterator.next()` now goes through `nextWithTimeout` with an
  idle deadline. Because each loop iteration starts a fresh race, the deadline
  **resets on every stdout/stderr/exit event** — a command that keeps emitting
  output is never killed; only *total silence* trips it.
- On idle-timeout the command is killed and the `finished` promise is rejected
  (and the stdout/stderr controllers errored) with a clear error:
  `"Microsandbox command exceeded idle timeout (<N>ms with no output or exit
  event)."`, so a wedged exec surfaces as a failure instead of hanging.
- `kill()` is **fire-and-forget** (`void command.kill().catch(() => {})`),
  matching the existing cancellation path in `microsandbox-runtime.ts`. The
  premise is that the native binding stalled; `kill()` calls into that same
  binding, so awaiting it could wedge again. The rejection must not depend on
  kill completing.
- The post-exit 100 ms drain behavior is unchanged.

The terminal branching in the `finally` block was refactored to a single
`terminalError` variable so the idle-timeout error, the iterator-threw error, and
the pre-existing "ended without an exit event" error all surface through one
path (first error wins; `ReadableStreamDefaultController.error()` is a no-op once
the stream is no longer readable).

### Design tradeoff and default

A pure wall-clock timeout would wrongly kill long-but-progressing commands; an
idle timeout (reset on output) is better but still risks killing a legitimate
long compute that emits *no* output for the whole window (e.g. `sleep 600`, a
silent heavy calculation). So the ceiling is a named constant with a **generous
5-minute default** and an override knob.

A false kill (terminating a legit silent compute) is worse than waiting a few
extra minutes to kill a truly-wedged exec, so the default biases generous. Five
minutes of **zero bytes** — no stdout, no stderr, no exit — is well beyond any
normal tool command, while still bounding the previously-unbounded hang. Tune it
per environment via the `idleTimeoutMs` option or the
`EVE_MICROSANDBOX_EXEC_IDLE_TIMEOUT_MS` env var (a malformed value falls back to
the default rather than disabling the backstop).

## Out of scope (follow-up)

The issue's fix #2 — threading a cancellation `AbortSignal` end-to-end from the
tool/turn context through `executeBashOnSandbox` → `runWithDevelopmentSandboxProgress`
→ `sandbox.run({ command, abortSignal })` — touches public API
(`SessionContext` / callback context) and belongs in a separate change. It would
also make agent-level cancellation and eval `timeoutMs` actually terminate a
running command. This PR is the self-contained backstop only.

## Test

`packages/eve/src/execution/sandbox/bindings/microsandbox-process.test.ts` builds
a fake async-iterable exec handle with a `kill()` spy and covers:

1. **Happy path** — stdout then `{kind:"exited", code:0}` → `wait()` resolves
   `{exitCode:0}`, stdout delivers data, `kill()` not called.
2. **Stall** — one stdout then never yields again → with a test-shortened 50 ms
   idle timeout, `wait()` rejects with the idle-timeout error and `kill()` was
   called once. (This also exercises the `idleTimeoutMs` override knob.)
3. **Ends without exit** — stream closes before an exit event → the existing
   "ended without an exit event" error still fires (guards the `finally` refactor).

```
pnpm --filter eve exec vitest run --config vitest.unit.config.ts \
  src/execution/sandbox/bindings/microsandbox-process.test.ts
# Test Files  1 passed (1)   Tests  3 passed (3)
```

`pnpm --filter eve run typecheck` passes.
