### PR TITLE
fix(eve): resume dev sessions on current artifacts

### DIFF
--- a/.changeset/bright-sessions-wait.md
+++ b/.changeset/bright-sessions-wait.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve dev runtime snapshots referenced by active between-turn sessions stored in the local Workflow world's serialized data format.

--- a/.changeset/bright-sessions-wait.md
+++ b/.changeset/bright-sessions-wait.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Preserve dev runtime snapshots referenced by active between-turn sessions stored in the local Workflow world's serialized data format.
+Resume ordinary local-dev follow-up turns with the current runtime artifacts while retaining old snapshots only for in-flight turns that still require them.

--- a/packages/eve/scripts/vendor-compiled/@workflow/core.mjs
+++ b/packages/eve/scripts/vendor-compiled/@workflow/core.mjs
@@ -112,6 +112,10 @@ export default {
       outputPath: "runtime",
     },
     {
+      input: "@workflow/core/serialization",
+      outputPath: "serialization",
+    },
+    {
       entry: "dist/private.js",
       outputPath: "private",
     },

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -7,6 +7,7 @@ import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
 import type { AgentLimitsDefinition } from "#shared/agent-definition.js";
 import type { JsonObject } from "#shared/json.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 
 export type { ContextAccessor } from "#context/key.js";
 export type { ChannelInstrumentationProjection } from "#channel/instrumentation.js";
@@ -118,6 +119,8 @@ export interface DeliverPayload {
  */
 export interface DeliverHookPayload {
   readonly auth?: SessionAuthContext | null;
+  /** Current request runtime artifacts used when starting a new turn. */
+  readonly compiledArtifactsSource?: RuntimeCompiledArtifactsSource;
   /** Inbound channel request id used only for workflow attributes. */
   readonly requestId?: string;
   readonly kind: "deliver";

--- a/packages/eve/src/execution/route-child-delivery.ts
+++ b/packages/eve/src/execution/route-child-delivery.ts
@@ -1,4 +1,5 @@
 import type { DeliverPayload, SessionAuthContext } from "#channel/types.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { coalesceDeliverPayloads } from "#execution/deliver-payloads.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { routeProxiedDeliverStep } from "#execution/workflow-steps.js";
@@ -15,6 +16,7 @@ import { routeProxiedDeliverStep } from "#execution/workflow-steps.js";
  */
 export async function routeDeliverToChildren(input: {
   readonly auth?: SessionAuthContext | null;
+  readonly compiledArtifactsSource?: RuntimeCompiledArtifactsSource;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly payloads: readonly DeliverPayload[];
   readonly sessionState: DurableSessionState;
@@ -24,6 +26,7 @@ export async function routeDeliverToChildren(input: {
 
   const routed = await routeProxiedDeliverStep({
     auth: input.auth,
+    compiledArtifactsSource: input.compiledArtifactsSource,
     parentWritable: input.parentWritable,
     payload,
     sessionState: input.sessionState,

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -225,6 +225,7 @@ async function waitForRuntimeActionResults(input: {
 
       const remainder = await routeDeliverToChildren({
         auth: value.delivery.auth,
+        compiledArtifactsSource: value.delivery.compiledArtifactsSource,
         parentWritable: input.cursor.parentWritable,
         payloads: value.delivery.payloads,
         sessionState: input.cursor.sessionState,

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -582,6 +582,94 @@ describe("workflowEntry", () => {
     expect(anchoredDispose).toHaveBeenCalledTimes(1);
   });
 
+  it("starts an ordinary follow-up turn with the request's current runtime artifacts", async () => {
+    const sessionState = createBaseSessionState();
+    const oldSource = {
+      appRoot: "/app/.eve/dev-runtime/snapshots/old/source/app",
+      kind: "disk" as const,
+      sandboxAppRoot: "/app",
+    };
+    const currentSource = {
+      appRoot: "/app/.eve/dev-runtime/snapshots/current/source/app",
+      kind: "disk" as const,
+      sandboxAppRoot: "/app",
+    };
+    const parkedContext = createSerializedContext({
+      "eve.bundle": { nodeId: "researcher", source: oldSource },
+    });
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      deliveryHooks: [
+        {
+          token: "http:test",
+          values: [
+            {
+              compiledArtifactsSource: currentSource,
+              kind: "deliver",
+              payloads: [{ message: "follow up" }],
+            },
+          ],
+        },
+      ],
+      turnControls: [
+        turnResult({ action: "park", serializedContext: parkedContext, sessionState }),
+        turnResult({ action: "done", output: "ok", sessionState }),
+      ],
+    });
+
+    await workflowEntry({
+      input: { message: "hello" },
+      serializedContext: createSerializedContext({ "eve.bundle": { source: oldSource } }),
+    });
+
+    expect(vi.mocked(dispatchTurnStep).mock.calls[1]?.[0].serializedContext).toEqual({
+      ...parkedContext,
+      "eve.bundle": { nodeId: "researcher", source: currentSource },
+    });
+  });
+
+  it("starts an input-response continuation with the request's current runtime artifacts", async () => {
+    const sessionState = createBaseSessionState();
+    const oldSource = {
+      appRoot: "/app/.eve/dev-runtime/snapshots/old/source/app",
+      kind: "disk" as const,
+    };
+    const currentSource = {
+      appRoot: "/app/.eve/dev-runtime/snapshots/current/source/app",
+      kind: "disk" as const,
+    };
+    const parkedContext = createSerializedContext({ "eve.bundle": { source: oldSource } });
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      deliveryHooks: [
+        {
+          token: "http:test",
+          values: [
+            {
+              compiledArtifactsSource: currentSource,
+              kind: "deliver",
+              payloads: [{ inputResponses: [{ requestId: "input-1", text: "yes" }] }],
+            },
+          ],
+        },
+      ],
+      turnControls: [
+        turnResult({ action: "park", serializedContext: parkedContext, sessionState }),
+        turnResult({ action: "done", output: "ok", sessionState }),
+      ],
+    });
+
+    await workflowEntry({
+      input: { message: "hello" },
+      serializedContext: createSerializedContext({ "eve.bundle": { source: oldSource } }),
+    });
+
+    expect(vi.mocked(dispatchTurnStep).mock.calls[1]?.[0].serializedContext).toEqual({
+      ...parkedContext,
+      "eve.bundle": { source: currentSource },
+    });
+  });
+
   it("recreates the delivery hook when a later turn re-keys the session", async () => {
     const baseSessionState = createBaseSessionState({ continuationToken: "slack:C01:" });
     const rekeyedSessionState: DurableSessionState = {

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -215,12 +215,14 @@ async function runDriverLoop(input: {
       if (action.authorizationNames && action.authorizationNames.length > 0) {
         const expected = action.authorizationNames.length;
         const allPayloads: DeliverPayload[] = [];
+        let compiledArtifactsSource: RuntimeCompiledArtifactsSource | undefined;
 
         while (allPayloads.length < expected) {
           const next = await authIterator.next();
           if (next.done) break;
           if (next.value.kind === "deliver") {
             allPayloads.push(...next.value.payloads);
+            compiledArtifactsSource = next.value.compiledArtifactsSource ?? compiledArtifactsSource;
           }
         }
 
@@ -229,13 +231,17 @@ async function runDriverLoop(input: {
           capabilities: input.capabilities,
           controlToken: nextTurnControlToken(),
           delivery: {
+            compiledArtifactsSource,
             kind: "deliver",
             payloads: allPayloads,
           },
           deliveryHook,
           mode: input.mode,
           parentWritable: input.driverWritable,
-          serializedContext: action.serializedContext,
+          serializedContext: refreshRuntimeArtifactsForTurn({
+            compiledArtifactsSource,
+            serializedContext: action.serializedContext,
+          }),
           sessionState: action.sessionState,
         });
         continue;
@@ -252,6 +258,7 @@ async function runDriverLoop(input: {
 
       const remainder = await routeDeliverToChildren({
         auth: nextDeliver.auth,
+        compiledArtifactsSource: nextDeliver.compiledArtifactsSource,
         parentWritable: input.driverWritable,
         payloads: nextDeliver.payloads,
         sessionState: action.sessionState,
@@ -268,6 +275,7 @@ async function runDriverLoop(input: {
         controlToken: nextTurnControlToken(),
         delivery: {
           auth: nextDeliver.auth,
+          compiledArtifactsSource: nextDeliver.compiledArtifactsSource,
           kind: "deliver",
           payloads: [remainder],
           requestId: nextDeliver.requestId,
@@ -275,7 +283,10 @@ async function runDriverLoop(input: {
         deliveryHook,
         mode: input.mode,
         parentWritable: input.driverWritable,
-        serializedContext: action.serializedContext,
+        serializedContext: refreshRuntimeArtifactsForTurn({
+          compiledArtifactsSource: nextDeliver.compiledArtifactsSource,
+          serializedContext: action.serializedContext,
+        }),
         sessionState: action.sessionState,
       });
     }
@@ -284,6 +295,28 @@ async function runDriverLoop(input: {
     await closeHookIterator(authIterator);
     await disposeHook(authHook);
   }
+}
+
+function refreshRuntimeArtifactsForTurn(input: {
+  readonly compiledArtifactsSource?: RuntimeCompiledArtifactsSource;
+  readonly serializedContext: Record<string, unknown>;
+}): Record<string, unknown> {
+  if (input.compiledArtifactsSource === undefined) {
+    return input.serializedContext;
+  }
+
+  const serializedBundle = input.serializedContext["eve.bundle"];
+  if (typeof serializedBundle !== "object" || serializedBundle === null) {
+    throw new Error('Cannot refresh runtime artifacts without serialized "eve.bundle" context.');
+  }
+
+  return {
+    ...input.serializedContext,
+    "eve.bundle": {
+      ...serializedBundle,
+      source: input.compiledArtifactsSource,
+    },
+  };
 }
 
 async function finalizeDone(input: {

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -55,8 +55,13 @@ describe("workflowEntryReference", () => {
 describe("createWorkflowRuntime#deliver", () => {
   const NOT_FOUND_TOKEN = "test:no-such-hook";
 
+  const compiledArtifactsSource: RuntimeCompiledArtifactsSource = {
+    appRoot: "/app/.eve/dev-runtime/snapshots/current/source/app",
+    kind: "disk",
+    sandboxAppRoot: "/app",
+  };
+
   function buildRuntime() {
-    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
     return createWorkflowRuntime({ compiledArtifactsSource });
   }
 
@@ -104,6 +109,7 @@ describe("createWorkflowRuntime#deliver", () => {
 
     expect(resumeHookMock).toHaveBeenCalledWith("test:token", {
       auth: null,
+      compiledArtifactsSource,
       kind: "deliver",
       payloads: [{ message: "hello" }],
       requestId: "req_deliver",
@@ -125,6 +131,7 @@ describe("createWorkflowRuntime#deliver", () => {
     expect(resumeHookMock).toHaveBeenCalledOnce();
     expect(resumeHookMock).toHaveBeenCalledWith("test:active-hook", {
       auth: null,
+      compiledArtifactsSource,
       kind: "deliver",
       payloads: [{ message: "hello" }],
     });

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -160,6 +160,7 @@ export function createWorkflowRuntime(config: {
     async deliver(input: DeliverInput): Promise<{ sessionId: string }> {
       const hookPayload: Extract<HookPayload, { kind: "deliver" }> = {
         auth: input.auth,
+        compiledArtifactsSource: config.compiledArtifactsSource,
         kind: "deliver",
         payloads: [input.payload],
         requestId: input.requestId,

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -26,6 +26,7 @@ import type { TokenUsage } from "#shared/token-usage.js";
 import type { JsonObject } from "#shared/json.js";
 import type { RunMode } from "#shared/run-mode.js";
 import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { createLogger, formatError } from "#internal/logging.js";
 import {
   createAuthorizationCompletedEvent,
@@ -548,6 +549,7 @@ export interface RoutedDeliverResult {
  */
 export async function routeProxiedDeliverStep(input: {
   readonly auth?: SessionAuthContext | null;
+  readonly compiledArtifactsSource?: RuntimeCompiledArtifactsSource;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly payload: DeliverPayload;
   readonly sessionState: DurableSessionState;
@@ -563,6 +565,7 @@ export async function routeProxiedDeliverStep(input: {
   for (const forChild of routed.forChildren) {
     await resumeHook(forChild.childContinuationToken, {
       auth: input.auth,
+      compiledArtifactsSource: input.compiledArtifactsSource,
       kind: "deliver",
       payloads: [forChild.payload],
     });

--- a/packages/eve/src/harness/messages.test.ts
+++ b/packages/eve/src/harness/messages.test.ts
@@ -1,6 +1,10 @@
 import type { FilePart, ModelMessage, UserContent } from "ai";
 import { describe, expect, it } from "vitest";
-import { coalesceTurnInputs, resolveAssistantStepText } from "#harness/messages.js";
+import {
+  coalesceDeliveries,
+  coalesceTurnInputs,
+  resolveAssistantStepText,
+} from "#harness/messages.js";
 import type { StepInput } from "#harness/types.js";
 
 function textFilePart(overrides: {
@@ -120,6 +124,33 @@ describe("coalesceTurnInputs", () => {
     const merged = result.message as UserContent;
     expect(merged).toHaveLength(1);
     expect(merged[0]).toBe(attachment);
+  });
+});
+
+describe("coalesceDeliveries", () => {
+  it("uses the newest runtime artifact source for buffered deliveries", () => {
+    const oldSource = { appRoot: "/snapshots/old", kind: "disk" as const };
+    const currentSource = { appRoot: "/snapshots/current", kind: "disk" as const };
+
+    expect(
+      coalesceDeliveries([
+        {
+          compiledArtifactsSource: oldSource,
+          kind: "deliver" as const,
+          payloads: [{ message: "first" }],
+        },
+        {
+          compiledArtifactsSource: currentSource,
+          kind: "deliver" as const,
+          payloads: [{ message: "second" }],
+        },
+      ]),
+    ).toEqual({
+      auth: undefined,
+      compiledArtifactsSource: currentSource,
+      kind: "deliver",
+      payloads: [{ message: "first" }, { message: "second" }],
+    });
   });
 });
 

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -3,6 +3,7 @@ import type { ModelMessage, TextPart, UserContent } from "ai";
 import type { DeliverPayload, SessionAuthContext } from "#channel/types.js";
 import type { InputResponse } from "#runtime/input/types.js";
 import type { StepInput } from "#harness/types.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 
 /**
  * Merges two {@link StepInput} values into one.
@@ -180,13 +181,14 @@ function toUserContentArray(value: string | UserContent): UserContentArray {
  */
 interface DeliverLike {
   readonly auth?: SessionAuthContext | null;
+  readonly compiledArtifactsSource?: RuntimeCompiledArtifactsSource;
   readonly kind: "deliver";
   readonly payloads: readonly DeliverPayload[];
 }
 
 /**
  * Coalesces an array of deliver-like items into a single item by
- * collecting all payloads and keeping the most recent auth value.
+ * collecting all payloads and keeping the most recent request metadata.
  *
  * Used by the workflow runtime to batch follow-up deliveries that
  * arrived while a turn or subagent delegation was in progress. Each
@@ -201,14 +203,18 @@ export function coalesceDeliveries<T extends DeliverLike>(items: readonly T[]): 
   }
 
   let auth = first.auth;
+  let compiledArtifactsSource = first.compiledArtifactsSource;
   const payloads = [...first.payloads];
 
   for (const item of rest) {
     if (item.auth !== undefined) {
       auth = item.auth;
     }
+    if (item.compiledArtifactsSource !== undefined) {
+      compiledArtifactsSource = item.compiledArtifactsSource;
+    }
     payloads.push(...item.payloads);
   }
 
-  return { ...first, auth, payloads };
+  return { ...first, auth, compiledArtifactsSource, payloads };
 }

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -6,7 +6,7 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { copyDevelopmentSourceSnapshot } from "#internal/nitro/dev-runtime-source-snapshot-copy.js";
 import { createDevelopmentSourceSnapshotPlan } from "#internal/nitro/dev-runtime-source-snapshot.js";
-import { collectActiveWorkflowSnapshotRoots } from "#internal/nitro/dev-runtime-workflow-snapshots.js";
+import { collectActiveTurnWorkflowSnapshotRoots } from "#internal/nitro/dev-runtime-workflow-snapshots.js";
 
 const DEV_RUNTIME_ARTIFACTS_DIRECTORY = "dev-runtime";
 const DEV_RUNTIME_ARTIFACTS_POINTER_VERSION = 2;
@@ -183,7 +183,7 @@ export async function pruneDevelopmentRuntimeArtifactsSnapshots(input: {
   );
   const protectedPaths = [
     ...collectProtectedSnapshotPaths(pointer),
-    ...(await collectActiveWorkflowSnapshotRoots({ appRoot: input.appRoot })),
+    ...(await collectActiveTurnWorkflowSnapshotRoots({ appRoot: input.appRoot })),
   ];
   const now = input.now ?? Date.now();
   const recentWindowMs = input.recentWindowMs ?? DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS;

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -6,13 +6,12 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { copyDevelopmentSourceSnapshot } from "#internal/nitro/dev-runtime-source-snapshot-copy.js";
 import { createDevelopmentSourceSnapshotPlan } from "#internal/nitro/dev-runtime-source-snapshot.js";
+import { collectActiveWorkflowSnapshotRoots } from "#internal/nitro/dev-runtime-workflow-snapshots.js";
 
 const DEV_RUNTIME_ARTIFACTS_DIRECTORY = "dev-runtime";
 const DEV_RUNTIME_ARTIFACTS_POINTER_VERSION = 2;
 const DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS = 15 * 60 * 1000;
 const DEV_RUNTIME_SNAPSHOT_RETAIN_COUNT = 5;
-const DEV_RUNTIME_WORKFLOW_DATA_MAX_SCAN_BYTES = 1024 * 1024;
-const TERMINAL_WORKFLOW_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "canceled"]);
 
 interface DevelopmentRuntimeArtifactsPointerV1 {
   readonly appRoot: string;
@@ -184,7 +183,7 @@ export async function pruneDevelopmentRuntimeArtifactsSnapshots(input: {
   );
   const protectedPaths = [
     ...collectProtectedSnapshotPaths(pointer),
-    ...(await collectWorkflowDataSnapshotPaths({ appRoot: input.appRoot, snapshotsDirectory })),
+    ...(await collectActiveWorkflowSnapshotRoots({ appRoot: input.appRoot })),
   ];
   const now = input.now ?? Date.now();
   const recentWindowMs = input.recentWindowMs ?? DEV_RUNTIME_SNAPSHOT_RECENT_WINDOW_MS;
@@ -295,121 +294,6 @@ function collectProtectedSnapshotPaths(
   }
 
   return [pointer.runtimeAppRoot, pointer.snapshotRoot];
-}
-
-async function collectWorkflowDataSnapshotPaths(input: {
-  readonly appRoot: string;
-  readonly snapshotsDirectory: string;
-}): Promise<readonly string[]> {
-  const workflowDataDirectory = join(input.appRoot, ".workflow-data");
-  const snapshotPaths = new Set<string>();
-
-  await collectSnapshotPathsFromDirectory({
-    directory: workflowDataDirectory,
-    snapshotPaths,
-    snapshotsDirectory: input.snapshotsDirectory,
-  });
-
-  return [...snapshotPaths];
-}
-
-async function collectSnapshotPathsFromDirectory(input: {
-  readonly directory: string;
-  readonly snapshotPaths: Set<string>;
-  readonly snapshotsDirectory: string;
-}): Promise<void> {
-  let entries: Dirent<string>[];
-
-  try {
-    entries = await readdir(input.directory, { withFileTypes: true });
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return;
-    }
-
-    throw error;
-  }
-
-  await Promise.all(
-    entries.map(async (entry) => {
-      const path = join(input.directory, entry.name);
-
-      if (entry.isDirectory()) {
-        await collectSnapshotPathsFromDirectory({
-          directory: path,
-          snapshotPaths: input.snapshotPaths,
-          snapshotsDirectory: input.snapshotsDirectory,
-        });
-        return;
-      }
-
-      if (!entry.isFile()) {
-        return;
-      }
-
-      const fileStats = await stat(path);
-      // Local workflow run payloads are small; keep this best-effort scan cheap.
-      if (fileStats.size > DEV_RUNTIME_WORKFLOW_DATA_MAX_SCAN_BYTES) {
-        return;
-      }
-
-      const source = await readFile(path, "utf8");
-      if (!shouldScanWorkflowDataSource(source)) {
-        return;
-      }
-
-      for (const snapshotPath of collectSnapshotPathsFromText(source, input.snapshotsDirectory)) {
-        input.snapshotPaths.add(snapshotPath);
-      }
-    }),
-  );
-}
-
-function collectSnapshotPathsFromText(
-  source: string,
-  snapshotsDirectory: string,
-): readonly string[] {
-  const snapshotPaths = new Set<string>();
-  const normalizedSnapshotsDirectory = snapshotsDirectory.replaceAll("\\", "/");
-  const pattern = new RegExp(`${escapeRegExp(normalizedSnapshotsDirectory)}/([^/"'\\s]+)`, "gu");
-  const normalizedSource = source.replaceAll("\\\\", "/").replaceAll("\\", "/");
-
-  for (const match of normalizedSource.matchAll(pattern)) {
-    const snapshotName = match[1];
-
-    if (snapshotName !== undefined && snapshotName.length > 0) {
-      snapshotPaths.add(join(snapshotsDirectory, snapshotName));
-    }
-  }
-
-  return [...snapshotPaths];
-}
-
-function shouldScanWorkflowDataSource(source: string): boolean {
-  const value = parseJsonObject(source);
-  if (value === undefined) {
-    return true;
-  }
-
-  const status = value.status;
-  return typeof status !== "string" || !TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
-}
-
-function parseJsonObject(source: string): Record<string, unknown> | undefined {
-  try {
-    const value = JSON.parse(source) as unknown;
-    return isObjectRecord(value) ? value : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function pathsOverlap(left: string, right: string): boolean {

--- a/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.integration.test.ts
@@ -1,0 +1,201 @@
+import { existsSync } from "node:fs";
+import { mkdir, readdir, utimes, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { dehydrateWorkflowArguments } from "#compiled/@workflow/core/serialization.js";
+import {
+  activateDevelopmentRuntimeArtifactsSnapshot,
+  pruneDevelopmentRuntimeArtifactsSnapshots,
+} from "#internal/nitro/dev-runtime-artifacts.js";
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+const createScratchDirectory = useTemporaryDirectories();
+const NOW = 1_000_000;
+const OLD_SNAPSHOT_TIME = new Date(1_000);
+
+describe("development runtime workflow snapshot retention", () => {
+  it("preserves compressed root and turn workflow snapshots without retaining terminal history", async () => {
+    const fixture = await createPruneFixture(["active-root", "active-turn", "completed", "stale"]);
+    const runsDirectory = join(fixture.appRoot, ".workflow-data", "default", "runs");
+    const eventsDirectory = join(fixture.appRoot, ".workflow-data", "default", "events");
+    await mkdir(runsDirectory, { recursive: true });
+    await mkdir(eventsDirectory, { recursive: true });
+
+    const rootInput = await serializeWorkflowInput({
+      serializedContext: createSerializedContext(fixture.snapshotRoots["active-root"]),
+    });
+    const turnInput = await serializeWorkflowInput({
+      stepInput: {
+        serializedContext: createSerializedContext(fixture.snapshotRoots["active-turn"]),
+      },
+    });
+    const completedInput = await serializeWorkflowInput({
+      serializedContext: createSerializedContext(fixture.snapshotRoots.completed),
+    });
+
+    await writeRun(runsDirectory, "active-root", {
+      input: encodeWorldLocalUint8Array(rootInput),
+      status: "running",
+      workflowName: "workflow//eve//workflowEntry",
+    });
+    await writeRun(runsDirectory, "active-turn", {
+      input: encodeWorldLocalUint8Array(turnInput),
+      status: "running",
+      workflowName: "workflow//eve//turnWorkflow",
+    });
+    await writeRun(runsDirectory, "completed", {
+      input: encodeWorldLocalUint8Array(completedInput),
+      status: "completed",
+      workflowName: "workflow//eve//workflowEntry",
+    });
+    await writeFile(
+      join(eventsDirectory, "completed-run-created.json"),
+      `${JSON.stringify({
+        eventData: { input: encodeWorldLocalUint8Array(completedInput) },
+        eventType: "run_created",
+        runId: "completed",
+      })}\n`,
+    );
+
+    await prune(fixture.appRoot);
+
+    await expect(readdir(fixture.snapshotsRoot)).resolves.toEqual(
+      expect.arrayContaining(["active", "active-root", "active-turn"]),
+    );
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "completed"))).toBe(false);
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "stale"))).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "invalid serialized input",
+      source: JSON.stringify({
+        input: {
+          __type: "Uint8Array",
+          data: Buffer.from("zstd-not-valid").toString("base64"),
+        },
+        runId: "uncertain",
+        status: "running",
+        workflowName: "workflow//eve//workflowEntry",
+      }),
+    },
+    {
+      name: "malformed run JSON",
+      source: '{"workflowName":"workflow//eve//workflowEntry",',
+    },
+  ])("aborts pruning for $name", async ({ source }) => {
+    const fixture = await createPruneFixture(["uncertain", "stale"]);
+    const runsDirectory = join(fixture.appRoot, ".workflow-data", "default", "runs");
+    await mkdir(runsDirectory, { recursive: true });
+    await writeFile(join(runsDirectory, "uncertain.json"), source);
+
+    await expect(prune(fixture.appRoot)).rejects.toThrow();
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "uncertain"))).toBe(true);
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "stale"))).toBe(true);
+  });
+});
+
+async function createPruneFixture(snapshotNames: readonly string[]): Promise<{
+  readonly appRoot: string;
+  readonly snapshotRoots: Readonly<Record<string, string>>;
+  readonly snapshotsRoot: string;
+}> {
+  const appRoot = await createScratchDirectory("eve-dev-runtime-workflow-snapshots-");
+  const snapshotsRoot = join(appRoot, ".eve", "dev-runtime", "snapshots");
+  const snapshotRoots = Object.fromEntries(
+    ["active", ...snapshotNames].map((name) => [name, join(snapshotsRoot, name)]),
+  );
+
+  for (const snapshotRoot of Object.values(snapshotRoots)) {
+    await mkdir(snapshotRoot, { recursive: true });
+    await writeFile(join(snapshotRoot, "marker.txt"), snapshotRoot);
+    await utimes(snapshotRoot, OLD_SNAPSHOT_TIME, OLD_SNAPSHOT_TIME);
+  }
+
+  const activeSnapshotRoot = snapshotRoots.active;
+  if (activeSnapshotRoot === undefined) {
+    throw new Error("Missing active snapshot fixture.");
+  }
+  await activateDevelopmentRuntimeArtifactsSnapshot({
+    appRoot,
+    snapshot: {
+      runtimeAppRoot: join(activeSnapshotRoot, "source", "app"),
+      snapshotRoot: activeSnapshotRoot,
+      snapshotSourceRoot: join(activeSnapshotRoot, "source"),
+    },
+  });
+
+  return { appRoot, snapshotRoots, snapshotsRoot };
+}
+
+async function serializeWorkflowInput(value: Record<string, unknown>): Promise<Uint8Array> {
+  const serialized = await dehydrateWorkflowArguments(
+    [{ ...value, padding: "x".repeat(3_000) }],
+    "wrun_test",
+    undefined,
+    [],
+    globalThis,
+    false,
+    false,
+    true,
+  );
+  if (!(serialized instanceof Uint8Array)) {
+    throw new Error("Expected Workflow arguments to serialize as Uint8Array.");
+  }
+  expect(Buffer.from(serialized).subarray(0, 4).toString("utf8")).toMatch(/^(gzip|zstd)$/);
+  return serialized;
+}
+
+function createSerializedContext(snapshotRoot: string | undefined): Record<string, unknown> {
+  if (snapshotRoot === undefined) {
+    throw new Error("Missing snapshot fixture.");
+  }
+  return {
+    "eve.bundle": {
+      source: {
+        appRoot: join(snapshotRoot, "source", "app"),
+        kind: "disk",
+      },
+    },
+  };
+}
+
+function requireSnapshotRoot(
+  snapshotRoots: Readonly<Record<string, string>>,
+  name: string,
+): string {
+  const snapshotRoot = snapshotRoots[name];
+  if (snapshotRoot === undefined) {
+    throw new Error(`Missing snapshot fixture "${name}".`);
+  }
+  return snapshotRoot;
+}
+
+function encodeWorldLocalUint8Array(value: Uint8Array): {
+  readonly __type: "Uint8Array";
+  readonly data: string;
+} {
+  return {
+    __type: "Uint8Array",
+    data: Buffer.from(value).toString("base64"),
+  };
+}
+
+async function writeRun(
+  runsDirectory: string,
+  runId: string,
+  run: Record<string, unknown>,
+): Promise<void> {
+  await writeFile(join(runsDirectory, `${runId}.json`), `${JSON.stringify({ ...run, runId })}\n`);
+}
+
+async function prune(appRoot: string): Promise<void> {
+  await pruneDevelopmentRuntimeArtifactsSnapshots({
+    appRoot,
+    now: NOW,
+    recentWindowMs: 0,
+    retainCount: 0,
+  });
+}

--- a/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.integration.test.ts
@@ -16,7 +16,7 @@ const NOW = 1_000_000;
 const OLD_SNAPSHOT_TIME = new Date(1_000);
 
 describe("development runtime workflow snapshot retention", () => {
-  it("preserves compressed root and turn workflow snapshots without retaining terminal history", async () => {
+  it("preserves compressed active turn snapshots without retaining parked roots or terminal history", async () => {
     const fixture = await createPruneFixture(["active-root", "active-turn", "completed", "stale"]);
     const runsDirectory = join(fixture.appRoot, ".workflow-data", "default", "runs");
     const eventsDirectory = join(fixture.appRoot, ".workflow-data", "default", "events");
@@ -62,9 +62,37 @@ describe("development runtime workflow snapshot retention", () => {
     await prune(fixture.appRoot);
 
     await expect(readdir(fixture.snapshotsRoot)).resolves.toEqual(
-      expect.arrayContaining(["active", "active-root", "active-turn"]),
+      expect.arrayContaining(["active", "active-turn"]),
     );
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "active-root"))).toBe(false);
     expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "completed"))).toBe(false);
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "stale"))).toBe(false);
+  });
+
+  it("does not let a broad disk app root protect the snapshots directory", async () => {
+    const fixture = await createPruneFixture(["stale"]);
+    const runsDirectory = join(fixture.appRoot, ".workflow-data", "default", "runs");
+    await mkdir(runsDirectory, { recursive: true });
+    const turnInput = await serializeWorkflowInput({
+      stepInput: {
+        serializedContext: {
+          "eve.bundle": {
+            source: {
+              appRoot: fixture.snapshotsRoot,
+              kind: "disk",
+            },
+          },
+        },
+      },
+    });
+    await writeRun(runsDirectory, "broad-root", {
+      input: encodeWorldLocalUint8Array(turnInput),
+      status: "running",
+      workflowName: "workflow//eve//turnWorkflow",
+    });
+
+    await prune(fixture.appRoot);
+
     expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "stale"))).toBe(false);
   });
 
@@ -78,22 +106,31 @@ describe("development runtime workflow snapshot retention", () => {
         },
         runId: "uncertain",
         status: "running",
-        workflowName: "workflow//eve//workflowEntry",
+        workflowName: "workflow//eve//turnWorkflow",
       }),
     },
     {
       name: "malformed run JSON",
       source: '{"workflowName":"workflow//eve//workflowEntry",',
     },
-  ])("aborts pruning for $name", async ({ source }) => {
+    {
+      name: "unknown run status",
+      source: JSON.stringify({
+        input: {},
+        status: "unknown",
+        workflowName: "workflow//eve//turnWorkflow",
+      }),
+    },
+  ])("does not let $name disable pruning", async ({ source }) => {
     const fixture = await createPruneFixture(["uncertain", "stale"]);
     const runsDirectory = join(fixture.appRoot, ".workflow-data", "default", "runs");
     await mkdir(runsDirectory, { recursive: true });
     await writeFile(join(runsDirectory, "uncertain.json"), source);
 
-    await expect(prune(fixture.appRoot)).rejects.toThrow();
-    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "uncertain"))).toBe(true);
-    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "stale"))).toBe(true);
+    await prune(fixture.appRoot);
+
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "uncertain"))).toBe(false);
+    expect(existsSync(requireSnapshotRoot(fixture.snapshotRoots, "stale"))).toBe(false);
   });
 });
 

--- a/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.ts
@@ -1,12 +1,12 @@
 import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { hydrateWorkflowArguments } from "#compiled/@workflow/core/serialization.js";
 
-const EVE_WORKFLOW_NAME_PREFIX = "workflow//eve//";
-const TERMINAL_WORKFLOW_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "canceled"]);
+const EVE_TURN_WORKFLOW_NAME = "workflow//eve//turnWorkflow";
+const ACTIVE_WORKFLOW_RUN_STATUSES = new Set(["pending", "running"]);
 
-export async function collectActiveWorkflowSnapshotRoots(input: {
+export async function collectActiveTurnWorkflowSnapshotRoots(input: {
   readonly appRoot: string;
 }): Promise<readonly string[]> {
   const workflowDataDirectory = join(input.appRoot, ".workflow-data");
@@ -24,9 +24,10 @@ export async function collectActiveWorkflowSnapshotRoots(input: {
           runEntries
             .filter((runEntry) => runEntry.isFile())
             .map(async (runEntry) => {
-              const snapshotRoot = await readActiveWorkflowSnapshotRoot(
-                join(runsDirectory, runEntry.name),
-              );
+              const snapshotRoot = await readActiveTurnWorkflowSnapshotRoot({
+                path: join(runsDirectory, runEntry.name),
+                snapshotsDirectory: join(input.appRoot, ".eve", "dev-runtime", "snapshots"),
+              });
               if (snapshotRoot !== undefined) {
                 snapshotRoots.add(snapshotRoot);
               }
@@ -38,35 +39,39 @@ export async function collectActiveWorkflowSnapshotRoots(input: {
   return [...snapshotRoots];
 }
 
-async function readActiveWorkflowSnapshotRoot(path: string): Promise<string | undefined> {
-  const run = parseRunRecord(await readFile(path, "utf8"), path);
-  if (!isEveWorkflowRun(run) || isTerminalWorkflowRun(run.status)) {
+async function readActiveTurnWorkflowSnapshotRoot(input: {
+  readonly path: string;
+  readonly snapshotsDirectory: string;
+}): Promise<string | undefined> {
+  const run = parseRunRecord(await readFile(input.path, "utf8"));
+  if (run === undefined || !isActiveEveTurnWorkflowRun(run)) {
     return undefined;
   }
 
   const serializedInput = parseWorldLocalUint8Array(run.input);
   if (serializedInput === undefined) {
-    return readDiskArtifactAppRoot(run.input, path);
+    return readDiskArtifactSnapshotRoot(run.input, input.snapshotsDirectory);
   }
 
-  let workflowInput: unknown;
   try {
-    workflowInput = await hydrateWorkflowArguments(
+    const workflowInput = await hydrateWorkflowArguments(
       serializedInput,
       typeof run.runId === "string" ? run.runId : "",
       undefined,
     );
-  } catch (error) {
-    throw new Error(`Cannot decode active eve workflow run "${path}".`, { cause: error });
+    return readDiskArtifactSnapshotRoot(workflowInput, input.snapshotsDirectory);
+  } catch {
+    return undefined;
   }
-
-  return readDiskArtifactAppRoot(workflowInput, path);
 }
 
-function readDiskArtifactAppRoot(value: unknown, path: string): string | undefined {
+function readDiskArtifactSnapshotRoot(
+  value: unknown,
+  snapshotsDirectory: string,
+): string | undefined {
   const workflowInput = Array.isArray(value) ? value[0] : value;
   if (!isObjectRecord(workflowInput)) {
-    throw new Error(`Active eve workflow run "${path}" has invalid input.`);
+    return undefined;
   }
 
   const stepInput = workflowInput.stepInput;
@@ -74,23 +79,34 @@ function readDiskArtifactAppRoot(value: unknown, path: string): string | undefin
     ? stepInput.serializedContext
     : workflowInput.serializedContext;
   if (!isObjectRecord(serializedContext)) {
-    throw new Error(`Active eve workflow run "${path}" has no serialized context.`);
+    return undefined;
   }
 
   const bundle = serializedContext["eve.bundle"];
   if (!isObjectRecord(bundle) || !isObjectRecord(bundle.source)) {
-    throw new Error(`Active eve workflow run "${path}" has no serialized bundle source.`);
+    return undefined;
   }
 
   const source = bundle.source;
-  if (source.kind !== "disk") {
+  if (source.kind !== "disk" || typeof source.appRoot !== "string" || source.appRoot.length === 0) {
     return undefined;
   }
-  if (typeof source.appRoot !== "string" || source.appRoot.length === 0) {
-    throw new Error(`Active eve workflow run "${path}" has an invalid disk artifact root.`);
+
+  const normalizedAppRoot = source.appRoot.replaceAll("\\", sep);
+  const relativeAppRoot = relative(resolve(snapshotsDirectory), resolve(normalizedAppRoot));
+  if (
+    relativeAppRoot.length === 0 ||
+    relativeAppRoot === ".." ||
+    relativeAppRoot.startsWith(`..${sep}`) ||
+    isAbsolute(relativeAppRoot)
+  ) {
+    return undefined;
   }
 
-  return source.appRoot.replaceAll("\\", "/");
+  const [snapshotName, sourceDirectory] = relativeAppRoot.split(sep);
+  return snapshotName === undefined || snapshotName.length === 0 || sourceDirectory !== "source"
+    ? undefined
+    : join(snapshotsDirectory, snapshotName);
 }
 
 function parseWorldLocalUint8Array(value: unknown): Uint8Array | undefined {
@@ -101,18 +117,18 @@ function parseWorldLocalUint8Array(value: unknown): Uint8Array | undefined {
   return Buffer.from(value.data, "base64");
 }
 
-function isEveWorkflowRun(run: Record<string, unknown>): boolean {
+function isActiveEveTurnWorkflowRun(run: Record<string, unknown>): boolean {
   const workflowName =
     typeof run.workflowName === "string"
       ? run.workflowName
       : typeof run.workflowId === "string"
         ? run.workflowId
         : undefined;
-  return workflowName?.startsWith(EVE_WORKFLOW_NAME_PREFIX) === true;
-}
-
-function isTerminalWorkflowRun(status: unknown): boolean {
-  return typeof status === "string" && TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
+  return (
+    workflowName === EVE_TURN_WORKFLOW_NAME &&
+    typeof run.status === "string" &&
+    ACTIVE_WORKFLOW_RUN_STATUSES.has(run.status)
+  );
 }
 
 async function readDirectoryEntries(path: string) {
@@ -126,18 +142,13 @@ async function readDirectoryEntries(path: string) {
   }
 }
 
-function parseRunRecord(source: string, path: string): Record<string, unknown> {
-  let value: unknown;
+function parseRunRecord(source: string): Record<string, unknown> | undefined {
   try {
-    value = JSON.parse(source) as unknown;
-  } catch (error) {
-    throw new Error(`Cannot parse workflow run "${path}".`, { cause: error });
+    const value = JSON.parse(source) as unknown;
+    return isObjectRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
   }
-
-  if (!isObjectRecord(value)) {
-    throw new Error(`Workflow run "${path}" is not a JSON object.`);
-  }
-  return value;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-workflow-snapshots.ts
@@ -1,0 +1,145 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { hydrateWorkflowArguments } from "#compiled/@workflow/core/serialization.js";
+
+const EVE_WORKFLOW_NAME_PREFIX = "workflow//eve//";
+const TERMINAL_WORKFLOW_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "canceled"]);
+
+export async function collectActiveWorkflowSnapshotRoots(input: {
+  readonly appRoot: string;
+}): Promise<readonly string[]> {
+  const workflowDataDirectory = join(input.appRoot, ".workflow-data");
+  const storeEntries = await readDirectoryEntries(workflowDataDirectory);
+  const snapshotRoots = new Set<string>();
+
+  await Promise.all(
+    storeEntries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const runsDirectory = join(workflowDataDirectory, entry.name, "runs");
+        const runEntries = await readDirectoryEntries(runsDirectory);
+
+        await Promise.all(
+          runEntries
+            .filter((runEntry) => runEntry.isFile())
+            .map(async (runEntry) => {
+              const snapshotRoot = await readActiveWorkflowSnapshotRoot(
+                join(runsDirectory, runEntry.name),
+              );
+              if (snapshotRoot !== undefined) {
+                snapshotRoots.add(snapshotRoot);
+              }
+            }),
+        );
+      }),
+  );
+
+  return [...snapshotRoots];
+}
+
+async function readActiveWorkflowSnapshotRoot(path: string): Promise<string | undefined> {
+  const run = parseRunRecord(await readFile(path, "utf8"), path);
+  if (!isEveWorkflowRun(run) || isTerminalWorkflowRun(run.status)) {
+    return undefined;
+  }
+
+  const serializedInput = parseWorldLocalUint8Array(run.input);
+  if (serializedInput === undefined) {
+    return readDiskArtifactAppRoot(run.input, path);
+  }
+
+  let workflowInput: unknown;
+  try {
+    workflowInput = await hydrateWorkflowArguments(
+      serializedInput,
+      typeof run.runId === "string" ? run.runId : "",
+      undefined,
+    );
+  } catch (error) {
+    throw new Error(`Cannot decode active eve workflow run "${path}".`, { cause: error });
+  }
+
+  return readDiskArtifactAppRoot(workflowInput, path);
+}
+
+function readDiskArtifactAppRoot(value: unknown, path: string): string | undefined {
+  const workflowInput = Array.isArray(value) ? value[0] : value;
+  if (!isObjectRecord(workflowInput)) {
+    throw new Error(`Active eve workflow run "${path}" has invalid input.`);
+  }
+
+  const stepInput = workflowInput.stepInput;
+  const serializedContext = isObjectRecord(stepInput)
+    ? stepInput.serializedContext
+    : workflowInput.serializedContext;
+  if (!isObjectRecord(serializedContext)) {
+    throw new Error(`Active eve workflow run "${path}" has no serialized context.`);
+  }
+
+  const bundle = serializedContext["eve.bundle"];
+  if (!isObjectRecord(bundle) || !isObjectRecord(bundle.source)) {
+    throw new Error(`Active eve workflow run "${path}" has no serialized bundle source.`);
+  }
+
+  const source = bundle.source;
+  if (source.kind !== "disk") {
+    return undefined;
+  }
+  if (typeof source.appRoot !== "string" || source.appRoot.length === 0) {
+    throw new Error(`Active eve workflow run "${path}" has an invalid disk artifact root.`);
+  }
+
+  return source.appRoot.replaceAll("\\", "/");
+}
+
+function parseWorldLocalUint8Array(value: unknown): Uint8Array | undefined {
+  if (!isObjectRecord(value) || value.__type !== "Uint8Array" || typeof value.data !== "string") {
+    return undefined;
+  }
+
+  return Buffer.from(value.data, "base64");
+}
+
+function isEveWorkflowRun(run: Record<string, unknown>): boolean {
+  const workflowName =
+    typeof run.workflowName === "string"
+      ? run.workflowName
+      : typeof run.workflowId === "string"
+        ? run.workflowId
+        : undefined;
+  return workflowName?.startsWith(EVE_WORKFLOW_NAME_PREFIX) === true;
+}
+
+function isTerminalWorkflowRun(status: unknown): boolean {
+  return typeof status === "string" && TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
+}
+
+async function readDirectoryEntries(path: string) {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function parseRunRecord(source: string, path: string): Record<string, unknown> {
+  let value: unknown;
+  try {
+    value = JSON.parse(source) as unknown;
+  } catch (error) {
+    throw new Error(`Cannot parse workflow run "${path}".`, { cause: error });
+  }
+
+  if (!isObjectRecord(value)) {
+    throw new Error(`Workflow run "${path}" is not a JSON object.`);
+  }
+  return value;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/eve/src/protocol/routes.ts
+++ b/packages/eve/src/protocol/routes.ts
@@ -77,8 +77,8 @@ export function createEveDevDispatchSchedulePath(scheduleId: string): string {
  * during in-turn interactive connection authorization.
  *
  * `:name` is the connection name; `:token` is the workflow hook token minted
- * by the workflow body so the route handler can resume the suspended turn
- * via `resumeHook(token, payload)`.
+ * by the workflow body so the route handler can deliver the callback through
+ * the current request runtime.
  *
  * The route is unauthenticated by design: an OAuth IdP follows this URL
  * via a 3xx redirect from the user's browser with no eve credentials
@@ -117,8 +117,8 @@ export function createEveContinueSessionRoutePath(sessionId: string): string {
  * The workflow body builds this path against {@link EVE_ROUTE_PREFIX} when
  * minting the redirect URL it hands to the IdP via `startAuthorization`.
  * The runtime's framework callback route handler matches the same path
- * pattern and forwards the projected request payload into
- * `resumeHook(token, payload)`.
+ * pattern and forwards the projected request payload through the current
+ * request runtime.
  */
 export function createEveConnectionCallbackRoutePath(name: string, token: string): string {
   return `${EVE_ROUTE_PREFIX}/connections/${encodeURIComponent(name)}/callback/${encodeURIComponent(token)}`;

--- a/packages/eve/src/runtime/connections/callback-route.test.ts
+++ b/packages/eve/src/runtime/connections/callback-route.test.ts
@@ -12,15 +12,17 @@ import {
   HTTP_CONNECTION_CALLBACK_CHANNEL_NAME_PREFIX,
 } from "#runtime/connections/callback-route.js";
 
-const resumeHookMock = vi.fn();
-
-vi.mock("#compiled/@workflow/core/runtime.js", () => ({
-  resumeHook: (token: string, payload: unknown) => resumeHookMock(token, payload),
-}));
+const deliverMock = vi.fn();
 
 function buildRouteContext(params: Readonly<Record<string, string>>): RouteContext {
   return {
-    agent: {} as RouteContext["agent"],
+    agent: {
+      deliver: (input) => deliverMock(input),
+      getEventStream: async () => new ReadableStream(),
+      run: async () => {
+        throw new Error("Unexpected callback route run.");
+      },
+    },
     waitUntil: () => {},
     params,
     requestIp: null,
@@ -62,7 +64,7 @@ describe("getConnectionCallbackChannelNames", () => {
 
 describe("handleConnectionCallbackRequest", () => {
   beforeEach(() => {
-    resumeHookMock.mockReset();
+    deliverMock.mockReset();
   });
 
   it("rejects requests with a missing connection name with 400", async () => {
@@ -71,7 +73,7 @@ describe("handleConnectionCallbackRequest", () => {
       buildRouteContext({ token: "tok" }),
     );
     expect(response.status).toBe(400);
-    expect(resumeHookMock).not.toHaveBeenCalled();
+    expect(deliverMock).not.toHaveBeenCalled();
   });
 
   it("rejects requests with a missing token with 400", async () => {
@@ -80,11 +82,11 @@ describe("handleConnectionCallbackRequest", () => {
       buildRouteContext({ name: "linear" }),
     );
     expect(response.status).toBe(400);
-    expect(resumeHookMock).not.toHaveBeenCalled();
+    expect(deliverMock).not.toHaveBeenCalled();
   });
 
-  it("forwards a GET callback into resumeHook as parsed params with no request headers", async () => {
-    resumeHookMock.mockResolvedValueOnce(undefined);
+  it("delivers a GET callback through the current request runtime", async () => {
+    deliverMock.mockResolvedValueOnce({ sessionId: "session-1" });
     const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "tok123")}?code=abc&state=xyz`;
     const response = await handleConnectionCallbackRequest(
       new Request(url, {
@@ -99,29 +101,23 @@ describe("handleConnectionCallbackRequest", () => {
     const body = await response.text();
     expect(body).toContain("Authorization complete");
 
-    expect(resumeHookMock).toHaveBeenCalledTimes(1);
-    const [token, payload] = resumeHookMock.mock.calls[0] ?? [];
-    expect(token).toBe("tok123");
-    // Exact match: only parsed params + method cross into the hook
-    // payload. The inbound `x-probe` header (and any `Cookie`) is dropped.
-    expect(payload).toEqual({
-      kind: "deliver",
-      payloads: [
-        {
-          authorizationCallback: {
-            connectionName: "linear",
-            callback: {
-              params: { code: "abc", state: "xyz" },
-              method: "GET",
-            },
+    expect(deliverMock).toHaveBeenCalledTimes(1);
+    expect(deliverMock).toHaveBeenCalledWith({
+      continuationToken: "tok123",
+      payload: {
+        authorizationCallback: {
+          connectionName: "linear",
+          callback: {
+            params: { code: "abc", state: "xyz" },
+            method: "GET",
           },
         },
-      ],
+      },
     });
   });
 
-  it("captures form-encoded POST bodies before resuming the hook", async () => {
-    resumeHookMock.mockResolvedValueOnce(undefined);
+  it("captures form-encoded POST bodies before delivering the callback", async () => {
+    deliverMock.mockResolvedValueOnce({ sessionId: "session-1" });
     const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "tok123")}`;
     await handleConnectionCallbackRequest(
       new Request(url, {
@@ -132,29 +128,23 @@ describe("handleConnectionCallbackRequest", () => {
       buildRouteContext({ name: "linear", token: "tok123" }),
     );
 
-    const [, payload] = resumeHookMock.mock.calls[0] ?? [];
-    expect(payload).toEqual({
-      kind: "deliver",
-      payloads: [
-        {
-          authorizationCallback: {
-            connectionName: "linear",
-            callback: {
-              params: { code: "abc", state: "xyz" },
-              method: "POST",
-              body: "code=abc&state=xyz",
-            },
+    expect(deliverMock).toHaveBeenCalledWith({
+      continuationToken: "tok123",
+      payload: {
+        authorizationCallback: {
+          connectionName: "linear",
+          callback: {
+            params: { code: "abc", state: "xyz" },
+            method: "POST",
+            body: "code=abc&state=xyz",
           },
         },
-      ],
+      },
     });
   });
 
   it("returns 404 when the workflow runtime reports no hook for the supplied token", async () => {
-    // `resumeHook` throws when no workflow run is currently waiting on
-    // the supplied token, e.g. the workflow already completed,
-    // disposed the hook, or the user replayed a stale callback URL.
-    resumeHookMock.mockRejectedValueOnce(new Error("hook not found"));
+    deliverMock.mockRejectedValueOnce(new Error("hook not found"));
     const response = await handleConnectionCallbackRequest(
       new Request(
         `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "tok")}`,

--- a/packages/eve/src/runtime/connections/callback-route.ts
+++ b/packages/eve/src/runtime/connections/callback-route.ts
@@ -10,7 +10,8 @@
  *
  * 1. Parses the inbound request into a JSON-serializable
  *    {@link AuthorizationCallback} (params only — never request headers).
- * 2. Calls `resumeHook(token, payload)` to wake the suspended workflow.
+ * 2. Delivers the callback through the current request runtime so the resumed
+ *    turn uses the current compiled artifacts.
  * 3. Renders the standard "Authorization complete" landing page so the
  *    user sees a friendly UI instead of an empty `202 Accepted`.
  *
@@ -22,7 +23,6 @@
  * internet.
  */
 
-import { resumeHook } from "#internal/workflow/runtime.js";
 import { EVE_CONNECTION_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
 import type { ChannelMethod, RouteContext } from "#public/definitions/channel.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
@@ -112,9 +112,9 @@ export async function handleConnectionCallbackRequest(
   // this hook upfront (before any turns run) so it always exists
   // when the callback arrives.
   try {
-    await resumeHook(token, {
-      kind: "deliver" as const,
-      payloads: [{ authorizationCallback: { connectionName: name, callback } }],
+    await ctx.agent.deliver({
+      continuationToken: token,
+      payload: { authorizationCallback: { connectionName: name, callback } },
     });
   } catch {
     return Response.json({ error: "Connection callback not pending.", ok: false }, { status: 404 });

--- a/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
@@ -155,15 +155,22 @@ describe("compiled vendor assets", () => {
     expect(forwardedLogs).toEqual(["warn:eve vendoring warning", "error:dependency build failure"]);
   });
 
-  it("copies @workflow/core declaration files from the installed package", async () => {
-    const [indexDts, createHookDts, workflowDts, workflowIndexDts, runtimeRunDts] =
-      await Promise.all([
-        readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/index.d.ts"), "utf8"),
-        readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/create-hook.d.ts"), "utf8"),
-        readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/workflow.d.ts"), "utf8"),
-        readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/workflow/index.d.ts"), "utf8"),
-        readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/runtime/run.d.ts"), "utf8"),
-      ]);
+  it("copies @workflow/core declaration files and serialization runtime", async () => {
+    const [
+      indexDts,
+      createHookDts,
+      workflowDts,
+      workflowIndexDts,
+      runtimeRunDts,
+      serializationRuntime,
+    ] = await Promise.all([
+      readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/index.d.ts"), "utf8"),
+      readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/create-hook.d.ts"), "utf8"),
+      readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/workflow.d.ts"), "utf8"),
+      readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/workflow/index.d.ts"), "utf8"),
+      readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/runtime/run.d.ts"), "utf8"),
+      readFile(join(COMPILED_VENDOR_ROOT, "@workflow/core/serialization.js"), "utf8"),
+    ]);
 
     expect(indexDts).toContain("Just the core utilities");
     expect(indexDts).toContain("from '#compiled/@workflow/errors/index.js'");
@@ -171,6 +178,7 @@ describe("compiled vendor assets", () => {
     expect(workflowDts).toBe(`export * from "./workflow/index.js";\n`);
     expect(workflowIndexDts).toContain("from '#compiled/@workflow/errors/index.js'");
     expect(runtimeRunDts).toContain("from '../_workflow-serde.js'");
+    expect(serializationRuntime).toContain("hydrateWorkflowArguments");
   });
 
   it("vendors the Workflow world targets selected by generated Nitro plugins", async () => {


### PR DESCRIPTION
## What

A parked local-dev session kept the immutable snapshot path from its first turn. Once that revision fell outside the five-snapshot and 15-minute pruning windows, the next message failed before model execution with `LoadCompiledManifestError` because its compiled manifest had been deleted.

This change gives each newly dispatched turn the artifact source resolved for the current request. That applies to ordinary messages, input responses, OAuth callbacks, and deliveries routed to delegated children. Conversation state stays durable, but a parked root session no longer owns its creation snapshot forever.

Active `turnWorkflow` runs still need their exact input while they are executing or replaying. The pruning adapter decodes Workflow's compressed local run input and protects only validated snapshot roots referenced by parseable `pending` or `running` turn records. Parked roots, terminal runs, malformed records, undecodable records, unknown statuses, and paths outside the expected `<snapshots>/<revision>/source/...` shape do not retain snapshots or disable cleanup.

The earlier alternative was to protect every nonterminal root workflow. That would make abandoned sessions permanent snapshot leases and defeat the pruning policy, so this PR does not do that.

The Workflow serialization entry is vendored because local run inputs may be gzip or zstd encoded. A patch changeset is included.

Closes #714.
