### PR TITLE
fix(eve): rethrow non-terminal task-mode model failures for durable step retry

### DIFF
--- a/.changeset/task-mode-durable-step-retry.md
+++ b/.changeset/task-mode-durable-step-retry.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Task-mode (subagent) runs no longer fail permanently on transient model errors such as a mid-stream provider overload. The harness now rethrows non-terminal model-call failures so the durable workflow engine retries the step from the last committed session state, preserving completed work; the run only ends with a failed subagent result once retries are exhausted or the error is unrecoverable.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -111,6 +111,8 @@ Do not rely on subagent delegation by itself as an approval boundary. Put sensit
 
 Each delegated subagent spins up its own child session and stream. The parent stream carries the control-plane events `subagent.called` and `subagent.completed`, plus interactive `input.requested`, `authorization.required`, and `authorization.completed` events proxied from descendants so the root channel can prompt the user. To follow the child's other progress, read `subagent.called.data.childSessionId` and subscribe at `GET /eve/v1/session/:childSessionId/stream`.
 
+Transient model failures inside a delegated run (for example a provider overload mid-stream) do not end the task: the durable engine retries the failed step from the last committed state, preserving completed work. Only unrecoverable errors, or retries that keep failing, surface to the parent as a failed subagent result.
+
 ## When to split
 
 Split out a subagent when the task needs a different prompt or specialist role, a narrower tool surface, or its own runtime context. Don't reach for one when a [skill](./skills) would do. If the agent can keep its identity and needs only an optional procedure, a skill is the lighter choice.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3248,6 +3248,60 @@ describe("createToolLoopHarness", () => {
     expect(types).toContain("session.failed");
   });
 
+  it("rethrows a non-terminal model-call error in task mode for durable step retry", async () => {
+    setupMockAgentError(new Error("Model blew up"));
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("task", emit));
+
+    // A task run cannot park (`next: null`) for a user retry, so a
+    // non-terminal failure rethrows instead of ending the run: the
+    // turn step runs inside a durable workflow step, and the engine
+    // retries a thrown step from the last committed session snapshot.
+    await expect(runStep(createTestSession(), { message: "Delegated task" })).rejects.toThrow(
+      "Model blew up",
+    );
+
+    // No terminal or park events — the failed attempt must stay
+    // invisible so an engine retry can replay the step cleanly.
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain("step.failed");
+    expect(types).not.toContain("turn.failed");
+    expect(types).not.toContain("session.failed");
+    expect(types).not.toContain("session.waiting");
+  });
+
+  it("rethrows a mid-stream provider overload in task mode instead of failing the run", async () => {
+    // Anthropic overload arrives as a stream `error` part on an already
+    // open HTTP 200 stream — no status code, no `isRetryable` flag — so
+    // it classifies as "recoverable" rather than "retry". In task mode
+    // that must rethrow for the engine's durable step retry, not become
+    // the subagent's terminal error result.
+    vi.mocked(ToolLoopAgent).mockImplementation(function (this: ToolLoopAgent) {
+      this.stream = vi.fn().mockImplementation(async () => ({
+        fullStream: (async function* () {
+          yield { text: "partial answer", type: "text-delta" };
+          yield { error: { message: "Overloaded", type: "overloaded_error" }, type: "error" };
+        })(),
+        steps: new Promise<never>(() => {}),
+      }));
+      return this;
+    } as MockAgentConstructor);
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("task", emit));
+
+    await expect(runStep(createTestSession(), { message: "Delegated task" })).rejects.toThrow(
+      "Overloaded",
+    );
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain("step.failed");
+    expect(types).not.toContain("turn.failed");
+    expect(types).not.toContain("session.failed");
+    expect(types).not.toContain("session.waiting");
+  });
+
   it("emits the full terminal failure cascade on an explicit Gateway invalid-request error", async () => {
     setupMockAgentError(
       createGatewayModelCallError({
@@ -4141,7 +4195,7 @@ describe("createToolLoopHarness", () => {
       }
     });
 
-    it("fails a task run terminally when the reissue also comes back empty", async () => {
+    it("rethrows a task run's empty response when the reissue also comes back empty", async () => {
       setupMockAgent(emptyResult);
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -4149,22 +4203,19 @@ describe("createToolLoopHarness", () => {
       const runStep = createToolLoopHarness(createTestConfig("task", emit));
 
       try {
-        const result = await runStep(createTestSession(), { message: "Hi" });
+        // A task cannot park for a user retry; after the in-harness
+        // reissue is exhausted the failure rethrows so the durable
+        // workflow engine retries the step from committed state.
+        await expect(runStep(createTestSession(), { message: "Hi" })).rejects.toThrow(
+          "did not return a response",
+        );
 
         expect(vi.mocked(ToolLoopAgent).mock.calls.length).toBe(2);
-        // A task cannot park for a user retry; the failure is the task's
-        // terminal result instead of a `next: null` park that turnWorkflow
-        // would reject.
-        expect(result.next).toEqual({
-          done: true,
-          isError: true,
-          output: expect.stringContaining("did not return a response"),
-        });
 
         const types = events.map((event) => event.type);
         expect(types).not.toContain("session.waiting");
-        expect(types).toContain("step.failed");
-        expect(types).toContain("session.failed");
+        expect(types).not.toContain("step.failed");
+        expect(types).not.toContain("session.failed");
       } finally {
         warnSpy.mockRestore();
         errorSpy.mockRestore();

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1141,23 +1141,22 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
         if (config.mode === "task") {
           // A task run cannot park for a user retry (turnWorkflow rejects
-          // `next: null` in task mode), so the failure is the task's
-          // terminal result, mirroring finishTaskTurn's unfulfilled-schema
-          // shape.
-          log.error(
-            requestSummary?.message ?? "model call failed; failing the task run",
+          // `next: null` in task mode), but its step runs inside a durable
+          // workflow step: rethrowing lets the engine retry the model call
+          // from the last committed session snapshot with fresh harness
+          // hooks, preserving the work of every completed step. Exhausted
+          // engine retries flow through the driver's terminal safety net
+          // (emitTerminalSessionFailureStep + the delegated-parent error
+          // notification), so the task still ends with the failed
+          // `subagent-result` it produced here before — now only after
+          // transient failures like a mid-stream provider overload had a
+          // chance to clear.
+          log.warn(
+            requestSummary?.message ??
+              "model call failed transiently in task mode — rethrowing for durable step retry",
             modelCallLogFields,
           );
-          await emitFailedStep(emit, emissionState, {
-            code: "MODEL_CALL_FAILED",
-            details,
-            message: errorMessage,
-            sessionId: session.sessionId,
-          });
-          return {
-            next: { done: true, isError: true, output: errorMessage },
-            session,
-          };
+          throw finalError;
         }
 
         log.error(


### PR DESCRIPTION
### Description

A subagent (task-mode) run died permanently when the provider failed transiently mid-stream — e.g. Anthropic's `overloaded_error`, which arrives as a stream `error` part on an already-open HTTP 200 stream with no status code and no `isRetryable` flag. It therefore classifies as `"recoverable"`, and the task-mode branch of the harness converted it into the task's terminal error result (`{ done: true, isError: true }`), ending the child run and losing all committed work.

Two retry layers already exist, and both were bypassed:

- The in-process model-call retry (`runModelCallWithRetries`) never engages because the error is not classified `"retry"` — and it *cannot* safely be, because a mid-stream error still fires `onStepFinish` in the AI SDK, resolving the harness's one-shot `stepResult` hooks; a same-hooks retry would read the stale partial result (see `step-hooks.ts` docs).
- The workflow engine's built-in step retry (default 3 attempts from the last committed session snapshot) never engages because the harness caught the error and returned a successful step result instead of throwing.

This change makes task mode rethrow non-terminal model-call failures. The engine then retries `turnStep` from the last committed session state — fresh harness, fresh hooks, prior steps' work preserved, and replayed emissions carry identical `turnId`/`stepIndex`/`sequence` stamps that consumers upsert idempotently. When engine retries exhaust, the existing driver safety net (`emitTerminalSessionFailureStep` + delegated-parent error notification) produces the same failed subagent result as before.

Unchanged behavior:

- Terminal classifications (auth/config errors, invalid requests, cancellation) keep the fast-fail task error result (#412).
- Conversation mode still parks recoverably for a user retry.
- Internal callers without an `emit` fn already received raw throws.

This intentionally replaces the deeper in-process stream-retry approach from #610 (closed): the durable engine already provides safe replay semantics that the harness-level retry had to rebuild by hand. A follow-up remains for the latent pre-existing hazard where a mid-stream error *already* classified `"retry"` (e.g. a mid-stream network error) performs an unsafe same-hooks in-process retry.

### How did you test your changes?

- `pnpm test:unit`
- `pnpm test:integration`
- New tests: task-mode rethrow for a generic recoverable error and for a mid-stream `overloaded_error` part (no `step.failed`/`session.failed` emitted); updated the empty-response task test to expect the rethrow; existing terminal (#412) and conversation-park tests unchanged and passing
- `pnpm fmt`, `pnpm lint`, `pnpm typecheck`, `pnpm guard:invariants`, `pnpm docs:check`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)