### PR TITLE
fix(eve): resolve Next build binary from package root

### DIFF
--- a/.changeset/tidy-pandas-build.md
+++ b/.changeset/tidy-pandas-build.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix default Next.js agent build commands to find hoisted eve installations in monorepos.

--- a/packages/eve/src/public/next/index.integration.test.ts
+++ b/packages/eve/src/public/next/index.integration.test.ts
@@ -1,9 +1,19 @@
 import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("#internal/application/package.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("#internal/application/package.js")>();
+  const { join } = await import("node:path");
+  return {
+    ...original,
+    resolvePackageRoot: vi.fn(() => join(process.cwd(), "node_modules", "eve")),
+  };
+});
+
+import { resolvePackageRoot } from "#internal/application/package.js";
 import { withEve, type EveNextConfig, type EveNextRewriteSections } from "./index.js";
 
 interface TestConfig extends EveNextConfig {
@@ -29,6 +39,9 @@ describe("withEve Vercel config", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    vi.mocked(resolvePackageRoot).mockImplementation(() =>
+      join(process.cwd(), "node_modules", "eve"),
+    );
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
@@ -307,6 +320,47 @@ describe("withEve Vercel config", () => {
         },
       },
     });
+  });
+
+  it("references an installed eve binary from a monorepo app", async () => {
+    const projectRoot = await createTempAppRoot();
+    const nextRoot = join(projectRoot, "apps", "nextjs");
+    const agentRoot = join(nextRoot, "agents", "app-agent");
+    const evePackageRoot = join(projectRoot, "node_modules", "eve");
+    await mkdir(join(projectRoot, ".vercel"), { recursive: true });
+    await writeFile(join(projectRoot, ".vercel", "project.json"), "{}\n");
+    await mkdir(agentRoot, { recursive: true });
+    await mkdir(join(evePackageRoot, "bin"), { recursive: true });
+    await writeFile(join(evePackageRoot, "package.json"), "{}\n");
+    await writeFile(join(evePackageRoot, "bin", "eve.js"), "");
+    process.chdir(nextRoot);
+    vi.mocked(resolvePackageRoot).mockReturnValue(evePackageRoot);
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_URL", "preview.example.com");
+
+    await resolveConfig(
+      withEve<TestConfig>(
+        {},
+        {
+          agents: {
+            "app-agent": "./agents/app-agent",
+          },
+        },
+      ),
+    );
+    const outputConfig = (await readJsonFile(
+      join(projectRoot, ".vercel", "output", "config.json"),
+    )) as {
+      services: Record<string, { buildCommand: string }>;
+    };
+    const buildCommand = outputConfig.services["eve-app-agent"]?.buildCommand;
+    const binaryPath = buildCommand?.match(/&& node '([^']+)' build$/)?.[1];
+
+    expect(binaryPath).toBeDefined();
+    const resolvedBinaryPath = resolve(agentRoot, binaryPath!);
+    expect(resolvedBinaryPath).toBe(join(evePackageRoot, "bin", "eve.js"));
+    expect((await stat(resolvedBinaryPath)).isFile()).toBe(true);
   });
 
   it("writes one Build Output service and route for each named agent", async () => {

--- a/packages/eve/src/public/next/index.test.ts
+++ b/packages/eve/src/public/next/index.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("#internal/application/package.js", async () => {
+  const { join } = await import("node:path");
+  return {
+    resolvePackageRoot: vi.fn(() => join(process.cwd(), "node_modules", "eve")),
+  };
+});
+
 vi.mock("./vercel-output-config.js", () => ({
   ensureEveVercelOutputConfig: vi.fn(
     async (input: {

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -2,6 +2,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 
 import type { NextConfig } from "next";
 
+import { resolvePackageRoot } from "#internal/application/package.js";
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
 import { resolveEveDestinationPrefix } from "./server.js";
 import { ensureEveVercelOutputConfig } from "./vercel-output-config.js";
@@ -325,23 +326,17 @@ function toPosixPath(path: string): string {
   return path.replaceAll("\\", "/");
 }
 
-function createDefaultBuildCommand(input: {
-  readonly agentRoot: string;
-  readonly nextRoot: string;
-}): string {
+function createDefaultBuildCommand(input: { readonly agentRoot: string }): string {
   const eveBinaryPath = toPosixPath(
-    relative(input.agentRoot, join(input.nextRoot, "node_modules", "eve", "bin", "eve.js")),
+    relative(input.agentRoot, join(resolvePackageRoot(), "bin", "eve.js")),
   );
   return `node ${quoteShellArg(eveBinaryPath)} build`;
 }
 
-function normalizeAgentsConfig(
-  options: WithEveOptions,
-  nextRoot: string,
-): readonly ResolvedEveNextAgent[] {
+function normalizeAgentsConfig(options: WithEveOptions): readonly ResolvedEveNextAgent[] {
   const servicePrefixBase = normalizeRoutePrefix(options.servicePrefix ?? EVE_NEXT_SERVICE_PREFIX);
   const resolveBuildCommand = (agentRoot: string, buildCommand: string | undefined) =>
-    buildCommand ?? options.eveBuildCommand ?? createDefaultBuildCommand({ agentRoot, nextRoot });
+    buildCommand ?? options.eveBuildCommand ?? createDefaultBuildCommand({ agentRoot });
 
   if (options.agents === undefined) {
     const appRoot = resolveApplicationRoot(options.eveRoot);
@@ -402,7 +397,7 @@ export function withEve<TConfig extends EveNextConfig>(
 ): EveNextConfigFunction<TConfig> {
   const nextRoot = process.cwd();
   const devServerTimeoutMs = resolveDevServerTimeout(options.devServerTimeoutMs);
-  const agents = normalizeAgentsConfig(options, nextRoot);
+  const agents = normalizeAgentsConfig(options);
 
   return async function eveNextConfig(phase, context) {
     const nextConfig = await resolveNextConfig(configOrFunction, phase, context);


### PR DESCRIPTION
### Description

Fixes #684.

`withEve` generated default service build commands using `<Next app>/node_modules/eve/bin/eve.js`. This fails in monorepos where the eve package is hoisted to the workspace root.

Resolve the binary from the currently loaded eve package using the existing `resolvePackageRoot()` helper. This preserves direct Node execution, supports standalone and hoisted installations, and leaves custom build commands unchanged.

Adds integration coverage for a Next app nested in a monorepo and a patch changeset. No documentation update is needed because this restores the intended behavior without changing the public API.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/next/index.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/public/next/index.integration.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build`
- `pnpm guard:invariants`
- Ran targeted Oxlint and oxfmt checks on the changed files.
- Packed eve and installed it in a clean standalone npm project. Confirmed `withEve` generated `node 'node_modules/eve/bin/eve.js' build` and that the referenced binary existed.
- Packed eve and installed it only at the root of a temporary pnpm workspace. From a nested Next app with no local eve installation, confirmed the generated command resolved the hoisted binary and executed successfully from the generated service root (`eve --version` returned `0.24.3`).

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)