### PR TITLE
Track eve init install footprint

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -16,6 +16,7 @@ on:
       - "packages/eve/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "scripts/init-install-report.mjs"
       - "scripts/nitro-bundle-report-compare.mjs"
       - "scripts/nitro-bundle-report-budget.mjs"
       - "scripts/nitro-bundle-report.mjs"

--- a/scripts/init-install-report.mjs
+++ b/scripts/init-install-report.mjs
@@ -168,6 +168,10 @@ async function runInitCommand(input) {
   const packageRoot = resolve(input.packageRoot);
   const cliPath = join(packageRoot, "bin", "eve.js");
 
+  if (!(await pathExists(cliPath))) {
+    return null;
+  }
+
   await execFile(process.execPath, [cliPath, "init", INIT_PROJECT_NAME], {
     cwd: input.parentDirectory,
     env: {
@@ -179,6 +183,8 @@ async function runInitCommand(input) {
     maxBuffer: 32 * 1024 * 1024,
     timeout: INIT_INSTALL_TIMEOUT_MS,
   });
+
+  return true;
 }
 
 export async function collectInitInstallReportFromTarball(options) {
@@ -186,11 +192,14 @@ export async function collectInitInstallReportFromTarball(options) {
   const initDirectory = await mkdtemp(join(tmpdir(), "eve-init-install-"));
 
   try {
-    await runInitCommand({
+    const initialized = await runInitCommand({
       evePackageSpec: `file:${options.tarballPath}`,
       packageRoot,
       parentDirectory: initDirectory,
     });
+    if (initialized !== true) {
+      return null;
+    }
 
     const projectRoot = join(initDirectory, INIT_PROJECT_NAME);
     const packageJson = await readJson(join(projectRoot, "package.json"));

--- a/scripts/init-install-report.mjs
+++ b/scripts/init-install-report.mjs
@@ -1,0 +1,296 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { lstat, mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { runPack } from "./package-publish-report.mjs";
+
+const execFile = promisify(execFileCallback);
+
+const INIT_PROJECT_NAME = "my-agent";
+const INIT_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+const INSTALLED_PACKAGE_BREAKDOWN_MAX_ENTRIES = 6;
+const INSTALLED_PACKAGE_BREAKDOWN_MIN_BYTES = 5_000_000;
+
+function normalizePath(path) {
+  return path.replaceAll("\\", "/");
+}
+
+function comparePaths(left, right) {
+  return left.localeCompare(right, "en");
+}
+
+async function pathExists(path) {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(path) {
+  const source = await readFile(path, "utf8");
+
+  return JSON.parse(source);
+}
+
+async function walkRegularFiles(root) {
+  /** @type {{ relativePath: string; size: number }[]} */
+  const files = [];
+
+  async function visit(currentPath) {
+    const entries = await readdir(currentPath, {
+      withFileTypes: true,
+    });
+    entries.sort((left, right) => comparePaths(left.name, right.name));
+
+    for (const entry of entries) {
+      const entryPath = join(currentPath, entry.name);
+
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const entryStats = await stat(entryPath);
+      files.push({
+        relativePath: normalizePath(relative(root, entryPath)),
+        size: entryStats.size,
+      });
+    }
+  }
+
+  await visit(root);
+  files.sort((left, right) => comparePaths(left.relativePath, right.relativePath));
+
+  return files;
+}
+
+function readInstalledPackageName(relativePath) {
+  const pathSegments = normalizePath(relativePath).split("/");
+  let packageStartIndex = 0;
+
+  for (const [index, segment] of pathSegments.entries()) {
+    if (segment === "node_modules" && index + 1 < pathSegments.length) {
+      packageStartIndex = index + 1;
+    }
+  }
+
+  const packageStart = pathSegments[packageStartIndex];
+
+  if (!packageStart || packageStart.startsWith(".")) {
+    return null;
+  }
+
+  if (packageStart.startsWith("@")) {
+    const scopedName = pathSegments[packageStartIndex + 1];
+
+    return scopedName ? `${packageStart}/${scopedName}` : null;
+  }
+
+  return packageStart;
+}
+
+function summarizeInstalledPackages(files) {
+  /** @type {Map<string, number>} */
+  const packageSizes = new Map();
+
+  for (const file of files) {
+    const packageName = readInstalledPackageName(file.relativePath);
+
+    if (!packageName) {
+      continue;
+    }
+
+    packageSizes.set(packageName, (packageSizes.get(packageName) ?? 0) + file.size);
+  }
+
+  const sortedPackages = [...packageSizes.entries()]
+    .sort((left, right) => right[1] - left[1] || comparePaths(left[0], right[0]))
+    .map(([name, bytes]) => ({
+      bytes,
+      name,
+    }));
+
+  if (sortedPackages.length <= INSTALLED_PACKAGE_BREAKDOWN_MAX_ENTRIES) {
+    return sortedPackages;
+  }
+
+  let retainedCount = INSTALLED_PACKAGE_BREAKDOWN_MAX_ENTRIES;
+
+  while (
+    retainedCount < sortedPackages.length &&
+    sortedPackages[retainedCount] &&
+    sortedPackages[retainedCount].bytes > INSTALLED_PACKAGE_BREAKDOWN_MIN_BYTES
+  ) {
+    retainedCount += 1;
+  }
+
+  return sortedPackages.slice(0, retainedCount);
+}
+
+function readDependencyBlock(packageJson, key) {
+  return Object.entries(packageJson[key] ?? {})
+    .filter((entry) => typeof entry[1] === "string")
+    .map(([name, range]) => ({
+      name,
+      range,
+    }))
+    .sort((left, right) => comparePaths(left.name, right.name));
+}
+
+function attachInstalledBytes(dependencies, packageSizes) {
+  return dependencies.map((dependency) => ({
+    ...dependency,
+    bytes: packageSizes.get(dependency.name) ?? 0,
+  }));
+}
+
+function normalizeDependencyRanges(dependencies, input) {
+  return dependencies.map((dependency) =>
+    dependency.name === input.packageName && dependency.range.startsWith("file:")
+      ? { ...dependency, range: input.packageSpec }
+      : dependency,
+  );
+}
+
+async function runInitCommand(input) {
+  const packageRoot = resolve(input.packageRoot);
+  const cliPath = join(packageRoot, "bin", "eve.js");
+
+  await execFile(process.execPath, [cliPath, "init", INIT_PROJECT_NAME], {
+    cwd: input.parentDirectory,
+    env: {
+      ...process.env,
+      CODEX_CI: "1",
+      EVE_INIT_PACKAGE_SPEC: input.evePackageSpec,
+      npm_config_user_agent: `npm/? node/${process.versions.node} ${process.platform} ${process.arch}`,
+    },
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: INIT_INSTALL_TIMEOUT_MS,
+  });
+}
+
+export async function collectInitInstallReportFromTarball(options) {
+  const packageRoot = resolve(options.packageRoot);
+  const initDirectory = await mkdtemp(join(tmpdir(), "eve-init-install-"));
+
+  try {
+    await runInitCommand({
+      evePackageSpec: `file:${options.tarballPath}`,
+      packageRoot,
+      parentDirectory: initDirectory,
+    });
+
+    const projectRoot = join(initDirectory, INIT_PROJECT_NAME);
+    const packageJson = await readJson(join(projectRoot, "package.json"));
+    const nodeModulesRoot = join(projectRoot, "node_modules");
+    const installedFiles = (await pathExists(nodeModulesRoot))
+      ? await walkRegularFiles(nodeModulesRoot)
+      : [];
+    const installedSizeBytes = installedFiles.reduce((total, file) => total + file.size, 0);
+    const packageSizes = new Map();
+    const packageSpec = `file:${basename(options.tarballPath)}`;
+
+    for (const file of installedFiles) {
+      const packageName = readInstalledPackageName(file.relativePath);
+
+      if (!packageName) {
+        continue;
+      }
+
+      packageSizes.set(packageName, (packageSizes.get(packageName) ?? 0) + file.size);
+    }
+
+    const dependencies = normalizeDependencyRanges(
+      attachInstalledBytes(readDependencyBlock(packageJson, "dependencies"), packageSizes),
+      {
+        packageName: "eve",
+        packageSpec,
+      },
+    );
+    const devDependencies = normalizeDependencyRanges(
+      attachInstalledBytes(readDependencyBlock(packageJson, "devDependencies"), packageSizes),
+      {
+        packageName: "eve",
+        packageSpec,
+      },
+    );
+    const directDependencyNames = new Set(dependencies.map((dependency) => dependency.name));
+    const directDevDependencyNames = new Set(devDependencies.map((dependency) => dependency.name));
+    const dependencyPackageBytes = dependencies.reduce(
+      (total, dependency) => total + dependency.bytes,
+      0,
+    );
+    const devDependencyPackageBytes = devDependencies.reduce(
+      (total, dependency) =>
+        directDependencyNames.has(dependency.name) ? total : total + dependency.bytes,
+      0,
+    );
+
+    return {
+      dependencyCount: dependencies.length,
+      dependencyPackageBytes,
+      dependencies,
+      devDependencies,
+      devDependencyCount: devDependencies.length,
+      devDependencyPackageBytes,
+      installedFileCount: installedFiles.length,
+      installedPackageCount: packageSizes.size,
+      installedSizeBytes,
+      packageLabel: options.packageLabel ?? basename(packageRoot),
+      packageRoot,
+      packageSpec,
+      packageManager: "npm",
+      projectName: INIT_PROJECT_NAME,
+      topInstalledPackages: summarizeInstalledPackages(installedFiles),
+      transitivePackageBytes: Math.max(
+        0,
+        installedSizeBytes - dependencyPackageBytes - devDependencyPackageBytes,
+      ),
+      unclassifiedInstalledPackageCount: [...packageSizes.keys()].filter(
+        (name) => !directDependencyNames.has(name) && !directDevDependencyNames.has(name),
+      ).length,
+    };
+  } finally {
+    await rm(initDirectory, {
+      force: true,
+      recursive: true,
+    });
+  }
+}
+
+export async function collectInitInstallReport(options) {
+  const packageRoot = resolve(options.packageRoot);
+  const packDirectory = await mkdtemp(join(tmpdir(), "eve-init-package-pack-"));
+
+  try {
+    const packResult = await runPack(packageRoot, packDirectory);
+    const tarballFilename = typeof packResult.filename === "string" ? packResult.filename : null;
+
+    if (!tarballFilename) {
+      throw new Error(`npm pack did not report a tarball filename for "${packageRoot}".`);
+    }
+
+    return collectInitInstallReportFromTarball({
+      packageLabel: options.packageLabel,
+      packageRoot,
+      tarballPath: join(packDirectory, tarballFilename),
+    });
+  } finally {
+    await rm(packDirectory, {
+      force: true,
+      recursive: true,
+    });
+  }
+}

--- a/scripts/nitro-bundle-report-compare.mjs
+++ b/scripts/nitro-bundle-report-compare.mjs
@@ -67,7 +67,7 @@ function createRuntimeDependencyChecks(packageComparison) {
 }
 
 function createInitInstallSizeBudgetChecks(initInstallComparison) {
-  if (initInstallComparison === null) {
+  if (initInstallComparison === null || initInstallComparison.status !== "present") {
     return [];
   }
 

--- a/scripts/nitro-bundle-report-compare.mjs
+++ b/scripts/nitro-bundle-report-compare.mjs
@@ -66,7 +66,21 @@ function createRuntimeDependencyChecks(packageComparison) {
   }));
 }
 
-function createSizeBudget(appComparison, packageComparison) {
+function createInitInstallSizeBudgetChecks(initInstallComparison) {
+  if (initInstallComparison === null) {
+    return [];
+  }
+
+  return [
+    createSizeBudgetCheck(initInstallComparison.installedSizeBytes, {
+      area: "Init",
+      metric: "Installed footprint",
+      summary: "`eve init` install footprint",
+    }),
+  ];
+}
+
+function createSizeBudget(appComparison, packageComparison, initInstallComparison) {
   const checks = [
     createSizeBudgetCheck(appComparison.uniqueFunctionBytes, {
       area: "Runtime",
@@ -85,6 +99,7 @@ function createSizeBudget(appComparison, packageComparison) {
     );
   }
 
+  checks.push(...createInitInstallSizeBudgetChecks(initInstallComparison));
   checks.push(...createRuntimeDependencyChecks(packageComparison));
 
   return {
@@ -335,6 +350,68 @@ function comparePublishedPackages(currentPackage, baselinePackage) {
   };
 }
 
+function compareInitInstallReports(currentInitInstall, baselineInitInstall) {
+  if (currentInitInstall === null && baselineInitInstall === null) {
+    return null;
+  }
+
+  const dependencyDiff = compareDependencyEntries(
+    readDependencyEntries(currentInitInstall?.dependencies),
+    readDependencyEntries(baselineInitInstall?.dependencies),
+  );
+  const devDependencyDiff = compareDependencyEntries(
+    readDependencyEntries(currentInitInstall?.devDependencies),
+    readDependencyEntries(baselineInitInstall?.devDependencies),
+  );
+
+  return {
+    dependenciesAdded: dependencyDiff.added,
+    dependenciesChanged: dependencyDiff.changed,
+    dependenciesRemoved: dependencyDiff.removed,
+    dependencyCount: compareNumericMetric(
+      readMetricValue(currentInitInstall?.dependencyCount),
+      readMetricValue(baselineInitInstall?.dependencyCount),
+    ),
+    dependencyPackageBytes: compareNumericMetric(
+      readMetricValue(currentInitInstall?.dependencyPackageBytes),
+      readMetricValue(baselineInitInstall?.dependencyPackageBytes),
+    ),
+    devDependenciesAdded: devDependencyDiff.added,
+    devDependenciesChanged: devDependencyDiff.changed,
+    devDependenciesRemoved: devDependencyDiff.removed,
+    devDependencyCount: compareNumericMetric(
+      readMetricValue(currentInitInstall?.devDependencyCount),
+      readMetricValue(baselineInitInstall?.devDependencyCount),
+    ),
+    devDependencyPackageBytes: compareNumericMetric(
+      readMetricValue(currentInitInstall?.devDependencyPackageBytes),
+      readMetricValue(baselineInitInstall?.devDependencyPackageBytes),
+    ),
+    installedFileCount: compareNumericMetric(
+      readMetricValue(currentInitInstall?.installedFileCount),
+      readMetricValue(baselineInitInstall?.installedFileCount),
+    ),
+    installedPackageCount: compareNumericMetric(
+      readMetricValue(currentInitInstall?.installedPackageCount),
+      readMetricValue(baselineInitInstall?.installedPackageCount),
+    ),
+    installedSizeBytes: compareNumericMetric(
+      readMetricValue(currentInitInstall?.installedSizeBytes),
+      readMetricValue(baselineInitInstall?.installedSizeBytes),
+    ),
+    status:
+      baselineInitInstall === null ? "added" : currentInitInstall === null ? "removed" : "present",
+    transitivePackageBytes: compareNumericMetric(
+      readMetricValue(currentInitInstall?.transitivePackageBytes),
+      readMetricValue(baselineInitInstall?.transitivePackageBytes),
+    ),
+    unclassifiedInstalledPackageCount: compareNumericMetric(
+      readMetricValue(currentInitInstall?.unclassifiedInstalledPackageCount),
+      readMetricValue(baselineInitInstall?.unclassifiedInstalledPackageCount),
+    ),
+  };
+}
+
 /**
  * Compares one Nitro bundle report to a baseline snapshot and returns the
  * byte/count deltas needed for regression tracking.
@@ -379,13 +456,18 @@ export function createNitroBundleReportComparison(report, baselineReport, option
     report?.publishedPackage ?? null,
     baselineReport?.publishedPackage ?? null,
   );
+  const initInstallComparison = compareInitInstallReports(
+    report?.initInstall ?? null,
+    baselineReport?.initInstall ?? null,
+  );
 
   return {
     app: appComparison,
     baselineGeneratedAt:
       typeof baselineReport?.generatedAt === "string" ? baselineReport.generatedAt : null,
     baselineLabel: typeof options.baselineLabel === "string" ? options.baselineLabel : "baseline",
+    initInstall: initInstallComparison,
     package: packageComparison,
-    sizeBudget: createSizeBudget(appComparison, packageComparison),
+    sizeBudget: createSizeBudget(appComparison, packageComparison, initInstallComparison),
   };
 }

--- a/scripts/nitro-bundle-report.mjs
+++ b/scripts/nitro-bundle-report.mjs
@@ -589,12 +589,6 @@ function summarizePackageTakeaways(publishedPackage) {
   ];
 }
 
-function summarizeInitInstallTakeaways(initInstall) {
-  return [
-    `- \`eve init ${initInstall.projectName}\`: installed footprint ${formatBytes(initInstall.installedSizeBytes)} across ${initInstall.installedPackageCount} package${initInstall.installedPackageCount === 1 ? "" : "s"} (${initInstall.dependencyCount} dependencies, ${initInstall.devDependencyCount} devDependencies).`,
-  ];
-}
-
 function summarizeFunctionTakeaways(report) {
   if (report.functions.length === 0) {
     return [];
@@ -762,32 +756,6 @@ function summarizeComparisonTakeaways(comparison) {
     }
   }
 
-  if (comparison.initInstall !== null) {
-    const initParts = [];
-
-    if (comparison.initInstall.status === "added") {
-      initParts.push("init install tracking added");
-    } else if (comparison.initInstall.status === "removed") {
-      initParts.push("init install tracking removed");
-    }
-
-    if (isNotableByteDelta(comparison.initInstall.installedSizeBytes)) {
-      initParts.push(
-        `install footprint ${formatByteMetricTransition(comparison.initInstall.installedSizeBytes)}`,
-      );
-    }
-
-    if (comparison.initInstall.installedPackageCount.delta !== 0) {
-      initParts.push(
-        `installed packages ${formatCountMetricTransition(comparison.initInstall.installedPackageCount)}`,
-      );
-    }
-
-    if (initParts.length > 0) {
-      lines.push(`- \`eve init\` delta: ${initParts.join("; ")}.`);
-    }
-  }
-
   const runtimeParts = [];
 
   if (isNotableByteDelta(comparison.app.uniqueFunctionBytes)) {
@@ -838,15 +806,6 @@ function renderSummaryTable(report) {
     lines.push(
       `| Package | Installed footprint | ${formatBytes(report.publishedPackage.installedSizeBytes)} |`,
     );
-  }
-
-  if (report.initInstall) {
-    lines.push(
-      `| Init | Installed footprint | ${formatBytes(report.initInstall.installedSizeBytes)} |`,
-    );
-    lines.push(`| Init | Installed packages | ${report.initInstall.installedPackageCount} |`);
-    lines.push(`| Init | dependencies | ${report.initInstall.dependencyCount} |`);
-    lines.push(`| Init | devDependencies | ${report.initInstall.devDependencyCount} |`);
   }
 
   lines.push(`| Runtime | Unique function payloads | ${report.uniqueFunctionCount} |`);
@@ -1096,27 +1055,6 @@ function renderComparisonSection(comparison) {
     );
   }
 
-  if (comparison.initInstall !== null) {
-    lines.push(
-      `| Init | Installed footprint | ${formatBytes(comparison.initInstall.installedSizeBytes.baseline)} | ${formatBytes(comparison.initInstall.installedSizeBytes.current)} | ${formatSizeDelta(comparison.initInstall.installedSizeBytes.delta)} |`,
-    );
-    lines.push(
-      `| Init | Installed packages | ${comparison.initInstall.installedPackageCount.baseline} | ${comparison.initInstall.installedPackageCount.current} | ${formatSignedCount(comparison.initInstall.installedPackageCount.delta)} |`,
-    );
-    lines.push(
-      `| Init | dependencies | ${comparison.initInstall.dependencyCount.baseline} | ${comparison.initInstall.dependencyCount.current} | ${formatSignedCount(comparison.initInstall.dependencyCount.delta)} |`,
-    );
-    lines.push(
-      `| Init | devDependencies | ${comparison.initInstall.devDependencyCount.baseline} | ${comparison.initInstall.devDependencyCount.current} | ${formatSignedCount(comparison.initInstall.devDependencyCount.delta)} |`,
-    );
-    lines.push(
-      `| Init | Dependency package bytes | ${formatBytes(comparison.initInstall.dependencyPackageBytes.baseline)} | ${formatBytes(comparison.initInstall.dependencyPackageBytes.current)} | ${formatSizeDelta(comparison.initInstall.dependencyPackageBytes.delta)} |`,
-    );
-    lines.push(
-      `| Init | devDependency package bytes | ${formatBytes(comparison.initInstall.devDependencyPackageBytes.baseline)} | ${formatBytes(comparison.initInstall.devDependencyPackageBytes.current)} | ${formatSizeDelta(comparison.initInstall.devDependencyPackageBytes.delta)} |`,
-    );
-  }
-
   lines.push(
     `| Runtime | Unique function payloads | ${comparison.app.uniqueFunctionCount.baseline} | ${comparison.app.uniqueFunctionCount.current} | ${formatSignedCount(comparison.app.uniqueFunctionCount.delta)} |`,
   );
@@ -1129,9 +1067,6 @@ function renderComparisonSection(comparison) {
   lines.push("");
 
   lines.push(...renderDependencyManifestDelta(comparison.package, comparison.baselineLabel));
-  lines.push(
-    ...renderInitDependencyManifestDelta(comparison.initInstall, comparison.baselineLabel),
-  );
   lines.push(...renderFunctionDeltaSection(comparison));
 
   return lines;
@@ -1257,6 +1192,76 @@ function renderPublishedPackageSection(publishedPackage) {
   return lines;
 }
 
+function renderInitInstallSummarySection(report) {
+  if (report.comparison?.initInstall) {
+    const comparison = report.comparison.initInstall;
+    const lines = ["### `eve init` install", ""];
+
+    if (comparison.status !== "present") {
+      lines.push(
+        "_This metric is shown for visibility only until both the baseline and current report include it._",
+        "",
+      );
+    }
+
+    const baselineValue = (metric, formatter = (value) => String(value)) =>
+      comparison.status === "added" ? "not tracked" : formatter(metric.baseline);
+    const currentValue = (metric, formatter = (value) => String(value)) =>
+      comparison.status === "removed" ? "not tracked" : formatter(metric.current);
+    const deltaValue = (metric, formatter) =>
+      comparison.status === "present"
+        ? formatter(metric.delta)
+        : comparison.status === "added"
+          ? "new metric"
+          : "removed metric";
+
+    lines.push("| Metric | Baseline | Current | Delta |");
+    lines.push("| --- | --- | --- | --- |");
+    lines.push(
+      `| Installed footprint | ${baselineValue(comparison.installedSizeBytes, formatBytes)} | ${currentValue(comparison.installedSizeBytes, formatBytes)} | ${deltaValue(comparison.installedSizeBytes, formatSizeDelta)} |`,
+    );
+    lines.push(
+      `| Installed packages | ${baselineValue(comparison.installedPackageCount)} | ${currentValue(comparison.installedPackageCount)} | ${deltaValue(comparison.installedPackageCount, formatSignedCount)} |`,
+    );
+    lines.push(
+      `| dependencies | ${baselineValue(comparison.dependencyCount)} | ${currentValue(comparison.dependencyCount)} | ${deltaValue(comparison.dependencyCount, formatSignedCount)} |`,
+    );
+    lines.push(
+      `| devDependencies | ${baselineValue(comparison.devDependencyCount)} | ${currentValue(comparison.devDependencyCount)} | ${deltaValue(comparison.devDependencyCount, formatSignedCount)} |`,
+    );
+    lines.push(
+      `| Dependency package bytes | ${baselineValue(comparison.dependencyPackageBytes, formatBytes)} | ${currentValue(comparison.dependencyPackageBytes, formatBytes)} | ${deltaValue(comparison.dependencyPackageBytes, formatSizeDelta)} |`,
+    );
+    lines.push(
+      `| devDependency package bytes | ${baselineValue(comparison.devDependencyPackageBytes, formatBytes)} | ${currentValue(comparison.devDependencyPackageBytes, formatBytes)} | ${deltaValue(comparison.devDependencyPackageBytes, formatSizeDelta)} |`,
+    );
+    lines.push("");
+    lines.push(...renderInitDependencyManifestDelta(comparison, report.comparison.baselineLabel));
+
+    return lines;
+  }
+
+  if (!report.initInstall) {
+    return [];
+  }
+
+  const lines = ["### `eve init` install", ""];
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Installed footprint | ${formatBytes(report.initInstall.installedSizeBytes)} |`);
+  lines.push(`| Installed packages | ${report.initInstall.installedPackageCount} |`);
+  lines.push(`| dependencies | ${report.initInstall.dependencyCount} |`);
+  lines.push(`| devDependencies | ${report.initInstall.devDependencyCount} |`);
+  lines.push(
+    `| Dependency package bytes | ${formatBytes(report.initInstall.dependencyPackageBytes)} |`,
+  );
+  lines.push(
+    `| devDependency package bytes | ${formatBytes(report.initInstall.devDependencyPackageBytes)} |`,
+  );
+  lines.push("");
+  return lines;
+}
+
 function renderInitDependencyTable(title, dependencies, totalBytes) {
   const lines = ["<details>", `<summary>${title} (${dependencies.length})</summary>`, ""];
 
@@ -1279,8 +1284,8 @@ function renderInitDependencyTable(title, dependencies, totalBytes) {
 }
 
 function renderInitInstallSection(initInstall) {
-  const lines = ["<details>", "<summary>eve init Install Drill-Down</summary>", ""];
-  lines.push("### Init Install Details", "");
+  const lines = ["<details>", "<summary><code>eve init</code> install drill-down</summary>", ""];
+  lines.push("### `eve init` install details", "");
   lines.push(`- Command: \`eve init ${initInstall.projectName}\``);
   lines.push(`- Package manager: \`${initInstall.packageManager}\``);
   lines.push(
@@ -1736,7 +1741,6 @@ export function renderNitroBundleReportMarkdown(report) {
     ? summarizeComparisonTakeaways(report.comparison)
     : [
         ...(report.publishedPackage ? summarizePackageTakeaways(report.publishedPackage) : []),
-        ...(report.initInstall ? summarizeInitInstallTakeaways(report.initInstall) : []),
         ...summarizeFunctionTakeaways(report),
       ];
   const lines = [
@@ -1756,6 +1760,8 @@ export function renderNitroBundleReportMarkdown(report) {
   if (!report.comparison) {
     lines.push(...renderSummaryTable(report));
   }
+
+  lines.push(...renderInitInstallSummarySection(report));
 
   lines.push(...renderMetadataSection(report));
 

--- a/scripts/nitro-bundle-report.mjs
+++ b/scripts/nitro-bundle-report.mjs
@@ -1,9 +1,21 @@
-import { lstat, mkdir, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createNitroBundleReportComparison } from "./nitro-bundle-report-compare.mjs";
-import { collectPublishedPackageReport } from "./package-publish-report.mjs";
+import { collectInitInstallReportFromTarball } from "./init-install-report.mjs";
+import { collectPublishedPackageReportFromPack, runPack } from "./package-publish-report.mjs";
 
 function normalizePath(path) {
   return path.replaceAll("\\", "/");
@@ -577,6 +589,12 @@ function summarizePackageTakeaways(publishedPackage) {
   ];
 }
 
+function summarizeInitInstallTakeaways(initInstall) {
+  return [
+    `- \`eve init ${initInstall.projectName}\`: installed footprint ${formatBytes(initInstall.installedSizeBytes)} across ${initInstall.installedPackageCount} package${initInstall.installedPackageCount === 1 ? "" : "s"} (${initInstall.dependencyCount} dependencies, ${initInstall.devDependencyCount} devDependencies).`,
+  ];
+}
+
 function summarizeFunctionTakeaways(report) {
   if (report.functions.length === 0) {
     return [];
@@ -744,6 +762,32 @@ function summarizeComparisonTakeaways(comparison) {
     }
   }
 
+  if (comparison.initInstall !== null) {
+    const initParts = [];
+
+    if (comparison.initInstall.status === "added") {
+      initParts.push("init install tracking added");
+    } else if (comparison.initInstall.status === "removed") {
+      initParts.push("init install tracking removed");
+    }
+
+    if (isNotableByteDelta(comparison.initInstall.installedSizeBytes)) {
+      initParts.push(
+        `install footprint ${formatByteMetricTransition(comparison.initInstall.installedSizeBytes)}`,
+      );
+    }
+
+    if (comparison.initInstall.installedPackageCount.delta !== 0) {
+      initParts.push(
+        `installed packages ${formatCountMetricTransition(comparison.initInstall.installedPackageCount)}`,
+      );
+    }
+
+    if (initParts.length > 0) {
+      lines.push(`- \`eve init\` delta: ${initParts.join("; ")}.`);
+    }
+  }
+
   const runtimeParts = [];
 
   if (isNotableByteDelta(comparison.app.uniqueFunctionBytes)) {
@@ -794,6 +838,15 @@ function renderSummaryTable(report) {
     lines.push(
       `| Package | Installed footprint | ${formatBytes(report.publishedPackage.installedSizeBytes)} |`,
     );
+  }
+
+  if (report.initInstall) {
+    lines.push(
+      `| Init | Installed footprint | ${formatBytes(report.initInstall.installedSizeBytes)} |`,
+    );
+    lines.push(`| Init | Installed packages | ${report.initInstall.installedPackageCount} |`);
+    lines.push(`| Init | dependencies | ${report.initInstall.dependencyCount} |`);
+    lines.push(`| Init | devDependencies | ${report.initInstall.devDependencyCount} |`);
   }
 
   lines.push(`| Runtime | Unique function payloads | ${report.uniqueFunctionCount} |`);
@@ -869,6 +922,82 @@ function renderDependencyManifestDelta(packageComparison, baselineLabel) {
     if (packageComparison.peerDependenciesChanged.length > 0) {
       lines.push(
         `- Changed: ${packageComparison.peerDependenciesChanged.map((dependency) => `\`${dependency.baseline}\` -> \`${dependency.current}\``).join(", ")}`,
+      );
+    }
+
+    lines.push("");
+  }
+
+  lines.push("</details>", "");
+  return lines;
+}
+
+function renderInitDependencyManifestDelta(initInstallComparison, baselineLabel) {
+  if (initInstallComparison === null) {
+    return [];
+  }
+
+  const dependencyChangeCount =
+    initInstallComparison.dependenciesAdded.length +
+    initInstallComparison.dependenciesChanged.length +
+    initInstallComparison.dependenciesRemoved.length;
+  const devDependencyChangeCount =
+    initInstallComparison.devDependenciesAdded.length +
+    initInstallComparison.devDependenciesChanged.length +
+    initInstallComparison.devDependenciesRemoved.length;
+
+  if (dependencyChangeCount === 0 && devDependencyChangeCount === 0) {
+    return [];
+  }
+
+  const lines = [
+    "<details>",
+    `<summary><code>eve init</code> dependency changes vs <code>${escapeHtml(baselineLabel)}</code></summary>`,
+    "",
+  ];
+
+  if (dependencyChangeCount > 0) {
+    lines.push("**dependencies**", "");
+
+    if (initInstallComparison.dependenciesAdded.length > 0) {
+      lines.push(
+        `- Added: ${initInstallComparison.dependenciesAdded.map((dependency) => `\`${dependency}\``).join(", ")}`,
+      );
+    }
+
+    if (initInstallComparison.dependenciesRemoved.length > 0) {
+      lines.push(
+        `- Removed: ${initInstallComparison.dependenciesRemoved.map((dependency) => `\`${dependency}\``).join(", ")}`,
+      );
+    }
+
+    if (initInstallComparison.dependenciesChanged.length > 0) {
+      lines.push(
+        `- Changed: ${initInstallComparison.dependenciesChanged.map((dependency) => `\`${dependency.baseline}\` -> \`${dependency.current}\``).join(", ")}`,
+      );
+    }
+
+    lines.push("");
+  }
+
+  if (devDependencyChangeCount > 0) {
+    lines.push("**devDependencies**", "");
+
+    if (initInstallComparison.devDependenciesAdded.length > 0) {
+      lines.push(
+        `- Added: ${initInstallComparison.devDependenciesAdded.map((dependency) => `\`${dependency}\``).join(", ")}`,
+      );
+    }
+
+    if (initInstallComparison.devDependenciesRemoved.length > 0) {
+      lines.push(
+        `- Removed: ${initInstallComparison.devDependenciesRemoved.map((dependency) => `\`${dependency}\``).join(", ")}`,
+      );
+    }
+
+    if (initInstallComparison.devDependenciesChanged.length > 0) {
+      lines.push(
+        `- Changed: ${initInstallComparison.devDependenciesChanged.map((dependency) => `\`${dependency.baseline}\` -> \`${dependency.current}\``).join(", ")}`,
       );
     }
 
@@ -967,6 +1096,27 @@ function renderComparisonSection(comparison) {
     );
   }
 
+  if (comparison.initInstall !== null) {
+    lines.push(
+      `| Init | Installed footprint | ${formatBytes(comparison.initInstall.installedSizeBytes.baseline)} | ${formatBytes(comparison.initInstall.installedSizeBytes.current)} | ${formatSizeDelta(comparison.initInstall.installedSizeBytes.delta)} |`,
+    );
+    lines.push(
+      `| Init | Installed packages | ${comparison.initInstall.installedPackageCount.baseline} | ${comparison.initInstall.installedPackageCount.current} | ${formatSignedCount(comparison.initInstall.installedPackageCount.delta)} |`,
+    );
+    lines.push(
+      `| Init | dependencies | ${comparison.initInstall.dependencyCount.baseline} | ${comparison.initInstall.dependencyCount.current} | ${formatSignedCount(comparison.initInstall.dependencyCount.delta)} |`,
+    );
+    lines.push(
+      `| Init | devDependencies | ${comparison.initInstall.devDependencyCount.baseline} | ${comparison.initInstall.devDependencyCount.current} | ${formatSignedCount(comparison.initInstall.devDependencyCount.delta)} |`,
+    );
+    lines.push(
+      `| Init | Dependency package bytes | ${formatBytes(comparison.initInstall.dependencyPackageBytes.baseline)} | ${formatBytes(comparison.initInstall.dependencyPackageBytes.current)} | ${formatSizeDelta(comparison.initInstall.dependencyPackageBytes.delta)} |`,
+    );
+    lines.push(
+      `| Init | devDependency package bytes | ${formatBytes(comparison.initInstall.devDependencyPackageBytes.baseline)} | ${formatBytes(comparison.initInstall.devDependencyPackageBytes.current)} | ${formatSizeDelta(comparison.initInstall.devDependencyPackageBytes.delta)} |`,
+    );
+  }
+
   lines.push(
     `| Runtime | Unique function payloads | ${comparison.app.uniqueFunctionCount.baseline} | ${comparison.app.uniqueFunctionCount.current} | ${formatSignedCount(comparison.app.uniqueFunctionCount.delta)} |`,
   );
@@ -979,6 +1129,9 @@ function renderComparisonSection(comparison) {
   lines.push("");
 
   lines.push(...renderDependencyManifestDelta(comparison.package, comparison.baselineLabel));
+  lines.push(
+    ...renderInitDependencyManifestDelta(comparison.initInstall, comparison.baselineLabel),
+  );
   lines.push(...renderFunctionDeltaSection(comparison));
 
   return lines;
@@ -1099,6 +1252,107 @@ function renderPublishedPackageSection(publishedPackage) {
     ...renderDependencyTable("Runtime dependencies", publishedPackage.runtimeDependencies),
   );
   lines.push(...renderDependencyTable("Peer dependencies", publishedPackage.peerDependencies));
+  lines.push("</details>", "");
+
+  return lines;
+}
+
+function renderInitDependencyTable(title, dependencies, totalBytes) {
+  const lines = ["<details>", `<summary>${title} (${dependencies.length})</summary>`, ""];
+
+  if (dependencies.length === 0) {
+    lines.push("None.", "", "</details>", "");
+    return lines;
+  }
+
+  lines.push("| Package | Range | Installed size | Share |");
+  lines.push("| --- | --- | --- | --- |");
+
+  for (const dependency of dependencies) {
+    lines.push(
+      `| \`${dependency.name}\` | \`${dependency.range}\` | ${formatBytes(dependency.bytes)} | ${formatPercent(dependency.bytes, totalBytes)} |`,
+    );
+  }
+
+  lines.push("", "</details>", "");
+  return lines;
+}
+
+function renderInitInstallSection(initInstall) {
+  const lines = ["<details>", "<summary>eve init Install Drill-Down</summary>", ""];
+  lines.push("### Init Install Details", "");
+  lines.push(`- Command: \`eve init ${initInstall.projectName}\``);
+  lines.push(`- Package manager: \`${initInstall.packageManager}\``);
+  lines.push(
+    `- Installed footprint: ${formatBytes(initInstall.installedSizeBytes)} across ${initInstall.installedFileCount} installed file${initInstall.installedFileCount === 1 ? "" : "s"}`,
+  );
+  lines.push(
+    `- Installed packages: ${initInstall.installedPackageCount} total (${initInstall.unclassifiedInstalledPackageCount} transitive-only)`,
+  );
+  lines.push(
+    `- dependencies: ${initInstall.dependencyCount} direct package${initInstall.dependencyCount === 1 ? "" : "s"} totaling ${formatBytes(initInstall.dependencyPackageBytes)}`,
+  );
+  lines.push(
+    `- devDependencies: ${initInstall.devDependencyCount} direct package${initInstall.devDependencyCount === 1 ? "" : "s"} totaling ${formatBytes(initInstall.devDependencyPackageBytes)}`,
+  );
+  lines.push(
+    `- Other transitive package files: ${formatBytes(initInstall.transitivePackageBytes)}`,
+  );
+  lines.push(
+    "",
+    "_Installed footprint is measured from an isolated temporary `eve init my-agent` using the current packed eve tarball._",
+    "",
+  );
+
+  lines.push(
+    ...renderHeavyDependencyList(
+      initInstall.topInstalledPackages,
+      initInstall.installedSizeBytes,
+      5,
+    ),
+  );
+
+  const installedPackageEntries = buildTopEntryChart(
+    initInstall.topInstalledPackages.map((pkg) => ({
+      bytes: pkg.bytes,
+      label: pkg.name,
+    })),
+    initInstall.installedSizeBytes,
+    {
+      maxEntries: INSTALLED_PACKAGE_BREAKDOWN_MAX_ENTRIES,
+      minBytes: INSTALLED_PACKAGE_BREAKDOWN_MIN_BYTES,
+      otherLabel: "Other installed packages",
+    },
+  );
+
+  if (installedPackageEntries.length > 0) {
+    lines.push("<details>");
+    lines.push("<summary>Installed footprint breakdown</summary>");
+    lines.push("");
+    lines.push(
+      ...renderAsciiBarChart(
+        "Installed package size",
+        installedPackageEntries,
+        initInstall.installedSizeBytes,
+      ),
+    );
+    lines.push("</details>", "");
+  }
+
+  lines.push(
+    ...renderInitDependencyTable(
+      "dependencies",
+      initInstall.dependencies,
+      initInstall.installedSizeBytes,
+    ),
+  );
+  lines.push(
+    ...renderInitDependencyTable(
+      "devDependencies",
+      initInstall.devDependencies,
+      initInstall.installedSizeBytes,
+    ),
+  );
   lines.push("</details>", "");
 
   return lines;
@@ -1239,6 +1493,58 @@ function renderFunctionDrillDown(report) {
   return lines;
 }
 
+async function collectPackageReports(options) {
+  if (!options.packageRoot) {
+    return {
+      initInstall: null,
+      publishedPackage: null,
+    };
+  }
+
+  const packageRoot = resolve(options.packageRoot);
+  const packDirectory = await mkdtemp(join(tmpdir(), "eve-package-pack-"));
+  const installDirectory = await mkdtemp(join(tmpdir(), "eve-package-install-"));
+
+  try {
+    const packResult = await runPack(packageRoot, packDirectory);
+    const tarballFilename = typeof packResult.filename === "string" ? packResult.filename : null;
+
+    if (!tarballFilename) {
+      throw new Error(`npm pack did not report a tarball filename for "${packageRoot}".`);
+    }
+
+    const tarballPath = join(packDirectory, tarballFilename);
+    const publishedPackage = await collectPublishedPackageReportFromPack({
+      installDirectory,
+      packageLabel: options.packageLabel,
+      packageRoot,
+      packResult,
+      tarballPath,
+    });
+    const initInstall = await collectInitInstallReportFromTarball({
+      packageLabel: options.packageLabel,
+      packageRoot,
+      tarballPath,
+    });
+
+    return {
+      initInstall,
+      publishedPackage,
+    };
+  } finally {
+    await Promise.all([
+      rm(packDirectory, {
+        force: true,
+        recursive: true,
+      }),
+      rm(installDirectory, {
+        force: true,
+        recursive: true,
+      }),
+    ]);
+  }
+}
+
 /**
  * Collects a bundle report from one Nitro Vercel build output tree.
  */
@@ -1259,24 +1565,18 @@ export async function collectNitroBundleReport(options) {
     );
   }
 
-  const [config, functionEntries, nitroMetadata, publishedPackage, staticFiles] = await Promise.all(
-    [
-      pathExists(join(outputDirectory, "config.json")).then((exists) =>
-        exists ? readJson(join(outputDirectory, "config.json")) : null,
-      ),
-      discoverFunctionEntries(functionsRoot),
-      pathExists(join(outputDirectory, "nitro.json")).then((exists) =>
-        exists ? readJson(join(outputDirectory, "nitro.json")) : null,
-      ),
-      options.packageRoot
-        ? collectPublishedPackageReport({
-            packageLabel: options.packageLabel,
-            packageRoot: options.packageRoot,
-          })
-        : Promise.resolve(null),
-      pathExists(staticRoot).then((exists) => (exists ? walkRegularFiles(staticRoot) : [])),
-    ],
-  );
+  const [config, functionEntries, packageReports, nitroMetadata, staticFiles] = await Promise.all([
+    pathExists(join(outputDirectory, "config.json")).then((exists) =>
+      exists ? readJson(join(outputDirectory, "config.json")) : null,
+    ),
+    discoverFunctionEntries(functionsRoot),
+    collectPackageReports(options),
+    pathExists(join(outputDirectory, "nitro.json")).then((exists) =>
+      exists ? readJson(join(outputDirectory, "nitro.json")) : null,
+    ),
+    pathExists(staticRoot).then((exists) => (exists ? walkRegularFiles(staticRoot) : [])),
+  ]);
+  const { initInstall, publishedPackage } = packageReports;
 
   /** @type {Map<string, { aliases: { isInternalRoute: boolean; relativeEntryPath: string; route: string }[]; realDirectoryPath: string }>} */
   const functionsByRealPath = new Map();
@@ -1381,6 +1681,7 @@ export async function collectNitroBundleReport(options) {
     functionAliasCount: functionEntries.length,
     functions,
     generatedAt: new Date().toISOString(),
+    initInstall,
     internalRouteCount: functions.reduce(
       (total, functionEntry) => total + functionEntry.internalRoutes.length,
       0,
@@ -1435,6 +1736,7 @@ export function renderNitroBundleReportMarkdown(report) {
     ? summarizeComparisonTakeaways(report.comparison)
     : [
         ...(report.publishedPackage ? summarizePackageTakeaways(report.publishedPackage) : []),
+        ...(report.initInstall ? summarizeInitInstallTakeaways(report.initInstall) : []),
         ...summarizeFunctionTakeaways(report),
       ];
   const lines = [
@@ -1459,6 +1761,10 @@ export function renderNitroBundleReportMarkdown(report) {
 
   if (report.publishedPackage) {
     lines.push(...renderPublishedPackageSection(report.publishedPackage));
+  }
+
+  if (report.initInstall) {
+    lines.push(...renderInitInstallSection(report.initInstall));
   }
 
   if (report.functions.length === 0) {

--- a/scripts/package-publish-report.mjs
+++ b/scripts/package-publish-report.mjs
@@ -347,7 +347,7 @@ async function rewriteCatalogReferencesInTarball(tarballPath, packageRoot) {
   }
 }
 
-async function runPack(packageRoot, packDirectory) {
+export async function runPack(packageRoot, packDirectory) {
   const packagePath = resolve(packageRoot);
   const { stderr, stdout } = await execFile(
     "npm",
@@ -437,17 +437,66 @@ async function collectInstalledPackageSnapshot(input) {
   };
 }
 
-/**
- * Collects one package publish report from the package manifest and an
- * isolated pack/install snapshot.
- */
-export async function collectPublishedPackageReport(options) {
+export async function collectPublishedPackageReportFromPack(options) {
   const packageRoot = resolve(options.packageRoot);
   const packageJson = await readJson(resolve(packageRoot, "package.json"));
   const packageName =
     typeof packageJson.name === "string" ? packageJson.name : basename(packageRoot);
   const runtimeDependencies = readRuntimeDependencies(packageJson);
   const peerDependencies = readPeerDependencies(packageJson);
+  const packResult = options.packResult;
+  const tarballFilename = typeof packResult.filename === "string" ? packResult.filename : null;
+
+  if (!tarballFilename) {
+    throw new Error(`npm pack did not report a tarball filename for "${packageRoot}".`);
+  }
+
+  const packedFiles = Array.isArray(packResult.files)
+    ? packResult.files
+        .filter(
+          (file) =>
+            file &&
+            typeof file === "object" &&
+            typeof file.path === "string" &&
+            typeof file.size === "number",
+        )
+        .map((file) => ({
+          path: file.path,
+          size: file.size,
+        }))
+    : [];
+  const installedSnapshot = await collectInstalledPackageSnapshot({
+    installRoot: options.installDirectory,
+    packageName,
+    tarballPath: options.tarballPath,
+  });
+
+  return {
+    installedDependencyBytes: installedSnapshot.installedDependencyBytes,
+    installedFileCount: installedSnapshot.installedFileCount,
+    installedPackageBytes: installedSnapshot.installedPackageBytes,
+    installedSizeBytes: installedSnapshot.installedSizeBytes,
+    packageLabel: options.packageLabel ?? basename(packageRoot),
+    packageName,
+    packageRoot,
+    packedSizeBytes: typeof packResult.size === "number" ? packResult.size : 0,
+    peerDependencies,
+    publishedFileCount: typeof packResult.entryCount === "number" ? packResult.entryCount : 0,
+    tarballFilename,
+    topInstalledPackages: installedSnapshot.topInstalledPackages,
+    topPublishedFiles: summarizeTopPublishedFiles(packedFiles, 5),
+    unpackedSizeBytes: typeof packResult.unpackedSize === "number" ? packResult.unpackedSize : 0,
+    version: typeof packageJson.version === "string" ? packageJson.version : "0.0.0",
+    runtimeDependencies,
+  };
+}
+
+/**
+ * Collects one package publish report from the package manifest and an
+ * isolated pack/install snapshot.
+ */
+export async function collectPublishedPackageReport(options) {
+  const packageRoot = resolve(options.packageRoot);
   const packDirectory = await mkdtemp(join(tmpdir(), "eve-package-pack-"));
   const installDirectory = await mkdtemp(join(tmpdir(), "eve-package-install-"));
 
@@ -459,44 +508,13 @@ export async function collectPublishedPackageReport(options) {
       throw new Error(`npm pack did not report a tarball filename for "${packageRoot}".`);
     }
 
-    const packedFiles = Array.isArray(packResult.files)
-      ? packResult.files
-          .filter(
-            (file) =>
-              file &&
-              typeof file === "object" &&
-              typeof file.path === "string" &&
-              typeof file.size === "number",
-          )
-          .map((file) => ({
-            path: file.path,
-            size: file.size,
-          }))
-      : [];
-    const installedSnapshot = await collectInstalledPackageSnapshot({
-      installRoot: installDirectory,
-      packageName,
+    return collectPublishedPackageReportFromPack({
+      installDirectory,
+      packageLabel: options.packageLabel,
+      packageRoot,
+      packResult,
       tarballPath: join(packDirectory, tarballFilename),
     });
-
-    return {
-      installedDependencyBytes: installedSnapshot.installedDependencyBytes,
-      installedFileCount: installedSnapshot.installedFileCount,
-      installedPackageBytes: installedSnapshot.installedPackageBytes,
-      installedSizeBytes: installedSnapshot.installedSizeBytes,
-      packageLabel: options.packageLabel ?? basename(packageRoot),
-      packageName,
-      packageRoot,
-      packedSizeBytes: typeof packResult.size === "number" ? packResult.size : 0,
-      peerDependencies,
-      publishedFileCount: typeof packResult.entryCount === "number" ? packResult.entryCount : 0,
-      tarballFilename,
-      topInstalledPackages: installedSnapshot.topInstalledPackages,
-      topPublishedFiles: summarizeTopPublishedFiles(packedFiles, 5),
-      unpackedSizeBytes: typeof packResult.unpackedSize === "number" ? packResult.unpackedSize : 0,
-      version: typeof packageJson.version === "string" ? packageJson.version : "0.0.0",
-      runtimeDependencies,
-    };
   } finally {
     await Promise.all([
       rm(packDirectory, {


### PR DESCRIPTION
## Summary
- add an isolated eve init install snapshot to bundle analysis
- report installed package count plus dependencies/devDependencies size breakdown
- compare init install deltas and include them in bundle warning checks

## Validation
- node --check scripts/init-install-report.mjs scripts/package-publish-report.mjs scripts/nitro-bundle-report.mjs scripts/nitro-bundle-report-compare.mjs
- CI=true pnpm exec oxfmt scripts/init-install-report.mjs scripts/package-publish-report.mjs scripts/nitro-bundle-report.mjs scripts/nitro-bundle-report-compare.mjs
- CI=true pnpm exec oxlint scripts/init-install-report.mjs scripts/package-publish-report.mjs scripts/nitro-bundle-report.mjs scripts/nitro-bundle-report-compare.mjs
- git diff --check
- generated /private/tmp/eve-bundle-report.json and /private/tmp/eve-bundle-report.md with init install snapshot