### PR TITLE
chore(eve): toolchain - update TypeScript to 7.0.2

### DIFF
--- a/.changeset/stable-typescript.md
+++ b/.changeset/stable-typescript.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+New projects created with `eve init` now use stable TypeScript 7.0.2 instead of the release candidate.

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -33,7 +33,7 @@ const BASE_VERSIONS = {
   aiPackageVersion: "7.0.0",
   connectPackageVersion: "0.2.2",
   evePackage: { version: "0.6.0", nodeEngine: ">=24" },
-  typescriptPackageVersion: "7.0.1-rc",
+  typescriptPackageVersion: "7.0.2",
   zodPackageVersion: "4.0.0",
 } as const;
 

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -706,7 +706,7 @@ describe("listAuthoredChannels", () => {
 });
 
 describe("scaffoldBaseProject", () => {
-  test("writes a base eve project with explicit versions", async () => {
+  test("writes a base eve project with the catalog TypeScript version", async () => {
     const targetDirectory = await createTempDir();
     const projectRoot = await scaffoldBaseProject({
       projectName: "demo-agent",
@@ -716,7 +716,6 @@ describe("scaffoldBaseProject", () => {
       aiPackageVersion: "7.0.0",
       connectPackageVersion: "0.2.2",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
     });
 
     const agentSource = await readFile(join(projectRoot, "agent/agent.ts"), "utf8");
@@ -728,6 +727,12 @@ describe("scaffoldBaseProject", () => {
     // running `eve dev`) import @vercel/connect; init ships it so a later
     // channel add never introduces a missing dependency.
     expect(packageJson).toContain('"@vercel/connect": "0.2.2"');
+    // The default path used by `eve init` must carry the stable toolchain
+    // version captured from the workspace catalog into generated projects.
+    expect(JSON.parse(packageJson)).toMatchObject({
+      devDependencies: { typescript: "7.0.2" },
+      engines: { node: "24.x" },
+    });
     // Every scaffold ships @types/node plus tsconfig `types: ["node"]` so agent
     // code touching `process`/`fs` typechecks out of the box, matching the eve
     // agent fixtures (without the `types` entry, NodeNext resolution does not
@@ -737,9 +742,6 @@ describe("scaffoldBaseProject", () => {
       compilerOptions: { types?: string[] };
     };
     expect(tsconfig.compilerOptions.types).toEqual(["node"]);
-    // Pinned to a single major so Vercel builds on a supported Node regardless
-    // of the project's dashboard Node pin.
-    expect(JSON.parse(packageJson)).toMatchObject({ engines: { node: "24.x" } });
     await expect(readFile(join(projectRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toBe(
       PNPM_WORKSPACE_CONTENT,
     );
@@ -774,7 +776,7 @@ describe("scaffoldBaseProject", () => {
         evePackage: TEST_EVE_PACKAGE,
         aiPackageVersion: "7.0.0",
         zodPackageVersion: "4.4.3",
-        typescriptPackageVersion: "7.0.1-rc",
+        typescriptPackageVersion: "7.0.2",
       });
 
       await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
@@ -817,7 +819,7 @@ describe("scaffoldBaseProject", () => {
       aiPackageVersion: "7.0.0",
       connectPackageVersion: "0.2.2",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
@@ -860,7 +862,7 @@ describe("scaffoldBaseProject", () => {
       aiPackageVersion: "7.0.0",
       connectPackageVersion: "0.2.2",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(false);
@@ -915,7 +917,7 @@ describe("scaffoldBaseProject", () => {
         aiPackageVersion: "7.0.0",
         connectPackageVersion: "0.2.2",
         zodPackageVersion: "4.4.3",
-        typescriptPackageVersion: "7.0.1-rc",
+        typescriptPackageVersion: "7.0.2",
       });
 
       const projectPackageJson = JSON.parse(
@@ -973,7 +975,7 @@ describe("scaffoldBaseProject", () => {
         aiPackageVersion: "7.0.0",
         connectPackageVersion: "0.2.2",
         zodPackageVersion: "4.4.3",
-        typescriptPackageVersion: "7.0.1-rc",
+        typescriptPackageVersion: "7.0.2",
       });
 
       const projectPackageJson = JSON.parse(
@@ -1010,7 +1012,7 @@ describe("scaffoldBaseProject", () => {
       evePackage: TEST_EVE_PACKAGE,
       aiPackageVersion: "7.0.0",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     const agentSource = await readFile(join(projectRoot, "agent/agent.ts"), "utf8");
@@ -1033,7 +1035,7 @@ describe("scaffoldBaseProject", () => {
       evePackage: TEST_EVE_PACKAGE,
       aiPackageVersion: "7.0.0",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     const agentSource = await readFile(join(projectRoot, "agent/agent.ts"), "utf8");
@@ -1051,7 +1053,7 @@ describe("scaffoldBaseProject", () => {
       evePackage: { version: "0.25.0", nodeEngine: ">=24.5.0" },
       aiPackageVersion: "7.0.0",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     const packageJson = JSON.parse(await readFile(join(projectRoot, "package.json"), "utf8")) as {
@@ -1071,7 +1073,7 @@ describe("scaffoldBaseProject", () => {
       evePackage: LATEST_EVE_PACKAGE,
       aiPackageVersion: "7.0.0",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
@@ -1088,7 +1090,7 @@ describe("scaffoldBaseProject", () => {
       evePackage: TEST_EVE_PACKAGE,
       aiPackageVersion: "7.0.0",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     const channelPath = join(projectRoot, "agent/channels/eve.ts");
@@ -1112,7 +1114,7 @@ describe("scaffoldBaseProject", () => {
         evePackage: TEST_EVE_PACKAGE,
         aiPackageVersion: "7.0.0",
         zodPackageVersion: "4.4.3",
-        typescriptPackageVersion: "7.0.1-rc",
+        typescriptPackageVersion: "7.0.2",
       }),
     ).rejects.toThrow(/Use an empty directory/);
 
@@ -1127,7 +1129,7 @@ describe("scaffoldBaseProject", () => {
       evePackage: TEST_EVE_PACKAGE,
       aiPackageVersion: "7.0.0",
       zodPackageVersion: "4.4.3",
-      typescriptPackageVersion: "7.0.1-rc",
+      typescriptPackageVersion: "7.0.2",
     });
 
     expect(projectRoot).toBe(targetDirectory);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 2.5.0
       version: 2.5.0
     typescript:
-      specifier: 7.0.1-rc
-      version: 7.0.1-rc
+      specifier: 7.0.2
+      version: 7.0.2
     vitest:
       specifier: 4.1.7
       version: 4.1.7
@@ -106,7 +106,7 @@ importers:
         version: 2.9.18
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
       vercel:
         specifier: 54.14.2
         version: 54.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.4)
@@ -309,7 +309,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   apps/fixtures/weather-agent:
     dependencies:
@@ -551,7 +551,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-channels:
     dependencies:
@@ -579,7 +579,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-model:
     dependencies:
@@ -592,7 +592,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-openapi-swagger:
     dependencies:
@@ -617,7 +617,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-schedules:
     dependencies:
@@ -642,7 +642,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-session-limits:
     dependencies:
@@ -664,7 +664,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-skills:
     dependencies:
@@ -689,7 +689,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-subagents:
     dependencies:
@@ -714,7 +714,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-subagents-hitl:
     dependencies:
@@ -730,7 +730,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-tools:
     dependencies:
@@ -755,7 +755,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-tools-hitl:
     dependencies:
@@ -780,7 +780,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-tools-sandbox:
     dependencies:
@@ -805,7 +805,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   e2e/fixtures/agent-workflow-stress:
     dependencies:
@@ -830,7 +830,7 @@ importers:
         version: 25.9.1
       typescript:
         specifier: 'catalog:'
-        version: 7.0.1-rc
+        version: 7.0.2
 
   packages/eve:
     dependencies:
@@ -6516,122 +6516,122 @@ packages:
     resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/typescript-aix-ppc64@7.0.1-rc':
-    resolution: {integrity: sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==}
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
     cpu: [ppc64]
     os: [aix]
 
-  '@typescript/typescript-darwin-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==}
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/typescript-darwin-x64@7.0.1-rc':
-    resolution: {integrity: sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==}
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==}
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@typescript/typescript-freebsd-x64@7.0.1-rc':
-    resolution: {integrity: sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==}
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@typescript/typescript-linux-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==}
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/typescript-linux-arm@7.0.1-rc':
-    resolution: {integrity: sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==}
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/typescript-linux-loong64@7.0.1-rc':
-    resolution: {integrity: sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==}
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
     engines: {node: '>=16.20.0'}
     cpu: [loong64]
     os: [linux]
 
-  '@typescript/typescript-linux-mips64el@7.0.1-rc':
-    resolution: {integrity: sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==}
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
     engines: {node: '>=16.20.0'}
     cpu: [mips64el]
     os: [linux]
 
-  '@typescript/typescript-linux-ppc64@7.0.1-rc':
-    resolution: {integrity: sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==}
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
     engines: {node: '>=16.20.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@typescript/typescript-linux-riscv64@7.0.1-rc':
-    resolution: {integrity: sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==}
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
     engines: {node: '>=16.20.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@typescript/typescript-linux-s390x@7.0.1-rc':
-    resolution: {integrity: sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==}
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
     engines: {node: '>=16.20.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@typescript/typescript-linux-x64@7.0.1-rc':
-    resolution: {integrity: sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==}
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==}
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@typescript/typescript-netbsd-x64@7.0.1-rc':
-    resolution: {integrity: sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==}
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [netbsd]
 
-  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==}
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@typescript/typescript-openbsd-x64@7.0.1-rc':
-    resolution: {integrity: sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==}
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [openbsd]
 
-  '@typescript/typescript-sunos-x64@7.0.1-rc':
-    resolution: {integrity: sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==}
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [sunos]
 
-  '@typescript/typescript-win32-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==}
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/typescript-win32-x64@7.0.1-rc':
-    resolution: {integrity: sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==}
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
@@ -12379,8 +12379,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@7.0.1-rc:
-    resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -18520,64 +18520,64 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/typescript-aix-ppc64@7.0.1-rc':
+  '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
-  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+  '@typescript/typescript-darwin-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-darwin-x64@7.0.1-rc':
+  '@typescript/typescript-darwin-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+  '@typescript/typescript-freebsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+  '@typescript/typescript-freebsd-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-arm64@7.0.1-rc':
+  '@typescript/typescript-linux-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-arm@7.0.1-rc':
+  '@typescript/typescript-linux-arm@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-loong64@7.0.1-rc':
+  '@typescript/typescript-linux-loong64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+  '@typescript/typescript-linux-mips64el@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+  '@typescript/typescript-linux-ppc64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+  '@typescript/typescript-linux-riscv64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-s390x@7.0.1-rc':
+  '@typescript/typescript-linux-s390x@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-x64@7.0.1-rc':
+  '@typescript/typescript-linux-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+  '@typescript/typescript-netbsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+  '@typescript/typescript-netbsd-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+  '@typescript/typescript-openbsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+  '@typescript/typescript-openbsd-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-sunos-x64@7.0.1-rc':
+  '@typescript/typescript-sunos-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-win32-arm64@7.0.1-rc':
+  '@typescript/typescript-win32-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-win32-x64@7.0.1-rc':
+  '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
   '@ungap/structured-clone@1.3.1': {}
@@ -26178,28 +26178,28 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  typescript@7.0.1-rc:
+  typescript@7.0.2:
     optionalDependencies:
-      '@typescript/typescript-aix-ppc64': 7.0.1-rc
-      '@typescript/typescript-darwin-arm64': 7.0.1-rc
-      '@typescript/typescript-darwin-x64': 7.0.1-rc
-      '@typescript/typescript-freebsd-arm64': 7.0.1-rc
-      '@typescript/typescript-freebsd-x64': 7.0.1-rc
-      '@typescript/typescript-linux-arm': 7.0.1-rc
-      '@typescript/typescript-linux-arm64': 7.0.1-rc
-      '@typescript/typescript-linux-loong64': 7.0.1-rc
-      '@typescript/typescript-linux-mips64el': 7.0.1-rc
-      '@typescript/typescript-linux-ppc64': 7.0.1-rc
-      '@typescript/typescript-linux-riscv64': 7.0.1-rc
-      '@typescript/typescript-linux-s390x': 7.0.1-rc
-      '@typescript/typescript-linux-x64': 7.0.1-rc
-      '@typescript/typescript-netbsd-arm64': 7.0.1-rc
-      '@typescript/typescript-netbsd-x64': 7.0.1-rc
-      '@typescript/typescript-openbsd-arm64': 7.0.1-rc
-      '@typescript/typescript-openbsd-x64': 7.0.1-rc
-      '@typescript/typescript-sunos-x64': 7.0.1-rc
-      '@typescript/typescript-win32-arm64': 7.0.1-rc
-      '@typescript/typescript-win32-x64': 7.0.1-rc
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ua-parser-js@1.0.41: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   react: "19.2.6"
   react-dom: "19.2.6"
   streamdown: "2.5.0"
-  typescript: "7.0.1-rc"
+  typescript: "7.0.2"
   vitest: "4.1.7"
   zod: "4.4.3"
 


### PR DESCRIPTION
## Summary

- replace the TypeScript 7 release candidate with stable TypeScript 7.0.2 in the workspace catalog
- refresh the lockfile, including the platform-specific compiler packages
- remove the remaining 7.0.1-rc references from scaffold and CLI integration fixtures
- verify the default path used by `eve init` writes TypeScript 7.0.2 into generated projects
- preserve the intentional TypeScript 6.0.3 compatibility pins in framework apps

## Why

TypeScript 7 is now stable, so the main eve toolchain and newly scaffolded projects no longer need to depend on the release candidate.

## Impact

The main workspace and catalog consumers now compile with stable TypeScript 7.0.2. New projects created with `eve init` also pin TypeScript 7.0.2. Existing projects and eve runtime behavior are unchanged.

## Release

Includes a patch changeset for the updated `eve init` output.

## Validation

- `pnpm typecheck` (23/23 workspace tasks)
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build` and inspected the stamped scaffold artifact
- targeted scaffold and CLI integration tests (99 tests)
- `pnpm lint`
- `pnpm check:deps`
- `pnpm guard:invariants`
- `pnpm changeset status`
- `git diff --check`
- confirmed no tracked `7.0.1-rc` references remain