### PR TITLE
fix(eve): skip nested git repos in dev snapshots

### DIFF
--- a/.changeset/dev-snapshot-nested-git-boundaries.md
+++ b/.changeset/dev-snapshot-nested-git-boundaries.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Stop `eve dev` source snapshots from recursing into nested git repositories or worktrees, avoiding duplicate checkout copies under directories such as `.claude/worktrees`.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -225,6 +225,48 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(join(snapshot.runtimeAppRoot, "dist"))).toBe(false);
   });
 
+  it("stops source snapshot recursion at nested git repositories", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-nested-git-");
+    const agentRoot = join(appRoot, "agent");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+    const worktreeRoot = join(appRoot, ".claude", "worktrees", "test-wt");
+    const nestedRepoRoot = join(appRoot, "vendor", "nested-repo");
+    const regularVendorRoot = join(appRoot, "vendor", "regular-package");
+
+    await mkdir(agentRoot, { recursive: true });
+    await mkdir(join(worktreeRoot, "agent"), { recursive: true });
+    await mkdir(join(nestedRepoRoot, ".git"), { recursive: true });
+    await mkdir(regularVendorRoot, { recursive: true });
+    await mkdir(compileDirectoryPath, { recursive: true });
+    await writeFile(join(appRoot, "package.json"), '{"type":"module"}\n');
+    await writeFile(join(agentRoot, "agent.ts"), "export const answer = 42;\n");
+    await writeFile(join(appRoot, ".claude", "notes.txt"), "agent notes\n");
+    await writeFile(join(worktreeRoot, ".git"), "gitdir: ../../../../.git/worktrees/test-wt\n");
+    await writeFile(join(worktreeRoot, "agent", "agent.ts"), "export const copied = false;\n");
+    await writeFile(join(nestedRepoRoot, ".git", "config"), "[core]\n");
+    await writeFile(join(nestedRepoRoot, "index.ts"), "export const copied = false;\n");
+    await writeFile(join(regularVendorRoot, "index.ts"), "export const copied = true;\n");
+    await writeFile(
+      join(compileDirectoryPath, "compiled-agent-manifest.json"),
+      `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`,
+    );
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+
+    expect(existsSync(join(snapshot.runtimeAppRoot, "agent", "agent.ts"))).toBe(true);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".claude", "notes.txt"))).toBe(true);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".claude", "worktrees", "test-wt"))).toBe(
+      false,
+    );
+    expect(existsSync(join(snapshot.runtimeAppRoot, "vendor", "nested-repo"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, "vendor", "regular-package", "index.ts"))).toBe(
+      true,
+    );
+  });
+
   it("prunes stale snapshots while preserving the active and recent snapshots", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-");
     const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -125,6 +125,10 @@ function shouldSkipSnapshotSource(
     return true;
   }
 
+  if (existsSync(join(sourcePath, ".git"))) {
+    return true;
+  }
+
   return isDirectAppRootSkipPath({
     appRoot: plan.appRoot,
     sourcePath,


### PR DESCRIPTION
### Description

Closes #526.

`eve dev` source snapshots now stop recursing when a copied child directory contains its own `.git` file or directory. That treats nested repositories, submodules, and git worktrees as source-copy boundaries without special-casing `.claude/worktrees`.

This keeps ordinary sibling content copied as before while avoiding duplicate checkout copies inside dev-runtime snapshots.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts -t 'nested git|generated output'`\n- `pnpm --filter eve run typecheck`\n- `pnpm --filter eve exec oxlint src/internal/nitro/dev-runtime-source-snapshot-copy.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts`\n- `pnpm exec oxfmt --check packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts .changeset/dev-snapshot-nested-git-boundaries.md`\n- `pnpm guard:invariants`\n- `pnpm changeset status --since origin/main`\n- `git diff --check`\n\nNote: `pnpm --filter eve run test:integration -- src/internal/nitro/dev-runtime-artifacts.integration.test.ts -t 'nested git|generated output'` expands to the full integration suite in this repo and hit an unrelated local `listen EPERM` in `src/client/client.integration.test.ts`; the tier-configured touched-file command above passed.\n\n### PR Checklist\n\n- [x] I linked an issue with prior discussion confirming this change is wanted\n- [x] I ran the relevant checks from CONTRIBUTING.md\n- [x] I added tests and documentation where relevant\n- [x] I added a changeset if this touches the published `eve` package\n- [x] DCO sign-off passes for every commit (`git commit --signoff`)\n