### PR TITLE
fix(eve) On the setup script, clarify that "Project" means Vercel Project

### DIFF
--- a/.changeset/ninety-readers-write.md
+++ b/.changeset/ninety-readers-write.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+On the setup script, clarify that "Project" means Vercel Project

--- a/packages/eve/src/cli/dev/tui/setup-panel.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.test.ts
@@ -733,7 +733,7 @@ describe("renderSelectQuestion", () => {
     const options = [
       {
         value: "project",
-        label: "AI Gateway via Project",
+        label: "AI Gateway via Vercel Project",
         hint: "Authenticates with AI Gateway automatically\nin a new or existing project. No keys to manage.",
       },
     ];

--- a/packages/eve/src/setup/flows/provider.ts
+++ b/packages/eve/src/setup/flows/provider.ts
@@ -75,7 +75,7 @@ function projectConnectionOption(
 ): SelectOption<ProviderConnection> {
   const option: SelectOption<ProviderConnection> = {
     value: "project",
-    label: "AI Gateway via Project",
+    label: "AI Gateway via Vercel Project",
     hint: "Authenticates with AI Gateway automatically\nin a new or existing project. No keys to manage.",
   };
   const disabledReason = authStatus === undefined ? undefined : vercelAuthBlockerReason(authStatus);


### PR DESCRIPTION
### Description

On the setup script, clarify that "Project" means Vercel Project

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
