### PR TITLE
docs: bump @vercel/geistdocs to 1.8.2

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,8 +21,11 @@
     "@vercel/agent-readability": "0.4.0",
     "@vercel/analytics": "2.0.1",
     "@vercel/eve-catalog": "workspace:*",
-    "@vercel/geistdocs": "1.8.1",
+    "@vercel/geistdocs": "1.8.2",
     "@vercel/speed-insights": "2.0.0",
+    "@vgpu/core": "0.0.7",
+    "@vgpu/render": "0.0.7",
+    "@vgpu/wgsl": "0.0.7",
     "ai": "6.0.191",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
@@ -50,25 +53,22 @@
     "tailwind-merge": "3.6.0",
     "use-stick-to-bottom": "1.1.4",
     "vaul": "1.1.2",
-    "zod": "catalog:",
-    "@vgpu/core": "0.0.7",
-    "@vgpu/render": "0.0.7",
-    "@vgpu/wgsl": "0.0.7"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.0",
     "@types/mdx": "2.0.13",
     "@types/node": "catalog:",
+    "@types/pngjs": "^6.0.5",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "postcss": "8.5.15",
-    "tailwindcss": "4.3.0",
-    "tw-animate-css": "1.4.0",
-    "typescript": "6.0.3",
-    "@types/pngjs": "^6.0.5",
     "@vgpu/adapter-node": "0.0.7",
     "@webgpu/types": "^0.1.69",
     "pngjs": "^7.0.0",
-    "tsx": "^4.21.0"
+    "postcss": "8.5.15",
+    "tailwindcss": "4.3.0",
+    "tsx": "^4.21.0",
+    "tw-animate-css": "1.4.0",
+    "typescript": "6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eve-catalog
       '@vercel/geistdocs':
-        specifier: 1.8.1
-        version: 1.8.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: 1.8.2
+        version: 1.8.2(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(1bf1af76e23df0ef2782fcce60ed20a8)
@@ -6638,8 +6638,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.19':
     resolution: {integrity: sha512-dA1ZWZHruRjFbLToqjcPHUyh5J7/Cl3qGFDge87ghAInuy/aXfalApzFbw61OIopGx0SSsIYi/8kbpJ+SbQ6ZQ==}
 
-  '@vercel/geistdocs@1.8.1':
-    resolution: {integrity: sha512-+yHua2sIMNFGN7bn6kLZ8D80YOpSdTr8ssoFUTmVN//tAKqV4Oe2rIk11ocMF5Qn4Cuy5Pq2l+otpZakAYCF8w==}
+  '@vercel/geistdocs@1.8.2':
+    resolution: {integrity: sha512-1F9BwMH3TCqvIigGF2f5H75/Ng3xe4XznuFAgXSiKTr7Tf9ww28Cvl+4s27lSO9/oklGZa0rcBTdyT8sIood7Q==}
     hasBin: true
     peerDependencies:
       next: 16.2.6
@@ -18403,7 +18403,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.8.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vercel/geistdocs@1.8.2(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
## What

Bump `@vercel/geistdocs` 1.8.1 → 1.8.2 in the docs app.

1.8.2 includes the code-block copy-button improvements that were upstreamed (vercel/geistdocs#135, #137):
- floating copy button reveals on hover/focus,
- stays visible on coarse pointers (touch),
- refreshed copy icon.

So the docs homepage code areas get the hover-reveal behavior with no local CSS override. Bump only — no component changes.

| **Before**  | **After** |
| ------------- | ------------- |
| <img width="1511" height="748" alt="image" src="https://github.com/user-attachments/assets/34c3a907-ad1d-48c4-9aeb-91e365aec2b9" /> | <video src="https://github.com/user-attachments/assets/f9951aa4-51b8-4194-99e0-802f6c22b849" />  |