### PR TITLE
fix(eve): dev auth - recover Vercel protection challenges

### DIFF
--- a/.changeset/tidy-cats-login.md
+++ b/.changeset/tidy-cats-login.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Recover `eve dev <url>` authentication when Vercel Deployment Protection returns an SSO redirect or a structured protected-deployment response.

--- a/packages/eve/src/cli/dev/tui/remote-connection.test.ts
+++ b/packages/eve/src/cli/dev/tui/remote-connection.test.ts
@@ -88,6 +88,12 @@ const VERCEL_SSO_CHALLENGE = `
 <a href="https://vercel.com/sso-api?url=https%3A%2F%2Fvpoke.playground-vercel.tools">
   Vercel Authentication
 </a>`;
+const VERCEL_SSO_URL =
+  "https://vercel.com/sso-api?url=https%3A%2F%2Fvpoke.playground-vercel.tools&nonce=test";
+const VERCEL_PROTECTED_DEPLOYMENT = JSON.stringify({
+  error: { code: "401", message: "Protected deployment" },
+  protection: { vercel_auth_callback: VERCEL_SSO_URL },
+});
 const TRUSTED_SOURCES_MISMATCH = [
   "The caller environment is not permitted.",
   "TRUSTED_SOURCES_ENVIRONMENT_MISMATCH",
@@ -162,6 +168,22 @@ describe("createRemoteConnectionController", () => {
     {
       name: "the Vercel Deployment Protection challenge",
       error: new ClientError(401, VERCEL_SSO_CHALLENGE),
+      expected: {
+        state: "auth-required",
+        challenge: { kind: "vercel-deployment-protection" },
+      },
+    },
+    {
+      name: "the Vercel Deployment Protection redirect",
+      error: new ClientError(302, "Redirecting...", { location: VERCEL_SSO_URL }),
+      expected: {
+        state: "auth-required",
+        challenge: { kind: "vercel-deployment-protection" },
+      },
+    },
+    {
+      name: "the structured Vercel Deployment Protection challenge",
+      error: new ClientError(401, VERCEL_PROTECTED_DEPLOYMENT),
       expected: {
         state: "auth-required",
         challenge: { kind: "vercel-deployment-protection" },

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -37,6 +37,8 @@ const REMOTE_VERIFIED_TARGET = await resolveTestVercelTarget({
   projectId: "prj_inbound",
   projectName: "inbound",
 });
+const VERCEL_SSO_URL =
+  "https://vercel.com/sso-api?url=https%3A%2F%2Fvpoke.playground-vercel.tools&nonce=test";
 
 /**
  * Real `Client` whose network-touching methods are replaced by vi spies.
@@ -1404,10 +1406,10 @@ describe("EveTUIRunner remote authentication", () => {
     expect(commandInvocations).toEqual([{ text: "/vc:login", status: undefined }]);
   });
 
-  it("runs /vc:login once at startup after the exact remote auth challenge", async () => {
+  it("runs /vc:login once at startup after Vercel redirects to its SSO challenge", async () => {
     const client = stubClient();
     vi.spyOn(client, "info")
-      .mockRejectedValueOnce(unauthorized())
+      .mockRejectedValueOnce(new ClientError(302, "Redirecting...", { location: VERCEL_SSO_URL }))
       .mockResolvedValueOnce(AGENT_INFO);
     const commandInvocations: Array<{ text: string; status: "failed" | undefined }> = [];
     const flow = successfulAuth();
@@ -1421,6 +1423,7 @@ describe("EveTUIRunner remote authentication", () => {
     });
 
     expect(flow).toHaveBeenCalledOnce();
+    expect(flow).toHaveBeenCalledWith(expect.objectContaining({ configureTrustedSources: true }));
     expect(commandInvocations).toEqual([{ text: "/vc:login", status: undefined }]);
   });
 

--- a/packages/eve/src/client/client-error.test.ts
+++ b/packages/eve/src/client/client-error.test.ts
@@ -22,4 +22,14 @@ describe("ClientError", () => {
 
     expect(error.message).toBe("Internal Server Error");
   });
+
+  it("preserves normalized response headers", () => {
+    const source = new Headers({ Location: "https://vercel.com/sso-api?url=https://eve.test" });
+    const error = new ClientError(302, "Redirecting...", source);
+    source.set("location", "https://example.com");
+
+    expect(error.headers).toEqual({
+      location: "https://vercel.com/sso-api?url=https://eve.test",
+    });
+  });
 });

--- a/packages/eve/src/client/client-error.ts
+++ b/packages/eve/src/client/client-error.ts
@@ -14,7 +14,12 @@ export class ClientError extends Error {
    */
   readonly body: string;
 
-  constructor(status: number, body: string) {
+  /**
+   * Response headers, normalized to lowercase names.
+   */
+  readonly headers: Readonly<Record<string, string>>;
+
+  constructor(status: number, body: string, headers?: ConstructorParameters<typeof Headers>[0]) {
     let message = body || `Server returned ${status}.`;
     try {
       const parsed: unknown = JSON.parse(body);
@@ -27,5 +32,6 @@ export class ClientError extends Error {
     this.name = "ClientError";
     this.status = status;
     this.body = body;
+    this.headers = Object.freeze(Object.fromEntries(new Headers(headers).entries()));
   }
 }

--- a/packages/eve/src/client/client.test.ts
+++ b/packages/eve/src/client/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AgentInfoResponseError } from "#client/agent-info-error.js";
 import { Client } from "#client/client.js";
+import { ClientError } from "#client/client-error.js";
 import type { AgentInfoResult } from "#client/types.js";
 import { resolveTestVercelTarget } from "#internal/testing/verified-vercel-target.js";
 import { resolveRemoteDevelopmentClientOptions } from "#services/dev-client/client-options.js";
@@ -84,6 +85,23 @@ describe("Client request policy", () => {
     const sent = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
     expect(sent.get("authorization")).toBe("Bearer oidc-tok");
     expect(sent.get("x-vercel-trusted-oidc-idp-token")).toBe("oidc-tok");
+  });
+
+  it("includes response headers in info request errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Redirecting...", {
+        status: 302,
+        headers: { location: "https://vercel.com/sso-api?url=https://eve.test" },
+      }),
+    );
+    const client = new Client({ host: "https://eve.test", redirect: "manual" });
+
+    const error = await client.info().catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ClientError);
+    expect((error as ClientError).headers.location).toBe(
+      "https://vercel.com/sso-api?url=https://eve.test",
+    );
   });
 
   it("keeps an in-flight remote request on one credential snapshot after rollback", async () => {

--- a/packages/eve/src/client/client.ts
+++ b/packages/eve/src/client/client.ts
@@ -54,7 +54,7 @@ export class Client {
 
     if (!response.ok) {
       const body = await response.text();
-      throw new ClientError(response.status, body);
+      throw new ClientError(response.status, body, response.headers);
     }
 
     return (await response.json()) as HealthResult;
@@ -78,7 +78,7 @@ export class Client {
 
     if (!response.ok) {
       const body = await response.text();
-      throw new ClientError(response.status, body);
+      throw new ClientError(response.status, body, response.headers);
     }
 
     let payload: unknown;

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -70,6 +70,7 @@ export async function openStreamBody(
 ): Promise<ReadableStream<Uint8Array>> {
   let lastStatus: number | undefined;
   let lastBody: string | undefined;
+  let lastHeaders: Headers | undefined;
 
   for (let attempt = 0; attempt < STREAM_OPEN_RETRY_ATTEMPTS; attempt += 1) {
     const url = createClientUrl(
@@ -87,16 +88,17 @@ export async function openStreamBody(
 
     if (response.ok) {
       if (!response.body) {
-        throw new ClientError(response.status, "Response body is null.");
+        throw new ClientError(response.status, "Response body is null.", response.headers);
       }
       return response.body;
     }
 
     lastStatus = response.status;
     lastBody = await response.text();
+    lastHeaders = response.headers;
 
     if (!STREAM_OPEN_RETRYABLE_STATUS.has(response.status)) {
-      throw new ClientError(response.status, lastBody);
+      throw new ClientError(response.status, lastBody, response.headers);
     }
 
     if (attempt < STREAM_OPEN_RETRY_ATTEMPTS - 1) {
@@ -104,7 +106,7 @@ export async function openStreamBody(
     }
   }
 
-  throw new ClientError(lastStatus ?? 0, lastBody ?? "Failed to open message stream.");
+  throw new ClientError(lastStatus ?? 0, lastBody ?? "Failed to open message stream.", lastHeaders);
 }
 
 async function sleep(ms: number): Promise<void> {

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -280,6 +280,7 @@ async function postTurnWithRetry(input: {
   const attempts = input.mustDeliver ? DELIVER_RETRY_ATTEMPTS : 1;
   let lastStatus: number | undefined;
   let lastBody: string | undefined;
+  let lastHeaders: Headers | undefined;
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const response = await fetch(input.url, {
@@ -294,9 +295,10 @@ async function postTurnWithRetry(input: {
 
     lastStatus = response.status;
     lastBody = await response.text();
+    lastHeaders = response.headers;
 
     if (!isRetryableDeliveryFailure(response.status, lastBody)) {
-      throw new ClientError(response.status, lastBody);
+      throw new ClientError(response.status, lastBody, response.headers);
     }
 
     if (attempt < attempts - 1) {
@@ -304,7 +306,11 @@ async function postTurnWithRetry(input: {
     }
   }
 
-  throw new ClientError(lastStatus ?? 0, lastBody ?? "Failed to deliver session turn.");
+  throw new ClientError(
+    lastStatus ?? 0,
+    lastBody ?? "Failed to deliver session turn.",
+    lastHeaders,
+  );
 }
 
 function isRetryableDeliveryFailure(status: number, body: string): boolean {

--- a/packages/eve/src/services/dev-client/vercel-auth-error.test.ts
+++ b/packages/eve/src/services/dev-client/vercel-auth-error.test.ts
@@ -19,6 +19,16 @@ const VERCEL_SSO_CHALLENGE_BODY = `<!doctype html><html lang=en><meta charset=ut
 <a href="https://vercel.com/sso-api?url=https%3A%2F%2Fexample.vercel.app">redirect</a>
 <a href="https://vercel.com/security">Vercel Authentication</a>
 </html>`;
+const VERCEL_SSO_URL = "https://vercel.com/sso-api?url=https%3A%2F%2Fexample.vercel.app&nonce=test";
+const VERCEL_PROTECTED_DEPLOYMENT_BODY = JSON.stringify({
+  error: { code: "401", message: "Protected deployment" },
+  protection: {
+    auto_vercel_auth_redirect: true,
+    password_enabled: false,
+    vercel_auth_enabled: true,
+    vercel_auth_callback: VERCEL_SSO_URL,
+  },
+});
 
 describe("isVercelAuthChallenge", () => {
   it("detects a real ClientError carrying the Vercel SSO challenge body", () => {
@@ -32,12 +42,75 @@ describe("isVercelAuthChallenge", () => {
     expect(isVercelAuthChallenge({ body: VERCEL_SSO_CHALLENGE_BODY, status: 401 })).toBe(true);
   });
 
-  it("requires HTTP 401 and the complete Vercel challenge signature", () => {
+  it("detects the manual-redirect response returned by Vercel for GET requests", () => {
+    expect(
+      isVercelAuthChallenge(new ClientError(302, "Redirecting...", { location: VERCEL_SSO_URL })),
+    ).toBe(true);
+    expect(
+      isVercelAuthChallenge({
+        body: "Redirecting...",
+        headers: { Location: VERCEL_SSO_URL },
+        status: 302,
+      }),
+    ).toBe(true);
+  });
+
+  it("detects the structured 401 returned by Vercel for API requests", () => {
+    expect(isVercelAuthChallenge(new ClientError(401, VERCEL_PROTECTED_DEPLOYMENT_BODY))).toBe(
+      true,
+    );
+    expect(isVercelAuthChallenge({ body: VERCEL_PROTECTED_DEPLOYMENT_BODY, status: 401 })).toBe(
+      true,
+    );
+  });
+
+  it("requires HTTP 401 and the complete legacy HTML challenge signature", () => {
     expect(isVercelAuthChallenge(new ClientError(500, VERCEL_SSO_CHALLENGE_BODY))).toBe(false);
     expect(
       isVercelAuthChallenge(new ClientError(401, "<title>Authentication Required</title>")),
     ).toBe(false);
     expect(isVercelAuthChallenge({ body: VERCEL_SSO_CHALLENGE_BODY })).toBe(false);
+  });
+
+  it("requires an exact Vercel SSO destination for redirect challenges", () => {
+    expect(
+      isVercelAuthChallenge(
+        new ClientError(302, "Redirecting...", {
+          location: "https://example.com/sso-api?url=https://eve.test",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isVercelAuthChallenge(
+        new ClientError(302, "Redirecting...", {
+          location: "https://vercel.com/sso-api",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isVercelAuthChallenge(new ClientError(200, "Redirecting...", { location: VERCEL_SSO_URL })),
+    ).toBe(false);
+  });
+
+  it("requires the complete structured Vercel challenge signature", () => {
+    expect(
+      isVercelAuthChallenge(
+        new ClientError(
+          401,
+          JSON.stringify({
+            error: { code: "401", message: "Protected deployment" },
+            protection: {
+              vercel_auth_callback: "https://example.com/sso-api?url=https://eve.test",
+            },
+          }),
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isVercelAuthChallenge(
+        new ClientError(401, JSON.stringify({ error: "Protected deployment" })),
+      ),
+    ).toBe(false);
   });
 
   it("returns false for non-error inputs", () => {

--- a/packages/eve/src/services/dev-client/vercel-auth-error.ts
+++ b/packages/eve/src/services/dev-client/vercel-auth-error.ts
@@ -30,6 +30,8 @@ const VERCEL_AUTH_CHALLENGE_MARKERS: readonly string[] = [
   "vercel.com/sso-api",
   "<title>Authentication Required</title>",
 ];
+const VERCEL_SSO_ORIGIN = "https://vercel.com";
+const VERCEL_SSO_PATH = "/sso-api";
 
 const TRUSTED_SOURCES_ERROR_CODE = /^TRUSTED_SOURCES_[A-Z0-9_]+$/u;
 
@@ -47,24 +49,74 @@ function bodyLooksLikeVercelAuthChallenge(body: string): boolean {
   return body.length > 0 && VERCEL_AUTH_CHALLENGE_MARKERS.every((marker) => body.includes(marker));
 }
 
+function isVercelSsoUrl(value: string): boolean {
+  const url = URL.parse(value);
+  return (
+    url?.origin === VERCEL_SSO_ORIGIN &&
+    url.pathname === VERCEL_SSO_PATH &&
+    url.searchParams.has("url")
+  );
+}
+
+function isVercelSsoRedirect(
+  status: number,
+  headers: Readonly<Record<string, unknown>> | undefined,
+): boolean {
+  if (status < 300 || status >= 400 || headers === undefined) return false;
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === "location" && typeof value === "string") {
+      return isVercelSsoUrl(value);
+    }
+  }
+  return false;
+}
+
+function bodyLooksLikeStructuredVercelAuthChallenge(body: string): boolean {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return false;
+  }
+  if (!isObject(payload) || !isObject(payload.error) || !isObject(payload.protection)) {
+    return false;
+  }
+
+  const code = payload.error.code;
+  const callback = payload.protection.vercel_auth_callback;
+  return (
+    (code === 401 || code === "401") &&
+    payload.error.message === "Protected deployment" &&
+    typeof callback === "string" &&
+    isVercelSsoUrl(callback)
+  );
+}
+
 /**
- * Returns `true` for an HTTP 401 carrying Vercel's protection challenge.
+ * Returns `true` for a Vercel Deployment Protection challenge.
  *
  * Accepts both real {@link ClientError} instances and structurally
- * compatible duck-typed errors (`{ status: number, body: string }`)
+ * compatible duck-typed errors (`{ status, body, headers }`)
  * so callers can detect the challenge regardless of whether the
  * error survived a network/IPC boundary.
  */
 export function isVercelAuthChallenge(error: unknown): boolean {
-  if (error instanceof ClientError) {
-    return error.status === 401 && bodyLooksLikeVercelAuthChallenge(error.body);
+  const candidate = error instanceof ClientError || isObject(error) ? error : undefined;
+  if (
+    candidate === undefined ||
+    typeof candidate.status !== "number" ||
+    typeof candidate.body !== "string"
+  ) {
+    return false;
   }
 
+  const headers = isObject(candidate.headers) ? candidate.headers : undefined;
   return (
-    isObject(error) &&
-    error.status === 401 &&
-    typeof error.body === "string" &&
-    bodyLooksLikeVercelAuthChallenge(error.body)
+    isVercelSsoRedirect(candidate.status, headers) ||
+    (candidate.status === 401 &&
+      (bodyLooksLikeVercelAuthChallenge(candidate.body) ||
+        bodyLooksLikeStructuredVercelAuthChallenge(candidate.body)))
   );
 }
 


### PR DESCRIPTION
## Summary

- preserve normalized response headers on `ClientError` across info, health, session, and stream requests
- recognize Vercel Deployment Protection redirects to `https://vercel.com/sso-api`
- recognize Vercel's structured `401 Protected deployment` API response
- classify both forms as authentication challenges so remote `eve dev` starts `/vc:login` recovery

## Root cause

The remote development client only recognized Vercel's older `401` HTML challenge. Vercel now returns a manual `302` SSO redirect for the startup info probe and a structured `401` for API requests, so eve classified protected deployments as unavailable and never entered its authentication recovery flow.

## Impact

`eve dev <protected-url>` now recovers through the existing verified-origin and Trusted Sources flow for both current Vercel response shapes. Redirect matching is restricted to the HTTPS Vercel SSO endpoint, and structured responses must include the complete nested protection signature.

## Validation

- `pnpm --filter eve test:unit` (4,571 passed, 1 skipped)
- `pnpm --filter eve typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm --filter eve build`
- focused formatting check and `git diff --check`
