### PR TITLE
fix(slack): collect thread attachments across recent messages instead of only the newest

### DIFF
--- a/.changeset/slack-thread-attachment-lookback.md
+++ b/.changeset/slack-thread-attachment-lookback.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix the Slack thread attachment lookback only ever inspecting the newest non-bot message. When a user posted an image in a thread and then mentioned the agent in a text-only follow-up, the image was silently dropped and the model saw no file parts. The lookback now collects attachments from recent non-bot messages across the thread, newest first, capped at 10 file parts.

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -360,6 +360,38 @@ describe("collectInboundFileParts", () => {
     expect((parts[0]!.data as URL).href).toBe("https://files.slack.com/a/b/from-user.csv");
   });
 
+  it("looks past a newer text-only message to find files earlier in the thread", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const thread = makeSlackThread({
+      refresh,
+      recentMessages: [
+        {
+          isMe: false,
+          raw: {
+            files: [
+              {
+                id: "F500",
+                name: "earlier.png",
+                mimetype: "image/png",
+                url_private: "https://files.slack.com/a/b/earlier.png",
+              },
+            ],
+          },
+        },
+        { isMe: false, raw: {} },
+      ],
+    });
+
+    const parts = await collectInboundFileParts({
+      mention: emptyMention,
+      thread,
+      policy: DEFAULT_UPLOAD_POLICY,
+    });
+
+    expect(parts).toHaveLength(1);
+    expect((parts[0]!.data as URL).href).toBe("https://files.slack.com/a/b/earlier.png");
+  });
+
   it.each([
     ["'disabled' literal", DISABLED_POLICY],
     ["maxBytes: 0", ZERO_BYTES_POLICY],

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -392,6 +392,76 @@ describe("collectInboundFileParts", () => {
     expect((parts[0]!.data as URL).href).toBe("https://files.slack.com/a/b/earlier.png");
   });
 
+  it("collects files from multiple thread messages, newest first", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const thread = makeSlackThread({
+      refresh,
+      recentMessages: [
+        {
+          isMe: false,
+          raw: {
+            files: [
+              {
+                id: "F600",
+                mimetype: "text/csv",
+                url_private: "https://files.slack.com/a/b/older.csv",
+              },
+            ],
+          },
+        },
+        {
+          isMe: false,
+          raw: {
+            files: [
+              {
+                id: "F601",
+                mimetype: "image/png",
+                url_private: "https://files.slack.com/a/b/newer.png",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const parts = await collectInboundFileParts({
+      mention: emptyMention,
+      thread,
+      policy: DEFAULT_UPLOAD_POLICY,
+    });
+
+    expect(parts).toHaveLength(2);
+    expect((parts[0]!.data as URL).href).toBe("https://files.slack.com/a/b/newer.png");
+    expect((parts[1]!.data as URL).href).toBe("https://files.slack.com/a/b/older.csv");
+  });
+
+  it("caps thread-history collection at 10 file parts", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const makeFiles = (prefix: string, count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `${prefix}${i}`,
+        mimetype: "image/png",
+        url_private: `https://files.slack.com/a/b/${prefix}${i}.png`,
+      }));
+    const thread = makeSlackThread({
+      refresh,
+      recentMessages: [
+        { isMe: false, raw: { files: makeFiles("old", 6) } },
+        { isMe: false, raw: { files: makeFiles("new", 6) } },
+      ],
+    });
+
+    const parts = await collectInboundFileParts({
+      mention: emptyMention,
+      thread,
+      policy: DEFAULT_UPLOAD_POLICY,
+    });
+
+    expect(parts).toHaveLength(10);
+    expect((parts[0]!.data as URL).href).toBe("https://files.slack.com/a/b/new0.png");
+    expect((parts[9]!.data as URL).href).toBe("https://files.slack.com/a/b/old3.png");
+  });
+
   it.each([
     ["'disabled' literal", DISABLED_POLICY],
     ["maxBytes: 0", ZERO_BYTES_POLICY],

--- a/packages/eve/src/public/channels/slack/attachments.ts
+++ b/packages/eve/src/public/channels/slack/attachments.ts
@@ -67,15 +67,22 @@ function toSlackFilePart(attachment: SlackAttachment, index: number): FilePart |
 }
 
 /**
+ * Upper bound on file parts collected from thread history for a single
+ * turn, keeping model input bounded on long, attachment-heavy threads.
+ */
+const THREAD_LOOKBACK_MAX_FILES = 10;
+
+/**
  * Collects file parts for an inbound mention.
  *
  * Prefers attachments on the triggering mention (the common case: user
  * uploads a file and mentions the bot in the same message). When the
  * mention has none, refreshes the thread via {@link SlackThread.refresh}
- * and picks the attachments of the latest message this app did not
- * author (the thread message `isMe` classification) — covering the case
- * where a user or another bot dropped a file in the thread first, then a
- * user mentioned the bot in a follow-up. Any error during refresh is logged
+ * and collects the attachments of every message this app did not author
+ * (the thread message `isMe` classification), newest first, capped at
+ * {@link THREAD_LOOKBACK_MAX_FILES} — covering the case where a user or
+ * another bot dropped a file in the thread first, then a user mentioned
+ * the bot in a follow-up. Any error during refresh is logged
  * and treated as "no attachments" so the text portion of the mention
  * still gets delivered.
  *
@@ -101,16 +108,16 @@ export async function collectInboundFileParts(input: {
   }
 
   const recent = input.thread.recentMessages;
-  for (let i = recent.length - 1; i >= 0; i -= 1) {
+  const collected: FilePart[] = [];
+  for (let i = recent.length - 1; i >= 0 && collected.length < THREAD_LOOKBACK_MAX_FILES; i -= 1) {
     const candidate = recent[i];
     if (!candidate || candidate.isMe) continue;
     const raw = candidate.raw as { files?: readonly Record<string, unknown>[] } | undefined;
     const attachments = extractAttachmentsFromRaw(raw?.files);
     const parts = collectSlackFileParts(attachments, input.policy);
-    if (parts.length > 0) return parts;
-    return [];
+    collected.push(...parts.slice(0, THREAD_LOOKBACK_MAX_FILES - collected.length));
   }
-  return [];
+  return collected;
 }
 
 function extractAttachmentsFromRaw(


### PR DESCRIPTION
### Description

Fixes #705.

`collectInboundFileParts` scans `thread.recentMessages` backwards, but the loop body ends with an unconditional return on the first non-bot message it inspects — the loop never advances. When a user posts an image in a thread and then mentions the bot in a text-only follow-up, the newest non-bot message has no files, so everything earlier is silently dropped and the model sees zero file parts. This is the exact case the function's own doc comment says the lookback exists to cover ("a user dropped a file in the thread first, then mentioned the bot in a follow-up").

The fix collects attachments across non-bot messages, newest first, capped at 10 file parts to keep model input bounded on long threads. If you'd rather keep single-message semantics ("most recent message that has files") instead of bounded accumulation, I'm happy to adjust — flagged the same question in #705.

We've been running this change in production for an internal Slack knowledge agent (as a patch-package patch of the dist) since eve 0.17.

### How did you test your changes?

- `pnpm run test:unit` in `packages/eve` — 445 files, 4683 passed (adds a regression test that fails on `main`, plus accumulation and cap cases)
- `pnpm run typecheck` — clean
- `pnpm lint` — clean
- Production use via the equivalent dist patch in our Slack deployment

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted (#705 — filed with a failing-test reproduction branch; no maintainer reply yet, the one open design question is flagged there and above)
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant (JSDoc updated; no public API change)
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
