### PR TITLE
fix(eve): scope Nitro workflow runtime queues

### DIFF
--- a/.changeset/fair-teams-push.md
+++ b/.changeset/fair-teams-push.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Install and enforce one stable agent-scoped workflow queue namespace before Nitro channel and schedule routes create workflow runtimes, so external entrypoints enqueue runs onto the same queue namespace as the agent's workflow handlers without cross-agent process contamination.

--- a/packages/eve/src/internal/nitro/routes/runtime-stack.test.ts
+++ b/packages/eve/src/internal/nitro/routes/runtime-stack.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Runtime } from "#channel/types.js";
+import type { CompiledModuleMap } from "#compiler/module-map.js";
+import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
+import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
+import type { RuntimeAdapterRegistry } from "#runtime/channels/registry.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import type { ResolvedRuntimeAgentNode } from "#runtime/graph.js";
+import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
+import type { RuntimeSandboxRegistry } from "#runtime/sandbox/registry.js";
+import {
+  getCompiledRuntimeAgentBundle,
+  type CompiledRuntimeAgentBundle,
+} from "#runtime/sessions/compiled-agent-cache.js";
+import type { RuntimeSubagentRegistry } from "#runtime/subagents/registry.js";
+import type { RuntimeToolRegistry } from "#runtime/tools/registry.js";
+import type { ResolvedAgent, ResolvedChannelDefinition } from "#runtime/types.js";
+import {
+  createNitroWorkflowRuntimeStack,
+  resolveNitroChannelRuntimeBundle,
+} from "#internal/nitro/routes/runtime-stack.js";
+import { resolveNitroCompiledArtifactsSource } from "#internal/nitro/routes/runtime-artifacts.js";
+import { WORKFLOW_QUEUE_NAMESPACE_ENV } from "#internal/workflow/queue-namespace.js";
+
+vi.mock("#execution/workflow-runtime.js", () => ({
+  createWorkflowRuntime: vi.fn(),
+}));
+
+vi.mock("#runtime/sessions/compiled-agent-cache.js", () => ({
+  getCompiledRuntimeAgentBundle: vi.fn(),
+}));
+
+vi.mock("#internal/nitro/routes/runtime-artifacts.js", () => ({
+  resolveNitroCompiledArtifactsSource: vi.fn(),
+}));
+
+const compiledArtifactsSource = {
+  appRoot: "/app/agent",
+  kind: "disk",
+} satisfies RuntimeCompiledArtifactsSource;
+const runtime = {} as Runtime;
+const mockedCreateWorkflowRuntime = vi.mocked(createWorkflowRuntime);
+const mockedGetCompiledRuntimeAgentBundle = vi.mocked(getCompiledRuntimeAgentBundle);
+const mockedResolveNitroCompiledArtifactsSource = vi.mocked(resolveNitroCompiledArtifactsSource);
+
+function createBundle(input?: {
+  readonly agentName?: string;
+  readonly channels?: readonly ResolvedChannelDefinition[];
+}): CompiledRuntimeAgentBundle {
+  const agentName = input?.agentName ?? "teams-agent";
+  const hookRegistry = createEmptyHookRegistry();
+  const subagentRegistry: RuntimeSubagentRegistry = {
+    preparedTools: [],
+    subagentsByName: new Map(),
+    subagentsByNodeId: new Map(),
+  };
+  const toolRegistry: RuntimeToolRegistry = {
+    preparedTools: [],
+    toolsByName: new Map(),
+  };
+  const agent = {
+    config: {
+      name: agentName,
+    },
+  } as ResolvedAgent;
+  const turnAgent: RuntimeTurnAgent = {
+    id: agentName,
+    instructions: [],
+    model: { id: "openai/gpt-5.4" } as RuntimeTurnAgent["model"],
+    tools: [],
+    workspaceSpec: {} as RuntimeTurnAgent["workspaceSpec"],
+  };
+  const root = {
+    agent,
+    channels: input?.channels ?? [],
+    hookRegistry,
+    nodeId: "__root__",
+    sandboxRegistry: {} as RuntimeSandboxRegistry,
+    subagentRegistry,
+    toolRegistry,
+    turnAgent,
+  } satisfies ResolvedRuntimeAgentNode;
+
+  return {
+    adapterRegistry: { adaptersByKind: new Map() } satisfies RuntimeAdapterRegistry,
+    compiledArtifactsSource,
+    graph: {
+      nodesByNodeId: new Map([[root.nodeId, root]]),
+      root,
+    },
+    hookRegistry,
+    moduleMap: {} as CompiledModuleMap,
+    resolvedAgent: agent,
+    subagentRegistry,
+    toolRegistry,
+    turnAgent,
+  };
+}
+
+describe("Nitro runtime stack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockedCreateWorkflowRuntime.mockReturnValue(runtime);
+    mockedResolveNitroCompiledArtifactsSource.mockReturnValue(compiledArtifactsSource);
+  });
+
+  it("installs the agent-scoped workflow queue namespace before creating the runtime", async () => {
+    const bundle = createBundle({ agentName: "teams-agent" });
+    mockedGetCompiledRuntimeAgentBundle.mockResolvedValue(bundle);
+    vi.stubEnv(WORKFLOW_QUEUE_NAMESPACE_ENV, undefined);
+    mockedCreateWorkflowRuntime.mockImplementation(() => {
+      expect(process.env[WORKFLOW_QUEUE_NAMESPACE_ENV]).toBe("eve7465616d732d6167656e74");
+      return runtime;
+    });
+
+    const stack = await createNitroWorkflowRuntimeStack(compiledArtifactsSource);
+
+    expect(stack).toEqual({ bundle, runtime });
+    expect(mockedGetCompiledRuntimeAgentBundle).toHaveBeenCalledWith({ compiledArtifactsSource });
+    expect(process.env[WORKFLOW_QUEUE_NAMESPACE_ENV]).toBe("eve7465616d732d6167656e74");
+    expect(mockedCreateWorkflowRuntime).toHaveBeenCalledWith({ compiledArtifactsSource });
+  });
+
+  it("returns resolved channels with a runtime using the same installed namespace", async () => {
+    const channels = [
+      {
+        fetch: async () => new Response("ok"),
+        logicalPath: "agent/channels/teams.ts",
+        method: "POST",
+        name: "teams",
+        sourceId: "channel-teams",
+        sourceKind: "module",
+        urlPath: "/eve/v1/teams",
+      } satisfies ResolvedChannelDefinition,
+    ];
+    mockedGetCompiledRuntimeAgentBundle.mockResolvedValue(
+      createBundle({ agentName: "support-agent", channels }),
+    );
+
+    const bundle = await resolveNitroChannelRuntimeBundle({ appRoot: "/app/agent" });
+
+    expect(mockedResolveNitroCompiledArtifactsSource).toHaveBeenCalledWith({
+      appRoot: "/app/agent",
+    });
+    expect(bundle).toEqual({ channels, runtime });
+    expect(process.env[WORKFLOW_QUEUE_NAMESPACE_ENV]).toBe("eve737570706f72742d6167656e74");
+  });
+});

--- a/packages/eve/src/internal/nitro/routes/runtime-stack.ts
+++ b/packages/eve/src/internal/nitro/routes/runtime-stack.ts
@@ -1,11 +1,16 @@
 import type { Runtime } from "#channel/types.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
-import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
+import {
+  getCompiledRuntimeAgentBundle,
+  type CompiledRuntimeAgentBundle,
+} from "#runtime/sessions/compiled-agent-cache.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
+import { installEveWorkflowQueueNamespace } from "#internal/workflow/queue-namespace.js";
 import {
   type NitroArtifactsConfig,
   resolveNitroCompiledArtifactsSource,
 } from "#internal/nitro/routes/runtime-artifacts.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 
 /**
  * Bundle returned to the per-channel Nitro dispatch handler.
@@ -22,22 +27,49 @@ export interface NitroChannelRuntimeBundle {
 }
 
 /**
+ * Bundle shared by Nitro routes that need to start or resume workflow sessions.
+ */
+export interface NitroWorkflowRuntimeStack {
+  readonly bundle: CompiledRuntimeAgentBundle;
+  readonly runtime: Runtime;
+}
+
+/**
+ * Creates the workflow runtime stack for a resolved compiled artifact source.
+ *
+ * No singleton caching is needed — session state lives inside the
+ * workflow's durable execution and the compiled bundle cache is versioned by
+ * the compiled artifacts source.
+ */
+export async function createNitroWorkflowRuntimeStack(
+  compiledArtifactsSource: RuntimeCompiledArtifactsSource,
+): Promise<NitroWorkflowRuntimeStack> {
+  const bundle = await getCompiledRuntimeAgentBundle({
+    compiledArtifactsSource,
+  });
+  installEveWorkflowQueueNamespace(bundle.graph.root.agent.config.name);
+  const runtime = createWorkflowRuntime({ compiledArtifactsSource });
+  return { bundle, runtime };
+}
+
+/**
+ * Resolves the workflow runtime stack for package-owned Nitro routes.
+ */
+export async function resolveNitroWorkflowRuntimeStack(
+  config: NitroArtifactsConfig,
+): Promise<NitroWorkflowRuntimeStack> {
+  return await createNitroWorkflowRuntimeStack(resolveNitroCompiledArtifactsSource(config));
+}
+
+/**
  * Resolves the per-request channel bundle: the agent's resolved channels
  * (already merged with framework defaults by `resolve-agent-graph.ts`)
  * and a fresh workflow runtime.
- *
- * No singleton caching is needed — session state lives inside the
- * workflow's durable execution and the channel set is recomputed from the
- * compiled bundle on each request.
  */
 export async function resolveNitroChannelRuntimeBundle(
   config: NitroArtifactsConfig,
 ): Promise<NitroChannelRuntimeBundle> {
-  const compiledArtifactsSource = resolveNitroCompiledArtifactsSource(config);
-  const bundle = await getCompiledRuntimeAgentBundle({
-    compiledArtifactsSource,
-  });
-  const runtime = createWorkflowRuntime({ compiledArtifactsSource });
+  const { bundle, runtime } = await resolveNitroWorkflowRuntimeStack(config);
   return {
     channels: bundle.graph.root.channels,
     runtime,

--- a/packages/eve/src/internal/nitro/routes/schedule-task.test.ts
+++ b/packages/eve/src/internal/nitro/routes/schedule-task.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Runtime } from "#channel/types.js";
+import { loadResolvedCompiledScheduleByTaskName } from "#runtime/schedules/resolve-schedule.js";
+import { resolveNitroCompiledArtifactsSource } from "#internal/nitro/routes/runtime-artifacts.js";
+import { createNitroWorkflowRuntimeStack } from "#internal/nitro/routes/runtime-stack.js";
+import { dispatchScheduleTask } from "#internal/nitro/routes/schedule-task.js";
+
+const triggerMock = vi.fn();
+const dispatcherConstructorMock = vi.fn();
+
+vi.mock("#channel/schedule.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#channel/schedule.js")>();
+  return {
+    ...actual,
+    expectScheduleRun: vi.fn(),
+    ScheduleDispatcher: class {
+      constructor(input: unknown) {
+        dispatcherConstructorMock(input);
+      }
+
+      trigger = triggerMock;
+    },
+  };
+});
+
+vi.mock("#runtime/schedules/resolve-schedule.js", () => ({
+  loadResolvedCompiledScheduleByTaskName: vi.fn(),
+}));
+
+vi.mock("#internal/nitro/routes/runtime-artifacts.js", () => ({
+  resolveNitroCompiledArtifactsSource: vi.fn(),
+}));
+
+vi.mock("#internal/nitro/routes/runtime-stack.js", () => ({
+  createNitroWorkflowRuntimeStack: vi.fn(),
+}));
+
+const compiledArtifactsSource = { appRoot: "/app/agent", kind: "disk" } as const;
+const runtime = {} as Runtime;
+const mockedLoadSchedule = vi.mocked(loadResolvedCompiledScheduleByTaskName);
+const mockedResolveSource = vi.mocked(resolveNitroCompiledArtifactsSource);
+const mockedCreateStack = vi.mocked(createNitroWorkflowRuntimeStack);
+
+describe("dispatchScheduleTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedResolveSource.mockReturnValue(compiledArtifactsSource);
+    mockedLoadSchedule.mockResolvedValue({
+      hasRun: false,
+      name: "daily-digest",
+      sourceKind: "markdown",
+    } as never);
+  });
+
+  it("dispatches through the namespace-initialized Nitro runtime stack", async () => {
+    const bundle = { graph: { root: { channels: [] } } };
+    mockedCreateStack.mockResolvedValue({ bundle, runtime } as never);
+    triggerMock.mockResolvedValue({
+      sessions: [{ id: "session-1" }],
+      waitUntilTasks: [],
+    });
+
+    await expect(dispatchScheduleTask("daily-digest", { appRoot: "/app/agent" })).resolves.toEqual({
+      scheduleId: "daily-digest",
+      sessionIds: ["session-1"],
+    });
+
+    expect(mockedCreateStack).toHaveBeenCalledWith(compiledArtifactsSource);
+    expect(dispatcherConstructorMock).toHaveBeenCalledWith({ channels: [], runtime });
+  });
+
+  it("does not dispatch when the process belongs to a different agent namespace", async () => {
+    const mismatch = new Error("Workflow queue namespace is already installed for another agent");
+    mockedCreateStack.mockRejectedValue(mismatch);
+
+    await expect(
+      dispatchScheduleTask("daily-digest", { appRoot: "/app/agent" }),
+    ).rejects.toBe(mismatch);
+    expect(triggerMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/internal/nitro/routes/schedule-task.ts
+++ b/packages/eve/src/internal/nitro/routes/schedule-task.ts
@@ -1,11 +1,11 @@
 import { expectScheduleRun, ScheduleDispatcher } from "#channel/schedule.js";
-import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { loadResolvedModuleExport } from "#runtime/resolve-helpers.js";
 import { loadResolvedCompiledScheduleByTaskName } from "#runtime/schedules/resolve-schedule.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import type { NitroArtifactsConfig } from "#internal/nitro/routes/runtime-artifacts.js";
 import { resolveNitroCompiledArtifactsSource } from "#internal/nitro/routes/runtime-artifacts.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { createNitroWorkflowRuntimeStack } from "#internal/nitro/routes/runtime-stack.js";
 
 /**
  * Dispatches one eve authored schedule via the execution engine.
@@ -36,8 +36,7 @@ export async function dispatchScheduleTaskFromArtifacts(
     compiledArtifactsSource,
   });
 
-  const bundle = await getCompiledRuntimeAgentBundle({ compiledArtifactsSource });
-  const runtime = createWorkflowRuntime({ compiledArtifactsSource });
+  const { bundle, runtime } = await createNitroWorkflowRuntimeStack(compiledArtifactsSource);
   const dispatcher = new ScheduleDispatcher({
     runtime,
     channels: bundle.graph.root.channels,

--- a/packages/eve/src/internal/workflow/queue-namespace.test.ts
+++ b/packages/eve/src/internal/workflow/queue-namespace.test.ts
@@ -27,11 +27,27 @@ describe("workflow queue namespace", () => {
   });
 
   it("installs the derived namespace for Workflow runtime operations", () => {
-    vi.stubEnv(WORKFLOW_QUEUE_NAMESPACE_ENV, "previous");
+    vi.stubEnv(WORKFLOW_QUEUE_NAMESPACE_ENV, undefined);
 
     try {
       expect(installEveWorkflowQueueNamespace("weather-agent")).toBe(
         "eve776561746865722d6167656e74",
+      );
+      expect(process.env[WORKFLOW_QUEUE_NAMESPACE_ENV]).toBe("eve776561746865722d6167656e74");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("keeps one agent namespace stable for the lifetime of the process", () => {
+    vi.stubEnv(WORKFLOW_QUEUE_NAMESPACE_ENV, "eve776561746865722d6167656e74");
+
+    try {
+      expect(installEveWorkflowQueueNamespace("weather-agent")).toBe(
+        "eve776561746865722d6167656e74",
+      );
+      expect(() => installEveWorkflowQueueNamespace("support-agent")).toThrow(
+        /already installed.*cannot replace/,
       );
       expect(process.env[WORKFLOW_QUEUE_NAMESPACE_ENV]).toBe("eve776561746865722d6167656e74");
     } finally {

--- a/packages/eve/src/internal/workflow/queue-namespace.ts
+++ b/packages/eve/src/internal/workflow/queue-namespace.ts
@@ -33,6 +33,12 @@ export function createEveWorkflowQueueTrigger(agentName: string) {
 /** Installs the agent-scoped namespace used by Workflow runtime operations. */
 export function installEveWorkflowQueueNamespace(agentName: string): string {
   const namespace = deriveEveWorkflowQueueNamespace(agentName);
+  const installedNamespace = process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
+  if (installedNamespace !== undefined && installedNamespace !== namespace) {
+    throw new Error(
+      `Workflow queue namespace is already installed as "${installedNamespace}"; cannot replace it with "${namespace}".`,
+    );
+  }
   process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = namespace;
   return namespace;
 }


### PR DESCRIPTION
Closes #641

## Summary
- install the agent-scoped workflow queue namespace before Nitro routes create workflow runtimes
- route channel dispatch and schedule dispatch through a shared Nitro workflow runtime stack
- add regression coverage plus a patch changeset for the published `eve` package

## Tests
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/nitro/routes/runtime-stack.test.ts src/internal/workflow/queue-namespace.test.ts src/internal/nitro/host/configure-nitro-routes.test.ts src/internal/application/compiled-artifacts.test.ts` (17 passed)
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/nitro/routes/runtime-stack.test.ts src/internal/nitro/routes/channel-dispatch.test.ts src/internal/workflow/queue-namespace.test.ts src/public/channels/teams/teamsChannel.test.ts` (21 passed)
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/nitro/routes/dev-schedule-dispatch.test.ts --testTimeout=15000` (4 passed)
- `pnpm --filter eve typecheck`
- `pnpm exec oxfmt --check packages/eve/src/internal/nitro/routes/runtime-stack.ts packages/eve/src/internal/nitro/routes/schedule-task.ts packages/eve/src/internal/nitro/routes/runtime-stack.test.ts`
- `pnpm exec oxlint --deny-warnings packages/eve/src/internal/nitro/routes/runtime-stack.ts packages/eve/src/internal/nitro/routes/schedule-task.ts packages/eve/src/internal/nitro/routes/runtime-stack.test.ts`
- `git diff --check`

## Notes
- I did not run a live Teams/Nitro deployment test locally; this is covered by the Nitro runtime-stack, channel-dispatch, Teams channel, and workflow queue namespace unit coverage above.
