### PR TITLE
fix(runtime): forward concurrent initial deliveries

### DIFF
--- a/.changeset/strong-deliveries-queue.md
+++ b/.changeset/strong-deliveries-queue.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Concurrent channel sends to the same continuation token now forward duplicate initial deliveries to the session that already owns the token. This prevents accepted work from failing admission with a hook conflict while the first delivery is still creating the session.

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -461,6 +461,140 @@ describe("createWorkflowRuntime#run", () => {
     });
   });
 
+  it("forwards a duplicate initial delivery to the hook owner when session creation races", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource);
+    const conflict = Object.assign(
+      new Error('Hook token "github:repo:123:pull:7" is already in use'),
+      {
+        conflictingRunId: "owner-session",
+        name: "HookConflictError",
+        token: "github:repo:123:pull:7",
+      },
+    );
+    startMock.mockRejectedValue(conflict);
+    const ownerHook = { runId: "owner-session", token: "github:repo:123:pull:7" };
+    getHookByTokenMock.mockResolvedValue(ownerHook);
+    resumeHookMock.mockResolvedValue(ownerHook);
+
+    const handle = await buildRuntime(compiledArtifactsSource).run({
+      adapter,
+      auth: {
+        attributes: {},
+        authenticator: "github",
+        principalId: "octocat",
+        principalType: "user",
+      },
+      continuationToken: "github:repo:123:pull:7",
+      input: {
+        context: ["pull request context"],
+        message: "Pull request labeled: #7",
+        outputSchema: { type: "object" },
+      },
+      mode: "conversation",
+      requestId: "delivery-2",
+    });
+
+    expect(handle.sessionId).toBe("owner-session");
+    expect(handle.continuationToken).toBe("github:repo:123:pull:7");
+    expect(resumeHookMock).toHaveBeenCalledWith(ownerHook, {
+      auth: {
+        attributes: {},
+        authenticator: "github",
+        principalId: "octocat",
+        principalType: "user",
+      },
+      kind: "deliver",
+      payloads: [
+        {
+          context: ["pull request context"],
+          message: "Pull request labeled: #7",
+          outputSchema: { type: "object" },
+        },
+      ],
+      requestId: "delivery-2",
+    });
+  });
+
+  it("does not forward when hook ownership changes after the start conflict", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource);
+    startMock.mockRejectedValue(
+      Object.assign(new Error("hook conflict"), {
+        conflictingRunId: "original-owner",
+        name: "HookConflictError",
+        token: "github:repo:123:pull:7",
+      }),
+    );
+    getHookByTokenMock.mockResolvedValue({
+      runId: "replacement-owner",
+      token: "github:repo:123:pull:7",
+    });
+
+    await expect(
+      buildRuntime(compiledArtifactsSource).run({
+        adapter,
+        auth: null,
+        continuationToken: "github:repo:123:pull:7",
+        input: { message: "do not misdeliver" },
+        mode: "conversation",
+      }),
+    ).rejects.toThrow(/owner changed.*original-owner.*replacement-owner/);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the forwarding failure instead of the stale start conflict", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource);
+    startMock.mockRejectedValue(
+      Object.assign(new Error("hook conflict"), {
+        conflictingRunId: "owner-session",
+        name: "HookConflictError",
+        token: "github:repo:123:pull:7",
+      }),
+    );
+    const ownerHook = { runId: "owner-session", token: "github:repo:123:pull:7" };
+    const forwardingFailure = new Error("hook transport unavailable");
+    getHookByTokenMock.mockResolvedValue(ownerHook);
+    resumeHookMock.mockRejectedValue(forwardingFailure);
+
+    await expect(
+      buildRuntime(compiledArtifactsSource).run({
+        adapter,
+        auth: null,
+        continuationToken: "github:repo:123:pull:7",
+        input: { message: "retry me" },
+        mode: "conversation",
+      }),
+    ).rejects.toBe(forwardingFailure);
+  });
+
+  it("does not forward unrelated workflow start hook conflicts", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource);
+    const conflict = Object.assign(
+      new Error('Hook token "github:repo:123:pull:9" is already in use'),
+      {
+        conflictingRunId: "owner-session",
+        name: "HookConflictError",
+        token: "github:repo:123:pull:9",
+      },
+    );
+    startMock.mockRejectedValue(conflict);
+
+    await expect(
+      buildRuntime(compiledArtifactsSource).run({
+        adapter,
+        auth: null,
+        continuationToken: "github:repo:123:pull:7",
+        input: { message: "Pull request opened: #7" },
+        mode: "conversation",
+      }),
+    ).rejects.toBe(conflict);
+
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to the current deployment when latest is unsupported", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -30,6 +30,7 @@ import {
   cancelRun,
   getHookByToken,
   getRun,
+  getHookByToken,
   getWorld,
   resumeHook,
   start,
@@ -43,6 +44,7 @@ import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts
 import { ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
+import { isHookConflictError } from "#execution/hook-ownership.js";
 import { buildRunContext } from "#execution/runtime-context.js";
 import { parseNdjsonStream } from "#execution/ndjson-stream.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
@@ -161,25 +163,16 @@ export function createWorkflowRuntime(config: {
           attributes: normalizeEveAttributes(attributes),
         });
       } catch (error) {
+        const forwarded = await forwardInitialDeliveryToHookOwner(error, input);
+        if (forwarded !== null) return forwarded;
+
         logError(log, "failed to start workflow run", error, {
           continuationToken: input.continuationToken,
         });
         throw error;
       }
 
-      let events: ReadableStream<MessageStreamEvent> | undefined;
-      const getEvents = () => {
-        events ??= parseNdjsonStream<MessageStreamEvent>(() => getRun(run.runId).getReadable());
-        return events;
-      };
-
-      return {
-        continuationToken: input.continuationToken ?? run.runId,
-        get events() {
-          return getEvents();
-        },
-        sessionId: run.runId,
-      };
+      return createRunHandle(run.runId, input.continuationToken ?? run.runId);
     },
 
     async cancelTurn(input: CancelTurnInput): Promise<CancelTurnResult> {
@@ -296,6 +289,63 @@ function isAlreadyTerminalSessionError(error: unknown): boolean {
     }
   }
   return false;
+}
+
+async function forwardInitialDeliveryToHookOwner(
+  error: unknown,
+  input: RunInput,
+): Promise<RunHandle | null> {
+  if (!input.continuationToken || !isHookConflictError(error)) return null;
+  if (error.token !== input.continuationToken) return null;
+
+  const hookPayload: Extract<HookPayload, { kind: "deliver" }> = {
+    auth: input.auth,
+    kind: "deliver",
+    payloads: [
+      {
+        message: input.input.message,
+        context: input.input.context,
+        outputSchema: input.input.outputSchema,
+      },
+    ],
+    requestId: input.requestId,
+  };
+
+  try {
+    const ownerHook = await getHookByToken(input.continuationToken);
+    if (
+      typeof error.conflictingRunId === "string" &&
+      ownerHook.runId !== error.conflictingRunId
+    ) {
+      throw new Error(
+        `Hook owner changed from "${error.conflictingRunId}" to "${ownerHook.runId}" before delivery could be forwarded.`,
+      );
+    }
+    const resumedHook = normalizeWorkflowHook(await resumeHook(ownerHook, hookPayload));
+    return createRunHandle(resumedHook.runId, input.continuationToken);
+  } catch (forwardError) {
+    logError(log, "failed to forward initial delivery to hook owner", forwardError, {
+      continuationToken: input.continuationToken,
+    });
+    throw forwardError;
+  }
+}
+
+function createRunHandle(runId: string, continuationToken: string): RunHandle {
+  let events: ReadableStream<HandleMessageStreamEvent> | undefined;
+  const getEvents = () => {
+    events ??= parseNdjsonStream<HandleMessageStreamEvent>(() => getRun(runId).getReadable());
+    return events;
+  };
+
+  return {
+    continuationToken,
+    get events() {
+      return getEvents();
+    },
+    sessionId: runId,
+  };
+}
 }
 
 /**


### PR DESCRIPTION
## Summary

- forward a duplicate initial delivery to the session that already owns the requested continuation token when workflow start races with an existing hook owner
- keep unrelated hook conflicts on the original error path by requiring an exact token match before forwarding
- reuse the runtime run-handle creation path for both newly started and forwarded-to-owner sessions
- add a patch changeset

Refs #624.

## Tests

- `pnpm --filter eve run build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/workflow-runtime.test.ts src/channel/send.test.ts`
- `pnpm --filter eve run typecheck`
- `pnpm exec oxfmt --check packages/eve/src/execution/workflow-runtime.ts packages/eve/src/execution/workflow-runtime.test.ts .changeset/strong-deliveries-queue.md`
- `pnpm exec oxlint --deny-warnings packages/eve/src/execution/workflow-runtime.ts packages/eve/src/execution/workflow-runtime.test.ts`
- `pnpm guard:invariants`
- `git diff --cached --check`
- `pnpm changeset status --since origin/main`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/workflow-entry.test.ts src/execution/session-delivery-hook.test.ts src/execution/turn-control-receiver.test.ts src/execution/turn-workflow.test.ts`