### PR TITLE
docs: drop the extensions guide from the sidebar

### DIFF
--- a/.changeset/hide-extensions-nav.md
+++ b/.changeset/hide-extensions-nav.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep the mounted extensions guide out of the docs sidebar for now. The page stays at `/docs/extensions`, but the feature isn't surfaced in the nav while its API stabilizes.

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -12,7 +12,6 @@
     "sandbox",
     "subagents",
     "schedules",
-    "extensions",
     "evals",
     "---",
     "guides",

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -37,6 +37,9 @@ const ROOTS = [
 const SIDEBAR_EXEMPT_PAGES = new Set([
   // Linked from the global footer instead of the docs sidebar.
   "responsible-use.md",
+  // Reachable at its URL but intentionally kept out of the sidebar for now
+  // while the mounted-extensions feature stabilizes.
+  "extensions.md",
 ]);
 
 // Only the top-level README.md is excluded. Nested READMEs (e.g.


### PR DESCRIPTION
## Summary

Removes the **extensions** guide from the docs sidebar while the mounted-extensions API stabilizes. The page is unchanged and still lives at **`/docs/extensions`** — it's just not linked in the nav.

- `docs/meta.json` — drop `"extensions"` from the sidebar order.
- `scripts/check-docs.mjs` — add `extensions.md` to `SIDEBAR_EXEMPT_PAGES` (same allowlist as `responsible-use.md`) so `check-docs` doesn't flag it as orphaned.

Fumadocs still renders the route from the MDX file regardless of nav membership, so the URL is preserved. Includes a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)