### PR TITLE
fix(runtime): flatten top-level union in MCP tool input schemas

### DIFF
--- a/.changeset/mcp-tool-schema-top-level-union.md
+++ b/.changeset/mcp-tool-schema-top-level-union.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+MCP connection tools whose input schema uses a top-level `oneOf`/`allOf`/`anyOf` union are now flattened to a single object schema before the model call. Anthropic rejects a top-level union in a tool's `input_schema` and fails the entire request with an HTTP 400 before the agent can respond, so one non-conforming third-party tool previously took down every tool in the turn. The flattened schema merges the union branches' properties (left optional, `additionalProperties` open) so no valid call is rejected, and the offending connection and tool name are logged. Nested unions are left untouched.

--- a/packages/eve/src/runtime/connections/mcp-client.test.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.test.ts
@@ -343,6 +343,65 @@ describe("McpConnectionClient authorization recovery", () => {
   });
 });
 
+describe("McpConnectionClient tool input schema sanitization", () => {
+  beforeEach(() => {
+    createMCPClient.mockReset();
+  });
+
+  it("flattens a tool's top-level union input schema for both metadata and the SDK tool set", async () => {
+    const toolsFromDefinitions = vi.fn().mockReturnValue({});
+    const client = {
+      close: vi.fn(),
+      listTools: vi.fn().mockResolvedValue({
+        tools: [
+          {
+            description: "",
+            inputSchema: {
+              anyOf: [
+                { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+                { type: "object", properties: { email: { type: "string" } }, required: ["email"] },
+              ],
+            },
+            name: "union_tool",
+          },
+          {
+            description: "",
+            inputSchema: { type: "object", properties: { q: { type: "string" } } },
+            name: "plain_tool",
+          },
+        ],
+      }),
+      toolsFromDefinitions,
+    };
+    createMCPClient.mockResolvedValue(client);
+
+    const mcpClient = new McpConnectionClient(makeConnection());
+    const metadata = await mcpClient.getToolMetadata();
+
+    expect(metadata.find((m) => m.name === "union_tool")?.inputSchema).toEqual({
+      additionalProperties: true,
+      properties: { email: { type: "string" }, id: { type: "string" } },
+      type: "object",
+    });
+
+    // The SDK tool set is built from the sanitized definitions, so the raw
+    // top-level union never reaches the model request.
+    const firstCall = toolsFromDefinitions.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const passedTools = (
+      firstCall![0] as { tools: { inputSchema: Record<string, unknown>; name: string }[] }
+    ).tools;
+    expect(passedTools.find((t) => t.name === "union_tool")?.inputSchema).not.toHaveProperty(
+      "anyOf",
+    );
+    // A conforming tool is passed through untouched.
+    expect(passedTools.find((t) => t.name === "plain_tool")?.inputSchema).toEqual({
+      properties: { q: { type: "string" } },
+      type: "object",
+    });
+  });
+});
+
 describe("passesToolFilter", () => {
   it("passes all tools when filter is undefined", () => {
     expect(passesToolFilter("any_tool", undefined)).toBe(true);

--- a/packages/eve/src/runtime/connections/mcp-client.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.ts
@@ -2,12 +2,14 @@ import { createMCPClient, type MCPClient } from "#compiled/@ai-sdk/mcp/index.js"
 import type { ToolSet } from "ai";
 
 import { buildCallbackContext } from "#context/build-callback-context.js";
+import { createLogger } from "#internal/logging.js";
 import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
 import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import { evictScopedToken, resolveScopedToken } from "#runtime/connections/scoped-authorization.js";
 import { resolveConnectionAuthorization } from "#runtime/connections/resolve-authorization.js";
 import { isObject } from "#shared/guards.js";
+import { flattenTopLevelUnionToolInputSchema } from "#shared/json-schema.js";
 import type {
   AuthorizationDefinition,
   ConnectionClient,
@@ -17,6 +19,8 @@ import type {
   HeaderValue,
   ToolFilterDefinition,
 } from "#runtime/connections/types.js";
+
+const logger = createLogger("connection.mcp-client");
 
 interface McpToolCache {
   readonly metadata: readonly ConnectionToolMetadata[];
@@ -179,9 +183,11 @@ export class McpConnectionClient implements ConnectionClient {
     // elements are `Tool<unknown, CallToolResult>`. The AI SDK's
     // `ToolSet` constraint only admits `Tool<any | never, any | never>`,
     // so a single-hop cast is required — the runtime shape is identical.
-    const tools = client.toolsFromDefinitions({ tools: filteredTools }) as ToolSet;
+    const sanitizedTools = filteredTools.map((t) => this.#sanitizeToolInputSchema(t));
 
-    const metadata: ConnectionToolMetadata[] = filteredTools.map((t) => ({
+    const tools = client.toolsFromDefinitions({ tools: sanitizedTools }) as ToolSet;
+
+    const metadata: ConnectionToolMetadata[] = sanitizedTools.map((t) => ({
       annotations: t.annotations as Record<string, unknown> | undefined,
       description: t.description ?? "",
       inputSchema: (t.inputSchema ?? {}) as Record<string, unknown>,
@@ -193,6 +199,32 @@ export class McpConnectionClient implements ConnectionClient {
     }));
 
     return { metadata, tools };
+  }
+
+  /**
+   * Rewrites a tool whose input schema uses a top-level `oneOf`/`allOf`/`anyOf`
+   * union into a single object schema. Anthropic rejects such a schema and
+   * fails the *entire* model request with an HTTP 400 before the agent can
+   * respond, so one non-conforming third-party tool would otherwise take down
+   * every tool in the turn. Logs the offending connection + tool name so a
+   * recurrence is diagnosable at a glance instead of surfacing only as an
+   * opaque `tools.N.custom.input_schema` gateway rejection.
+   */
+  #sanitizeToolInputSchema<T extends { readonly name: string; readonly inputSchema?: unknown }>(
+    tool: T,
+  ): T {
+    if (!isObject(tool.inputSchema)) {
+      return tool;
+    }
+    const { changed, schema } = flattenTopLevelUnionToolInputSchema(tool.inputSchema);
+    if (!changed) {
+      return tool;
+    }
+    logger.warn(
+      "rewrote a connection tool's top-level union input schema — providers such as Anthropic reject oneOf/allOf/anyOf at the top level of a tool input_schema",
+      { connection: this.#connection.connectionName, tool: tool.name },
+    );
+    return { ...tool, inputSchema: schema };
   }
 
   async close(): Promise<void> {

--- a/packages/eve/src/shared/json-schema.test.ts
+++ b/packages/eve/src/shared/json-schema.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { flattenTopLevelUnionToolInputSchema } from "#shared/json-schema.js";
+
+describe("flattenTopLevelUnionToolInputSchema", () => {
+  it("returns the original object unchanged when the top level is already an object", () => {
+    const schema = { type: "object", properties: { id: { type: "string" } }, required: ["id"] };
+
+    const result = flattenTopLevelUnionToolInputSchema(schema);
+
+    expect(result.changed).toBe(false);
+    expect(result.schema).toBe(schema);
+  });
+
+  it("flattens a top-level anyOf into a single permissive object schema", () => {
+    const result = flattenTopLevelUnionToolInputSchema({
+      anyOf: [
+        { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+        { type: "object", properties: { email: { type: "string" } }, required: ["email"] },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.schema).toEqual({
+      type: "object",
+      additionalProperties: true,
+      properties: {
+        id: { type: "string" },
+        email: { type: "string" },
+      },
+    });
+    // Branch-level `required` is dropped: branches disagree on which field
+    // is present, so nothing is universally required.
+    expect(result.schema).not.toHaveProperty("required");
+  });
+
+  it("flattens oneOf and allOf the same way", () => {
+    for (const key of ["oneOf", "allOf"] as const) {
+      const result = flattenTopLevelUnionToolInputSchema({
+        [key]: [
+          { type: "object", properties: { a: { type: "string" } } },
+          { type: "object", properties: { b: { type: "number" } } },
+        ],
+      });
+      expect(result.changed).toBe(true);
+      expect(result.schema).toMatchObject({
+        type: "object",
+        properties: { a: { type: "string" }, b: { type: "number" } },
+      });
+      expect(result.schema).not.toHaveProperty(key);
+    }
+  });
+
+  it("keeps the first branch's schema when property names collide", () => {
+    const result = flattenTopLevelUnionToolInputSchema({
+      anyOf: [
+        { type: "object", properties: { value: { type: "string" } } },
+        { type: "object", properties: { value: { type: "number" } } },
+      ],
+    });
+
+    expect((result.schema.properties as Record<string, unknown>).value).toEqual({ type: "string" });
+  });
+
+  it("preserves top-level annotations and drops the union key", () => {
+    const result = flattenTopLevelUnionToolInputSchema({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      description: "Do a thing.",
+      title: "DoThing",
+      oneOf: [{ type: "object", properties: { x: { type: "string" } } }],
+    });
+
+    expect(result.schema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      description: "Do a thing.",
+      title: "DoThing",
+      type: "object",
+    });
+    expect(result.schema).not.toHaveProperty("oneOf");
+  });
+
+  it("falls back to an empty permissive object when branches are not objects", () => {
+    const result = flattenTopLevelUnionToolInputSchema({
+      anyOf: [{ type: "string" }, { type: "number" }],
+    });
+
+    expect(result.schema).toEqual({
+      type: "object",
+      additionalProperties: true,
+      properties: {},
+    });
+  });
+
+  it("leaves nested unions untouched — only the top level is constrained", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        target: { anyOf: [{ type: "string" }, { type: "null" }] },
+      },
+    };
+
+    const result = flattenTopLevelUnionToolInputSchema(schema);
+
+    expect(result.changed).toBe(false);
+    expect(result.schema).toBe(schema);
+  });
+});

--- a/packages/eve/src/shared/json-schema.ts
+++ b/packages/eve/src/shared/json-schema.ts
@@ -1,10 +1,84 @@
 import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index.js";
 
+import { isObject } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 
 const STANDARD_JSON_SCHEMA_TARGET: StandardJSONSchemaV1.Target = "draft-07";
 
 type JsonSchemaDirection = "input" | "output";
+
+/**
+ * Keys that express a schema union/intersection. Anthropic's Messages API
+ * rejects a tool whose `input_schema` carries any of these at the top
+ * level (`"tools.N.custom.input_schema: input_schema does not support
+ * oneOf, allOf, or anyOf at the top level"`) — the top level must be a
+ * single object schema.
+ */
+const TOP_LEVEL_UNION_KEYS = ["anyOf", "oneOf", "allOf"] as const;
+
+/**
+ * Result of {@link flattenTopLevelUnionToolInputSchema}. `changed` is `true`
+ * only when a top-level union was found and rewritten; when `false`, `schema`
+ * is the original object by reference so callers can cheaply detect a no-op.
+ */
+export interface ToolInputSchemaSanitizationResult {
+  readonly schema: Record<string, unknown>;
+  readonly changed: boolean;
+}
+
+/**
+ * Rewrites a tool input schema whose **top level** is a `oneOf`/`allOf`/`anyOf`
+ * union into a single object schema, so it survives providers (notably
+ * Anthropic) that reject a top-level union in a tool's `input_schema`.
+ *
+ * eve does not author third-party MCP tool schemas and cannot assume they
+ * honor this rule — worse, a server can change its schemas at any time. An
+ * un-sanitized top-level union fails the *entire* model request with an HTTP
+ * 400 before the agent can produce a response, taking down every other tool
+ * in the request with it. This flattening keeps one bad external tool from
+ * breaking the whole turn.
+ *
+ * The object-typed branches' `properties` are merged (first branch wins for a
+ * shared name) and left optional, with `additionalProperties` open, so no
+ * valid call is rejected. Nested unions are intentionally left untouched —
+ * the constraint is top-level only — and the server's own validation still
+ * enforces the real union when the tool runs.
+ */
+export function flattenTopLevelUnionToolInputSchema(
+  schema: Record<string, unknown>,
+): ToolInputSchemaSanitizationResult {
+  const unionKey = TOP_LEVEL_UNION_KEYS.find((key) => Array.isArray(schema[key]));
+  if (unionKey === undefined) {
+    return { changed: false, schema };
+  }
+
+  const mergedProperties: Record<string, unknown> = {};
+  for (const branch of schema[unionKey] as readonly unknown[]) {
+    if (!isObject(branch) || !isObject(branch.properties)) {
+      continue;
+    }
+    for (const [name, propertySchema] of Object.entries(branch.properties)) {
+      if (!(name in mergedProperties)) {
+        mergedProperties[name] = propertySchema;
+      }
+    }
+  }
+
+  const flattened: Record<string, unknown> = {
+    additionalProperties: true,
+    properties: mergedProperties,
+    type: "object",
+  };
+  // Carry over top-level annotations the model benefits from; drop the
+  // union key and anything provider-specific that prompted the rejection.
+  for (const key of ["description", "title", "$schema"] as const) {
+    if (typeof schema[key] === "string") {
+      flattened[key] = schema[key];
+    }
+  }
+
+  return { changed: true, schema: flattened };
+}
 
 /**
  * Normalizes one Standard Schema or JSON Schema definition into plain JSON


### PR DESCRIPTION
## Problem

A connection (MCP) tool whose `input_schema` uses a top-level `oneOf`/`allOf`/`anyOf` union takes down the **entire turn**. Anthropic's Messages API rejects such a schema and fails the whole model request with an HTTP 400 **before the agent produces a response**:

```
tools.N.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

Because eve passes third-party MCP tool schemas straight through (`mcp-client.ts` → `toolsFromDefinitions` + metadata), one non-conforming external tool poisons the request for every other tool in it. The failure surfaces to the user only as the generic `summarizeKnownModelCallRequestError` message ("AI Gateway rejected the model request before the agent produced a response"), with no indication of which tool caused it.

This was hit in production against a live third-party MCP server whose tool schema had a top-level union. eve can't author or pin external schemas — and a server can change them at any time — so the runtime has to defend against it.

## Fix

Sanitize at MCP ingestion, before the schema reaches the model:

- New `flattenTopLevelUnionToolInputSchema` (`shared/json-schema.ts`) rewrites a top-level union into a single object schema — merging the branches' `properties` (first branch wins on collision, all optional) with `additionalProperties: true`, so no valid call is rejected. Top-level `description`/`title`/`$schema` are preserved; **nested** unions are left untouched (Anthropic only forbids them at the top level). The server's own validation still enforces the real union at call time.
- `McpConnectionClient` applies it to every listed tool, feeding the sanitized definitions to **both** `toolsFromDefinitions` and the connection metadata, and **logs the offending connection + tool name** so a recurrence is diagnosable at a glance instead of only as an opaque `tools.N.custom.input_schema` rejection.

## Tests

- `shared/json-schema.test.ts` — unit coverage for anyOf/oneOf/allOf, no-op passthrough (by reference), property-collision precedence, non-object branches, annotation preservation, and nested-union passthrough.
- `mcp-client.test.ts` — wiring test asserting a listed tool's top-level union is flattened in both the exposed metadata and the definitions handed to `toolsFromDefinitions`, and a conforming tool is untouched.

`pnpm --filter eve typecheck`, `pnpm lint`, `pnpm fmt`, and the two test files (50 tests) pass locally. Changeset included (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)