### PR TITLE
fix(eve): show Teams approval tool input

### DIFF
--- a/.changeset/teams-approval-inputs.md
+++ b/.changeset/teams-approval-inputs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show tool call input in Teams approval prompts so operators can inspect approval-gated actions before approving.

--- a/packages/eve/src/public/channels/teams/hitl.test.ts
+++ b/packages/eve/src/public/channels/teams/hitl.test.ts
@@ -10,6 +10,7 @@ import {
   TEAMS_HITL_FREEFORM_INPUT_ID,
 } from "#public/channels/teams/hitl.js";
 import { parseTeamsActivity } from "#public/channels/teams/inbound.js";
+import { TEAMS_ADAPTIVE_CARD_TEXT_MAX_LENGTH } from "#public/channels/teams/limits.js";
 import type { InputRequest } from "#runtime/input/types.js";
 
 describe("Teams HITL helpers", () => {
@@ -21,6 +22,93 @@ describe("Teams HITL helpers", () => {
       data: { [TEAMS_HITL_DATA_KEY]: { optionId: "approve", requestId: "REQ" } },
       type: "Action.Submit",
     });
+  });
+
+  it("includes approval tool input in the card body and fallback text", () => {
+    const body = renderInputRequestMessage(
+      request({
+        action: {
+          callId: "TC",
+          input: {
+            collection: "org_members",
+            filter: { _id: "org_123" },
+            operation: "deleteOne",
+          },
+          kind: "tool-call",
+          toolName: "delete_org_member",
+        },
+        prompt: "Approve tool call: delete_org_member",
+      }),
+    );
+    const card = body.attachments?.[0]?.content as { body?: Array<Record<string, unknown>> };
+    const detailBlock = card.body?.find(
+      (entry) => typeof entry.text === "string" && entry.text.includes("Tool input"),
+    );
+
+    expect(body.text).toContain("Tool input");
+    expect(body.text).toContain('"collection": "org_members"');
+    expect(detailBlock).toMatchObject({
+      type: "TextBlock",
+      wrap: true,
+    });
+    expect(detailBlock?.text).toContain('"operation": "deleteOne"');
+    expect(detailBlock?.text).toContain('"_id": "org_123"');
+  });
+
+  it("omits empty approval tool input from the card body and fallback text", () => {
+    const body = renderInputRequestMessage(request());
+    const card = body.attachments?.[0]?.content as { body?: Array<Record<string, unknown>> };
+
+    expect(body.text).toBe("Approve deploy?");
+    expect(
+      card.body?.some(
+        (entry) => typeof entry.text === "string" && entry.text.includes("Tool input"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps non-approval tool input out of the card body and fallback text", () => {
+    const body = renderInputRequestMessage(
+      request({
+        action: {
+          callId: "TC",
+          input: { query: "status" },
+          kind: "tool-call",
+          toolName: "lookup_status",
+        },
+        display: "select",
+        options: [{ id: "status", label: "Status" }],
+        prompt: "Choose what to inspect",
+      }),
+    );
+    const card = body.attachments?.[0]?.content as { body?: Array<Record<string, unknown>> };
+
+    expect(body.text).toBe("Choose what to inspect");
+    expect(
+      card.body?.some(
+        (entry) => typeof entry.text === "string" && entry.text.includes("Tool input"),
+      ),
+    ).toBe(false);
+  });
+
+  it("truncates approval tool input inside the Teams text limit", () => {
+    const body = renderInputRequestMessage(
+      request({
+        action: {
+          callId: "TC",
+          input: { body: "x".repeat(TEAMS_ADAPTIVE_CARD_TEXT_MAX_LENGTH + 500) },
+          kind: "tool-call",
+          toolName: "send_large_payload",
+        },
+      }),
+    );
+    const card = body.attachments?.[0]?.content as { body?: Array<Record<string, unknown>> };
+    const detailBlock = card.body?.find(
+      (entry) => typeof entry.text === "string" && entry.text.includes("Tool input"),
+    );
+
+    expect(detailBlock?.text).toHaveLength(TEAMS_ADAPTIVE_CARD_TEXT_MAX_LENGTH);
+    expect(detailBlock?.text).toContain("...");
   });
 
   it("renders select requests with a ChoiceSet", () => {
@@ -69,7 +157,7 @@ describe("Teams HITL helpers", () => {
   });
 });
 
-function request(): InputRequest {
+function request(overrides: Partial<InputRequest> = {}): InputRequest {
   return {
     action: { callId: "TC", input: {}, kind: "tool-call", toolName: "deploy" },
     display: "confirmation",
@@ -79,6 +167,7 @@ function request(): InputRequest {
     ],
     prompt: "Approve deploy?",
     requestId: "REQ",
+    ...overrides,
   };
 }
 

--- a/packages/eve/src/public/channels/teams/hitl.ts
+++ b/packages/eve/src/public/channels/teams/hitl.ts
@@ -30,6 +30,8 @@ export const TEAMS_HITL_CHOICE_INPUT_ID = "eve_option";
 /** Text input id used for freeform HITL requests. */
 export const TEAMS_HITL_FREEFORM_INPUT_ID = "eve_freeform_text";
 
+const TOOL_INPUT_PREFIX = "Tool input\n";
+
 /** Renders one input request as a Teams message body containing an Adaptive Card. */
 export function renderInputRequestMessage(
   request: InputRequest,
@@ -37,7 +39,7 @@ export function renderInputRequestMessage(
 ): TeamsMessageBody {
   return {
     attachments: [renderInputRequestAttachment(request, options)],
-    text: request.prompt,
+    text: formatInputRequestFallbackText(request),
   };
 }
 
@@ -59,6 +61,7 @@ export function renderInputRequestAttachment(
         type: "TextBlock",
         wrap: true,
       },
+      ...renderInputRequestDetailBlocks(request),
       ...renderInputs(request),
     ],
     type: "AdaptiveCard",
@@ -69,6 +72,16 @@ export function renderInputRequestAttachment(
     content: parseJsonObject(card),
     contentType: TEAMS_ADAPTIVE_CARD_CONTENT_TYPE,
   };
+}
+
+/**
+ * Creates the fallback text for one HITL request. Teams clients use this
+ * outside the Adaptive Card surface, so include the same approval details
+ * that appear in the card.
+ */
+function formatInputRequestFallbackText(request: InputRequest): string {
+  const details = formatToolInputDetails(request);
+  return details === undefined ? request.prompt : `${request.prompt}\n${details}`;
 }
 
 /** Renders an answered Teams card that replaces a pending HITL prompt. */
@@ -188,6 +201,19 @@ function renderInputs(request: InputRequest): readonly Record<string, unknown>[]
   return [];
 }
 
+function renderInputRequestDetailBlocks(request: InputRequest): readonly Record<string, unknown>[] {
+  const details = formatToolInputDetails(request);
+  return details === undefined
+    ? []
+    : [
+        {
+          text: details,
+          type: "TextBlock",
+          wrap: true,
+        },
+      ];
+}
+
 function renderActions(request: InputRequest): readonly Record<string, unknown>[] {
   const options = request.options;
   if (options && options.length > 0 && request.display !== "select") {
@@ -214,6 +240,25 @@ function renderActions(request: InputRequest): readonly Record<string, unknown>[
       type: "Action.Submit",
     },
   ];
+}
+
+function formatToolInputDetails(request: InputRequest): string | undefined {
+  if (!isApprovalRequest(request)) return undefined;
+
+  const json = JSON.stringify(request.action.input, null, 2);
+  if (json === "{}") return undefined;
+
+  const bodyBudget = TEAMS_ADAPTIVE_CARD_TEXT_MAX_LENGTH - TOOL_INPUT_PREFIX.length;
+  return `${TOOL_INPUT_PREFIX}${truncate(json, bodyBudget)}`;
+}
+
+function isApprovalRequest(request: InputRequest): boolean {
+  return (
+    request.display === "confirmation" &&
+    request.options?.length === 2 &&
+    request.options[0]?.id === "approve" &&
+    request.options[1]?.id === "deny"
+  );
 }
 
 function readActivityValue(activity: TeamsActivity): Record<string, unknown> | null {


### PR DESCRIPTION
### Description

#### Problem

Teams approval prompts currently render the approval question, but not the tool call input that the approval is gating. That makes it harder for an operator to inspect the actual arguments before approving, especially for write-like actions.

#### Change

This adds bounded tool input details to Teams approval-card rendering:

- the Teams message fallback text includes the non-empty approval tool input
- the Adaptive Card body includes the same non-empty approval tool input in a `TextBlock`
- empty `{}` input stays omitted
- select/freeform and other non-approval HITL prompts stay unchanged

Why this boundary: this only touches Teams card body/fallback rendering. It does not change continuation tokens, submit resolution, auth, Slack behavior, or public APIs.

#### Risk

The main risk is exposing more of the already approval-gated tool input in the Teams surface. The value is that the approver can see what they are approving, and the rendered text is bounded to the existing Teams card text limit.

Known limitation: I verified the Teams payload renderer locally, but did not run this inside a live Teams client.

#### Validation

See the exact commands under "How did you test your changes?" below.

#### Out of scope

- thread-stable continuation key work
- Teams message-form submit resolution
- Teams card-tap auth gating
- Slack HITL rendering
- subagent input formatting or schema work

#### Issue linkage

Addresses the Teams approval-card body/fallback slice discussed in https://github.com/vercel/eve/issues/451.

### How did you test your changes?

- `pnpm exec oxfmt --check packages/eve/src/public/channels/teams/hitl.ts packages/eve/src/public/channels/teams/hitl.test.ts .changeset/teams-approval-inputs.md`
- `pnpm exec oxlint packages/eve/src/public/channels/teams/hitl.ts packages/eve/src/public/channels/teams/hitl.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/teams/hitl.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve run test:unit`

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
