### PR TITLE
fix(eve): slack - show approval tool inputs

### DIFF
--- a/.changeset/slack-approval-inputs.md
+++ b/.changeset/slack-approval-inputs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show tool call input in Slack approval prompts so operators can inspect approval-gated actions before approving.

--- a/.changeset/slack-hitl-limits.md
+++ b/.changeset/slack-hitl-limits.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Harden Slack HITL posting against API limits: large approval batches now split across multiple messages instead of exceeding Slack's 50-block cap, and long freeform answers are truncated so the answered-card update cannot fail.

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -14,13 +14,18 @@ import {
   renderInputRequestBlocks,
 } from "#public/channels/slack/hitl.js";
 import type { SlackMessage } from "#public/channels/slack/inbound.js";
-import { truncateMessageText, truncateTypingStatus } from "#public/channels/slack/limits.js";
+import {
+  SLACK_MAX_BLOCKS_PER_MESSAGE,
+  truncateMessageText,
+  truncateTypingStatus,
+} from "#public/channels/slack/limits.js";
 import type {
   SlackChannelEvents,
   SlackChannelInternalEvents,
   SlackContext,
   SlackMentionResult,
 } from "#public/channels/slack/slackChannel.js";
+import type { InputRequest } from "#runtime/input/types.js";
 
 const log = createLogger("slack.defaults");
 const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
@@ -94,19 +99,41 @@ function firstNonEmptyLine(text: string): string | undefined {
  * Default `input.requested` handler — renders each pending HITL
  * request as Slack `block_actions`. Buttons by default; radio for
  * ≤6-option select requests; static_select for >6-option select
- * requests. Override by declaring `events["input.requested"]`.
+ * requests. Batches split into multiple posts when they would exceed
+ * Slack's 50-block message cap. Override by declaring
+ * `events["input.requested"]`.
  */
 export function defaultInputRequestedHandler(): NonNullable<SlackChannelEvents["input.requested"]> {
   return async (data, channel, _ctx) => {
-    if (data.requests.length === 0) return;
-    const promptText = truncateMessageText(
-      data.requests.map(formatInputRequestFallbackText).join("\n"),
-    );
-    await channel.thread.post({
-      blocks: data.requests.flatMap(renderInputRequestBlocks),
-      text: promptText,
-    });
+    for (const post of buildInputRequestPosts(data.requests)) {
+      await channel.thread.post(post);
+    }
   };
+}
+
+/**
+ * Groups HITL requests into `chat.postMessage` payloads that stay under
+ * Slack's block-count cap. A request's blocks never split across posts,
+ * so its buttons always land in the same message as its prompt.
+ */
+function buildInputRequestPosts(
+  requests: readonly InputRequest[],
+): Array<{ blocks: unknown[]; text: string }> {
+  const groups: Array<{ blocks: unknown[]; fallbacks: string[] }> = [];
+  for (const request of requests) {
+    const blocks = renderInputRequestBlocks(request);
+    const current = groups.at(-1);
+    if (current && current.blocks.length + blocks.length <= SLACK_MAX_BLOCKS_PER_MESSAGE) {
+      current.blocks.push(...blocks);
+      current.fallbacks.push(formatInputRequestFallbackText(request));
+    } else {
+      groups.push({ blocks, fallbacks: [formatInputRequestFallbackText(request)] });
+    }
+  }
+  return groups.map((group) => ({
+    blocks: group.blocks,
+    text: truncateMessageText(group.fallbacks.join("\n")),
+  }));
 }
 
 /**

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -9,7 +9,10 @@ import {
   formatConnectionDisplayName,
   type ConnectionAuthorizationOutcome,
 } from "#public/channels/slack/connections.js";
-import { renderInputRequestBlocks } from "#public/channels/slack/hitl.js";
+import {
+  formatInputRequestFallbackText,
+  renderInputRequestBlocks,
+} from "#public/channels/slack/hitl.js";
 import type { SlackMessage } from "#public/channels/slack/inbound.js";
 import { truncateMessageText, truncateTypingStatus } from "#public/channels/slack/limits.js";
 import type {
@@ -96,7 +99,9 @@ function firstNonEmptyLine(text: string): string | undefined {
 export function defaultInputRequestedHandler(): NonNullable<SlackChannelEvents["input.requested"]> {
   return async (data, channel, _ctx) => {
     if (data.requests.length === 0) return;
-    const promptText = truncateMessageText(data.requests.map((r) => r.prompt).join("\n"));
+    const promptText = truncateMessageText(
+      data.requests.map(formatInputRequestFallbackText).join("\n"),
+    );
     await channel.thread.post({
       blocks: data.requests.flatMap(renderInputRequestBlocks),
       text: promptText,

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -469,4 +469,15 @@ describe("buildAnsweredBlocks", () => {
       text: { text: ":white_check_mark: *Deny*" },
     });
   });
+
+  it("caps long freeform answer labels at the section limit", () => {
+    const blocks = buildAnsweredBlocks({
+      promptBlock: undefined,
+      answerLabel: "x".repeat(SLACK_SECTION_TEXT_MAX_LENGTH + 500),
+    });
+
+    const answer = blocks[0] as { text: { text: string } };
+    expect(answer.text.text.length).toBeLessThanOrEqual(SLACK_SECTION_TEXT_MAX_LENGTH);
+    expect(answer.text.text).toMatch(/^:white_check_mark: \*x+\.\.\.\*$/u);
+  });
 });

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -422,7 +422,7 @@ describe("buildAnsweredBlocks", () => {
       text: { type: "mrkdwn", text: "Approve deploy?" },
     };
     const blocks = buildAnsweredBlocks({
-      promptBlock,
+      promptBlocks: [promptBlock],
       answerLabel: "Approve",
       userId: "U01",
     });
@@ -463,7 +463,7 @@ describe("buildAnsweredBlocks", () => {
   });
 
   it("omits the attribution block when no userId is supplied", () => {
-    const blocks = buildAnsweredBlocks({ promptBlock: undefined, answerLabel: "Deny" });
+    const blocks = buildAnsweredBlocks({ promptBlocks: [], answerLabel: "Deny" });
     expect(blocks).toHaveLength(1);
     expect(blocks[0]).toMatchObject({
       text: { text: ":white_check_mark: *Deny*" },
@@ -472,7 +472,7 @@ describe("buildAnsweredBlocks", () => {
 
   it("caps long freeform answer labels at the section limit", () => {
     const blocks = buildAnsweredBlocks({
-      promptBlock: undefined,
+      promptBlocks: [],
       answerLabel: "x".repeat(SLACK_SECTION_TEXT_MAX_LENGTH + 500),
     });
 

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -5,6 +5,7 @@ import {
   buildAnsweredBlocks,
   buildFreeformModalView,
   deriveHitlResponse,
+  formatInputRequestFallbackText,
   freeformRequestIdFromActionId,
   HITL_ACTION_PREFIX,
   HITL_FREEFORM_ACTION_PREFIX,
@@ -113,6 +114,60 @@ describe("renderInputRequestBlocks", () => {
       value: "deny",
       style: "danger",
     });
+  });
+
+  it("shows tool input for confirmation approval requests", () => {
+    const request = makeRequest({
+      action: {
+        kind: "tool-call",
+        callId: "call_mongo",
+        toolName: "mongodb-mutate",
+        input: {
+          operation: "deleteOne",
+          collection: "org_members",
+          filter: { _id: "qudw7ekkzulpgw3j" },
+        },
+      },
+      display: "confirmation",
+      prompt: "Approve tool call: mongodb-mutate",
+      requestId: "approval_1",
+      options: [
+        { id: "approve", label: "Yes" },
+        { id: "deny", label: "No" },
+      ],
+    });
+
+    const blocks = renderInputRequestBlocks(request);
+
+    expect(blocks).toHaveLength(3);
+    const details = blocks[1] as { type: string; text: { type: string; text: string } };
+    expect(details).toMatchObject({ type: "section", text: { type: "mrkdwn" } });
+    expect(details.text.text).toContain("*Tool input*");
+    expect(details.text.text).toContain('"collection": "org_members"');
+    expect(details.text.text).toContain('"_id": "qudw7ekkzulpgw3j"');
+    expect(blocks[2]).toMatchObject({ type: "actions" });
+  });
+
+  it("keeps long approval input details within the section limit", () => {
+    const blocks = renderInputRequestBlocks(
+      makeRequest({
+        action: {
+          kind: "tool-call",
+          callId: "call_long",
+          toolName: "dangerous_tool",
+          input: { value: "x".repeat(SLACK_SECTION_TEXT_MAX_LENGTH + 500) },
+        },
+        display: "confirmation",
+        options: [
+          { id: "approve", label: "Yes" },
+          { id: "deny", label: "No" },
+        ],
+      }),
+    );
+
+    const details = blocks[1] as { text: { text: string } };
+    expect(details.text.text.length).toBeLessThanOrEqual(SLACK_SECTION_TEXT_MAX_LENGTH);
+    expect(details.text.text).toMatch(/\.\.\.\n```$/u);
   });
 
   it("renders a radio_buttons widget for select-display requests with ≤6 options", () => {
@@ -267,6 +322,39 @@ describe("renderInputRequestBlocks", () => {
   });
 });
 
+describe("formatInputRequestFallbackText", () => {
+  it("includes approval tool input in Slack fallback text", () => {
+    const text = formatInputRequestFallbackText(
+      makeRequest({
+        action: {
+          kind: "tool-call",
+          callId: "call_mongo",
+          toolName: "mongodb-mutate",
+          input: {
+            operation: "deleteOne",
+            collection: "orgs",
+            filter: { _id: "48gtnni64rxqtaoh" },
+          },
+        },
+        display: "confirmation",
+        prompt: "Approve tool call: mongodb-mutate",
+        options: [
+          { id: "approve", label: "Yes" },
+          { id: "deny", label: "No" },
+        ],
+      }),
+    );
+
+    expect(text).toContain("Approve tool call: mongodb-mutate");
+    expect(text).toContain('"collection": "orgs"');
+    expect(text).toContain('"_id": "48gtnni64rxqtaoh"');
+  });
+
+  it("leaves non-approval fallback text unchanged", () => {
+    expect(formatInputRequestFallbackText(makeRequest({ prompt: "Pick one" }))).toBe("Pick one");
+  });
+});
+
 describe("buildFreeformModalView", () => {
   it("emits a modal with the canonical callback_id and the prompt as a header block", () => {
     const view = buildFreeformModalView({
@@ -347,6 +435,30 @@ describe("buildAnsweredBlocks", () => {
     expect(blocks[2]).toMatchObject({
       type: "context",
       elements: [{ type: "mrkdwn", text: "Answered by <@U01>" }],
+    });
+  });
+
+  it("preserves multiple prompt/detail blocks", () => {
+    const promptBlock = {
+      type: "section",
+      text: { type: "mrkdwn", text: "Approve tool call: mongodb-mutate" },
+    };
+    const detailBlock = {
+      type: "section",
+      text: { type: "mrkdwn", text: '*Tool input*\n```\n{ "_id": "org_1" }\n```' },
+    };
+
+    const blocks = buildAnsweredBlocks({
+      promptBlocks: [promptBlock, detailBlock],
+      answerLabel: "Yes",
+      userId: "U01",
+    });
+
+    expect(blocks[0]).toBe(promptBlock);
+    expect(blocks[1]).toBe(detailBlock);
+    expect(blocks[2]).toMatchObject({
+      type: "section",
+      text: { text: ":white_check_mark: *Yes*" },
     });
   });
 

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -62,6 +62,8 @@ const RADIO_SELECT_OPTION_LIMIT = 6;
 const BUTTON_ACTION_ID_RE = /^(?<requestId>.+):button:\d+$/u;
 const TOOL_INPUT_PREFIX = "*Tool input*\n```\n";
 const TOOL_INPUT_SUFFIX = "\n```";
+const ANSWERED_TEXT_PREFIX = ":white_check_mark: *";
+const ANSWERED_TEXT_SUFFIX = "*";
 
 /**
  * Subset of one Slack interactivity action the HITL decoder reads.
@@ -325,9 +327,15 @@ export function buildAnsweredBlocks(input: {
       blocks.push(promptBlock);
     }
   }
+  // Freeform answers echo user-typed text, which can exceed the section
+  // limit on its own; cap the label so `chat.update` cannot fail.
+  const answerLabel = truncateWithEllipsis(
+    input.answerLabel,
+    SLACK_SECTION_TEXT_MAX_LENGTH - ANSWERED_TEXT_PREFIX.length - ANSWERED_TEXT_SUFFIX.length,
+  );
   blocks.push({
     type: "section",
-    text: { type: "mrkdwn", text: `:white_check_mark: *${input.answerLabel}*` },
+    text: { type: "mrkdwn", text: `${ANSWERED_TEXT_PREFIX}${answerLabel}${ANSWERED_TEXT_SUFFIX}` },
   });
   if (input.userId && input.userId.length > 0) {
     blocks.push({
@@ -353,11 +361,11 @@ function formatToolInputDetails(request: InputRequest): string | undefined {
 
   const bodyBudget =
     SLACK_SECTION_TEXT_MAX_LENGTH - TOOL_INPUT_PREFIX.length - TOOL_INPUT_SUFFIX.length;
-  const body = truncateCodeBlockBody(json, bodyBudget);
+  const body = truncateWithEllipsis(json, bodyBudget);
   return `${TOOL_INPUT_PREFIX}${body}${TOOL_INPUT_SUFFIX}`;
 }
 
-function truncateCodeBlockBody(value: string, maxLength: number): string {
+function truncateWithEllipsis(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   const sliceLength = Math.max(0, maxLength - 3);
   return `${value.slice(0, sliceLength).trimEnd()}...`;

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -305,24 +305,21 @@ function buildOption(opt: NonNullable<InputRequest["options"]>[number]): Record<
 
 /**
  * Renders the "answered" replacement blocks for a previously-posted
- * HITL card. Preserves the original prompt block (so context stays
- * visible), appends a confirmation line naming the chosen answer, and
- * attributes the click to the user when their id is known.
+ * HITL card. Preserves the original prompt/detail blocks (so context
+ * stays visible), appends a confirmation line naming the chosen answer,
+ * and attributes the click to the user when their id is known.
  *
  * Slack's `chat.update` replaces every block in one shot, so the caller
  * passes the full list to `blocks` and the rendered fallback text to
  * `text`.
  */
 export function buildAnsweredBlocks(input: {
-  readonly promptBlock?: unknown;
-  readonly promptBlocks?: readonly unknown[];
+  readonly promptBlocks: readonly unknown[];
   readonly answerLabel: string;
   readonly userId?: string;
 }): unknown[] {
   const blocks: unknown[] = [];
-  const promptBlocks =
-    input.promptBlocks ?? (input.promptBlock === undefined ? [] : [input.promptBlock]);
-  for (const promptBlock of promptBlocks) {
+  for (const promptBlock of input.promptBlocks) {
     if (promptBlock !== undefined && promptBlock !== null) {
       blocks.push(promptBlock);
     }

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  SLACK_SECTION_TEXT_MAX_LENGTH,
   truncateModalTitle,
   truncatePlainText,
   truncateSectionText,
@@ -59,6 +60,8 @@ export const HITL_FREEFORM_MODAL_ACTION_ID = "eve_freeform_text";
  */
 const RADIO_SELECT_OPTION_LIMIT = 6;
 const BUTTON_ACTION_ID_RE = /^(?<requestId>.+):button:\d+$/u;
+const TOOL_INPUT_PREFIX = "*Tool input*\n```\n";
+const TOOL_INPUT_SUFFIX = "\n```";
 
 /**
  * Subset of one Slack interactivity action the HITL decoder reads.
@@ -137,6 +140,7 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
     text: { text: truncateSectionText(request.prompt), type: "mrkdwn" },
     type: "section",
   };
+  const details = renderInputRequestDetailBlocks(request);
   const actionId = `${HITL_ACTION_PREFIX}${request.requestId}`;
 
   const options = request.options;
@@ -152,12 +156,13 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
             options: options.map(buildOption),
             placeholder: { type: "plain_text", text: "Choose an option" },
           };
-    return [prompt, { type: "actions", elements: [widget] }];
+    return [prompt, ...details, { type: "actions", elements: [widget] }];
   }
 
   if (options && options.length > 0) {
     return [
       prompt,
+      ...details,
       {
         type: "actions",
         elements: options.map((opt, index) => buildButton(opt, actionId, index)),
@@ -168,6 +173,7 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
   if (acceptsFreeform) {
     return [
       prompt,
+      ...details,
       {
         type: "actions",
         elements: [
@@ -184,6 +190,16 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
   }
 
   return [prompt];
+}
+
+/**
+ * Creates the fallback text for one HITL request. Slack clients use this
+ * outside the rich Block Kit surface, so include the same approval details
+ * that appear in the blocks.
+ */
+export function formatInputRequestFallbackText(request: InputRequest): string {
+  const details = formatToolInputDetails(request);
+  return details === undefined ? request.prompt : `${request.prompt}\n${details}`;
 }
 
 /**
@@ -296,13 +312,18 @@ function buildOption(opt: NonNullable<InputRequest["options"]>[number]): Record<
  * `text`.
  */
 export function buildAnsweredBlocks(input: {
-  readonly promptBlock: unknown;
+  readonly promptBlock?: unknown;
+  readonly promptBlocks?: readonly unknown[];
   readonly answerLabel: string;
   readonly userId?: string;
 }): unknown[] {
   const blocks: unknown[] = [];
-  if (input.promptBlock !== undefined && input.promptBlock !== null) {
-    blocks.push(input.promptBlock);
+  const promptBlocks =
+    input.promptBlocks ?? (input.promptBlock === undefined ? [] : [input.promptBlock]);
+  for (const promptBlock of promptBlocks) {
+    if (promptBlock !== undefined && promptBlock !== null) {
+      blocks.push(promptBlock);
+    }
   }
   blocks.push({
     type: "section",
@@ -315,4 +336,38 @@ export function buildAnsweredBlocks(input: {
     });
   }
   return blocks;
+}
+
+function renderInputRequestDetailBlocks(request: InputRequest): unknown[] {
+  const details = formatToolInputDetails(request);
+  return details === undefined
+    ? []
+    : [{ type: "section", text: { type: "mrkdwn", text: details } }];
+}
+
+function formatToolInputDetails(request: InputRequest): string | undefined {
+  if (!isApprovalRequest(request)) return undefined;
+
+  const json = JSON.stringify(request.action.input, null, 2);
+  if (json === "{}") return undefined;
+
+  const bodyBudget =
+    SLACK_SECTION_TEXT_MAX_LENGTH - TOOL_INPUT_PREFIX.length - TOOL_INPUT_SUFFIX.length;
+  const body = truncateCodeBlockBody(json, bodyBudget);
+  return `${TOOL_INPUT_PREFIX}${body}${TOOL_INPUT_SUFFIX}`;
+}
+
+function truncateCodeBlockBody(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  const sliceLength = Math.max(0, maxLength - 3);
+  return `${value.slice(0, sliceLength).trimEnd()}...`;
+}
+
+function isApprovalRequest(request: InputRequest): boolean {
+  return (
+    request.display === "confirmation" &&
+    request.options?.length === 2 &&
+    request.options[0]?.id === "approve" &&
+    request.options[1]?.id === "deny"
+  );
 }

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -177,16 +177,24 @@ function extractActionLabel(action: Record<string, unknown>): string | undefined
 }
 
 function findPromptBlock(blocks: readonly unknown[]): unknown {
+  return findPromptBlocks(blocks)[0];
+}
+
+function findPromptBlocks(blocks: readonly unknown[]): unknown[] {
+  const promptBlocks: unknown[] = [];
   for (const block of blocks) {
-    if (
-      typeof block === "object" &&
-      block !== null &&
-      (block as { type?: unknown }).type === "section"
-    ) {
-      return block;
+    if (typeof block !== "object" || block === null) {
+      continue;
+    }
+    const type = (block as { type?: unknown }).type;
+    if (type === "actions") {
+      break;
+    }
+    if (type === "section" || type === "context" || type === "divider" || type === "image") {
+      promptBlocks.push(block);
     }
   }
-  return undefined;
+  return promptBlocks;
 }
 
 function readPromptTextFromBlocks(blocks: readonly unknown[]): string | undefined {
@@ -462,7 +470,7 @@ async function updateAnsweredHitlCard(
   if (!answerLabel) return;
 
   const blocks = buildAnsweredBlocks({
-    promptBlock: findPromptBlock(interaction.messageBlocks),
+    promptBlocks: findPromptBlocks(interaction.messageBlocks),
     answerLabel,
     userId: hitlAction.user.id,
   });

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -502,7 +502,7 @@ async function updateAnsweredFreeformCard(input: {
   readonly deps: InteractionHandlerDeps;
 }): Promise<void> {
   const blocks = buildAnsweredBlocks({
-    promptBlock: undefined,
+    promptBlocks: [],
     answerLabel: input.answerLabel,
     userId: input.userId,
   });

--- a/packages/eve/src/public/channels/slack/limits.ts
+++ b/packages/eve/src/public/channels/slack/limits.ts
@@ -35,6 +35,12 @@ export const SLACK_SECTION_TEXT_MAX_LENGTH = 3000;
 export const SLACK_MESSAGE_TEXT_MAX_LENGTH = 40000;
 
 /**
+ * `chat.postMessage` rejects payloads with more than 50 blocks
+ * (`invalid_blocks`).
+ */
+export const SLACK_MAX_BLOCKS_PER_MESSAGE = 50;
+
+/**
  * `views.open` modal title is capped at 24 characters.
  */
 export const SLACK_MODAL_TITLE_MAX_LENGTH = 24;

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -17,6 +17,7 @@ import {
   HITL_FREEFORM_MODAL_CALLBACK_ID,
 } from "#public/channels/slack/hitl.js";
 import {
+  SLACK_MAX_BLOCKS_PER_MESSAGE,
   SLACK_MESSAGE_TEXT_MAX_LENGTH,
   SLACK_SECTION_TEXT_MAX_LENGTH,
 } from "#public/channels/slack/limits.js";
@@ -432,7 +433,7 @@ describe("slackChannel() default event handlers", () => {
     };
     expect(body).toMatchObject({
       channel: "C01",
-      text: "Approve tool call: mongodb-mutate",
+      text: 'Approve tool call: mongodb-mutate\n*Tool input*\n```\n{\n  "operation": "deleteMany"\n}\n```',
       thread_ts: "1700000000.000001",
     });
 
@@ -486,6 +487,55 @@ describe("slackChannel() default event handlers", () => {
     expect(promptSection?.text?.text.length).toBeLessThanOrEqual(SLACK_SECTION_TEXT_MAX_LENGTH);
     expect(promptSection?.text?.text.endsWith("...")).toBe(true);
     expect(body.text.length).toBeLessThanOrEqual(SLACK_MESSAGE_TEXT_MAX_LENGTH);
+  });
+
+  it("input.requested splits large batches so no post exceeds Slack's block cap", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    // 20 approval requests render 3 blocks each (prompt, tool input,
+    // actions) = 60 blocks, which must split across two posts.
+    const requests = Array.from({ length: 20 }, (_, index) => ({
+      action: {
+        callId: `call_${index}`,
+        input: { operation: "deleteMany" },
+        kind: "tool-call" as const,
+        toolName: "mongodb-mutate",
+      },
+      display: "confirmation" as const,
+      options: [
+        { id: "approve", label: "Yes" },
+        { id: "deny", label: "No" },
+      ],
+      prompt: `Approve tool call ${index}`,
+      requestId: `approval_${index}`,
+    }));
+
+    await callEvent(
+      adapter,
+      makeEvent("input.requested", { requests, sequence: 0, stepIndex: 0, turnId: "t1" }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const allRequestIds: string[] = [];
+    for (const [url, init] of fetchMock.mock.calls) {
+      expect(String(url)).toBe("https://slack.com/api/chat.postMessage");
+      const body = parseSlackRequestBody(init as RequestInit) as {
+        blocks: Array<{ type: string; elements?: Array<{ action_id: string }> }>;
+      };
+      expect(body.blocks.length).toBeLessThanOrEqual(SLACK_MAX_BLOCKS_PER_MESSAGE);
+      for (const block of body.blocks) {
+        for (const element of block.elements ?? []) {
+          const requestId = element.action_id.replace(/^.*:(approval_\d+):button:\d+$/u, "$1");
+          if (!allRequestIds.includes(requestId)) allRequestIds.push(requestId);
+        }
+      }
+    }
+    expect(allRequestIds).toHaveLength(20);
   });
 
   it("turn.started calls assistant.threads.setStatus", async () => {


### PR DESCRIPTION
## Summary

- Show approval-gated tool input in Slack HITL messages as a bounded code block.
- Include the same tool input in Slack fallback text for notification/accessibility surfaces.
- Preserve prompt/detail blocks when Slack updates an answered HITL card.
- Add a patch changeset for eve.

## Validation

- pnpm --filter eve build:compiled
- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/hitl.test.ts src/public/channels/slack/interactions.test.ts
- pnpm --filter eve typecheck
- pnpm lint
- pnpm guard:invariants