### PR TITLE
Fix heading text: add 'your' to feature grid

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/feature-grid.tsx
+++ b/apps/docs/app/[lang]/(home)/components/feature-grid.tsx
@@ -51,7 +51,7 @@ export function FeatureGrid(): JSX.Element {
     <section className="px-6 py-24">
       <div className="mx-auto max-w-5xl">
         <h2 className="text-center font-medium! text-heading-32 tracking-tighter text-gray-1000 sm:text-heading-40">
-          Everything you need for production agents
+          Everything your need for production agents
         </h2>
         <p className="mx-auto mt-4 max-w-2xl text-center text-gray-900 text-balance">
           Durability, sandboxing, human-in-the-loop, and evals are built into the framework. Focus


### PR DESCRIPTION
Fixed the missing 'your' in the feature grid heading.

Changed:
- "Everything you need for production agents"
- To: "Everything your need for production agents"

cc @rauchg @shardara