### PR TITLE
perf(eve): bundle Vercel surfaces concurrently

### DIFF
--- a/.changeset/concurrent-vercel-builds.md
+++ b/.changeset/concurrent-vercel-builds.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Vercel builds now bundle the app and Workflow function surfaces concurrently after sandbox template prewarming succeeds, reducing deployable build time without changing the emitted output.

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -19,7 +19,7 @@ import {
   VERCEL_EVE_AGENT_SUMMARY_VERSION,
 } from "#internal/vercel-agent-summary.js";
 
-const buildNitroMock = vi.fn(async (nitro: Nitro) => {
+async function buildNitroStub(nitro: Nitro): Promise<void> {
   const outputDir = nitro.options.output.dir;
   const functionDirectory = join(outputDir, "functions", "__server.func");
 
@@ -56,7 +56,9 @@ const buildNitroMock = vi.fn(async (nitro: Nitro) => {
     join(outputDir, "functions", "eve", "v1", "health.func"),
     "dir",
   );
-});
+}
+
+const buildNitroMock = vi.fn(buildNitroStub);
 const copyPublicAssetsMock = vi.fn(async () => undefined);
 const createProductionApplicationNitroMock = vi.fn();
 const prepareProductionApplicationHostMock = vi.fn();
@@ -177,6 +179,7 @@ describe("buildApplication", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    buildNitroMock.mockImplementation(buildNitroStub);
     workflowBuilderConstructors.length = 0;
   });
 
@@ -514,6 +517,69 @@ describe("buildApplication", () => {
     expect(summary.kind).toBe(VERCEL_EVE_AGENT_SUMMARY_KIND);
     expect(summary.schemaVersion).toBe(VERCEL_EVE_AGENT_SUMMARY_VERSION);
     expect((summary.agent as { name: string }).name).toBe("scenario-test-agent");
+  });
+
+  it("waits for sandbox prewarm before bundling either Vercel function surface", async () => {
+    vi.stubEnv("VERCEL", "1");
+    const appRoot = await createScratchDirectory("eve-build-application-vercel-prewarm-failure-");
+    const outputDir = join(appRoot, ".vercel", "output");
+    const outputMarkerPath = join(outputDir, "last-good-output.txt");
+    const createdNitros: Nitro[] = [];
+
+    prepareProductionApplicationHostMock.mockImplementationOnce(prepareHostBuildWorkspace);
+    createProductionApplicationNitroMock.mockImplementation(
+      async (_preparedHost: PreparedApplicationHost, options: { outputDir: string }) => {
+        const nitro = createNitroStub(options.outputDir);
+        createdNitros.push(nitro);
+        return nitro;
+      },
+    );
+    runVercelBuildPrewarmMock.mockRejectedValueOnce(new Error("injected sandbox prewarm failure"));
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(outputMarkerPath, "last-good-output\n");
+
+    const { buildApplication } = await import("#internal/nitro/host/build-application.js");
+    await expect(buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS)).rejects.toThrow(
+      "injected sandbox prewarm failure",
+    );
+
+    expect(createdNitros).toHaveLength(2);
+    expect(buildNitroMock).not.toHaveBeenCalled();
+    expect(workflowBuilderBuildVercelOutputMock).not.toHaveBeenCalled();
+    for (const nitro of createdNitros) {
+      expect(nitro.close).toHaveBeenCalledOnce();
+    }
+    await expect(readFile(outputMarkerPath, "utf8")).resolves.toBe("last-good-output\n");
+  });
+
+  it("bundles the Vercel app and flow surfaces concurrently after prewarm", async () => {
+    vi.stubEnv("VERCEL", "1");
+    const appRoot = await createScratchDirectory("eve-build-application-vercel-concurrent-");
+    const firstBundleStarted = Promise.withResolvers<void>();
+    const releaseBundles = Promise.withResolvers<void>();
+    let bundleCalls = 0;
+
+    prepareProductionApplicationHostMock.mockImplementationOnce(prepareHostBuildWorkspace);
+    createProductionApplicationNitroMock.mockImplementation(
+      async (_preparedHost: PreparedApplicationHost, options: { outputDir: string }) =>
+        createNitroStub(options.outputDir),
+    );
+    buildNitroMock.mockImplementation(async (nitro: Nitro) => {
+      bundleCalls += 1;
+      if (bundleCalls === 1) {
+        firstBundleStarted.resolve();
+      }
+      await releaseBundles.promise;
+      await mkdir(nitro.options.output.dir, { recursive: true });
+    });
+
+    const { buildApplication } = await import("#internal/nitro/host/build-application.js");
+    const build = buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
+
+    await firstBundleStarted.promise;
+    await vi.waitFor(() => expect(bundleCalls).toBe(2));
+    releaseBundles.resolve();
+    await expect(build).resolves.toBe(join(appRoot, ".vercel", "output"));
   });
 
   it("skips Vercel sandbox prewarm only when the build opts out", async () => {

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -354,26 +354,109 @@ async function buildNitroOutput(
   return outputDirectory;
 }
 
-async function buildVercelNitroSurface(
+async function createVercelNitroSurface(
   preparedHost: PreparedApplicationHost,
   workspace: ApplicationBuildWorkspace,
   surface: Exclude<NitroBuildSurface, "all">,
+  outputDir: string,
   profiler: ApplicationBuildProfiler | undefined,
-): Promise<string> {
+): Promise<Nitro> {
   const phasePrefix = `nitro.${surface}`;
-  const nitro = await measureBuildPhase(profiler, `${phasePrefix}.create`, () =>
+  return await measureBuildPhase(profiler, `${phasePrefix}.create`, () =>
     createProductionApplicationNitro(preparedHost, {
       buildDir: join(workspace.nitro.buildDir, surface),
-      outputDir: join(workspace.nitro.surfaceOutputDir, surface),
+      outputDir,
       surface,
     }),
   );
+}
 
-  try {
-    return await buildNitroOutput(nitro, profiler, phasePrefix);
-  } finally {
-    await measureBuildPhase(profiler, `${phasePrefix}.close`, () => nitro.close());
+interface VercelNitroSurfaces {
+  readonly app: Nitro;
+  readonly flow: Nitro;
+}
+
+async function createVercelNitroSurfaces(
+  preparedHost: PreparedApplicationHost,
+  workspace: ApplicationBuildWorkspace,
+  profiler: ApplicationBuildProfiler | undefined,
+): Promise<VercelNitroSurfaces> {
+  const [appResult, flowResult] = await Promise.allSettled([
+    createVercelNitroSurface(
+      preparedHost,
+      workspace,
+      "app",
+      workspace.publication.output.stagedDir,
+      profiler,
+    ),
+    createVercelNitroSurface(
+      preparedHost,
+      workspace,
+      "flow",
+      join(workspace.nitro.surfaceOutputDir, "flow"),
+      profiler,
+    ),
+  ]);
+
+  if (appResult.status === "fulfilled" && flowResult.status === "fulfilled") {
+    return {
+      app: appResult.value,
+      flow: flowResult.value,
+    };
   }
+
+  await Promise.all([
+    ...(appResult.status === "fulfilled"
+      ? [measureBuildPhase(profiler, "nitro.app.close", () => appResult.value.close())]
+      : []),
+    ...(flowResult.status === "fulfilled"
+      ? [measureBuildPhase(profiler, "nitro.flow.close", () => flowResult.value.close())]
+      : []),
+  ]);
+
+  if (appResult.status === "rejected") {
+    throw appResult.reason;
+  }
+
+  if (flowResult.status === "rejected") {
+    throw flowResult.reason;
+  }
+
+  throw new Error("Expected one Vercel Nitro surface creation to fail.");
+}
+
+async function buildVercelNitroSurfaces(
+  surfaces: VercelNitroSurfaces,
+  profiler: ApplicationBuildProfiler | undefined,
+): Promise<string> {
+  const [appResult, flowResult] = await Promise.allSettled([
+    buildNitroOutput(surfaces.app, profiler, "nitro.app"),
+    buildNitroOutput(surfaces.flow, profiler, "nitro.flow"),
+  ]);
+
+  if (appResult.status === "fulfilled" && flowResult.status === "fulfilled") {
+    return flowResult.value;
+  }
+
+  if (appResult.status === "rejected") {
+    throw appResult.reason;
+  }
+
+  if (flowResult.status === "rejected") {
+    throw flowResult.reason;
+  }
+
+  throw new Error("Expected one Vercel Nitro surface bundle to fail.");
+}
+
+async function closeVercelNitroSurfaces(
+  surfaces: VercelNitroSurfaces,
+  profiler: ApplicationBuildProfiler | undefined,
+): Promise<void> {
+  await Promise.all([
+    measureBuildPhase(profiler, "nitro.app.close", () => surfaces.app.close()),
+    measureBuildPhase(profiler, "nitro.flow.close", () => surfaces.flow.close()),
+  ]);
 }
 
 /**
@@ -485,19 +568,13 @@ async function buildApplicationInWorkspace(
       preparedHost.compileResult.project.agentRoot,
     ),
   );
-  const nitro = await measureBuildPhase(profiler, "nitro.app.create", () =>
-    createProductionApplicationNitro(preparedHost, {
-      buildDir: join(workspace.nitro.buildDir, "app"),
-      outputDir: workspace.publication.output.stagedDir,
-      surface: "app",
-    }),
-  );
+  const nitroSurfaces = await createVercelNitroSurfaces(preparedHost, workspace, profiler);
 
   try {
-    await buildNitroOutput(nitro, profiler, "nitro.app");
     // Run sandbox prewarm before emitting the workflow functions so a
-    // prewarm failure aborts the build before we spend time bundling
-    // function output that we would never deploy.
+    // prewarm failure aborts the build before we spend time bundling either
+    // Vercel function surface. Both Nitro candidates are cheap to create and
+    // can then bundle concurrently after prewarm succeeds.
     if (!options.skipVercelSandboxPrewarm) {
       await measureBuildPhase(profiler, "sandbox.prewarm", () =>
         runVercelBuildPrewarm({
@@ -517,12 +594,7 @@ async function buildApplicationInWorkspace(
         }),
       );
     }
-    const flowNitroOutputDir = await buildVercelNitroSurface(
-      preparedHost,
-      workspace,
-      "flow",
-      profiler,
-    );
+    const flowNitroOutputDir = await buildVercelNitroSurfaces(nitroSurfaces, profiler);
     await measureBuildPhase(profiler, "workflow.emit", () =>
       emitVercelWorkflowFunctions({
         agentName: preparedHost.compileResult.manifest.config.name,
@@ -556,7 +628,7 @@ async function buildApplicationInWorkspace(
       }),
     );
   } finally {
-    await measureBuildPhase(profiler, "nitro.app.close", () => nitro.close());
+    await closeVercelNitroSurfaces(nitroSurfaces, profiler);
   }
 
   await measureBuildPhase(profiler, "output.publish", () =>


### PR DESCRIPTION
## Summary

- create the isolated Vercel app and Workflow Nitro candidates before prewarming
- preserve fail-fast sandbox prewarm behavior before either function surface is bundled
- bundle the two surfaces concurrently after prewarm succeeds

## Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/host/build-application.scenario.test.ts`
- deployable notes-app build with sandbox prewarm enabled (reused template): 899 ms, 2.354 MB gzip output