### PR TITLE
fix(eve): discord - restore environment credential fallback

### DIFF
--- a/.changeset/discord-environment-credentials.md
+++ b/.changeset/discord-environment-credentials.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Restore the `DISCORD_BOT_TOKEN` environment fallback for proactive Discord messages, typing indicators, and bot-authenticated requests when `discordChannel()` is configured without explicit credentials.

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -163,6 +163,7 @@ function commandBody(overrides?: Record<string, unknown>): string {
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -412,6 +413,41 @@ describe("discordChannel() default event handlers", () => {
     await expect(
       callAdapterEventHandler(adapter, makeEvent("turn.started", {}), ctx),
     ).resolves.toEqual(makeEvent("turn.started", {}));
+  });
+
+  it("uses the environment bot token for proactive messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ channel_id: "C01", id: "M01" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = withState(getAdapter(discordChannel()), {
+      channelId: "C01",
+      initialResponseSent: true,
+    });
+    const { accessor } = captureAccessor("discord:C01:");
+    const ctx = buildAdapterContext(adapter, accessor);
+    vi.stubEnv("DISCORD_BOT_TOKEN", "environment-token");
+
+    await callEvent(
+      adapter,
+      makeEvent("message.completed", {
+        finishReason: "stop",
+        message: "Hello from the agent",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://discord.com/api/v10/channels/C01/messages");
+    expect(new Headers((init as RequestInit).headers).get("authorization")).toBe(
+      "Bot environment-token",
+    );
   });
 
   it("edits the original response and rekeys the session on the first post", async () => {

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -11,6 +11,7 @@ import {
   createDiscordFollowupMessage,
   discordContinuationToken,
   editDiscordOriginalResponse,
+  resolveDiscordBotToken,
   sendDiscordChannelMessage,
   splitDiscordMessageContent,
   triggerDiscordTypingIndicator,
@@ -674,7 +675,7 @@ function mergeCredentials(
 ): DiscordChannelCredentials {
   const merged: DiscordChannelCredentials = {
     applicationId: state.applicationId ?? credentials?.applicationId,
-    botToken: credentials?.botToken,
+    botToken: credentials?.botToken ?? (() => resolveDiscordBotToken()),
     publicKey: credentials?.publicKey,
     webhookVerifier: credentials?.webhookVerifier,
   };


### PR DESCRIPTION
## Summary

Restore Discord's documented `DISCORD_BOT_TOKEN` environment fallback when `discordChannel()` is configured without explicit credentials.

## Root cause

Channel credential merging preserved an omitted bot token as `undefined`. The low-level Discord API uses `undefined` to mean that a request is intentionally unauthenticated, so bot-authenticated channel operations never reached the existing environment-aware token resolver.

## Change

Supply a lazy, resolver-backed bot credential when the channel has no explicit token. Explicit credentials still take precedence, environment changes are read at request time, and intentionally unauthenticated interaction-webhook requests remain unchanged.

## Impact

Proactive and scheduled Discord sessions can again send messages, emit typing indicators, and make bot-authenticated requests using `DISCORD_BOT_TOKEN` alone.

## Tests

- `pnpm --filter eve test:unit` (4,564 passed, 1 skipped)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- scoped `oxfmt --check` for the changed files

Closes #149

Thanks to @tonystrawberry for reporting this issue.

Co-authored with @tonystrawberry in recognition of their earlier implementation work in #150.