### PR TITLE
feat(eve): export callSlackApi and resolveSlackBotToken from eve/channels/slack

### DIFF
--- a/.changeset/export-call-slack-api.md
+++ b/.changeset/export-call-slack-api.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Export `callSlackApi` and `resolveSlackBotToken` from `eve/channels/slack`. Code running outside a webhook-side handler — schedules resolving reactions or reading history, for example — has no `ctx.slack` handle; these were the internal primitives behind `slack.request`, already public-shaped and documented, and are now importable so apps stop hand-rolling `fetch` against the Slack Web API.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -70,6 +70,33 @@ export default slackChannel({
 
 `threadContext` performs one `conversations.replies` request for each triggering thread reply and requires the matching Slack history scope. Omit it when the agent should see only direct mentions. `loadThreadContextMessages` remains available when you need custom filtering or non-model processing of the raw thread messages.
 
+### Slack API calls outside a handler
+
+Inside webhook-side handlers (`onAppMention`, `onInteraction`, `events`),
+`ctx.slack.request(operation, body)` is the raw-API escape hatch. Outside
+those contexts there is no handle — a schedule resolving reactions on old
+messages, for example, has no inbound Slack request. For that, call the
+same primitive the handle uses directly:
+
+```ts
+import { callSlackApi, resolveSlackBotToken } from "eve/channels/slack";
+import { connectSlackCredentials } from "@vercel/connect/eve";
+
+const { botToken } = connectSlackCredentials("slack/my-agent");
+const response = await callSlackApi({
+  botToken,
+  operation: "reactions.get",
+  body: { channel: "C0123456789", timestamp: "1712345678.000100", full: true },
+});
+if (!response.ok) throw new Error(String(response.error));
+```
+
+`callSlackApi` resolves function-form tokens (secret managers, Connect
+rotation) at call time and form-encodes the body — the only safe default,
+since Slack's JSON support is partial (`conversations.replies` rejects
+JSON). `resolveSlackBotToken` materializes a `SlackBotToken` to a string
+when you need the bearer token itself.
+
 ### Delivery
 
 The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and tool status on `actions.requested`. Reasoning snippets build progressively: extensions of at least four characters appear immediately, while smaller streamed deltas use the five-second refresh interval to avoid one Slack request per token. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -40,6 +40,8 @@ export type {
 } from "#public/channels/slack/inbound.js";
 
 export {
+  callSlackApi,
+  resolveSlackBotToken,
   slackContinuationToken,
   type SlackPostInput,
   type SlackPostedMessage,


### PR DESCRIPTION
## Why

Inside webhook-side handlers (`onAppMention`, `onInteraction`, `events`), `ctx.slack.request(operation, body)` is the designed escape hatch for arbitrary Slack Web API calls. Outside those contexts there is no handle: a **schedule** resolving reactions on day-old messages, reading thread history for a sweep, or posting a card out-of-band has no inbound Slack request to build a `SlackHandle` from.

The result is that apps hand-roll `fetch("https://slack.com/api/…")` for exactly the calls `slack.request` already implements — reimplementing token resolution (including the function-form Connect token) and rediscovering that Slack's JSON support is partial (`conversations.replies` rejects JSON bodies; form encoding is the only safe default). Concrete example: the e0 ambient learning loop in vercel/internal-agents carries four such hand-rolled call sites today (reactions.get, conversations.history/replies from schedules, out-of-band chat.postMessage).

## What

Re-export the two primitives behind the handle's `request()` from the public entry point:

```ts
import { callSlackApi, resolveSlackBotToken } from "eve/channels/slack";
```

Both already live in `#public/channels/slack/api.ts`, are public-shaped, and carry doc comments — only the re-export was missing (`SlackApiResponse` is already exported). Also adds a "Slack API calls outside a handler" section to the Slack channel docs and a patch changeset.

## Verification

Pure re-export + docs; the exported names verified against `api.ts`. A local `pnpm typecheck` was blocked by an unrelated esbuild platform-binary mismatch in my environment — leaning on CI here; will fix anything it surfaces.