### PR TITLE
fix(eve): keep Microsandbox broker secrets out of env

### DIFF
--- a/.changeset/microsandbox-broker-env.md
+++ b/.changeset/microsandbox-broker-env.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Stop exposing Microsandbox credential-broker transform rules in guest command environments. Brokered secrets now remain with the Microsandbox secret API while sandbox-visible Git configuration uses only placeholder values.

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts
@@ -164,24 +164,33 @@ describe.skipIf(onWindows)("createMicrosandboxNetworkPlan", () => {
     ]);
   });
 
-  it("keeps brokered header values out of the guest environment", () => {
+  it("keeps brokered secret values out of the guest environment", () => {
     const plan = createMicrosandboxNetworkPlan({
       allow: {
         "github.com": [
           {
-            transform: [{ headers: { Authorization: "Basic real-secret" } }],
+            transform: [
+              {
+                headers: {
+                  Authorization: "Basic real-token",
+                  "X-Api-Key": "real-api-key",
+                },
+              },
+            ],
           },
         ],
       },
     });
 
-    expect(createTransformBrokerEnvironment(plan)).toEqual({
-      GIT_CONFIG_COUNT: "1",
-      GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
-      GIT_CONFIG_VALUE_0: expect.stringMatching(
-        /^Authorization: __EVE_MSB_SECRET_[A-Fa-f0-9]{24}__$/u,
-      ),
-    });
+    const env = createTransformBrokerEnvironment(plan);
+    const rule = plan.transformHeaderRules[0]!;
+
+    expect(env.EVE_MICROSANDBOX_NETWORK_TRANSFORMS).toBeUndefined();
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("http.https://github.com/.extraheader");
+    expect(env.GIT_CONFIG_VALUE_0).toBe(`Authorization: ${rule.placeholderHeaders.Authorization}`);
+    expect(JSON.stringify(env)).not.toContain("Basic real-token");
+    expect(JSON.stringify(env)).not.toContain("real-api-key");
   });
 
   it("serializes policy JSON using microsandbox's native snake-case schema", () => {


### PR DESCRIPTION
## Summary
- Stop exporting `EVE_MICROSANDBOX_NETWORK_TRANSFORMS` into Microsandbox command environments.
- Keep native Microsandbox secret registration unchanged, so placeholder headers still resolve through the Microsandbox secret API outside the guest process.
- Preserve placeholder-only Git `extraheader` environment configuration for brokered `Authorization` headers.

Fixes #600

## Testing
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/microsandbox.test.ts` (11 passed)
- `pnpm exec oxfmt --check packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts .changeset/microsandbox-broker-env.md`
- `pnpm exec oxlint packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm guard:invariants`
- `pnpm changeset status --since origin/main`
- `git diff --check`

## Notes
- `pnpm install` completed in this Git worktree; its hook installer printed an `ENOTDIR` warning because worktrees use a `.git` file, but dependencies linked successfully and the checks above ran against this branch.