### PR TITLE
fix(chat-sdk): register GET and POST for adapter webhook routes

### DIFF
--- a/.changeset/red-snakes-lick.md
+++ b/.changeset/red-snakes-lick.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+chatSdkChannel now mounts both GET and POST on each adapter's webhook route, so adapters that verify with a GET challenge like X's CRC check work through the bridge. POST-only adapters are unaffected.

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -133,7 +133,7 @@ async function firePost(
 }
 
 describe("chatSdkChannel", () => {
-  it("mounts one webhook route per Chat SDK adapter", () => {
+  it("mounts GET and POST webhook routes per Chat SDK adapter", () => {
     const bridge = chatSdkChannel({
       adapters: {
         test: testAdapter(),
@@ -144,7 +144,40 @@ describe("chatSdkChannel", () => {
 
     expect(
       bridge.channel.routes.map((route) => ({ method: route.method, path: route.path })),
-    ).toEqual([{ method: "POST", path: "/eve/v1/test" }]);
+    ).toEqual([
+      { method: "GET", path: "/eve/v1/test" },
+      { method: "POST", path: "/eve/v1/test" },
+    ]);
+  });
+
+  it("routes GET verification challenges to the adapter webhook", async () => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const compiled = asCompiled<ChatSdkChannelState>(bridge.channel);
+    const get = compiled.routes.find(
+      (route) => route.method === "GET" && route.path === "/eve/v1/test",
+    );
+    if (!get || !isHttpRouteDefinition(get)) {
+      throw new Error("Expected GET /eve/v1/test.");
+    }
+
+    const response = await get.handler(
+      new Request("https://example.com/eve/v1/test?crc_token=abc123", { method: "GET" }),
+      {
+        getSession: vi.fn() as any,
+        params: {},
+        receive: vi.fn() as any,
+        requestIp: null,
+        send: vi.fn() as any,
+        waitUntil: vi.fn(),
+      } satisfies RouteHandlerArgs<ChatSdkChannelState>,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ response_token: "sha256=abc123" });
   });
 
   it("hands Chat SDK mentions to Eve through bridge.send", async () => {
@@ -631,6 +664,10 @@ class TestAdapter {
   }
 
   async handleWebhook(request: Request, options?: WebhookOptions): Promise<Response> {
+    if (request.method === "GET") {
+      const crcToken = new URL(request.url).searchParams.get("crc_token");
+      return Response.json({ response_token: `sha256=${crcToken}` });
+    }
     const body = (await request.json()) as {
       actionId?: string;
       kind?: string;

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -25,10 +25,12 @@ import {
 import { isNotImplemented } from "#public/channels/chat-sdk/notImplemented.js";
 import {
   defineChannel,
+  GET,
   POST,
   type Channel,
   type ChannelEvents,
   type ChannelSessionOps,
+  type RouteHandlerArgs,
   type SendFn,
   type SendOptions,
   type Session,
@@ -282,8 +284,15 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
         thread: threadFromState(bot, state),
       };
     },
-    routes: adapterNames(config.adapters).map((adapterName) =>
-      POST<ChatSdkChannelState>(routeForAdapter(adapterName, config), async (request, args) => {
+    // Register both methods on each adapter's webhook path. Providers such as X
+    // verify ownership with a GET challenge (CRC) and deliver events via POST;
+    // the adapter dispatches on request.method, so one handler serves both.
+    routes: adapterNames(config.adapters).flatMap((adapterName) => {
+      const path = routeForAdapter(adapterName, config);
+      const handler = async (
+        request: Request,
+        args: RouteHandlerArgs<ChatSdkChannelState>,
+      ): Promise<Response> => {
         const webhook = bot.webhooks[adapterName];
         const ctx = new ContextContainer();
         ctx.setVirtualContext(ActiveWebhookKey, { send: args.send });
@@ -295,8 +304,12 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
             },
           }),
         );
-      }),
-    ),
+      };
+      return [
+        GET<ChatSdkChannelState>(path, handler),
+        POST<ChatSdkChannelState>(path, handler),
+      ];
+    }),
     async receive(input, { send }) {
       const thread = serializeReceiveTarget(bot, input.target);
       return send(input.message, {


### PR DESCRIPTION
## summary

`chatSdkChannel` registered only a POST route per adapter, so any adapter that verifies webhook ownership with a GET challenge could not complete registration through the bridge. X's Account Activity API uses a GET CRC check (an HMAC of `crc_token` keyed by the consumer secret) at registration and re-validates it hourly, so with POST-only the webhook could never register

this mounts both GET and POST on each adapter's webhook route, delegating to a single handler. adapters already dispatch on `request.method` internally (the X adapter answers the CRC on GET and processes events on POST), so one handler serves both. this matches the native twilio channel, which already registers GET and POST per route. POST-only adapters are unaffected

### before / after

- before: `GET /eve/v1/<adapter>` returns 404, X's CRC challenge fails and the webhook cannot register
- after: `GET /eve/v1/<adapter>` reaches the adapter webhook and returns the CRC `response_token`, POST event delivery is unchanged
