### PR TITLE
feat(voice): add realtime voice channel

### DIFF
--- a/.changeset/realtime-voice-channel.md
+++ b/.changeset/realtime-voice-channel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a realtime voice channel (`eve/channels/voice`). Talk to your agent over a WebSocket: an utterance is transcribed with AI Gateway speech-to-text, delivered to a normal durable session (so tools, skills, and subagents all work), and the streamed reply is spoken back one sentence at a time with Gateway text-to-speech. Push-to-talk with barge-in; a browser client ships with the Next.js web template at `/voice`.

--- a/apps/templates/web-chat-next/agent/channels/voice.ts
+++ b/apps/templates/web-chat-next/agent/channels/voice.ts
@@ -1,0 +1,15 @@
+import { localDev, placeholderAuth, vercelOidc } from "eve/channels/auth";
+import { voiceChannel } from "eve/channels/voice";
+
+export default voiceChannel({
+  auth: [
+    // Lets the eve TUI and your Vercel deployments reach the deployed agent.
+    vercelOidc(),
+    // Open on localhost for `eve dev` and the browser voice demo.
+    localDev(),
+    // This placeholder will not allow browser requests in production.
+    // Replace it with your app's auth provider before shipping voice.
+    placeholderAuth(),
+  ],
+  greeting: "Hi! I'm your eve agent. Hold the button and say something.",
+});

--- a/apps/templates/web-chat-next/app/_components/voice-call.tsx
+++ b/apps/templates/web-chat-next/app/_components/voice-call.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { LoaderIcon, MicIcon, SquareIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type VoiceStatus = "connecting" | "idle" | "listening" | "thinking" | "speaking" | "error";
+
+interface TranscriptEntry {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+}
+
+const AUDIO_MIME: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  opus: "audio/ogg",
+  ogg: "audio/ogg",
+};
+
+const STATUS_LABEL: Record<VoiceStatus, string> = {
+  connecting: "Connecting…",
+  idle: "Hold to talk",
+  listening: "Listening…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+  error: "Disconnected",
+};
+
+/**
+ * Push-to-talk voice client for the eve `voiceChannel`. Hold the button to
+ * record one utterance; releasing sends it. The agent's spoken reply streams
+ * back sentence by sentence and plays automatically. Talking again interrupts
+ * playback (barge-in).
+ */
+export function VoiceCall({ wsUrl }: { readonly wsUrl?: string }) {
+  const [status, setStatus] = useState<VoiceStatus>("connecting");
+  const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const audioFormatRef = useRef("mp3");
+  const playQueueRef = useRef<Blob[]>([]);
+  const playingRef = useRef(false);
+  const currentAudioRef = useRef<HTMLAudioElement | null>(null);
+
+  const resolveUrl = useCallback((): string => {
+    if (wsUrl) return wsUrl;
+    const url = new URL("/eve/v1/voice", window.location.href);
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    return url.toString();
+  }, [wsUrl]);
+
+  const stopPlayback = useCallback(() => {
+    playQueueRef.current = [];
+    playingRef.current = false;
+    const audio = currentAudioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.src = "";
+      currentAudioRef.current = null;
+    }
+  }, []);
+
+  const playNext = useCallback(() => {
+    if (playingRef.current) return;
+    const next = playQueueRef.current.shift();
+    if (!next) return;
+    playingRef.current = true;
+    const audio = new Audio(URL.createObjectURL(next));
+    currentAudioRef.current = audio;
+    const advance = () => {
+      URL.revokeObjectURL(audio.src);
+      playingRef.current = false;
+      currentAudioRef.current = null;
+      playNext();
+    };
+    audio.onended = advance;
+    audio.onerror = advance;
+    void audio.play().catch(advance);
+  }, []);
+
+  const appendAssistantText = useCallback((text: string) => {
+    setTranscript((entries) => {
+      const last = entries[entries.length - 1];
+      if (last?.role === "assistant") {
+        const merged = [...entries];
+        merged[merged.length - 1] = { role: "assistant", text: `${last.text} ${text}`.trim() };
+        return merged;
+      }
+      return [...entries, { role: "assistant", text }];
+    });
+  }, []);
+
+  const handleControl = useCallback(
+    (raw: string) => {
+      let message: { type?: string; [key: string]: unknown };
+      try {
+        message = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      switch (message.type) {
+        case "ready":
+          if (typeof message.audioFormat === "string") audioFormatRef.current = message.audioFormat;
+          setStatus("idle");
+          break;
+        case "user_transcript":
+          if (typeof message.text === "string" && message.text.length > 0) {
+            setTranscript((entries) => [
+              ...entries,
+              { role: "user", text: message.text as string },
+            ]);
+          }
+          break;
+        case "assistant_text":
+          if (typeof message.text === "string") appendAssistantText(message.text);
+          break;
+        case "status":
+          if (message.state === "thinking" || message.state === "speaking") {
+            setStatus(message.state);
+          } else if (message.state === "idle") {
+            setStatus((current) => (current === "listening" ? current : "idle"));
+          }
+          break;
+        case "error":
+          if (typeof message.message === "string") setError(message.message);
+          break;
+        default:
+          break;
+      }
+    },
+    [appendAssistantText],
+  );
+
+  useEffect(() => {
+    const ws = new WebSocket(resolveUrl());
+    ws.binaryType = "arraybuffer";
+    wsRef.current = ws;
+
+    ws.onopen = () => setStatus("idle");
+    ws.onerror = () => {
+      setStatus("error");
+      setError("Could not reach the voice channel.");
+    };
+    ws.onclose = () => setStatus("error");
+    ws.onmessage = (event) => {
+      if (typeof event.data === "string") {
+        handleControl(event.data);
+        return;
+      }
+      const mime = AUDIO_MIME[audioFormatRef.current] ?? "audio/mpeg";
+      playQueueRef.current.push(new Blob([event.data as ArrayBuffer], { type: mime }));
+      playNext();
+    };
+
+    return () => {
+      ws.close();
+      stopPlayback();
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    };
+  }, [resolveUrl, handleControl, playNext, stopPlayback]);
+
+  const startRecording = useCallback(async () => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    if (status === "listening") return;
+
+    // Talking interrupts whatever the agent is currently saying.
+    stopPlayback();
+    ws.send(JSON.stringify({ type: "barge_in" }));
+
+    try {
+      let stream = streamRef.current;
+      if (!stream) {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        streamRef.current = stream;
+      }
+      const recorder = new MediaRecorder(stream);
+      chunksRef.current = [];
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) chunksRef.current.push(event.data);
+      };
+      recorder.onstop = async () => {
+        const blob = new Blob(chunksRef.current, { type: recorder.mimeType });
+        chunksRef.current = [];
+        if (blob.size === 0) return;
+        const buffer = await blob.arrayBuffer();
+        if (wsRef.current?.readyState === WebSocket.OPEN) wsRef.current.send(buffer);
+      };
+      recorderRef.current = recorder;
+      recorder.start();
+      setStatus("listening");
+    } catch {
+      setError("Microphone access was denied.");
+      setStatus("idle");
+    }
+  }, [status, stopPlayback]);
+
+  const stopRecording = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+    recorderRef.current = null;
+    setStatus((current) => (current === "listening" ? "thinking" : current));
+  }, []);
+
+  const isBusy = status === "thinking" || status === "speaking";
+
+  return (
+    <main className="flex h-dvh flex-col bg-background text-foreground">
+      <header className="flex h-14 shrink-0 items-center justify-center border-b">
+        <span className="text-muted-foreground text-sm">Voice · eve agent</span>
+      </header>
+
+      <div className="flex-1 space-y-3 overflow-y-auto p-4">
+        {transcript.length === 0 ? (
+          <p className="mt-8 text-center text-muted-foreground text-sm">
+            Hold the microphone button and speak to your agent.
+          </p>
+        ) : (
+          transcript.map((entry, index) => (
+            <div
+              key={index}
+              className={cn("flex", entry.role === "user" ? "justify-end" : "justify-start")}
+            >
+              <span
+                className={cn(
+                  "max-w-[80%] rounded-2xl px-4 py-2 text-sm",
+                  entry.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted",
+                )}
+              >
+                {entry.text}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      {error ? <p className="px-4 pb-2 text-center text-destructive text-xs">{error}</p> : null}
+
+      <footer className="flex flex-col items-center gap-2 border-t p-6">
+        <button
+          type="button"
+          disabled={status === "connecting" || status === "error"}
+          onPointerDown={() => void startRecording()}
+          onPointerUp={stopRecording}
+          onPointerLeave={stopRecording}
+          className={cn(
+            "flex size-20 items-center justify-center rounded-full text-primary-foreground transition-colors disabled:opacity-50",
+            status === "listening" ? "bg-destructive" : "bg-primary",
+          )}
+          aria-label="Hold to talk"
+        >
+          {isBusy ? (
+            <LoaderIcon className="size-8 animate-spin" />
+          ) : status === "listening" ? (
+            <SquareIcon className="size-7" />
+          ) : (
+            <MicIcon className="size-8" />
+          )}
+        </button>
+        <span className="text-muted-foreground text-sm">{STATUS_LABEL[status]}</span>
+      </footer>
+    </main>
+  );
+}

--- a/apps/templates/web-chat-next/app/voice/page.tsx
+++ b/apps/templates/web-chat-next/app/voice/page.tsx
@@ -1,0 +1,20 @@
+import { VoiceCall } from "@/app/_components/voice-call";
+
+/**
+ * In local development `withEve()` runs the agent on its own origin and exposes
+ * it via `EVE_BASE_URL`. WebSocket upgrades don't reliably survive the Next.js
+ * rewrite, so the voice client connects straight to that origin. In production
+ * (agent same-origin behind the rewrite) the client falls back to the page
+ * origin.
+ */
+function resolveVoiceWsUrl(): string | undefined {
+  const base = process.env.EVE_BASE_URL;
+  if (!base) return undefined;
+  const url = new URL("/eve/v1/voice", base);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+export default function VoicePage() {
+  return <VoiceCall wsUrl={resolveVoiceWsUrl()} />;
+}

--- a/docs/channels/meta.json
+++ b/docs/channels/meta.json
@@ -8,6 +8,7 @@
     "teams",
     "telegram",
     "twilio",
+    "voice",
     "github",
     "linear",
     "custom"

--- a/docs/channels/voice.mdx
+++ b/docs/channels/voice.mdx
@@ -1,0 +1,69 @@
+---
+title: "Voice"
+description: "Talk to your agent in real time over a WebSocket with Gateway speech-to-text and text-to-speech."
+type: integration
+---
+
+The voice channel lets a client talk to your agent over a single WebSocket. eve stays the brain: an incoming utterance is transcribed (AI Gateway speech-to-text), the transcript feeds a normal durable session, and the streamed reply is spoken back one sentence at a time (AI Gateway text-to-speech). Because the durable agent runs the turn, the full framework — instructions, tools, skills, subagents, and multi-turn memory — is available by voice. See [Channels](./overview) for the contract this builds on.
+
+**Beta.** Gateway voice support is in beta. Speech-to-text and text-to-speech are OpenAI-only today, and your `AI_GATEWAY_API_KEY` (or Vercel OIDC token) must have voice access enabled.
+
+## Add the channel
+
+```ts title="agent/channels/voice.ts"
+import { localDev, placeholderAuth, vercelOidc } from "eve/channels/auth";
+import { voiceChannel } from "eve/channels/voice";
+
+export default voiceChannel({
+  auth: [vercelOidc(), localDev(), placeholderAuth()],
+  greeting: "Hi! I'm your eve agent. What can I help you with?",
+});
+```
+
+This mounts one WebSocket route at `/eve/v1/voice`. Auth is evaluated on the upgrade with the shared [auth helpers](./eve#authentication); a failed walk rejects the handshake. Credentials for transcription and synthesis are resolved by the Gateway provider the same way your agent's language model is, so there is nothing extra to wire.
+
+## Configuration
+
+| Option                | Default            | Description                                       |
+| --------------------- | ------------------ | ------------------------------------------------- |
+| `auth`                | —                  | Route auth evaluated on the WebSocket upgrade.    |
+| `route`               | `/eve/v1/voice`    | WebSocket route path.                             |
+| `transcription.model` | `openai/whisper-1` | Gateway speech-to-text model id.                  |
+| `speech.model`        | `openai/tts-1`     | Gateway text-to-speech model id.                  |
+| `speech.voice`        | `alloy`            | Provider voice.                                   |
+| `speech.outputFormat` | `mp3`              | Audio container sent to the client.               |
+| `speech.instructions` | —                  | Free-form delivery guidance for the speech model. |
+| `speech.speed`        | —                  | Playback speed multiplier.                        |
+| `greeting`            | —                  | Line spoken as soon as the socket opens.          |
+
+## Wire protocol
+
+One WebSocket is one conversation. The two frame kinds are the discriminator, so audio needs no envelope:
+
+- **Binary frames** carry raw audio. Client → server: one complete spoken utterance. Server → client: synthesized speech in the configured `audioFormat`.
+- **Text frames** carry JSON control messages.
+
+Server → client control messages:
+
+- `{ "type": "ready", "audioFormat": "mp3" }` — sent once when the socket opens.
+- `{ "type": "user_transcript", "text": "..." }` — what the agent heard.
+- `{ "type": "assistant_text", "text": "..." }` — a chunk of the reply, sent with the audio frame that speaks it.
+- `{ "type": "status", "state": "thinking" | "speaking" | "idle" }`
+- `{ "type": "error", "message": "..." }` — recoverable; the socket stays open.
+
+Client → server control messages:
+
+- `{ "type": "barge_in" }` — interrupt the in-flight turn so the user can talk over the agent.
+- `{ "type": "text", "text": "..." }` — send typed text as if spoken (skips transcription).
+
+## How turns work
+
+Transcription and synthesis are **batch, not streaming**, which shapes the client:
+
+- **The client decides where an utterance ends.** Send one complete utterance per binary frame — typically push-to-talk (hold to record, release to send). There is no server-side voice-activity detection.
+- **Replies are synthesized per sentence.** As the agent streams text, the channel splits it on sentence boundaries and synthesizes each sentence as soon as it is complete, so the first sentence plays while later ones are still being written.
+- **Barge-in is client-led.** When the user starts talking again, stop local playback and send `barge_in` (or just a new utterance); the server aborts the rest of the current turn.
+
+## Browser client
+
+A push-to-talk browser client ships with the [Next.js web template](../guides/frontend/nextjs) at `/voice`. It captures the microphone, streams each utterance as a binary frame, plays the returned audio, and renders the transcript from the control messages above. In local development the client connects straight to the agent origin (from `EVE_BASE_URL`) because WebSocket upgrades do not reliably survive the Next.js rewrite.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -231,6 +231,11 @@
       "import": "./dist/src/public/channels/twilio/index.js",
       "default": "./dist/src/public/channels/twilio/index.js"
     },
+    "./channels/voice": {
+      "types": "./dist/src/public/channels/voice/index.d.ts",
+      "import": "./dist/src/public/channels/voice/index.js",
+      "default": "./dist/src/public/channels/voice/index.js"
+    },
     "./channels/telegram": {
       "types": "./dist/src/public/channels/telegram/index.d.ts",
       "import": "./dist/src/public/channels/telegram/index.js",

--- a/packages/eve/src/internal/voice/gateway-voice-models.ts
+++ b/packages/eve/src/internal/voice/gateway-voice-models.ts
@@ -1,0 +1,21 @@
+import { gateway, type SpeechModel, type TranscriptionModel } from "ai";
+
+/**
+ * Resolves a Gateway transcription (speech-to-text) model by id, e.g.
+ * `"openai/whisper-1"`.
+ *
+ * The AI Gateway provider resolves credentials the same way eve's language
+ * models do — an `AI_GATEWAY_API_KEY` when present, otherwise a Vercel OIDC
+ * token — so a voice channel needs no separate credential wiring.
+ */
+export function transcriptionModel(modelId: string): TranscriptionModel {
+  return gateway.transcriptionModel(modelId);
+}
+
+/**
+ * Resolves a Gateway speech (text-to-speech) model by id, e.g. `"openai/tts-1"`.
+ * See {@link transcriptionModel} for how credentials are resolved.
+ */
+export function speechModel(modelId: string): SpeechModel {
+  return gateway.speechModel(modelId);
+}

--- a/packages/eve/src/internal/voice/sentence-chunker.test.ts
+++ b/packages/eve/src/internal/voice/sentence-chunker.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { createSentenceChunker } from "#internal/voice/sentence-chunker.js";
+
+describe("createSentenceChunker", () => {
+  it("emits a chunk once a sentence terminator is followed by whitespace", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push("Hello there. ")).toEqual(["Hello there."]);
+  });
+
+  it("buffers across deltas until a sentence completes", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push("Hello")).toEqual([]);
+    expect(chunker.push(" there")).toEqual([]);
+    expect(chunker.push(". How are you? ")).toEqual(["Hello there.", "How are you?"]);
+  });
+
+  it("waits for the character after a terminator so decimals stay intact", () => {
+    const chunker = createSentenceChunker();
+    // Trailing "3." must not be spoken as its own sentence.
+    expect(chunker.push("Pi is 3.")).toEqual([]);
+    expect(chunker.push("14 exactly. ")).toEqual(["Pi is 3.14 exactly."]);
+  });
+
+  it("does not split unspaced decimals mid-stream", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push("It costs 3.14 dollars today. ")).toEqual(["It costs 3.14 dollars today."]);
+  });
+
+  it("treats a newline as a boundary", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push("First line\nSecond")).toEqual(["First line"]);
+  });
+
+  it("keeps closing quotes with the sentence", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push('She said "go." ')).toEqual(['She said "go."']);
+  });
+
+  it("merges too-short fragments into the following sentence", () => {
+    const chunker = createSentenceChunker({ minChunkLength: 3 });
+    expect(chunker.push("A. Longer sentence here. ")).toEqual(["A. Longer sentence here."]);
+  });
+
+  it("flushes the trailing remainder that never hit a boundary", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push("Final words without punctuation")).toEqual([]);
+    expect(chunker.flush()).toBe("Final words without punctuation");
+  });
+
+  it("returns null from flush when nothing is buffered", () => {
+    const chunker = createSentenceChunker();
+    chunker.push("Done. ");
+    expect(chunker.flush()).toBeNull();
+  });
+
+  it("handles multiple sentences in a single delta", () => {
+    const chunker = createSentenceChunker();
+    expect(chunker.push("One. Two! Three? ")).toEqual(["One.", "Two!", "Three?"]);
+  });
+});

--- a/packages/eve/src/internal/voice/sentence-chunker.ts
+++ b/packages/eve/src/internal/voice/sentence-chunker.ts
@@ -1,0 +1,95 @@
+/**
+ * Splits a stream of assistant text deltas into speakable chunks on sentence
+ * boundaries.
+ *
+ * Gateway text-to-speech is batch, not streaming, so the voice channel
+ * synthesizes one sentence at a time as the agent produces text. That lets
+ * playback of the first sentence start while the model is still writing later
+ * ones, instead of waiting for the whole reply.
+ *
+ * Feed deltas with {@link SentenceChunker.push} and speak each returned chunk;
+ * call {@link SentenceChunker.flush} once the turn completes to emit any
+ * trailing text that never hit a sentence boundary.
+ */
+export interface SentenceChunker {
+  /**
+   * Appends a text delta and returns any newly completed speakable chunks. A
+   * delta that does not complete a sentence returns an empty array and is
+   * buffered until a later delta (or {@link SentenceChunker.flush}) closes it.
+   */
+  push(delta: string): string[];
+  /** Returns and clears any buffered remainder, or `null` when empty. */
+  flush(): string | null;
+}
+
+const SENTENCE_TERMINATORS = new Set([".", "!", "?", "…"]);
+const CLOSING_MARKS = new Set(['"', "'", ")", "]", "”", "’"]);
+
+/**
+ * Creates a {@link SentenceChunker}.
+ *
+ * A sentence boundary is a terminator (`.`, `!`, `?`, `…`), optionally followed
+ * by closing quotes/brackets, then whitespace — requiring the trailing
+ * whitespace keeps decimals like `3.14` and unspaced abbreviations intact. A
+ * newline is always treated as a boundary. Chunks shorter than
+ * `minChunkLength` (after trimming) are held back and merged into the next one
+ * so single stray characters are not spoken on their own.
+ */
+export function createSentenceChunker(options: { minChunkLength?: number } = {}): SentenceChunker {
+  const minChunkLength = options.minChunkLength ?? 2;
+  let buffer = "";
+
+  const push = (delta: string): string[] => {
+    buffer += delta;
+    const chunks: string[] = [];
+    let start = 0;
+    let index = 0;
+
+    while (index < buffer.length) {
+      const char = buffer[index] ?? "";
+      const isNewline = char === "\n";
+      const isTerminator = SENTENCE_TERMINATORS.has(char);
+
+      if (!isNewline && !isTerminator) {
+        index += 1;
+        continue;
+      }
+
+      let boundary = index + 1;
+      if (isTerminator) {
+        while (boundary < buffer.length && CLOSING_MARKS.has(buffer[boundary] ?? "")) boundary += 1;
+        // Need to see the character after the terminator to know it is a real
+        // boundary (whitespace) and not a decimal/abbreviation. If it is the
+        // end of the buffer, wait for the next delta.
+        if (boundary >= buffer.length) break;
+        if (!/\s/.test(buffer[boundary] ?? "")) {
+          index = boundary;
+          continue;
+        }
+      }
+
+      const candidate = buffer.slice(start, boundary).trim();
+      if (candidate.length >= minChunkLength) {
+        chunks.push(candidate);
+        while (boundary < buffer.length && /\s/.test(buffer[boundary] ?? "")) boundary += 1;
+        start = boundary;
+        index = boundary;
+      } else {
+        // Too short to speak alone — keep scanning so it merges into the next
+        // sentence.
+        index = boundary;
+      }
+    }
+
+    buffer = buffer.slice(start);
+    return chunks;
+  };
+
+  const flush = (): string | null => {
+    const remainder = buffer.trim();
+    buffer = "";
+    return remainder.length > 0 ? remainder : null;
+  };
+
+  return { push, flush };
+}

--- a/packages/eve/src/internal/voice/synthesize.test.ts
+++ b/packages/eve/src/internal/voice/synthesize.test.ts
@@ -1,0 +1,32 @@
+import { MockSpeechModelV3 } from "ai/test";
+import { describe, expect, it } from "vitest";
+
+import { synthesizeSpeech } from "#internal/voice/synthesize.js";
+
+describe("synthesizeSpeech", () => {
+  it("forwards text and voice to the model and returns audio bytes", async () => {
+    const audioBytes = new Uint8Array([9, 8, 7]);
+    let received: { text?: string; voice?: string } = {};
+    const model = new MockSpeechModelV3({
+      modelId: "openai/tts-1",
+      doGenerate: async (options) => {
+        received = { text: options.text, voice: options.voice };
+        return {
+          audio: audioBytes,
+          warnings: [],
+          response: { timestamp: new Date(), modelId: "openai/tts-1" },
+        };
+      },
+    });
+
+    const result = await synthesizeSpeech({
+      model,
+      text: "Hello there.",
+      voice: "alloy",
+      outputFormat: "mp3",
+    });
+
+    expect(result.audio).toEqual(audioBytes);
+    expect(received).toEqual({ text: "Hello there.", voice: "alloy" });
+  });
+});

--- a/packages/eve/src/internal/voice/synthesize.ts
+++ b/packages/eve/src/internal/voice/synthesize.ts
@@ -1,0 +1,50 @@
+import { experimental_generateSpeech as generateSpeech, type SpeechModel } from "ai";
+
+/** Options for {@link synthesizeSpeech}. */
+export interface SynthesizeSpeechOptions {
+  /** Gateway speech model, e.g. from `speechModel("openai/tts-1")`. */
+  readonly model: SpeechModel;
+  /** Text to speak — typically one sentence produced by the agent. */
+  readonly text: string;
+  /** Provider voice, e.g. `"alloy"`. Defaults to the model's default voice. */
+  readonly voice?: string;
+  /** Audio container, e.g. `"mp3"` or `"wav"`. Defaults to the model's default. */
+  readonly outputFormat?: string;
+  /** Free-form delivery guidance, e.g. `"Speak calmly"`. */
+  readonly instructions?: string;
+  /** Playback speed multiplier. */
+  readonly speed?: number;
+  /** Aborts an in-flight synthesis, e.g. on barge-in. */
+  readonly abortSignal?: AbortSignal;
+}
+
+/** Synthesized speech audio for a chunk of text. */
+export interface SynthesizeSpeechResult {
+  /** Encoded audio bytes in {@link SynthesizeSpeechResult.format}. */
+  readonly audio: Uint8Array;
+  /** Audio container/codec of {@link SynthesizeSpeechResult.audio}, e.g. `"mp3"`. */
+  readonly format: string;
+}
+
+/**
+ * Synthesizes speech audio from text through the AI Gateway.
+ *
+ * Synthesis is batch, not streaming: the whole text is converted and the
+ * complete audio returned. The voice channel calls this once per sentence so
+ * the first sentence can play while later ones are still being generated.
+ */
+export async function synthesizeSpeech(
+  options: SynthesizeSpeechOptions,
+): Promise<SynthesizeSpeechResult> {
+  const result = await generateSpeech({
+    model: options.model,
+    text: options.text,
+    voice: options.voice,
+    outputFormat: options.outputFormat,
+    instructions: options.instructions,
+    speed: options.speed,
+    abortSignal: options.abortSignal,
+  });
+
+  return { audio: result.audio.uint8Array, format: result.audio.format };
+}

--- a/packages/eve/src/internal/voice/transcribe.test.ts
+++ b/packages/eve/src/internal/voice/transcribe.test.ts
@@ -1,0 +1,30 @@
+import { MockTranscriptionModelV3 } from "ai/test";
+import { describe, expect, it } from "vitest";
+
+import { transcribeAudio } from "#internal/voice/transcribe.js";
+
+describe("transcribeAudio", () => {
+  it("forwards audio to the model and maps the transcript result", async () => {
+    let receivedAudio: unknown;
+    const model = new MockTranscriptionModelV3({
+      modelId: "openai/whisper-1",
+      doGenerate: async (options) => {
+        receivedAudio = options.audio;
+        return {
+          text: "hello world",
+          segments: [],
+          language: "en",
+          durationInSeconds: 1.5,
+          warnings: [],
+          response: { timestamp: new Date(), modelId: "openai/whisper-1" },
+        };
+      },
+    });
+
+    const audio = new Uint8Array([1, 2, 3]);
+    const result = await transcribeAudio({ model, audio });
+
+    expect(result).toEqual({ text: "hello world", language: "en", durationInSeconds: 1.5 });
+    expect(receivedAudio).toBe(audio);
+  });
+});

--- a/packages/eve/src/internal/voice/transcribe.ts
+++ b/packages/eve/src/internal/voice/transcribe.ts
@@ -1,0 +1,41 @@
+import { experimental_transcribe as transcribe, type TranscriptionModel } from "ai";
+
+/** Options for {@link transcribeAudio}. */
+export interface TranscribeAudioOptions {
+  /** Gateway transcription model, e.g. from `transcriptionModel("openai/whisper-1")`. */
+  readonly model: TranscriptionModel;
+  /** Raw bytes of one spoken utterance (e.g. webm/opus captured in the browser). */
+  readonly audio: Uint8Array;
+  /** Aborts an in-flight transcription, e.g. when the peer disconnects. */
+  readonly abortSignal?: AbortSignal;
+}
+
+/** Transcript of one spoken utterance. */
+export interface TranscribeAudioResult {
+  readonly text: string;
+  readonly language: string | undefined;
+  readonly durationInSeconds: number | undefined;
+}
+
+/**
+ * Transcribes one audio utterance to text through the AI Gateway.
+ *
+ * Transcription is batch, not streaming: the whole utterance is sent and the
+ * complete transcript returned, so callers must decide where an utterance ends
+ * (the voice channel relies on the client to send one utterance per message).
+ */
+export async function transcribeAudio(
+  options: TranscribeAudioOptions,
+): Promise<TranscribeAudioResult> {
+  const result = await transcribe({
+    model: options.model,
+    audio: options.audio,
+    abortSignal: options.abortSignal,
+  });
+
+  return {
+    text: result.text,
+    language: result.language,
+    durationInSeconds: result.durationInSeconds,
+  };
+}

--- a/packages/eve/src/public/channels/voice/index.ts
+++ b/packages/eve/src/public/channels/voice/index.ts
@@ -1,0 +1,23 @@
+export {
+  voiceChannel,
+  createVoiceConnection,
+  type VoiceChannel,
+  type VoiceChannelConfig,
+  type VoiceSpeechConfig,
+  type VoiceTranscriptionConfig,
+} from "#public/channels/voice/voiceChannel.js";
+export {
+  parseVoiceClientMessage,
+  serializeVoiceServerMessage,
+  type VoiceAssistantTextMessage,
+  type VoiceAudioFormat,
+  type VoiceBargeInMessage,
+  type VoiceClientMessage,
+  type VoiceErrorMessage,
+  type VoiceReadyMessage,
+  type VoiceServerMessage,
+  type VoiceStatusMessage,
+  type VoiceTextMessage,
+  type VoiceTurnState,
+  type VoiceUserTranscriptMessage,
+} from "#public/channels/voice/protocol.js";

--- a/packages/eve/src/public/channels/voice/protocol.test.ts
+++ b/packages/eve/src/public/channels/voice/protocol.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseVoiceClientMessage,
+  serializeVoiceServerMessage,
+} from "#public/channels/voice/protocol.js";
+
+describe("parseVoiceClientMessage", () => {
+  it("parses a barge_in control message", () => {
+    expect(parseVoiceClientMessage('{"type":"barge_in"}')).toEqual({ type: "barge_in" });
+  });
+
+  it("parses a text control message", () => {
+    expect(parseVoiceClientMessage('{"type":"text","text":"hello"}')).toEqual({
+      type: "text",
+      text: "hello",
+    });
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseVoiceClientMessage("not json")).toBeNull();
+  });
+
+  it("returns null for an unknown message type", () => {
+    expect(parseVoiceClientMessage('{"type":"nope"}')).toBeNull();
+  });
+
+  it("returns null for a text message missing its text field", () => {
+    expect(parseVoiceClientMessage('{"type":"text"}')).toBeNull();
+  });
+
+  it("returns null for a non-object payload", () => {
+    expect(parseVoiceClientMessage("42")).toBeNull();
+  });
+});
+
+describe("serializeVoiceServerMessage", () => {
+  it("serializes a server message to JSON", () => {
+    expect(serializeVoiceServerMessage({ type: "ready", audioFormat: "mp3" })).toBe(
+      '{"type":"ready","audioFormat":"mp3"}',
+    );
+  });
+
+  it("round-trips through JSON.parse", () => {
+    const message = { type: "status", state: "speaking" } as const;
+    expect(JSON.parse(serializeVoiceServerMessage(message))).toEqual(message);
+  });
+});

--- a/packages/eve/src/public/channels/voice/protocol.ts
+++ b/packages/eve/src/public/channels/voice/protocol.ts
@@ -1,0 +1,103 @@
+/**
+ * Wire protocol for the realtime voice channel.
+ *
+ * The transport is a single WebSocket per conversation. The two frame kinds are
+ * used as a discriminator, so no envelope is needed around audio:
+ *
+ * - **Binary frames** carry raw audio. Client → server: one complete spoken
+ *   utterance (e.g. webm/opus). Server → client: synthesized speech in the
+ *   channel's configured {@link VoiceReadyMessage.audioFormat}.
+ * - **Text frames** carry JSON control messages ({@link VoiceServerMessage} /
+ *   {@link VoiceClientMessage}).
+ */
+
+/** Audio container/codec of the binary audio frames, e.g. `"mp3"`. */
+export type VoiceAudioFormat = string;
+
+/** High-level state of the current voice turn, surfaced for client UI. */
+export type VoiceTurnState = "thinking" | "speaking" | "idle";
+
+/** Sent once when the socket opens, before any audio. */
+export interface VoiceReadyMessage {
+  readonly type: "ready";
+  /** Container/codec every server binary audio frame will use. */
+  readonly audioFormat: VoiceAudioFormat;
+}
+
+/** The transcript of the user's most recent spoken utterance. */
+export interface VoiceUserTranscriptMessage {
+  readonly type: "user_transcript";
+  readonly text: string;
+}
+
+/** A chunk of the agent's reply, emitted alongside the audio frame that speaks it. */
+export interface VoiceAssistantTextMessage {
+  readonly type: "assistant_text";
+  readonly text: string;
+}
+
+/** A turn-state transition for driving client UI. */
+export interface VoiceStatusMessage {
+  readonly type: "status";
+  readonly state: VoiceTurnState;
+}
+
+/** A recoverable error during a turn; the socket stays open. */
+export interface VoiceErrorMessage {
+  readonly type: "error";
+  readonly message: string;
+}
+
+/** A JSON control message sent from server to client over a text frame. */
+export type VoiceServerMessage =
+  | VoiceReadyMessage
+  | VoiceUserTranscriptMessage
+  | VoiceAssistantTextMessage
+  | VoiceStatusMessage
+  | VoiceErrorMessage;
+
+/** Interrupts the in-flight turn so the user can talk over the agent. */
+export interface VoiceBargeInMessage {
+  readonly type: "barge_in";
+}
+
+/** Sends typed text as if the user had spoken it (skips transcription). */
+export interface VoiceTextMessage {
+  readonly type: "text";
+  readonly text: string;
+}
+
+/** A JSON control message sent from client to server over a text frame. */
+export type VoiceClientMessage = VoiceBargeInMessage | VoiceTextMessage;
+
+/**
+ * Parses a client control text frame. Returns `null` for malformed JSON or an
+ * unrecognized message so the channel can safely ignore it.
+ */
+export function parseVoiceClientMessage(text: string): VoiceClientMessage | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const type = (value as { type?: unknown }).type;
+  if (type === "barge_in") {
+    return { type: "barge_in" };
+  }
+  if (type === "text") {
+    const text = (value as { text?: unknown }).text;
+    if (typeof text === "string") {
+      return { type: "text", text };
+    }
+  }
+  return null;
+}
+
+/** Serializes a server control message to a JSON text frame. */
+export function serializeVoiceServerMessage(message: VoiceServerMessage): string {
+  return JSON.stringify(message);
+}

--- a/packages/eve/src/public/channels/voice/voiceChannel.integration.test.ts
+++ b/packages/eve/src/public/channels/voice/voiceChannel.integration.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("#internal/voice/gateway-voice-models.js", () => ({
+  transcriptionModel: () => ({ id: "stt" }),
+  speechModel: () => ({ id: "tts" }),
+}));
+vi.mock("#internal/voice/transcribe.js", () => ({ transcribeAudio: vi.fn() }));
+vi.mock("#internal/voice/synthesize.js", () => ({ synthesizeSpeech: vi.fn() }));
+
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { none } from "#public/channels/auth.js";
+import type {
+  SendFn,
+  Session,
+  WebSocketMessage,
+  WebSocketPeer,
+} from "#public/definitions/defineChannel.js";
+import { transcribeAudio } from "#internal/voice/transcribe.js";
+import { synthesizeSpeech } from "#internal/voice/synthesize.js";
+import { createVoiceConnection } from "#public/channels/voice/voiceChannel.js";
+
+const transcribeMock = vi.mocked(transcribeAudio);
+const synthesizeMock = vi.mocked(synthesizeSpeech);
+
+function eventStream(events: HandleMessageStreamEvent[]): ReadableStream<HandleMessageStreamEvent> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) controller.enqueue(event);
+      controller.close();
+    },
+  });
+}
+
+/** A minimal in-memory peer that records the frames the channel sends. */
+function createFakePeer(): WebSocketPeer & {
+  readonly textFrames: Array<Record<string, unknown>>;
+  readonly binaryFrames: Uint8Array[];
+} {
+  const textFrames: Array<Record<string, unknown>> = [];
+  const binaryFrames: Uint8Array[] = [];
+  return {
+    id: "peer-1",
+    context: {},
+    namespace: "",
+    request: new Request("https://agent.test/eve/v1/voice"),
+    topics: new Set<string>(),
+    close() {},
+    publish() {},
+    subscribe() {},
+    unsubscribe() {},
+    terminate() {},
+    send(data: unknown) {
+      if (typeof data === "string") {
+        textFrames.push(JSON.parse(data));
+      } else {
+        binaryFrames.push(data as Uint8Array);
+      }
+    },
+    textFrames,
+    binaryFrames,
+  };
+}
+
+function binaryMessage(bytes: Uint8Array): WebSocketMessage {
+  return {
+    id: "m1",
+    data: bytes,
+    rawData: bytes,
+    uint8Array: () => bytes,
+    arrayBuffer: () => bytes.buffer as ArrayBuffer,
+    blob: () => new Blob([]),
+    json: () => {
+      throw new Error("json() is not used for binary frames");
+    },
+    text: () => "",
+  };
+}
+
+function textMessage(text: string): WebSocketMessage {
+  return {
+    id: "m1",
+    data: text,
+    rawData: text,
+    uint8Array: () => new TextEncoder().encode(text),
+    arrayBuffer: () => new ArrayBuffer(0),
+    blob: () => new Blob([text]),
+    json: () => JSON.parse(text),
+    text: () => text,
+  };
+}
+
+const REPLY_EVENTS: HandleMessageStreamEvent[] = [
+  { type: "turn.started", data: { turnId: "t1", sequence: 0 } },
+  {
+    type: "message.appended",
+    data: {
+      messageDelta: "Hi there. ",
+      messageSoFar: "Hi there. ",
+      sequence: 1,
+      stepIndex: 0,
+      turnId: "t1",
+    },
+  },
+  {
+    type: "message.completed",
+    data: {
+      message: "Hi there.",
+      finishReason: "stop",
+      sequence: 2,
+      stepIndex: 0,
+      turnId: "t1",
+    },
+  },
+  { type: "turn.completed", data: { turnId: "t1", sequence: 3 } },
+];
+
+function connect() {
+  const audioOut = new Uint8Array([1, 2, 3]);
+  synthesizeMock.mockResolvedValue({ audio: audioOut, format: "mp3" });
+
+  const getEventStream = vi.fn(async () => eventStream(REPLY_EVENTS));
+  const send = vi.fn<SendFn>(
+    async (_input, options): Promise<Session> => ({
+      id: "session-1",
+      continuationToken: options.continuationToken,
+      getEventStream,
+    }),
+  );
+
+  const hooks = createVoiceConnection({
+    config: { auth: [none()] },
+    send,
+    sttModelId: "openai/whisper-1",
+    ttsModelId: "openai/tts-1",
+    voice: "alloy",
+    outputFormat: "mp3",
+  });
+
+  return { hooks, send, audioOut };
+}
+
+async function authorize(hooks: ReturnType<typeof connect>["hooks"]): Promise<void> {
+  const result = await hooks.upgrade?.(new Request("https://agent.test/eve/v1/voice"));
+  expect(result).not.toBeInstanceOf(Response);
+}
+
+describe("voiceChannel connection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("transcribes an utterance, runs a turn, and speaks the reply", async () => {
+    transcribeMock.mockResolvedValue({ text: "hello", language: "en", durationInSeconds: 1 });
+    const { hooks, send, audioOut } = connect();
+    const peer = createFakePeer();
+    await authorize(hooks);
+
+    hooks.message?.(peer, binaryMessage(new Uint8Array([9, 9])));
+
+    await vi.waitFor(() => {
+      expect(peer.textFrames.some((f) => f.type === "status" && f.state === "idle")).toBe(true);
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [input, options] = send.mock.calls[0] ?? [];
+    expect(input).toBe("hello");
+    expect(options).toMatchObject({ mode: "conversation" });
+    expect(options?.continuationToken).toBeTruthy();
+
+    expect(peer.textFrames).toContainEqual({ type: "user_transcript", text: "hello" });
+    expect(peer.textFrames).toContainEqual({ type: "assistant_text", text: "Hi there." });
+    expect(peer.textFrames).toContainEqual({ type: "status", state: "thinking" });
+    expect(peer.textFrames).toContainEqual({ type: "status", state: "speaking" });
+    expect(peer.binaryFrames).toEqual([audioOut]);
+  });
+
+  it("does not start a turn when the transcript is empty", async () => {
+    transcribeMock.mockResolvedValue({ text: "   ", language: undefined, durationInSeconds: 0 });
+    const { hooks, send } = connect();
+    const peer = createFakePeer();
+    await authorize(hooks);
+
+    hooks.message?.(peer, binaryMessage(new Uint8Array([0])));
+
+    await vi.waitFor(() => {
+      expect(peer.textFrames.some((f) => f.type === "status" && f.state === "idle")).toBe(true);
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("runs a turn from a text control frame without transcribing", async () => {
+    const { hooks, send } = connect();
+    const peer = createFakePeer();
+    await authorize(hooks);
+
+    hooks.message?.(peer, textMessage(JSON.stringify({ type: "text", text: "typed hello" })));
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+    expect(transcribeMock).not.toHaveBeenCalled();
+    const [input] = send.mock.calls[0] ?? [];
+    expect(input).toBe("typed hello");
+  });
+
+  it("rejects the upgrade when auth fails", async () => {
+    // An empty auth walk rejects with a 401 before any session starts.
+    const failingSend: SendFn = async () => {
+      throw new Error("should not send");
+    };
+    const rejecting = createVoiceConnection({
+      config: { auth: [] },
+      send: failingSend,
+      sttModelId: "openai/whisper-1",
+      ttsModelId: "openai/tts-1",
+      voice: "alloy",
+      outputFormat: "mp3",
+    });
+
+    const result = await rejecting.upgrade?.(new Request("https://agent.test/eve/v1/voice"));
+    expect(result).toBeInstanceOf(Response);
+    expect(result instanceof Response ? result.status : 0).toBe(401);
+  });
+});

--- a/packages/eve/src/public/channels/voice/voiceChannel.ts
+++ b/packages/eve/src/public/channels/voice/voiceChannel.ts
@@ -1,0 +1,323 @@
+import type { SessionAuthContext } from "#channel/types.js";
+import { createLogger, logError } from "#internal/logging.js";
+import { transcriptionModel, speechModel } from "#internal/voice/gateway-voice-models.js";
+import { createSentenceChunker } from "#internal/voice/sentence-chunker.js";
+import { synthesizeSpeech } from "#internal/voice/synthesize.js";
+import { transcribeAudio } from "#internal/voice/transcribe.js";
+import { routeAuth, type AuthFn } from "#public/channels/auth.js";
+import {
+  defineChannel,
+  WS,
+  type Channel,
+  type SendFn,
+  type WebSocketMessage,
+  type WebSocketPeer,
+  type WebSocketRouteHooks,
+} from "#public/definitions/defineChannel.js";
+import {
+  parseVoiceClientMessage,
+  serializeVoiceServerMessage,
+  type VoiceServerMessage,
+} from "#public/channels/voice/protocol.js";
+
+const log = createLogger("voice.channel");
+
+const DEFAULT_ROUTE = "/eve/v1/voice";
+const DEFAULT_TRANSCRIPTION_MODEL = "openai/whisper-1";
+const DEFAULT_SPEECH_MODEL = "openai/tts-1";
+const DEFAULT_VOICE = "alloy";
+const DEFAULT_OUTPUT_FORMAT = "mp3";
+
+/** Speech-to-text settings for {@link voiceChannel}. */
+export interface VoiceTranscriptionConfig {
+  /** Gateway transcription model id. Defaults to `"openai/whisper-1"`. */
+  readonly model?: string;
+}
+
+/** Text-to-speech settings for {@link voiceChannel}. */
+export interface VoiceSpeechConfig {
+  /** Gateway speech model id. Defaults to `"openai/tts-1"`. */
+  readonly model?: string;
+  /** Provider voice. Defaults to `"alloy"`. */
+  readonly voice?: string;
+  /** Audio container/codec sent to the client. Defaults to `"mp3"`. */
+  readonly outputFormat?: string;
+  /** Free-form delivery guidance passed to the speech model. */
+  readonly instructions?: string;
+  /** Playback speed multiplier. */
+  readonly speed?: number;
+}
+
+/** Configuration for {@link voiceChannel}. */
+export interface VoiceChannelConfig {
+  /**
+   * Route auth, evaluated on the WebSocket upgrade. Reuse the shared helpers
+   * from `eve/channels/auth` (e.g. `[vercelOidc(), localDev()]`); a failed walk
+   * rejects the handshake.
+   */
+  readonly auth: AuthFn<Request> | readonly AuthFn<Request>[];
+  /** WebSocket route path. Defaults to `/eve/v1/voice`. */
+  readonly route?: string;
+  readonly transcription?: VoiceTranscriptionConfig;
+  readonly speech?: VoiceSpeechConfig;
+  /** Optional line spoken to the caller as soon as the socket opens. */
+  readonly greeting?: string;
+}
+
+/** Concrete return type of {@link voiceChannel}. */
+export interface VoiceChannel extends Channel {}
+
+/**
+ * Realtime voice channel: talk to the agent over a WebSocket.
+ *
+ * Each connection is one conversation. A client sends one spoken utterance per
+ * binary frame; the channel transcribes it (Gateway speech-to-text), delivers
+ * the transcript to a durable agent session, and speaks the streamed reply back
+ * one sentence at a time (Gateway text-to-speech). Because the durable agent
+ * runs the turn, the full framework — instructions, tools, skills, subagents,
+ * and multi-turn memory — is available by voice.
+ *
+ * Transcription and synthesis are batch, not streaming, so the client decides
+ * where an utterance ends (typically push-to-talk) and replies are synthesized
+ * per sentence to start playback before the whole reply is ready. See
+ * `protocol.ts` for the frame convention (binary = audio, text = JSON control).
+ */
+export function voiceChannel(config: VoiceChannelConfig): VoiceChannel {
+  const route = config.route ?? DEFAULT_ROUTE;
+  const sttModelId = config.transcription?.model ?? DEFAULT_TRANSCRIPTION_MODEL;
+  const ttsModelId = config.speech?.model ?? DEFAULT_SPEECH_MODEL;
+  const voice = config.speech?.voice ?? DEFAULT_VOICE;
+  const outputFormat = config.speech?.outputFormat ?? DEFAULT_OUTPUT_FORMAT;
+
+  return defineChannel({
+    kindHint: "voice",
+    routes: [
+      WS(route, (_req, { send }) =>
+        createVoiceConnection({ config, send, sttModelId, ttsModelId, voice, outputFormat }),
+      ),
+    ],
+  });
+}
+
+interface VoiceConnectionDeps {
+  readonly config: VoiceChannelConfig;
+  readonly send: SendFn;
+  readonly sttModelId: string;
+  readonly ttsModelId: string;
+  readonly voice: string;
+  readonly outputFormat: string;
+}
+
+/**
+ * Builds the per-connection WebSocket hooks. Exposed for tests; channel authors
+ * use {@link voiceChannel}.
+ */
+export function createVoiceConnection(deps: VoiceConnectionDeps): WebSocketRouteHooks {
+  const { config, send, sttModelId, ttsModelId, voice, outputFormat } = deps;
+  const sttModel = transcriptionModel(sttModelId);
+  const ttsModel = speechModel(ttsModelId);
+
+  // One conversation per socket: a stable continuation token threads every turn
+  // through the same durable session, and a global event cursor keeps each turn
+  // reading only the events it produced.
+  const continuationToken = crypto.randomUUID();
+  let auth: SessionAuthContext | null = null;
+  let nextEventIndex = 0;
+  let activeTurn: AbortController | null = null;
+
+  const tell = (peer: WebSocketPeer, message: VoiceServerMessage): void => {
+    peer.send(serializeVoiceServerMessage(message));
+  };
+
+  const speak = async (peer: WebSocketPeer, text: string, signal: AbortSignal): Promise<void> => {
+    const result = await synthesizeSpeech({
+      model: ttsModel,
+      text,
+      voice,
+      outputFormat,
+      instructions: config.speech?.instructions,
+      speed: config.speech?.speed,
+      abortSignal: signal,
+    });
+    if (signal.aborted) return;
+    tell(peer, { type: "assistant_text", text });
+    peer.send(result.audio);
+  };
+
+  const runTurn = async (peer: WebSocketPeer, input: string): Promise<void> => {
+    activeTurn?.abort();
+    const controller = new AbortController();
+    activeTurn = controller;
+    const { signal } = controller;
+    const chunker = createSentenceChunker();
+    let speaking = false;
+
+    const startSpeaking = (): void => {
+      if (!speaking) {
+        tell(peer, { type: "status", state: "speaking" });
+        speaking = true;
+      }
+    };
+
+    try {
+      tell(peer, { type: "status", state: "thinking" });
+      const session = await send(input, { auth, continuationToken, mode: "conversation" });
+      const stream = await session.getEventStream({ startIndex: nextEventIndex });
+      const reader = stream.getReader();
+      try {
+        while (!signal.aborted) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          nextEventIndex += 1;
+
+          if (value.type === "message.appended") {
+            for (const chunk of chunker.push(value.data.messageDelta)) {
+              startSpeaking();
+              await speak(peer, chunk, signal);
+              if (signal.aborted) break;
+            }
+          } else if (value.type === "message.completed") {
+            const remainder = chunker.flush();
+            if (remainder !== null) {
+              startSpeaking();
+              await speak(peer, remainder, signal);
+            }
+          } else if (isTurnEndEvent(value.type)) {
+            break;
+          }
+        }
+      } finally {
+        await reader.cancel().catch(() => {});
+      }
+
+      if (!signal.aborted) {
+        tell(peer, { type: "status", state: "idle" });
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        logError(log, "voice turn failed", error);
+        tell(peer, { type: "error", message: "The voice turn failed." });
+        tell(peer, { type: "status", state: "idle" });
+      }
+    } finally {
+      if (activeTurn === controller) {
+        activeTurn = null;
+      }
+    }
+  };
+
+  const handleUtterance = async (peer: WebSocketPeer, audio: Uint8Array): Promise<void> => {
+    let transcript: string;
+    try {
+      const result = await transcribeAudio({ model: sttModel, audio });
+      transcript = result.text.trim();
+    } catch (error) {
+      logError(log, "voice transcription failed", error);
+      tell(peer, { type: "error", message: "Could not transcribe the audio." });
+      return;
+    }
+
+    tell(peer, { type: "user_transcript", text: transcript });
+    if (transcript.length === 0) {
+      tell(peer, { type: "status", state: "idle" });
+      return;
+    }
+    await runTurn(peer, transcript);
+  };
+
+  return {
+    async upgrade(request) {
+      const result = await routeAuth(request, config.auth);
+      if (result instanceof Response) {
+        return result;
+      }
+      auth = result;
+    },
+
+    open(peer) {
+      tell(peer, { type: "ready", audioFormat: outputFormat });
+      const greeting = config.greeting?.trim();
+      if (greeting !== undefined && greeting.length > 0) {
+        void speakGreeting(peer, greeting);
+      }
+    },
+
+    message(peer, message) {
+      const controlText = readControlText(message);
+      if (controlText !== null) {
+        handleControl(peer, controlText);
+        return;
+      }
+      // A new utterance interrupts whatever the agent is currently saying.
+      activeTurn?.abort();
+      void handleUtterance(peer, message.uint8Array());
+    },
+
+    close() {
+      activeTurn?.abort();
+      activeTurn = null;
+    },
+
+    error() {
+      activeTurn?.abort();
+      activeTurn = null;
+    },
+  };
+
+  function handleControl(peer: WebSocketPeer, text: string): void {
+    const message = parseVoiceClientMessage(text);
+    if (message === null) {
+      return;
+    }
+    if (message.type === "barge_in") {
+      activeTurn?.abort();
+      activeTurn = null;
+      tell(peer, { type: "status", state: "idle" });
+      return;
+    }
+    const trimmed = message.text.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    activeTurn?.abort();
+    void runTurn(peer, trimmed);
+  }
+
+  async function speakGreeting(peer: WebSocketPeer, greeting: string): Promise<void> {
+    const controller = new AbortController();
+    try {
+      tell(peer, { type: "status", state: "speaking" });
+      await speak(peer, greeting, controller.signal);
+      tell(peer, { type: "status", state: "idle" });
+    } catch (error) {
+      logError(log, "voice greeting failed", error);
+    }
+  }
+}
+
+const TURN_END_EVENTS: ReadonlySet<string> = new Set([
+  "turn.completed",
+  "turn.failed",
+  "session.completed",
+  "session.failed",
+  "input.requested",
+]);
+
+function isTurnEndEvent(type: string): boolean {
+  return TURN_END_EVENTS.has(type);
+}
+
+/**
+ * Returns the frame's text when it is a control frame, or `null` when it is a
+ * binary audio frame. The two WebSocket frame kinds are the discriminator: a
+ * string payload is JSON control, anything else is audio.
+ */
+function readControlText(message: WebSocketMessage): string | null {
+  if (typeof message.rawData === "string") {
+    return message.rawData;
+  }
+  if (typeof message.data === "string") {
+    return message.data;
+  }
+  return null;
+}

--- a/packages/eve/src/setup/build.ts
+++ b/packages/eve/src/setup/build.ts
@@ -28,6 +28,13 @@ const SOURCE_ONLY_ROOT_ENTRIES = new Set([
 ]);
 const WEB_CHANNEL_SOURCE_PATH = "agent/channels/eve.ts";
 
+// Demo-only files that live in the app but are kept out of the generated
+// scaffold. The realtime voice demo depends on beta Gateway voice access, so
+// `eve init --web` stays lean rather than shipping a /voice page that would
+// error without it. (`agent/channels/voice.ts` is already excluded by the
+// `agent/` rule below.)
+const SOURCE_ONLY_PATHS = new Set(["app/voice/page.tsx", "app/_components/voice-call.tsx"]);
+
 const FILE_TRANSFORMS: Record<string, ReadonlyArray<readonly [string, string]>> = {
   "app/_components/agent-chat.tsx": [
     ['const AGENT_NAME = "eve-agent";', 'const AGENT_NAME = "__EVE_INIT_APP_NAME__";'],
@@ -61,6 +68,7 @@ function shouldCopySourcePath(relativePath: string): boolean {
   if (
     rootEntry.startsWith(".") ||
     SOURCE_ONLY_ROOT_ENTRIES.has(rootEntry) ||
+    SOURCE_ONLY_PATHS.has(relativePath) ||
     relativePath.endsWith(".tsbuildinfo")
   ) {
     return false;


### PR DESCRIPTION
## Summary

Adds a realtime **voice channel** (`eve/channels/voice`) so a client can talk to an eve agent over a single WebSocket. eve stays the brain: an utterance is transcribed with AI Gateway speech-to-text, delivered to a **normal durable session** (instructions, tools, skills, subagents, and multi-turn memory all work), and the streamed reply is spoken back **one sentence at a time** with Gateway text-to-speech. Push-to-talk with barge-in.

This is the STT → session → TTS design (not the single gateway realtime model), chosen so the full framework is available by voice and any agent model works — mirroring the existing `twilioChannel` voice flow, but over a live WebSocket.

## What's in it

- **`src/internal/voice/`** — thin AI SDK wrappers over the Gateway provider (`experimental_transcribe` / `experimental_generateSpeech`; no new runtime dep, no REST), plus a `sentence-chunker` that splits streamed text so the first sentence plays while later ones are still being written.
- **`src/public/channels/voice/`** — `voiceChannel(config)`: one `WS()` route that auths on upgrade (`routeAuth`), transcribes each binary utterance, drives `send()` into a durable session, streams sentence-sized audio frames back, and supports barge-in. `protocol.ts` documents the wire format (binary = audio, text = JSON control).
- **Template demo** — `web-chat-next` gets `agent/channels/voice.ts` and a push-to-talk `/voice` page. Connects to the agent's direct WS origin via `EVE_BASE_URL` in dev (WS upgrades don't survive the Next rewrite). **Excluded from the `eve init --web` scaffold** since Gateway voice is gated beta.
- **Docs** (`docs/channels/voice.mdx` + nav) and a `patch` **changeset**.

## Wire protocol

One WebSocket = one conversation. Binary frames carry audio; text frames carry JSON control (`ready` / `user_transcript` / `assistant_text` / `status` / `error` from the server; `barge_in` / `text` from the client). Transcription and synthesis are batch, so the client decides where an utterance ends (push-to-talk) and replies are synthesized per sentence.

## Verification

- `tsc --noEmit` (0 errors), `guard:invariants`, `docs:check`, `check:web-template` (no drift), `oxlint`/`oxfmt` clean.
- **24 voice tests pass**: 20 unit (sentence-chunker, protocol, transcribe/synthesize wrappers) + 4 integration (transcribe → session → per-sentence synth → audio frames; empty transcript; typed-text control; auth rejection).
- Build emits the channel to `dist`.

## Scope / follow-ups

- No scenario (real-WS) or e2e test — integration covers the handler; a live path needs Gateway **voice-beta** credentials not available in CI.
- **Manual end-to-end** (hold-to-talk in the browser against a real voice key + mic) has not been run yet.
- Hands-free client VAD and a `useEveVoice` hook in `eve/react` are natural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)