### PR TITLE
perf: only scan the run store when pruning dev-runtime snapshots

### DIFF
--- a/.changeset/eager-mice-brake.md
+++ b/.changeset/eager-mice-brake.md
@@ -1,0 +1,15 @@
+---
+"eve": patch
+---
+
+perf: only scan the run store when pruning dev-runtime snapshots
+
+`pruneDevelopmentRuntimeArtifactsSnapshots` walked the whole of `.workflow-data` and read every
+file under 1MB to find snapshot references, so `eve dev` boot cost grew with everything the local
+workflow world had ever written rather than with live work. Only runs carry a snapshot reference
+(via `input.serializedContext["eve.bundle"]`), and runs are a small minority of the store — the
+event, step, hook, stream, wait and lock directories were being read in full for nothing.
+
+Those directories are now skipped. On a store shaped like a reported one (10,885 files: ~78%
+events, ~13% steps, ~5% runs, ~4% hooks) the scan drops from 10,885 file reads to 500, and from
+~253ms to ~12ms.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -423,6 +423,74 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(staleSnapshotRoot)).toBe(false);
   });
 
+  it("only reads the run store when collecting protected snapshots", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-run-store-");
+    const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
+    const runReferencedSnapshotRoot = join(snapshotsRoot, "referenced-by-run");
+    const eventReferencedSnapshotRoot = join(snapshotsRoot, "referenced-by-event");
+    const oldSnapshotTime = new Date(1_000);
+    const now = 1_000_000;
+
+    for (const snapshotRoot of [runReferencedSnapshotRoot, eventReferencedSnapshotRoot]) {
+      await mkdir(snapshotRoot, { recursive: true });
+      await writeFile(join(snapshotRoot, "marker.txt"), snapshotRoot);
+      await utimes(snapshotRoot, oldSnapshotTime, oldSnapshotTime);
+    }
+
+    const workflowDataRoot = join(appRoot, ".workflow-data", "default");
+    await mkdir(join(workflowDataRoot, "runs"), { recursive: true });
+    await mkdir(join(workflowDataRoot, "events"), { recursive: true });
+
+    // A non-terminal run holds the only reference that should protect a snapshot.
+    await writeFile(
+      join(workflowDataRoot, "runs", "running-turn.json"),
+      `${JSON.stringify(
+        {
+          status: "running",
+          input: {
+            serializedContext: {
+              "eve.bundle": {
+                source: {
+                  appRoot: join(runReferencedSnapshotRoot, "source", "app").replaceAll("\\", "/"),
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    // The event store is the bulk of a real `.workflow-data` (an observed store was ~78% events)
+    // and never carries a snapshot reference, so the pruner must not spend a read on it. Writing
+    // a snapshot path here proves the directory is skipped: if it were still scanned, this
+    // snapshot would be protected and survive the prune.
+    await writeFile(
+      join(workflowDataRoot, "events", "turn-event.json"),
+      `${JSON.stringify(
+        {
+          eventType: "turn.completed",
+          payload: {
+            appRoot: join(eventReferencedSnapshotRoot, "source", "app").replaceAll("\\", "/"),
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    await pruneDevelopmentRuntimeArtifactsSnapshots({
+      appRoot,
+      now,
+      recentWindowMs: 0,
+      retainCount: 0,
+    });
+
+    expect(existsSync(runReferencedSnapshotRoot)).toBe(true);
+    expect(existsSync(eventReferencedSnapshotRoot)).toBe(false);
+  });
+
   it("removes a partially staged snapshot when staging fails", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-artifacts-failed-stage-");
     const agentRoot = join(appRoot, "agent");

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -13,6 +13,20 @@ const DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS = 15 * 60 * 1000;
 const DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT = 5;
 const DEV_RUNTIME_WORKFLOW_DATA_MAX_SCAN_BYTES = 1024 * 1024;
 const TERMINAL_WORKFLOW_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "canceled"]);
+/**
+ * Stores of `@workflow/world-local` that never reference a dev-runtime snapshot. A snapshot path
+ * only reaches disk through a run's `input.serializedContext["eve.bundle"]`, so these directories
+ * hold nothing the snapshot pruner needs — but they are where nearly all the files live, and each
+ * one was being read in full on every boot.
+ */
+const WORKFLOW_DATA_SNAPSHOTLESS_DIRECTORIES = new Set([
+  ".locks",
+  "events",
+  "hooks",
+  "steps",
+  "streams",
+  "waits",
+]);
 
 interface DevelopmentRuntimeArtifactsPointerV1 {
   readonly appRoot: string;
@@ -335,6 +349,15 @@ async function collectSnapshotPathsFromDirectory(input: {
       const path = join(input.directory, entry.name);
 
       if (entry.isDirectory()) {
+        // Only runs carry a snapshot reference (in `input.serializedContext["eve.bundle"]`), so
+        // descending into the other stores of the local workflow world just burns IO: they are
+        // the bulk of the files (an observed store was ~78% events, ~13% steps, ~4% hooks vs ~5%
+        // runs) and every one of them was being read in full on each boot. Skipping them by name
+        // keeps the scan proportional to runs instead of to everything ever written.
+        if (WORKFLOW_DATA_SNAPSHOTLESS_DIRECTORIES.has(entry.name)) {
+          return;
+        }
+
         await collectSnapshotPathsFromDirectory({
           directory: path,
           snapshotPaths: input.snapshotPaths,


### PR DESCRIPTION
Addresses the boot-time half of #474.

### The problem

`pruneDevelopmentRuntimeArtifactsSnapshots` protects snapshots that a still-running turn depends on. To find them it walks **all** of `.workflow-data` and `readFile`s every file under 1MB:

```ts
const source = await readFile(path, 'utf8');
if (!shouldScanWorkflowDataSource(source)) return;   // ← the filter runs *after* the read
```

So boot cost scales with everything the local workflow world has ever written, not with live work. The store in #474 had reached ~10,900 files, and a full read of it ran on every `eve dev` boot (and on every authored-source change, via `dev-authored-source-watcher`).

### The fix

A snapshot reference only reaches disk through a **run** — `input.serializedContext["eve.bundle"]`. The other stores of `@workflow/world-local` (`events`, `steps`, `hooks`, `streams`, `waits`, `.locks`) never carry one, and they are almost the entire store: the reported breakdown was **8,466 events / 1,460 steps / 459 hooks against 500 runs** — runs are ~5% of the files.

Those directories are now skipped by name, before any read happens. Runs are still scanned exactly as before, so nothing a live run depends on loses its protection.

### Measured

Rebuilt a store at the reported proportions (10,885 files) and ran the collector both ways:

| | files read | time |
|---|---|---|
| before | 10,885 | ~253 ms |
| after | **500** | **~12 ms** |

500 reads = exactly the run count, i.e. every run is still visited.

### Test

Added an integration test that pins both halves:

- a snapshot referenced by a **non-terminal run** survives the prune (no regression in protection)
- a snapshot path planted in the **event store** does *not* survive — which is what proves the directory is actually skipped

Verified by mutation: removing the skip makes exactly that new test fail, and the 13 pre-existing tests pass either way.

`pnpm vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts` → **14 passed**. oxlint and `tsc` clean. Patch changeset included.

### Not covered here

#474 also reports per-operation directory scans inside `@workflow/core`'s local queue, and runs stranded in `running` forever by killed dev servers. Both live outside this file — happy to take either as a follow-up if you'd like them split that way.