### PR TITLE
fix(docs): enable Copy Page markdown requests

### DIFF
--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -11,7 +11,7 @@ const proxy = createProxy({
 export const config = {
   // Matcher ignoring `/_next/`, `/api/`, public static assets, favicon, sitemap, robots, etc.
   matcher: [
-    "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|eve\\.tgz$|.*\\.[^/]+$).*)",
+    "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|eve\\.tgz$|.*\\.(?!mdx?$)[^/]+$).*)",
   ],
 };
 


### PR DESCRIPTION
## Summary

- allow documentation Markdown URLs through the docs proxy
- restore the Markdown fetch used by the Copy Page action

### Why this is needed

Copy Page requests the current documentation URL with a Markdown extension:

~~~text
/docs/introduction -> /docs/introduction.md
~~~

The proxy rewrites Markdown documentation requests to the corresponding llms.mdx route. Its matcher previously excluded every path with an extension, so the .md request bypassed that rewrite and returned the Next.js 404 page instead of Markdown.

### Matcher change

~~~ts
// Before: excludes every extension, including .md and .mdx
|.*\.[^/]+$

// After: still excludes static assets, but permits .md and .mdx
|.*\.(?!mdx?$)[^/]+$
~~~

That allows the intended rewrite:

~~~text
/docs/introduction.md -> /[lang]/llms.mdx/introduction
~~~

## Testing

- verified the matcher accepts .md and .mdx documentation URLs while excluding static assets and API routes
- manually confirmed Copy Page works locally

Closes #744