### PR TITLE
fix(eve): bubble subagent authorization events up to the parent session

### DIFF
--- a/.changeset/subagent-auth-bubbling.md
+++ b/.changeset/subagent-auth-bubbling.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Bubble subagent `authorization.required` and `authorization.completed` events up to the parent session's channel. Previously a subagent whose connection needed interactive OAuth parked silently — the sign-in link was written only to the child's unconsumed stream and the run hung. The events now proxy up through each delegation hop so the user can complete the sign-in; the OAuth callback still resumes the subagent directly.

--- a/docs/connections/overview.mdx
+++ b/docs/connections/overview.mdx
@@ -136,7 +136,7 @@ export default defineMcpClientConnection({
 });
 ```
 
-`"linear/myagent"` is the UID you chose when registering the Connect client. `connect("linear/myagent")` is shorthand for a user-scoped interactive OAuth connection: eve resolves a token for the active user before each tool call, emits `authorization.required` when that user has not authorized yet, and resumes the parked turn after the callback completes.
+`"linear/myagent"` is the UID you chose when registering the Connect client. `connect("linear/myagent")` is shorthand for a user-scoped interactive OAuth connection: eve resolves a token for the active user before each tool call, emits `authorization.required` when that user has not authorized yet, and resumes the parked turn after the callback completes. When the connection is used inside a [subagent](/docs/subagents), the authorization events surface on the root session's channel and the callback resumes the subagent directly.
 
 That means the channel that creates or continues the session must authenticate a real user. For a web app, configure `agent/channels/eve.ts` so your app session maps to `principalType: "user"`; for platform channels, use the built-in channel auth that maps the sender to a user principal. If no authenticated user is attached to the session, the first user-scoped connection call fails with `reason: "principal_required"`.
 

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -109,7 +109,9 @@ Because the name lives in the same runtime tool namespace as authored tools, a s
 
 Do not rely on subagent delegation by itself as an approval boundary. Put sensitive tools behind `approval`, connection approval, route/session authorization, or other controls wherever those tools can be called.
 
-Each delegated subagent spins up its own child session and stream. The parent stream carries only the control-plane events `subagent.called` and `subagent.completed`. To follow the child's full progress, read `subagent.called.data.childSessionId` and subscribe at `GET /eve/v1/session/:childSessionId/stream`.
+Each delegated subagent spins up its own child session and stream. The parent stream carries the control-plane events `subagent.called` and `subagent.completed`, plus any proxied requests described next. To follow the child's full progress, read `subagent.called.data.childSessionId` and subscribe at `GET /eve/v1/session/:childSessionId/stream`.
+
+When a subagent needs a human, the request surfaces on the parent session's channel, recursively through nested delegation. Tool approvals and `ask_question` prompts proxy up as `input.requested` events, and the response routes back down to the child. Connection authorization surfaces the same way — the child's `authorization.required` and `authorization.completed` events appear on the parent's channel so the user can complete the sign-in — but nothing routes back down: the challenge's callback resumes the subagent directly.
 
 ## When to split
 

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -1,6 +1,10 @@
 import type { UserContent } from "ai";
 
-import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import type {
+  AuthorizationCompletedStreamEvent,
+  AuthorizationRequiredStreamEvent,
+  HandleMessageStreamEvent,
+} from "#protocol/message.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
@@ -157,11 +161,30 @@ export interface SubagentInputRequestHookPayload {
 }
 
 /**
+ * Proxy payload sent from a child subagent to its parent when the child
+ * parks on (or completes) an authorization challenge.
+ *
+ * Runtime-internal, like {@link SubagentInputRequestHookPayload}. Carries the
+ * child's stream event verbatim: the embedded `webhookUrl` targets the
+ * child's own auth hook, so the parent only re-renders the event — the
+ * authorization callback resumes the child directly and nothing routes back
+ * down through the parent.
+ */
+export interface SubagentAuthorizationEventHookPayload {
+  readonly callId: string;
+  readonly childSessionId: string;
+  readonly event: AuthorizationCompletedStreamEvent | AuthorizationRequiredStreamEvent;
+  readonly kind: "subagent-authorization-event";
+  readonly subagentName: string;
+}
+
+/**
  * Serializable payload sent through the workflow `resumeHook`.
  */
 export type HookPayload =
   | DeliverHookPayload
   | RuntimeActionResultHookPayload
+  | SubagentAuthorizationEventHookPayload
   | SubagentInputRequestHookPayload;
 
 /**

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -14,6 +14,13 @@ if (SUBAGENT_INPUT_REQUESTED === undefined) {
   throw new Error("SUBAGENT_ADAPTER is missing its input.requested handler.");
 }
 
+const SUBAGENT_AUTH_REQUIRED = SUBAGENT_ADAPTER["authorization.required"];
+const SUBAGENT_AUTH_COMPLETED = SUBAGENT_ADAPTER["authorization.completed"];
+
+if (SUBAGENT_AUTH_REQUIRED === undefined || SUBAGENT_AUTH_COMPLETED === undefined) {
+  throw new Error("SUBAGENT_ADAPTER is missing an authorization event handler.");
+}
+
 const resumeHookMock = vi.fn();
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
@@ -108,6 +115,81 @@ describe("SUBAGENT_ADAPTER input.requested handler", () => {
   });
 });
 
+describe("SUBAGENT_ADAPTER authorization event handlers", () => {
+  it("forwards authorization.required verbatim via resumeHook", async () => {
+    resumeHookMock.mockClear();
+    const ctx = makeContext();
+
+    const data = {
+      authorization: { url: "https://idp.example.com/sign-in", displayName: "Linear" },
+      description: "Sign in to Linear",
+      name: "linear",
+      sequence: 2,
+      stepIndex: 1,
+      turnId: "turn-0",
+      webhookUrl: "https://agent.example.com/.eve/connections/linear/child-session:auth",
+    };
+
+    await SUBAGENT_AUTH_REQUIRED(data, ctx);
+
+    expect(resumeHookMock).toHaveBeenCalledTimes(1);
+    expect(resumeHookMock).toHaveBeenCalledWith("parent-token", {
+      callId: "call-123",
+      childSessionId: "child-session",
+      event: { type: "authorization.required", data },
+      kind: "subagent-authorization-event",
+      subagentName: "linear",
+    });
+  });
+
+  it("forwards authorization.completed verbatim via resumeHook", async () => {
+    resumeHookMock.mockClear();
+    const ctx = makeContext();
+
+    const data = {
+      name: "linear",
+      outcome: "authorized" as const,
+      sequence: 5,
+      stepIndex: 2,
+      turnId: "turn-0",
+    };
+
+    await SUBAGENT_AUTH_COMPLETED(data, ctx);
+
+    expect(resumeHookMock).toHaveBeenCalledTimes(1);
+    expect(resumeHookMock).toHaveBeenCalledWith("parent-token", {
+      callId: "call-123",
+      childSessionId: "child-session",
+      event: { type: "authorization.completed", data },
+      kind: "subagent-authorization-event",
+      subagentName: "linear",
+    });
+  });
+
+  it("skips forwarding when the adapter state is missing a parent continuation token", async () => {
+    resumeHookMock.mockClear();
+    const base = makeContext();
+    const ctx: ChannelAdapterContext = {
+      ctx: base.ctx,
+      state: {},
+      session: base.session,
+    };
+
+    await SUBAGENT_AUTH_REQUIRED(
+      {
+        description: "Sign in to Linear",
+        name: "linear",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-0",
+      },
+      ctx,
+    );
+
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("SUBAGENT_ADAPTER forward failure logging", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -157,6 +239,46 @@ describe("SUBAGENT_ADAPTER forward failure logging", () => {
       childContinuationToken: "child-token",
       childSessionId: "child-session",
       errorId: expect.any(String),
+      parentContinuationToken: "parent-token",
+      subagentName: "linear",
+      error: expect.objectContaining({
+        message: expect.stringContaining("parent gone"),
+      }),
+    });
+  });
+
+  it("warn-logs a structured breadcrumb and rethrows when forwarding an authorization event fails", async () => {
+    resumeHookMock.mockClear();
+    resumeHookMock.mockImplementationOnce(async () => {
+      throw new Error("parent gone");
+    });
+
+    const ctx = makeContext();
+
+    await expect(
+      SUBAGENT_AUTH_REQUIRED(
+        {
+          description: "Sign in to Linear",
+          name: "linear",
+          sequence: 0,
+          stepIndex: 1,
+          turnId: "turn-0",
+        },
+        ctx,
+      ),
+    ).rejects.toThrow("parent gone");
+
+    const warnCall = warnSpy.mock.calls.find((call: unknown[]) =>
+      String(call[0]).startsWith("[eve:execution.subagent-adapter]"),
+    );
+    expect(warnCall).toBeDefined();
+    const [, warnPayload] = warnCall!;
+    expect(warnPayload).toMatchObject({
+      callId: "call-123",
+      childSessionId: "child-session",
+      errorId: expect.any(String),
+      eventType: "authorization.required",
+      name: "linear",
       parentContinuationToken: "parent-token",
       subagentName: "linear",
       error: expect.objectContaining({

--- a/packages/eve/src/execution/subagent-adapter.ts
+++ b/packages/eve/src/execution/subagent-adapter.ts
@@ -1,7 +1,10 @@
 import { resumeHook } from "#internal/workflow/runtime.js";
 
-import type { ChannelAdapter } from "#channel/adapter.js";
-import type { SubagentInputRequestHookPayload } from "#channel/types.js";
+import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
+import type {
+  SubagentAuthorizationEventHookPayload,
+  SubagentInputRequestHookPayload,
+} from "#channel/types.js";
 import { ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
 import { createErrorId, createLogger } from "#internal/logging.js";
 
@@ -65,7 +68,11 @@ export function isSubagentAdapterState(value: unknown): value is SubagentAdapter
  * parent.
  *
  * It proxies child `input.requested` events upward so the parent channel
- * can render HITL prompts and route responses back down to the child.
+ * can render HITL prompts and route responses back down to the child, and
+ * child `authorization.*` events upward so the parent channel can render the
+ * sign-in challenge. Authorization needs no downward routing: the challenge's
+ * webhook URL targets the child's own auth hook, so the authorization
+ * callback resumes the child directly.
  */
 export const SUBAGENT_ADAPTER: ChannelAdapter = {
   kind: SUBAGENT_ADAPTER_KIND,
@@ -95,7 +102,37 @@ export const SUBAGENT_ADAPTER: ChannelAdapter = {
       parentContinuationToken: state.parentContinuationToken,
     });
   },
+  async "authorization.required"(data, ctx) {
+    await forwardAuthorizationEvent({ type: "authorization.required", data }, ctx);
+  },
+  async "authorization.completed"(data, ctx) {
+    await forwardAuthorizationEvent({ type: "authorization.completed", data }, ctx);
+  },
 };
+
+async function forwardAuthorizationEvent(
+  event: SubagentAuthorizationEventHookPayload["event"],
+  ctx: ChannelAdapterContext,
+): Promise<void> {
+  const state = ctx.state;
+
+  if (!isSubagentAdapterState(state)) {
+    return;
+  }
+
+  const hookPayload: SubagentAuthorizationEventHookPayload = {
+    callId: state.callId,
+    childSessionId: ctx.ctx.require(SessionIdKey),
+    event,
+    kind: "subagent-authorization-event",
+    subagentName: state.subagentName,
+  };
+
+  await forwardSubagentAuthorizationEventStep({
+    hookPayload,
+    parentContinuationToken: state.parentContinuationToken,
+  });
+}
 
 /**
  * Forwards one child HITL batch up to its parent via the durable
@@ -116,6 +153,34 @@ async function forwardSubagentInputRequestStep(input: {
       childContinuationToken: input.hookPayload.childContinuationToken,
       childSessionId: input.hookPayload.childSessionId,
       errorId,
+      parentContinuationToken: input.parentContinuationToken,
+      subagentName: input.hookPayload.subagentName,
+      error,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Forwards one child authorization event up to its parent via the durable
+ * workflow `resumeHook` path.
+ */
+async function forwardSubagentAuthorizationEventStep(input: {
+  readonly hookPayload: SubagentAuthorizationEventHookPayload;
+  readonly parentContinuationToken: string;
+}): Promise<void> {
+  "use step";
+
+  try {
+    await resumeHook(input.parentContinuationToken, input.hookPayload);
+  } catch (error) {
+    const errorId = createErrorId();
+    log.warn("failed to forward proxied authorization event to parent", {
+      callId: input.hookPayload.callId,
+      childSessionId: input.hookPayload.childSessionId,
+      errorId,
+      eventType: input.hookPayload.event.type,
+      name: input.hookPayload.event.data.name,
       parentContinuationToken: input.parentContinuationToken,
       subagentName: input.hookPayload.subagentName,
       error,

--- a/packages/eve/src/execution/subagent-auth-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-auth-proxy.integration.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import type { SubagentAuthorizationEventHookPayload } from "#channel/types.js";
+import { ContextContainer } from "#context/container.js";
+import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { serializeContext } from "#context/serialize.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { createRuntimeAdapterRegistry } from "#runtime/channels/registry.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
+import type { ResolvedChannelDefinition } from "#runtime/types.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+
+/**
+ * Integration coverage for subagent authorization-event proxying: the
+ * upward-only pipeline that renders a child's `authorization.required` /
+ * `authorization.completed` events on the parent's channel.
+ *
+ * Unlike the HITL proxy there is no downward routing — the challenge's
+ * webhook URL targets the child's own auth hook, so the authorization
+ * callback resumes the child directly. These tests pin the seam the
+ * `runProxyAuthorizationEventStep` workflow step drives: the parent
+ * adapter's `authorization.*` handlers observing and mutating adapter
+ * state across a serialize/rehydrate boundary. Hop-by-hop forwarding
+ * (subagent adapter → parent inbox → proxy step) is unit-tested in
+ * `subagent-adapter.test.ts`, `workflow-steps.test.ts`, and
+ * `turn-workflow.test.ts`.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal synthetic bundle satisfying the runtime's `ChannelKey` codec:
+ * the codec pulls `adapterRegistry` off the bundle in context and
+ * rehydrates the adapter by `kind`. Every other bundle field is unused
+ * by the proxy path under test.
+ */
+function buildMockBundle(adapters: readonly ChannelAdapter[]): CompiledBundle {
+  const channels: readonly ResolvedChannelDefinition[] = adapters.map((adapter, index) => ({
+    adapter,
+    fetch: async () => new Response(null),
+    logicalPath: `channels/mock-${index}.ts`,
+    method: "POST",
+    name: `mock-${index}`,
+    sourceId: `channels/mock-${index}`,
+    sourceKind: "module",
+    urlPath: `/eve/mock-${index}`,
+  }));
+
+  return {
+    adapterRegistry: createRuntimeAdapterRegistry({ channels }),
+    compiledArtifactsSource: {} as RuntimeCompiledArtifactsSource,
+    graph: {} as CompiledBundle["graph"],
+    hookRegistry: createEmptyHookRegistry(),
+    moduleMap: {} as CompiledBundle["moduleMap"],
+    resolvedAgent: {} as CompiledBundle["resolvedAgent"],
+    subagentRegistry: {} as CompiledBundle["subagentRegistry"],
+    toolRegistry: {} as CompiledBundle["toolRegistry"],
+    turnAgent: {} as CompiledBundle["turnAgent"],
+  };
+}
+
+/**
+ * Slack-shaped adapter for the pending-auth message lifecycle: the
+ * `authorization.required` handler records a pending message marker
+ * per connection name on adapter state, and `authorization.completed`
+ * resolves it — mirroring how the real Slack channel edits its public
+ * "waiting for sign-in" message on completion.
+ */
+interface AuthishState extends Record<string, unknown> {
+  pendingAuthMessageTs?: Record<string, string>;
+  resolvedAuthMessages?: Record<string, string>;
+}
+
+type AuthishCtx = ChannelAdapterContext<AuthishState>;
+
+const AUTHISH_ADAPTER_KIND = "authish-mock";
+
+function buildAuthishAdapter(): ChannelAdapter<AuthishCtx> {
+  return {
+    kind: AUTHISH_ADAPTER_KIND,
+    "authorization.required"(data, ctx) {
+      ctx.state.pendingAuthMessageTs = {
+        ...ctx.state.pendingAuthMessageTs,
+        [data.name]: `msg-for-${data.name}`,
+      };
+    },
+    "authorization.completed"(data, ctx) {
+      const pending = ctx.state.pendingAuthMessageTs?.[data.name];
+      if (pending === undefined) {
+        return;
+      }
+      const { [data.name]: _, ...rest } = ctx.state.pendingAuthMessageTs ?? {};
+      ctx.state.pendingAuthMessageTs = rest;
+      ctx.state.resolvedAuthMessages = {
+        ...ctx.state.resolvedAuthMessages,
+        [data.name]: `${pending}:${data.outcome}`,
+      };
+    },
+  };
+}
+
+function buildRequiredEvent(): SubagentAuthorizationEventHookPayload["event"] {
+  return {
+    type: "authorization.required",
+    data: {
+      authorization: { displayName: "Linear", url: "https://idp.example.com/sign-in" },
+      description: "Sign in to Linear",
+      name: "linear",
+      sequence: 3,
+      stepIndex: 1,
+      turnId: "child-turn",
+      webhookUrl: "https://agent.example.com/.eve/connections/linear/sess-child:auth",
+    },
+  };
+}
+
+function buildCompletedEvent(): SubagentAuthorizationEventHookPayload["event"] {
+  return {
+    type: "authorization.completed",
+    data: {
+      name: "linear",
+      outcome: "authorized",
+      sequence: 7,
+      stepIndex: 2,
+      turnId: "child-turn",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — pending-auth adapter-state lifecycle across a serialize boundary
+// ---------------------------------------------------------------------------
+
+describe("subagent auth proxy → adapter-state lifecycle across a serialize boundary", () => {
+  it("lets the authorization.completed hop observe state written by the authorization.required hop", async () => {
+    const authishAdapter = buildAuthishAdapter();
+    const bundle = buildMockBundle([authishAdapter as ChannelAdapter]);
+
+    const ctx = new ContextContainer();
+    ctx.set(BundleKey, bundle);
+    ctx.set(ChannelKey, authishAdapter as ChannelAdapter);
+
+    // Hop 1: the parent renders the child's proxied
+    // `authorization.required`. This is the exact emit shape
+    // `runProxyAuthorizationEventStep` drives on the workflow runtime.
+    const events: HandleMessageStreamEvent[] = [];
+    {
+      const adapter = ctx.require(ChannelKey);
+      const adapterCtx = buildAdapterContext(adapter, ctx);
+      events.push(await callAdapterEventHandler(adapter, buildRequiredEvent(), adapterCtx));
+      // The workflow step's post-emit persistence: pin handler state
+      // mutations back onto the context before serialization.
+      ctx.set(ChannelKey, { ...adapter, state: { ...adapterCtx.state } });
+    }
+
+    // The serialized adapter state carries the pending marker across
+    // the step boundary.
+    const serialized = serializeContext(ctx);
+    const serializedChannel = serialized[ChannelKey.name] as {
+      readonly kind: string;
+      readonly state: AuthishState;
+    };
+    expect(serializedChannel.kind).toBe(AUTHISH_ADAPTER_KIND);
+    expect(serializedChannel.state.pendingAuthMessageTs).toEqual({ linear: "msg-for-linear" });
+
+    // Hop 2: a fresh context rehydrated from the serialized wire shape
+    // (behavior from the registry by kind, state from the wire) handles
+    // the child's `authorization.completed` and must observe the marker
+    // written on hop 1.
+    const rehydratedAdapter: ChannelAdapter = {
+      ...(authishAdapter as ChannelAdapter),
+      state: serializedChannel.state,
+    };
+    const rehydratedCtx = new ContextContainer();
+    rehydratedCtx.set(BundleKey, bundle);
+    rehydratedCtx.set(ChannelKey, rehydratedAdapter);
+
+    {
+      const adapter = rehydratedCtx.require(ChannelKey);
+      const adapterCtx = buildAdapterContext<AuthishCtx>(
+        adapter as ChannelAdapter<AuthishCtx>,
+        rehydratedCtx,
+      );
+      events.push(
+        await callAdapterEventHandler(adapter, buildCompletedEvent(), adapterCtx as never),
+      );
+      expect(adapterCtx.state.pendingAuthMessageTs).toEqual({});
+      expect(adapterCtx.state.resolvedAuthMessages).toEqual({
+        linear: "msg-for-linear:authorized",
+      });
+    }
+
+    // Both events pass through the adapter dispatch verbatim: the
+    // child's turn coordinates and child-scoped webhook URL are
+    // untouched, so the authorization callback still resumes the child
+    // directly.
+    expect(events.map((event) => event.type)).toEqual([
+      "authorization.required",
+      "authorization.completed",
+    ]);
+    const [required, completed] = events as Array<{ data: Record<string, unknown> }>;
+    expect(required!.data).toMatchObject({
+      name: "linear",
+      turnId: "child-turn",
+      webhookUrl: "https://agent.example.com/.eve/connections/linear/sess-child:auth",
+    });
+    expect(completed!.data).toMatchObject({
+      name: "linear",
+      outcome: "authorized",
+      turnId: "child-turn",
+    });
+  });
+
+  it("passes authorization events through unchanged when the adapter declares no auth handlers", async () => {
+    // A bare adapter (no authorization.* handlers) must not block the
+    // event from reaching the parent stream — `callAdapterEventHandler`
+    // returns it unchanged.
+    const bareAdapter: ChannelAdapter = { kind: "bare-mock" };
+    const bundle = buildMockBundle([bareAdapter]);
+
+    const ctx = new ContextContainer();
+    ctx.set(BundleKey, bundle);
+    ctx.set(ChannelKey, bareAdapter);
+
+    const adapterCtx = buildAdapterContext(bareAdapter, ctx);
+    const event = buildRequiredEvent();
+    const transformed = await callAdapterEventHandler(bareAdapter, event, adapterCtx);
+
+    expect(transformed).toBe(event);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — framework registry keeps the subagent adapter rehydratable
+// ---------------------------------------------------------------------------
+
+describe("subagent auth proxy → nested delegation prerequisites", () => {
+  it("registers the subagent adapter kind as a framework adapter so middle hops rehydrate by kind", () => {
+    // Nested chains rely on a middle child's ChannelKey rehydrating to
+    // the framework subagent adapter after a step boundary: its
+    // `authorization.*` handlers are what forward the event another hop
+    // up (unit-tested in subagent-adapter.test.ts). If the framework
+    // registration disappears, the recursion silently breaks.
+    const bundle = buildMockBundle([]);
+    const registered = bundle.adapterRegistry.adaptersByKind.get(SUBAGENT_ADAPTER_KIND);
+
+    expect(registered).toBeDefined();
+    expect(registered?.["authorization.required"]).toBeTypeOf("function");
+    expect(registered?.["authorization.completed"]).toBeTypeOf("function");
+    expect(registered?.["input.requested"]).toBeTypeOf("function");
+  });
+});

--- a/packages/eve/src/execution/subagent-auth-proxy.test.ts
+++ b/packages/eve/src/execution/subagent-auth-proxy.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ChannelAdapter } from "#channel/adapter.js";
+import type { SubagentAuthorizationEventHookPayload } from "#channel/types.js";
+import { ContextContainer } from "#context/container.js";
+import { AuthKey, ContinuationTokenKey, ModeKey, SessionIdKey } from "#context/keys.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { serializeContext } from "#context/serialize.js";
+import type { HarnessSession } from "#harness/types.js";
+import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
+import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
+import {
+  createDurableSessionState,
+  DURABLE_SESSION_VERSION,
+  type DurableSessionState,
+  projectSessionState,
+  readDurableSession,
+} from "#execution/durable-session-store.js";
+import { projectToDurableSession } from "#execution/session.js";
+import { runProxyAuthorizationEventStep } from "#execution/subagent-auth-proxy.js";
+
+vi.mock("./durable-session-store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./durable-session-store.js")>();
+  return {
+    ...actual,
+    createDurableSessionState: vi.fn(),
+    readDurableSession: vi.fn(),
+  };
+});
+
+vi.mock("../runtime/sessions/compiled-agent-cache.js", () => ({
+  getCompiledRuntimeAgentBundle: vi.fn(),
+}));
+
+const TestTurnAgent = {
+  id: "test-agent",
+  instructions: ["You are a test agent."],
+  model: { id: "test-model" },
+  skills: [],
+  tools: [],
+  workspaceSpec: {} as never,
+};
+
+const DEFAULT_WORKFLOW_STREAM_NAMESPACE = "__default__";
+const workflowWritesByNamespace = new Map<string, unknown[]>();
+
+function createTestWritable(
+  namespace = DEFAULT_WORKFLOW_STREAM_NAMESPACE,
+): WritableStream<Uint8Array> {
+  return new WritableStream<Uint8Array>({
+    write(chunk) {
+      const existing = workflowWritesByNamespace.get(namespace) ?? [];
+      existing.push(chunk);
+      workflowWritesByNamespace.set(namespace, existing);
+    },
+  });
+}
+
+function installSessionStoreMocks(session: HarnessSession): void {
+  vi.mocked(readDurableSession).mockResolvedValue(session);
+  vi.mocked(createDurableSessionState).mockImplementation(({ session: nextSession }) => {
+    return {
+      ...projectSessionState({ session: nextSession }),
+      snapshot: {
+        session: projectToDurableSession(nextSession),
+        version: DURABLE_SESSION_VERSION,
+      },
+    };
+  });
+}
+
+function createStubSession(): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "http:proxy-test",
+    history: [],
+    sessionId: "parent-session",
+  };
+}
+
+function createStubSessionState(): DurableSessionState {
+  return {
+    continuationToken: "http:proxy-test",
+    emissionState: { sequence: 0, sessionStarted: false, stepIndex: 0, turnId: "" },
+    hasProxyInputRequests: false,
+    sessionId: "parent-session",
+    version: 1,
+  };
+}
+
+function buildSerializedContextForAdapter(adapter: ChannelAdapter): Record<string, unknown> {
+  const bundle = {
+    adapterRegistry: {
+      adaptersByKind: new Map([[adapter.kind, adapter]]),
+    },
+    compiledArtifactsSource: {} as never,
+    graph: {
+      nodesByNodeId: new Map(),
+      root: {
+        sandboxRegistry: { sandbox: null },
+        turnAgent: TestTurnAgent,
+      },
+    },
+    hookRegistry: createEmptyHookRegistry(),
+    resolvedAgent: { config: {} },
+    subagentRegistry: {},
+    toolRegistry: {},
+    turnAgent: TestTurnAgent,
+  } as never;
+
+  vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(bundle);
+
+  const ctx = new ContextContainer();
+  ctx.set(AuthKey, null);
+  ctx.set(BundleKey, bundle);
+  ctx.set(ChannelKey, adapter);
+  ctx.set(ContinuationTokenKey, "http:proxy-test");
+  ctx.set(ModeKey, "conversation");
+  ctx.set(SessionIdKey, "parent-session");
+  return serializeContext(ctx);
+}
+
+function buildRequiredPayload(): SubagentAuthorizationEventHookPayload {
+  return {
+    callId: "call-1",
+    childSessionId: "child-session",
+    event: {
+      type: "authorization.required",
+      data: {
+        authorization: { url: "https://idp.example.com/sign-in" },
+        description: "Sign in to Linear",
+        name: "linear",
+        sequence: 3,
+        stepIndex: 1,
+        turnId: "child-turn",
+        webhookUrl: "https://agent.example.com/.eve/connections/linear/child-session:auth",
+      },
+    },
+    kind: "subagent-authorization-event",
+    subagentName: "linear",
+  };
+}
+
+afterEach(() => {
+  workflowWritesByNamespace.clear();
+  vi.restoreAllMocks();
+});
+
+describe("runProxyAuthorizationEventStep", () => {
+  it("re-emits the child's event verbatim and persists adapter-state mutations", async () => {
+    // The stub adapter mirrors Slack's contract: `authorization.required`
+    // records a pending-auth marker on adapter state that the later
+    // `authorization.completed` hop must observe across the serialized
+    // context boundary.
+    const handled: unknown[] = [];
+    const cachingAdapter: ChannelAdapter = {
+      kind: "thread-context",
+      async "authorization.required"(data, adapterCtx) {
+        handled.push(data);
+        adapterCtx.state.pendingAuthMessageTs = { [data.name]: "123.456" };
+      },
+    };
+
+    installSessionStoreMocks(createStubSession());
+
+    const hookPayload = buildRequiredPayload();
+    const result = await runProxyAuthorizationEventStep({
+      hookPayload,
+      parentWritable: createTestWritable(),
+      serializedContext: buildSerializedContextForAdapter(cachingAdapter),
+      sessionState: createStubSessionState(),
+    });
+
+    // Verbatim: the parent adapter sees the child's original event data,
+    // including the child-scoped webhook URL and turn coordinates.
+    expect(handled).toEqual([hookPayload.event.data]);
+
+    const channel = result.serializedContext[ChannelKey.name] as {
+      kind: string;
+      state: { pendingAuthMessageTs?: Record<string, string> };
+    };
+    expect(channel.kind).toBe("thread-context");
+    expect(channel.state.pendingAuthMessageTs).toEqual({ linear: "123.456" });
+
+    // Auth needs no downward routing, so no proxy-entry map is recorded.
+    expect(result.sessionState.hasProxyInputRequests).toBe(false);
+
+    // Exactly one stream write even in conversation mode: unlike the HITL
+    // proxy there is no `turn.completed` + `session.waiting` epilogue —
+    // the parent turn is still awaiting the subagent result and the child
+    // resumes autonomously after the authorization callback.
+    const writes = workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE) ?? [];
+    expect(writes).toHaveLength(1);
+  });
+
+  it("forwards authorization.completed to the adapter handler", async () => {
+    const handled: Array<{ type: string; data: unknown }> = [];
+    const adapter: ChannelAdapter = {
+      kind: "thread-context",
+      async "authorization.completed"(data) {
+        handled.push({ type: "authorization.completed", data });
+      },
+    };
+
+    installSessionStoreMocks(createStubSession());
+
+    const result = await runProxyAuthorizationEventStep({
+      hookPayload: {
+        callId: "call-1",
+        childSessionId: "child-session",
+        event: {
+          type: "authorization.completed",
+          data: {
+            name: "linear",
+            outcome: "authorized",
+            sequence: 7,
+            stepIndex: 2,
+            turnId: "child-turn",
+          },
+        },
+        kind: "subagent-authorization-event",
+        subagentName: "linear",
+      },
+      parentWritable: createTestWritable(),
+      serializedContext: buildSerializedContextForAdapter(adapter),
+      sessionState: createStubSessionState(),
+    });
+
+    expect(handled).toEqual([
+      {
+        type: "authorization.completed",
+        data: expect.objectContaining({ name: "linear", outcome: "authorized" }),
+      },
+    ]);
+    expect(result.sessionState.hasProxyInputRequests).toBe(false);
+  });
+});

--- a/packages/eve/src/execution/subagent-auth-proxy.ts
+++ b/packages/eve/src/execution/subagent-auth-proxy.ts
@@ -1,0 +1,86 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import type { SubagentAuthorizationEventHookPayload } from "#channel/types.js";
+import { withContextScope } from "#context/run-step.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import type { HarnessSession } from "#harness/types.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { encodeMessageStreamEvent, timestampHandleMessageStreamEvent } from "#protocol/message.js";
+import {
+  createDurableSessionState,
+  type DurableSessionState,
+  readDurableSession,
+} from "#execution/durable-session-store.js";
+import { setChannelContext } from "#execution/channel-context.js";
+import { hydrateDurableSession } from "#execution/session.js";
+import { reconcileSessionContinuationToken } from "#execution/workflow-steps.js";
+
+export interface ProxyAuthorizationEventResult {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}
+
+/**
+ * Re-emits a child subagent's `authorization.required` /
+ * `authorization.completed` event through the parent's adapter so the
+ * parent channel renders the sign-in challenge (and later resolves it).
+ *
+ * Emits the child's event verbatim: its webhook URL targets the child's
+ * own auth hook, so the authorization callback resumes the child
+ * directly — no routing map and no downward delivery exist for auth.
+ * Deliberately emits no turn epilogue in any mode: the parent turn is
+ * not waiting on its own channel, it is still awaiting the subagent
+ * result, and the child resumes autonomously after the callback.
+ */
+export async function runProxyAuthorizationEventStep(input: {
+  readonly hookPayload: SubagentAuthorizationEventHookPayload;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<ProxyAuthorizationEventResult> {
+  "use step";
+
+  const durableSession = await readDurableSession(input.sessionState);
+  const ctx = await deserializeContext(input.serializedContext);
+  const adapter = ctx.require(ChannelKey);
+  const adapterCtx = buildAdapterContext(adapter, ctx);
+  const bundle = ctx.require(BundleKey);
+  const session = hydrateDurableSession({
+    compactionOverrides: {
+      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+    },
+    durable: durableSession,
+    turnAgent: bundle.turnAgent,
+  });
+  const writer = input.parentWritable.getWriter();
+
+  let scopeResult: { readonly session: HarnessSession };
+  try {
+    scopeResult = await withContextScope(ctx, session, async (enrichedSession) => {
+      const transformed = await callAdapterEventHandler(
+        adapter,
+        input.hookPayload.event,
+        adapterCtx,
+      );
+      await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(transformed)));
+      return { result: undefined, session: enrichedSession };
+    });
+  } finally {
+    writer.releaseLock();
+  }
+
+  // Persist adapter-state mutations (e.g. Slack's pending-auth message
+  // cache written by the `authorization.required` handler) so the
+  // `authorization.completed` hop and the next `turnStep` observe them
+  // across the serialized context boundary.
+  setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
+
+  const nextSerializedContext = serializeContext(ctx);
+  const nextSession = reconcileSessionContinuationToken(ctx, scopeResult.session);
+  const nextState = createDurableSessionState({ session: nextSession });
+
+  return {
+    serializedContext: nextSerializedContext,
+    sessionState: nextState,
+  };
+}

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -10,6 +10,7 @@ import {
   type TurnWorkflowInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+import { runProxyAuthorizationEventStep } from "#execution/subagent-auth-proxy.js";
 import { runProxyInputRequestStep, turnStep } from "#execution/workflow-steps.js";
 
 const resumeHookMock = vi.fn();
@@ -26,6 +27,10 @@ vi.mock("#compiled/@workflow/core/runtime.js", () => ({
 
 vi.mock("./route-child-delivery.js", () => ({
   routeDeliverToChildren: vi.fn(),
+}));
+
+vi.mock("./subagent-auth-proxy.js", () => ({
+  runProxyAuthorizationEventStep: vi.fn(),
 }));
 
 vi.mock("./workflow-steps.js", () => ({
@@ -528,6 +533,95 @@ describe("turnWorkflow", () => {
         sessionState: proxyState,
       }),
     );
+  });
+
+  it("proxies child authorization events without requesting a delivery", async () => {
+    const pendingState = createSessionState();
+    const authProxyState = createSessionState();
+    const completedState = createSessionState();
+    const authorizationEvent = {
+      callId: "call-1",
+      childSessionId: "child-session",
+      event: {
+        type: "authorization.required" as const,
+        data: {
+          description: "Sign in to Linear",
+          name: "linear",
+          sequence: 3,
+          stepIndex: 1,
+          turnId: "turn_0",
+          webhookUrl: "https://eve.example.com/.eve/connections/linear/child-session:auth",
+        },
+      },
+      kind: "subagent-authorization-event" as const,
+      subagentName: "delegate",
+    };
+    installInbox([
+      authorizationEvent,
+      {
+        kind: "runtime-action-result",
+        results: [
+          {
+            callId: "call-1",
+            kind: "subagent-result",
+            output: "child output",
+            subagentName: "delegate",
+          },
+        ],
+      },
+    ]);
+    vi.mocked(dispatchRuntimeActionsStep).mockResolvedValue({
+      results: [],
+      sessionState: pendingState,
+    });
+    vi.mocked(runProxyAuthorizationEventStep).mockResolvedValue({
+      serializedContext: { state: "auth-proxied" },
+      sessionState: authProxyState,
+    });
+    vi.mocked(turnStep)
+      .mockResolvedValueOnce({
+        action: "park",
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        pendingRuntimeActionKeys: ["subagent-call:delegate:call-1"],
+        serializedContext: { state: "pending" },
+        sessionState: pendingState,
+      })
+      .mockResolvedValueOnce({
+        action: "done",
+        output: "done",
+        serializedContext: { state: "done" },
+        sessionState: completedState,
+      });
+
+    const { input, parentWritable } = createInput({
+      driverCapabilities: { turnInbox: true },
+      mode: "task",
+      sessionState: pendingState,
+    });
+    await turnWorkflow(input);
+
+    expect(runProxyAuthorizationEventStep).toHaveBeenCalledOnce();
+    expect(runProxyAuthorizationEventStep).toHaveBeenCalledWith({
+      hookPayload: authorizationEvent,
+      parentWritable,
+      serializedContext: { state: "pending" },
+      sessionState: pendingState,
+    });
+
+    // The proxied result is adopted, so the resumed turn continues on the
+    // proxy step's session/context.
+    expect(vi.mocked(turnStep).mock.calls[1]?.[0]).toMatchObject({
+      serializedContext: { state: "auth-proxied" },
+      sessionState: authProxyState,
+    });
+
+    // Auth needs no user delivery through the parent's channel — the
+    // authorization callback resumes the child directly.
+    expect(
+      resumeHookMock.mock.calls.filter((call) => call[1]?.kind === "turn-delivery-request"),
+    ).toHaveLength(0);
+    expect(routeDeliverToChildren).not.toHaveBeenCalled();
   });
 
   it("mints a unique delivery request id per wait so a stale forward is not re-accepted", async () => {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -20,6 +20,7 @@ import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import { TurnExecutionCursor } from "#execution/turn-execution-cursor.js";
 import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
+import { runProxyAuthorizationEventStep } from "#execution/subagent-auth-proxy.js";
 import { runProxyInputRequestStep, turnStep } from "#execution/workflow-steps.js";
 import { resolveRuntimeActionResultsForKeys } from "#harness/runtime-actions.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
@@ -205,6 +206,20 @@ async function waitForRuntimeActionResults(input: {
 
     if (value.kind === "subagent-input-request") {
       const proxyResult = await runProxyInputRequestStep({
+        hookPayload: value,
+        parentWritable: input.cursor.parentWritable,
+        serializedContext: input.cursor.serializedContext,
+        sessionState: input.cursor.sessionState,
+      });
+      await input.cursor.adopt(proxyResult);
+      continue;
+    }
+
+    // Authorization events only render on the parent channel: the child's
+    // webhook URL targets its own auth hook, so the callback resumes the
+    // child directly and no delivery request is needed here.
+    if (value.kind === "subagent-authorization-event") {
+      const proxyResult = await runProxyAuthorizationEventStep({
         hookPayload: value,
         parentWritable: input.cursor.parentWritable,
         serializedContext: input.cursor.serializedContext,


### PR DESCRIPTION
## Summary

Fixes #568.

A subagent whose connection needed interactive OAuth parked silently: the `authorization.required` event was written only to the child's unconsumed stream, so the sign-in link never reached the user and the run hung. Approval and other input requests already bubble up through the HITL proxy; authorization events did not.

This mirrors the **upward half** of the HITL pipeline — and only that half:

- `SUBAGENT_ADAPTER` gains `authorization.required` / `authorization.completed` handlers that forward the child's event verbatim to the parent's turn inbox as a new runtime-internal `subagent-authorization-event` hook payload.
- The parent's inbox loop dispatches it to a new `runProxyAuthorizationEventStep`, which re-emits the event through the parent's channel adapter (so Slack, the TUI, etc. render the sign-in challenge) and persists adapter-state mutations across the step boundary.
- **No downward routing**: the challenge's webhook URL targets the child's own `${childSessionId}:auth` hook, so the OAuth callback resumes the child directly. No routing map, no delivery request through the parent's channel.
- **No turn epilogue**: unlike proxied HITL, the parent turn is not waiting on its own channel — it's still awaiting the subagent result, and the child resumes autonomously after the callback. Pinned with a test.
- Nested delegation chains forward recursively for free: each middle hop's channel adapter is itself the subagent adapter, so the re-emit triggers the next hop up.

`authorization.completed` is bubbled too so channels can resolve their pending-auth UI (e.g. Slack edits its "waiting for sign-in" message).

The step lives in a new `subagent-auth-proxy.ts` module (sibling of `subagent-hitl-proxy.ts`) rather than `workflow-steps.ts`, which is at the 700-line structural cap.

## Tradeoff noted

Re-emitting verbatim means Slack's pending-auth message is keyed by bare connection name: a parent and child authorizing the same connection dedupe to one public message. That's semantically right — credentials are scoped (connection, principal) at the provider, one sign-in satisfies both — with a minor edge that a completion can clear a same-name pending message from another session early.

## Testing

- Unit: adapter forwarding + failure breadcrumbs (`subagent-adapter.test.ts`), proxy step verbatim re-emit / state persistence / no-epilogue (`subagent-auth-proxy.test.ts`), inbox branch asserting no `turn-delivery-request` is issued (`turn-workflow.test.ts`)
- Integration: adapter-state lifecycle across a serialize/rehydrate boundary and framework-registry rehydration for nested hops (`subagent-auth-proxy.integration.test.ts`)
- `pnpm typecheck`, `pnpm lint`, `pnpm guard:invariants`, `pnpm docs:check`, full unit + integration tiers all pass

## Docs & changeset

- `docs/subagents.mdx`: paragraph on how subagent HITL and authorization surface on the parent channel
- `docs/connections/overview.mdx`: note that subagent auth surfaces on the root session's channel
- Patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)