### PR TITLE
Fix resumed step message projection

### DIFF
--- a/.changeset/resumed-step-message-parts.md
+++ b/.changeset/resumed-step-message-parts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve assistant text and reasoning parts when a turn resumes with a reused step index after authorization.

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -649,6 +649,134 @@ describe("defaultMessageReducer", () => {
     ]);
   });
 
+  it("keeps text from a resumed step as a separate part", () => {
+    const reducer = defaultMessageReducer();
+    let data = reducer.initial();
+
+    data = reducer.reduce(
+      data,
+      createStepStartedEvent({
+        sequence: 0,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createReasoningCompletedEvent({
+        reasoning: "Need to fetch email.",
+        sequence: 1,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        message: "I'll use Outlook to list today's messages.",
+        sequence: 2,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createActionsRequestedEvent({
+        actions: [
+          {
+            callId: "call_1",
+            input: { top: 50 },
+            kind: "tool-call",
+            toolName: "outlook__me_ListMessages",
+          },
+        ],
+        sequence: 3,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createAuthorizationRequiredEvent({
+        description: "Authorization required for outlook",
+        name: "outlook",
+        sequence: 4,
+        stepIndex: 1,
+        turnId: "turn_1",
+        webhookUrl: "https://agent.example.com/eve/v1/connections/outlook/callback/hook",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createAuthorizationCompletedEvent({
+        name: "outlook",
+        outcome: "authorized",
+        sequence: 5,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createStepStartedEvent({
+        sequence: 6,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createReasoningCompletedEvent({
+        reasoning: "Authorization is complete, so fetch the messages.",
+        sequence: 7,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        message: "Got it. Now I'll fetch today's messages.",
+        sequence: 8,
+        stepIndex: 1,
+        turnId: "turn_1",
+      }),
+    );
+
+    const assistant = data.messages.find((message) => message.id === "turn_1:assistant");
+    const textParts = assistant?.parts.filter((part) => part.type === "text");
+    const reasoningParts = assistant?.parts.filter((part) => part.type === "reasoning");
+
+    expect(textParts).toEqual([
+      {
+        state: "done",
+        stepIndex: 1,
+        text: "I'll use Outlook to list today's messages.",
+        type: "text",
+      },
+      {
+        state: "done",
+        stepIndex: 1,
+        text: "Got it. Now I'll fetch today's messages.",
+        type: "text",
+      },
+    ]);
+    expect(reasoningParts).toEqual([
+      {
+        state: "done",
+        stepIndex: 1,
+        text: "Need to fetch email.",
+        type: "reasoning",
+      },
+      {
+        state: "done",
+        stepIndex: 1,
+        text: "Authorization is complete, so fetch the messages.",
+        type: "reasoning",
+      },
+    ]);
+  });
+
   it("removes streamed text for a null message completion", () => {
     const reducer = defaultMessageReducer();
     let data = reducer.reduce(

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -363,7 +363,7 @@ function ensureStepStartPart(message: EveAssistantMessage, stepIndex: number): E
 }
 
 function upsertPart(message: EveAssistantMessage, next: EveMessagePart): EveAssistantMessage {
-  const index = message.parts.findIndex((part) => partKey(part) === partKey(next));
+  const index = findUpsertPartIndex(message.parts, next);
   const parts =
     index === -1
       ? [...message.parts, next]
@@ -380,10 +380,16 @@ function upsertPart(message: EveAssistantMessage, next: EveMessagePart): EveAssi
 }
 
 function removeTextPart(message: EveAssistantMessage, stepIndex: number): EveAssistantMessage {
-  const parts = message.parts.filter(
-    (part) => part.type !== "text" || part.stepIndex !== stepIndex,
+  const index = findLastIndex(
+    message.parts,
+    (part) => part.type === "text" && part.stepIndex === stepIndex && part.state !== "done",
   );
-  if (parts.length === message.parts.length) {
+  const fallbackIndex =
+    index === -1
+      ? findLastIndex(message.parts, (part) => part.type === "text" && part.stepIndex === stepIndex)
+      : index;
+
+  if (fallbackIndex === -1) {
     return message;
   }
 
@@ -393,8 +399,38 @@ function removeTextPart(message: EveAssistantMessage, stepIndex: number): EveAss
       ...message.metadata,
       status: "complete",
     },
-    parts,
+    parts: [...message.parts.slice(0, fallbackIndex), ...message.parts.slice(fallbackIndex + 1)],
   };
+}
+
+function findUpsertPartIndex(parts: readonly EveMessagePart[], next: EveMessagePart): number {
+  if (next.type === "text" || next.type === "reasoning") {
+    const streamingIndex = findLastIndex(
+      parts,
+      (part) =>
+        part.type === next.type && part.stepIndex === next.stepIndex && part.state !== "done",
+    );
+    if (streamingIndex !== -1) {
+      return streamingIndex;
+    }
+
+    return -1;
+  }
+
+  return parts.findIndex((part) => partKey(part) === partKey(next));
+}
+
+function findLastIndex<T>(
+  items: readonly T[],
+  predicate: (item: T, index: number) => boolean,
+): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index] as T, index)) {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 function updateToolPart(


### PR DESCRIPTION
## Summary
- Preserve completed assistant text and reasoning parts when the runtime resumes a turn with a reused step index, such as after OAuth authorization.
- Keep active streaming text/reasoning updates in place while appending a new part once the previous part is done.
- Add a regression test for the OAuth resume event shape reported in #436.

Closes #436.

## Validation
- `corepack pnpm exec oxfmt packages/eve/src/client/message-reducer.ts packages/eve/src/client/message-reducer.test.ts .changeset/resumed-step-message-parts.md`
- `corepack pnpm exec oxlint packages/eve/src/client/message-reducer.ts packages/eve/src/client/message-reducer.test.ts`
- `corepack pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/client/message-reducer.test.ts`
- `pnpm --filter eve run typecheck`
- `git diff --check`

Note: local Node is v22.22.2 while the repo declares Node >=24, so pnpm emitted engine warnings during validation.