### PR TITLE
fix(eve): degrade missing attachment bytes on resume instead of failing the turn

### DIFF
--- a/.changeset/honor-missing-attachment-on-resume.md
+++ b/.changeset/honor-missing-attachment-on-resume.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Resuming a durable session that referenced an inbound file attachment no longer fails the turn when the staging sandbox has been torn down. The missing attachment now degrades to a text reference noting the file is unavailable, so the run continues instead of ending in `session.failed`.

--- a/.changeset/honor-missing-attachment-on-resume.md
+++ b/.changeset/honor-missing-attachment-on-resume.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Resuming a durable session that referenced an inbound file attachment no longer fails the turn when the staging sandbox has been torn down. The missing attachment now degrades to a text reference noting the file is unavailable, so the run continues instead of ending in `session.failed`.
+Resuming a durable session whose history references a file attachment no longer fails the turn when the staged bytes are gone (for example after a redeploy pointed the session at a fresh sandbox). The missing attachment degrades to a `FileNotFound` text notice the model can interpret, so the run continues instead of ending in `session.failed`.

--- a/packages/eve/src/harness/attachment-staging.integration.test.ts
+++ b/packages/eve/src/harness/attachment-staging.integration.test.ts
@@ -611,12 +611,16 @@ describe("hydrateSandboxAttachments (integration)", () => {
     expect(hydrated).toBe(messages);
   });
 
-  it("throws a descriptive error when an inlinable sandbox ref points at a missing file", async () => {
+  it("degrades to a text reference when an inlinable sandbox ref points at a missing file", async () => {
+    // Resuming a durable session whose staging sandbox was torn down
+    // leaves historical attachment refs pointing at bytes that are gone.
+    // Hydration must not fail the whole turn over it — it degrades to a
+    // text part so the run survives (#276).
     const sandbox = mockSandbox({ id: "sbx_missing" });
     const runtime = createTestRuntime();
 
     // Ref pointing at a path that was never written. Use an
-    // inlinable media type so the error path (byte read) fires —
+    // inlinable media type so the byte-read path fires —
     // non-inlinable refs never touch the sandbox.
     const danglingRef = new URL(
       "eve-sandbox:?path=%2Fworkspace%2Fattachments%2Fdeadbeefdeadbeef%2Fghost.png&size=5&type=image%2Fpng",
@@ -624,6 +628,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
     const messages = [
       {
         content: [
+          { type: "text", text: "what's in the image?" },
           {
             data: danglingRef,
             filename: "/workspace/attachments/deadbeefdeadbeef/ghost.png",
@@ -635,9 +640,53 @@ describe("hydrateSandboxAttachments (integration)", () => {
       },
     ];
 
-    await expect(
-      runtime.runAsSession({ sandbox }, async () => hydrateSandboxAttachments(messages)),
-    ).rejects.toThrow(/references missing file/);
+    const hydrated = await runtime.runAsSession({ sandbox }, async () =>
+      hydrateSandboxAttachments(messages),
+    );
+
+    const hydratedContent = hydrated[0]?.content as Exclude<UserContent, string>;
+    // The leading text survives and the dangling file ref is replaced by
+    // an unavailability notice — no file part reaches the model.
+    expect(hydratedContent[0]).toEqual({ type: "text", text: "what's in the image?" });
+    expect(hydratedContent[1]).toEqual({
+      text: "Attached file /workspace/attachments/deadbeefdeadbeef/ghost.png (image/png) is no longer available in this session.",
+      type: "text",
+    });
+    const fileParts = hydratedContent.filter((p) => (p as FilePart).type === "file");
+    expect(fileParts).toHaveLength(0);
+  });
+
+  it("survives a resume after the staging sandbox was torn down (#276)", async () => {
+    // Stage an image into one sandbox, then hydrate the resulting
+    // ref-only message against a fresh sandbox — the same shape as
+    // resuming a durable session whose ephemeral sandbox is gone. The
+    // bytes are unreachable, but the turn must not fail.
+    const stagingSandbox = mockSandbox({ id: "sbx_resume_stage" });
+    const runtime = createTestRuntime();
+
+    const stagedContent = (await runtime.runAsSession({ sandbox: stagingSandbox }, async () =>
+      stageAttachmentsToSandbox([
+        { type: "text", text: "describe the image" },
+        { data: smallImageBytes, filename: "logo.png", mediaType: "image/png", type: "file" },
+      ] as UserContent),
+    )) as UserContent;
+
+    const refPart = (stagedContent as FilePart[]).find((p) => p.type === "file") as FilePart;
+    const stagedPath = refPart.filename as string;
+
+    const messages = [{ content: stagedContent, role: "user" as const }];
+    const freshSandbox = mockSandbox({ id: "sbx_resume_fresh" });
+    const hydrated = await runtime.runAsSession({ sandbox: freshSandbox }, async () =>
+      hydrateSandboxAttachments(messages),
+    );
+
+    const hydratedContent = hydrated[0]?.content as Exclude<UserContent, string>;
+    expect(hydratedContent[0]).toEqual({ type: "text", text: "describe the image" });
+    expect(hydratedContent[1]).toEqual({
+      text: `Attached file ${stagedPath} (image/png) is no longer available in this session.`,
+      type: "text",
+    });
+    expect(hydratedContent.filter((p) => (p as FilePart).type === "file")).toHaveLength(0);
   });
 
   it("does not touch the sandbox when every ref is non-inlinable — text references carry all the info", async () => {

--- a/packages/eve/src/harness/attachment-staging.integration.test.ts
+++ b/packages/eve/src/harness/attachment-staging.integration.test.ts
@@ -649,7 +649,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
     // an unavailability notice — no file part reaches the model.
     expect(hydratedContent[0]).toEqual({ type: "text", text: "what's in the image?" });
     expect(hydratedContent[1]).toEqual({
-      text: "Attached file /workspace/attachments/deadbeefdeadbeef/ghost.png (image/png) is no longer available in this session.",
+      text: "FileNotFound: Current snapshot may be newer and does not contain /workspace/attachments/deadbeefdeadbeef/ghost.png.",
       type: "text",
     });
     const fileParts = hydratedContent.filter((p) => (p as FilePart).type === "file");
@@ -683,7 +683,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
     const hydratedContent = hydrated[0]?.content as Exclude<UserContent, string>;
     expect(hydratedContent[0]).toEqual({ type: "text", text: "describe the image" });
     expect(hydratedContent[1]).toEqual({
-      text: `Attached file ${stagedPath} (image/png) is no longer available in this session.`,
+      text: `FileNotFound: Current snapshot may be newer and does not contain ${stagedPath}.`,
       type: "text",
     });
     expect(hydratedContent.filter((p) => (p as FilePart).type === "file")).toHaveLength(0);

--- a/packages/eve/src/harness/attachment-staging.ts
+++ b/packages/eve/src/harness/attachment-staging.ts
@@ -11,6 +11,7 @@ import { SandboxKey } from "#context/keys.js";
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { fileDataToBytes } from "#internal/attachments/data.js";
 import { EveAttachmentError } from "#internal/attachments/errors.js";
+import { createLogger } from "#internal/logging.js";
 import { deserializeUrlFilePart, isSerializedUrlFilePart } from "#internal/attachments/url-refs.js";
 import {
   decodeSandboxRef,
@@ -27,6 +28,8 @@ import { toErrorMessage } from "#shared/errors.js";
  * translates to the backend-native location.
  */
 export const ATTACHMENTS_ROOT = "/workspace/attachments";
+
+const log = createLogger("harness.attachment-staging");
 
 const UNSAFE_FILENAME_CHARS = /[^\w.-]+/g;
 const SHA_PREFIX_LENGTH = 16;
@@ -229,10 +232,22 @@ async function hydrateMessageContent(content: unknown, sandbox: SandboxSession):
       }
       const bytes = await sandbox.readBinaryFile({ path: ref.path });
       if (bytes === null) {
-        throw new Error(
-          `Sandbox-ref FilePart references missing file: "${ref.path}". ` +
-            "The staging pipeline invariant (every eve-sandbox: ref has bytes on disk) was violated.",
+        // Resuming a durable session can outlive the sandbox that staged
+        // an earlier turn's attachment: an ephemeral backend tears the
+        // sandbox down between turns, so the bytes behind a historical
+        // ref are gone. Degrade to a text reference instead of failing
+        // the whole turn — the run continues and the model is told the
+        // attachment is no longer reachable rather than chasing a path
+        // that has nothing behind it.
+        log.warn(
+          "sandbox-ref attachment bytes missing on hydration — degrading to text reference",
+          {
+            mediaType: ref.mediaType,
+            path: ref.path,
+            size: ref.size,
+          },
         );
+        return renderMissingSandboxRefAsTextPart(ref);
       }
       return { ...filePart, data: bytes, mediaType: ref.mediaType };
     }),
@@ -271,6 +286,20 @@ function shouldInlineSandboxRefAsBytes(ref: SandboxRef): boolean {
  */
 function renderSandboxRefAsTextPart(ref: SandboxRef): TextPart {
   return { text: `Attached file ${ref.path} (${ref.mediaType})`, type: "text" };
+}
+
+/**
+ * Renders a sandbox-resident attachment whose staged bytes are gone (the
+ * staging sandbox was torn down before the session resumed) as a
+ * {@link TextPart}. Unlike {@link renderSandboxRefAsTextPart}, this states
+ * the file is unreachable so the model does not try to read a path that no
+ * longer resolves.
+ */
+function renderMissingSandboxRefAsTextPart(ref: SandboxRef): TextPart {
+  return {
+    text: `Attached file ${ref.path} (${ref.mediaType}) is no longer available in this session.`,
+    type: "text",
+  };
 }
 
 async function stageFilePart(

--- a/packages/eve/src/harness/attachment-staging.ts
+++ b/packages/eve/src/harness/attachment-staging.ts
@@ -232,13 +232,8 @@ async function hydrateMessageContent(content: unknown, sandbox: SandboxSession):
       }
       const bytes = await sandbox.readBinaryFile({ path: ref.path });
       if (bytes === null) {
-        // Resuming a durable session can outlive the sandbox that staged
-        // an earlier turn's attachment: an ephemeral backend tears the
-        // sandbox down between turns, so the bytes behind a historical
-        // ref are gone. Degrade to a text reference instead of failing
-        // the whole turn — the run continues and the model is told the
-        // attachment is no longer reachable rather than chasing a path
-        // that has nothing behind it.
+        // #325: sandbox snapshots can change during a session lifecycle
+        // as they are deployment bounded.
         log.warn(
           "sandbox-ref attachment bytes missing on hydration — degrading to text reference",
           {
@@ -247,7 +242,10 @@ async function hydrateMessageContent(content: unknown, sandbox: SandboxSession):
             size: ref.size,
           },
         );
-        return renderMissingSandboxRefAsTextPart(ref);
+        return {
+          text: `FileNotFound: Current snapshot may be newer and does not contain ${ref.path}.`,
+          type: "text",
+        } satisfies TextPart;
       }
       return { ...filePart, data: bytes, mediaType: ref.mediaType };
     }),
@@ -286,20 +284,6 @@ function shouldInlineSandboxRefAsBytes(ref: SandboxRef): boolean {
  */
 function renderSandboxRefAsTextPart(ref: SandboxRef): TextPart {
   return { text: `Attached file ${ref.path} (${ref.mediaType})`, type: "text" };
-}
-
-/**
- * Renders a sandbox-resident attachment whose staged bytes are gone (the
- * staging sandbox was torn down before the session resumed) as a
- * {@link TextPart}. Unlike {@link renderSandboxRefAsTextPart}, this states
- * the file is unreachable so the model does not try to read a path that no
- * longer resolves.
- */
-function renderMissingSandboxRefAsTextPart(ref: SandboxRef): TextPart {
-  return {
-    text: `Attached file ${ref.path} (${ref.mediaType}) is no longer available in this session.`,
-    type: "text",
-  };
 }
 
 async function stageFilePart(


### PR DESCRIPTION
Fixes #276. Carries #325 forward (both commits cherry-picked with authorship intact, re-signed) plus a correction to the root-cause story and a recovery hint in the model-facing text.

## The incident

Resuming a Slack thread that contained an image failed every follow-up turn:

```
Step "step//eve@0.11.5//turnStep" failed after 3 retries: Sandbox-ref FilePart
references missing file: "/workspace/attachments/<id>/crayon.png".
```

`hydrateMessageContent` threw on the missing read, the turn ended in `session.failed`, and the bot never replied again in that thread.

## Actual root cause (differs from #325's framing)

The sandbox was never torn down. Session sandbox names embed the deployment id (`keys.ts` scopes session keys with `scopeKind: "deployment"`, which hashes `VERCEL_DEPLOYMENT_ID`). Tracing the reporting incident in project `v`: the screenshot turn ran at 18:19 UTC on `dpl_ExWJSEJ...` and the failing turn 2h05m later on `dpl_7NnBDX3...`, with four production deploys in between. `sha256(deploymentId)[:16]` matches both sandbox names exactly. The old sandbox still exists, bytes intact; the resumed session derives a new name, gets a 404, and eve creates a fresh sandbox from the template. Across project `v`, 55 of 1221 sessions show sandboxes under 2+ deployment hashes, so this fires for any thread that crosses a deploy.

## What this does

Hydration no longer throws when a historical `eve-sandbox:` ref has no bytes behind it. The file part becomes an error-shaped text part:

> FileNotFound: Current snapshot may be newer and does not contain /workspace/attachments/.../crayon.png.

plus a `log.warn` with path/size/mediaType. A freshly staged attachment in the current turn hydrates as before. The error shape is new relative to #325, which used a prose notice; models already know how to react to a failed read (answer without the file, or ask for it again), so the notice reads like one.

This is the floor, not the fix for the class. Keeping session filesystems alive across deploys (sandbox drives) is a separate research PR.

## Tests

Rewrote the "missing file" integration case to assert the degrade (leading text survives, ref becomes the notice, no file part reaches the model) and added a regression staging into one sandbox and hydrating against a fresh one, the same shape as a resume after a deploy. Attachment-staging unit + integration suites green.
