### PR TITLE
fix(eve): sandbox - keep brokered secrets out of Microsandbox env

### DIFF
--- a/.changeset/safe-microsandbox-secrets.md
+++ b/.changeset/safe-microsandbox-secrets.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent brokered credential values from being exposed to commands running in Microsandbox. Guest Git configuration continues to use broker-managed placeholders for authenticated requests.

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts
@@ -269,12 +269,7 @@ export function createTransformBrokerEnvironment(
     });
   }
 
-  return {
-    EVE_MICROSANDBOX_NETWORK_TRANSFORMS: Buffer.from(
-      JSON.stringify(plan.transformHeaderRules),
-    ).toString("base64"),
-    ...gitConfigEnvironment,
-  };
+  return gitConfigEnvironment;
 }
 
 interface VercelNetworkPolicyRule {

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMicrosandboxSandboxBackend } from "#execution/sandbox/bindings/microsandbox.js";
 import {
   createMicrosandboxNetworkPlan,
+  createTransformBrokerEnvironment,
   serializeMicrosandboxNetworkPolicyJson,
 } from "#execution/sandbox/bindings/microsandbox-network.js";
 import {
@@ -161,6 +162,26 @@ describe.skipIf(onWindows)("createMicrosandboxNetworkPlan", () => {
         },
       }),
     ]);
+  });
+
+  it("keeps brokered header values out of the guest environment", () => {
+    const plan = createMicrosandboxNetworkPlan({
+      allow: {
+        "github.com": [
+          {
+            transform: [{ headers: { Authorization: "Basic real-secret" } }],
+          },
+        ],
+      },
+    });
+
+    expect(createTransformBrokerEnvironment(plan)).toEqual({
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
+      GIT_CONFIG_VALUE_0: expect.stringMatching(
+        /^Authorization: __EVE_MSB_SECRET_[A-Fa-f0-9]{24}__$/u,
+      ),
+    });
   });
 
   it("serializes policy JSON using microsandbox's native snake-case schema", () => {


### PR DESCRIPTION
## Summary

- remove the unused guest environment payload that serialized Microsandbox network transform rules
- preserve the `GIT_CONFIG_*` entries that send broker-managed placeholders through authenticated Git requests
- add regression coverage and a patch changeset

## Root cause

`MicrosandboxVm.spawn()` merges the environment returned by `createTransformBrokerEnvironment()` into every guest command. That helper base64-encoded each complete transform rule, including its real header values, into `EVE_MICROSANDBOX_NETWORK_TRANSFORMS`. Nothing in eve reads that payload, so it exposed credentials to guest code without serving a runtime purpose.

## Impact

Brokered credential values no longer enter the guest command environment when using Microsandbox. Authenticated Git requests continue to carry placeholders that Microsandbox replaces through its broker outside the guest process.

## Tests

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/microsandbox.test.ts`
- `pnpm test:unit`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check packages/eve/src/execution/sandbox/bindings/microsandbox-network.ts packages/eve/src/execution/sandbox/bindings/microsandbox.test.ts .changeset/safe-microsandbox-secrets.md`

Closes #600

Credit to @Dev11940518 for reporting the credential exposure.

Independent implementation based on #600 and current `main`. Thanks to @iroiro147 for also investing time in an earlier implementation attempt in #606.