### PR TITLE
feat(eve): pass dispatch context to remote-agent outbound auth

### DIFF
--- a/.changeset/outbound-auth-context.md
+++ b/.changeset/outbound-auth-context.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Outbound auth functions for remote agents now receive an `OutboundAuthContext` with the dispatched tool call's raw `message`, `remoteAgentName`, and `callId`, so custom auth schemes can derive credentials from what is being sent. Existing zero-argument auth functions keep working unchanged.

--- a/docs/guides/remote-agents.md
+++ b/docs/guides/remote-agents.md
@@ -45,6 +45,23 @@ A remote agent lowers to the same `{ message, outputSchema? }` tool shape as a l
 
 If you are calling another Vercel-deployed eve agent, reach for `vercelOidc()`. The remote verifies the OIDC token to authorize the caller. See [Auth & route protection](./auth-and-route-protection) for the receiving side.
 
+For other schemes, supply your own function. It runs once per outbound dispatch and receives an `OutboundAuthContext` with the call being dispatched — `message` (the raw tool-call message from the parent model, before eve wraps it in the delegated prompt), `remoteAgentName`, and `callId` — so credentials can depend on what is being sent:
+
+```ts title="agent/subagents/weather.ts"
+import { defineRemoteAgent } from "eve";
+import type { OutboundAuthContext } from "eve/agents/auth";
+
+export default defineRemoteAgent({
+  url: "https://weather-agent.example.com",
+  description: "Answers weather questions.",
+  auth: async ({ message, remoteAgentName }: OutboundAuthContext) => ({
+    headers: { authorization: `Bearer ${await mintScopedToken(remoteAgentName, message)}` },
+  }),
+});
+```
+
+Functions that ignore the context (like the built-in helpers) remain valid `OutboundAuthFn`s.
+
 ## How remote dispatch and callbacks work
 
 A local subagent runs inline. A remote one runs in its own deployment, so dispatch is asynchronous:

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -104,6 +104,39 @@ describe("startRemoteAgentSession", () => {
     expect(body.mode).toBe("task");
   });
 
+  it("passes the outbound auth context to the auth function", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, sessionId: "remote-session" }), { status: 202 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = vi.fn().mockResolvedValue({ headers: { authorization: "Bearer contextual" } });
+
+    await startRemoteAgentSession({
+      action: createAction(),
+      callbackBaseUrl: "https://caller.example.com",
+      remote: { ...createRemoteAgent(), auth },
+      session: {
+        agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+        compaction: { recentWindowSize: 10, threshold: 100000 },
+        continuationToken: "eve:parent-token",
+        history: [],
+        sessionId: "parent-session",
+      },
+    });
+
+    expect(auth).toHaveBeenCalledExactlyOnceWith({
+      callId: "call-remote",
+      message: "find the marker",
+      remoteAgentName: "research",
+    });
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      authorization: "Bearer contextual",
+    });
+  });
+
   it("targets an active turn inbox when a callback token is supplied", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -3,6 +3,7 @@ import { createEveCallbackRoutePath } from "#protocol/routes.js";
 import { createWorkflowCallbackUrl } from "#execution/workflow-callback-url.js";
 import { formatSubagentInput } from "#execution/subagent-invocation.js";
 import type { HarnessSession } from "#harness/types.js";
+import type { OutboundAuthContext } from "#public/agents/auth.js";
 import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types.js";
 import type { RuntimeSubagentRegistry } from "#runtime/subagents/registry.js";
 import type { ResolvedRuntimeRemoteAgentNode } from "#runtime/types.js";
@@ -22,7 +23,10 @@ export async function startRemoteAgentSession(input: {
     throw new Error("Cannot dispatch remote agent without a callback base URL.");
   }
 
-  const headers = await resolveRemoteAgentRequestHeaders(input.remote);
+  const headers = await resolveRemoteAgentRequestHeaders({
+    action: input.action,
+    remote: input.remote,
+  });
   const response = await fetch(createRemoteAgentSessionUrl(input.remote), {
     body: JSON.stringify({
       callback: {
@@ -88,18 +92,26 @@ function createRemoteAgentSessionUrl(remote: ResolvedRuntimeRemoteAgentNode): st
   return new URL(remote.path, `${trimTrailingSlash(remote.url)}/`).toString();
 }
 
-async function resolveRemoteAgentRequestHeaders(
-  remote: ResolvedRuntimeRemoteAgentNode,
-): Promise<Record<string, string>> {
+async function resolveRemoteAgentRequestHeaders(input: {
+  readonly action: RuntimeRemoteAgentCallActionRequest;
+  readonly remote: ResolvedRuntimeRemoteAgentNode;
+}): Promise<Record<string, string>> {
   const headers: Record<string, string> = {};
-  if (remote.headers !== undefined) {
+  if (input.remote.headers !== undefined) {
     Object.assign(
       headers,
-      typeof remote.headers === "function" ? await remote.headers() : remote.headers,
+      typeof input.remote.headers === "function"
+        ? await input.remote.headers()
+        : input.remote.headers,
     );
   }
-  if (remote.auth !== undefined) {
-    Object.assign(headers, (await remote.auth()).headers);
+  if (input.remote.auth !== undefined) {
+    const context: OutboundAuthContext = {
+      callId: input.action.callId,
+      message: rawRemoteAgentCallMessage(input.action),
+      remoteAgentName: input.action.remoteAgentName,
+    };
+    Object.assign(headers, (await input.remote.auth(context)).headers);
   }
   return headers;
 }
@@ -108,13 +120,16 @@ function formatRemoteAgentCallInputMessage(input: {
   readonly action: RuntimeRemoteAgentCallActionRequest;
   readonly remote: ResolvedRuntimeRemoteAgentNode;
 }): string {
-  const message = typeof input.action.input.message === "string" ? input.action.input.message : "";
   return formatSubagentInput({
     description: input.remote.description,
-    message,
+    message: rawRemoteAgentCallMessage(input.action),
     name: input.action.remoteAgentName,
     type: "remote",
   }).message;
+}
+
+function rawRemoteAgentCallMessage(action: RuntimeRemoteAgentCallActionRequest): string {
+  return typeof action.input.message === "string" ? action.input.message : "";
 }
 
 function trimTrailingSlash(value: string): string {

--- a/packages/eve/src/public/agents/auth.ts
+++ b/packages/eve/src/public/agents/auth.ts
@@ -3,12 +3,31 @@ import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
 import type { TokenValue } from "#client/types.js";
 
 /**
- * Outbound request auth hook for remote agent dispatch. Runs once per
- * outbound request; returns the headers (e.g. `authorization`) to merge onto
- * that request. Use {@link vercelOidc}, {@link bearer}, or {@link basic} to
- * construct one, or supply a custom function for other schemes.
+ * Per-dispatch context handed to an {@link OutboundAuthFn}. Carries the
+ * parent's remote-agent tool call so custom auth schemes can derive
+ * credentials from what is being dispatched.
  */
-export type OutboundAuthFn = () => Promise<{
+export interface OutboundAuthContext {
+  /** Tool-call id of the parent's remote-agent call. */
+  readonly callId: string;
+  /**
+   * Raw `message` the parent model passed in the tool call, before eve wraps
+   * it in the delegated subagent prompt sent to the remote deployment.
+   */
+  readonly message: string;
+  /** Name of the remote agent being dispatched. */
+  readonly remoteAgentName: string;
+}
+
+/**
+ * Outbound request auth hook for remote agent dispatch. Runs once per
+ * outbound request with the {@link OutboundAuthContext} for that dispatch;
+ * returns the headers (e.g. `authorization`) to merge onto the request. Use
+ * {@link vercelOidc}, {@link bearer}, or {@link basic} to construct one, or
+ * supply a custom function for other schemes — functions that ignore the
+ * context remain valid.
+ */
+export type OutboundAuthFn = (context: OutboundAuthContext) => Promise<{
   readonly headers: Readonly<Record<string, string>>;
 }>;
 


### PR DESCRIPTION
## Summary

Outbound auth functions for remote agents (`OutboundAuthFn` from `eve/agents/auth`) now receive an `OutboundAuthContext` describing the dispatch, so custom auth schemes can derive credentials from what is being sent:

- `message` — the raw tool-call message from the parent model (before eve wraps it in the delegated subagent prompt)
- `remoteAgentName` — the remote agent being dispatched
- `callId` — the parent's tool-call id

The built-in helpers (`vercelOidc`, `bearer`, `basic`) and any existing zero-argument custom auth functions remain valid — a `() => Promise<...>` is assignable to the widened signature, so this is non-breaking for authors.

## Changes

- `packages/eve/src/public/agents/auth.ts` — new exported `OutboundAuthContext` interface; `OutboundAuthFn` widened to `(context: OutboundAuthContext) => Promise<{ headers }>`.
- `packages/eve/src/execution/remote-agent-dispatch.ts` — threads the runtime action into header resolution and builds the context; raw-message extraction is factored into `rawRemoteAgentCallMessage` and shared with the prompt formatter so the two cannot drift.
- `docs/guides/remote-agents.md` — documents the context with a custom-auth example.
- Changeset (patch).

## Testing

- New unit test asserting the auth function is invoked exactly once with the expected context and that its headers land on the outbound request.
- `pnpm typecheck`, `pnpm test:unit` (4419 tests), `pnpm lint`, `pnpm docs:check`, and `pnpm guard:invariants` all pass locally.

## Notes

- Deliberately does **not** pass the serialized request body (request-signing use case) — that would force reordering body construction before auth resolution; deferred until someone needs it.
- Commit currently carries the DCO trailer but needs to be re-signed with a GPG/SSH key before merge (authored in an environment without the signing key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)