### PR TITLE
fix(eve): stream cancellation - abort provider requests on sink failures

### DIFF
--- a/.changeset/fast-ordered-streaming.md
+++ b/.changeset/fast-ordered-streaming.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Keep provider streams moving while durable event writes are in flight. eve now coalesces only adjacent queued text or reasoning appends behind an ordered writer, preserving event order while avoiding one durable round trip per provider delta.
+Keep provider streams moving while durable event writes are in flight. eve now coalesces only adjacent queued text or reasoning appends behind an ordered writer, preserving event order while avoiding one durable round trip per provider delta, and cancels the in-flight model request if a durable write fails. Event-sink failures no longer trigger model retries, and turn cancellation now interrupts retry backoff.

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -2,12 +2,13 @@ import { jsonSchema, type TextStreamPart, type ToolSet } from "ai";
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  emitStreamContent,
+  emitStreamContent as emitOrderedStreamContent,
   getHarnessEmissionState,
   type HarnessEmissionState,
   setHarnessEmissionState,
 } from "#harness/emission.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import type { HarnessEmitFn, HarnessSession } from "#harness/types.js";
 import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 
@@ -15,6 +16,15 @@ async function* streamOf(parts: TextStreamPart<ToolSet>[]): AsyncIterable<TextSt
   for (const part of parts) {
     yield part;
   }
+}
+
+function emitStreamContent(
+  emitFn: HarnessEmitFn,
+  state: HarnessEmissionState,
+  fullStream: AsyncIterable<TextStreamPart<ToolSet>>,
+  options?: Parameters<typeof emitOrderedStreamContent>[3],
+) {
+  return emitOrderedStreamContent(createOrderedStreamEmitter(emitFn), state, fullStream, options);
 }
 
 const EMISSION_STATE: HarnessEmissionState = {
@@ -600,13 +610,54 @@ describe("emitStreamContent action requests", () => {
 });
 
 describe("emitStreamContent error-part handling", () => {
+  it("reports consumption failure before waiting for pending writes to drain", async () => {
+    let resolveWrite!: () => void;
+    const pendingWrite = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    const failures: unknown[] = [];
+    let settled = false;
+    const run = emitStreamContent(
+      async () => pendingWrite,
+      EMISSION_STATE,
+      streamOf([
+        { id: "text-1", text: "A", type: "text-delta" } as TextStreamPart<ToolSet>,
+        { reason: "provider aborted", type: "abort" } as TextStreamPart<ToolSet>,
+      ]),
+      {
+        excludedActionToolNames: new Set(),
+        onConsumptionFailure(error) {
+          failures.push(error);
+        },
+        tools: new Map(),
+      },
+    );
+    void run.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await vi.waitFor(() => expect(failures).toHaveLength(1));
+
+    const failure = failures[0];
+    expect(failure).toMatchObject({ message: "provider aborted", name: "AbortError" });
+    expect(settled).toBe(false);
+
+    resolveWrite();
+    await expect(run).rejects.toBe(failure);
+  });
+
   it("interrupts a stalled provider pull when the durable emitter fails", async () => {
     const writeError = new Error("durable write failed");
     let rejectWrite!: (error: unknown) => void;
     const firstWrite = new Promise<void>((_resolve, reject) => {
       rejectWrite = reject;
     });
-    let providerCancelled = false;
+    let iteratorReturned = false;
     let stalledReadStarted = false;
     const firstPart = {
       id: "text-1",
@@ -626,7 +677,7 @@ describe("emitStreamContent error-part handling", () => {
             return new Promise(() => {});
           },
           return(): Promise<IteratorResult<TextStreamPart<ToolSet>>> {
-            providerCancelled = true;
+            iteratorReturned = true;
             return Promise.resolve({ done: true, value: undefined });
           },
         };
@@ -639,7 +690,7 @@ describe("emitStreamContent error-part handling", () => {
     rejectWrite(writeError);
 
     await rejected;
-    expect(providerCancelled).toBe(true);
+    expect(iteratorReturned).toBe(true);
   });
 
   it("preserves the original Error instance when the stream emits one", async () => {

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -48,7 +48,7 @@ import type {
 } from "#runtime/actions/types.js";
 import { createProviderStreamActionBatch } from "#harness/stream-actions.js";
 import { normalizeModelStreamError } from "#harness/model-call-error.js";
-import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
+import type { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import { interruptStreamOnFailure } from "#harness/interruptible-stream.js";
 import { isInlineAuthorizationToolResult } from "#harness/inline-tool-authorization.js";
 import type {
@@ -338,36 +338,40 @@ interface EmittedStreamContent {
 
 interface StreamActionEmissionOptions {
   readonly excludedActionToolNames: ReadonlySet<string>;
+  readonly onConsumptionFailure?: (error: unknown) => void;
   readonly tools: HarnessToolMap;
 }
 
+type OrderedStreamEmitter = ReturnType<typeof createOrderedStreamEmitter>;
+
 /**
- * Consumes the AI SDK `fullStream` and emits real-time text and reasoning
- * events.
- *
- * Emits local tool events in source order. Provider calls that arrive in one
- * stream batch into one request event before their first result. A result
- * without a streamed call resumes a call from an earlier step.
+ * Consumes the AI SDK `fullStream` with a caller-owned emitter whose failure
+ * signal is wired to the model request. Emits tools in source order, batching
+ * provider calls before their first result and resuming unstreamed calls.
  */
 export async function emitStreamContent(
-  emitFn: HarnessEmitFn,
+  orderedEmitter: OrderedStreamEmitter,
   state: HarnessEmissionState,
   fullStream: AsyncIterable<TextStreamPart<ToolSet>>,
   options?: StreamActionEmissionOptions,
 ): Promise<EmittedStreamContent> {
-  const orderedEmitter = createOrderedStreamEmitter(emitFn);
   const providerActionBatch = createProviderStreamActionBatch({
     emitFn: orderedEmitter.emit,
     state,
   });
   try {
-    return await consumeStreamContent(
-      orderedEmitter.emit,
-      state,
-      interruptStreamOnFailure(fullStream, orderedEmitter.failureSignal),
-      providerActionBatch,
-      options,
-    );
+    try {
+      return await consumeStreamContent(
+        orderedEmitter.emit,
+        state,
+        interruptStreamOnFailure(fullStream, orderedEmitter.failureSignal),
+        providerActionBatch,
+        options,
+      );
+    } catch (error) {
+      options?.onConsumptionFailure?.(error);
+      throw error;
+    }
   } finally {
     try {
       await providerActionBatch.cancel();

--- a/packages/eve/src/harness/tool-loop-cancellation.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-cancellation.integration.test.ts
@@ -69,6 +69,39 @@ function createHangingStreamModel(onStreamStarted: () => void): MockLanguageMode
   });
 }
 
+function createSuccessfulStreamModel(): {
+  readonly doStream: ReturnType<typeof vi.fn>;
+  readonly model: MockLanguageModelV3;
+} {
+  const doStream = vi.fn(async () => ({
+    stream: new ReadableStream<StreamPart>({
+      start(controller) {
+        controller.enqueue({ type: "stream-start", warnings: [] });
+        controller.enqueue({ id: "text-1", type: "text-start" });
+        controller.enqueue({ delta: "All done.", id: "text-1", type: "text-delta" });
+        controller.enqueue({ id: "text-1", type: "text-end" });
+        controller.enqueue({
+          finishReason: { raw: undefined, unified: "stop" },
+          type: "finish",
+          usage: {
+            inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+            outputTokens: { reasoning: 0, text: 1, total: 1 },
+          },
+        });
+        controller.close();
+      },
+    }),
+  }));
+  return {
+    doStream,
+    model: new MockLanguageModelV3({
+      modelId: "integration-model",
+      provider: "eve-integration-mock",
+      doStream,
+    }),
+  };
+}
+
 describe("tool loop cancellation (real AI SDK)", () => {
   it("aborting mid-stream settles with the canonical cancellation and no failure events", async () => {
     const abortController = new AbortController();
@@ -184,17 +217,40 @@ describe("tool loop cancellation (real AI SDK)", () => {
     }
   });
 
-  it("leaves behavior unchanged when the signal never aborts", async () => {
-    const buildModel = (): MockLanguageModelV3 =>
-      new MockLanguageModelV3({
-        modelId: "integration-model",
-        provider: "eve-integration-mock",
-        doStream: async () => ({
+  it.each([
+    { label: "without a parent signal", withParentSignal: false },
+    { label: "with a live parent signal", withParentSignal: true },
+  ])("aborts the provider on a durable emitter failure $label", async ({ withParentSignal }) => {
+    const turnController = new AbortController();
+    const writeError = Object.assign(
+      new Error("Stream write failed: HTTP 503 (PUT https://workflow.test/events): unavailable"),
+      { statusCode: 503 },
+    );
+    let providerSignal: AbortSignal | undefined;
+    let providerAbortReason: unknown;
+    let attempt = 0;
+
+    const doStream = vi
+      .fn()
+      .mockImplementation(async (options: Parameters<MockLanguageModelV3["doStream"]>[0]) => {
+        attempt += 1;
+        providerSignal ??= options.abortSignal;
+
+        return {
           stream: new ReadableStream<StreamPart>({
             start(controller) {
+              options.abortSignal?.addEventListener(
+                "abort",
+                () => {
+                  providerAbortReason = options.abortSignal?.reason;
+                  controller.error(providerAbortReason);
+                },
+                { once: true },
+              );
               controller.enqueue({ type: "stream-start", warnings: [] });
               controller.enqueue({ id: "text-1", type: "text-start" });
-              controller.enqueue({ delta: "All done.", id: "text-1", type: "text-delta" });
+              controller.enqueue({ delta: "Working on it", id: "text-1", type: "text-delta" });
+              if (attempt === 1) return;
               controller.enqueue({ id: "text-1", type: "text-end" });
               controller.enqueue({
                 finishReason: { raw: undefined, unified: "stop" },
@@ -207,7 +263,122 @@ describe("tool loop cancellation (real AI SDK)", () => {
               controller.close();
             },
           }),
-        }),
+        };
+      });
+    const model = new MockLanguageModelV3({
+      modelId: "integration-model",
+      provider: "eve-integration-mock",
+      doStream,
+    });
+
+    const events: HandleMessageStreamEvent[] = [];
+    let writeFailed = false;
+    const emit: HarnessEmitFn = async (event) => {
+      if (!writeFailed && event.type === "message.appended") {
+        writeFailed = true;
+        throw writeError;
+      }
+      events.push(event);
+    };
+    const runStep = createToolLoopHarness(
+      createConfig(
+        model,
+        emit,
+        withParentSignal ? { abortSignal: turnController.signal } : undefined,
+      ),
+    );
+
+    const result = await runStep(createSession(), { message: "Do a lot of work" });
+
+    expect(result.next).toBeNull();
+    expect(doStream).toHaveBeenCalledTimes(1);
+    expect(providerSignal).toBeInstanceOf(AbortSignal);
+    expect(providerSignal?.aborted).toBe(true);
+    expect(providerSignal?.reason).toBe(writeError);
+    expect(providerAbortReason).toBe(writeError);
+    expect(turnController.signal.aborted).toBe(false);
+    expect(events.find((event) => event.type === "step.failed")?.data).toMatchObject({
+      code: "WORKFLOW_STREAM_WRITE_FAILED",
+      details: { operation: "write", statusCode: 503 },
+      message: writeError.message,
+    });
+    expect(events.map((event) => event.type)).toContain("session.waiting");
+  });
+
+  it("does not model-retry a retryable event-sink failure", async () => {
+    const sinkError = Object.assign(new Error("channel event sink unavailable"), {
+      isRetryable: true,
+    });
+    const { doStream, model } = createSuccessfulStreamModel();
+
+    const events: HandleMessageStreamEvent[] = [];
+    let writeFailed = false;
+    const emit: HarnessEmitFn = async (event) => {
+      if (!writeFailed && event.type === "message.appended") {
+        writeFailed = true;
+        throw sinkError;
+      }
+      events.push(event);
+    };
+
+    const result = await createToolLoopHarness(createConfig(model, emit))(createSession(), {
+      message: "Do some work",
+    });
+
+    expect(result.next).toBeNull();
+    expect(doStream).toHaveBeenCalledTimes(1);
+    expect(events.find((event) => event.type === "step.failed")?.data).toMatchObject({
+      code: "EVENT_SINK_FAILED",
+      message: sinkError.message,
+    });
+  });
+
+  it("rethrows an event-sink failure in task mode without retrying the model", async () => {
+    const sinkError = Object.assign(new Error("task event sink unavailable"), {
+      isRetryable: true,
+    });
+    const { doStream, model } = createSuccessfulStreamModel();
+    let writeFailed = false;
+    const emit: HarnessEmitFn = async (event) => {
+      if (!writeFailed && event.type === "message.appended") {
+        writeFailed = true;
+        throw sinkError;
+      }
+    };
+    const runStep = createToolLoopHarness(createConfig(model, emit, { mode: "task" }));
+
+    await expect(runStep(createSession(), { message: "Do some work" })).rejects.toBe(sinkError);
+    expect(doStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves behavior unchanged when the signal never aborts", async () => {
+    const providerSignals: Array<AbortSignal | undefined> = [];
+    const buildModel = (): MockLanguageModelV3 =>
+      new MockLanguageModelV3({
+        modelId: "integration-model",
+        provider: "eve-integration-mock",
+        doStream: async (options) => {
+          providerSignals.push(options.abortSignal);
+          return {
+            stream: new ReadableStream<StreamPart>({
+              start(controller) {
+                controller.enqueue({ type: "stream-start", warnings: [] });
+                controller.enqueue({ id: "text-1", type: "text-start" });
+                controller.enqueue({ delta: "All done.", id: "text-1", type: "text-delta" });
+                controller.enqueue({ id: "text-1", type: "text-end" });
+                controller.enqueue({
+                  finishReason: { raw: undefined, unified: "stop" },
+                  type: "finish",
+                  usage: {
+                    inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+                    outputTokens: { reasoning: 0, text: 1, total: 1 },
+                  },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
       });
 
     const inert = createEventCollector();
@@ -223,5 +394,11 @@ describe("tool loop cancellation (real AI SDK)", () => {
 
     expect(inertResult.next).toBe(bareResult.next);
     expect(inert.events.map((event) => event.type)).toEqual(bare.events.map((event) => event.type));
+    expect(providerSignals).toHaveLength(2);
+    expect(providerSignals[0]).not.toBe(providerSignals[1]);
+    for (const signal of providerSignals) {
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+    }
   });
 });

--- a/packages/eve/src/harness/tool-loop-stream-retry.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-stream-retry.integration.test.ts
@@ -97,18 +97,24 @@ describe("tool loop streamed provider retries", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
     let attempt = 0;
-    const doStream = vi.fn(async () => ({
-      stream: new ReadableStream<StreamPart>({
-        start(controller) {
-          attempt += 1;
-          if (attempt === 1) {
-            enqueueOverload(controller, "Discard this partial response.");
-            return;
-          }
-          enqueueTextSuccess(controller, "Recovered answer.");
-        },
-      }),
-    }));
+    const providerSignals: Array<AbortSignal | undefined> = [];
+    const signalsInitiallyAborted: boolean[] = [];
+    const doStream = vi.fn(async (options: Parameters<MockLanguageModelV3["doStream"]>[0]) => {
+      providerSignals.push(options.abortSignal);
+      signalsInitiallyAborted.push(options.abortSignal?.aborted ?? true);
+      return {
+        stream: new ReadableStream<StreamPart>({
+          start(controller) {
+            attempt += 1;
+            if (attempt === 1) {
+              enqueueOverload(controller, "Discard this partial response.");
+              return;
+            }
+            enqueueTextSuccess(controller, "Recovered answer.");
+          },
+        }),
+      };
+    });
     const model = new MockLanguageModelV3({
       doStream,
       modelId: "retry-integration-model",
@@ -133,6 +139,10 @@ describe("tool loop streamed provider retries", () => {
     expect(events.filter((event) => event.type === "step.failed")).toHaveLength(0);
     expect(events.filter((event) => event.type === "turn.failed")).toHaveLength(0);
     expect(events.filter((event) => event.type === "session.failed")).toHaveLength(0);
+    expect(signalsInitiallyAborted).toEqual([false, false]);
+    expect(providerSignals[0]).not.toBe(providerSignals[1]);
+    expect(providerSignals[0]?.aborted).toBe(true);
+    expect(providerSignals[1]?.aborted).toBe(false);
   });
 
   it("fails once after the overloaded retry attempts are exhausted", async () => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3053,7 +3053,9 @@ describe("createToolLoopHarness", () => {
       this.stream = vi
         .fn()
         .mockImplementation(async (options: { abortSignal?: AbortSignal; messages: unknown[] }) => {
-          expect(options.abortSignal).toBe(abortController.signal);
+          expect(options.abortSignal).toBeInstanceOf(AbortSignal);
+          expect(options.abortSignal).not.toBe(abortController.signal);
+          expect(options.abortSignal?.aborted).toBe(false);
           if (settings.prepareStep) {
             await settings.prepareStep({
               context: undefined,
@@ -3067,6 +3069,8 @@ describe("createToolLoopHarness", () => {
           return {
             fullStream: (async function* () {
               abortController.abort(abortReason);
+              expect(options.abortSignal?.aborted).toBe(true);
+              expect(options.abortSignal?.reason).toBe(abortReason);
               yield { reason: abortReason.message, type: "abort" };
             })(),
             steps: new Promise<never>(() => {}),
@@ -3113,6 +3117,42 @@ describe("createToolLoopHarness", () => {
     expect(eventTypes).not.toContain("step.failed");
     expect(eventTypes).not.toContain("turn.failed");
     expect(eventTypes).not.toContain("session.failed");
+  });
+
+  it("interrupts model retry backoff when the turn signal aborts", async () => {
+    vi.useFakeTimers();
+    try {
+      const abortController = new AbortController();
+      const cancellation = new TurnCancelledError();
+      const streamMock = vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("socket hang up"), { isRetryable: true }));
+      vi.mocked(ToolLoopAgent).mockImplementation(function (this: ToolLoopAgent) {
+        this.stream = streamMock;
+        return this;
+      } as MockAgentConstructor);
+
+      const { emit } = createEventCollector();
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", emit, { abortSignal: abortController.signal }),
+      );
+      const run = runStep(createTestSession(), { message: "Hi" });
+      const rejected = expect(run).rejects.toBe(cancellation);
+
+      for (let index = 0; index < 200 && vi.getTimerCount() === 0; index += 1) {
+        await Promise.resolve();
+      }
+      expect(streamMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(1);
+
+      abortController.abort(cancellation);
+
+      await rejected;
+      expect(streamMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not start a model call when the turn signal is already aborted", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -127,13 +127,17 @@ import {
   summarizeKnownModelCallRequestError,
 } from "#harness/model-call-error.js";
 import { throwIfTurnAborted } from "#harness/turn-cancellation.js";
+import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
 import {
   CONDITIONAL_DELIVERY_INSTRUCTION,
   EMPTY_DELIVERY_SENTINEL,
   hasEmptyDeliverySentinel,
 } from "#shared/empty-delivery.js";
-import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
+import {
+  extractWorkflowStreamWriteErrorDetails,
+  isWorkflowStreamWriteError,
+} from "#harness/workflow-stream-error.js";
 import { ensureOtelIntegration } from "#harness/otel-integration.js";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
 import {
@@ -174,6 +178,7 @@ import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type {
   CompactionConfig,
+  HarnessEmitFn,
   HarnessSession,
   HarnessToolMap,
   StepFn,
@@ -199,6 +204,30 @@ const environment = process.env.NODE_ENV ?? "unknown";
 const eveVersion = resolveInstalledPackageInfo().version;
 
 const log = createLogger("harness.tool-loop");
+
+// Keep the original object as AbortSignal.reason while retaining enough
+// provenance to prevent a sink failure from entering model retry/recovery.
+const eventSinkFailures = new WeakSet<object>();
+
+function trackEventSinkFailures(emitFn: HarnessEmitFn): HarnessEmitFn {
+  return async (event, messages) => {
+    try {
+      await emitFn(event, messages);
+    } catch (error) {
+      const failure = isWeakKey(error) ? error : new Error(toErrorMessage(error), { cause: error });
+      eventSinkFailures.add(failure);
+      throw failure;
+    }
+  };
+}
+
+function isEventSinkFailure(error: unknown): boolean {
+  return isWeakKey(error) && eventSinkFailures.has(error);
+}
+
+function isWeakKey(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
 
 /**
  * Wired as the agent's `onToolExecutionEnd`. On the `tool-error` branch
@@ -433,7 +462,8 @@ function resolveStepOtelContext(
 }
 
 export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
-  const emit = config.handleEvent;
+  const emit =
+    config.handleEvent === undefined ? undefined : trackEventSinkFailures(config.handleEvent);
   const telemetryConfig = getInstrumentationConfig();
   if (telemetryConfig !== undefined) {
     ensureOtelIntegration();
@@ -868,56 +898,69 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             FINAL_OUTPUT_TOOL_NAME,
             ...hiddenRuntimeActionToolNames,
           ]);
-          const streamResult = await agent.stream({
-            abortSignal: config.abortSignal,
-            messages: callMessages,
-          });
-          const {
-            emittedActionCallIds,
-            handledInlineToolResultCallIds,
-            invalidInputToolCallIds,
-            inlineAuthorizationResults,
-            trailingInlineToolResultParts,
-          } = await emitStreamContent(emit, emissionState, streamResult.fullStream, {
-            excludedActionToolNames,
-            tools: config.tools,
-          });
-          throwIfTurnAborted(config.abortSignal);
-          const [stepResult, accumulatedResponseMessages] = await Promise.all([
-            hooks.stepResult,
-            streamResult.responseMessages,
-          ]);
-          if (
-            isEmptyModelResponse(stepResult) &&
-            extractToolResultCallIds(accumulatedResponseMessages).size === 0 &&
-            inlineAuthorizationResults.length === 0 &&
-            trailingInlineToolResultParts.length === 0
-          ) {
-            throw new EmptyModelResponseError();
-          }
-          await emitStepActions(emit, emissionState, stepResult, {
-            emittedActionCallIds,
-            excludedActionCallIds: invalidInputToolCallIds,
-            excludedActionToolNames,
-            handledInlineToolResultCallIds,
-            tools: advertisedHarnessTools,
-          });
-          const existingToolResults = stepResult.toolResults as TypedToolResult<ToolSet>[];
-          const toolResultsByCallId = new Map(
-            existingToolResults.map((toolResult) => [toolResult.toolCallId, toolResult]),
+          const orderedEmitter = createOrderedStreamEmitter(emit);
+          const attemptController = new AbortController();
+          const modelAbortSignal = AbortSignal.any(
+            config.abortSignal === undefined
+              ? [attemptController.signal, orderedEmitter.failureSignal]
+              : [config.abortSignal, attemptController.signal, orderedEmitter.failureSignal],
           );
-          for (const toolResult of inlineAuthorizationResults) {
-            toolResultsByCallId.set(toolResult.toolCallId, toolResult);
+          try {
+            const streamResult = await agent.stream({
+              abortSignal: modelAbortSignal,
+              messages: callMessages,
+            });
+            const {
+              emittedActionCallIds,
+              handledInlineToolResultCallIds,
+              invalidInputToolCallIds,
+              inlineAuthorizationResults,
+              trailingInlineToolResultParts,
+            } = await emitStreamContent(orderedEmitter, emissionState, streamResult.fullStream, {
+              excludedActionToolNames,
+              onConsumptionFailure: (error) => attemptController.abort(error),
+              tools: config.tools,
+            });
+            throwIfTurnAborted(config.abortSignal);
+            const [stepResult, accumulatedResponseMessages] = await Promise.all([
+              hooks.stepResult,
+              streamResult.responseMessages,
+            ]);
+            if (
+              isEmptyModelResponse(stepResult) &&
+              extractToolResultCallIds(accumulatedResponseMessages).size === 0 &&
+              inlineAuthorizationResults.length === 0 &&
+              trailingInlineToolResultParts.length === 0
+            ) {
+              throw new EmptyModelResponseError();
+            }
+            await emitStepActions(emit, emissionState, stepResult, {
+              emittedActionCallIds,
+              excludedActionCallIds: invalidInputToolCallIds,
+              excludedActionToolNames,
+              handledInlineToolResultCallIds,
+              tools: advertisedHarnessTools,
+            });
+            const existingToolResults = stepResult.toolResults as TypedToolResult<ToolSet>[];
+            const toolResultsByCallId = new Map(
+              existingToolResults.map((toolResult) => [toolResult.toolCallId, toolResult]),
+            );
+            for (const toolResult of inlineAuthorizationResults) {
+              toolResultsByCallId.set(toolResult.toolCallId, toolResult);
+            }
+            return withAccumulatedResponseMessages({
+              invalidInputToolCallIds,
+              responseMessages: appendMissingToolResultMessages({
+                append: trailingInlineToolResultParts,
+                responseMessages: accumulatedResponseMessages,
+              }),
+              stepResult,
+              toolResults: [...toolResultsByCallId.values()],
+            });
+          } catch (error) {
+            attemptController.abort(error);
+            throw error;
           }
-          return withAccumulatedResponseMessages({
-            invalidInputToolCallIds,
-            responseMessages: appendMissingToolResultMessages({
-              append: trailingInlineToolResultParts,
-              responseMessages: accumulatedResponseMessages,
-            }),
-            stepResult,
-            toolResults: [...toolResultsByCallId.values()],
-          });
         }
         const generateResult = await agent.generate({
           abortSignal: config.abortSignal,
@@ -1002,27 +1045,29 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       // Stage order: drop a gateway-rejected provider tool first, then
       // reissue an empty response; see runModelCallRecoveryPipeline for
       // the skip/act semantics.
-      const recoveryResult = await runModelCallRecoveryPipeline({
-        error,
-        stages: [
-          (current) =>
-            attemptUnsupportedProviderToolRecovery({
-              error: current.error,
-              runOneModelCall,
-              sessionId: session.sessionId,
-              turnId: emissionState.turnId,
-            }),
-          (current) =>
-            attemptEmptyResponseRecovery({
-              emptyDeliveryEnabled,
-              error: current.error,
-              retryCallOptions: current.retryCallOptions,
-              runOneModelCall,
-              sessionId: session.sessionId,
-              turnId: emissionState.turnId,
-            }),
-        ],
-      });
+      const recoveryResult: ModelCallRecoveryBase = isEventSinkFailure(error)
+        ? { error, outcome: "failed" }
+        : await runModelCallRecoveryPipeline({
+            error,
+            stages: [
+              (current) =>
+                attemptUnsupportedProviderToolRecovery({
+                  error: current.error,
+                  runOneModelCall,
+                  sessionId: session.sessionId,
+                  turnId: emissionState.turnId,
+                }),
+              (current) =>
+                attemptEmptyResponseRecovery({
+                  emptyDeliveryEnabled,
+                  error: current.error,
+                  retryCallOptions: current.retryCallOptions,
+                  runOneModelCall,
+                  sessionId: session.sessionId,
+                  turnId: emissionState.turnId,
+                }),
+            ],
+          });
       throwIfTurnAborted(config.abortSignal);
 
       if (recoveryResult.outcome === "recovered") {
@@ -1046,25 +1091,34 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           throw finalError;
         }
 
-        // A durable event-stream write failure reaches this catch only
-        // because `emitStreamContent` runs inside the model-call
-        // try/catch — the model call itself may have succeeded. Label it
-        // as the workflow-infrastructure failure it is instead of
-        // misattributing it to the model provider, and surface the
-        // failing endpoint + platform error code as evidence.
+        const eventSinkFailure = isEventSinkFailure(finalError);
+        if (eventSinkFailure && config.mode === "task") {
+          throw finalError;
+        }
+
+        // Sink failures can surface inside the model-call try/catch after the
+        // model itself succeeds. Keep them out of model error reporting, and
+        // preserve workflow transport diagnostics when its signature exists.
         const streamWriteDetails = extractWorkflowStreamWriteErrorDetails(finalError);
-        if (streamWriteDetails !== null) {
+        if (eventSinkFailure || streamWriteDetails !== null) {
           const errorId = createErrorId();
-          log.error("workflow stream write failed — parking session for retry by the user", {
-            ...streamWriteDetails,
-            errorId,
-            error: finalError,
-            sessionId: session.sessionId,
-            turnId: emissionState.turnId,
-          });
+          const workflowStreamFailure = streamWriteDetails !== null;
+          const details = streamWriteDetails ?? {};
+          log.error(
+            workflowStreamFailure
+              ? "workflow stream write failed — parking session for retry by the user"
+              : "event sink failed — parking session for retry by the user",
+            {
+              ...details,
+              errorId,
+              error: finalError,
+              sessionId: session.sessionId,
+              turnId: emissionState.turnId,
+            },
+          );
           emissionState = await emitRecoverableFailedTurn(emit, emissionState, {
-            code: "WORKFLOW_STREAM_WRITE_FAILED",
-            details: { ...streamWriteDetails, errorId },
+            code: workflowStreamFailure ? "WORKFLOW_STREAM_WRITE_FAILED" : "EVENT_SINK_FAILED",
+            details: { ...details, errorId },
             message: toErrorMessage(finalError),
           });
           const parkedSession = setHarnessEmissionState(session, emissionState);
@@ -1635,6 +1689,9 @@ function isEmptyModelResponse(step: HarnessStepResult): boolean {
  * both shapes into the one-shot empty-response reissue.
  */
 function rethrowNoOutputAsEmptyResponse(error: unknown): never {
+  if (isEventSinkFailure(error)) {
+    throw error;
+  }
   if (isNoOutputGeneratedError(error)) {
     throw new EmptyModelResponseError({ cause: error });
   }
@@ -2388,9 +2445,10 @@ function resolveApprovalKeyFromTools(
 
 /**
  * Retries `fn` with exponential backoff while the thrown error is
- * classified as `"retry"`. Rethrows the last error once attempts are
- * exhausted or the error is classified as something other than
- * transient.
+ * classified as `"retry"`. Event-sink failures are never model retries,
+ * even when their transport error happens to carry a retryable status.
+ * Rethrows the last error once attempts are exhausted or the error is
+ * classified as something other than transient.
  */
 async function runModelCallWithRetries<T>(
   fn: (attempt: number) => Promise<T>,
@@ -2403,7 +2461,12 @@ async function runModelCallWithRetries<T>(
       return await fn(attempt);
     } catch (error) {
       throwIfTurnAborted(abortSignal);
-      if (attempt === MODEL_CALL_MAX_ATTEMPTS || classifyModelCallError(error) !== "retry") {
+      if (
+        isEventSinkFailure(error) ||
+        isWorkflowStreamWriteError(error) ||
+        attempt === MODEL_CALL_MAX_ATTEMPTS ||
+        classifyModelCallError(error) !== "retry"
+      ) {
         throw error;
       }
       const delayMs =
@@ -2415,9 +2478,33 @@ async function runModelCallWithRetries<T>(
         turnId: diag.turnId,
         error,
       });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await waitForModelRetryDelay(delayMs, abortSignal);
     }
   }
+}
+
+async function waitForModelRetryDelay(
+  delayMs: number,
+  abortSignal: AbortSignal | undefined,
+): Promise<void> {
+  if (abortSignal === undefined) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return;
+  }
+
+  throwIfTurnAborted(abortSignal);
+  await new Promise<void>((resolve) => {
+    const onAbort = (): void => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      abortSignal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  });
+  throwIfTurnAborted(abortSignal);
 }
 
 function findAuthorizationSignalFromToolResults(


### PR DESCRIPTION
## Summary

- compose parent cancellation, per-attempt teardown, and ordered-emitter failure into each streamed model request
- abort the provider before draining pending event writes while preserving the original sink error as the abort reason
- keep event-sink failures out of model retry/recovery paths, with workflow diagnostics and task-mode infrastructure retries preserved
- make retry backoff cancellable and give every retry a fresh signal
- add real AI SDK regressions for provider cancellation, reason identity, retry isolation, and sink-failure behavior

## Testing

- `pnpm --filter eve build:js`
- `pnpm --filter eve test:unit` — 4,682 passed, 1 skipped
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/harness/tool-loop-cancellation.integration.test.ts` — 7 passed
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/harness/tool-loop-stream-retry.integration.test.ts` — 2 passed
- `pnpm --filter eve typecheck`
- targeted `oxlint` and `oxfmt --check`
- `pnpm guard:invariants`
- `git diff --check origin/main...HEAD`