### PR TITLE
fix(eve): stabilize Teams continuation tokens

### DIFF
--- a/.changeset/teams-stable-continuation.md
+++ b/.changeset/teams-stable-continuation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Normalize Teams channel-thread conversation ids when deriving continuation tokens so parked messages and later card invokes resume the same session.

--- a/packages/eve/src/public/channels/teams/api.test.ts
+++ b/packages/eve/src/public/channels/teams/api.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   callTeamsConnectorApi,
+  parseTeamsConversationThreadId,
   replyToTeamsActivity,
   resolveTeamsAccessToken,
   sendTeamsActivity,
   splitTeamsMessageText,
-  normalizeTeamsContinuationAddress,
   teamsContinuationToken,
   triggerTeamsTypingIndicator,
   updateTeamsActivity,
@@ -23,22 +23,28 @@ describe("Teams Connector API wrapper", () => {
     ).toBe("T%201:19%3Aabc%40thread.skype:A%3A1");
   });
 
-  it("normalizes channel thread suffixes before building continuation tokens", () => {
-    expect(
-      normalizeTeamsContinuationAddress({
-        conversationId: "19:abc@thread.tacv2;messageid=THREAD_ROOT",
-        replyToActivityId: "VOLATILE_ACTIVITY",
-      }),
-    ).toEqual({
-      conversationId: "19:abc@thread.tacv2",
-      replyToActivityId: "THREAD_ROOT",
+  it("normalizes channel-thread conversation suffixes in continuation tokens", () => {
+    expect(parseTeamsConversationThreadId("19:abc@thread.skype;messageid=A%3A1")).toEqual({
+      conversationId: "19:abc@thread.skype",
+      threadRootActivityId: "A:1",
+    });
+    expect(parseTeamsConversationThreadId("19:abc@thread.skype;messageid=")).toEqual({
+      conversationId: "19:abc@thread.skype",
+      threadRootActivityId: undefined,
     });
     expect(
       teamsContinuationToken({
-        conversationId: "19:abc@thread.tacv2;messageid=THREAD_ROOT",
-        tenantId: "TENANT",
+        conversationId: "19:abc@thread.skype;messageid=A%3A1",
+        tenantId: "T 1",
       }),
-    ).toBe("TENANT:19%3Aabc%40thread.tacv2:THREAD_ROOT");
+    ).toBe("T%201:19%3Aabc%40thread.skype:A%3A1");
+    expect(
+      teamsContinuationToken({
+        conversationId: "19:abc@thread.skype;messageid=stale",
+        replyToActivityId: "A:1",
+        tenantId: "T 1",
+      }),
+    ).toBe("T%201:19%3Aabc%40thread.skype:A%3A1");
   });
 
   it("requests and caches Bot Connector access tokens", async () => {

--- a/packages/eve/src/public/channels/teams/api.ts
+++ b/packages/eve/src/public/channels/teams/api.ts
@@ -129,38 +129,50 @@ const accessTokenCache = new Map<
   { readonly accessToken: string; readonly expiresAt: number }
 >();
 
+/** Normalized Teams conversation id plus the thread root encoded in `;messageid=...`, when present. */
+export interface TeamsConversationThreadParts {
+  readonly conversationId: string;
+  readonly threadRootActivityId?: string;
+}
+
+/** Splits Bot Framework channel-thread conversation ids like `19:...;messageid=...`. */
+export function parseTeamsConversationThreadId(
+  conversationId: string,
+): TeamsConversationThreadParts {
+  const [baseConversationId, ...parameters] = conversationId.split(";");
+  let threadRootActivityId: string | undefined;
+
+  for (const parameter of parameters) {
+    const separatorIndex = parameter.indexOf("=");
+    const key = separatorIndex === -1 ? parameter : parameter.slice(0, separatorIndex);
+    if (key.toLowerCase() !== "messageid") continue;
+
+    const rawValue = separatorIndex === -1 ? "" : parameter.slice(separatorIndex + 1);
+    const decodedValue = decodeTeamsConversationPart(rawValue);
+    if (decodedValue) threadRootActivityId = decodedValue;
+    break;
+  }
+
+  return {
+    conversationId: baseConversationId || conversationId,
+    threadRootActivityId,
+  };
+}
+
 /** Builds the channel-local continuation token for one Teams conversation/thread. */
 export function teamsContinuationToken(input: {
   readonly conversationId: string;
   readonly replyToActivityId?: string | null;
   readonly tenantId?: string | null;
 }): string {
-  const address = normalizeTeamsContinuationAddress(input);
-  return [input.tenantId ?? "_", address.conversationId, address.replyToActivityId ?? ""]
+  const conversation = parseTeamsConversationThreadId(input.conversationId);
+  return [
+    input.tenantId ?? "_",
+    conversation.conversationId,
+    input.replyToActivityId ?? conversation.threadRootActivityId ?? "",
+  ]
     .map((component) => encodeURIComponent(component))
     .join(":");
-}
-
-/** Normalizes the thread suffix that Teams inconsistently includes in channel conversation ids. */
-export function normalizeTeamsContinuationAddress(input: {
-  readonly conversationId: string;
-  readonly replyToActivityId?: string | null;
-}): { readonly conversationId: string; readonly replyToActivityId: string | null } {
-  const marker = ";messageid=";
-  const markerIndex = input.conversationId.lastIndexOf(marker);
-  if (markerIndex < 0) {
-    return {
-      conversationId: input.conversationId,
-      replyToActivityId: input.replyToActivityId ?? null,
-    };
-  }
-
-  const conversationId = input.conversationId.slice(0, markerIndex);
-  const threadRoot = input.conversationId.slice(markerIndex + marker.length);
-  return {
-    conversationId,
-    replyToActivityId: threadRoot || input.replyToActivityId || null,
-  };
 }
 
 /** Resolves a Teams app id, falling back to `MICROSOFT_APP_ID` then `TEAMS_APP_ID`. */
@@ -387,6 +399,14 @@ function normalizeAccessTokenResult(result: TeamsAccessTokenResult): {
     accessToken: result.accessToken,
     expiresAt,
   };
+}
+
+function decodeTeamsConversationPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function toPostedActivity(body: unknown): TeamsPostedActivity {

--- a/packages/eve/src/public/channels/teams/inbound.test.ts
+++ b/packages/eve/src/public/channels/teams/inbound.test.ts
@@ -35,6 +35,20 @@ describe("Teams inbound parsing", () => {
     );
   });
 
+  it("prefers channel-thread messageid suffixes as the Teams thread root", () => {
+    const activity = parseTeamsActivity(
+      messageActivity({
+        conversationId: "CONV;messageid=ROOT_FROM_CONVERSATION",
+        conversationType: "channel",
+        replyToId: "VOLATILE_REPLY",
+      }),
+    );
+
+    expect(activity?.type === "message" ? teamsThreadRootActivityId(activity) : "bad").toBe(
+      "ROOT_FROM_CONVERSATION",
+    );
+  });
+
   it("keeps ambient RSC messages parseable but unmentioned", () => {
     const raw = messageActivity({ conversationType: "groupChat", text: "ambient" });
     raw.entities = [];
@@ -64,7 +78,9 @@ describe("Teams inbound parsing", () => {
 });
 
 function messageActivity(input: {
+  readonly conversationId?: string;
   readonly conversationType: string;
+  readonly replyToId?: string;
   readonly text?: string;
 }): Record<string, unknown> {
   return {
@@ -73,7 +89,7 @@ function messageActivity(input: {
       team: { id: "TEAM" },
       tenant: { id: "TENANT" },
     },
-    conversation: { conversationType: input.conversationType, id: "CONV" },
+    conversation: { conversationType: input.conversationType, id: input.conversationId ?? "CONV" },
     entities: [
       {
         mentioned: { id: "BOT", name: "eve Bot" },
@@ -84,6 +100,7 @@ function messageActivity(input: {
     from: { id: "USER", name: "Ada" },
     id: "ACTIVITY_1",
     recipient: { id: "BOT", name: "eve Bot" },
+    replyToId: input.replyToId,
     serviceUrl: "https://smba.example.test/teams",
     text: input.text ?? "hello",
     textFormat: "xml",

--- a/packages/eve/src/public/channels/teams/inbound.ts
+++ b/packages/eve/src/public/channels/teams/inbound.ts
@@ -12,6 +12,7 @@ import type {
   TeamsChannelAccount,
   TeamsMention,
 } from "#public/channels/teams/api.js";
+import { parseTeamsConversationThreadId } from "#public/channels/teams/api.js";
 import { isNonEmptyString, isObject } from "#shared/guards.js";
 import { parseJsonObject } from "#shared/json.js";
 
@@ -126,7 +127,11 @@ export function teamsThreadRootActivityId(
   activity: TeamsMessageActivity | TeamsInvokeActivity,
 ): string | null {
   if (activity.scope === "personal") return null;
-  return activity.replyToId ?? activity.id;
+  return (
+    parseTeamsConversationThreadId(activity.conversation.id).threadRootActivityId ??
+    activity.replyToId ??
+    activity.id
+  );
 }
 
 /**

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -14,11 +14,6 @@ function asCompiled<T = unknown>(channel: unknown): CompiledChannel<T> {
 async function firePost(
   channel: unknown,
   body: Record<string, unknown>,
-  overrides: {
-    readonly resolveActiveSession?: (options: {
-      readonly continuationToken: string;
-    }) => Promise<{ readonly sessionId: string } | undefined>;
-  } = {},
 ): Promise<{
   readonly response: Response;
   readonly send: ReturnType<typeof vi.fn>;
@@ -32,9 +27,7 @@ async function firePost(
 
   const send = vi.fn(async (_input: unknown, _options: unknown) => ({
     continuationToken: "TOKEN",
-    cancel: async () => ({ status: "no_active_turn" as const }),
     getEventStream: async () => new ReadableStream(),
-    getStreamTailIndex: async () => -1,
     id: "SESSION",
   }));
   const waitUntil = vi.fn();
@@ -46,9 +39,6 @@ async function firePost(
     }),
     {
       getSession: vi.fn(),
-      resolveActiveSession: overrides.resolveActiveSession ?? vi.fn().mockResolvedValue(undefined),
-      cancel: vi.fn(),
-      reset: vi.fn(),
       params: {},
       receive: vi.fn(),
       requestIp: null,
@@ -118,91 +108,16 @@ describe("teamsChannel", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("default dispatch ignores bot-authored personal messages", async () => {
-    const channel = teamsChannel({ credentials: { webhookVerifier: () => true } });
-    const raw = messageActivity({ conversationType: "personal" });
-    raw.from = { id: "OTHER_BOT", name: "Other bot", role: "bot" };
-
-    const { send } = await firePost(channel, raw);
-
-    expect(send).not.toHaveBeenCalled();
-  });
-
-  it("exposes the subscription helper to onMessage", async () => {
-    const observed: boolean[] = [];
-    const resolveActiveSession = vi.fn().mockResolvedValue({ sessionId: "SESSION" });
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      async onMessage(ctx) {
-        observed.push(await ctx.isSubscribed());
-        return null;
-      },
-    });
-    const raw = messageActivity({ conversationType: "channel" });
-    raw.entities = [];
-    raw.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
-
-    await firePost(channel, raw, { resolveActiveSession });
-
-    expect(observed).toEqual([true]);
-    expect(resolveActiveSession).toHaveBeenCalledWith({
-      continuationToken: "TENANT:CONV:THREAD_ROOT",
-    });
-  });
-
-  it("allows a mention-or-subscription onMessage policy", async () => {
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      async onMessage(ctx, message) {
-        return message.isBotMentioned || (await ctx.isSubscribed()) ? { auth: null } : null;
-      },
-    });
-    const raw = messageActivity({ conversationType: "channel" });
-    raw.entities = [];
-    raw.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
-
-    const { send } = await firePost(channel, raw, {
-      resolveActiveSession: vi.fn().mockResolvedValue({ sessionId: "SESSION" }),
-    });
-
-    expect(send).toHaveBeenCalledTimes(1);
-  });
-
-  it("passes bot-authored messages to onMessage", async () => {
-    const onMessage = vi.fn((_ctx: unknown, _message: unknown) => null);
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      onMessage,
-    });
-    const raw = messageActivity({ conversationType: "channel" });
-    raw.entities = [];
-    raw.from = { id: "OTHER_BOT", name: "Other bot", role: "bot" };
-
-    const { send } = await firePost(channel, raw);
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
-    expect(onMessage).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ from: expect.objectContaining({ id: "OTHER_BOT", role: "bot" }) }),
-    );
-    expect(send).not.toHaveBeenCalled();
-  });
-
-  it("resumes invoke HITL responses with the clicker's auth and recorded thread", async () => {
+  it("handles Adaptive Card invoke HITL responses", async () => {
     const channel = teamsChannel({ credentials: { webhookVerifier: () => true } });
     const { response, send } = await firePost(channel, {
       ...baseActivity({ conversationType: "channel" }),
-      from: { aadObjectId: "AAD_USER", id: "USER", name: "Ada" },
       name: "adaptiveCard/action",
       type: "invoke",
       value: {
         action: {
           data: {
-            eve_input: {
-              replyToActivityId: "THREAD_ROOT",
-              requestId: "REQ",
-              optionId: "approve",
-            },
+            eve_input: { requestId: "REQ", optionId: "approve" },
           },
         },
       },
@@ -212,104 +127,67 @@ describe("teamsChannel", () => {
     expect(send).toHaveBeenCalledWith(
       { inputResponses: [{ optionId: "approve", requestId: "REQ" }] },
       expect.objectContaining({
-        auth: expect.objectContaining({ subject: "AAD_USER" }),
-        continuationToken: "TENANT:CONV:THREAD_ROOT",
+        auth: null,
+        continuationToken: "TENANT:CONV:ACTIVITY_1",
       }),
     );
   });
 
-  it("handles unmentioned message-form HITL responses before the mention gate", async () => {
-    const onMessage = vi.fn(() => null);
-    const raw = messageActivity({ conversationType: "channel" });
-    raw.entities = [];
-    raw.text = "";
-    raw.value = {
-      eve_input: {
-        replyToActivityId: "THREAD_ROOT",
-        requestId: "REQ",
-        optionId: "deny",
+  it("uses the same continuation token for suffixed channel messages and bare invokes", async () => {
+    const channel = teamsChannel({
+      credentials: { webhookVerifier: () => true },
+      onMessage() {
+        return {
+          auth: {
+            attributes: {},
+            authenticator: "test",
+            principalId: "USER",
+            principalType: "user",
+          },
+        };
       },
-    };
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      onInputResponse: () => ({ auth: null }),
-      onMessage,
     });
 
-    const { send } = await firePost(channel, raw);
-
-    expect(onMessage).not.toHaveBeenCalled();
-    expect(send).toHaveBeenCalledWith(
-      { inputResponses: [{ optionId: "deny", requestId: "REQ" }] },
-      expect.objectContaining({ continuationToken: "TENANT:CONV:THREAD_ROOT" }),
+    const message = await firePost(
+      channel,
+      messageActivity({
+        conversationId: "CONV;messageid=ROOT_ACTIVITY",
+        conversationType: "channel",
+        id: "REPLY_ACTIVITY",
+        replyToId: "VOLATILE_REPLY",
+      }),
     );
-  });
-
-  it("rejects HITL responses when a custom message gate has no input gate", async () => {
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      onMessage: () => ({ auth: null }),
-    });
-    const { send } = await firePost(channel, {
-      ...baseActivity({ conversationType: "channel" }),
+    const invoke = await firePost(channel, {
+      ...baseActivity({
+        conversationId: "CONV",
+        conversationType: "channel",
+        replyToId: "ROOT_ACTIVITY",
+      }),
       name: "adaptiveCard/action",
       type: "invoke",
       value: {
         action: {
           data: {
-            eve_input: {
-              replyToActivityId: "THREAD_ROOT",
-              requestId: "REQ",
-              optionId: "approve",
-            },
+            eve_input: { requestId: "REQ", optionId: "approve" },
           },
         },
       },
     });
 
-    expect(send).not.toHaveBeenCalled();
-  });
-
-  it("normalizes suffixed channel conversation ids", async () => {
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      onMessage: () => ({ auth: null }),
+    expect(message.send.mock.calls[0]![1]).toMatchObject({
+      continuationToken: "TENANT:CONV:ROOT_ACTIVITY",
+      state: {
+        conversationId: "CONV;messageid=ROOT_ACTIVITY",
+        replyToActivityId: "ROOT_ACTIVITY",
+      },
     });
-    const raw = messageActivity({ conversationType: "channel" });
-    raw.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
-    raw.replyToId = "VOLATILE_ACTIVITY";
-
-    const { send } = await firePost(channel, raw);
-
-    expect(send.mock.calls[0]![1]).toMatchObject({
-      continuationToken: "TENANT:CONV:THREAD_ROOT",
-      state: { replyToActivityId: "THREAD_ROOT" },
+    expect(invoke.send.mock.calls[0]![1]).toMatchObject({
+      continuationToken: "TENANT:CONV:ROOT_ACTIVITY",
+      state: {
+        conversationId: "CONV",
+        replyToActivityId: "ROOT_ACTIVITY",
+      },
     });
-  });
-
-  it("keeps a channel thread token stable when follow-ups omit replyToId", async () => {
-    const channel = teamsChannel({
-      credentials: { webhookVerifier: () => true },
-      onMessage: () => ({ auth: null }),
-    });
-    const initial = messageActivity({ conversationType: "channel" });
-    initial.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
-    initial.id = "THREAD_ROOT";
-    const followUp = messageActivity({ conversationType: "channel" });
-    followUp.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
-    followUp.id = "FOLLOW_UP_ACTIVITY";
-
-    const initialRequest = await firePost(channel, initial);
-    const followUpRequest = await firePost(channel, followUp);
-    const initialOptions = initialRequest.send.mock.calls[0]![1] as {
-      readonly continuationToken: string;
-    };
-
-    expect(followUpRequest.send.mock.calls[0]![1]).toMatchObject({
-      continuationToken: initialOptions.continuationToken,
-      state: { replyToActivityId: "THREAD_ROOT" },
-    });
-    expect(initialOptions.continuationToken).toBe("TENANT:CONV:THREAD_ROOT");
   });
 
   it("receive starts proactive sessions and anchors initial channel messages", async () => {
@@ -328,9 +206,7 @@ describe("teamsChannel", () => {
     });
     const send = vi.fn(async (_input: unknown, _options: unknown) => ({
       continuationToken: "TOKEN",
-      cancel: async () => ({ status: "no_active_turn" as const }),
       getEventStream: async () => new ReadableStream(),
-      getStreamTailIndex: async () => -1,
       id: "SESSION",
     }));
 
@@ -357,7 +233,12 @@ describe("teamsChannel", () => {
   });
 });
 
-function messageActivity(input: { readonly conversationType: string }): Record<string, unknown> {
+function messageActivity(input: {
+  readonly conversationId?: string;
+  readonly conversationType: string;
+  readonly id?: string;
+  readonly replyToId?: string;
+}): Record<string, unknown> {
   return {
     ...baseActivity(input),
     entities: [
@@ -373,17 +254,23 @@ function messageActivity(input: { readonly conversationType: string }): Record<s
   };
 }
 
-function baseActivity(input: { readonly conversationType: string }): Record<string, unknown> {
+function baseActivity(input: {
+  readonly conversationId?: string;
+  readonly conversationType: string;
+  readonly id?: string;
+  readonly replyToId?: string;
+}): Record<string, unknown> {
   return {
     channelData: {
       channel: { id: "CHANNEL" },
       team: { id: "TEAM" },
       tenant: { id: "TENANT" },
     },
-    conversation: { conversationType: input.conversationType, id: "CONV" },
+    conversation: { conversationType: input.conversationType, id: input.conversationId ?? "CONV" },
     from: { id: "USER", name: "Ada" },
-    id: "ACTIVITY_1",
+    id: input.id ?? "ACTIVITY_1",
     recipient: { id: "BOT", name: "eve Bot" },
+    replyToId: input.replyToId,
     serviceUrl: "https://smba.example.test/teams",
   };
 }


### PR DESCRIPTION
## Summary

- normalize Teams channel-thread conversation ids carrying `;messageid=...` before deriving continuation tokens
- prefer the parsed channel-thread root over volatile inbound `replyToId` for channel/group thread anchors
- ignore empty `messageid` suffixes so they cannot become thread roots

Refs #451.

## Tests

- `pnpm exec oxfmt --check packages/eve/src/public/channels/teams/api.ts packages/eve/src/public/channels/teams/api.test.ts packages/eve/src/public/channels/teams/inbound.ts packages/eve/src/public/channels/teams/inbound.test.ts packages/eve/src/public/channels/teams/teamsChannel.test.ts .changeset/teams-stable-continuation.md`
- `pnpm --filter eve exec oxlint src/public/channels/teams/api.ts src/public/channels/teams/api.test.ts src/public/channels/teams/inbound.ts src/public/channels/teams/inbound.test.ts src/public/channels/teams/teamsChannel.test.ts --deny-warnings`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/teams/api.test.ts src/public/channels/teams/inbound.test.ts src/public/channels/teams/teamsChannel.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm changeset status --since origin/main`
- `pnpm guard:invariants`
- `git diff --check && git diff --cached --check`