### PR TITLE
fix(eve): streaming - preserve throughput during durable writes

### DIFF
--- a/.changeset/fast-ordered-streaming.md
+++ b/.changeset/fast-ordered-streaming.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep provider streams moving while durable event writes are in flight. eve now coalesces only adjacent queued text or reasoning appends behind an ordered writer, preserving event order while avoiding one durable round trip per provider delta.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -62,7 +62,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | `session.failed`          | The session failed.                                                                                              |
 | `session.completed`       | The session reached a terminal end.                                                                              |
 
-`reasoning.appended` and `message.appended` stream deltas as they arrive, and each one carries both the new delta and the cumulative text for the current block. The finalized block shows up on `message.completed` and `reasoning.completed`, which is the compatibility path for clients that don't render incremental streaming.
+`reasoning.appended` and `message.appended` stream incremental output as it arrives. When the durable stream writer is busy, eve may coalesce adjacent deltas of the same type; the text remains in source order, and any other event forms an ordering barrier. Each append carries both the new delta and the cumulative text for the current block. The finalized block shows up on `message.completed` and `reasoning.completed`, which is the compatibility path for clients that don't render incremental streaming.
 
 Note: consider the privacy, confidentiality, and user-experience implications for displaying, storing, or transmitting reasoning events in your application.
 

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -42,7 +42,7 @@ for await (const event of response) {
 }
 ```
 
-`message.appended` and `reasoning.appended` are incremental delta events. Their completed forms, `message.completed` and `reasoning.completed`, are the compatibility path for clients that don't render deltas.
+`message.appended` and `reasoning.appended` are incremental delta events. eve may combine adjacent deltas of the same type while a durable stream write is in flight, but preserves their text and event ordering; any different event is a barrier. Their completed forms, `message.completed` and `reasoning.completed`, are the compatibility path for clients that don't render deltas.
 
 ## Handle event types
 

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -127,32 +127,44 @@ describe("setHarnessEmissionState", () => {
 });
 
 describe("emitStreamContent empty delivery", () => {
-  it("emits each normal text delta before reading the next stream part", async () => {
-    const emit = createEmitStub();
-    let releaseSecondPart!: () => void;
-    const secondPartReady = new Promise<void>((resolve) => {
-      releaseSecondPart = resolve;
+  it("keeps reading provider deltas while the durable emitter is blocked", async () => {
+    let releaseFirstWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let providerFinished = false;
+    let writes = 0;
+    const emit = vi.fn(async (_event: Parameters<HarnessEmitFn>[0]) => {
+      writes += 1;
+      if (writes === 1) await firstWrite;
     });
     async function* controlledStream(): AsyncIterable<TextStreamPart<ToolSet>> {
-      yield { id: "text-1", text: "first", type: "text-delta" } as TextStreamPart<ToolSet>;
-      await secondPartReady;
-      yield { id: "text-1", text: " second", type: "text-delta" } as TextStreamPart<ToolSet>;
+      yield { id: "text-1", text: "A", type: "text-delta" } as TextStreamPart<ToolSet>;
+      yield { id: "text-1", text: "B", type: "text-delta" } as TextStreamPart<ToolSet>;
+      yield { id: "text-1", text: "C", type: "text-delta" } as TextStreamPart<ToolSet>;
       yield { finishReason: "stop", type: "finish-step" } as TextStreamPart<ToolSet>;
+      providerFinished = true;
     }
 
     const run = emitStreamContent(emit, EMISSION_STATE, controlledStream());
-    try {
-      await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(1));
-      expect(vi.mocked(emit).mock.calls[0]?.[0]).toEqual(
-        expect.objectContaining({
-          data: expect.objectContaining({ messageDelta: "first", messageSoFar: "first" }),
-          type: "message.appended",
-        }),
-      );
-    } finally {
-      releaseSecondPart();
-      await run;
-    }
+    await vi.waitFor(() => expect(providerFinished).toBe(true));
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    releaseFirstWrite();
+    await run;
+
+    const appended = vi
+      .mocked(emit)
+      .mock.calls.map(([event]) => event)
+      .filter((event) => event.type === "message.appended");
+    expect(appended).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ messageDelta: "A", messageSoFar: "A" }),
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({ messageDelta: "BC", messageSoFar: "ABC" }),
+      }),
+    ]);
   });
 
   it("streams a split sentinel immediately and completes with a null message", async () => {

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -127,20 +127,19 @@ describe("setHarnessEmissionState", () => {
 });
 
 describe("emitStreamContent empty delivery", () => {
-  it("reduces 368 fine-grained deltas to three dispatches behind a blocked writer", async () => {
+  it("reduces 368 saturated deltas to eight bounded dispatches", async () => {
     const deltaCount = 368;
-    let releaseFirstWrite!: () => void;
-    const firstWrite = new Promise<void>((resolve) => {
-      releaseFirstWrite = resolve;
-    });
+    const writeReleases: Array<() => void> = [];
+    let providerDeltas = 0;
     let providerFinished = false;
-    let writes = 0;
     const emit = vi.fn(async (_event: Parameters<HarnessEmitFn>[0]) => {
-      writes += 1;
-      if (writes === 1) await firstWrite;
+      await new Promise<void>((resolve) => {
+        writeReleases.push(resolve);
+      });
     });
     async function* controlledStream(): AsyncIterable<TextStreamPart<ToolSet>> {
       for (let index = 0; index < deltaCount; index += 1) {
+        providerDeltas += 1;
         yield { id: "text-1", text: "x", type: "text-delta" } as TextStreamPart<ToolSet>;
       }
       yield { finishReason: "stop", type: "finish-step" } as TextStreamPart<ToolSet>;
@@ -148,19 +147,24 @@ describe("emitStreamContent empty delivery", () => {
     }
 
     const run = emitStreamContent(emit, EMISSION_STATE, controlledStream());
-    await vi.waitFor(() => expect(providerFinished).toBe(true));
+    await vi.waitFor(() => expect(providerDeltas).toBe(65));
+    expect(providerFinished).toBe(false);
     expect(emit).toHaveBeenCalledTimes(1);
 
-    releaseFirstWrite();
+    for (let writeIndex = 0; writeIndex < 8; writeIndex += 1) {
+      await vi.waitFor(() => expect(writeReleases.length).toBe(writeIndex + 1));
+      writeReleases[writeIndex]?.();
+    }
     await run;
 
     const events = vi.mocked(emit).mock.calls.map(([event]) => event);
     const appended = events.filter((event) => event.type === "message.appended");
-    expect(events).toHaveLength(3);
-    expect(appended).toHaveLength(2);
-    expect(appended[0]?.data.messageDelta).toBe("x");
-    expect(appended[1]?.data.messageDelta).toBe("x".repeat(deltaCount - 1));
-    expect(appended[1]?.data.messageSoFar).toBe("x".repeat(deltaCount));
+    expect(providerFinished).toBe(true);
+    expect(events).toHaveLength(8);
+    expect(appended.map((event) => event.data.messageDelta.length)).toEqual([
+      1, 64, 64, 64, 64, 64, 47,
+    ]);
+    expect(appended.at(-1)?.data.messageSoFar).toBe("x".repeat(deltaCount));
     expect(events.at(-1)?.type).toBe("message.completed");
   });
 
@@ -246,6 +250,35 @@ describe("emitStreamContent empty delivery", () => {
 });
 
 describe("emitStreamContent action requests", () => {
+  it("cancels a pending provider action batch when the stream aborts", async () => {
+    vi.useFakeTimers();
+    const emit = createEmitStub();
+
+    try {
+      await expect(
+        emitStreamContent(
+          emit,
+          EMISSION_STATE,
+          streamOf([
+            {
+              input: { query: "eve" },
+              providerExecuted: true,
+              toolCallId: "search-1",
+              toolName: "web_search",
+              type: "tool-call",
+            },
+            { reason: "cancelled", type: "abort" },
+          ] as TextStreamPart<ToolSet>[]),
+        ),
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      await vi.runAllTimersAsync();
+      expect(emit).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits a provider action batch before any provider result arrives", async () => {
     const events: Parameters<HarnessEmitFn>[0][] = [];
     const emit: HarnessEmitFn = async (event) => {
@@ -567,6 +600,48 @@ describe("emitStreamContent action requests", () => {
 });
 
 describe("emitStreamContent error-part handling", () => {
+  it("interrupts a stalled provider pull when the durable emitter fails", async () => {
+    const writeError = new Error("durable write failed");
+    let rejectWrite!: (error: unknown) => void;
+    const firstWrite = new Promise<void>((_resolve, reject) => {
+      rejectWrite = reject;
+    });
+    let providerCancelled = false;
+    let stalledReadStarted = false;
+    const firstPart = {
+      id: "text-1",
+      text: "A",
+      type: "text-delta",
+    } as TextStreamPart<ToolSet>;
+    const stalledStream: AsyncIterable<TextStreamPart<ToolSet>> = {
+      [Symbol.asyncIterator]() {
+        let reads = 0;
+        return {
+          next(): Promise<IteratorResult<TextStreamPart<ToolSet>>> {
+            reads += 1;
+            if (reads === 1) {
+              return Promise.resolve({ done: false, value: firstPart });
+            }
+            stalledReadStarted = true;
+            return new Promise(() => {});
+          },
+          return(): Promise<IteratorResult<TextStreamPart<ToolSet>>> {
+            providerCancelled = true;
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        };
+      },
+    };
+    const run = emitStreamContent(async () => firstWrite, EMISSION_STATE, stalledStream);
+    const rejected = expect(run).rejects.toBe(writeError);
+    await vi.waitFor(() => expect(stalledReadStarted).toBe(true));
+
+    rejectWrite(writeError);
+
+    await rejected;
+    expect(providerCancelled).toBe(true);
+  });
+
   it("preserves the original Error instance when the stream emits one", async () => {
     const original = new TypeError("upstream rejected");
 

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -127,7 +127,8 @@ describe("setHarnessEmissionState", () => {
 });
 
 describe("emitStreamContent empty delivery", () => {
-  it("keeps reading provider deltas while the durable emitter is blocked", async () => {
+  it("reduces 368 fine-grained deltas to three dispatches behind a blocked writer", async () => {
+    const deltaCount = 368;
     let releaseFirstWrite!: () => void;
     const firstWrite = new Promise<void>((resolve) => {
       releaseFirstWrite = resolve;
@@ -139,9 +140,9 @@ describe("emitStreamContent empty delivery", () => {
       if (writes === 1) await firstWrite;
     });
     async function* controlledStream(): AsyncIterable<TextStreamPart<ToolSet>> {
-      yield { id: "text-1", text: "A", type: "text-delta" } as TextStreamPart<ToolSet>;
-      yield { id: "text-1", text: "B", type: "text-delta" } as TextStreamPart<ToolSet>;
-      yield { id: "text-1", text: "C", type: "text-delta" } as TextStreamPart<ToolSet>;
+      for (let index = 0; index < deltaCount; index += 1) {
+        yield { id: "text-1", text: "x", type: "text-delta" } as TextStreamPart<ToolSet>;
+      }
       yield { finishReason: "stop", type: "finish-step" } as TextStreamPart<ToolSet>;
       providerFinished = true;
     }
@@ -153,18 +154,14 @@ describe("emitStreamContent empty delivery", () => {
     releaseFirstWrite();
     await run;
 
-    const appended = vi
-      .mocked(emit)
-      .mock.calls.map(([event]) => event)
-      .filter((event) => event.type === "message.appended");
-    expect(appended).toEqual([
-      expect.objectContaining({
-        data: expect.objectContaining({ messageDelta: "A", messageSoFar: "A" }),
-      }),
-      expect.objectContaining({
-        data: expect.objectContaining({ messageDelta: "BC", messageSoFar: "ABC" }),
-      }),
-    ]);
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    const appended = events.filter((event) => event.type === "message.appended");
+    expect(events).toHaveLength(3);
+    expect(appended).toHaveLength(2);
+    expect(appended[0]?.data.messageDelta).toBe("x");
+    expect(appended[1]?.data.messageDelta).toBe("x".repeat(deltaCount - 1));
+    expect(appended[1]?.data.messageSoFar).toBe("x".repeat(deltaCount));
+    expect(events.at(-1)?.type).toBe("message.completed");
   });
 
   it("streams a split sentinel immediately and completes with a null message", async () => {

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -46,12 +46,11 @@ import type {
   RuntimeActionRequest,
   RuntimeToolResultActionResult,
 } from "#runtime/actions/types.js";
-import { isAuthorizationSignal, isPendingAuthorizationToolOutput } from "#harness/authorization.js";
-import { contextStorage } from "#context/container.js";
-import { readToolInterrupt } from "#harness/tool-interrupts.js";
 import { createProviderStreamActionBatch } from "#harness/stream-actions.js";
 import { normalizeModelStreamError } from "#harness/model-call-error.js";
 import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
+import { interruptStreamOnFailure } from "#harness/interruptible-stream.js";
+import { isInlineAuthorizationToolResult } from "#harness/inline-tool-authorization.js";
 import type {
   HarnessEmitFn,
   HarnessSession,
@@ -357,10 +356,24 @@ export async function emitStreamContent(
   options?: StreamActionEmissionOptions,
 ): Promise<EmittedStreamContent> {
   const orderedEmitter = createOrderedStreamEmitter(emitFn);
+  const providerActionBatch = createProviderStreamActionBatch({
+    emitFn: orderedEmitter.emit,
+    state,
+  });
   try {
-    return await consumeStreamContent(orderedEmitter.emit, state, fullStream, options);
+    return await consumeStreamContent(
+      orderedEmitter.emit,
+      state,
+      interruptStreamOnFailure(fullStream, orderedEmitter.failureSignal),
+      providerActionBatch,
+      options,
+    );
   } finally {
-    await orderedEmitter.drain();
+    try {
+      await providerActionBatch.cancel();
+    } finally {
+      await orderedEmitter.closeAndDrain();
+    }
   }
 }
 
@@ -368,6 +381,7 @@ async function consumeStreamContent(
   emitFn: HarnessEmitFn,
   state: HarnessEmissionState,
   fullStream: AsyncIterable<TextStreamPart<ToolSet>>,
+  providerActionBatch: ReturnType<typeof createProviderStreamActionBatch>,
   options?: StreamActionEmissionOptions,
 ): Promise<EmittedStreamContent> {
   let currentReasoning = "";
@@ -378,7 +392,6 @@ async function consumeStreamContent(
   const emittedActionCallIds = new Set<string>();
   const emittedActionResultCallIds = new Set<string>();
   const providerToolCallIdsSeen = new Set<string>();
-  const providerActionBatch = createProviderStreamActionBatch({ emitFn, state });
   const handledInlineToolResultCallIds = new Set<string>();
   const invalidInputToolCallIds = new Set<string>();
   const inlineAuthorizationResults: TypedToolResult<ToolSet>[] = [];
@@ -678,16 +691,4 @@ async function consumeStreamContent(
     inlineAuthorizationResults,
     trailingInlineToolResultParts,
   };
-}
-
-function isInlineAuthorizationToolResult(toolResult: TypedToolResult<ToolSet>): boolean {
-  if (isPendingAuthorizationToolOutput(toolResult.output)) {
-    return true;
-  }
-  const ctx = contextStorage.getStore();
-  if (ctx === undefined) {
-    return false;
-  }
-  const stashed = readToolInterrupt(ctx, toolResult.toolCallId);
-  return stashed !== undefined && isAuthorizationSignal(stashed);
 }

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -51,6 +51,7 @@ import { contextStorage } from "#context/container.js";
 import { readToolInterrupt } from "#harness/tool-interrupts.js";
 import { createProviderStreamActionBatch } from "#harness/stream-actions.js";
 import { normalizeModelStreamError } from "#harness/model-call-error.js";
+import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import type {
   HarnessEmitFn,
   HarnessSession,
@@ -350,6 +351,20 @@ interface StreamActionEmissionOptions {
  * without a streamed call resumes a call from an earlier step.
  */
 export async function emitStreamContent(
+  emitFn: HarnessEmitFn,
+  state: HarnessEmissionState,
+  fullStream: AsyncIterable<TextStreamPart<ToolSet>>,
+  options?: StreamActionEmissionOptions,
+): Promise<EmittedStreamContent> {
+  const orderedEmitter = createOrderedStreamEmitter(emitFn);
+  try {
+    return await consumeStreamContent(orderedEmitter.emit, state, fullStream, options);
+  } finally {
+    await orderedEmitter.drain();
+  }
+}
+
+async function consumeStreamContent(
   emitFn: HarnessEmitFn,
   state: HarnessEmissionState,
   fullStream: AsyncIterable<TextStreamPart<ToolSet>>,

--- a/packages/eve/src/harness/inline-tool-authorization.ts
+++ b/packages/eve/src/harness/inline-tool-authorization.ts
@@ -1,0 +1,17 @@
+import type { ToolSet, TypedToolResult } from "ai";
+import { contextStorage } from "#context/container.js";
+import { isAuthorizationSignal, isPendingAuthorizationToolOutput } from "#harness/authorization.js";
+import { readToolInterrupt } from "#harness/tool-interrupts.js";
+
+/** Returns whether an inline tool result represents a pending authorization interrupt. */
+export function isInlineAuthorizationToolResult(toolResult: TypedToolResult<ToolSet>): boolean {
+  if (isPendingAuthorizationToolOutput(toolResult.output)) {
+    return true;
+  }
+  const ctx = contextStorage.getStore();
+  if (ctx === undefined) {
+    return false;
+  }
+  const stashed = readToolInterrupt(ctx, toolResult.toolCallId);
+  return stashed !== undefined && isAuthorizationSignal(stashed);
+}

--- a/packages/eve/src/harness/interruptible-stream.ts
+++ b/packages/eve/src/harness/interruptible-stream.ts
@@ -1,0 +1,61 @@
+/**
+ * Stops consuming `stream` as soon as `failureSignal` aborts, including while
+ * the underlying iterator is stalled in `next()`.
+ */
+export async function* interruptStreamOnFailure<T>(
+  stream: AsyncIterable<T>,
+  failureSignal: AbortSignal,
+): AsyncIterable<T> {
+  const iterator = stream[Symbol.asyncIterator]();
+  let completed = false;
+
+  try {
+    while (true) {
+      const result = await nextOrFailure(iterator, failureSignal);
+      if (result.done) {
+        completed = true;
+        return;
+      }
+      yield result.value;
+    }
+  } finally {
+    if (!completed && iterator.return !== undefined) {
+      try {
+        const closing = iterator.return();
+        void Promise.resolve(closing).catch(() => {});
+      } catch {}
+    }
+  }
+}
+
+function nextOrFailure<T>(
+  iterator: AsyncIterator<T>,
+  failureSignal: AbortSignal,
+): Promise<IteratorResult<T>> {
+  if (failureSignal.aborted) return Promise.reject(failureSignal.reason);
+
+  return new Promise<IteratorResult<T>>((resolve, reject) => {
+    const onFailure = (): void => {
+      reject(failureSignal.reason);
+    };
+    failureSignal.addEventListener("abort", onFailure, { once: true });
+    let next: Promise<IteratorResult<T>>;
+    try {
+      next = iterator.next();
+    } catch (error) {
+      failureSignal.removeEventListener("abort", onFailure);
+      reject(error);
+      return;
+    }
+    next.then(
+      (result) => {
+        failureSignal.removeEventListener("abort", onFailure);
+        resolve(result);
+      },
+      (error: unknown) => {
+        failureSignal.removeEventListener("abort", onFailure);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/eve/src/harness/ordered-stream-emitter.test.ts
+++ b/packages/eve/src/harness/ordered-stream-emitter.test.ts
@@ -37,7 +37,7 @@ function reasoning(delta: string, soFar: string) {
 }
 
 describe("createOrderedStreamEmitter", () => {
-  it("keeps consuming while a write is active and merges adjacent pending text", async () => {
+  it("keeps consuming while a write is active and preserves the latest event metadata", async () => {
     const firstWrite = deferred();
     const events: HandleMessageStreamEvent[] = [];
     const emitFn = vi.fn(async (event: HandleMessageStreamEvent) => {
@@ -47,14 +47,17 @@ describe("createOrderedStreamEmitter", () => {
     const emitter = createOrderedStreamEmitter(emitFn);
 
     await emitter.emit(message("A", "A"));
-    await emitter.emit(message("B", "AB"));
-    await emitter.emit(message("C", "ABC"));
+    await emitter.emit({ ...message("B", "AB"), meta: { at: "2026-07-10T18:00:00.000Z" } });
+    await emitter.emit({ ...message("C", "ABC"), meta: { at: "2026-07-10T18:00:01.000Z" } });
 
     expect(emitFn).toHaveBeenCalledTimes(1);
     firstWrite.resolve();
-    await emitter.drain();
+    await emitter.closeAndDrain();
 
-    expect(events).toEqual([message("A", "A"), message("BC", "ABC")]);
+    expect(events).toEqual([
+      message("A", "A"),
+      { ...message("BC", "ABC"), meta: { at: "2026-07-10T18:00:01.000Z" } },
+    ]);
   });
 
   it("treats other event types and stream coordinates as ordering barriers", async () => {
@@ -81,7 +84,7 @@ describe("createOrderedStreamEmitter", () => {
     await emitter.emit(completed);
 
     firstWrite.resolve();
-    await emitter.drain();
+    await emitter.closeAndDrain();
 
     expect(events).toEqual([
       message("A", "A"),
@@ -92,7 +95,7 @@ describe("createOrderedStreamEmitter", () => {
     ]);
   });
 
-  it("surfaces sink failures from drain and later emissions", async () => {
+  it("surfaces sink failures from close and later emissions", async () => {
     const writeError = new Error("durable write failed");
     const emitter = createOrderedStreamEmitter(async () => {
       throw writeError;
@@ -100,7 +103,41 @@ describe("createOrderedStreamEmitter", () => {
 
     await emitter.emit(message("A", "A"));
 
-    await expect(emitter.drain()).rejects.toBe(writeError);
+    await expect(emitter.closeAndDrain()).rejects.toBe(writeError);
     await expect(emitter.emit(message("B", "AB"))).rejects.toBe(writeError);
+  });
+
+  it("rejects emissions after closing", async () => {
+    const emitter = createOrderedStreamEmitter(async () => {});
+
+    await emitter.closeAndDrain();
+
+    await expect(emitter.emit(message("A", "A"))).rejects.toThrow(/closed/);
+  });
+
+  it("counts merged empty deltas toward the pending-event limit", async () => {
+    const firstWrite = deferred();
+    const events: HandleMessageStreamEvent[] = [];
+    const emitter = createOrderedStreamEmitter(
+      async (event) => {
+        events.push(event);
+        if (events.length === 1) await firstWrite.promise;
+      },
+      { maxPendingEvents: 2 },
+    );
+
+    await emitter.emit(message("A", "A"));
+    await emitter.emit(reasoning("", ""));
+    let accepted = false;
+    const limited = emitter.emit(reasoning("", "")).then(() => {
+      accepted = true;
+    });
+    await Promise.resolve();
+
+    expect(accepted).toBe(false);
+    firstWrite.resolve();
+    await limited;
+    await emitter.closeAndDrain();
+    expect(events).toEqual([message("A", "A"), reasoning("", "")]);
   });
 });

--- a/packages/eve/src/harness/ordered-stream-emitter.test.ts
+++ b/packages/eve/src/harness/ordered-stream-emitter.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
+import {
+  createMessageAppendedEvent,
+  createMessageCompletedEvent,
+  createReasoningAppendedEvent,
+} from "#protocol/message.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function message(delta: string, soFar: string, stepIndex = 0) {
+  return createMessageAppendedEvent({
+    messageDelta: delta,
+    messageSoFar: soFar,
+    sequence: 1,
+    stepIndex,
+    turnId: "turn_1",
+  });
+}
+
+function reasoning(delta: string, soFar: string) {
+  return createReasoningAppendedEvent({
+    reasoningDelta: delta,
+    reasoningSoFar: soFar,
+    sequence: 1,
+    stepIndex: 0,
+    turnId: "turn_1",
+  });
+}
+
+describe("createOrderedStreamEmitter", () => {
+  it("keeps consuming while a write is active and merges adjacent pending text", async () => {
+    const firstWrite = deferred();
+    const events: HandleMessageStreamEvent[] = [];
+    const emitFn = vi.fn(async (event: HandleMessageStreamEvent) => {
+      events.push(event);
+      if (events.length === 1) await firstWrite.promise;
+    });
+    const emitter = createOrderedStreamEmitter(emitFn);
+
+    await emitter.emit(message("A", "A"));
+    await emitter.emit(message("B", "AB"));
+    await emitter.emit(message("C", "ABC"));
+
+    expect(emitFn).toHaveBeenCalledTimes(1);
+    firstWrite.resolve();
+    await emitter.drain();
+
+    expect(events).toEqual([message("A", "A"), message("BC", "ABC")]);
+  });
+
+  it("treats other event types and stream coordinates as ordering barriers", async () => {
+    const firstWrite = deferred();
+    const events: HandleMessageStreamEvent[] = [];
+    const emitFn = vi.fn(async (event: HandleMessageStreamEvent) => {
+      events.push(event);
+      if (events.length === 1) await firstWrite.promise;
+    });
+    const emitter = createOrderedStreamEmitter(emitFn);
+    const completed = createMessageCompletedEvent({
+      message: "CD",
+      sequence: 1,
+      stepIndex: 1,
+      turnId: "turn_1",
+    });
+
+    await emitter.emit(message("A", "A"));
+    await emitter.emit(message("B", "AB"));
+    await emitter.emit(message("C", "C", 1));
+    await emitter.emit(message("D", "CD", 1));
+    await emitter.emit(reasoning("R", "R"));
+    await emitter.emit(reasoning("S", "RS"));
+    await emitter.emit(completed);
+
+    firstWrite.resolve();
+    await emitter.drain();
+
+    expect(events).toEqual([
+      message("A", "A"),
+      message("B", "AB"),
+      message("CD", "CD", 1),
+      reasoning("RS", "RS"),
+      completed,
+    ]);
+  });
+
+  it("surfaces sink failures from drain and later emissions", async () => {
+    const writeError = new Error("durable write failed");
+    const emitter = createOrderedStreamEmitter(async () => {
+      throw writeError;
+    });
+
+    await emitter.emit(message("A", "A"));
+
+    await expect(emitter.drain()).rejects.toBe(writeError);
+    await expect(emitter.emit(message("B", "AB"))).rejects.toBe(writeError);
+  });
+});

--- a/packages/eve/src/harness/ordered-stream-emitter.ts
+++ b/packages/eve/src/harness/ordered-stream-emitter.ts
@@ -13,11 +13,13 @@ interface PendingEmission {
   deltaParts?: string[];
   event: HandleMessageStreamEvent;
   messages?: readonly import("ai").ModelMessage[];
+  sourceEvents: number;
 }
 
 interface OrderedStreamEmitter {
-  drain(): Promise<void>;
+  closeAndDrain(): Promise<void>;
   emit: HarnessEmitFn;
+  readonly failureSignal: AbortSignal;
 }
 
 /**
@@ -37,11 +39,15 @@ export function createOrderedStreamEmitter(
   }
 
   const pending: PendingEmission[] = [];
+  const capacityWaiters = new Set<() => void>();
   const idleWaiters = new Set<() => void>();
+  let closeRequested = false;
   let pendingDeltaCharacters = 0;
+  let pendingSourceEvents = 0;
   let failure: unknown;
   let failed = false;
   let pumping = false;
+  const failureController = new AbortController();
 
   const throwIfFailed = (): void => {
     if (failed) throw failure;
@@ -52,6 +58,15 @@ export function createOrderedStreamEmitter(
     idleWaiters.clear();
   };
 
+  const hasCapacity = (): boolean =>
+    pendingSourceEvents < maxPendingEvents && pendingDeltaCharacters < MAX_PENDING_DELTA_CHARACTERS;
+
+  const settleCapacityWaiters = (): void => {
+    if (!hasCapacity()) return;
+    for (const resolve of capacityWaiters) resolve();
+    capacityWaiters.clear();
+  };
+
   const pump = async (): Promise<void> => {
     if (pumping || failed) return;
     pumping = true;
@@ -60,13 +75,21 @@ export function createOrderedStreamEmitter(
       const next = pending.shift();
       if (next === undefined) break;
       pendingDeltaCharacters -= next.deltaCharacters;
+      pendingSourceEvents -= next.sourceEvents;
+      settleCapacityWaiters();
 
       try {
         await emitFn(materializeEvent(next), next.messages);
       } catch (error) {
-        failure = error;
-        failed = true;
+        if (!failed) {
+          failure = error;
+          failed = true;
+          failureController.abort(error);
+        }
         pending.length = 0;
+        pendingDeltaCharacters = 0;
+        pendingSourceEvents = 0;
+        settleCapacityWaiters();
         break;
       }
     }
@@ -87,13 +110,25 @@ export function createOrderedStreamEmitter(
     throwIfFailed();
   };
 
+  const waitForCapacity = async (): Promise<void> => {
+    if (hasCapacity()) return;
+    await new Promise<void>((resolve) => {
+      capacityWaiters.add(resolve);
+    });
+    throwIfFailed();
+  };
+
   return {
-    async drain() {
+    async closeAndDrain() {
+      closeRequested = true;
       void pump();
       await waitForIdle();
     },
     async emit(event, messages) {
       throwIfFailed();
+      if (closeRequested) {
+        throw new TypeError("Cannot emit after the ordered stream emitter has closed.");
+      }
 
       const lastIndex = pending.length - 1;
       const last = pending[lastIndex];
@@ -103,22 +138,26 @@ export function createOrderedStreamEmitter(
           deltaCharacters: delta?.length ?? 0,
           event,
           messages,
+          sourceEvents: 1,
         });
       } else {
         last.deltaCharacters += delta?.length ?? 0;
+        last.sourceEvents += 1;
       }
       pendingDeltaCharacters += delta?.length ?? 0;
+      pendingSourceEvents += 1;
 
       void pump();
 
       if (
-        pending.length >= maxPendingEvents ||
+        pendingSourceEvents >= maxPendingEvents ||
         pendingDeltaCharacters >= MAX_PENDING_DELTA_CHARACTERS
       ) {
-        await waitForIdle();
+        await waitForCapacity();
       }
       throwIfFailed();
     },
+    failureSignal: failureController.signal,
   };
 }
 
@@ -159,21 +198,21 @@ function materializeEvent(emission: PendingEmission): HandleMessageStreamEvent {
 
   if (emission.event.type === "message.appended") {
     return {
+      ...emission.event,
       data: {
         ...emission.event.data,
         messageDelta: emission.deltaParts.join(""),
       },
-      type: "message.appended",
     };
   }
 
   if (emission.event.type === "reasoning.appended") {
     return {
+      ...emission.event,
       data: {
         ...emission.event.data,
         reasoningDelta: emission.deltaParts.join(""),
       },
-      type: "reasoning.appended",
     };
   }
 

--- a/packages/eve/src/harness/ordered-stream-emitter.ts
+++ b/packages/eve/src/harness/ordered-stream-emitter.ts
@@ -1,0 +1,192 @@
+import type {
+  HandleMessageStreamEvent,
+  MessageAppendedStreamEvent,
+  ReasoningAppendedStreamEvent,
+} from "#protocol/message.js";
+import type { HarnessEmitFn } from "#harness/types.js";
+
+const MAX_PENDING_EVENTS = 64;
+const MAX_PENDING_DELTA_CHARACTERS = 64 * 1024;
+
+interface PendingEmission {
+  deltaCharacters: number;
+  deltaParts?: string[];
+  event: HandleMessageStreamEvent;
+  messages?: readonly import("ai").ModelMessage[];
+}
+
+interface OrderedStreamEmitter {
+  drain(): Promise<void>;
+  emit: HarnessEmitFn;
+}
+
+/**
+ * Decouples model-stream consumption from the durable event sink while
+ * preserving FIFO dispatch. Adjacent append events waiting behind the active
+ * write are folded together; every other event remains an ordering barrier.
+ * Coalescing before the durable writer keeps one Workflow chunk per emitted
+ * event, so event-count reconnect cursors remain aligned with chunk indexes.
+ */
+export function createOrderedStreamEmitter(
+  emitFn: HarnessEmitFn,
+  options: { readonly maxPendingEvents?: number } = {},
+): OrderedStreamEmitter {
+  const maxPendingEvents = options.maxPendingEvents ?? MAX_PENDING_EVENTS;
+  if (!Number.isInteger(maxPendingEvents) || maxPendingEvents < 1) {
+    throw new RangeError("maxPendingEvents must be a positive integer.");
+  }
+
+  const pending: PendingEmission[] = [];
+  const idleWaiters = new Set<() => void>();
+  let pendingDeltaCharacters = 0;
+  let failure: unknown;
+  let failed = false;
+  let pumping = false;
+
+  const throwIfFailed = (): void => {
+    if (failed) throw failure;
+  };
+
+  const settleIdleWaiters = (): void => {
+    for (const resolve of idleWaiters) resolve();
+    idleWaiters.clear();
+  };
+
+  const pump = async (): Promise<void> => {
+    if (pumping || failed) return;
+    pumping = true;
+
+    while (pending.length > 0) {
+      const next = pending.shift();
+      if (next === undefined) break;
+      pendingDeltaCharacters -= next.deltaCharacters;
+
+      try {
+        await emitFn(materializeEvent(next), next.messages);
+      } catch (error) {
+        failure = error;
+        failed = true;
+        pending.length = 0;
+        break;
+      }
+    }
+
+    pumping = false;
+    settleIdleWaiters();
+  };
+
+  const waitForIdle = async (): Promise<void> => {
+    if (!pumping && pending.length === 0) {
+      throwIfFailed();
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      idleWaiters.add(resolve);
+    });
+    throwIfFailed();
+  };
+
+  return {
+    async drain() {
+      void pump();
+      await waitForIdle();
+    },
+    async emit(event, messages) {
+      throwIfFailed();
+
+      const lastIndex = pending.length - 1;
+      const last = pending[lastIndex];
+      const delta = appendDelta(event);
+      if (last === undefined || !mergeAdjacentAppends(last, event, messages)) {
+        pending.push({
+          deltaCharacters: delta?.length ?? 0,
+          event,
+          messages,
+        });
+      } else {
+        last.deltaCharacters += delta?.length ?? 0;
+      }
+      pendingDeltaCharacters += delta?.length ?? 0;
+
+      void pump();
+
+      if (
+        pending.length >= maxPendingEvents ||
+        pendingDeltaCharacters >= MAX_PENDING_DELTA_CHARACTERS
+      ) {
+        await waitForIdle();
+      }
+      throwIfFailed();
+    },
+  };
+}
+
+function mergeAdjacentAppends(
+  left: PendingEmission,
+  right: HandleMessageStreamEvent,
+  messages: readonly import("ai").ModelMessage[] | undefined,
+): boolean {
+  if (left.event.type === "message.appended" && right.type === "message.appended") {
+    if (!sameCoordinates(left.event, right)) return false;
+    left.deltaParts ??= [left.event.data.messageDelta];
+    left.deltaParts.push(right.data.messageDelta);
+    left.event = right;
+    left.messages = messages;
+    return true;
+  }
+
+  if (left.event.type === "reasoning.appended" && right.type === "reasoning.appended") {
+    if (!sameCoordinates(left.event, right)) return false;
+    left.deltaParts ??= [left.event.data.reasoningDelta];
+    left.deltaParts.push(right.data.reasoningDelta);
+    left.event = right;
+    left.messages = messages;
+    return true;
+  }
+
+  return false;
+}
+
+function appendDelta(event: HandleMessageStreamEvent): string | undefined {
+  if (event.type === "message.appended") return event.data.messageDelta;
+  if (event.type === "reasoning.appended") return event.data.reasoningDelta;
+  return undefined;
+}
+
+function materializeEvent(emission: PendingEmission): HandleMessageStreamEvent {
+  if (emission.deltaParts === undefined) return emission.event;
+
+  if (emission.event.type === "message.appended") {
+    return {
+      data: {
+        ...emission.event.data,
+        messageDelta: emission.deltaParts.join(""),
+      },
+      type: "message.appended",
+    };
+  }
+
+  if (emission.event.type === "reasoning.appended") {
+    return {
+      data: {
+        ...emission.event.data,
+        reasoningDelta: emission.deltaParts.join(""),
+      },
+      type: "reasoning.appended",
+    };
+  }
+
+  return emission.event;
+}
+
+function sameCoordinates(
+  left: MessageAppendedStreamEvent | ReasoningAppendedStreamEvent,
+  right: MessageAppendedStreamEvent | ReasoningAppendedStreamEvent,
+): boolean {
+  return (
+    left.data.sequence === right.data.sequence &&
+    left.data.stepIndex === right.data.stepIndex &&
+    left.data.turnId === right.data.turnId
+  );
+}

--- a/packages/eve/src/harness/stream-actions.ts
+++ b/packages/eve/src/harness/stream-actions.ts
@@ -9,6 +9,7 @@ interface ActionEventCoordinates {
 }
 
 interface ProviderStreamActionBatch {
+  cancel(): Promise<void>;
   flush(): Promise<void>;
   observe(action: RuntimeToolCallActionRequest): void;
 }
@@ -22,9 +23,14 @@ export function createProviderStreamActionBatch(input: {
   let actionFlush: Promise<void> = Promise.resolve();
   let actionFlushError: unknown;
   let actionFlushTimer: ReturnType<typeof setTimeout> | undefined;
+  let cancelled = false;
   let resolveActionFlushTimer: (() => void) | undefined;
 
   const emitPendingActions = async (): Promise<void> => {
+    if (cancelled) {
+      pendingActions.clear();
+      return;
+    }
     if (pendingActions.size === 0) return;
 
     const actions = [...pendingActions.values()];
@@ -40,6 +46,7 @@ export function createProviderStreamActionBatch(input: {
   };
 
   const scheduleFlush = (): void => {
+    if (cancelled) return;
     if (actionFlushTimer !== undefined) return;
 
     let resolveTimer: (() => void) | undefined;
@@ -60,19 +67,31 @@ export function createProviderStreamActionBatch(input: {
       });
   };
 
+  const releaseFlushTimer = (): void => {
+    if (actionFlushTimer === undefined) return;
+
+    clearTimeout(actionFlushTimer);
+    actionFlushTimer = undefined;
+    const resolveTimer = resolveActionFlushTimer;
+    resolveActionFlushTimer = undefined;
+    resolveTimer?.();
+  };
+
   return {
+    async cancel() {
+      cancelled = true;
+      pendingActions.clear();
+      releaseFlushTimer();
+      await actionFlush;
+    },
     observe(action) {
+      if (cancelled) return;
       pendingActions.set(action.callId, action);
       scheduleFlush();
     },
     async flush() {
-      if (actionFlushTimer !== undefined) {
-        clearTimeout(actionFlushTimer);
-        actionFlushTimer = undefined;
-        const resolveTimer = resolveActionFlushTimer;
-        resolveActionFlushTimer = undefined;
-        resolveTimer?.();
-      }
+      if (cancelled) return;
+      releaseFlushTimer();
 
       await actionFlush;
       if (actionFlushError !== undefined) throw actionFlushError;


### PR DESCRIPTION
Closes #690

## Summary

- decouple AI SDK provider-stream consumption from the active durable event write
- coalesce only adjacent queued `message.appended` or `reasoning.appended` events with matching turn and step coordinates
- preserve strict FIFO ordering across tool, lifecycle, completion, failure, reasoning/text, and step boundaries
- retain one Workflow chunk per emitted logical event so event-count reconnect cursors remain aligned with `startIndex`
- bound pending work by source-event count and delta bytes, including empty deltas
- interrupt stalled provider pulls when the durable sink fails, cancel late producers, and close the emitter before its final drain
- preserve the complete latest event envelope, including top-level metadata, when coalescing

## Why

The turn loop awaited one durable Workflow stream PUT for every provider delta. With fine-grained providers and roughly 400 ms durable-write latency, provider output was throttled to the journal round-trip rate.

Simply dropping the application-level `await` would not activate Workflow `writeMulti`, because Web Streams serializes calls into the underlying sink. Combining several NDJSON events into one chunk would reduce requests but break reconnect cursor semantics. The ordered emitter instead adapts coalescing to actual sink latency without changing cross-event ordering.

The queue always has at most one durable write in flight. Provider consumption continues concurrently while up to 64 source events (or 64 KiB of delta text) coalesce behind that write. When the active write completes, the next ordered batch starts immediately and reopens queue capacity.

## Performance evidence

### Deterministic saturated-writer regression

The regression test replays the 368 one-character text deltas from the reported OpenAI trace and manually gates every durable dispatch. It verifies the bounded pipeline directly: while the first dispatch is open, the provider advances through one active delta plus 64 pending deltas, then applies backpressure until the next ordered batch starts.

| | Before | After |
|---|---:|---:|
| Provider deltas | 368 | 368 |
| Durable dispatches, including completion | 369 | 8 |
| Saturated round-trip reduction | — | **46.1×** |

The eight post-fix dispatches are seven ordered append writes with batch sizes `[1, 64, 64, 64, 64, 64, 47]`, followed by `message.completed`. This assertion is deterministic, enforces the memory bound, and has no wall-clock threshold.

### Production-trace latency model

The table below replays the report measurements as evenly spaced delta arrivals using the observed 410 ms durable-write latency. It includes the terminal completion write and the reasoning-to-text barrier for xAI. These are projections from measured inputs, not a deployed post-fix benchmark.

| Trace | Raw provider time | Before: writes / modeled time | After: writes / modeled time | Modeled speedup |
|---|---:|---:|---:|---:|
| `anthropic/claude-opus-4.8` — 20 text deltas | 10.70s | 21 / 11.52s | 21 / 11.52s | 1.0× |
| `openai/gpt-5.6-sol` — 368 text deltas | 11.47s | 369 / 154.44s | 23 / 12.58s | **12.3×** |
| `xai/grok-4.5` — 325 text + 43 reasoning deltas | 10.28s | 370 / 152.42s | 26 / 11.38s | **13.4×** |

This also captures the intended provider-dependent behavior: already-chunky streams remain unchanged, while fine-grained streams approach raw provider duration plus a short ordered drain tail.

## Validation

- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm test:unit` — 441 files, 4,651 passed, 1 skipped
- targeted ordered-emitter and stream-emission tests — 2 files, 25 passed
- oxlint on all changed TypeScript files

A patch changeset and streaming documentation updates are included.
