### PR TITLE
fix(eve): propagate terminal subagent model-call failures to the parent

### DIFF
--- a/.changeset/subagent-terminal-error-propagation.md
+++ b/.changeset/subagent-terminal-error-propagation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Terminal model-call failures in delegated subagent runs (e.g. an unresolvable model id returning 404) now propagate to the parent as a failed subagent result instead of a successful empty output, so orchestrator sessions no longer report success when a delegation failed.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -2556,6 +2556,39 @@ describe("createToolLoopHarness", () => {
     expect(types).not.toContain("session.waiting");
   });
 
+  it("surfaces a terminal model-call error to the parent as a failed task result", async () => {
+    // Regression test for https://github.com/vercel/eve/issues/412 — a
+    // delegated subagent runs in task mode; when its model id does not
+    // resolve (terminal 404), the failure must reach the parent as an
+    // error result, not a successful empty output.
+    const error = Object.assign(new Error("No endpoints found for anthropic/claude-3.5-haiku"), {
+      name: "AI_APICallError",
+      statusCode: 404,
+    });
+    setupMockAgentError(error);
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("task", emit));
+
+    const result = await runStep(createTestSession(), { message: "Delegated task" });
+
+    // The task's terminal result must be marked as an error with the
+    // failure message as output, mirroring the non-terminal task-mode
+    // failure shape. Today the terminal branch returns
+    // `{ done: true, output: "" }`, which the parent driver treats as a
+    // successful delegation with empty output.
+    expect(result.next).toMatchObject({
+      done: true,
+      isError: true,
+      output: expect.stringContaining("No endpoints found for anthropic/claude-3.5-haiku"),
+    });
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("step.failed");
+    expect(types).toContain("turn.failed");
+    expect(types).toContain("session.failed");
+  });
+
   it("emits the full terminal failure cascade on an explicit Gateway invalid-request error", async () => {
     setupMockAgentError(
       createGatewayModelCallError({

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -987,8 +987,15 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             message: errorMessage,
             sessionId: session.sessionId,
           });
+          // In task mode (delegated subagent runs) the terminal failure
+          // must be the task's error result so the parent driver resumes
+          // with a failed `subagent-result` instead of a successful empty
+          // output (https://github.com/vercel/eve/issues/412).
           return {
-            next: { done: true, output: "" },
+            next:
+              config.mode === "task"
+                ? { done: true, isError: true, output: errorMessage }
+                : { done: true, output: "" },
             session,
           };
         }


### PR DESCRIPTION
Fixes #412.

## What

- Terminal model-call failures in task-mode runs now produce `{ done: true, isError: true, output: errorMessage }` instead of the success shape `{ done: true, output: "" }` (`tool-loop.ts`)
- Regression test reproducing the issue's exact scenario: task mode + 404 `AI_APICallError`
- Changeset (patch)

## The bug

From #412: a subagent pointed at a retired model slug 404'd on every call, yet the orchestrator reported "completed successfully". The only trace of the failure was on the child session's stream:

```
MODEL_CALL_FAILED — No endpoints found for anthropic/claude-3.5-haiku (404)
```

The broken boundary is the terminal branch of the model-call error handler in `tool-loop.ts`. Non-terminal errors already had a task-mode arm returning the error shape, but terminal errors (structural 4xx — exactly what a bad model id produces) returned `{ done: true, output: "" }` before ever checking the mode. Since delegated subagents always run in task mode, `finalizeDone` in `workflow-entry.ts` saw `isError !== true` and resumed the parent via `createDelegatedSubagentSuccessResult` — a clean empty answer.

## The fix

One conditional in the terminal branch: task mode returns the same error shape the non-terminal task-mode branch already used. Everything downstream is existing machinery — `turn-workflow` forwards `isError`, `finalizeDone` fires the session callback with `status: "failed"` and resumes the parent with `SUBAGENT_EXECUTION_FAILED` carrying the real error message.

Conversation-mode terminal behavior is unchanged: the session still tears down with `session.failed` and empty output, and existing tests assert that shape.

## Not addressed

Issue suggestion 3 (fail fast on an unresolvable model id at startup) is a separate startup-validation concern; this PR covers the propagation path (suggestions 1, 2, and 4).
