### PR TITLE
fix(eve): slack - preserve literal bare at tokens

### DIFF
--- a/.changeset/tidy-slack-tokens.md
+++ b/.changeset/tidy-slack-tokens.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack outbound messages now preserve literal bare `@` tokens, including scoped package names, while explicit `<@USER_ID>` mention syntax continues to pass through unchanged.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -101,6 +101,8 @@ when you need the bearer token itself.
 
 The default handlers reply in-thread and show progress. Typing indicators post automatically: `Thinking…` on inbound, `Working…` on `turn.started`, a truncated reasoning snippet on `reasoning.appended`, and an action label on `actions.requested` — the tool name plus its most telling argument (`grep useEveAgent`, `read_file agent/agent.ts`), the subagent or remote-agent name for dispatched calls, and `+N more` when the model requests several actions at once. The model's own pre-tool narration, when present, takes precedence over the derived label. Reasoning snippets build progressively: extensions of at least four characters appear immediately, while smaller streamed deltas use the five-second refresh interval to avoid one Slack request per token. Override `events["reasoning.appended"]` if you prefer generic wording. Override `onAppMention` or the `events` handlers to customize.
 
+Outbound text preserves bare `@` tokens as literal text. To mention a user, embed Slack's `<@USER_ID>` syntax directly or use `channel.thread.mentionUser(userId)`.
+
 When a session starts without a `threadTs` (say, from a schedule or `receive(slack, ...)`), eve gives it a unique temporary continuation token. The first agent post anchors the session to the Slack message timestamp, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 
 The example below overrides `onAppMention` to gate on an authored message and posts the completed reply to the thread. Event handlers receive `(eventData, channel, ctx)`, with Slack platform handles on `channel.thread` and `channel.slack`:

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -333,6 +333,65 @@ describe("SlackThread.post with files", () => {
   });
 });
 
+describe("Slack outbound text", () => {
+  let mock: ReturnType<typeof buildFetchMock>;
+
+  beforeEach(() => {
+    mock = buildFetchMock();
+    vi.stubGlobal("fetch", mock.fetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves literal at-prefixed tokens in markdown and text posts", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+    const mention = thread.mentionUser("U012ABC456");
+
+    expect(mention).toBe("<@U012ABC456>");
+    await thread.post({ markdown: `bump @scope/package and ping ${mention}` });
+    await thread.post({ text: "email @support or ping <@U012ABC456>" });
+
+    const posts = mock.calls.filter(
+      (call) => call.url === "https://slack.com/api/chat.postMessage",
+    );
+    expect(posts).toHaveLength(2);
+    expect(posts[0]!.body).toMatchObject({
+      markdown_text: "bump @scope/package and ping <@U012ABC456>",
+    });
+    expect(posts[1]!.body).toMatchObject({
+      text: "email @support or ping <@U012ABC456>",
+    });
+  });
+
+  it("preserves literal at-prefixed tokens in file upload comments", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await thread.post({
+      text: "report for @scope/package and <@U012ABC456>",
+      files: [{ data: Buffer.from([1]), filename: "report.csv", mimeType: "text/csv" }],
+    });
+
+    const complete = mock.calls.find(
+      (call) => call.url === "https://slack.com/api/files.completeUploadExternal",
+    );
+    expect(complete?.body).toMatchObject({
+      initial_comment: "report for @scope/package and <@U012ABC456>",
+    });
+  });
+});
+
 describe("SlackThread.refresh", () => {
   let mock: ReturnType<typeof buildFetchMock>;
 

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -33,7 +33,7 @@ import { isCardElement, type CardElement, type FileUpload } from "#compiled/chat
 import { createLogger, logError } from "#internal/logging.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
 import { truncateTypingStatus } from "#public/channels/slack/limits.js";
-import { rewriteBareMentions, slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
+import { slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
 
 const log = createLogger("slack.api");
 
@@ -368,7 +368,7 @@ export function buildSlackBinding(input: {
       // text + files: single Slack message with files attached via
       // files.completeUploadExternal's mrkdwn-only initial_comment.
       if (files.length > 0 && !shouldPostBeforeFiles) {
-        const comment = "text" in message ? rewriteBareMentions(message.text) : undefined;
+        const comment = "text" in message ? message.text : undefined;
         const result = await uploadFiles(files, { initialComment: comment });
         const id =
           Array.isArray(result.raw.files) && result.raw.files.length > 0
@@ -514,10 +514,10 @@ function buildPostMessageOptions(
     return base;
   }
   if ("markdown" in message) {
-    base.markdownText = rewriteBareMentions(message.markdown);
+    base.markdownText = message.markdown;
     return base;
   }
-  base.text = rewriteBareMentions(message.text);
+  base.text = message.text;
   return base;
 }
 

--- a/packages/eve/src/public/channels/slack/mrkdwn.test.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.test.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  gfmToSlackMrkdwn,
-  rewriteBareMentions,
-  slackMrkdwnToGfm,
-} from "#public/channels/slack/mrkdwn.js";
-
-describe("rewriteBareMentions", () => {
-  it("rewrites bare @USER tokens into Slack mention syntax", () => {
-    expect(rewriteBareMentions("ping @U123 please")).toBe("ping <@U123> please");
-  });
-
-  it("leaves already-wrapped mentions alone", () => {
-    expect(rewriteBareMentions("ping <@U123> please")).toBe("ping <@U123> please");
-  });
-
-  it("does not touch email-shaped runs", () => {
-    expect(rewriteBareMentions("contact foo@bar.com")).toBe("contact foo@bar.com");
-  });
-
-  it("rewrites every occurrence in a single pass", () => {
-    expect(rewriteBareMentions("@A and @B")).toBe("<@A> and <@B>");
-  });
-});
+import { gfmToSlackMrkdwn, slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
 
 describe("gfmToSlackMrkdwn", () => {
   it("converts ** and __ bold to single-star bold", () => {

--- a/packages/eve/src/public/channels/slack/mrkdwn.ts
+++ b/packages/eve/src/public/channels/slack/mrkdwn.ts
@@ -1,16 +1,8 @@
 import {
   formatSlackLink,
-  linkBareSlackMentions,
   markdownBoldToSlackMrkdwn,
   slackMrkdwnToMarkdown,
 } from "#compiled/@chat-adapter/slack/format.js";
-
-const BARE_MENTION_RE = /(?<![<\w])@(\w+)/gu;
-
-/** Rewrites bare Slack mention tokens into Slack's linked mention syntax. */
-export function rewriteBareMentions(text: string): string {
-  return linkBareSlackMentions(text).replace(BARE_MENTION_RE, "<@$1>");
-}
 
 /** Converts markdown into Slack mrkdwn for legacy Slack text surfaces. */
 export function gfmToSlackMrkdwn(input: string): string {


### PR DESCRIPTION
## Root cause

eve rewrote every bare `@word` token in outbound Slack markdown, text, and file upload comments into `<@word>`. Slack interprets the bracketed form as mention syntax, so literal values such as `@scope/package` were corrupted before delivery.

## Change

- Pass outbound `markdown_text`, `text`, and upload `initial_comment` values through unchanged.
- Preserve explicit `<@USER_ID>` mentions and the existing `thread.mentionUser(userId)` helper.
- Remove the obsolete rewrite helper and add payload-level regression coverage.
- Document the outbound mention contract and add a patch changeset.

## Impact

Scoped package names and other bare at-prefixed tokens now render literally in Slack. Callers can still create real mentions explicitly with `<@USER_ID>` or `thread.mentionUser(userId)`.

## Tests

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/api.test.ts src/public/channels/slack/mrkdwn.test.ts`
- `pnpm exec oxfmt --check packages/eve/src/public/channels/slack/api.test.ts packages/eve/src/public/channels/slack/api.ts packages/eve/src/public/channels/slack/mrkdwn.test.ts packages/eve/src/public/channels/slack/mrkdwn.ts docs/channels/slack.mdx .changeset/tidy-slack-tokens.md`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm docs:check`

Closes #563

Credit to @amotarao for reporting the issue.

Independent implementation based on #563 and current `main`. Thanks to @iroiro147 for also investing time in earlier implementation attempts in #586 and #631.