### PR TITLE
fix(eve): harness - retry streamed provider failures

### DIFF
--- a/.changeset/calm-agents-retry.md
+++ b/.changeset/calm-agents-retry.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Transient provider errors delivered inside a model stream, including Anthropic overload events, now retry the current model call with backoff. Subagents preserve completed earlier work across those attempts, and partial failed output or unexecuted local tool proposals are cleared before a retry.

--- a/docs/concepts/default-harness.md
+++ b/docs/concepts/default-harness.md
@@ -20,6 +20,14 @@ export default defineAgent({
 
 Compaction also preserves the framework's own tool state automatically. It resets read-before-write tracking (so a write afterward re-reads the file whose read evidence was summarized away) and re-injects the active todo list, so the model keeps its task list across the summary. There is no per-tool hook to configure.
 
+## Transient model failures
+
+The harness automatically retries transient model-call failures, including rate limits, timeouts, network failures, server errors, and provider overload events delivered inside a stream. It makes up to three attempts with exponential backoff and restarts only the current uncommitted model call. Earlier model steps, completed tool results, sandbox changes, and other durable session work remain intact.
+
+A recovered attempt stays within the same logical step and does not emit `step.failed` or `turn.failed`. Partial text or reasoning from the discarded attempt is replaced when the retry streams. A local tool call proposed by an incomplete response has not executed yet—the AI SDK executes local tools only after the provider finishes the model response—so the harness closes that proposal and lets the retry produce a fresh call. It does not automatically replay a request after provider-executed tool activity, where eve cannot guarantee that the upstream operation is safe to repeat.
+
+After all attempts fail, conversation sessions park so the user can try again. Task-mode runs, including subagents and schedules, return an error result to their caller because they cannot wait for new user input. Authentication failures, invalid requests, and other structural configuration errors are not retried.
+
 ## Built-in tools
 
 These ship with every agent, no imports. The harness shows the model the tool descriptors first, then executes only what the model actually calls; discovery never runs them. The shell and file tools (`bash`, `read_file`, `write_file`, `glob`, `grep`) live in the app runtime and proxy their work into the agent's single [sandbox](../sandbox); the rest run in the app runtime. The "Where it runs" column below names where each tool's effect lands.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -111,6 +111,8 @@ Do not rely on subagent delegation by itself as an approval boundary. Put sensit
 
 Each delegated subagent spins up its own child session and stream. The parent stream carries only the control-plane events `subagent.called` and `subagent.completed`. To follow the child's full progress, read `subagent.called.data.childSessionId` and subscribe at `GET /eve/v1/session/:childSessionId/stream`.
 
+Subagent model calls use the harness's automatic transient-failure retries. A retry restarts only the child's current uncommitted model call, so completed earlier steps, tool results, and sandbox work stay available. If every attempt fails, the child returns a failed tool result to its parent instead of reporting an empty success.
+
 ## When to split
 
 Split out a subagent when the task needs a different prompt or specialist role, a narrower tool surface, or its own runtime context. Don't reach for one when a [skill](./skills) would do. If the agent can keep its identity and needs only an optional procedure, a skill is the lighter choice.

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -913,6 +913,90 @@ describe("EveTUIRunner reused step indexes", () => {
 });
 
 describe("EveTUIRunner replay guards", () => {
+  it("replaces partial text when the harness retries a failed stream attempt", async () => {
+    const prompts: Array<string | undefined> = ["weather", undefined];
+    const emitted: AgentTUIStreamEvent[] = [];
+    const session = sessionYielding([
+      { type: "step.started", data: { sequence: 0, stepIndex: 0, turnId: "turn_0" } },
+      {
+        type: "reasoning.appended",
+        data: {
+          reasoningDelta: "Partial thought",
+          reasoningSoFar: "Partial thought",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn_0",
+        },
+      },
+      {
+        type: "message.appended",
+        data: {
+          messageDelta: "Partial answer",
+          messageSoFar: "Partial answer",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn_0",
+        },
+      },
+      {
+        type: "message.completed",
+        data: {
+          finishReason: "error",
+          message: null,
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn_0",
+        },
+      },
+      {
+        type: "message.appended",
+        data: {
+          messageDelta: "Recovered answer",
+          messageSoFar: "Recovered answer",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn_0",
+        },
+      },
+      {
+        type: "message.completed",
+        data: {
+          finishReason: "stop",
+          message: "Recovered answer",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn_0",
+        },
+      },
+      { type: "turn.completed", data: { sequence: 0, turnId: "turn_0" } },
+      { type: "session.waiting", data: { wait: "next-user-message" } },
+    ]);
+    const renderer: AgentTUIRenderer = {
+      readPrompt: vi.fn(async () => prompts.shift()),
+      renderStream: vi.fn(async (result) => {
+        for await (const event of result.events as AsyncIterable<AgentTUIStreamEvent>) {
+          emitted.push(event);
+        }
+      }),
+    };
+
+    await new EveTUIRunner({ session, renderer, name: "Weather Agent" }).run();
+
+    expect(emitted).toContainEqual({
+      id: "text:turn_0:0",
+      text: "",
+      type: "assistant-replace",
+    });
+    expect(emitted).toContainEqual({
+      id: "reasoning:turn_0:0",
+      text: "",
+      type: "reasoning-replace",
+    });
+    expect(
+      emitted.filter((event) => event.type === "assistant-delta").map((event) => event.delta),
+    ).toEqual(["Partial answer", "Recovered answer"]);
+  });
+
   it("deduplicates repeated call IDs and divergent text attempts in one turn", async () => {
     const prompts: Array<string | undefined> = ["weather", undefined];
     const emitted: AgentTUIStreamEvent[] = [];

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -113,8 +113,10 @@ export type AgentTUIStreamEvent =
   | { type: "step-start" }
   | { type: "step-finish"; usage?: AgentTUIStreamUsage }
   | { type: "assistant-delta"; id: string; delta: string }
+  | { type: "assistant-replace"; id: string; text: string }
   | { type: "assistant-complete"; id: string; text?: string | null }
   | { type: "reasoning-delta"; id: string; delta: string }
+  | { type: "reasoning-replace"; id: string; text: string }
   | { type: "reasoning-complete"; id: string }
   | { type: "tool-call"; toolCallId: string; toolName: string; input: unknown }
   | { type: "tool-approval-request"; approvalId: string; toolCallId: string }
@@ -1836,6 +1838,21 @@ async function* eveEventsToTUIStream(
         const base = textPartId(event.data.turnId, event.data.stepIndex);
         const state = partStateFor(textParts, base);
         const message = event.data.message;
+
+        if (message === null && event.data.finishReason === "error") {
+          const textId = partGenerationId(base, state.generation);
+          state.text = "";
+          state.completed = false;
+          yield { type: "assistant-replace", id: textId, text: "" };
+
+          const reasoningBase = reasoningPartId(event.data.turnId, event.data.stepIndex);
+          const reasoningState = partStateFor(reasoningParts, reasoningBase);
+          const reasoningId = partGenerationId(reasoningBase, reasoningState.generation);
+          reasoningState.text = "";
+          reasoningState.completed = false;
+          yield { type: "reasoning-replace", id: reasoningId, text: "" };
+          break;
+        }
 
         if (state.completed) {
           if (message === null || message === state.text) break;

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -579,6 +579,29 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(countOccurrences(snapshot, "get_weather")).toBe(2);
   });
 
+  it("replaces partial assistant and reasoning blocks for a retried stream attempt", async () => {
+    const { screen, renderer } = makeRenderer();
+
+    await renderer.renderStream(
+      streamOf([
+        { type: "reasoning-delta", id: "reasoning:turn-0:0", delta: "Partial thought" },
+        { type: "assistant-delta", id: "text:turn-0:0", delta: "Partial answer" },
+        { type: "reasoning-replace", id: "reasoning:turn-0:0", text: "" },
+        { type: "assistant-replace", id: "text:turn-0:0", text: "" },
+        { type: "assistant-delta", id: "text:turn-0:0", delta: "Recovered answer" },
+        { type: "assistant-complete", id: "text:turn-0:0" },
+        { type: "finish" },
+      ]),
+      { submittedPrompt: "retry", continueSession: true },
+    );
+    renderer.shutdown();
+
+    const snapshot = screen.snapshot();
+    expect(snapshot).toContain("Recovered answer");
+    expect(snapshot).not.toContain("Partial answer");
+    expect(snapshot).not.toContain("Partial thought");
+  });
+
   it("settles a tool block when its result arrives in a later stream pass", async () => {
     const { screen, renderer } = makeRenderer();
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -2318,6 +2318,18 @@ export class TerminalRenderer implements AgentTUIRenderer {
         break;
       }
 
+      case "assistant-replace": {
+        const text = stripTerminalControls(event.text);
+        turnState.text.set(event.id, text);
+        if (text.trim().length === 0) {
+          this.#removeBlock(event.id);
+          this.#paint();
+        } else {
+          this.#upsertAssistantBlock(event.id, text, true);
+        }
+        break;
+      }
+
       case "assistant-complete": {
         const existing = turnState.text.get(event.id) ?? "";
         const text =
@@ -2337,6 +2349,19 @@ export class TerminalRenderer implements AgentTUIRenderer {
         this.#setStreamStatus(STATUS.streaming);
         turnState.reasoning.set(event.id, text);
         this.#upsertReasoningBlock(event.id, text, true, displayModes);
+        break;
+      }
+
+      case "reasoning-replace": {
+        if (displayModes.reasoning === "hidden") break;
+        const text = stripTerminalControls(event.text);
+        turnState.reasoning.set(event.id, text);
+        if (text.trim().length === 0) {
+          this.#removeBlock(event.id);
+          this.#paint();
+        } else {
+          this.#upsertReasoningBlock(event.id, text, true, displayModes);
+        }
         break;
       }
 

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -9,6 +9,7 @@ import {
   createInputRequestedEvent,
   createMessageAppendedEvent,
   createMessageCompletedEvent,
+  createReasoningAppendedEvent,
   createReasoningCompletedEvent,
   createResultCompletedEvent,
   createStepStartedEvent,
@@ -690,6 +691,43 @@ describe("defaultMessageReducer", () => {
       },
       { type: "step-start" },
     ]);
+  });
+
+  it("removes partial text and reasoning when a failed model attempt is retried", () => {
+    const reducer = defaultMessageReducer();
+    let data = reducer.reduce(
+      reducer.initial(),
+      createReasoningAppendedEvent({
+        reasoningDelta: "Partial reasoning",
+        reasoningSoFar: "Partial reasoning",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageAppendedEvent({
+        messageDelta: "Partial answer",
+        messageSoFar: "Partial answer",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        finishReason: "error",
+        message: null,
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    );
+
+    expect(data.messages[0]?.parts).toEqual([{ type: "step-start" }]);
+    expect(data.messages[0]?.metadata?.status).toBe("streaming");
   });
 
   it("projects structured file parts from message.received onto the user message", () => {

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -249,7 +249,9 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
     case "message.completed":
       return updateAssistantMessage(data, event.data.turnId, (message) => {
         if (event.data.message === null) {
-          return removeTextPart(message, event.data.stepIndex);
+          return event.data.finishReason === "error"
+            ? removeStreamedAttemptParts(message, event.data.stepIndex)
+            : removeTextPart(message, event.data.stepIndex);
         }
 
         return upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
@@ -392,6 +394,27 @@ function removeTextPart(message: EveAssistantMessage, stepIndex: number): EveAss
     metadata: {
       ...message.metadata,
       status: "complete",
+    },
+    parts,
+  };
+}
+
+function removeStreamedAttemptParts(
+  message: EveAssistantMessage,
+  stepIndex: number,
+): EveAssistantMessage {
+  const parts = message.parts.filter(
+    (part) => (part.type !== "text" && part.type !== "reasoning") || part.stepIndex !== stepIndex,
+  );
+  if (parts.length === message.parts.length) {
+    return message;
+  }
+
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      status: "streaming",
     },
     parts,
   };

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -7,6 +7,7 @@ import {
   type HarnessEmissionState,
   setHarnessEmissionState,
 } from "#harness/emission.js";
+import { getModelStreamFailureState } from "#harness/model-stream-attempt.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessEmitFn, HarnessSession } from "#harness/types.js";
 import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
@@ -590,6 +591,67 @@ describe("emitStreamContent error-part handling", () => {
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe("upstream 503");
     expect((caught as Error).name).toBe("APICallError");
+    expect((caught as Error).cause).toBe(raw);
+  });
+
+  it("retains pending local calls and provider activity on a streamed failure", async () => {
+    const raw = { message: "Overloaded", type: "overloaded_error" };
+    let caught: unknown;
+
+    try {
+      await emitStreamContent(
+        createEmitStub(),
+        EMISSION_STATE,
+        streamOf([
+          {
+            input: {},
+            providerExecuted: false,
+            toolCallId: "call-local",
+            toolName: "local_tool",
+            type: "tool-call",
+          } as TextStreamPart<ToolSet>,
+          {
+            input: {},
+            providerExecuted: true,
+            toolCallId: "call-provider",
+            toolName: "web_search",
+            type: "tool-call",
+          } as TextStreamPart<ToolSet>,
+          { error: raw, type: "error" } as TextStreamPart<ToolSet>,
+        ]),
+        {
+          excludedActionToolNames: new Set(),
+          tools: new Map([
+            [
+              "local_tool",
+              {
+                description: "Local tool",
+                execute: vi.fn(),
+                inputSchema: jsonSchema({ type: "object" }),
+                name: "local_tool",
+              },
+            ],
+          ]),
+        },
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect((caught as Error).cause).toBe(raw);
+    expect(getModelStreamFailureState(caught)).toEqual({
+      pendingLocalActionRequests: [
+        {
+          callId: "call-local",
+          input: {},
+          kind: "tool-call",
+          toolName: "local_tool",
+        },
+      ],
+      providerExecutedActionObserved: true,
+      reasoningObserved: false,
+      textObserved: false,
+    });
   });
 
   it("falls back to a JSON-ish message for opaque plain-object throwables", async () => {

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -1,14 +1,5 @@
-import type {
-  ModelMessage,
-  TextStreamPart,
-  ToolSet,
-  TypedToolCall,
-  TypedToolError,
-  TypedToolResult,
-} from "ai";
+import type { TextStreamPart, ToolSet, TypedToolCall, TypedToolError, TypedToolResult } from "ai";
 
-type ToolResponsePart = Extract<ModelMessage, { role: "tool" }>["content"][number];
-type InlineToolResultPart = Extract<ToolResponsePart, { type: "tool-result" }>;
 type InlineToolResultJsonValue = Extract<InlineToolResultPart["output"], { type: "json" }>["value"];
 
 import type { AssistantStepFinishReason, RuntimeIdentity } from "#protocol/message.js";
@@ -32,7 +23,6 @@ import {
 } from "#protocol/message.js";
 import type { RunMode } from "#shared/run-mode.js";
 import { hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
-import { toError } from "#shared/errors.js";
 import type { JsonObject } from "#shared/json.js";
 import {
   createRuntimeToolResultFromStepResult,
@@ -46,19 +36,21 @@ import {
 import { createInvalidToolCallInputError } from "#harness/tool-call-input-errors.js";
 import type {
   RuntimeActionRequest,
+  RuntimeToolCallActionRequest,
   RuntimeToolResultActionResult,
 } from "#runtime/actions/types.js";
 import { isAuthorizationSignal, isPendingAuthorizationToolOutput } from "#harness/authorization.js";
 import { contextStorage } from "#context/container.js";
 import { readToolInterrupt } from "#harness/tool-interrupts.js";
 import { createProviderStreamActionBatch } from "#harness/stream-actions.js";
-import type {
-  HarnessEmitFn,
-  HarnessSession,
-  HarnessToolMap,
-  SessionStateMap,
-  StepInput,
-} from "#harness/types.js";
+import {
+  type EmittedStreamContent,
+  type InlineToolResultPart,
+  normalizeModelStreamError,
+  setModelStreamFailureState,
+  type StreamActionEmissionOptions,
+} from "#harness/model-stream-attempt.js";
+import type { HarnessEmitFn, HarnessSession, SessionStateMap, StepInput } from "#harness/types.js";
 
 // ---------------------------------------------------------------------------
 // Emission state
@@ -324,27 +316,6 @@ export function normalizeAssistantStepFinishReason(
 // ---------------------------------------------------------------------------
 
 /**
- * Result of consuming one step's `fullStream`.
- *
- * Inline results avoid duplicate post-step events. Approval-resume results
- * also repair persisted history or route authorization back to the park
- * detector.
- */
-interface EmittedStreamContent {
-  readonly emittedActionCallIds: ReadonlySet<string>;
-  readonly handledInlineToolResultCallIds: ReadonlySet<string>;
-  readonly invalidInputToolCallIds: ReadonlySet<string>;
-  readonly inlineAuthorizationResults: readonly TypedToolResult<ToolSet>[];
-  readonly inlineToolResultParts: readonly InlineToolResultPart[];
-  readonly trailingInlineToolResultParts: readonly InlineToolResultPart[];
-}
-
-interface StreamActionEmissionOptions {
-  readonly excludedActionToolNames: ReadonlySet<string>;
-  readonly tools: HarnessToolMap;
-}
-
-/**
  * Consumes the AI SDK `fullStream` and emits real-time text and reasoning
  * events.
  *
@@ -360,12 +331,16 @@ export async function emitStreamContent(
 ): Promise<EmittedStreamContent> {
   let currentReasoning = "";
   let currentMessage = "";
+  let reasoningObserved = false;
+  let textObserved = false;
   let finishReason: AssistantStepFinishReason = "stop";
   let streamError: Error | undefined;
   const toolCallIdsSeenInStream = new Set<string>();
   const emittedActionCallIds = new Set<string>();
   const emittedActionResultCallIds = new Set<string>();
   const providerToolCallIdsSeen = new Set<string>();
+  const pendingLocalActionRequests = new Map<string, RuntimeToolCallActionRequest>();
+  let providerExecutedActionObserved = false;
   const providerActionBatch = createProviderStreamActionBatch({ emitFn, state });
   const handledInlineToolResultCallIds = new Set<string>();
   const invalidInputToolCallIds = new Set<string>();
@@ -399,6 +374,9 @@ export async function emitStreamContent(
     }
 
     emittedActionCallIds.add(action.callId);
+    if (action.kind === "tool-call") {
+      pendingLocalActionRequests.set(action.callId, action);
+    }
     await emitFn(
       createActionsRequestedEvent({
         actions: [action],
@@ -414,6 +392,7 @@ export async function emitStreamContent(
     readonly toolCallId: string;
     readonly toolName: string;
   }): Promise<void> => {
+    providerExecutedActionObserved = true;
     if (providerToolCallIdsSeen.has(toolCall.toolCallId)) {
       return;
     }
@@ -443,6 +422,7 @@ export async function emitStreamContent(
       return;
     }
     emittedActionResultCallIds.add(result.callId);
+    pendingLocalActionRequests.delete(result.callId);
     await emitFn(
       createActionResultEvent({
         result,
@@ -493,6 +473,7 @@ export async function emitStreamContent(
     switch (part.type) {
       case "reasoning-delta":
         await providerActionBatch.flush();
+        reasoningObserved = true;
         currentReasoning += part.text;
         await emitFn(
           createReasoningAppendedEvent({
@@ -506,6 +487,7 @@ export async function emitStreamContent(
         break;
       case "text-delta":
         await providerActionBatch.flush();
+        textObserved = true;
         // Flush accumulated reasoning before text begins.
         if (currentReasoning.trim().length > 0) {
           await emitFn(
@@ -619,7 +601,7 @@ export async function emitStreamContent(
         // so plain-object shapes (structured-clone survivors, typed
         // gateway payloads) keep their `message`, `name`, `stack`, and
         // `cause` instead of degrading to `new Error("[object Object]")`.
-        streamError = toError(part.error);
+        streamError = normalizeModelStreamError(part.error);
         break;
       case "abort":
         // The SDK does not resolve step results for aborted in-flight steps.
@@ -632,6 +614,12 @@ export async function emitStreamContent(
   await providerActionBatch.flush();
 
   if (streamError !== undefined) {
+    setModelStreamFailureState(streamError, {
+      pendingLocalActionRequests: [...pendingLocalActionRequests.values()],
+      providerExecutedActionObserved,
+      reasoningObserved,
+      textObserved,
+    });
     throw streamError;
   }
 

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -144,6 +144,16 @@ describe("classifyModelCallError", () => {
     expect(classifyModelCallError(err)).toBe("retry");
   });
 
+  it("returns retry for Anthropic overloaded stream payloads", () => {
+    const overloaded = {
+      message: "Overloaded",
+      type: "overloaded_error",
+    };
+
+    expect(classifyModelCallError(overloaded)).toBe("retry");
+    expect(classifyModelCallError(new Error("stream failed", { cause: overloaded }))).toBe("retry");
+  });
+
   it("returns retry for HTTP statuses the AI SDK treats as retryable", () => {
     for (const statusCode of [408, 409, 429]) {
       const err = Object.assign(new Error("retryable"), { statusCode });

--- a/packages/eve/src/harness/model-call-error.ts
+++ b/packages/eve/src/harness/model-call-error.ts
@@ -490,7 +490,7 @@ function readObjectField(value: unknown, key: string): Record<string, unknown> |
 }
 
 function isRetryableGatewayType(type: string | undefined): boolean {
-  return type === "rate_limit_exceeded" || type === "timeout_error";
+  return type === "overloaded_error" || type === "rate_limit_exceeded" || type === "timeout_error";
 }
 
 function isTerminalGatewayType(type: string | undefined): boolean {

--- a/packages/eve/src/harness/model-stream-attempt.ts
+++ b/packages/eve/src/harness/model-stream-attempt.ts
@@ -1,0 +1,55 @@
+import type { ModelMessage, ToolSet, TypedToolResult } from "ai";
+
+import type { HarnessToolMap } from "#harness/types.js";
+import type { RuntimeToolCallActionRequest } from "#runtime/actions/types.js";
+import { toError } from "#shared/errors.js";
+
+type ToolResponsePart = Extract<ModelMessage, { role: "tool" }>["content"][number];
+export type InlineToolResultPart = Extract<ToolResponsePart, { type: "tool-result" }>;
+
+/** Result of consuming one model attempt's full stream. */
+export interface EmittedStreamContent {
+  readonly emittedActionCallIds: ReadonlySet<string>;
+  readonly handledInlineToolResultCallIds: ReadonlySet<string>;
+  readonly invalidInputToolCallIds: ReadonlySet<string>;
+  readonly inlineAuthorizationResults: readonly TypedToolResult<ToolSet>[];
+  readonly inlineToolResultParts: readonly InlineToolResultPart[];
+  readonly trailingInlineToolResultParts: readonly InlineToolResultPart[];
+}
+
+export interface StreamActionEmissionOptions {
+  readonly excludedActionToolNames: ReadonlySet<string>;
+  readonly tools: HarnessToolMap;
+}
+
+/** Attempt-local state retained when a model error aborts a stream. */
+export interface ModelStreamFailureState {
+  readonly pendingLocalActionRequests: readonly RuntimeToolCallActionRequest[];
+  readonly providerExecutedActionObserved: boolean;
+  readonly reasoningObserved: boolean;
+  readonly textObserved: boolean;
+}
+
+const modelStreamFailureStates = new WeakMap<Error, ModelStreamFailureState>();
+
+/** Preserves a plain provider payload as the normalized error's cause. */
+export function normalizeModelStreamError(raw: unknown): Error {
+  const error = toError(raw);
+  if (error === raw) return error;
+
+  Object.defineProperty(error, "cause", {
+    configurable: true,
+    value: raw,
+  });
+  return error;
+}
+
+/** Records attempt-local state on the error consumed by the retry layer. */
+export function setModelStreamFailureState(error: Error, state: ModelStreamFailureState): void {
+  modelStreamFailureStates.set(error, state);
+}
+
+/** Returns attempt-local stream state attached to a normalized model error. */
+export function getModelStreamFailureState(error: unknown): ModelStreamFailureState | undefined {
+  return error instanceof Error ? modelStreamFailureStates.get(error) : undefined;
+}

--- a/packages/eve/src/harness/tool-loop-retry.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-retry.integration.test.ts
@@ -1,0 +1,364 @@
+import { jsonSchema, type LanguageModel } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { createToolLoopHarness } from "#harness/tool-loop.js";
+import { TurnCancelledError } from "#harness/turn-cancellation.js";
+import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
+
+type StreamResult = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>;
+type StreamPart = StreamResult["stream"] extends ReadableStream<infer Part> ? Part : never;
+
+const usage = {
+  inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+  outputTokens: { reasoning: 0, text: 1, total: 1 },
+} as const;
+
+function createSession(overrides?: Partial<HarnessSession>): HarnessSession {
+  return {
+    agent: {
+      modelReference: { id: "retry-integration-model" },
+      system: "You are a test assistant.",
+      tools: [],
+    },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "http:retry-integration-session",
+    history: [
+      { content: "Complete the long task.", role: "user" },
+      { content: "Prior work is complete.", role: "assistant" },
+    ],
+    sessionId: "retry-integration-session",
+    ...overrides,
+  };
+}
+
+function createEventCollector(): {
+  emit: HarnessEmitFn;
+  events: HandleMessageStreamEvent[];
+} {
+  const events: HandleMessageStreamEvent[] = [];
+  return {
+    emit: async (event) => {
+      events.push(event);
+    },
+    events,
+  };
+}
+
+function createConfig(
+  model: LanguageModel,
+  emit: HarnessEmitFn,
+  overrides?: Partial<ToolLoopHarnessConfig>,
+): ToolLoopHarnessConfig {
+  return {
+    handleEvent: emit,
+    mode: "task",
+    resolveModel: vi.fn().mockResolvedValue(model),
+    tools: new Map(),
+    ...overrides,
+  };
+}
+
+function enqueueOverload(
+  controller: ReadableStreamDefaultController<StreamPart>,
+  partialText?: string,
+): void {
+  controller.enqueue({ type: "stream-start", warnings: [] });
+  if (partialText !== undefined) {
+    controller.enqueue({ id: "partial", type: "text-start" });
+    controller.enqueue({ delta: partialText, id: "partial", type: "text-delta" });
+    controller.enqueue({ id: "partial", type: "text-end" });
+  }
+  controller.enqueue({
+    error: { message: "Overloaded", type: "overloaded_error" },
+    type: "error",
+  });
+  controller.close();
+}
+
+function enqueueTextSuccess(
+  controller: ReadableStreamDefaultController<StreamPart>,
+  text: string,
+): void {
+  controller.enqueue({ type: "stream-start", warnings: [] });
+  controller.enqueue({ id: "answer", type: "text-start" });
+  controller.enqueue({ delta: text, id: "answer", type: "text-delta" });
+  controller.enqueue({ id: "answer", type: "text-end" });
+  controller.enqueue({
+    finishReason: { raw: undefined, unified: "stop" },
+    type: "finish",
+    usage,
+  });
+  controller.close();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("tool loop transient stream retries (real AI SDK)", () => {
+  it("retries a partial overloaded stream with fresh hooks and preserves prior task work", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    let attempt = 0;
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream<StreamPart>({
+        start(controller) {
+          attempt += 1;
+          if (attempt === 1) {
+            enqueueOverload(controller, "Discard this partial response.");
+            return;
+          }
+          enqueueTextSuccess(controller, "Recovered answer.");
+        },
+      }),
+    }));
+    const model = new MockLanguageModelV3({
+      doStream,
+      modelId: "retry-integration-model",
+      provider: "eve-integration-mock",
+    });
+    const { emit, events } = createEventCollector();
+
+    const result = await createToolLoopHarness(createConfig(model, emit))(createSession(), {
+      message: "Continue.",
+    });
+
+    expect(doStream).toHaveBeenCalledTimes(2);
+    expect(result.next).toEqual({ done: true, output: "Recovered answer." });
+    expect(result.session.history).toContainEqual({
+      content: "Prior work is complete.",
+      role: "assistant",
+    });
+    expect(JSON.stringify(result.session.history)).toContain("Recovered answer.");
+    expect(JSON.stringify(result.session.history)).not.toContain("Discard this partial response.");
+    expect(events.filter((event) => event.type === "step.started")).toHaveLength(1);
+    expect(events.filter((event) => event.type === "step.completed")).toHaveLength(1);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "message.completed" &&
+          event.data.finishReason === "error" &&
+          event.data.message === null,
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.type === "step.failed")).toBe(false);
+    expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    expect(events.some((event) => event.type === "session.failed")).toBe(false);
+  });
+
+  it("does not execute a discarded local tool proposal and closes it before retrying", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const execute = vi.fn(() => "tool-result");
+    let attempt = 0;
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream<StreamPart>({
+        start(controller) {
+          attempt += 1;
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({
+            input: JSON.stringify({ value: attempt }),
+            toolCallId: `call-${attempt}`,
+            toolName: "local_tool",
+            type: "tool-call",
+          });
+          if (attempt === 1) {
+            controller.enqueue({
+              error: { message: "Overloaded", type: "overloaded_error" },
+              type: "error",
+            });
+            controller.close();
+            return;
+          }
+          controller.enqueue({
+            finishReason: { raw: undefined, unified: "tool-calls" },
+            type: "finish",
+            usage,
+          });
+          controller.close();
+        },
+      }),
+    }));
+    const model = new MockLanguageModelV3({
+      doStream,
+      modelId: "retry-integration-model",
+      provider: "eve-integration-mock",
+    });
+    const tools: ToolLoopHarnessConfig["tools"] = new Map([
+      [
+        "local_tool",
+        {
+          description: "Local tool",
+          execute,
+          inputSchema: jsonSchema({
+            properties: { value: { type: "number" } },
+            required: ["value"],
+            type: "object",
+          }),
+          name: "local_tool",
+        },
+      ],
+    ]);
+    const session = createSession({
+      agent: {
+        modelReference: { id: "retry-integration-model" },
+        system: "You are a test assistant.",
+        tools: [
+          {
+            description: "Local tool",
+            inputSchema: {
+              properties: { value: { type: "number" } },
+              required: ["value"],
+              type: "object",
+            },
+            name: "local_tool",
+          },
+        ],
+      },
+    });
+    const { emit, events } = createEventCollector();
+
+    const result = await createToolLoopHarness(createConfig(model, emit, { tools }))(session, {
+      message: "Use the tool.",
+    });
+
+    expect(doStream).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.next).toBeTypeOf("function");
+    const firstCallResult = events.find((event) => {
+      if (event.type !== "action.result") return false;
+      return event.data.result.callId === "call-1";
+    });
+    expect(firstCallResult?.type).toBe("action.result");
+    if (firstCallResult?.type === "action.result") {
+      expect(firstCallResult.data).toMatchObject({
+        result: {
+          callId: "call-1",
+          isError: true,
+          output: {
+            code: "MODEL_CALL_RETRIED",
+          },
+        },
+        status: "failed",
+      });
+    }
+    const secondCallResult = events.find((event) => {
+      if (event.type !== "action.result") return false;
+      return event.data.result.callId === "call-2";
+    });
+    expect(secondCallResult?.type).toBe("action.result");
+    if (secondCallResult?.type === "action.result") {
+      expect(secondCallResult.data.status).toBe("completed");
+    }
+  });
+
+  it("does not replay an overloaded attempt after provider-executed activity", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream<StreamPart>({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({
+            input: JSON.stringify({ query: "weather" }),
+            providerExecuted: true,
+            toolCallId: "provider-call",
+            toolName: "web_search",
+            type: "tool-call",
+          });
+          controller.enqueue({
+            error: { message: "Overloaded", type: "overloaded_error" },
+            type: "error",
+          });
+          controller.close();
+        },
+      }),
+    }));
+    const model = new MockLanguageModelV3({
+      doStream,
+      modelId: "retry-integration-model",
+      provider: "eve-integration-mock",
+    });
+    const { emit } = createEventCollector();
+
+    const result = await createToolLoopHarness(createConfig(model, emit))(createSession(), {
+      message: "Search.",
+    });
+
+    expect(doStream).toHaveBeenCalledTimes(1);
+    expect(result.next).toMatchObject({ done: true, isError: true, output: "Overloaded" });
+  });
+
+  it("fails a task once after three overloaded attempts are exhausted", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream<StreamPart>({
+        start(controller) {
+          enqueueOverload(controller);
+        },
+      }),
+    }));
+    const model = new MockLanguageModelV3({
+      doStream,
+      modelId: "retry-integration-model",
+      provider: "eve-integration-mock",
+    });
+    const { emit, events } = createEventCollector();
+
+    const result = await createToolLoopHarness(createConfig(model, emit))(createSession(), {
+      message: "Continue.",
+    });
+
+    expect(doStream).toHaveBeenCalledTimes(3);
+    expect(result.next).toMatchObject({ done: true, isError: true, output: "Overloaded" });
+    expect(events.filter((event) => event.type === "step.failed")).toHaveLength(1);
+    expect(events.filter((event) => event.type === "turn.failed")).toHaveLength(1);
+    expect(events.filter((event) => event.type === "session.failed")).toHaveLength(1);
+  });
+
+  it("interrupts retry backoff when the turn is cancelled", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const abortController = new AbortController();
+    const cancellation = new TurnCancelledError();
+    vi.spyOn(console, "warn").mockImplementation((line) => {
+      if (String(line).includes("model call failed transiently")) {
+        abortController.abort(cancellation);
+      }
+    });
+
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream<StreamPart>({
+        start(controller) {
+          enqueueOverload(controller);
+        },
+      }),
+    }));
+    const model = new MockLanguageModelV3({
+      doStream,
+      modelId: "retry-integration-model",
+      provider: "eve-integration-mock",
+    });
+    const { emit, events } = createEventCollector();
+    const run = createToolLoopHarness(
+      createConfig(model, emit, { abortSignal: abortController.signal }),
+    );
+
+    await expect(run(createSession(), { message: "Continue." })).rejects.toBe(cancellation);
+
+    expect(doStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === "step.failed")).toBe(false);
+    expect(events.some((event) => event.type === "turn.failed")).toBe(false);
+    expect(events.some((event) => event.type === "session.failed")).toBe(false);
+  });
+});

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -39,6 +39,7 @@ import {
   createCompactionCompletedEvent,
   createCompactionRequestedEvent,
   createInputRequestedEvent,
+  createMessageCompletedEvent,
   createResultCompletedEvent,
   createStepStartedEvent,
 } from "#protocol/message.js";
@@ -92,11 +93,15 @@ import {
   getHarnessEmissionState,
   setHarnessEmissionState,
 } from "#harness/emission.js";
+import { getModelStreamFailureState } from "#harness/model-stream-attempt.js";
 import {
   extractQuestionInputRequests,
   extractToolApprovalInputRequests,
 } from "#harness/input-extraction.js";
-import { createToolResultMessagePartFromToolError } from "#harness/action-result-helpers.js";
+import {
+  createRuntimeToolResultFromValue,
+  createToolResultMessagePartFromToolError,
+} from "#harness/action-result-helpers.js";
 import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-context.js";
 import {
   consumeDeferredStepInput,
@@ -736,20 +741,26 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
      * The empty-response reissue passes `retryReason` to label the retried
      * call's telemetry.
      */
-    const runOneModelCall = async (opts: {
+    type ModelCallOptions = {
       disabledProviderTools?: ReadonlySet<string>;
       extraSystemNote?: string;
       preparedInput?: ReturnType<typeof prepareModelCallInput>;
-      retryReason?: "empty-response";
+      retryAttempt?: number;
+      retryReason?: "empty-response" | "transient-error";
       suppressStepStartedEmission?: boolean;
       trailingUserNote?: string;
-    }): Promise<HarnessStepResult> => {
+    };
+
+    const runSingleModelCall = async (opts: ModelCallOptions): Promise<HarnessStepResult> => {
       const { instructions, telemetryRuntimeContext = {} } =
         opts.preparedInput ?? prepareModelCallInput(opts.extraSystemNote);
       // Label the reissued call's telemetry; without this a retry is only
       // visible as a second LLM span under one step.
       if (opts.retryReason) {
         telemetryRuntimeContext["eve.retry.reason"] = opts.retryReason;
+      }
+      if (opts.retryAttempt !== undefined) {
+        telemetryRuntimeContext["eve.retry.attempt"] = opts.retryAttempt;
       }
       // Trailing rather than an extraSystemNote prepend: keeps the provider's
       // cached prompt prefix valid, and handleStepResult rebuilds history
@@ -953,15 +964,73 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         return stepResult;
       };
 
-      return runModelCallWithRetries(
-        () => executeModelCall().catch(rethrowNoOutputAsEmptyResponse),
+      return executeModelCall().catch(rethrowNoOutputAsEmptyResponse);
+    };
+
+    const prepareTransientModelCallRetry = async (error: unknown): Promise<boolean> => {
+      const failureState = getModelStreamFailureState(error);
+      if (failureState?.providerExecutedActionObserved === true) {
+        log.warn("not retrying transient model failure after provider-executed activity", {
+          error,
+          sessionId: session.sessionId,
+          turnId: emissionState.turnId,
+        });
+        return false;
+      }
+
+      if (emit !== undefined && failureState !== undefined) {
+        if (failureState.reasoningObserved || failureState.textObserved) {
+          await emit(
+            createMessageCompletedEvent({
+              finishReason: "error",
+              message: null,
+              sequence: emissionState.sequence,
+              stepIndex: emissionState.stepIndex,
+              turnId: emissionState.turnId,
+            }),
+          );
+        }
+        for (const action of failureState.pendingLocalActionRequests) {
+          await emit(
+            createActionResultEvent({
+              result: createRuntimeToolResultFromValue({
+                callId: action.callId,
+                isError: true,
+                output: {
+                  code: "MODEL_CALL_RETRIED",
+                  message:
+                    "The model response ended before this tool call executed; retrying the model call.",
+                },
+                toolName: action.toolName,
+              }),
+              sequence: emissionState.sequence,
+              stepIndex: emissionState.stepIndex,
+              turnId: emissionState.turnId,
+            }),
+          );
+        }
+      }
+
+      return true;
+    };
+
+    const runOneModelCall = async (opts: ModelCallOptions): Promise<HarnessStepResult> =>
+      runModelCallWithRetries(
+        (attempt) =>
+          runSingleModelCall({
+            ...opts,
+            preparedInput: attempt === 1 ? opts.preparedInput : undefined,
+            retryAttempt: attempt === 1 ? opts.retryAttempt : attempt,
+            retryReason: attempt === 1 ? opts.retryReason : "transient-error",
+            suppressStepStartedEmission: attempt === 1 ? opts.suppressStepStartedEmission : true,
+          }),
         {
           sessionId: session.sessionId,
           turnId: emissionState.turnId,
         },
         config.abortSignal,
+        prepareTransientModelCallRetry,
       );
-    };
 
     // Resolve first-attempt instrumentation before step.started dispatch
     // allows dynamic tool resolvers to update the effective toolset.
@@ -1365,7 +1434,7 @@ type RecoveryRetryCallOptions = {
  */
 type RecoveryModelCallFn = (
   opts: RecoveryRetryCallOptions & {
-    readonly retryReason?: "empty-response";
+    readonly retryReason?: "empty-response" | "transient-error";
     readonly suppressStepStartedEmission?: boolean;
     readonly trailingUserNote?: string;
   },
@@ -2357,17 +2426,21 @@ function resolveApprovalKeyFromTools(
  * transient.
  */
 async function runModelCallWithRetries<T>(
-  fn: () => Promise<T>,
+  fn: (attempt: number) => Promise<T>,
   diag: { readonly sessionId: string; readonly turnId: string },
   abortSignal?: AbortSignal,
+  prepareRetry?: (error: unknown) => Promise<boolean>,
 ): Promise<T> {
   for (let attempt = 1; ; attempt++) {
     throwIfTurnAborted(abortSignal);
     try {
-      return await fn();
+      return await fn(attempt);
     } catch (error) {
       throwIfTurnAborted(abortSignal);
       if (attempt === MODEL_CALL_MAX_ATTEMPTS || classifyModelCallError(error) !== "retry") {
+        throw error;
+      }
+      if (prepareRetry !== undefined && !(await prepareRetry(error))) {
         throw error;
       }
       const delayMs =
@@ -2379,9 +2452,36 @@ async function runModelCallWithRetries<T>(
         turnId: diag.turnId,
         error,
       });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await waitForModelCallRetry(delayMs, abortSignal);
     }
   }
+}
+
+async function waitForModelCallRetry(delayMs: number, abortSignal?: AbortSignal): Promise<void> {
+  if (abortSignal === undefined) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      abortSignal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      abortSignal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+    if (abortSignal.aborted) onAbort();
+  });
+  throwIfTurnAborted(abortSignal);
 }
 
 function findAuthorizationSignalFromToolResults(

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -330,6 +330,57 @@ describe("chatSdkChannel", () => {
     ]);
   });
 
+  it("keeps the streamed anchor so a retry replaces partial output", async () => {
+    const adapter = testAdapter();
+    const bridge = chatSdkChannel({
+      adapters: { test: adapter },
+      state: memoryState(),
+      streamingEditIntervalMs: 0,
+      userName: "bot",
+    });
+    const state: ChatSdkChannelState = {
+      anchorMessageId: "posted-1",
+      editSupported: true,
+      streamStepIndex: 0,
+      thread: serializedThread(),
+    };
+    const channelAdapter = withState(getAdapter(bridge.channel), state);
+    const ctx = buildAdapterContext(channelAdapter, stubAccessor());
+
+    await callEvent(
+      channelAdapter,
+      makeEvent("message.completed", {
+        finishReason: "error",
+        message: null,
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+    await callEvent(
+      channelAdapter,
+      makeEvent("message.appended", {
+        messageDelta: "Recovered answer",
+        messageSoFar: "Recovered answer",
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    expect(adapter.posted).toEqual([]);
+    expect(adapter.edited).toEqual([
+      {
+        message: { markdown: "Recovered answer" },
+        messageId: "posted-1",
+        threadId: THREAD_ID,
+      },
+    ]);
+    expect(state.anchorMessageId).toBe("posted-1");
+  });
+
   it("falls back to a fresh post when streaming edits are not implemented", async () => {
     const adapter = testAdapter();
     adapter.editError = new NotImplementedError("editMessage");

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -381,6 +381,11 @@ function defaultEvents<TAdapters extends ChatSdkAdapters>(
       }
       channel.state.pendingToolCallMessage = null;
       if (!event.message) {
+        // A transient stream retry uses an error/null completion to discard
+        // the failed attempt. Keep the live anchor so the retry's full
+        // `messageSoFar` snapshot replaces it instead of posting a second
+        // message and leaving the partial response visible.
+        if (event.finishReason === "error") return;
         clearStream(channel.state);
         return;
       }


### PR DESCRIPTION
### Description

Retry transient provider stream failures at the model-call boundary so task-mode and subagent runs preserve their previously committed session history instead of failing the entire run.

Anthropic `overloaded_error` payloads were losing their structured type during normalization, which prevented retry classification. Each retry now uses a fresh `ToolLoopAgent` and one-shot hooks, discards uncommitted partial output, resolves abandoned local tool proposals, and avoids replay once provider-executed activity has begun. Exhausted retries retain the existing conversation and task failure behavior.

This also updates built-in stream consumers to replace failed partial output, adds retry telemetry, documents the behavior, and includes a patch changeset.

### How did you test your changes?

- `pnpm test:unit`
- Targeted real AI SDK retry integration tests
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `git diff --check`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
