### PR TITLE
Use Vercel CLI for project creation

### DIFF
--- a/.changeset/tidy-vercel-link-projects.md
+++ b/.changeset/tidy-vercel-link-projects.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Create new Vercel projects through `vercel link` instead of posting directly to the projects API. This lets the Vercel CLI apply its framework and local config handling while eve reads the resulting link metadata, keeps framework-specific eve host integrations when detected, and otherwise ensures new projects use the eve framework preset.

--- a/packages/eve/src/setup/boxes/deploy-project.test.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.test.ts
@@ -121,9 +121,9 @@ describe("deployProject box", () => {
 
     await runInteractive([box], pendingState(), silentSink);
 
-    // `--yes` is required even interactively: without skipAutoDetectionConfirmation
-    // the deployments API rejects a never-configured project (created via the bare
-    // projects API) with missing_project_settings, and the CLI cannot recover.
+    // `--yes` is required even interactively: setup already made the deploy
+    // decision, so deploy should not re-open settings confirmation for a fresh
+    // project.
     expect(deps.runVercel).toHaveBeenNthCalledWith(
       1,
       ["deploy", "--prod", "--yes"],

--- a/packages/eve/src/setup/boxes/deploy-project.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.ts
@@ -144,12 +144,10 @@ export function deployProject(
         }
       }
 
-      // `--yes` in both modes: it makes the CLI send skipAutoDetectionConfirmation,
-      // which the deployments API requires for a project that has never been
-      // configured (eve creates projects via the bare projects API, so the record
-      // has no framework settings, and the CLI has no interactive recovery for the
-      // resulting missing_project_settings error). The deploy decision itself was
-      // already made by the shouldRun gate, so there is nothing left to confirm.
+      // `--yes` in both modes: setup already made the deploy decision, and fresh
+      // Vercel projects may still need the CLI to skip deployment-setting
+      // confirmation before the deployments API accepts the first production
+      // deploy.
       const deployArgs = input.headless
         ? ["deploy", "--prod", "--yes", "--non-interactive"]
         : ["deploy", "--prod", "--yes"];

--- a/packages/eve/src/setup/boxes/link-project.test.ts
+++ b/packages/eve/src/setup/boxes/link-project.test.ts
@@ -56,6 +56,24 @@ describe("linkVercelProject box", () => {
     expect(next.project).toEqual({ kind: "linked", projectId: "prj_my_agent" });
   });
 
+  it("passes headless mode into project linking", async () => {
+    const prompter = createPrompter();
+    const deps = fakeDeps();
+    const state = resolvedState();
+    state.vercelProject = { kind: "new", project: "my-agent", team: "team" };
+    const box = linkVercelProject({ prompter, headless: true, deps });
+
+    await runHeadless([box], state, silentSink);
+
+    expect(deps.linkProject).toHaveBeenCalledWith(
+      prompter,
+      "/tmp/project",
+      { kind: "new", project: "my-agent", team: "team" },
+      expect.anything(),
+      { signal: undefined, headless: true },
+    );
+  });
+
   it("does not run when no Vercel project is planned", async () => {
     const deps = fakeDeps();
     const box = linkVercelProject({ prompter: createPrompter(), deps });

--- a/packages/eve/src/setup/boxes/link-project.ts
+++ b/packages/eve/src/setup/boxes/link-project.ts
@@ -18,15 +18,19 @@ export interface LinkProjectDeps {
 }
 
 export interface LinkProjectOptions {
-  /** Streams link progress and command output. The box never prompts through it. */
+  /** Streams link progress and, in interactive runs, may confirm ambiguous framework detection. */
   prompter: Prompter;
+  /** Headless runs must not ask follow-up questions after the plan is fixed. */
+  headless?: boolean;
   deps?: LinkProjectDeps;
 }
 
 /**
  * Executes the resolved Vercel project plan after scaffolding, once the project
- * directory exists. Gather prompts for nothing — every decision was made in the
- * resolve-provisioning box.
+ * directory exists. Gather prompts for nothing: the team/project decision was
+ * made in the resolve-provisioning box. Interactive runs may still confirm
+ * ambiguous host framework detections; headless runs resolve those
+ * deterministically inside `linkProject`.
  *
  * The plan is authoritative: the box always re-links to the planned project so
  * a stale or mismatched `.vercel` link can't silently win. Re-linking the same
@@ -60,9 +64,13 @@ export function linkVercelProject(
       }
       const projectRoot = requireProjectPath(state);
       const onOutput = createPromptCommandOutput(options.prompter.log);
-      const linked = await deps.linkProject(options.prompter, projectRoot, plan, onOutput, {
-        signal,
-      });
+      const linked = await deps.linkProject(
+        options.prompter,
+        projectRoot,
+        plan,
+        onOutput,
+        options.headless ? { signal, headless: true } : { signal },
+      );
       signal?.throwIfAborted();
       if (!linked) {
         throw new Error(

--- a/packages/eve/src/setup/onboarding.ts
+++ b/packages/eve/src/setup/onboarding.ts
@@ -182,7 +182,7 @@ export function composeOnboardingBoxes(options: OnboardingBoxesOptions): AnySetu
     // The complete-setup execution phase: everything a one-shot run defers.
     ...[
       detectAiGateway(),
-      linkVercelProject({ prompter: options.prompter }),
+      linkVercelProject({ prompter: options.prompter, headless: options.headless }),
       applyAiGatewayCredential({ prompter: options.prompter }),
       addChannels({
         asker,

--- a/packages/eve/src/setup/vercel-project-framework.ts
+++ b/packages/eve/src/setup/vercel-project-framework.ts
@@ -1,0 +1,248 @@
+import { createPromptCommandOutput } from "#setup/cli/index.js";
+import { captureVercel } from "#setup/primitives/index.js";
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import { extname, join } from "node:path";
+import { z } from "zod";
+
+import type { Prompter } from "./prompter.js";
+import { isForbiddenApiFailure, normalizeVercelApiResult } from "./vercel-api-failure.js";
+import {
+  parseVercelJson,
+  requireVercelTeamAccess,
+  type VercelProjectOperationOptions,
+  VERCEL_PROJECT_REQUEST_TIMEOUT_MS,
+} from "./vercel-project-api.js";
+
+const VercelProjectFrameworkSchema = z.object({
+  framework: z.string().min(1).nullish(),
+});
+
+const EVE_FRAMEWORK_PRESET = "eve";
+
+interface EveFrameworkIntegration {
+  readonly label: string;
+  readonly importSpecifier: string;
+}
+
+const EVE_FRAMEWORK_INTEGRATIONS: Readonly<Record<string, EveFrameworkIntegration>> = {
+  nextjs: { label: "Next.js", importSpecifier: "eve/next" },
+  nuxt: { label: "Nuxt", importSpecifier: "eve/nuxt" },
+  nuxtjs: { label: "Nuxt", importSpecifier: "eve/nuxt" },
+  sveltekit: { label: "SvelteKit", importSpecifier: "eve/sveltekit" },
+};
+
+const FRAMEWORK_INTEGRATION_SOURCE_EXTENSIONS = new Set([
+  ".cjs",
+  ".cts",
+  ".js",
+  ".json",
+  ".jsx",
+  ".mjs",
+  ".mts",
+  ".svelte",
+  ".ts",
+  ".tsx",
+  ".vue",
+]);
+
+const FRAMEWORK_INTEGRATION_IGNORED_DIRECTORIES = new Set([
+  ".eve",
+  ".git",
+  ".next",
+  ".nuxt",
+  ".output",
+  ".svelte-kit",
+  ".turbo",
+  ".vercel",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+export interface CreatedProjectFrameworkOptions extends VercelProjectOperationOptions {
+  /** Detects whether project sources already use the eve integration for a host framework. */
+  detectFrameworkIntegrationImport?: (
+    projectRoot: string,
+    importSpecifier: string,
+  ) => Promise<boolean>;
+  /** Never prompt; ambiguous host framework detections fall back to the eve preset. */
+  headless?: boolean;
+}
+
+function parseProjectFramework(stdout: string, description: string): string | undefined {
+  const parsed = VercelProjectFrameworkSchema.safeParse(parseVercelJson(stdout, description));
+  if (!parsed.success) {
+    throw new Error(`Could not read Vercel project framework from ${description}.`);
+  }
+  return parsed.data.framework ?? undefined;
+}
+
+async function fetchProjectFramework(
+  projectRoot: string,
+  team: string,
+  projectId: string,
+  options: VercelProjectOperationOptions,
+): Promise<string | undefined> {
+  const result = normalizeVercelApiResult(
+    await captureVercel(["api", `/v9/projects/${projectId}`, "--scope", team, "--raw"], {
+      cwd: projectRoot,
+      signal: options.signal,
+      timeoutMs: VERCEL_PROJECT_REQUEST_TIMEOUT_MS,
+    }),
+  );
+  if (result.ok) {
+    return parseProjectFramework(result.stdout, `project ${projectId}`);
+  }
+  if (isForbiddenApiFailure(result.failure)) requireVercelTeamAccess(result.failure);
+  throw new Error(`Could not inspect Vercel project "${projectId}". ${result.failure.message}`);
+}
+
+async function setProjectFramework(
+  projectRoot: string,
+  team: string,
+  projectId: string,
+  framework: string,
+  onOutput: ReturnType<typeof createPromptCommandOutput>,
+  options: VercelProjectOperationOptions,
+): Promise<void> {
+  const result = normalizeVercelApiResult(
+    await captureVercel(
+      [
+        "api",
+        `/v9/projects/${projectId}`,
+        "--scope",
+        team,
+        "--method",
+        "PATCH",
+        "--raw-field",
+        `framework=${framework}`,
+        "--raw",
+      ],
+      {
+        cwd: projectRoot,
+        onOutput,
+        signal: options.signal,
+        timeoutMs: VERCEL_PROJECT_REQUEST_TIMEOUT_MS,
+      },
+    ),
+  );
+  if (result.ok) return;
+  if (isForbiddenApiFailure(result.failure)) requireVercelTeamAccess(result.failure);
+  throw new Error(
+    `Could not set Vercel project "${projectId}" framework to ${framework}. ${result.failure.message}`,
+  );
+}
+
+async function confirmDetectedFramework(
+  prompter: Prompter,
+  framework: string,
+  integration: EveFrameworkIntegration,
+): Promise<"keep" | "switch-to-eve"> {
+  const keepDetected = await prompter.select<boolean>({
+    message: `Vercel detected ${integration.label}. Is this project using ${integration.importSpecifier}?`,
+    options: [
+      {
+        value: true,
+        label: `Yes, keep ${framework}`,
+        hint: `Use this for a host app that integrates eve through ${integration.importSpecifier}.`,
+      },
+      {
+        value: false,
+        label: "No, switch to eve",
+        hint: "Use this for a standalone eve agent.",
+      },
+    ],
+  });
+  return keepDetected ? "keep" : "switch-to-eve";
+}
+
+function sourceMentionsPackageSpecifier(source: string, importSpecifier: string): boolean {
+  return (
+    source.includes(`"${importSpecifier}"`) ||
+    source.includes(`'${importSpecifier}'`) ||
+    source.includes(`\`${importSpecifier}\``)
+  );
+}
+
+async function directoryContainsPackageSpecifier(
+  directory: string,
+  importSpecifier: string,
+): Promise<boolean> {
+  let entries: Dirent<string>[];
+  try {
+    entries = await fs.readdir(directory, { encoding: "utf8", withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (FRAMEWORK_INTEGRATION_IGNORED_DIRECTORIES.has(entry.name)) continue;
+      if (await directoryContainsPackageSpecifier(entryPath, importSpecifier)) return true;
+      continue;
+    }
+    if (!entry.isFile() || !FRAMEWORK_INTEGRATION_SOURCE_EXTENSIONS.has(extname(entry.name))) {
+      continue;
+    }
+    try {
+      if (sourceMentionsPackageSpecifier(await fs.readFile(entryPath, "utf8"), importSpecifier)) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+async function detectFrameworkIntegrationImport(
+  projectRoot: string,
+  importSpecifier: string,
+): Promise<boolean> {
+  return directoryContainsPackageSpecifier(projectRoot, importSpecifier);
+}
+
+async function resolveDetectedFrameworkAction(
+  prompter: Prompter,
+  projectRoot: string,
+  framework: string,
+  options: CreatedProjectFrameworkOptions,
+): Promise<"keep" | "switch-to-eve"> {
+  const integration = EVE_FRAMEWORK_INTEGRATIONS[framework];
+  if (integration === undefined) return "switch-to-eve";
+  const importDetected = await (
+    options.detectFrameworkIntegrationImport ?? detectFrameworkIntegrationImport
+  )(projectRoot, integration.importSpecifier);
+  if (importDetected) return "keep";
+  if (options.headless) return "switch-to-eve";
+  return confirmDetectedFramework(prompter, framework, integration);
+}
+
+export async function ensureCreatedProjectFramework(
+  prompter: Prompter,
+  projectRoot: string,
+  team: string,
+  projectId: string,
+  onOutput: ReturnType<typeof createPromptCommandOutput>,
+  options: CreatedProjectFrameworkOptions,
+): Promise<void> {
+  const framework = await fetchProjectFramework(projectRoot, team, projectId, options);
+  if (framework === EVE_FRAMEWORK_PRESET) return;
+  const frameworkAction =
+    framework === undefined
+      ? "switch-to-eve"
+      : await resolveDetectedFrameworkAction(prompter, projectRoot, framework, options);
+  if (frameworkAction === "switch-to-eve") {
+    await setProjectFramework(
+      projectRoot,
+      team,
+      projectId,
+      EVE_FRAMEWORK_PRESET,
+      onOutput,
+      options,
+    );
+  }
+}

--- a/packages/eve/src/setup/vercel-project.test.ts
+++ b/packages/eve/src/setup/vercel-project.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createPromptCommandOutput, WHIMSY_POOLS } from "#setup/cli/index.js";
 import { captureVercel, runVercel, type VercelCaptureResult } from "#setup/primitives/index.js";
-import { hasVercelHostFramework } from "#setup/scaffold/index.js";
 
 import { HumanActionRequiredError } from "#setup/human-action.js";
 import type { Prompter, PrompterValue, SingleSelectOptions } from "./prompter.js";
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { readProjectLink } from "./project-resolution.js";
 import {
   assertNewProjectNameAvailable,
   getVercelAuthStatus,
@@ -29,17 +29,17 @@ vi.mock("#setup/primitives/index.js", async (importOriginal) => {
   };
 });
 
-vi.mock("#setup/scaffold/index.js", async (importOriginal) => {
-  const original = await importOriginal<typeof import("#setup/scaffold/index.js")>();
+vi.mock("./project-resolution.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./project-resolution.js")>();
   return {
     ...original,
-    hasVercelHostFramework: vi.fn(async () => false),
+    readProjectLink: vi.fn(),
   };
 });
 
-const mockedHasVercelHostFramework = vi.mocked(hasVercelHostFramework);
 const mockedCaptureVercel = vi.mocked(captureVercel);
 const mockedRunVercel = vi.mocked(runVercel);
+const mockedReadProjectLink = vi.mocked(readProjectLink);
 
 /** Wraps stdout as a successful capture result for the mocked `captureVercel`. */
 const captured = (value: unknown): VercelCaptureResult => ({
@@ -68,10 +68,9 @@ function createSpyPrompter(overrides: {
 
 beforeEach(() => {
   mockedCaptureVercel.mockReset();
-  mockedHasVercelHostFramework.mockReset();
-  mockedHasVercelHostFramework.mockResolvedValue(false);
   mockedRunVercel.mockReset();
   mockedRunVercel.mockResolvedValue(true);
+  mockedReadProjectLink.mockReset();
 });
 
 describe("vercelAuthBlockerReason", () => {
@@ -557,9 +556,12 @@ describe("linkProject", () => {
           JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
         ),
       )
-      .mockResolvedValueOnce(
-        captured(JSON.stringify({ id: "prj_new", name: "my-agent", accountId: "team-a" })),
-      );
+      .mockResolvedValueOnce(captured({ framework: "eve" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
     const { prompter } = createFakePrompter();
 
     await expect(
@@ -570,6 +572,7 @@ describe("linkProject", () => {
         createPromptCommandOutput(prompter.log),
       ),
     ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+    expect(mockedCaptureVercel).toHaveBeenCalledTimes(2);
     expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
       1,
       ["api", "/v9/projects/my-agent", "--scope", "team-a", "--raw"],
@@ -577,64 +580,366 @@ describe("linkProject", () => {
     );
     expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
       2,
-      [
-        "api",
-        "/v10/projects",
-        "--scope",
-        "team-a",
-        "--method",
-        "POST",
-        "--raw-field",
-        "name=my-agent",
-        "--raw-field",
-        "framework=eve",
-        "--raw",
-      ],
-      { cwd: "/tmp/eve-agent", onOutput: expect.any(Function) },
+      ["api", "/v9/projects/prj_new", "--scope", "team-a", "--raw"],
+      { cwd: "/tmp/eve-agent", signal: undefined, timeoutMs: 15_000 },
     );
     expect(mockedRunVercel).toHaveBeenCalledWith(
-      ["link", "--project", "prj_new", "--scope", "team-a", "--yes"],
+      ["link", "--project", "my-agent", "--scope", "team-a", "--yes"],
       expect.objectContaining({ cwd: "/tmp/eve-agent", nonInteractive: true }),
     );
   });
 
-  it("leaves the framework preset unset for host framework projects", async () => {
-    mockedHasVercelHostFramework.mockResolvedValueOnce(true);
+  it("uses the requested project name when Vercel's link metadata omits the name", async () => {
     mockedCaptureVercel
       .mockResolvedValueOnce(
         failedCapture(
           JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
         ),
       )
-      .mockResolvedValueOnce(
-        captured(JSON.stringify({ id: "prj_new", name: "my-web-agent", accountId: "team-a" })),
-      );
+      .mockResolvedValueOnce(captured({ framework: "eve" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+    });
     const { prompter } = createFakePrompter();
 
     await expect(
       linkProject(
         prompter,
-        "/tmp/eve-web-agent",
-        { kind: "new", project: "my-web-agent", team: "team-a" },
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
         createPromptCommandOutput(prompter.log),
       ),
-    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-web-agent" });
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+  });
+
+  it("keeps a detected host framework when the framework-specific eve import is present", async () => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: "nextjs" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const detectFrameworkIntegrationImport = vi.fn(async () => true);
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+
+    expect(detectFrameworkIntegrationImport).toHaveBeenCalledWith("/tmp/eve-agent", "eve/next");
+    expect(mockedCaptureVercel).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { framework: "nuxtjs", importSpecifier: "eve/nuxt" },
+    { framework: "sveltekit", importSpecifier: "eve/sveltekit" },
+  ])("keeps a detected $framework project when $importSpecifier is present", async (testCase) => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: testCase.framework }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const detectFrameworkIntegrationImport = vi.fn(async () => true);
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+
+    expect(detectFrameworkIntegrationImport).toHaveBeenCalledWith(
+      "/tmp/eve-agent",
+      testCase.importSpecifier,
+    );
+    expect(mockedCaptureVercel).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a detected host framework when the user confirms the framework-specific eve import", async () => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: "nextjs" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const single = vi.fn(() => true);
+    const detectFrameworkIntegrationImport = vi.fn(async () => false);
+    const { prompter } = createFakePrompter({ single });
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+
+    expect(single).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Vercel detected Next.js. Is this project using eve/next?",
+      }),
+    );
+    expect(mockedCaptureVercel).toHaveBeenCalledTimes(2);
+  });
+
+  it("sets the project framework to eve when the user rejects a detected host framework", async () => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: "nextjs" }))
+      .mockResolvedValueOnce(captured({ framework: "eve" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const detectFrameworkIntegrationImport = vi.fn(async () => false);
+    const { prompter } = createFakePrompter({ single: () => false });
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
 
     expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
-      2,
+      3,
       [
         "api",
-        "/v10/projects",
+        "/v9/projects/prj_new",
         "--scope",
         "team-a",
         "--method",
-        "POST",
+        "PATCH",
         "--raw-field",
-        "name=my-web-agent",
+        "framework=eve",
         "--raw",
       ],
-      { cwd: "/tmp/eve-web-agent", onOutput: expect.any(Function) },
+      {
+        cwd: "/tmp/eve-agent",
+        onOutput: expect.any(Function),
+        signal: undefined,
+        timeoutMs: 15_000,
+      },
     );
+  });
+
+  it("sets the project framework to eve when Vercel returns no framework", async () => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: null }))
+      .mockResolvedValueOnce(captured({ framework: "eve" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const single = vi.fn(() => {
+      throw new Error("Unexpected prompt for missing framework.");
+    });
+    const detectFrameworkIntegrationImport = vi.fn(async () => true);
+    const { prompter } = createFakePrompter({ single });
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+
+    expect(single).not.toHaveBeenCalled();
+    expect(detectFrameworkIntegrationImport).not.toHaveBeenCalled();
+    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
+      3,
+      [
+        "api",
+        "/v9/projects/prj_new",
+        "--scope",
+        "team-a",
+        "--method",
+        "PATCH",
+        "--raw-field",
+        "framework=eve",
+        "--raw",
+      ],
+      {
+        cwd: "/tmp/eve-agent",
+        onOutput: expect.any(Function),
+        signal: undefined,
+        timeoutMs: 15_000,
+      },
+    );
+  });
+
+  it("sets the project framework to eve in headless mode when a detected host framework is ambiguous", async () => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: "nextjs" }))
+      .mockResolvedValueOnce(captured({ framework: "eve" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const single = vi.fn(() => {
+      throw new Error("Unexpected prompt in headless framework resolution.");
+    });
+    const detectFrameworkIntegrationImport = vi.fn(async () => false);
+    const { prompter } = createFakePrompter({ single });
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport, headless: true },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+
+    expect(single).not.toHaveBeenCalled();
+    expect(detectFrameworkIntegrationImport).toHaveBeenCalledWith("/tmp/eve-agent", "eve/next");
+    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
+      3,
+      [
+        "api",
+        "/v9/projects/prj_new",
+        "--scope",
+        "team-a",
+        "--method",
+        "PATCH",
+        "--raw-field",
+        "framework=eve",
+        "--raw",
+      ],
+      {
+        cwd: "/tmp/eve-agent",
+        onOutput: expect.any(Function),
+        signal: undefined,
+        timeoutMs: 15_000,
+      },
+    );
+  });
+
+  it("sets the project framework to eve when the detected framework has no eve integration", async () => {
+    mockedCaptureVercel
+      .mockResolvedValueOnce(
+        failedCapture(
+          JSON.stringify({ error: { code: "not_found", message: "Project not found" } }),
+        ),
+      )
+      .mockResolvedValueOnce(captured({ framework: "hugo" }))
+      .mockResolvedValueOnce(captured({ framework: "eve" }));
+    mockedReadProjectLink.mockResolvedValueOnce({
+      orgId: "team-a",
+      projectId: "prj_new",
+      projectName: "my-agent",
+    });
+    const single = vi.fn(() => {
+      throw new Error("Unexpected prompt for unsupported framework.");
+    });
+    const detectFrameworkIntegrationImport = vi.fn(async () => true);
+    const { prompter } = createFakePrompter({ single });
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+        { detectFrameworkIntegrationImport },
+      ),
+    ).resolves.toEqual({ projectId: "prj_new", projectName: "my-agent" });
+
+    expect(single).not.toHaveBeenCalled();
+    expect(detectFrameworkIntegrationImport).not.toHaveBeenCalled();
+    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
+      3,
+      [
+        "api",
+        "/v9/projects/prj_new",
+        "--scope",
+        "team-a",
+        "--method",
+        "PATCH",
+        "--raw-field",
+        "framework=eve",
+        "--raw",
+      ],
+      {
+        cwd: "/tmp/eve-agent",
+        onOutput: expect.any(Function),
+        signal: undefined,
+        timeoutMs: 15_000,
+      },
+    );
+  });
+
+  it("surfaces a missing Vercel link file after new project creation as an incomplete link", async () => {
+    mockedCaptureVercel.mockResolvedValueOnce(
+      failedCapture(JSON.stringify({ error: { code: "not_found", message: "Project not found" } })),
+    );
+    mockedReadProjectLink.mockResolvedValueOnce(undefined);
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      linkProject(
+        prompter,
+        "/tmp/eve-agent",
+        { kind: "new", project: "my-agent", team: "team-a" },
+        createPromptCommandOutput(prompter.log),
+      ),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/eve/src/setup/vercel-project.ts
+++ b/packages/eve/src/setup/vercel-project.ts
@@ -1,19 +1,18 @@
 import { createPromptCommandOutput, whimsyFor } from "#setup/cli/index.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
 import { captureVercel, runVercel, type VercelCaptureFailure } from "#setup/primitives/index.js";
-import { hasVercelHostFramework } from "#setup/scaffold/index.js";
 import pc from "picocolors";
 import { z } from "zod";
 
 import {
   assertNoLegacyProjectLinkDirectory,
+  readProjectLink,
   type ProjectResolution,
 } from "./project-resolution.js";
 import type { Prompter } from "./prompter.js";
 import type { ResolvedVercelProjectSpec, VercelProjectIdentity } from "./state.js";
 import { withSpinner } from "./with-spinner.js";
 import {
-  isConflictApiFailure,
   isForbiddenApiFailure,
   isNotFoundApiFailure,
   normalizeVercelApiResult,
@@ -29,13 +28,16 @@ import {
   type VercelProjectOperationOptions,
   VERCEL_PROJECT_REQUEST_TIMEOUT_MS,
 } from "./vercel-project-api.js";
+import {
+  ensureCreatedProjectFramework,
+  type CreatedProjectFrameworkOptions,
+} from "./vercel-project-framework.js";
 
 const VercelProjectReferenceSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
 });
 
-const EVE_FRAMEWORK_PRESET = "eve";
 export interface PickProjectOptions extends VercelProjectOperationOptions {
   /** Whether an empty project list may fall back to entering a name to create. */
   allowCreateWhenEmpty?: boolean;
@@ -45,6 +47,8 @@ export interface PickTeamOptions extends VercelProjectOperationOptions {
   /** Builds the team selector heading from the current team's display name. */
   selectMessage?: (currentTeam: string) => string;
 }
+
+export interface LinkProjectOperationOptions extends CreatedProjectFrameworkOptions {}
 
 export function unresolvedProject(): ProjectResolution {
   return { kind: "unresolved" };
@@ -89,49 +93,6 @@ export async function resolveProjectByNameOrId(
   if (isForbiddenApiFailure(result.failure)) requireVercelTeamAccess(result.failure);
   throw new Error(
     `Could not resolve project "${projectNameOrId}" in ${team}. ${result.failure.message}`,
-  );
-}
-
-async function createProject(
-  projectRoot: string,
-  team: string,
-  projectName: string,
-  onOutput: ReturnType<typeof createPromptCommandOutput>,
-  options: VercelProjectOperationOptions,
-): Promise<VercelProjectIdentity> {
-  const createProjectArgs = [
-    "api",
-    "/v10/projects",
-    "--scope",
-    team,
-    "--method",
-    "POST",
-    "--raw-field",
-    `name=${projectName}`,
-  ];
-  // Host framework integrations (Next.js, Nuxt, SvelteKit) own the top-level
-  // Vercel build. Leaving the preset unset lets Vercel detect that framework
-  // while vercel.json/build-output config owns the internal Eve service.
-  if (!(await hasVercelHostFramework(projectRoot))) {
-    createProjectArgs.push("--raw-field", `framework=${EVE_FRAMEWORK_PRESET}`);
-  }
-  createProjectArgs.push("--raw");
-  const result = normalizeVercelApiResult(
-    await captureVercel(createProjectArgs, {
-      cwd: projectRoot,
-      onOutput,
-      signal: options.signal,
-    }),
-  );
-  if (result.ok) {
-    return parseProjectReference(result.stdout, `created project ${projectName}`);
-  }
-  if (isConflictApiFailure(result.failure)) {
-    throw new Error(projectNameCollisionMessage(projectName, team));
-  }
-  if (isForbiddenApiFailure(result.failure)) requireVercelTeamAccess(result.failure);
-  throw new Error(
-    `Could not create Vercel project "${projectName}" in ${team}. ${result.failure.message}`,
   );
 }
 
@@ -581,31 +542,49 @@ export async function pickNewProjectName(
 /**
  * Ensures the concrete project exists (creating it for a `new` plan) and links
  * this directory to it. Acts on a fully-resolved spec — never prompts for a
- * team or project. Returns the linked project, or undefined if `vercel link`
- * did not complete.
+ * team or project. A newly created project keeps a detected host framework
+ * when the matching eve integration import is present; otherwise missing,
+ * unsupported, or rejected framework detections are switched back to eve.
+ * Returns the linked project, or undefined if `vercel link` did not complete.
  */
 export async function linkProject(
   prompter: Prompter,
   projectRoot: string,
   spec: ResolvedVercelProjectSpec,
   onOutput: ReturnType<typeof createPromptCommandOutput>,
-  options: VercelProjectOperationOptions = {},
+  options: LinkProjectOperationOptions = {},
 ): Promise<VercelProjectIdentity | undefined> {
   await assertNoLegacyProjectLinkDirectory(projectRoot);
   const scope = ["--scope", spec.team];
-  let project: VercelProjectIdentity;
   if (spec.kind === "new") {
-    project = await withSpinner(
+    const linked = await withSpinner(
       prompter,
       `Creating Vercel project "${spec.project}" in ${spec.team}...`,
       async () => {
         await assertNewProjectNameAvailable(projectRoot, spec.team, spec.project, options);
-        return createProject(projectRoot, spec.team, spec.project, onOutput, options);
+        return runVercel(["link", "--project", spec.project, ...scope, "--yes"], {
+          cwd: projectRoot,
+          onOutput,
+          nonInteractive: true,
+          signal: options.signal,
+        });
       },
     );
-  } else {
-    project = spec.project;
+    if (!linked) return undefined;
+    const link = await readProjectLink(projectRoot);
+    if (link === undefined) return undefined;
+    await ensureCreatedProjectFramework(
+      prompter,
+      projectRoot,
+      spec.team,
+      link.projectId,
+      onOutput,
+      options,
+    );
+    return { projectId: link.projectId, projectName: link.projectName ?? spec.project };
   }
+
+  const project = spec.project;
   const linked = await withSpinner(
     prompter,
     `Linking this directory to Vercel project "${project.projectName}"...`,


### PR DESCRIPTION
## Summary
- create new linked Vercel projects through Vercel CLI link instead of direct project API calls
- read the resulting .vercel/project.json metadata after successful linking
- keep detected host frameworks when project sources already reference the matching eve integration (`eve/next`, `eve/nuxt`, or `eve/sveltekit`)
- ensure new projects use the eve framework preset when Vercel returns no framework, an unsupported framework, or a rejected ambiguous host framework
- prompt only in interactive runs when a supported host framework is detected without a matching eve integration import; headless ambiguous detections patch back to eve
- use the shared Vercel project request timeout for both framework inspection and framework PATCH calls
- keep the Vercel project orchestration file under the source line-count cap by moving framework handling into its own setup helper
- refresh stale deploy comments and add a patch changeset

## Tests
- pnpm --filter eve run test:unit
- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/structural-tests/file-length.test.ts src/setup/vercel-project.test.ts src/setup/boxes/link-project.test.ts src/setup/boxes/deploy-project.test.ts
- pnpm --filter eve run typecheck
- pnpm lint

## Issues
Fixes #438