### PR TITLE
fix(eve): clear error when eval files are nested inside agent/

### DIFF
--- a/.changeset/eval-nested-dir-error.md
+++ b/.changeset/eval-nested-dir-error.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve eval` now prints a clear, actionable message when it finds no evals but detects `*.eval.ts` files placed inside `agent/`. Instead of the generic "No evals found", it names the offending directories and reminds you that eval files belong in the top-level `evals/` directory (a sibling of `agent/`).

--- a/packages/eve/src/evals/cli/eval.ts
+++ b/packages/eve/src/evals/cli/eval.ts
@@ -5,7 +5,11 @@ import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { createDevelopmentServer, type DevelopmentServer } from "#internal/nitro/host.js";
 import { createEvalClient } from "#evals/cli/eval-client.js";
-import { discoverAndImportEvals, discoverEvalConfig } from "#evals/runner/discover.js";
+import {
+  discoverAndImportEvals,
+  discoverEvalConfig,
+  findMisplacedEvalDirs,
+} from "#evals/runner/discover.js";
 import { runEvals } from "#evals/runner/run-evals.js";
 import { ConsoleReporter } from "#evals/runner/reporters/console.js";
 import { JUnit } from "#evals/runner/reporters/junit.js";
@@ -48,7 +52,15 @@ export async function runEvalCommand(
   const discovered = await discoverAndImportEvals(appRoot, requestedEvalIds);
 
   if (discovered.length === 0) {
-    if (requestedEvalIds) {
+    const misplaced = await findMisplacedEvalDirs(appRoot);
+    if (misplaced.length > 0) {
+      logger.error(
+        "No evals found under evals/, but eval files are present inside agent/:\n" +
+          misplaced.map((dir) => `  - ${dir}`).join("\n") +
+          "\neve eval only scans the top-level evals/ directory (a sibling of agent/). " +
+          "Move these files there.",
+      );
+    } else if (requestedEvalIds) {
       logger.error(`No evals found matching: ${requestedEvalIds.join(", ")}`);
     } else {
       logger.error("No evals found. Create files under evals/ with the *.eval.ts extension.");

--- a/packages/eve/src/evals/runner/discover.integration.test.ts
+++ b/packages/eve/src/evals/runner/discover.integration.test.ts
@@ -7,6 +7,7 @@ import {
   discoverAndImportEvals,
   discoverEvalConfig,
   discoverEvalFiles,
+  findMisplacedEvalDirs,
   matchesEvalFilter,
 } from "#evals/runner/discover.js";
 
@@ -230,6 +231,57 @@ describe("discoverEvalFiles", () => {
 
     const exact = await discoverAndImportEvals(tempDir, ["runtime/beta"]);
     expect(exact.map((evaluation) => evaluation.id)).toEqual(["runtime/beta"]);
+  });
+});
+
+describe("findMisplacedEvalDirs", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "eve-eval-misplaced-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when agent/ does not exist", async () => {
+    expect(await findMisplacedEvalDirs(tempDir)).toEqual([]);
+  });
+
+  it("returns an empty array when agent/ has no eval files", async () => {
+    await mkdir(join(tempDir, "agent", "skills"), { recursive: true });
+    await writeFile(join(tempDir, "agent", "agent.ts"), "export default {}");
+
+    expect(await findMisplacedEvalDirs(tempDir)).toEqual([]);
+  });
+
+  it("detects an evals directory nested directly in agent/", async () => {
+    await mkdir(join(tempDir, "agent", "evals"), { recursive: true });
+    await writeFile(join(tempDir, "agent", "evals", "weather.eval.ts"), "export default {}");
+
+    expect(await findMisplacedEvalDirs(tempDir)).toEqual(["agent/evals"]);
+  });
+
+  it("detects eval files nested deeper in the agent tree", async () => {
+    await mkdir(join(tempDir, "agent", "skills", "weather"), { recursive: true });
+    await writeFile(
+      join(tempDir, "agent", "skills", "weather", "forecast.eval.ts"),
+      "export default {}",
+    );
+    await mkdir(join(tempDir, "agent", "evals"), { recursive: true });
+    await writeFile(join(tempDir, "agent", "evals", "alpha.eval.ts"), "export default {}");
+
+    expect(await findMisplacedEvalDirs(tempDir)).toEqual(["agent/evals", "agent/skills/weather"]);
+  });
+
+  it("does not flag the legitimate top-level evals/ directory", async () => {
+    await mkdir(join(tempDir, "agent"), { recursive: true });
+    await writeFile(join(tempDir, "agent", "agent.ts"), "export default {}");
+    await mkdir(join(tempDir, "evals"), { recursive: true });
+    await writeFile(join(tempDir, "evals", "weather.eval.ts"), "export default {}");
+
+    expect(await findMisplacedEvalDirs(tempDir)).toEqual([]);
   });
 });
 

--- a/packages/eve/src/evals/runner/discover.ts
+++ b/packages/eve/src/evals/runner/discover.ts
@@ -36,6 +36,31 @@ export async function discoverEvalFiles(appRoot: string): Promise<string[]> {
 }
 
 /**
+ * Finds directories under `<appRoot>/agent/` that directly contain
+ * `*.eval.ts` files. Used to produce a clear error when eval files are placed
+ * inside the agent tree instead of the top-level `evals/` directory that
+ * {@link discoverEvalFiles} scans.
+ *
+ * Returns app-root-relative, POSIX-normalized directory paths, sorted and
+ * de-duplicated. Returns `[]` when `agent/` is absent.
+ */
+export async function findMisplacedEvalDirs(appRoot: string): Promise<string[]> {
+  const agentDir = join(appRoot, "agent");
+  const dirs = new Set<string>();
+
+  try {
+    await collectMisplacedEvalDirs(agentDir, appRoot, dirs);
+  } catch (error) {
+    if (isNoEntryError(error)) {
+      return [];
+    }
+    throw error;
+  }
+
+  return [...dirs].sort((a, b) => a.localeCompare(b));
+}
+
+/**
  * Derives the canonical eval id from one absolute eval file path.
  *
  * `<appRoot>/evals/sub/weather.eval.ts` → `"sub/weather"`.
@@ -201,6 +226,22 @@ async function collectEvalFiles(dir: string, files: string[]): Promise<void> {
       await collectEvalFiles(entryPath, files);
     } else if (entry.isFile() && entry.name.endsWith(EVAL_FILE_SUFFIX)) {
       files.push(entryPath);
+    }
+  }
+}
+
+async function collectMisplacedEvalDirs(
+  dir: string,
+  appRoot: string,
+  dirs: Set<string>,
+): Promise<void> {
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      await collectMisplacedEvalDirs(join(dir, entry.name), appRoot, dirs);
+    } else if (entry.isFile() && entry.name.endsWith(EVAL_FILE_SUFFIX)) {
+      dirs.add(relative(appRoot, dir).split(/[\\/]/u).join("/"));
     }
   }
 }


### PR DESCRIPTION
## Problem

`eve eval` only scans the top-level `evals/` directory (a sibling of `agent/`). When authors instead place `*.eval.ts` files inside the agent tree (e.g. `agent/evals/foo.eval.ts` or `agent/skills/weather/foo.eval.ts`), discovery returns nothing and the CLI prints the generic `No evals found. Create files under evals/ with the *.eval.ts extension.` — misleading, since the author *did* write evals; they're just in the wrong place.

## Change

- Add `findMisplacedEvalDirs(appRoot)` to `evals/runner/discover.ts` — recursively scans `<appRoot>/agent/` for directories directly containing `*.eval.ts` files, returning app-root-relative, POSIX-normalized, sorted, de-duplicated paths (`[]` when `agent/` is absent). Reuses the existing `EVAL_FILE_SUFFIX` and `isNoEntryError`.
- In the empty-discovery branch of `runEvalCommand` (`evals/cli/eval.ts`), prefer a clear, actionable message that names the offending directories and points at the top-level `evals/` directory. Exit code stays `2`.

New message a user sees when eval files sit inside `agent/`:

```
No evals found under evals/, but eval files are present inside agent/:
  - agent/evals
eve eval only scans the top-level evals/ directory (a sibling of agent/). Move these files there.
```

Out of scope: auto-discovering/running evals nested in `agent/`. This is a better error message, not a new discovery location.

## Tests

- New `describe("findMisplacedEvalDirs")` block in `discover.integration.test.ts` (no `agent/`, no eval files, nested directly in `agent/evals`, deeper nesting, and does not flag the legit top-level `evals/`).
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/evals/runner/discover.integration.test.ts` → 21 passed.
- `pnpm fmt` / `pnpm lint` / `pnpm --filter eve typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)