### PR TITLE
ci: gate e2e workflows on changed paths instead of paths trigger

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -47,8 +47,6 @@ jobs:
   discover-fixtures:
     name: discover-fixtures
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true'
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
     steps:
@@ -64,7 +62,10 @@ jobs:
   e2e:
     name: e2e-local (${{ matrix.name }})
     runs-on: ubuntu-latest
-    needs: discover-fixtures
+    needs: [changes, discover-fixtures]
+    # Gate here (not on discover-fixtures): the matrix must expand so each
+    # named check reports a skipped status that satisfies required checks.
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -3,23 +3,52 @@ name: E2E Tests (Local)
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - "packages/eve/**"
-      - "pnpm-workspace.yaml"
-      - "pnpm-lock.yaml"
-      - "apps/fixtures/**"
-      - "e2e/**"
-      - ".github/workflows/e2e-local.yml"
-      - ".github/scripts/discover-e2e-fixtures.sh"
 
 concurrency:
   group: e2e-local-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # The workflow must run on every PR so required checks report a status, but
+  # the e2e jobs only need to run when relevant paths changed. Downstream jobs
+  # skip (which satisfies required checks) when nothing relevant changed.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          echo "Changed files:"
+          echo "$changed"
+          pattern='^(packages/eve/|apps/fixtures/|e2e/|pnpm-workspace\.yaml$|pnpm-lock\.yaml$|\.github/workflows/e2e-local\.yml$|\.github/scripts/discover-e2e-fixtures\.sh$)'
+          if grep -qE "$pattern" <<<"$changed"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   discover-fixtures:
     name: discover-fixtures
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
     steps:

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -3,23 +3,52 @@ name: E2E Tests (Vercel)
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - "packages/eve/**"
-      - "pnpm-workspace.yaml"
-      - "pnpm-lock.yaml"
-      - "apps/fixtures/**"
-      - "e2e/**"
-      - ".github/workflows/e2e-vercel.yml"
-      - ".github/scripts/discover-e2e-fixtures.sh"
 
 concurrency:
   group: e2e-vercel-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # The workflow must run on every PR so required checks report a status, but
+  # the e2e jobs only need to run when relevant paths changed. Downstream jobs
+  # skip (which satisfies required checks) when nothing relevant changed.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          echo "Changed files:"
+          echo "$changed"
+          pattern='^(packages/eve/|apps/fixtures/|e2e/|pnpm-workspace\.yaml$|pnpm-lock\.yaml$|\.github/workflows/e2e-vercel\.yml$|\.github/scripts/discover-e2e-fixtures\.sh$)'
+          if grep -qE "$pattern" <<<"$changed"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   discover-fixtures:
     name: discover-fixtures
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
     steps:

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -47,8 +47,6 @@ jobs:
   discover-fixtures:
     name: discover-fixtures
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.relevant == 'true'
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
     steps:
@@ -64,7 +62,10 @@ jobs:
   e2e:
     name: e2e-vercel (${{ matrix.name }})
     runs-on: ubuntu-latest
-    needs: discover-fixtures
+    needs: [changes, discover-fixtures]
+    # Gate here (not on discover-fixtures): the matrix must expand so each
+    # named check reports a skipped status that satisfies required checks.
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Makes `e2e-local` and `e2e-vercel` run on every PR so their required checks always report a status, while skipping the actual e2e work when no relevant paths changed.

## Why

Both workflows used `on.pull_request.paths`, so PRs that didn't touch the listed paths never triggered them — leaving required checks stuck as "Expected" and blocking merge.

## How

- Removed the `paths` filter from the `pull_request` trigger.
- Added a cheap `changes` job that diffs against the base branch and checks the same path list.
- `changes` and `discover-fixtures` always run so the dynamic matrix still expands; the `e2e` matrix job is gated on `changes` output, so each named matrix check reports "skipped" (which satisfies required checks) when nothing relevant changed.
- `workflow_dispatch` runs always bypass the gate.