### PR TITLE
docs: sentence-case docs hero title

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/home-content.tsx
+++ b/apps/docs/app/[lang]/(home)/components/home-content.tsx
@@ -33,7 +33,7 @@ export const HomeContent = () => (
       <div className="relative z-10 max-w-5xl text-center font-normal! text-heading-40 md:text-heading-48 lg:text-heading-56">
         <EveLogoShader />
         <h1 className="relative text-balance w-full max-w-[10em]">
-          The Framework for Building Agents
+          The framework for building agents
         </h1>
       </div>
       <p className="text-balance relative z-10 w-full text-center text-copy-16 text-gray-900 md:max-w-2xl md:text-copy-18 lg:text-copy-20">


### PR DESCRIPTION
Sentence-cases the docs app hero title from "The Framework for Building Agents" to "The framework for building agents".
