### PR TITLE
fix(eve): sanitize auth challenge header values

### DIFF
--- a/.changeset/auth-challenge-header-values.md
+++ b/.changeset/auth-challenge-header-values.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Sanitize CR and LF characters from generated `www-authenticate` challenge parameter values so malformed auth details cannot inject additional response headers.

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -251,12 +251,20 @@ describe("createUnauthorizedResponse", () => {
     const response = createUnauthorizedResponse({
       challenges: [
         { scheme: "Basic", parameters: { realm: "weather" } },
-        { scheme: "Bearer", parameters: { error: 'need "token"' } },
+        {
+          scheme: "Bearer",
+          parameters: { error: 'need "token"', error_description: "bad\r\nnext" },
+        },
       ],
     });
 
-    expect(response.headers.get("www-authenticate")).toContain('Basic realm="weather"');
-    expect(response.headers.get("www-authenticate")).toMatch(/Bearer error="need \\"token\\""/);
+    const header = response.headers.get("www-authenticate");
+
+    expect(header).toContain('Basic realm="weather"');
+    expect(header).toMatch(/Bearer error="need \\"token\\""/);
+    expect(header).toContain('error_description="badnext"');
+    expect(header).not.toContain("\r");
+    expect(header).not.toContain("\n");
   });
 });
 

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -442,7 +442,11 @@ function formatChallenge(challenge: UnauthorizedChallenge): string {
 }
 
 function escapeChallengeValue(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\r", "")
+    .replaceAll("\n", "");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Strip CR and LF from generated `www-authenticate` challenge parameter values
- Preserve existing escaping for backslashes and double quotes
- Add unit coverage for CRLF-bearing challenge values

Closes #281

## Testing
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/auth.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve exec oxlint src/public/channels/auth.ts src/public/channels/auth.test.ts`
- `pnpm exec oxfmt --check packages/eve/src/public/channels/auth.ts packages/eve/src/public/channels/auth.test.ts .changeset/auth-challenge-header-values.md`
- `pnpm guard:invariants`
- `pnpm changeset status --since origin/main`
- `git diff --check`