### PR TITLE
fix(eve): emit framework.slug in Vercel build output config

### DIFF
--- a/.changeset/framework-slug.md
+++ b/.changeset/framework-slug.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Vercel deployments now emit `framework: { slug: "eve" }` alongside the version in the Build Output API config. Vercel's build-output deserializer drops the entire `framework` object when `slug` is absent, so this restores framework attribution end to end — `framework_slug` and `framework_version` are now populated in AI Gateway routing and access logs.

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -322,6 +322,7 @@ describe("createApplicationNitro", () => {
           config: {
             version: 3,
             framework: {
+              slug: "eve",
               version: resolveInstalledPackageInfo().version,
             },
           },
@@ -365,6 +366,7 @@ describe("createApplicationNitro", () => {
       config: {
         version: 3,
         framework: {
+          slug: "eve",
           version: resolveInstalledPackageInfo().version,
         },
       },

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
+import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
+
+describe("createEveVercelOptions", () => {
+  it("returns undefined when the Vercel build output is disabled", () => {
+    expect(createEveVercelOptions(false)).toBeUndefined();
+  });
+
+  it("emits both framework slug and version so the proxy keeps the framework object", () => {
+    expect(createEveVercelOptions(true)).toEqual({
+      config: {
+        version: 3,
+        framework: {
+          slug: EVE_PACKAGE_NAME,
+          version: resolveInstalledPackageInfo().version,
+        },
+      },
+    });
+  });
+});

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
@@ -1,4 +1,5 @@
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 
 export function createEveVercelOptions(enabled: boolean) {
   if (!enabled) {
@@ -9,6 +10,7 @@ export function createEveVercelOptions(enabled: boolean) {
     config: {
       version: 3 as const,
       framework: {
+        slug: EVE_PACKAGE_NAME,
         version: resolveInstalledPackageInfo().version,
       },
     },


### PR DESCRIPTION
## Summary

eve deployments never populate the Vercel's `framework_slug`. Vercel reads both from the routing output's per-function `framework` object, but eve's Build Output API `config.json` declared `framework: { version }` with **no `slug`**

## Change

- `createEveVercelOptions` now emits `framework: { slug, version }`, reusing the existing `EVE_PACKAGE_NAME` constant so the slug stays in lockstep with package identity.

## Tests

- New unit test `vercel-build-output-config.test.ts` covers the disabled case (`undefined`) and asserts the enabled config emits both `slug: "eve"` and the resolved package version.
- Did not extend `build-application.scenario.test.ts`: it mocks the nitro build and fabricates its own `config.json`, so `createEveVercelOptions` output never reaches it.

Local: `typecheck`, `guard:invariants`, `fmt`, `lint`, and the new unit test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)