### PR TITLE
feat(events): emit invalid tool call events

### DIFF
--- a/.changeset/invalid-tool-call-events.md
+++ b/.changeset/invalid-tool-call-events.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit `action.invalid` stream events for model tool calls that fail validation before execution.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -47,6 +47,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | `message.received`        | An inbound user message was accepted; carries flattened text plus structured text/file parts.                    |
 | `step.started`            | A model step began.                                                                                              |
 | `actions.requested`       | The model requested one or more actions, including tool calls; calls stream before execution.                    |
+| `action.invalid`          | A model-emitted tool call failed validation before it could be requested or executed.                            |
 | `action.result`           | A tool call returned.                                                                                            |
 | `input.requested`         | The run paused for human input ([HITL](/docs/human-in-the-loop) approval or `ask_question`); carries `requests`. |
 | `subagent.called`         | A subagent was delegated; carries `childSessionId` to attach to.                                                 |

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -85,6 +85,7 @@ The most common UI events are:
 | `reasoning.appended` | Render reasoning deltas when the model provides them.                          |
 | `message.appended`   | Render assistant text deltas.                                                  |
 | `actions.requested`  | Show tool calls as the model requests them, before execution.                  |
+| `action.invalid`     | Show or count tool calls that failed validation before execution.              |
 | `action.result`      | Show tool call results.                                                        |
 | `input.requested`    | Pause the UI for approval or a question answer.                                |
 | `result.completed`   | Read structured output from an [output schema](./output-schema).               |

--- a/packages/eve/src/client/index.ts
+++ b/packages/eve/src/client/index.ts
@@ -87,6 +87,8 @@ export type {
 // ---------------------------------------------------------------------------
 
 export type {
+  ActionInvalidReason,
+  ActionInvalidStreamEvent,
   ActionResultStreamEvent,
   ActionsRequestedStreamEvent,
   AssistantStepFinishReason,

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -1,4 +1,4 @@
-import { jsonSchema, type TextStreamPart, type ToolSet } from "ai";
+import { jsonSchema, NoSuchToolError, type TextStreamPart, type ToolSet } from "ai";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -534,6 +534,101 @@ describe("emitStreamContent action requests", () => {
       },
     ]);
     expect(providerResult.trailingInlineToolResultParts).toEqual([]);
+  });
+
+  it("emits invalid action events for AI SDK invalid tool calls", async () => {
+    const emit = createEmitStub();
+    const error = new NoSuchToolError({
+      availableTools: ["web_search"],
+      toolName: "missing_tool",
+    });
+
+    const result = await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        { id: "text-1", text: "I'll check that.", type: "text-delta" },
+        {
+          dynamic: true,
+          error,
+          input: { query: "eve" },
+          invalid: true,
+          toolCallId: "call-missing",
+          toolName: "missing_tool",
+          type: "tool-call",
+        },
+        { finishReason: "tool-calls", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+      {
+        excludedActionToolNames: new Set(),
+        tools: new Map(),
+      },
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events.map((event) => event.type)).toEqual([
+      "message.appended",
+      "message.completed",
+      "action.invalid",
+    ]);
+    expect(events[2]).toEqual({
+      data: {
+        callId: "call-missing",
+        errorText: error.message,
+        input: { query: "eve" },
+        reason: "no-such-tool",
+        sequence: 0,
+        stepIndex: 0,
+        toolName: "missing_tool",
+        turnId: "turn_0",
+      },
+      type: "action.invalid",
+    });
+    expect([...result.emittedInvalidToolCallIds]).toEqual(["call-missing"]);
+    expect([...result.emittedActionCallIds]).toEqual([]);
+  });
+
+  it("does not leak provider-executed invalid calls into the action lifecycle", async () => {
+    const emit = createEmitStub();
+    const error = new NoSuchToolError({
+      availableTools: ["web_search"],
+      toolName: "missing_tool",
+    });
+
+    const result = await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        {
+          dynamic: true,
+          error,
+          input: { query: "eve" },
+          invalid: true,
+          providerExecuted: true,
+          toolCallId: "call-missing",
+          toolName: "missing_tool",
+          type: "tool-call",
+        },
+        {
+          input: { query: "eve" },
+          output: { results: [] },
+          providerExecuted: true,
+          toolCallId: "call-missing",
+          toolName: "missing_tool",
+          type: "tool-result",
+        },
+        { finishReason: "tool-calls", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+      {
+        excludedActionToolNames: new Set(),
+        tools: new Map(),
+      },
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events.map((event) => event.type)).toEqual(["action.invalid"]);
+    expect([...result.emittedInvalidToolCallIds]).toEqual(["call-missing"]);
+    expect([...result.emittedActionCallIds]).toEqual([]);
   });
 
   it("turns non-object tool call input into a failed tool result for the model", async () => {

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -52,6 +52,7 @@ import { normalizeModelStreamError } from "#harness/model-call-error.js";
 import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import { interruptStreamOnFailure } from "#harness/interruptible-stream.js";
 import { isInlineAuthorizationToolResult } from "#harness/inline-tool-authorization.js";
+import { emitActionInvalidEvent } from "#harness/invalid-tool-call-events.js";
 import type {
   HarnessEmitFn,
   HarnessSession,
@@ -59,10 +60,6 @@ import type {
   SessionStateMap,
   StepInput,
 } from "#harness/types.js";
-
-// ---------------------------------------------------------------------------
-// Emission state
-// ---------------------------------------------------------------------------
 
 /**
  * Tracks emission lifecycle state across harness step invocations.
@@ -126,10 +123,6 @@ export function setHarnessEmissionState(
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Turn lifecycle helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Emits `session.started` (once), `turn.started`, and `message.received` at the
@@ -297,10 +290,6 @@ export async function emitTurnEpilogue(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
 /**
  * Maps an AI SDK finish reason string to the eve-owned
  * {@link AssistantStepFinishReason} union. Unknown values become `"other"`.
@@ -320,10 +309,6 @@ export function normalizeAssistantStepFinishReason(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Stream content emission
-// ---------------------------------------------------------------------------
-
 /**
  * Result of consuming one step's `fullStream`.
  *
@@ -332,6 +317,7 @@ export function normalizeAssistantStepFinishReason(
  */
 interface EmittedStreamContent {
   readonly emittedActionCallIds: ReadonlySet<string>;
+  readonly emittedInvalidToolCallIds: ReadonlySet<string>;
   readonly handledInlineToolResultCallIds: ReadonlySet<string>;
   readonly invalidInputToolCallIds: ReadonlySet<string>;
   readonly inlineAuthorizationResults: readonly TypedToolResult<ToolSet>[];
@@ -393,6 +379,7 @@ async function consumeStreamContent(
   const toolCallIdsSeenInStream = new Set<string>();
   const emittedActionCallIds = new Set<string>();
   const emittedActionResultCallIds = new Set<string>();
+  const emittedInvalidToolCallIds = new Set<string>();
   const providerToolCallIdsSeen = new Set<string>();
   const handledInlineToolResultCallIds = new Set<string>();
   const invalidInputToolCallIds = new Set<string>();
@@ -400,7 +387,7 @@ async function consumeStreamContent(
   const trailingInlineToolResultParts: InlineToolResultPart[] = [];
 
   const flushCurrentMessage = async (): Promise<void> => {
-    if (currentMessage.length === 0) {
+    if (currentMessage.trim().length === 0) {
       return;
     }
     await emitFn(
@@ -420,9 +407,7 @@ async function consumeStreamContent(
       return;
     }
 
-    if (currentMessage.trim().length > 0) {
-      await flushCurrentMessage();
-    }
+    await flushCurrentMessage();
 
     emittedActionCallIds.add(action.callId);
     await emitFn(
@@ -449,9 +434,7 @@ async function consumeStreamContent(
     }
     emittedActionCallIds.add(toolCall.toolCallId);
 
-    if (currentMessage.trim().length > 0) {
-      await flushCurrentMessage();
-    }
+    await flushCurrentMessage();
 
     const resolved = resolveProviderToolCallRequest(toolCall);
     if (resolved.toolError !== undefined) {
@@ -480,11 +463,22 @@ async function consumeStreamContent(
   };
 
   const emitToolCall = async (toolCall: TypedToolCall<ToolSet>): Promise<void> => {
-    if (isInvalidToolCall(toolCall)) {
-      invalidInputToolCallIds.add(toolCall.toolCallId);
+    if (options === undefined) {
       return;
     }
-    if (options === undefined || options.excludedActionToolNames.has(toolCall.toolName)) {
+
+    if (toolCall.invalid === true) {
+      await emitActionInvalidEvent({
+        emitFn,
+        emittedToolCallIds: emittedInvalidToolCallIds,
+        flushBeforeEmit: flushCurrentMessage,
+        state,
+        toolCall,
+      });
+      return;
+    }
+
+    if (options.excludedActionToolNames.has(toolCall.toolName)) {
       return;
     }
 
@@ -499,9 +493,7 @@ async function consumeStreamContent(
       if (error instanceof TypeError) {
         const toolError = createInvalidToolCallInputError({ error, toolCall });
         invalidInputToolCallIds.add(toolCall.toolCallId);
-        if (currentMessage.trim().length > 0) {
-          await flushCurrentMessage();
-        }
+        await flushCurrentMessage();
         await emitActionResult(createRuntimeToolResultFromToolError(toolError));
         handledInlineToolResultCallIds.add(toolCall.toolCallId);
         trailingInlineToolResultParts.push(createToolResultMessagePartFromToolError(toolError));
@@ -558,7 +550,10 @@ async function consumeStreamContent(
       case "tool-call": {
         const toolCall = part as TypedToolCall<ToolSet>;
         toolCallIdsSeenInStream.add(toolCall.toolCallId);
-        if (toolCall.providerExecuted === true) {
+        if (toolCall.invalid === true) {
+          await providerActionBatch.flush();
+          await emitToolCall(toolCall);
+        } else if (toolCall.providerExecuted === true) {
           await collectProviderToolCall(toolCall);
         } else {
           await providerActionBatch.flush();
@@ -570,6 +565,9 @@ async function consumeStreamContent(
         const inlineToolResult = part as TypedToolResult<ToolSet>;
         // Preliminary chunks can be superseded by the terminal result.
         if (inlineToolResult.preliminary === true) {
+          break;
+        }
+        if (emittedInvalidToolCallIds.has(inlineToolResult.toolCallId)) {
           break;
         }
         if (inlineToolResult.providerExecuted === true) {
@@ -613,6 +611,9 @@ async function consumeStreamContent(
       }
       case "tool-error": {
         const toolError = part as TypedToolError<ToolSet>;
+        if (emittedInvalidToolCallIds.has(toolError.toolCallId)) {
+          break;
+        }
         if (toolError.providerExecuted === true) {
           await collectProviderToolCall(toolError);
           await providerActionBatch.flush();
@@ -688,6 +689,7 @@ async function consumeStreamContent(
 
   return {
     emittedActionCallIds,
+    emittedInvalidToolCallIds,
     handledInlineToolResultCallIds,
     invalidInputToolCallIds,
     inlineAuthorizationResults,

--- a/packages/eve/src/harness/invalid-tool-call-events.ts
+++ b/packages/eve/src/harness/invalid-tool-call-events.ts
@@ -1,0 +1,64 @@
+import { NoSuchToolError, type ToolSet, type TypedToolCall } from "ai";
+
+import { createActionInvalidEvent, type ActionInvalidStreamEvent } from "#protocol/message.js";
+import { toError } from "#shared/errors.js";
+import { parseJsonValue } from "#shared/json.js";
+
+interface ActionInvalidEventCoordinates {
+  readonly sequence: number;
+  readonly stepIndex: number;
+  readonly turnId: string;
+}
+
+/** Converts an AI SDK invalid tool call into eve's public invalid-action event. */
+export function createActionInvalidEventFromToolCall(input: {
+  readonly state: ActionInvalidEventCoordinates;
+  readonly toolCall: TypedToolCall<ToolSet>;
+}): ActionInvalidStreamEvent {
+  const toolError = (input.toolCall as { readonly error?: unknown }).error;
+  const serializedInput = tryParseJsonValue(input.toolCall.input);
+
+  return createActionInvalidEvent({
+    callId: input.toolCall.toolCallId,
+    errorText: toolError === undefined ? "Tool call is invalid." : toError(toolError).message,
+    input: serializedInput,
+    reason:
+      toolError !== undefined && NoSuchToolError.isInstance(toolError)
+        ? "no-such-tool"
+        : "invalid-input",
+    sequence: input.state.sequence,
+    stepIndex: input.state.stepIndex,
+    toolName: input.toolCall.toolName,
+    turnId: input.state.turnId,
+  });
+}
+
+/** Emits an invalid-action event once per tool-call id, optionally after flushing narration. */
+export async function emitActionInvalidEvent(input: {
+  readonly emitFn: (event: ActionInvalidStreamEvent) => Promise<void>;
+  readonly emittedToolCallIds: Set<string>;
+  readonly flushBeforeEmit?: () => Promise<void>;
+  readonly state: ActionInvalidEventCoordinates;
+  readonly toolCall: TypedToolCall<ToolSet>;
+}): Promise<void> {
+  if (input.emittedToolCallIds.has(input.toolCall.toolCallId)) {
+    return;
+  }
+
+  await input.flushBeforeEmit?.();
+  input.emittedToolCallIds.add(input.toolCall.toolCallId);
+  await input.emitFn(
+    createActionInvalidEventFromToolCall({
+      state: input.state,
+      toolCall: input.toolCall,
+    }),
+  );
+}
+
+function tryParseJsonValue(value: unknown): ReturnType<typeof parseJsonValue> | undefined {
+  try {
+    return parseJsonValue(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -32,6 +32,7 @@ import {
 } from "#harness/prompt-cache.js";
 import { createRuntimeActionRequestFromToolCall } from "#harness/runtime-actions.js";
 import { isInvalidToolCall } from "#harness/tool-call-input-errors.js";
+import { createActionInvalidEventFromToolCall } from "#harness/invalid-tool-call-events.js";
 import type { RuntimeToolResultActionResult } from "#runtime/actions/types.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 import { contextStorage } from "#context/container.js";
@@ -195,13 +196,11 @@ export function buildStepHooks(input: StepHooksInput): StepHooks {
  * Emits `actions.requested`, `action.result`, and `step.completed` events
  * from a captured step result.
  *
- * Tool calls and results that match `excludedActionToolNames`, belong to
- * tool-approval requests, or are marked `invalid` by the AI SDK (e.g. the
- * model emitted unparsable JSON) are filtered out of the emitted events.
- * The AI SDK feeds the invalid-call error back to the model on the next
- * step via `step.response.messages` so it can retry with well-formed
- * arguments — the runtime event stream only sees successfully parsed
- * tool calls.
+ * Tool calls and results that match `excludedActionToolNames` or belong to
+ * tool-approval requests are filtered out of `actions.requested` /
+ * `action.result`. Tool calls marked `invalid` by the AI SDK (e.g. the model
+ * emitted unparsable JSON or targeted an unknown tool) emit `action.invalid`
+ * instead, then stay out of the action lifecycle.
  *
  * `handledInlineToolResultCallIds` contains results emitted by
  * `emitStreamContent` or sent to authorization. Skip them here.
@@ -212,6 +211,7 @@ export async function emitStepActions(
   step: HarnessStepResult,
   options: {
     readonly emittedActionCallIds?: ReadonlySet<string>;
+    readonly emittedInvalidToolCallIds?: ReadonlySet<string>;
     readonly excludedActionCallIds?: ReadonlySet<string>;
     readonly excludedActionToolNames: ReadonlySet<string>;
     readonly handledInlineToolResultCallIds?: ReadonlySet<string>;
@@ -223,6 +223,7 @@ export async function emitStepActions(
       .filter(isProviderExecutedToolCall)
       .map((toolCall) => toolCall.toolCallId),
   );
+  const invalidToolCalls = (step.toolCalls as TypedToolCall<ToolSet>[]).filter(isInvalidToolCall);
   const excludedCallIds = new Set<string>([
     ...(options.excludedActionCallIds ?? []),
     ...providerExecutedCallIds,
@@ -230,13 +231,19 @@ export async function emitStepActions(
       content: (step.content ?? []) as ContentPart<ToolSet>[],
       excludedCallIds: options.excludedActionCallIds,
     }).map((request) => request.action.callId),
-    ...(step.toolCalls as TypedToolCall<ToolSet>[])
-      .filter(isInvalidToolCall)
-      .map((toolCall) => toolCall.toolCallId),
+    ...invalidToolCalls.map((toolCall) => toolCall.toolCallId),
   ]);
 
   const isExcluded = (toolCallId: string, toolName: string): boolean =>
     excludedCallIds.has(toolCallId) || options.excludedActionToolNames.has(toolName);
+
+  for (const toolCall of invalidToolCalls) {
+    if (options.emittedInvalidToolCallIds?.has(toolCall.toolCallId)) {
+      continue;
+    }
+
+    await emitFn(createActionInvalidEventFromToolCall({ state, toolCall }));
+  }
 
   // Streamed calls already emitted their request. The loop below emits their
   // result.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -61,6 +61,9 @@ import {
 } from "#shared/empty-delivery.js";
 
 vi.mock("ai", () => ({
+  NoSuchToolError: {
+    isInstance: vi.fn(() => false),
+  },
   ToolLoopAgent: vi.fn(),
   gateway: {
     tools: {
@@ -2514,9 +2517,22 @@ describe("createToolLoopHarness", () => {
     // Must not throw.
     await expect(runStep(createTestSession(), { message: "Do it" })).resolves.toBeDefined();
 
-    // The invalid call must be absent from the action event stream.
+    // The invalid call must be absent from the executable action lifecycle,
+    // while still leaving a durable invalid-action breadcrumb.
     expect(events.some((event) => event.type === "actions.requested")).toBe(false);
     expect(events.some((event) => event.type === "action.result")).toBe(false);
+    const invalidEvents = events.filter((event) => event.type === "action.invalid");
+    expect(invalidEvents).toHaveLength(1);
+    expect(invalidEvents[0]?.data).toEqual({
+      callId: "call-bad",
+      errorText: "SyntaxError: Unexpected token in JSON",
+      input: '{"answer": "...", "keyObservations": \n- bullet',
+      reason: "invalid-input",
+      sequence: 0,
+      stepIndex: 0,
+      toolName: "add",
+      turnId: "turn_0",
+    });
 
     // The recoverable-failure path must not fire — the step completes
     // normally so the next turn can feed the SDK's tool-error back to
@@ -2762,6 +2778,13 @@ describe("createToolLoopHarness", () => {
       stepIndex: 0,
       turnId: "turn_0",
     });
+    expect(events.find((event) => event.type === "action.invalid")?.data).toMatchObject({
+      callId: "call-bad",
+      errorText: "SyntaxError",
+      input: '{"bad":',
+      reason: "invalid-input",
+      toolName: "add",
+    });
 
     const actionResults = events.filter((event) => event.type === "action.result");
     expect(actionResults).toHaveLength(1);
@@ -2831,6 +2854,12 @@ describe("createToolLoopHarness", () => {
     // dropped so the AI SDK's tool-error feedback drives the next step.
     expect(result.session.state?.["eve.runtime.pendingActionBatch"]).toBeUndefined();
     expect(events.some((event) => event.type === "actions.requested")).toBe(false);
+    expect(events.find((event) => event.type === "action.invalid")?.data).toMatchObject({
+      callId: "call-subagent-bad",
+      input: '{"malformed',
+      reason: "invalid-input",
+      toolName: "delegate",
+    });
     expect(events.some((event) => event.type === "turn.failed")).toBe(false);
   });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -981,6 +981,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           });
           const {
             emittedActionCallIds,
+            emittedInvalidToolCallIds,
             handledInlineToolResultCallIds,
             invalidInputToolCallIds,
             inlineAuthorizationResults,
@@ -1004,6 +1005,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           }
           await emitStepActions(emit, emissionState, stepResult, {
             emittedActionCallIds,
+            emittedInvalidToolCallIds,
             excludedActionCallIds: invalidInputToolCallIds,
             excludedActionToolNames,
             handledInlineToolResultCallIds,

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -5,6 +5,7 @@ import { encodeSandboxRef } from "#internal/attachments/sandbox-refs.js";
 import { serializeUrlFilePart } from "#internal/attachments/url-refs.js";
 import {
   EVE_MESSAGE_STREAM_VERSION,
+  createActionInvalidEvent,
   createActionResultEvent,
   createAuthorizationCompletedEvent,
   createAuthorizationRequiredEvent,
@@ -38,6 +39,33 @@ describe("message stream protocol", () => {
     expect(createTurnCancelledEvent({ sequence: 2, turnId: "turn_2" })).toEqual({
       data: { sequence: 2, turnId: "turn_2" },
       type: "turn.cancelled",
+    });
+  });
+
+  it("creates action.invalid events", () => {
+    expect(
+      createActionInvalidEvent({
+        callId: "call-bad",
+        errorText: "Model tried to call unavailable tool 'missing'.",
+        input: { city: "Vienna" },
+        reason: "no-such-tool",
+        sequence: 2,
+        stepIndex: 1,
+        toolName: "missing",
+        turnId: "turn_2",
+      }),
+    ).toEqual({
+      data: {
+        callId: "call-bad",
+        errorText: "Model tried to call unavailable tool 'missing'.",
+        input: { city: "Vienna" },
+        reason: "no-such-tool",
+        sequence: 2,
+        stepIndex: 1,
+        toolName: "missing",
+        turnId: "turn_2",
+      },
+      type: "action.invalid",
     });
   });
 

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -75,6 +75,12 @@ export interface MessageStreamEventMeta {
 export type ActionResultStatus = "completed" | "failed" | "rejected";
 
 /**
+ * Stable reason for one model-emitted tool call that could not become a
+ * runtime action.
+ */
+export type ActionInvalidReason = "invalid-input" | "no-such-tool";
+
+/**
  * Stable failure payload projected onto `action.result`.
  *
  * This keeps UI consumers from having to parse provider- or tool-specific
@@ -252,6 +258,24 @@ export interface ActionResultStreamEvent {
     turnId: string;
   };
   type: "action.result";
+}
+
+/**
+ * Stream event emitted when the model produced a tool call that failed
+ * validation before the runtime could request or execute the action.
+ */
+export interface ActionInvalidStreamEvent {
+  data: {
+    callId: string;
+    errorText: string;
+    input?: JsonValue;
+    reason: ActionInvalidReason;
+    sequence: number;
+    stepIndex: number;
+    toolName: string;
+    turnId: string;
+  };
+  type: "action.invalid";
 }
 
 /**
@@ -618,6 +642,7 @@ export type UnstampedMessageStreamEvent =
   | ActionsRequestedStreamEvent
   | InputRequestedStreamEvent
   | ActionResultStreamEvent
+  | ActionInvalidStreamEvent
   | ReasoningCompletedStreamEvent
   | StepCompletedStreamEvent
   | StepFailedStreamEvent
@@ -944,6 +969,38 @@ export function createActionsRequestedEvent(input: {
       turnId: input.turnId,
     },
     type: "actions.requested",
+  };
+}
+
+/**
+ * Creates the `action.invalid` event for one model-emitted tool call that
+ * failed validation before it could be requested or executed.
+ */
+export function createActionInvalidEvent(input: {
+  readonly callId: string;
+  readonly errorText: string;
+  readonly input?: JsonValue;
+  readonly reason: ActionInvalidReason;
+  readonly sequence: number;
+  readonly stepIndex: number;
+  readonly toolName: string;
+  readonly turnId: string;
+}): ActionInvalidStreamEvent {
+  const data: ActionInvalidStreamEvent["data"] = {
+    callId: input.callId,
+    errorText: input.errorText,
+    reason: input.reason,
+    sequence: input.sequence,
+    stepIndex: input.stepIndex,
+    toolName: input.toolName,
+    turnId: input.turnId,
+  };
+  if (input.input !== undefined) {
+    data.input = input.input;
+  }
+  return {
+    data,
+    type: "action.invalid",
   };
 }
 


### PR DESCRIPTION
Summary
- add an `action.invalid` stream event for model tool calls that fail validation before execution
- classify invalid calls as `no-such-tool` or `invalid-input`, include JSON-serializable raw input when available, and dedupe by call id across streamed and post-step emission
- keep invalid calls out of `actions.requested` / `action.result`, export the client event types, document the event, and add a changeset

Refs #542.

Tests
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/protocol/message.test.ts src/harness/emission.test.ts src/harness/tool-loop.test.ts`
- `pnpm --filter eve run test:unit`
- `pnpm --filter eve run typecheck`
- `pnpm --filter eve run build:js`
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check .changeset/invalid-tool-call-events.md docs/concepts/sessions-runs-and-streaming.md docs/guides/client/streaming.mdx packages/eve/src/protocol/message.ts packages/eve/src/protocol/message.test.ts packages/eve/src/client/index.ts packages/eve/src/harness/emission.ts packages/eve/src/harness/emission.test.ts packages/eve/src/harness/invalid-tool-call-events.ts packages/eve/src/harness/step-hooks.ts packages/eve/src/harness/tool-loop.ts packages/eve/src/harness/tool-loop.test.ts`
- `pnpm exec oxlint --deny-warnings packages/eve/src/protocol/message.ts packages/eve/src/protocol/message.test.ts packages/eve/src/client/index.ts packages/eve/src/harness/emission.ts packages/eve/src/harness/emission.test.ts packages/eve/src/harness/invalid-tool-call-events.ts packages/eve/src/harness/step-hooks.ts packages/eve/src/harness/tool-loop.ts packages/eve/src/harness/tool-loop.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --cached --check`