### PR TITLE
test(eve): pin Teams thread continuation

### DIFF
--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -207,6 +207,31 @@ describe("teamsChannel", () => {
     });
   });
 
+  it("keeps a channel thread token stable when follow-ups omit replyToId", async () => {
+    const channel = teamsChannel({
+      credentials: { webhookVerifier: () => true },
+      onMessage: () => ({ auth: null }),
+    });
+    const initial = messageActivity({ conversationType: "channel" });
+    initial.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
+    initial.id = "THREAD_ROOT";
+    const followUp = messageActivity({ conversationType: "channel" });
+    followUp.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
+    followUp.id = "FOLLOW_UP_ACTIVITY";
+
+    const initialRequest = await firePost(channel, initial);
+    const followUpRequest = await firePost(channel, followUp);
+    const initialOptions = initialRequest.send.mock.calls[0]![1] as {
+      readonly continuationToken: string;
+    };
+
+    expect(followUpRequest.send.mock.calls[0]![1]).toMatchObject({
+      continuationToken: initialOptions.continuationToken,
+      state: { replyToActivityId: "THREAD_ROOT" },
+    });
+    expect(initialOptions.continuationToken).toBe("TENANT:CONV:THREAD_ROOT");
+  });
+
   it("receive starts proactive sessions and anchors initial channel messages", async () => {
     const requests: Array<{ body: unknown; url: string }> = [];
     const channel = teamsChannel({


### PR DESCRIPTION
## What

- send an initial Teams channel activity and a follow-up with no `replyToId`
- assert that both activities address the same eve continuation
- assert that channel state remains anchored to the thread root

## Regression boundary

Before #754, Teams fell back from a missing `replyToId` to the current activity ID. A follow-up in the same channel thread therefore produced a new continuation token and lost the prior session. #754 fixed the normalization on `main`, but its tests do not compare the initial and follow-up activities as one continuity contract.

This test fails on the parent of #754 with `FOLLOW_UP_ACTIVITY` in the token and passes on current `main` with `THREAD_ROOT`. There is no second production change or changeset.

Closes #211.