### PR TITLE
feat(next): configure eve service install commands

### DIFF
--- a/.changeset/bright-cats-install.md
+++ b/.changeset/bright-cats-install.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow Next.js integrations to configure install commands for generated eve Vercel services.

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -30,7 +30,7 @@ export default withEve(nextConfig, {
 });
 ```
 
-For multiple agents, use `agents`. String values are agent roots; object values can override the build command or private production service prefix for that agent:
+For multiple agents, use `agents`. String values are agent roots; object values can override the build command, install command, or private production service prefix for that agent:
 
 ```ts
 export default withEve(nextConfig, {
@@ -39,6 +39,7 @@ export default withEve(nextConfig, {
     billing: {
       root: "./agents/billing",
       buildCommand: "pnpm build:billing-agent",
+      installCommand: "pnpm install:billing-agent",
       servicePrefix: "/_eve_internal/billing",
     },
   },
@@ -61,8 +62,9 @@ All fields are optional.
 | Option               | Type                  | Default                | Purpose                                                                                                                                                    |
 | -------------------- | --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `eveRoot`            | `string`              | Next.js app root       | Path to one unnamed eve app root, relative to `process.cwd()` unless absolute. Do not combine with `agents`.                                               |
-| `agents`             | `Record<string, ...>` | unset                  | Named eve agents to mount under `/eve/agents/<name>/eve/v1/*`. Each value is a root string or `{ root, buildCommand?, servicePrefix? }`.                   |
+| `agents`             | `Record<string, ...>` | unset                  | Named eve agents to mount under `/eve/agents/<name>/eve/v1/*`. Each value is a root string or `{ root, buildCommand?, installCommand?, servicePrefix? }`.  |
 | `eveBuildCommand`    | `string`              | generated              | Build command for generated eve Vercel services. In multi-agent mode this is the default for agents without their own `buildCommand`.                      |
+| `eveInstallCommand`  | `string`              | Vercel default         | Install command for generated eve Vercel services. In multi-agent mode this is the default for agents without their own `installCommand`.                  |
 | `servicePrefix`      | `string`              | `"/_eve_internal/eve"` | Private route namespace for legacy manual Vercel service configs and non-Vercel production proxying. Named agents derive unique defaults from this prefix. |
 | `devServerTimeoutMs` | `number`              | `180000`               | Maximum time to wait for each eve development server to become available.                                                                                  |
 
@@ -100,11 +102,12 @@ For a public demo, use `none()` (also from `eve/channels/auth`) to skip authenti
 ## Dev vs deploy topology
 
 - **Local dev.** `npm run dev` boots the eve dev server next to `next dev` and rewrites the eve routes over to it. The browser only ever talks to the Next.js origin.
-- **Vercel.** The web app and the eve runtime deploy as a single project. `withEve()` writes Build Output `services` for eve and `routes` that send `/eve/v1/**` to that service before filesystem routing; the Next.js app itself remains the default app. By default, generated services run the installed eve binary from the agent root, so the agent directory does not need its own `package.json`. When the agent needs its own build step, set `eveBuildCommand`:
+- **Vercel.** The web app and the eve runtime deploy as a single project. `withEve()` writes Build Output `services` for eve and `routes` that send `/eve/v1/**` to that service before filesystem routing; the Next.js app itself remains the default app. By default, generated services run the installed eve binary from the agent root, so the agent directory does not need its own `package.json`. When the agent needs its own install or build steps, set `eveInstallCommand` or `eveBuildCommand`:
 
   ```ts
   export default withEve(nextConfig, {
     eveBuildCommand: "npm run build:eve",
+    eveInstallCommand: "npm install",
   });
   ```
 

--- a/packages/eve/src/public/next/index.integration.test.ts
+++ b/packages/eve/src/public/next/index.integration.test.ts
@@ -254,7 +254,7 @@ describe("withEve Vercel config", () => {
     expect(rewrites).toBeUndefined();
   });
 
-  it("accepts a custom eve service build command", async () => {
+  it("accepts custom eve service build and install commands", async () => {
     const appRoot = await createTempAppRoot();
     process.chdir(appRoot);
     await mkdir(join(appRoot, ".vercel"), { recursive: true });
@@ -268,6 +268,7 @@ describe("withEve Vercel config", () => {
         {},
         {
           eveBuildCommand: "pnpm build:eve",
+          eveInstallCommand: "pnpm install:eve",
         },
       ),
     );
@@ -277,6 +278,7 @@ describe("withEve Vercel config", () => {
       services: {
         eve: {
           buildCommand: "pnpm build:eve",
+          installCommand: "pnpm install:eve",
         },
       },
     });
@@ -296,11 +298,13 @@ describe("withEve Vercel config", () => {
           agents: {
             billing: {
               buildCommand: "pnpm build:billing-agent",
+              installCommand: "pnpm install:billing-agent",
               root: "./agents/billing",
               servicePrefix: "/_eve_internal/billing",
             },
             support: "./agents/support",
           },
+          eveInstallCommand: "pnpm install:eve",
         },
       ),
     );
@@ -328,6 +332,7 @@ describe("withEve Vercel config", () => {
         "eve-billing": {
           buildCommand: "pnpm build:billing-agent",
           framework: "eve",
+          installCommand: "pnpm install:billing-agent",
           routes: [
             {
               src: "^/eve/agents/billing/eve/v1/(.*)$",
@@ -346,6 +351,7 @@ describe("withEve Vercel config", () => {
         "eve-support": {
           buildCommand: "node '../../node_modules/eve/bin/eve.js' build",
           framework: "eve",
+          installCommand: "pnpm install:eve",
           routes: [
             {
               src: "^/eve/agents/support/eve/v1/(.*)$",

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -85,6 +85,11 @@ export interface WithEveAgentOptions {
    */
   readonly buildCommand?: string;
   /**
+   * Install command for this generated eve Vercel service. Defaults to
+   * {@link WithEveOptions.eveInstallCommand}.
+   */
+  readonly installCommand?: string;
+  /**
    * Private route namespace for this agent's legacy manually configured Vercel
    * service and non-Vercel production proxying.
    */
@@ -128,6 +133,11 @@ export interface WithEveOptions {
    */
   readonly eveBuildCommand?: string;
   /**
+   * Install command for the generated eve Vercel service. In multi-agent mode
+   * this is the default for agents without their own `installCommand`.
+   */
+  readonly eveInstallCommand?: string;
+  /**
    * Private route namespace for legacy manually configured Vercel services and
    * non-Vercel production proxying. Defaults to {@link EVE_NEXT_SERVICE_PREFIX}
    * (`/_eve_internal/eve`). `withEve` normalizes the prefix (adds a leading
@@ -140,6 +150,7 @@ export interface WithEveOptions {
 interface ResolvedEveNextAgent {
   readonly appRoot: string;
   readonly buildCommand: string;
+  readonly installCommand?: string;
   readonly localProductionPortOffset: number;
   readonly name?: string;
   readonly publicRoutePrefix: string;
@@ -349,6 +360,7 @@ function normalizeAgentsConfig(
       {
         appRoot,
         buildCommand: resolveBuildCommand(appRoot, undefined),
+        installCommand: options.eveInstallCommand,
         localProductionPortOffset: 0,
         publicRoutePrefix: "",
         servicePrefix: servicePrefixBase,
@@ -374,6 +386,7 @@ function normalizeAgentsConfig(
     return {
       appRoot,
       buildCommand: resolveBuildCommand(appRoot, agentConfig.buildCommand),
+      installCommand: agentConfig.installCommand ?? options.eveInstallCommand,
       localProductionPortOffset: index,
       name,
       publicRoutePrefix: createNamedAgentRoutePrefix(name),
@@ -411,6 +424,7 @@ export function withEve<TConfig extends EveNextConfig>(
       agents: agents.map((agent) => ({
         appRoot: agent.appRoot,
         buildCommand: agent.buildCommand,
+        installCommand: agent.installCommand,
         name: agent.name,
         publicRoutePrefix: agent.publicRoutePrefix,
         servicePrefix: agent.servicePrefix,

--- a/packages/eve/src/public/next/vercel-output-config.ts
+++ b/packages/eve/src/public/next/vercel-output-config.ts
@@ -22,6 +22,7 @@ interface VercelServiceConfig {
   readonly buildCommand?: string;
   readonly entrypoint?: string;
   readonly framework?: string;
+  readonly installCommand?: string;
   readonly mount?: string | VercelServiceMount;
   readonly routes?: readonly VercelRouteConfig[];
   readonly routePrefix?: string;
@@ -32,6 +33,7 @@ interface VercelServiceConfig {
 interface MutableGeneratedVercelServiceConfig {
   buildCommand: string;
   framework: "eve";
+  installCommand?: string;
   routePrefix?: string;
   routes: readonly VercelRouteConfig[];
   root: string;
@@ -81,6 +83,7 @@ export interface EnsureVercelOutputConfigResult {
 export interface EnsureVercelOutputConfigAgentInput {
   readonly appRoot: string;
   readonly buildCommand: string;
+  readonly installCommand?: string;
   readonly name?: string;
   readonly publicRoutePrefix: string;
   readonly servicePrefix: string;
@@ -471,6 +474,10 @@ export async function ensureEveVercelOutputConfig(input: {
         routes: insertEveServiceRequestPathRoute(undefined, routeSrc),
         root: resolveRelativeEntrypoint(input.nextRoot, agent.appRoot),
       };
+
+      if (agent.installCommand !== undefined) {
+        serviceConfig.installCommand = agent.installCommand;
+      }
 
       if (agent.publicRoutePrefix.length > 0) {
         serviceConfig.routePrefix = agent.publicRoutePrefix;


### PR DESCRIPTION
## Summary

- add `eveInstallCommand` for the default generated eve Vercel service
- allow named agents to override the default with `installCommand`
- emit the resolved install command into generated Vercel service configuration
- document the options and add a patch changeset

## Why

`withEve` already supports custom service build commands, but consumers cannot configure the corresponding Vercel service install command. In pnpm monorepos this can force a redundant service install after the host application build and mutate the shared dependency store.

Closes #681.

## Validation

- focused Next.js integration tests: 10/10
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm lint` (one pre-existing warning)
- `pnpm guard:invariants`
- formatting
- `git diff --check`