### PR TITLE
fix(subagents): proxy authorization events

### DIFF
--- a/.changeset/subagent-auth-proxy.md
+++ b/.changeset/subagent-auth-proxy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Proxy subagent authorization requests and completions through the parent session so user-facing channels can render and clear connection auth prompts while callbacks still resume the child session.

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -163,11 +163,39 @@ export interface SubagentInputRequestHookPayload {
 }
 
 /**
+ * Authorization event emitted by a descendant subagent while the parent is
+ * parked on the delegated runtime-action result.
+ */
+export interface SubagentAuthorizationRequiredHookPayload {
+  readonly callId: string;
+  readonly childContinuationToken: string;
+  readonly childSessionId: string;
+  readonly event: Extract<HandleMessageStreamEvent, { type: "authorization.required" }>["data"];
+  readonly kind: "subagent-authorization-required";
+  readonly subagentName: string;
+}
+
+/**
+ * Authorization completion emitted by a descendant subagent after its callback
+ * resumes. Proxied to the parent so channel UI can clear pending auth state.
+ */
+export interface SubagentAuthorizationCompletedHookPayload {
+  readonly callId: string;
+  readonly childContinuationToken: string;
+  readonly childSessionId: string;
+  readonly event: Extract<HandleMessageStreamEvent, { type: "authorization.completed" }>["data"];
+  readonly kind: "subagent-authorization-completed";
+  readonly subagentName: string;
+}
+
+/**
  * Serializable payload sent through the workflow `resumeHook`.
  */
 export type HookPayload =
   | DeliverHookPayload
   | RuntimeActionResultHookPayload
+  | SubagentAuthorizationCompletedHookPayload
+  | SubagentAuthorizationRequiredHookPayload
   | SubagentInputRequestHookPayload;
 
 /**

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -8,7 +8,17 @@ import { ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
 import type { InputRequest } from "#runtime/input/types.js";
 import { SUBAGENT_ADAPTER } from "#execution/subagent-adapter.js";
 
+const SUBAGENT_AUTHORIZATION_COMPLETED = SUBAGENT_ADAPTER["authorization.completed"];
+const SUBAGENT_AUTHORIZATION_REQUIRED = SUBAGENT_ADAPTER["authorization.required"];
 const SUBAGENT_INPUT_REQUESTED = SUBAGENT_ADAPTER["input.requested"];
+
+if (SUBAGENT_AUTHORIZATION_COMPLETED === undefined) {
+  throw new Error("SUBAGENT_ADAPTER is missing its authorization.completed handler.");
+}
+
+if (SUBAGENT_AUTHORIZATION_REQUIRED === undefined) {
+  throw new Error("SUBAGENT_ADAPTER is missing its authorization.required handler.");
+}
 
 if (SUBAGENT_INPUT_REQUESTED === undefined) {
   throw new Error("SUBAGENT_ADAPTER is missing its input.requested handler.");
@@ -53,6 +63,86 @@ function sampleRequest(): InputRequest {
     requestId: "req-1",
   };
 }
+
+describe("SUBAGENT_ADAPTER authorization.required handler", () => {
+  it("forwards the child's authorization request via resumeHook", async () => {
+    resumeHookMock.mockClear();
+    const ctx = makeContext();
+
+    await SUBAGENT_AUTHORIZATION_REQUIRED(
+      {
+        authorization: {
+          displayName: "Weather",
+          url: "https://idp.example/authorize?redirect_uri=child",
+        },
+        description: "Sign in to continue.",
+        name: "weather",
+        sequence: 2,
+        stepIndex: 1,
+        turnId: "turn-auth",
+        webhookUrl: "https://eve.example/eve/v1/connections/weather/callback/child-session:auth",
+      },
+      ctx,
+    );
+
+    expect(resumeHookMock).toHaveBeenCalledTimes(1);
+    expect(resumeHookMock).toHaveBeenCalledWith("parent-token", {
+      callId: "call-123",
+      childContinuationToken: "child-token",
+      childSessionId: "child-session",
+      event: {
+        authorization: {
+          displayName: "Weather",
+          url: "https://idp.example/authorize?redirect_uri=child",
+        },
+        description: "Sign in to continue.",
+        name: "weather",
+        sequence: 2,
+        stepIndex: 1,
+        turnId: "turn-auth",
+        webhookUrl: "https://eve.example/eve/v1/connections/weather/callback/child-session:auth",
+      },
+      kind: "subagent-authorization-required",
+      subagentName: "linear",
+    });
+  });
+});
+
+describe("SUBAGENT_ADAPTER authorization.completed handler", () => {
+  it("forwards the child's authorization completion via resumeHook", async () => {
+    resumeHookMock.mockClear();
+    const ctx = makeContext();
+
+    await SUBAGENT_AUTHORIZATION_COMPLETED(
+      {
+        authorization: { displayName: "Weather" },
+        name: "weather",
+        outcome: "authorized",
+        sequence: 3,
+        stepIndex: 2,
+        turnId: "turn-auth",
+      },
+      ctx,
+    );
+
+    expect(resumeHookMock).toHaveBeenCalledTimes(1);
+    expect(resumeHookMock).toHaveBeenCalledWith("parent-token", {
+      callId: "call-123",
+      childContinuationToken: "child-token",
+      childSessionId: "child-session",
+      event: {
+        authorization: { displayName: "Weather" },
+        name: "weather",
+        outcome: "authorized",
+        sequence: 3,
+        stepIndex: 2,
+        turnId: "turn-auth",
+      },
+      kind: "subagent-authorization-completed",
+      subagentName: "linear",
+    });
+  });
+});
 
 describe("SUBAGENT_ADAPTER input.requested handler", () => {
   it("forwards the child's HITL batch via resumeHook", async () => {
@@ -157,6 +247,7 @@ describe("SUBAGENT_ADAPTER forward failure logging", () => {
       childContinuationToken: "child-token",
       childSessionId: "child-session",
       errorId: expect.any(String),
+      eventKind: "subagent-input-request",
       parentContinuationToken: "parent-token",
       subagentName: "linear",
       error: expect.objectContaining({

--- a/packages/eve/src/execution/subagent-adapter.ts
+++ b/packages/eve/src/execution/subagent-adapter.ts
@@ -1,7 +1,11 @@
 import { resumeHook } from "#internal/workflow/runtime.js";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
-import type { SubagentInputRequestHookPayload } from "#channel/types.js";
+import type {
+  SubagentAuthorizationCompletedHookPayload,
+  SubagentAuthorizationRequiredHookPayload,
+  SubagentInputRequestHookPayload,
+} from "#channel/types.js";
 import { ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
 import { createErrorId, createLogger } from "#internal/logging.js";
 
@@ -64,11 +68,69 @@ export function isSubagentAdapterState(value: unknown): value is SubagentAdapter
  * Framework adapter that bridges a child subagent session to its
  * parent.
  *
- * It proxies child `input.requested` events upward so the parent channel
- * can render HITL prompts and route responses back down to the child.
+ * It proxies child HITL and authorization events upward so the parent channel
+ * can render prompts while callbacks and responses still resume the child.
  */
 export const SUBAGENT_ADAPTER: ChannelAdapter = {
   kind: SUBAGENT_ADAPTER_KIND,
+  async "authorization.completed"(data, ctx) {
+    const state = ctx.state;
+
+    if (!isSubagentAdapterState(state)) {
+      return;
+    }
+
+    const hookPayload: SubagentAuthorizationCompletedHookPayload = {
+      callId: state.callId,
+      childContinuationToken: ctx.ctx.require(ContinuationTokenKey),
+      childSessionId: ctx.ctx.require(SessionIdKey),
+      event: {
+        name: data.name,
+        outcome: data.outcome,
+        sequence: data.sequence,
+        stepIndex: data.stepIndex,
+        turnId: data.turnId,
+        ...(data.authorization !== undefined ? { authorization: data.authorization } : {}),
+        ...(data.reason !== undefined ? { reason: data.reason } : {}),
+      },
+      kind: "subagent-authorization-completed",
+      subagentName: state.subagentName,
+    };
+
+    await forwardSubagentHookPayloadStep({
+      hookPayload,
+      parentContinuationToken: state.parentContinuationToken,
+    });
+  },
+  async "authorization.required"(data, ctx) {
+    const state = ctx.state;
+
+    if (!isSubagentAdapterState(state)) {
+      return;
+    }
+
+    const hookPayload: SubagentAuthorizationRequiredHookPayload = {
+      callId: state.callId,
+      childContinuationToken: ctx.ctx.require(ContinuationTokenKey),
+      childSessionId: ctx.ctx.require(SessionIdKey),
+      event: {
+        description: data.description,
+        name: data.name,
+        sequence: data.sequence,
+        stepIndex: data.stepIndex,
+        turnId: data.turnId,
+        ...(data.authorization !== undefined ? { authorization: data.authorization } : {}),
+        ...(data.webhookUrl !== undefined ? { webhookUrl: data.webhookUrl } : {}),
+      },
+      kind: "subagent-authorization-required",
+      subagentName: state.subagentName,
+    };
+
+    await forwardSubagentHookPayloadStep({
+      hookPayload,
+      parentContinuationToken: state.parentContinuationToken,
+    });
+  },
   async "input.requested"(data, ctx) {
     const state = ctx.state;
 
@@ -90,7 +152,7 @@ export const SUBAGENT_ADAPTER: ChannelAdapter = {
       subagentName: state.subagentName,
     };
 
-    await forwardSubagentInputRequestStep({
+    await forwardSubagentHookPayloadStep({
       hookPayload,
       parentContinuationToken: state.parentContinuationToken,
     });
@@ -98,11 +160,14 @@ export const SUBAGENT_ADAPTER: ChannelAdapter = {
 };
 
 /**
- * Forwards one child HITL batch up to its parent via the durable
+ * Forwards one child control-plane event up to its parent via the durable
  * workflow `resumeHook` path.
  */
-async function forwardSubagentInputRequestStep(input: {
-  readonly hookPayload: SubagentInputRequestHookPayload;
+async function forwardSubagentHookPayloadStep(input: {
+  readonly hookPayload:
+    | SubagentAuthorizationCompletedHookPayload
+    | SubagentAuthorizationRequiredHookPayload
+    | SubagentInputRequestHookPayload;
   readonly parentContinuationToken: string;
 }): Promise<void> {
   "use step";
@@ -111,11 +176,12 @@ async function forwardSubagentInputRequestStep(input: {
     await resumeHook(input.parentContinuationToken, input.hookPayload);
   } catch (error) {
     const errorId = createErrorId();
-    log.warn("failed to forward proxied HITL batch to parent", {
+    log.warn("failed to forward proxied subagent event to parent", {
       callId: input.hookPayload.callId,
       childContinuationToken: input.hookPayload.childContinuationToken,
       childSessionId: input.hookPayload.childSessionId,
       errorId,
+      eventKind: input.hookPayload.kind,
       parentContinuationToken: input.parentContinuationToken,
       subagentName: input.hookPayload.subagentName,
       error,

--- a/packages/eve/src/execution/subagent-auth-proxy-step.ts
+++ b/packages/eve/src/execution/subagent-auth-proxy-step.ts
@@ -1,0 +1,110 @@
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import type {
+  SubagentAuthorizationCompletedHookPayload,
+  SubagentAuthorizationRequiredHookPayload,
+} from "#channel/types.js";
+import { ContinuationTokenKey } from "#context/keys.js";
+import { withContextScope } from "#context/run-step.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import {
+  createDurableSessionState,
+  readDurableSession,
+  type DurableSessionState,
+} from "#execution/durable-session-store.js";
+import {
+  emitProxiedAuthorizationCompleted,
+  emitProxiedAuthorizationRequired,
+} from "#execution/subagent-hitl-proxy.js";
+import { setChannelContext } from "#execution/channel-context.js";
+import { hydrateDurableSession } from "#execution/session.js";
+import type { HarnessSession } from "#harness/types.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import {
+  encodeMessageStreamEvent,
+  timestampHandleMessageStreamEvent,
+  type HandleMessageStreamEvent,
+} from "#protocol/message.js";
+
+export type ProxyAuthorizationEventPayload =
+  | SubagentAuthorizationCompletedHookPayload
+  | SubagentAuthorizationRequiredHookPayload;
+
+export interface ProxyAuthorizationEventResult {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}
+
+/**
+ * Emits a proxied descendant authorization lifecycle event through the
+ * parent's adapter and persists adapter-state mutations made while rendering.
+ */
+export async function runProxyAuthorizationEventStep(input: {
+  readonly hookPayload: ProxyAuthorizationEventPayload;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<ProxyAuthorizationEventResult> {
+  "use step";
+
+  const durableSession = await readDurableSession(input.sessionState);
+  const ctx = await deserializeContext(input.serializedContext);
+  const adapter = ctx.require(ChannelKey);
+  const adapterCtx = buildAdapterContext(adapter, ctx);
+  const bundle = ctx.require(BundleKey);
+  const session = hydrateDurableSession({
+    compactionOverrides: {
+      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+    },
+    durable: durableSession,
+    turnAgent: bundle.turnAgent,
+  });
+  const writer = input.parentWritable.getWriter();
+
+  let scopeSession: HarnessSession = session;
+  try {
+    const emit = async (event: HandleMessageStreamEvent): Promise<void> => {
+      const transformed = await callAdapterEventHandler(adapter, event, adapterCtx);
+      await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(transformed)));
+    };
+
+    const scopeResult = await withContextScope(ctx, session, async (enrichedSession) => {
+      if (input.hookPayload.kind === "subagent-authorization-required") {
+        await emitProxiedAuthorizationRequired({
+          emit,
+          hookPayload: input.hookPayload,
+        });
+      } else {
+        await emitProxiedAuthorizationCompleted({
+          emit,
+          hookPayload: input.hookPayload,
+        });
+      }
+
+      return { result: undefined, session: enrichedSession };
+    });
+    scopeSession = scopeResult.session;
+  } finally {
+    writer.releaseLock();
+  }
+
+  setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
+
+  const nextSerializedContext = serializeContext(ctx);
+  const nextSession = reconcileSessionContinuationToken(ctx, scopeSession);
+  const nextState = createDurableSessionState({ session: nextSession });
+
+  return {
+    serializedContext: nextSerializedContext,
+    sessionState: nextState,
+  };
+}
+
+function reconcileSessionContinuationToken(
+  ctx: Awaited<ReturnType<typeof deserializeContext>>,
+  session: HarnessSession,
+): HarnessSession {
+  const next = ctx.get(ContinuationTokenKey);
+  if (next === undefined || next === session.continuationToken) return session;
+  return { ...session, continuationToken: next };
+}

--- a/packages/eve/src/execution/subagent-hitl-proxy.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.ts
@@ -1,4 +1,9 @@
-import type { DeliverPayload, SubagentInputRequestHookPayload } from "#channel/types.js";
+import type {
+  DeliverPayload,
+  SubagentAuthorizationCompletedHookPayload,
+  SubagentAuthorizationRequiredHookPayload,
+  SubagentInputRequestHookPayload,
+} from "#channel/types.js";
 import {
   emitTurnEpilogue,
   getHarnessEmissionState,
@@ -9,7 +14,11 @@ import {
   toProxyInputRequestEntries,
 } from "#harness/proxy-input-requests.js";
 import type { HarnessEmitFn, HarnessSession, SessionStateMap } from "#harness/types.js";
-import { createInputRequestedEvent } from "#protocol/message.js";
+import {
+  createAuthorizationCompletedEvent,
+  createAuthorizationRequiredEvent,
+  createInputRequestedEvent,
+} from "#protocol/message.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { InputResponse } from "#runtime/input/types.js";
 
@@ -52,6 +61,29 @@ export async function emitProxiedInputRequest(input: {
     entries: toProxyInputRequestEntries(input.hookPayload),
     session: nextSession,
   };
+}
+
+/**
+ * Emits a descendant subagent's authorization request through the parent
+ * channel. The event preserves the child's callback URL so OAuth completion
+ * resumes the child session that owns the pending authorization.
+ */
+export async function emitProxiedAuthorizationRequired(input: {
+  readonly emit: HarnessEmitFn;
+  readonly hookPayload: SubagentAuthorizationRequiredHookPayload;
+}): Promise<void> {
+  await input.emit(createAuthorizationRequiredEvent(input.hookPayload.event));
+}
+
+/**
+ * Emits a descendant subagent's authorization completion through the parent
+ * channel so UI adapters can clear pending auth state.
+ */
+export async function emitProxiedAuthorizationCompleted(input: {
+  readonly emit: HarnessEmitFn;
+  readonly hookPayload: SubagentAuthorizationCompletedHookPayload;
+}): Promise<void> {
+  await input.emit(createAuthorizationCompletedEvent(input.hookPayload.event));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -10,6 +10,7 @@ import {
   type TurnWorkflowInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+import { runProxyAuthorizationEventStep } from "#execution/subagent-auth-proxy-step.js";
 import { runProxyInputRequestStep, turnStep } from "#execution/workflow-steps.js";
 
 const resumeHookMock = vi.fn();
@@ -26,6 +27,10 @@ vi.mock("#compiled/@workflow/core/runtime.js", () => ({
 
 vi.mock("./route-child-delivery.js", () => ({
   routeDeliverToChildren: vi.fn(),
+}));
+
+vi.mock("./subagent-auth-proxy-step.js", () => ({
+  runProxyAuthorizationEventStep: vi.fn(),
 }));
 
 vi.mock("./workflow-steps.js", () => ({
@@ -527,6 +532,119 @@ describe("turnWorkflow", () => {
         payloads: [{ inputResponses: [{ optionId: "approve", requestId: "approval-1" }] }],
         sessionState: proxyState,
       }),
+    );
+  });
+
+  it("proxies child authorization lifecycle events while awaiting the child result", async () => {
+    const pendingState = createSessionState();
+    const authRequiredState = createSessionState();
+    const authCompletedState = createSessionState();
+    const completedState = createSessionState();
+    const requiredPayload = {
+      callId: "call-1",
+      childContinuationToken: "subagent:parent:call-1",
+      childSessionId: "child-session",
+      event: {
+        authorization: {
+          displayName: "Weather",
+          url: "https://idp.example/authorize?redirect_uri=child",
+        },
+        description: "Sign in to continue.",
+        name: "weather",
+        sequence: 2,
+        stepIndex: 1,
+        turnId: "child-turn",
+        webhookUrl: "https://eve.example/eve/v1/connections/weather/callback/child-session:auth",
+      },
+      kind: "subagent-authorization-required" as const,
+      subagentName: "delegate",
+    };
+    const completedPayload = {
+      callId: "call-1",
+      childContinuationToken: "subagent:parent:call-1",
+      childSessionId: "child-session",
+      event: {
+        authorization: { displayName: "Weather" },
+        name: "weather",
+        outcome: "authorized" as const,
+        sequence: 3,
+        stepIndex: 2,
+        turnId: "child-turn",
+      },
+      kind: "subagent-authorization-completed" as const,
+      subagentName: "delegate",
+    };
+    installInbox([
+      requiredPayload,
+      completedPayload,
+      {
+        kind: "runtime-action-result",
+        results: [
+          {
+            callId: "call-1",
+            kind: "subagent-result",
+            output: "authorized child output",
+            subagentName: "delegate",
+          },
+        ],
+      },
+    ]);
+    vi.mocked(dispatchRuntimeActionsStep).mockResolvedValue({
+      results: [],
+      sessionState: pendingState,
+    });
+    vi.mocked(runProxyAuthorizationEventStep)
+      .mockResolvedValueOnce({
+        serializedContext: { state: "auth-required" },
+        sessionState: authRequiredState,
+      })
+      .mockResolvedValueOnce({
+        serializedContext: { state: "auth-completed" },
+        sessionState: authCompletedState,
+      });
+    vi.mocked(turnStep)
+      .mockResolvedValueOnce({
+        action: "park",
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        pendingRuntimeActionKeys: ["subagent-call:delegate:call-1"],
+        serializedContext: { state: "pending" },
+        sessionState: pendingState,
+      })
+      .mockResolvedValueOnce({
+        action: "done",
+        output: "done",
+        serializedContext: { state: "done" },
+        sessionState: completedState,
+      });
+
+    const { input, parentWritable } = createInput({
+      driverCapabilities: { turnInbox: true },
+      mode: "task",
+      sessionState: pendingState,
+    });
+    await turnWorkflow(input);
+
+    expect(runProxyAuthorizationEventStep).toHaveBeenCalledTimes(2);
+    expect(runProxyAuthorizationEventStep).toHaveBeenNthCalledWith(1, {
+      hookPayload: requiredPayload,
+      parentWritable,
+      serializedContext: { state: "pending" },
+      sessionState: pendingState,
+    });
+    expect(runProxyAuthorizationEventStep).toHaveBeenNthCalledWith(2, {
+      hookPayload: completedPayload,
+      parentWritable,
+      serializedContext: { state: "auth-required" },
+      sessionState: authRequiredState,
+    });
+    expect(vi.mocked(turnStep).mock.calls[1]?.[0].input).toEqual({
+      kind: "runtime-action-result",
+      results: [expect.objectContaining({ callId: "call-1", output: "authorized child output" })],
+    });
+    expect(resumeHookMock).not.toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({ kind: "turn-delivery-request" }),
     );
   });
 

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -20,6 +20,7 @@ import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import { TurnExecutionCursor } from "#execution/turn-execution-cursor.js";
 import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
+import { runProxyAuthorizationEventStep } from "#execution/subagent-auth-proxy-step.js";
 import { runProxyInputRequestStep, turnStep } from "#execution/workflow-steps.js";
 import { resolveRuntimeActionResultsForKeys } from "#harness/runtime-actions.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
@@ -205,6 +206,20 @@ async function waitForRuntimeActionResults(input: {
 
     if (value.kind === "subagent-input-request") {
       const proxyResult = await runProxyInputRequestStep({
+        hookPayload: value,
+        parentWritable: input.cursor.parentWritable,
+        serializedContext: input.cursor.serializedContext,
+        sessionState: input.cursor.sessionState,
+      });
+      await input.cursor.adopt(proxyResult);
+      continue;
+    }
+
+    if (
+      value.kind === "subagent-authorization-required" ||
+      value.kind === "subagent-authorization-completed"
+    ) {
+      const proxyResult = await runProxyAuthorizationEventStep({
         hookPayload: value,
         parentWritable: input.cursor.parentWritable,
         serializedContext: input.cursor.serializedContext,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
-import type { DeliverPayload, SubagentInputRequestHookPayload } from "#channel/types.js";
+import type {
+  DeliverPayload,
+  SubagentAuthorizationRequiredHookPayload,
+  SubagentInputRequestHookPayload,
+} from "#channel/types.js";
 import { ContextContainer } from "#context/container.js";
 import { ContextKey } from "#context/key.js";
 import { AuthKey, ContinuationTokenKey, ModeKey, SessionIdKey } from "#context/keys.js";
@@ -24,6 +28,7 @@ import { createTurnWorkflowInput } from "#execution/durable-session-migrations/t
 import { projectToDurableSession } from "#execution/session.js";
 import { createExecutionNodeStep } from "#execution/node-step.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
+import { runProxyAuthorizationEventStep } from "#execution/subagent-auth-proxy-step.js";
 import {
   dispatchTurnStep,
   emitTerminalSessionFailureStep,
@@ -1189,6 +1194,28 @@ describe("runProxyInputRequestStep", () => {
     };
   }
 
+  function buildAuthorizationRequiredPayload(): SubagentAuthorizationRequiredHookPayload {
+    return {
+      callId: "call-1",
+      childContinuationToken: "subagent:parent-session:call-1",
+      childSessionId: "child-session",
+      event: {
+        authorization: {
+          displayName: "Weather",
+          url: "https://idp.example/authorize?redirect_uri=child",
+        },
+        description: "Sign in to continue.",
+        name: "weather",
+        sequence: 2,
+        stepIndex: 1,
+        turnId: "child-turn",
+        webhookUrl: "https://eve.example/eve/v1/connections/weather/callback/child-session:auth",
+      },
+      kind: "subagent-authorization-required",
+      subagentName: "linear",
+    };
+  }
+
   it("persists adapter-state mutations from the input.requested handler onto the returned serializedContext", async () => {
     // The stub adapter mirrors Slack's contract: its `input.requested`
     // handler writes a `pendingRequests` entry onto `adapterCtx.state`
@@ -1286,6 +1313,59 @@ describe("runProxyInputRequestStep", () => {
 
     expect(result.sessionState.continuationToken).toBe("http:proxy-rekeyed");
     expect(result.serializedContext[ContinuationTokenKey.name]).toBe("http:proxy-rekeyed");
+  });
+
+  it("proxies authorization.required through the parent adapter and preserves the child callback URL", async () => {
+    const cachingAdapter: ChannelAdapter = {
+      kind: "thread-context",
+      async "authorization.required"(data, adapterCtx) {
+        adapterCtx.state.pendingAuth = {
+          name: data.name,
+          webhookUrl: data.webhookUrl,
+        };
+      },
+    };
+
+    const session: HarnessSession = createStubSession({
+      continuationToken: "http:proxy-test",
+      sessionId: "parent-session",
+    });
+    installSessionStoreMocks([session]);
+
+    const sessionState = createStubSessionState({
+      sessionId: "parent-session",
+      continuationToken: "http:proxy-test",
+    });
+
+    const result = await runProxyAuthorizationEventStep({
+      hookPayload: buildAuthorizationRequiredPayload(),
+      parentWritable: createTestWritable(),
+      serializedContext: buildSerializedContextForAdapter(cachingAdapter),
+      sessionState,
+    });
+
+    const channel = result.serializedContext[ChannelKey.name] as {
+      kind: string;
+      state: { pendingAuth?: { name: string; webhookUrl: string } };
+    };
+    expect(channel.kind).toBe("thread-context");
+    expect(channel.state.pendingAuth).toEqual({
+      name: "weather",
+      webhookUrl: "https://eve.example/eve/v1/connections/weather/callback/child-session:auth",
+    });
+
+    expect(result.sessionState.hasProxyInputRequests).toBe(false);
+
+    const writes = workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE) ?? [];
+    expect(writes).toHaveLength(1);
+    const event = JSON.parse(new TextDecoder().decode(writes[0] as Uint8Array).trim()) as {
+      data: { webhookUrl?: string };
+      type: string;
+    };
+    expect(event.type).toBe("authorization.required");
+    expect(event.data.webhookUrl).toBe(
+      "https://eve.example/eve/v1/connections/weather/callback/child-session:auth",
+    );
   });
 });
 


### PR DESCRIPTION
### Description

Fixes #568.

Subagent sessions already proxied `input.requested` events to the parent turn, but `authorization.required` stayed on the child stream. This adds subagent authorization hook payloads and forwards child `authorization.required` / `authorization.completed` events through the parent turn inbox so user-facing channels can render and clear connection auth prompts.

The proxied required event preserves the child callback URL, so the existing connection callback route resumes the child session that owns the pending authorization.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/subagent-adapter.test.ts src/execution/turn-workflow.test.ts src/execution/workflow-steps.test.ts src/internal/structural-tests/file-length.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm exec oxfmt --check packages/eve/src/channel/types.ts packages/eve/src/execution/subagent-adapter.ts packages/eve/src/execution/subagent-hitl-proxy.ts packages/eve/src/execution/subagent-auth-proxy-step.ts packages/eve/src/execution/turn-workflow.ts packages/eve/src/execution/workflow-steps.ts packages/eve/src/execution/subagent-adapter.test.ts packages/eve/src/execution/turn-workflow.test.ts packages/eve/src/execution/workflow-steps.test.ts`
- `pnpm exec oxlint packages/eve/src/channel/types.ts packages/eve/src/execution/subagent-adapter.ts packages/eve/src/execution/subagent-hitl-proxy.ts packages/eve/src/execution/subagent-auth-proxy-step.ts packages/eve/src/execution/turn-workflow.ts packages/eve/src/execution/workflow-steps.ts packages/eve/src/execution/subagent-adapter.test.ts packages/eve/src/execution/turn-workflow.test.ts packages/eve/src/execution/workflow-steps.test.ts`
- `pnpm changeset status --since origin/main`
- `npx -y -p node@24 -p pnpm@11.7.0 -c 'node -v && pnpm --filter eve run test:unit'` (Node v24.18.0; 430 files passed, 4533 passed, 1 skipped)
- `npx -y -p node@24 -p pnpm@11.7.0 -c 'node -v && pnpm --filter eve run build:js && pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/workflow-entry.integration.test.ts'` (Node v24.18.0; 1 file passed, 8 passed)
- `git diff --check`

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
