### PR TITLE
fix(eve): protect nitro-referenced dev snapshots

### DIFF
--- a/.changeset/dev-runtime-nitro-prune-protection.md
+++ b/.changeset/dev-runtime-nitro-prune-protection.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Protect dev-runtime snapshots referenced by generated Nitro artifacts from stale snapshot pruning, so `eve dev` routes do not lose boot-time compiled-artifact imports after rebuild churn.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -669,6 +669,58 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(retiredSnapshotRoot)).toBe(false);
   });
 
+  it("preserves snapshots referenced by generated Nitro files", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-nitro-");
+    const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
+    const activeSnapshotRoot = join(snapshotsRoot, "active");
+    const nitroReferencedSnapshotRoot = join(snapshotsRoot, "nitro-referenced");
+    const staleSnapshotRoot = join(snapshotsRoot, "stale");
+    const oldSnapshotTime = new Date(1_000);
+
+    for (const snapshotRoot of [
+      activeSnapshotRoot,
+      nitroReferencedSnapshotRoot,
+      staleSnapshotRoot,
+    ]) {
+      await mkdir(snapshotRoot, { recursive: true });
+      await writeFile(join(snapshotRoot, "marker.txt"), snapshotRoot);
+      await utimes(snapshotRoot, oldSnapshotTime, oldSnapshotTime);
+    }
+
+    await activateDevelopmentRuntimeArtifactsSnapshot({
+      appRoot,
+      snapshot: {
+        runtimeAppRoot: join(activeSnapshotRoot, "source", "app"),
+        snapshotRoot: activeSnapshotRoot,
+        snapshotSourceRoot: join(activeSnapshotRoot, "source"),
+      },
+    });
+    await mkdir(join(appRoot, ".eve", "nitro", "workflow"), { recursive: true });
+    await writeFile(
+      join(appRoot, ".eve", "nitro", "workflow", "steps.mjs"),
+      `import "${join(
+        nitroReferencedSnapshotRoot,
+        "source",
+        "app",
+        ".eve",
+        "compile",
+        "compiled-artifacts-bootstrap.mjs",
+      ).replaceAll("\\", "/")}";\n`,
+    );
+
+    await pruneDevelopmentRuntimeArtifactsSnapshots({
+      appRoot,
+      now: 1_000_000,
+      recentWindowMs: 0,
+      retainCount: 0,
+    });
+
+    await expect(readdir(snapshotsRoot)).resolves.toEqual(
+      expect.arrayContaining(["active", "nitro-referenced"]),
+    );
+    expect(existsSync(staleSnapshotRoot)).toBe(false);
+  });
+
   it("removes a partially staged snapshot when staging fails", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-failed-stage-");
     const agentRoot = join(appRoot, "agent");

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -1,24 +1,18 @@
 import { randomUUID } from "node:crypto";
-import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
+import { cp, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync, type Dirent } from "node:fs";
 import { dirname, join, relative, resolve, sep } from "node:path";
 
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { copyDevelopmentSourceSnapshot } from "#internal/nitro/dev-runtime-source-snapshot-copy.js";
-import {
-  createDevelopmentSourceSnapshotPlan,
-  toDevelopmentSourceSnapshotPath,
-} from "#internal/nitro/dev-runtime-source-snapshot.js";
-import {
-  DEVELOPMENT_RUNTIME_ARTIFACTS_ACTIVATED_MARKER,
-  pruneDevelopmentRuntimeArtifactsSnapshotDirectory,
-  recordRetiredDevelopmentRuntimeArtifactsSnapshot,
-} from "#internal/nitro/dev-runtime-artifacts-retention.js";
-import { renameWithTransientBusyRetry } from "#shared/rename-with-retry.js";
+import { createDevelopmentSourceSnapshotPlan } from "#internal/nitro/dev-runtime-source-snapshot.js";
 
 const DEV_RUNTIME_ARTIFACTS_DIRECTORY = "dev-runtime";
-const DEV_RUNTIME_ARTIFACTS_GENERATION_METADATA = "generation.json";
 const DEV_RUNTIME_ARTIFACTS_POINTER_VERSION = 2;
+const DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS = 15 * 60 * 1000;
+const DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT = 5;
+const DEV_RUNTIME_PROTECTED_REFERENCE_MAX_SCAN_BYTES = 1024 * 1024;
+const TERMINAL_WORKFLOW_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "canceled"]);
 
 interface DevelopmentRuntimeArtifactsPointerV1 {
   readonly appRoot: string;
@@ -42,17 +36,6 @@ export interface DevelopmentRuntimeArtifactsSnapshot {
   readonly runtimeAppRoot: string;
   readonly snapshotRoot: string;
   readonly snapshotSourceRoot: string;
-  readonly sourceRoot: string;
-}
-
-export interface ActiveDevelopmentRuntimeArtifactsSnapshot {
-  readonly runtimeAppRoot: string;
-  readonly snapshotRoot: string;
-}
-
-export interface DevelopmentRuntimeArtifactsActivation {
-  commit(): void;
-  rollback(): Promise<void>;
 }
 
 /**
@@ -67,11 +50,18 @@ function resolveDevelopmentRuntimeArtifactsSnapshotsDirectory(appRoot: string): 
   return join(appRoot, ".eve", DEV_RUNTIME_ARTIFACTS_DIRECTORY, "snapshots");
 }
 
-function isDevelopmentRuntimeArtifactsSnapshotRoot(appRoot: string, snapshotRoot: string): boolean {
-  return (
-    dirname(resolve(snapshotRoot)) ===
-    resolve(resolveDevelopmentRuntimeArtifactsSnapshotsDirectory(appRoot))
-  );
+/**
+ * Publishes one immutable dev runtime snapshot and points future sessions at it.
+ */
+export async function publishDevelopmentRuntimeArtifactsSnapshot(
+  compileResult: CompileAgentResult,
+): Promise<DevelopmentRuntimeArtifactsSnapshot> {
+  const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot(compileResult);
+  await activateDevelopmentRuntimeArtifactsSnapshot({
+    appRoot: compileResult.project.appRoot,
+    snapshot,
+  });
+  return snapshot;
 }
 
 /**
@@ -107,8 +97,6 @@ export async function stageDevelopmentRuntimeArtifactsSnapshot(
         "compiled-agent-manifest.json",
       ),
       runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
-      snapshotSourceRoot: sourceSnapshotPlan.snapshotSourceRoot,
-      sourceRoot: sourceSnapshotPlan.sourceRoot,
     });
     await validateSnapshotCompiledManifestRoots({
       manifestPath: join(
@@ -119,10 +107,6 @@ export async function stageDevelopmentRuntimeArtifactsSnapshot(
       ),
       runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
     });
-    await writeFile(
-      join(snapshotRoot, DEV_RUNTIME_ARTIFACTS_GENERATION_METADATA),
-      `${JSON.stringify({ runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot })}\n`,
-    );
   } catch (error) {
     await rm(snapshotRoot, { force: true, recursive: true }).catch(() => {});
     throw error;
@@ -132,7 +116,6 @@ export async function stageDevelopmentRuntimeArtifactsSnapshot(
     runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
     snapshotRoot,
     snapshotSourceRoot: sourceSnapshotPlan.snapshotSourceRoot,
-    sourceRoot: sourceSnapshotPlan.sourceRoot,
   };
 }
 
@@ -143,67 +126,7 @@ export async function activateDevelopmentRuntimeArtifactsSnapshot(input: {
   readonly appRoot: string;
   readonly snapshot: DevelopmentRuntimeArtifactsSnapshot;
 }): Promise<void> {
-  const activation = await activateDevelopmentRuntimeArtifactsSnapshotTransaction(input);
-  activation.commit();
-}
-
-export async function activateDevelopmentRuntimeArtifactsSnapshotTransaction(input: {
-  readonly appRoot: string;
-  readonly snapshot: DevelopmentRuntimeArtifactsSnapshot;
-}): Promise<DevelopmentRuntimeArtifactsActivation> {
-  const markerPath = join(
-    input.snapshot.snapshotRoot,
-    DEVELOPMENT_RUNTIME_ARTIFACTS_ACTIVATED_MARKER,
-  );
-  const pointerPath = resolveDevelopmentRuntimeArtifactsPointerPath(input.appRoot);
-  const previousPointer = readDevelopmentRuntimeArtifactsPointer(pointerPath);
-  const previousPointerSource = await readOptionalFile(pointerPath);
-
-  try {
-    await writeFile(markerPath, "");
-    await writeDevelopmentRuntimeArtifactsPointer(input);
-    if (
-      previousPointer?.version === DEV_RUNTIME_ARTIFACTS_POINTER_VERSION &&
-      previousPointer.snapshotRoot !== input.snapshot.snapshotRoot &&
-      isDevelopmentRuntimeArtifactsSnapshotRoot(input.appRoot, previousPointer.snapshotRoot)
-    ) {
-      await recordRetiredDevelopmentRuntimeArtifactsSnapshot(previousPointer.snapshotRoot).catch(
-        (error) => {
-          console.warn(
-            `[eve:dev] failed to record retired runtime generation "${previousPointer.snapshotRoot}": ${String(error)}`,
-          );
-        },
-      );
-    }
-  } catch (error) {
-    throw await rollbackFailedActivation({
-      cause: error,
-      markerPath,
-      pointerPath,
-      previousPointerSource,
-    });
-  }
-
-  let settled = false;
-  return {
-    commit() {
-      settled = true;
-    },
-    async rollback() {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      const rollbackError = await restoreDevelopmentRuntimeArtifactsActivation({
-        markerPath,
-        pointerPath,
-        previousPointerSource,
-      });
-      if (rollbackError !== undefined) {
-        throw rollbackError;
-      }
-    },
-  };
+  await writeDevelopmentRuntimeArtifactsPointer(input);
 }
 
 /**
@@ -225,21 +148,6 @@ export function readDevelopmentRuntimeArtifactsSnapshotRoot(
   return pointer.runtimeAppRoot;
 }
 
-export function readActiveDevelopmentRuntimeArtifactsSnapshot(
-  appRoot: string,
-): ActiveDevelopmentRuntimeArtifactsSnapshot | undefined {
-  const pointer = readDevelopmentRuntimeArtifactsPointer(
-    resolveDevelopmentRuntimeArtifactsPointerPath(appRoot),
-  );
-  if (pointer === undefined || pointer.version === 1) {
-    return undefined;
-  }
-  return {
-    runtimeAppRoot: pointer.runtimeAppRoot,
-    snapshotRoot: pointer.snapshotRoot,
-  };
-}
-
 /**
  * Reads a revision token for the latest dev runtime artifact snapshot.
  */
@@ -255,28 +163,73 @@ export function readDevelopmentRuntimeArtifactsRevision(
 }
 
 /**
- * Bounds dev snapshot storage without consulting a Workflow World. The active
- * generation is always retained; retired generations receive a grace period,
- * and the newest retired generations remain as a rebuild-rate safety net.
+ * Starts best-effort cleanup for stale dev-runtime snapshots without delaying
+ * `eve dev` startup or rebuild handling.
  */
+export function pruneDevelopmentRuntimeArtifactsSnapshotsInBackground(appRoot: string): void {
+  void pruneDevelopmentRuntimeArtifactsSnapshots({ appRoot }).catch((error) => {
+    console.warn(`[eve:dev] failed to prune stale runtime snapshots: ${formatErrorMessage(error)}`);
+  });
+}
+
 export async function pruneDevelopmentRuntimeArtifactsSnapshots(input: {
   readonly appRoot: string;
-  readonly gracePeriodMs?: number;
   readonly now?: number;
+  readonly recentWindowMs?: number;
   readonly retainCount?: number;
 }): Promise<void> {
+  const snapshotsDirectory = resolveDevelopmentRuntimeArtifactsSnapshotsDirectory(input.appRoot);
   const pointer = readDevelopmentRuntimeArtifactsPointer(
     resolveDevelopmentRuntimeArtifactsPointerPath(input.appRoot),
   );
-  await pruneDevelopmentRuntimeArtifactsSnapshotDirectory({
-    activeSnapshotRoot:
-      pointer?.version === DEV_RUNTIME_ARTIFACTS_POINTER_VERSION ? pointer.snapshotRoot : undefined,
-    gracePeriodMs: input.gracePeriodMs,
-    now: input.now,
-    protectAll: pointer?.version === 1,
-    retainCount: input.retainCount,
-    snapshotsDirectory: resolveDevelopmentRuntimeArtifactsSnapshotsDirectory(input.appRoot),
-  });
+  const protectedPaths = [
+    ...collectProtectedSnapshotPaths(pointer),
+    ...(await collectProtectedReferenceSnapshotPaths({
+      appRoot: input.appRoot,
+      snapshotsDirectory,
+    })),
+  ];
+  const now = input.now ?? Date.now();
+  const recentWindowMs = input.recentWindowMs ?? DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS;
+  const retainCount = input.retainCount ?? DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT;
+
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(snapshotsDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  const snapshots = (
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory())
+        .map(async (entry) => {
+          const path = join(snapshotsDirectory, entry.name);
+          return {
+            path,
+            mtimeMs: (await stat(path)).mtimeMs,
+          };
+        }),
+    )
+  ).sort((left, right) => right.mtimeMs - left.mtimeMs);
+
+  await Promise.all(
+    snapshots.map(async (snapshot, index) => {
+      if (
+        index < retainCount ||
+        now - snapshot.mtimeMs <= recentWindowMs ||
+        protectedPaths.some((protectedPath) => pathsOverlap(snapshot.path, protectedPath))
+      ) {
+        return;
+      }
+
+      await rm(snapshot.path, { force: true, recursive: true });
+    }),
+  );
 }
 
 function readDevelopmentRuntimeArtifactsPointer(
@@ -333,19 +286,159 @@ function readDevelopmentRuntimeArtifactsPointer(
   }
 }
 
+function collectProtectedSnapshotPaths(
+  pointer: DevelopmentRuntimeArtifactsPointerV1 | DevelopmentRuntimeArtifactsPointerV2 | undefined,
+): readonly string[] {
+  if (pointer === undefined) {
+    return [];
+  }
+
+  if (pointer.version === 1) {
+    return [pointer.appRoot];
+  }
+
+  return [pointer.runtimeAppRoot, pointer.snapshotRoot];
+}
+
+async function collectProtectedReferenceSnapshotPaths(input: {
+  readonly appRoot: string;
+  readonly snapshotsDirectory: string;
+}): Promise<readonly string[]> {
+  const referenceDirectories = [
+    join(input.appRoot, ".workflow-data"),
+    join(input.appRoot, ".eve", "nitro"),
+  ];
+  const snapshotPaths = new Set<string>();
+
+  await Promise.all(
+    referenceDirectories.map((directory) =>
+      collectSnapshotPathsFromDirectory({
+        directory,
+        snapshotPaths,
+        snapshotsDirectory: input.snapshotsDirectory,
+      }),
+    ),
+  );
+
+  return [...snapshotPaths];
+}
+
+async function collectSnapshotPathsFromDirectory(input: {
+  readonly directory: string;
+  readonly snapshotPaths: Set<string>;
+  readonly snapshotsDirectory: string;
+}): Promise<void> {
+  let entries: Dirent<string>[];
+
+  try {
+    entries = await readdir(input.directory, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(input.directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await collectSnapshotPathsFromDirectory({
+          directory: path,
+          snapshotPaths: input.snapshotPaths,
+          snapshotsDirectory: input.snapshotsDirectory,
+        });
+        return;
+      }
+
+      if (!entry.isFile()) {
+        return;
+      }
+
+      const fileStats = await stat(path);
+      // Protected-reference files are small; keep this best-effort scan cheap.
+      if (fileStats.size > DEV_RUNTIME_PROTECTED_REFERENCE_MAX_SCAN_BYTES) {
+        return;
+      }
+
+      const source = await readFile(path, "utf8");
+      if (!shouldScanWorkflowDataSource(source)) {
+        return;
+      }
+
+      for (const snapshotPath of collectSnapshotPathsFromText(source, input.snapshotsDirectory)) {
+        input.snapshotPaths.add(snapshotPath);
+      }
+    }),
+  );
+}
+
+function collectSnapshotPathsFromText(
+  source: string,
+  snapshotsDirectory: string,
+): readonly string[] {
+  const snapshotPaths = new Set<string>();
+  const normalizedSnapshotsDirectory = snapshotsDirectory.replaceAll("\\", "/");
+  const pattern = new RegExp(`${escapeRegExp(normalizedSnapshotsDirectory)}/([^/"'\\s]+)`, "gu");
+  const normalizedSource = source.replaceAll("\\\\", "/").replaceAll("\\", "/");
+
+  for (const match of normalizedSource.matchAll(pattern)) {
+    const snapshotName = match[1];
+
+    if (snapshotName !== undefined && snapshotName.length > 0) {
+      snapshotPaths.add(join(snapshotsDirectory, snapshotName));
+    }
+  }
+
+  return [...snapshotPaths];
+}
+
+function shouldScanWorkflowDataSource(source: string): boolean {
+  const value = parseJsonObject(source);
+  if (value === undefined) {
+    return true;
+  }
+
+  const status = value.status;
+  return typeof status !== "string" || !TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
+}
+
+function parseJsonObject(source: string): Record<string, unknown> | undefined {
+  try {
+    const value = JSON.parse(source) as unknown;
+    return isObjectRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return isPathInsideOrEqual(left, right) || isPathInsideOrEqual(right, left);
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function rewriteSnapshotCompiledManifest(input: {
   readonly appRoot: string;
   readonly manifestPath: string;
   readonly runtimeAppRoot: string;
-  readonly snapshotSourceRoot: string;
-  readonly sourceRoot: string;
 }): Promise<void> {
   const manifest = JSON.parse(await readFile(input.manifestPath, "utf8")) as unknown;
   const rewritten = rewriteManifestRoots({
     appRoot: input.appRoot,
     runtimeAppRoot: input.runtimeAppRoot,
-    snapshotSourceRoot: input.snapshotSourceRoot,
-    sourceRoot: input.sourceRoot,
     value: manifest,
   });
 
@@ -355,8 +448,6 @@ async function rewriteSnapshotCompiledManifest(input: {
 function rewriteManifestRoots(input: {
   readonly appRoot: string;
   readonly runtimeAppRoot: string;
-  readonly snapshotSourceRoot: string;
-  readonly sourceRoot: string;
   readonly value: unknown;
 }): unknown {
   if (Array.isArray(input.value)) {
@@ -378,41 +469,14 @@ function rewriteManifestRoots(input: {
       continue;
     }
 
-    if (typeof value === "string" && key === "sourceRoot") {
-      rewritten[key] = rewritePathWithinSourceRoot({
-        path: value,
-        snapshotSourceRoot: input.snapshotSourceRoot,
-        sourceRoot: input.sourceRoot,
-      });
-      continue;
-    }
-
     rewritten[key] = rewriteManifestRoots({
       appRoot: input.appRoot,
       runtimeAppRoot: input.runtimeAppRoot,
-      snapshotSourceRoot: input.snapshotSourceRoot,
-      sourceRoot: input.sourceRoot,
       value,
     });
   }
 
   return rewritten;
-}
-
-function rewritePathWithinSourceRoot(input: {
-  readonly path: string;
-  readonly snapshotSourceRoot: string;
-  readonly sourceRoot: string;
-}): string {
-  if (!isPathInsideOrEqual(input.path, input.sourceRoot)) {
-    return input.path;
-  }
-
-  return toDevelopmentSourceSnapshotPath({
-    snapshotSourceRoot: input.snapshotSourceRoot,
-    sourcePath: input.path,
-    sourceRoot: input.sourceRoot,
-  });
 }
 
 function rewritePathWithinAppRoot(input: {
@@ -437,6 +501,7 @@ async function writeDevelopmentRuntimeArtifactsPointer(input: {
   readonly snapshot: DevelopmentRuntimeArtifactsSnapshot;
 }): Promise<void> {
   const pointerPath = resolveDevelopmentRuntimeArtifactsPointerPath(input.appRoot);
+  const temporaryPointerPath = `${pointerPath}.${randomUUID()}.tmp`;
   const pointer: DevelopmentRuntimeArtifactsPointerV2 = {
     appRoot: input.appRoot,
     kind: "eve-dev-runtime-artifacts-pointer",
@@ -445,76 +510,14 @@ async function writeDevelopmentRuntimeArtifactsPointer(input: {
     version: DEV_RUNTIME_ARTIFACTS_POINTER_VERSION,
   };
 
-  await writeDevelopmentRuntimeArtifactsPointerSource(
-    pointerPath,
-    `${JSON.stringify(pointer, null, 2)}\n`,
-  );
-}
-
-async function writeDevelopmentRuntimeArtifactsPointerSource(
-  pointerPath: string,
-  source: string,
-): Promise<void> {
-  const temporaryPointerPath = `${pointerPath}.${randomUUID()}.tmp`;
   await mkdir(dirname(pointerPath), { recursive: true });
-  await writeFile(temporaryPointerPath, source);
+  await writeFile(temporaryPointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
   try {
-    await renameWithTransientBusyRetry(temporaryPointerPath, pointerPath);
+    await rename(temporaryPointerPath, pointerPath);
   } catch (error) {
     await rm(temporaryPointerPath, { force: true }).catch(() => {});
     throw error;
   }
-}
-
-async function readOptionalFile(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, "utf8");
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-async function rollbackFailedActivation(input: {
-  readonly cause: unknown;
-  readonly markerPath: string;
-  readonly pointerPath: string;
-  readonly previousPointerSource: string | undefined;
-}): Promise<unknown> {
-  const rollbackError = await restoreDevelopmentRuntimeArtifactsActivation(input);
-  if (rollbackError === undefined) {
-    return input.cause;
-  }
-  return new AggregateError(
-    [input.cause, rollbackError],
-    "Development runtime activation and rollback failed.",
-    { cause: input.cause },
-  );
-}
-
-async function restoreDevelopmentRuntimeArtifactsActivation(input: {
-  readonly markerPath: string;
-  readonly pointerPath: string;
-  readonly previousPointerSource: string | undefined;
-}): Promise<AggregateError | undefined> {
-  const restoration = await Promise.allSettled([
-    input.previousPointerSource === undefined
-      ? rm(input.pointerPath, { force: true })
-      : writeDevelopmentRuntimeArtifactsPointerSource(
-          input.pointerPath,
-          input.previousPointerSource,
-        ),
-    rm(input.markerPath, { force: true }),
-  ]);
-  const errors = restoration.flatMap((result) =>
-    result.status === "rejected" ? [result.reason] : [],
-  );
-  if (errors.length === 0) {
-    return undefined;
-  }
-  return new AggregateError(errors, "Failed to restore development runtime activation.");
 }
 
 async function validateSnapshotCompiledManifestRoots(input: {


### PR DESCRIPTION
## Summary

- protect stale dev-runtime snapshots that are still referenced by generated `.eve/nitro` artifacts
- keep existing pointer and active workflow-data protections intact while allowing unrelated stale snapshots to prune
- add regression coverage for an aggressive prune that preserves a Nitro-referenced snapshot

Refs #534.

## Tests

- `pnpm install` (completed; hook installer printed an `ENOTDIR` warning because this checkout is a Git worktree)
- `pnpm --filter eve run test:integration -- src/internal/nitro/dev-runtime-artifacts.integration.test.ts -t 'generated Nitro files'` (50 files passed, 386 tests passed)
- `pnpm --filter eve run typecheck`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check packages/eve/src/internal/nitro/dev-runtime-artifacts.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts .changeset/dev-runtime-nitro-prune-protection.md`
- `pnpm exec oxlint packages/eve/src/internal/nitro/dev-runtime-artifacts.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts`
- `git diff --check`
- `pnpm changeset status --since origin/main`
