### PR TITLE
feat(fixtures): add compliance-agent demonstrating policy-driven tool approval

### DIFF
--- a/apps/fixtures/compliance-agent/.gitignore
+++ b/apps/fixtures/compliance-agent/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/apps/fixtures/compliance-agent/README.md
+++ b/apps/fixtures/compliance-agent/README.md
@@ -1,0 +1,28 @@
+# Compliance agent
+
+A governance-focused eve fixture demonstrating policy-driven tool approval patterns
+for regulated workflows. Each tool uses a different approval strategy to model the
+four policy effects proposed in [#145](https://github.com/vercel/eve/issues/145).
+
+| Tool                | Approval                  | Effect demonstrated                                |
+| ------------------- | ------------------------- | -------------------------------------------------- |
+| `initiate_transfer` | Custom `Approval<TInput>` | deny (AML pattern) · escalate (high-value) · allow |
+| `fetch_customer`    | `once()`                  | ask once per session, then allow automatically     |
+| `record_audit`      | `never()`                 | always allow — pure audit sink                     |
+
+## Run locally
+
+```sh
+pnpm dev
+```
+
+## Policy effects
+
+- **deny** — `initiate_transfer` returns `{ type: "denied" }` for narrations that match
+  a suspicious-pattern regex before the tool executes.
+- **escalate** — Transfers above 10 000 in the currency's major unit (1 000 000 minor
+  units) return `{ type: "user-approval" }`, surfacing a human approval step.
+- **allow (session-scoped)** — `fetch_customer` uses `once()`: the first call in a session
+  asks for approval; subsequent calls proceed automatically via `approvedTools`.
+- **allow (unconditional)** — `record_audit` uses `never()` and always executes, providing
+  a tamper-evident compliance trail regardless of other decisions.

--- a/apps/fixtures/compliance-agent/agent/agent.ts
+++ b/apps/fixtures/compliance-agent/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-sonnet-5",
+});

--- a/apps/fixtures/compliance-agent/agent/instructions.md
+++ b/apps/fixtures/compliance-agent/agent/instructions.md
@@ -1,0 +1,1 @@
+You are a compliance-aware financial assistant. Before initiating any transfer, fetch the customer record to verify KYC tier and identity status. Always record an audit event after every compliance decision. Be transparent about why a tool call was denied or requires approval.

--- a/apps/fixtures/compliance-agent/agent/skills/compliance-workflow.md
+++ b/apps/fixtures/compliance-agent/agent/skills/compliance-workflow.md
@@ -1,0 +1,12 @@
+---
+description: Follow this workflow for every financial transaction to satisfy compliance obligations.
+---
+
+Before initiating any transfer:
+
+1. Call `fetch_customer` with the account number to confirm KYC tier and identity verification status.
+2. Call `record_audit` with `event_type: "pii_accessed"` and the account number as the subject.
+3. Call `initiate_transfer` with the validated inputs.
+4. Call `record_audit` with `event_type: "transfer_initiated"` or `"approval_denied"` depending on the outcome.
+
+If the transfer is denied or escalated, include the reason in the audit metadata.

--- a/apps/fixtures/compliance-agent/agent/tools/fetch_customer.ts
+++ b/apps/fixtures/compliance-agent/agent/tools/fetch_customer.ts
@@ -1,0 +1,20 @@
+import { defineTool } from "eve/tools";
+import { once } from "eve/tools/approval";
+import { z } from "zod";
+
+export default defineTool({
+  description:
+    "Fetch a customer record by account number. Requires one-time session approval before accessing PII.",
+  inputSchema: z.object({
+    account_number: z.string(),
+  }),
+  approval: once(),
+  async execute(input) {
+    return {
+      account_number: input.account_number,
+      name: "Alex Rivera",
+      kyc_tier: 2,
+      identity_verified: true,
+    };
+  },
+});

--- a/apps/fixtures/compliance-agent/agent/tools/initiate_transfer.ts
+++ b/apps/fixtures/compliance-agent/agent/tools/initiate_transfer.ts
@@ -1,0 +1,97 @@
+import { createHash } from "node:crypto";
+import { defineTool } from "eve/tools";
+import type { Approval } from "eve/tools/approval";
+import { z } from "zod";
+
+const TransferInput = z.object({
+  recipient_account: z.string(),
+  // Amount in the currency's minor unit (e.g. cents for USD, kobo for NGN).
+  amount_minor_units: z.number().int().positive(),
+  // ISO 4217 currency code.
+  currency: z.string().length(3),
+  narration: z.string().max(100),
+  // Required for schedule / app-principal callers — side-effecting tools must
+  // be safely retryable when there is no human in the loop to re-approve.
+  idempotency_key: z.string().optional(),
+});
+
+type TransferInput = z.output<typeof TransferInput>;
+
+const SUSPICIOUS_NARRATION = /\b(test|dummy|fake|launder|evade)\b/i;
+// 1 000 000 minor units = 10 000 in any 2-decimal currency (USD, EUR, NGN…).
+const HIGH_VALUE_THRESHOLD = 1_000_000;
+
+/**
+ * Deterministic digest of the tool input.
+ *
+ * Included in the execute output so the audit receipt can prove the input
+ * that was approved equals the input that was executed (approval is a gate,
+ * not a blank authorisation).
+ */
+function inputDigest(input: Record<string, unknown>): string {
+  const canonical = JSON.stringify(input, Object.keys(input).sort());
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}
+
+const transferApproval: Approval<TransferInput> = (ctx) => {
+  // Fail-closed: if we cannot inspect the input we cannot evaluate policy.
+  // Return "not-applicable" would pass through silently — we deny instead.
+  if (!ctx.toolInput) {
+    return {
+      type: "denied",
+      reason: "Tool input unavailable for policy evaluation — failing closed",
+    };
+  }
+
+  const { narration, amount_minor_units, idempotency_key } = ctx.toolInput;
+  const principal = ctx.session.auth.current;
+
+  // AML narration screen — always applied, regardless of caller type.
+  if (SUSPICIOUS_NARRATION.test(narration)) {
+    return { type: "denied", reason: "Narration flagged by AML pattern screening" };
+  }
+
+  // Schedule / app-principal: no human is present to serve an approval UI.
+  // Side-effecting tools are permitted only when the caller supplies an
+  // idempotency key that makes retries safe.
+  if (principal?.principalType === "runtime" && principal.authenticator === "app") {
+    return idempotency_key
+      ? { type: "approved" }
+      : {
+          type: "denied",
+          reason: "Schedule calls to financial_transfer require an idempotency_key",
+        };
+  }
+
+  // High-value threshold — pause for human approval.
+  if (amount_minor_units > HIGH_VALUE_THRESHOLD) {
+    return { type: "user-approval" };
+  }
+
+  // Explicit allow — not the default when policy lookup fails.
+  return { type: "approved" };
+};
+
+export default defineTool({
+  description: "Initiate a funds transfer between accounts.",
+  inputSchema: TransferInput,
+  approval: transferApproval,
+  async execute(input, ctx) {
+    const principal = ctx.session.auth.current;
+    return {
+      reference: `TXN-${input.recipient_account.slice(-6).toUpperCase()}`,
+      status: "submitted",
+      recipient_account: input.recipient_account,
+      amount_minor_units: input.amount_minor_units,
+      currency: input.currency,
+      narration: input.narration,
+      // Adapter contract fields — stable surface for regulated teams.
+      side_effect_class: "financial_transfer" as const,
+      // Execute re-derives principal from its own ToolContext, not from any
+      // closure over the approval-time context. Approval is a gate, not an
+      // authorization that carries forward.
+      session_principal: principal?.principalType ?? "anonymous",
+      input_digest: inputDigest(input as unknown as Record<string, unknown>),
+    };
+  },
+});

--- a/apps/fixtures/compliance-agent/agent/tools/record_audit.ts
+++ b/apps/fixtures/compliance-agent/agent/tools/record_audit.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto";
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { z } from "zod";
+
+const SIDE_EFFECT_CLASS = [
+  "financial_transfer",
+  "pii_read",
+  "external_write",
+  "audit_sink",
+  "none",
+] as const;
+
+export default defineTool({
+  description: "Record a compliance audit event. Always executes without requiring approval.",
+  inputSchema: z.object({
+    event_type: z.enum([
+      "transfer_initiated",
+      "pii_accessed",
+      "policy_decision",
+      "approval_granted",
+      "approval_denied",
+    ]),
+    subject: z.string(),
+    // Adapter contract fields. Pass these to make the receipt fully observable:
+    // a consumer can verify that the logged decision matches what Eve recorded.
+    side_effect_class: z.enum(SIDE_EFFECT_CLASS).optional(),
+    input_digest: z.string().optional(),
+    session_principal: z.string().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  }),
+  approval: never(),
+  async execute(input) {
+    return {
+      logged: true,
+      // Unique receipt id — correlates this entry across SIEM pipelines.
+      receipt_id: randomUUID(),
+      event_type: input.event_type,
+      subject: input.subject,
+      side_effect_class: input.side_effect_class ?? "none",
+      ...(input.input_digest !== undefined ? { input_digest: input.input_digest } : {}),
+      ...(input.session_principal !== undefined
+        ? { session_principal: input.session_principal }
+        : {}),
+    };
+  },
+});

--- a/apps/fixtures/compliance-agent/package.json
+++ b/apps/fixtures/compliance-agent/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "compliance-agent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "eve dev",
+    "build": "eve build",
+    "start": "eve start",
+    "info": "eve info",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "eve": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/fixtures/compliance-agent/test/compliance-agent.test.ts
+++ b/apps/fixtures/compliance-agent/test/compliance-agent.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Regression suite for the compliance-agent fixture.
+ *
+ * Organised around four independently observable aspects of the Eve tool
+ * lifecycle, with the five invariants from vercel/eve#145 expressed as
+ * properties of those observations:
+ *
+ *   1. Policy decision        — approval() resolves before execute() is reached
+ *   2. Human approval state   — "user-approval" is a gate, not a policy decision
+ *   3. Audit receipt          — receipt_id is independent of execution result
+ *   4. Execution result       — execute re-derives session_principal from ToolContext
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ApprovalContext, ToolContext } from "eve/tools";
+import transfer from "../agent/tools/initiate_transfer.js";
+import fetchCustomer from "../agent/tools/fetch_customer.js";
+import recordAudit from "../agent/tools/record_audit.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+type TransferInput = {
+  recipient_account: string;
+  amount_minor_units: number;
+  currency: string;
+  narration: string;
+  idempotency_key?: string;
+};
+
+function makeTransferApprovalCtx(
+  toolInput: Partial<TransferInput> | undefined,
+  opts: {
+    principalType?: string;
+    authenticator?: string;
+    approvedTools?: string[];
+  } = {},
+): ApprovalContext<TransferInput> {
+  return {
+    toolName: "initiate_transfer",
+    toolInput: toolInput as TransferInput | undefined,
+    approvedTools: new Set(opts.approvedTools ?? []),
+    session: {
+      id: "test-session",
+      auth: {
+        current:
+          opts.principalType != null
+            ? {
+                principalType: opts.principalType,
+                authenticator: opts.authenticator ?? "test",
+                principalId: "test-principal",
+                attributes: {},
+              }
+            : null,
+        initiator: null,
+      },
+      turn: { id: "turn-1", sequence: 1 },
+    },
+    getSandbox: () => Promise.reject(new Error("no sandbox in tests")),
+    getSkill: () => {
+      throw new Error("no skill in tests");
+    },
+  };
+}
+
+function makeFetchCustomerApprovalCtx(opts: { approvedTools?: string[] } = {}): ApprovalContext<{
+  account_number: string;
+}> {
+  return {
+    toolName: "fetch_customer",
+    toolInput: { account_number: "ACC-001" },
+    approvedTools: new Set(opts.approvedTools ?? []),
+    session: {
+      id: "test-session",
+      auth: { current: null, initiator: null },
+      turn: { id: "turn-1", sequence: 1 },
+    },
+    getSandbox: () => Promise.reject(new Error("no sandbox in tests")),
+    getSkill: () => {
+      throw new Error("no skill in tests");
+    },
+  };
+}
+
+function makeToolCtx(opts: { principalType?: string; authenticator?: string } = {}): ToolContext {
+  return {
+    session: {
+      id: "test-session",
+      auth: {
+        current:
+          opts.principalType != null
+            ? {
+                principalType: opts.principalType,
+                authenticator: opts.authenticator ?? "test",
+                principalId: "test-principal",
+                attributes: {},
+              }
+            : null,
+        initiator: null,
+      },
+      turn: { id: "turn-1", sequence: 1 },
+    },
+    getSandbox: () => Promise.reject(new Error("no sandbox in tests")),
+    getSkill: () => {
+      throw new Error("no skill in tests");
+    },
+    getToken: () => Promise.reject(new Error("no token in tests")),
+    requireAuth: () => {
+      throw new Error("requireAuth in tests");
+    },
+  } as unknown as ToolContext;
+}
+
+// Low-value clean transfer — approved outright by policy, no human gate.
+const CLEAN_TRANSFER: TransferInput = {
+  recipient_account: "ACC-999888",
+  amount_minor_units: 500_000,
+  currency: "NGN",
+  narration: "Monthly rent payment",
+};
+
+// High-value transfer — policy routes to human approval gate.
+const HIGH_VALUE_TRANSFER: TransferInput = {
+  ...CLEAN_TRANSFER,
+  amount_minor_units: 2_000_000,
+};
+
+const SCHEDULE_PRINCIPAL = { principalType: "runtime", authenticator: "app" } as const;
+
+// ─── Observation 1: Policy decision ──────────────────────────────────────────
+//
+// Invariant: policy evaluation happens inside approval(), which resolves before
+// execute() is ever called. Denial is observable from approval() alone —
+// execute() is unreachable when approval() returns { type: "denied" }.
+
+describe("policy decision — fires before execute", () => {
+  it("absent toolInput → denied (fail-closed, not silent pass-through)", async () => {
+    const result = await transfer.approval!(makeTransferApprovalCtx(undefined));
+    expect(result).toMatchObject({ type: "denied" });
+  });
+
+  it("deny reason names the fail-closed semantics so the decision is observable", async () => {
+    const result = await transfer.approval!(makeTransferApprovalCtx(undefined));
+    expect(result).toMatchObject({
+      type: "denied",
+      reason: expect.stringContaining("failing closed"),
+    });
+  });
+
+  it("AML narration → denied at the approval boundary, before execute is reached", async () => {
+    const result = await transfer.approval!(
+      makeTransferApprovalCtx({ ...CLEAN_TRANSFER, narration: "launder proceeds" }),
+    );
+    expect(result).toMatchObject({ type: "denied", reason: expect.stringContaining("AML") });
+  });
+
+  it("clean low-value transfer → approved at the approval boundary", async () => {
+    const result = await transfer.approval!(makeTransferApprovalCtx(CLEAN_TRANSFER));
+    expect(result).toMatchObject({ type: "approved" });
+  });
+
+  it("schedule call without idempotency_key → denied (side effects must be safely retryable)", async () => {
+    const result = await transfer.approval!(
+      makeTransferApprovalCtx(CLEAN_TRANSFER, SCHEDULE_PRINCIPAL),
+    );
+    expect(result).toMatchObject({
+      type: "denied",
+      reason: expect.stringContaining("idempotency_key"),
+    });
+  });
+
+  it("schedule call with idempotency_key → approved", async () => {
+    const result = await transfer.approval!(
+      makeTransferApprovalCtx(
+        { ...CLEAN_TRANSFER, idempotency_key: "idem-abc123" },
+        SCHEDULE_PRINCIPAL,
+      ),
+    );
+    expect(result).toMatchObject({ type: "approved" });
+  });
+
+  it("schedule + AML violation → denied (AML check runs before idempotency check)", async () => {
+    const result = await transfer.approval!(
+      makeTransferApprovalCtx(
+        { ...CLEAN_TRANSFER, narration: "test funds", idempotency_key: "idem-1" },
+        SCHEDULE_PRINCIPAL,
+      ),
+    );
+    expect(result).toMatchObject({ type: "denied", reason: expect.stringContaining("AML") });
+  });
+});
+
+// ─── Observation 2: Human approval state ─────────────────────────────────────
+//
+// Invariant: "approval callback is a gate, not authorization."
+// "user-approval" is a distinct observable — it means a human must decide;
+// it is not a policy decision and not the same as { type: "denied" }.
+// approvedTools communicates the human's prior decision back into the callback;
+// it relaxes the gate only after explicit approval, never by default.
+
+describe("human approval state — gate, not authorization", () => {
+  it("high-value transfer → user-approval (human must decide, policy has not denied)", async () => {
+    const result = await transfer.approval!(makeTransferApprovalCtx(HIGH_VALUE_TRANSFER));
+    expect(result).toMatchObject({ type: "user-approval" });
+  });
+
+  it('"user-approval" is distinct from { type: "denied" } — it is a gate, not a block', async () => {
+    const gate = await transfer.approval!(makeTransferApprovalCtx(HIGH_VALUE_TRANSFER));
+    const block = await transfer.approval!(
+      makeTransferApprovalCtx({ ...CLEAN_TRANSFER, narration: "launder proceeds" }),
+    );
+    // Gate suspends execution for human decision; block terminates it.
+    // Both are objects but type discriminates them — they must not be equal.
+    expect(gate).toMatchObject({ type: "user-approval" });
+    expect(block).toMatchObject({ type: "denied" });
+    expect(gate).not.toEqual(block);
+  });
+
+  it("PII tool without approvedTools → user-approval (gate not yet cleared)", async () => {
+    const result = await fetchCustomer.approval!(makeFetchCustomerApprovalCtx());
+    expect(result).toBe("user-approval");
+  });
+
+  it("PII tool after explicit approval (toolName in approvedTools) → not-applicable (gate cleared)", async () => {
+    const result = await fetchCustomer.approval!(
+      makeFetchCustomerApprovalCtx({ approvedTools: ["fetch_customer"] }),
+    );
+    expect(result).toBe("not-applicable");
+  });
+
+  it("denial does not add the tool to approvedTools — next call still requires user-approval", async () => {
+    // After a denial, approvedTools is empty. The gate must remain closed.
+    const result = await fetchCustomer.approval!(makeFetchCustomerApprovalCtx());
+    expect(result).toBe("user-approval");
+  });
+
+  it("approval is a gate not authorization — execute still re-derives its own principal", async () => {
+    // approval() returns approved with no principal context.
+    const approvalCtx = makeTransferApprovalCtx(CLEAN_TRANSFER);
+    const approvalDecision = await transfer.approval!(approvalCtx);
+    expect(approvalDecision).toMatchObject({ type: "approved" });
+    expect(approvalCtx.session.auth.current).toBeNull(); // no principal at approval time
+
+    // execute() is called later with a ToolContext that has a real principal.
+    // The session_principal in the result comes from that ToolContext, not from
+    // the approval context — confirming approval did not carry authorization forward.
+    const execResult = await transfer.execute!(
+      CLEAN_TRANSFER,
+      makeToolCtx({ principalType: "user" }),
+    );
+    expect(execResult.session_principal).toBe("user");
+  });
+});
+
+// ─── Observation 3: Audit receipt ────────────────────────────────────────────
+//
+// The audit receipt is an independent observation: it carries its own receipt_id
+// and echoes side_effect_class, input_digest, and session_principal so the record
+// can be correlated with the execution result without coupling the two.
+
+describe("audit receipt — independent of execution result", () => {
+  it("receipt_id is a valid UUID generated on each call", async () => {
+    const result = await recordAudit.execute!(
+      {
+        event_type: "transfer_initiated",
+        subject: "ACC-999888",
+        side_effect_class: "financial_transfer",
+        input_digest: "abc123def456",
+        session_principal: "user",
+      },
+      makeToolCtx(),
+    );
+    expect(result.logged).toBe(true);
+    expect(result.receipt_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("receipt_id is unique per call — two receipts for the same input differ", async () => {
+    const input = { event_type: "pii_accessed" as const, subject: "ACC-001" };
+    const r1 = await recordAudit.execute!(input, makeToolCtx());
+    const r2 = await recordAudit.execute!(input, makeToolCtx());
+    expect(r1.receipt_id).not.toBe(r2.receipt_id);
+  });
+
+  it("audit receipt echoes side_effect_class, input_digest, session_principal for correlation", async () => {
+    const result = await recordAudit.execute!(
+      {
+        event_type: "transfer_initiated",
+        subject: "ACC-999888",
+        side_effect_class: "financial_transfer",
+        input_digest: "abc123def456",
+        session_principal: "user",
+      },
+      makeToolCtx(),
+    );
+    expect(result.side_effect_class).toBe("financial_transfer");
+    expect(result.input_digest).toBe("abc123def456");
+    expect(result.session_principal).toBe("user");
+  });
+});
+
+// ─── Observation 4: Execution result ─────────────────────────────────────────
+//
+// Invariant: "execute re-derives the session principal at execution time."
+// The ToolContext passed to execute() is the authoritative source for
+// session_principal — it is never inherited from the approval-time context.
+// input_digest is deterministic over the input so the audit record can prove
+// that the executed input matches the approved input.
+
+describe("execution result — session principal re-derived at call time", () => {
+  it("session_principal reflects the ToolContext passed at execute time, not approval time", async () => {
+    const execResult = await transfer.execute!(
+      CLEAN_TRANSFER,
+      makeToolCtx({ principalType: "user" }),
+    );
+    expect(execResult.session_principal).toBe("user");
+  });
+
+  it("two execute calls with different ToolContexts produce different session_principal values", async () => {
+    const userResult = await transfer.execute!(
+      CLEAN_TRANSFER,
+      makeToolCtx({ principalType: "user" }),
+    );
+    const serviceResult = await transfer.execute!(
+      { ...CLEAN_TRANSFER, idempotency_key: "idem-1" },
+      makeToolCtx({ principalType: "runtime", authenticator: "app" }),
+    );
+    expect(userResult.session_principal).toBe("user");
+    expect(serviceResult.session_principal).toBe("runtime");
+  });
+
+  it("side_effect_class is present and stable in execute output", async () => {
+    const result = await transfer.execute!(CLEAN_TRANSFER, makeToolCtx({ principalType: "user" }));
+    expect(result.side_effect_class).toBe("financial_transfer");
+  });
+
+  it("input_digest is deterministic — same input produces the same digest", async () => {
+    const r1 = await transfer.execute!(CLEAN_TRANSFER, makeToolCtx({ principalType: "user" }));
+    const r2 = await transfer.execute!(CLEAN_TRANSFER, makeToolCtx({ principalType: "user" }));
+    expect(r1.input_digest).toBe(r2.input_digest);
+  });
+
+  it("input_digest changes when input changes — approved input and executed input are verifiable", async () => {
+    const r1 = await transfer.execute!(CLEAN_TRANSFER, makeToolCtx({ principalType: "user" }));
+    const r2 = await transfer.execute!(
+      { ...CLEAN_TRANSFER, amount_minor_units: 999_999 },
+      makeToolCtx({ principalType: "user" }),
+    );
+    expect(r1.input_digest).not.toBe(r2.input_digest);
+  });
+
+  it("execute produces a TXN reference — execution result is observable independently of policy decision", async () => {
+    const result = await transfer.execute!(CLEAN_TRANSFER, makeToolCtx({ principalType: "user" }));
+    expect(result.reference).toMatch(/^TXN-/);
+    expect(result.status).toBe("submitted");
+  });
+});

--- a/apps/fixtures/compliance-agent/tsconfig.json
+++ b/apps/fixtures/compliance-agent/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "allowJs": true,
+    "rootDir": "."
+  },
+  "include": ["agent/**/*", "evals/**/*", ".eve/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "build", ".turbo", ".vercel"]
+}

--- a/apps/fixtures/compliance-agent/turbo.json
+++ b/apps/fixtures/compliance-agent/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["$TURBO_EXTENDS$", "eve#build"]
+    },
+    "test": {
+      "dependsOn": ["eve#build"]
+    }
+  }
+}

--- a/apps/fixtures/compliance-agent/vitest.config.ts
+++ b/apps/fixtures/compliance-agent/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,22 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  apps/fixtures/compliance-agent:
+    dependencies:
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+
   apps/fixtures/weather-agent:
     dependencies:
       eve:


### PR DESCRIPTION
### Description

Adds `apps/fixtures/compliance-agent` — a governance-focused fixture showing
how eve's existing `Approval<TInput>` API models the four policy effects
discussed in #145, without any framework changes.

Three tools, one approval pattern each:

| Tool | Approval | Effect |
|---|---|---|
| `initiate_transfer` | Custom `Approval<TInput>` | deny (AML narration regex) · escalate (high-value → `user-approval`) · allow |
| `fetch_customer` | `once()` | one-time PII consent gate; auto-approved thereafter via `approvedTools` |
| `record_audit` | `never()` | unconditional audit sink — always executes |

Currency-neutral (ISO 4217 + amount in minor units). No third-party dependencies
beyond `eve` + `zod`.

Closes #145

### How did you test your changes?

```sh
pnpm --filter compliance-agent typecheck  # passes with zero errors
pnpm guard:invariants                     # passes
pnpm guard:fixtures                       # passes
```

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)