### PR TITLE
fix(eve): forward authored model providerOptions to the model call

### DIFF
--- a/.changeset/forward-model-provider-options.md
+++ b/.changeset/forward-model-provider-options.md
@@ -1,0 +1,11 @@
+---
+"eve": patch
+---
+
+fix(harness): forward authored model `providerOptions` to the model call
+
+Authored `modelOptions.providerOptions` were resolved onto the model reference but
+only applied on the `gateway-auto` cache path, so direct-provider agents silently
+lost them. For the OpenAI Responses model this left `store` defaulting to `true`,
+which broke multi-turn against `store: false` backends (prior turns were sent as
+unresolvable `item_reference`s, failing follow-ups with "Item … not found").

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -858,6 +858,31 @@ describe("createToolLoopHarness", () => {
     expect(vi.mocked(ToolLoopAgent).mock.calls[0]?.[0]).toMatchObject({ reasoning: "high" });
   });
 
+  it("forwards the authored model provider options to the model call", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Hello!", role: "assistant" }] },
+      text: "Hello!",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const runStep = createToolLoopHarness(createTestConfig());
+    const session = createTestSession({
+      agent: {
+        modelReference: { id: "test-model", providerOptions: { openai: { store: false } } },
+        system: "You are a test assistant.",
+        tools: [],
+      },
+    });
+
+    await runStep(session, { message: "Hi" });
+
+    expect(vi.mocked(ToolLoopAgent).mock.calls[0]?.[0]).toMatchObject({
+      providerOptions: { openai: { store: false } },
+    });
+  });
+
   it("accumulates provider-reported token usage across the session", async () => {
     setupMockAgent({
       finishReason: "stop",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -730,6 +730,15 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         },
         onStepFinish: hooks.onStepFinish,
         prepareStep: hooks.prepareStep,
+        // Authored `modelOptions.providerOptions` (e.g. `{ openai: { store:
+        // false } }`) must reach the model call. Without this only the
+        // `gateway-auto` cache path in `prepareStep` ever applied them, so
+        // direct-provider agents silently lost their provider options — which,
+        // for the OpenAI Responses model, left `store` defaulting to true and
+        // broke multi-turn (prior turns sent as unresolvable `item_reference`s).
+        providerOptions: session.agent.modelReference.providerOptions as
+          | ProviderMetadata
+          | undefined,
         reasoning: session.agent.reasoning,
         runtimeContext: telemetryRuntimeContext,
         stopWhen: isStepCount(1),


### PR DESCRIPTION
### Description

```typescript
import { defineAgent } from "eve";
import { createOpenAI } from "@ai-sdk/openai";

const openai = createOpenAI({ /* baseURL/fetch for a store:false-only backend */ });

export default defineAgent({
  model: openai.responses("gpt-5.5"),
  // but this never reaches the model call, so `store` stays true.
  modelOptions: { providerOptions: { openai: { store: false } } },
});
```

After 2 turns requests failed with `AI_APICallError: Item with id 'msg_…' not found. Items are not persisted when store is set to false.`

`modelOptions.providerOptions` was resolved onto `modelReference.providerOptions` but never passed to the AI SDK model call, only the `gateway-auto` cache path in `prepareStep` ever applied it. So direct-provider agents silently lost their provider options.

This broke multi-turn for the OpenAI Responses model: with `providerOptions.openai.store` never reaching the call, `store` defaulted to `true`, so prior turns were sent as `{ type: "item_reference", id }` — which a `store: false` backend can't resolve, failing every follow-up with "Item with id 'msg_…' not found. Items are not persisted when store is false."

Pass `session.agent.modelReference.providerOptions` through to the `ToolLoopAgent` settings so authored provider options reach the model on every turn. The `gateway-auto` path already merges these in via `prepareStep`, so it's unaffected.

### How did you test your changes?

Ran from packages/eve:

```
pnpm build:compiled
pnpm exec vitest run --config vitest.unit.config.ts src/harness/tool-loop.test.ts
```

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
