### PR TITLE
[docs] Round the docs homepage CTA button and align its section

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/cta.tsx
+++ b/apps/docs/app/[lang]/(home)/components/cta.tsx
@@ -3,13 +3,15 @@ import Link from "next/link";
 
 export function CTA() {
   return (
-    <section className="flex flex-col items-center justify-between gap-4 px-8 py-10 md:flex-row sm:px-12">
-      <h2 className="font-medium! text-heading-32 tracking-tighter text-gray-1000 sm:text-heading-40">
-        Build your first agent today.
-      </h2>
-      <Button asChild size="lg" className="w-fit text-base h-12">
-        <Link href="/docs/getting-started">Get started</Link>
-      </Button>
+    <section className="px-4 py-10">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 md:flex-row">
+        <h2 className="font-medium! text-heading-32 tracking-tighter text-gray-1000 sm:text-heading-40">
+          Build your first agent today.
+        </h2>
+        <Button asChild size="lg" className="w-fit text-base h-12 rounded-full">
+          <Link href="/docs/getting-started">Get started</Link>
+        </Button>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Small homepage polish on the docs site.

- Make the "Get started" button `rounded-full` (to match the footer style of vercel.com)
- Drop the CTA section's extra horizontal padding and wrap its content in the same `mx-auto max-w-5xl` container the other homepage sections use, so its edges line up with them

| **Before**  | **After** |
| ------------- | ------------- |
| <img width="1500" alt="CleanShot 2026-07-13 at 22 58 21@2x" src="https://github.com/user-attachments/assets/0e794ddb-3dea-4dcd-9be4-bc2a7cd0900c" /> | <img width="1500" alt="CleanShot 2026-07-13 at 22 57 02@2x" src="https://github.com/user-attachments/assets/bbddda38-2fcc-4b0e-bc70-410cc1d410c0" />  |