### PR TITLE
fix(eve): keep text and reasoning blocks when a step resumes after auth

### DIFF
--- a/.changeset/reducer-keep-text-on-step-resume.md
+++ b/.changeset/reducer-keep-text-on-step-resume.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `defaultMessageReducer` dropping an assistant text or reasoning block when a step resumes after an authorization (OAuth) flow. A resumed step reuses the same `stepIndex`, so the second block no longer overwrites the first — both now stay in `data.messages[].parts` in stream order.

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -691,4 +691,115 @@ describe("defaultMessageReducer", () => {
       { type: "step-start" },
     ]);
   });
+
+  it("keeps both text and reasoning blocks when a step resumes after authorization", () => {
+    const reducer = defaultMessageReducer();
+    let data = reducer.reduce(
+      reducer.initial(),
+      createStepStartedEvent({ sequence: 0, stepIndex: 0, turnId: "turn_0" }),
+    );
+    data = reducer.reduce(
+      data,
+      createReasoningCompletedEvent({
+        reasoning: "Let me list today's messages.",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        message: "I'll use outlook to fetch today's emails.",
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createActionsRequestedEvent({
+        actions: [
+          { callId: "call_1", input: { top: 50 }, kind: "tool-call", toolName: "outlook__list" },
+        ],
+        sequence: 3,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createAuthorizationRequiredEvent({
+        description: "Authorization required for outlook",
+        name: "outlook",
+        sequence: 4,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createAuthorizationCompletedEvent({
+        name: "outlook",
+        outcome: "authorized",
+        sequence: 5,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+
+    // The runtime resumes the same step after the OAuth flow completes.
+    data = reducer.reduce(
+      data,
+      createStepStartedEvent({ sequence: 6, stepIndex: 0, turnId: "turn_0" }),
+    );
+    data = reducer.reduce(
+      data,
+      createReasoningCompletedEvent({
+        reasoning: "Now I'll fetch today's messages.",
+        sequence: 7,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        message: "Got it. Fetching today's messages now.",
+        sequence: 8,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+
+    const parts = data.messages[0]?.parts ?? [];
+    expect(parts.filter((part) => part.type === "text")).toEqual([
+      {
+        state: "done",
+        stepIndex: 0,
+        text: "I'll use outlook to fetch today's emails.",
+        type: "text",
+      },
+      {
+        state: "done",
+        stepIndex: 0,
+        text: "Got it. Fetching today's messages now.",
+        type: "text",
+      },
+    ]);
+    expect(parts.filter((part) => part.type === "reasoning")).toEqual([
+      {
+        state: "done",
+        stepIndex: 0,
+        text: "Let me list today's messages.",
+        type: "reasoning",
+      },
+      {
+        state: "done",
+        stepIndex: 0,
+        text: "Now I'll fetch today's messages.",
+        type: "reasoning",
+      },
+    ]);
+  });
 });

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -107,7 +107,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
 
     case "reasoning.appended":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
-        upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        upsertStreamingPart(ensureStepStartPart(message, event.data.stepIndex), {
           state: "streaming",
           stepIndex: event.data.stepIndex,
           text: event.data.reasoningSoFar,
@@ -117,7 +117,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
 
     case "reasoning.completed":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
-        upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        upsertStreamingPart(ensureStepStartPart(message, event.data.stepIndex), {
           state: "done",
           stepIndex: event.data.stepIndex,
           text: event.data.reasoning,
@@ -238,7 +238,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
 
     case "message.appended":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
-        upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        upsertStreamingPart(ensureStepStartPart(message, event.data.stepIndex), {
           state: "streaming",
           stepIndex: event.data.stepIndex,
           text: event.data.messageSoFar,
@@ -252,7 +252,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
           return removeTextPart(message, event.data.stepIndex);
         }
 
-        return upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        return upsertStreamingPart(ensureStepStartPart(message, event.data.stepIndex), {
           state: "done",
           stepIndex: event.data.stepIndex,
           text: event.data.message,
@@ -379,11 +379,61 @@ function upsertPart(message: EveAssistantMessage, next: EveMessagePart): EveAssi
   };
 }
 
+type EveStreamingPart = Extract<EveMessagePart, { readonly type: "reasoning" | "text" }>;
+
+// Text and reasoning can recur within one step: an authorization (OAuth)
+// interrupt resumes the same stepIndex and emits a fresh block. Update the
+// current block while it is still streaming, but once it is done a new event of
+// the same kind starts a new block instead of overwriting the finished one.
+function upsertStreamingPart(
+  message: EveAssistantMessage,
+  next: EveStreamingPart,
+): EveAssistantMessage {
+  let index = -1;
+  for (let i = message.parts.length - 1; i >= 0; i -= 1) {
+    const part = message.parts[i];
+    if (
+      (part?.type === "text" || part?.type === "reasoning") &&
+      part.type === next.type &&
+      part.stepIndex === next.stepIndex
+    ) {
+      index = i;
+      break;
+    }
+  }
+
+  const current = index === -1 ? undefined : message.parts[index];
+  const reuse =
+    (current?.type === "text" || current?.type === "reasoning") && current.state === "streaming";
+
+  const parts = reuse
+    ? [...message.parts.slice(0, index), next, ...message.parts.slice(index + 1)]
+    : [...message.parts, next];
+
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      status: next.type === "text" && next.state === "done" ? "complete" : "streaming",
+    },
+    parts,
+  };
+}
+
 function removeTextPart(message: EveAssistantMessage, stepIndex: number): EveAssistantMessage {
-  const parts = message.parts.filter(
-    (part) => part.type !== "text" || part.stepIndex !== stepIndex,
-  );
-  if (parts.length === message.parts.length) {
+  // Drop only the trailing in-progress text block for this step so an empty
+  // completion cannot wipe an earlier block kept from before a resume.
+  let index = -1;
+  for (let i = message.parts.length - 1; i >= 0; i -= 1) {
+    const part = message.parts[i];
+    if (part?.type === "text" && part.stepIndex === stepIndex) {
+      index = i;
+      break;
+    }
+  }
+
+  const current = index === -1 ? undefined : message.parts[index];
+  if (current?.type !== "text" || current.state !== "streaming") {
     return message;
   }
 
@@ -393,7 +443,7 @@ function removeTextPart(message: EveAssistantMessage, stepIndex: number): EveAss
       ...message.metadata,
       status: "complete",
     },
-    parts,
+    parts: [...message.parts.slice(0, index), ...message.parts.slice(index + 1)],
   };
 }
 


### PR DESCRIPTION
Closes #436.

When an OAuth authorization resolves mid-step, the runtime resumes the same step — a second `step.started`/`message.completed` arrives with the same `turnId` and `stepIndex`. `defaultMessageReducer` keyed text and reasoning parts by `stepIndex` alone, so the resumed block overwrote the earlier one and `useEveAgent().data.messages` lost the first assistant message even though it was in the raw stream.

The reducer now updates the current text/reasoning block only while it's still streaming; once a block is `done`, the next event of the same kind in that step starts a new block instead of replacing it. `removeTextPart` (null completion) is scoped to the trailing in-progress block too, so an empty delivery can't wipe a block kept from before the resume.

Added a test that feeds the issue's event shape (reasoning + message, auth required/completed, step resumes at the same index) and asserts both text and reasoning blocks survive in order.