### PR TITLE
fix(eve): preserve prompt cache for connection tools

### DIFF
--- a/.changeset/calm-tools-cache.md
+++ b/.changeset/calm-tools-cache.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve prompt-cache prefixes for connection tools on supported direct Anthropic models by loading discovered definitions at the `connection_search` result. A discovered connection tool name now keeps its first model-visible definition for the session.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -74,6 +74,30 @@ A dynamic tool or skill whose name matches an **authored** one **overrides** it 
 | `turn.started`    | Once per turn          | Every model call in the turn    |
 | `step.started`    | Before each model call | That model call                 |
 
+### Prompt caching
+
+Anthropic serializes tools before the system prompt and messages. Changing a
+tool's name, description, input schema, or presence therefore changes every
+cache prefix after that position, although an unchanged earlier tool breakpoint
+may still match. Recreating an identical model-facing definition is harmless.
+Resolve at the earliest scope that matches the capability's lifetime: prefer
+`session.started` for a session-stable catalog and `turn.started` for a per-turn
+catalog. Use `step.started` only when the model-visible definition must change
+between calls.
+
+eve preserves this prefix for connection tools on supported models reached
+through a direct Anthropic Messages adapter: `connection_search` introduces the
+matched definitions at its result position, and an introduced name keeps its
+first model-visible definition for the session. Other dynamic tools, OpenAI
+models, and models reached through AI Gateway currently use eager tool catalogs;
+changing those definitions still invalidates the provider's prompt cache.
+
+This provider split follows Anthropic's
+[`defer_loading` and prompt-caching contract](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference#defer_loading-and-prompt-caching).
+OpenAI documents the equivalent positional mechanism as
+[`additional_tools`](https://developers.openai.com/api/docs/guides/tools-tool-search#add-tools-at-a-specific-point-in-the-input),
+but the AI SDK request interface used by eve does not yet expose that input item.
+
 ### Execution order
 
 When a stream event fires, three things happen in order.

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -4,6 +4,11 @@ import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import type { ApprovalContext } from "#public/definitions/approval.js";
 import { defineTool } from "#public/definitions/tool.js";
+import {
+  attachToolActivation,
+  createToolActivationId,
+  getToolActivation,
+} from "#harness/tool-activation.js";
 
 vi.mock("#context/build-callback-context.js", () => ({
   buildCallbackContext: () => ({
@@ -497,6 +502,27 @@ function createReplayableTool(
 }
 
 describe("dispatchDynamicToolEvent", () => {
+  it("preserves internal activation metadata on step-scoped tools", async () => {
+    const ctx = createCtx();
+    const activation = {
+      id: createToolActivationId("connection_search"),
+      kind: "target" as const,
+    };
+    const entry = attachToolActivation(createReplayableTool(), activation);
+    const resolver = createResolver("connection", ["step.started"], () => ({
+      linear__list_issues: entry,
+    }));
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("step.started"),
+    });
+
+    expect(getToolActivation(buildDynamicTools(ctx)[0])).toBe(activation);
+  });
+
   it("resolves tools for matching event and stores on scoped durable key", async () => {
     const ctx = createCtx();
     const resolver = createResolver("weather", ["session.started"], () => ({

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -22,6 +22,7 @@ import {
 } from "#context/keys.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
+import { copyToolActivation } from "#harness/tool-activation.js";
 
 const log = createLogger("dynamic-tools");
 
@@ -30,7 +31,7 @@ const log = createLogger("dynamic-tools");
 // ---------------------------------------------------------------------------
 
 function toHarnessToolDefinition(name: string, entry: DynamicToolEntry): HarnessToolDefinition {
-  return {
+  return copyToolActivation(entry, {
     description: entry.description,
     execute: (input: unknown, options) =>
       entry.execute(input as Record<string, unknown>, buildBaseToolContext(options)),
@@ -41,7 +42,7 @@ function toHarnessToolDefinition(name: string, entry: DynamicToolEntry): Harness
     ...(entry.toModelOutput !== undefined
       ? { toModelOutput: entry.toModelOutput as (output: unknown) => unknown }
       : {}),
-  };
+  });
 }
 
 function convertInputSchema(schema: unknown): FlexibleSchema {

--- a/packages/eve/src/harness/prompt-cache.test.ts
+++ b/packages/eve/src/harness/prompt-cache.test.ts
@@ -150,7 +150,7 @@ describe("applyLastToolCacheBreakpoint", () => {
     });
   });
 
-  it("merges existing providerOptions on the last tool", () => {
+  it("deep-merges existing Anthropic options on the last tool", () => {
     const tools = {
       only: {
         description: "one",
@@ -163,11 +163,55 @@ describe("applyLastToolCacheBreakpoint", () => {
       { providerOptions: Record<string, unknown> } | undefined
     >;
 
-    // The marker's anthropic namespace overrides the existing one.
     expect(result.only?.providerOptions).toEqual({
-      anthropic: { cacheControl: { type: "ephemeral" } },
+      anthropic: { cacheControl: { type: "ephemeral" }, other: 1 },
       openai: { something: 2 },
     });
+  });
+
+  it("marks the last eager tool when deferred tools follow it", () => {
+    const tools = {
+      eager: {
+        description: "available immediately",
+        providerOptions: { anthropic: { other: 1 } },
+      },
+      deferredOne: {
+        description: "loaded after search",
+        providerOptions: { anthropic: { deferLoading: true } },
+      },
+      deferredTwo: {
+        description: "also loaded after search",
+        providerOptions: { anthropic: { deferLoading: true } },
+      },
+    } as unknown as ToolSet;
+
+    expect(applyLastToolCacheBreakpoint(tools, marker)).toEqual({
+      eager: {
+        description: "available immediately",
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral" }, other: 1 },
+        },
+      },
+      deferredOne: {
+        description: "loaded after search",
+        providerOptions: { anthropic: { deferLoading: true } },
+      },
+      deferredTwo: {
+        description: "also loaded after search",
+        providerOptions: { anthropic: { deferLoading: true } },
+      },
+    });
+  });
+
+  it("does not place a cache breakpoint when every tool is deferred", () => {
+    const tools = {
+      deferred: {
+        description: "loaded after search",
+        providerOptions: { anthropic: { deferLoading: true } },
+      },
+    } as unknown as ToolSet;
+
+    expect(applyLastToolCacheBreakpoint(tools, marker)).toBe(tools);
   });
 
   it("does not mutate the input tool set or its tools", () => {

--- a/packages/eve/src/harness/prompt-cache.ts
+++ b/packages/eve/src/harness/prompt-cache.ts
@@ -89,13 +89,14 @@ export function mergeGatewayAutoCaching(
 }
 
 /**
- * Returns a new ToolSet where the last tool entry carries the Anthropic
- * cache marker on `providerOptions`. Used on the `anthropic-direct` path
- * to place a stable breakpoint at the end of the tools block, caching the
- * full tool definitions across every turn.
+ * Returns a new ToolSet where the last non-deferred tool entry carries the
+ * Anthropic cache marker on `providerOptions`. Used on the
+ * `anthropic-direct` path to place a stable breakpoint at the end of the
+ * eager tools block without combining `cache_control` and `defer_loading`,
+ * which Anthropic rejects.
  *
- * No-op when `tools` has no entries. Preserves existing `providerOptions`
- * on tools (merges the cache marker in via spread).
+ * No-op when `tools` has no eligible entries. Preserves existing
+ * `providerOptions`, including other Anthropic options.
  */
 export function applyLastToolCacheBreakpoint(
   tools: ToolSet,
@@ -106,19 +107,40 @@ export function applyLastToolCacheBreakpoint(
     return tools;
   }
 
+  const breakpointIndex = entries.findLastIndex(([, tool]) => {
+    const providerOptions = (tool as { readonly providerOptions?: unknown }).providerOptions;
+    if (providerOptions === null || typeof providerOptions !== "object") return true;
+    const anthropic = (providerOptions as Record<string, unknown>).anthropic;
+    if (anthropic === null || typeof anthropic !== "object") return true;
+    return (anthropic as Record<string, unknown>).deferLoading !== true;
+  });
+
+  if (breakpointIndex === -1) {
+    return tools;
+  }
+
   const result: Record<string, unknown> = {};
   for (let i = 0; i < entries.length; i++) {
     const [name, tool] = entries[i] as [string, Record<string, unknown>];
-    if (i === entries.length - 1) {
+    if (i === breakpointIndex) {
       const existingProviderOptions =
         tool.providerOptions !== undefined && typeof tool.providerOptions === "object"
           ? (tool.providerOptions as Record<string, unknown>)
+          : undefined;
+      const existingAnthropic =
+        existingProviderOptions?.anthropic !== undefined &&
+        typeof existingProviderOptions.anthropic === "object" &&
+        existingProviderOptions.anthropic !== null
+          ? (existingProviderOptions.anthropic as Record<string, unknown>)
           : undefined;
       result[name] = {
         ...tool,
         providerOptions: {
           ...existingProviderOptions,
-          ...marker,
+          anthropic: {
+            ...existingAnthropic,
+            ...marker.anthropic,
+          },
         },
       };
     } else {

--- a/packages/eve/src/harness/provider-tool-activation.test.ts
+++ b/packages/eve/src/harness/provider-tool-activation.test.ts
@@ -1,0 +1,358 @@
+import {
+  generateText,
+  jsonSchema,
+  tool,
+  type JSONValue,
+  type LanguageModel,
+  type ToolSet,
+} from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { createAnthropic } from "#compiled/@ai-sdk/anthropic/index.js";
+
+import {
+  applyProviderToolActivations,
+  resolveToolActivationTransport,
+} from "#harness/provider-tool-activation.js";
+import { attachToolActivation, createToolActivationId } from "#harness/tool-activation.js";
+import { applyLastToolCacheBreakpoint, getAnthropicCacheMarker } from "#harness/prompt-cache.js";
+
+function makeModel(provider: string, modelId: string): LanguageModel {
+  return {
+    provider,
+    modelId,
+    specificationVersion: "v4",
+  } as LanguageModel;
+}
+
+function makeActivationTools() {
+  const activationId = createToolActivationId("connection_search");
+  const toModelOutput = vi.fn(
+    async ({
+      output,
+    }: {
+      readonly input: unknown;
+      readonly output: JSONValue;
+      readonly toolCallId: string;
+    }) => ({
+      type: "json" as const,
+      value: output,
+    }),
+  );
+  const loader = attachToolActivation(
+    tool({
+      description: "Search connection tools",
+      execute: async () => [] as JSONValue,
+      inputSchema: jsonSchema<Record<string, never>>({ type: "object" }),
+      toModelOutput,
+    }),
+    {
+      id: activationId,
+      kind: "loader",
+      project(output) {
+        if (!Array.isArray(output)) return { tools: [] };
+        return {
+          tools: output.flatMap((item) => {
+            if (
+              item === null ||
+              typeof item !== "object" ||
+              typeof (item as { qualifiedName?: unknown }).qualifiedName !== "string" ||
+              typeof (item as { description?: unknown }).description !== "string"
+            ) {
+              return [];
+            }
+            return [
+              {
+                description: (item as { description: string }).description,
+                inputSchema: { type: "object" as const },
+                name: (item as { qualifiedName: string }).qualifiedName,
+              },
+            ];
+          }),
+        };
+      },
+    },
+  );
+  const target = attachToolActivation(
+    tool({
+      description: "List issues",
+      execute: async () => [] as JSONValue,
+      inputSchema: jsonSchema<Record<string, never>>({ type: "object" }),
+      providerOptions: {
+        anthropic: { existing: true },
+        openai: { strict: true },
+      },
+    }),
+    { id: activationId, kind: "target" },
+  );
+  const tools = { connection_search: loader, linear__list_issues: target } satisfies ToolSet;
+
+  return {
+    loader,
+    target,
+    toModelOutput,
+    tools,
+  };
+}
+
+function requireToModelOutput(tools: ToolSet, name: string) {
+  const toModelOutput = tools[name]?.toModelOutput;
+  if (toModelOutput === undefined) throw new Error(`Missing toModelOutput for ${name}`);
+  return toModelOutput;
+}
+
+describe("resolveToolActivationTransport", () => {
+  it.each(["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4.8", "claude-fable-5"])(
+    "uses Anthropic tool references for supported direct model %s",
+    (modelId) => {
+      expect(resolveToolActivationTransport(makeModel("anthropic.messages", modelId))).toBe(
+        "anthropic-tool-reference",
+      );
+    },
+  );
+
+  it.each(["claude-opus-4-1", "claude-sonnet-3-7", "claude-3-5-haiku-latest"])(
+    "keeps unsupported Anthropic model %s eager",
+    (modelId) => {
+      expect(resolveToolActivationTransport(makeModel("anthropic.messages", modelId))).toBe(
+        "eager",
+      );
+    },
+  );
+
+  it("keeps Bedrock and Vertex adapters eager until their transport is proven", () => {
+    expect(
+      resolveToolActivationTransport(makeModel("bedrock.anthropic", "claude-sonnet-4-6")),
+    ).toBe("eager");
+    expect(resolveToolActivationTransport(makeModel("vertex.anthropic", "claude-sonnet-4-6"))).toBe(
+      "eager",
+    );
+  });
+
+  it("keeps Gateway model strings eager", () => {
+    expect(resolveToolActivationTransport("anthropic/claude-sonnet-4.6")).toBe("eager");
+    expect(resolveToolActivationTransport("openai/gpt-5.4")).toBe("eager");
+  });
+});
+
+describe("applyProviderToolActivations", () => {
+  it("marks targets deferred and emits Anthropic references after the loader result", async () => {
+    const { loader, target, tools } = makeActivationTools();
+
+    const result = applyProviderToolActivations({
+      model: makeModel("anthropic.messages", "claude-sonnet-4-6"),
+      tools,
+    });
+
+    expect(result).not.toBe(tools);
+    expect(result.connection_search).not.toBe(loader);
+    expect(result.linear__list_issues).not.toBe(target);
+    expect(result.linear__list_issues?.providerOptions).toEqual({
+      anthropic: { deferLoading: true, existing: true },
+      openai: { strict: true },
+    });
+
+    const toModelOutput = requireToModelOutput(result, "connection_search");
+    const output = [
+      {
+        connection: "linear",
+        description: "List issues",
+        inputSchema: { type: "object" },
+        qualifiedName: "linear__list_issues",
+        tool: "list_issues",
+      },
+      {
+        connection: "github",
+        description: "GitHub",
+        error: "metadata unavailable",
+      },
+    ];
+
+    expect(await toModelOutput({ input: {}, output, toolCallId: "call_search" })).toEqual({
+      type: "content",
+      value: [
+        { text: JSON.stringify(output), type: "text" },
+        {
+          providerOptions: {
+            anthropic: {
+              toolName: "linear__list_issues",
+              type: "tool-reference",
+            },
+          },
+          type: "custom",
+        },
+      ],
+    });
+  });
+
+  it("preserves the ordinary result when the loader introduces no tools", async () => {
+    const { tools, toModelOutput: sourceToModelOutput } = makeActivationTools();
+    const result = applyProviderToolActivations({
+      model: makeModel("anthropic.messages", "claude-sonnet-4-6"),
+      tools,
+    });
+    const toModelOutput = requireToModelOutput(result, "connection_search");
+    const output = [{ connection: "github", description: "GitHub" }];
+
+    expect(await toModelOutput({ input: {}, output, toolCallId: "call_search" })).toEqual({
+      type: "json",
+      value: output,
+    });
+    expect(sourceToModelOutput).toHaveBeenCalledOnce();
+  });
+
+  it("is a no-op for eager transports", () => {
+    const { tools } = makeActivationTools();
+    expect(
+      applyProviderToolActivations({
+        model: "anthropic/claude-sonnet-4.6",
+        tools,
+      }),
+    ).toBe(tools);
+  });
+
+  it("serializes deferred definitions and references through the Anthropic adapter", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({
+          content: [{ text: "done", type: "text" }],
+          id: "msg_test",
+          model: "claude-sonnet-4-6",
+          role: "assistant",
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          type: "message",
+          usage: { input_tokens: 10, output_tokens: 1 },
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 },
+      );
+    });
+    const anthropic = createAnthropic({ apiKey: "test", fetch });
+    const activationId = createToolActivationId("connection_search");
+    const searchOutput = [
+      {
+        connection: "linear",
+        description: "List issues",
+        inputSchema: { type: "object" },
+        qualifiedName: "linear__list_issues",
+        tool: "list_issues",
+      },
+    ];
+    const loader = attachToolActivation(
+      tool({
+        description: "Search connection tools",
+        execute: async () => searchOutput,
+        inputSchema: jsonSchema({ type: "object" }),
+      }),
+      {
+        id: activationId,
+        kind: "loader",
+        project: () => ({
+          tools: [
+            {
+              description: "List issues",
+              inputSchema: { type: "object" },
+              name: "linear__list_issues",
+            },
+          ],
+        }),
+      },
+    );
+    const target = attachToolActivation(
+      tool({
+        description: "List issues",
+        execute: async () => [],
+        inputSchema: jsonSchema({ type: "object" }),
+      }),
+      { id: activationId, kind: "target" },
+    );
+    const activated = applyProviderToolActivations({
+      model: anthropic("claude-sonnet-4-6"),
+      tools: { connection_search: loader, linear__list_issues: target },
+    });
+    const effectiveTools = applyLastToolCacheBreakpoint(activated, getAnthropicCacheMarker());
+    const toModelOutput = requireToModelOutput(effectiveTools, "connection_search");
+    const modelOutput = await toModelOutput({
+      input: { keywords: "issues" },
+      output: searchOutput,
+      toolCallId: "call_search",
+    });
+
+    await generateText({
+      maxOutputTokens: 16,
+      messages: [
+        { content: "Find an issue tool.", role: "user" },
+        {
+          content: [
+            {
+              input: { keywords: "issues" },
+              toolCallId: "call_search",
+              toolName: "connection_search",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+        {
+          content: [
+            {
+              output: modelOutput as never,
+              toolCallId: "call_search",
+              toolName: "connection_search",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ],
+      model: anthropic("claude-sonnet-4-6"),
+      tools: effectiveTools,
+    });
+
+    expect(requestBody?.tools).toEqual([
+      {
+        cache_control: { type: "ephemeral" },
+        description: "Search connection tools",
+        input_schema: { type: "object" },
+        name: "connection_search",
+      },
+      {
+        defer_loading: true,
+        description: "List issues",
+        input_schema: { type: "object" },
+        name: "linear__list_issues",
+      },
+    ]);
+    expect(requestBody?.messages).toEqual([
+      {
+        content: [{ text: "Find an issue tool.", type: "text" }],
+        role: "user",
+      },
+      {
+        content: [
+          {
+            id: "call_search",
+            input: { keywords: "issues" },
+            name: "connection_search",
+            type: "tool_use",
+          },
+        ],
+        role: "assistant",
+      },
+      {
+        content: [
+          {
+            content: [
+              { text: JSON.stringify(searchOutput), type: "text" },
+              { tool_name: "linear__list_issues", type: "tool_reference" },
+            ],
+            tool_use_id: "call_search",
+            type: "tool_result",
+          },
+        ],
+        role: "user",
+      },
+    ]);
+  });
+});

--- a/packages/eve/src/harness/provider-tool-activation.ts
+++ b/packages/eve/src/harness/provider-tool-activation.ts
@@ -1,0 +1,170 @@
+import type { LanguageModel, ToolSet } from "ai";
+
+import {
+  copyToolActivation,
+  getToolActivation,
+  type HarnessToolActivation,
+  type ToolActivationProjection,
+} from "#harness/tool-activation.js";
+
+/** Provider transport used to place loaded definitions after their result. */
+export type ToolActivationTransport = "anthropic-tool-reference" | "eager";
+
+/** Resolves the transport supported by the active model adapter. */
+export function resolveToolActivationTransport(model: LanguageModel): ToolActivationTransport {
+  // The AI SDK request protocol used by eve cannot express OpenAI's positional
+  // `additional_tools` item through either the direct adapter or Gateway.
+  // Native OpenAI `tool_search` is not an equivalent fallback because its
+  // `{ tools }` output would discard the existing connection summaries and
+  // partial errors.
+  if (typeof model === "string") return "eager";
+  if (typeof model.provider !== "string" || typeof model.modelId !== "string") return "eager";
+
+  const provider = model.provider.toLowerCase().split(".")[0];
+  if (provider !== "anthropic") return "eager";
+
+  return supportsAnthropicToolSearch(model.modelId) ? "anthropic-tool-reference" : "eager";
+}
+
+/** Applies provider-native loading semantics to activation-marked tools. */
+export function applyProviderToolActivations(input: {
+  readonly model: LanguageModel;
+  readonly tools: ToolSet;
+}): ToolSet {
+  const entries = Object.entries(input.tools);
+  const loaderIds = new Set(
+    entries.flatMap(([, tool]) => {
+      const activation = getToolActivation(tool);
+      return activation?.kind === "loader" ? [activation.id] : [];
+    }),
+  );
+  if (loaderIds.size === 0) return input.tools;
+  if (resolveToolActivationTransport(input.model) === "eager") return input.tools;
+
+  const result: Record<string, ToolSet[string]> = {};
+  for (const [name, tool] of entries) {
+    const activation = getToolActivation(tool);
+    if (activation === undefined || !loaderIds.has(activation.id)) {
+      result[name] = tool;
+      continue;
+    }
+
+    result[name] =
+      activation.kind === "loader"
+        ? buildAnthropicLoader(tool, activation)
+        : buildAnthropicDeferredTarget(tool);
+  }
+
+  return result as ToolSet;
+}
+
+function supportsAnthropicToolSearch(modelId: string): boolean {
+  const match = /^claude-[a-z]+-(\d+)(?:[.-](\d+))?/.exec(modelId.toLowerCase());
+  if (match === null) return false;
+
+  const major = Number(match[1]);
+  const minor = match[2] === undefined ? undefined : Number(match[2]);
+  return major > 4 || (major === 4 && minor !== undefined && minor >= 5);
+}
+
+type ToolModelOutputInput = {
+  readonly output: unknown;
+  readonly toolCallId?: string;
+};
+
+type ToolWithModelOutput = ToolSet[string] & {
+  readonly toModelOutput?: (input: ToolModelOutputInput) => unknown | Promise<unknown>;
+};
+
+function buildAnthropicLoader(
+  tool: ToolSet[string],
+  activation: Extract<HarnessToolActivation, { readonly kind: "loader" }>,
+): ToolSet[string] {
+  const source = tool as ToolWithModelOutput;
+  const originalToModelOutput = source.toModelOutput;
+  const adapted = {
+    ...source,
+    async toModelOutput(input: ToolModelOutputInput) {
+      const ordinaryOutput =
+        originalToModelOutput === undefined
+          ? defaultToolModelOutput(input.output)
+          : await originalToModelOutput(input);
+      const projection = activation.project(input.output);
+      return addAnthropicToolReferences(ordinaryOutput, projection);
+    },
+  } as ToolSet[string];
+  return copyToolActivation(tool, adapted);
+}
+
+function buildAnthropicDeferredTarget(tool: ToolSet[string]): ToolSet[string] {
+  const source = tool as ToolSet[string] & {
+    readonly providerOptions?: Readonly<Record<string, unknown>>;
+  };
+  const anthropic = asRecord(source.providerOptions?.anthropic);
+  const adapted = {
+    ...source,
+    providerOptions: {
+      ...source.providerOptions,
+      anthropic: {
+        ...anthropic,
+        deferLoading: true,
+      },
+    },
+  } as ToolSet[string];
+  return copyToolActivation(tool, adapted);
+}
+
+function addAnthropicToolReferences(
+  ordinaryOutput: unknown,
+  projection: ToolActivationProjection,
+): unknown {
+  const names = [...new Set(projection.tools.map((tool) => tool.name))];
+  if (names.length === 0) return ordinaryOutput;
+
+  const content = toContentParts(ordinaryOutput);
+  if (content === null) return ordinaryOutput;
+
+  return {
+    type: "content" as const,
+    value: [
+      ...content,
+      ...names.map((toolName) => ({
+        providerOptions: {
+          anthropic: {
+            toolName,
+            type: "tool-reference" as const,
+          },
+        },
+        type: "custom" as const,
+      })),
+    ],
+  };
+}
+
+function defaultToolModelOutput(output: unknown): unknown {
+  return typeof output === "string"
+    ? { type: "text" as const, value: output }
+    : { type: "json" as const, value: output ?? null };
+}
+
+function toContentParts(output: unknown): readonly unknown[] | null {
+  const record = asRecord(output);
+  if (record === undefined) return null;
+
+  if (record.type === "content" && Array.isArray(record.value)) {
+    return record.value;
+  }
+  if (record.type === "text" && typeof record.value === "string") {
+    return [{ text: record.value, type: "text" as const }];
+  }
+  if (record.type === "json") {
+    return [{ text: JSON.stringify(record.value), type: "text" as const }];
+  }
+  return null;
+}
+
+function asRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Readonly<Record<string, unknown>>)
+    : undefined;
+}

--- a/packages/eve/src/harness/tool-activation.ts
+++ b/packages/eve/src/harness/tool-activation.ts
@@ -1,0 +1,62 @@
+import type { JsonObject } from "#shared/json.js";
+
+declare const toolActivationIdBrand: unique symbol;
+
+/** Framework-owned identity shared by one tool loader and its loaded tools. */
+export type ToolActivationId = string & {
+  readonly [toolActivationIdBrand]: true;
+};
+
+/** Provider-neutral snapshot of one tool introduced by a loader result. */
+export interface ActivatedToolDefinition {
+  readonly description: string;
+  readonly inputSchema: JsonObject;
+  readonly name: string;
+}
+
+/** Tools introduced by one loader result. */
+export interface ToolActivationProjection {
+  readonly tools: readonly ActivatedToolDefinition[];
+}
+
+/** Internal relationship between a loader and the tools its result introduces. */
+export type HarnessToolActivation =
+  | {
+      readonly kind: "loader";
+      readonly id: ToolActivationId;
+      readonly project: (output: unknown) => ToolActivationProjection;
+    }
+  | {
+      readonly kind: "target";
+      readonly id: ToolActivationId;
+    };
+
+const activations = new WeakMap<object, HarnessToolActivation>();
+
+/** Creates a typed activation identity from a framework-owned stable name. */
+export function createToolActivationId(value: string): ToolActivationId {
+  return value as ToolActivationId;
+}
+
+/** Attaches internal activation metadata without changing the model-facing tool. */
+export function attachToolActivation<T extends object>(
+  tool: T,
+  activation: HarnessToolActivation,
+): T {
+  activations.set(tool, activation);
+  return tool;
+}
+
+/** Reads framework-owned activation metadata, when present. */
+export function getToolActivation(tool: unknown): HarnessToolActivation | undefined {
+  return typeof tool === "object" && tool !== null ? activations.get(tool) : undefined;
+}
+
+/** Copies activation metadata while lowering or cloning a tool definition. */
+export function copyToolActivation<T extends object>(source: unknown, target: T): T {
+  const activation = getToolActivation(source);
+  if (activation !== undefined) {
+    activations.set(target, activation);
+  }
+  return target;
+}

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -38,6 +38,7 @@ import {
 import { hasDeferredStepInput, setPendingInputBatch } from "#harness/input-requests.js";
 import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
+import { attachToolActivation, createToolActivationId } from "#harness/tool-activation.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import { TurnCancelledError } from "#harness/turn-cancellation.js";
 import {
@@ -7796,6 +7797,66 @@ describe("createToolLoopHarness", () => {
       const lastTool = toolEntries[toolEntries.length - 1]?.[1];
       expect(lastTool?.providerOptions).toEqual({
         anthropic: { cacheControl: { type: "ephemeral" } },
+      });
+    });
+
+    it("anthropic-direct path: activates loaded tools before placing the cache marker", async () => {
+      setupStopResult();
+      const activationId = createToolActivationId("connection_search");
+      const search = attachToolActivation(
+        {
+          description: "Search connection tools",
+          execute: vi.fn(),
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "connection_search",
+        },
+        {
+          id: activationId,
+          kind: "loader",
+          project: () => ({
+            tools: [
+              {
+                description: "List issues",
+                inputSchema: { type: "object" },
+                name: "linear__list_issues",
+              },
+            ],
+          }),
+        },
+      );
+      const target = attachToolActivation(
+        {
+          description: "List issues",
+          execute: vi.fn(),
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "linear__list_issues",
+        },
+        { id: activationId, kind: "target" },
+      );
+      const config: ToolLoopHarnessConfig = {
+        mode: "conversation",
+        resolveModel: vi.fn().mockResolvedValue({
+          provider: "anthropic.messages",
+          modelId: "claude-sonnet-4-6",
+          specificationVersion: "v4",
+        } as LanguageModel),
+        tools: new Map([
+          [search.name, search],
+          [target.name, target],
+        ]),
+      };
+      const runStep = createToolLoopHarness(config);
+      await runStep(createTestSession(), { message: "hi" });
+
+      const toolsPassed = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0]?.tools as Record<
+        string,
+        { providerOptions?: Record<string, unknown> }
+      >;
+      expect(toolsPassed.connection_search?.providerOptions).toEqual({
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      });
+      expect(toolsPassed.linear__list_issues?.providerOptions).toEqual({
+        anthropic: { deferLoading: true },
       });
     });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -109,6 +109,7 @@ import {
 import { getInstrumentationConfig } from "#harness/instrumentation-config.js";
 import { resolveAssistantStepText } from "#harness/messages.js";
 import { normalizeProviderToolHistory } from "#harness/provider-tool-history.js";
+import { applyProviderToolActivations } from "#harness/provider-tool-activation.js";
 import {
   type AuthorizationSignal,
   isAuthorizationSignal,
@@ -816,8 +817,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       });
       session = advertisedModelTools.session;
       const modelTools = advertisedModelTools.modelTools;
-
-      const effectiveTools = marker ? applyLastToolCacheBreakpoint(modelTools, marker) : modelTools;
+      const activatedModelTools = applyProviderToolActivations({ model, tools: modelTools });
+      const effectiveTools = marker
+        ? applyLastToolCacheBreakpoint(activatedModelTools, marker)
+        : activatedModelTools;
 
       const hooks = buildStepHooks({
         cachePath,

--- a/packages/eve/src/harness/tools.test.ts
+++ b/packages/eve/src/harness/tools.test.ts
@@ -14,6 +14,11 @@ import {
 } from "#runtime/framework-tools/web-search.js";
 import type { JsonObject } from "#shared/json.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import {
+  attachToolActivation,
+  createToolActivationId,
+  getToolActivation,
+} from "#harness/tool-activation.js";
 import { buildToolApproval, buildToolSet, buildToolSetWithProviderTools } from "#harness/tools.js";
 import type { HarnessToolMap } from "#harness/types.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
@@ -98,6 +103,28 @@ async function projectSdkToolOutput(input: {
 }
 
 describe("buildToolSet", () => {
+  it("preserves internal tool activation metadata", () => {
+    const activation = {
+      id: createToolActivationId("connection_search"),
+      kind: "target" as const,
+    };
+    const definition = attachToolActivation(
+      {
+        description: "List issues",
+        execute: () => [],
+        inputSchema: jsonSchema({ type: "object" }),
+        name: "linear__list_issues",
+      },
+      activation,
+    );
+
+    const result = buildToolSet({
+      tools: new Map([[definition.name, definition]]),
+    });
+
+    expect(getToolActivation(result.linear__list_issues)).toBe(activation);
+  });
+
   it("forwards the AI SDK execute options to the tool definition", async () => {
     const abortController = new AbortController();
     let receivedOptions: ToolExecuteOptions | undefined;

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -27,6 +27,7 @@ import {
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { withToolOutputSerializationError } from "#harness/tool-output-serialization.js";
 import type { ToolExecuteOptions } from "#shared/tool-definition.js";
+import { copyToolActivation } from "#harness/tool-activation.js";
 
 type ToolModelOutputValue =
   | { readonly type: "json"; readonly value: JSONValue }
@@ -130,6 +131,7 @@ export function buildToolSet(input: {
             }
           : {}),
     });
+    copyToolActivation(definition, aiTool);
     tools[definition.name] = aiTool;
     if (definition.approval !== undefined) {
       toolApprovals.set(aiTool, approval);

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { extractDiscoveredTools } from "#runtime/framework-tools/connection-search-dynamic.js";
+import {
+  createConnectionSearchEvents,
+  extractDiscoveredTools,
+  projectConnectionSearchActivation,
+} from "#runtime/framework-tools/connection-search-dynamic.js";
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
+import { getToolActivation } from "#harness/tool-activation.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Msg = any;
@@ -70,12 +77,52 @@ describe("extractDiscoveredTools", () => {
     expect(result[0]!.qualifiedName).toBe("linear__list_issues");
   });
 
+  it("extracts tools from an Anthropic content result", () => {
+    const output = [
+      {
+        connection: "linear",
+        description: "List issues",
+        qualifiedName: "linear__list_issues",
+        tool: "list_issues",
+      },
+    ];
+    const messages: Msg[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "connection_search",
+            output: {
+              type: "content",
+              value: [
+                { type: "text", text: JSON.stringify(output) },
+                {
+                  type: "custom",
+                  providerOptions: {
+                    anthropic: {
+                      type: "tool-reference",
+                      toolName: "linear__list_issues",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(extractDiscoveredTools(messages)).toEqual(output);
+  });
+
   it("returns empty for no tool results", () => {
     const messages: Msg[] = [{ role: "user", content: [{ type: "text", text: "hello" }] }];
     expect(extractDiscoveredTools(messages)).toHaveLength(0);
   });
 
-  it("deduplicates by qualifiedName (latest wins)", () => {
+  it("keeps the first definition for a qualified name", () => {
     const messages: Msg[] = [
       {
         role: "tool",
@@ -117,7 +164,7 @@ describe("extractDiscoveredTools", () => {
 
     const result = extractDiscoveredTools(messages);
     expect(result).toHaveLength(1);
-    expect(result[0]!.description).toBe("New description");
+    expect(result[0]!.description).toBe("Old description");
   });
 
   it("skips items without tool or qualifiedName", () => {
@@ -149,5 +196,157 @@ describe("extractDiscoveredTools", () => {
     const result = extractDiscoveredTools(messages);
     expect(result).toHaveLength(1);
     expect(result[0]!.description).toBe("Valid");
+  });
+});
+
+describe("projectConnectionSearchActivation", () => {
+  it("projects only successful discovered tool definitions", () => {
+    expect(
+      projectConnectionSearchActivation([
+        {
+          connection: "linear",
+          description: "List issues",
+          inputSchema: { properties: { state: { type: "string" } }, type: "object" },
+          qualifiedName: "linear__list_issues",
+          tool: "list_issues",
+        },
+        {
+          connection: "github",
+          description: "GitHub",
+          error: "metadata unavailable",
+        },
+      ]),
+    ).toEqual({
+      tools: [
+        {
+          description: "List issues",
+          inputSchema: { properties: { state: { type: "string" } }, type: "object" },
+          name: "linear__list_issues",
+        },
+      ],
+    });
+  });
+
+  it("does not activate tools for authorization and summary outputs", () => {
+    expect(
+      projectConnectionSearchActivation([
+        { connection: "linear", description: "Linear", needsAuthorization: true },
+        { connection: "github", description: "GitHub" },
+      ]),
+    ).toEqual({ tools: [] });
+    expect(projectConnectionSearchActivation({ type: "authorization-pending" })).toEqual({
+      tools: [],
+    });
+  });
+});
+
+describe("createConnectionSearchEvents", () => {
+  it("marks the search tool as a loader and discovered tools as its targets", async () => {
+    const runtimeContext = new ContextContainer();
+    runtimeContext.set(ConnectionRegistryKey, {
+      getConnectionApproval: () => undefined,
+      getConnections: () => [
+        {
+          connectionName: "linear",
+          description: "Linear",
+          url: "https://linear.example.test/mcp",
+        },
+      ],
+    } as never);
+    const messages: Msg[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "connection_search",
+            output: [
+              {
+                connection: "linear",
+                description: "List issues",
+                inputSchema: { type: "object" },
+                qualifiedName: "linear__list_issues",
+                tool: "list_issues",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const handler = createConnectionSearchEvents()["step.started"]!;
+
+    const tools = (await contextStorage.run(runtimeContext, () =>
+      handler(
+        {},
+        {
+          channel: {},
+          messages,
+          session: { auth: { current: null, initiator: null }, id: "session-1" },
+        },
+      ),
+    )) as Record<string, object>;
+
+    expect(getToolActivation(tools.connection_search)).toMatchObject({ kind: "loader" });
+    expect(getToolActivation(tools.linear__list_issues)).toMatchObject({ kind: "target" });
+    expect(getToolActivation(tools.connection_search)?.id).toBe(
+      getToolActivation(tools.linear__list_issues)?.id,
+    );
+  });
+
+  it("keeps a context-only definition eager after its activation result is compacted", async () => {
+    const runtimeContext = new ContextContainer();
+    let description = "Original description";
+    runtimeContext.set(ConnectionRegistryKey, {
+      getClient: () => ({
+        getToolMetadata: async () => [
+          {
+            description,
+            inputSchema: { type: "object" },
+            name: "list_issues",
+          },
+        ],
+      }),
+      getConnectionApproval: () => undefined,
+      getConnections: () => [
+        {
+          connectionName: "linear",
+          description: "Linear",
+          url: "https://linear.example.test/mcp",
+        },
+      ],
+    } as never);
+    const handler = createConnectionSearchEvents()["step.started"]!;
+
+    await contextStorage.run(runtimeContext, async () => {
+      const tools = (await handler(
+        {},
+        {
+          channel: {},
+          messages: [],
+          session: { auth: { current: null, initiator: null }, id: "session-1" },
+        },
+      )) as Record<
+        string,
+        { execute(input: Record<string, unknown>, ctx: unknown): Promise<unknown> }
+      >;
+      const first = await tools.connection_search!.execute({ keywords: "issues" }, {});
+      description = "Changed description";
+      const second = await tools.connection_search!.execute({ keywords: "issues" }, {});
+
+      expect(first).toMatchObject([{ description: "Original description" }]);
+      expect(second).toMatchObject([{ description: "Original description" }]);
+
+      const restored = (await handler(
+        {},
+        {
+          channel: {},
+          messages: [],
+          session: { auth: { current: null, initiator: null }, id: "session-1" },
+        },
+      )) as Record<string, { description: string }>;
+      expect(restored.linear__list_issues?.description).toBe("Original description");
+      expect(getToolActivation(restored.linear__list_issues)).toBeUndefined();
+    });
   });
 });

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -31,10 +31,16 @@ import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
 import { createLogger } from "#internal/logging.js";
 import type { DynamicToolEvents, DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import type { ModelMessage } from "ai";
+import {
+  attachToolActivation,
+  createToolActivationId,
+  type ToolActivationProjection,
+} from "#harness/tool-activation.js";
 
 import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 
 const logger = createLogger("framework.connection-search-dynamic");
+const CONNECTION_SEARCH_ACTIVATION_ID = createToolActivationId("connection_search");
 
 const CONNECTION_SEARCH_RESULT_ITEM_SCHEMA: JsonObject = {
   additionalProperties: false,
@@ -88,6 +94,32 @@ interface ConnectionSearchResultItem {
   readonly outputSchema?: Record<string, unknown>;
   readonly tool?: string;
   readonly qualifiedName?: string;
+}
+
+/** Projects successful search results into provider-neutral tool activations. */
+export function projectConnectionSearchActivation(output: unknown): ToolActivationProjection {
+  if (!Array.isArray(output)) return { tools: [] };
+
+  return {
+    tools: output.flatMap((candidate) => {
+      if (candidate === null || typeof candidate !== "object") return [];
+      const item = candidate as ConnectionSearchResultItem;
+      if (
+        item.tool === undefined ||
+        item.qualifiedName === undefined ||
+        typeof item.description !== "string"
+      ) {
+        return [];
+      }
+      return [
+        {
+          description: item.description,
+          inputSchema: (item.inputSchema ?? { type: "object" }) as JsonObject,
+          name: item.qualifiedName,
+        },
+      ];
+    }),
+  };
 }
 
 function tokenize(text: string): string[] {
@@ -299,14 +331,23 @@ async function executeConnectionSearch(
   const matched = results.slice(0, limit).map((r) => r.item);
 
   if (matched.length > 0) {
-    const allResults = [...matched, ...failedConnections];
     const existing = ctx.get(ConnectionSearchResultsKey) ?? [];
-    const merged = new Map(existing.map((r) => [r.qualifiedName, r]));
+    const merged = new Map(
+      existing.flatMap((result) =>
+        result.qualifiedName === undefined ? [] : [[result.qualifiedName, result] as const],
+      ),
+    );
+    const canonicalMatched = matched.map((result) => {
+      if (result.qualifiedName === undefined) return result;
+      return merged.get(result.qualifiedName) ?? result;
+    });
     for (const r of matched) {
-      if (r.qualifiedName) merged.set(r.qualifiedName, r);
+      if (r.qualifiedName !== undefined && !merged.has(r.qualifiedName)) {
+        merged.set(r.qualifiedName, r);
+      }
     }
     ctx.set(ConnectionSearchResultsKey, [...merged.values()]);
-    return allResults;
+    return [...canonicalMatched, ...failedConnections];
   }
 
   const summaries: ConnectionSearchResultItem[] = targetConnections.map((c) => {
@@ -324,7 +365,8 @@ async function executeConnectionSearch(
 /**
  * Extracts connection search results from conversation history.
  * Scans tool-result messages for `connection_search` results and
- * returns deduplicated tool metadata (latest result wins per qualifiedName).
+ * returns deduplicated tool metadata. The first definition for a qualified
+ * name wins so a result replay cannot rewrite an earlier activation point.
  */
 export function extractDiscoveredTools(
   messages: readonly ModelMessage[],
@@ -340,16 +382,12 @@ export function extractDiscoveredTools(
     }>;
     for (const part of parts) {
       if (part.type !== "tool-result" || part.toolName !== "connection_search") continue;
-      const output = part.output;
-      if (output === undefined || output === null) continue;
-      const items = (
-        typeof output === "object" && "type" in output && "value" in output
-          ? (output as { value: unknown }).value
-          : output
-      ) as unknown;
-      if (!Array.isArray(items)) continue;
-      for (const item of items as ConnectionSearchResultItem[]) {
-        if (item.tool && item.qualifiedName) {
+      const items = extractConnectionSearchItems(part.output);
+      if (items === undefined) continue;
+      for (const candidate of items) {
+        if (candidate === null || typeof candidate !== "object") continue;
+        const item = candidate as ConnectionSearchResultItem;
+        if (item.tool && item.qualifiedName && !byQualifiedName.has(item.qualifiedName)) {
           byQualifiedName.set(item.qualifiedName, item);
         }
       }
@@ -359,13 +397,35 @@ export function extractDiscoveredTools(
   return [...byQualifiedName.values()];
 }
 
+function extractConnectionSearchItems(output: unknown): readonly unknown[] | undefined {
+  if (Array.isArray(output)) return output;
+  if (output === null || typeof output !== "object") return undefined;
+
+  const result = output as { readonly type?: unknown; readonly value?: unknown };
+  if (result.type === "json" && Array.isArray(result.value)) return result.value;
+  if (result.type !== "content" || !Array.isArray(result.value)) return undefined;
+
+  for (const candidate of result.value) {
+    if (candidate === null || typeof candidate !== "object") continue;
+    const part = candidate as { readonly text?: unknown; readonly type?: unknown };
+    if (part.type !== "text" || typeof part.text !== "string") continue;
+    try {
+      const parsed: unknown = JSON.parse(part.text);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // The ordinary connection_search result is the only JSON text part.
+    }
+  }
+  return undefined;
+}
+
 /**
  * Creates the connection search dynamic tool resolver events.
  *
- * The resolver subscribes to `step.started` so it re-derives the tool
- * set from conversation history on every step. After compaction, old
- * `connection_search` results disappear from messages and discovered
- * tools naturally drop from the toolset.
+ * The resolver subscribes to `step.started` so it re-derives the tool set
+ * from durable search results and conversation history on every step. After
+ * compaction removes an introducing result, its durable definition remains
+ * callable but is advertised eagerly because no tool reference remains.
  */
 export function createConnectionSearchEvents(): DynamicToolEvents {
   return {
@@ -376,13 +436,20 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
       const connections = registry.getConnections();
       const connectionNames = connections.map((c) => c.connectionName);
       const fromMessages = extractDiscoveredTools(ctx.messages);
+      const referencedNames = new Set(
+        fromMessages.flatMap((result) =>
+          result.qualifiedName === undefined ? [] : [result.qualifiedName],
+        ),
+      );
       const fromContext = loadContext().get(ConnectionSearchResultsKey) ?? [];
       const mergedMap = new Map<string, ConnectionSearchResultItem>();
       for (const r of fromContext) {
         if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
       }
       for (const r of fromMessages) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
+        if (r.qualifiedName && !mergedMap.has(r.qualifiedName)) {
+          mergedMap.set(r.qualifiedName, r);
+        }
       }
       const discovered = [...mergedMap.values()];
 
@@ -420,13 +487,19 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
         },
         outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
       };
+      attachToolActivation(tools["connection_search"], {
+        id: CONNECTION_SEARCH_ACTIVATION_ID,
+        kind: "loader",
+        project: projectConnectionSearchActivation,
+      });
 
       for (const result of discovered) {
         const connectionName = result.connection;
         const toolName = result.tool!;
         const approval = registry.getConnectionApproval(connectionName);
+        const qualifiedName = qualifiedConnectionToolName(connectionName, toolName);
 
-        tools[qualifiedConnectionToolName(connectionName, toolName)] = {
+        tools[qualifiedName] = {
           description: result.description,
           inputSchema: (result.inputSchema ?? {
             type: "object",
@@ -504,6 +577,12 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
             }
           },
         };
+        if (referencedNames.has(qualifiedName)) {
+          attachToolActivation(tools[qualifiedName], {
+            id: CONNECTION_SEARCH_ACTIVATION_ID,
+            kind: "target",
+          });
+        }
       }
 
       return tools;


### PR DESCRIPTION
### Description

Addresses #716.

`connection_search` currently adds each discovered definition to the next request's top-level tool catalog. Direct Anthropic requests serialize tools before the system prompt and messages, so that insertion prevents reuse of every later cached prefix.

What:

- Mark framework-owned connection discovery as a loader/target relationship that survives dynamic-tool lowering.
- On supported direct Anthropic models, send discovered connection definitions with `defer_loading` and append matching `tool_reference` blocks to the `connection_search` result that introduced them.
- Keep the first model-visible definition for each qualified name. If compaction removes its introducing result, restore the durable definition eagerly so the tool remains callable.
- Keep the Anthropic cache breakpoint on the last eager tool and preserve existing provider options.
- Document the cache cost of other dynamic tool changes and add a patch changeset.

### Provider boundary

Other authored dynamic tools remain eager. This path is scoped to `connection_search`, where eve owns both the loader result and the loaded definitions.

OpenAI and Gateway model strings also remain eager. OpenAI's positional mechanism is [`additional_tools`](https://developers.openai.com/api/docs/guides/tools-tool-search#add-tools-at-a-specific-point-in-the-input), but the AI SDK request interface used here has no representation for that input item. Replacing `connection_search` with OpenAI's native client `tool_search` would change its result to `{ tools }`, dropping connection summaries, partial errors, and authorization signals. Anthropic's custom-tool path can preserve that contract with [`defer_loading` and `tool_reference`](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference#defer_loading-and-prompt-caching).

This does not add a live-provider cache-token eval. The adapter-level test captures the exact Anthropic request JSON, including `cache_control`, `defer_loading`, and the result-positioned `tool_reference`.

### How did you test your changes?

- `pnpm typecheck` — 27/27 workspace tasks passed.
- `pnpm lint` — passed with the existing control-regex warning in `src/public/next/server.ts`.
- `pnpm guard:invariants` and `pnpm docs:check` — passed.
- Focused unit suite across the six changed areas — 277/277 tests passed.
- `pnpm test:unit` — 4,699 passed and 1 skipped; 3 tests failed in untouched `src/execution/sandbox/bindings/vercel.test.ts` because the run supplied ambient Vercel credential fields to credential-free mock expectations.

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
