### PR TITLE
fix(eve): surface terminal model-call failures from subagents to the parent

### DIFF
--- a/.changeset/fix-subagent-terminal-model-call-failure.md
+++ b/.changeset/fix-subagent-terminal-model-call-failure.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix a terminal model-call failure (e.g. an invalid API key or a structural 4xx) inside a subagent run being reported to the delegating parent as a successful, empty-output result instead of an error. The parent orchestrator would previously log the run as completed even though the subagent's model call failed.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -2556,6 +2556,34 @@ describe("createToolLoopHarness", () => {
     expect(types).not.toContain("session.waiting");
   });
 
+  it("fails a task run terminally on a structural 4xx model-call error instead of reporting success", async () => {
+    // Regression test for vercel/eve#412: a terminal model-call failure
+    // (e.g. invalid API key) inside a subagent run must surface as
+    // `isError: true` to the parent orchestrator, not as a silent
+    // `{ done: true, output: "" }` success.
+    const error = Object.assign(new Error("invalid api key"), {
+      name: "AI_APICallError",
+      statusCode: 401,
+    });
+    setupMockAgentError(error);
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("task", emit));
+
+    const result = await runStep(createTestSession(), { message: "Hi" });
+
+    expect(result.next).toEqual({
+      done: true,
+      isError: true,
+      output: expect.stringContaining("invalid api key"),
+    });
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("step.failed");
+    expect(types).toContain("session.failed");
+    expect(types).not.toContain("session.waiting");
+  });
+
   it("emits the full terminal failure cascade on an explicit Gateway invalid-request error", async () => {
     setupMockAgentError(
       createGatewayModelCallError({

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -988,7 +988,15 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             sessionId: session.sessionId,
           });
           return {
-            next: { done: true, output: "" },
+            // A task run cannot park for a user retry, so a terminal
+            // failure must still surface as the task's error result
+            // instead of the conversation-mode `output: ""` placeholder —
+            // otherwise the delegating parent sees a successful
+            // subagent-result tool call with an empty output.
+            next:
+              config.mode === "task"
+                ? { done: true, isError: true, output: errorMessage }
+                : { done: true, output: "" },
             session,
           };
         }


### PR DESCRIPTION
Fixes #412

## Problem

A terminal `MODEL_CALL_FAILED` classification (structural 4xx, invalid API key, unresolvable model id, etc.) made `createToolLoopHarness`'s step function return `{ next: { done: true, output: "" }, session }` regardless of run mode.

For a subagent (`config.mode === "task"`), that result is what `finalizeDone` in `workflow-entry.ts` rolls up into the parent's `subagent-result` tool call via `createDelegatedSubagentSuccessResult`/`createDelegatedSubagentErrorResult`, gated on `action.isError === true`. Since the terminal branch never set `isError`, a subagent whose model call failed terminally (e.g. a 404 for an unresolvable model id, matching the repro in #412) was reported to the parent as a successful call with empty output. The orchestrator then continued and the top-level session reported success even though the subagent's model call failed.

The non-terminal (recoverable / retry-exhausted) failure path a few lines below already special-cases `config.mode === "task"` and returns `{ done: true, isError: true, output: errorMessage }` for exactly this reason — the terminal branch above it was just missing the same check.

## Fix

Apply the same `config.mode === "task"` check to the terminal branch, so a terminal model-call failure in a subagent surfaces as `{ done: true, isError: true, output: errorMessage }` instead of silently swallowing the failure. Non-task-mode behavior (`{ done: true, output: "" }`, tearing down the conversation session) is unchanged.

## Testing

Added a regression test in `tool-loop.test.ts` mirroring the existing "structural 4xx" terminal-cascade test, but in `task` mode, asserting `result.next` carries `isError: true` and the error message instead of an empty success output. Confirmed it fails on `main` and passes with the fix.

Ran the full `packages/eve` unit suite before/after — no new failures (a handful of pre-existing Windows-path-separator failures in unrelated CLI/nitro-host tests are present on `main` as well, unrelated to this change).

Added a changeset (patch) for the published `eve` package.