### PR TITLE
Add finite session lifecycle primitives

### DIFF
--- a/.changeset/clean-finite-sessions.md
+++ b/.changeset/clean-finite-sessions.md
@@ -4,4 +4,6 @@
 
 Add a finite `ClientSession.snapshot()` API for durable event reconciliation
 and a public `SessionNotReadyError` auth contract that maps transient session
-readiness to a stable, non-cacheable HTTP 425 response.
+readiness to a stable, non-cacheable HTTP 425 response. Eve continuation
+requests are now resume-only and bounded-retry readiness races instead of
+silently starting a duplicate session.

--- a/.changeset/clean-finite-sessions.md
+++ b/.changeset/clean-finite-sessions.md
@@ -1,0 +1,7 @@
+---
+"eve": minor
+---
+
+Add a finite `ClientSession.snapshot()` API for durable event reconciliation
+and a public `SessionNotReadyError` auth contract that maps transient session
+readiness to a stable, non-cacheable HTTP 425 response.

--- a/.changeset/clean-finite-sessions.md
+++ b/.changeset/clean-finite-sessions.md
@@ -6,4 +6,5 @@ Add a finite `ClientSession.snapshot()` API for durable event reconciliation
 and a public `SessionNotReadyError` auth contract that maps transient session
 readiness to a stable, non-cacheable HTTP 425 response. Eve continuation
 requests are now resume-only and bounded-retry readiness races instead of
-silently starting a duplicate session.
+silently starting a duplicate session. Channel lifecycle callbacks can read
+`rawContinuationToken` when they need the exact client-facing token.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -103,6 +103,7 @@ export default eveChannel({
     "message.completed"(eventData, channel, ctx) {
       console.log("eve response completed", {
         continuationToken: channel.continuationToken,
+        clientContinuationToken: channel.rawContinuationToken,
         sessionId: ctx.session.id,
       });
     },

--- a/docs/guides/client/continuations.mdx
+++ b/docs/guides/client/continuations.mdx
@@ -115,6 +115,27 @@ for await (const event of session.stream()) {
 
 `stream()` attaches to an existing run; to send new user input, use `send()`. For overriding the cursor with `startIndex` and the full reconnection model, see [Streaming](./streaming#open-a-stream-manually).
 
+## Read a finite durable snapshot
+
+Use `session.snapshot()` when a request or hook must reconcile persisted events
+and then settle. Eve captures the durable tail when the request begins, returns
+the ordered suffix through that tail, and advances the session to the exclusive
+next cursor:
+
+```ts
+const session = client.session(savedState);
+const snapshot = await session.snapshot();
+
+await persistEvents(snapshot.events);
+await saveSessionState(snapshot.state);
+```
+
+Unlike `session.stream()`, `snapshot()` does not stay attached while a
+continuable session waits for a future turn. The `ClientSession` remains the
+owner of its continuation token; the snapshot response advances only the
+durable stream cursor. Pass `startIndex` only when intentionally overriding the
+cursor for that read.
+
 ## What to read next
 
 - [Streaming](./streaming): stream events and reconnect by index

--- a/docs/guides/client/continuations.mdx
+++ b/docs/guides/client/continuations.mdx
@@ -35,7 +35,7 @@ interface SessionState {
 
 The continuation token resumes the conversation. The session ID and stream index let the client reconnect to the right stream position without replaying events it already consumed.
 
-`SessionState` is a cursor, not a chat transcript. If your app shows historical messages, persist the stream events separately and store them under your own chat or thread ID. On reload, pass the saved `SessionState` back to `client.session(savedState)` or `useEveAgent({ initialSession })`, and pass the saved events to your renderer or `useEveAgent({ initialEvents })`.
+`SessionState` is a cursor, not a chat transcript. If your app shows historical messages, persist the stream events separately and store them under your own chat or thread ID. On reload, create one `ClientSession` from the saved state and pass that same object to every operation for the chat, including `useEveAgent({ session })` and manual replay. Pass saved events to your renderer or `useEveAgent({ initialEvents })`.
 
 ## Resume a saved session
 
@@ -59,6 +59,10 @@ const session = client.session(continuationToken);
 const response = await session.send("Continue where we left off.");
 await response.result();
 ```
+
+Keep that `ClientSession` as the chat-level lifecycle owner. Do not create one
+session object for stream replay and another for sending: replay advances the
+cursor and continuation state that the next send must use.
 
 The shorthand can send a follow-up, but it doesn't know the previous stream cursor. Prefer full `SessionState` when you control persistence.
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -35,7 +35,11 @@ Every handler receives the same `HookContext`:
 ```ts
 interface HookContext {
   readonly agent: { readonly name: string; readonly nodeId?: string };
-  readonly channel: { readonly kind?: string; readonly continuationToken?: string };
+  readonly channel: {
+    readonly kind?: string;
+    readonly continuationToken?: string;
+    readonly rawContinuationToken?: string;
+  };
   readonly session: { readonly id: string };
 }
 ```

--- a/packages/eve/src/channel/cross-channel-receive.test.ts
+++ b/packages/eve/src/channel/cross-channel-receive.test.ts
@@ -11,6 +11,7 @@ import type { Runtime } from "#channel/types.js";
 function makeRuntime(): Runtime {
   return {
     deliver: vi.fn(),
+    getEventSnapshot: vi.fn(),
     getEventStream: vi.fn(),
     run: vi.fn(),
   };
@@ -20,6 +21,9 @@ function makeSession(): Session {
   return {
     id: "sess_1",
     continuationToken: "tok",
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return new ReadableStream();
     },

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -67,6 +67,11 @@ type BaseSendOptions = {
   continuationToken: string;
   mode?: RunMode;
   /**
+   * Requires delivery to an existing parked session. When delivery cannot
+   * resume, propagate the runtime error instead of starting a new session.
+   */
+  resumeOnly?: boolean;
+  /**
    * Human-readable title for a newly started workflow session. Defaults to
    * the first user message and is ignored when resuming an existing session.
    */

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -24,6 +24,7 @@ function createMockRunHandle(): RunHandle {
 function createMockRuntime(): Runtime {
   return {
     deliver: vi.fn().mockRejectedValue(new Error("no parked session")),
+    getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
   };

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -17,6 +17,7 @@ function createMockRunHandle(): RunHandle {
 function createRuntime(deliverError: unknown): Runtime {
   return {
     deliver: vi.fn().mockRejectedValue(deliverError),
+    getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
   };
@@ -85,6 +86,7 @@ describe("createSendFn", () => {
     const context = ["thread background"];
     const deliverRuntime: Runtime = {
       deliver: vi.fn().mockResolvedValue({ sessionId: "existing-session-id" }),
+      getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
     };
@@ -116,6 +118,7 @@ describe("createSendFn", () => {
   it("adds channel request ids to deliver and run inputs when provided", async () => {
     const deliverRuntime: Runtime = {
       deliver: vi.fn().mockResolvedValue({ sessionId: "existing-session-id" }),
+      getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
     };
@@ -142,6 +145,7 @@ describe("createSendFn", () => {
     } as const;
     const deliverRuntime: Runtime = {
       deliver: vi.fn().mockResolvedValue({ sessionId: "existing-session-id" }),
+      getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
     };

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -49,6 +49,22 @@ describe("createSendFn", () => {
     warn.mockRestore();
   });
 
+  it("never starts a duplicate session when resume-only delivery finds no active session", async () => {
+    const noSession = new RuntimeNoActiveSessionError("test:token");
+    const runtime = createRuntime(noSession);
+    const send = createSendFn(runtime, ADAPTER, "test");
+
+    await expect(
+      send("follow-up", {
+        auth: null,
+        continuationToken: "token",
+        resumeOnly: true,
+      }),
+    ).rejects.toBe(noSession);
+    expect(runtime.deliver).toHaveBeenCalledTimes(1);
+    expect(runtime.run).not.toHaveBeenCalled();
+  });
+
   it("warns and falls back to a new session when delivery fails unexpectedly", async () => {
     const runtime = createRuntime(new Error("boom"));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -26,6 +26,7 @@ export function createSendFn<TState = undefined>(
     const state = (options as { state?: TState }).state;
     const title = (options as { title?: string }).title;
     const rawToken = (options as { continuationToken: string }).continuationToken;
+    const resumeOnly = (options as { resumeOnly?: boolean }).resumeOnly ?? false;
     const continuationToken = `${channelName}:${rawToken}`;
 
     const {
@@ -47,6 +48,10 @@ export function createSendFn<TState = undefined>(
 
       return createSession(sessionId, rawToken, runtime);
     } catch (error) {
+      if (resumeOnly) {
+        throw error;
+      }
+
       // No-active-session is the expected resume-or-start signal. The
       // failure itself is logged in `deliver`; this only records the fallback.
       if (!isRuntimeNoActiveSessionError(error)) {

--- a/packages/eve/src/channel/session.test.ts
+++ b/packages/eve/src/channel/session.test.ts
@@ -39,6 +39,16 @@ describe("buildSessionHandle", () => {
     expect(session.continuationToken).toBe("slack:C1:T1");
   });
 
+  it("exposes the channel-local continuation token without parsing in authored hooks", () => {
+    const ctx = new ContextContainer();
+    ctx.set(ContinuationTokenKey, "eve:eve:client-token");
+
+    const session = buildSessionHandle(ctx);
+
+    expect(session.continuationToken).toBe("eve:eve:client-token");
+    expect(session.rawContinuationToken).toBe("eve:client-token");
+  });
+
   it("namespaces the channel-local token on setContinuationToken", () => {
     const ctx = new ContextContainer();
     ctx.set(ContinuationTokenKey, "slack:C1:");

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -1,6 +1,6 @@
 import type { ContextAccessor } from "#context/key.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
-import type { Runtime } from "#channel/types.js";
+import type { EventSnapshot, Runtime } from "#channel/types.js";
 import type { SessionAuth } from "#context/keys.js";
 import { AuthKey, ContinuationTokenKey, InitiatorAuthKey, SessionIdKey } from "#context/keys.js";
 
@@ -19,6 +19,7 @@ export interface Session {
   getEventStream(options?: {
     startIndex?: number;
   }): Promise<ReadableStream<HandleMessageStreamEvent>>;
+  getEventSnapshot(options?: { startIndex?: number }): Promise<EventSnapshot>;
 }
 
 /**
@@ -41,6 +42,9 @@ export function createSession(id: string, continuationToken: string, runtime: Ru
     continuationToken,
     async getEventStream(options?: { startIndex?: number }) {
       return runtime.getEventStream(id, options);
+    },
+    async getEventSnapshot(options?: { startIndex?: number }) {
+      return runtime.getEventSnapshot(id, options);
     },
   };
 }

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -32,6 +32,8 @@ export interface Session {
 export interface SessionHandle {
   readonly id: string;
   readonly continuationToken: string;
+  /** Channel-local token accepted by `send`, without Eve's channel namespace. */
+  readonly rawContinuationToken: string;
   readonly auth: SessionAuth;
   setContinuationToken(rawToken: string): void;
 }
@@ -71,6 +73,9 @@ export function buildSessionHandle(accessor: ContextAccessor): SessionHandle {
     get continuationToken() {
       return accessor.get(ContinuationTokenKey) ?? "";
     },
+    get rawContinuationToken() {
+      return removeContinuationTokenNamespace(accessor.get(ContinuationTokenKey) ?? "");
+    },
     get auth(): SessionAuth {
       return {
         current: accessor.get(AuthKey) ?? null,
@@ -89,6 +94,11 @@ export function buildSessionHandle(accessor: ContextAccessor): SessionHandle {
       accessor.set(ContinuationTokenKey, token);
     },
   };
+}
+
+function removeContinuationTokenNamespace(token: string): string {
+  const separatorIndex = token.indexOf(":");
+  return separatorIndex < 0 ? token : token.slice(separatorIndex + 1);
 }
 
 function namespaceContinuationToken(currentToken: string, rawToken: string): string {

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -74,7 +74,7 @@ export function buildSessionHandle(accessor: ContextAccessor): SessionHandle {
       return accessor.get(ContinuationTokenKey) ?? "";
     },
     get rawContinuationToken() {
-      return removeContinuationTokenNamespace(accessor.get(ContinuationTokenKey) ?? "");
+      return toRawContinuationToken(accessor.get(ContinuationTokenKey) ?? "");
     },
     get auth(): SessionAuth {
       return {
@@ -96,7 +96,7 @@ export function buildSessionHandle(accessor: ContextAccessor): SessionHandle {
   };
 }
 
-function removeContinuationTokenNamespace(token: string): string {
+export function toRawContinuationToken(token: string): string {
   const separatorIndex = token.indexOf(":");
   return separatorIndex < 0 ? token : token.slice(separatorIndex + 1);
 }

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -388,6 +388,19 @@ export interface Runtime {
     sessionId: string,
     options?: GetEventStreamOptions,
   ): Promise<ReadableStream<HandleMessageStreamEvent>>;
+
+  /**
+   * Returns the durable event suffix through a tail captured at invocation.
+   * Unlike {@link getEventStream}, this operation is finite even when the
+   * session remains parked for a future turn.
+   */
+  getEventSnapshot(sessionId: string, options?: GetEventStreamOptions): Promise<EventSnapshot>;
+}
+
+/** A finite durable-event suffix and its exclusive next cursor. */
+export interface EventSnapshot {
+  readonly events: readonly HandleMessageStreamEvent[];
+  readonly nextStreamIndex: number;
 }
 
 /**

--- a/packages/eve/src/client/index.ts
+++ b/packages/eve/src/client/index.ts
@@ -51,6 +51,8 @@ export type {
   SendTurnInput,
   SendTurnPayload,
   SessionState,
+  SessionSnapshot,
+  SnapshotOptions,
   StreamOptions,
   TokenValue,
 } from "#client/types.js";

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -265,4 +265,152 @@ describe("ClientSession", () => {
 
     expect(result.inputRequests.map((request) => request.requestId)).toEqual(["approval_1"]);
   });
+
+  it("snapshots the current durable tail without waiting for a continuable session", async () => {
+    const events = [
+      {
+        type: "message.completed",
+        data: {
+          message: "Ready for the next question.",
+          sequence: 2,
+          stepIndex: 0,
+          turnId: "turn_1",
+        },
+      },
+      { type: "session.waiting", data: { wait: "next-user-message" } },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      Response.json({
+        events,
+        state: {
+          continuationToken: "eve:test",
+          sessionId: "session_1",
+          streamIndex: 12,
+        },
+      }),
+    );
+    const session = createSession({
+      continuationToken: "eve:test",
+      sessionId: "session_1",
+      streamIndex: 10,
+    });
+
+    const snapshot = await session.snapshot({ startIndex: 10 });
+
+    expect(snapshot).toEqual({
+      events,
+      state: {
+        continuationToken: "eve:test",
+        sessionId: "session_1",
+        streamIndex: 12,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/eve/v1/session/session_1/snapshot?startIndex=10",
+    );
+  });
+
+  it("preserves client continuation custody while advancing from a server snapshot", async () => {
+    const events = [
+      { type: "message.completed", data: { message: "first" } },
+      { type: "session.waiting", data: { wait: "next-user-message" } },
+    ];
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      Response.json({
+        events,
+        state: {
+          sessionId: "session_1",
+          streamIndex: 12,
+        },
+      }),
+    );
+    const session = createSession({
+      continuationToken: "eve:client-owned",
+      sessionId: "session_1",
+      streamIndex: 10,
+    });
+
+    const snapshot = await session.snapshot();
+
+    expect(snapshot).toEqual({
+      events,
+      state: {
+        continuationToken: "eve:client-owned",
+        sessionId: "session_1",
+        streamIndex: 12,
+      },
+    });
+    expect(session.state).toEqual(snapshot.state);
+  });
+
+  it("streams one live turn and settles while the parent remains continuable", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const events = [
+      {
+        type: "message.completed",
+        data: {
+          message: "Ready for the next question.",
+          sequence: 2,
+          stepIndex: 0,
+          turnId: "turn_1",
+        },
+      },
+      { type: "session.waiting", data: { wait: "next-user-message" } },
+    ];
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+        }
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(body));
+    const session = createSession({
+      continuationToken: "eve:test",
+      sessionId: "session_1",
+      streamIndex: 10,
+    });
+
+    const received = [];
+    for await (const event of session.streamTurn({ startIndex: 10 })) {
+      received.push(event);
+    }
+
+    expect(received).toEqual(events);
+    expect(cancelled).toBe(true);
+    expect(session.state).toEqual({
+      continuationToken: "eve:test",
+      sessionId: "session_1",
+      streamIndex: 12,
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "/eve/v1/session/session_1/stream?startIndex=10",
+    );
+  });
+
+  it("rejects a live turn that disconnects before its boundary without advancing the cursor", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      createStreamResponse([{ type: "turn.started", data: { sequence: 1, turnId: "turn_1" } }]),
+    );
+    const initialState = {
+      continuationToken: "eve:test",
+      sessionId: "session_1",
+      streamIndex: 10,
+    };
+    const session = createSession(initialState);
+
+    await expect(
+      (async () => {
+        for await (const _event of session.streamTurn({ startIndex: 10 })) {
+          void _event;
+        }
+      })(),
+    ).rejects.toThrow(/boundary/i);
+    expect(session.state).toEqual(initialState);
+  });
 });

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -88,6 +88,54 @@ describe("ClientSession", () => {
     });
   });
 
+  it("bounded-retries continuation readiness without changing session identity", async () => {
+    const requests: Array<{ body: unknown; url: string }> = [];
+    let attempt = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      requests.push({
+        body: JSON.parse(String(init?.body)),
+        url:
+          typeof request === "string"
+            ? request
+            : request instanceof URL
+              ? request.href
+              : request.url,
+      });
+      attempt += 1;
+      if (attempt === 1) {
+        return Response.json(
+          { code: "session_not_ready", error: "Session is not ready.", ok: false },
+          { headers: { "cache-control": "no-store" }, status: 425 },
+        );
+      }
+      return Response.json({ ok: true, sessionId: "session_1" });
+    });
+    const session = createSession({
+      continuationToken: "eve:existing",
+      sessionId: "session_1",
+      streamIndex: 7,
+    });
+
+    const response = await session.send("follow-up");
+
+    expect(response.sessionId).toBe("session_1");
+    expect(session.state).toEqual({
+      continuationToken: "eve:existing",
+      sessionId: "session_1",
+      streamIndex: 7,
+    });
+    expect(requests).toEqual([
+      {
+        body: { continuationToken: "eve:existing", message: "follow-up" },
+        url: "https://eve.test/eve/v1/session/session_1",
+      },
+      {
+        body: { continuationToken: "eve:existing", message: "follow-up" },
+        url: "https://eve.test/eve/v1/session/session_1",
+      },
+    ]);
+  });
+
   it("rejects clientContext-only sends", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(createAcceptedResponse());
     const session = createSession({

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -192,6 +192,7 @@ export class ClientSession {
       body: JSON.stringify(body),
       headers,
       mustDeliver: (input.inputResponses?.length ?? 0) > 0,
+      retryNotReady: session.sessionId !== undefined,
       redirect: this.#context.redirect,
       signal: input.signal,
       url,
@@ -352,11 +353,12 @@ async function postTurnWithRetry(input: {
   readonly body: string;
   readonly headers: Headers;
   readonly mustDeliver: boolean;
+  readonly retryNotReady: boolean;
   readonly redirect?: ClientRedirectPolicy;
   readonly signal?: AbortSignal;
   readonly url: string;
 }): Promise<Response> {
-  const attempts = input.mustDeliver ? DELIVER_RETRY_ATTEMPTS : 1;
+  const attempts = input.mustDeliver || input.retryNotReady ? DELIVER_RETRY_ATTEMPTS : 1;
   let lastStatus: number | undefined;
   let lastBody: string | undefined;
   let lastHeaders: Headers | undefined;
@@ -393,7 +395,10 @@ async function postTurnWithRetry(input: {
 }
 
 function isRetryableDeliveryFailure(status: number, body: string): boolean {
-  return status === 500 && /target session was not found/i.test(body);
+  return (
+    (status === 425 && /session_not_ready/i.test(body)) ||
+    (status === 500 && /target session was not found/i.test(body))
+  );
 }
 
 async function sleep(ms: number): Promise<void> {

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -3,6 +3,7 @@ import { EVE_SESSION_ID_HEADER, isCurrentTurnBoundaryEvent } from "#protocol/mes
 import {
   EVE_CREATE_SESSION_ROUTE_PATH,
   createEveContinueSessionRoutePath,
+  createEveSessionSnapshotRoutePath,
 } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { MessageResponse } from "#client/message-response.js";
@@ -16,6 +17,8 @@ import type {
   SendTurnInput,
   SendTurnPayload,
   SessionState,
+  SessionSnapshot,
+  SnapshotOptions,
   StreamOptions,
 } from "#client/types.js";
 
@@ -99,6 +102,67 @@ export class ClientSession {
     return this.#streamAndAdvance(sessionId, options);
   }
 
+  /**
+   * Reattaches to the current live turn and settles after Eve's first session
+   * boundary. The underlying conversation stream may remain open for future
+   * turns; this iterable does not.
+   */
+  streamTurn(options?: StreamOptions): AsyncIterable<HandleMessageStreamEvent> {
+    const currentState = this.#state;
+    const sessionId = currentState.sessionId;
+    if (!sessionId) {
+      throw new Error("Session has no session ID. Send a message first.");
+    }
+
+    const initialState: SessionState = {
+      ...currentState,
+      streamIndex: options?.startIndex ?? currentState.streamIndex,
+    };
+    return this.#createEventStream(sessionId, initialState.continuationToken, initialState, {
+      requireBoundary: true,
+      signal: options?.signal,
+    });
+  }
+
+  /**
+   * Reads the durable event suffix through a tail fixed by the server at
+   * request time. Unlike {@link stream}, this operation is finite even when
+   * the parent session is waiting for a future turn.
+   */
+  async snapshot(options?: SnapshotOptions): Promise<SessionSnapshot> {
+    const initialState = this.#state;
+    const sessionId = initialState.sessionId;
+    if (!sessionId) {
+      throw new Error("Session has no session ID. Send a message first.");
+    }
+
+    const startIndex = options?.startIndex ?? initialState.streamIndex;
+    const url = createClientUrl(
+      this.#context.host,
+      createEveSessionSnapshotRoutePath(sessionId),
+      startIndex > 0 ? { startIndex: String(startIndex) } : undefined,
+    );
+    const response = await fetch(url, {
+      headers: await this.#context.resolveHeaders(),
+      redirect: this.#context.redirect,
+    });
+    const body = await response.text();
+    if (!response.ok) {
+      throw new ClientError(response.status, body, response.headers);
+    }
+    const responseSnapshot = JSON.parse(body) as SessionSnapshot;
+    const snapshot: SessionSnapshot = {
+      events: responseSnapshot.events,
+      state: {
+        continuationToken: initialState.continuationToken,
+        sessionId,
+        streamIndex: responseSnapshot.state.streamIndex,
+      },
+    };
+    this.#state = snapshot.state;
+    return snapshot;
+  }
+
   // ---------------------------------------------------------------------------
   // Internal: POST to message route
   // ---------------------------------------------------------------------------
@@ -158,9 +222,14 @@ export class ClientSession {
     sessionId: string,
     continuationToken: string | undefined,
     initialState: SessionState,
-    input: SendTurnPayload,
+    input: {
+      readonly headers?: Readonly<Record<string, string>>;
+      readonly requireBoundary?: boolean;
+      readonly signal?: AbortSignal;
+    },
   ): AsyncGenerator<HandleMessageStreamEvent> {
     const events: HandleMessageStreamEvent[] = [];
+    let reachedBoundary = false;
 
     try {
       let currentStreamIndex = initialState.sessionId === sessionId ? initialState.streamIndex : 0;
@@ -184,6 +253,7 @@ export class ClientSession {
 
             if (isCurrentTurnBoundaryEvent(event)) {
               foundBoundary = true;
+              reachedBoundary = true;
               break;
             }
           }
@@ -210,13 +280,22 @@ export class ClientSession {
         remainingReconnectAttempts -= 1;
       }
     } finally {
-      this.#state = advanceSession({
-        continuationToken,
-        events,
-        preserveCompletedSessions: this.#context.preserveCompletedSessions,
-        sessionId,
-        session: initialState,
-      });
+      if (!input.requireBoundary || reachedBoundary) {
+        this.#state = advanceSession({
+          continuationToken,
+          events,
+          preserveCompletedSessions: this.#context.preserveCompletedSessions,
+          sessionId,
+          session: initialState,
+        });
+      }
+    }
+
+    if (input.requireBoundary && !reachedBoundary) {
+      if (input.signal?.aborted) {
+        throw new DOMException("Eve session turn stream aborted.", "AbortError");
+      }
+      throw new Error("Eve session turn stream ended without a turn boundary.");
     }
   }
 

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -186,6 +186,26 @@ export interface StreamOptions {
 }
 
 /**
+ * Options for {@link ClientSession.snapshot}.
+ */
+export interface SnapshotOptions {
+  /**
+   * Number of durable events already consumed. Defaults to the session's
+   * stored stream cursor.
+   */
+  readonly startIndex?: number;
+}
+
+/**
+ * One finite durable-event suffix and the exclusive cursor after its captured
+ * tail.
+ */
+export interface SessionSnapshot {
+  readonly events: HandleMessageStreamEvent[];
+  readonly state: SessionState;
+}
+
+/**
  * Aggregated result of one message turn, returned by
  * {@link MessageResponse.result}.
  */

--- a/packages/eve/src/context/hook-lifecycle.integration.test.ts
+++ b/packages/eve/src/context/hook-lifecycle.integration.test.ts
@@ -53,6 +53,40 @@ function hook(slug: string, hooks: Partial<ResolvedHookDefinition>): ResolvedHoo
 }
 
 describe("dispatchStreamEventHooks", () => {
+  it("exposes the raw continuation token while retaining the runtime namespace", async () => {
+    const observed: Array<{ continuationToken?: string; rawContinuationToken?: string }> = [];
+    const registry = createRuntimeHookRegistry([
+      hook("token-custody", {
+        events: {
+          "session.completed": async (_event, ctx) => {
+            observed.push({
+              continuationToken: ctx.channel.continuationToken,
+              rawContinuationToken: ctx.channel.rawContinuationToken,
+            });
+          },
+        },
+      }),
+    ]);
+    const ctx = buildCtx();
+    ctx.set(ContinuationTokenKey, "eve:eve:client-token");
+    ctx.set(ChannelKey, { kind: "eve" } as never);
+
+    await contextStorage.run(ctx, () =>
+      dispatchStreamEventHooks({
+        ctx,
+        registry,
+        event: { type: "session.completed" } satisfies HandleMessageStreamEvent,
+      }),
+    );
+
+    expect(observed).toEqual([
+      {
+        continuationToken: "eve:eve:client-token",
+        rawContinuationToken: "eve:client-token",
+      },
+    ]);
+  });
+
   it("invokes typed then wildcard subscribers and propagates errors", async () => {
     const calls: string[] = [];
     const registry = createRuntimeHookRegistry([

--- a/packages/eve/src/context/hook-lifecycle.ts
+++ b/packages/eve/src/context/hook-lifecycle.ts
@@ -1,4 +1,5 @@
 import { getAdapterKind } from "#channel/adapter.js";
+import { toRawContinuationToken } from "#channel/session.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import type { HookContext } from "#public/definitions/hook.js";
 import type { RuntimeHookRegistry } from "#runtime/hooks/registry.js";
@@ -51,6 +52,8 @@ function buildHookContext(ctx: ContextContainer): HookContext {
     channel: {
       kind,
       continuationToken,
+      rawContinuationToken:
+        continuationToken === undefined ? undefined : toRawContinuationToken(continuationToken),
     },
   };
 }

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -211,6 +211,9 @@ function createTestNode(
 function createNoopRuntime(): Runtime {
   return {
     deliver: vi.fn(),
+    getEventSnapshot: vi
+      .fn()
+      .mockRejectedValue(new Error("runtime.getEventSnapshot should not be called in this test")),
     run: vi.fn().mockRejectedValue(new Error("runtime.run should not be called in this test")),
     getEventStream: vi
       .fn()

--- a/packages/eve/src/execution/runtime-errors.test.ts
+++ b/packages/eve/src/execution/runtime-errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRuntimeNoActiveSessionError,
+  RuntimeNoActiveSessionError,
+} from "#execution/runtime-errors.js";
+
+describe("isRuntimeNoActiveSessionError", () => {
+  it("recognizes the stable error identity after realm serialization", () => {
+    const continuationToken = "http:serialized-session";
+    const serializedError = JSON.parse(
+      JSON.stringify(new RuntimeNoActiveSessionError(continuationToken)),
+    ) as unknown;
+
+    expect(serializedError).toEqual({
+      code: "NO_ACTIVE_SESSION",
+      continuationToken,
+      name: "RuntimeNoActiveSessionError",
+    });
+    expect(isRuntimeNoActiveSessionError(serializedError)).toBe(true);
+  });
+});

--- a/packages/eve/src/execution/runtime-errors.ts
+++ b/packages/eve/src/execution/runtime-errors.ts
@@ -19,5 +19,16 @@ export class RuntimeNoActiveSessionError extends Error {
 export function isRuntimeNoActiveSessionError(
   error: unknown,
 ): error is RuntimeNoActiveSessionError {
-  return error instanceof RuntimeNoActiveSessionError;
+  if (error instanceof RuntimeNoActiveSessionError) {
+    return true;
+  }
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const candidate = error as Record<string, unknown>;
+  return (
+    candidate.name === "RuntimeNoActiveSessionError" &&
+    candidate.code === "NO_ACTIVE_SESSION" &&
+    typeof candidate.continuationToken === "string"
+  );
 }

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -131,6 +131,63 @@ describe("createWorkflowRuntime#deliver", () => {
   });
 });
 
+describe("createWorkflowRuntime#getEventSnapshot", () => {
+  it.each([
+    {
+      events: [
+        { data: { message: "ready" }, type: "message.completed" },
+        { data: { wait: "next-user-message" }, type: "session.waiting" },
+      ],
+      expectedNextStreamIndex: 12,
+      name: "captured suffix",
+      startIndex: 10,
+      tailIndex: 11,
+    },
+    {
+      events: [],
+      expectedNextStreamIndex: 12,
+      name: "cursor already beyond the tail",
+      startIndex: 12,
+      tailIndex: 11,
+    },
+  ])("returns the finite $name", async (testCase) => {
+    const encoder = new TextEncoder();
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let cancelled = false;
+    const readable = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    }) as ReadableStream<Uint8Array> & { getTailIndex(): Promise<number> };
+    readable.getTailIndex = vi.fn(async () => {
+      for (const event of testCase.events) {
+        controller?.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+      }
+      return testCase.tailIndex;
+    });
+    const getReadable = vi.fn(() => readable);
+    getRunMock.mockReturnValue({ getReadable });
+    const runtime = createWorkflowRuntime({
+      compiledArtifactsSource: {} as RuntimeCompiledArtifactsSource,
+    });
+
+    await expect(
+      runtime.getEventSnapshot("driver-run", { startIndex: testCase.startIndex }),
+    ).resolves.toEqual({
+      events: testCase.events,
+      nextStreamIndex: testCase.expectedNextStreamIndex,
+    });
+
+    expect(getRunMock).toHaveBeenCalledWith("driver-run");
+    expect(getReadable).toHaveBeenCalledWith({ startIndex: testCase.startIndex });
+    expect(readable.getTailIndex).toHaveBeenCalledTimes(1);
+    expect(cancelled).toBe(testCase.events.length > 0);
+  });
+});
+
 describe("createWorkflowRuntime#run", () => {
   const adapter: ChannelAdapter = { kind: "http" };
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -2,6 +2,7 @@ import { HookNotFoundError } from "#compiled/@workflow/errors/index.js";
 
 import type {
   DeliverInput,
+  EventSnapshot,
   GetEventStreamOptions,
   HookPayload,
   RunHandle,
@@ -187,6 +188,39 @@ export function createWorkflowRuntime(config: {
       return parseNdjsonStream<HandleMessageStreamEvent>(() =>
         getRun(sessionId).getReadable({ startIndex: options?.startIndex }),
       );
+    },
+
+    async getEventSnapshot(
+      sessionId: string,
+      options?: GetEventStreamOptions,
+    ): Promise<EventSnapshot> {
+      const startIndex = options?.startIndex ?? 0;
+      const readable = getRun(sessionId).getReadable({ startIndex });
+      const tailIndex = await readable.getTailIndex();
+      if (tailIndex < startIndex) {
+        return { events: [], nextStreamIndex: startIndex };
+      }
+
+      const expectedCount = tailIndex - startIndex + 1;
+      const parsed = parseNdjsonStream<HandleMessageStreamEvent>(() => readable);
+      const reader = parsed.getReader();
+      const events: HandleMessageStreamEvent[] = [];
+      try {
+        while (events.length < expectedCount) {
+          const result = await reader.read();
+          if (result.done) {
+            throw new Error(
+              `Durable event stream ended before captured tail ${tailIndex} for session ${sessionId}.`,
+            );
+          }
+          events.push(result.value);
+        }
+      } finally {
+        await reader.cancel();
+        reader.releaseLock();
+      }
+
+      return { events, nextStreamIndex: tailIndex + 1 };
     },
   };
 }

--- a/packages/eve/src/harness/attachment-staging.test.ts
+++ b/packages/eve/src/harness/attachment-staging.test.ts
@@ -23,6 +23,7 @@ const STUB_ADAPTER_CTX: ChannelAdapterContext = {
   session: {
     id: "",
     continuationToken: "",
+    rawContinuationToken: "",
     auth: { current: null, initiator: null },
     setContinuationToken: () => {},
   },

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -154,6 +154,9 @@ describe("dispatchChannelRequest", () => {
     const targetReceive = vi.fn().mockResolvedValue({
       id: "sess_target",
       continuationToken: "tok",
+      async getEventSnapshot() {
+        return { events: [], nextStreamIndex: 0 };
+      },
       async getEventStream() {
         return new ReadableStream();
       },
@@ -227,6 +230,7 @@ describe("dispatchChannelRequest", () => {
   it("tags route sends with Vercel's request id", async () => {
     const runtimeForTest: Runtime = {
       deliver: vi.fn().mockResolvedValue({ sessionId: "sess_route" }),
+      getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
       run: vi.fn(),
     };
@@ -272,6 +276,7 @@ describe("dispatchChannelRequest", () => {
   it("does not invent a channel request id when Vercel did not send one", async () => {
     const runtimeForTest: Runtime = {
       deliver: vi.fn().mockResolvedValue({ sessionId: "sess_route" }),
+      getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
       run: vi.fn(),
     };
@@ -312,6 +317,7 @@ describe("dispatchChannelRequest", () => {
   it("does not mutate route-owned run and deliver inputs", async () => {
     const runtimeForTest: Runtime = {
       deliver: vi.fn().mockResolvedValue({ sessionId: "sess_deliver" }),
+      getEventSnapshot: vi.fn().mockResolvedValue({ events: [], nextStreamIndex: 0 }),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
       run: vi.fn().mockResolvedValue({
         continuationToken: "route-token",

--- a/packages/eve/src/protocol/routes.ts
+++ b/packages/eve/src/protocol/routes.ts
@@ -33,6 +33,11 @@ export const EVE_CONTINUE_SESSION_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/session/:
 export const EVE_MESSAGE_STREAM_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/session/:sessionId/stream`;
 
 /**
+ * Stable framework-owned finite event snapshot route pattern.
+ */
+export const EVE_SESSION_SNAPSHOT_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/session/:sessionId/snapshot`;
+
+/**
  * Framework-owned route pattern for dispatching one authored schedule
  * exactly once from the dev server.
  *
@@ -101,6 +106,13 @@ export const EVE_CALLBACK_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/callback/:token`;
  */
 export function createEveMessageStreamRoutePath(sessionId: string): string {
   return `${EVE_ROUTE_PREFIX}/session/${encodeURIComponent(sessionId)}/stream`;
+}
+
+/**
+ * Creates the stable framework-owned finite event snapshot route path.
+ */
+export function createEveSessionSnapshotRoutePath(sessionId: string): string {
+  return `${EVE_ROUTE_PREFIX}/session/${encodeURIComponent(sessionId)}/snapshot`;
 }
 
 /**

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -17,6 +17,7 @@ import {
   none,
   placeholderAuth,
   routeAuth,
+  SessionNotReadyError,
   UnauthenticatedError,
   vercelOidc,
   vercelSubject,
@@ -471,6 +472,29 @@ describe("routeAuth", () => {
       await expect(result.json()).resolves.toEqual({
         code: "forbidden",
         error: "custom auth rejection",
+        ok: false,
+      });
+    }
+    expect(never).not.toHaveBeenCalled();
+  });
+
+  it("returns a retryable readiness response immediately and stops the walk", async () => {
+    const never = vi.fn(() => SAMPLE_CONTEXT);
+
+    const result = await routeAuth(makeRequest(), [
+      () => {
+        throw new SessionNotReadyError();
+      },
+      never,
+    ]);
+
+    expect(result).toBeInstanceOf(Response);
+    if (result instanceof Response) {
+      expect(result.status).toBe(425);
+      expect(result.headers.get("cache-control")).toBe("no-store");
+      await expect(result.json()).resolves.toEqual({
+        code: "session_not_ready",
+        error: "Session is not ready.",
         ok: false,
       });
     }

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -481,6 +481,32 @@ export class ForbiddenError extends Error {
 }
 
 /**
+ * Error thrown by auth callbacks when an otherwise valid request targets a
+ * session whose authorization state is not ready yet. `routeAuth` maps it to
+ * a structured, non-cacheable 425 response so Eve clients can retry the same
+ * request without treating readiness as an authentication failure.
+ */
+export class SessionNotReadyError extends Error {
+  readonly response: Response;
+
+  constructor(message = "Session is not ready.") {
+    super(message);
+    this.name = "SessionNotReadyError";
+    this.response = Response.json(
+      {
+        code: "session_not_ready",
+        error: message,
+        ok: false,
+      },
+      {
+        headers: { "cache-control": "no-store" },
+        status: 425,
+      },
+    );
+  }
+}
+
+/**
  * Route auth callback. Returned value semantics inside {@link routeAuth}:
  *
  * - A {@link SessionAuthContext} accepts the request and halts the walk.

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -100,6 +100,9 @@ async function firePost(
   const send = vi.fn<SendFn<ChatSdkChannelState>>().mockResolvedValue({
     continuationToken: "chat-sdk:test",
     id: "session-1",
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return new ReadableStream();
     },
@@ -240,6 +243,9 @@ describe("chatSdkChannel", () => {
     const send = vi.fn<SendFn<ChatSdkChannelState>>().mockResolvedValue({
       continuationToken: "chat-sdk:test",
       id: "session-1",
+      async getEventSnapshot() {
+        return { events: [], nextStreamIndex: 0 };
+      },
       async getEventStream() {
         return new ReadableStream();
       },

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -254,6 +254,7 @@ describe("eveChannel — events", () => {
         "message.completed"(data, channel, ctx) {
           observed.push(data.message ?? "");
           observed.push(channel.continuationToken);
+          observed.push(channel.rawContinuationToken);
           observed.push(ctx.session.id);
         },
       },
@@ -265,7 +266,7 @@ describe("eveChannel — events", () => {
       turn: { id: "turn-1", sequence: 1 },
     };
     const ctx = new ContextContainer();
-    ctx.set(ContinuationTokenKey, "eve:continuation");
+    ctx.set(ContinuationTokenKey, "eve:eve:continuation");
     ctx.set(SessionIdKey, "sess-eve-event");
     ctx.set(SessionKey, session);
 
@@ -283,7 +284,12 @@ describe("eveChannel — events", () => {
       );
     });
 
-    expect(observed).toEqual(["done", "eve:continuation", "sess-eve-event"]);
+    expect(observed).toEqual([
+      "done",
+      "eve:eve:continuation",
+      "eve:continuation",
+      "sess-eve-event",
+    ]);
   });
 });
 

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -5,7 +5,7 @@ import { buildAdapterContext } from "#channel/adapter-context.js";
 import { callAdapterEventHandler, type ChannelAdapter } from "#channel/adapter.js";
 import { isCompiledChannel } from "#channel/compiled-channel.js";
 import { createJsonMessageRequest } from "#internal/testing/route-harness.js";
-import { type AuthFn, none } from "#public/channels/auth.js";
+import { type AuthFn, none, SessionNotReadyError } from "#public/channels/auth.js";
 import { eveChannel, defaultEveAuth, type EveChannelInput } from "#public/channels/eve.js";
 import type { SessionAuthContext } from "#channel/types.js";
 import type { RouteHandlerArgs, SendFn, SendOptions, SendPayload } from "#channel/routes.js";
@@ -60,6 +60,9 @@ function createEveCreateHandler(input: EveChannelInput) {
   const mockSend = vi.fn<SendFn>().mockResolvedValue({
     id: "test-session-id",
     continuationToken: "eve:test",
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return new ReadableStream();
     },
@@ -95,6 +98,9 @@ function createEveContinueHandler(input: EveChannelInput) {
   const mockSession: ChannelSession = {
     id: "test-session-id",
     continuationToken: "eve:test",
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return new ReadableStream();
     },
@@ -277,6 +283,51 @@ describe("eveChannel — events", () => {
     });
 
     expect(observed).toEqual(["done", "eve:continuation", "sess-eve-event"]);
+  });
+});
+
+describe("eveChannel — stream session", () => {
+  it("returns retryable auth readiness without looking up or opening the session", async () => {
+    const channel = eveChannel({
+      auth: () => {
+        throw new SessionNotReadyError();
+      },
+    });
+    const streamRoute = channel.routes.find(
+      (route) => route.method === "GET" && route.path === "/eve/v1/session/:sessionId/stream",
+    );
+    if (!streamRoute) throw new Error("No session stream route found");
+
+    const getEventStream = vi.fn(async () => new ReadableStream());
+    const getSession = vi.fn(() => ({
+      continuationToken: "eve:test",
+      getEventSnapshot: vi.fn(async () => ({ events: [], nextStreamIndex: 0 })),
+      getEventStream,
+      id: "test-session-id",
+    }));
+    const args: RouteHandlerArgs = {
+      getSession,
+      params: { sessionId: "test-session-id" },
+      receive: vi.fn() as any,
+      requestIp: "127.0.0.1",
+      send: vi.fn() as any,
+      waitUntil: () => undefined,
+    };
+
+    const response = await (streamRoute as any).handler(
+      new Request("https://example.com/eve/v1/session/test-session-id/stream"),
+      args,
+    );
+
+    expect(response.status).toBe(425);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      code: "session_not_ready",
+      error: "Session is not ready.",
+      ok: false,
+    });
+    expect(getSession).not.toHaveBeenCalled();
+    expect(getEventStream).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -11,6 +11,7 @@ import type { SessionAuthContext } from "#channel/types.js";
 import type { RouteHandlerArgs, SendFn, SendOptions, SendPayload } from "#channel/routes.js";
 import type { Session as ChannelSession } from "#channel/session.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
+import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import type { ContextAccessor } from "#context/key.js";
 import {
   ContinuationTokenKey,
@@ -328,6 +329,47 @@ describe("eveChannel — stream session", () => {
     });
     expect(getSession).not.toHaveBeenCalled();
     expect(getEventStream).not.toHaveBeenCalled();
+  });
+});
+
+describe("eveChannel — continue session", () => {
+  it("dispatches the built-in continuation route as resume-only", async () => {
+    const handler = createEveContinueHandler({ auth: none() });
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({
+        continuationToken: "http:existing",
+        message: "follow-up",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handler.send).toHaveBeenCalledTimes(1);
+    expect(handler.send.mock.calls[0]?.[1]).toMatchObject({
+      continuationToken: "http:existing",
+      resumeOnly: true,
+    });
+  });
+
+  it("returns retryable readiness when resume-only delivery has no active session", async () => {
+    const handler = createEveContinueHandler({ auth: none() });
+    handler.send.mockRejectedValueOnce(new RuntimeNoActiveSessionError("eve:http:existing"));
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({
+        continuationToken: "http:existing",
+        message: "follow-up",
+      }),
+    );
+
+    expect(response.status).toBe(425);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      code: "session_not_ready",
+      error: "Session is not ready.",
+      ok: false,
+    });
+    expect(handler.send).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -15,7 +15,8 @@ import {
 } from "#protocol/message.js";
 import { EVE_INFO_ROUTE_PATH, EVE_SESSION_SNAPSHOT_ROUTE_PATTERN } from "#protocol/routes.js";
 import { type InputResponse, isInputResponse } from "#runtime/input/types.js";
-import { type AuthFn, routeAuth } from "#public/channels/auth.js";
+import { type AuthFn, routeAuth, SessionNotReadyError } from "#public/channels/auth.js";
+import { isRuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import {
   collectUploadPolicyViolations,
   formatUploadPolicyViolation,
@@ -286,18 +287,27 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           dispatchAuth = messageResult.auth;
         }
 
-        const session = await send(
-          {
-            inputResponses: body.inputResponses,
-            message: body.message,
-            context,
-            outputSchema: body.outputSchema,
-          },
-          {
-            auth: dispatchAuth,
-            continuationToken: body.continuationToken,
-          },
-        );
+        let session: Awaited<ReturnType<typeof send>>;
+        try {
+          session = await send(
+            {
+              inputResponses: body.inputResponses,
+              message: body.message,
+              context,
+              outputSchema: body.outputSchema,
+            },
+            {
+              auth: dispatchAuth,
+              continuationToken: body.continuationToken,
+              resumeOnly: true,
+            },
+          );
+        } catch (error) {
+          if (isRuntimeNoActiveSessionError(error)) {
+            return new SessionNotReadyError().response;
+          }
+          throw error;
+        }
 
         return Response.json(
           {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -13,7 +13,7 @@ import {
   EVE_STREAM_FORMAT_HEADER,
   EVE_STREAM_VERSION_HEADER,
 } from "#protocol/message.js";
-import { EVE_INFO_ROUTE_PATH } from "#protocol/routes.js";
+import { EVE_INFO_ROUTE_PATH, EVE_SESSION_SNAPSHOT_ROUTE_PATTERN } from "#protocol/routes.js";
 import { type InputResponse, isInputResponse } from "#runtime/input/types.js";
 import { type AuthFn, routeAuth } from "#public/channels/auth.js";
 import {
@@ -347,6 +347,39 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         } catch {
           return Response.json({ error: "Session not found.", ok: false }, { status: 404 });
         }
+      }),
+
+      GET(EVE_SESSION_SNAPSHOT_ROUTE_PATTERN, async (req, { getSession, params }) => {
+        const authResult = await routeAuth(req, input.auth);
+        if (authResult instanceof Response) return authResult;
+
+        const sessionId = params.sessionId;
+        if (!sessionId) {
+          return Response.json({ error: "Missing session id.", ok: false }, { status: 400 });
+        }
+
+        const startIndex = parseStartIndex(req);
+        if (startIndex instanceof Response) return startIndex;
+
+        let session;
+        try {
+          session = getSession(sessionId);
+        } catch {
+          return Response.json({ error: "Session not found.", ok: false }, { status: 404 });
+        }
+
+        const snapshot = await session.getEventSnapshot({ startIndex });
+        return Response.json(
+          {
+            events: snapshot.events,
+            state: {
+              continuationToken: session.continuationToken,
+              sessionId,
+              streamIndex: snapshot.nextStreamIndex,
+            },
+          },
+          { headers: { "cache-control": "no-store" } },
+        );
       }),
     ],
     events: input.events,

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -27,6 +27,7 @@ async function firePost(
 
   const send = vi.fn(async (_input: unknown, _options: unknown) => ({
     continuationToken: "TOKEN",
+    getEventSnapshot: async () => ({ events: [], nextStreamIndex: 0 }),
     getEventStream: async () => new ReadableStream(),
     id: "SESSION",
   }));
@@ -149,6 +150,7 @@ describe("teamsChannel", () => {
     });
     const send = vi.fn(async (_input: unknown, _options: unknown) => ({
       continuationToken: "TOKEN",
+      getEventSnapshot: async () => ({ events: [], nextStreamIndex: 0 }),
       getEventStream: async () => new ReadableStream(),
       id: "SESSION",
     }));

--- a/packages/eve/src/public/definitions/channel.test.ts
+++ b/packages/eve/src/public/definitions/channel.test.ts
@@ -543,6 +543,9 @@ describe("defineChannel", () => {
         return {
           id: channelId,
           continuationToken: channelId,
+          async getEventSnapshot() {
+            return { events: [], nextStreamIndex: 0 };
+          },
           async getEventStream() {
             return new ReadableStream();
           },

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -191,6 +191,8 @@ type EventData<T extends HandleMessageStreamEvent["type"]> =
  */
 export interface ChannelSessionOps {
   readonly continuationToken: string;
+  /** Channel-local token accepted by `send`, without Eve's channel namespace. */
+  readonly rawContinuationToken: string;
   setContinuationToken(token: string): void;
 }
 
@@ -357,6 +359,7 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
         const channel = {
           ...adapterCtx,
           continuationToken: adapterCtx.session?.continuationToken ?? "",
+          rawContinuationToken: adapterCtx.session?.rawContinuationToken ?? "",
           setContinuationToken: (token: string) => adapterCtx.session?.setContinuationToken(token),
         };
         if (eventType === "session.failed") {

--- a/packages/eve/src/public/definitions/hook.ts
+++ b/packages/eve/src/public/definitions/hook.ts
@@ -17,6 +17,8 @@ export interface HookContext extends SessionContext {
   readonly channel: {
     readonly kind?: string;
     readonly continuationToken?: string;
+    /** Channel-local token accepted by `send`, without Eve's channel namespace. */
+    readonly rawContinuationToken?: string;
   };
 }
 

--- a/packages/eve/test/eve-run-stream-channel.test.ts
+++ b/packages/eve/test/eve-run-stream-channel.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { HandleMessageStreamEvent } from "../src/protocol/message.js";
 import type { RouteHandlerArgs, GetSessionFn } from "../src/channel/routes.js";
 import type { Session } from "../src/channel/session.js";
-import { EVE_MESSAGE_STREAM_ROUTE_PATTERN } from "../src/protocol/routes.js";
+import {
+  EVE_MESSAGE_STREAM_ROUTE_PATTERN,
+  EVE_SESSION_SNAPSHOT_ROUTE_PATTERN,
+} from "../src/protocol/routes.js";
 import { none } from "../src/public/channels/auth.js";
 import { eveChannel } from "../src/public/channels/eve.js";
 
@@ -24,6 +27,15 @@ function createGetHandler() {
     (r) => r.method === "GET" && r.path === EVE_MESSAGE_STREAM_ROUTE_PATTERN,
   );
   if (!getRoute) throw new Error("No stream GET route found");
+  return getRoute;
+}
+
+function createSnapshotHandler() {
+  const channel = eveChannel({ auth: none() });
+  const getRoute = channel.routes.find(
+    (route) => route.method === "GET" && route.path === EVE_SESSION_SNAPSHOT_ROUTE_PATTERN,
+  );
+  if (!getRoute) throw new Error("No snapshot GET route found");
   return getRoute;
 }
 
@@ -154,6 +166,58 @@ describe("eveChannel GET stream", () => {
   });
 });
 
+describe("eveChannel GET snapshot", () => {
+  it("returns the captured durable tail without opening the continuable live stream", async () => {
+    const events: HandleMessageStreamEvent[] = [
+      {
+        type: "message.completed",
+        data: {
+          finishReason: "stop",
+          message: "ready",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+      },
+      { type: "session.waiting", data: { wait: "next-user-message" } },
+    ];
+    const liveStream = new ReadableStream<HandleMessageStreamEvent>({
+      start(controller) {
+        for (const event of events) controller.enqueue(event);
+        // The durable parent remains open for a future turn.
+      },
+    });
+    const getEventStream = vi.fn().mockResolvedValue(liveStream);
+    const getEventSnapshot = vi.fn().mockResolvedValue({ events, nextStreamIndex: 12 });
+    const getSession = vi.fn<GetSessionFn>().mockReturnValue({
+      continuationToken: "eve:test",
+      getEventSnapshot,
+      getEventStream,
+      id: "session_xyz",
+    } as unknown as Session);
+    const getRoute = createSnapshotHandler();
+
+    const response = await (getRoute as any).handler(
+      new Request("https://example.com/eve/v1/session/session_xyz/snapshot?startIndex=10", {
+        method: "GET",
+      }),
+      createArgs({ getSession, params: { sessionId: "session_xyz" } }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      events,
+      state: {
+        continuationToken: "eve:test",
+        sessionId: "session_xyz",
+        streamIndex: 12,
+      },
+    });
+    expect(getEventSnapshot).toHaveBeenCalledWith({ startIndex: 10 });
+    expect(getEventStream).not.toHaveBeenCalled();
+  });
+});
+
 function createEvents(
   events: readonly HandleMessageStreamEvent[],
 ): ReadableStream<HandleMessageStreamEvent> {
@@ -171,6 +235,9 @@ function createMockGetSession(events: ReadableStream<HandleMessageStreamEvent>) 
   return vi.fn<GetSessionFn>().mockReturnValue({
     id: "session_xyz",
     continuationToken: "",
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return events;
     },

--- a/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
+++ b/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
@@ -95,6 +95,9 @@ function createCapturingRuntime(captured: CapturedRun[]): Runtime {
     async deliver() {
       throw new Error("deliver should not be called in this scenario");
     },
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return new ReadableStream();
     },

--- a/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
+++ b/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
@@ -73,6 +73,9 @@ function createCapturingRuntime(captured: CapturedRun[]): Runtime {
     async deliver() {
       throw new Error("deliver should not be called in this scenario");
     },
+    async getEventSnapshot() {
+      return { events: [], nextStreamIndex: 0 };
+    },
     async getEventStream() {
       return new ReadableStream<HandleMessageStreamEvent>();
     },


### PR DESCRIPTION
## What changed

- add a public finite `ClientSession.snapshot()` API that returns ordered events plus the resulting session state/cursor
- add a typed public `SessionNotReadyError` (HTTP 425, no-store) and bounded client retry for a just-created session
- make continuation sends resume-only so they never create a replacement parent
- expose the raw client continuation token to session handles and lifecycle hooks without application namespace parsing

## Why

Server-authoritative applications need to project a finite event suffix and authorize the short create-to-addressable window without copying Eve routes, adopting a live stream inside hooks, or keeping duplicate continuation-token authorities. The continuation client must also fail rather than silently fork a new parent.

Addresses #724 and #727.

## Validation

- focused Eve unit suites: 88/88
- hook lifecycle integration: 1/1 on Windows
- TypeScript: green on Node 24 under WSL
- production build and package: green
- `git diff --check`: green

The broader Windows unit run passes changed suites; unrelated existing path/bin tests remain platform-specific. Direct Linux integration config currently hits the repository's existing `#internal/workflow-bundle/workflow-builders.js` resolution failure, while the focused Windows integration tracer passes.