### PR TITLE
feat(eve): accept per-selection reasoning in dynamic model selection (#629)

### DIFF
--- a/.changeset/dynamic-model-selection-reasoning.md
+++ b/.changeset/dynamic-model-selection-reasoning.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Dynamic model selection now accepts a per-selection `reasoning` field alongside `model`, `modelContextWindowTokens`, and `modelOptions`. A `defineDynamic` resolver can return `{ model, reasoning }` to override the agent-level reasoning effort for the selected model (for example, dropping a downshifted classifier to `low`); omitting it keeps the agent-level `reasoning`.

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -80,10 +80,14 @@ selection object, or `null` to leave the scope unset.
   credentials fails at request time.
 - **Serialization.** Session/turn selections must be model id strings; return
   live `LanguageModel` objects only from `step.started`.
-- **Selection object.** `{ model, modelContextWindowTokens?, modelOptions? }`.
+- **Selection object.** `{ model, modelContextWindowTokens?, modelOptions?, reasoning? }`.
   Set `modelContextWindowTokens` when the selected model's window differs
   from the fallback's — it is never inherited. Omitted `modelOptions` reuses
-  the agent-level `modelOptions`.
+  the agent-level `modelOptions`. Set `reasoning` (same values as the
+  agent-level [reasoning effort](#reasoning-effort)) to override the
+  agent-level `reasoning` for the selected model; omitted, it reuses the
+  agent-level `reasoning`. Useful when a downshifted classifier should run at
+  a lower effort than the agent default.
 
 Runtime identity reports a dynamic agent's model as `dynamic:<fallback id>`.
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -1019,6 +1019,32 @@ describe("createToolLoopHarness", () => {
     expect(vi.mocked(ToolLoopAgent).mock.calls[0]?.[0]).toMatchObject({ reasoning: "high" });
   });
 
+  it("lets a per-selection reasoning override the agent reasoning effort", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Hello!", role: "assistant" }] },
+      text: "Hello!",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const runStep = createToolLoopHarness(createTestConfig());
+    const session = createTestSession({
+      agent: {
+        // A dynamic selection downshifts to a cheap model and drops reasoning
+        // to `low`, overriding the agent-level `high`.
+        modelReference: { id: "test-model", reasoning: "low" },
+        reasoning: "high",
+        system: "You are a test assistant.",
+        tools: [],
+      },
+    });
+
+    await runStep(session, { message: "Classify quickly" });
+
+    expect(vi.mocked(ToolLoopAgent).mock.calls[0]?.[0]).toMatchObject({ reasoning: "low" });
+  });
+
   it("accumulates provider-reported token usage across the session", async () => {
     setupMockAgent({
       finishReason: "stop",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -846,7 +846,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         },
         onStepFinish: hooks.onStepFinish,
         prepareStep: hooks.prepareStep,
-        reasoning: session.agent.reasoning,
+        // A dynamic per-selection `reasoning` overrides the agent default; it
+        // rides on the model reference so it survives the durable/serializable
+        // boundary the same way `modelContextWindowTokens`/`providerOptions` do.
+        reasoning: session.agent.modelReference.reasoning ?? session.agent.reasoning,
         runtimeContext: telemetryRuntimeContext,
         stopWhen: isStepCount(1),
         telemetry: enrichTelemetry(telemetryConfig, agentName, telemetryRuntimeContext),

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -110,7 +110,13 @@ export function normalizeAgentDefinition(
   return definition as Readonly<NormalizedAgentDefinition>;
 }
 
-function normalizeAgentReasoningDefinition(
+/**
+ * Validates a reasoning-effort value against the enum the agent-level
+ * `reasoning` field accepts, returning the narrowed value or throwing
+ * `message`. Shared so authored and dynamic (per-selection) reasoning validate
+ * identically.
+ */
+export function normalizeAgentReasoningDefinition(
   value: unknown,
   message: string,
 ): NonNullable<NormalizedAgentDefinition["reasoning"]> {

--- a/packages/eve/src/runtime/agent/resolve-model.test.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.test.ts
@@ -95,6 +95,35 @@ describe("dynamic runtime model resolution", () => {
       }),
     ).toThrowError(/unknown key\(s\): contextWindowTokens/);
   });
+
+  it("carries a per-selection reasoning onto the reference", () => {
+    const resolved = normalizeDynamicRuntimeModelResult({
+      fallback: { id: "openai/gpt-5.5", reasoning: "xhigh" },
+      result: { model: "openai/gpt-5.5-mini", reasoning: "low" },
+    });
+
+    expect(resolved.reference.reasoning).toBe("low");
+  });
+
+  it("leaves reasoning unset when the selection omits it", () => {
+    const resolved = normalizeDynamicRuntimeModelResult({
+      fallback: { id: "openai/gpt-5.5", reasoning: "xhigh" },
+      result: "openai/gpt-5.5-mini",
+    });
+
+    // Never inherited from the fallback; the model-call site falls back to the
+    // agent-level reasoning.
+    expect(resolved.reference.reasoning).toBeUndefined();
+  });
+
+  it("rejects a selection with an invalid reasoning value", () => {
+    expect(() =>
+      normalizeDynamicRuntimeModelResult({
+        fallback: { id: "openai/gpt-5.5" },
+        result: { model: "openai/gpt-5.5-mini", reasoning: "turbo" } as never,
+      }),
+    ).toThrowError(/invalid reasoning value/);
+  });
 });
 
 function createModuleMap(moduleNamespace: Record<string, unknown>): CompiledModuleMap {

--- a/packages/eve/src/runtime/agent/resolve-model.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.ts
@@ -1,6 +1,9 @@
 import type { LanguageModel } from "ai";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
-import { normalizeAgentDefinition } from "#internal/authored-definition/core.js";
+import {
+  normalizeAgentDefinition,
+  normalizeAgentReasoningDefinition,
+} from "#internal/authored-definition/core.js";
 import { formatLanguageModelGatewayId } from "#internal/runtime-model.js";
 import type {
   RuntimeDynamicModelReference,
@@ -144,6 +147,9 @@ export function normalizeDynamicRuntimeModelResult(input: {
       : parseProviderOptionsRecord(selection.modelOptions.providerOptions);
   // Never inherited from the fallback: a different model's window is not a safe guess.
   const contextWindowTokens = selection.modelContextWindowTokens;
+  // Carried per-selection; the model-call site falls back to the agent-level
+  // `reasoning` when this is undefined.
+  const reasoning = selection.reasoning;
 
   if (typeof selection.model === "string") {
     const id = formatLanguageModelGatewayId(selection.model);
@@ -152,6 +158,7 @@ export function normalizeDynamicRuntimeModelResult(input: {
         id,
         contextWindowTokens,
         providerOptions,
+        reasoning,
       },
     };
   }
@@ -164,11 +171,17 @@ export function normalizeDynamicRuntimeModelResult(input: {
       id: formatLanguageModelGatewayId(selection.model),
       contextWindowTokens,
       providerOptions,
+      reasoning,
     },
   };
 }
 
-const DYNAMIC_MODEL_SELECTION_KEYS = new Set(["model", "modelContextWindowTokens", "modelOptions"]);
+const DYNAMIC_MODEL_SELECTION_KEYS = new Set([
+  "model",
+  "modelContextWindowTokens",
+  "modelOptions",
+  "reasoning",
+]);
 
 function validateDynamicModelSelection(selection: PublicAgentModelSelectionDefinition): void {
   const unknownKeys = Object.keys(selection).filter(
@@ -176,7 +189,7 @@ function validateDynamicModelSelection(selection: PublicAgentModelSelectionDefin
   );
   if (unknownKeys.length > 0) {
     throw new Error(
-      `Dynamic model resolver returned a selection with unknown key(s): ${unknownKeys.join(", ")}. Expected { model, modelContextWindowTokens?, modelOptions? }.`,
+      `Dynamic model resolver returned a selection with unknown key(s): ${unknownKeys.join(", ")}. Expected { model, modelContextWindowTokens?, modelOptions?, reasoning? }.`,
     );
   }
 
@@ -187,6 +200,13 @@ function validateDynamicModelSelection(selection: PublicAgentModelSelectionDefin
   ) {
     throw new Error(
       "Dynamic model resolver returned an invalid modelContextWindowTokens value. Expected a positive integer.",
+    );
+  }
+
+  if (selection.reasoning !== undefined) {
+    normalizeAgentReasoningDefinition(
+      selection.reasoning,
+      "Dynamic model resolver returned an invalid reasoning value. Expected one of: provider-default, none, minimal, low, medium, high, xhigh.",
     );
   }
 }
@@ -213,7 +233,7 @@ function isModelSelectionDefinition(value: unknown): value is PublicAgentModelSe
 function validateRuntimeLanguageModel(model: unknown): asserts model is LanguageModel {
   if (!isRuntimeLanguageModel(model)) {
     throw new Error(
-      "Dynamic model resolver returned an invalid model. Return an AI Gateway model id string, an AI SDK language model, or { model, modelContextWindowTokens?, modelOptions? }.",
+      "Dynamic model resolver returned an invalid model. Return an AI Gateway model id string, an AI SDK language model, or { model, modelContextWindowTokens?, modelOptions?, reasoning? }.",
     );
   }
 }

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -48,6 +48,12 @@ export type InternalAgentModelDefinition = {
   contextWindowTokens?: number;
   source?: ModuleSourceRef;
   providerOptions?: Record<string, JsonObject>;
+  /**
+   * Per-selection reasoning effort carried by a dynamic model selection. Unset
+   * for the compiled agent-level model; when a dynamic selection sets it, it
+   * overrides the agent-level `reasoning` for that selection's model calls.
+   */
+  reasoning?: AgentReasoningDefinition;
 };
 
 /**
@@ -65,6 +71,11 @@ export interface PublicAgentModelSelectionDefinition {
   readonly modelContextWindowTokens?: number;
   /** Provider options for the selected model; defaults to the agent-level `modelOptions`. */
   readonly modelOptions?: AgentModelOptionsDefinition;
+  /**
+   * Reasoning effort for the selected model; overrides the agent-level
+   * `reasoning`. Defaults to the agent-level `reasoning` when omitted.
+   */
+  readonly reasoning?: AgentReasoningDefinition;
 }
 
 export type PublicAgentDynamicModelResult =


### PR DESCRIPTION
A `defineDynamic` selection accepted `{ model, modelContextWindowTokens, modelOptions }` but not `reasoning`, so a downshifted session kept the agent-level `reasoning` (e.g. `xhigh`), defeating the point of dropping to a cheap classifier.

## What changed

- Add `reasoning?: AgentReasoningDefinition` to `PublicAgentModelSelectionDefinition` and to the runtime model reference `InternalAgentModelDefinition` (`packages/eve/src/shared/agent-definition.ts`).
- Add `reasoning` to `DYNAMIC_MODEL_SELECTION_KEYS` and validate it in `validateDynamicModelSelection` against the same enum the agent-level field accepts, reusing the now-exported `normalizeAgentReasoningDefinition` (`packages/eve/src/runtime/agent/resolve-model.ts`, `packages/eve/src/internal/authored-definition/core.ts`). Both selection-shape error strings (`resolve-model.ts:192` and `:236`) now list `reasoning?`.
- Carry the value onto the reference in `normalizeDynamicRuntimeModelResult`, and apply it at the model-call precedence point: `session.agent.modelReference.reasoning ?? session.agent.reasoning` (`packages/eve/src/harness/tool-loop.ts:852`). Per-selection overrides the agent default; omitted falls back to it. Same precedence as `modelContextWindowTokens`/`modelOptions`.
- Document the field on the selection object (`docs/agent-config.md`).

## How I verified

- Before: a resolver returning `{ model, reasoning }` throws `unknown key(s): reasoning` at `resolve-model.ts:178`. Reverting only the `tool-loop.ts` precedence line, the override test sees the model call get `reasoning: "high"` (agent default) instead of `"low"` (per-selection).
- After: per-selection `reasoning` lands on the reference and reaches the model call; omitting it keeps the agent default. Invalid values are rejected with a reasoning-specific error.
- Tests (`packages/eve/src/runtime/agent/resolve-model.test.ts`, `packages/eve/src/harness/tool-loop.test.ts`): "carries a per-selection reasoning onto the reference", "leaves reasoning unset when the selection omits it", "rejects a selection with an invalid reasoning value", "lets a per-selection reasoning override the agent reasoning effort". Each fails before, passes after.
- Full local green: `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (4687 passed, 1 skipped), `pnpm docs:check`.

Problem 2 from the issue (small-model `outputSchema` reliability) is out of scope for this PR.

Closes #629.
