### PR TITLE
perf(eve): prune unused connection runtime

### DIFF
--- a/.changeset/prune-no-connection-runtime.md
+++ b/.changeset/prune-no-connection-runtime.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reduce Vercel function bundle size for agents without declared connections by excluding unused connection discovery and MCP/OpenAPI runtime code.

--- a/packages/eve/src/internal/nitro/host/connection-runtime-prune-plugin.test.ts
+++ b/packages/eve/src/internal/nitro/host/connection-runtime-prune-plugin.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { createConnectionRuntimePrunePlugin } from "#internal/nitro/host/connection-runtime-prune-plugin.js";
+
+function resolveAndLoad(source: string): string {
+  const plugin = createConnectionRuntimePrunePlugin();
+  const resolved = plugin.resolveId?.(source, undefined);
+  if (resolved == null) {
+    throw new Error(`Expected ${source} to resolve to a pruned runtime facade.`);
+  }
+  const id = typeof resolved === "string" ? resolved : resolved.id;
+  const loaded = plugin.load?.(id);
+  if (loaded == null) {
+    throw new Error(`Expected ${source} to load a pruned runtime facade.`);
+  }
+  return loaded;
+}
+
+describe("createConnectionRuntimePrunePlugin", () => {
+  it("replaces every connection-only runtime facade", () => {
+    expect(resolveAndLoad("/repo/packages/eve/dist/src/runtime/connections/registry.js")).toContain(
+      "export class ConnectionRegistryImpl",
+    );
+    expect(resolveAndLoad("#runtime/resolve-connection.js")).toContain(
+      "export async function resolveConnectionDefinition",
+    );
+    expect(
+      resolveAndLoad(
+        "/repo/packages/eve/dist/src/runtime/framework-tools/connection-search-dynamic.js",
+      ),
+    ).toContain("export function createConnectionSearchResolver");
+  });
+
+  it("leaves non-connection runtime modules untouched", () => {
+    const plugin = createConnectionRuntimePrunePlugin();
+
+    expect(plugin.resolveId?.("#runtime/framework-tools/skill.js", undefined)).toBeNull();
+    expect(
+      plugin.resolveId?.("/repo/packages/eve/dist/src/runtime/resolve-agent.js", undefined),
+    ).toBe(null);
+  });
+});

--- a/packages/eve/src/internal/nitro/host/connection-runtime-prune-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/connection-runtime-prune-plugin.ts
@@ -1,0 +1,92 @@
+const PRUNED_CONNECTION_REGISTRY_MODULE_ID = "\0eve-pruned-connection-registry";
+const PRUNED_CONNECTION_RESOLVER_MODULE_ID = "\0eve-pruned-connection-resolver";
+const PRUNED_CONNECTION_SEARCH_MODULE_ID = "\0eve-pruned-connection-search";
+
+const CONNECTION_REGISTRY_SOURCE_RE = /[/\\]runtime[/\\]connections[/\\]registry\.(?:[cm]?[jt]s)$/;
+const CONNECTION_RESOLVER_SOURCE_RE = /[/\\]runtime[/\\]resolve-connection\.(?:[cm]?[jt]s)$/;
+const CONNECTION_SEARCH_SOURCE_RE =
+  /[/\\]runtime[/\\]framework-tools[/\\]connection-search-dynamic\.(?:[cm]?[jt]s)$/;
+
+const PRUNED_MODULE_IDS_BY_SOURCE = new Map<string, string>([
+  ["#runtime/connections/registry.js", PRUNED_CONNECTION_REGISTRY_MODULE_ID],
+  ["#runtime/resolve-connection.js", PRUNED_CONNECTION_RESOLVER_MODULE_ID],
+  ["#runtime/framework-tools/connection-search-dynamic.js", PRUNED_CONNECTION_SEARCH_MODULE_ID],
+]);
+
+interface BundlerPluginShape {
+  readonly name: string;
+  load?(id: string): string | null | undefined;
+  resolveId?(
+    source: string,
+    importer: string | undefined,
+  ): string | { id: string } | null | undefined;
+}
+
+function getPrunedModuleId(source: string): string | undefined {
+  const directMatch = PRUNED_MODULE_IDS_BY_SOURCE.get(source);
+  if (directMatch !== undefined) {
+    return directMatch;
+  }
+
+  if (CONNECTION_REGISTRY_SOURCE_RE.test(source)) {
+    return PRUNED_CONNECTION_REGISTRY_MODULE_ID;
+  }
+  if (CONNECTION_RESOLVER_SOURCE_RE.test(source)) {
+    return PRUNED_CONNECTION_RESOLVER_MODULE_ID;
+  }
+  if (CONNECTION_SEARCH_SOURCE_RE.test(source)) {
+    return PRUNED_CONNECTION_SEARCH_MODULE_ID;
+  }
+
+  return undefined;
+}
+
+function createPrunedRuntimeSource(exportSource: string): string {
+  return [
+    "function pruned() {",
+    '  throw new Error("Connection runtime is pruned from this hosted bundle because the compiled manifest declares no connections.");',
+    "}",
+    exportSource,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Creates the hosted-bundle specialization for manifests that declare no
+ * connections anywhere in their local graph. The core runtime always imports
+ * these facades, but every call is guarded by the resolved connection list.
+ * Replacing the facades keeps the MCP and OpenAPI clients, connection search,
+ * and connection-definition hydration out of a function that cannot use them.
+ */
+export function createConnectionRuntimePrunePlugin(): BundlerPluginShape {
+  return {
+    name: "eve-hosted-connection-runtime-prune",
+    load(id) {
+      switch (id) {
+        case PRUNED_CONNECTION_REGISTRY_MODULE_ID:
+          return createPrunedRuntimeSource(
+            [
+              "export class ConnectionRegistryImpl {",
+              "  constructor() {",
+              "    pruned();",
+              "  }",
+              "}",
+            ].join("\n"),
+          );
+        case PRUNED_CONNECTION_RESOLVER_MODULE_ID:
+          return createPrunedRuntimeSource(
+            "export async function resolveConnectionDefinition() {\n  pruned();\n}",
+          );
+        case PRUNED_CONNECTION_SEARCH_MODULE_ID:
+          return createPrunedRuntimeSource(
+            "export function createConnectionSearchResolver() {\n  return pruned();\n}",
+          );
+        default:
+          return null;
+      }
+    },
+    resolveId(source) {
+      return getPrunedModuleId(source) ?? null;
+    },
+  };
+}

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldPruneLocalSandboxBackends } from "#internal/nitro/host/create-application-nitro.js";
+import {
+  shouldPruneConnectionRuntime,
+  shouldPruneLocalSandboxBackends,
+} from "#internal/nitro/host/create-application-nitro.js";
+import {
+  createCompiledAgentManifest,
+  createCompiledAgentNodeManifest,
+} from "#compiler/manifest.js";
+import { classifyModelRouting } from "#internal/classify-model-routing.js";
 
 describe("shouldPruneLocalSandboxBackends", () => {
   it("prunes local backends from hosted Vercel builds when the sandbox uses defaultSandbox", () => {
@@ -36,6 +44,85 @@ describe("shouldPruneLocalSandboxBackends", () => {
     expect(
       shouldPruneLocalSandboxBackends({
         configuredBackendNames: new Set(),
+        preset: undefined,
+      }),
+    ).toBe(false);
+  });
+});
+
+function createManifest(input: { hasConnection?: boolean; subagentHasConnection?: boolean } = {}) {
+  const connection = {
+    connectionName: "linear",
+    description: "Linear",
+    logicalPath: "connections/linear.ts",
+    protocol: "mcp" as const,
+    sourceId: "connections/linear.ts",
+    sourceKind: "module" as const,
+    url: "https://mcp.linear.app",
+  };
+  const config = {
+    model: {
+      id: "openai/gpt-5.5",
+      routing: classifyModelRouting("openai/gpt-5.5"),
+    },
+    name: "test-agent",
+  };
+  const subagent = createCompiledAgentNodeManifest({
+    agentRoot: "/app/agent/subagents/researcher",
+    appRoot: "/app",
+    config: { ...config, name: "researcher" },
+    connections: input.subagentHasConnection ? [connection] : [],
+  });
+
+  return createCompiledAgentManifest({
+    agentRoot: "/app/agent",
+    appRoot: "/app",
+    config,
+    connections: input.hasConnection ? [connection] : [],
+    subagents: [
+      {
+        agent: subagent,
+        description: "Researches requests.",
+        entryPath: "subagents/researcher",
+        logicalPath: "subagents/researcher/agent.ts",
+        name: "researcher",
+        nodeId: "subagents/researcher/agent.ts",
+        rootPath: "/app/agent/subagents/researcher",
+        sourceId: "subagents/researcher/agent.ts",
+        sourceKind: "module",
+      },
+    ],
+  });
+}
+
+describe("shouldPruneConnectionRuntime", () => {
+  it("prunes connection-only runtime paths from a Vercel build with no connections", () => {
+    expect(
+      shouldPruneConnectionRuntime({
+        manifest: createManifest(),
+        preset: "vercel",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps connection runtime paths when any local agent node has a connection", () => {
+    for (const manifest of [
+      createManifest({ hasConnection: true }),
+      createManifest({ subagentHasConnection: true }),
+    ]) {
+      expect(
+        shouldPruneConnectionRuntime({
+          manifest,
+          preset: "vercel",
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("keeps connection runtime paths outside Vercel builds", () => {
+    expect(
+      shouldPruneConnectionRuntime({
+        manifest: createManifest(),
         preset: undefined,
       }),
     ).toBe(false);

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -17,6 +17,7 @@ import {
 } from "#internal/application/cache-metadata.js";
 import { createProductionNitroArtifactsConfig } from "#internal/nitro/host/artifacts-config.js";
 import { createCompiledSandboxBackendPrunePlugin } from "#internal/nitro/host/compiled-sandbox-backend-prune-plugin.js";
+import { createConnectionRuntimePrunePlugin } from "#internal/nitro/host/connection-runtime-prune-plugin.js";
 import { createExtensionScopePlugin } from "#internal/bundler/extension-scope-plugin.js";
 import {
   configureDevelopmentNitroRoutes,
@@ -166,6 +167,25 @@ export function shouldPruneLocalSandboxBackends(input: {
     ![...input.configuredBackendNames].some((backendName) =>
       LOCAL_SANDBOX_BACKEND_NAMES.has(backendName),
     )
+  );
+}
+
+/**
+ * Vercel functions can omit connection-only runtime paths when no local agent
+ * node in the compiled manifest declares a connection. Development builds
+ * deliberately keep them: their compiler artifacts can change in place while
+ * the Nitro process remains alive.
+ */
+export function shouldPruneConnectionRuntime(input: {
+  readonly manifest: CompiledAgentManifest;
+  readonly preset: "vercel" | undefined;
+}): boolean {
+  if (input.preset !== "vercel") {
+    return false;
+  }
+
+  return ![input.manifest, ...input.manifest.subagents.map((subagent) => subagent.agent)].some(
+    (node) => node.connections.length > 0,
   );
 }
 
@@ -637,6 +657,12 @@ function createApplicationNitroBundlerConfiguration(
   })
     ? createCompiledSandboxBackendPrunePlugin()
     : null;
+  const connectionRuntimePrunePlugin = shouldPruneConnectionRuntime({
+    manifest: preparedHost.compileResult.manifest,
+    preset,
+  })
+    ? createConnectionRuntimePrunePlugin()
+    : null;
   const configuredOptionalEnginePackages: string[] = [];
   const unconfiguredOptionalEnginePackages: string[] = [];
   for (const [backendName, packageName] of Object.entries(
@@ -655,6 +681,7 @@ function createApplicationNitroBundlerConfiguration(
   );
   const nitroBundlerPlugins = [
     compiledSandboxBackendPrunePlugin,
+    connectionRuntimePrunePlugin,
     createOptionalEngineDependencyPlugin(unconfiguredOptionalEnginePackages),
     extensionScopePlugin,
   ].filter((plugin) => plugin !== null);

--- a/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
+++ b/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
@@ -9,6 +9,7 @@ import {
   resolveInstalledPackageInfo,
   resolvePackageRoot,
 } from "../../src/internal/application/package.js";
+import type { ApplicationBuildProfile } from "../../src/internal/application/build-profile.js";
 import { buildApplication } from "../../src/internal/nitro/host.js";
 import { useTemporaryDirectories } from "../../src/internal/testing/use-temporary-app-roots.js";
 
@@ -769,6 +770,61 @@ describe("app runtime dependency tracing", () => {
     expect(vercelFunctionsSource).not.toContain("rollup:reload");
     expect(vercelFunctionsSource).not.toContain("WORKFLOW_LOCAL_DATA_DIR");
     expect(vercelFunctionsSource).not.toContain("DataDirAccessError");
+  }, 30_000);
+
+  it("prunes connection-only runtime code from a hosted app without connections", async () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "");
+
+    const appRoot = await createScratchDirectory("eve-app-hosted-no-connections-build-");
+    const profilePath = join(appRoot, "build-profile.json");
+
+    await mkdir(join(appRoot, "agent"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(appRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "hosted-no-connections-build-test",
+          private: true,
+          type: "module",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(appRoot, "agent", "agent.ts"),
+      ["export default {", '  model: "openai/gpt-5.4-mini",', "};", ""].join("\n"),
+    );
+    await writeFile(join(appRoot, "agent", "instructions.md"), "No connections here.\n");
+
+    const outputDir = await buildApplication(appRoot, {
+      ...DEPLOYABLE_BUILD_OPTIONS,
+      profileOutputPath: profilePath,
+    });
+    const flowFunctionSource = await readJavaScriptModulesRecursively(
+      join(outputDir, "functions", ".well-known", "workflow", "v1", "flow.func"),
+    );
+    const profile = JSON.parse(await readFile(profilePath, "utf8")) as ApplicationBuildProfile;
+    const flowBundle = profile.output.functionBundles.find(
+      (bundle) => bundle.path === "functions/.well-known/workflow/v1/flow.func",
+    );
+
+    expect(flowFunctionSource).not.toContain("McpConnectionClient");
+    expect(flowFunctionSource).not.toContain("OpenApiConnectionClient");
+    expect(flowFunctionSource).not.toContain("framework.connection-search-dynamic");
+    expect(flowBundle).toBeDefined();
+
+    if (flowBundle === undefined) {
+      throw new Error("Expected the deployable build profile to include the flow function.");
+    }
+
+    // This leaves deliberate headroom for ordinary bundled-code changes while
+    // keeping the MCP/OpenAPI dependency regression visible in CI.
+    expect(flowBundle.rawBytes).toBeLessThan(6_400_000);
+    expect(flowBundle.gzipBytes).toBeLessThan(1_550_000);
   }, 30_000);
 
   it("loads instrumentation runtime dependencies from hosted Vercel output", async () => {


### PR DESCRIPTION
## Summary

- use compiled manifest connection facts to omit the MCP/OpenAPI registry, connection hydration, and connection search from Vercel functions with no declared connections
- retain authored channel code and the shared authorization callback route; any root or local subagent connection keeps the existing runtime
- add a deployable flow-function size regression test

## Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/nitro/host/connection-runtime-prune-plugin.test.ts src/internal/nitro/host/create-application-nitro.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/app-runtime-dependencies.scenario.test.ts -t "prunes connection-only runtime code"`
- deployable notes app build with sandbox prewarm reused: flow function 6,046,476 → 5,711,774 raw bytes and 1,468,804 → 1,395,310 gzip bytes