### PR TITLE
ci: report required e2e matrix checks on irrelevant diffs

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -61,7 +61,10 @@ jobs:
     name: e2e-local (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
-    if: needs.changes.outputs.relevant == 'true'
+    # No job-level `if`: these matrix jobs are required checks under their
+    # expanded names, and a skipped matrix never reports them, leaving PRs
+    # stuck on "Expected - Waiting for status to be reported". Instead every
+    # step is guarded, so an irrelevant diff reports success in seconds.
     strategy:
       fail-fast: false
       matrix:
@@ -73,35 +76,41 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.relevant == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup pnpm
+        if: needs.changes.outputs.relevant == 'true'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Setup Node.js
+        if: needs.changes.outputs.relevant == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
 
       - name: Install dependencies
+        if: needs.changes.outputs.relevant == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build eve package
+        if: needs.changes.outputs.relevant == 'true'
         # Full build, not build:js: the deployed/runtime bundles must carry the
         # stamped package version (scripts/stamp-version-tokens.mjs) and docs.
         run: pnpm --filter eve run build
 
       - name: Run fixture evals
+        if: needs.changes.outputs.relevant == 'true'
         run: |
           mkdir -p "$EVE_EVAL_JUNIT_DIR"
           cd "${{ matrix.dir }}"
           pnpm exec eve eval --strict --verbose --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
 
       - name: Upload eval artifacts
-        if: failure()
+        if: (failure()) && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6
         with:
           name: eval-artifacts-${{ matrix.name }}

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -61,7 +61,10 @@ jobs:
     name: e2e-vercel (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
-    if: needs.changes.outputs.relevant == 'true'
+    # No job-level `if`: these matrix jobs are required checks under their
+    # expanded names, and a skipped matrix never reports them, leaving PRs
+    # stuck on "Expected - Waiting for status to be reported". Instead every
+    # step is guarded, so an irrelevant diff reports success in seconds.
     strategy:
       fail-fast: false
       matrix:
@@ -76,28 +79,34 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.relevant == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup pnpm
+        if: needs.changes.outputs.relevant == 'true'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Setup Node.js
+        if: needs.changes.outputs.relevant == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
 
       - name: Install dependencies
+        if: needs.changes.outputs.relevant == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build eve package
+        if: needs.changes.outputs.relevant == 'true'
         # Full build, not build:js: the deployed/runtime bundles must carry the
         # stamped package version (scripts/stamp-version-tokens.mjs) and docs.
         run: pnpm --filter eve run build
 
       - name: Deploy fixture and run evals
+        if: needs.changes.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           mkdir -p "$EVE_EVAL_JUNIT_DIR"
@@ -145,7 +154,7 @@ jobs:
           fi
 
       - name: Upload eval artifacts
-        if: failure()
+        if: (failure()) && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6
         with:
           name: eval-artifacts-vercel-${{ matrix.name }}


### PR DESCRIPTION
## Symptom

On any PR whose diff the e2e `changes` filter deems irrelevant (docs-only, catalog-only — e.g. #672), the merge box shows **11 "Expected — Waiting for status to be reported"** required checks and blocks forever, despite 2 approvals and every executed check passing.

## Cause

Branch protection requires the e2e checks under their **expanded matrix names** (`e2e-vercel (agent-tools)`, `e2e-local (agent-skills)`, …). Both workflows skip the whole matrix with a job-level `if: needs.changes.outputs.relevant == 'true'` — and a skipped matrix never expands, so the required names are **never reported at all**. GitHub treats never-reported required contexts as "Expected" indefinitely. (The lone `e2e-* (${{ matrix.name }})` placeholder row is the unexpanded matrix.)

## Fix

Move the guard from the job to **every step**: the matrix always expands and every job reports success under its required name; on an irrelevant diff all steps skip and the job completes in seconds. The `if: failure()` artifact-upload steps get the guard ANDed in. No ruleset changes needed, behavior on relevant diffs unchanged.

Cost: ~15 no-op runner spins per irrelevant PR (seconds each). Alternative considered: requiring an aggregate join-job instead of expanded names — cleaner long-term, but needs a ruleset edit; happy to follow up that way if preferred.

## Verification

YAML parses; both workflows' e2e jobs have no job-level `if` and all steps guarded. Real proof is on the next docs-only PR: the required e2e names should report success instead of sticking on Expected. (This PR itself touches only workflows, which the filter also treats as irrelevant — so it should demonstrate the fix on itself if workflow paths are excluded, or run e2e normally if included.)