### PR TITLE
feat(eve): chunk long Slack replies instead of failing with msg_too_long

### DIFF
--- a/.changeset/slack-chunk-long-messages.md
+++ b/.changeset/slack-chunk-long-messages.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack channel replies whose plain text or Markdown exceed Slack's `chat.postMessage` field limit (40,000 characters for plain `text`, 12,000 for the native `markdown_text` field) are now split into multiple ordered thread messages instead of failing with `msg_too_long`. Splitting prefers paragraph, line, then word boundaries. Set `chunkMessages: false` on the channel to keep the previous single-post behavior; structured (`blocks`/`card`) and file posts are unaffected.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -74,6 +74,8 @@ export default slackChannel({
 
 The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets build progressively: extensions of at least four characters appear immediately, while smaller streamed deltas use the five-second refresh interval to avoid one Slack request per token. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
 
+A plain text or Markdown reply longer than Slack's `chat.postMessage` field limit — 40,000 characters for plain `text`, 12,000 for the native `markdown_text` field — is split into multiple thread messages, preferring paragraph, line, then word boundaries, instead of failing the post with `msg_too_long`. Structured (`blocks`/`card`) and file posts are unaffected. Set `chunkMessages: false` to keep the single-post behavior.
+
 When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), eve gives it a unique temporary continuation token. The first agent post anchors the session to the Slack message timestamp, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 
 The example below overrides `onAppMention` to gate on an authored message and posts the completed reply to the thread. Event handlers receive `(eventData, channel, ctx)`, with Slack platform handles on `channel.thread` and `channel.slack`:

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Card, CardText } from "#compiled/chat/index.js";
 import { decodeSlackApiBody } from "#public/channels/slack/api-encoding.js";
 import { buildSlackBinding, callSlackApi } from "#public/channels/slack/api.js";
+import {
+  SLACK_MARKDOWN_TEXT_MAX_LENGTH,
+  SLACK_MESSAGE_TEXT_MAX_LENGTH,
+} from "#public/channels/slack/limits.js";
 
 interface FetchCall {
   url: string;
@@ -657,5 +661,117 @@ describe("auto-anchor on first post", () => {
     await Promise.all([thread.post("a"), thread.post("b"), thread.post("c")]);
 
     expect(anchors).toHaveLength(1);
+  });
+});
+
+describe("SlackThread.post chunking", () => {
+  let mock: ReturnType<typeof buildFetchMock>;
+
+  beforeEach(() => {
+    mock = buildFetchMock();
+    vi.stubGlobal("fetch", mock.fetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const postMessageCalls = () =>
+    mock.calls.filter((c) => c.url === "https://slack.com/api/chat.postMessage");
+
+  it("splits a text reply over the Slack limit into multiple posts that each fit", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.post({ text: "a".repeat(SLACK_MESSAGE_TEXT_MAX_LENGTH + 1000) });
+
+    const posts = postMessageCalls();
+    expect(posts.length).toBeGreaterThan(1);
+    for (const post of posts) {
+      const body = post.body as { text?: string };
+      expect((body.text ?? "").length).toBeLessThanOrEqual(SLACK_MESSAGE_TEXT_MAX_LENGTH);
+    }
+  });
+
+  it("splits an over-limit markdown reply into posts that each fit the markdown_text limit", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.post({ markdown: "b".repeat(SLACK_MESSAGE_TEXT_MAX_LENGTH + 1000) });
+
+    const posts = postMessageCalls();
+    expect(posts.length).toBeGreaterThan(1);
+    for (const post of posts) {
+      const body = post.body as { markdown_text?: string };
+      expect((body.markdown_text ?? "").length).toBeLessThanOrEqual(SLACK_MARKDOWN_TEXT_MAX_LENGTH);
+    }
+  });
+
+  it("chunks a markdown reply between the markdown and text limits (regression: markdown_text is 12000, not 40000)", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    // Fits the 40000 `text` cap but exceeds the 12000 `markdown_text` cap, so it
+    // must still be chunked — otherwise Slack rejects it with `msg_too_long`.
+    await thread.post({ markdown: "b".repeat(SLACK_MARKDOWN_TEXT_MAX_LENGTH + 5000) });
+
+    const posts = postMessageCalls();
+    expect(posts.length).toBeGreaterThan(1);
+    for (const post of posts) {
+      const body = post.body as { markdown_text?: string };
+      expect((body.markdown_text ?? "").length).toBeLessThanOrEqual(SLACK_MARKDOWN_TEXT_MAX_LENGTH);
+    }
+  });
+
+  it("does not chunk a markdown reply within the markdown_text limit", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.post({ markdown: "b".repeat(SLACK_MARKDOWN_TEXT_MAX_LENGTH - 100) });
+
+    expect(postMessageCalls()).toHaveLength(1);
+  });
+
+  it("posts a single message when chunking is disabled", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+      chunkMessages: false,
+    });
+
+    await thread.post({ text: "a".repeat(SLACK_MESSAGE_TEXT_MAX_LENGTH + 1000) });
+
+    expect(postMessageCalls()).toHaveLength(1);
+  });
+
+  it("does not chunk a reply within the limit", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.post({ text: "short reply" });
+
+    expect(postMessageCalls()).toHaveLength(1);
   });
 });

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -32,7 +32,12 @@ import { isCardElement, type CardElement, type FileUpload } from "#compiled/chat
 
 import { createLogger, logError } from "#internal/logging.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
-import { truncateTypingStatus } from "#public/channels/slack/limits.js";
+import {
+  SLACK_MARKDOWN_TEXT_MAX_LENGTH,
+  SLACK_MESSAGE_TEXT_MAX_LENGTH,
+  splitForSlackMessage,
+  truncateTypingStatus,
+} from "#public/channels/slack/limits.js";
 import { rewriteBareMentions, slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
 
 const log = createLogger("slack.api");
@@ -332,10 +337,13 @@ export function buildSlackBinding(input: {
   readonly threadTs: string;
   readonly teamId: string | undefined;
   readonly onThreadTsChanged?: (ts: string) => void;
+  /** Chunk over-limit text/markdown replies instead of erroring. Defaults to `true`. */
+  readonly chunkMessages?: boolean;
 }): SlackBinding {
   const request = createSlackRequester(input.botToken);
   const messages: SlackThreadMessage[] = [];
   let currentThreadTs = input.threadTs;
+  const chunkingEnabled = input.chunkMessages ?? true;
 
   function handleMessageTs(ts: string): void {
     if (currentThreadTs || ts === currentThreadTs) return;
@@ -375,6 +383,28 @@ export function buildSlackBinding(input: {
             ? String((result.raw.files[0] as { id?: unknown }).id ?? "")
             : "";
         return { id, raw: result.raw };
+      }
+
+      // Long plain text / markdown posts in ordered chunks instead of failing
+      // with `msg_too_long`; the first chunk anchors the thread and the return
+      // matches the single-post contract. Each kind chunks against its own cap.
+      const chunkable = files.length === 0 && chunkingEnabled ? longTextField(message) : undefined;
+      const chunkLimit =
+        chunkable?.kind === "markdown"
+          ? SLACK_MARKDOWN_TEXT_MAX_LENGTH
+          : SLACK_MESSAGE_TEXT_MAX_LENGTH;
+      if (chunkable && chunkable.value.length > chunkLimit) {
+        let first: SlackPostedMessage | undefined;
+        for (const part of splitForSlackMessage(chunkable.value, chunkLimit)) {
+          const chunk: SlackPostInput = chunkable.kind === "text" ? { text: part } : { markdown: part };
+          const chunkResponse = await postSlackMessage(
+            buildPostMessageOptions(chunk, input.channelId, currentThreadTs, input.botToken),
+          );
+          handleMessageTs(chunkResponse.id);
+          first ??= { id: chunkResponse.id, raw: chunkResponse.raw };
+        }
+        // `value.length > limit > 0` guarantees at least one chunk was posted.
+        return first as SlackPostedMessage;
       }
 
       const response = await postSlackMessage(
@@ -487,6 +517,21 @@ function normalizePostInput(message: string | CardElement | SlackPostInput): Sla
   if (typeof message === "string") return { markdown: message };
   if (isCardElement(message)) return { card: message };
   return message;
+}
+
+/**
+ * Returns the single free-text body of a message (the `text` or `markdown`
+ * variant) so it can be length-checked and chunked, or `undefined` for
+ * structured (`blocks`/`card`) messages, whose length is bounded per-block and
+ * must not be split at the message level.
+ */
+function longTextField(
+  message: SlackPostInput,
+): { readonly kind: "text" | "markdown"; readonly value: string } | undefined {
+  if ("blocks" in message || "card" in message) return undefined;
+  if ("text" in message) return { kind: "text", value: message.text };
+  if ("markdown" in message) return { kind: "markdown", value: message.markdown };
+  return undefined;
 }
 
 function buildPostMessageOptions(

--- a/packages/eve/src/public/channels/slack/limits.test.ts
+++ b/packages/eve/src/public/channels/slack/limits.test.ts
@@ -6,6 +6,7 @@ import {
   SLACK_MODAL_TITLE_MAX_LENGTH,
   SLACK_SECTION_TEXT_MAX_LENGTH,
   SLACK_TYPING_STATUS_MAX_LENGTH,
+  splitForSlackMessage,
   truncateMessageText,
   truncateModalTitle,
   truncatePlainText,
@@ -107,5 +108,41 @@ describe("truncateMessageText", () => {
     const result = truncateMessageText(long);
     expect(result.length).toBeLessThanOrEqual(SLACK_MESSAGE_TEXT_MAX_LENGTH);
     expect(result.endsWith("...")).toBe(true);
+  });
+});
+
+describe("splitForSlackMessage", () => {
+  it("returns the text unchanged when it already fits", () => {
+    expect(splitForSlackMessage("hello world", 40)).toEqual(["hello world"]);
+    expect(splitForSlackMessage("a".repeat(SLACK_MESSAGE_TEXT_MAX_LENGTH))).toHaveLength(1);
+  });
+
+  it("splits over-limit text into chunks that each fit and are non-empty", () => {
+    const long = "a".repeat(SLACK_MESSAGE_TEXT_MAX_LENGTH * 2 + 500);
+    const chunks = splitForSlackMessage(long);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SLACK_MESSAGE_TEXT_MAX_LENGTH);
+      expect(chunk.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("prefers paragraph boundaries", () => {
+    const para = "p".repeat(60);
+    expect(splitForSlackMessage([para, para].join("\n\n"), 100)).toEqual([para, para]);
+  });
+
+  it("falls back to word boundaries when there are no newlines", () => {
+    const chunks = splitForSlackMessage("word ".repeat(40).trim(), 20);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(20);
+      expect(chunk.startsWith(" ")).toBe(false);
+      expect(chunk.endsWith(" ")).toBe(false);
+    }
+  });
+
+  it("hard-cuts a single run with no usable boundary", () => {
+    expect(splitForSlackMessage("z".repeat(45), 20)).toEqual(["z".repeat(20), "z".repeat(20), "z".repeat(5)]);
   });
 });

--- a/packages/eve/src/public/channels/slack/limits.ts
+++ b/packages/eve/src/public/channels/slack/limits.ts
@@ -35,6 +35,14 @@ export const SLACK_SECTION_TEXT_MAX_LENGTH = 3000;
 export const SLACK_MESSAGE_TEXT_MAX_LENGTH = 40000;
 
 /**
+ * `chat.postMessage`'s native `markdown_text` field is capped at 12000 chars —
+ * a lower limit than the plain `text` field. A markdown reply must be chunked
+ * against this cap, not {@link SLACK_MESSAGE_TEXT_MAX_LENGTH}, or it still
+ * fails with `msg_too_long`.
+ */
+export const SLACK_MARKDOWN_TEXT_MAX_LENGTH = 12000;
+
+/**
  * `chat.postMessage` rejects payloads with more than 50 blocks
  * (`invalid_blocks`).
  */
@@ -90,6 +98,42 @@ export function truncateMessageText(value: string): string {
  */
 export function truncateModalTitle(value: string): string {
   return truncateWithEllipsis(value, SLACK_MODAL_TITLE_MAX_LENGTH);
+}
+
+/**
+ * Splits a message body that exceeds a Slack length limit into ordered chunks
+ * that each fit, so a long reply is delivered as multiple messages instead of
+ * failing with `msg_too_long` (or being silently truncated). Prefers to break
+ * on a paragraph, then a line, then a word boundary within each window, and
+ * hard-cuts only when a single run has no boundary. Returns `[text]` unchanged
+ * when it already fits, and never returns empty chunks.
+ *
+ * Defaults to {@link SLACK_MESSAGE_TEXT_MAX_LENGTH} (the `chat.postMessage`
+ * `text` cap); pass a smaller `maxLength` for other surfaces.
+ */
+export function splitForSlackMessage(
+  text: string,
+  maxLength: number = SLACK_MESSAGE_TEXT_MAX_LENGTH,
+): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > maxLength) {
+    const window = remaining.slice(0, maxLength);
+    // Prefer the latest paragraph/line/word boundary in the window; ignore
+    // boundaries in the first half so we don't emit tiny fragments.
+    let cut = window.lastIndexOf("\n\n");
+    if (cut < maxLength / 2) cut = window.lastIndexOf("\n");
+    if (cut < maxLength / 2) cut = window.lastIndexOf(" ");
+    if (cut <= 0) cut = maxLength; // no usable boundary — hard cut at the limit
+
+    const chunk = remaining.slice(0, cut).trimEnd();
+    if (chunk.length > 0) chunks.push(chunk);
+    remaining = remaining.slice(cut).replace(/^\s+/u, "");
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
 }
 
 function truncateWithEllipsis(value: string, maxLength: number): string {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -373,6 +373,16 @@ export interface SlackChannelConfig {
   readonly route?: string;
 
   /**
+   * When a reply's plain text/markdown exceeds Slack's `chat.postMessage` field
+   * limit (40000 chars for `text`, 12000 for the native `markdown_text` field),
+   * split it into multiple thread messages instead of failing the post with
+   * `msg_too_long`. Defaults to `true`. Set `false` to keep the single-post
+   * behavior. Structured (`blocks`/`card`) and file posts are unaffected either
+   * way.
+   */
+  readonly chunkMessages?: boolean;
+
+  /**
    * Inbound upload policy applied to file attachments before they reach
    * the harness. Violating attachments are dropped with a warning so the
    * mention's text portion still gets delivered. Pass `"disabled"` to
@@ -451,12 +461,14 @@ function rebuildSlackContext(
   state: SlackChannelState,
   session: SessionHandle,
   credentials: SlackChannelCredentials | undefined,
+  chunkMessages: boolean | undefined,
 ): SlackChannelContext {
   const { thread, slack } = buildSlackBinding({
     botToken: credentials?.botToken,
     channelId: state.channelId ?? "",
     threadTs: state.threadTs ?? "",
     teamId: state.teamId ?? undefined,
+    chunkMessages,
     onThreadTsChanged(ts) {
       state.threadTs = ts;
       if (state.channelId) {
@@ -542,7 +554,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     },
 
     context(state, session) {
-      return rebuildSlackContext(state, session, config.credentials);
+      return rebuildSlackContext(state, session, config.credentials, config.chunkMessages);
     },
 
     routes: [


### PR DESCRIPTION
Closes #838.

## What

Plain text / Markdown Slack replies that exceed Slack's `chat.postMessage` `text` limit (40,000 chars) are now split into multiple ordered thread messages instead of failing the single post with `msg_too_long`.

- Splitting prefers paragraph, then line, then word boundaries; hard-cuts only a single run with no usable boundary.
- Structured (`blocks`/`card`) and file posts are unaffected — they keep the single-call path.
- Opt out with `chunkMessages: false` on the channel config to keep the previous single-post behavior.

## Changes

- `limits.ts`: new `splitForSlackMessage(text, maxLength?)` helper + tests.
- `api.ts`: chunking in `SlackThread.post`, `longTextField` helper, `chunkMessages` option on `buildSlackBinding`.
- `slackChannel.ts`: `chunkMessages` threaded through `SlackChannelConfig`.
- Docs note in `docs/channels/slack.mdx` and a patch changeset.

## Scope note

This addresses the `msg_too_long` case for plain text/markdown replies. The `msg_blocks_too_long` / per-block budget portion of #838 is not covered here and can follow up separately.

## Testing

- `limits.test.ts` (incl. new `splitForSlackMessage` cases) and `api.test.ts` chunking cases pass on CI (Node 24). Locally the `#compiled` vendor build is blocked by a Node 25 shell, so the api-level cases were validated via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)