### PR TITLE
fix(eve): dev runtime - reduce snapshot disk usage

### DIFF
--- a/.changeset/fix-dev-runtime-snapshots.md
+++ b/.changeset/fix-dev-runtime-snapshots.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reduce development runtime snapshot disk usage by excluding `.env*`, generated dependency, and build output directories, using clone-friendly file copies where supported, and pruning stale snapshots after dev rebuilds.

--- a/e2e/fixtures/agent-tools/evals/channel-metadata/shared.ts
+++ b/e2e/fixtures/agent-tools/evals/channel-metadata/shared.ts
@@ -9,7 +9,9 @@ import type { EveEvalTargetHandle } from "eve/evals";
  * cross-checks happen inside `run()` where the attached stream is in hand.
  */
 export const METADATA_TOOL = "dynamic-channel-metadata";
-export const PROMPT = "Call the `dynamic-channel-metadata` tool and report everything it returned.";
+export const PROMPT =
+  "If the `dynamic-channel-metadata` tool is available, call it and report everything it returned. " +
+  "If the tool is not available, reply exactly: metadata tool unavailable. Do not ask for more information.";
 
 export async function startChannelSession(
   target: EveEvalTargetHandle,

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -184,6 +184,47 @@ describe("development runtime artifact snapshots", () => {
     });
   });
 
+  it("excludes generated output and dependency directories from source snapshots", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-generated-output-");
+    const agentRoot = join(appRoot, "agent");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+    const manifestPath = join(compileDirectoryPath, "compiled-agent-manifest.json");
+
+    await mkdir(agentRoot, { recursive: true });
+    await mkdir(join(appRoot, "node_modules", "heavy-package"), { recursive: true });
+    await mkdir(join(appRoot, ".next", "cache"), { recursive: true });
+    await mkdir(join(appRoot, ".generated", "compiled"), { recursive: true });
+    await mkdir(join(appRoot, "build"), { recursive: true });
+    await mkdir(join(appRoot, "dist"), { recursive: true });
+    await mkdir(compileDirectoryPath, { recursive: true });
+    await writeFile(join(appRoot, ".env"), "SECRET=default\n");
+    await writeFile(join(appRoot, ".env.local"), "SECRET=local\n");
+    await writeFile(join(appRoot, ".env.example"), "SECRET=example\n");
+    await writeFile(join(appRoot, "package.json"), '{"type":"module"}\n');
+    await writeFile(join(agentRoot, "agent.ts"), "export const answer = 42;\n");
+    await writeFile(join(appRoot, "node_modules", "heavy-package", "index.js"), "export {}\n");
+    await writeFile(join(appRoot, ".next", "cache", "webpack.bin"), "cache\n");
+    await writeFile(join(appRoot, ".generated", "compiled", "bundle.js"), "generated\n");
+    await writeFile(join(appRoot, "build", "server.js"), "build\n");
+    await writeFile(join(appRoot, "dist", "index.js"), "dist\n");
+    await writeFile(manifestPath, `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`);
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+
+    expect(existsSync(join(snapshot.runtimeAppRoot, "agent", "agent.ts"))).toBe(true);
+    expect(existsSync(join(snapshot.runtimeAppRoot, "node_modules"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".env"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".env.local"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".env.example"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".next"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".generated"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, "build"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, "dist"))).toBe(false);
+  });
+
   it("prunes stale snapshots while preserving the active and recent snapshots", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-");
     const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
@@ -556,6 +597,8 @@ describe("development runtime artifact snapshots", () => {
 
     await mkdir(agentRoot, { recursive: true });
     await mkdir(join(packageRoot, "src"), { recursive: true });
+    await mkdir(join(packageRoot, "build"), { recursive: true });
+    await mkdir(join(packageRoot, "dist"), { recursive: true });
     await mkdir(join(packageRoot, "node_modules"), { recursive: true });
     await mkdir(externalPackageRoot, { recursive: true });
     await mkdir(join(workspaceRoot, "packages", "unused"), { recursive: true });
@@ -591,7 +634,7 @@ describe("development runtime artifact snapshots", () => {
           dependencies: {
             "external-message": "1.0.0",
           },
-          exports: "./src/index.ts",
+          exports: "./dist/index.js",
           name: "@repo/message",
           type: "module",
         },
@@ -618,6 +661,11 @@ describe("development runtime artifact snapshots", () => {
     );
     await writeFile(
       join(packageRoot, "src", "index.ts"),
+      'export const sourceMessage = "snapshotted-source";\n',
+    );
+    await writeFile(join(packageRoot, "build", "artifact.js"), "build output\n");
+    await writeFile(
+      join(packageRoot, "dist", "index.js"),
       'import { externalMessage } from "external-message";\nexport const message = `snapshotted:${externalMessage}`;\n',
     );
     await writeFile(
@@ -641,9 +689,13 @@ describe("development runtime artifact snapshots", () => {
       project: { appRoot },
     } as CompileAgentResult);
 
-    await writeFile(join(packageRoot, "src", "index.ts"), 'export const message = "live";\n');
+    await writeFile(join(packageRoot, "dist", "index.js"), 'export const message = "live";\n');
 
     expect(existsSync(join(snapshot.snapshotSourceRoot, "packages", "message"))).toBe(true);
+    expect(existsSync(join(snapshot.snapshotSourceRoot, "packages", "message", "build"))).toBe(
+      true,
+    );
+    expect(existsSync(join(snapshot.snapshotSourceRoot, "packages", "message", "dist"))).toBe(true);
     expect(existsSync(join(snapshot.snapshotSourceRoot, "packages", "unused"))).toBe(false);
     await expect(
       lstat(

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { constants as fsConstants, existsSync } from "node:fs";
 import { cp, lstat, mkdir, readFile, readdir, symlink, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 
@@ -17,14 +17,18 @@ import {
 } from "#internal/nitro/dev-runtime-source-snapshot.js";
 
 const SNAPSHOT_SKIP_NAMES = new Set([
+  ".generated",
   ".eve",
   ".git",
+  ".next",
   ".output",
   ".turbo",
   ".vercel",
   ".workflow-data",
   "node_modules",
 ]);
+const SNAPSHOT_APP_ROOT_SKIP_NAMES = new Set(["build", "dist"]);
+const SNAPSHOT_COPY_MODE = fsConstants.COPYFILE_FICLONE;
 
 export async function copyDevelopmentSourceSnapshot(
   plan: DevelopmentSourceSnapshotPlan,
@@ -71,7 +75,10 @@ async function copySnapshotPath(input: {
     }
 
     await mkdir(dirname(input.targetPath), { recursive: true });
-    await cp(input.sourcePath, input.targetPath, { recursive: true });
+    await cp(input.sourcePath, input.targetPath, {
+      mode: SNAPSHOT_COPY_MODE,
+      recursive: true,
+    });
   } catch (error) {
     throw new DevelopmentRuntimeSourceSnapshotError(
       `Failed to copy development runtime source snapshot path "${input.sourcePath}" to "${input.targetPath}": ${formatErrorMessage(error)}`,
@@ -89,24 +96,56 @@ async function copySnapshotDirectory(input: {
   for (const entry of await readdir(input.sourcePath, { withFileTypes: true })) {
     const sourcePath = join(input.sourcePath, entry.name);
 
-    if (shouldSkipSnapshotSource(input.plan.sourceRoot, sourcePath)) {
+    if (shouldSkipSnapshotSource(input.plan, sourcePath)) {
       continue;
     }
 
     await cp(sourcePath, join(input.targetPath, entry.name), {
-      filter: (source) => !shouldSkipSnapshotSource(input.plan.sourceRoot, source),
+      filter: (source) => !shouldSkipSnapshotSource(input.plan, source),
+      mode: SNAPSHOT_COPY_MODE,
       recursive: true,
     });
   }
 }
 
-function shouldSkipSnapshotSource(sourceRoot: string, sourcePath: string): boolean {
-  const relativePath = relative(sourceRoot, sourcePath);
+function shouldSkipSnapshotSource(
+  plan: DevelopmentSourceSnapshotPlan,
+  sourcePath: string,
+): boolean {
+  const relativePath = relative(plan.sourceRoot, sourcePath);
   if (relativePath.length === 0) {
     return false;
   }
 
-  return relativePath.split(/[\\/]/).some((part) => SNAPSHOT_SKIP_NAMES.has(part));
+  if (
+    relativePath
+      .split(/[\\/]/)
+      .some((part) => SNAPSHOT_SKIP_NAMES.has(part) || part.startsWith(".env"))
+  ) {
+    return true;
+  }
+
+  return isDirectAppRootSkipPath({
+    appRoot: plan.appRoot,
+    sourcePath,
+  });
+}
+
+function isDirectAppRootSkipPath(input: {
+  readonly appRoot: string;
+  readonly sourcePath: string;
+}): boolean {
+  if (!isPathInsideOrEqual(input.sourcePath, input.appRoot)) {
+    return false;
+  }
+
+  const relativePath = relative(input.appRoot, input.sourcePath);
+  if (relativePath.length === 0) {
+    return false;
+  }
+
+  const firstPart = relativePath.split(/[\\/]/)[0];
+  return firstPart !== undefined && SNAPSHOT_APP_ROOT_SKIP_NAMES.has(firstPart);
 }
 
 async function rewriteSnapshotTsConfigAbsoluteExtends(

--- a/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts
@@ -105,6 +105,7 @@ const mockedWatcher = vi.hoisted(() => {
 const prepareApplicationHostMock = vi.hoisted(() => vi.fn());
 const clearCompiledRuntimeAgentBundleCacheMock = vi.hoisted(() => vi.fn());
 const startDevelopmentSandboxPrewarmInBackgroundMock = vi.hoisted(() => vi.fn());
+const pruneDevelopmentRuntimeArtifactsSnapshotsInBackgroundMock = vi.hoisted(() => vi.fn());
 const resolveNitroCompiledArtifactsSourceMock = vi.hoisted(() =>
   vi.fn((config: { readonly appRoot?: string }) => ({
     appRoot: `${config.appRoot ?? "/tmp/eve-test"}/.eve/dev-runtime-test`,
@@ -125,6 +126,17 @@ vi.mock("./prepare-application-host.js", () => ({
 vi.mock("#execution/sandbox/development-prewarm.js", () => ({
   startDevelopmentSandboxPrewarmInBackground: startDevelopmentSandboxPrewarmInBackgroundMock,
 }));
+
+vi.mock("#internal/nitro/dev-runtime-artifacts.js", async () => {
+  const actual = await vi.importActual<typeof import("#internal/nitro/dev-runtime-artifacts.js")>(
+    "#internal/nitro/dev-runtime-artifacts.js",
+  );
+  return {
+    ...actual,
+    pruneDevelopmentRuntimeArtifactsSnapshotsInBackground:
+      pruneDevelopmentRuntimeArtifactsSnapshotsInBackgroundMock,
+  };
+});
 
 vi.mock("#internal/nitro/routes/runtime-artifacts.js", () => ({
   resolveNitroCompiledArtifactsSource: resolveNitroCompiledArtifactsSourceMock,
@@ -159,6 +171,7 @@ beforeEach(() => {
   prepareApplicationHostMock.mockReset();
   clearCompiledRuntimeAgentBundleCacheMock.mockReset();
   startDevelopmentSandboxPrewarmInBackgroundMock.mockReset();
+  pruneDevelopmentRuntimeArtifactsSnapshotsInBackgroundMock.mockReset();
   resolveNitroCompiledArtifactsSourceMock.mockClear();
 });
 
@@ -191,6 +204,9 @@ describe("startAuthoredSourceWatcher", () => {
       await watcher.rebuild();
 
       expect(prepareApplicationHostMock).toHaveBeenCalledWith(previousHost.appRoot, { dev: true });
+      expect(pruneDevelopmentRuntimeArtifactsSnapshotsInBackgroundMock).toHaveBeenCalledWith(
+        nextHost.appRoot,
+      );
       expect(clearCompiledRuntimeAgentBundleCacheMock).toHaveBeenCalledTimes(1);
     } finally {
       await watcher.close();

--- a/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.ts
+++ b/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.ts
@@ -7,6 +7,7 @@ import { toErrorMessage } from "#shared/errors.js";
 import { resolveTsConfigDependencyPaths } from "#internal/application/tsconfig-dependencies.js";
 import { createNitroArtifactsConfig } from "#internal/nitro/host/artifacts-config.js";
 import { resolveDevelopmentSourceSnapshotWatchPaths } from "#internal/nitro/dev-runtime-source-snapshot.js";
+import { pruneDevelopmentRuntimeArtifactsSnapshotsInBackground } from "#internal/nitro/dev-runtime-artifacts.js";
 import { startDevelopmentSandboxPrewarmInBackground } from "#execution/sandbox/development-prewarm.js";
 import {
   computeChannelRouteRegistrations,
@@ -144,6 +145,9 @@ export async function startAuthoredSourceWatcher(input: {
           const nextHost = await prepareApplicationHost(previousHost.appRoot, {
             dev: input.nitro.options.dev === true,
           });
+          if (input.nitro.options.dev === true) {
+            pruneDevelopmentRuntimeArtifactsSnapshotsInBackground(nextHost.appRoot);
+          }
           const artifactsConfig = createNitroArtifactsConfig({
             appRoot: nextHost.appRoot,
             dev: input.nitro.options.dev === true,


### PR DESCRIPTION
## Summary
- exclude `.env*`, dependency, and generated framework/cache directories from dev runtime source snapshots
- skip app-root `build`/`dist` output while preserving `build`/`dist` inside linked local workspace packages
- request clone-friendly file copies where the filesystem supports it, and prune stale dev runtime snapshots after successful `eve dev` rebuilds
- harden the `agent-tools` negative-control eval so a missing dynamic tool completes instead of parking on a human-input request

## Root Cause
The dev runtime source snapshot copier traversed authored roots without skipping sensitive local env files or several generated directories, and long-lived dev rebuilds only accumulated snapshots until the next startup prune. A blanket `build`/`dist` exclusion breaks local-package e2e fixtures because workspace packages can export their built `dist` files through app `node_modules` symlinks, so this keeps those outputs only for linked local packages.

While validating the fix, the original all-fixture local e2e module-resolution failure narrowed to one unrelated `agent-tools` eval where the model asked for input when a dynamic tool was intentionally unavailable. The eval prompt now makes that fallback deterministic.

Fixes #487

## Tests
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm exec oxlint packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts packages/eve/src/internal/nitro/host/dev-authored-source-watcher.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts packages/eve/src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts e2e/fixtures/agent-tools/evals/channel-metadata/shared.ts e2e/fixtures/agent-tools/evals/channel-metadata/anchored-no-topic.eval.ts`
- `pnpm exec oxfmt --check packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts packages/eve/src/internal/nitro/host/dev-authored-source-watcher.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts packages/eve/src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts .changeset/fix-dev-runtime-snapshots.md e2e/fixtures/agent-tools/evals/channel-metadata/shared.ts e2e/fixtures/agent-tools/evals/channel-metadata/anchored-no-topic.eval.ts`
- `git diff --check`