### PR TITLE
Add ACP model helper

### DIFF
--- a/.changeset/add-acp-model-helper.md
+++ b/.changeset/add-acp-model-helper.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add an `eve/acp` helper for using Agent Client Protocol agents as AI SDK language models from `defineAgent({ model })`.

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -41,6 +41,45 @@ Direct provider model ids use the provider's native format. For Anthropic, the
 version uses hyphens (`claude-opus-4-8`), while the Gateway id above uses a dot
 (`anthropic/claude-opus-4.8`).
 
+You can also route model calls through an Agent Client Protocol agent. Install
+the ACP provider bridge, then use `acp()` from `eve/acp`:
+
+```bash
+npm install @mcpc-tech/acp-ai-provider
+```
+
+```ts title="agent/agent.ts"
+import { acp } from "eve/acp";
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: acp("opencode"),
+});
+```
+
+Pass the model id understood by that ACP agent as the second argument when you
+want to pin the backing model:
+
+```ts title="agent/agent.ts"
+export default defineAgent({
+  model: acp("opencode", "opencode-go/kimi-k2.7-code"),
+});
+```
+
+The built-in presets cover common ACP agents such as OpenCode, Gemini, and the
+adapter commands for Codex and Claude. For any other ACP-compatible agent, pass
+its command directly:
+
+```ts title="agent/agent.ts"
+export default defineAgent({
+  model: acp({
+    command: "kimi",
+    args: ["acp"],
+    model: "moonshot-v1-auto",
+  }),
+});
+```
+
 Model use is subject to the terms, data-processing commitments, retention behavior, and available controls of the selected provider and routing path. Review the [AI Gateway model catalog](https://vercel.com/ai-gateway/models) for gateway-routed models, and review the provider's terms when you configure a direct `LanguageModel`.
 
 ## Reasoning effort

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -75,6 +75,7 @@ A few non-`define*` helpers round out the set: `disableTool` from `eve/tools` (s
 | `eve/tools/defaults`                                        | the built-in tools as plain values                        |
 | `eve/tools/approval`                                        | `always`, `once`, `never`                                 |
 | `eve/connections`                                           | `defineMcpClientConnection`, `defineOpenAPIConnection`    |
+| `eve/acp`                                                   | `acp` helper for ACP-backed language models               |
 | `eve/channels`                                              | `defineChannel`, route verbs                              |
 | `eve/channels/eve`                                          | `eveChannel`                                              |
 | `eve/channels/auth`                                         | `localDev`, `vercelOidc`, `placeholderAuth`               |

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -116,6 +116,11 @@
       "import": "./dist/src/public/connections/index.js",
       "default": "./dist/src/public/connections/index.js"
     },
+    "./acp": {
+      "types": "./dist/src/public/acp/index.d.ts",
+      "import": "./dist/src/public/acp/index.js",
+      "default": "./dist/src/public/acp/index.js"
+    },
     "./agents/auth": {
       "types": "./dist/src/public/agents/auth.d.ts",
       "import": "./dist/src/public/agents/auth.js",
@@ -297,6 +302,7 @@
     "@chat-adapter/slack": "4.31.0",
     "@chat-adapter/state-memory": "4.31.0",
     "@clack/core": "1.3.1",
+    "@mcpc-tech/acp-ai-provider": "^0.3.3",
     "@nuxt/kit": "^4.0.0",
     "@standard-schema/spec": "1.1.0",
     "@sveltejs/kit": "^2.0.0",
@@ -340,6 +346,7 @@
     "zod-validation-error": "5.0.0"
   },
   "peerDependencies": {
+    "@mcpc-tech/acp-ai-provider": "^0.3.3",
     "@opentelemetry/api": "^1.0.0",
     "@sveltejs/kit": "^2.0.0",
     "ai": "catalog:",
@@ -385,6 +392,9 @@
       "optional": true
     },
     "vue": {
+      "optional": true
+    },
+    "@mcpc-tech/acp-ai-provider": {
       "optional": true
     }
   },

--- a/packages/eve/src/public/acp/index.test.ts
+++ b/packages/eve/src/public/acp/index.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAcpProviderConfig } from "./index.js";
+
+describe("acp model config", () => {
+  it("defaults to opencode without keeping the child process alive", () => {
+    expect(resolveAcpProviderConfig()).toMatchObject({
+      args: ["acp"],
+      command: "opencode",
+      persistSession: false,
+      session: {
+        cwd: process.cwd(),
+        mcpServers: [],
+      },
+    });
+  });
+
+  it("accepts a model shorthand for preset agents", () => {
+    expect(resolveAcpProviderConfig("opencode", "opencode-go/kimi-k2.7-code")).toMatchObject({
+      command: "opencode",
+      model: "opencode-go/kimi-k2.7-code",
+    });
+  });
+
+  it("accepts arbitrary ACP commands for registry agents without presets", () => {
+    expect(
+      resolveAcpProviderConfig({
+        args: ["acp"],
+        command: "kimi",
+        cwd: "/workspace",
+        model: "moonshot-v1-auto",
+      }),
+    ).toMatchObject({
+      args: ["acp"],
+      command: "kimi",
+      model: "moonshot-v1-auto",
+      session: {
+        cwd: "/workspace",
+      },
+    });
+  });
+
+  it("normalizes named MCP servers", () => {
+    expect(
+      resolveAcpProviderConfig("opencode", {
+        mcpServers: {
+          filesystem: {
+            args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+            command: "npx",
+          },
+        },
+      }).session.mcpServers,
+    ).toEqual([
+      {
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+        command: "npx",
+        env: [],
+        name: "filesystem",
+      },
+    ]);
+  });
+});

--- a/packages/eve/src/public/acp/index.ts
+++ b/packages/eve/src/public/acp/index.ts
@@ -1,0 +1,157 @@
+import type { LanguageModel } from "ai";
+import { createACPProvider } from "@mcpc-tech/acp-ai-provider";
+
+export type AcpPreset = "claude" | "codex" | "gemini" | "opencode";
+
+export interface AcpMcpServerConfig {
+  readonly args: readonly string[];
+  readonly command: string;
+  readonly env?: readonly AcpMcpServerEnvVariable[];
+  readonly name: string;
+  readonly type?: "stdio";
+}
+
+export interface AcpMcpServerEnvVariable {
+  readonly name: string;
+  readonly value: string;
+}
+
+export type AcpMcpServers =
+  | readonly AcpMcpServerConfig[]
+  | Readonly<Record<string, Omit<AcpMcpServerConfig, "name">>>;
+
+export interface AcpModelOptions {
+  readonly args?: readonly string[];
+  readonly authMethodId?: string;
+  readonly command?: string;
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly mcpServers?: AcpMcpServers;
+  readonly mode?: string;
+  readonly model?: string;
+  readonly persistSession?: boolean;
+  readonly sessionDelayMs?: number;
+}
+
+export interface ResolvedAcpProviderConfig {
+  readonly args: readonly string[];
+  readonly authMethodId?: string;
+  readonly command: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly mode?: string;
+  readonly model?: string;
+  readonly persistSession: boolean;
+  readonly session: {
+    readonly cwd: string;
+    readonly mcpServers: readonly AcpMcpServerConfig[];
+  };
+  readonly sessionDelayMs?: number;
+}
+
+const ACP_PRESETS = {
+  claude: {
+    args: [],
+    command: "claude-code-acp",
+  },
+  codex: {
+    args: [],
+    command: "codex-acp",
+  },
+  gemini: {
+    args: ["--experimental-acp"],
+    command: "gemini",
+  },
+  opencode: {
+    args: ["acp"],
+    command: "opencode",
+  },
+} as const satisfies Readonly<
+  Record<AcpPreset, { readonly args: readonly string[]; readonly command: string }>
+>;
+
+export function acp(preset?: AcpPreset): LanguageModel;
+export function acp(preset: AcpPreset, model: string): LanguageModel;
+export function acp(preset: AcpPreset, options: AcpModelOptions): LanguageModel;
+export function acp(options: AcpModelOptions): LanguageModel;
+export function acp(
+  presetOrOptions: AcpPreset | AcpModelOptions = "opencode",
+  modelOrOptions?: string | AcpModelOptions,
+): LanguageModel {
+  const config = resolveAcpProviderConfig(presetOrOptions, modelOrOptions);
+  const provider = createACPProvider({
+    args: [...config.args],
+    authMethodId: config.authMethodId,
+    command: config.command,
+    env: config.env === undefined ? undefined : { ...config.env },
+    persistSession: config.persistSession,
+    session: {
+      cwd: config.session.cwd,
+      mcpServers: config.session.mcpServers.map((server) => ({
+        ...server,
+        args: [...server.args],
+        env: server.env === undefined ? [] : server.env.map((entry) => ({ ...entry })),
+      })),
+    },
+    sessionDelayMs: config.sessionDelayMs,
+  });
+
+  return provider.languageModel(config.model, config.mode) as LanguageModel;
+}
+
+export function resolveAcpProviderConfig(
+  presetOrOptions: AcpPreset | AcpModelOptions = "opencode",
+  modelOrOptions?: string | AcpModelOptions,
+): ResolvedAcpProviderConfig {
+  const preset = typeof presetOrOptions === "string" ? ACP_PRESETS[presetOrOptions] : undefined;
+  const inputOptions = typeof presetOrOptions === "string" ? undefined : presetOrOptions;
+  const overrideOptions =
+    typeof modelOrOptions === "string" ? { model: modelOrOptions } : modelOrOptions;
+  const options = { ...inputOptions, ...overrideOptions };
+  const command = options.command ?? preset?.command;
+
+  if (command === undefined) {
+    throw new Error("acp() requires a preset or command.");
+  }
+
+  return {
+    args: options.args ?? preset?.args ?? [],
+    authMethodId: options.authMethodId,
+    command,
+    env: options.env,
+    mode: options.mode,
+    model: options.model,
+    persistSession: options.persistSession ?? false,
+    session: {
+      cwd: options.cwd ?? process.cwd(),
+      mcpServers: normalizeMcpServers(options.mcpServers),
+    },
+    sessionDelayMs: options.sessionDelayMs,
+  };
+}
+
+function normalizeMcpServers(mcpServers: AcpMcpServers | undefined): readonly AcpMcpServerConfig[] {
+  if (mcpServers === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(mcpServers)) {
+    return mcpServers.map((server) => ({
+      ...server,
+      args: [...server.args],
+      env:
+        server.env === undefined
+          ? []
+          : server.env.map((entry: AcpMcpServerEnvVariable) => ({ ...entry })),
+    }));
+  }
+
+  return Object.entries(mcpServers).map(([name, server]) => ({
+    name,
+    ...server,
+    args: [...server.args],
+    env:
+      server.env === undefined
+        ? []
+        : server.env.map((entry: AcpMcpServerEnvVariable) => ({ ...entry })),
+  }));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -830,6 +830,9 @@ importers:
       '@clack/core':
         specifier: 1.3.1
         version: 1.3.1
+      '@mcpc-tech/acp-ai-provider':
+        specifier: ^0.3.3
+        version: 0.3.3
       '@nuxt/kit':
         specifier: ^4.0.0
         version: 4.4.6(magicast@0.5.3)
@@ -961,6 +964,11 @@ importers:
         version: 4.1.7(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
+
+  '@agentclientprotocol/sdk@0.14.1':
+    resolution: {integrity: sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@ai-sdk/anthropic@4.0.0':
     resolution: {integrity: sha512-N0lT1g6/5DEIZvalpkpwYRCdu7n5qb8qPN3PcTem6k4VkPBLC2+T2LAAyx1GS0eNOxavVa0CP7n2kCiye0yyfw==}
@@ -2123,6 +2131,12 @@ packages:
       tailwindcss:
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -2391,6 +2405,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@mcpc-tech/acp-ai-provider@0.3.3':
+    resolution: {integrity: sha512-qWgE+/YFrGjYzgzb4ePFWlRPCI9wpyiVCS7hbWhixu3VT9WZfFFhzwx0hLuKWsRr7e4oe4hR5UqZBTf49bHzLQ==}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -2399,6 +2416,16 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/zstd@7.0.0':
     resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
@@ -6997,6 +7024,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -8425,6 +8460,10 @@ packages:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@3.2.0:
     resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
     engines: {node: ^8.12.0 || >=9.7.0}
@@ -8450,6 +8489,12 @@ packages:
     engines: {node: '>=22.13.0'}
     peerDependencies:
       ai: ^6.0.0 || ^7.0.0-beta.0
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -9039,6 +9084,10 @@ packages:
   hls.js@1.6.16:
     resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -9483,6 +9532,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -12898,11 +12950,22 @@ packages:
 
 snapshots:
 
+  '@agentclientprotocol/sdk@0.14.1(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
   '@ai-sdk/anthropic@4.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.0
       '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.120(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
 
   '@ai-sdk/gateway@3.0.120(zod@4.4.3)':
     dependencies:
@@ -12944,6 +13007,13 @@ snapshots:
       ai: 7.0.0(zod@4.4.3)
     transitivePeerDependencies:
       - zod
+
+  '@ai-sdk/provider-utils@4.0.27(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
     dependencies:
@@ -13934,6 +14004,10 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
 
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -14168,6 +14242,18 @@ snapshots:
       - encoding
       - supports-color
 
+  '@mcpc-tech/acp-ai-provider@0.3.3':
+    dependencies:
+      '@agentclientprotocol/sdk': 0.14.1(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      ai: 6.0.191(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
@@ -14203,6 +14289,28 @@ snapshots:
       '@chevrotain/types': 11.1.2
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -19023,6 +19131,14 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ai@6.0.191(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.120(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
+      zod: 3.25.76
+
   ai@6.0.191(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 3.0.120(zod@4.4.3)
@@ -19037,6 +19153,10 @@ snapshots:
       '@ai-sdk/provider': 4.0.0
       '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -20777,6 +20897,10 @@ snapshots:
 
   eventsource-parser@3.0.8: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   execa@3.2.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -20822,6 +20946,11 @@ snapshots:
   experimental-ai-sdk-code-mode@1.0.16(ai@7.0.0(zod@4.4.3)):
     dependencies:
       ai: 7.0.0(zod@4.4.3)
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -21610,6 +21739,8 @@ snapshots:
 
   hls.js@1.6.16: {}
 
+  hono@4.12.27: {}
+
   hookable@5.5.3: {}
 
   hookable@6.1.1: {}
@@ -22008,6 +22139,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 


### PR DESCRIPTION
## Summary

Adds an `eve/acp` helper for using Agent Client Protocol agents as AI SDK language models in `defineAgent({ model })`.

```ts
import { acp } from "eve/acp";
import { defineAgent } from "eve";

export default defineAgent({
  model: acp("opencode"),
});
```

The helper keeps the default path small while allowing model selection and arbitrary ACP commands:

```ts
model: acp("opencode", "opencode-go/kimi-k2.7-code")
model: acp({ command: "kimi", args: ["acp"], model: "moonshot-v1-auto" })
```

## Notes

- Adds presets for OpenCode, Gemini, Codex via `codex-acp`, and Claude via `claude-code-acp`.
- Leaves `@mcpc-tech/acp-ai-provider` as an optional peer dependency so the base eve install stays lightweight.
- Defaults `persistSession` to `false`; local smoke testing showed `true` keeps the ACP child process alive after one-shot `generateText()` calls.

## Testing

- `PATH=/Users/j/.nvm/versions/node/v24.13.0/bin:$PATH pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/acp/index.test.ts`
- `PATH=/Users/j/.nvm/versions/node/v24.13.0/bin:$PATH pnpm --filter eve run typecheck`
- `PATH=/Users/j/.nvm/versions/node/v24.13.0/bin:$PATH pnpm docs:check`

External smoke tests in a throwaway app:

- `acp("opencode")` through `generateText()` returned `eve acp smoke ok`.
- `acp("opencode", { model: "opencode-go/kimi-k2.7-code" })` through `generateText()` returned `eve acp smoke ok`.
- Codex via `brokk-codex-acp` accepted `initialize` + `session/new`, but emitted Codex app-server logs, so it is not used as the clean default.
- Installed Claude Code did not expose a native ACP subcommand; this PR uses the Zed adapter command name for the preset.
