### PR TITLE
Emit an action.result when an ask_question is answered

### DIFF
--- a/.changeset/ask-question-settles-after-answer.md
+++ b/.changeset/ask-question-settles-after-answer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `ask_question` tool calls appearing to run forever in the dev TUI after the user answers. Resolved question requests now emit a successful `action.result` event (previously only denied tool approvals did), so consumers settle the call and its spinner clears once answered.

--- a/packages/eve/src/harness/input-requests.test.ts
+++ b/packages/eve/src/harness/input-requests.test.ts
@@ -558,6 +558,56 @@ describe("resolvePendingInput", () => {
     });
   });
 
+  it("returns an answered action for a resolved question", () => {
+    const session = setPendingInputBatch({
+      event: { sequence: 5, stepIndex: 1, turnId: "turn_0" },
+      requests: [
+        {
+          action: {
+            callId: "question-call",
+            input: { prompt: "Proceed with this plan?" },
+            kind: "tool-call",
+            toolName: "ask_question",
+          },
+          allowFreeform: false,
+          display: "select",
+          options: [
+            { id: "go", label: "Start researching" },
+            { id: "revise", label: "Adjust the plan" },
+          ],
+          prompt: "Proceed with this plan?",
+          requestId: "question-1",
+        } satisfies InputRequest,
+      ],
+      responseMessages: [],
+      session: createHarnessSession(),
+    });
+
+    const result = resolvePendingInput({
+      stepInput: {
+        inputResponses: [{ requestId: "question-1", optionId: "go", text: "go ahead" }],
+      },
+      session,
+    });
+
+    expect(result.outcome).toBe("resolved");
+    // The answered question must surface as a successful action result so the
+    // stream settles the `ask_question` call instead of leaving it spinning.
+    expect(result.answeredActions).toEqual({
+      event: { sequence: 5, stepIndex: 1, turnId: "turn_0" },
+      results: [
+        {
+          callId: "question-call",
+          kind: "tool-result",
+          output: { optionId: "go", status: "answered", text: "go ahead" },
+          toolName: "ask_question",
+        },
+      ],
+    });
+    // A question resolution is not a denial.
+    expect(result.rejectedActions).toBeUndefined();
+  });
+
   it("does not return a rejected action when an approval is granted", () => {
     const session = setPendingInputBatch({
       event: { sequence: 5, stepIndex: 1, turnId: "turn_0" },

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -7,6 +7,7 @@ import type {
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import { resolveTextToResponses } from "#channel/resolve-text.js";
 import { parseJsonObject } from "#shared/json.js";
+import { createRuntimeToolResultFromValue } from "#harness/action-result-helpers.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
 import type { HarnessSession, SessionStateMap, StepInput } from "#harness/types.js";
 
@@ -46,6 +47,19 @@ interface PendingInputBatch {
  * emit as `rejected` `action.result` events against the originating turn.
  */
 export interface RejectedActionBatch {
+  readonly event: PendingInputBatchEvent;
+  readonly results: readonly RuntimeToolResultActionResult[];
+}
+
+/**
+ * Resolved question requests (answered or ignored) from one resolved batch,
+ * ready for the caller to emit as successful `action.result` events against the
+ * originating turn. Unlike an approved tool call -- which subsequently runs and
+ * emits its own tool result -- a question's result IS the user's response, so it
+ * otherwise lives only in model history and consumers (e.g. the TUI) never see
+ * the call settle, leaving it spinning.
+ */
+export interface AnsweredActionBatch {
   readonly event: PendingInputBatchEvent;
   readonly results: readonly RuntimeToolResultActionResult[];
 }
@@ -169,6 +183,7 @@ export function resolvePendingInput(input: {
     }
 
     const rejectedActions = buildRejectedActionBatch(pendingBatch, []);
+    const answeredActions = buildAnsweredActionBatch(pendingBatch, []);
     session = clearPendingInputBatch(session);
 
     return {
@@ -176,6 +191,7 @@ export function resolvePendingInput(input: {
       outcome: "resolved",
       messages,
       rejectedActions,
+      answeredActions,
       session,
     };
   }
@@ -197,6 +213,7 @@ export function resolvePendingInput(input: {
   }
 
   const rejectedActions = buildRejectedActionBatch(pendingBatch, responses);
+  const answeredActions = buildAnsweredActionBatch(pendingBatch, responses);
   session = clearPendingInputBatch(session);
 
   // AI SDK cannot process tool-approval responses and a new user message
@@ -216,6 +233,7 @@ export function resolvePendingInput(input: {
       outcome: "resolved",
       messages,
       rejectedActions,
+      answeredActions,
       session,
     };
   }
@@ -225,6 +243,7 @@ export function resolvePendingInput(input: {
     outcome: "resolved",
     messages,
     rejectedActions,
+    answeredActions,
     session,
   };
 }
@@ -300,6 +319,7 @@ type ResolvePendingInputResult = {
   readonly outcome: "resolved" | "continue" | "unresolved";
   readonly messages: ModelMessage[];
   readonly rejectedActions?: RejectedActionBatch;
+  readonly answeredActions?: AnsweredActionBatch;
   readonly session: HarnessSession;
 };
 
@@ -529,6 +549,46 @@ function buildRejectedActionBatch(
       },
       toolName: request.action.toolName,
     });
+  }
+
+  return results.length > 0 ? { event: batch.event, results } : undefined;
+}
+
+/**
+ * Builds one successful `action.result` payload per resolved question request
+ * (non-approval input request) so the stream records the answer that otherwise
+ * lives only in model history. Without it, consumers never see the `ask_question`
+ * tool call settle and its UI keeps spinning after the user has answered.
+ *
+ * Approval requests are excluded: an approved call runs and emits its own tool
+ * result, and a denied call is surfaced by {@link buildRejectedActionBatch}.
+ */
+function buildAnsweredActionBatch(
+  batch: PendingInputBatch,
+  responses: readonly InputResponse[],
+): AnsweredActionBatch | undefined {
+  if (batch.event === undefined) {
+    return undefined;
+  }
+
+  const responseMap = new Map(responses.map((r) => [r.requestId, r]));
+  const results: RuntimeToolResultActionResult[] = [];
+  for (const request of batch.requests) {
+    if (isApprovalRequest(request)) {
+      continue;
+    }
+
+    const response = responseMap.get(request.requestId);
+    results.push(
+      createRuntimeToolResultFromValue({
+        callId: request.action.callId,
+        output:
+          response !== undefined
+            ? { optionId: response.optionId, status: "answered", text: response.text }
+            : { status: "ignored" },
+        toolName: request.action.toolName,
+      }),
+    );
   }
 
   return results.length > 0 ? { event: batch.event, results } : undefined;

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -467,6 +467,24 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
     }
 
+    // Surface resolved question requests as successful `action.result` events.
+    // The answer otherwise lives only in model history, so consumers (e.g. the
+    // TUI) never see the `ask_question` call settle and it keeps spinning after
+    // the user has answered. Attributed to the requesting turn via the parked
+    // batch's emit coordinates.
+    if (emit && pending.answeredActions) {
+      for (const result of pending.answeredActions.results) {
+        await emit(
+          createActionResultEvent({
+            result,
+            sequence: pending.answeredActions.event.sequence,
+            stepIndex: pending.answeredActions.event.stepIndex,
+            turnId: pending.answeredActions.event.turnId,
+          }),
+        );
+      }
+    }
+
     // --- Turn preamble ------------------------------------------------------
 
     if (emit && hasStepInput(input)) {


### PR DESCRIPTION
## Problem

Answering an `ask_question` leaves its tool call spinning forever in the dev TUI. When the user picks an option, the answer is written into model history, but no `action.result` stream event is emitted for it — only *denied* tool approvals emit one (`buildRejectedActionBatch` → the `rejectedActions` loop in `tool-loop.ts`). The TUI settles a tool block to `done` only when it receives a `tool-result` for that call (`terminal-renderer.ts`), so the `ask_question` block never settles and keeps its running spinner for the rest of the turn.

## Fix

Emit a successful `action.result` for each resolved **question** request (answered or ignored), mirroring the existing denied-approval path:

- `buildAnsweredActionBatch()` builds one tool-result per non-approval request via `createRuntimeToolResultFromValue` (the shared `action.result` coercion point).
- `resolvePendingInput()` returns it as `answeredActions`.
- The tool loop emits each as a non-rejected `action.result`.

Approval requests are intentionally excluded: an approved call runs and emits its own result, and a denied call is already surfaced by `buildRejectedActionBatch`.

## Testing

- New unit test in `input-requests.test.ts`: a resolved question produces an `answeredActions` batch (and no `rejectedActions`).
- `pnpm --filter eve typecheck`, `pnpm lint`, and the harness unit suite (`vitest … src/harness/`, 409 tests) pass locally.
- Changeset included (`patch`).
