### PR TITLE
fix: don't show external link popup for internal links

### DIFF
--- a/apps/docs/app/[lang]/integrations/components/markdown.tsx
+++ b/apps/docs/app/[lang]/integrations/components/markdown.tsx
@@ -1,13 +1,29 @@
 "use client";
 
 import { createCodePlugin } from "@streamdown/code";
+import Link from "next/link";
 import { useMemo } from "react";
-import { Streamdown } from "streamdown";
+import { type Components, Streamdown } from "streamdown";
 import { geistShikiTheme } from "@vercel/geistdocs/shiki-theme";
 
 interface MarkdownProps {
   children: string;
 }
+
+/**
+ * Render internal links with Next's client
+ * router and external links with a plain anchor. This overrides Streamdown's
+ * default anchor, whose `linkSafety` treats every link — internal ones
+ * included — as external and interrupts navigation with a confirmation modal.
+ */
+const components: Partial<Components> = {
+  a: ({ href, ...props }) =>
+    typeof href === "string" && href.startsWith("/") ? (
+      <Link href={href} {...props} />
+    ) : (
+      <a href={href} rel="noreferrer" target="_blank" {...props} />
+    ),
+};
 
 /**
  * Renders static markdown (prose + fenced code) for integration detail
@@ -24,6 +40,7 @@ export const Markdown = ({ children }: MarkdownProps) => {
   return (
     <Streamdown
       className="text-gray-900 [&_a]:font-medium [&_a]:text-gray-1000 [&_a]:underline [&_a]:underline-offset-4 [&_code]:text-gray-1000 [&_li]:my-1 [&_p]:my-3 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5"
+      components={components}
       mode="static"
       plugins={{ code: codePlugin }}
       shikiTheme={[geistShikiTheme, geistShikiTheme]}


### PR DESCRIPTION
### Description

Right now internal links show an external link popup. Go to https://eve.dev/integrations/discord and click "See the Discord channel docs".

<img width="810" height="553" alt="image" src="https://github.com/user-attachments/assets/bca7141d-45f2-4b53-b1b3-eed0158833bf" />


### How did you test your changes?

Local dev preview

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
