### PR TITLE
fix(eve): allow project creation from link

### DIFF
--- a/.changeset/fuzzy-links-create.md
+++ b/.changeset/fuzzy-links-create.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve link` now lets you create a Vercel project or link an existing one, matching the project setup available through `/model` usage.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -166,7 +166,7 @@ Local dev keeps immutable runtime source snapshots under `.eve/dev-runtime/snaps
 eve link
 ```
 
-Links the current directory to an existing Vercel project. You select a team and then one of its recent projects; type a project name and choose **Search for '<name>'** to search the rest of that team's projects. Vercel links the selected project, eve verifies its project ID, and then pulls the project's environment so an AI Gateway credential (`VERCEL_OIDC_TOKEN` or `AI_GATEWAY_API_KEY`) lands in `.env.local`. Running it again re-links: the pickers always run, and the new choice wins. The command is interactive only; in CI, use `vercel link --project <name> --yes --non-interactive` instead. A running `eve dev` reloads env files automatically, so you don't need to restart after the pull.
+Links the current directory to a Vercel project. After selecting a team, you can create a project named for the agent or link an existing project. The existing-project picker shows recent projects; type a project name and choose **Search for '<name>'** to search the rest of that team's projects. Vercel links the resolved project, eve verifies its project ID, and then pulls the project's environment so an AI Gateway credential (`VERCEL_OIDC_TOKEN` or `AI_GATEWAY_API_KEY`) lands in `.env.local`. Running it again re-links: the pickers always run, and the new choice wins. The command is interactive only; in CI, use `vercel link --project <name> --yes --non-interactive` instead. A running `eve dev` reloads env files automatically, so you don't need to restart after the pull.
 
 ## `eve deploy`
 

--- a/packages/eve/src/cli/commands/link.integration.test.ts
+++ b/packages/eve/src/cli/commands/link.integration.test.ts
@@ -136,12 +136,12 @@ describe("runLinkCommand", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  test("links through the shared flow and reports success", async () => {
+  test("creates a project through the shared flow and reports success", async () => {
     const projectRoot = await createAgentProject();
     const logger = new TestLogger();
     const fake = createFakePrompter({
       single: (opts) => {
-        if (opts.message === "Vercel project") return "link";
+        if (opts.message === "Vercel project") return "new";
         throw new Error(`Unexpected select: ${opts.message}`);
       },
     });
@@ -158,6 +158,8 @@ describe("runLinkCommand", () => {
     expect(process.exitCode).toBeUndefined();
     expect(fake.prompter.intro).toHaveBeenCalledWith("Link your eve agent to Vercel");
     expect(fake.prompter.outro).toHaveBeenCalledWith("Project linked.");
+    expect(flowDeps.resolveProvisioning?.pickNewProjectName).toHaveBeenCalled();
+    expect(flowDeps.resolveProvisioning?.pickProject).not.toHaveBeenCalled();
     expect(flowDeps.linkProject?.linkProject).toHaveBeenCalled();
   });
 });

--- a/packages/eve/src/cli/commands/link.ts
+++ b/packages/eve/src/cli/commands/link.ts
@@ -24,11 +24,12 @@ const defaultDependencies: LinkCommandDependencies = {
 };
 
 /**
- * `eve link`: pick a Vercel team and project (re-linking when one is already
- * linked), run `vercel link` for the selected project, then pull env so the AI Gateway
- * credential lands in `.env.local`. The flow itself is {@link runLinkFlow}, shared with the dev
- * TUI `/model` menu's provider row. Interactive only: the pickers are the point of the command,
- * so a non-TTY run refuses with guidance instead of guessing a project.
+ * `eve link`: pick a Vercel team, then create or select a project (re-linking
+ * when one is already linked), run `vercel link` for the resolved project,
+ * then pull env so the AI Gateway credential lands in `.env.local`. The flow
+ * itself is {@link runLinkFlow}, shared with the dev TUI `/model` menu's
+ * provider row. Interactive only: the pickers are the point of the command, so
+ * a non-TTY run refuses with guidance instead of guessing a project.
  */
 export async function runLinkCommand(
   logger: LinkCliLogger,
@@ -51,7 +52,12 @@ export async function runLinkCommand(
   const prompter = dependencies.createPrompter?.() ?? createPrompter();
   prompter.intro("Link your eve agent to Vercel");
   try {
-    const result = await runLinkFlow({ appRoot, prompter, deps: dependencies.flowDeps });
+    const result = await runLinkFlow({
+      appRoot,
+      prompter,
+      projectSelection: "create-or-link",
+      deps: dependencies.flowDeps,
+    });
     prompter.outro(result.kind === "cancelled" ? "Cancelled." : "Project linked.");
   } catch (error) {
     logger.error(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Summary

- let eve link create a new Vercel project or select an existing one
- use the same create-or-link project selection already exposed by the eve dev model flow
- update focused integration coverage, CLI documentation, and release notes

## Why

The eve link command previously skipped project creation and opened the existing-project picker directly, while the equivalent model setup flow offered both choices. This makes the dedicated command consistent and avoids a dead end when no suitable project exists.

## Test plan

- [x] focused eve link integration test
- [x] changed-file formatting check
- [x] pnpm docs:check
- [x] eve package typecheck
- [x] git diff --check