### PR TITLE
fix(eve): cancellation - avoid auth teardown stalls

### DIFF
--- a/.changeset/dispose-auth-hook-teardown.md
+++ b/.changeset/dispose-auth-hook-teardown.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Session teardown now disposes authorization hooks without waiting on pending durable iterator reads, preventing cancelled sessions from hanging during cleanup.

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -12,7 +12,11 @@ import {
 import { hydrateDurableSession } from "#execution/session.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { emitCancelledTurn } from "#harness/cancelled-turn-emission.js";
-import { getHarnessEmissionState, setHarnessEmissionState } from "#harness/emission.js";
+import {
+  getHarnessEmissionState,
+  isHarnessBetweenTurns,
+  setHarnessEmissionState,
+} from "#harness/emission.js";
 import {
   clearAllProxyInputRequests,
   hasProxyInputRequests,
@@ -63,7 +67,7 @@ export async function settleCancelledTurnStep(input: {
   // (the proxy epilogue clears the turn id); re-emitting would fabricate
   // a turn id and duplicate the boundary.
   const alreadyEpilogued =
-    emissionState.turnId === "" && hasProxyInputRequests(durableSession.state);
+    isHarnessBetweenTurns(session) && hasProxyInputRequests(durableSession.state);
 
   if (!alreadyEpilogued) {
     const writer = input.parentWritable.getWriter();

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -96,6 +96,11 @@ interface DeliveryHookConfig {
   readonly values?: readonly HookPayload[];
 }
 
+interface AuthHookConfig {
+  readonly dispose?: () => void;
+  readonly return?: () => Promise<IteratorResult<HookPayload>>;
+}
+
 describe("workflowEntry", () => {
   beforeEach(() => {
     vi.stubEnv("VERCEL_PROJECT_PRODUCTION_URL", "");
@@ -764,6 +769,28 @@ describe("workflowEntry", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(symbolDispose).not.toHaveBeenCalled();
   });
+
+  it("disposes the auth hook without closing its iterator", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+
+    const authDispose = vi.fn();
+    const authReturn = createIteratorReturn();
+    installHookMocks({
+      authHook: { dispose: authDispose, return: authReturn },
+      turnControls: [turnResult({ action: "done", output: "ok", sessionState })],
+    });
+
+    await expect(
+      workflowEntry({
+        input: { message: "hello" },
+        serializedContext: createSerializedContext(),
+      }),
+    ).resolves.toEqual({ output: "ok" });
+
+    expect(authDispose).toHaveBeenCalledOnce();
+    expect(authReturn).not.toHaveBeenCalled();
+  });
 });
 
 function createSerializedContext(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -817,6 +844,7 @@ function turnResult(input: {
 }
 
 function installHookMocks(input: {
+  readonly authHook?: AuthHookConfig;
   readonly deliveryHooks?: readonly DeliveryHookConfig[];
   readonly symbolDispose?: () => void;
   readonly turnControls: readonly TurnControlPayload[];
@@ -836,7 +864,12 @@ function installHookMocks(input: {
     }
 
     if (token.endsWith(":auth")) {
-      return createMockHook({ token, values: [] }) as never;
+      return createMockHook({
+        dispose: input.authHook?.dispose,
+        return: input.authHook?.return,
+        token,
+        values: [],
+      }) as never;
     }
 
     const config = deliveryHooks.shift() ?? { token, values: [] };

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -25,7 +25,7 @@ import { createSessionStep } from "#execution/create-session-step.js";
 import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.js";
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
 import { fireSessionCallbackStep } from "#execution/session-callback-step.js";
-import { closeHookIterator, disposeHook } from "#execution/hook-ownership.js";
+import { disposeHook } from "#execution/hook-ownership.js";
 import {
   createSessionDeliveryHook,
   type SessionDeliveryHook,
@@ -301,7 +301,9 @@ async function runDriverLoop(input: {
   } finally {
     await disposeSettledTurnControl?.();
     await deliveryHook.dispose();
-    await closeHookIterator(authIterator);
+    // Dispose without closing the iterator: a session cancelled while
+    // awaiting authorization can leave a durable read in flight, and an
+    // async iterator only honors `return()` after that read settles.
     await disposeHook(authHook);
   }
 }


### PR DESCRIPTION
## Summary

- dispose the session auth hook without closing a potentially blocked durable iterator
- use `isHarnessBetweenTurns` when detecting an already-emitted cancellation boundary
- add regression coverage and a patch changeset

Follow-up to #573.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/workflow-entry.test.ts src/execution/turn-workflow.test.ts src/execution/workflow-steps.test.ts src/execution/turn-cancellation-control.test.ts` (64 passed)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/turn-cancellation.integration.test.ts` (6 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`