### PR TITLE
fix(eve): remove unnecessary preview deployment check that prevented production access from `eve dev`

### DIFF
--- a/.changeset/fresh-snakes-flow.md
+++ b/.changeset/fresh-snakes-flow.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+fix(eve): remove unnecessary preview deployment check that prevented production access from `eve dev`

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -786,7 +786,7 @@ describe("verifyVercelOidc", () => {
     }
   });
 
-  it("rejects a development user token on production", async () => {
+  it("authenticates a development user token as a service principal on production", async () => {
     vi.stubEnv("VERCEL_PROJECT_ID", "prj_current");
     vi.stubEnv("VERCEL_TARGET_ENV", "production");
 
@@ -799,7 +799,15 @@ describe("verifyVercelOidc", () => {
         user_id: "user_ada",
       });
 
-      await expect(verifyVercelOidc(token)).resolves.toEqual({ ok: false });
+      const result = await verifyVercelOidc(token);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.sessionAuth).toMatchObject({
+          principalType: "service",
+          subject: "owner:acme:project:weather-agent:environment:development",
+        });
+      }
     } finally {
       issuer.restore();
     }

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -724,8 +724,8 @@ export interface VerifyVercelOidcOptions {
  *   `email`) are exposed as auth attributes.
  * - Development tokens with a `user_id` claim authenticate as
  *   `principalType: "user"` only when both the token and configured current
- *   project environment are `development`. A same-project preview target may
- *   use one as a `"service"` principal; other target environments reject it.
+ *   project environment are `development`. Other same-project target
+ *   environments may use one as a `"service"` principal.
  * - Tokens from other Vercel projects are accepted **only** when their `sub`
  *   matches one of {@link VerifyVercelOidcOptions.subjects}.
  *

--- a/packages/eve/src/runtime/governance/auth/oidc.ts
+++ b/packages/eve/src/runtime/governance/auth/oidc.ts
@@ -106,14 +106,11 @@ export async function authenticateOidcStrategy(input: {
         };
       }
 
-      if (input.strategy.currentVercelProject?.environment !== "preview") {
-        return {
-          kind: "caller-not-allowed",
-        };
-      }
-
-      // Preview may use a same-project development credential only through the
-      // generic service path below, never as the user embedded in the token.
+      /*
+       * A same-project development credential for a different current
+       * environment identifies the project, not the embedded local user.
+       * Let the generic service path below authenticate it via `sub`.
+       */
     }
 
     if (typeof verified.payload.sub !== "string" || verified.payload.sub.length === 0) {


### PR DESCRIPTION
### Description

Connecting from `eve dev` to a deployed production eve agent could fail with "The selected Vercel project did not authorize ..." even when trusted sources allowed `development -> production` access.

This removes the preview-only gate for same-project development Vercel OIDC credentials. When the token is for the current project but a different environment, it now falls through to the existing service-principal path instead of being rejected.

- Allow same-project development credentials to authenticate as service principals for production targets.
- Keep same-environment development credentials authenticated as user principals.
- Update the Vercel OIDC behavior docs, unit coverage, and changeset.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
