### PR TITLE
feat(channels): export helper APIs

### DIFF
--- a/.changeset/channel-helper-exports.md
+++ b/.changeset/channel-helper-exports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose additional channel helper APIs for Slack, GitHub, and Linear integrations.

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -126,6 +126,23 @@ Before the first model call, every triggered turn checks out the relevant ref in
 
 For anything the channel doesn't wrap, call `ctx.github.request({ method, path, body })`. It carries installation-token auth.
 
+Outside a channel handler, use the same transport helper directly:
+
+```ts
+import { callGitHubApi } from "eve/channels/github";
+
+const repo = await callGitHubApi({
+  credentials,
+  installationId,
+  method: "GET",
+  path: "/repos/vercel/eve",
+});
+```
+
+`callGitHubApi` uses the channel's installation-token flow by default, accepts
+the same API base URL and fetch overrides as the channel, and throws
+`GitHubApiError` for non-2xx responses.
+
 ## What to read next
 
 - [Channels overview](./overview): the channel contract and every built-in channel

--- a/docs/channels/linear.mdx
+++ b/docs/channels/linear.mdx
@@ -94,6 +94,21 @@ Inbound file attachments are not supported on this channel today.
 
 Event handlers receive `channel.linear`, which exposes `createActivity`, `listActivities`, and `updateSession` for custom Agent Activity delivery and Agent Session metadata.
 
+When you need to verify Linear webhooks in a custom route before applying
+app-specific filtering, use the same verifier the channel uses:
+
+```ts
+import { verifyLinearRequest } from "eve/channels/linear";
+
+export async function POST(request: Request) {
+  const body = await verifyLinearRequest(request, {
+    webhookSecret: process.env.LINEAR_WEBHOOK_SECRET,
+  });
+
+  return new Response(body);
+}
+```
+
 ## Custom hooks
 
 Return `{ auth }` to dispatch, or `null` to acknowledge without waking the agent.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -134,6 +134,24 @@ export default slackChannel({
 
 HITL renders as Slack buttons and selects. When the user responds, the parked session (paused awaiting input) resumes.
 
+When you only need to add small app-specific context around the stock HITL UI,
+wrap the default renderer instead of copying its Block Kit payloads:
+
+```ts
+import { defaultInputRequestedHandler, slackChannel } from "eve/channels/slack";
+
+const renderDefaultInput = defaultInputRequestedHandler();
+
+export default slackChannel({
+  events: {
+    async "input.requested"(eventData, channel, ctx) {
+      await channel.thread.post("Please review this request.");
+      await renderDefaultInput(eventData, channel, ctx);
+    },
+  },
+});
+```
+
 Authorization prompts split public status from private credentials. A sign-in challenge (OAuth URL, device code) is a credential. Anyone who completes it binds their identity to the session's connection. The default `authorization.required` handler posts a public, link-free status in the thread, delivers the actual challenge ephemerally to the triggering user, device code included, and then updates that public status when `authorization.completed` fires. The handler receives a private-delivery context with `postEphemeral`, `postDirectMessage` (needs the `im:write` scope), and `state`. There is, intentionally, no public `post` and no raw API access.
 
 ```ts

--- a/packages/eve/src/internal/testing/scenario-apps/github-route-portability.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/github-route-portability.ts
@@ -3,13 +3,23 @@ import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
 export const GITHUB_ROUTE_PORTABILITY_DESCRIPTOR: ScenarioAppDescriptor = {
   files: {
     "agent/channels/github.ts": `import {
+  callGitHubApi,
   githubChannel,
+  type GitHubApiResponse,
+  type GitHubRequestOptions,
   type GitHubCheckRunEvent,
   type GitHubCheckSuiteEvent,
   type GitHubWorkflowRunEvent,
 } from "eve/channels/github";
 
 const ignore = <T>(_event: T): null => null;
+const requestOptions: GitHubRequestOptions = { auth: false };
+const repoRequest: Promise<GitHubApiResponse<{ readonly id: number }>> = callGitHubApi({
+  method: "GET",
+  path: "/repos/vercel/eve",
+  options: requestOptions,
+});
+void repoRequest;
 
 export default githubChannel({
   botName: "testbot",

--- a/packages/eve/src/internal/testing/scenario-apps/index.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/index.ts
@@ -3,6 +3,7 @@ export { DISCORD_ROUTE_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario
 export { EXTENSION_AGENT_DESCRIPTOR } from "#internal/testing/scenario-apps/extension-agent.js";
 export { GITHUB_ROUTE_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/github-route-portability.js";
 export { EVE_ROUTE_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/eve-route-portability.js";
+export { LINEAR_ROUTE_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/linear-route-portability.js";
 export { SANDBOX_BUNDLING_DESCRIPTOR } from "#internal/testing/scenario-apps/sandbox-bundling.js";
 export { SANDBOX_WORKSPACES_DESCRIPTOR } from "#internal/testing/scenario-apps/sandbox-workspaces.js";
 export { SLACK_CUSTOM_CHANNEL_PORTABILITY_DESCRIPTOR } from "#internal/testing/scenario-apps/slack-custom-channel-portability.js";

--- a/packages/eve/src/internal/testing/scenario-apps/linear-route-portability.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/linear-route-portability.ts
@@ -1,0 +1,24 @@
+import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
+
+export const LINEAR_ROUTE_PORTABILITY_DESCRIPTOR: ScenarioAppDescriptor = {
+  files: {
+    "agent/channels/linear.ts": `import {
+  linearChannel,
+  verifyLinearRequest,
+  type LinearVerifyOptions,
+} from "eve/channels/linear";
+
+const verifyOptions: LinearVerifyOptions = {
+  webhookSecret: "test-secret",
+};
+const verifiedBody: Promise<string> = verifyLinearRequest(
+  new Request("https://example.com/eve/v1/linear", { method: "POST" }),
+  verifyOptions,
+);
+void verifiedBody;
+
+export default linearChannel({});
+`,
+  },
+  name: "linear-route-portability",
+};

--- a/packages/eve/src/internal/testing/scenario-apps/slack-route-portability.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/slack-route-portability.ts
@@ -2,10 +2,20 @@ import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
 
 export const SLACK_ROUTE_PORTABILITY_DESCRIPTOR: ScenarioAppDescriptor = {
   files: {
-    "agent/channels/slack.ts": `import { slackChannel } from "eve/channels/slack";
+    "agent/channels/slack.ts": `import {
+  defaultInputRequestedHandler,
+  slackChannel,
+  type SlackChannelEvents,
+} from "eve/channels/slack";
+
+const inputRequested: NonNullable<SlackChannelEvents["input.requested"]> =
+  defaultInputRequestedHandler();
 
 export default slackChannel({
   botName: "testbot",
+  events: {
+    "input.requested": inputRequested,
+  },
 });
 `,
   },

--- a/packages/eve/src/public/channels/github/index.ts
+++ b/packages/eve/src/public/channels/github/index.ts
@@ -1,4 +1,5 @@
 export {
+  callGitHubApi,
   GitHubApiError,
   type GitHubApiMethod,
   type GitHubApiOptions,
@@ -6,6 +7,7 @@ export {
   type GitHubJsonObject,
   type GitHubPostedComment,
   type GitHubReactionContent,
+  type GitHubRequestOptions,
 } from "#public/channels/github/api.js";
 export { type GitHubHandle, type GitHubThread } from "#public/channels/github/binding.js";
 export {

--- a/packages/eve/src/public/channels/helper-exports.test.ts
+++ b/packages/eve/src/public/channels/helper-exports.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { callGitHubApi } from "#public/channels/github/index.js";
+import { verifyLinearRequest } from "#public/channels/linear/index.js";
+import { defaultInputRequestedHandler } from "#public/channels/slack/index.js";
+
+describe("channel helper runtime exports", () => {
+  it("loads helpers from their public channel barrels", () => {
+    expect(callGitHubApi).toBeTypeOf("function");
+    expect(verifyLinearRequest).toBeTypeOf("function");
+    expect(defaultInputRequestedHandler).toBeTypeOf("function");
+  });
+});

--- a/packages/eve/src/public/channels/linear/index.ts
+++ b/packages/eve/src/public/channels/linear/index.ts
@@ -61,6 +61,7 @@ export {
 } from "#public/channels/linear/linearChannel.js";
 export {
   signLinearWebhookBody,
+  verifyLinearRequest,
   type LinearVerifyOptions,
   type LinearWebhookVerifier,
 } from "#public/channels/linear/verify.js";

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -50,7 +50,7 @@ export {
   type SlackUploadFilesResult,
 } from "#public/channels/slack/api.js";
 
-export { defaultSlackAuth } from "#public/channels/slack/defaults.js";
+export { defaultInputRequestedHandler, defaultSlackAuth } from "#public/channels/slack/defaults.js";
 
 export {
   describeActionRequest,

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -11,6 +11,7 @@ import {
   EVE_ROUTE_PORTABILITY_DESCRIPTOR,
   DISCORD_ROUTE_PORTABILITY_DESCRIPTOR,
   GITHUB_ROUTE_PORTABILITY_DESCRIPTOR,
+  LINEAR_ROUTE_PORTABILITY_DESCRIPTOR,
   SLACK_ROUTE_PORTABILITY_DESCRIPTOR,
   TEAMS_ROUTE_PORTABILITY_DESCRIPTOR,
   TELEGRAM_ROUTE_PORTABILITY_DESCRIPTOR,
@@ -115,10 +116,20 @@ export default defineSandbox({
   {
     descriptor: GITHUB_ROUTE_PORTABILITY_DESCRIPTOR,
     include: ["src/public/channels/github/index.ts", "src/public/definitions/channel.ts"],
-    name: "lets tsc typecheck a default-exported githubChannel without extra annotations",
+    name: "lets tsc typecheck a default-exported githubChannel and helper API without extra annotations",
     packageExports: {
       "./channels/github": {
         types: "./dist/src/public/channels/github/index.d.ts",
+      },
+    },
+  },
+  {
+    descriptor: LINEAR_ROUTE_PORTABILITY_DESCRIPTOR,
+    include: ["src/public/channels/linear/index.ts", "src/public/definitions/channel.ts"],
+    name: "lets tsc typecheck a default-exported linearChannel and verifier helper without extra annotations",
+    packageExports: {
+      "./channels/linear": {
+        types: "./dist/src/public/channels/linear/index.d.ts",
       },
     },
   },


### PR DESCRIPTION
## Summary

- export `defaultInputRequestedHandler` from `eve/channels/slack`
- export `callGitHubApi` from `eve/channels/github` and `verifyLinearRequest` from `eve/channels/linear`
- document the helper usage and extend public API portability coverage for the new imports

Closes #351.

## Tests

- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/public-api-portability.scenario.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check packages/eve/src/public/channels/slack/index.ts packages/eve/src/public/channels/github/index.ts packages/eve/src/public/channels/linear/index.ts packages/eve/src/internal/testing/scenario-apps/slack-route-portability.ts packages/eve/src/internal/testing/scenario-apps/github-route-portability.ts packages/eve/src/internal/testing/scenario-apps/linear-route-portability.ts packages/eve/src/internal/testing/scenario-apps/index.ts packages/eve/test/scenarios/public-api-portability.scenario.test.ts docs/channels/slack.mdx docs/channels/github.mdx docs/channels/linear.mdx .changeset/channel-helper-exports.md`
- `pnpm --filter eve exec oxlint src/public/channels/slack/index.ts src/public/channels/github/index.ts src/public/channels/linear/index.ts src/internal/testing/scenario-apps/slack-route-portability.ts src/internal/testing/scenario-apps/github-route-portability.ts src/internal/testing/scenario-apps/linear-route-portability.ts src/internal/testing/scenario-apps/index.ts test/scenarios/public-api-portability.scenario.test.ts --deny-warnings`
- `pnpm changeset status --since origin/main`
- `git diff --cached --check`