### PR TITLE
fix(eve): dev snapshots - skip nested git repositories

### DIFF
--- a/.changeset/quiet-worktrees-snapshot.md
+++ b/.changeset/quiet-worktrees-snapshot.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Stop `eve dev` source snapshots from copying nested Git repositories and worktrees, preventing duplicate checkouts from inflating each development snapshot.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -225,6 +225,45 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(join(snapshot.runtimeAppRoot, "dist"))).toBe(false);
   });
 
+  it("stops copying at nested git repository boundaries", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-nested-git-");
+    const agentRoot = join(appRoot, "agent");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+    const worktreeRoot = join(appRoot, ".claude", "worktrees", "review");
+    const nestedRepositoryRoot = join(appRoot, "vendor", "nested-repository");
+    const regularDirectoryRoot = join(appRoot, "vendor", "regular-directory");
+
+    await mkdir(agentRoot, { recursive: true });
+    await mkdir(worktreeRoot, { recursive: true });
+    await mkdir(join(nestedRepositoryRoot, ".git"), { recursive: true });
+    await mkdir(regularDirectoryRoot, { recursive: true });
+    await mkdir(compileDirectoryPath, { recursive: true });
+    await writeFile(join(appRoot, "package.json"), '{"type":"module"}\n');
+    await writeFile(join(agentRoot, "agent.ts"), "export const answer = 42;\n");
+    await writeFile(join(appRoot, ".claude", "notes.md"), "keep this file\n");
+    await writeFile(join(worktreeRoot, ".git"), "gitdir: ../../../../.git/worktrees/review\n");
+    await writeFile(join(worktreeRoot, "duplicate.ts"), "export const duplicate = true;\n");
+    await writeFile(join(nestedRepositoryRoot, "duplicate.ts"), "export const duplicate = true;\n");
+    await writeFile(join(regularDirectoryRoot, "source.ts"), "export const copied = true;\n");
+    await writeFile(
+      join(compileDirectoryPath, "compiled-agent-manifest.json"),
+      `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`,
+    );
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+
+    expect(existsSync(join(snapshot.runtimeAppRoot, "agent", "agent.ts"))).toBe(true);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".claude", "notes.md"))).toBe(true);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".claude", "worktrees", "review"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, "vendor", "nested-repository"))).toBe(false);
+    expect(
+      existsSync(join(snapshot.runtimeAppRoot, "vendor", "regular-directory", "source.ts")),
+    ).toBe(true);
+  });
+
   it("prunes stale snapshots while preserving the active and recent snapshots", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-prune-");
     const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -125,6 +125,10 @@ function shouldSkipSnapshotSource(
     return true;
   }
 
+  if (existsSync(join(sourcePath, ".git"))) {
+    return true;
+  }
+
   return isDirectAppRootSkipPath({
     appRoot: plan.appRoot,
     sourcePath,


### PR DESCRIPTION
## Summary

- stop development source snapshots at nested Git repository and worktree boundaries
- retain ordinary sibling content while excluding duplicate nested checkouts
- cover both `.git` files used by worktrees and `.git` directories used by repositories

## Root cause

The snapshot copier excluded entries named `.git`, but it did not exclude the directory that owned that marker. It therefore copied every other file from nested repositories and worktrees before omitting only their marker.

## Impact

`eve dev` no longer duplicates nested checkouts into every runtime snapshot, avoiding unnecessary snapshot time and disk growth.

Reported by @katsuhisa91 in #526.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts` (13 tests passed)
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- `pnpm exec oxlint --fix packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts`

Closes #526

Independent implementation based on #526 and current `main`. Thanks to @iroiro147 for also investing time in an earlier implementation attempt in #589.