### PR TITLE
feat(eve): send versioned User-Agent on AI Gateway model calls

### DIFF
--- a/.changeset/gateway-eve-version-ua.md
+++ b/.changeset/gateway-eve-version-ua.md
@@ -1,0 +1,9 @@
+---
+"eve": patch
+---
+
+Send a versioned `User-Agent` on AI Gateway model calls. eve now sets a leading
+`eve/<version> (<agent name>)` product token, and the AI SDK appends its own
+`ai/<version> ai-sdk/provider-utils/<version> runtime/node.js/<version>` tokens
+after it, so gateway traffic is attributable to both the eve and SDK versions
+alongside the existing `x-title` and `http-referer` attribution headers.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -8019,6 +8019,7 @@ describe("createToolLoopHarness", () => {
 
         const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
         expect(agentCall?.headers).toEqual({
+          "user-agent": "eve/0.0.0 (Weather Agent)",
           "x-title": "Weather Agent",
           "http-referer": "https://my-agent.vercel.app",
         });
@@ -8027,6 +8028,39 @@ describe("createToolLoopHarness", () => {
           delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
         } else {
           process.env.VERCEL_PROJECT_PRODUCTION_URL = originalProductionUrl;
+        }
+      }
+    });
+
+    it("sets a versioned user-agent suffixed with the agent name", async () => {
+      setupStopResultForAttribution();
+      const originalProductionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+      delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+      const originalUrl = process.env.VERCEL_URL;
+      delete process.env.VERCEL_URL;
+      try {
+        const config: ToolLoopHarnessConfig = {
+          mode: "conversation",
+          resolveModel: vi.fn().mockResolvedValue("anthropic/claude-sonnet-4-5"),
+          runtimeIdentity: {
+            agentId: "weather-agent",
+            agentName: "Weather Agent",
+            eveVersion: "9.9.9",
+            modelId: "anthropic/claude-sonnet-4-5",
+          },
+          tools: new Map(),
+        };
+        const runStep = createToolLoopHarness(config);
+        await runStep(createTestSession(), { message: "hi" });
+
+        const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
+        expect(agentCall?.headers?.["user-agent"]).toBe("eve/9.9.9 (Weather Agent)");
+      } finally {
+        if (originalProductionUrl !== undefined) {
+          process.env.VERCEL_PROJECT_PRODUCTION_URL = originalProductionUrl;
+        }
+        if (originalUrl !== undefined) {
+          process.env.VERCEL_URL = originalUrl;
         }
       }
     });
@@ -8053,6 +8087,7 @@ describe("createToolLoopHarness", () => {
 
         const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
         expect(agentCall?.headers).toEqual({
+          "user-agent": "eve/0.0.0 (weather-agent)",
           "x-title": "weather-agent",
         });
       } finally {
@@ -8088,6 +8123,7 @@ describe("createToolLoopHarness", () => {
 
         const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
         expect(agentCall?.headers).toEqual({
+          "user-agent": "eve/0.0.0 (My Agent)",
           "x-title": "My Agent",
           "http-referer": "https://preview-123.vercel.app",
         });
@@ -8183,6 +8219,7 @@ describe("createToolLoopHarness", () => {
 
         const compactCall = vi.mocked(compactMessages).mock.calls[0];
         expect(compactCall?.[5]).toEqual({
+          "user-agent": "eve/0.0.0 (Weather Agent)",
           "x-title": "Weather Agent",
           "http-referer": "https://my-agent.vercel.app",
         });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -19,6 +19,7 @@ import {
 } from "ai";
 import { isScheduleAppAuth } from "#channel/schedule-auth.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 import {
   createErrorId,
   createLogger,
@@ -263,8 +264,15 @@ function enrichTelemetry(
  * Builds AI Gateway app attribution headers when the model is gateway-routed.
  *
  * Gateway routing is detected by `typeof model === "string"` — the same
- * condition used for the `gateway-auto` cache path. Returns `undefined`
- * for non-gateway models or when no meaningful attribution is available.
+ * condition used for the `gateway-auto` cache path. Sets a leading
+ * `user-agent` product token (`eve/<version> (<agent>)`); the AI SDK then
+ * appends its own `ai/<v> ai-sdk/provider-utils/<v> runtime/node.js/<v>`
+ * tokens after it (via `withUserAgentSuffix`), so the gateway sees both the
+ * eve and SDK versions without eve reconstructing the SDK's. The agent name
+ * rides in a UA comment so a spaced display name stays a valid User-Agent.
+ * Also sets the OpenRouter-style `x-title` (agent name) and `http-referer`
+ * (deployment host). Returns `undefined` for non-gateway models or when no
+ * meaningful attribution is available.
  */
 function buildGatewayAttributionHeaders(
   model: LanguageModel,
@@ -274,18 +282,20 @@ function buildGatewayAttributionHeaders(
     return undefined;
   }
 
+  const version = runtimeIdentity?.eveVersion;
   const title = runtimeIdentity?.agentName ?? runtimeIdentity?.agentId;
   const deploymentHost = process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL;
   const referer = deploymentHost ? `https://${deploymentHost}` : undefined;
 
-  if (!title && !referer) {
-    return undefined;
-  }
-
   const headers: Record<string, string> = {};
+  if (version) {
+    headers["user-agent"] = title
+      ? `${EVE_PACKAGE_NAME}/${version} (${title})`
+      : `${EVE_PACKAGE_NAME}/${version}`;
+  }
   if (title) headers["x-title"] = title;
   if (referer) headers["http-referer"] = referer;
-  return headers;
+  return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
 async function resolveActiveRuntimeModel(input: {


### PR DESCRIPTION
## What

On gateway-routed model calls (and compaction), eve now sets a leading `user-agent` product token:

```
eve/<version> (<agent name>)
```

The AI SDK appends its own tokens after it via `withUserAgentSuffix`, so the wire header becomes e.g.:

```
eve/0.22.4 (Weather Agent) ai/7.0.0 ai-sdk/provider-utils/5.0.0 runtime/node.js/24
```

This makes gateway traffic attributable to **both** the eve version/agent and the AI SDK version, alongside the existing `x-title` (agent name) and `http-referer` (deployment host) attribution headers.

## Why

Previously the gateway received only `x-title` and `http-referer` — the eve version never reached the AI Gateway on model-call requests. eve sets only the leading product token and lets the AI SDK contribute its own version tokens (verified empirically), so there's no fragile reconstruction of SDK/runtime versions.

## Notes

- The agent name rides in a UA comment `(...)` so a spaced display name (e.g. "Weather Agent") stays a valid `User-Agent`.
- Applies only to gateway-routed models (`typeof model === "string"`); non-gateway model objects are unaffected.
- No request-side tags/metadata are sent to the gateway — headers remain its only attribution surface.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/tool-loop.test.ts` — 151 passed (updated 4 attribution expectations, added a focused versioned-UA test).
- `pnpm typecheck`, `pnpm lint`, `pnpm guard:invariants` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)