### PR TITLE
fix(eve): dev client - preserve remote URL query parameters

### DIFF
--- a/.changeset/tidy-snails-listen.md
+++ b/.changeset/tidy-snails-listen.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve query parameters passed to `eve dev` and send them on every agent request, including session POSTs and streams.

--- a/docs/guides/client/overview.mdx
+++ b/docs/guides/client/overview.mdx
@@ -19,7 +19,7 @@ const client = new Client({
 });
 ```
 
-`host` is the origin where the eve routes are mounted. In a same-origin browser integration this is often `""`; scripts and backend services usually name the full URL.
+`host` is the URL where the eve routes are mounted. In a same-origin browser integration this is often `""`; scripts and backend services usually name the full URL. Any query parameters on `host` are included on every request, including session POSTs and event streams. Request-specific parameters, such as a stream cursor, take precedence when names overlap.
 
 ## Check health
 

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -136,6 +136,10 @@ eve dev https://user:pass@<your-app>
 
 For bearer tokens or custom schemes, repeat `-H, --header` to attach request headers.
 
+Query parameters in the target URL are preserved on every request, including
+session POSTs and event streams. This also supports deployment-protection URLs
+that carry their bypass credential in the query string.
+
 At startup the TUI asks Vercel to resolve the remote origin under the active scope. A resolved response is the authority for a project-scoped OIDC token—refreshing an expired development token when refresh credentials exist—or an automation-bypass secret. An unresolved host is probed anonymously. The TUI then requests `/eve/v1/info`, with a ten-second timeout. A successful response marks the remote ready. An eve OIDC challenge, Vercel Deployment Protection challenge, or `TRUSTED_SOURCES_ENVIRONMENT_MISMATCH` opens `/vc:login` automatically; ordinary network failures and server errors remain remote-availability errors and do not start an authentication flow. Esc or Ctrl-C cancels the authentication flow.
 
 In a remote session, `/vc:login` first resolves the deployment's Vercel project from its URL. If the active Vercel scope cannot resolve it, the flow asks for another team and reruns the lookup in that team's scope. If the CLI is logged out, the same panel runs the browser login first. The flow asks before adding any required Trusted Sources rule and requests a project-scoped token through `@vercel/oidc`. It does not relink the directory or modify `.env.local`. Finally, it retries `/eve/v1/info` to prove the credential works. A failure reports any login or Trusted Sources update that completed before it stopped.

--- a/packages/eve/src/cli/dev/url.test.ts
+++ b/packages/eve/src/cli/dev/url.test.ts
@@ -5,9 +5,9 @@ import { InvalidArgumentError } from "#compiled/commander/index.js";
 import { parseDevelopmentServerUrl } from "./url.js";
 
 describe("parseDevelopmentServerUrl", () => {
-  it("accepts https remote URLs and strips hash and query", () => {
+  it("accepts https remote URLs, preserves query parameters, and strips the hash", () => {
     expect(parseDevelopmentServerUrl("https://my-app.vercel.app/path?token=1#frag")).toBe(
-      "https://my-app.vercel.app/path",
+      "https://my-app.vercel.app/path?token=1",
     );
   });
 

--- a/packages/eve/src/cli/dev/url.ts
+++ b/packages/eve/src/cli/dev/url.ts
@@ -34,7 +34,6 @@ export function parseDevelopmentServerUrl(value: string): string {
     assertDevelopmentServerProtocol(url, value);
     assertSecureRemoteProtocol(url, value);
     url.hash = "";
-    url.search = "";
 
     return url.toString();
   } catch (error) {

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -137,6 +137,23 @@ describe("eve dev --input", () => {
 });
 
 describe("eve dev --url protocol", () => {
+  it("preserves query parameters on the remote target URL", async () => {
+    const runDevelopmentTui = await runInteractiveDev([
+      "dev",
+      "https://example.com?x-vercel-protection-bypass=secret",
+    ]);
+
+    expect(runDevelopmentTui).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          kind: "remote",
+          serverUrl: "https://example.com/?x-vercel-protection-bypass=secret",
+          workspaceRoot: process.cwd(),
+        },
+      }),
+    );
+  });
+
   it("lowers URL userinfo to a Basic authorization header and strips it from the target URL", async () => {
     const runDevelopmentTui = await runInteractiveDev([
       "dev",

--- a/packages/eve/src/client/client.test.ts
+++ b/packages/eve/src/client/client.test.ts
@@ -45,6 +45,35 @@ afterEach(() => {
 });
 
 describe("Client request policy", () => {
+  it("includes host query parameters on every agent request", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json(AGENT_INFO))
+      .mockResolvedValueOnce(Response.json({ ok: true, status: "ready", workflowId: "wf" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        Response.json({ continuationToken: "eve:test", sessionId: "session_1" }, { status: 202 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(`${JSON.stringify({ data: {}, type: "session.completed" })}\n`),
+      );
+    const client = new Client({
+      host: "https://eve.test?x-vercel-protection-bypass=secret",
+    });
+
+    await client.info();
+    await client.health();
+    await client.fetch("/custom");
+    await (await client.session().send("hello")).result();
+
+    expect(fetchMock.mock.calls).toHaveLength(5);
+    for (const [request] of fetchMock.mock.calls) {
+      expect(new URL(String(request)).searchParams.get("x-vercel-protection-bypass")).toBe(
+        "secret",
+      );
+    }
+  });
+
   it("enforces its redirect policy for info, health, raw fetch, and sessions", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -68,7 +68,8 @@ export type ClientRedirectPolicy = NonNullable<RequestInit["redirect"]>;
  */
 export interface ClientOptions {
   /**
-   * Base URL of the eve agent server.
+   * Base URL of the eve agent server. Query parameters are included on every
+   * request; request-specific parameters override parameters with the same name.
    */
   readonly host: string;
 

--- a/packages/eve/src/client/url.test.ts
+++ b/packages/eve/src/client/url.test.ts
@@ -15,6 +15,25 @@ describe("createClientUrl", () => {
     );
   });
 
+  it("preserves host query parameters on agent routes", () => {
+    expect(
+      createClientUrl(
+        "https://agent.example.com?x-vercel-protection-bypass=secret",
+        "/eve/v1/session",
+      ),
+    ).toBe("https://agent.example.com/eve/v1/session?x-vercel-protection-bypass=secret");
+  });
+
+  it("merges route query parameters over host query parameters", () => {
+    expect(
+      createClientUrl(
+        "https://agent.example.com?token=secret&startIndex=stale",
+        "/eve/v1/session/123/stream",
+        { startIndex: "4" },
+      ),
+    ).toBe("https://agent.example.com/eve/v1/session/123/stream?token=secret&startIndex=4");
+  });
+
   it("supports same-origin proxy prefixes", () => {
     expect(createClientUrl("/api", "/eve/v1/session")).toBe("/api/eve/v1/session");
   });
@@ -22,6 +41,12 @@ describe("createClientUrl", () => {
   it("adds query parameters without forcing an absolute URL", () => {
     expect(createClientUrl("/api", "/eve/v1/session/123/stream", { startIndex: "4" })).toBe(
       "/api/eve/v1/session/123/stream?startIndex=4",
+    );
+  });
+
+  it("preserves query parameters on same-origin proxy prefixes", () => {
+    expect(createClientUrl("/api?token=secret", "/eve/v1/session")).toBe(
+      "/api/eve/v1/session?token=secret",
     );
   });
 });

--- a/packages/eve/src/client/url.ts
+++ b/packages/eve/src/client/url.ts
@@ -11,18 +11,20 @@ export function createClientUrl(
   searchParams?: Readonly<Record<string, string>>,
 ): string {
   const normalizedRoute = routePath.startsWith("/") ? routePath : `/${routePath}`;
-  const search = formatSearch(searchParams);
 
   if (isAbsoluteUrl(host)) {
     const url = new URL(host);
     const basePath = trimTrailingSlash(url.pathname);
     url.pathname = `${basePath}${normalizedRoute}`;
-    url.search = search;
+    mergeSearchParams(url.searchParams, searchParams);
     url.hash = "";
     return url.toString();
   }
 
-  return `${trimTrailingSlash(host)}${normalizedRoute}${search}`;
+  const url = new URL(host, "http://eve.local");
+  const basePath = trimTrailingSlash(url.pathname);
+  mergeSearchParams(url.searchParams, searchParams);
+  return `${basePath}${normalizedRoute}${formatSearch(url.searchParams)}`;
 }
 
 function isAbsoluteUrl(value: string): boolean {
@@ -34,10 +36,18 @@ function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
-function formatSearch(searchParams: Readonly<Record<string, string>> | undefined): string {
-  if (!searchParams || Object.keys(searchParams).length === 0) {
-    return "";
-  }
+function mergeSearchParams(
+  target: URLSearchParams,
+  searchParams: Readonly<Record<string, string>> | undefined,
+): void {
+  if (searchParams === undefined) return;
 
-  return `?${new URLSearchParams(searchParams).toString()}`;
+  for (const [name, value] of Object.entries(searchParams)) {
+    target.set(name, value);
+  }
+}
+
+function formatSearch(searchParams: URLSearchParams): string {
+  const value = searchParams.toString();
+  return value.length === 0 ? "" : `?${value}`;
 }


### PR DESCRIPTION
## Summary

- preserve query parameters passed to `eve dev <url>`
- include host query parameters on info, health, raw, session POST, and stream requests
- let request-specific parameters such as stream cursors override matching host parameters
- document the behavior and add a patch changeset

## Root cause

The CLI URL parser removed the supplied query string, and the shared client URL builder replaced host query parameters whenever it appended an eve route. Deployment-protection bypass parameters therefore never reached session POSTs or event streams.

## Impact

Protected deployments can now be targeted with a bypass query parameter in the URL, and the parameter remains present throughout the full client session lifecycle.

## Validation

- `pnpm test:unit` (4,568 passed, 1 skipped)
- `pnpm --filter eve typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `git diff --check`