### PR TITLE
fix(eve): merge system instructions before model calls

### DIFF
--- a/.changeset/merge-system-instructions.md
+++ b/.changeset/merge-system-instructions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Merge assembled system instructions into one system message at the model-call boundary. This avoids provider failures on models that reject multiple system messages while preserving history and dynamic instruction lifecycles.

--- a/packages/eve/src/harness/instrumentation-runtime-context.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.ts
@@ -32,7 +32,7 @@ export interface BuildTelemetryRuntimeContextInput {
   readonly emissionState: HarnessEmissionState;
   readonly environment: string;
   readonly modelInput: {
-    readonly instructions: string | readonly SystemModelMessage[] | undefined;
+    readonly instructions: string | SystemModelMessage | undefined;
     readonly messages: readonly ModelMessage[];
   };
   readonly session: HarnessSession;

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3515,12 +3515,12 @@ describe("createToolLoopHarness", () => {
         const reissueTools = reissueCall!.tools as Record<string, unknown>;
         expect(reissueTools.web_search).toBeUndefined();
         expect(reissueTools.add).toBeDefined();
-        const reissueInstructions = reissueCall!.instructions as Array<{
+        const reissueInstructions = reissueCall!.instructions as {
           role: string;
           content: string;
-        }>;
-        expect(Array.isArray(reissueInstructions)).toBe(true);
-        expect(reissueInstructions[0]?.content).toContain("web_search");
+        };
+        expect(reissueInstructions.role).toBe("system");
+        expect(reissueInstructions.content).toContain("web_search");
         expect(reissueCall!.runtimeContext).toMatchObject({
           "eve.retry.reason": "empty-response",
         });
@@ -3664,7 +3664,7 @@ describe("createToolLoopHarness", () => {
     it("retries with the offending tool dropped and a one-shot system note", async () => {
       const resolveRuntimeContext = vi.fn((input: InstrumentationStepStartedEventInput) => ({
         runtimeContext: {
-          "test.attempt": Array.isArray(input.modelInput.instructions) ? "retry" : "original",
+          "test.attempt": typeof input.modelInput.instructions === "string" ? "original" : "retry",
         },
       }));
       mockGetInstrumentationConfig.mockReturnValue({
@@ -3750,14 +3750,10 @@ describe("createToolLoopHarness", () => {
 
       // The retry's instructions prepend a one-shot system note about
       // the removed capability so the model has explicit context.
-      const retryInstructions = retryCall!.instructions as
-        | string
-        | Array<{ role: string; content: string }>;
-      expect(Array.isArray(retryInstructions)).toBe(true);
-      const noteEntry = (retryInstructions as Array<{ role: string; content: string }>)[0];
-      expect(noteEntry?.role).toBe("system");
-      expect(noteEntry?.content).toContain("web_search");
-      expect(noteEntry?.content).toContain("not available");
+      const retryInstructions = retryCall!.instructions as { role: string; content: string };
+      expect(retryInstructions.role).toBe("system");
+      expect(retryInstructions.content).toContain("web_search");
+      expect(retryInstructions.content).toContain("not available");
       expect(resolveRuntimeContext.mock.calls[1]?.[0].modelInput.instructions).toEqual(
         retryInstructions,
       );
@@ -8648,10 +8644,10 @@ describe("createToolLoopHarness", () => {
       await runStep(session, { message: "Hi" });
 
       const { instructions, messages } = getLastAgentSettings();
-      expect(instructions).toEqual([
-        { role: "system", content: "You are a test assistant." },
-        { role: "system", content: "durable-system" },
-      ]);
+      expect(instructions).toEqual({
+        role: "system",
+        content: "You are a test assistant.\n\ndurable-system",
+      });
       expect(messages.find((m) => m.role === "system")).toBeUndefined();
       expect(messages.at(-1)).toEqual({ role: "user", content: "Hi" });
     });
@@ -8695,10 +8691,10 @@ describe("createToolLoopHarness", () => {
         );
 
         const { instructions } = getLastAgentSettings();
-        expect(instructions).toEqual([
-          { role: "system", content: "You are a test assistant." },
-          { role: "system", content: CONDITIONAL_DELIVERY_INSTRUCTION },
-        ]);
+        expect(instructions).toEqual({
+          role: "system",
+          content: `You are a test assistant.\n\n${CONDITIONAL_DELIVERY_INSTRUCTION}`,
+        });
       },
     );
 
@@ -8771,15 +8767,17 @@ describe("createToolLoopHarness", () => {
       ctx.set(SessionDynamicInstructionsKey, {
         context: [{ role: "system" as const, content: "dynamic-system-instruction" }],
       });
+      const userContent: UserContent = [{ type: "text", text: "Hi" }];
 
-      await contextStorage.run(ctx, () => runStep(session, { message: "Hi" }));
+      await contextStorage.run(ctx, () => runStep(session, { message: userContent }));
 
       const { instructions, messages } = getLastAgentSettings();
-      expect(instructions).toEqual([
-        { role: "system", content: "You are a test assistant." },
-        { role: "system", content: "dynamic-system-instruction" },
-      ]);
+      expect(instructions).toEqual({
+        role: "system",
+        content: "You are a test assistant.\n\ndynamic-system-instruction",
+      });
       expect(messages.find((m) => m.content === "dynamic-system-instruction")).toBeUndefined();
+      expect(messages.at(-1)?.content).toEqual(userContent);
     });
 
     it("does not persist dynamic instruction messages to session history", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -259,6 +259,37 @@ function enrichTelemetry(
   };
 }
 
+function mergeSystemInstructions(
+  instructions: readonly SystemModelMessage[],
+): SystemModelMessage | undefined {
+  if (instructions.length === 0) {
+    return undefined;
+  }
+
+  if (instructions.length === 1) {
+    return { ...instructions[0]! };
+  }
+
+  let providerOptions: SystemModelMessage["providerOptions"] | undefined;
+  for (const instruction of instructions) {
+    if (instruction.providerOptions !== undefined) {
+      providerOptions = {
+        ...providerOptions,
+        ...instruction.providerOptions,
+      };
+    }
+  }
+
+  const merged: SystemModelMessage = {
+    role: "system",
+    content: instructions.map((instruction) => instruction.content).join("\n\n"),
+  };
+  if (providerOptions !== undefined) {
+    merged.providerOptions = providerOptions;
+  }
+  return merged;
+}
+
 /**
  * Builds AI Gateway app attribution headers when the model is gateway-routed.
  *
@@ -705,10 +736,14 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         systemMessages.length > 0 || extraSystemEntry.length > 0
           ? [...extraSystemEntry, ...baseSystemEntry, ...systemMessages]
           : undefined;
-      const instructions =
+      const markedInstructions =
         rawInstructions !== undefined && marker
           ? applySystemCacheBreakpoint(rawInstructions, marker)
-          : (rawInstructions ?? session.agent.system ?? undefined);
+          : rawInstructions;
+      const instructions =
+        markedInstructions !== undefined
+          ? mergeSystemInstructions(markedInstructions)
+          : (session.agent.system ?? undefined);
 
       return {
         instructions,

--- a/packages/eve/src/public/instrumentation/index.ts
+++ b/packages/eve/src/public/instrumentation/index.ts
@@ -79,12 +79,12 @@ export interface InstrumentationStep {
 
 /**
  * Final model input assembled for one model-call attempt, snapshotted for
- * instrumentation. `instructions` is the resolved system prompt (a single
- * string, an array of system messages, or undefined when there is none).
+ * instrumentation. `instructions` is the resolved system prompt (a string,
+ * a system message with provider options, or undefined when there is none).
  * `messages` is the non-system conversation passed to the model.
  */
 export interface InstrumentationModelInput {
-  readonly instructions: string | readonly SystemModelMessage[] | undefined;
+  readonly instructions: string | SystemModelMessage | undefined;
   readonly messages: readonly ModelMessage[];
 }
 


### PR DESCRIPTION
## Summary
- merge assembled system instructions into a single system message before constructing the model call
- keep session history, dynamic instruction lifecycle, and array-form user content unchanged
- preserve Anthropic direct-cache provider options by applying the cache marker before merging

Fixes #596.

## Tests
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/tool-loop.test.ts` (148 passed)
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve exec oxlint src/harness/tool-loop.ts src/harness/tool-loop.test.ts src/harness/instrumentation-runtime-context.ts src/public/instrumentation/index.ts`
- `pnpm exec oxfmt --check packages/eve/src/harness/tool-loop.ts packages/eve/src/harness/tool-loop.test.ts packages/eve/src/harness/instrumentation-runtime-context.ts packages/eve/src/public/instrumentation/index.ts .changeset/merge-system-instructions.md`
- `pnpm guard:invariants`
- `pnpm changeset status --since origin/main`
- `git diff --check`