### PR TITLE
fix(eve): emit a final chat message when the session token limit is reached

### DIFF
--- a/.changeset/session-token-limit-chat-message.md
+++ b/.changeset/session-token-limit-chat-message.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Sessions that reach their configured token limit now emit one final chat message ("The session reached its configured input token limit. Start a new session to continue.") before the failure cascade, so conversations no longer end silently on surfaces that only render messages.

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -94,7 +94,9 @@ export default defineAgent({
 Input and output budgets are checked independently. The model call that crosses
 either limit is allowed to finish because providers only report exact token
 usage after a call completes. Follow-up model calls in the same session fail
-with `SESSION_TOKEN_LIMIT_REACHED`.
+with `SESSION_TOKEN_LIMIT_REACHED`, and the session emits one final chat
+message explaining the limit before it fails so the conversation does not end
+silently.
 
 When `maxInputTokensPerSession` is omitted, eve applies a default input budget:
 `40_000_000` provider-reported input tokens for root sessions and `5_000_000`

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -950,10 +950,14 @@ describe("createToolLoopHarness", () => {
         "turn.started",
         "message.received",
         "step.started",
+        "message.completed",
         "step.failed",
         "turn.failed",
         "session.failed",
       ]);
+      expect(events.find((event) => event.type === "message.completed")?.data).toMatchObject({
+        message: `${testCase.message} Start a new session to continue.`,
+      });
       expect(events.find((event) => event.type === "step.failed")?.data).toMatchObject({
         code: "SESSION_TOKEN_LIMIT_REACHED",
         details: testCase.details,

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -37,6 +37,7 @@ import {
   createCompactionCompletedEvent,
   createCompactionRequestedEvent,
   createInputRequestedEvent,
+  createMessageCompletedEvent,
   createResultCompletedEvent,
 } from "#protocol/message.js";
 import type { InstrumentationDefinition } from "#public/instrumentation/index.js";
@@ -1156,6 +1157,10 @@ function formatSessionTokenLimitMessage(kind: SessionTokenLimitViolation["kind"]
   return `The session reached its configured ${kind} token limit.`;
 }
 
+function formatSessionTokenLimitChatMessage(kind: SessionTokenLimitViolation["kind"]): string {
+  return `${formatSessionTokenLimitMessage(kind)} Start a new session to continue.`;
+}
+
 async function failSessionTokenLimit(input: {
   readonly config: ToolLoopHarnessConfig;
   readonly emit?: ToolLoopHarnessConfig["handleEvent"];
@@ -1174,6 +1179,17 @@ async function failSessionTokenLimit(input: {
   };
 
   if (input.emit) {
+    // One final chat-visible message before the failure cascade: surfaces
+    // that render only `message.*` events (session UIs, message-only
+    // channel handlers) would otherwise end the conversation silently.
+    await input.emit(
+      createMessageCompletedEvent({
+        message: formatSessionTokenLimitChatMessage(input.violation.kind),
+        sequence: input.emissionState.sequence,
+        stepIndex: input.emissionState.stepIndex,
+        turnId: input.emissionState.turnId,
+      }),
+    );
     await emitFailedStep(input.emit, input.emissionState, {
       code: SESSION_TOKEN_LIMIT_REACHED_CODE,
       details,


### PR DESCRIPTION
When a session crosses `maxInputTokensPerSession` or `maxOutputTokensPerSession`, the next turn fails with `SESSION_TOKEN_LIMIT_REACHED` and the harness emits only the failure cascade (`step.failed` -> `turn.failed` -> `session.failed`). Channels with failure handlers post generic error copy, but anything that renders only `message.*` events shows nothing at all. The client message reducer drops failure events (`message-reducer.ts` returns data unchanged for `turn.failed`/`session.failed`), and a custom channel without failure handlers never sees them. The conversation just stops.

## What

- `failSessionTokenLimit` emits one `message.completed` before the failure cascade: "The session reached its configured input token limit. Start a new session to continue."
- The token-limit test asserts the event's position in the cascade and its text.
- One sentence in `docs/agent-config.md`, plus a changeset.

## Why an event, not a reducer fix

Patching the client reducer would cover one consumer. Emitting `message.completed` covers every consumer that renders assistant messages, since the channel defaults (Slack, Chat SDK, Teams) already post that event. The failure cascade is unchanged, so adapters keep the structured `code`/`details` and still learn the session is terminal.

## Scope

Channels that post on `turn.failed`/`session.failed` will now show this message before their failure copy. That stacking already happens for every terminal failure today; this change adds the one message that explains what actually happened.

Task mode is untouched: the parent already receives the limit message as an `isError` output (#412), and this event only adds the chat-visible copy.
