### PR TITLE
fix(eve): detect credentialed deployment protection

### DIFF
--- a/.changeset/bright-dogs-login.md
+++ b/.changeset/bright-dogs-login.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Start remote authentication when a credentialed Vercel deployment returns an `UNAUTHORIZED` protection response.

--- a/packages/eve/src/cli/dev/tui/remote-connection.test.ts
+++ b/packages/eve/src/cli/dev/tui/remote-connection.test.ts
@@ -190,6 +190,16 @@ describe("createRemoteConnectionController", () => {
       },
     },
     {
+      name: "Vercel's credentialed Deployment Protection rejection",
+      error: new ClientError(401, "You must sign in\n\nUNAUTHORIZED\n\niad1::request-id\n", {
+        "x-vercel-error": "UNAUTHORIZED",
+      }),
+      expected: {
+        state: "auth-required",
+        challenge: { kind: "vercel-deployment-protection" },
+      },
+    },
+    {
       name: "a 403 Trusted Sources environment mismatch",
       error: new ClientError(403, TRUSTED_SOURCES_MISMATCH),
       expected: {

--- a/packages/eve/src/services/dev-client/vercel-auth-error.test.ts
+++ b/packages/eve/src/services/dev-client/vercel-auth-error.test.ts
@@ -64,6 +64,16 @@ describe("isVercelAuthChallenge", () => {
     );
   });
 
+  it("detects Vercel's credentialed deployment-protection rejection", () => {
+    expect(
+      isVercelAuthChallenge(
+        new ClientError(401, "You must sign in\n\nUNAUTHORIZED\n\niad1::request-id\n", {
+          "x-vercel-error": "UNAUTHORIZED",
+        }),
+      ),
+    ).toBe(true);
+  });
+
   it("requires HTTP 401 and the complete legacy HTML challenge signature", () => {
     expect(isVercelAuthChallenge(new ClientError(500, VERCEL_SSO_CHALLENGE_BODY))).toBe(false);
     expect(

--- a/packages/eve/src/services/dev-client/vercel-auth-error.ts
+++ b/packages/eve/src/services/dev-client/vercel-auth-error.ts
@@ -72,6 +72,18 @@ function isVercelSsoRedirect(
   return false;
 }
 
+function isVercelUnauthorized(
+  status: number,
+  headers: Readonly<Record<string, unknown>> | undefined,
+): boolean {
+  if (status !== 401 || headers === undefined) return false;
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === "x-vercel-error" && value === "UNAUTHORIZED") return true;
+  }
+  return false;
+}
+
 function bodyLooksLikeStructuredVercelAuthChallenge(body: string): boolean {
   let payload: unknown;
   try {
@@ -114,6 +126,7 @@ export function isVercelAuthChallenge(error: unknown): boolean {
   const headers = isObject(candidate.headers) ? candidate.headers : undefined;
   return (
     isVercelSsoRedirect(candidate.status, headers) ||
+    isVercelUnauthorized(candidate.status, headers) ||
     (candidate.status === 401 &&
       (bodyLooksLikeVercelAuthChallenge(candidate.body) ||
         bodyLooksLikeStructuredVercelAuthChallenge(candidate.body)))


### PR DESCRIPTION
## What

- Treat HTTP 401 responses carrying `x-vercel-error: UNAUTHORIZED` as Vercel Deployment Protection challenges.
- Route that monitor result into the existing `auth-required` state so remote `eve dev` starts `/vc:login`.

The live credentialed probe resolved the deployment and then returned:

```
HTTP 401
x-vercel-error: UNAUTHORIZED

You must sign in
UNAUTHORIZED
<request-id>
```

[#654](https://github.com/vercel/eve/pull/654) covers the anonymous 302 SSO redirect and structured protected-deployment response. Once the monitor resolves the project and attaches an OIDC token, Vercel uses this different response instead. The monitor classified it as `Remote unavailable`, so startup never entered the authentication flow.

This keys on the stable Vercel response header instead of the body, which includes a changing request id. The authentication flow itself is unchanged.