### PR TITLE
Expose Gateway cost metadata

### DIFF
--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -3,6 +3,7 @@ import type {
   LanguageModelUsage,
   ModelMessage,
   PrepareStepFunction,
+  ProviderMetadata,
   StepResult,
   ToolSet,
   ToolResultPart,
@@ -13,6 +14,7 @@ import {
   createActionResultEvent,
   createActionsRequestedEvent,
   createStepCompletedEvent,
+  type StepCompletedProviderMetadata,
 } from "#protocol/message.js";
 import {
   createRuntimeToolResultFromToolError,
@@ -437,18 +439,14 @@ function extractStepUsage(input: {
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-function extractStepProviderMetadata(providerMetadata: unknown):
-  | {
-      gateway: {
-        generationId: string;
-      };
-    }
-  | undefined {
+function extractStepProviderMetadata(
+  providerMetadata: ProviderMetadata | undefined,
+): StepCompletedProviderMetadata | undefined {
   const generationId = readGatewayGenerationId(providerMetadata);
   return generationId === undefined ? undefined : { gateway: { generationId } };
 }
 
-function extractGatewayCostUsd(providerMetadata: unknown): number | undefined {
+function extractGatewayCostUsd(providerMetadata: ProviderMetadata | undefined): number | undefined {
   const gateway = readGatewayMetadata(providerMetadata);
   const cost = gateway?.cost;
   if (typeof cost === "number" && Number.isFinite(cost)) {
@@ -461,21 +459,16 @@ function extractGatewayCostUsd(providerMetadata: unknown): number | undefined {
   return undefined;
 }
 
-function readGatewayGenerationId(providerMetadata: unknown): string | undefined {
+function readGatewayGenerationId(
+  providerMetadata: ProviderMetadata | undefined,
+): string | undefined {
   const generationId = readGatewayMetadata(providerMetadata)?.generationId;
   return typeof generationId === "string" && generationId.length > 0 ? generationId : undefined;
 }
 
-function readGatewayMetadata(providerMetadata: unknown): Record<string, unknown> | undefined {
-  if (
-    !providerMetadata ||
-    typeof providerMetadata !== "object" ||
-    Array.isArray(providerMetadata)
-  ) {
-    return undefined;
-  }
-  const gateway = (providerMetadata as Record<string, unknown>).gateway;
-  return gateway && typeof gateway === "object" && !Array.isArray(gateway)
-    ? (gateway as Record<string, unknown>)
-    : undefined;
+function readGatewayMetadata(
+  providerMetadata: ProviderMetadata | undefined,
+): ProviderMetadata[string] | undefined {
+  const gateway = providerMetadata?.gateway;
+  return gateway && typeof gateway === "object" && !Array.isArray(gateway) ? gateway : undefined;
 }

--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -47,7 +47,14 @@ import { readToolInterrupt } from "#harness/tool-interrupts.js";
  */
 export type HarnessStepResult = Pick<
   StepResult<ToolSet>,
-  "content" | "finishReason" | "response" | "text" | "toolCalls" | "toolResults" | "usage"
+  | "content"
+  | "finishReason"
+  | "providerMetadata"
+  | "response"
+  | "text"
+  | "toolCalls"
+  | "toolResults"
+  | "usage"
 >;
 
 // ---------------------------------------------------------------------------
@@ -285,10 +292,14 @@ export async function emitStepActions(
   await emitFn(
     createStepCompletedEvent({
       finishReason: normalizeAssistantStepFinishReason(step.finishReason),
+      providerMetadata: extractStepProviderMetadata(step.providerMetadata),
       sequence: state.sequence,
       stepIndex: state.stepIndex,
       turnId: state.turnId,
-      usage: extractStepUsage(step.usage),
+      usage: extractStepUsage({
+        costUsd: extractGatewayCostUsd(step.providerMetadata),
+        usage: step.usage,
+      }),
     }),
   );
 }
@@ -387,24 +398,32 @@ function extractToolResultParts(messages: readonly ModelMessage[]): ToolResultPa
  * Projects the AI SDK's `LanguageModelUsage` into the flat `step.completed`
  * event usage shape. Returns `undefined` when the SDK reports no usage.
  */
-function extractStepUsage(usage: LanguageModelUsage | undefined):
+function extractStepUsage(input: {
+  readonly costUsd: number | undefined;
+  readonly usage: LanguageModelUsage | undefined;
+}):
   | {
+      costUsd?: number;
       inputTokens?: number;
       outputTokens?: number;
       cacheReadTokens?: number;
       cacheWriteTokens?: number;
     }
   | undefined {
-  if (usage === undefined) {
-    return undefined;
-  }
-
   const result: {
+    costUsd?: number;
     inputTokens?: number;
     outputTokens?: number;
     cacheReadTokens?: number;
     cacheWriteTokens?: number;
   } = {};
+
+  if (input.costUsd !== undefined) result.costUsd = input.costUsd;
+
+  const usage = input.usage;
+  if (usage === undefined) {
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
 
   if (usage.inputTokens !== undefined) result.inputTokens = usage.inputTokens;
   if (usage.outputTokens !== undefined) result.outputTokens = usage.outputTokens;
@@ -416,4 +435,47 @@ function extractStepUsage(usage: LanguageModelUsage | undefined):
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function extractStepProviderMetadata(providerMetadata: unknown):
+  | {
+      gateway: {
+        generationId: string;
+      };
+    }
+  | undefined {
+  const generationId = readGatewayGenerationId(providerMetadata);
+  return generationId === undefined ? undefined : { gateway: { generationId } };
+}
+
+function extractGatewayCostUsd(providerMetadata: unknown): number | undefined {
+  const gateway = readGatewayMetadata(providerMetadata);
+  const cost = gateway?.cost;
+  if (typeof cost === "number" && Number.isFinite(cost)) {
+    return cost;
+  }
+  if (typeof cost === "string") {
+    const parsed = Number(cost);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function readGatewayGenerationId(providerMetadata: unknown): string | undefined {
+  const generationId = readGatewayMetadata(providerMetadata)?.generationId;
+  return typeof generationId === "string" && generationId.length > 0 ? generationId : undefined;
+}
+
+function readGatewayMetadata(providerMetadata: unknown): Record<string, unknown> | undefined {
+  if (
+    !providerMetadata ||
+    typeof providerMetadata !== "object" ||
+    Array.isArray(providerMetadata)
+  ) {
+    return undefined;
+  }
+  const gateway = (providerMetadata as Record<string, unknown>).gateway;
+  return gateway && typeof gateway === "object" && !Array.isArray(gateway)
+    ? (gateway as Record<string, unknown>)
+    : undefined;
 }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -878,8 +878,10 @@ describe("createToolLoopHarness", () => {
     expect(getSessionTokenUsage(result.session)).toEqual({
       cacheReadTokens: 2,
       cacheWriteTokens: 1,
+      costUsd: 0,
       inputTokens: 7,
       outputTokens: 3,
+      sawCost: false,
     });
   });
 
@@ -899,8 +901,10 @@ describe("createToolLoopHarness", () => {
       usage: {
         cacheReadTokens: 2,
         cacheWriteTokens: 1,
+        costUsd: 0,
         inputTokens: 12,
         outputTokens: 3,
+        sawCost: false,
       },
       tokenKind: "input",
     },
@@ -919,8 +923,10 @@ describe("createToolLoopHarness", () => {
       usage: {
         cacheReadTokens: 2,
         cacheWriteTokens: 1,
+        costUsd: 0,
         inputTokens: 7,
         outputTokens: 3,
+        sawCost: false,
       },
       tokenKind: "output",
     },
@@ -7356,6 +7362,12 @@ describe("createToolLoopHarness", () => {
     it("step.completed event includes usage and cache stats", async () => {
       setupMockAgent({
         finishReason: "stop",
+        providerMetadata: {
+          gateway: {
+            cost: "0.0123",
+            generationId: "gen_test_gateway",
+          },
+        },
         response: { messages: [{ content: "done", role: "assistant" }] },
         text: "done",
         toolCalls: [],
@@ -7377,10 +7389,14 @@ describe("createToolLoopHarness", () => {
 
       const stepCompleted = events.find((e) => e.type === "step.completed");
       expect(stepCompleted?.data.usage).toEqual({
+        costUsd: 0.0123,
         inputTokens: 1000,
         outputTokens: 50,
         cacheReadTokens: 800,
         cacheWriteTokens: 200,
+      });
+      expect(stepCompleted?.data.providerMetadata).toEqual({
+        gateway: { generationId: "gen_test_gateway" },
       });
     });
 
@@ -7399,6 +7415,32 @@ describe("createToolLoopHarness", () => {
 
       const stepCompleted = events.find((e) => e.type === "step.completed");
       expect(stepCompleted?.data.usage).toBeUndefined();
+    });
+
+    it("step.completed event includes gateway cost when tokens are absent", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        providerMetadata: {
+          gateway: {
+            cost: 0.0042,
+            generationId: "gen_cost_only",
+          },
+        },
+        response: { messages: [{ content: "done", role: "assistant" }] },
+        text: "done",
+        toolCalls: [],
+        toolResults: [],
+      });
+
+      const { emit, events } = createEventCollector();
+      const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+      await runStep(createTestSession(), { message: "hi" });
+
+      const stepCompleted = events.find((e) => e.type === "step.completed");
+      expect(stepCompleted?.data.usage).toEqual({ costUsd: 0.0042 });
+      expect(stepCompleted?.data.providerMetadata).toEqual({
+        gateway: { generationId: "gen_cost_only" },
+      });
     });
   });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -8,6 +8,7 @@ import {
   isStepCount,
   type LanguageModel,
   type ModelMessage,
+  type ProviderMetadata,
   type SystemModelMessage,
   type TelemetryOptions,
   ToolLoopAgent,
@@ -1131,7 +1132,7 @@ function extractTokenUsageDelta(input: {
   };
 }
 
-function extractGatewayCostUsd(providerMetadata: unknown): number | undefined {
+function extractGatewayCostUsd(providerMetadata: ProviderMetadata | undefined): number | undefined {
   const gateway = readGatewayMetadata(providerMetadata);
   const cost = gateway?.cost;
   if (typeof cost === "number" && Number.isFinite(cost)) {
@@ -1144,18 +1145,11 @@ function extractGatewayCostUsd(providerMetadata: unknown): number | undefined {
   return undefined;
 }
 
-function readGatewayMetadata(providerMetadata: unknown): Record<string, unknown> | undefined {
-  if (
-    !providerMetadata ||
-    typeof providerMetadata !== "object" ||
-    Array.isArray(providerMetadata)
-  ) {
-    return undefined;
-  }
-  const gateway = (providerMetadata as Record<string, unknown>).gateway;
-  return gateway && typeof gateway === "object" && !Array.isArray(gateway)
-    ? (gateway as Record<string, unknown>)
-    : undefined;
+function readGatewayMetadata(
+  providerMetadata: ProviderMetadata | undefined,
+): ProviderMetadata[string] | undefined {
+  const gateway = providerMetadata?.gateway;
+  return gateway && typeof gateway === "object" && !Array.isArray(gateway) ? gateway : undefined;
 }
 
 function formatSessionTokenLimitMessage(kind: SessionTokenLimitViolation["kind"]): string {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -815,6 +815,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
                     }
                   : {}),
               },
+              providerMetadata: stepResult.providerMetadata,
               text: stepResult.text,
               toolCalls: stepResult.toolCalls,
               toolResults: [...toolResultsByCallId.values()],
@@ -1068,7 +1069,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const nextTurnUsage = accumulateTurnUsage({
       previous: getTurnUsageState(session.state),
       turnId: emissionState.turnId,
-      usage: extractTokenUsageDelta(result.usage),
+      usage: extractTokenUsageDelta({
+        costUsd: extractGatewayCostUsd(result.providerMetadata),
+        usage: result.usage,
+      }),
     });
     session = setTurnUsageState(session, nextTurnUsage);
     // `formatLanguageModelGatewayId` requires `model.provider` to be a string;
@@ -1087,6 +1091,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       "$eve.output_tokens": nextTurnUsage.outputTokens,
       "$eve.cache_read_tokens": nextTurnUsage.cacheReadTokens,
       "$eve.cache_write_tokens": nextTurnUsage.cacheWriteTokens,
+      "$eve.cost_usd": nextTurnUsage.sawCost ? nextTurnUsage.costUsd : undefined,
       "$eve.tool_count": config.tools.size,
     });
 
@@ -1108,19 +1113,49 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
 const SESSION_TOKEN_LIMIT_REACHED_CODE = "SESSION_TOKEN_LIMIT_REACHED";
 
-function extractTokenUsageDelta(
-  usage: HarnessStepResult["usage"] | undefined,
-): TokenUsageDelta | undefined {
-  if (usage === undefined) {
+function extractTokenUsageDelta(input: {
+  readonly costUsd: number | undefined;
+  readonly usage: HarnessStepResult["usage"] | undefined;
+}): TokenUsageDelta | undefined {
+  const usage = input.usage;
+  if (usage === undefined && input.costUsd === undefined) {
     return undefined;
   }
 
   return {
-    cacheReadTokens: usage.inputTokenDetails?.cacheReadTokens,
-    cacheWriteTokens: usage.inputTokenDetails?.cacheWriteTokens,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
+    cacheReadTokens: usage?.inputTokenDetails?.cacheReadTokens,
+    cacheWriteTokens: usage?.inputTokenDetails?.cacheWriteTokens,
+    costUsd: input.costUsd,
+    inputTokens: usage?.inputTokens,
+    outputTokens: usage?.outputTokens,
   };
+}
+
+function extractGatewayCostUsd(providerMetadata: unknown): number | undefined {
+  const gateway = readGatewayMetadata(providerMetadata);
+  const cost = gateway?.cost;
+  if (typeof cost === "number" && Number.isFinite(cost)) {
+    return cost;
+  }
+  if (typeof cost === "string") {
+    const parsed = Number(cost);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function readGatewayMetadata(providerMetadata: unknown): Record<string, unknown> | undefined {
+  if (
+    !providerMetadata ||
+    typeof providerMetadata !== "object" ||
+    Array.isArray(providerMetadata)
+  ) {
+    return undefined;
+  }
+  const gateway = (providerMetadata as Record<string, unknown>).gateway;
+  return gateway && typeof gateway === "object" && !Array.isArray(gateway)
+    ? (gateway as Record<string, unknown>)
+    : undefined;
 }
 
 function formatSessionTokenLimitMessage(kind: SessionTokenLimitViolation["kind"]): string {

--- a/packages/eve/src/harness/turn-tag-state.test.ts
+++ b/packages/eve/src/harness/turn-tag-state.test.ts
@@ -12,8 +12,10 @@ import type { HarnessSession } from "#harness/types.js";
 const ZERO_SESSION_USAGE = {
   cacheReadTokens: 0,
   cacheWriteTokens: 0,
+  costUsd: 0,
   inputTokens: 0,
   outputTokens: 0,
+  sawCost: false,
 };
 
 function makeSession(state?: HarnessSession["state"]): HarnessSession {
@@ -45,6 +47,8 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 3,
       cacheReadTokens: 2,
       cacheWriteTokens: 0,
+      costUsd: 0,
+      sawCost: false,
       session: {
         ...ZERO_SESSION_USAGE,
         cacheReadTokens: 2,
@@ -72,11 +76,40 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 50,
       cacheReadTokens: 800,
       cacheWriteTokens: 200,
+      costUsd: 0,
+      sawCost: false,
       session: {
         cacheReadTokens: 800,
         cacheWriteTokens: 200,
+        costUsd: 0,
         inputTokens: 1000,
         outputTokens: 50,
+        sawCost: false,
+      },
+    });
+  });
+
+  it("accumulates gateway cost from normalized usage", () => {
+    const next = accumulateTurnUsage({
+      previous: undefined,
+      turnId: "turn_0",
+      usage: {
+        costUsd: 0.0123,
+      },
+    });
+
+    expect(next).toEqual({
+      turnId: "turn_0",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      costUsd: 0.0123,
+      sawCost: true,
+      session: {
+        ...ZERO_SESSION_USAGE,
+        costUsd: 0.0123,
+        sawCost: true,
       },
     });
   });
@@ -88,11 +121,15 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 50,
       cacheReadTokens: 8,
       cacheWriteTokens: 5,
+      costUsd: 0.01,
+      sawCost: true,
       session: {
         cacheReadTokens: 8,
         cacheWriteTokens: 5,
+        costUsd: 0.01,
         inputTokens: 100,
         outputTokens: 50,
+        sawCost: true,
       },
     };
     const next = accumulateTurnUsage({
@@ -101,6 +138,7 @@ describe("accumulateTurnUsage", () => {
       usage: {
         cacheReadTokens: 4,
         cacheWriteTokens: 3,
+        costUsd: 0.02,
         inputTokens: 12,
         outputTokens: 7,
       },
@@ -112,11 +150,15 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 57,
       cacheReadTokens: 12,
       cacheWriteTokens: 8,
+      costUsd: 0.03,
+      sawCost: true,
       session: {
         cacheReadTokens: 12,
         cacheWriteTokens: 8,
+        costUsd: 0.03,
         inputTokens: 112,
         outputTokens: 57,
+        sawCost: true,
       },
     });
   });
@@ -128,11 +170,15 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 50,
       cacheReadTokens: 8,
       cacheWriteTokens: 5,
+      costUsd: 0.01,
+      sawCost: true,
       session: {
         cacheReadTokens: 80,
         cacheWriteTokens: 50,
+        costUsd: 0.05,
         inputTokens: 1000,
         outputTokens: 500,
+        sawCost: true,
       },
     };
     const next = accumulateTurnUsage({
@@ -147,11 +193,15 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 5,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
+      costUsd: 0,
+      sawCost: false,
       session: {
         cacheReadTokens: 80,
         cacheWriteTokens: 50,
+        costUsd: 0.05,
         inputTokens: 1020,
         outputTokens: 505,
+        sawCost: true,
       },
     });
   });
@@ -169,6 +219,8 @@ describe("accumulateTurnUsage", () => {
       outputTokens: 0,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
+      costUsd: 0,
+      sawCost: false,
       session: ZERO_SESSION_USAGE,
     });
   });
@@ -182,6 +234,8 @@ describe("session state round-trip", () => {
       outputTokens: 1,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
+      costUsd: 0,
+      sawCost: false,
       session: {
         ...ZERO_SESSION_USAGE,
         inputTokens: 5,
@@ -195,6 +249,8 @@ describe("session state round-trip", () => {
       outputTokens: 1,
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
+      costUsd: 0,
+      sawCost: false,
       session: {
         ...ZERO_SESSION_USAGE,
         inputTokens: 5,
@@ -215,6 +271,8 @@ describe("session state round-trip", () => {
       outputTokens: 1,
       cacheReadTokens: 1,
       cacheWriteTokens: 0,
+      costUsd: 0,
+      sawCost: false,
       session: {
         ...ZERO_SESSION_USAGE,
         cacheReadTokens: 1,
@@ -246,13 +304,17 @@ describe("session token limits", () => {
       turnId: "turn_0",
       cacheReadTokens: 0,
       cacheWriteTokens: 0,
+      costUsd: 0,
       inputTokens: 10,
       outputTokens: 3,
+      sawCost: false,
       session: {
         cacheReadTokens: 0,
         cacheWriteTokens: 0,
+        costUsd: 0,
         inputTokens: 10,
         outputTokens: 3,
+        sawCost: false,
       },
     });
 

--- a/packages/eve/src/harness/turn-tag-state.ts
+++ b/packages/eve/src/harness/turn-tag-state.ts
@@ -22,8 +22,10 @@ const HARNESS_TURN_USAGE_STATE_KEY = "eve.harness.turnUsage";
 export interface TokenUsageTotals {
   readonly cacheReadTokens: number;
   readonly cacheWriteTokens: number;
+  readonly costUsd: number;
   readonly inputTokens: number;
   readonly outputTokens: number;
+  readonly sawCost: boolean;
 }
 
 export type TokenUsageDelta = Partial<TokenUsageTotals>;
@@ -43,8 +45,10 @@ export interface TurnUsageState extends TokenUsageTotals {
 const ZERO_TOKEN_USAGE: TokenUsageTotals = {
   cacheReadTokens: 0,
   cacheWriteTokens: 0,
+  costUsd: 0,
   inputTokens: 0,
   outputTokens: 0,
+  sawCost: false,
 };
 
 /** Reads the stored per-turn token state, or `undefined` when absent. */
@@ -131,8 +135,10 @@ function addTokenUsage(base: TokenUsageTotals, delta: TokenUsageTotals): TokenUs
   return {
     cacheReadTokens: base.cacheReadTokens + delta.cacheReadTokens,
     cacheWriteTokens: base.cacheWriteTokens + delta.cacheWriteTokens,
+    costUsd: base.costUsd + delta.costUsd,
     inputTokens: base.inputTokens + delta.inputTokens,
     outputTokens: base.outputTokens + delta.outputTokens,
+    sawCost: base.sawCost || delta.sawCost,
   };
 }
 
@@ -146,7 +152,9 @@ function toTokenUsageDelta(usage: TokenUsageDelta | undefined): TokenUsageTotals
   return {
     cacheReadTokens: usage.cacheReadTokens ?? 0,
     cacheWriteTokens: usage.cacheWriteTokens ?? 0,
+    costUsd: usage.costUsd ?? 0,
     inputTokens,
     outputTokens,
+    sawCost: usage.costUsd !== undefined,
   };
 }

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -14,7 +14,7 @@ import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 
 describe("message stream protocol", () => {
   it("pins the stream version for timed session events", () => {
-    expect(EVE_MESSAGE_STREAM_VERSION).toBe("16");
+    expect(EVE_MESSAGE_STREAM_VERSION).toBe("17");
   });
 
   it("creates result.completed events", () => {

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -10,7 +10,7 @@ export const EVE_STREAM_FORMAT_HEADER = "x-eve-stream-format";
 export const EVE_STREAM_VERSION_HEADER = "x-eve-stream-version";
 export const EVE_MESSAGE_STREAM_CONTENT_TYPE = "application/x-ndjson; charset=utf-8";
 export const EVE_MESSAGE_STREAM_FORMAT = "ndjson";
-export const EVE_MESSAGE_STREAM_VERSION = "16";
+export const EVE_MESSAGE_STREAM_VERSION = "17";
 
 /**
  * eve-owned finish reason for one completed assistant step.
@@ -357,10 +357,16 @@ export interface StepStartedStreamEvent {
 export interface StepCompletedStreamEvent {
   data: {
     finishReason: AssistantStepFinishReason;
+    providerMetadata?: {
+      gateway?: {
+        generationId?: string;
+      };
+    };
     sequence: number;
     stepIndex: number;
     turnId: string;
     usage?: {
+      readonly costUsd?: number;
       readonly inputTokens?: number;
       readonly outputTokens?: number;
       readonly cacheReadTokens?: number;
@@ -987,10 +993,16 @@ export function createStepStartedEvent(input: {
  */
 export function createStepCompletedEvent(input: {
   readonly finishReason: AssistantStepFinishReason;
+  readonly providerMetadata?: {
+    readonly gateway?: {
+      readonly generationId?: string;
+    };
+  };
   readonly sequence: number;
   readonly stepIndex: number;
   readonly turnId: string;
   readonly usage?: {
+    readonly costUsd?: number;
     readonly inputTokens?: number;
     readonly outputTokens?: number;
     readonly cacheReadTokens?: number;
@@ -1006,6 +1018,9 @@ export function createStepCompletedEvent(input: {
 
   if (input.usage !== undefined) {
     data.usage = input.usage;
+  }
+  if (input.providerMetadata !== undefined) {
+    data.providerMetadata = input.providerMetadata;
   }
 
   return {

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -1,5 +1,5 @@
 import type { ConnectionAuthorizationChallenge } from "#public/connections/errors.js";
-import type { UserContent } from "ai";
+import type { ProviderMetadata, UserContent } from "ai";
 
 import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
@@ -26,6 +26,15 @@ export type AssistantStepFinishReason =
   | "other"
   | "stop"
   | "tool-calls";
+
+type ProviderMetadataEntry = NonNullable<ProviderMetadata[string]>;
+type GatewayGenerationId = Extract<ProviderMetadataEntry["generationId"], string>;
+
+export interface StepCompletedProviderMetadata {
+  readonly gateway: {
+    readonly generationId: GatewayGenerationId;
+  };
+}
 
 /**
  * Durable metadata attached to one persisted session stream event.
@@ -357,11 +366,7 @@ export interface StepStartedStreamEvent {
 export interface StepCompletedStreamEvent {
   data: {
     finishReason: AssistantStepFinishReason;
-    providerMetadata?: {
-      gateway?: {
-        generationId?: string;
-      };
-    };
+    providerMetadata?: StepCompletedProviderMetadata;
     sequence: number;
     stepIndex: number;
     turnId: string;
@@ -993,11 +998,7 @@ export function createStepStartedEvent(input: {
  */
 export function createStepCompletedEvent(input: {
   readonly finishReason: AssistantStepFinishReason;
-  readonly providerMetadata?: {
-    readonly gateway?: {
-      readonly generationId?: string;
-    };
-  };
+  readonly providerMetadata?: StepCompletedProviderMetadata;
   readonly sequence: number;
   readonly stepIndex: number;
   readonly turnId: string;


### PR DESCRIPTION
- add Gateway generation id and costUsd to step.completed when AI Gateway returns provider metadata
- persist cumulative turn cost as $eve.cost_usd only after Gateway reports cost
- bump stream version to 17