### PR TITLE
fix(eve): retry + wait during prewarm step if sandbox is mid-snapshot

### DIFF
--- a/.changeset/retry-sandbox-snapshotting-prewarm.md
+++ b/.changeset/retry-sandbox-snapshotting-prewarm.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fixed an intermittent build failure when two deployments build the same app at the same time. Builds now wait for the in-progress sandbox snapshot to finish instead of failing.

--- a/packages/eve/src/execution/sandbox/bindings/vercel-errors.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { isVercelSnapshottingError } from "#execution/sandbox/bindings/vercel-errors.js";
+
+function snapshottingError(overrides?: { status?: number; code?: string }): Error {
+  return Object.assign(new Error("Status code 422 is not ok"), {
+    json: { error: { code: overrides?.code ?? "sandbox_snapshotting" } },
+    response: { status: overrides?.status ?? 422 },
+  });
+}
+
+describe("isVercelSnapshottingError", () => {
+  it("matches a 422 sandbox_snapshotting response", () => {
+    expect(isVercelSnapshottingError(snapshottingError())).toBe(true);
+  });
+
+  it("matches when the SDK error is wrapped as a cause", () => {
+    const wrapped = new Error("Failed to look up Vercel sandbox", { cause: snapshottingError() });
+    expect(isVercelSnapshottingError(wrapped)).toBe(true);
+  });
+
+  it("requires the snapshotting code, not just a 422", () => {
+    expect(isVercelSnapshottingError(snapshottingError({ code: "bad_request" }))).toBe(false);
+  });
+
+  it("requires a 422, not just the snapshotting code", () => {
+    expect(isVercelSnapshottingError(snapshottingError({ status: 500 }))).toBe(false);
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/vercel-errors.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-errors.ts
@@ -26,6 +26,26 @@ export function isVercelSandboxMissingError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * True when a request failed because the target sandbox is mid-snapshot
+ * (HTTP 422, `code: "sandbox_snapshotting"`) — a transient race the caller
+ * can wait out.
+ */
+export function isVercelSnapshottingError(error: unknown): boolean {
+  for (const candidate of walkErrorChain(error)) {
+    const status =
+      (candidate as { response?: { status?: number } }).response?.status ??
+      (candidate as { status?: number }).status ??
+      (candidate as { statusCode?: number }).statusCode;
+    const code = (candidate as { json?: { error?: { code?: string } } }).json?.error?.code;
+    if (status === 422 && code === "sandbox_snapshotting") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function* walkErrorChain(error: unknown): Generator<unknown> {
   let current = error;
   const seen = new Set<unknown>();

--- a/packages/eve/src/execution/sandbox/bindings/vercel-tags.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-tags.ts
@@ -1,0 +1,75 @@
+import type { SandboxBackendTags } from "#public/definitions/sandbox-backend.js";
+import type {
+  VercelCreateOptions,
+  VercelSandbox,
+} from "#execution/sandbox/bindings/vercel-sdk-types.js";
+
+const VERCEL_SANDBOX_TAG_LIMIT = 5;
+
+/**
+ * Merges author-supplied tags with eve's reserved tags into the flat
+ * `Record<string, string>` the Vercel SDK expects, or `undefined` when
+ * there are none. Throws if the merged set exceeds Vercel's tag limit.
+ */
+export function resolveVercelSandboxTags(
+  userTags: VercelCreateOptions["tags"],
+  eveTags: SandboxBackendTags | undefined,
+): Record<string, string> | undefined {
+  const tags: Record<string, string> = {};
+
+  if (userTags !== undefined) {
+    for (const [key, value] of Object.entries(userTags as Record<string, string>)) {
+      tags[key] = value;
+    }
+  }
+
+  if (eveTags !== undefined) {
+    for (const [key, value] of Object.entries(eveTags)) {
+      tags[key] = value;
+    }
+  }
+
+  const count = Object.keys(tags).length;
+  if (count === 0) {
+    return undefined;
+  }
+
+  if (count > VERCEL_SANDBOX_TAG_LIMIT) {
+    throw new Error(
+      `Vercel Sandbox supports at most ${VERCEL_SANDBOX_TAG_LIMIT} tags. ` +
+        'eve reserves "agent", "channel", and "sessionId"; remove or consolidate custom tags passed to vercel().',
+    );
+  }
+
+  return tags;
+}
+
+/**
+ * Applies `tags` to an existing sandbox, skipping the network update when
+ * they already match.
+ */
+export async function ensureVercelSandboxTags(
+  sandbox: VercelSandbox,
+  tags: Record<string, string> | undefined,
+): Promise<void> {
+  if (tags === undefined || areVercelSandboxTagsEqual(sandbox.tags, tags)) {
+    return;
+  }
+
+  await sandbox.update({ tags });
+}
+
+function areVercelSandboxTagsEqual(
+  current: Record<string, string> | undefined,
+  next: Record<string, string>,
+): boolean {
+  const currentTags = current ?? {};
+  const currentEntries = Object.entries(currentTags);
+  const nextEntries = Object.entries(next);
+
+  if (currentEntries.length !== nextEntries.length) {
+    return false;
+  }
+
+  return nextEntries.every(([key, value]) => currentTags[key] === value);
+}

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -1746,3 +1746,102 @@ describe("vercel (public factory)", () => {
     expect(typeof backend.prewarm).toBe("function");
   });
 });
+
+describe("createVercelSandbox prewarm snapshotting retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /*
+   * Mirrors the 422 body the SDK surfaces when a request lands on a
+   * sandbox that a concurrent build is mid-snapshot on. `getNamedVercelSandbox`
+   * rewraps this in its own Error with the original as `cause`, so the
+   * classifier must walk the cause chain to see the 422 + code.
+   */
+  function createSnapshottingError(): Error {
+    return Object.assign(new Error("Status code 422 is not ok"), {
+      json: {
+        error: {
+          code: "sandbox_snapshotting",
+          message: "Sandbox is creating a snapshot and will be stopped shortly.",
+        },
+      },
+      response: { status: 422 },
+    });
+  }
+
+  async function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+    const settled = Promise.allSettled([promise]);
+    await vi.runAllTimersAsync();
+    return (await settled)[0]!;
+  }
+
+  it("waits and retries a template that a concurrent build is snapshotting", async () => {
+    const templateSandbox = createMockSandbox({ name: "template-key" });
+    let remainingFailures = 2;
+    const get = vi.fn().mockImplementation(async () => {
+      if (remainingFailures > 0) {
+        remainingFailures -= 1;
+        throw createSnapshottingError();
+      }
+      return null;
+    });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn().mockResolvedValue(templateSandbox),
+        get,
+      },
+    };
+
+    const backend = createTestVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    const result = await settle(
+      backend.prewarm({
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+        seedFiles: [],
+        templateKey: "template-key",
+      }),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    // Two snapshotting failures, then a successful lookup on the third try.
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(sandboxModule.Sandbox.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls, then surfaces an informative error when the snapshot never completes", async () => {
+    const get = vi.fn().mockRejectedValue(createSnapshottingError());
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn(),
+        get,
+      },
+    };
+
+    const backend = createTestVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    const result = await settle(
+      backend.prewarm({
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+        seedFiles: [],
+        templateKey: "template-key",
+      }),
+    );
+
+    expect(result.status).toBe("rejected");
+    // Names the concurrent-snapshot wait we gave up on, not a bare 422.
+    expect((result as PromiseRejectedResult).reason).toMatchObject({
+      message: expect.stringMatching(/Failed to prewarm.*did not finish in time/),
+    });
+    // Polled repeatedly across the deadline rather than failing on the first 422.
+    expect(get.mock.calls.length).toBeGreaterThan(10);
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -39,7 +39,12 @@ import {
 import {
   isVercelSandboxMissingError,
   isVercelSnapshotUnavailableError,
+  isVercelSnapshottingError,
 } from "#execution/sandbox/bindings/vercel-errors.js";
+import {
+  ensureVercelSandboxTags,
+  resolveVercelSandboxTags,
+} from "#execution/sandbox/bindings/vercel-tags.js";
 import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
 import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
 import { writeSandboxSeedFiles } from "#execution/sandbox/bindings/local-backend-utils.js";
@@ -189,13 +194,61 @@ async function ensureTemplateWithUnavailableRetry(
   input: EnsureTemplateInput,
 ): Promise<EnsureTemplateOutcome> {
   try {
-    return await ensureTemplate(input);
+    return await ensureTemplateWaitingForConcurrentSnapshot(input);
   } catch (error) {
     if (!isVercelSnapshotUnavailableError(error) && !isVercelSandboxMissingError(error)) {
       throw error;
     }
     input.log?.("cached template disappeared; rebuilding sandbox template");
-    return await ensureTemplate(input);
+    return await ensureTemplateWaitingForConcurrentSnapshot(input);
+  }
+}
+
+/*
+ * How long to keep polling for a concurrent build's in-progress snapshot
+ * before giving up, and how long to wait between polls. Taking a snapshot
+ * is a compress-and-upload-to-S3 operation that can run for tens of
+ * seconds, so we wait generously rather than fail a build over a transient
+ * race that resolves on its own.
+ */
+const SNAPSHOTTING_POLL_DEADLINE_MS = 120_000;
+const SNAPSHOTTING_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Polls `ensureTemplate` while it keeps failing with a `sandbox_snapshotting`
+ * 422. Template keys are content-derived, so a name collision means a
+ * concurrent build is producing the identical image: once its snapshot
+ * finishes, the next attempt reuses it instead of rebuilding. Other errors
+ * propagate at once; exceeding the deadline throws, naming the template.
+ */
+async function ensureTemplateWaitingForConcurrentSnapshot(
+  input: EnsureTemplateInput,
+): Promise<EnsureTemplateOutcome> {
+  let waitedMs = 0;
+  for (;;) {
+    try {
+      return await ensureTemplate(input);
+    } catch (error) {
+      if (!isVercelSnapshottingError(error)) {
+        throw error;
+      }
+      if (waitedMs >= SNAPSHOTTING_POLL_DEADLINE_MS) {
+        throw new Error(
+          `Gave up after ${Math.round(SNAPSHOTTING_POLL_DEADLINE_MS / 1_000)}s waiting for an ` +
+            `in-progress snapshot of sandbox template "${input.templateKey}" to complete. A ` +
+            "concurrent build is snapshotting the same template and it did not finish in time; " +
+            "retry the build, or rerun once the other build has completed.",
+          { cause: error },
+        );
+      }
+      input.log?.(
+        `sandbox template "${input.templateKey}" is being snapshotted by a concurrent build; ` +
+          `waited ${Math.round(waitedMs / 1_000)}s of ` +
+          `${Math.round(SNAPSHOTTING_POLL_DEADLINE_MS / 1_000)}s, polling again`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, SNAPSHOTTING_POLL_INTERVAL_MS));
+      waitedMs += SNAPSHOTTING_POLL_INTERVAL_MS;
+    }
   }
 }
 
@@ -565,65 +618,6 @@ function getVercelSandboxName(metadata: Record<string, unknown> | undefined): st
   return typeof sandboxName === "string" ? sandboxName : undefined;
 }
 
-function resolveVercelSandboxTags(
-  userTags: VercelCreateOptions["tags"],
-  eveTags: SandboxBackendTags | undefined,
-): Record<string, string> | undefined {
-  const tags: Record<string, string> = {};
-
-  if (userTags !== undefined) {
-    for (const [key, value] of Object.entries(userTags as Record<string, string>)) {
-      tags[key] = value;
-    }
-  }
-
-  if (eveTags !== undefined) {
-    for (const [key, value] of Object.entries(eveTags)) {
-      tags[key] = value;
-    }
-  }
-
-  const count = Object.keys(tags).length;
-  if (count === 0) {
-    return undefined;
-  }
-
-  if (count > VERCEL_SANDBOX_TAG_LIMIT) {
-    throw new Error(
-      `Vercel Sandbox supports at most ${VERCEL_SANDBOX_TAG_LIMIT} tags. ` +
-        'eve reserves "agent", "channel", and "sessionId"; remove or consolidate custom tags passed to vercel().',
-    );
-  }
-
-  return tags;
-}
-
-async function ensureVercelSandboxTags(
-  sandbox: VercelSandbox,
-  tags: Record<string, string> | undefined,
-): Promise<void> {
-  if (tags === undefined || areVercelSandboxTagsEqual(sandbox.tags, tags)) {
-    return;
-  }
-
-  await sandbox.update({ tags });
-}
-
-function areVercelSandboxTagsEqual(
-  current: Record<string, string> | undefined,
-  next: Record<string, string>,
-): boolean {
-  const currentTags = current ?? {};
-  const currentEntries = Object.entries(currentTags);
-  const nextEntries = Object.entries(next);
-
-  if (currentEntries.length !== nextEntries.length) {
-    return false;
-  }
-
-  return nextEntries.every(([key, value]) => currentTags[key] === value);
-}
-
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     const responseJson = (error as { readonly json?: unknown }).json;
@@ -647,5 +641,3 @@ function errorMessage(error: unknown): string {
  * too short for multi-step workflows — the VM expires between steps.
  */
 const DEFAULT_SANDBOX_TIMEOUT_MS = 30 * 60 * 1_000;
-
-const VERCEL_SANDBOX_TAG_LIMIT = 5;


### PR DESCRIPTION
### Description

Simultaneous builds (e.g. multiple deploys triggered off of the same branch) resulted in build failures when the prewarm/snapshot step triggered while another sandbox snapshot was in progress. This raised a 422 (`sandbox_snapshotting`) which wasn't specially handled, leading to a build failure.

This PR introduces a check for the `sandbox_snapshotting` 422 and probes until the snapshot completes (or 120s has elapsed) instead of failing the build entirely. Adds a unit test for this case which failed before the change was impl.

### How did you test your changes?

```bash
pnpm --filter eve exec vitest run --config vitest.unit.config.ts \
  src/execution/sandbox/bindings/vercel.test.ts \
  src/execution/sandbox/bindings/vercel-errors.test.ts
```

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
