### PR TITLE
Clarify SQL query tool description and schema

### DIFF
--- a/docs/tutorial/query-sample-data.mdx
+++ b/docs/tutorial/query-sample-data.mdx
@@ -9,6 +9,11 @@ The analytics assistant can hold a conversation, but it can't see a single row o
 
 To make the first query work without setup, bundle a small in-memory dataset under `agent/lib/`. Keep it tiny. This is throwaway scaffolding, not the real warehouse (that comes in Step 4).
 
+Install the in-memory SQLite helper:
+
+```bash
+npm install sql.js
+
 ```ts title="agent/lib/sample-db.ts"
 // A toy SQLite-in-memory stand-in. Swap for your real warehouse in Step 4.
 import initSqlJs from "sql.js";
@@ -51,8 +56,9 @@ import { runReadOnlySql } from "../lib/sample-db.js";
 
 export default defineTool({
   description:
-    "Run a read-only SQL query against the analytics tables (orders, customers) " +
-    "and return the columns and rows.",
+    "Run a read-only SQL query against the analytics tables. " +
+    "Schema: orders(id, customer_id, amount_cents, created_at); " +
+    "customers(id, name, plan). Amounts are in cents.",
   inputSchema: z.object({
     sql: z.string().describe("A single read-only SELECT statement."),
   }),


### PR DESCRIPTION
Updated the description for the SQL query tool to clarify the schema details.

### Description

Docs change to clarify setup and reduce amount of human thinking as working through the tutorial. 

- Add `npm install sql.js` before the sample-db step (missing dependency caused runtime failures)
- Document table schema in the `run_sql` tool description so the first query succeeds without a retry loop
- Clarify in Step 1 that the sample dataset is added in Step 3, not bundled at init


### How did you test your changes?

- [x] Follow tutorial Steps 1–3 from a fresh `npx eve@latest init` project
- [x] Confirm `npm run dev` starts without missing-module errors after Step 3
- [ ] Ask "Which customer has spent the most?" and confirm `run_sql` succeeds on the first call

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
