### PR TITLE
fix(docs): trust internal links on integration pages

### DIFF
--- a/apps/docs/app/[lang]/integrations/components/markdown.tsx
+++ b/apps/docs/app/[lang]/integrations/components/markdown.tsx
@@ -25,6 +25,12 @@ export const Markdown = ({ children }: MarkdownProps) => {
     <Streamdown
       className="text-gray-900 [&_a]:font-medium [&_a]:text-gray-1000 [&_a]:underline [&_a]:underline-offset-4 [&_code]:text-gray-1000 [&_li]:my-1 [&_p]:my-3 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5"
       mode="static"
+      // Streamdown's link-safety modal is on by default, built for
+      // AI-generated content: with no onLinkCheck it interposes an
+      // "Open external link?" dialog on EVERY link, including internal
+      // /docs/* paths. This markdown is static, repo-authored copy, so
+      // links are trusted and navigate like the rest of the docs site.
+      linkSafety={{ enabled: false }}
       plugins={{ code: codePlugin }}
       shikiTheme={[geistShikiTheme, geistShikiTheme]}
     >


### PR DESCRIPTION
## Symptom

On an integrations page (e.g. `/integrations/twilio`, added in #672), clicking a link in the markdown copy — including clearly internal ones like `/docs/channels/twilio` — pops an **"Open external link?"** confirmation dialog claiming "You're about to visit an external website."

## Cause

The integration detail sections render through **Streamdown**, whose link-safety modal is **enabled by default** (`linkSafety: {enabled: true}` in its context defaults). That harness is built for AI-generated streaming content: with no `onLinkCheck` configured, it intercepts **every** anchor click and shows the confirmation — it never distinguishes internal from external, it just labels everything external.

## Fix

`linkSafety={{ enabled: false }}` on the integrations `Markdown` component. This copy is static, repo-authored text from `lib/integrations/data.ts` — the same trust level as every other docs page, none of which interpose a dialog. Links now navigate normally (internal paths in-app, external ones as regular anchors).

Deliberately *not* chosen: keeping the modal for true externals via `onLinkCheck` — Streamdown opens checked-ok links with `window.open(_blank)`, which would force internal docs links into new tabs. If a per-domain policy is ever wanted for docs, it belongs in a shared anchor component, not this AI-content harness.

One-line diff plus a comment; no changeset (apps/docs is unpublished).