### PR TITLE
fix(eve): drain Microsandbox sessions on dispose

### DIFF
--- a/.changeset/drain-microsandbox-sessions.md
+++ b/.changeset/drain-microsandbox-sessions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Drain Microsandbox VMs when disposing eve sandbox handles so detached sessions do not remain running after the client is released.

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.test.ts
@@ -148,6 +148,28 @@ describe("createMicrosandboxHandle", () => {
     });
   });
 
+  it("requests a VM drain before detaching a disposed session handle", async () => {
+    const vm = createFakeMicrosandboxVm("session-key");
+    runtimeMocks.createPreparedMicrosandbox.mockResolvedValue(vm);
+    const options = resolveMicrosandboxOptions({ image: MICROSANDBOX_DEFAULT_IMAGE });
+
+    const handle = await createMicrosandboxHandle({
+      backendName: "microsandbox",
+      createInput: {
+        runtimeContext: { appRoot: "/tmp/eve-app" },
+        sessionKey: "session-key",
+        templateKey: "template-key",
+      },
+      options,
+      optionsHash: "options-hash",
+    });
+
+    await handle.dispose();
+
+    expect(vm.drainAndDetach).toHaveBeenCalledTimes(1);
+    expect(vm.detach).not.toHaveBeenCalled();
+  });
+
   it("reports a missing template snapshot race as not provisioned", async () => {
     runtimeMocks.createPreparedMicrosandbox.mockRejectedValueOnce(
       new Error("snapshot template-snapshot not found"),
@@ -228,7 +250,8 @@ function createFakeMicrosandboxVm(sessionKey: string) {
         version: 2,
       };
     },
-    async detach() {},
+    detach: vi.fn(async () => {}),
+    drainAndDetach: vi.fn(async () => {}),
     async readFileBytes(path: string) {
       return files.get(path) ?? null;
     },

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.ts
@@ -310,7 +310,7 @@ function createHandle(
     },
     async dispose() {
       onDispose?.();
-      await sandbox.detach();
+      await sandbox.drainAndDetach();
     },
   };
 }

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.test.ts
@@ -193,6 +193,34 @@ describe.skipIf(process.platform === "win32")("connectMicrosandbox", () => {
 });
 
 describe.skipIf(process.platform === "win32")("MicrosandboxVm", () => {
+  it("drains the sandbox before detaching the SDK client", async () => {
+    const sandbox = {
+      detach: vi.fn(async () => {}),
+      drain: vi.fn(async () => {}),
+    };
+    const vm = new MicrosandboxVm(
+      {
+        module: {} as never,
+        options: resolveMicrosandboxOptions({ image: MICROSANDBOX_DEFAULT_IMAGE }),
+        sessionKey: "session-key",
+      },
+      sandbox as never,
+      "sandbox-name",
+      undefined,
+    );
+
+    await vm.drainAndDetach();
+
+    expect(sandbox.drain).toHaveBeenCalledTimes(1);
+    expect(sandbox.detach).toHaveBeenCalledTimes(1);
+    const drainOrder = sandbox.drain.mock.invocationCallOrder[0];
+    const detachOrder = sandbox.detach.mock.invocationCallOrder[0];
+    if (drainOrder === undefined || detachOrder === undefined) {
+      throw new Error("Expected drain and detach to be called.");
+    }
+    expect(drainOrder).toBeLessThan(detachOrder);
+  });
+
   it("finishes streamed commands when the exec handle emits an exit event", async () => {
     const sandbox = {
       async execStreamWith() {

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-runtime.ts
@@ -127,6 +127,11 @@ export class MicrosandboxVm {
     await this.#sandbox.detach().catch(() => {});
   }
 
+  async drainAndDetach(): Promise<void> {
+    await this.#sandbox.drain().catch(() => {});
+    await this.detach();
+  }
+
   async readFileBytes(path: string): Promise<Buffer | null> {
     try {
       const fs = this.#sandbox.fs();


### PR DESCRIPTION
## Related issue

- Related issue: #504

## Motivation

While investigating a local eve development run, the machine rapidly drained battery and the fan spun up. The immediate cause was one or more `msb sandbox` processes continuing to consume CPU after the process that started the eve session had exited.

Those `msb` processes were detached Microsandbox VMs. eve creates Microsandbox sessions in detached mode so they can survive SDK client reconnects, but sandbox handle disposal only released the SDK client with `detach()`. If the normal development cleanup path does not run, the VM can remain independently running even though eve has released the session handle.

This draft change makes disposal drain the Microsandbox VM before detaching the SDK client. The direction needs maintainer confirmation because `dispose()` may be part of the reusable detached-session contract, while terminal development cleanup may need a separate stop/snapshot path.

## Summary

- drain Microsandbox VMs before detaching the SDK client when eve disposes a sandbox handle
- add unit coverage for handle disposal and drain-before-detach ordering
- add a patch changeset for eve

## Open questions for maintainers

I am not certain these lifecycle decisions are mine to make as a contributor, so I would appreciate maintainer direction before this is considered final:

- Should `dispose()` for a Microsandbox handle preserve the reusable detached-session contract, or is it the right place to signal that eve is done with the VM and it should leave the running state?
- If disposal should terminate or wind down the VM, is `drain()` the right Microsandbox primitive, or should eve use a bounded shutdown path such as `stopWithTimeout()` or the existing development cleanup/snapshot flow?
- How should reconnect handle sandboxes whose provider status is `draining`? Should eve continue treating them as connectable live sessions, or should it restore/start from durable state instead?
- Should this behavior apply to all Microsandbox handle disposal paths, or only to development cleanup cases where the user is exiting `eve dev` and wants leftover VMs stopped?
- What level of scenario coverage would maintainers want here: mocked call-order unit tests only, or a real Microsandbox scenario that proves dispose/reconnect or dispose/shutdown behavior end to end?

## Verification

Completed locally:

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/microsandbox-lifecycle.test.ts src/execution/sandbox/bindings/microsandbox-runtime.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm lint`

Pending before this is ready for final review/merge:

- broader `pnpm test` / maintainer-requested scenario coverage after the lifecycle direction is confirmed