### PR TITLE
fix(eve): slack channel - preserve markdown with file uploads

### DIFF
--- a/.changeset/slack-markdown-file-posts.md
+++ b/.changeset/slack-markdown-file-posts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack channel posts that combine Markdown and file uploads now send the Markdown message first and upload files as a threaded follow-up. This preserves Slack's full Markdown rendering, including tables, instead of downgrading the response into a file upload comment.

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -246,7 +246,43 @@ describe("SlackThread.post with files", () => {
     vi.unstubAllGlobals();
   });
 
-  it("{ markdown, files } produces a single Slack message via completeUploadExternal", async () => {
+  it("{ markdown, files } posts markdown before uploading files", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    const posted = await thread.post({
+      markdown: [
+        "**Report attached**",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        "| Net | +488 |",
+      ].join("\n"),
+      files: [{ data: Buffer.from([1, 2]), filename: "report.csv", mimeType: "text/csv" }],
+    });
+
+    expect(posted.id).toBe("1700000001.000001");
+
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect(post).toBeDefined();
+    expect((post!.body as { markdown_text: string; thread_ts: string }).markdown_text).toContain(
+      "| Metric | Value |",
+    );
+    expect((post!.body as { markdown_text: string; thread_ts: string }).thread_ts).toBe("1.0");
+
+    const complete = mock.calls.find(
+      (c) => c.url === "https://slack.com/api/files.completeUploadExternal",
+    )!;
+    expect((complete.body as { initial_comment?: string }).initial_comment).toBeUndefined();
+    expect((complete.body as { channel_id: string; thread_ts: string }).channel_id).toBe("C01");
+    expect((complete.body as { channel_id: string; thread_ts: string }).thread_ts).toBe("1.0");
+  });
+
+  it("{ text, files } keeps a single Slack upload comment", async () => {
     const { thread } = buildSlackBinding({
       botToken: "xoxb-test",
       channelId: "C01",
@@ -255,14 +291,12 @@ describe("SlackThread.post with files", () => {
     });
 
     await thread.post({
-      markdown: "**Report attached**",
+      text: "*Report attached*",
       files: [{ data: Buffer.from([1, 2]), filename: "report.csv", mimeType: "text/csv" }],
     });
 
-    const postMessageCall = mock.calls.find(
-      (c) => c.url === "https://slack.com/api/chat.postMessage",
-    );
-    expect(postMessageCall).toBeUndefined();
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect(post).toBeUndefined();
 
     const complete = mock.calls.find(
       (c) => c.url === "https://slack.com/api/files.completeUploadExternal",
@@ -516,7 +550,7 @@ describe("auto-anchor on first post", () => {
     expect(slack.threadTs).toBe("");
   });
 
-  it("does not anchor on a files-only post", async () => {
+  it("anchors before uploading files for a markdown post", async () => {
     const anchors: string[] = [];
     const { thread, slack } = buildSlackBinding({
       botToken: "xoxb-test",
@@ -530,6 +564,35 @@ describe("auto-anchor on first post", () => {
 
     await thread.post({
       markdown: "**Report attached**",
+      files: [{ data: Buffer.from([1]), filename: "report.csv", mimeType: "text/csv" }],
+    });
+
+    expect(anchors).toEqual(["1700000001.000001"]);
+    expect(slack.threadTs).toBe("1700000001.000001");
+
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage")!;
+    expect((post.body as { thread_ts?: string }).thread_ts).toBeUndefined();
+
+    const complete = mock.calls.find(
+      (c) => c.url === "https://slack.com/api/files.completeUploadExternal",
+    )!;
+    expect((complete.body as { thread_ts: string }).thread_ts).toBe("1700000001.000001");
+  });
+
+  it("does not anchor on an upload-only text/file post", async () => {
+    const anchors: string[] = [];
+    const { thread, slack } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "",
+      teamId: undefined,
+      onThreadTsChanged(ts) {
+        anchors.push(ts);
+      },
+    });
+
+    await thread.post({
+      text: "*Report attached*",
       files: [{ data: Buffer.from([1]), filename: "report.csv", mimeType: "text/csv" }],
     });
 

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -33,11 +33,7 @@ import { isCardElement, type CardElement, type FileUpload } from "#compiled/chat
 import { createLogger, logError } from "#internal/logging.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
 import { truncateTypingStatus } from "#public/channels/slack/limits.js";
-import {
-  gfmToSlackMrkdwn,
-  rewriteBareMentions,
-  slackMrkdwnToGfm,
-} from "#public/channels/slack/mrkdwn.js";
+import { rewriteBareMentions, slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
 
 const log = createLogger("slack.api");
 
@@ -124,14 +120,15 @@ export interface SlackPostedMessage {
  * - The channel uploads each file via Slack's modern
  *   `files.getUploadURLExternal` → POST bytes → `files.completeUploadExternal`
  *   flow.
- * - For `{ markdown }` / `{ text }`: the text becomes the file post's
- *   `initial_comment`, producing a single Slack message with text and
- *   files.
- * - For `{ blocks }` / `{ card }`: the structured message lands first
- *   via `chat.postMessage`, then the files are uploaded as a
+ * - For `{ text }`: the text becomes the file post's `initial_comment`,
+ *   producing a single Slack message with text and files. Slack
+ *   interprets `initial_comment` as mrkdwn.
+ * - For `{ markdown }` / `{ blocks }` / `{ card }`: the message lands
+ *   first via `chat.postMessage`, then the files are uploaded as a
  *   follow-up message in the same thread. Slack has no native way to
- *   attach arbitrary files inside a Block Kit message, so the two
- *   land as separate posts in the same thread.
+ *   attach arbitrary files inside those message surfaces, and
+ *   `initial_comment` cannot render Slack's full Markdown table/header
+ *   support.
  */
 interface SlackPostWithFiles {
   readonly files?: readonly FileUpload[];
@@ -220,10 +217,10 @@ export interface SlackThread {
    * becomes `{ card }`. Otherwise pass a {@link SlackPostInput}
    * explicitly, any variant of which may carry `files`.
    *
-   * With `files`, the channel runs Slack's three-step upload flow and
-   * either attaches them to this message (markdown / text variants) or
-   * posts them as a follow-up in the same thread (blocks / card
-   * variants).
+   * With `files`, the channel runs Slack's three-step upload flow. The
+   * `{ text }` variant attaches files with the text as the upload
+   * comment; `{ markdown }`, `{ blocks }`, and `{ card }` post the
+   * message first and upload files as a follow-up in the same thread.
    */
   post(message: string | CardElement | SlackPostInput): Promise<SlackPostedMessage>;
 
@@ -326,7 +323,8 @@ interface SlackBinding {
  * Auto-anchor: when the binding starts without a `threadTs`, the first
  * `chat.postMessage` adopts its own `ts` as the thread root, updating the
  * live `threadTs` and firing `onThreadTsChanged` so the caller can
- * persist the anchor. Ephemerals and files-only posts do not anchor.
+ * persist the anchor. Ephemerals and upload-only file posts do not
+ * anchor.
  */
 export function buildSlackBinding(input: {
   readonly botToken: SlackBotToken | undefined;
@@ -365,16 +363,12 @@ export function buildSlackBinding(input: {
       const message = normalizePostInput(rawMessage);
       const files = message.files ?? [];
       const hasStructured = "blocks" in message || "card" in message;
+      const shouldPostBeforeFiles = hasStructured || "markdown" in message;
 
-      // markdown / text + files: single Slack message with files attached
-      // via files.completeUploadExternal's initial_comment.
-      if (files.length > 0 && !hasStructured) {
-        const comment =
-          "markdown" in message
-            ? rewriteBareMentions(gfmToSlackMrkdwn(message.markdown))
-            : "text" in message
-              ? rewriteBareMentions(message.text)
-              : undefined;
+      // text + files: single Slack message with files attached via
+      // files.completeUploadExternal's mrkdwn-only initial_comment.
+      if (files.length > 0 && !shouldPostBeforeFiles) {
+        const comment = "text" in message ? rewriteBareMentions(message.text) : undefined;
         const result = await uploadFiles(files, { initialComment: comment });
         const id =
           Array.isArray(result.raw.files) && result.raw.files.length > 0
@@ -389,13 +383,13 @@ export function buildSlackBinding(input: {
       const id = response.id;
       handleMessageTs(id);
 
-      // blocks / card + files: structured message lands first, then upload
-      // files as a follow-up post in the same thread.
-      if (files.length > 0 && hasStructured) {
+      // markdown / blocks / card + files: message lands first, then
+      // files upload as a follow-up post in the same thread.
+      if (files.length > 0 && shouldPostBeforeFiles) {
         try {
           await uploadFiles(files);
         } catch (error) {
-          log.warn("file upload after structured post failed", { error });
+          log.warn("file upload after message post failed", { error });
         }
       }
       return { id, raw: response.raw };


### PR DESCRIPTION
## Summary

- preserve Slack Markdown rendering when `SlackThread.post` combines `{ markdown, files }`
- send Markdown responses through `chat.postMessage` first, then upload files as a threaded follow-up
- keep `{ text, files }` on the existing single upload-comment path
- add unit coverage for Markdown tables, upload comments, and auto-anchor behavior
- add a patch changeset for `eve`

## Root cause

The Slack channel previously handled `{ markdown, files }` by converting Markdown to legacy mrkdwn and passing it as `files.completeUploadExternal.initial_comment`. Slack upload comments do not support the newer Markdown rendering path, so Markdown tables appeared as literal pipe text.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/api.test.ts`
- `pnpm exec oxlint --fix packages/eve/src/public/channels/slack/api.ts packages/eve/src/public/channels/slack/api.test.ts`
- `pnpm --filter eve typecheck`