### PR TITLE
fix(eve): subagents - proxy authorization events

### DIFF
--- a/.changeset/subagents-forward-authorization.md
+++ b/.changeset/subagents-forward-authorization.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Surface authorization prompts and completion updates from local subagents on the parent channel, including through nested delegation chains, while keeping the authorization callback scoped to the child session.

--- a/apps/frameworks/nuxt/package.json
+++ b/apps/frameworks/nuxt/package.json
@@ -17,6 +17,8 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "typescript": "6.0.3",
+    "vue-tsc": "3.3.6"
   }
 }

--- a/docs/connections/overview.mdx
+++ b/docs/connections/overview.mdx
@@ -138,6 +138,8 @@ export default defineMcpClientConnection({
 
 `"linear/myagent"` is the UID you chose when registering the Connect client. `connect("linear/myagent")` is shorthand for a user-scoped interactive OAuth connection: eve resolves a token for the active user before each tool call, emits `authorization.required` when that user has not authorized yet, and resumes the parked turn after the callback completes.
 
+When a local subagent needs interactive authorization, eve surfaces the authorization lifecycle on the root session's channel, including through nested subagent chains. The challenge still points to the child session's callback, so completing it resumes the child directly while the parent continues waiting for its result.
+
 That means the channel that creates or continues the session must authenticate a real user. For a web app, configure `agent/channels/eve.ts` so your app session maps to `principalType: "user"`; for platform channels, use the built-in channel auth that maps the sender to a user principal. If no authenticated user is attached to the session, the first user-scoped connection call fails with `reason: "principal_required"`.
 
 If the remote service should act as the agent itself instead of the end-user, make the Connect connection app-scoped:

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -109,7 +109,7 @@ Because the name lives in the same runtime tool namespace as authored tools, a s
 
 Do not rely on subagent delegation by itself as an approval boundary. Put sensitive tools behind `approval`, connection approval, route/session authorization, or other controls wherever those tools can be called.
 
-Each delegated subagent spins up its own child session and stream. The parent stream carries only the control-plane events `subagent.called` and `subagent.completed`. To follow the child's full progress, read `subagent.called.data.childSessionId` and subscribe at `GET /eve/v1/session/:childSessionId/stream`.
+Each delegated subagent spins up its own child session and stream. The parent stream carries the control-plane events `subagent.called` and `subagent.completed`, plus interactive `input.requested`, `authorization.required`, and `authorization.completed` events proxied from descendants so the root channel can prompt the user. To follow the child's other progress, read `subagent.called.data.childSessionId` and subscribe at `GET /eve/v1/session/:childSessionId/stream`.
 
 ## When to split
 

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -162,12 +162,33 @@ export interface SubagentInputRequestHookPayload {
   readonly subagentName: string;
 }
 
+/** Authorization lifecycle event forwarded from a delegated child. */
+export type SubagentAuthorizationEvent = Extract<
+  HandleMessageStreamEvent,
+  { type: "authorization.required" | "authorization.completed" }
+>;
+
+/**
+ * Proxy payload sent from a child subagent while it waits for authorization.
+ *
+ * Runtime-internal. The parent re-emits the unchanged event through its own
+ * channel; the authorization callback continues to target the child directly.
+ */
+export interface SubagentAuthorizationEventHookPayload {
+  readonly callId: string;
+  readonly childSessionId: string;
+  readonly event: SubagentAuthorizationEvent;
+  readonly kind: "subagent-authorization-event";
+  readonly subagentName: string;
+}
+
 /**
  * Serializable payload sent through the workflow `resumeHook`.
  */
 export type HookPayload =
   | DeliverHookPayload
   | RuntimeActionResultHookPayload
+  | SubagentAuthorizationEventHookPayload
   | SubagentInputRequestHookPayload;
 
 /**

--- a/packages/eve/src/execution/reconcile-session-continuation-token.test.ts
+++ b/packages/eve/src/execution/reconcile-session-continuation-token.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { ContextContainer } from "#context/container.js";
 import { ContinuationTokenKey } from "#context/keys.js";
-import { reconcileSessionContinuationToken } from "#execution/workflow-steps.js";
+import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import type { HarnessSession } from "#harness/types.js";
 
 function makeSession(continuationToken: string): HarnessSession {

--- a/packages/eve/src/execution/reconcile-session-continuation-token.ts
+++ b/packages/eve/src/execution/reconcile-session-continuation-token.ts
@@ -1,0 +1,13 @@
+import type { ContextAccessor } from "#context/key.js";
+import { ContinuationTokenKey } from "#context/keys.js";
+import type { HarnessSession } from "#harness/types.js";
+
+/** Re-stamps a session after a channel handler changes its continuation token. */
+export function reconcileSessionContinuationToken(
+  ctx: ContextAccessor,
+  session: HarnessSession,
+): HarnessSession {
+  const next = ctx.get(ContinuationTokenKey);
+  if (next === undefined || next === session.continuationToken) return session;
+  return { ...session, continuationToken: next };
+}

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ChannelAdapterContext } from "#channel/adapter.js";
+import { callAdapterEventHandler, type ChannelAdapterContext } from "#channel/adapter.js";
 import { buildSessionHandle } from "#channel/session.js";
 import { type SubagentAdapterState } from "#execution/subagent-adapter.js";
 import { ContextContainer } from "#context/container.js";
@@ -9,9 +9,17 @@ import type { InputRequest } from "#runtime/input/types.js";
 import { SUBAGENT_ADAPTER } from "#execution/subagent-adapter.js";
 
 const SUBAGENT_INPUT_REQUESTED = SUBAGENT_ADAPTER["input.requested"];
+const SUBAGENT_AUTHORIZATION_REQUIRED = SUBAGENT_ADAPTER["authorization.required"];
+const SUBAGENT_AUTHORIZATION_COMPLETED = SUBAGENT_ADAPTER["authorization.completed"];
 
 if (SUBAGENT_INPUT_REQUESTED === undefined) {
   throw new Error("SUBAGENT_ADAPTER is missing its input.requested handler.");
+}
+if (SUBAGENT_AUTHORIZATION_REQUIRED === undefined) {
+  throw new Error("SUBAGENT_ADAPTER is missing its authorization.required handler.");
+}
+if (SUBAGENT_AUTHORIZATION_COMPLETED === undefined) {
+  throw new Error("SUBAGENT_ADAPTER is missing its authorization.completed handler.");
 }
 
 const resumeHookMock = vi.fn();
@@ -53,6 +61,81 @@ function sampleRequest(): InputRequest {
     requestId: "req-1",
   };
 }
+
+const authorization = {
+  displayName: "Linear",
+  instructions: "Sign in to continue.",
+  url: "https://idp.example/authorize",
+};
+
+describe("SUBAGENT_ADAPTER authorization handlers", () => {
+  it("forwards a required event through each nested subagent adapter hop", async () => {
+    resumeHookMock.mockClear();
+    const data = {
+      authorization,
+      description: "Authorization required for linear",
+      name: "linear",
+      sequence: 2,
+      stepIndex: 3,
+      turnId: "turn-auth",
+      webhookUrl: "https://eve.example/connections/linear/callback/child-session%3Aauth",
+    };
+
+    await callAdapterEventHandler(
+      SUBAGENT_ADAPTER,
+      { data, type: "authorization.required" },
+      makeContext(),
+    );
+
+    expect(resumeHookMock).toHaveBeenCalledWith("parent-token", {
+      callId: "call-123",
+      childSessionId: "child-session",
+      event: { data, type: "authorization.required" },
+      kind: "subagent-authorization-event",
+      subagentName: "linear",
+    });
+  });
+
+  it("forwards authorization.completed unchanged via resumeHook", async () => {
+    resumeHookMock.mockClear();
+    const data = {
+      authorization,
+      name: "linear",
+      outcome: "authorized" as const,
+      sequence: 2,
+      stepIndex: 4,
+      turnId: "turn-auth",
+    };
+
+    await SUBAGENT_AUTHORIZATION_COMPLETED(data, makeContext());
+
+    expect(resumeHookMock).toHaveBeenCalledWith("parent-token", {
+      callId: "call-123",
+      childSessionId: "child-session",
+      event: { data, type: "authorization.completed" },
+      kind: "subagent-authorization-event",
+      subagentName: "linear",
+    });
+  });
+
+  it("skips forwarding when the adapter state is invalid", async () => {
+    resumeHookMock.mockClear();
+    const base = makeContext();
+
+    await SUBAGENT_AUTHORIZATION_REQUIRED(
+      {
+        description: "Authorization required for linear",
+        name: "linear",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-auth",
+      },
+      { ctx: base.ctx, state: {}, session: base.session },
+    );
+
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("SUBAGENT_ADAPTER input.requested handler", () => {
   it("forwards the child's HITL batch via resumeHook", async () => {
@@ -162,6 +245,39 @@ describe("SUBAGENT_ADAPTER forward failure logging", () => {
       error: expect.objectContaining({
         message: expect.stringContaining("parent gone"),
       }),
+    });
+  });
+
+  it("includes the authorization event type when auth forwarding fails", async () => {
+    resumeHookMock.mockClear();
+    resumeHookMock.mockRejectedValueOnce(new Error("parent gone"));
+
+    await expect(
+      SUBAGENT_AUTHORIZATION_REQUIRED(
+        {
+          authorization,
+          description: "Authorization required for linear",
+          name: "linear",
+          sequence: 2,
+          stepIndex: 3,
+          turnId: "turn-auth",
+          webhookUrl: "https://eve.example/connections/linear/callback/child-session%3Aauth",
+        },
+        makeContext(),
+      ),
+    ).rejects.toThrow("parent gone");
+
+    const warnCall = warnSpy.mock.calls.find((call: unknown[]) =>
+      String(call[0]).startsWith("[eve:execution.subagent-adapter]"),
+    );
+    expect(warnCall?.[1]).toMatchObject({
+      callId: "call-123",
+      childSessionId: "child-session",
+      errorId: expect.any(String),
+      eventType: "authorization.required",
+      parentContinuationToken: "parent-token",
+      subagentName: "linear",
+      error: expect.objectContaining({ message: expect.stringContaining("parent gone") }),
     });
   });
 });

--- a/packages/eve/src/execution/subagent-adapter.ts
+++ b/packages/eve/src/execution/subagent-adapter.ts
@@ -1,7 +1,11 @@
 import { resumeHook } from "#internal/workflow/runtime.js";
 
-import type { ChannelAdapter } from "#channel/adapter.js";
-import type { SubagentInputRequestHookPayload } from "#channel/types.js";
+import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
+import type {
+  SubagentAuthorizationEvent,
+  SubagentAuthorizationEventHookPayload,
+  SubagentInputRequestHookPayload,
+} from "#channel/types.js";
 import { ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
 import { createErrorId, createLogger } from "#internal/logging.js";
 
@@ -69,6 +73,12 @@ export function isSubagentAdapterState(value: unknown): value is SubagentAdapter
  */
 export const SUBAGENT_ADAPTER: ChannelAdapter = {
   kind: SUBAGENT_ADAPTER_KIND,
+  async "authorization.required"(data, ctx) {
+    await forwardSubagentAuthorizationEvent({ data, type: "authorization.required" }, ctx);
+  },
+  async "authorization.completed"(data, ctx) {
+    await forwardSubagentAuthorizationEvent({ data, type: "authorization.completed" }, ctx);
+  },
   async "input.requested"(data, ctx) {
     const state = ctx.state;
 
@@ -96,6 +106,52 @@ export const SUBAGENT_ADAPTER: ChannelAdapter = {
     });
   },
 };
+
+async function forwardSubagentAuthorizationEvent(
+  event: SubagentAuthorizationEvent,
+  ctx: ChannelAdapterContext,
+): Promise<void> {
+  const state = ctx.state;
+
+  if (!isSubagentAdapterState(state)) {
+    return;
+  }
+
+  await forwardSubagentAuthorizationEventStep({
+    hookPayload: {
+      callId: state.callId,
+      childSessionId: ctx.ctx.require(SessionIdKey),
+      event,
+      kind: "subagent-authorization-event",
+      subagentName: state.subagentName,
+    },
+    parentContinuationToken: state.parentContinuationToken,
+  });
+}
+
+/** Forwards one child authorization event to its active parent turn. */
+async function forwardSubagentAuthorizationEventStep(input: {
+  readonly hookPayload: SubagentAuthorizationEventHookPayload;
+  readonly parentContinuationToken: string;
+}): Promise<void> {
+  "use step";
+
+  try {
+    await resumeHook(input.parentContinuationToken, input.hookPayload);
+  } catch (error) {
+    const errorId = createErrorId();
+    log.warn("failed to forward subagent authorization event to parent", {
+      callId: input.hookPayload.callId,
+      childSessionId: input.hookPayload.childSessionId,
+      errorId,
+      eventType: input.hookPayload.event.type,
+      parentContinuationToken: input.parentContinuationToken,
+      subagentName: input.hookPayload.subagentName,
+      error,
+    });
+    throw error;
+  }
+}
 
 /**
  * Forwards one child HITL batch up to its parent via the durable

--- a/packages/eve/src/execution/subagent-auth-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-auth-proxy.integration.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
+import type {
+  SubagentAuthorizationEvent,
+  SubagentAuthorizationEventHookPayload,
+} from "#channel/types.js";
+import { ContextContainer } from "#context/container.js";
+import { AuthKey, ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
+import { emitProxiedSubagentEvent } from "#execution/subagent-event-proxy-step.js";
+import { projectToDurableSession } from "#execution/session.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { TimedHandleMessageStreamEvent } from "#protocol/message.js";
+import { deserializeRuntimeAdapter } from "#runtime/channels/registry.js";
+import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
+import {
+  BundleKey,
+  ChannelKey,
+  type CompiledBundle,
+} from "#runtime/sessions/runtime-context-keys.js";
+
+interface AuthorizationAdapterState extends Record<string, unknown> {
+  outcome?: string;
+  pendingName?: string;
+}
+
+type AuthorizationAdapterContext = ChannelAdapterContext<AuthorizationAdapterState>;
+
+const authorizationAdapter: ChannelAdapter<AuthorizationAdapterContext> = {
+  kind: "authorization-proxy-test",
+  "authorization.required"(data, ctx) {
+    ctx.state.pendingName = data.name;
+    ctx.session.setContinuationToken("auth-thread");
+  },
+  "authorization.completed"(data, ctx) {
+    delete ctx.state.pendingName;
+    ctx.state.outcome = data.outcome;
+  },
+};
+
+const turnAgent = {
+  id: "test-agent",
+  instructions: ["You are a test agent."],
+  model: { id: "test-model" },
+  skills: [],
+  tools: [],
+  workspaceSpec: {} as never,
+};
+
+function buildBundle(adapter: ChannelAdapter): CompiledBundle {
+  return {
+    adapterRegistry: {
+      adaptersByKind: new Map([[adapter.kind, adapter]]),
+    },
+    compiledArtifactsSource: {} as never,
+    graph: {
+      nodesByNodeId: new Map(),
+      root: {
+        sandboxRegistry: { sandbox: null },
+        turnAgent,
+      },
+    },
+    hookRegistry: createEmptyHookRegistry(),
+    resolvedAgent: { config: {} },
+    subagentRegistry: {},
+    toolRegistry: {},
+    turnAgent,
+  } as never;
+}
+
+function buildContext(input: { readonly adapter: ChannelAdapter; readonly sessionId: string }): {
+  readonly bundle: ReturnType<typeof buildBundle>;
+  readonly ctx: ContextContainer;
+} {
+  const bundle = buildBundle(input.adapter);
+  const ctx = new ContextContainer();
+  ctx.set(AuthKey, null);
+  ctx.set(BundleKey, bundle);
+  ctx.set(ChannelKey, input.adapter);
+  ctx.set(ContinuationTokenKey, "http:parent");
+  ctx.set(SessionIdKey, input.sessionId);
+  return { bundle, ctx };
+}
+
+function rehydrateContext(input: {
+  readonly bundle: ReturnType<typeof buildBundle>;
+  readonly serializedContext: Record<string, unknown>;
+}): ContextContainer {
+  const ctx = new ContextContainer();
+  ctx.set(AuthKey, null);
+  ctx.set(BundleKey, input.bundle);
+  ctx.set(
+    ChannelKey,
+    deserializeRuntimeAdapter(
+      input.bundle.adapterRegistry,
+      input.serializedContext[ChannelKey.name],
+    ),
+  );
+  ctx.set(ContinuationTokenKey, input.serializedContext[ContinuationTokenKey.name] as string);
+  ctx.set(SessionIdKey, input.serializedContext[SessionIdKey.name] as string);
+  return ctx;
+}
+
+function createSession(sessionId: string): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test-model" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "http:parent",
+    history: [],
+    sessionId,
+  };
+}
+
+function authorizationPayload(
+  event: SubagentAuthorizationEvent,
+): SubagentAuthorizationEventHookPayload {
+  return {
+    callId: "call-child",
+    childSessionId: "child-session",
+    event,
+    kind: "subagent-authorization-event",
+    subagentName: "researcher",
+  };
+}
+
+function createCapturingWritable(chunks: Uint8Array[]): WritableStream<Uint8Array> {
+  return new WritableStream<Uint8Array>({
+    write(chunk) {
+      chunks.push(chunk);
+    },
+  });
+}
+
+function decodeEvent(chunk: Uint8Array): TimedHandleMessageStreamEvent {
+  return JSON.parse(new TextDecoder().decode(chunk).trim()) as TimedHandleMessageStreamEvent;
+}
+
+describe("subagent authorization proxy", () => {
+  it("preserves events and parent adapter state across required/completed steps", async () => {
+    const parentSessionId = "parent-session";
+    const session = createSession(parentSessionId);
+    const { bundle, ctx } = buildContext({
+      adapter: authorizationAdapter,
+      sessionId: parentSessionId,
+    });
+    const chunks: Uint8Array[] = [];
+    const parentWritable = createCapturingWritable(chunks);
+    const requiredEvent: SubagentAuthorizationEvent = {
+      data: {
+        authorization: {
+          displayName: "Linear",
+          instructions: "Sign in to continue.",
+          url: "https://idp.example/authorize",
+        },
+        description: "Authorization required for linear",
+        name: "linear",
+        sequence: 0,
+        stepIndex: 1,
+        turnId: "child-turn",
+        webhookUrl: "https://eve.example/connections/linear/callback/child-session%3Aauth",
+      },
+      type: "authorization.required",
+    };
+
+    const required = await emitProxiedSubagentEvent({
+      ctx,
+      durableSession: projectToDurableSession(session),
+      hookPayload: authorizationPayload(requiredEvent),
+      parentWritable,
+    });
+
+    expect(required.sessionState.continuationToken).toBe("http:auth-thread");
+    expect(required.serializedContext[ContinuationTokenKey.name]).toBe("http:auth-thread");
+    expect(required.serializedContext[ChannelKey.name]).toEqual({
+      kind: authorizationAdapter.kind,
+      state: { pendingName: "linear" },
+    });
+
+    const completedEvent: SubagentAuthorizationEvent = {
+      data: {
+        authorization: requiredEvent.data.authorization,
+        name: "linear",
+        outcome: "authorized",
+        sequence: 0,
+        stepIndex: 2,
+        turnId: "child-turn",
+      },
+      type: "authorization.completed",
+    };
+    const completed = await emitProxiedSubagentEvent({
+      ctx: rehydrateContext({ bundle, serializedContext: required.serializedContext }),
+      durableSession: required.sessionState.snapshot!.session,
+      hookPayload: authorizationPayload(completedEvent),
+      parentWritable,
+    });
+
+    expect(completed.serializedContext[ChannelKey.name]).toEqual({
+      kind: authorizationAdapter.kind,
+      state: { outcome: "authorized" },
+    });
+    expect(chunks).toHaveLength(2);
+    expect(decodeEvent(chunks[0]!)).toMatchObject(requiredEvent);
+    expect(decodeEvent(chunks[1]!)).toMatchObject(completedEvent);
+  });
+});

--- a/packages/eve/src/execution/subagent-event-proxy-step.ts
+++ b/packages/eve/src/execution/subagent-event-proxy-step.ts
@@ -1,0 +1,125 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import type {
+  SubagentAuthorizationEventHookPayload,
+  SubagentInputRequestHookPayload,
+} from "#channel/types.js";
+import type { ContextContainer } from "#context/container.js";
+import { ModeKey } from "#context/keys.js";
+import { withContextScope } from "#context/run-step.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import { setChannelContext } from "#execution/channel-context.js";
+import {
+  createDurableSessionState,
+  type DurableSession,
+  type DurableSessionState,
+  readDurableSession,
+} from "#execution/durable-session-store.js";
+import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
+import { hydrateDurableSession } from "#execution/session.js";
+import { emitProxiedInputRequest } from "#execution/subagent-hitl-proxy.js";
+import { upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { encodeMessageStreamEvent, timestampHandleMessageStreamEvent } from "#protocol/message.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+
+type SubagentEventHookPayload =
+  | SubagentAuthorizationEventHookPayload
+  | SubagentInputRequestHookPayload;
+
+type ProxyInputRequestEntries = readonly (readonly [
+  requestId: string,
+  childContinuationToken: string,
+])[];
+
+interface ProxySubagentEventResult {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}
+
+/** Proxies one child event through its parent channel across a durable step boundary. */
+export async function runProxySubagentEventStep(input: {
+  readonly hookPayload: SubagentEventHookPayload;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<ProxySubagentEventResult> {
+  "use step";
+
+  const durableSession = await readDurableSession(input.sessionState);
+  const ctx = await deserializeContext(input.serializedContext);
+
+  return emitProxiedSubagentEvent({
+    ctx,
+    durableSession,
+    hookPayload: input.hookPayload,
+    parentWritable: input.parentWritable,
+  });
+}
+
+/** Applies one proxied child event to an already-hydrated parent context. */
+export async function emitProxiedSubagentEvent(input: {
+  readonly ctx: ContextContainer;
+  readonly durableSession: DurableSession;
+  readonly hookPayload: SubagentEventHookPayload;
+  readonly parentWritable: WritableStream<Uint8Array>;
+}): Promise<ProxySubagentEventResult> {
+  const { ctx } = input;
+  const adapter = ctx.require(ChannelKey);
+  const bundle = ctx.require(BundleKey);
+  const session = hydrateDurableSession({
+    compactionOverrides: {
+      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+    },
+    durable: input.durableSession,
+    turnAgent: bundle.turnAgent,
+  });
+  const adapterCtx = buildAdapterContext(adapter, ctx);
+  const writer = input.parentWritable.getWriter();
+
+  let proxyEntries: ProxyInputRequestEntries | undefined;
+  let scopedSession: HarnessSession;
+  try {
+    const emit = async (event: HandleMessageStreamEvent): Promise<void> => {
+      const transformed = await callAdapterEventHandler(adapter, event, adapterCtx);
+      await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(transformed)));
+    };
+
+    const scopeResult = await withContextScope(ctx, session, async (enrichedSession) => {
+      if (input.hookPayload.kind === "subagent-authorization-event") {
+        await emit(input.hookPayload.event);
+        return { result: undefined, session: enrichedSession };
+      }
+
+      const proxyResult = await emitProxiedInputRequest({
+        emit,
+        hookPayload: input.hookPayload,
+        mode: ctx.require(ModeKey),
+        session: enrichedSession,
+      });
+      return { result: proxyResult.entries, session: proxyResult.session };
+    });
+    proxyEntries = scopeResult.result;
+    scopedSession = scopeResult.session;
+  } finally {
+    writer.releaseLock();
+  }
+
+  setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
+
+  if (proxyEntries !== undefined && input.hookPayload.kind === "subagent-input-request") {
+    scopedSession = upsertProxyInputRequests({
+      entries: proxyEntries,
+      forChildContinuationToken: input.hookPayload.childContinuationToken,
+      session: scopedSession,
+    });
+  }
+
+  const nextSession = reconcileSessionContinuationToken(ctx, scopedSession);
+
+  return {
+    serializedContext: serializeContext(ctx),
+    sessionState: createDurableSessionState({ session: nextSession }),
+  };
+}

--- a/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
@@ -207,7 +207,7 @@ describe("subagent HITL proxy → Slack-style text-approve regression (Finding #
     ctx.set(ChannelKey, slackishAdapter);
 
     // Drive a child HITL batch up through the parent's adapter. This
-    // is the exact call shape used by `runProxyInputRequestStep` on
+    // is the exact call shape used by `runProxySubagentEventStep` on
     // the workflow runtime.
     const approvalRequest = buildApprovalRequest("req-approve-1");
     const hookPayload = buildHitlPayload({

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -4,13 +4,14 @@ import type { HookPayload } from "#channel/types.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { dispatchWorkflowRuntimeActionsStep } from "#execution/dispatch-workflow-runtime-actions-step.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { turnWorkflow } from "#execution/turn-workflow.js";
 import {
   TURN_WORKFLOW_INPUT_VERSION,
   type TurnWorkflowInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
-import { runProxyInputRequestStep, turnStep } from "#execution/workflow-steps.js";
+import { turnStep } from "#execution/workflow-steps.js";
 
 const resumeHookMock = vi.fn();
 const createHookMock = vi.fn();
@@ -28,8 +29,11 @@ vi.mock("./route-child-delivery.js", () => ({
   routeDeliverToChildren: vi.fn(),
 }));
 
+vi.mock("./subagent-event-proxy-step.js", () => ({
+  runProxySubagentEventStep: vi.fn(),
+}));
+
 vi.mock("./workflow-steps.js", () => ({
-  runProxyInputRequestStep: vi.fn(),
   turnStep: vi.fn(),
 }));
 
@@ -483,7 +487,7 @@ describe("turnWorkflow", () => {
       results: [],
       sessionState: pendingState,
     });
-    vi.mocked(runProxyInputRequestStep).mockResolvedValue({
+    vi.mocked(runProxySubagentEventStep).mockResolvedValue({
       serializedContext: { state: "proxied" },
       sessionState: proxyState,
     });
@@ -511,7 +515,7 @@ describe("turnWorkflow", () => {
     });
     await turnWorkflow(input);
 
-    expect(runProxyInputRequestStep).toHaveBeenCalledOnce();
+    expect(runProxySubagentEventStep).toHaveBeenCalledOnce();
     expect(resumeHookMock).toHaveBeenCalledWith("turn-token", {
       continuationToken: "http:test",
       inboxToken: "turn-token:inbox",
@@ -528,6 +532,133 @@ describe("turnWorkflow", () => {
         sessionState: proxyState,
       }),
     );
+  });
+
+  it("proxies child authorization lifecycle events while continuing to await its result", async () => {
+    const pendingState = createSessionState();
+    const requiredState = createSessionState();
+    const completedAuthState = createSessionState();
+    const completedState = createSessionState();
+    const requiredEvent = {
+      data: {
+        authorization: { displayName: "Linear", url: "https://idp.example/authorize" },
+        description: "Authorization required for linear",
+        name: "linear",
+        sequence: 0,
+        stepIndex: 1,
+        turnId: "turn_0",
+        webhookUrl: "https://eve.example/connections/linear/callback/child%3Aauth",
+      },
+      type: "authorization.required" as const,
+    };
+    const completedEvent = {
+      data: {
+        authorization: { displayName: "Linear", url: "https://idp.example/authorize" },
+        name: "linear",
+        outcome: "authorized" as const,
+        sequence: 0,
+        stepIndex: 2,
+        turnId: "turn_0",
+      },
+      type: "authorization.completed" as const,
+    };
+    installInbox([
+      {
+        callId: "call-1",
+        childSessionId: "child-session",
+        event: requiredEvent,
+        kind: "subagent-authorization-event",
+        subagentName: "delegate",
+      },
+      {
+        callId: "call-1",
+        childSessionId: "child-session",
+        event: completedEvent,
+        kind: "subagent-authorization-event",
+        subagentName: "delegate",
+      },
+      {
+        kind: "runtime-action-result",
+        results: [
+          {
+            callId: "call-1",
+            kind: "subagent-result",
+            output: "authorized child output",
+            subagentName: "delegate",
+          },
+        ],
+      },
+    ]);
+    vi.mocked(dispatchRuntimeActionsStep).mockResolvedValue({
+      results: [],
+      sessionState: pendingState,
+    });
+    vi.mocked(runProxySubagentEventStep)
+      .mockResolvedValueOnce({
+        serializedContext: { state: "auth-required" },
+        sessionState: requiredState,
+      })
+      .mockResolvedValueOnce({
+        serializedContext: { state: "auth-completed" },
+        sessionState: completedAuthState,
+      });
+    vi.mocked(turnStep)
+      .mockResolvedValueOnce({
+        action: "park",
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        pendingRuntimeActionKeys: ["subagent-call:delegate:call-1"],
+        serializedContext: { state: "pending" },
+        sessionState: pendingState,
+      })
+      .mockResolvedValueOnce({
+        action: "done",
+        output: "done",
+        serializedContext: { state: "done" },
+        sessionState: completedState,
+      });
+
+    const { input, parentWritable } = createInput({
+      driverCapabilities: { turnInbox: true },
+      mode: "task",
+      sessionState: pendingState,
+    });
+    await turnWorkflow(input);
+
+    expect(vi.mocked(runProxySubagentEventStep).mock.calls).toEqual([
+      [
+        {
+          hookPayload: expect.objectContaining({ event: requiredEvent }),
+          parentWritable,
+          serializedContext: { state: "pending" },
+          sessionState: pendingState,
+        },
+      ],
+      [
+        {
+          hookPayload: expect.objectContaining({ event: completedEvent }),
+          parentWritable,
+          serializedContext: { state: "auth-required" },
+          sessionState: requiredState,
+        },
+      ],
+    ]);
+    expect(vi.mocked(turnStep).mock.calls[1]?.[0]).toMatchObject({
+      input: {
+        kind: "runtime-action-result",
+        results: [expect.objectContaining({ output: "authorized child output" })],
+      },
+      serializedContext: { state: "auth-completed" },
+      sessionState: completedAuthState,
+    });
+    expect(resumeHookMock).not.toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({ kind: "turn-delivery-request" }),
+    );
+    expect(routeDeliverToChildren).not.toHaveBeenCalled();
+    expect(
+      resumeHookMock.mock.calls.filter((call) => call[1]?.kind === "turn-result"),
+    ).toHaveLength(1);
   });
 
   it("mints a unique delivery request id per wait so a stale forward is not re-accepted", async () => {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -17,10 +17,11 @@ import {
 } from "#execution/hook-ownership.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { TurnExecutionCursor } from "#execution/turn-execution-cursor.js";
 import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
-import { runProxyInputRequestStep, turnStep } from "#execution/workflow-steps.js";
+import { turnStep } from "#execution/workflow-steps.js";
 import { resolveRuntimeActionResultsForKeys } from "#harness/runtime-actions.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
 
@@ -203,8 +204,8 @@ async function waitForRuntimeActionResults(input: {
       continue;
     }
 
-    if (value.kind === "subagent-input-request") {
-      const proxyResult = await runProxyInputRequestStep({
+    if (value.kind === "subagent-input-request" || value.kind === "subagent-authorization-event") {
+      const proxyResult = await runProxySubagentEventStep({
         hookPayload: value,
         parentWritable: input.cursor.parentWritable,
         serializedContext: input.cursor.serializedContext,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -24,11 +24,11 @@ import { createTurnWorkflowInput } from "#execution/durable-session-migrations/t
 import { projectToDurableSession } from "#execution/session.js";
 import { createExecutionNodeStep } from "#execution/node-step.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
+import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import {
   dispatchTurnStep,
   emitTerminalSessionFailureStep,
   resolveEffectiveOutputSchema,
-  runProxyInputRequestStep,
   turnStep,
 } from "#execution/workflow-steps.js";
 import {
@@ -1113,7 +1113,7 @@ describe("emitTerminalSessionFailureStep", () => {
   });
 });
 
-describe("runProxyInputRequestStep", () => {
+describe("runProxySubagentEventStep", () => {
   // Ensures adapter state mutations made while proxying input requests
   // are serialized for the next durable workflow step.
 
@@ -1220,7 +1220,7 @@ describe("runProxyInputRequestStep", () => {
       continuationToken: "http:proxy-test",
     });
 
-    const result = await runProxyInputRequestStep({
+    const result = await runProxySubagentEventStep({
       hookPayload: buildHookPayload(),
       parentWritable: createTestWritable(),
       serializedContext: buildSerializedContextForAdapter(cachingAdapter),
@@ -1277,7 +1277,7 @@ describe("runProxyInputRequestStep", () => {
       continuationToken: "http:proxy-test",
     });
 
-    const result = await runProxyInputRequestStep({
+    const result = await runProxySubagentEventStep({
       hookPayload: buildHookPayload(),
       parentWritable: createTestWritable(),
       serializedContext: buildSerializedContextForAdapter(rekeyingAdapter),

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -1,24 +1,19 @@
 import { buildAdapterContext } from "#channel/adapter-context.js";
 import { callAdapterEventHandler, defaultDeliverResult } from "#channel/adapter.js";
-import type {
-  DeliverPayload,
-  SessionAuthContext,
-  SubagentInputRequestHookPayload,
-} from "#channel/types.js";
+import type { DeliverPayload, SessionAuthContext } from "#channel/types.js";
 import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
 import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-lifecycle.js";
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
 import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
 import { dispatchDynamicToolEvent } from "#context/dynamic-tool-lifecycle.js";
-import { AuthKey, CapabilitiesKey, ContinuationTokenKey, ModeKey } from "#context/keys.js";
+import { AuthKey, CapabilitiesKey, ModeKey } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
-import { runStep, withContextScope } from "#context/run-step.js";
+import { runStep } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import { getHarnessEmissionState } from "#harness/emission.js";
 import { setChannelContext } from "#execution/channel-context.js";
 import { hasPendingInputBatch } from "#harness/input-requests.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
-import { upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
 import {
   getRuntimeActionKeysFromWorkflowInterrupt,
   isWorkflowRuntimeActionInterrupt,
@@ -60,8 +55,9 @@ import {
   type TurnWorkflowDispatchInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { createExecutionNodeStep } from "#execution/node-step.js";
-import { emitProxiedInputRequest, routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
+import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
+import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
 import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
@@ -448,20 +444,6 @@ function derivePendingState(session: HarnessSession): {
 }
 
 /**
- * Re-stamps `session.continuationToken` from `ContinuationTokenKey`
- * after channels call `setContinuationToken(...)`. Idempotent when the
- * token is unchanged.
- */
-export function reconcileSessionContinuationToken(
-  ctx: Awaited<ReturnType<typeof deserializeContext>>,
-  session: HarnessSession,
-): HarnessSession {
-  const next = ctx.get(ContinuationTokenKey);
-  if (next === undefined || next === session.continuationToken) return session;
-  return { ...session, continuationToken: next };
-}
-
-/**
  * Resolves the single output schema in effect for this turn, decoupling schema
  * enforcement from {@link RunMode}: downstream the harness reads
  * `session.outputSchema` unconditionally and never re-derives it from mode.
@@ -552,84 +534,6 @@ export async function emitTerminalSessionFailureStep(input: {
       error: writeError,
     });
   }
-}
-
-export interface ProxyInputRequestResult {
-  readonly serializedContext: Record<string, unknown>;
-  readonly sessionState: DurableSessionState;
-}
-
-/**
- * Emits a proxied `input.requested` event through the parent's adapter
- * and records the routing entries on the parent session.
- */
-export async function runProxyInputRequestStep(input: {
-  readonly hookPayload: SubagentInputRequestHookPayload;
-  readonly parentWritable: WritableStream<Uint8Array>;
-  readonly serializedContext: Record<string, unknown>;
-  readonly sessionState: DurableSessionState;
-}): Promise<ProxyInputRequestResult> {
-  "use step";
-
-  const durableSession = await readDurableSession(input.sessionState);
-  const ctx = await deserializeContext(input.serializedContext);
-  const adapter = ctx.require(ChannelKey);
-  const adapterCtx = buildAdapterContext(adapter, ctx);
-  const mode = ctx.require(ModeKey);
-  const bundle = ctx.require(BundleKey);
-  const session = hydrateDurableSession({
-    compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
-    },
-    durable: durableSession,
-    turnAgent: bundle.turnAgent,
-  });
-  const writer = input.parentWritable.getWriter();
-
-  let scopeResult: {
-    readonly result: readonly (readonly [requestId: string, childContinuationToken: string])[];
-    readonly session: HarnessSession;
-  };
-  try {
-    const emit = async (event: HandleMessageStreamEvent): Promise<void> => {
-      const transformed = await callAdapterEventHandler(adapter, event, adapterCtx);
-      await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(transformed)));
-    };
-
-    scopeResult = await withContextScope(ctx, session, async (enrichedSession) => {
-      const proxyResult = await emitProxiedInputRequest({
-        emit,
-        hookPayload: input.hookPayload,
-        mode,
-        session: enrichedSession,
-      });
-      return { result: proxyResult.entries, session: proxyResult.session };
-    });
-  } finally {
-    writer.releaseLock();
-  }
-
-  // Persist adapter-state mutations (e.g. Slack's `pendingRequests`
-  // cache populated by the `input.requested` handler) so the next
-  // `turnStep` observes them across the serialized context
-  // boundary. Without this the workflow runtime rehydrates a stale
-  // adapter and later text-reply deliveries miss the cached batch.
-  setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
-
-  const nextSerializedContext = serializeContext(ctx);
-
-  const sessionWithProxyEntries = upsertProxyInputRequests({
-    entries: scopeResult.result,
-    forChildContinuationToken: input.hookPayload.childContinuationToken,
-    session: scopeResult.session,
-  });
-  const nextSession = reconcileSessionContinuationToken(ctx, sessionWithProxyEntries);
-  const nextState = createDurableSessionState({ session: nextSession });
-
-  return {
-    serializedContext: nextSerializedContext,
-    sessionState: nextState,
-  };
 }
 
 export interface RoutedDeliverResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
         version: 0.4.0(@sveltejs/kit@2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(h3@1.15.11)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@vercel/analytics':
         specifier: 2.0.1
-        version: 2.0.1(1bf1af76e23df0ef2782fcce60ed20a8)
+        version: 2.0.1(9a62e6fe36b19419a4b842141e24505b)
       '@vercel/eve-catalog':
         specifier: workspace:*
         version: link:../../packages/eve-catalog
@@ -145,7 +145,7 @@ importers:
         version: 1.8.2(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vercel/speed-insights':
         specifier: 2.0.0
-        version: 2.0.0(1bf1af76e23df0ef2782fcce60ed20a8)
+        version: 2.0.0(9a62e6fe36b19419a4b842141e24505b)
       '@vgpu/core':
         specifier: 0.0.7
         version: 0.0.7
@@ -385,7 +385,7 @@ importers:
         version: link:../../../packages/eve
       nuxt:
         specifier: ^4.0.0
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       vue:
         specifier: ^3.5.0
         version: 3.5.35(typescript@6.0.3)
@@ -396,6 +396,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vue-tsc:
+        specifier: 3.3.6
+        version: 3.3.6(typescript@6.0.3)
 
   apps/frameworks/sveltekit:
     dependencies:
@@ -7101,6 +7107,15 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
   '@vue-macros/common@3.1.2':
     resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
     engines: {node: '>=20.19.0'}
@@ -7151,6 +7166,9 @@ packages:
 
   '@vue/devtools-shared@8.1.2':
     resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
+
+  '@vue/language-core@3.3.6':
+    resolution: {integrity: sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==}
 
   '@vue/reactivity@3.5.35':
     resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
@@ -7274,6 +7292,9 @@ packages:
 
   ajv@8.6.3:
     resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -12959,6 +12980,12 @@ packages:
       vite:
         optional: true
 
+  vue-tsc@3.3.6:
+    resolution: {integrity: sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.35:
     resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
     peerDependencies:
@@ -14822,7 +14849,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.6(355aa972cbce473ecd0a6783b15860ed)':
+  '@nuxt/nitro-server@4.4.6(80ec3e2a65e1fab382d1d374d5c16490)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -14840,76 +14867,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
-      nypm: 0.6.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.8.1
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unctx: 2.5.0
-      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
-      vue: 3.5.35(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - srvx
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
-
-  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)(typescript@6.0.3)':
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
-      '@vue/shared': 3.5.35
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.8.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.11
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -14960,6 +14918,75 @@ snapshots:
       - uploadthing
       - xml2js
     optional: true
+
+  '@nuxt/nitro-server@4.4.6(cf83cc8aada395eae3d5f5547153fd26)':
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.6(magicast@0.5.3)
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
+      '@vue/shared': 3.5.35
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.11
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
+      nypm: 0.6.6
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.8.1
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unstorage: 1.17.5(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)
+      vue: 3.5.35(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - srvx
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
 
   '@nuxt/schema@4.4.6':
     dependencies:
@@ -14978,7 +15005,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@4.4.6(357c5152dbdbefdd44e9614a9454cdd1)':
+  '@nuxt/vite-builder@4.4.6(a74f7c2620db87caaf6d736975b46e9f)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -14996,7 +15023,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -15007,7 +15034,68 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
+      rolldown: 1.1.0
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.60.4)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.4.6(b8f492d2de80c3cd2c6f050b6678c8b3)':
+    dependencies:
+      '@nuxt/kit': 4.4.6(magicast@0.5.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
+      '@vitejs/plugin-vue': 6.0.7(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      autoprefixer: 10.5.0(postcss@8.5.15)
+      consola: 3.4.2
+      cssnano: 8.0.1(postcss@8.5.15)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.15
+      seroval: 1.5.4
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))
       vue: 3.5.35(typescript@6.0.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -15039,67 +15127,6 @@ snapshots:
       - vue-tsc
       - yaml
     optional: true
-
-  '@nuxt/vite-builder@4.4.6(772227546e20b752c7ab17acaadd8237)':
-    dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
-      '@vitejs/plugin-vue': 6.0.7(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      autoprefixer: 10.5.0(postcss@8.5.15)
-      consola: 3.4.2
-      cssnano: 8.0.1(postcss@8.5.15)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.15
-      seroval: 1.5.4
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      vue: 3.5.35(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
-      rolldown: 1.1.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.60.4)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
 
   '@opentelemetry/api-logs@0.214.0':
     dependencies:
@@ -18646,11 +18673,11 @@ snapshots:
       h3: 1.15.11
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@vercel/analytics@2.0.1(1bf1af76e23df0ef2782fcce60ed20a8)':
+  '@vercel/analytics@2.0.1(9a62e6fe36b19419a4b842141e24505b)':
     optionalDependencies:
       '@sveltejs/kit': 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       react: 19.2.6
       svelte: 5.56.1(@typescript-eslint/types@8.59.4)
       vue: 3.5.35(typescript@6.0.3)
@@ -19107,11 +19134,11 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@vercel/speed-insights@2.0.0(1bf1af76e23df0ef2782fcce60ed20a8)':
+  '@vercel/speed-insights@2.0.0(9a62e6fe36b19419a4b842141e24505b)':
     optionalDependencies:
       '@sveltejs/kit': 2.61.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0)
       react: 19.2.6
       svelte: 5.56.1(@typescript-eslint/types@8.59.4)
       vue: 3.5.35(typescript@6.0.3)
@@ -19211,6 +19238,18 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vue-macros/common@3.1.2(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.35
@@ -19298,6 +19337,16 @@ snapshots:
       perfect-debounce: 2.1.0
 
   '@vue/devtools-shared@8.1.2': {}
+
+  '@vue/language-core@3.3.6':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
 
   '@vue/reactivity@3.5.35':
     dependencies:
@@ -19467,6 +19516,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+
+  alien-signals@3.2.1: {}
 
   ansi-colors@4.1.3: {}
 
@@ -23663,16 +23714,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(db0@0.3.4)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.1.0)(srvx@0.11.16)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.6(80ec3e2a65e1fab382d1d374d5c16490)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(357c5152dbdbefdd44e9614a9454cdd1)
+      '@nuxt/vite-builder': 4.4.6(b8f492d2de80c3cd2c6f050b6678c8b3)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0
@@ -23793,16 +23844,16 @@ snapshots:
       - yaml
     optional: true
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vercel/blob@2.4.0)(@vercel/functions@3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.70.0)(rolldown@1.1.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.0)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(355aa972cbce473ecd0a6783b15860ed)
+      '@nuxt/nitro-server': 4.4.6(cf83cc8aada395eae3d5f5547153fd26)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(772227546e20b752c7ab17acaadd8237)
+      '@nuxt/vite-builder': 4.4.6(a74f7c2620db87caaf6d736975b46e9f)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0
@@ -26539,7 +26590,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.13.0(eslint@10.4.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.70.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.6(typescript@6.0.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 4.0.3
@@ -26556,6 +26607,7 @@ snapshots:
       optionator: 0.9.4
       oxlint: 1.70.0
       typescript: 6.0.3
+      vue-tsc: 3.3.6(typescript@6.0.3)
 
   vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.6(magicast@0.5.3))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -26740,6 +26792,12 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.35
       vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  vue-tsc@3.3.6(typescript@6.0.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.6
+      typescript: 6.0.3
 
   vue@3.5.35(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Summary

- forward `authorization.required` and `authorization.completed` from delegated children through each active parent channel
- preserve parent adapter state and continuation-token changes across the durable proxy boundary
- keep OAuth callbacks scoped to the child session while allowing nested subagent chains to surface auth at the root channel
- document the behavior and include a patch changeset

## Root cause

The framework-owned subagent adapter forwarded `input.requested` events to the active parent turn, but it had no equivalent path for authorization lifecycle events. A child could therefore park on interactive authorization while its challenge remained visible only on the unconsumed child stream.

## User impact

Authorization prompts raised by local subagents now reach the user-facing parent channel, and completion events update or clear channel UI before the child result returns. No public API or authorization event wire shape changes.

## Validation

- `pnpm test:unit` — 4,534 passed, 1 skipped
- `pnpm test:integration` — 386 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`

## End-to-end coverage

This PR does not add a fixture-owned e2e eval for delegated authorization. The existing eval driver waits for a public turn boundary, but this proxy intentionally keeps the parent turn active while the child waits for OAuth completion, so the driver cannot currently observe and complete the in-flight authorization flow.

A follow-up PR will add the missing eval capability for observing in-flight events and completing authorization callbacks, then extend `agent-subagents-hitl` to cover `authorization.required`, `authorization.completed`, and eventual child completion.

The signed commit includes co-author trailers for the contributors behind #519, #569, and #602 in appreciation of their prior work.

Fixes #568
