### PR TITLE
chore(e2e): ci - run fixtures across model providers

### DIFF
--- a/.github/scripts/discover-e2e-fixtures.sh
+++ b/.github/scripts/discover-e2e-fixtures.sh
@@ -3,7 +3,7 @@
 #
 # A fixture qualifies when it has an `evals/` directory under one of the
 # fixture roots. Emits a JSON array of `{ name, dir }` objects (sorted by dir)
-# to the `matrix` GitHub Actions output for `matrix.include`.
+# to the `matrix` GitHub Actions output for the workflow's `fixture` axis.
 set -euo pipefail
 
 roots=("e2e/fixtures" "apps/fixtures")

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -58,7 +58,7 @@ jobs:
         run: .github/scripts/discover-e2e-fixtures.sh
 
   e2e:
-    name: e2e-local (${{ matrix.fixture.name }}, ${{ matrix.model.id }})
+    name: e2e-local (${{ matrix.fixture.name }}, ${{ matrix.model.name }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
     # No job-level `if`: these matrix jobs are required checks under their
@@ -70,10 +70,10 @@ jobs:
       matrix:
         fixture: ${{ fromJSON(needs.discover-fixtures.outputs.matrix) }}
         model:
-          - id: openai/gpt-5.6-sol
-            slug: openai-gpt-5-6-sol
-          - id: anthropic/claude-opus-4.8
-            slug: anthropic-claude-opus-4-8
+          - name: openai-sol
+            id: openai/gpt-5.6-sol
+          - name: anthropic-opus
+            id: anthropic/claude-opus-4.8
 
     env:
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
@@ -114,13 +114,13 @@ jobs:
           mkdir -p "$EVE_EVAL_JUNIT_DIR"
           cd "${{ matrix.fixture.dir }}"
           pnpm exec eve eval --strict --verbose \
-            --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.slug }}.xml"
+            --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.name }}.xml"
 
       - name: Upload eval artifacts
         if: (failure()) && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6
         with:
-          name: eval-artifacts-${{ matrix.fixture.name }}-${{ matrix.model.slug }}
+          name: eval-artifacts-${{ matrix.fixture.name }}-${{ matrix.model.name }}
           path: |
             .junit
             e2e/fixtures/*/.eve/evals

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -58,7 +58,7 @@ jobs:
         run: .github/scripts/discover-e2e-fixtures.sh
 
   e2e:
-    name: e2e-local (${{ matrix.name }})
+    name: e2e-local (${{ matrix.fixture.name }}, ${{ matrix.model.id }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
     # No job-level `if`: these matrix jobs are required checks under their
@@ -68,10 +68,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.discover-fixtures.outputs.matrix) }}
+        fixture: ${{ fromJSON(needs.discover-fixtures.outputs.matrix) }}
+        model:
+          - id: openai/gpt-5.6-sol
+            slug: openai-gpt-5-6-sol
+          - id: anthropic/claude-opus-4.8
+            slug: anthropic-claude-opus-4-8
 
     env:
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+      EVE_E2E_MODEL: ${{ matrix.model.id }}
       EVE_EVAL_JUNIT_DIR: ${{ github.workspace }}/.junit
 
     steps:
@@ -106,14 +112,15 @@ jobs:
         if: needs.changes.outputs.relevant == 'true'
         run: |
           mkdir -p "$EVE_EVAL_JUNIT_DIR"
-          cd "${{ matrix.dir }}"
-          pnpm exec eve eval --strict --verbose --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
+          cd "${{ matrix.fixture.dir }}"
+          pnpm exec eve eval --strict --verbose \
+            --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.slug }}.xml"
 
       - name: Upload eval artifacts
         if: (failure()) && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6
         with:
-          name: eval-artifacts-${{ matrix.name }}
+          name: eval-artifacts-${{ matrix.fixture.name }}-${{ matrix.model.slug }}
           path: |
             .junit
             e2e/fixtures/*/.eve/evals

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -61,10 +61,9 @@ jobs:
     name: e2e-local (${{ matrix.fixture.name }}, ${{ matrix.model.name }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
-    # No job-level `if`: these matrix jobs are required checks under their
-    # expanded names, and a skipped matrix never reports them, leaving PRs
-    # stuck on "Expected - Waiting for status to be reported". Instead every
-    # step is guarded, so an irrelevant diff reports success in seconds.
+    # No job-level `if`: the stable aggregate check below requires a successful
+    # matrix result. Guarding each step lets an irrelevant diff satisfy it in
+    # seconds without running setup or evals.
     strategy:
       fail-fast: false
       matrix:
@@ -128,3 +127,18 @@ jobs:
           include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
+
+  e2e-required:
+    name: e2e-local
+    runs-on: ubuntu-latest
+    needs: [e2e]
+    if: always()
+    steps:
+      - name: Require successful e2e matrix
+        env:
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ "$E2E_RESULT" != "success" ]; then
+            echo "E2E matrix result: $E2E_RESULT"
+            exit 1
+          fi

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -58,7 +58,7 @@ jobs:
         run: .github/scripts/discover-e2e-fixtures.sh
 
   e2e:
-    name: e2e-vercel (${{ matrix.fixture.name }}, ${{ matrix.model.id }})
+    name: e2e-vercel (${{ matrix.fixture.name }}, ${{ matrix.model.name }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
     # No job-level `if`: these matrix jobs are required checks under their
@@ -70,10 +70,10 @@ jobs:
       matrix:
         fixture: ${{ fromJSON(needs.discover-fixtures.outputs.matrix) }}
         model:
-          - id: openai/gpt-5.6-sol
-            slug: openai-gpt-5-6-sol
-          - id: anthropic/claude-opus-4.8
-            slug: anthropic-claude-opus-4-8
+          - name: openai-sol
+            id: openai/gpt-5.6-sol
+          - name: anthropic-opus
+            id: anthropic/claude-opus-4.8
 
     env:
       EVE_E2E_MODEL: ${{ matrix.model.id }}
@@ -143,7 +143,7 @@ jobs:
             --env "EVE_E2E_MODEL=$EVE_E2E_MODEL" "${token_args[@]}" | tail -n 1)"
 
           npx eve eval --strict --verbose --url "$DEPLOYMENT_URL" \
-            --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.slug }}.xml"
+            --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.name }}.xml"
 
           # Redeploy-tagged evals rebuild and redeploy the fixture from inside
           # the eval body, repointing a run-scoped alias at each new
@@ -158,14 +158,14 @@ jobs:
             EVE_E2E_REDEPLOY_ALIAS="$ALIAS" \
               npx eve eval --tag redeploy --strict --verbose \
               --url "https://$ALIAS" \
-              --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.slug }}-redeploy.xml"
+              --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.name }}-redeploy.xml"
           fi
 
       - name: Upload eval artifacts
         if: (failure()) && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6
         with:
-          name: eval-artifacts-vercel-${{ matrix.fixture.name }}-${{ matrix.model.slug }}
+          name: eval-artifacts-vercel-${{ matrix.fixture.name }}-${{ matrix.model.name }}
           path: |
             .junit
             e2e/fixtures/*/.eve/evals

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -61,10 +61,9 @@ jobs:
     name: e2e-vercel (${{ matrix.fixture.name }}, ${{ matrix.model.name }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
-    # No job-level `if`: these matrix jobs are required checks under their
-    # expanded names, and a skipped matrix never reports them, leaving PRs
-    # stuck on "Expected - Waiting for status to be reported". Instead every
-    # step is guarded, so an irrelevant diff reports success in seconds.
+    # No job-level `if`: the stable aggregate check below requires a successful
+    # matrix result. Guarding each step lets an irrelevant diff satisfy it in
+    # seconds without running setup or evals.
     strategy:
       fail-fast: false
       matrix:
@@ -173,3 +172,18 @@ jobs:
           include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
+
+  e2e-required:
+    name: e2e-vercel
+    runs-on: ubuntu-latest
+    needs: [e2e]
+    if: always()
+    steps:
+      - name: Require successful e2e matrix
+        env:
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ "$E2E_RESULT" != "success" ]; then
+            echo "E2E matrix result: $E2E_RESULT"
+            exit 1
+          fi

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -58,7 +58,7 @@ jobs:
         run: .github/scripts/discover-e2e-fixtures.sh
 
   e2e:
-    name: e2e-vercel (${{ matrix.name }})
+    name: e2e-vercel (${{ matrix.fixture.name }}, ${{ matrix.model.id }})
     runs-on: ubuntu-latest
     needs: [changes, discover-fixtures]
     # No job-level `if`: these matrix jobs are required checks under their
@@ -68,9 +68,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.discover-fixtures.outputs.matrix) }}
+        fixture: ${{ fromJSON(needs.discover-fixtures.outputs.matrix) }}
+        model:
+          - id: openai/gpt-5.6-sol
+            slug: openai-gpt-5-6-sol
+          - id: anthropic/claude-opus-4.8
+            slug: anthropic-claude-opus-4-8
 
     env:
+      EVE_E2E_MODEL: ${{ matrix.model.id }}
       EVE_EVAL_JUNIT_DIR: ${{ github.workspace }}/.junit
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -110,7 +116,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$EVE_EVAL_JUNIT_DIR"
-          cd "${{ matrix.dir }}"
+          cd "${{ matrix.fixture.dir }}"
 
           token_args=()
           if [ -n "${VERCEL_TOKEN:-}" ]; then
@@ -133,9 +139,11 @@ jobs:
             VERCEL_TARGET_ENV=preview \
             VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
             pnpm exec eve build
-          DEPLOYMENT_URL="$(pnpm exec vc deploy --prebuilt --yes --target=preview "${token_args[@]}" | tail -n 1)"
+          DEPLOYMENT_URL="$(pnpm exec vc deploy --prebuilt --yes --target=preview \
+            --env "EVE_E2E_MODEL=$EVE_E2E_MODEL" "${token_args[@]}" | tail -n 1)"
 
-          npx eve eval --strict --verbose --url "$DEPLOYMENT_URL" --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}.xml"
+          npx eve eval --strict --verbose --url "$DEPLOYMENT_URL" \
+            --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.slug }}.xml"
 
           # Redeploy-tagged evals rebuild and redeploy the fixture from inside
           # the eval body, repointing a run-scoped alias at each new
@@ -143,20 +151,21 @@ jobs:
           # never change what they serve) and are skipped in the main suite
           # above because EVE_E2E_REDEPLOY_ALIAS is unset there.
           if npx eve eval --tag redeploy --list >/dev/null 2>&1; then
-            ALIAS="eve-e2e-${{ matrix.name }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.vercel.app"
+            ALIAS="eve-e2e-${{ matrix.fixture.name }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ strategy.job-index }}.vercel.app"
             # vc alias does not infer the team from the project link the way
             # link/deploy do, so pass the scope explicitly.
             pnpm exec vc alias set "$DEPLOYMENT_URL" "$ALIAS" "${token_args[@]}" "${scope_args[@]}"
             EVE_E2E_REDEPLOY_ALIAS="$ALIAS" \
               npx eve eval --tag redeploy --strict --verbose \
-              --url "https://$ALIAS" --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}-redeploy.xml"
+              --url "https://$ALIAS" \
+              --junit "$EVE_EVAL_JUNIT_DIR/${{ matrix.fixture.name }}-${{ matrix.model.slug }}-redeploy.xml"
           fi
 
       - name: Upload eval artifacts
         if: (failure()) && needs.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v6
         with:
-          name: eval-artifacts-vercel-${{ matrix.name }}
+          name: eval-artifacts-vercel-${{ matrix.fixture.name }}-${{ matrix.model.slug }}
           path: |
             .junit
             e2e/fixtures/*/.eve/evals

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -116,10 +116,11 @@ When adding e2e coverage:
 then runs one fixture directory. Its matrix crosses every discovered fixture
 with these model entries:
 
-```text
-openai/gpt-5.6-sol
-anthropic/claude-opus-4.8
-```
+- `openai-sol` → `openai/gpt-5.6-sol`
+- `anthropic-opus` → `anthropic/claude-opus-4.8`
+
+The short name is the stable Actions check identifier; the full id selects the
+provider model. Updating a model version does not rename required checks.
 
 Each leg exports the selected id as `EVE_E2E_MODEL` before it runs:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -121,6 +121,10 @@ with these model entries:
 
 The short name is the stable Actions check identifier; the full id selects the
 provider model. Updating a model version does not rename required checks.
+Each workflow also publishes one stable aggregate check, `e2e-local` or
+`e2e-vercel`, which succeeds only when every fixture and model leg succeeds.
+Require those two checks in the repository ruleset so newly added fixtures and
+models become required automatically.
 
 Each leg exports the selected id as `EVE_E2E_MODEL` before it runs:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,7 +9,7 @@ Run evals from the fixture directory:
 
 ```sh
 cd e2e/fixtures/agent-basic-runtime
-pnpm exec eve eval --strict
+EVE_E2E_MODEL="openai/gpt-5.6-sol" pnpm exec eve eval --strict
 ```
 
 Every retained e2e eval is deterministic and self-contained. Coverage that
@@ -39,8 +39,8 @@ comes from the deployment URL returned by `vc deploy --prebuilt`.
 One-time project setup:
 
 - Configure the shared Vercel project for Node.js 24.
-- Provide the model-provider credentials the fixtures need (the agents and
-  judges run against `openai/gpt-5.5`) in the project's Preview environment.
+- Provide the model-provider credentials needed by `EVE_E2E_MODEL` in the
+  project's Preview environment.
 - Provide `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` in CI.
 
 Run a fixture against Vercel from its directory:
@@ -51,7 +51,8 @@ vc env pull --yes --environment=preview
 VERCEL=1 VERCEL_ENV=preview VERCEL_TARGET_ENV=preview \
   VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
   pnpm exec eve build
-DEPLOYMENT_URL="$(vc deploy --prebuilt --yes --target=preview | tail -n 1)"
+DEPLOYMENT_URL="$(vc deploy --prebuilt --yes --target=preview \
+  --env "EVE_E2E_MODEL=$EVE_E2E_MODEL" | tail -n 1)"
 npx eve eval --strict --url "$DEPLOYMENT_URL"
 ```
 
@@ -80,17 +81,19 @@ must run against the alias — the `e2e-vercel` workflow sets
 evals as a second `eve eval` invocation after the main suite. Without the
 alias env (local matrix, plain `eve eval --strict`) the eval skips.
 
-Most fixture agents run against `anthropic/claude-sonnet-5` and judges run
-against `openai/gpt-5.5`. Both are real models, so the environment must provide
-the corresponding model-provider credentials. `agent-prompt-cache` is the one
-fixture that authors a direct `@ai-sdk/anthropic` model instance instead of a
-gateway model id: its eval asserts the harness's Anthropic cache-breakpoint
-placement, which only runs on that path. The instance points at the AI
+Most fixture agents and their configured judges use `EVE_E2E_MODEL`, defaulting
+to `openai/gpt-5.6-sol` for local runs. CI sets it from the model matrix, so
+adding a matrix entry runs every discovered fixture against that model.
+`agent-prompt-cache` is the one fixture that authors a direct
+`@ai-sdk/anthropic` model instance instead of a gateway model id: its eval
+asserts the harness's Anthropic cache-breakpoint placement, which only runs on
+that path. It uses the matrix model when it is an Anthropic model and otherwise
+falls back to `anthropic/claude-opus-4.8`. The instance points at the AI
 Gateway's Anthropic-compatible Messages endpoint so it uses the same
-`AI_GATEWAY_API_KEY` credential as every other fixture. `agent-workflow-stress` uses eve's
-`mockModel` fixture helper so its 100-turn runs stay fast and deterministic. Its
-concurrent and sequential evals cover high-volume session execution and repeated
-session resumption respectively.
+`AI_GATEWAY_API_KEY` credential as every other fixture.
+`agent-workflow-stress` uses eve's `mockModel` fixture helper so its 100-turn
+runs stay fast and deterministic. Its concurrent and sequential evals cover
+high-volume session execution and repeated session resumption respectively.
 
 ## Fixtures
 
@@ -110,12 +113,20 @@ When adding e2e coverage:
 ## CI
 
 `.github/workflows/e2e-local.yml` builds the eve package once per matrix leg,
-then runs one fixture directory:
+then runs one fixture directory. Its matrix crosses every discovered fixture
+with these model entries:
+
+```text
+openai/gpt-5.6-sol
+anthropic/claude-opus-4.8
+```
+
+Each leg exports the selected id as `EVE_E2E_MODEL` before it runs:
 
 ```sh
 pnpm --filter eve run build
 cd "$FIXTURE_DIR"
-pnpm exec eve eval --strict --junit "$JUNIT_PATH"
+EVE_E2E_MODEL="$MODEL" pnpm exec eve eval --strict --junit "$JUNIT_PATH"
 ```
 
 Always build with the full `build` script (not `build:js`); only the full
@@ -126,7 +137,8 @@ Vercel project id, builds Vercel output locally, deploys that output, and runs:
 
 ```sh
 pnpm exec eve build
-DEPLOYMENT_URL="$(vc deploy --prebuilt --yes --target=preview | tail -n 1)"
+DEPLOYMENT_URL="$(vc deploy --prebuilt --yes --target=preview \
+  --env "EVE_E2E_MODEL=$EVE_E2E_MODEL" | tail -n 1)"
 npx eve eval --strict --url "$DEPLOYMENT_URL" --junit "$JUNIT_PATH"
 ```
 

--- a/e2e/fixtures/agent-basic-runtime/agent/agent.ts
+++ b/e2e/fixtures/agent-basic-runtime/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-basic-runtime/evals/evals.config.ts
+++ b/e2e/fixtures/agent-basic-runtime/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-channels/agent/agent.ts
+++ b/e2e/fixtures/agent-channels/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-channels/evals/evals.config.ts
+++ b/e2e/fixtures/agent-channels/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-model/agent/agent.ts
+++ b/e2e/fixtures/agent-model/agent/agent.ts
@@ -1,5 +1,7 @@
 import { defineAgent, defineDynamic, type DynamicResolveContext } from "eve";
 
+const model = process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol";
+
 /**
  * Dynamic-model e2e fixture. Resolves at `turn.started` (not the usual
  * `session.started`) so one session can exercise selection, null fallback,
@@ -7,7 +9,7 @@ import { defineAgent, defineDynamic, type DynamicResolveContext } from "eve";
  */
 export default defineAgent({
   model: defineDynamic({
-    fallback: "openai/gpt-5.5",
+    fallback: model,
     events: {
       "turn.started": (_event, ctx) => {
         const text = lastUserText(ctx.messages);
@@ -18,7 +20,7 @@ export default defineAgent({
 
         if (text.includes("[model: mini]")) {
           return {
-            model: "openai/gpt-5.5-mini",
+            model,
             modelContextWindowTokens: 128_000,
           };
         }

--- a/e2e/fixtures/agent-model/evals/dynamic-model/fallback.eval.ts
+++ b/e2e/fixtures/agent-model/evals/dynamic-model/fallback.eval.ts
@@ -1,5 +1,7 @@
 import { defineEval } from "eve/evals";
 
+const model = process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol";
+
 /**
  * No selection marker: the resolver returns `null`, the fallback serves the
  * turn, and the runtime identity reports `dynamic:<fallback id>`.
@@ -15,8 +17,7 @@ export default defineEval({
     t.eventsSatisfy("runtime identity reports a dynamic model", (events) =>
       events.some(
         (event) =>
-          event.type === "session.started" &&
-          event.data.runtime?.modelId === "dynamic:openai/gpt-5.5",
+          event.type === "session.started" && event.data.runtime?.modelId === `dynamic:${model}`,
       ),
     );
   },

--- a/e2e/fixtures/agent-model/evals/dynamic-model/turn-selection.eval.ts
+++ b/e2e/fixtures/agent-model/evals/dynamic-model/turn-selection.eval.ts
@@ -1,8 +1,9 @@
 import { defineEval } from "eve/evals";
 
 /**
- * A marked turn selects `openai/gpt-5.5-mini`; the next unmarked turn falls
- * back. Both completing proves each reference serves a real model call.
+ * A marked turn selects an explicit reference to `EVE_E2E_MODEL`; the next
+ * unmarked turn falls back to the same matrix-selected model. Both completing
+ * proves the selection and fallback paths serve real model calls.
  */
 export default defineEval({
   description: "Dynamic model smoke: per-turn selection and null fallback in one session.",

--- a/e2e/fixtures/agent-model/evals/evals.config.ts
+++ b/e2e/fixtures/agent-model/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-openapi-swagger/agent/agent.ts
+++ b/e2e/fixtures/agent-openapi-swagger/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-openapi-swagger/evals/evals.config.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-prompt-cache/agent/agent.ts
+++ b/e2e/fixtures/agent-prompt-cache/agent/agent.ts
@@ -21,6 +21,10 @@ import { vercelOidc } from "eve/agents/auth";
  * Vercel OIDC as the fallback.
  */
 const resolveVercelOidc = vercelOidc();
+const matrixModel = process.env.EVE_E2E_MODEL ?? "anthropic/claude-opus-4.8";
+const promptCacheModel = matrixModel.startsWith("anthropic/")
+  ? matrixModel
+  : "anthropic/claude-opus-4.8";
 
 const anthropic = createAnthropic({
   baseURL: "https://ai-gateway.vercel.sh/v1",
@@ -39,7 +43,7 @@ const anthropic = createAnthropic({
 });
 
 const agent: AgentDefinition = defineAgent({
-  model: anthropic("anthropic/claude-haiku-4-5"),
+  model: anthropic(promptCacheModel),
   modelContextWindowTokens: 200_000,
 });
 

--- a/e2e/fixtures/agent-prompt-cache/evals/evals.config.ts
+++ b/e2e/fixtures/agent-prompt-cache/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Judge is unused here; assertions are numeric. Kept for config parity. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-schedules/agent/agent.ts
+++ b/e2e/fixtures/agent-schedules/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-schedules/evals/evals.config.ts
+++ b/e2e/fixtures/agent-schedules/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-session-limits/agent/agent.ts
+++ b/e2e/fixtures/agent-session-limits/agent/agent.ts
@@ -1,7 +1,7 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   // A one-token input budget guarantees every completed model call crosses
   // the limit, so the next conversation turn deterministically parks on the
   // session-limit continuation prompt.

--- a/e2e/fixtures/agent-session-limits/evals/evals.config.ts
+++ b/e2e/fixtures/agent-session-limits/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-skills/agent/agent.ts
+++ b/e2e/fixtures/agent-skills/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-skills/evals/evals.config.ts
+++ b/e2e/fixtures/agent-skills/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/stock-price/agent.ts
@@ -3,6 +3,6 @@ import { defineAgent } from "eve";
 export default defineAgent({
   description:
     'Look up the current stock price for a given ticker symbol. Pass the ticker symbol you want to look up in the message (e.g. "AAPL", "GOOG", or "TSLA").',
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents-hitl/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-subagents/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents/agent/subagents/echo-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/echo-marker/agent.ts
@@ -12,6 +12,6 @@ import { defineAgent } from "eve";
 export default defineAgent({
   description:
     "Smoke-test echo subagent. Call this whenever the user mentions the phrase 'echo marker subagent'. Pass any short text as the input; the subagent replies with a fixed marker token.",
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents/evals/evals.config.ts
+++ b/e2e/fixtures/agent-subagents/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-tools-hitl-openai/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-hitl-openai/agent/agent.ts
@@ -1,11 +1,11 @@
 import { defineAgent } from "eve";
 
 /**
- * HITL fixture pinned to the OpenAI Responses provider path
+ * HITL fixture whose OpenAI matrix leg covers the Responses provider path
  * (https://github.com/vercel/eve/issues/236). Approval-gated executable
  * tools must complete an approve and execute cycle when the replayed history is
  * validated by OpenAI's `function_call` / `function_call_output` pairing.
  */
 export default defineAgent({
-  model: "openai/gpt-5.5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
 });

--- a/e2e/fixtures/agent-tools-hitl-openai/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-hitl-openai/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-tools-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools-hitl/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-tools-sandbox/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools-sandbox/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-tools-sandbox/evals/sandbox/redeploy.eval.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/sandbox/redeploy.eval.ts
@@ -164,13 +164,17 @@ async function deployToAlias(t: EveEvalContext, alias: string, phase: string): P
 
   const tokenArgs =
     process.env.VERCEL_TOKEN === undefined ? [] : ["--token", process.env.VERCEL_TOKEN];
+  const modelArgs =
+    process.env.EVE_E2E_MODEL === undefined
+      ? []
+      : ["--env", `EVE_E2E_MODEL=${process.env.EVE_E2E_MODEL}`];
   // vc alias does not infer the team from the project link the way deploy
   // does, so pass the scope explicitly.
   const scopeArgs =
     process.env.VERCEL_ORG_ID === undefined ? [] : ["--scope", process.env.VERCEL_ORG_ID];
   const deploy = await execFileAsync(
     "pnpm",
-    ["exec", "vc", "deploy", "--prebuilt", "--yes", "--target=preview", ...tokenArgs],
+    ["exec", "vc", "deploy", "--prebuilt", "--yes", "--target=preview", ...modelArgs, ...tokenArgs],
     EXEC_OPTIONS,
   );
   const deploymentUrl = deploy.stdout.trim().split("\n").at(-1)?.trim();

--- a/e2e/fixtures/agent-tools/agent/agent.ts
+++ b/e2e/fixtures/agent-tools/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools/evals/evals.config.ts
+++ b/e2e/fixtures/agent-tools/evals/evals.config.ts
@@ -2,5 +2,5 @@ import { defineEvalConfig } from "eve/evals";
 
 /** Default judge model for any `t.judge.*` assertion in this fixture. */
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });

--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
@@ -43,7 +43,13 @@ function providerRequestsPrecedeResults(events: readonly HandleMessageStreamEven
 export default defineEval({
   description: "Provider tools smoke: gateway web search answers a current-events question.",
   async test(t) {
-    const turn = await t.send("Who won the 2026 NBA finals");
+    const turn = await t.send(
+      [
+        "Important date context: the 2026 NBA Finals have absolutely already been played, and a champion has been crowned.",
+        "Do not claim the event is in the future, even if your internal knowledge incorrectly places the current date in 2025.",
+        `Call ${TOOL_NAME} to verify who won the 2026 NBA Finals, then answer with the winning team.`,
+      ].join("\n"),
+    );
 
     t.succeeded();
     t.calledTool(TOOL_NAME);

--- a/e2e/fixtures/extensions/agent/agent.ts
+++ b/e2e/fixtures/extensions/agent/agent.ts
@@ -1,6 +1,6 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-5",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
   reasoning: "high",
 });

--- a/e2e/fixtures/extensions/evals/evals.config.ts
+++ b/e2e/fixtures/extensions/evals/evals.config.ts
@@ -1,5 +1,5 @@
 import { defineEvalConfig } from "eve/evals";
 
 export default defineEvalConfig({
-  judge: { model: "openai/gpt-5.5" },
+  judge: { model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol" },
 });


### PR DESCRIPTION
### Description

Run every discovered e2e fixture through a model matrix in both local and Vercel workflows. The initial matrix covers `openai/gpt-5.6-sol` and `anthropic/claude-opus-4.8`, with agents and judges reading the selected model from `EVE_E2E_MODEL`.

Use stable family names (`openai-sol` and `anthropic-opus`) in Actions check, JUnit, and artifact names so model version updates do not rename matrix checks. Publish stable aggregate `e2e-local` and `e2e-vercel` checks that require every fixture and model leg to succeed, allowing the ruleset to require only those two checks as the matrix grows.

Propagate the selected model into Vercel runtime and redeploy-tagged evals, keep the Anthropic-direct prompt-cache and deterministic stress fixtures on their specialized model paths, and reinforce the 2026 NBA Finals web-search prompt against stale model date assumptions.

### How did you test your changes?

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter agent-tools-sandbox typecheck`
- `pnpm --filter agent-tools typecheck`
- `pnpm guard:invariants`
- Parsed both workflow YAML files with Ruby YAML
- Ran `.github/scripts/discover-e2e-fixtures.sh`
- Built `agent-basic-runtime` with `EVE_E2E_MODEL=anthropic/claude-opus-4.8` and verified the compiled manifest model

Live e2e evals are CI-only.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not applicable; no published package changes)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
