### PR TITLE
fix(slack): preserve literal bare @ tokens

### DIFF
--- a/.changeset/slack-preserve-bare-at.md
+++ b/.changeset/slack-preserve-bare-at.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack channel posts now preserve literal bare `@` tokens such as scoped npm packages instead of rewriting them into Slack mention markup. Explicit `<@USERID>` mentions and `thread.mentionUser(userId)` output continue to render as mentions.

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -234,6 +234,84 @@ describe("SlackHandle.uploadFiles", () => {
   });
 });
 
+describe("SlackThread outbound mention formatting", () => {
+  let mock: ReturnType<typeof buildFetchMock>;
+
+  beforeEach(() => {
+    mock = buildFetchMock();
+    vi.stubGlobal("fetch", mock.fetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves literal bare @ tokens in markdown posts", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+    const markdown =
+      "bump @scope/package-name, install `@scope/another-package`, ping <@U012ABC456>";
+
+    await thread.post(markdown);
+
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect((post!.body as { markdown_text: string }).markdown_text).toBe(markdown);
+  });
+
+  it("preserves literal bare @ tokens in text posts", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+    const text = "release notes mention @scope/package-name and literal @word";
+
+    await thread.post({ text });
+
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect((post!.body as { text: string }).text).toBe(text);
+  });
+
+  it("preserves literal bare @ tokens in file initial comments", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+    const text = "attached report for @scope/package-name";
+
+    await thread.post({
+      text,
+      files: [{ data: Buffer.from([1, 2]), filename: "report.csv", mimeType: "text/csv" }],
+    });
+
+    const complete = mock.calls.find(
+      (c) => c.url === "https://slack.com/api/files.completeUploadExternal",
+    )!;
+    expect((complete.body as { initial_comment: string }).initial_comment).toBe(text);
+  });
+
+  it("preserves explicit Slack mention markup from mentionUser", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.post(`ping ${thread.mentionUser("U012ABC456")}`);
+
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect((post!.body as { markdown_text: string }).markdown_text).toBe("ping <@U012ABC456>");
+  });
+});
+
 describe("SlackThread.post with files", () => {
   let mock: ReturnType<typeof buildFetchMock>;
 

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -33,7 +33,7 @@ import { isCardElement, type CardElement, type FileUpload } from "#compiled/chat
 import { createLogger, logError } from "#internal/logging.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
 import { truncateTypingStatus } from "#public/channels/slack/limits.js";
-import { rewriteBareMentions, slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
+import { slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
 
 const log = createLogger("slack.api");
 
@@ -368,7 +368,7 @@ export function buildSlackBinding(input: {
       // text + files: single Slack message with files attached via
       // files.completeUploadExternal's mrkdwn-only initial_comment.
       if (files.length > 0 && !shouldPostBeforeFiles) {
-        const comment = "text" in message ? rewriteBareMentions(message.text) : undefined;
+        const comment = "text" in message ? message.text : undefined;
         const result = await uploadFiles(files, { initialComment: comment });
         const id =
           Array.isArray(result.raw.files) && result.raw.files.length > 0
@@ -514,10 +514,10 @@ function buildPostMessageOptions(
     return base;
   }
   if ("markdown" in message) {
-    base.markdownText = rewriteBareMentions(message.markdown);
+    base.markdownText = message.markdown;
     return base;
   }
-  base.text = rewriteBareMentions(message.text);
+  base.text = message.text;
   return base;
 }
 

--- a/packages/eve/src/public/channels/slack/mrkdwn.test.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.test.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  gfmToSlackMrkdwn,
-  rewriteBareMentions,
-  slackMrkdwnToGfm,
-} from "#public/channels/slack/mrkdwn.js";
-
-describe("rewriteBareMentions", () => {
-  it("rewrites bare @USER tokens into Slack mention syntax", () => {
-    expect(rewriteBareMentions("ping @U123 please")).toBe("ping <@U123> please");
-  });
-
-  it("leaves already-wrapped mentions alone", () => {
-    expect(rewriteBareMentions("ping <@U123> please")).toBe("ping <@U123> please");
-  });
-
-  it("does not touch email-shaped runs", () => {
-    expect(rewriteBareMentions("contact foo@bar.com")).toBe("contact foo@bar.com");
-  });
-
-  it("rewrites every occurrence in a single pass", () => {
-    expect(rewriteBareMentions("@A and @B")).toBe("<@A> and <@B>");
-  });
-});
+import { gfmToSlackMrkdwn, slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
 
 describe("gfmToSlackMrkdwn", () => {
   it("converts ** and __ bold to single-star bold", () => {

--- a/packages/eve/src/public/channels/slack/mrkdwn.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.ts
@@ -1,16 +1,8 @@
 import {
   formatSlackLink,
-  linkBareSlackMentions,
   markdownBoldToSlackMrkdwn,
   slackMrkdwnToMarkdown,
 } from "#compiled/@chat-adapter/slack/format.js";
-
-const BARE_MENTION_RE = /(?<![<\w])@(\w+)/gu;
-
-/** Rewrites bare Slack mention tokens into Slack's linked mention syntax. */
-export function rewriteBareMentions(text: string): string {
-  return linkBareSlackMentions(text).replace(BARE_MENTION_RE, "<@$1>");
-}
 
 /** Converts markdown into Slack mrkdwn for legacy Slack text surfaces. */
 export function gfmToSlackMrkdwn(input: string): string {


### PR DESCRIPTION
Closes #563

## Summary
- stop rewriting outbound Slack bare `@word` tokens into `<@word>` mention markup
- preserve literal scoped packages and other bare `@` text in markdown posts, text posts, and file `initial_comment` uploads
- keep explicit Slack mention markup and `thread.mentionUser(userId)` output unchanged

## Tests
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/api.test.ts src/public/channels/slack/mrkdwn.test.ts` (38 passed)
- `pnpm --filter eve exec sh -c 'vitest run --config vitest.unit.config.ts src/public/channels/slack/*.test.ts'` (255 passed)
- `pnpm exec oxfmt --check packages/eve/src/public/channels/slack/api.ts packages/eve/src/public/channels/slack/api.test.ts packages/eve/src/public/channels/slack/mrkdwn.ts packages/eve/src/public/channels/slack/mrkdwn.test.ts .changeset/slack-preserve-bare-at.md`
- `pnpm exec oxlint --deny-warnings packages/eve/src/public/channels/slack/api.ts packages/eve/src/public/channels/slack/api.test.ts packages/eve/src/public/channels/slack/mrkdwn.ts packages/eve/src/public/channels/slack/mrkdwn.test.ts`
- `pnpm --filter eve run build:compiled`
- `pnpm --filter eve run typecheck`
- `pnpm changeset status --since refs/remotes/origin/main`
- `git diff --check refs/remotes/origin/main...HEAD`
