### PR TITLE
docs: reword agent/ section heading to 'Your agent/ is a directory'

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/file-tree.tsx
+++ b/apps/docs/app/[lang]/(home)/components/file-tree.tsx
@@ -227,6 +227,7 @@ export async function FileTree() {
         heading={
           <div className="mx-auto max-w-5xl">
             <h2 className="text-center font-medium! text-heading-32 tracking-tighter text-gray-1000 sm:text-heading-40">
+              Your{" "}
               <span className="relative -top-[0.08em] ml-1 inline-flex items-center gap-[0.16em] rounded-lg bg-gray-200 px-3 py-[0.04em] pr-4 align-baseline font-[450]!">
                 <IconFolderOpen aria-hidden className="size-[0.58em] text-gray-900" />
                 agent/


### PR DESCRIPTION
Rewords the eve.dev home page section heading from "agent/ is a directory" to "Your agent/ is a directory".

