### PR TITLE
docs: document PR title convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ the DCO `Signed-off-by` trailer. Use `git commit -s` for every commit, and if a
 commit is missing the trailer, amend it with `git commit --amend -s --no-edit`
 before pushing.
 
+When opening a pull request, use a Conventional Commits-style title for normal
+contribution PRs: `fix(eve): ...`, `feat(eve): ...`, `docs: ...`, or
+`research(eve): ...`. Keep the summary concise, imperative, and lowercase unless
+it names a proper noun.
+
 ## Commands
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,9 @@ To avoid PRs that are unlikely to be reviewed or merged:
    ```
 
 6. Make sure `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass.
-7. Open the PR with a clear description of the problem and solution.
+7. Open the PR with a Conventional Commits-style title, such as
+   `fix(eve): resolve session cleanup` or `docs: clarify PR title format`, and a
+   clear description of the problem and solution.
 
 Releases are managed with [Changesets](https://github.com/changesets/changesets) by the maintainers.
 


### PR DESCRIPTION
### Description

Closes #501.

This documents the repository's Conventional Commits-style PR title convention in both the agent-facing guidance and the contributor workflow:

- adds the PR title rule to AGENTS.md so coding agents see it before opening PRs
- mirrors the same guidance in CONTRIBUTING.md for human contributors

### How did you test your changes?

Docs-only change; no automated tests run.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

Note: this generated workspace does not have `gpg` installed, so the local commit could not be cryptographically signed here.