### PR TITLE
docs: fix /docs/channels link on human-in-the-loop page

### DIFF
--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -295,6 +295,6 @@ The framework handles staging bytes to the sandbox, enforcing upload policy, hyd
 
 ## What to read next
 
-- [Channels overview](./overview)
+- [Channels overview](/docs/channels)
 - [Dynamic capabilities](../guides/dynamic-capabilities)
 - [Auth & route protection](../guides/auth-and-route-protection)

--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent from Discord HTTP Interactions, including slash c
 type: integration
 ---
 
-The Discord channel wires your agent into Discord's HTTP Interactions, including slash and application commands, message components, and modal submissions. Discord enforces a three-second ACK deadline, so the channel verifies the Ed25519 signature headers, acknowledges the command right away, and runs the eve work in the background. See [Channels](./overview) for the contract this builds on.
+The Discord channel wires your agent into Discord's HTTP Interactions, including slash and application commands, message components, and modal submissions. Discord enforces a three-second ACK deadline, so the channel verifies the Ed25519 signature headers, acknowledges the command right away, and runs the eve work in the background. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Add the channel
 
@@ -82,5 +82,5 @@ Inbound file attachments are not supported on this channel today.
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent from GitHub App webhooks, with @mention dispatch,
 type: integration
 ---
 
-The GitHub channel lets the agent work directly on a repository. Someone `@mentions` it in an issue, PR, or review comment, and the agent answers right there in the thread, with the PR diff already in context and the repo checked out into the sandbox. It takes GitHub App webhooks at `/eve/v1/github`, checks the signature, derives auth from whoever triggered the event, and replies on the native surface. See [Channels](./overview) for the contract this builds on.
+The GitHub channel lets the agent work directly on a repository. Someone `@mentions` it in an issue, PR, or review comment, and the agent answers right there in the thread, with the PR diff already in context and the repo checked out into the sandbox. It takes GitHub App webhooks at `/eve/v1/github`, checks the signature, derives auth from whoever triggered the event, and replies on the native surface. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Add the channel
 
@@ -95,5 +95,5 @@ For anything the channel doesn't wrap, call `ctx.github.request({ method, path, 
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/channels/linear.mdx
+++ b/docs/channels/linear.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent through Linear Agent Sessions, with native Agent 
 type: integration
 ---
 
-The Linear channel uses Linear's Agent Session surface rather than ordinary comments. Users delegate work to the agent from Linear, eve receives `AgentSessionEvent` webhooks at `/eve/v1/linear`, and the channel replies with native Agent Activities, including `thought`, `action`, `elicitation`, `response`, and `error`. See [Channels](./overview) for the contract this builds on.
+The Linear channel uses Linear's Agent Session surface rather than ordinary comments. Users delegate work to the agent from Linear, eve receives `AgentSessionEvent` webhooks at `/eve/v1/linear`, and the channel replies with native Agent Activities, including `thought`, `action`, `elicitation`, `response`, and `error`. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Add the channel
 
@@ -157,5 +157,5 @@ For issue or comment targets, the channel calls Linear's proactive Agent Session
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [MCP connections](../connections/mcp): use the Linear MCP connection when the agent needs to inspect or edit Linear data from another channel

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
 description: "How users reach your agent: the channel contract, the base eve HTTP channel, and authoring custom channels."
+url: /channels
 ---
 
 A channel is the edge adapter between a platform and your agent. It does three things:
@@ -30,32 +31,32 @@ Scaffold a channel file with `eve channels add` (interactive), or pass a kind: `
 
 ## The eve HTTP channel (default)
 
-The eve channel is the framework's default HTTP session API, the routes the terminal UI, [`useEveAgent`](../guides/frontend/overview), and `curl` all talk to. It is enabled by default, even with no `agent/channels/eve.ts` file. Add that file only to override the defaults, most often the route auth policy. See [HTTP channel](./eve) for routes, auth, and customization.
+The eve channel is the framework's default HTTP session API, the routes the terminal UI, [`useEveAgent`](/docs/guides/frontend/overview), and `curl` all talk to. It is enabled by default, even with no `agent/channels/eve.ts` file. Add that file only to override the defaults, most often the route auth policy. See [HTTP channel](/docs/channels/eve) for routes, auth, and customization.
 
 ## Custom channels
 
-When eve doesn't ship a channel for your surface, build one with `defineChannel` from `eve/channels`. A custom channel declares route handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `WS`), an `events` map, and a `send` call inside a handler to start or resume a session. See [Custom channels](./custom) for the full walkthrough, including WebSocket routes, cross-channel hand-off, channel metadata, continuation tokens, and file uploads.
+When eve doesn't ship a channel for your surface, build one with `defineChannel` from `eve/channels`. A custom channel declares route handlers (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `WS`), an `events` map, and a `send` call inside a handler to start or resume a session. See [Custom channels](/docs/channels/custom) for the full walkthrough, including WebSocket routes, cross-channel hand-off, channel metadata, continuation tokens, and file uploads.
 
 ## Relationship to the Chat SDK
 
-eve uses the Chat SDK's **card-builder components** (Cards, Buttons, Actions, etc.) for composing rich Slack messages. When you build a card with the [Slack channel](./slack), the underlying primitives come from the Chat SDK and get converted to Slack Block Kit at post time.
+eve uses the Chat SDK's **card-builder components** (Cards, Buttons, Actions, etc.) for composing rich Slack messages. When you build a card with the [Slack channel](/docs/channels/slack), the underlying primitives come from the Chat SDK and get converted to Slack Block Kit at post time.
 
 eve does **not** use the Chat SDK's runtime. The `Chat`, `Adapter`, and `Thread` primitives are never imported or reachable through eve's public API. eve implements its own channel layer (webhook handling, signature verification, event parsing, and thread management). Building Slack messages works like Chat SDK cards, but wiring a channel means authoring against eve's `defineChannel(...)` API, not a Chat SDK adapter.
 
 ## Which channel?
 
-| You want…                                   | Use                                                        |
-| ------------------------------------------- | ---------------------------------------------------------- |
-| A web app / browser chat UI                 | eve channel + [`useEveAgent`](../guides/frontend/overview) |
-| Local tooling, SDK clients, `curl`          | eve channel (default)                                      |
-| Slack mentions, DMs, buttons                | [Slack](./slack)                                           |
-| Discord slash commands, components          | [Discord](./discord)                                       |
-| Microsoft Teams messages + Adaptive Cards   | [Teams](./teams)                                           |
-| Telegram bot messages                       | [Telegram](./telegram)                                     |
-| SMS or speech-transcribed phone calls       | [Twilio](./twilio)                                         |
-| GitHub @mentions, PR review with checkout   | [GitHub](./github)                                         |
-| Linear issue delegation and Agent Sessions  | [Linear](./linear)                                         |
-| Anything else (internal webhook, WebSocket) | Custom channel (`defineChannel`, above)                    |
+| You want…                                   | Use                                                           |
+| ------------------------------------------- | ------------------------------------------------------------- |
+| A web app / browser chat UI                 | eve channel + [`useEveAgent`](/docs/guides/frontend/overview) |
+| Local tooling, SDK clients, `curl`          | eve channel (default)                                         |
+| Slack mentions, DMs, buttons                | [Slack](/docs/channels/slack)                                 |
+| Discord slash commands, components          | [Discord](/docs/channels/discord)                             |
+| Microsoft Teams messages + Adaptive Cards   | [Teams](/docs/channels/teams)                                 |
+| Telegram bot messages                       | [Telegram](/docs/channels/telegram)                           |
+| SMS or speech-transcribed phone calls       | [Twilio](/docs/channels/twilio)                               |
+| GitHub @mentions, PR review with checkout   | [GitHub](/docs/channels/github)                               |
+| Linear issue delegation and Agent Sessions  | [Linear](/docs/channels/linear)                               |
+| Anything else (internal webhook, WebSocket) | Custom channel (`defineChannel`, above)                       |
 
 ## Disclaimer
 
@@ -65,7 +66,7 @@ Where an eve agent communicates with people, you may be required to disclose tha
 
 ## What to read next
 
-- [Slack](./slack): the most common platform channel, end to end
-- [Custom channels](./custom): build a channel for any surface with `defineChannel`
-- [Frontend](../guides/frontend/overview): browser chat on the eve channel with `useEveAgent`
+- [Slack](/docs/channels/slack): the most common platform channel, end to end
+- [Custom channels](/docs/channels/custom): build a channel for any surface with `defineChannel`
+- [Frontend](/docs/guides/frontend/overview): browser chat on the eve channel with `useEveAgent`
 - [Integrations](/integrations): browse every built-in channel and connection in one gallery

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent from Slack app mentions and DMs, with thread anch
 type: integration
 ---
 
-The Slack channel puts your agent inside a workspace. It answers `@mentions` and DMs, replies in threads, shows typing indicators, and turns human-in-the-loop (HITL) prompts into buttons. Use it when the conversation should happen where your team already works. Credentials run through [Vercel Connect](../guides/auth-and-route-protection), which handles both the outbound bot token and inbound webhook verification, so there's no `SLACK_BOT_TOKEN` or `SLACK_SIGNING_SECRET` for you to manage. See [Channels](./overview) for the contract this builds on.
+The Slack channel puts your agent inside a workspace. It answers `@mentions` and DMs, replies in threads, shows typing indicators, and turns human-in-the-loop (HITL) prompts into buttons. Use it when the conversation should happen where your team already works. Credentials run through [Vercel Connect](../guides/auth-and-route-protection), which handles both the outbound bot token and inbound webhook verification, so there's no `SLACK_BOT_TOKEN` or `SLACK_SIGNING_SECRET` for you to manage. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Set up Connect
 
@@ -121,5 +121,5 @@ Inbound files behind authenticated Slack URLs are staged with `fetchFile`. See [
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent from Microsoft Teams via the Bot Framework Activi
 type: integration
 ---
 
-The Teams channel runs your agent inside Microsoft Teams as a bot. It takes Bot Framework Activity POSTs, checks the Bot Connector bearer JWT on each one, and routes message activities to your agent. Human-in-the-loop (HITL) prompts come back as Adaptive Cards, and replies go out over the Bot Framework Connector REST API. See [Channels](./overview) for the contract this builds on.
+The Teams channel runs your agent inside Microsoft Teams as a bot. It takes Bot Framework Activity POSTs, checks the Bot Connector bearer JWT on each one, and routes message activities to your agent. Human-in-the-loop (HITL) prompts come back as Adaptive Cards, and replies go out over the Bot Framework Connector REST API. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Add the channel
 
@@ -63,5 +63,5 @@ export default teamsChannel({
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent from Telegram bot webhooks, with inline-keyboard 
 type: integration
 ---
 
-The Telegram channel puts your agent behind a Telegram bot. It takes Bot API webhooks, checks the `X-Telegram-Bot-Api-Secret-Token` header before trusting anything, and routes the messages it cares about (private chats plus group messages that address the bot) to a reply over `sendMessage`. See [Channels](./overview) for the contract this builds on.
+The Telegram channel puts your agent behind a Telegram bot. It takes Bot API webhooks, checks the `X-Telegram-Bot-Api-Secret-Token` header before trusting anything, and routes the messages it cares about (private chats plus group messages that address the bot) to a reply over `sendMessage`. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Add the channel
 
@@ -68,5 +68,5 @@ export default telegramChannel({
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/channels/twilio.mdx
+++ b/docs/channels/twilio.mdx
@@ -4,7 +4,7 @@ description: "Reach your agent over SMS and speech-transcribed phone calls with 
 type: integration
 ---
 
-The Twilio channel puts your agent on a phone number, so people can text it or call it. Inbound SMS arrives as a webhook. Inbound calls are answered with TwiML `<Gather input="speech">`, and the resulting transcript feeds the same eve session that SMS uses, so a caller and a texter look identical downstream. Every request is checked against `X-Twilio-Signature` before anything else runs. The raw continuation token is `From:To`. See [Channels](./overview) for the contract this builds on.
+The Twilio channel puts your agent on a phone number, so people can text it or call it. Inbound SMS arrives as a webhook. Inbound calls are answered with TwiML `<Gather input="speech">`, and the resulting transcript feeds the same eve session that SMS uses, so a caller and a texter look identical downstream. Every request is checked against `X-Twilio-Signature` before anything else runs. The raw continuation token is `From:To`. See [Channels](/docs/channels) for the contract this builds on.
 
 ## Add the channel
 
@@ -80,5 +80,5 @@ For example, you may be required to inform callers and texters that calls are re
 
 ## What to read next
 
-- [Channels overview](./overview): the channel contract and every built-in channel
+- [Channels overview](/docs/channels): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic

--- a/docs/concepts/security-model.md
+++ b/docs/concepts/security-model.md
@@ -54,7 +54,7 @@ Credential brokering gives the model _authenticated_ network access from inside 
 
 ## Channel verification
 
-A [channel](../channels/overview) is your agent's front door, so authenticating inbound traffic is its job. The built-in platform channels follow two rules, and so must any channel you write yourself:
+A [channel](/docs/channels) is your agent's front door, so authenticating inbound traffic is its job. The built-in platform channels follow two rules, and so must any channel you write yourself:
 
 - **Verify signatures in constant time.** Platform channels (Slack, GitHub,
   Telegram, Twilio) verify the platform's HMAC signature over the raw request body

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -126,6 +126,6 @@ The order is structural, not incidental. By the time a resolver or hook reads ch
 ## What to read next
 
 - [Execution model & durability](./execution-model-and-durability): what makes a session durable and how parked work resumes.
-- [Channels](../channels/overview): what owns the continuation token and delivery.
+- [Channels](/docs/channels): what owns the continuation token and delivery.
 - [TypeScript SDK](../guides/client/overview): call these routes from scripts and server-side code.
 - [Frontend](../guides/frontend/overview): `useEveAgent` instead of raw routes.

--- a/docs/evals/targets.mdx
+++ b/docs/evals/targets.mdx
@@ -45,4 +45,4 @@ After verification, eve sends the available Vercel credentials:
 
 - [Running evals](./running): `--url` and the rest of the CLI in practice
 - [Schedules](../schedules): the surface `dispatchSchedule` drives
-- [Channels](../channels/overview): ingress you can exercise with `target.fetch`
+- [Channels](/docs/channels): ingress you can exercise with `target.fetch`

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -199,7 +199,7 @@ To add a platform channel after setup, run `eve channels add slack` from an inte
 ## What to read next
 
 - [Instructions](./instructions) and [Tools](./tools): the core building blocks
-- [Channels](./channels/overview): reach the agent from Slack, Discord, or a web UI
+- [Channels](/docs/channels): reach the agent from Slack, Discord, or a web UI
 - [Frontend](./guides/frontend/overview): browser chat with `useEveAgent`
 - [TypeScript SDK](./guides/client/overview): call the agent from scripts or server-side code
 - [Sessions, runs and streaming](./concepts/sessions-runs-and-streaming): the durable session model

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -70,7 +70,7 @@ import { localDev, vercelOidc } from "eve/channels/auth";
 export default eveChannel({ auth: [vercelOidc(), localDev()] });
 ```
 
-For a public demo, use `none()` (also from `eve/channels/auth`) to skip authentication. See [Channels](../../channels/overview) and [Auth & route protection](../auth-and-route-protection).
+For a public demo, use `none()` (also from `eve/channels/auth`) to skip authentication. See [Channels](/docs/channels) and [Auth & route protection](../auth-and-route-protection).
 
 ## Dev vs deploy topology
 

--- a/docs/guides/frontend/nuxt.mdx
+++ b/docs/guides/frontend/nuxt.mdx
@@ -69,7 +69,7 @@ import { localDev, vercelOidc } from "eve/channels/auth";
 export default eveChannel({ auth: [vercelOidc(), localDev()] });
 ```
 
-For a public demo, use `none()` (also from `eve/channels/auth`) to skip authentication. See [Channels](../../channels/overview) and [Auth & route protection](../auth-and-route-protection).
+For a public demo, use `none()` (also from `eve/channels/auth`) to skip authentication. See [Channels](/docs/channels) and [Auth & route protection](../auth-and-route-protection).
 
 ## Dev vs deploy topology
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -7,7 +7,7 @@ The frontend helpers put a browser chat or agent UI on top of an eve agent. `use
 
 ## The integration model
 
-A browser UI is a client of the agent's HTTP routes (the [eve channel](../../channels/overview)). Two layers wire it up:
+A browser UI is a client of the agent's HTTP routes (the [eve channel](/docs/channels)). Two layers wire it up:
 
 - **The framework integration** mounts the eve routes on your app's origin, so the browser never crosses a CORS boundary or reads an env var to find the agent. Pick yours: [Next.js](./nextjs) (`withEve`), [Nuxt](./nuxt) (the `eve/nuxt` module), or [SvelteKit](./sveltekit) (the `eveSvelteKit` Vite plugin). On any other stack the hook talks to same-origin `/eve/v1/*` routes directly, or you pass an explicit `host`.
 - **The hook** (`useEveAgent`) holds the session state, streaming, errors, and composer status. It defaults to same-origin eve routes such as `/eve/v1/session`.
@@ -279,6 +279,6 @@ const agent = useEveAgent({
 ## What to read next
 
 - [Sessions, runs & streaming](../../concepts/sessions-runs-and-streaming): the event stream and session cursor
-- [Channels](../../channels/overview): the HTTP routes the hook talks to
+- [Channels](/docs/channels): the HTTP routes the hook talks to
 - [TypeScript SDK](../client/overview): the lower-level client underneath the frontend hooks
 - [Next.js](./nextjs): step-by-step setup for wiring eve into a Next.js app

--- a/docs/guides/frontend/sveltekit.mdx
+++ b/docs/guides/frontend/sveltekit.mdx
@@ -78,7 +78,7 @@ import { localDev, vercelOidc } from "eve/channels/auth";
 export default eveChannel({ auth: [vercelOidc(), localDev()] });
 ```
 
-For a public demo, use `none()` (also from `eve/channels/auth`) to skip authentication. See [Channels](../../channels/overview) and [Auth & route protection](../auth-and-route-protection).
+For a public demo, use `none()` (also from `eve/channels/auth`) to skip authentication. See [Channels](/docs/channels) and [Auth & route protection](../auth-and-route-protection).
 
 ## Dev vs deploy topology
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -31,7 +31,7 @@ You can understand most eve projects by reading that tree:
 - [`agent.ts`](./agent-config) chooses the model and configures runtime options.
 - [`tools/`](./tools) holds typed functions the model can call.
 - [`skills/`](./skills) holds longer procedures the model loads only when they are useful.
-- [`channels/`](./channels/overview) connect the agent to HTTP clients, Slack, Discord, and the other places people talk to it.
+- [`channels/`](/docs/channels) connect the agent to HTTP clients, Slack, Discord, and the other places people talk to it.
 
 Start with only `instructions.md` and `agent.ts`. Add the other folders when the agent needs them.
 
@@ -98,6 +98,6 @@ The result stays readable before it runs. The directory tells you what the agent
 - [Getting started](./getting-started): scaffold and run your first agent
 - [Tools](./tools): the typed actions your agent calls
 - [Instructions](./instructions): the always-on system prompt that shapes behavior
-- [Channels](./channels/overview): reach the agent from Slack, Discord, or a web UI
+- [Channels](/docs/channels): reach the agent from Slack, Discord, or a web UI
 - [Connections](./connections): pull in tools from external services
 - [Project layout](./reference/project-layout): every authored slot under `agent/`

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -38,7 +38,7 @@ export default defineTool({
 | `defineMcpClientConnection`                           | `eve/connections`                             | `agent/connections/<name>.ts`        | [MCP connections](../connections/mcp)                  |
 | `defineOpenAPIConnection`                             | `eve/connections`                             | `agent/connections/<name>.ts`        | [OpenAPI connections](../connections/openapi)          |
 | `defineChannel`                                       | `eve/channels`                                | `agent/channels/<name>.ts`           | [Custom channels](../channels/custom)                  |
-| `eveChannel`, `slackChannel`, and the other platforms | `eve/channels/<platform>`                     | `agent/channels/<platform>.ts`       | [Channels](../channels/overview)                       |
+| `eveChannel`, `slackChannel`, and the other platforms | `eve/channels/<platform>`                     | `agent/channels/<platform>.ts`       | [Channels](/docs/channels)                             |
 | `defineSkill`                                         | `eve/skills`                                  | `agent/skills/<name>.ts`             | [Skills](../skills)                                    |
 | `defineInstructions`                                  | `eve/instructions`                            | `agent/instructions.ts`              | [Instructions](../instructions)                        |
 | `defineHook`                                          | `eve/hooks`                                   | `agent/hooks/<slug>.ts`              | [Hooks](../guides/hooks)                               |

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -110,5 +110,5 @@ The gotcha is custom hosting. If you adapt the generated output to a process man
 
 ## What to read next
 
-- [Channels](./channels/overview): deliver schedule output to users.
+- [Channels](/docs/channels): deliver schedule output to users.
 - [Sessions, runs & streaming](./concepts/sessions-runs-and-streaming): inspect a schedule run.


### PR DESCRIPTION
Fixes #478

### Problem

On [Human-in-the-loop → Answering from a client or channel](https://eve.dev/docs/human-in-the-loop#answering-from-a-client-or-channel), the inline link **channel** points to `/docs/channels`, which returns **404** on eve.dev today. The channels overview only existed at `/docs/channels/overview`.

Connections and tools already expose short section URLs via frontmatter (`url: /connections`, `url: /tools` on their overview pages). Channels overview did not, so the HITL copy was inconsistent with how other sections are linked.

### Verification (before)

| URL | eve.dev (prod) |
|-----|----------------|
| `/docs/channels` | **404** |
| `/docs/channels/overview` | 200 |
| `/docs/connections` | 200 |
| `/docs/connections/overview` | 404 (expected with alias) |

HITL source: `docs/tools/human-in-the-loop.md` links to `[channel](/docs/channels)`.

### Fix

- Add `url: /channels` to `docs/channels/overview.mdx` (parity with connections/tools).
- Update internal doc links that targeted `channels/overview` or `./overview` under `docs/channels/` to `/docs/channels` or absolute `/docs/channels/...` paths, because the URL alias changes how relative links resolve on the overview page (fumadocs serves it at `/docs/channels`).

No changeset (docs-only).

### Verification (after)

- `pnpm docs:check` (frontmatter, nav, internal links, snippets, MDX compile)
- `pnpm --filter eve-docs build`: Next.js build succeeded
- Local `next start`: `GET /docs/channels` → **200** (middleware rewrite to `/en/docs/channels`)

### How to test

1. `pnpm docs:check`
2. `pnpm --filter eve-docs build && pnpm --filter eve-docs start`
3. Open `http://localhost:3000/docs/channels` and confirm channels overview renders.
4. From Human-in-the-loop, confirm the **channel** link targets `/docs/channels`.

### PR checklist

- [x] Linked issue #478
- [x] Ran `pnpm docs:check`
- [x] Tests/docs where relevant (docs link + site build)
- [ ] No changeset (published `eve` package unchanged)
- [x] DCO sign-off (`git commit -s`)