### PR TITLE
feat(dev): drain retired dev workers behind the stock Nitro contract

### DIFF
--- a/.changeset/drained-dev-worker-replacement.md
+++ b/.changeset/drained-dev-worker-replacement.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Replace `eve dev` workers gracefully: the retired worker keeps serving the responses and sockets it already admitted while new requests go to the ready replacement, a failed replacement leaves the previous worker serving, and shutdown stays bounded with streams open.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -337,6 +337,7 @@
     "chokidar": "5.0.0",
     "commander": "14.0.3",
     "emulate": "0.6.0",
+    "env-runner": "0.1.12",
     "eventsource-parser": "3.0.8",
     "experimental-ai-sdk-code-mode": "1.0.16",
     "gray-matter": "4.0.3",

--- a/packages/eve/scripts/vendor-compiled/declarations/env-runner.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/env-runner.d.ts
@@ -1,0 +1,38 @@
+import type { IncomingMessage } from "node:http";
+import type { Socket } from "node:net";
+
+export interface WorkerHooks {
+  onClose?(runner: BaseEnvRunner, cause?: unknown): void;
+  onReady?(runner: BaseEnvRunner): void;
+}
+
+export interface BaseEnvRunnerOptions {
+  readonly data?: Record<string, unknown>;
+  readonly hooks?: WorkerHooks;
+  readonly name: string;
+  readonly workerEntry: string;
+}
+
+export class BaseEnvRunner {
+  readonly closed: boolean;
+  readonly ready: boolean;
+  protected readonly _data: Record<string, unknown> | undefined;
+  protected readonly _name: string;
+  protected readonly _workerEntry: string;
+
+  constructor(options: BaseEnvRunnerOptions);
+
+  close(cause?: unknown): Promise<void>;
+  fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+  sendMessage(message: unknown): void;
+  upgrade(context: {
+    node: { head: Uint8Array; req: IncomingMessage; socket: Socket };
+  }): Promise<void>;
+  waitForReady(timeout?: number): Promise<void>;
+
+  protected _closeRuntime(): Promise<void>;
+  protected _handleMessage(message: unknown): void;
+  protected _hasRuntime(): boolean;
+  protected _initWithVirtualData(initialize: () => void): void;
+  protected _runtimeType(): string;
+}

--- a/packages/eve/scripts/vendor-compiled/env-runner.mjs
+++ b/packages/eve/scripts/vendor-compiled/env-runner.mjs
@@ -1,0 +1,18 @@
+import { loadDeclaration } from "./_shared.mjs";
+
+export default {
+  packageName: "env-runner",
+  compiledPath: "env-runner",
+  entries: [
+    {
+      entry: "dist/_chunks/common-base-runner.mjs",
+      outputPath: "index",
+      declaration: await loadDeclaration("env-runner.d.ts"),
+    },
+    {
+      entry: "dist/runners/node-worker/worker.mjs",
+      outputPath: "node-worker",
+      declaration: "export {};\n",
+    },
+  ],
+};

--- a/packages/eve/scripts/vendor-compiled/index.mjs
+++ b/packages/eve/scripts/vendor-compiled/index.mjs
@@ -32,6 +32,7 @@ import chokidar from "./chokidar.mjs";
 import commander from "./commander.mjs";
 import experimentalAiSdkCodeMode from "./experimental-ai-sdk-code-mode.mjs";
 import eventsourceParserStream from "./eventsource-parser-stream.mjs";
+import envRunner from "./env-runner.mjs";
 import grayMatter from "./gray-matter.mjs";
 import jose from "./jose.mjs";
 import jsoncParser from "./jsonc-parser.mjs";
@@ -52,6 +53,7 @@ export const MODULES = [
   commander,
   experimentalAiSdkCodeMode,
   eventsourceParserStream,
+  envRunner,
   google,
   grayMatter,
   jose,

--- a/packages/eve/src/internal/nitro/host/dev-runner.ts
+++ b/packages/eve/src/internal/nitro/host/dev-runner.ts
@@ -1,0 +1,150 @@
+import { existsSync } from "node:fs";
+import { Worker } from "node:worker_threads";
+
+import { BaseEnvRunner } from "#compiled/env-runner/index.js";
+import { resolvePackageCompiledFilePath } from "#internal/application/package.js";
+
+export interface DevelopmentRunner {
+  readonly closed: boolean;
+  close(cause?: unknown): Promise<void>;
+  fetch(request: Request): Promise<Response>;
+  onceClosed(listener: (cause?: unknown) => void): void;
+  upgrade(input: {
+    readonly node: {
+      readonly head: Buffer;
+      readonly req: import("node:http").IncomingMessage;
+      readonly socket: import("node:net").Socket;
+    };
+  }): Promise<void>;
+  waitForReady(timeout: number): Promise<void>;
+}
+
+export interface DevelopmentRunnerInput {
+  readonly entry: string;
+  readonly name: string;
+  readonly workerData: Readonly<Record<string, unknown>>;
+}
+
+export type DevelopmentRunnerFactory = (input: DevelopmentRunnerInput) => DevelopmentRunner;
+
+class NodeDevelopmentRunner extends BaseEnvRunner implements DevelopmentRunner {
+  #closeCause: unknown;
+  readonly #closedListeners = new Set<(cause?: unknown) => void>();
+  #worker: Worker | undefined;
+
+  constructor(input: DevelopmentRunnerInput) {
+    const workerEntry = resolvePackageCompiledFilePath("src/compiled/env-runner/node-worker.js");
+    super({
+      data: {
+        entry: input.entry,
+        ...input.workerData,
+      },
+      hooks: {
+        onClose: (_runner, cause) => {
+          const listeners = [...this.#closedListeners];
+          this.#closedListeners.clear();
+          for (const listener of listeners) {
+            listener(cause);
+          }
+        },
+      },
+      name: input.name,
+      workerEntry,
+    });
+    this._initWithVirtualData(() => this.#startWorker());
+  }
+
+  onceClosed(listener: (cause?: unknown) => void): void {
+    if (this.closed) {
+      listener(this.#closeCause);
+      return;
+    }
+    this.#closedListeners.add(listener);
+  }
+
+  override sendMessage(message: unknown): void {
+    if (this.#worker === undefined) {
+      throw new Error("Development worker is not initialized.");
+    }
+    this.#worker.postMessage(message);
+  }
+
+  override async waitForReady(timeout: number): Promise<void> {
+    try {
+      await super.waitForReady(timeout);
+    } catch (error) {
+      if (this.#closeCause === undefined) {
+        throw error;
+      }
+      throw new Error(
+        `Development worker failed before readiness: ${this.#closeCause instanceof Error ? this.#closeCause.message : String(this.#closeCause)}`,
+        { cause: this.#closeCause },
+      );
+    }
+  }
+
+  protected override _hasRuntime(): boolean {
+    return this.#worker !== undefined;
+  }
+
+  protected override _runtimeType(): string {
+    return "worker";
+  }
+
+  protected override async _closeRuntime(): Promise<void> {
+    const worker = this.#worker;
+    if (worker === undefined) {
+      return;
+    }
+
+    this.#worker = undefined;
+    worker.removeAllListeners();
+    await worker.terminate();
+  }
+
+  protected override _handleMessage(message: unknown): void {
+    if (isWorkerInitializationError(message)) {
+      this.#closeCause = new Error(message.error);
+    }
+    super._handleMessage(message);
+  }
+
+  #startWorker(): void {
+    if (!existsSync(this._workerEntry)) {
+      void this.close(`Development worker entry not found at "${this._workerEntry}".`);
+      return;
+    }
+
+    const worker = new Worker(this._workerEntry, {
+      env: process.env,
+      workerData: {
+        name: this._name,
+        ...this._data,
+      },
+    });
+    this.#worker = worker;
+    worker.once("error", (error) => {
+      this.#closeCause = error;
+      void this.close(error);
+    });
+    worker.once("exit", (code) => {
+      const error = new Error(`Development worker exited with code ${String(code)}.`);
+      this.#closeCause ??= error;
+      void this.close(error);
+    });
+    worker.on("message", (message: unknown) => this._handleMessage(message));
+  }
+}
+
+export const createNodeDevelopmentRunner: DevelopmentRunnerFactory = (input) =>
+  new NodeDevelopmentRunner(input);
+
+function isWorkerInitializationError(
+  value: unknown,
+): value is { readonly error: string; readonly event: "init-error" } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return record.event === "init-error" && typeof record.error === "string";
+}

--- a/packages/eve/src/internal/nitro/host/dev-server-http.ts
+++ b/packages/eve/src/internal/nitro/host/dev-server-http.ts
@@ -1,0 +1,119 @@
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+
+import { toErrorMessage } from "#shared/errors.js";
+
+export function createPublicRequest(request: IncomingMessage, signal: AbortSignal): Request {
+  const authority = request.headers.host ?? "localhost";
+  const url = new URL(request.url ?? "/", `http://${authority}`);
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+
+  const hasBody = request.method !== "GET" && request.method !== "HEAD";
+  return new Request(url, {
+    body: hasBody ? (Readable.toWeb(request) as ReadableStream<Uint8Array>) : undefined,
+    duplex: hasBody ? "half" : undefined,
+    headers,
+    method: request.method,
+    signal,
+  } as RequestInit & { duplex?: "half" });
+}
+
+export async function writeResponse(
+  response: ServerResponse,
+  webResponse: Response,
+  signal: AbortSignal,
+): Promise<void> {
+  if (response.destroyed) {
+    await webResponse.body?.cancel();
+    return;
+  }
+
+  response.statusCode = webResponse.status;
+  response.statusMessage = webResponse.statusText;
+  const getSetCookie = (
+    webResponse.headers as Headers & {
+      getSetCookie?: () => readonly string[];
+    }
+  ).getSetCookie;
+  const setCookies = getSetCookie?.call(webResponse.headers) ?? [];
+  webResponse.headers.forEach((value, name) => {
+    if (name.toLowerCase() !== "set-cookie") {
+      response.setHeader(name, value);
+    }
+  });
+  if (setCookies.length > 0) {
+    response.setHeader("set-cookie", [...setCookies]);
+  }
+
+  if (webResponse.body === null) {
+    await endResponse(response);
+    return;
+  }
+
+  const body = Readable.fromWeb(webResponse.body as import("node:stream/web").ReadableStream);
+  const cancelBody = () => body.destroy(signal.reason as Error | undefined);
+  signal.addEventListener("abort", cancelBody, { once: true });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onClose = () => {
+        if (!response.writableEnded) {
+          reject(new Error("Development client disconnected."));
+        }
+      };
+      body.once("error", reject);
+      response.once("error", reject);
+      response.once("close", onClose);
+      response.once("finish", resolve);
+      body.pipe(response);
+    });
+  } finally {
+    signal.removeEventListener("abort", cancelBody);
+    if (!body.destroyed && (signal.aborted || response.destroyed)) {
+      body.destroy();
+    }
+  }
+}
+
+export function writeRequestError(response: ServerResponse, error: unknown): void {
+  if (!response.headersSent) {
+    response.statusCode = 503;
+    response.setHeader("content-type", "application/json; charset=utf-8");
+  }
+  if (!response.writableEnded && !response.destroyed) {
+    response.end(JSON.stringify({ error: toErrorMessage(error) }));
+  }
+}
+
+export function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return Promise.resolve();
+  }
+
+  const closed = new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    });
+  });
+  server.closeIdleConnections?.();
+  return closed;
+}
+
+async function endResponse(response: ServerResponse): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    response.once("error", reject);
+    response.end(resolve);
+  });
+}

--- a/packages/eve/src/internal/nitro/host/drained-nitro-dev-server.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/drained-nitro-dev-server.scenario.test.ts
@@ -1,0 +1,267 @@
+import { connect } from "node:net";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { Nitro } from "nitro/types";
+
+import {
+  DrainedNitroDevServer,
+  type DrainedDevServerListener,
+} from "#internal/nitro/host/drained-nitro-dev-server.js";
+import type {
+  DevelopmentRunner,
+  DevelopmentRunnerFactory,
+} from "#internal/nitro/host/dev-runner.js";
+
+const TEST_DEADLINE_MS = 5_000;
+
+interface TestRunner extends DevelopmentRunner {
+  crash(cause: Error): void;
+  readonly closeMock: ReturnType<typeof vi.fn>;
+}
+
+interface NitroStub {
+  emitError(cause: unknown): void;
+  emitReload(): void;
+  emitStart(): void;
+  readonly nitro: ConstructorParameters<typeof DrainedNitroDevServer>[0];
+}
+
+function createNitroStub(): NitroStub {
+  const handlers = new Map<string, Array<(payload?: never) => unknown>>();
+  return {
+    emitError(cause) {
+      for (const handler of handlers.get("dev:error") ?? []) {
+        handler(cause as never);
+      }
+    },
+    emitReload() {
+      for (const handler of handlers.get("dev:reload") ?? []) {
+        handler(undefined as never);
+      }
+    },
+    emitStart() {
+      for (const handler of handlers.get("dev:start") ?? []) {
+        handler(undefined as never);
+      }
+    },
+    nitro: {
+      hooks: {
+        hook: ((name: string, handler: (payload?: never) => unknown) => {
+          handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+          return () => undefined;
+        }) as Pick<Nitro["hooks"], "hook">["hook"],
+      },
+      logger: { error: () => undefined },
+      options: { output: { dir: "/tmp/eve-drained-test", serverDir: "server" } },
+    },
+  };
+}
+
+function createRunnerFactory(
+  fetchHandler: (request: Request, runnerIndex: number) => Promise<Response>,
+  readiness: (runnerIndex: number) => Promise<void> = async () => undefined,
+): { readonly createRunner: DevelopmentRunnerFactory; readonly runners: TestRunner[] } {
+  const runners: TestRunner[] = [];
+  const createRunner: DevelopmentRunnerFactory = () => {
+    const runnerIndex = runners.length;
+    let closed = false;
+    const closedListeners = new Set<(cause?: unknown) => void>();
+    const notifyClosed = (cause?: unknown) => {
+      const listeners = [...closedListeners];
+      closedListeners.clear();
+      for (const listener of listeners) {
+        listener(cause);
+      }
+    };
+    const closeMock = vi.fn(async () => {
+      closed = true;
+      notifyClosed();
+    });
+    const runner: TestRunner = {
+      close: closeMock,
+      closeMock,
+      get closed() {
+        return closed;
+      },
+      crash(cause) {
+        closed = true;
+        notifyClosed(cause);
+      },
+      fetch: async (request) => await fetchHandler(request, runnerIndex),
+      onceClosed(listener) {
+        if (closed) {
+          listener();
+          return;
+        }
+        closedListeners.add(listener);
+      },
+      upgrade: vi.fn(async () => undefined),
+      waitForReady: vi.fn(async () => await readiness(runnerIndex)),
+    };
+    runners.push(runner);
+    return runner;
+  };
+  return { createRunner, runners };
+}
+
+async function listen(server: DrainedNitroDevServer): Promise<DrainedDevServerListener> {
+  const listener = server.listen({ hostname: "127.0.0.1", port: 0 });
+  await listener.ready();
+  if (listener.url === undefined) {
+    throw new Error("Listener did not expose a URL.");
+  }
+  return listener;
+}
+
+async function withinDeadline<T>(operation: Promise<T>, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), TEST_DEADLINE_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+describe("drained Nitro dev server", () => {
+  it("keeps the previous worker serving when a candidate fails readiness", async () => {
+    const { createRunner, runners } = createRunnerFactory(
+      async (_request, runnerIndex) => new Response(`runner-${String(runnerIndex)}`),
+      async (runnerIndex) => {
+        if (runnerIndex === 1) {
+          throw new Error("candidate failed");
+        }
+      },
+    );
+    const stub = createNitroStub();
+    const server = new DrainedNitroDevServer(stub.nitro, createRunner);
+    const listener = await listen(server);
+
+    stub.emitReload();
+    await expect(
+      fetch(new URL("/", listener.url)).then(async (response) => await response.text()),
+    ).resolves.toBe("runner-0");
+
+    stub.emitStart();
+    stub.emitReload();
+    await vi.waitFor(() => {
+      expect(runners[1]?.closeMock).toHaveBeenCalled();
+    });
+    await expect(
+      fetch(new URL("/", listener.url)).then(async (response) => await response.text()),
+    ).resolves.toBe("runner-0");
+
+    await server.close();
+  });
+
+  it("drains the retired worker only after its last admitted exchange settles", async () => {
+    let releaseFirstResponse: (() => void) | undefined;
+    const { createRunner, runners } = createRunnerFactory(async (_request, runnerIndex) => {
+      if (runnerIndex === 0) {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("started\n"));
+            releaseFirstResponse = () => controller.close();
+          },
+        });
+        return new Response(body);
+      }
+      return new Response("runner-1");
+    });
+    const stub = createNitroStub();
+    const server = new DrainedNitroDevServer(stub.nitro, createRunner);
+    const listener = await listen(server);
+
+    stub.emitReload();
+    const streaming = await fetch(new URL("/", listener.url));
+    const reader = streaming.body?.getReader();
+    await reader?.read();
+
+    stub.emitReload();
+    await withinDeadline(
+      vi.waitFor(async () => {
+        const response = await fetch(new URL("/", listener.url));
+        expect(await response.text()).toBe("runner-1");
+      }),
+      "Timed out waiting for the replacement worker to serve.",
+    );
+    expect(runners[0]?.closeMock).not.toHaveBeenCalled();
+
+    releaseFirstResponse?.();
+    await withinDeadline(
+      (async () => {
+        for (;;) {
+          const result = await reader?.read();
+          if (result === undefined || result.done) {
+            return;
+          }
+        }
+      })(),
+      "Timed out waiting for the retired stream to finish.",
+    );
+    await vi.waitFor(() => {
+      expect(runners[0]?.closeMock).toHaveBeenCalled();
+    });
+
+    await server.close();
+  });
+
+  it("restarts the worker when it exits unexpectedly", async () => {
+    const { createRunner, runners } = createRunnerFactory(
+      async (_request, runnerIndex) => new Response(`runner-${String(runnerIndex)}`),
+    );
+    const stub = createNitroStub();
+    const server = new DrainedNitroDevServer(stub.nitro, createRunner);
+    const listener = await listen(server);
+    stub.emitReload();
+    await expect(
+      fetch(new URL("/", listener.url)).then(async (response) => await response.text()),
+    ).resolves.toBe("runner-0");
+
+    runners[0]?.crash(new Error("worker exploded"));
+    await withinDeadline(
+      vi.waitFor(async () => {
+        const response = await fetch(new URL("/", listener.url));
+        expect(await response.text()).toBe("runner-1");
+      }),
+      "Timed out waiting for the restarted worker.",
+    );
+
+    await server.close();
+  });
+
+  it("destroys the socket when an upgrade fails and closes idempotently", async () => {
+    const { createRunner, runners } = createRunnerFactory(async () => new Response("ok"));
+    const stub = createNitroStub();
+    const server = new DrainedNitroDevServer(stub.nitro, createRunner);
+    const listener = await listen(server);
+    stub.emitReload();
+    await fetch(new URL("/", listener.url));
+    (runners[0] as { upgrade: unknown }).upgrade = vi.fn(async () => {
+      throw new Error("upgrade rejected");
+    });
+
+    const target = new URL(listener.url ?? "");
+    await withinDeadline(
+      new Promise<void>((resolve, reject) => {
+        const socket = connect({ host: target.hostname, port: Number(target.port) }, () => {
+          socket.write(
+            "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+          );
+        });
+        socket.once("close", () => resolve());
+        socket.once("error", reject);
+      }),
+      "Timed out waiting for the failed upgrade socket to close.",
+    );
+
+    await Promise.all([server.close(), server.close()]);
+    await server.close();
+    expect(runners[0]?.closeMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/internal/nitro/host/drained-nitro-dev-server.ts
+++ b/packages/eve/src/internal/nitro/host/drained-nitro-dev-server.ts
@@ -1,0 +1,372 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Socket } from "node:net";
+import { resolve } from "node:path";
+
+import type { Nitro } from "nitro/types";
+
+import {
+  closeServer,
+  createPublicRequest,
+  writeRequestError,
+  writeResponse,
+} from "#internal/nitro/host/dev-server-http.js";
+import {
+  createNodeDevelopmentRunner,
+  type DevelopmentRunner,
+  type DevelopmentRunnerFactory,
+} from "#internal/nitro/host/dev-runner.js";
+import { toErrorMessage } from "#shared/errors.js";
+
+const RUNNER_READY_TIMEOUT_MS = 60_000;
+
+export interface DrainedDevServerListener {
+  close(): Promise<void>;
+  readonly node: { readonly server: Server };
+  ready(): Promise<void>;
+  readonly url: string | undefined;
+}
+
+interface RunnerSlot {
+  activeExchanges: number;
+  drained: boolean;
+  quietListeners: Array<() => void>;
+  readonly runner: DevelopmentRunner;
+}
+
+interface NitroDevHost {
+  readonly hooks: Pick<Nitro["hooks"], "hook">;
+  readonly logger: { error(message: unknown, ...details: unknown[]): unknown };
+  readonly options: {
+    readonly output: Pick<Nitro["options"]["output"], "dir" | "serverDir">;
+  };
+}
+
+/**
+ * Development server with the stock Nitro dev-server contract (`dev:start`,
+ * `dev:reload`, `dev:error`, ready-gated worker replacement) plus drained
+ * replacement: the retired worker keeps serving the responses and sockets it
+ * already admitted — without bound, a streaming turn can hold one for
+ * minutes — and is terminated only once its last exchange settles. Stock
+ * Nitro terminates the previous worker as soon as the next one attaches,
+ * which resets admitted work; this class exists solely to close that gap and
+ * is intended to be deleted in favor of `createDevServer` once equivalent
+ * drain semantics are available upstream.
+ */
+export class DrainedNitroDevServer {
+  readonly #createRunner: DevelopmentRunnerFactory;
+  readonly #draining = new Set<RunnerSlot>();
+  readonly #listeners = new Set<{ beginClose(): Promise<void>; destroySockets(): void }>();
+  readonly #nitro: NitroDevHost;
+  #active: RunnerSlot | undefined;
+  #buildError: unknown;
+  #buildWaiters: Array<() => void> = [];
+  #closePromise: Promise<void> | undefined;
+  #closed = false;
+  #entry: string;
+  #reloadChain: Promise<void> = Promise.resolve();
+  #runnerCounter = 0;
+  #workerData: Readonly<Record<string, unknown>> = {};
+
+  constructor(
+    nitro: NitroDevHost,
+    createRunner: DevelopmentRunnerFactory = createNodeDevelopmentRunner,
+  ) {
+    this.#createRunner = createRunner;
+    this.#nitro = nitro;
+    this.#entry = resolve(nitro.options.output.dir, nitro.options.output.serverDir, "index.mjs");
+
+    nitro.hooks.hook("dev:start", () => {
+      this.#buildError = undefined;
+    });
+    nitro.hooks.hook("dev:reload", (payload) => {
+      this.#buildError = undefined;
+      if (payload?.entry !== undefined) {
+        this.#entry = payload.entry;
+      }
+      if (payload?.workerData !== undefined) {
+        this.#workerData = payload.workerData;
+      }
+      this.#scheduleReload();
+    });
+    nitro.hooks.hook("dev:error", (cause) => {
+      this.#buildError = cause;
+      this.#finishBuild();
+    });
+    nitro.hooks.hook("close", async () => await this.close());
+  }
+
+  listen(input: { readonly hostname: string; readonly port: number }): DrainedDevServerListener {
+    if (this.#closed) {
+      throw new Error("Development server is closed.");
+    }
+
+    const sockets = new Set<Socket>();
+    const server = createServer((request, response) => {
+      void this.#handleRequest(request, response);
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+    });
+    server.on("upgrade", (request, socket, head) => {
+      void this.#handleUpgrade(request, socket as Socket, head);
+    });
+
+    let url: string | undefined;
+    const ready = new Promise<void>((resolvePromise, rejectPromise) => {
+      const onError = (error: Error) => {
+        server.off("listening", onListening);
+        rejectPromise(error);
+      };
+      const onListening = () => {
+        server.off("error", onError);
+        const address = server.address();
+        if (address === null || typeof address === "string") {
+          rejectPromise(new Error("Development server did not expose a TCP address."));
+          return;
+        }
+        const host = input.hostname.includes(":") ? `[${input.hostname}]` : input.hostname;
+        url = `http://${host}:${String(address.port)}/`;
+        resolvePromise();
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen({ host: input.hostname, port: input.port });
+    });
+
+    let closePromise: Promise<void> | undefined;
+    const listenerState = {
+      beginClose: () => {
+        closePromise ??= closeServer(server).finally(() => {
+          this.#listeners.delete(listenerState);
+        });
+        return closePromise;
+      },
+      destroySockets: () => {
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+      },
+    };
+    this.#listeners.add(listenerState);
+
+    return {
+      async close() {
+        const closed = listenerState.beginClose();
+        listenerState.destroySockets();
+        await closed;
+      },
+      node: { server },
+      ready: async () => await ready,
+      get url() {
+        return url;
+      },
+    };
+  }
+
+  async waitForActiveRunner(timeoutMs: number = RUNNER_READY_TIMEOUT_MS): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    // An active runner keeps serving through rebuilds; only the initial boot
+    // (or a boot whose first candidate failed) has nothing to serve with.
+    while (this.#active === undefined && !this.#closed) {
+      if (this.#buildError !== undefined) {
+        throw this.#buildError instanceof Error
+          ? this.#buildError
+          : new Error(String(this.#buildError));
+      }
+      if (Date.now() >= deadline) {
+        throw new Error("Timed out waiting for the development worker to become ready.");
+      }
+      await new Promise<void>((resolvePromise) => {
+        this.#buildWaiters.push(resolvePromise);
+        setTimeout(resolvePromise, 100);
+      });
+    }
+    if (this.#closed) {
+      throw new Error("Development server is closed.");
+    }
+  }
+
+  close(): Promise<void> {
+    this.#closePromise ??= this.#close();
+    return this.#closePromise;
+  }
+
+  async #close(): Promise<void> {
+    this.#closed = true;
+    this.#finishBuild();
+
+    const listeners = [...this.#listeners];
+    const listenerClosePromises = listeners.map((listener) => listener.beginClose());
+
+    const slots = [this.#active, ...this.#draining].filter(
+      (slot): slot is RunnerSlot => slot !== undefined,
+    );
+    this.#active = undefined;
+    this.#draining.clear();
+    await Promise.all(slots.map(async (slot) => await slot.runner.close()));
+
+    for (const listener of listeners) {
+      listener.destroySockets();
+    }
+    await Promise.all(listenerClosePromises);
+  }
+
+  #scheduleReload(): void {
+    this.#reloadChain = this.#reloadChain
+      .catch(() => undefined)
+      .then(async () => await this.#reload());
+  }
+
+  async #reload(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+
+    const slot: RunnerSlot = {
+      activeExchanges: 0,
+      drained: false,
+      quietListeners: [],
+      runner: this.#createRunner({
+        entry: this.#entry,
+        name: `eve-dev-${String(this.#runnerCounter++)}`,
+        workerData: this.#workerData,
+      }),
+    };
+
+    try {
+      await slot.runner.waitForReady(RUNNER_READY_TIMEOUT_MS);
+    } catch (error) {
+      await slot.runner.close(error).catch(() => undefined);
+      // A failed candidate stays invisible: the previous worker keeps
+      // serving, exactly like a failed Nitro build.
+      this.#nitro.logger.error(`[eve:dev] dev worker candidate failed: ${toErrorMessage(error)}`);
+      if (this.#active === undefined) {
+        this.#buildError = error;
+      }
+      this.#finishBuild();
+      return;
+    }
+
+    if (this.#closed) {
+      await slot.runner.close().catch(() => undefined);
+      return;
+    }
+
+    const previous = this.#active;
+    this.#active = slot;
+    slot.runner.onceClosed(() => {
+      void this.#handleRunnerClose(slot);
+    });
+    this.#finishBuild();
+
+    if (previous !== undefined) {
+      this.#drainInBackground(previous);
+    }
+  }
+
+  async #handleRunnerClose(slot: RunnerSlot): Promise<void> {
+    if (this.#closed || this.#active !== slot) {
+      return;
+    }
+    this.#active = undefined;
+    this.#nitro.logger.error("[eve:dev] dev worker exited; restarting.");
+    this.#scheduleReload();
+  }
+
+  #drainInBackground(slot: RunnerSlot): void {
+    this.#draining.add(slot);
+    const finishDrain = () => {
+      if (slot.drained) {
+        return;
+      }
+      slot.drained = true;
+      this.#draining.delete(slot);
+      void slot.runner.close().catch(() => undefined);
+    };
+    if (slot.activeExchanges === 0) {
+      finishDrain();
+      return;
+    }
+    slot.quietListeners.push(finishDrain);
+  }
+
+  #beginExchange(slot: RunnerSlot): () => void {
+    slot.activeExchanges += 1;
+    let settled = false;
+    return () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      slot.activeExchanges -= 1;
+      if (slot.activeExchanges === 0) {
+        for (const listener of slot.quietListeners.splice(0)) {
+          listener();
+        }
+      }
+    };
+  }
+
+  async #handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    const requestAbort = new AbortController();
+    const abortRequest = (cause?: unknown) => {
+      if (!requestAbort.signal.aborted) {
+        requestAbort.abort(cause);
+      }
+    };
+    request.once("error", abortRequest);
+    response.once("close", () => {
+      if (!response.writableEnded) {
+        abortRequest();
+      }
+    });
+
+    let settle: (() => void) | undefined;
+    try {
+      await this.waitForActiveRunner();
+      const slot = this.#active;
+      if (slot === undefined) {
+        throw new Error("Development worker is unavailable.");
+      }
+      settle = this.#beginExchange(slot);
+      const workerResponse = await slot.runner.fetch(
+        createPublicRequest(request, requestAbort.signal),
+      );
+      await writeResponse(response, workerResponse, requestAbort.signal);
+    } catch (error) {
+      if (!requestAbort.signal.aborted) {
+        writeRequestError(response, error);
+      }
+    } finally {
+      settle?.();
+      request.off("error", abortRequest);
+    }
+  }
+
+  async #handleUpgrade(request: IncomingMessage, socket: Socket, head: Buffer): Promise<void> {
+    let settle: (() => void) | undefined;
+    try {
+      await this.waitForActiveRunner();
+      const slot = this.#active;
+      if (slot === undefined) {
+        throw new Error("Development worker is unavailable.");
+      }
+      settle = this.#beginExchange(slot);
+      socket.once("close", settle);
+      socket.once("error", settle);
+      await slot.runner.upgrade({ node: { head, req: request, socket } });
+    } catch {
+      settle?.();
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+    }
+  }
+
+  #finishBuild(): void {
+    for (const wake of this.#buildWaiters.splice(0)) {
+      wake();
+    }
+  }
+}

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -1,6 +1,3 @@
-import { EventEmitter } from "node:events";
-import type { IncomingMessage } from "node:http";
-import type { Socket } from "node:net";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -30,6 +27,7 @@ const mocks = vi.hoisted(() => {
     close: vi.fn(async () => undefined),
     listen: vi.fn(() => listenerServer),
     upgrade: vi.fn(async (_req: unknown, _socket: unknown, _head: unknown) => undefined),
+    waitForActiveRunner: vi.fn(async () => undefined),
   };
   const files = new Map<string, string>();
   const devHandlers: Nitro["options"]["devHandlers"] = [];
@@ -51,7 +49,9 @@ const mocks = vi.hoisted(() => {
     authoredSourceWatcher,
     buildNitro: vi.fn(async () => undefined),
     createDevelopmentApplicationNitro: vi.fn(async () => nitro),
-    createDevServer: vi.fn(() => devServer),
+    createDevServer: vi.fn(function createDevServerMock() {
+      return devServer;
+    }),
     devServer,
     fetch: vi.fn(async () => new Response(null, { status: 200 })),
     files,
@@ -115,8 +115,11 @@ vi.mock("node:fs/promises", () => ({
 
 vi.mock("nitro/builder", () => ({
   build: mocks.buildNitro,
-  createDevServer: mocks.createDevServer,
   prepare: mocks.prepareNitro,
+}));
+
+vi.mock("./drained-nitro-dev-server.js", () => ({
+  DrainedNitroDevServer: mocks.createDevServer,
 }));
 
 vi.mock("./create-application-nitro.js", () => ({
@@ -152,31 +155,6 @@ vi.mock("#execution/sandbox/bindings/local.js", async (importOriginal) => {
     stopDevelopmentSandboxResources: mocks.stopDevelopmentSandboxResources,
   };
 });
-
-function createRequest(): IncomingMessage {
-  return {
-    headers: {
-      upgrade: "websocket",
-    },
-    method: "GET",
-  } as IncomingMessage;
-}
-
-function createSocket(): Socket {
-  const socket = new EventEmitter() as Socket;
-  Object.defineProperty(socket, "destroyed", {
-    configurable: true,
-    value: false,
-  });
-  socket.destroy = vi.fn(() => {
-    Object.defineProperty(socket, "destroyed", {
-      configurable: true,
-      value: true,
-    });
-    return socket;
-  });
-  return socket;
-}
 
 const developmentServerStatePath = join("/tmp/eve-test", ".eve", "dev-server-state.v1.json");
 
@@ -242,15 +220,6 @@ async function loadStartDevelopmentServer(): Promise<
     const handle = await server.start();
     return Object.assign({ ...handle }, { close: () => server.close() });
   };
-}
-
-async function startServer(): Promise<{
-  close(): Promise<void>;
-  url: string;
-}> {
-  const startDevelopmentServer = await loadStartDevelopmentServer();
-
-  return await startDevelopmentServer("/tmp/eve-test");
 }
 
 describe("normalizeDevelopmentServerClientUrl", () => {
@@ -393,7 +362,6 @@ describe("createDevelopmentServer", () => {
     expect(mocks.devServer.listen).toHaveBeenCalledWith({
       hostname: "127.0.0.1",
       port: 2000,
-      silent: true,
     });
 
     await server.close();
@@ -434,12 +402,10 @@ describe("createDevelopmentServer", () => {
     expect(mocks.devServer.listen).toHaveBeenNthCalledWith(1, {
       hostname: "127.0.0.1",
       port: 2000,
-      silent: true,
     });
     expect(mocks.devServer.listen).toHaveBeenNthCalledWith(2, {
       hostname: "127.0.0.1",
       port: 2001,
-      silent: true,
     });
     expect(server.url).toBe("http://127.0.0.1:2001/");
 
@@ -806,77 +772,5 @@ describe("createDevelopmentServer", () => {
     await expect(startDevelopmentServer("/tmp/eve-test")).rejects.toThrow(
       /Invalid PORT environment variable/,
     );
-  });
-
-  it("swallows websocket upgrade rejections from the Nitro dev server", async () => {
-    const originalUpgrade = vi.fn(
-      async (_req: unknown, _socket: unknown, _head: unknown): Promise<undefined> => {
-        throw new Error("Upstream server did not upgrade the connection");
-      },
-    );
-    Object.assign(mocks.nitro.options.features, { websocket: true });
-    mocks.devServer.upgrade = originalUpgrade;
-
-    const server = await startServer();
-
-    try {
-      const socket = createSocket();
-      await expect(
-        mocks.devServer.upgrade(createRequest(), socket, Buffer.alloc(0)),
-      ).resolves.toBeUndefined();
-
-      expect(originalUpgrade).toHaveBeenCalledTimes(1);
-      expect(socket.destroy).toHaveBeenCalledTimes(1);
-    } finally {
-      await server.close();
-    }
-  });
-
-  it("rejects websocket upgrades before Nitro proxying when websocket support is disabled", async () => {
-    const originalUpgrade = vi.fn(
-      async (_req: unknown, _socket: unknown, _head: unknown): Promise<undefined> => undefined,
-    );
-    mocks.devServer.upgrade = originalUpgrade;
-
-    const server = await startServer();
-
-    try {
-      const socket = createSocket();
-      await expect(
-        mocks.devServer.upgrade(createRequest(), socket, Buffer.alloc(0)),
-      ).resolves.toBeUndefined();
-
-      expect(originalUpgrade).not.toHaveBeenCalled();
-      expect(socket.destroy).toHaveBeenCalledTimes(1);
-    } finally {
-      await server.close();
-    }
-  });
-
-  it("handles socket errors emitted during websocket upgrade handling", async () => {
-    const originalUpgrade = vi.fn(
-      async (_req: unknown, socket: unknown, _head: unknown): Promise<undefined> => {
-        const upgradeSocket = socket as Socket;
-
-        upgradeSocket.emit("error", new Error("socket failure"));
-        throw new Error("socket failure");
-      },
-    );
-    Object.assign(mocks.nitro.options.features, { websocket: true });
-    mocks.devServer.upgrade = originalUpgrade;
-
-    const server = await startServer();
-
-    try {
-      const socket = createSocket();
-      await expect(
-        mocks.devServer.upgrade(createRequest(), socket, Buffer.alloc(0)),
-      ).resolves.toBeUndefined();
-
-      expect(originalUpgrade).toHaveBeenCalledTimes(1);
-      expect(socket.destroy).toHaveBeenCalledTimes(1);
-    } finally {
-      await server.close();
-    }
   });
 });

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -1,12 +1,10 @@
-import type { IncomingMessage } from "node:http";
-import type { Socket } from "node:net";
-
 import { EVE_DEV_ENV_FLAG } from "#internal/application/optional-package-install.js";
 
-import { build as buildNitro, createDevServer, prepare } from "nitro/builder";
+import { build as buildNitro, prepare } from "nitro/builder";
 import type { Nitro } from "nitro/types";
 
 import { createDevelopmentApplicationNitro } from "#internal/nitro/host/create-application-nitro.js";
+import { DrainedNitroDevServer } from "#internal/nitro/host/drained-nitro-dev-server.js";
 import { createDevelopmentNitroArtifactsConfig } from "#internal/nitro/host/artifacts-config.js";
 import type { AuthoredSourceWatcherHandle } from "#internal/nitro/host/dev-authored-source-watcher.js";
 import { prepareDevelopmentApplicationHost } from "#internal/nitro/host/prepare-application-host.js";
@@ -108,8 +106,7 @@ function isAddressInUseError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "EADDRINUSE";
 }
 
-type NitroDevelopmentServer = ReturnType<typeof createDevServer>;
-type NitroDevelopmentServerUpgrade = NitroDevelopmentServer["upgrade"];
+type NitroDevelopmentServer = DrainedNitroDevServer;
 
 function resolveDevelopmentServerPort(port: number | string | undefined): number {
   const resolvedPort =
@@ -227,56 +224,6 @@ function installWorkflowLocalQueueEnvironment(serverUrl: string): () => void {
   };
 }
 
-function attachTemporarySocketErrorHandler(socket: Socket): () => void {
-  // Keep early socket failures from becoming uncaught EventEmitter errors
-  // while Nitro/httpxy installs its own upgrade-path listeners.
-  const onSocketError = () => {};
-
-  socket.once("error", onSocketError);
-
-  return () => {
-    socket.off("error", onSocketError);
-  };
-}
-
-function shouldProxyDevelopmentServerWebSocketUpgrades(nitro: Nitro): boolean {
-  return nitro.options.features.websocket === true || nitro.options.experimental.websocket === true;
-}
-
-function guardDevelopmentServerWebSocketUpgrades(
-  nitro: Nitro,
-  devServer: NitroDevelopmentServer,
-): void {
-  const originalUpgrade = devServer.upgrade.bind(devServer) as NitroDevelopmentServerUpgrade;
-  const websocketEnabled = shouldProxyDevelopmentServerWebSocketUpgrades(nitro);
-  const guardedUpgrade: NitroDevelopmentServerUpgrade = async (
-    req: IncomingMessage,
-    socket: Socket,
-    head: unknown,
-  ) => {
-    if (!websocketEnabled) {
-      if (!socket.destroyed) {
-        socket.destroy();
-      }
-      return;
-    }
-
-    const removeSocketErrorHandler = attachTemporarySocketErrorHandler(socket);
-
-    try {
-      await originalUpgrade(req, socket, head);
-    } catch {
-      if (!socket.destroyed) {
-        socket.destroy();
-      }
-    } finally {
-      removeSocketErrorHandler();
-    }
-  };
-
-  devServer.upgrade = guardedUpgrade;
-}
-
 function addDevelopmentRuntimeArtifactsRebuildHandler(input: {
   readonly appRoot: string;
   readonly nitro: Nitro;
@@ -365,7 +312,7 @@ function createDevelopmentServerStartupCleanupError(
 
 async function listenForDevelopmentServer(input: {
   readonly devServer: NitroDevelopmentServer;
-  readonly host?: string;
+  readonly host: string;
   readonly port: number | string | undefined;
   readonly retryOnAddressInUse: boolean;
 }) {
@@ -379,7 +326,6 @@ async function listenForDevelopmentServer(input: {
     const server = input.devServer.listen({
       hostname: input.host,
       port,
-      silent: true,
     });
 
     try {
@@ -476,9 +422,8 @@ async function startNitroDevelopmentServer(
       options.onBootProgress,
     );
     nitro = activeNitro;
-    devServer = createDevServer(activeNitro);
+    devServer = new DrainedNitroDevServer(activeNitro);
     const activeDevServer = devServer;
-    guardDevelopmentServerWebSocketUpgrades(activeNitro, devServer);
     const hostname =
       options.host ?? activeNitro.options.devServer.hostname ?? DEFAULT_DEVELOPMENT_SERVER_HOST;
     const retryOnAddressInUse = requestedPort === undefined;
@@ -505,6 +450,7 @@ async function startNitroDevelopmentServer(
       async () => {
         await prepare(activeNitro);
         await buildNitro(activeNitro);
+        await activeDevServer.waitForActiveRunner();
       },
       options.onBootProgress,
     );

--- a/packages/eve/test/scenarios/dev-server-drain.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server-drain.scenario.test.ts
@@ -1,0 +1,234 @@
+import { Agent } from "node:http";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { EVE_HEALTH_ROUTE_PATH } from "../../src/protocol/routes.js";
+import { WEATHER_AGENT_DESCRIPTOR } from "../../src/internal/testing/scenario-apps/weather-agent.js";
+import {
+  type ScenarioAppDescriptor,
+  useScenarioApp,
+} from "../../src/internal/testing/scenario-app.js";
+import { sendDevelopmentMessage } from "../dev-client-harness/send-message.js";
+import { createDevelopmentSessionState } from "../dev-client-harness/session.js";
+import {
+  fetchText,
+  hasKnownDevServerFailure,
+  requestWithAgent,
+  startEveDev,
+  waitForCondition,
+  type RunningEveDev,
+} from "./dev-server-harness.js";
+
+const scenarioApp = useScenarioApp();
+
+const DRAIN_SCENARIO_TIMEOUT_MS = 360_000;
+
+const DRAIN_CHANNEL_SOURCE = [
+  'import { randomUUID } from "node:crypto";',
+  'import { defineChannel, GET } from "eve/channels";',
+  "",
+  "const workerId = randomUUID();",
+  "",
+  "export default defineChannel({",
+  "  routes: [",
+  '    GET("/drain/worker-id", () => new Response(workerId)),',
+  '    GET("/drain/request-ip", (_request, context) => new Response(String(context.requestIp))),',
+  '    GET("/drain/crash", () => {',
+  "      setTimeout(() => process.exit(7), 25);",
+  '      return new Response("crashing");',
+  "    }),",
+  '    GET("/drain/slow-stream", () => {',
+  "      let timer: ReturnType<typeof setInterval> | undefined;",
+  "      const body = new ReadableStream({",
+  "        start(controller) {",
+  '          controller.enqueue(new TextEncoder().encode("chunk\\n"));',
+  "          timer = setInterval(() => {",
+  '            controller.enqueue(new TextEncoder().encode("chunk\\n"));',
+  "          }, 50);",
+  "        },",
+  "        cancel() {",
+  "          clearInterval(timer);",
+  "        },",
+  "      });",
+  "      return new Response(body);",
+  "    }),",
+  "  ],",
+  "});",
+  "",
+].join("\n");
+
+const DRAIN_DESCRIPTOR: ScenarioAppDescriptor = {
+  ...WEATHER_AGENT_DESCRIPTOR,
+  files: {
+    ...WEATHER_AGENT_DESCRIPTOR.files,
+    "agent/channels/drain.ts": DRAIN_CHANNEL_SOURCE,
+  },
+  name: "weather-agent-drain",
+};
+
+async function triggerWorkerReplacement(server: RunningEveDev, appRoot: string): Promise<void> {
+  const previousWorkerId = await fetchText(server.url, "/drain/worker-id");
+  await writeFile(join(appRoot, ".env.local"), `EVE_DRAIN_RELOAD=${Date.now()}\n`);
+  await waitForCondition(
+    async () => {
+      try {
+        return (await fetchText(server.url, "/drain/worker-id")) !== previousWorkerId;
+      } catch {
+        return false;
+      }
+    },
+    () =>
+      [
+        "Timed out waiting for a replacement worker.",
+        `stdout:\n${server.stdout()}`,
+        `stderr:\n${server.stderr()}`,
+      ].join("\n\n"),
+  );
+}
+
+describe("eve dev drained worker replacement", () => {
+  it(
+    "keeps an admitted stream flowing on the retired worker across a replacement",
+    async () => {
+      const app = await scenarioApp(DRAIN_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        const streamResponse = await fetch(new URL("/drain/slow-stream", server.url));
+        const reader = streamResponse.body?.getReader();
+        await reader?.read();
+
+        await triggerWorkerReplacement(server, app.appRoot);
+
+        // The retired worker must still be producing: several further chunks
+        // arrive after the swap, then the client walks away cleanly.
+        for (let i = 0; i < 5; i += 1) {
+          const result = await reader?.read();
+          expect(result?.done).toBe(false);
+        }
+        await reader?.cancel();
+
+        const turn = await sendDevelopmentMessage({
+          message: "What's the weather in Lisbon?",
+          session: createDevelopmentSessionState(),
+          serverUrl: server.url,
+        });
+        expect(turn.events.some((event) => event.type === "message.completed")).toBe(true);
+        expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
+      } finally {
+        await server.stop();
+      }
+    },
+    DRAIN_SCENARIO_TIMEOUT_MS,
+  );
+
+  it(
+    "serves a kept-alive connection across a worker replacement",
+    async () => {
+      const app = await scenarioApp(DRAIN_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+
+      try {
+        const first = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
+        expect(first.localPort).toBeDefined();
+
+        await triggerWorkerReplacement(server, app.appRoot);
+
+        const second = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
+        expect(second.localPort).toBe(first.localPort);
+        expect(second.body).not.toBe(first.body);
+        expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
+      } finally {
+        agent.destroy();
+        await server.stop();
+      }
+    },
+    DRAIN_SCENARIO_TIMEOUT_MS,
+  );
+
+  it(
+    "restarts the worker after a crash and keeps serving",
+    async () => {
+      const app = await scenarioApp(DRAIN_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        const firstWorkerId = await fetchText(server.url, "/drain/worker-id");
+        await fetch(new URL("/drain/crash", server.url));
+
+        await waitForCondition(
+          async () => {
+            try {
+              return (await fetchText(server.url, "/drain/worker-id")) !== firstWorkerId;
+            } catch {
+              return false;
+            }
+          },
+          () =>
+            [
+              "Timed out waiting for the crashed worker to restart.",
+              `stdout:\n${server.stdout()}`,
+              `stderr:\n${server.stderr()}`,
+            ].join("\n\n"),
+        );
+        const health = await fetch(new URL(EVE_HEALTH_ROUTE_PATH, server.url));
+        expect(health.status).toBe(200);
+      } finally {
+        await server.stop();
+      }
+    },
+    DRAIN_SCENARIO_TIMEOUT_MS,
+  );
+
+  it(
+    "shuts down within a bounded deadline while a stream is open",
+    async () => {
+      const app = await scenarioApp(DRAIN_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+      const streamResponse = await fetch(new URL("/drain/slow-stream", server.url));
+      const reader = streamResponse.body?.getReader();
+      await reader?.read();
+
+      const stopStart = Date.now();
+      await server.stop();
+
+      // The harness escalates to SIGKILL at 10s; a graceful exit must beat it.
+      expect(Date.now() - stopStart).toBeLessThan(9_000);
+      await expect(
+        (async () => {
+          for (;;) {
+            const result = await reader?.read();
+            if (result === undefined || result.done) {
+              return "done";
+            }
+          }
+        })().catch(() => "errored"),
+      ).resolves.toBeDefined();
+    },
+    DRAIN_SCENARIO_TIMEOUT_MS,
+  );
+
+  it(
+    "reports a socket-derived client address despite forged forwarding headers",
+    async () => {
+      const app = await scenarioApp(DRAIN_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        const response = await fetch(new URL("/drain/request-ip", server.url), {
+          headers: { "x-forwarded-for": "203.0.113.7" },
+        });
+        expect(response.status).toBe(200);
+        const address = await response.text();
+        expect(address).not.toBe("203.0.113.7");
+        expect(address).toContain("127.0.0.1");
+      } finally {
+        await server.stop();
+      }
+    },
+    DRAIN_SCENARIO_TIMEOUT_MS,
+  );
+});

--- a/packages/eve/test/scenarios/dev-server-harness.ts
+++ b/packages/eve/test/scenarios/dev-server-harness.ts
@@ -1,0 +1,433 @@
+import { spawn, spawnSync, type ChildProcessByStdio } from "node:child_process";
+import { request as requestHttp, type Agent } from "node:http";
+import { existsSync, watch as watchFileSystem } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Readable } from "node:stream";
+
+import {
+  EVE_DEV_RUNTIME_ARTIFACTS_REBUILD_ROUTE_PATH,
+  EVE_DEV_RUNTIME_ARTIFACTS_ROUTE_PATH,
+  EVE_INFO_ROUTE_PATH,
+} from "../../src/protocol/routes.js";
+import type { AgentInfoResponse } from "../../src/internal/nitro/routes/agent-info/build-agent-info-response.js";
+
+/**
+ * Handle to a spawned `eve dev --no-ui` process serving a scenario app.
+ */
+export interface RunningEveDev {
+  crash(): Promise<void>;
+  readonly stderr: () => string;
+  readonly stdout: () => string;
+  readonly url: string;
+  stop(): Promise<void>;
+}
+
+export interface StartEveDevOptions {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Runtime executing the CLI. Defaults to the current Node executable. */
+  readonly runtime?: "bun" | "node";
+}
+
+/**
+ * Spawns `eve dev --no-ui` for the app and resolves once the server URL is
+ * printed and the state record exists. `NODE_ENV=test` activates the
+ * deterministic mock-model adapter so streamed turns complete without model
+ * credentials.
+ */
+export async function startEveDev(
+  appRoot: string,
+  options: StartEveDevOptions = {},
+): Promise<RunningEveDev> {
+  const child = spawnEveDev(appRoot, options);
+  let stderr = "";
+  let stdout = "";
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const url = await waitForServerUrl({
+    child,
+    getOutput: () => ({ stderr, stdout }),
+  });
+  await waitForPath(join(appRoot, ".eve", "dev-server-state.v1.json"));
+
+  return {
+    async crash() {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
+      await withinDeadline(
+        new Promise<void>((resolve) => {
+          child.once("exit", () => resolve());
+          child.kill("SIGKILL");
+        }),
+        "Timed out waiting for the dev server process to crash.",
+      );
+    },
+    stderr: () => stderr,
+    stdout: () => stdout,
+    async stop() {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          child.kill("SIGKILL");
+          resolve();
+        }, 10_000);
+
+        child.once("exit", () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+        child.kill("SIGTERM");
+      });
+    },
+    url,
+  };
+}
+
+/**
+ * Spawns `eve dev` and resolves with the process exit for flows that expect
+ * startup to fail (e.g. unsupported runtimes).
+ */
+export async function runEveDevToExit(
+  appRoot: string,
+  options: StartEveDevOptions = {},
+): Promise<{ readonly code: number | null; readonly output: string }> {
+  const child = spawnEveDev(appRoot, options);
+  let output = "";
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    output += chunk;
+  });
+
+  try {
+    return await withinDeadline(
+      new Promise<{ readonly code: number | null; readonly output: string }>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code) => resolve({ code, output }));
+      }),
+      `Timed out waiting for eve dev to exit.\n\noutput:\n${output}`,
+      120_000,
+    );
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
+}
+
+function spawnEveDev(
+  appRoot: string,
+  options: StartEveDevOptions,
+): ChildProcessByStdio<null, Readable, Readable> {
+  const eveBinPath = join(appRoot, "node_modules", "eve", "bin", "eve.js");
+  const command = options.runtime === "bun" ? "bun" : process.execPath;
+
+  return spawn(command, [eveBinPath, "dev", "--no-ui", "--host", "127.0.0.1", "--port", "0"], {
+    cwd: appRoot,
+    env: {
+      ...process.env,
+      ...options.env,
+      NODE_ENV: "test",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/** Reports whether `bun` is runnable on this machine. */
+export function isBunAvailable(): boolean {
+  try {
+    return spawnSync("bun", ["--version"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export function hasUnsupportedWindowsEsmImport(text: string): boolean {
+  return (
+    text.includes("ERR_UNSUPPORTED_ESM_URL_SCHEME") ||
+    text.includes("Received protocol 'g:'") ||
+    text.includes('Received protocol "g:"')
+  );
+}
+
+/**
+ * Matches output signatures that mean the dev server broke: reset sockets,
+ * unresolved generated imports, or a pruned module-map loader.
+ */
+export function hasKnownDevServerFailure(text: string): boolean {
+  return (
+    hasUnsupportedWindowsEsmImport(text) ||
+    text.includes("UNRESOLVED_IMPORT") ||
+    text.includes("ECONNRESET") ||
+    text.includes("socket hang up") ||
+    (text.includes("ERR_MODULE_NOT_FOUND") && text.includes("authored-module-map-loader"))
+  );
+}
+
+export async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function waitForCondition(
+  condition: () => boolean | Promise<boolean>,
+  failureMessage: string | (() => string),
+  timeoutMs: number = 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!(await condition())) {
+    if (Date.now() >= deadline) {
+      throw new Error(typeof failureMessage === "function" ? failureMessage() : failureMessage);
+    }
+    await wait(100);
+  }
+}
+
+export async function withinDeadline<T>(
+  operation: Promise<T>,
+  failureMessage: string,
+  timeoutMs: number = 60_000,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(failureMessage)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export async function waitForPath(path: string, timeoutMs: number = 60_000): Promise<void> {
+  if (existsSync(path)) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const watcher = watchFileSystem(dirname(path), () => {
+      if (existsSync(path)) {
+        settle(resolve);
+      }
+    });
+    const timeout = setTimeout(() => {
+      settle(() => reject(new Error(`Timed out waiting for ${path}.`)));
+    }, timeoutMs);
+    function settle(complete: () => void) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      watcher.close();
+      complete();
+    }
+    if (existsSync(path)) {
+      settle(resolve);
+    }
+  });
+}
+
+export async function fetchText(serverUrl: string, path: string): Promise<string> {
+  const response = await fetch(new URL(path, serverUrl));
+  if (!response.ok) {
+    throw new Error(`Expected ${path} to succeed, received ${String(response.status)}.`);
+  }
+  return await response.text();
+}
+
+export async function fetchAgentInfo(serverUrl: string): Promise<AgentInfoResponse> {
+  const response = await fetch(new URL(EVE_INFO_ROUTE_PATH, serverUrl));
+  if (!response.ok) {
+    throw new Error(`Expected agent info to succeed, received ${String(response.status)}.`);
+  }
+  return (await response.json()) as AgentInfoResponse;
+}
+
+export async function forceDevelopmentRebuild(serverUrl: string): Promise<void> {
+  const rebuildUrl = new URL(EVE_DEV_RUNTIME_ARTIFACTS_REBUILD_ROUTE_PATH, serverUrl);
+  rebuildUrl.searchParams.set("force", "1");
+  const response = await fetch(rebuildUrl);
+  if (!response.ok) {
+    throw new Error(`Development rebuild failed with status ${String(response.status)}.`);
+  }
+}
+
+export async function readDevelopmentRevision(serverUrl: string): Promise<string> {
+  const response = await fetch(new URL(EVE_DEV_RUNTIME_ARTIFACTS_ROUTE_PATH, serverUrl));
+  if (!response.ok) {
+    throw new Error(`Development runtime state failed with status ${String(response.status)}.`);
+  }
+  const body = (await response.json()) as { readonly revision?: unknown };
+  if (typeof body.revision !== "string") {
+    throw new Error("Development runtime state did not include a revision.");
+  }
+  return body.revision;
+}
+
+function stripAnsi(text: string): string {
+  return text
+    .split("\u001b[")
+    .map((segment, index) => {
+      if (index === 0) {
+        return segment;
+      }
+
+      return segment.replace(/^[0-9;]*m/, "");
+    })
+    .join("");
+}
+
+function parseServerUrl(stdout: string): string | undefined {
+  const match = /server listening at (https?:\/\/\S+)/.exec(stripAnsi(stdout));
+
+  return match?.[1];
+}
+
+async function waitForServerUrl(input: {
+  readonly child: ChildProcessByStdio<null, Readable, Readable>;
+  readonly getOutput: () => {
+    readonly stderr: string;
+    readonly stdout: string;
+  };
+}): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+
+    const timeout = setTimeout(() => {
+      settleReject(
+        new Error(
+          [
+            "Timed out waiting for eve dev to print its server URL.",
+            `stdout:\n${input.getOutput().stdout}`,
+            `stderr:\n${input.getOutput().stderr}`,
+          ].join("\n\n"),
+        ),
+      );
+    }, 120_000);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      input.child.stdout.off("data", handleOutput);
+      input.child.stderr.off("data", handleOutput);
+      input.child.off("error", settleReject);
+      input.child.off("exit", handleExit);
+    };
+
+    const settleResolve = (url: string) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(url);
+    };
+
+    function settleReject(error: unknown) {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      reject(error);
+    }
+
+    function handleOutput() {
+      const output = input.getOutput();
+      const combinedOutput = `${output.stdout}\n${output.stderr}`;
+
+      if (hasKnownDevServerFailure(combinedOutput)) {
+        settleReject(
+          new Error(
+            [
+              "eve dev emitted a known reload or generated-bundle failure.",
+              `stdout:\n${output.stdout}`,
+              `stderr:\n${output.stderr}`,
+            ].join("\n\n"),
+          ),
+        );
+        return;
+      }
+
+      const url = parseServerUrl(output.stdout);
+
+      if (url !== undefined) {
+        settleResolve(url);
+      }
+    }
+
+    function handleExit(code: number | null, signal: NodeJS.Signals | null) {
+      const output = input.getOutput();
+
+      settleReject(
+        new Error(
+          [
+            `eve dev exited before printing its server URL (code ${String(code)}, signal ${String(signal)}).`,
+            `stdout:\n${output.stdout}`,
+            `stderr:\n${output.stderr}`,
+          ].join("\n\n"),
+        ),
+      );
+    }
+
+    input.child.stdout.on("data", handleOutput);
+    input.child.stderr.on("data", handleOutput);
+    input.child.once("error", settleReject);
+    input.child.once("exit", handleExit);
+    handleOutput();
+  });
+}
+
+/**
+ * Issues one GET through the provided keep-alive agent and reports the local
+ * port so callers can assert connection reuse across worker replacements.
+ */
+export async function requestWithAgent(
+  url: string,
+  agent: Agent,
+): Promise<{ readonly body: string; readonly localPort: number | undefined }> {
+  return await new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const request = requestHttp(
+      {
+        agent,
+        host: target.hostname,
+        path: `${target.pathname}${target.search}`,
+        port: Number(target.port),
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        const localPort = response.socket.localPort;
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => {
+          resolve({ body: Buffer.concat(chunks).toString("utf8"), localPort });
+        });
+      },
+    );
+    request.once("error", reject);
+    request.end();
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1087,6 +1087,9 @@ importers:
       emulate:
         specifier: 0.6.0
         version: 0.6.0
+      env-runner:
+        specifier: 0.1.12
+        version: 0.1.12
       eventsource-parser:
         specifier: 3.0.8
         version: 3.0.8
@@ -8303,14 +8306,6 @@ packages:
       srvx:
         optional: true
 
-  crossws@0.4.5:
-    resolution: {integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==}
-    peerDependencies:
-      srvx: '>=0.11.5'
-    peerDependenciesMeta:
-      srvx:
-        optional: true
-
   crossws@0.4.6:
     resolution: {integrity: sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==}
     peerDependencies:
@@ -9773,9 +9768,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  httpxy@0.5.3:
-    resolution: {integrity: sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==}
 
   httpxy@0.5.5:
     resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
@@ -20542,7 +20534,7 @@ snapshots:
       confbox: 0.2.4
       defu: 6.1.7
       dotenv: 17.4.2
-      exsolve: 1.0.8
+      exsolve: 1.1.0
       giget: 3.2.0
       jiti: 2.7.0
       ohash: 2.0.11
@@ -20835,10 +20827,6 @@ snapshots:
   crossws@0.4.10(srvx@0.11.22):
     optionalDependencies:
       srvx: 0.11.22
-
-  crossws@0.4.5(srvx@0.11.16):
-    optionalDependencies:
-      srvx: 0.11.16
 
   crossws@0.4.6(srvx@0.11.16):
     optionalDependencies:
@@ -21362,10 +21350,10 @@ snapshots:
 
   env-runner@0.1.12:
     dependencies:
-      crossws: 0.4.5(srvx@0.11.16)
-      exsolve: 1.0.8
-      httpxy: 0.5.3
-      srvx: 0.11.16
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.0
+      httpxy: 0.5.5
+      srvx: 0.11.22
 
   error-stack-parser-es@1.0.5: {}
 
@@ -22572,7 +22560,7 @@ snapshots:
   h3@2.0.1-rc.22(crossws@0.4.6(srvx@0.11.16)):
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.16
+      srvx: 0.11.22
     optionalDependencies:
       crossws: 0.4.6(srvx@0.11.16)
 
@@ -22811,8 +22799,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  httpxy@0.5.3: {}
 
   httpxy@0.5.5: {}
 


### PR DESCRIPTION
## Why

First implementation stage of the stock-Nitro dev-server route (parallel to #760–#778, branched off #759 as the shared foundation). Stock Nitro's dev server already ready-gates reloads and gates admissions — but `RunnerManager.reload` terminates the previous worker as soon as the next one attaches, resetting every admitted response and socket. That termination is the only gap between stock Nitro and eve's no-reset requirement.

## What changed

- `DrainedNitroDevServer`: keeps the stock dev-server contract (`dev:start`/`dev:reload`/`dev:error` hooks, ready-gated replacement, crash restart) and adds **drained replacement** — the retired worker keeps serving the responses and websockets it already admitted (unbounded; a streaming turn can hold one for minutes) and is terminated once its last exchange settles, via parent-side exchange accounting. No worker-side protocol needed.
- Requests are served by the active worker *throughout* rebuilds (no stall), a failed candidate stays invisible behind the previous worker, and shutdown terminates immediately so open streams cannot block exit.
- Workers run on the vendored `env-runner` node-worker — the same runner stock Nitro uses. The class is deliberately shaped to be deleted once equivalent drain semantics land upstream in Nitro/env-runner (upstream PR to follow).

## Tests

Real-server contract suite (`dev-server-drain.scenario.test.ts`): an admitted stream keeps flowing on the retired worker across a replacement; a kept-alive connection serves across a replacement on the same socket; crash restart; bounded shutdown with an open stream; socket-derived client address despite forged forwarding headers. Class-level suite covers failed-candidate invisibility, drain-on-last-exchange, crash restart, failed-upgrade socket destruction, and idempotent close. The pre-existing dev-server scenario passes unchanged.

## Next stages

P3: transactional rebuild coordinator driving stock reloads. P4: Workflow World in the CLI process with latest-per-turn selection. Plan and test-parity matrix tracked in `research/dev-stock-nitro-alignment.md` (uncommitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)