### PR TITLE
fix: inline dynamic imports in authored module bundles

### DIFF
--- a/.changeset/calm-dynamic-generations.md
+++ b/.changeset/calm-dynamic-generations.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Inline dynamic imports in eve's single-file authored module bundles so channels and tools can load modules dynamically during development and production builds.

--- a/e2e/fixtures/agent-tools/agent/lib/dynamic-import-marker.ts
+++ b/e2e/fixtures/agent-tools/agent/lib/dynamic-import-marker.ts
@@ -1,0 +1,1 @@
+export const marker = "authored-dynamic-import-loaded";

--- a/e2e/fixtures/agent-tools/agent/tools/read-dynamic-dependency.ts
+++ b/e2e/fixtures/agent-tools/agent/tools/read-dynamic-dependency.ts
@@ -1,0 +1,17 @@
+import { readDynamicImportMarker } from "@eve-e2e/dynamic-import-dependency";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+export default defineTool({
+  description:
+    "Loads the dynamic dependency marker. Only call when the user explicitly asks to use `read-dynamic-dependency`.",
+  inputSchema: z.object({}),
+  async execute() {
+    const [{ marker: authoredMarker }, dependencyMarker] = await Promise.all([
+      import("../lib/dynamic-import-marker"),
+      readDynamicImportMarker(),
+    ]);
+
+    return { authoredMarker, dependencyMarker };
+  },
+});

--- a/e2e/fixtures/agent-tools/evals/static-tools/dynamic-dependency-import.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/dynamic-dependency-import.eval.ts
@@ -1,0 +1,20 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "Static tools smoke: authored modules and dependencies can use dynamic imports.",
+  async test(t) {
+    await t.send(
+      "Call the `read-dynamic-dependency` tool. Reply with its marker exactly as returned.",
+    );
+
+    t.succeeded();
+    t.calledTool("read-dynamic-dependency", {
+      output: (value: unknown) =>
+        typeof value === "object" &&
+        value !== null &&
+        !Array.isArray(value) &&
+        (value as Record<string, unknown>).authoredMarker === "authored-dynamic-import-loaded" &&
+        (value as Record<string, unknown>).dependencyMarker === "dynamic-dependency-loaded",
+    });
+  },
+});

--- a/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/index.d.ts
+++ b/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/index.d.ts
@@ -1,0 +1,1 @@
+export declare function readDynamicImportMarker(): Promise<string>;

--- a/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/index.js
+++ b/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/index.js
@@ -1,0 +1,4 @@
+export async function readDynamicImportMarker() {
+  const { marker } = await import("./marker.js");
+  return marker;
+}

--- a/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/marker.js
+++ b/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/marker.js
@@ -1,0 +1,1 @@
+export const marker = "dynamic-dependency-loaded";

--- a/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/package.json
+++ b/e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@eve-e2e/dynamic-import-dependency",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  }
+}

--- a/e2e/fixtures/agent-tools/package.json
+++ b/e2e/fixtures/agent-tools/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "eve eval --strict"
   },
   "dependencies": {
+    "@eve-e2e/dynamic-import-dependency": "file:./fixtures/dynamic-import-dependency",
     "@opentelemetry/core": "2.6.1",
     "@opentelemetry/sdk-trace-base": "2.6.1",
     "@vercel/otel": "2.1.2",

--- a/packages/eve/src/internal/authored-module-loader.scenario.test.ts
+++ b/packages/eve/src/internal/authored-module-loader.scenario.test.ts
@@ -101,6 +101,30 @@ describe("loadAuthoredModuleNamespace", () => {
     expect(moduleNamespace.result).toBe("directory-index");
   });
 
+  it("loads authored modules with dynamic relative imports", async () => {
+    const app = await scenarioApp({
+      files: {
+        "agent/lib/dynamic-value.ts": 'export const value = "dynamic-relative-import";\n',
+        "agent/tools/use_dynamic_value.ts": [
+          "export async function readValue() {",
+          '  const { value } = await import("../lib/dynamic-value");',
+          "  return value;",
+          "}",
+          "",
+        ].join("\n"),
+      },
+      name: "dynamic-relative-import",
+    });
+
+    const moduleNamespace = await loadAuthoredModuleNamespace(
+      join(app.appRoot, "agent", "tools", "use_dynamic_value.ts"),
+    );
+
+    await expect((moduleNamespace.readValue as () => Promise<string>)()).resolves.toBe(
+      "dynamic-relative-import",
+    );
+  });
+
   it("resolves extensionless CommonJS requires with dotted JavaScript basenames", async () => {
     const app = await scenarioApp({
       files: {

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -284,6 +284,7 @@ async function buildAuthoredModuleBundle(
       tsconfig: tsconfigPath,
       write: false,
       output: {
+        codeSplitting: false,
         comments: false,
         format: "esm",
         sourcemap: configuration.sourcemap,

--- a/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
@@ -17,7 +17,7 @@ import { useScenarioApp } from "#internal/testing/scenario-app.js";
 describe("development generation artifacts", () => {
   const scenarioApp = useScenarioApp();
 
-  it("executes its ESM external closure after the original source and dependencies are removed", async () => {
+  it("executes dynamic imports and its ESM external closure after source removal", async () => {
     const app = await scenarioApp({
       dependencies: {
         "fixture-bundled": "1.0.0",
@@ -33,13 +33,13 @@ describe("development generation artifacts", () => {
         ].join("\n"),
         "agent/instructions.md": "Use the available tools.",
         "agent/tools/read_value.mjs": [
-          'import { bundledValue } from "fixture-bundled";',
+          'import { readBundledValue } from "fixture-bundled";',
           'import { externalValue } from "fixture-external/feature";',
           "",
           "export default {",
           '  description: "Read dependency values.",',
-          "  execute() {",
-          "    return `${bundledValue}:${externalValue}`;",
+          "  async execute() {",
+          "    return `${await readBundledValue()}:${externalValue}`;",
           "  },",
           "};",
           "",
@@ -84,10 +84,10 @@ describe("development generation artifacts", () => {
     const toolSourceId = compileResult.manifest.tools[0]?.sourceId;
     expect(toolSourceId).toBeDefined();
     const tool = moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules[toolSourceId!] as {
-      default: { execute(): string };
+      default: { execute(): Promise<string> };
     };
 
-    expect(tool.default.execute()).toBe(
+    await expect(tool.default.execute()).resolves.toBe(
       "bundled-original:serde-original:external-original:payload-original",
     );
   });
@@ -238,8 +238,11 @@ async function writeDependencyFixture(appRoot: string): Promise<string> {
     join(bundledRoot, "index.mjs"),
     [
       '"use workflow";',
-      'import { serdeMarker } from "@workflow/serde";',
-      "export const bundledValue = `bundled-original:${serdeMarker}`;",
+      // Generation bundles are one file, so bundled dynamic imports must be inlined.
+      "export async function readBundledValue() {",
+      '  const { serdeMarker } = await import("@workflow/serde");',
+      "  return `bundled-original:${serdeMarker}`;",
+      "}",
       "",
     ].join("\n"),
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,9 @@ importers:
 
   e2e/fixtures/agent-tools:
     dependencies:
+      '@eve-e2e/dynamic-import-dependency':
+        specifier: file:./fixtures/dynamic-import-dependency
+        version: file:e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency
       '@opentelemetry/core':
         specifier: 2.6.1
         version: 2.6.1(@opentelemetry/api@1.9.1)
@@ -2515,6 +2518,9 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eve-e2e/dynamic-import-dependency@file:e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency':
+    resolution: {directory: e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency, type: directory}
 
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
@@ -14833,6 +14839,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@eve-e2e/dynamic-import-dependency@file:e2e/fixtures/agent-tools/fixtures/dynamic-import-dependency': {}
 
   '@fastify/busboy@2.1.1': {}
 


### PR DESCRIPTION
## Summary

- disable code splitting for eve's single-file authored-module bundle contract used by development and production compilation
- cover direct authored dynamic imports and dynamic imports inside retained development-generation dependencies
- add an agent-tools e2e eval that exercises both forms through local and Vercel CI

## Validation

- pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/authored-module-loader.scenario.test.ts -t "loads authored modules with dynamic relative imports"
- pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/dev-generation-artifacts.scenario.test.ts -t "executes dynamic imports and its ESM external closure after source removal"
- pnpm --filter eve build
- pnpm --filter agent-tools typecheck
- pnpm lint
- e2e eval intentionally left to CI