### PR TITLE
[docs]: reveal code-block copy buttons on hover

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/file-tree-view.tsx
+++ b/apps/docs/app/[lang]/(home)/components/file-tree-view.tsx
@@ -79,7 +79,9 @@ export function FileTreeView({ items, heading }: { items: FileTreeItem[]; headin
               <p className="border-b px-4 py-3 text-gray-900 text-copy-14">
                 {selected.description}
               </p>
-              <div className="grow pb-6 [&>div]:mb-0">{selected.code}</div>
+              <div className="grow pb-6 [&>div]:mb-0 [&_button]:opacity-0 [&_button]:transition-opacity [&:hover_button]:opacity-100 [&:focus-within_button]:opacity-100">
+                {selected.code}
+              </div>
             </div>
           </div>
         </div>

--- a/apps/docs/app/[lang]/(home)/components/nextjs-interop.tsx
+++ b/apps/docs/app/[lang]/(home)/components/nextjs-interop.tsx
@@ -78,7 +78,9 @@ export async function NextjsInterop() {
                 <div className="flex h-12 items-center gap-2 border-b px-4">
                   <span className="text-sm text-gray-1000">{file.fileName}</span>
                 </div>
-                <div className="overflow-x-auto text-[13px] [&>div]:mb-0">{rendered[i]}</div>
+                <div className="overflow-x-auto text-[13px] [&>div]:mb-0 [&_button]:opacity-0 [&_button]:transition-opacity [&:hover_button]:opacity-100 [&:focus-within_button]:opacity-100">
+                  {rendered[i]}
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
On the docs homepage, the copy-to-clipboard buttons on the code areas were always visible. This hides them by default and reveals them on hover/focus of the code area, matching the intended design.


| **Before**  | **After** |
| ------------- | ------------- |
| <img width="1511" height="748" alt="image" src="https://github.com/user-attachments/assets/4dacaa28-97c6-408c-969c-d459862de666" /> | <video src="https://github.com/user-attachments/assets/fde81763-dd0d-4ca5-93ac-5a5efd9dd0ee" /> |






_The mobile stacked file list keeps its copy buttons always visible (no hover on touch)._