### PR TITLE
perf(eve): stage workflow output directly

### DIFF
--- a/.changeset/direct-workflow-output-staging.md
+++ b/.changeset/direct-workflow-output-staging.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Vercel Workflow function output now stages directly into the invocation-owned deployment output, avoiding an intermediate full-function copy during builds.

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -103,6 +103,18 @@ vi.mock("../../workflow-bundle/builder.js", () => ({
     }
 
     async buildVercelOutput(options: unknown): Promise<void> {
+      const measure = (
+        options as {
+          measure?: <T>(
+            phase: "build" | "function.stage",
+            operation: () => Promise<T>,
+          ) => Promise<T>;
+        }
+      ).measure;
+      if (measure !== undefined) {
+        await measure("build", async () => undefined);
+        await measure("function.stage", async () => undefined);
+      }
       await workflowBuilderBuildVercelOutputMock(options);
     }
   },
@@ -449,11 +461,14 @@ describe("buildApplication", () => {
     )?.[1]?.outputDir;
     expect(flowOutputDir).toEqual(expect.stringContaining(join(appRoot, ".eve", "builds")));
     expect(workflowBuilderConstructors).toHaveLength(1);
-    expect(workflowBuilderBuildVercelOutputMock).toHaveBeenCalledWith({
-      flowNitroOutputDir: flowOutputDir,
-      outputDir: expect.stringContaining(join(appRoot, ".eve", "builds")),
-      runtime: "nodejs24.x",
-    });
+    expect(workflowBuilderBuildVercelOutputMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowNitroOutputDir: flowOutputDir,
+        measure: expect.any(Function),
+        outputDir: expect.stringContaining(join(appRoot, ".eve", "builds")),
+        runtime: "nodejs24.x",
+      }),
+    );
     const nestedFunctionStats = await lstat(
       join(appRoot, ".vercel", "output", "functions", "eve", "v1", "health.func"),
     );
@@ -508,7 +523,11 @@ describe("buildApplication", () => {
     const profile = JSON.parse(await readFile(profilePath, "utf8")) as ApplicationBuildProfile;
     expect(profile.target).toBe("vercel");
     expect(profile.phases).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: "sandbox.prewarm" })]),
+      expect.arrayContaining([
+        expect.objectContaining({ name: "sandbox.prewarm" }),
+        expect.objectContaining({ name: "workflow.build" }),
+        expect.objectContaining({ name: "workflow.function.stage" }),
+      ]),
     );
 
     const summary = JSON.parse(

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -314,6 +314,7 @@ async function emitVercelWorkflowFunctions(input: {
   compiledArtifactsBootstrapPath: string;
   flowNitroOutputDir: string;
   outputDir: string;
+  profiler: ApplicationBuildProfiler | undefined;
   workflowBuildDir: string;
 }): Promise<void> {
   const builder = new WorkflowBundleBuilder({
@@ -328,6 +329,9 @@ async function emitVercelWorkflowFunctions(input: {
 
   await builder.buildVercelOutput({
     flowNitroOutputDir: input.flowNitroOutputDir,
+    measure(phase, operation) {
+      return measureBuildPhase(input.profiler, `workflow.${phase}`, operation);
+    },
     outputDir: input.outputDir,
     runtime,
   });
@@ -602,6 +606,7 @@ async function buildApplicationInWorkspace(
         compiledArtifactsBootstrapPath: preparedHost.compiledArtifacts.bootstrapPath,
         flowNitroOutputDir,
         outputDir: workspace.publication.output.stagedDir,
+        profiler,
         workflowBuildDir: workspace.workflow.buildDir,
       }),
     );

--- a/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -413,9 +413,14 @@ describe("WorkflowBundleBuilder", () => {
         rootDir,
         watch: false,
       });
+      const measuredPhases: string[] = [];
 
       await builder.buildVercelOutput({
         flowNitroOutputDir,
+        measure: async (phase, operation) => {
+          measuredPhases.push(phase);
+          return await operation();
+        },
         outputDir,
         runtime: "nodejs24.x",
       });
@@ -428,11 +433,13 @@ describe("WorkflowBundleBuilder", () => {
         "v1",
         "flow.func",
       );
+      const intermediateWorkflowOutputDir = join(outDir, "vercel-build-output");
       const flowConfig = JSON.parse(
         await readFile(join(generatedFlowFunctionDir, ".vc-config.json"), "utf8"),
       ) as { environment?: Record<string, unknown> };
 
       expect(builder.buildCalls).toBe(1);
+      expect(measuredPhases).toEqual(["build", "function.stage"]);
       expect(flowConfig.environment).toEqual({
         EVE_EXISTING_FLAG: "kept",
         NODE_OPTIONS: "--experimental-require-module",
@@ -520,6 +527,7 @@ describe("WorkflowBundleBuilder", () => {
       ).resolves.toContain('"rolldown": "1.0.0-rc.18"');
       await expect(readFile(join(staleStepFunctionDir, "index.js"), "utf8")).rejects.toThrow();
       await expect(readFile(join(staleWebhookFunctionDir, "index.js"), "utf8")).rejects.toThrow();
+      await expect(lstat(intermediateWorkflowOutputDir)).rejects.toThrow();
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }

--- a/packages/eve/src/internal/workflow-bundle/builder.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 
 import {
@@ -47,6 +47,18 @@ import {
   type WorkflowManifest,
 } from "#internal/workflow-bundle/workflow-builders.js";
 import { deriveEveWorkflowQueueNamespace } from "#internal/workflow/queue-namespace.js";
+
+type VercelWorkflowOutputPhase = "build" | "function.stage";
+
+type VercelWorkflowOutputMeasure = <T>(
+  phase: VercelWorkflowOutputPhase,
+  operation: () => Promise<T>,
+) => Promise<T>;
+
+const runUnmeasuredVercelWorkflowOutputPhase = async <T>(
+  _phase: VercelWorkflowOutputPhase,
+  operation: () => Promise<T>,
+): Promise<T> => await operation();
 
 export class WorkflowBundleBuilder {
   readonly #agentName: string;
@@ -357,20 +369,13 @@ export class WorkflowBundleBuilder {
 
   async buildVercelOutput(options: {
     flowNitroOutputDir: string;
+    measure?: VercelWorkflowOutputMeasure;
     outputDir: string;
     runtime?: string;
   }): Promise<void> {
-    await this.build();
+    const measure = options.measure ?? runUnmeasuredVercelWorkflowOutputPhase;
+    await measure("build", () => this.build());
 
-    const stagedWorkflowGeneratedDir = join(
-      this.#outDir,
-      "vercel-build-output",
-      "functions",
-      ".well-known",
-      "workflow",
-      "v1",
-    );
-    const stagedFlowFunctionDir = join(stagedWorkflowGeneratedDir, "flow.func");
     const workflowGeneratedDir = join(
       options.outputDir,
       "functions",
@@ -395,48 +400,37 @@ export class WorkflowBundleBuilder {
     const staleStepFunctionDir = join(workflowGeneratedDir, "step.func");
     const staleWebhookFunctionDir = join(workflowGeneratedDir, "webhook", "[token].func");
 
-    await copyNitroFunctionDirectory({
-      fallbackPath: nitroFlowServerFunctionDir,
-      sourcePath: nitroFlowFunctionDir,
-      targetPath: stagedFlowFunctionDir,
+    await measure("function.stage", async () => {
+      await Promise.all([
+        rm(staleStepFunctionDir, {
+          force: true,
+          recursive: true,
+        }),
+        rm(staleWebhookFunctionDir, {
+          force: true,
+          recursive: true,
+        }),
+      ]);
+      await mkdir(workflowGeneratedDir, { recursive: true });
+      await copyNitroFunctionDirectory({
+        fallbackPath: nitroFlowServerFunctionDir,
+        sourcePath: nitroFlowFunctionDir,
+        targetPath: flowFunctionDir,
+      });
+      await Promise.all([
+        this.#patchVercelFunctionConfig(flowFunctionDir, {
+          experimentalTriggers: [createEveWorkflowQueueTrigger(this.#agentName)],
+          maxDuration: "max",
+          runtime: options.runtime ?? null,
+          shouldAddHelpers: false,
+        }),
+        copyFile(join(this.#outDir, "manifest.json"), join(workflowGeneratedDir, "manifest.json")),
+      ]);
+      await retargetNitroFunctionDirectoryToWorkflowRoute({
+        functionDirectoryPath: flowFunctionDir,
+        workflowRoutePath: "/.well-known/workflow/v1/flow",
+      });
     });
-
-    await Promise.all([
-      this.#patchVercelFunctionConfig(stagedFlowFunctionDir, {
-        experimentalTriggers: [createEveWorkflowQueueTrigger(this.#agentName)],
-        maxDuration: "max",
-        runtime: options.runtime ?? null,
-        shouldAddHelpers: false,
-      }),
-      cp(join(this.#outDir, "manifest.json"), join(stagedWorkflowGeneratedDir, "manifest.json")),
-    ]);
-    await retargetNitroFunctionDirectoryToWorkflowRoute({
-      functionDirectoryPath: stagedFlowFunctionDir,
-      workflowRoutePath: "/.well-known/workflow/v1/flow",
-    });
-
-    await Promise.all([
-      rm(flowFunctionDir, {
-        force: true,
-        recursive: true,
-      }),
-      rm(staleStepFunctionDir, {
-        force: true,
-        recursive: true,
-      }),
-      rm(staleWebhookFunctionDir, {
-        force: true,
-        recursive: true,
-      }),
-    ]);
-    await mkdir(workflowGeneratedDir, { recursive: true });
-    await Promise.all([
-      cp(stagedFlowFunctionDir, flowFunctionDir, { recursive: true }),
-      cp(
-        join(stagedWorkflowGeneratedDir, "manifest.json"),
-        join(workflowGeneratedDir, "manifest.json"),
-      ),
-    ]);
   }
 
   async #getBuildInputFiles(): Promise<string[]> {


### PR DESCRIPTION
## Summary

- write the patched Workflow flow function directly into the invocation-owned Vercel output staging directory
- remove the intermediate full-function copy
- report Workflow build and function-staging timings separately

## Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/workflow-bundle/builder.scenario.test.ts src/internal/nitro/host/build-application.scenario.test.ts`
- deployable notes-app build with sandbox prewarm enabled; unchanged 2.354 MB gzip output