### PR TITLE
fix(eve): shut down eval sandbox handles

### DIFF
--- a/.changeset/eval-sandbox-shutdown.md
+++ b/.changeset/eval-sandbox-shutdown.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve eval` now shuts down tracked sandbox handles after a local one-shot eval run completes. This prevents local sandbox compute, including microsandbox sessions, from outliving the eval process.

--- a/packages/eve/src/evals/cli/eval.ts
+++ b/packages/eve/src/evals/cli/eval.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
+import { shutdownActiveSandboxHandles } from "#execution/sandbox/active-handles.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { createDevelopmentServer, type DevelopmentServer } from "#internal/nitro/host.js";
 import { createEvalClient } from "#evals/cli/eval-client.js";
@@ -166,6 +167,9 @@ export async function runEvalCommand(
   } finally {
     if (devServer) {
       await devServer.close();
+      await shutdownActiveSandboxHandles({
+        log: (message) => logger.error(message),
+      });
     }
   }
 

--- a/packages/eve/test/scenarios/eval-command-environment.scenario.test.ts
+++ b/packages/eve/test/scenarios/eval-command-environment.scenario.test.ts
@@ -4,9 +4,14 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { runCli } from "../../src/cli/run.js";
+import {
+  clearActiveSandboxHandlesForTest,
+  trackActiveSandboxHandle,
+} from "../../src/execution/sandbox/active-handles.js";
 import { useTemporaryDirectories } from "../../src/internal/testing/use-temporary-app-roots.js";
 
 const mockedEvalDependencies = vi.hoisted(() => ({
+  createDevelopmentServer: vi.fn(),
   discoverAndImportEvals: vi.fn(),
   discoverEvalConfig: vi.fn(),
   executeEval: vi.fn(),
@@ -24,6 +29,10 @@ vi.mock("../../src/evals/runner/execute-eval.js", () => ({
 
 vi.mock("../../src/evals/target.js", () => ({
   resolveEvalTargetHandle: mockedEvalDependencies.resolveEvalTargetHandle,
+}));
+
+vi.mock("../../src/internal/nitro/host.js", () => ({
+  createDevelopmentServer: mockedEvalDependencies.createDevelopmentServer,
 }));
 
 const createScratchDirectory = useTemporaryDirectories();
@@ -74,6 +83,8 @@ afterEach(() => {
   clearDevelopmentEnvironment();
   process.exitCode = undefined;
   vi.restoreAllMocks();
+  clearActiveSandboxHandlesForTest();
+  mockedEvalDependencies.createDevelopmentServer.mockReset();
   mockedEvalDependencies.discoverAndImportEvals.mockReset();
   mockedEvalDependencies.discoverEvalConfig.mockReset();
   mockedEvalDependencies.executeEval.mockReset();
@@ -136,6 +147,51 @@ describe("eve eval environment loading", () => {
     );
     expect(mockedEvalDependencies.resolveEvalTargetHandle).toHaveBeenCalled();
     expect(mockedEvalDependencies.executeEval).toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("shuts down tracked sandbox handles after a local eval run", async () => {
+    const fixtureRoot = await createEnvironmentFixture();
+    const previousCwd = process.cwd();
+    const logger = {
+      error: vi.fn(),
+      log: vi.fn(),
+    };
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const close = vi.fn(async () => {});
+    const handle = { shutdown: vi.fn(async () => {}) };
+    const evaluation = makeEvaluation("local");
+
+    trackActiveSandboxHandle({ backendName: "microsandbox", handle, sessionKey: "session-1" });
+    process.chdir(fixtureRoot);
+    mockedEvalDependencies.createDevelopmentServer.mockReturnValue({
+      close,
+      start: vi.fn(async () => ({
+        appRoot: fixtureRoot,
+        kind: "started" as const,
+        url: "http://127.0.0.1:43123",
+      })),
+    });
+    mockedEvalDependencies.discoverAndImportEvals.mockResolvedValue([evaluation]);
+    mockedEvalDependencies.discoverEvalConfig.mockResolvedValue(TEST_CONFIG);
+    mockedEvalDependencies.resolveEvalTargetHandle.mockResolvedValue({
+      attachSession: vi.fn(),
+      capabilities: { devRoutes: true },
+      dispatchSchedule: vi.fn(),
+      fetch: vi.fn(),
+      kind: "local",
+      url: "http://127.0.0.1:43123",
+    });
+    mockedEvalDependencies.executeEval.mockResolvedValue(makeEvalResult(evaluation.id));
+
+    try {
+      await runCli(["eval"], logger);
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(handle.shutdown).toHaveBeenCalledTimes(1);
     expect(exit).toHaveBeenCalledWith(0);
   });
 


### PR DESCRIPTION
## Summary

- drain the active sandbox handle registry after local `eve eval` closes its one-shot dev server
- add a scenario regression proving tracked sandbox handles are shut down
- add a patch changeset for the published `eve` package

References https://github.com/vercel/eve/issues/504#issuecomment-4892679741

## Verification

- `CI=true pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/eval-command-environment.scenario.test.ts`
- `CI=true pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/active-handles.test.ts src/internal/nitro/host/sandbox-shutdown-plugin.test.ts`
- `CI=true pnpm --filter eve typecheck`
- `git diff --check`