### PR TITLE
feat(docs): add instrumentation providers to the integrations directory

### DIFF
--- a/apps/docs/app/[lang]/integrations/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/integrations/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { SetupTabs } from "../components/setup-tabs";
 const typeLabel = {
   channel: "Channel",
   connection: "Connection",
+  instrumentation: "Instrumentation",
 } as const;
 
 const languages = Object.keys(translations);

--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -14,6 +14,7 @@ const FILTERS: { value: Filter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "channel", label: "Channels" },
   { value: "connection", label: "Connections" },
+  { value: "instrumentation", label: "Instrumentation" },
 ];
 
 const TYPE_DESCRIPTIONS: Record<IntegrationType, string> = {
@@ -21,6 +22,8 @@ const TYPE_DESCRIPTIONS: Record<IntegrationType, string> = {
     "Channels are the surfaces where users talk to your agent: Slack, Discord, web chat, and more.",
   connection:
     "Connections are the tools your agent calls during a run: services reached over MCP or OpenAPI.",
+  instrumentation:
+    "Instrumentation providers are OpenTelemetry backends that receive your agent's traces: every model call, tool execution, and turn.",
 };
 
 interface GalleryProps {

--- a/apps/docs/app/[lang]/integrations/components/integration-card.tsx
+++ b/apps/docs/app/[lang]/integrations/components/integration-card.tsx
@@ -5,6 +5,7 @@ import { logos } from "@/lib/integrations/logos";
 const typeLabel: Record<Integration["type"], string> = {
   channel: "Channel",
   connection: "Connection",
+  instrumentation: "Instrumentation",
 };
 
 interface IntegrationCardProps {

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -5,7 +5,7 @@ import { Gallery } from "./components/gallery";
 
 const title = "Integrations";
 const description =
-  "Browse every third-party service eve connects to: messaging channels, MCP connections, and OpenAPI connections, each with install, quick start, and configuration steps.";
+  "Browse every third-party service eve connects to: messaging channels, MCP and OpenAPI connections, and OpenTelemetry instrumentation providers, each with install, quick start, and configuration steps.";
 
 export const metadata: Metadata = {
   title,
@@ -21,8 +21,8 @@ const IntegrationsPage = () => (
         Integrations
       </h1>
       <p className="mt-5 max-w-2xl text-gray-900 text-lg">
-        Connect eve to the services your agent needs, including messaging channels and tool
-        connections over MCP or OpenAPI.
+        Connect eve to the services your agent needs, including messaging channels, tool connections
+        over MCP or OpenAPI, and OpenTelemetry instrumentation providers.
       </p>
     </section>
     <Gallery integrations={integrations} />

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -4,6 +4,7 @@ import {
   channelEntries,
   connectionEntries,
   connectionProtocols as protocolsForIdentity,
+  instrumentationEntries,
 } from "@vercel/eve-catalog";
 import type { LogoKey } from "./logos";
 
@@ -16,7 +17,7 @@ import type { LogoKey } from "./logos";
  * keyed by slug.
  */
 
-export type IntegrationType = "channel" | "connection";
+export type IntegrationType = "channel" | "connection" | "instrumentation";
 
 /** Wire protocol and transport identity types are owned by the shared catalog. */
 export type { ConnectionProtocol, McpTransport, OpenApiTransport } from "@vercel/eve-catalog";
@@ -536,6 +537,234 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
   },
 };
 
+/**
+ * Instrumentation overlay: presentation plus hand-authored setup markdown.
+ * Instrumentation providers are OpenTelemetry backends configured in
+ * `agent/instrumentation.ts`, so they follow the channel shape (markdown)
+ * rather than the generated connection shape.
+ */
+type InstrumentationPresentation = ChannelPresentation;
+
+const instrumentationPresentations: Record<string, InstrumentationPresentation> = {
+  braintrust: {
+    logo: "braintrust",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "evals", "monitoring"],
+    install: `Install the framework, the Vercel OpenTelemetry wrapper, and Braintrust's exporter:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel @braintrust/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\`. eve auto-discovers it and runs it at server startup, and its presence enables telemetry:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { BraintrustExporter } from "@braintrust/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new BraintrustExporter({
+        parent: \`project_name:\${agentName}\`,
+        filterAISpans: true,
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Create an API key in the Braintrust dashboard and expose it as \`BRAINTRUST_API_KEY\`. Spans land in the Braintrust project named after your agent. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  "sentry-instrumentation": {
+    logo: "sentry",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "otlp", "errors"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Sentry ingests OTLP directly, so no Sentry SDK is required:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your project's Sentry traces endpoint:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+        headers: {
+          "x-sentry-auth": \`sentry sentry_key=\${process.env.SENTRY_PUBLIC_KEY}\`,
+        },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Copy the OTLP traces endpoint and public key from your Sentry project under **Settings → Client Keys (DSN)** and expose them as environment variables. Sentry's OTLP intake accepts traces only, and span events are dropped at ingestion. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  "datadog-instrumentation": {
+    logo: "datadog",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "apm", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at Datadog's intake for your site, authenticated with your API key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+        headers: { "dd-api-key": process.env.DD_API_KEY! },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Datadog's direct OTLP trace intake is site-specific (for example \`datadoghq.com\` vs \`datadoghq.eu\`) and currently in Preview; look up the endpoint for your site in Datadog's OTLP intake docs. For production, Datadog recommends routing through an OpenTelemetry Collector with the Datadog exporter instead. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  "honeycomb-instrumentation": {
+    logo: "honeycomb",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "queries", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Honeycomb ingests OTLP directly:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Honeycomb's OTLP endpoint with your ingest key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://api.honeycomb.io/v1/traces",
+        headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Create an ingest key under your Honeycomb environment settings and expose it as \`HONEYCOMB_API_KEY\`. Spans arrive in a dataset named after your agent (the OTel service name). EU teams use \`https://api.eu1.honeycomb.io/v1/traces\`. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  arize: {
+    logo: "arize",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "llm observability", "evaluation", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Arize AX ingests OTLP directly:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Arize's OTLP endpoint with your space ID and API key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      attributes: { "openinference.project.name": agentName },
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://otlp.arize.com/v1/traces",
+        headers: {
+          space_id: process.env.ARIZE_SPACE_ID!,
+          api_key: process.env.ARIZE_API_KEY!,
+        },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Copy the space ID and API key from your Arize AX space settings and expose them as \`ARIZE_SPACE_ID\` and \`ARIZE_API_KEY\`. The \`openinference.project.name\` resource attribute routes spans to a project named after your agent. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  raindrop: {
+    logo: "raindrop",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "ai issues", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Raindrop ingests OTLP directly:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Raindrop's OTLP endpoint with your write key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://api.raindrop.ai/v1/traces",
+        headers: {
+          Authorization: \`Bearer \${process.env.RAINDROP_WRITE_KEY}\`,
+        },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Create a write key in the Raindrop dashboard and expose it as \`RAINDROP_WRITE_KEY\`. Raindrop's Vercel AI SDK integration picks up the AI SDK spans eve emits on every turn. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  jaeger: {
+    logo: "jaeger",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "local", "self-hosted"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your Jaeger collector:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "http://localhost:4318/v1/traces",
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Run Jaeger locally with Docker and open the UI at \`http://localhost:16686\`:
+
+\`\`\`bash
+docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:latest
+\`\`\`
+
+Point the exporter at your collector's OTLP HTTP endpoint when self-hosting. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+};
+
 function buildChannel(entry: IntegrationEntry): Integration {
   const presentation = channelPresentations[entry.slug];
   if (presentation === undefined) {
@@ -589,6 +818,27 @@ function buildConnection(entry: IntegrationEntry): Integration {
   };
 }
 
+function buildInstrumentation(entry: IntegrationEntry): Integration {
+  const presentation = instrumentationPresentations[entry.slug];
+  if (presentation === undefined) {
+    throw new Error(
+      `Instrumentation provider "${entry.slug}" is in the catalog gallery but has no docs presentation.`,
+    );
+  }
+  return {
+    slug: entry.slug,
+    name: entry.name,
+    type: "instrumentation",
+    tagline: entry.tagline,
+    logo: presentation.logo,
+    docsHref: presentation.docsHref,
+    keywords: presentation.keywords,
+    install: presentation.install,
+    quickStart: presentation.quickStart,
+    configure: presentation.configure,
+  };
+}
+
 const channels: Integration[] = channelEntries()
   .filter((entry) => entry.surfaces.gallery)
   .map(buildChannel);
@@ -596,6 +846,10 @@ const channels: Integration[] = channelEntries()
 const connections: Integration[] = connectionEntries()
   .filter((entry) => entry.surfaces.gallery)
   .map(buildConnection);
+
+const instrumentation: Integration[] = instrumentationEntries()
+  .filter((entry) => entry.surfaces.gallery)
+  .map(buildInstrumentation);
 
 /** Display label for each connection protocol. */
 export const protocolLabel: Record<ConnectionProtocol, string> = {
@@ -616,7 +870,7 @@ export const authModeLabel: Record<AuthMode, string> = {
   jwtBearer: "JWT bearer",
 };
 
-export const integrations: Integration[] = [...channels, ...connections];
+export const integrations: Integration[] = [...channels, ...connections, ...instrumentation];
 
 export const getIntegration = (slug: string): Integration | undefined =>
   integrations.find((integration) => integration.slug === slug);

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -1,6 +1,7 @@
 import {
   SiAirtable,
   SiBitly,
+  SiBraintrust,
   SiBrex,
   SiClickhouse,
   SiCloudinary,
@@ -8,6 +9,7 @@ import {
   SiDatadog,
   SiEgnyte,
   SiHuggingface,
+  SiJaeger,
   SiMake,
   SiMiro,
   SiMixpanel,
@@ -287,6 +289,32 @@ export const ticketTailorLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const braintrustLogo = (props: LogoProps) => <SiBraintrust {...props} />;
+
+export const jaegerLogo = (props: LogoProps) => <SiJaeger color="default" {...props} />;
+
+export const arizeLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 50 54.1" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M25.01 5.71c1.37-.05 2.65.64 3.37 1.81 6.87 9.89 13.73 19.79 20.56 29.69 1.35 1.79 1 4.33-.78 5.69l-.22.15c-1.92 1.29-4.53.77-5.81-1.15l-.09-.14c-4.73-6.8-9.43-13.61-14.1-20.42l-.28-.34c-1.88-2.67-3.74-2.67-5.57 0-4.77 6.84-9.53 13.7-14.29 20.57-.67 1.16-1.84 1.94-3.16 2.13-1.61.25-3.2-.52-4-1.94-.91-1.41-.84-3.24.17-4.58 2.28-3.31 4.59-6.61 6.89-9.92 4.54-6.51 9.07-13.03 13.6-19.55.78-1.29 2.2-2.05 3.71-2Z"
+      fill="#FF008C"
+    />
+    <path
+      d="M24.84 44.06c2.76-.06 5.04 2.14 5.1 4.9v.04c.02 2.78-2.22 5.05-5 5.06-2.78.02-5.05-2.22-5.07-4.99-.04-2.72 2.13-4.97 4.85-5.01h.12Z"
+      fill="#FF008C"
+    />
+  </svg>
+);
+
+export const raindropLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M12 2.25c3.93 4.92 6.55 8.58 6.55 11.7a6.55 6.55 0 1 1-13.1 0c0-3.12 2.62-6.78 6.55-11.7Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const logos = {
   eve: eveLogo,
   web: webLogo,
@@ -301,7 +329,9 @@ export const logos = {
   datadog: datadogLogo,
   honeycomb: honeycombLogo,
   airtable: airtableLogo,
+  arize: arizeLogo,
   bitly: bitlyLogo,
+  braintrust: braintrustLogo,
   brex: brexLogo,
   candid: candidLogo,
   clickhouse: clickhouseLogo,
@@ -310,6 +340,7 @@ export const logos = {
   egnyte: egnyteLogo,
   embat: embatLogo,
   "hugging-face": huggingFaceLogo,
+  jaeger: jaegerLogo,
   "local-falcon": localFalconLogo,
   make: makeLogo,
   manufact: manufactLogo,
@@ -321,6 +352,7 @@ export const logos = {
   planetscale: planetscaleLogo,
   posthog: posthogLogo,
   postman: postmanLogo,
+  raindrop: raindropLogo,
   razorpay: razorpayLogo,
   sentry: sentryLogo,
   similarweb: similarwebLogo,

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   connectionEntries,
   connectionProtocols,
   getIntegrationEntry,
+  instrumentationEntries,
 } from "./index.js";
 
 describe("integration catalog", () => {
@@ -14,8 +15,10 @@ describe("integration catalog", () => {
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 
-  it("partitions cleanly into channels and connections", () => {
-    expect(channelEntries().length + connectionEntries().length).toBe(INTEGRATIONS.length);
+  it("partitions cleanly into channels, connections, and instrumentation", () => {
+    expect(
+      channelEntries().length + connectionEntries().length + instrumentationEntries().length,
+    ).toBe(INTEGRATIONS.length);
   });
 
   it("gives every connection a transport and description", () => {
@@ -28,6 +31,13 @@ describe("integration catalog", () => {
 
   it("keeps channels free of connection identity", () => {
     for (const entry of channelEntries()) {
+      expect(entry.connection).toBeUndefined();
+    }
+  });
+
+  it("keeps instrumentation providers free of connection identity", () => {
+    expect(instrumentationEntries().length).toBeGreaterThan(0);
+    for (const entry of instrumentationEntries()) {
       expect(entry.connection).toBeUndefined();
     }
   });

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Shared identity for eve integrations. This package is the single source of
- * truth for *which* integrations exist (channels and connections) and how a
- * connection is wired (transport + model-facing description).
+ * truth for *which* integrations exist (channels, connections, and
+ * instrumentation providers) and how a connection is wired (transport +
+ * model-facing description).
  *
  * Surface-specific concerns live with their consumer, keyed by {@link
  * IntegrationEntry.slug}: the scaffolder (eve) overlays the
@@ -18,7 +19,7 @@
  */
 
 /** Surface an integration targets. Extend as new kinds are catalogued. */
-export type IntegrationKind = "channel" | "connection";
+export type IntegrationKind = "channel" | "connection" | "instrumentation";
 
 /** Wire protocol a connection speaks at runtime. */
 export type ConnectionProtocol = "mcp" | "openapi";
@@ -555,6 +556,58 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
       mcp: { url: "https://mcp-server.zomato.com/mcp" },
     },
   },
+  // Instrumentation providers are OpenTelemetry backends configured in
+  // `agent/instrumentation.ts`. Slugs stay unique across the whole catalog, so
+  // providers that also ship a connection carry an `-instrumentation` suffix.
+  {
+    slug: "braintrust",
+    name: "Braintrust",
+    kind: "instrumentation",
+    tagline: "Export AI SDK spans to Braintrust for tracing, evals, and monitoring.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "sentry-instrumentation",
+    name: "Sentry",
+    kind: "instrumentation",
+    tagline: "Send agent traces to Sentry's OTLP endpoint for tracing and debugging.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "datadog-instrumentation",
+    name: "Datadog",
+    kind: "instrumentation",
+    tagline: "Export agent traces to Datadog APM alongside the rest of your stack.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "honeycomb-instrumentation",
+    name: "Honeycomb",
+    kind: "instrumentation",
+    tagline: "Send OpenTelemetry traces to Honeycomb and query every agent turn.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "arize",
+    name: "Arize",
+    kind: "instrumentation",
+    tagline: "Export traces to Arize AX for LLM observability and evaluation.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "raindrop",
+    name: "Raindrop",
+    kind: "instrumentation",
+    tagline: "Send agent traces to Raindrop to detect and debug AI product issues.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "jaeger",
+    name: "Jaeger",
+    kind: "instrumentation",
+    tagline: "Trace your agent with a local or self-hosted Jaeger OTLP backend.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
 ];
 
 const BY_SLUG = new Map(INTEGRATIONS.map((entry) => [entry.slug, entry]));
@@ -577,4 +630,9 @@ export function connectionEntries(): IntegrationEntry[] {
 /** All channel entries, in catalog order. */
 export function channelEntries(): IntegrationEntry[] {
   return integrationsByKind("channel");
+}
+
+/** All instrumentation entries, in catalog order. */
+export function instrumentationEntries(): IntegrationEntry[] {
+  return integrationsByKind("instrumentation");
 }


### PR DESCRIPTION
## Summary

Adds an **Instrumentation** section to the docs Integrations page, listing the OpenTelemetry backends an eve agent can export traces to from `agent/instrumentation.ts`.

- Extends `@vercel/eve-catalog` with a third `IntegrationKind`, `"instrumentation"`, an `instrumentationEntries()` helper, and seven entries: the providers the [instrumentation guide](https://github.com/vercel/eve/blob/main/docs/guides/instrumentation.md) names (Braintrust, Raindrop, Arize, Honeycomb, Datadog, Jaeger) plus Sentry.
- Docs overlay in `apps/docs/lib/integrations/data.ts` with hand-authored install / quick start / configure markdown per provider, following the channel (markdown) shape. Every quick start is a complete `agent/instrumentation.ts` using `defineInstrumentation` + `registerOTel`.
- Gallery gets an **Instrumentation** filter with a section description; card and detail pages get the new type badge; hero copy and page metadata mention instrumentation providers.
- New logos: `SiBraintrust` and `SiJaeger` from simple-icons, Arize's brand mark (from their official logo SVG), and a simplified Raindrop droplet in `currentColor` (matching the hand-authored Honeycomb precedent).

Slugs stay unique across the catalog, so providers that already ship a connection use an `-instrumentation` suffix (`sentry-instrumentation`, `datadog-instrumentation`, `honeycomb-instrumentation`); the rest keep bare slugs.

Provider endpoints/auth were checked against each provider's current docs: Sentry direct OTLP traces intake (`x-sentry-auth`), Honeycomb (`x-honeycomb-team`), Arize AX (`space_id`/`api_key` + `openinference.project.name` routing), Raindrop (Bearer write key), Datadog (site-specific OTLP intake, noted as Preview with the Collector recommendation), Jaeger (local OTLP), Braintrust (`@braintrust/otel`, per the existing guide).

No changeset: docs app + private `@vercel/eve-catalog` only; the published `eve` package is untouched.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt`, `pnpm guard:invariants` all pass.
- `@vercel/eve-catalog` unit tests updated for the three-way partition and pass (8/8).
- Booted the docs app and verified `/integrations` renders the new filter + seven cards, and all seven detail pages (200) render their setup markdown.