### PR TITLE
Add static skill visibility and load authorization

### DIFF
--- a/.changeset/static-skill-visibility.md
+++ b/.changeset/static-skill-visibility.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a session- and turn-scoped static skill visibility resolver that keeps prompt announcements and framework `load_skill` authorization in sync.

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -93,11 +93,11 @@ may see and load. Packages remain materialized, so sibling files such as
 omitted from the prompt and rejected by `load_skill`:
 
 ```ts title="agent/agent.ts"
-import { defineAgent, defineDynamic } from "eve";
+import { defineAgent, defineStaticSkillVisibility } from "eve";
 
 export default defineAgent({
   model: "anthropic/claude-opus-4.8",
-  staticSkillVisibility: defineDynamic({
+  staticSkillVisibility: defineStaticSkillVisibility({
     events: {
       "session.started": (_event, ctx) =>
         ctx.session.auth.initiator?.attributes.plan === "enterprise" ? "all" : ["support"],
@@ -109,6 +109,9 @@ export default defineAgent({
 ```
 
 Handlers may return `"all"` or a list of path-derived static skill names.
+Use `defineStaticSkillVisibility` for this slot; unlike general-purpose
+`defineDynamic`, its authoring type only permits `session.started` and
+`turn.started` handlers.
 Unknown, duplicate, malformed, or thrown results fail closed to an empty
 static-skill set. Omitting `staticSkillVisibility` preserves the default where
 all static skills are available. The resolved set is durable for replay and is

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -85,6 +85,35 @@ selection object, or `null` to leave the scope unset.
   from the fallback's — it is never inherited. Omitted `modelOptions` reuses
   the agent-level `modelOptions`.
 
+### Limit static skills dynamically
+
+`staticSkillVisibility` controls which compiled static skills a session or turn
+may see and load. Packages remain materialized, so sibling files such as
+`references/` remain available to a visible skill, but hidden skill names are
+omitted from the prompt and rejected by `load_skill`:
+
+```ts title="agent/agent.ts"
+import { defineAgent, defineDynamic } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-opus-4.8",
+  staticSkillVisibility: defineDynamic({
+    events: {
+      "session.started": (_event, ctx) =>
+        ctx.session.auth.initiator?.attributes.plan === "enterprise" ? "all" : ["support"],
+      "turn.started": (_event, ctx) =>
+        ctx.session.auth.initiator?.attributes.plan === "enterprise" ? "all" : ["support"],
+    },
+  }),
+});
+```
+
+Handlers may return `"all"` or a list of path-derived static skill names.
+Unknown, duplicate, malformed, or thrown results fail closed to an empty
+static-skill set. Omitting `staticSkillVisibility` preserves the default where
+all static skills are available. The resolved set is durable for replay and is
+replaced by `turn.started`; prompt variants change when the set changes.
+
 Runtime identity reports a dynamic agent's model as `dynamic:<fallback id>`.
 
 ## Reasoning effort

--- a/docs/plans/active/2026-07-11-static-skill-visibility-load-authorization.md
+++ b/docs/plans/active/2026-07-11-static-skill-visibility-load-authorization.md
@@ -21,9 +21,11 @@ turn, and the exact same resolved selection controls both the model's
 
 ## Public contract
 
-`AgentDefinition.staticSkillVisibility` accepts the existing `defineDynamic`
-sentinel. Its handlers may run only at `session.started` and `turn.started`
-and return either:
+`AgentDefinition.staticSkillVisibility` accepts Eve's dedicated
+`defineStaticSkillVisibility({ events })` sentinel, which retains the same
+event-handler ergonomics while giving this public slot an exact lifecycle
+type. Its handlers may run only at `session.started` and `turn.started` and
+return either:
 
 - `"all"` — all compiled static skills;
 - a readonly string array — exactly those compiled static skill names, including

--- a/docs/plans/active/2026-07-11-static-skill-visibility-load-authorization.md
+++ b/docs/plans/active/2026-07-11-static-skill-visibility-load-authorization.md
@@ -1,0 +1,97 @@
+# Static skill visibility and load authorization
+
+## Concept
+
+Add one Eve-owned `staticSkillVisibility` contract to the authored agent
+definition. It resolves the compiled static skill names visible for a session or
+turn, and the exact same resolved selection controls both the model's
+`Available skills` announcement and framework `load_skill` authorization.
+
+## Authority boundary
+
+- The compiler remains authoritative for the complete, path-derived static
+  skill inventory and materialized package resources.
+- The authored agent's `staticSkillVisibility` resolver is the only runtime
+  authority for which static names are visible in a session/turn.
+- Eve runtime owns validation, durable context storage, prompt filtering, and
+  framework-tool authorization. No Remi loader, semantic router, manifest
+  patching, or alternate runtime is introduced.
+- Dynamic skills remain additive and retain their existing resolver ownership,
+  sandbox materialization, and collision rules.
+
+## Public contract
+
+`AgentDefinition.staticSkillVisibility` accepts the existing `defineDynamic`
+sentinel. Its handlers may run only at `session.started` and `turn.started`
+and return either:
+
+- `"all"` — all compiled static skills;
+- a readonly string array — exactly those compiled static skill names, including
+  `[]` for none.
+
+With no resolver, Eve preserves the current all-static behavior. A resolver
+result containing an unknown static name, malformed value, unsupported event,
+or thrown handler fails closed to an empty static selection for that boundary.
+The selection is name-based, immutable, and session/turn scoped; it does not
+move or delete package files.
+
+## Owned files
+
+Expected implementation and proof surface, narrowed from WS2 after checkout
+inspection:
+
+- Public/compiler contract: `packages/eve/src/public/definitions/agent.ts`,
+  `packages/eve/src/public/index.ts`, `packages/eve/src/shared/agent-definition.ts`,
+  `packages/eve/src/internal/authored-definition/core.ts`,
+  `packages/eve/src/compiler/manifest.ts`,
+  `packages/eve/src/compiler/normalize-agent-config.ts`, and module-map/runtime
+  type seams as required by the compiled source reference.
+- Runtime authority: `packages/eve/src/runtime/resolve-agent.ts`,
+  `packages/eve/src/runtime/types.ts`,
+  `packages/eve/src/runtime/agent/bootstrap.ts`,
+  `packages/eve/src/context/keys.ts`, a focused static-visibility lifecycle
+  module, `packages/eve/src/execution/workflow-steps.ts`,
+  `packages/eve/src/execution/session.ts`, and
+  `packages/eve/src/runtime/framework-tools/skill.ts`.
+- Focused tests adjacent to compiler normalization, lifecycle/context,
+  session/prompt, framework skill authorization, workspace resource
+  materialization, and replay serialization.
+- One patch changeset for the published `eve` package.
+
+## Replay and cache semantics
+
+The resolved selection is stored in a registered serializable context key.
+`session.started` establishes the session value once; `turn.started` replaces
+the turn value before the model call. The current context selection survives
+workflow step boundaries and durable replay, while the resolver is re-evaluated
+only on its declared lifecycle events. Continuation steps within a turn reuse
+the same selection. Prompt refresh uses the selection before composing the
+static skill block, and dynamic announcements remain additive after it.
+
+Changing the selection changes the system-prompt prefix intentionally, so Eve's
+existing prompt-cache breakpoints treat it as a new prompt variant; an
+unchanged selection keeps the normal cache path. Materialized static packages
+and sibling files remain present regardless of visibility, and replay does not
+re-materialize or delete them.
+
+## Proof contract
+
+Focused tests must cover all, subset, empty, unknown-id fail-closed, direct
+hidden-name rejection, selected packaged sibling-file access, dynamic plus
+static visibility, static/dynamic name collision behavior, next-turn
+re-resolution, context replay, prompt filtering, and no-resolver compatibility.
+Then run the Eve typecheck and full suite using repository-prescribed tier
+configs, plus `pnpm diff:check`/the repository's equivalent diff hygiene check,
+and self-review the exact diff for authority leakage or scope expansion.
+
+## Release path and cleanup
+
+This PR targets upstream Eve `main` as one ready PR. Because the upstream
+repository is read-only for the current GitHub identity, push the branch to an
+available fork and open one ready cross-repository PR against `vercel/eve:main`
+if fork publication is available. Do not merge, self-approve, publish a
+package, update Linear, or open a second PR. After the upstream merge, release
+the published `eve` package with the changeset, then Remi may update its Eve
+dependency. No compatibility shim, category router, post-tool navigation,
+custom loader, manifest patch, sibling runtime, or package release is included
+in this change.

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -70,6 +70,32 @@ describe("compiledAgentManifestSchema", () => {
     });
   });
 
+  it("preserves static skill visibility resolver source", () => {
+    const manifest = createCompiledAgentManifest({
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      config: {
+        model: { id: "openai/gpt-5.5", routing: classifyModelRouting("openai/gpt-5.5") },
+        name: "app",
+        staticSkillVisibility: {
+          eventNames: ["session.started", "turn.started"],
+          logicalPath: "agent.ts",
+          sourceId: "agent-config",
+          sourceKind: "module",
+        },
+      },
+    });
+
+    const parsed = compiledAgentManifestSchema.parse(manifest);
+
+    expect(parsed.config.staticSkillVisibility).toEqual({
+      eventNames: ["session.started", "turn.started"],
+      logicalPath: "agent.ts",
+      sourceId: "agent-config",
+      sourceKind: "module",
+    });
+  });
+
   it("preserves uncapped (false) session token limits", () => {
     const manifest = createCompiledAgentManifest({
       agentRoot: "/app/agent",

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -124,11 +124,19 @@ type CompiledAgentCompactionDefinition = Omit<InternalAgentCompactionDefinition,
 /**
  * Normalized additive agent configuration preserved in the compiled manifest.
  */
-export type CompiledAgentDefinition = Omit<InternalAgentDefinition, "model" | "compaction"> & {
+export type CompiledAgentDefinition = Omit<
+  InternalAgentDefinition,
+  "model" | "compaction" | "staticSkillVisibility"
+> & {
   model: CompiledRuntimeModelReference;
   compaction?: CompiledAgentCompactionDefinition;
   dynamicModel?: CompiledDynamicModelDefinition;
+  staticSkillVisibility?: CompiledStaticSkillVisibilityDefinition;
 };
+
+export interface CompiledStaticSkillVisibilityDefinition extends ModuleSourceRef {
+  readonly eventNames: readonly ("session.started" | "turn.started")[];
+}
 
 /**
  * Normalized authored instructions prompt preserved in the compiled
@@ -289,6 +297,17 @@ const compiledDynamicModelDefinitionSchema: z.ZodType<CompiledDynamicModelDefini
   })
   .strict();
 
+const compiledStaticSkillVisibilityDefinitionSchema: z.ZodType<CompiledStaticSkillVisibilityDefinition> =
+  z
+    .object({
+      eventNames: z.array(z.enum(["session.started", "turn.started"])).readonly(),
+      exportName: z.string().optional(),
+      sourceKind: z.literal("module"),
+      logicalPath: z.string(),
+      sourceId: z.string(),
+    })
+    .strict();
+
 const channelMethodSchema = z.union([
   z.literal("GET"),
   z.literal("POST"),
@@ -407,6 +426,7 @@ const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
     compaction: compiledAgentCompactionDefinitionSchema.optional(),
     description: z.string().optional(),
     dynamicModel: compiledDynamicModelDefinitionSchema.optional(),
+    staticSkillVisibility: compiledStaticSkillVisibilityDefinitionSchema.optional(),
     experimental: z
       .object({
         workflow: compiledAgentWorkflowDefinitionSchema.optional(),
@@ -792,6 +812,13 @@ export function createCompiledAgentNodeManifest(input: {
           ? undefined
           : {
               ...input.config.dynamicModel,
+            },
+      staticSkillVisibility:
+        input.config.staticSkillVisibility === undefined
+          ? undefined
+          : {
+              ...input.config.staticSkillVisibility,
+              eventNames: [...input.config.staticSkillVisibility.eventNames],
             },
       experimental:
         input.config.experimental === undefined

--- a/packages/eve/src/compiler/normalize-agent-config.test.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAgentSourceManifest, createModuleSourceRef } from "#discover/manifest.js";
+import { defineStaticSkillVisibility } from "#public/definitions/agent.js";
 import { defineDynamic } from "#public/definitions/tool.js";
 import { compileAgentConfig } from "#compiler/normalize-agent-config.js";
 import type { ManifestCompileContext } from "#compiler/normalize-helpers.js";
@@ -60,7 +61,7 @@ describe("compileAgentConfig", () => {
   it("compiles static skill visibility with session and turn events", async () => {
     mocks.loadModuleBackedDefinition.mockResolvedValue({
       model: "openai/gpt-5.5",
-      staticSkillVisibility: defineDynamic({
+      staticSkillVisibility: defineStaticSkillVisibility({
         events: {
           "session.started": () => "all",
           "turn.started": () => ["support"],

--- a/packages/eve/src/compiler/normalize-agent-config.test.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.test.ts
@@ -56,6 +56,39 @@ describe("compileAgentConfig", () => {
       sourceKind: "module",
     });
   });
+
+  it("compiles static skill visibility with session and turn events", async () => {
+    mocks.loadModuleBackedDefinition.mockResolvedValue({
+      model: "openai/gpt-5.5",
+      staticSkillVisibility: defineDynamic({
+        events: {
+          "session.started": () => "all",
+          "turn.started": () => ["support"],
+        },
+      }),
+    });
+
+    const manifest = createAgentSourceManifest({
+      agentId: "app",
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      configModule: createModuleSourceRef({
+        logicalPath: "agent.ts",
+        sourceId: "agent-config",
+      }),
+    });
+
+    const compiled = await compileAgentConfig(manifest, {
+      modelCatalog: createModelCatalog(),
+    });
+
+    expect(compiled.staticSkillVisibility).toEqual({
+      eventNames: ["session.started", "turn.started"],
+      logicalPath: "agent.ts",
+      sourceId: "agent-config",
+      sourceKind: "module",
+    });
+  });
 });
 
 function createModelCatalog(): ManifestCompileContext["modelCatalog"] {

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -73,6 +73,7 @@ export async function compileAgentConfig(
     };
     description?: string;
     dynamicModel?: CompiledAgentDefinition["dynamicModel"];
+    staticSkillVisibility?: CompiledAgentDefinition["staticSkillVisibility"];
     experimental?: CompiledAgentDefinition["experimental"];
     model: CompiledRuntimeModelReference;
     name: string;
@@ -96,6 +97,21 @@ export async function compileAgentConfig(
     }
     compiledConfig.dynamicModel = {
       eventNames: Object.keys(definition.model.events) as DynamicToolEventName[],
+      exportName: configModule.exportName,
+      sourceKind: "module",
+      logicalPath: configModule.logicalPath,
+      sourceId: configModule.sourceId,
+    };
+  }
+
+  if (definition.staticSkillVisibility !== undefined) {
+    if (configModule === undefined) {
+      throw new Error("Expected static skill visibility definitions to be authored in agent.ts.");
+    }
+    compiledConfig.staticSkillVisibility = {
+      eventNames: Object.keys(definition.staticSkillVisibility.events) as Array<
+        "session.started" | "turn.started"
+      >,
       exportName: configModule.exportName,
       sourceKind: "module",
       logicalPath: configModule.logicalPath,

--- a/packages/eve/src/context/static-skill-visibility.test.ts
+++ b/packages/eve/src/context/static-skill-visibility.test.ts
@@ -2,14 +2,19 @@ import { describe, expect, it } from "vitest";
 
 import type { CompiledModuleMap } from "#compiler/module-map.js";
 import { ContextContainer } from "#context/container.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   dispatchStaticSkillVisibilityEvent,
   filterVisibleStaticSkills,
+  initializeStaticSkillVisibility,
   StaticSkillVisibilityKey,
 } from "#context/static-skill-visibility.js";
-import { defineDynamic } from "#public/definitions/tool.js";
+import { createSession, refreshSessionFromTurnAgent } from "#execution/session.js";
+import { defineStaticSkillVisibility } from "#public/definitions/agent.js";
 import { createSessionStartedEvent, createTurnStartedEvent } from "#protocol/message.js";
+import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
 import type { ResolvedStaticSkillVisibilityReference } from "#runtime/types.js";
+import type { StaticSkillVisibility } from "#shared/agent-definition.js";
 
 const STATIC_SKILL_NAMES = ["alpha", "beta", "packaged"] as const;
 const RESOLVER: ResolvedStaticSkillVisibilityReference = {
@@ -21,11 +26,36 @@ const RESOLVER: ResolvedStaticSkillVisibilityReference = {
 };
 
 describe("static skill visibility lifecycle", () => {
+  it("defaults to all static skills and reconciles durable inventory on replay", async () => {
+    const ctx = new ContextContainer();
+    initializeStaticSkillVisibility(ctx, STATIC_SKILL_NAMES);
+    expect(ctx.get(StaticSkillVisibilityKey)).toEqual({
+      kind: "all",
+      names: [...STATIC_SKILL_NAMES],
+    });
+
+    ctx.set(StaticSkillVisibilityKey, { kind: "all", names: ["alpha", "removed"] });
+    const replayedAll = await deserializeContext(serializeContext(ctx));
+    initializeStaticSkillVisibility(replayedAll, ["alpha", "beta"]);
+    expect(replayedAll.get(StaticSkillVisibilityKey)).toEqual({
+      kind: "all",
+      names: ["alpha", "beta"],
+    });
+
+    ctx.set(StaticSkillVisibilityKey, { kind: "subset", names: ["beta", "removed"] });
+    const replayedSubset = await deserializeContext(serializeContext(ctx));
+    initializeStaticSkillVisibility(replayedSubset, ["alpha", "beta"]);
+    expect(replayedSubset.get(StaticSkillVisibilityKey)).toEqual({
+      kind: "subset",
+      names: ["beta"],
+    });
+  });
+
   it("supports all, subset, empty, unknown, and next-turn resolutions", async () => {
-    let selection: unknown = "all";
+    let selection: StaticSkillVisibility = "all";
     const ctx = new ContextContainer();
     const moduleMap = createModuleMap(
-      defineDynamic({
+      defineStaticSkillVisibility({
         events: {
           "session.started": () => selection,
           "turn.started": () => selection,
@@ -55,7 +85,7 @@ describe("static skill visibility lifecycle", () => {
   it("fails closed when the resolver throws and preserves the state across replay", async () => {
     const ctx = new ContextContainer();
     const moduleMap = createModuleMap(
-      defineDynamic({
+      defineStaticSkillVisibility({
         events: {
           "session.started": () => {
             throw new Error("policy unavailable");
@@ -80,7 +110,86 @@ describe("static skill visibility lifecycle", () => {
 
     expect(visible).toEqual([{ description: "packaged skill", name: "packaged" }]);
   });
+
+  it("changes the actual session prompt at a lifecycle boundary and stays cache-stable within it", async () => {
+    let selection: StaticSkillVisibility = ["beta"];
+    const ctx = new ContextContainer();
+    initializeStaticSkillVisibility(ctx, STATIC_SKILL_NAMES);
+    const moduleMap = createModuleMap(
+      defineStaticSkillVisibility({
+        events: {
+          "session.started": () => selection,
+          "turn.started": () => selection,
+        },
+      }),
+    );
+    const turnAgent = createTestTurnAgent();
+    const session = createSession({
+      continuationToken: "root-token",
+      sessionId: "session-1",
+      skillRoot: "/home/agent/.agents/skills",
+      turnAgent,
+    });
+
+    await dispatch(ctx, moduleMap, createSessionStartedEvent());
+    const refreshed = refreshSessionFromTurnAgent({
+      session,
+      skillRoot: "/home/agent/.agents/skills",
+      turnAgent: {
+        ...turnAgent,
+        availableSkills: filterVisibleStaticSkills(
+          turnAgent.availableSkills,
+          ctx.get(StaticSkillVisibilityKey),
+        ),
+      },
+    });
+    expect(refreshed.agent.system).toContain("- beta: beta skill");
+    expect(refreshed.agent.system).not.toContain("- alpha: alpha skill");
+
+    const sameTurn = refreshSessionFromTurnAgent({
+      session: refreshed,
+      skillRoot: "/home/agent/.agents/skills",
+      turnAgent: {
+        ...turnAgent,
+        availableSkills: filterVisibleStaticSkills(
+          turnAgent.availableSkills,
+          ctx.get(StaticSkillVisibilityKey),
+        ),
+      },
+    });
+    expect(sameTurn.agent.system).toBe(refreshed.agent.system);
+
+    selection = ["packaged"];
+    await dispatch(ctx, moduleMap, createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }));
+    const nextTurn = refreshSessionFromTurnAgent({
+      session: refreshed,
+      skillRoot: "/home/agent/.agents/skills",
+      turnAgent: {
+        ...turnAgent,
+        availableSkills: filterVisibleStaticSkills(
+          turnAgent.availableSkills,
+          ctx.get(StaticSkillVisibilityKey),
+        ),
+      },
+    });
+    expect(nextTurn.agent.system).toContain("- packaged: packaged skill");
+    expect(nextTurn.agent.system).not.toBe(refreshed.agent.system);
+  });
 });
+
+function createTestTurnAgent(): RuntimeTurnAgent {
+  return {
+    availableSkills: STATIC_SKILL_NAMES.map((name) => ({
+      description: `${name} skill`,
+      name,
+    })),
+    id: "test-agent",
+    instructions: ["You are a helpful assistant."],
+    model: { id: "test-model" },
+    tools: [],
+    workspaceSpec: { rootEntries: [] },
+  };
+}
 
 async function dispatch(
   ctx: ContextContainer,

--- a/packages/eve/src/context/static-skill-visibility.test.ts
+++ b/packages/eve/src/context/static-skill-visibility.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompiledModuleMap } from "#compiler/module-map.js";
+import { ContextContainer } from "#context/container.js";
+import {
+  dispatchStaticSkillVisibilityEvent,
+  filterVisibleStaticSkills,
+  StaticSkillVisibilityKey,
+} from "#context/static-skill-visibility.js";
+import { defineDynamic } from "#public/definitions/tool.js";
+import { createSessionStartedEvent, createTurnStartedEvent } from "#protocol/message.js";
+import type { ResolvedStaticSkillVisibilityReference } from "#runtime/types.js";
+
+const STATIC_SKILL_NAMES = ["alpha", "beta", "packaged"] as const;
+const RESOLVER: ResolvedStaticSkillVisibilityReference = {
+  eventNames: ["session.started", "turn.started"],
+  exportName: "default",
+  logicalPath: "agent.ts",
+  sourceId: "agent-config",
+  sourceKind: "module",
+};
+
+describe("static skill visibility lifecycle", () => {
+  it("supports all, subset, empty, unknown, and next-turn resolutions", async () => {
+    let selection: unknown = "all";
+    const ctx = new ContextContainer();
+    const moduleMap = createModuleMap(
+      defineDynamic({
+        events: {
+          "session.started": () => selection,
+          "turn.started": () => selection,
+        },
+      }),
+    );
+
+    await dispatch(ctx, moduleMap, createSessionStartedEvent());
+    expect(ctx.get(StaticSkillVisibilityKey)).toEqual({
+      kind: "all",
+      names: [...STATIC_SKILL_NAMES],
+    });
+
+    selection = ["beta"];
+    await dispatch(ctx, moduleMap, createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }));
+    expect(ctx.get(StaticSkillVisibilityKey)).toEqual({ kind: "subset", names: ["beta"] });
+
+    selection = [];
+    await dispatch(ctx, moduleMap, createTurnStartedEvent({ sequence: 1, turnId: "turn_1" }));
+    expect(ctx.get(StaticSkillVisibilityKey)).toEqual({ kind: "subset", names: [] });
+
+    selection = ["unknown"];
+    await dispatch(ctx, moduleMap, createTurnStartedEvent({ sequence: 2, turnId: "turn_2" }));
+    expect(ctx.get(StaticSkillVisibilityKey)).toEqual({ kind: "subset", names: [] });
+  });
+
+  it("fails closed when the resolver throws and preserves the state across replay", async () => {
+    const ctx = new ContextContainer();
+    const moduleMap = createModuleMap(
+      defineDynamic({
+        events: {
+          "session.started": () => {
+            throw new Error("policy unavailable");
+          },
+        },
+      }),
+    );
+
+    await dispatch(ctx, moduleMap, createSessionStartedEvent());
+    expect(ctx.get(StaticSkillVisibilityKey)).toEqual({ kind: "subset", names: [] });
+
+    const replayed = new ContextContainer();
+    replayed.set(StaticSkillVisibilityKey, ctx.get(StaticSkillVisibilityKey)!);
+    expect(replayed.get(StaticSkillVisibilityKey)).toEqual({ kind: "subset", names: [] });
+  });
+
+  it("filters prompt descriptions without changing packaged skill identity", () => {
+    const visible = filterVisibleStaticSkills(
+      STATIC_SKILL_NAMES.map((name) => ({ description: `${name} skill`, name })),
+      { kind: "subset", names: ["packaged"] },
+    );
+
+    expect(visible).toEqual([{ description: "packaged skill", name: "packaged" }]);
+  });
+});
+
+async function dispatch(
+  ctx: ContextContainer,
+  moduleMap: CompiledModuleMap,
+  event: Parameters<typeof dispatchStaticSkillVisibilityEvent>[0]["event"],
+): Promise<void> {
+  await dispatchStaticSkillVisibilityEvent({
+    ctx,
+    event,
+    messages: [],
+    resolver: RESOLVER,
+    scope: { moduleMap, nodeId: undefined },
+    staticSkillNames: STATIC_SKILL_NAMES,
+  });
+}
+
+function createModuleMap(resolver: unknown): CompiledModuleMap {
+  return {
+    nodes: {
+      __root__: {
+        modules: {
+          [RESOLVER.sourceId]: {
+            default: {
+              model: "openai/gpt-5.5",
+              staticSkillVisibility: resolver,
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/packages/eve/src/context/static-skill-visibility.ts
+++ b/packages/eve/src/context/static-skill-visibility.ts
@@ -1,0 +1,125 @@
+import type { ModelMessage } from "ai";
+
+import type { CompiledModuleMap } from "#compiler/module-map.js";
+import { buildResolveContext } from "#context/dynamic-resolve-context.js";
+import type { AlsContext } from "#context/container.js";
+import { ContextKey } from "#context/key.js";
+import { createLogger } from "#internal/logging.js";
+import { normalizeAgentDefinition } from "#internal/authored-definition/core.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { loadResolvedModuleExport } from "#runtime/resolve-helpers.js";
+import type { ResolvedStaticSkillVisibilityReference } from "#runtime/types.js";
+import { toErrorMessage } from "#shared/errors.js";
+
+const log = createLogger("static-skill-visibility");
+
+export interface StaticSkillVisibilityState {
+  readonly kind: "all" | "subset";
+  readonly names: readonly string[];
+}
+
+export const StaticSkillVisibilityKey = new ContextKey<StaticSkillVisibilityState>(
+  "eve.staticSkillVisibility",
+);
+
+export function initializeStaticSkillVisibility(
+  ctx: AlsContext,
+  staticSkillNames: readonly string[],
+): void {
+  if (ctx.get(StaticSkillVisibilityKey) !== undefined) return;
+  ctx.set(StaticSkillVisibilityKey, {
+    kind: "all",
+    names: [...staticSkillNames],
+  });
+}
+
+export function filterVisibleStaticSkills<T extends { readonly name: string }>(
+  skills: readonly T[] | undefined,
+  visibility: StaticSkillVisibilityState | undefined,
+): readonly T[] {
+  if (skills === undefined || visibility === undefined || visibility.kind === "all") {
+    return skills ?? [];
+  }
+
+  const visible = new Set(visibility.names);
+  return skills.filter((skill) => visible.has(skill.name));
+}
+
+export function getVisibleStaticSkillNames(ctx: {
+  get<T>(key: ContextKey<T>): T | undefined;
+}): readonly string[] | undefined {
+  return ctx.get(StaticSkillVisibilityKey)?.names;
+}
+
+export async function dispatchStaticSkillVisibilityEvent(input: {
+  readonly ctx: AlsContext;
+  readonly event: HandleMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  readonly resolver: ResolvedStaticSkillVisibilityReference | undefined;
+  readonly scope: {
+    readonly moduleMap: CompiledModuleMap;
+    readonly nodeId: string | undefined;
+  };
+  readonly staticSkillNames: readonly string[];
+}): Promise<void> {
+  if (input.resolver === undefined) return;
+  if (input.event.type !== "session.started" && input.event.type !== "turn.started") return;
+  if (!input.resolver.eventNames.includes(input.event.type)) return;
+
+  try {
+    const definition = await loadResolvedModuleExport({
+      definition: input.resolver,
+      kindLabel: "static skill visibility",
+      moduleMap: input.scope.moduleMap,
+      nodeId: input.scope.nodeId,
+    });
+    const normalized = normalizeAgentDefinition(
+      definition,
+      `Expected the authored agent config export "${input.resolver.exportName ?? "default"}" from "${input.resolver.logicalPath}" to match the public eve shape.`,
+    );
+    const visibility = normalized.staticSkillVisibility;
+    if (visibility === undefined) {
+      throw new Error("The compiled static skill visibility source no longer exports a resolver.");
+    }
+    const handler = visibility.events[input.event.type];
+    if (handler === undefined) return;
+
+    const result = await handler(input.event, buildResolveContext(input.ctx, input.messages));
+    input.ctx.set(
+      StaticSkillVisibilityKey,
+      normalizeStaticSkillVisibilityResult(result, input.staticSkillNames),
+    );
+  } catch (error) {
+    log.error(`Static skill visibility resolver (${input.event.type}) failed closed.`, {
+      error: toErrorMessage(error),
+    });
+    input.ctx.set(StaticSkillVisibilityKey, { kind: "subset", names: [] });
+  }
+}
+
+function normalizeStaticSkillVisibilityResult(
+  result: unknown,
+  staticSkillNames: readonly string[],
+): StaticSkillVisibilityState {
+  if (result === "all") {
+    return { kind: "all", names: [...staticSkillNames] };
+  }
+
+  if (!Array.isArray(result) || !result.every((name): name is string => typeof name === "string")) {
+    throw new Error('Expected static skill visibility to return "all" or an array of skill names.');
+  }
+
+  const knownNames = new Set(staticSkillNames);
+  const selectedNames = new Set(result);
+  if (selectedNames.size !== result.length) {
+    throw new Error("Static skill visibility returned duplicate skill names.");
+  }
+  const unknownNames = result.filter((name) => !knownNames.has(name));
+  if (unknownNames.length > 0) {
+    throw new Error(
+      `Static skill visibility returned unknown skill names: ${unknownNames.join(", ")}.`,
+    );
+  }
+
+  return { kind: "subset", names: [...result] };
+}

--- a/packages/eve/src/context/static-skill-visibility.ts
+++ b/packages/eve/src/context/static-skill-visibility.ts
@@ -26,11 +26,22 @@ export function initializeStaticSkillVisibility(
   ctx: AlsContext,
   staticSkillNames: readonly string[],
 ): void {
-  if (ctx.get(StaticSkillVisibilityKey) !== undefined) return;
-  ctx.set(StaticSkillVisibilityKey, {
-    kind: "all",
-    names: [...staticSkillNames],
-  });
+  const currentNames = [...staticSkillNames];
+  const currentNameSet = new Set(currentNames);
+  const existing = ctx.get(StaticSkillVisibilityKey);
+
+  if (existing?.kind === "subset") {
+    ctx.set(StaticSkillVisibilityKey, {
+      kind: "subset",
+      names: existing.names.filter((name) => currentNameSet.has(name)),
+    });
+    return;
+  }
+
+  // `all` is an authorization mode, not a cached inventory. Refreshing its
+  // names keeps prompt projection and load_skill authorization aligned when a
+  // durable continuation encounters a changed compiled skill catalog.
+  ctx.set(StaticSkillVisibilityKey, { kind: "all", names: currentNames });
 }
 
 export function filterVisibleStaticSkills<T extends { readonly name: string }>(

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -4,7 +4,7 @@ import type { Runtime, SessionCapabilities } from "#channel/types.js";
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
-import type { HandleEventFn, HarnessToolMap, StepFn } from "#harness/types.js";
+import type { BeforeTurnEventFn, HandleEventFn, HarnessToolMap, StepFn } from "#harness/types.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { createLogger } from "#internal/logging.js";
 import type { RuntimeIdentity } from "#protocol/message.js";
@@ -62,6 +62,7 @@ export interface CreateExecutionNodeStepInput {
    */
   readonly createRuntime: CreateRuntime;
   readonly handleEvent?: HandleEventFn;
+  readonly beforeTurnEvent?: BeforeTurnEventFn;
   readonly mode: RunMode;
   readonly modelResolutionScope: RuntimeModelResolutionScope;
   readonly node: ResolvedRuntimeAgentNode;
@@ -93,6 +94,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     workflow: input.node.agent.workflowEnabled === true,
     workflowMaxSubagents: input.workflowMaxSubagents,
     handleEvent: input.handleEvent,
+    beforeTurnEvent: input.beforeTurnEvent,
     mode: input.mode,
     onCompaction: preserveFrameworkStateOnCompaction,
     dispatchDynamicModelEvent: dispatchModelEvent,

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -6,6 +6,12 @@ import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-li
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
 import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
 import { dispatchDynamicToolEvent } from "#context/dynamic-tool-lifecycle.js";
+import {
+  dispatchStaticSkillVisibilityEvent,
+  filterVisibleStaticSkills,
+  initializeStaticSkillVisibility,
+  StaticSkillVisibilityKey,
+} from "#context/static-skill-visibility.js";
 import { AuthKey, CapabilitiesKey, ModeKey } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
@@ -117,6 +123,10 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const ctx = await deserializeContext(input.serializedContext);
   const adapter = ctx.require(ChannelKey);
   const bundle = ctx.require(BundleKey);
+  initializeStaticSkillVisibility(
+    ctx,
+    bundle.turnAgent.availableSkills?.map((skill) => skill.name) ?? [],
+  );
 
   // Populate the callback base URL so getHookUrl() works during tool
   // execution, preferring eve's active local origin over metadata fallback.
@@ -326,9 +336,16 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       lifecycleSession: HarnessSession,
       stepInput: StepInput | undefined,
     ): Promise<StepResult> => {
+      const turnAgent = {
+        ...bundle.turnAgent,
+        availableSkills: filterVisibleStaticSkills(
+          bundle.turnAgent.availableSkills,
+          ctx.get(StaticSkillVisibilityKey),
+        ),
+      };
       const skillRoot = await resolveSessionSkillRoot({
         ctx,
-        turnAgent: bundle.turnAgent,
+        turnAgent,
       });
       const refreshedSession = refreshSessionFromTurnAgent({
         compactionOverrides: {
@@ -336,13 +353,42 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
         },
         session: lifecycleSession,
         skillRoot,
-        turnAgent: bundle.turnAgent,
+        turnAgent,
       });
 
       const step = createExecutionNodeStep({
         abortSignal: input.abortSignal,
         capabilities,
         createRuntime: createWorkflowRuntime,
+        beforeTurnEvent: async ({ event, messages, session }) => {
+          await dispatchStaticSkillVisibilityEvent({
+            ctx,
+            event,
+            messages: messages ?? [],
+            resolver: bundle.resolvedAgent.config.staticSkillVisibility,
+            scope: {
+              moduleMap: bundle.moduleMap,
+              nodeId: bundle.nodeId,
+            },
+            staticSkillNames: bundle.turnAgent.availableSkills?.map((skill) => skill.name) ?? [],
+          });
+
+          const resolvedTurnAgent = {
+            ...bundle.turnAgent,
+            availableSkills: filterVisibleStaticSkills(
+              bundle.turnAgent.availableSkills,
+              ctx.get(StaticSkillVisibilityKey),
+            ),
+          };
+          return refreshSessionFromTurnAgent({
+            compactionOverrides: {
+              thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+            },
+            session,
+            skillRoot,
+            turnAgent: resolvedTurnAgent,
+          });
+        },
         handleEvent,
         mode,
         modelResolutionScope: {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -499,6 +499,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const stepInput = consumeDeferredStepInput({ input, session });
     session = stepInput.session;
 
+    const emitTurnEvent = async (
+      event: Parameters<NonNullable<typeof emit>>[0],
+      messages?: readonly ModelMessage[],
+    ): Promise<void> => {
+      if (config.beforeTurnEvent !== undefined) {
+        session = await config.beforeTurnEvent({ event, messages, session });
+      }
+      await emit?.(event, messages);
+    };
+
     const resolvedRuntimeActions = await resolvePendingRuntimeActions({
       emit,
       session,
@@ -518,7 +528,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     if (pending.outcome === "unresolved") {
       if (emit && pending.deferredMessage === true && hasStepInput(input)) {
         emissionState = await emitTurnPreamble(
-          emit,
+          emitTurnEvent,
           input ?? {},
           emissionState,
           config.runtimeIdentity,
@@ -551,11 +561,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
     }
 
+    session = pending.session;
+
     // --- Turn preamble ------------------------------------------------------
 
     if (emit && hasStepInput(input)) {
       emissionState = await emitTurnPreamble(
-        emit,
+        emitTurnEvent,
         input ?? {},
         emissionState,
         config.runtimeIdentity,
@@ -567,7 +579,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
     }
 
-    session = pending.session;
     let messages: ModelMessage[] = pending.messages;
 
     // A resolved session-limit continuation prompt grants a fresh token

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -220,6 +220,16 @@ export type HandleEventFn = (
 ) => Promise<void>;
 
 /**
+ * Refresh hook for lifecycle state that must affect the prompt before the
+ * harness emits a turn preamble event.
+ */
+export type BeforeTurnEventFn = (input: {
+  readonly event: HandleMessageStreamEvent;
+  readonly messages?: readonly ModelMessage[];
+  readonly session: HarnessSession;
+}) => Promise<HarnessSession> | HarnessSession;
+
+/**
  * Dependencies injected into the tool-loop harness at construction time.
  */
 export interface ToolLoopHarnessConfig {
@@ -248,6 +258,7 @@ export interface ToolLoopHarnessConfig {
    */
   readonly workflowMaxSubagents?: number;
   readonly handleEvent?: HandleEventFn;
+  readonly beforeTurnEvent?: BeforeTurnEventFn;
   /**
    * Execution mode for the current harness.
    *

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -42,6 +42,42 @@ describe("normalizeAgentDefinition", () => {
     expect(typeof (definition.model as typeof model).events["session.started"]).toBe("function");
   });
 
+  it("accepts static skill visibility handlers at session and turn boundaries", () => {
+    const visibility = defineDynamic({
+      events: {
+        "session.started": () => "all",
+        "turn.started": () => ["support"],
+      },
+    });
+
+    const definition = normalizeAgentDefinition(
+      { model: "openai/gpt-5.5", staticSkillVisibility: visibility },
+      FAILURE_MESSAGE,
+    );
+
+    expect(definition.staticSkillVisibility).toMatchObject({ kind: "eve:dynamic" });
+    expect(Object.keys(definition.staticSkillVisibility?.events ?? {})).toEqual([
+      "session.started",
+      "turn.started",
+    ]);
+  });
+
+  it("rejects step-scoped static skill visibility", () => {
+    expect(() =>
+      normalizeAgentDefinition(
+        {
+          model: "openai/gpt-5.5",
+          staticSkillVisibility: defineDynamic({
+            events: { "step.started": () => ["support"] },
+          }),
+        },
+        FAILURE_MESSAGE,
+      ),
+    ).toThrow(
+      '"staticSkillVisibility" only supports "session.started" and "turn.started" handlers.',
+    );
+  });
+
   it("rejects a dynamic model without a fallback", () => {
     expect(() =>
       normalizeAgentDefinition(

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeAgentDefinition,
   normalizeScheduleDefinition,
 } from "#internal/authored-definition/core.js";
+import { defineStaticSkillVisibility } from "#public/definitions/agent.js";
 import { defineDynamic } from "#public/definitions/tool.js";
 
 const FAILURE_MESSAGE = "Expected the agent config to match the public eve shape.";
@@ -43,7 +44,7 @@ describe("normalizeAgentDefinition", () => {
   });
 
   it("accepts static skill visibility handlers at session and turn boundaries", () => {
-    const visibility = defineDynamic({
+    const visibility = defineStaticSkillVisibility({
       events: {
         "session.started": () => "all",
         "turn.started": () => ["support"],
@@ -67,9 +68,10 @@ describe("normalizeAgentDefinition", () => {
       normalizeAgentDefinition(
         {
           model: "openai/gpt-5.5",
-          staticSkillVisibility: defineDynamic({
+          staticSkillVisibility: {
             events: { "step.started": () => ["support"] },
-          }),
+            kind: "eve:dynamic",
+          },
         },
         FAILURE_MESSAGE,
       ),

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -56,6 +56,7 @@ export function normalizeAgentDefinition(
       "modelOptions",
       "outputSchema",
       "reasoning",
+      "staticSkillVisibility",
     ],
     message,
   );
@@ -100,6 +101,33 @@ export function normalizeAgentDefinition(
 
   if (record.reasoning !== undefined) {
     definition.reasoning = normalizeAgentReasoningDefinition(record.reasoning, message);
+  }
+
+  if (record.staticSkillVisibility !== undefined) {
+    if (!isDynamicSentinel(record.staticSkillVisibility)) {
+      throw new Error(`${message} "staticSkillVisibility" must be created with defineDynamic.`);
+    }
+    const visibility = expectObjectRecord(record.staticSkillVisibility, message);
+    expectOnlyKnownKeys(visibility, ["events", "kind"], message);
+    if (visibility.events === undefined || "fallback" in visibility) {
+      throw new Error(`${message} "staticSkillVisibility" does not support a fallback.`);
+    }
+    const events = expectObjectRecord(visibility.events, message);
+    const normalizedEvents: MutableDynamicEvents = {};
+    for (const [eventName, handler] of Object.entries(events)) {
+      if (eventName !== "session.started" && eventName !== "turn.started") {
+        throw new Error(
+          `${message} "staticSkillVisibility" only supports "session.started" and "turn.started" handlers.`,
+        );
+      }
+      normalizedEvents[eventName] = expectFunction(handler, message) as NonNullable<
+        DynamicEvents[DynamicToolEventName]
+      >;
+    }
+    definition.staticSkillVisibility = {
+      events: normalizedEvents,
+      kind: "eve:dynamic",
+    } as NonNullable<NormalizedAgentDefinition["staticSkillVisibility"]>;
   }
 
   if (record.limits !== undefined) {

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -17,6 +17,8 @@ export type {
   PublicAgentModelDefinition as AgentModelDefinition,
   PublicAgentStaticModelDefinition as AgentStaticModelDefinition,
   PublicAgentCompactionDefinition as AgentCompactionDefinition,
+  PublicAgentStaticSkillVisibilityDefinition as AgentStaticSkillVisibilityDefinition,
+  StaticSkillVisibility,
 } from "#shared/agent-definition.js";
 
 /**

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -1,4 +1,9 @@
-import type { PublicAgentDefinition } from "#shared/agent-definition.js";
+import { DYNAMIC_SENTINEL_KIND } from "#shared/dynamic-tool-definition.js";
+import type {
+  PublicAgentDefinition,
+  PublicAgentStaticSkillVisibilityDefinition,
+  StaticSkillVisibilityEvents,
+} from "#shared/agent-definition.js";
 import type { ExactDefinition } from "#public/definitions/exact.js";
 
 export type {
@@ -18,6 +23,7 @@ export type {
   PublicAgentStaticModelDefinition as AgentStaticModelDefinition,
   PublicAgentCompactionDefinition as AgentCompactionDefinition,
   PublicAgentStaticSkillVisibilityDefinition as AgentStaticSkillVisibilityDefinition,
+  StaticSkillVisibilityEvents,
   StaticSkillVisibility,
 } from "#shared/agent-definition.js";
 
@@ -46,4 +52,20 @@ export function defineAgent<TAgent extends AgentDefinition>(
   definition: ExactDefinition<TAgent, AgentDefinition>,
 ): TAgent {
   return definition;
+}
+
+/**
+ * Defines the session/turn-only resolver used by `agent.ts` static skill
+ * visibility. The dedicated wrapper keeps unsupported lifecycle keys out of
+ * the public slot while retaining the `defineDynamic({ events })` shape.
+ */
+export function defineStaticSkillVisibility<
+  const TEvents extends StaticSkillVisibilityEvents,
+>(definition: {
+  readonly events: ExactDefinition<TEvents, StaticSkillVisibilityEvents>;
+}): PublicAgentStaticSkillVisibilityDefinition {
+  return {
+    events: definition.events,
+    kind: DYNAMIC_SENTINEL_KIND,
+  };
 }

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -10,6 +10,7 @@ import { defineInstrumentation } from "#public/definitions/instrumentation.js";
 import { defineSandbox } from "#public/definitions/sandbox.js";
 import { defineSchedule } from "#public/definitions/schedule.js";
 import { defineSkill } from "#public/definitions/skill.js";
+import { defineStaticSkillVisibility } from "#public/definitions/agent.js";
 import { defineTool } from "#public/definitions/tool.js";
 
 describe("definition helper exact inputs", () => {
@@ -75,6 +76,36 @@ function typeOnlyFixtures(): void {
         return { runtimeContext: { "test.session_id": sessionId } };
       },
     },
+  });
+
+  defineAgent({
+    model: "anthropic/claude-sonnet-5",
+    staticSkillVisibility: defineStaticSkillVisibility({
+      events: {
+        "session.started": () => "all",
+        "turn.started": () => ["support"],
+      },
+    }),
+  });
+
+  defineAgent({
+    model: "anthropic/claude-sonnet-5",
+    staticSkillVisibility: defineStaticSkillVisibility({
+      events: {
+        // @ts-expect-error Static skill visibility is limited to session.started and turn.started.
+        "step.started": () => ["support"],
+      },
+    }),
+  });
+
+  defineAgent({
+    model: "anthropic/claude-sonnet-5",
+    staticSkillVisibility: defineStaticSkillVisibility({
+      events: {
+        // @ts-expect-error Static skill visibility rejects tool lifecycle handlers.
+        "tool.started": () => ["support"],
+      },
+    }),
   });
 
   defineInstrumentation({

--- a/packages/eve/src/public/index.ts
+++ b/packages/eve/src/public/index.ts
@@ -10,6 +10,8 @@ export {
   type AgentModelDefinition,
   type AgentModelOptionsDefinition,
   type AgentReasoningDefinition,
+  type AgentStaticSkillVisibilityDefinition,
+  type StaticSkillVisibility,
   type AgentWorkflowDefinition,
   type AgentWorkflowWorldDefinition,
   defineAgent,

--- a/packages/eve/src/public/index.ts
+++ b/packages/eve/src/public/index.ts
@@ -11,10 +11,13 @@ export {
   type AgentModelOptionsDefinition,
   type AgentReasoningDefinition,
   type AgentStaticSkillVisibilityDefinition,
+  type StaticSkillVisibilityEventName,
+  type StaticSkillVisibilityEvents,
   type StaticSkillVisibility,
   type AgentWorkflowDefinition,
   type AgentWorkflowWorldDefinition,
   defineAgent,
+  defineStaticSkillVisibility,
 } from "#public/definitions/agent.js";
 export { defineDynamic } from "#public/definitions/tool.js";
 export type { DynamicResolveContext, DynamicSentinel } from "#shared/dynamic-tool-definition.js";

--- a/packages/eve/src/runtime/framework-tools/skill.test.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.test.ts
@@ -62,6 +62,29 @@ describe("load_skill executor", () => {
     ).resolves.toBe("Dynamic instructions.");
   });
 
+  it("lets a dynamic skill override a same-named hidden static skill", async () => {
+    const sandbox = mockSandbox({
+      initialFiles: {
+        "/home/agent/.agents/skills/shared/SKILL.md": "Dynamic replacement.",
+      },
+    });
+    const ctx = new ContextContainer();
+    ctx.set(SandboxKey, sandbox.access);
+    ctx.set(StaticSkillVisibilityKey, { kind: "subset", names: [] });
+    ctx.set(DynamicSkillManifestKey, {
+      resolver: [{ description: "Dynamic replacement", name: "shared" }],
+    });
+
+    const execute = SKILL_TOOL_DEFINITION.execute;
+    if (execute === undefined) throw new Error("load_skill tool is missing an execute function");
+
+    await expect(
+      contextStorage.run(ctx, () =>
+        execute({ skill: "shared" }, { messages: [], toolCallId: "call_shared" }),
+      ),
+    ).resolves.toBe("Dynamic replacement.");
+  });
+
   it("retains sibling assets for a selected packaged static skill", async () => {
     const sandbox = mockSandbox({
       initialFiles: {

--- a/packages/eve/src/runtime/framework-tools/skill.test.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { DynamicSkillManifestKey, SandboxKey } from "#context/keys.js";
+import { StaticSkillVisibilityKey } from "#context/static-skill-visibility.js";
 import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
 import type { ConnectionRegistry } from "#runtime/connections/types.js";
 import { SKILL_TOOL_DEFINITION } from "#runtime/framework-tools/skill.js";
+import { createSandboxSkillHandle } from "#runtime/skills/sandbox-access.js";
 
 describe("SKILL_TOOL_DEFINITION", () => {
   it("describes when skill loading should be used", () => {
@@ -22,6 +24,66 @@ describe("SKILL_TOOL_DEFINITION", () => {
 });
 
 describe("load_skill executor", () => {
+  it("rejects a materialized static skill hidden by the resolved visibility set", async () => {
+    const ctx = new ContextContainer();
+    ctx.set(SandboxKey, mockSandbox().access);
+    ctx.set(StaticSkillVisibilityKey, { kind: "subset", names: ["visible"] });
+
+    const execute = SKILL_TOOL_DEFINITION.execute;
+    if (execute === undefined) throw new Error("load_skill tool is missing an execute function");
+
+    await expect(
+      contextStorage.run(ctx, () =>
+        execute({ skill: "hidden" }, { messages: [], toolCallId: "call_hidden" }),
+      ),
+    ).rejects.toThrow('Skill "hidden" is not available in this run. Available skills: visible.');
+  });
+
+  it("keeps dynamic skills additive when static visibility is empty", async () => {
+    const sandbox = mockSandbox({
+      initialFiles: {
+        "/home/agent/.agents/skills/dynamic/SKILL.md": "Dynamic instructions.",
+      },
+    });
+    const ctx = new ContextContainer();
+    ctx.set(SandboxKey, sandbox.access);
+    ctx.set(StaticSkillVisibilityKey, { kind: "subset", names: [] });
+    ctx.set(DynamicSkillManifestKey, {
+      resolver: [{ description: "Dynamic skill", name: "dynamic" }],
+    });
+
+    const execute = SKILL_TOOL_DEFINITION.execute;
+    if (execute === undefined) throw new Error("load_skill tool is missing an execute function");
+
+    await expect(
+      contextStorage.run(ctx, () =>
+        execute({ skill: "dynamic" }, { messages: [], toolCallId: "call_dynamic" }),
+      ),
+    ).resolves.toBe("Dynamic instructions.");
+  });
+
+  it("retains sibling assets for a selected packaged static skill", async () => {
+    const sandbox = mockSandbox({
+      initialFiles: {
+        "/home/agent/.agents/skills/packaged/SKILL.md": "Packaged instructions.",
+        "/home/agent/.agents/skills/packaged/references/guide.md": "Sibling guide.",
+      },
+    });
+    const ctx = new ContextContainer();
+    ctx.set(SandboxKey, sandbox.access);
+    ctx.set(StaticSkillVisibilityKey, { kind: "subset", names: ["packaged"] });
+
+    const execute = SKILL_TOOL_DEFINITION.execute;
+    if (execute === undefined) throw new Error("load_skill tool is missing an execute function");
+    await expect(
+      contextStorage.run(ctx, () =>
+        execute({ skill: "packaged" }, { messages: [], toolCallId: "call_packaged" }),
+      ),
+    ).resolves.toBe("Packaged instructions.");
+
+    const handle = createSandboxSkillHandle(sandbox.access, "packaged");
+    await expect(handle.file("references/guide.md").text()).resolves.toBe("Sibling guide.");
+  });
   it("surfaces dynamic skill names when the requested id is missing", async () => {
     const ctx = new ContextContainer();
     ctx.set(SandboxKey, mockSandbox().access);

--- a/packages/eve/src/runtime/framework-tools/skill.ts
+++ b/packages/eve/src/runtime/framework-tools/skill.ts
@@ -1,6 +1,10 @@
 import { loadContext } from "#context/container.js";
 import { DynamicSkillManifestKey, SandboxKey } from "#context/keys.js";
 import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
+import {
+  getVisibleStaticSkillNames,
+  StaticSkillVisibilityKey,
+} from "#context/static-skill-visibility.js";
 import { loadSkillFromSandbox } from "#runtime/skills/sandbox-access.js";
 import type { ResolvedToolDefinition } from "#runtime/types.js";
 import type { JsonObject } from "#shared/json.js";
@@ -31,6 +35,22 @@ async function executeLoadSkillTool(args: LoadSkillInput): Promise<unknown> {
 
   const { skill } = args;
   const availableSkills = availableSkillNames(ctx);
+  const visibleStaticSkills = ctx.get(StaticSkillVisibilityKey);
+  if (visibleStaticSkills !== undefined && !availableSkills.includes(skill)) {
+    const connectionName = ctx
+      .get(ConnectionRegistryKey)
+      ?.getConnectionNames()
+      .find((name) => name.toLowerCase() === skill.toLowerCase());
+    if (connectionName !== undefined) {
+      throw new Error(
+        `"${connectionName}" is an installed connection, not a skill. ` +
+          `Use connection_search with connection "${connectionName}" to find its tools.`,
+      );
+    }
+    const hint =
+      availableSkills.length > 0 ? ` Available skills: ${availableSkills.join(", ")}.` : "";
+    throw new Error(`Skill "${skill}" is not available in this run.${hint}`);
+  }
   try {
     return await loadSkillFromSandbox(sandbox, skill, availableSkills);
   } catch (error) {
@@ -53,10 +73,11 @@ async function executeLoadSkillTool(args: LoadSkillInput): Promise<unknown> {
 // importing the bundle (for authored skills) would cycle through the
 // framework-tools barrel.
 function availableSkillNames(ctx: ReturnType<typeof loadContext>): string[] {
+  const staticSkills = getVisibleStaticSkillNames(ctx) ?? [];
   const dynamic = Object.values(ctx.get(DynamicSkillManifestKey) ?? {})
     .flat()
     .map((s) => s.name);
-  return [...new Set(dynamic)].sort();
+  return [...new Set([...staticSkills, ...dynamic])].sort();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -156,6 +156,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
     name: string;
     outputSchema?: ResolvedAgent["config"]["outputSchema"];
     reasoning?: ResolvedAgent["config"]["reasoning"];
+    staticSkillVisibility?: ResolvedAgent["config"]["staticSkillVisibility"];
     source?: ResolvedAgent["config"]["source"];
     limits?: ResolvedAgent["config"]["limits"];
   } = {
@@ -218,6 +219,13 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
     config.dynamicModel = {
       ...createResolvedModuleSourceRef(manifest.config.dynamicModel),
       eventNames: [...manifest.config.dynamicModel.eventNames],
+    };
+  }
+
+  if (manifest.config.staticSkillVisibility !== undefined) {
+    config.staticSkillVisibility = {
+      ...createResolvedModuleSourceRef(manifest.config.staticSkillVisibility),
+      eventNames: [...manifest.config.staticSkillVisibility.eventNames],
     };
   }
 

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -43,6 +43,11 @@ import type { SandboxBootstrapContext, SandboxSessionContext } from "#shared/san
  */
 export type ResolvedModuleSourceRef = Readonly<ModuleSourceRef>;
 
+/** Runtime source reference for one authored static-skill visibility resolver. */
+export interface ResolvedStaticSkillVisibilityReference extends ResolvedModuleSourceRef {
+  readonly eventNames: readonly ("session.started" | "turn.started")[];
+}
+
 /**
  * Authored instructions prompt resolved from `instructions.md` or
  * `instructions.{ts,...}`.
@@ -302,8 +307,9 @@ export type ResolvedRuntimeDelegationNode =
  * Runtime-owned additive agent configuration resolved from `agent.ts`.
  */
 export type ResolvedAgentDefinition = Readonly<
-  Omit<InternalAgentDefinition, "build" | "source"> & {
+  Omit<InternalAgentDefinition, "build" | "source" | "staticSkillVisibility"> & {
     dynamicModel?: RuntimeDynamicModelReference;
+    staticSkillVisibility?: ResolvedStaticSkillVisibilityReference;
     source?: Readonly<NonNullable<InternalAgentDefinition["source"]>>;
   }
 >;

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -82,6 +82,12 @@ export type PublicAgentDynamicModelDefinition = DynamicSentinel<
   PublicAgentStaticModelDefinition
 >;
 
+/** Static skill names visible to one session or turn. */
+export type StaticSkillVisibility = "all" | readonly string[];
+
+/** Dynamic resolver shape for the agent's compiled static skill visibility. */
+export type PublicAgentStaticSkillVisibilityDefinition = DynamicSentinel<StaticSkillVisibility>;
+
 export interface PublicAgentDynamicModelDefinitionInput {
   /** Compiled static model: build-time metadata and the active model when no scope is set. */
   readonly fallback: PublicAgentStaticModelDefinition;
@@ -273,6 +279,7 @@ export type InternalAgentDefinition = {
   reasoning?: AgentReasoningDefinition;
   source?: ModuleSourceRef;
   limits?: AgentLimitsDefinition;
+  staticSkillVisibility?: PublicAgentStaticSkillVisibilityDefinition;
 };
 
 /**
@@ -321,6 +328,12 @@ export type PublicAgentDefinition = {
    * Framework-owned runtime limits for this agent's runs.
    */
   readonly limits?: AgentLimitsDefinition;
+  /**
+   * Optional session/turn resolver for compiled static skills. Handlers return
+   * `"all"` or a list of path-derived skill names; without this field all
+   * static skills remain available.
+   */
+  readonly staticSkillVisibility?: PublicAgentStaticSkillVisibilityDefinition;
   /**
    * Optional structured return type used when this agent runs in task mode
    * (for example as a subagent, schedule, or remote job). Interactive

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -3,6 +3,7 @@ import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index
 import type { JsonObject } from "#shared/json.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 import {
+  DYNAMIC_SENTINEL_KIND,
   isDynamicSentinel,
   type DynamicResolveContext,
   type DynamicSentinel,
@@ -85,8 +86,24 @@ export type PublicAgentDynamicModelDefinition = DynamicSentinel<
 /** Static skill names visible to one session or turn. */
 export type StaticSkillVisibility = "all" | readonly string[];
 
-/** Dynamic resolver shape for the agent's compiled static skill visibility. */
-export type PublicAgentStaticSkillVisibilityDefinition = DynamicSentinel<StaticSkillVisibility>;
+/** Lifecycle boundaries supported by the static skill visibility resolver. */
+export type StaticSkillVisibilityEventName = "session.started" | "turn.started";
+
+/** Event map accepted by the static skill visibility resolver. */
+export type StaticSkillVisibilityEvents = {
+  readonly [K in StaticSkillVisibilityEventName]?: (
+    event: unknown,
+    ctx: DynamicResolveContext,
+  ) => StaticSkillVisibility | Promise<StaticSkillVisibility>;
+} & {
+  readonly "step.started"?: never;
+};
+
+/** Dedicated sentinel shape for the agent's compiled static skill visibility. */
+export type PublicAgentStaticSkillVisibilityDefinition = {
+  readonly kind: typeof DYNAMIC_SENTINEL_KIND;
+  readonly events: StaticSkillVisibilityEvents;
+};
 
 export interface PublicAgentDynamicModelDefinitionInput {
   /** Compiled static model: build-time metadata and the active model when no scope is set. */


### PR DESCRIPTION
### Description

Adds Eve's session/turn-scoped `staticSkillVisibility` resolver. One durable resolved set now filters static skill prompt announcements and authorizes framework `load_skill`; packages stay materialized so selected skills retain sibling assets, while dynamic skills remain additive.

The public slot uses the dedicated `defineStaticSkillVisibility({ events })` helper so TypeScript rejects `step.started` and tool lifecycle keys while retaining the familiar dynamic-event shape. The resolver accepts `"all"` or a validated static-skill name subset at `session.started` and `turn.started`. Unknown, duplicate, malformed, and thrown results fail closed to an empty static-skill set. Omitting the resolver preserves the existing all-static-skills behavior. Durable state is reconciled against the current compiled inventory before prompt and load authorization. The focused Eve plan is included at `docs/plans/active/2026-07-11-static-skill-visibility-load-authorization.md`.

### How did you test your changes?

- `mise exec node@24 -- pnpm exec oxlint ...` on all changed TypeScript files — passed.
- `mise exec node@24 -- pnpm exec oxfmt --check ...` — passed.
- `git diff --check` — passed.
- Focused Vitest/compiler/runtime tests were selected: 32 tests pass, while five suites stop at collection because Eve's generated `#compiled/*` aliases are absent. The repository's `scripts/vendor-compiled.mjs` `InvalidArg` failure reproduces on an untouched `origin/main` checkout under the declared Node 24 toolchain; CI is the clean-environment authority for the focused tests, typecheck, and full suite.
- Added proof for context serialization round-trip, inventory reconciliation, actual prompt filtering/cache behavior, default-all, empty/unknown/throw fail-closed behavior, dynamic/static same-name override, continuation reuse, and packaged sibling assets.

Eval impact: no Eve eval contract applies; this is a framework authorization/prompt-projection primitive with no eval fixture changes.

### Release

Includes a patch changeset for the published `eve` package. No package was published in this PR.

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
