### PR TITLE
fix(eve): keep Nitro dev inputs outside runtime snapshots

### DIFF
--- a/.changeset/stable-dev-host-artifacts.md
+++ b/.changeset/stable-dev-host-artifacts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve dev` now keeps Nitro build inputs outside prunable runtime snapshots. Long-running development servers no longer fail structural rebuilds with stale import errors after snapshot cleanup.

--- a/packages/eve/src/internal/application/paths.ts
+++ b/packages/eve/src/internal/application/paths.ts
@@ -54,6 +54,10 @@ export function resolveNitroBuildDirectory(
   return join(rootDirectory, surface);
 }
 
+export function resolveApplicationHostArtifactsDirectory(appRoot: string): string {
+  return join(appRoot, ".eve", "host");
+}
+
 /**
  * Resolves the staged Nitro output directory for one isolated build surface.
  */

--- a/packages/eve/src/internal/nitro/host/prepare-application-host.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/prepare-application-host.scenario.test.ts
@@ -1,0 +1,80 @@
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
+import {
+  pruneDevelopmentRuntimeArtifactsSnapshots,
+  resolveDevelopmentRuntimeArtifactsPointerPath,
+} from "#internal/nitro/dev-runtime-artifacts.js";
+import { useTemporaryAppRoots } from "#internal/testing/use-temporary-app-roots.js";
+import { prepareApplicationHost } from "#internal/nitro/host/prepare-application-host.js";
+
+const createAppRoot = useTemporaryAppRoots();
+
+interface DevelopmentRuntimePointer {
+  readonly runtimeAppRoot: string;
+  readonly snapshotRoot: string;
+}
+
+async function readDevelopmentRuntimePointer(appRoot: string): Promise<DevelopmentRuntimePointer> {
+  return JSON.parse(
+    await readFile(resolveDevelopmentRuntimeArtifactsPointerPath(appRoot), "utf8"),
+  ) as DevelopmentRuntimePointer;
+}
+
+describe("prepareApplicationHost", () => {
+  it("keeps Nitro host inputs stable when their runtime snapshot is pruned", async () => {
+    const { agentRoot, appRoot } = await createAppRoot("eve-stable-dev-host-artifacts-", {
+      files: {
+        "agent/instructions.md": "Use the configured model.",
+      },
+      packageName: "stable-dev-host-artifacts",
+    });
+    const agentModulePath = join(agentRoot, "agent.mjs");
+    await writeFile(agentModulePath, 'export default { model: "openai/gpt-5.4" };\n');
+
+    const firstHost = await prepareApplicationHost(appRoot, { dev: true });
+    const firstPointer = await readDevelopmentRuntimePointer(appRoot);
+    const stableHostDirectory = join(appRoot, ".eve", "host");
+    const stableBootstrapPath = join(stableHostDirectory, "compiled-artifacts-bootstrap.mjs");
+    const snapshotBootstrapPath = join(
+      firstPointer.runtimeAppRoot,
+      ".eve",
+      "compile",
+      "compiled-artifacts-bootstrap.mjs",
+    );
+
+    expect(firstHost.compiledArtifacts.bootstrapPath).toBe(stableBootstrapPath);
+    expect(firstHost.compiledArtifacts.workflowWorldPluginPath).toBe(
+      join(stableHostDirectory, "compiled-artifacts-workflow-world.mjs"),
+    );
+    expect(firstHost.compiledArtifacts.bootstrapPath).not.toContain("/.eve/dev-runtime/snapshots/");
+    expect(await readFile(stableBootstrapPath, "utf8")).toContain(
+      normalizeEsmImportSpecifier(agentModulePath),
+    );
+    expect(existsSync(snapshotBootstrapPath)).toBe(false);
+
+    await writeFile(
+      agentModulePath,
+      'export default { model: "openai/gpt-5.4" };\n// revision two\n',
+    );
+    const nextHost = await prepareApplicationHost(appRoot, { dev: true });
+    const nextPointer = await readDevelopmentRuntimePointer(appRoot);
+
+    expect(nextHost.compiledArtifacts.bootstrapPath).toBe(stableBootstrapPath);
+    expect(nextPointer.snapshotRoot).not.toBe(firstPointer.snapshotRoot);
+
+    await pruneDevelopmentRuntimeArtifactsSnapshots({
+      appRoot,
+      now: Date.now() + 1_000,
+      recentWindowMs: 0,
+      retainCount: 0,
+    });
+
+    expect(existsSync(firstPointer.snapshotRoot)).toBe(false);
+    expect(existsSync(stableBootstrapPath)).toBe(true);
+  });
+});

--- a/packages/eve/src/internal/nitro/host/prepare-application-host.ts
+++ b/packages/eve/src/internal/nitro/host/prepare-application-host.ts
@@ -1,17 +1,16 @@
-import { readFile } from "node:fs/promises";
-
 import { compileAgent } from "#compiler/compile-agent.js";
-import type { CompiledAgentManifest } from "#compiler/manifest.js";
 import { createScheduleRegistrations } from "#runtime/schedules/register.js";
 import { loadResolvedCompiledSchedules } from "#runtime/schedules/resolve-schedule.js";
 import { writeCompiledArtifactsFiles } from "#internal/application/compiled-artifacts.js";
-import { resolveWorkflowBuildDirectory } from "#internal/application/paths.js";
+import {
+  resolveApplicationHostArtifactsDirectory,
+  resolveWorkflowBuildDirectory,
+} from "#internal/application/paths.js";
 import { createAuthoredSourceRuntimeCompiledArtifactsSource } from "#internal/application/runtime-compiled-artifacts-source.js";
 import {
   activateDevelopmentRuntimeArtifactsSnapshot,
   stageDevelopmentRuntimeArtifactsSnapshot,
 } from "#internal/nitro/dev-runtime-artifacts.js";
-import { resolveRuntimeCompilerArtifactPaths } from "#runtime/loaders/artifact-paths.js";
 import type { PreparedApplicationHost } from "#internal/nitro/host/types.js";
 
 /**
@@ -38,23 +37,9 @@ export async function prepareApplicationHost(
     options.dev === true
       ? await stageDevelopmentRuntimeArtifactsSnapshot(compileResult)
       : undefined;
-  const runtimeArtifactsRoot =
-    runtimeArtifactsSnapshot === undefined
-      ? compileResult.project.appRoot
-      : runtimeArtifactsSnapshot.runtimeAppRoot;
-  const runtimeArtifactPaths = resolveRuntimeCompilerArtifactPaths(runtimeArtifactsRoot);
-  const runtimeCompileResult =
-    options.dev === true
-      ? {
-          ...compileResult,
-          manifest: JSON.parse(
-            await readFile(runtimeArtifactPaths.compiledManifestPath, "utf8"),
-          ) as CompiledAgentManifest,
-        }
-      : compileResult;
   const compiledArtifacts = await writeCompiledArtifactsFiles({
-    compileResult: runtimeCompileResult,
-    outDir: runtimeArtifactPaths.compileDirectoryPath,
+    compileResult,
+    outDir: resolveApplicationHostArtifactsDirectory(compileResult.project.appRoot),
   });
   if (runtimeArtifactsSnapshot !== undefined) {
     await activateDevelopmentRuntimeArtifactsSnapshot({

--- a/packages/eve/test/scenarios/dev-server.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server.scenario.test.ts
@@ -1,10 +1,18 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Readable } from "node:stream";
 
 import { describe, expect, it } from "vitest";
 
 import { EVE_HEALTH_ROUTE_PATH } from "../../src/protocol/routes.js";
+import {
+  pruneDevelopmentRuntimeArtifactsSnapshots,
+  readDevelopmentRuntimeArtifactsSnapshotRoot,
+  resolveDevelopmentRuntimeArtifactsPointerPath,
+} from "../../src/internal/nitro/dev-runtime-artifacts.js";
+import { STRUCTURAL_RELOAD_LOG_LINE } from "../../src/internal/nitro/host/dev-watcher-log.js";
 import { WEATHER_AGENT_DESCRIPTOR } from "../../src/internal/testing/scenario-apps/weather-agent.js";
 import {
   type ScenarioAppDescriptor,
@@ -59,6 +67,7 @@ function hasUnsupportedWindowsEsmImport(text: string): boolean {
 function hasKnownDevBundlingFailure(text: string): boolean {
   return (
     hasUnsupportedWindowsEsmImport(text) ||
+    text.includes("UNRESOLVED_IMPORT") ||
     (text.includes("ERR_MODULE_NOT_FOUND") && text.includes("authored-module-map-loader"))
   );
 }
@@ -73,6 +82,21 @@ async function wait(ms: number): Promise<void> {
   await new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  failureMessage: string,
+  timeoutMs: number = 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(failureMessage);
+    }
+    await wait(100);
+  }
 }
 
 async function waitForServerUrl(input: {
@@ -234,7 +258,7 @@ async function startEveDev(appRoot: string): Promise<RunningEveDev> {
 
 describe("eve dev server", () => {
   it(
-    "boots the packaged development server and completes a streamed turn",
+    "rebuilds after pruning its startup runtime snapshot and completes a streamed turn",
     async () => {
       const app = await scenarioApp(DEV_SERVER_AGENT_DESCRIPTOR);
       const server = await startEveDev(app.appRoot);
@@ -256,6 +280,45 @@ describe("eve dev server", () => {
           ok: true,
           status: "ready",
         });
+
+        const pointerPath = resolveDevelopmentRuntimeArtifactsPointerPath(app.appRoot);
+        const startupRuntimeRoot = readDevelopmentRuntimeArtifactsSnapshotRoot(pointerPath);
+        if (startupRuntimeRoot === undefined) {
+          throw new Error("Expected eve dev to publish an initial runtime snapshot.");
+        }
+
+        await writeFile(
+          join(app.appRoot, "agent", "instructions.md"),
+          "Use the weather tool and answer with the current conditions.\n",
+        );
+        await waitForCondition(() => {
+          const currentRuntimeRoot = readDevelopmentRuntimeArtifactsSnapshotRoot(pointerPath);
+          return currentRuntimeRoot !== undefined && currentRuntimeRoot !== startupRuntimeRoot;
+        }, `Timed out waiting for authored HMR.\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`);
+
+        const authoredRuntimeRoot = readDevelopmentRuntimeArtifactsSnapshotRoot(pointerPath);
+        if (authoredRuntimeRoot === undefined) {
+          throw new Error("Expected authored HMR to publish a runtime snapshot.");
+        }
+
+        await pruneDevelopmentRuntimeArtifactsSnapshots({
+          appRoot: app.appRoot,
+          now: Date.now() + 1_000,
+          recentWindowMs: 0,
+          retainCount: 0,
+        });
+        expect(existsSync(startupRuntimeRoot)).toBe(false);
+
+        await writeFile(join(app.appRoot, ".env.local"), "EVE_SCENARIO_RELOAD=1\n");
+        await waitForCondition(
+          () => server.stdout().includes(STRUCTURAL_RELOAD_LOG_LINE),
+          `Timed out waiting for a structural Nitro reload.\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`,
+        );
+        await waitForCondition(() => {
+          const currentRuntimeRoot = readDevelopmentRuntimeArtifactsSnapshotRoot(pointerPath);
+          return currentRuntimeRoot !== undefined && currentRuntimeRoot !== authoredRuntimeRoot;
+        }, `Timed out waiting for the structural reload snapshot.\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`);
+        await wait(2_000);
 
         let messageResult: Awaited<ReturnType<typeof sendDevelopmentMessage>>;
         try {


### PR DESCRIPTION
## Summary

Nitro retains its plugin and build-input paths for the lifetime of `eve dev`. Those paths previously pointed into the startup runtime snapshot; after HMR advanced `current.json` and pruning removed that snapshot, a later structural rebuild failed with `UNRESOLVED_IMPORT`.

This change generates Nitro and workflow build inputs once under stable `.eve/host` paths instead of generating them inside runtime snapshots. Snapshot staging otherwise continues copying `.eve/compile` unchanged.

Regression coverage starts the packaged dev server, advances and prunes its startup snapshot, forces a structural Nitro reload, and completes a fresh streamed turn.

## Testing

- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm typecheck`
- `pnpm test:unit`
- focused integration and scenario suites
- packaged `eve dev` pruning and structural-reload scenario