### PR TITLE
fix(eve): resolve MCP connection url from re-imported module at runtime

### DIFF
--- a/.changeset/mcp-connection-runtime-url.md
+++ b/.changeset/mcp-connection-runtime-url.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`defineMcpClientConnection` connections now honor the URL produced by the re-imported authored module at runtime instead of the build-time snapshot. Env-driven endpoints — most notably Vercel Services bindings, whose target host is only injected at request time — resolve to the correct URL on cold start. When the module omits or blanks `url`, the compiled manifest value is still used, so existing static-URL connections are unaffected.

--- a/packages/eve/src/runtime/resolve-connection.test.ts
+++ b/packages/eve/src/runtime/resolve-connection.test.ts
@@ -45,4 +45,65 @@ describe("resolveConnectionDefinition", () => {
     expect(resolved.authorization).toBe(auth);
     expect(resolved.headers).toBe(headers);
   });
+
+  it("prefers the URL produced by the re-imported module over the manifest snapshot", async () => {
+    const definition: CompiledConnectionDefinition = {
+      connectionName: "backlog",
+      description: "Backlog MCP",
+      logicalPath: "connections/backlog.ts",
+      protocol: "mcp",
+      sourceId: "connections/backlog",
+      sourceKind: "module",
+      url: "http://backlog-mcp.invalid/mcp",
+    };
+    const runtimeUrl = "https://backlog-mcp.internal.vercel/mcp";
+    const moduleMap: CompiledModuleMap = {
+      nodes: {
+        [ROOT_COMPILED_AGENT_NODE_ID]: {
+          modules: {
+            [definition.sourceId]: {
+              default: {
+                description: definition.description,
+                url: runtimeUrl,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = await resolveConnectionDefinition(definition, moduleMap, undefined);
+
+    expect(resolved.url).toBe(runtimeUrl);
+  });
+
+  it("falls back to the manifest URL when the module omits or blanks it", async () => {
+    const definition: CompiledConnectionDefinition = {
+      connectionName: "warehouse",
+      description: "Tenant warehouse",
+      logicalPath: "connections/warehouse.ts",
+      protocol: "mcp",
+      sourceId: "connections/warehouse",
+      sourceKind: "module",
+      url: "https://warehouse.example.com/mcp",
+    };
+    const moduleMap: CompiledModuleMap = {
+      nodes: {
+        [ROOT_COMPILED_AGENT_NODE_ID]: {
+          modules: {
+            [definition.sourceId]: {
+              default: {
+                description: definition.description,
+                url: "",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const resolved = await resolveConnectionDefinition(definition, moduleMap, undefined);
+
+    expect(resolved.url).toBe(definition.url);
+  });
 });

--- a/packages/eve/src/runtime/resolve-connection.ts
+++ b/packages/eve/src/runtime/resolve-connection.ts
@@ -46,14 +46,26 @@ export async function resolveConnectionDefinition(
       name: definition.connectionName,
     } as const;
 
+    // Prefer the URL produced by the re-imported module over the
+    // manifest snapshot. Authored connections may compute the URL from
+    // ambient state (env vars injected only at runtime, most notably
+    // Vercel Services bindings whose target is unresolvable at build).
+    // The compiler still validated a URL at build; using the runtime
+    // value keeps env-driven and binding-driven endpoints correct
+    // without requiring authors to opt into a resolver form.
+    const runtimeUrl =
+      typeof resolvedRecord.url === "string" && resolvedRecord.url.length > 0
+        ? resolvedRecord.url
+        : definition.url;
+
     const sourceKey = `connection-source:${definition.sourceId}`;
     stampDefinitionKey(resolvedRecord, sourceKey);
     registerDefinitionSource(sourceKey, sourceEntry);
-    // Use the compiled `url` (the MCP endpoint or OpenAPI base URL) as
-    // the secondary key so it matches the authoring-time key stamped by
-    // the `define*` factory for both protocols. The live record only
-    // carries `url` for MCP connections.
-    registerDefinitionSource(`connection:${definition.url}`, sourceEntry);
+    // Use the runtime URL as the secondary key so it matches the
+    // authoring-time key stamped by the `define*` factory (which runs
+    // on the same re-imported module). The live record only carries
+    // `url` for MCP connections.
+    registerDefinitionSource(`connection:${runtimeUrl}`, sourceEntry);
 
     const hasAuth = resolvedRecord.auth !== undefined;
     const hasHeaders = resolvedRecord.headers !== undefined;
@@ -84,7 +96,7 @@ export async function resolveConnectionDefinition(
       protocol: definition.protocol,
       sourceId: definition.sourceId,
       sourceKind: "module",
-      url: definition.url,
+      url: runtimeUrl,
     };
 
     if (hasAuth) {


### PR DESCRIPTION
Closes #521.

## Summary

`defineMcpClientConnection` connections now honor the URL produced by the re-imported authored module at runtime instead of the manifest snapshot captured at build time. Env-driven endpoints — most notably Vercel Services bindings, whose target host is only injected at request time — resolve to the correct URL on cold start.

- `resolveConnectionDefinition` prefers `resolvedRecord.url` when the re-imported module exports a non-empty string. When it omits or blanks `url`, it falls back to the compiled manifest value, so existing static-URL connections are unaffected.
- The `connection:<url>` secondary source key now uses the runtime URL, matching the key stamped by `defineMcpClientConnection` on the same re-imported module.

Authoring stays unchanged — the current shape is enough:

```ts
const base = process.env.BACKLOG_MCP_BASE ?? "http://backlog-mcp.invalid";
export default defineMcpClientConnection({
  url: `${base}/mcp`,
  description: "...",
});
```

At build the placeholder URL is baked into the manifest; at runtime the module is re-imported with the real binding env in place and its computed URL wins. No new API surface, no new marker on the compiled manifest.

I intentionally did not add the `url: (ctx) => …` resolver form proposed in the issue — the reproducer (Vercel Services bindings) is a module-scoped env problem, not a per-caller one, and this fix closes it without expanding the API. Happy to layer the function form on top separately if a per-caller URL use case shows up.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm oxlint --fix` / `pnpm oxfmt`
- [x] `pnpm guard:invariants`
- [x] `pnpm test:unit` (4381 passed)
- [x] Added two `resolve-connection.test.ts` cases: runtime URL preferred, manifest fallback when the module blanks `url`.
