### PR TITLE
feat(sandbox): forward supported just-bash SandboxOptions through justbash()

### DIFF
--- a/.changeset/justbash-forward-sandbox-options.md
+++ b/.changeset/justbash-forward-sandbox-options.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Forward the just-bash `SandboxOptions` that the `justbash()` backend previously hardcoded or omitted — `timeoutMs`, `maxCallDepth`, `maxCommandCount`, `maxLoopIterations`, and `defenseInDepth` — through `JustBashSandboxCreateOptions`. Each is optional and falls back to just-bash's own default when omitted, so existing apps are unaffected. (The bundled-interpreter capability flags like `python` are not reachable through `Sandbox.create` and remain gated upstream — see vercel-labs/just-bash#284.)

--- a/packages/eve/src/execution/sandbox/bindings/just-bash-capability-options.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash-capability-options.integration.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createJustBashSandboxBackend } from "#execution/sandbox/bindings/just-bash.js";
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+// Capture every `Sandbox.create(options)` call so we can assert which
+// capability options the just-bash backend forwards. `vi.hoisted` runs
+// before the `vi.mock` factory, so the array is in scope inside it.
+const created = vi.hoisted(() => ({ options: [] as unknown[] }));
+
+// A minimal functional stand-in for the optional `just-bash` package:
+// just enough surface for `createBashSandbox` to build a sandbox handle
+// without a real interpreter. `Sandbox.create` records its options.
+vi.mock("just-bash", () => {
+  class ReadWriteFs {
+    async mkdir(): Promise<void> {}
+    async writeFile(): Promise<void> {}
+    async readFileBuffer(): Promise<Uint8Array> {
+      return new Uint8Array();
+    }
+    async rm(): Promise<void> {}
+  }
+  const Sandbox = {
+    create: vi.fn(async (options: unknown) => {
+      created.options.push(options);
+      return {
+        bashEnvInstance: { getEnv: () => ({}) },
+        async runCommand() {
+          return {};
+        },
+        async stop() {},
+      };
+    }),
+  };
+  return { ReadWriteFs, Sandbox };
+});
+
+const createScratchDirectory = useTemporaryDirectories();
+
+beforeEach(() => {
+  created.options.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("just-bash backend forwards capability options to Sandbox.create", () => {
+  it("threads author-supplied SandboxOptions through to the interpreter", async () => {
+    const appRoot = await createScratchDirectory("eve-just-bash-options-");
+    const backend = createJustBashSandboxBackend({
+      createOptions: {
+        defenseInDepth: false,
+        maxCallDepth: 64,
+        maxCommandCount: 5000,
+        maxLoopIterations: 100000,
+        timeoutMs: 30000,
+      },
+    });
+
+    await backend.create({
+      runtimeContext: { appRoot },
+      sessionKey: "session-with-options",
+      templateKey: null,
+    });
+
+    expect(created.options).toHaveLength(1);
+    expect(created.options[0]).toMatchObject({
+      defenseInDepth: false,
+      maxCallDepth: 64,
+      maxCommandCount: 5000,
+      maxLoopIterations: 100000,
+      timeoutMs: 30000,
+      // Untouched defaults the backend has always set.
+      network: { dangerouslyAllowFullInternetAccess: true },
+    });
+  });
+
+  it("leaves the Sandbox.create call unchanged when no options are passed", async () => {
+    const appRoot = await createScratchDirectory("eve-just-bash-no-options-");
+    const backend = createJustBashSandboxBackend();
+
+    await backend.create({
+      runtimeContext: { appRoot },
+      sessionKey: "session-without-options",
+      templateKey: null,
+    });
+
+    expect(created.options).toHaveLength(1);
+    const options = created.options[0] as Record<string, unknown>;
+    // Every capability field defaults to just-bash's own behavior, i.e.
+    // it is forwarded as `undefined` (equivalent to absent).
+    expect(options.defenseInDepth).toBeUndefined();
+    expect(options.maxCallDepth).toBeUndefined();
+    expect(options.maxCommandCount).toBeUndefined();
+    expect(options.maxLoopIterations).toBeUndefined();
+    expect(options.timeoutMs).toBeUndefined();
+    // The pre-existing hardcoded defaults remain.
+    expect(options.network).toEqual({ dangerouslyAllowFullInternetAccess: true });
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
@@ -31,6 +31,28 @@ interface LocalSandboxMetadata {
   readonly version: typeof LOCAL_SANDBOX_METADATA_VERSION;
 }
 
+/**
+ * Capability options forwarded into just-bash's
+ * `Sandbox.create(SandboxOptions)`. Defined locally (rather than imported
+ * from `just-bash`) because the package is an optional peer dependency —
+ * eve must type-check without it installed. The shape is a structural
+ * subset of just-bash's `SandboxOptions`, so the object assigns directly
+ * into the `Sandbox.create` call.
+ *
+ * Only the fields just-bash's `Sandbox.create` actually forwards into its
+ * internal `Bash` are surfaced. The bundled interpreter flags
+ * (`python`, `javascript`, `commands`, …) live on `BashOptions` and are
+ * dropped by `Sandbox.create`, so they are intentionally absent here —
+ * see issue #431.
+ */
+export interface JustBashSandboxOptions {
+  readonly defenseInDepth?: boolean;
+  readonly maxCallDepth?: number;
+  readonly maxCommandCount?: number;
+  readonly maxLoopIterations?: number;
+  readonly timeoutMs?: number;
+}
+
 export interface BashSandbox {
   captureState(): Promise<Record<string, unknown> | null>;
   dispose(): Promise<void>;
@@ -75,6 +97,7 @@ export async function createBashSandbox(input: {
   readonly appRoot: string;
   readonly autoInstall: boolean;
   readonly rootPath: string;
+  readonly sandboxOptions?: JustBashSandboxOptions;
   readonly sessionKey: string;
 }): Promise<BashSandbox> {
   const { ReadWriteFs, Sandbox } = await loadJustBashModule({
@@ -97,11 +120,18 @@ export async function createBashSandbox(input: {
 
   const sandbox = await Sandbox.create({
     cwd: WORKSPACE_ROOT,
+    // Author-supplied capability options (undefined entries fall back to
+    // just-bash's own defaults, keeping behavior unchanged when omitted).
+    defenseInDepth: input.sandboxOptions?.defenseInDepth,
     env: metadata?.env as Record<string, string> | undefined,
     fs: filesystem,
+    maxCallDepth: input.sandboxOptions?.maxCallDepth,
+    maxCommandCount: input.sandboxOptions?.maxCommandCount,
+    maxLoopIterations: input.sandboxOptions?.maxLoopIterations,
     network: {
       dangerouslyAllowFullInternetAccess: true,
     },
+    timeoutMs: input.sandboxOptions?.timeoutMs,
   });
 
   return {

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.ts
@@ -17,6 +17,7 @@ import {
   createBashSandbox,
   createJustBashHandle,
   justBashSetNetworkPolicyUnsupported,
+  type JustBashSandboxOptions,
 } from "#execution/sandbox/bindings/just-bash-runtime.js";
 import {
   LOCAL_SANDBOX_TEMPLATE_RECENT_WINDOW_MS,
@@ -64,6 +65,17 @@ export function createJustBashSandboxBackend(
   input: CreateJustBashSandboxBackendInput = {},
 ): SandboxBackend {
   const autoInstall = input.createOptions?.autoInstall ?? true;
+  // Capability options forwarded into just-bash's `Sandbox.create`
+  // (everything on the public surface except the eve-only `autoInstall`).
+  // Undefined fields are dropped so each one falls back to just-bash's
+  // own default and behavior stays unchanged when nothing is passed.
+  const sandboxOptions: JustBashSandboxOptions = {
+    defenseInDepth: input.createOptions?.defenseInDepth,
+    maxCallDepth: input.createOptions?.maxCallDepth,
+    maxCommandCount: input.createOptions?.maxCommandCount,
+    maxLoopIterations: input.createOptions?.maxLoopIterations,
+    timeoutMs: input.createOptions?.timeoutMs,
+  };
   return {
     name: JUST_BASH_BACKEND_NAME,
     async prewarm(prewarmInput: SandboxBackendPrewarmInput): Promise<SandboxBackendPrewarmResult> {
@@ -81,6 +93,7 @@ export function createJustBashSandboxBackend(
         appRoot: prewarmInput.runtimeContext.appRoot,
         autoInstall,
         rootPath: temporaryTemplateRootPath,
+        sandboxOptions,
         sessionKey: prewarmInput.templateKey,
       });
       const templateSession = buildSandboxSession(
@@ -158,6 +171,7 @@ export function createJustBashSandboxBackend(
         appRoot: createInput.runtimeContext.appRoot,
         autoInstall,
         rootPath: sessionRootPath,
+        sandboxOptions,
         sessionKey: createInput.sessionKey,
       });
 

--- a/packages/eve/src/public/sandbox/just-bash-sandbox.ts
+++ b/packages/eve/src/public/sandbox/just-bash-sandbox.ts
@@ -5,6 +5,22 @@
  * interpreter with a virtual filesystem — no daemon or VM required, but
  * no real binaries either. The `just-bash` package is not bundled with
  * eve; it is loaded lazily from the application install.
+ *
+ * Beyond `autoInstall`, the remaining fields forward through to
+ * just-bash's `Sandbox.create(SandboxOptions)` call. They mirror the
+ * `SandboxOptions` surface that just-bash actually accepts at sandbox
+ * creation — execution limits, an overall timeout, and the
+ * defense-in-depth toggle. Each defaults to just-bash's own default
+ * (i.e. unchanged behavior) when omitted, so existing applications are
+ * unaffected.
+ *
+ * Note: just-bash's bundled interpreters (`python3`, the `js-exec`
+ * QuickJS runtime) are NOT reachable through this surface. Those flags
+ * live on just-bash's `BashOptions` (the `new Bash(...)` constructor),
+ * and `Sandbox.create` — the call eve uses — does not forward them into
+ * the `Bash` it builds. Enabling them requires an upstream just-bash
+ * change (forward the capability flags through `SandboxOptions`) or a
+ * different construction path in eve; see issue #431.
  */
 export interface JustBashSandboxCreateOptions {
   /**
@@ -14,4 +30,37 @@ export interface JustBashSandboxCreateOptions {
    * actionable install error instead. Defaults to `true`.
    */
   readonly autoInstall?: boolean;
+  /**
+   * Overall wall-clock timeout for the sandbox, in milliseconds. Maps to
+   * just-bash `SandboxOptions.timeoutMs`. Omit to use just-bash's
+   * default (no eve-imposed timeout).
+   */
+  readonly timeoutMs?: number;
+  /**
+   * Maximum function/subshell call depth before the interpreter aborts.
+   * Maps to just-bash `SandboxOptions.maxCallDepth`. Guards against
+   * runaway recursion. Omit to use just-bash's default.
+   */
+  readonly maxCallDepth?: number;
+  /**
+   * Maximum number of commands a single script may execute before the
+   * interpreter aborts. Maps to just-bash `SandboxOptions.maxCommandCount`.
+   * Omit to use just-bash's default.
+   */
+  readonly maxCommandCount?: number;
+  /**
+   * Maximum loop iterations before the interpreter aborts. Maps to
+   * just-bash `SandboxOptions.maxLoopIterations`. Omit to use just-bash's
+   * default.
+   */
+  readonly maxLoopIterations?: number;
+  /**
+   * Defense-in-depth hardening: monkey-patches dangerous JavaScript
+   * globals (`Function`, `eval`, `setTimeout`, `process`, …) while a
+   * script runs, as a secondary escape-mitigation layer. Maps to
+   * just-bash `SandboxOptions.defenseInDepth`. just-bash enables this by
+   * default; pass `false` to opt out. Omit to use just-bash's default
+   * (enabled).
+   */
+  readonly defenseInDepth?: boolean;
 }


### PR DESCRIPTION
## What

Forward the just-bash `SandboxOptions` fields that `justbash()` currently hardcodes or
omits, through `JustBashSandboxCreateOptions` → `Sandbox.create(...)`:

- `timeoutMs`
- `maxCallDepth`
- `maxCommandCount`
- `maxLoopIterations`
- `defenseInDepth`

Today `JustBashSandboxCreateOptions` exposes only `autoInstall`, and `createBashSandbox`
calls `Sandbox.create({ cwd, env, fs, network })` with everything else hardcoded — so an
author has no way to set the interpreter's execution limits, an overall timeout, or
toggle defense-in-depth.

## Why

This is the "backends should forward their options" generalization (cf. #239): the
just-bash backend should let authors set the `SandboxOptions` just-bash actually accepts,
rather than silently fixing them. Each new field is optional and forwarded as `undefined`
when omitted, falling back to just-bash's own default — so existing apps are unaffected.

## Relationship to #431 (capability flags / Python)

This does **not** yet close #431. #431 asks for `python3` (and js-exec) through
`justbash()`, but those capability flags live on just-bash's `BashOptions` (the
`new Bash(...)` constructor) and just-bash's `Sandbox.create` — the call eve uses — drops
them. That's an upstream gap, filed and fixed in **vercel-labs/just-bash#284**. Once that
change ships in a just-bash release eve depends on, this same passthrough extends to
`python` / `javascript` / `commands` / `customCommands` / `fetch` to genuinely close #431.
The `JustBashSandboxCreateOptions` doc comment notes this explicitly.

The limits/timeout/defense-in-depth forwarding here is complete and self-contained —
mergeable on its own as the #239-class "backends forward their options" passthrough. The
bundled-interpreter capability flags (`python`, `javascript`, …) are a follow-up that
extends this same `JustBashSandboxCreateOptions` surface once just-bash#284 ships in a
release eve depends on; that follow-up is what closes #431.

## Backward compatibility

No behavior change when the new fields are omitted — each forwards as `undefined`, i.e.
just-bash's existing default (network still defaults to full internet access exactly as
before).

## Tests

`packages/eve/src/execution/sandbox/bindings/just-bash-capability-options.integration.test.ts`
(new): mocks the `just-bash` module's `Sandbox.create`, asserts (a) author-supplied
options are forwarded into the call, and (b) omitting them leaves the call unchanged from
today (new fields `undefined`, network default intact).

## Validation

- `pnpm --filter eve run typecheck` — clean
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts just-bash-capability-options` — pass

Refs #431, #239. Upstream prerequisite for the capability flags: vercel-labs/just-bash#284.
