### PR TITLE
fix(eve): dev runtime - support package-less flat agents

### DIFF
--- a/.changeset/flat-instructions-dev.md
+++ b/.changeset/flat-instructions-dev.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `eve dev` to start from a package-less flat agent that only has `instructions.md`. Development runtime snapshots now generate private package metadata when the authored app has none.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -155,6 +155,35 @@ describe("development runtime artifact snapshots", () => {
     });
   });
 
+  it("stages package-less flat markdown agents with generated runtime package metadata", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-flat-package-less-");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+
+    await mkdir(compileDirectoryPath, { recursive: true });
+    await writeFile(join(appRoot, "instructions.md"), "You are a precise assistant.\n");
+    await writeFile(
+      join(compileDirectoryPath, "compiled-agent-manifest.json"),
+      `${JSON.stringify({ agentRoot: appRoot, appRoot }, null, 2)}\n`,
+    );
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+
+    await expect(readFile(join(snapshot.runtimeAppRoot, "instructions.md"), "utf8")).resolves.toBe(
+      "You are a precise assistant.\n",
+    );
+    await expect(
+      readFile(join(snapshot.runtimeAppRoot, "package.json"), "utf8").then(
+        (source) => JSON.parse(source) as Record<string, unknown>,
+      ),
+    ).resolves.toEqual({
+      private: true,
+      type: "module",
+    });
+  });
+
   it("prunes stale snapshots while preserving the active and recent snapshots", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-");
     const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -53,6 +53,7 @@ export async function copyDevelopmentSourceSnapshot(
 
   await rewriteSnapshotTsConfigAbsoluteExtends(plan);
   await createSnapshotSymlinks(plan);
+  await ensureRuntimePackageJson(plan);
   await validateDevelopmentSourceSnapshot(plan);
 }
 
@@ -264,6 +265,27 @@ async function createSnapshotSymlinks(plan: DevelopmentSourceSnapshotPlan): Prom
     await mkdir(dirname(snapshotLinkPath), { recursive: true });
     await symlink(relativeTarget, snapshotLinkPath, "junction");
   }
+}
+
+async function ensureRuntimePackageJson(plan: DevelopmentSourceSnapshotPlan): Promise<void> {
+  const runtimePackageJsonPath = join(plan.runtimeAppRoot, "package.json");
+
+  if (existsSync(runtimePackageJsonPath)) {
+    return;
+  }
+
+  await mkdir(plan.runtimeAppRoot, { recursive: true });
+  await writeFile(
+    runtimePackageJsonPath,
+    `${JSON.stringify(
+      {
+        private: true,
+        type: "module",
+      },
+      null,
+      2,
+    )}\n`,
+  );
 }
 
 async function validateDevelopmentSourceSnapshot(


### PR DESCRIPTION
## Summary

- Generate private package metadata inside dev runtime snapshots when an authored flat agent has no package.json.
- Add regression coverage for a package-less flat agent with only instructions.md.
- Add a patch changeset for the published eve package.

## Root cause

Flat agent discovery accepts instructions.md at the app root, but dev runtime snapshot validation still required package.json in the runtime app root. That made the one-file npx eve dev starter fail before Nitro could start.

## Validation

- pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts
- pnpm lint packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
- pnpm --filter eve typecheck
- Local repro: package-less temp dir with instructions.md starts via node packages/eve/bin/eve.js dev --no-ui --port 0
