### PR TITLE
perf(eve): shorten Vercel build critical path

### DIFF
--- a/.changeset/fast-vercel-build-critical-path.md
+++ b/.changeset/fast-vercel-build-critical-path.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reduce deployable Vercel build latency by overlapping sandbox prewarm with isolated function bundling and reusing workflow artifacts already generated for the flow surface.

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -70,7 +70,7 @@ const resolveDiscoveryProjectMock = vi.fn(async (appRoot: string) => ({
   layout: "nested" as const,
 }));
 const runVercelBuildPrewarmMock = vi.fn(async () => undefined);
-const workflowBuilderBuildVercelOutputMock = vi.fn(async (_options: unknown) => undefined);
+const workflowBuilderStageVercelOutputMock = vi.fn(async (_options: unknown) => undefined);
 const workflowBuilderConstructors: unknown[] = [];
 
 vi.mock("nitro/builder", () => ({
@@ -102,20 +102,16 @@ vi.mock("../../workflow-bundle/builder.js", () => ({
       workflowBuilderConstructors.push(options);
     }
 
-    async buildVercelOutput(options: unknown): Promise<void> {
+    async stageVercelOutput(options: unknown): Promise<void> {
       const measure = (
         options as {
-          measure?: <T>(
-            phase: "build" | "function.stage",
-            operation: () => Promise<T>,
-          ) => Promise<T>;
+          measure?: <T>(phase: "function.stage", operation: () => Promise<T>) => Promise<T>;
         }
       ).measure;
       if (measure !== undefined) {
-        await measure("build", async () => undefined);
         await measure("function.stage", async () => undefined);
       }
-      await workflowBuilderBuildVercelOutputMock(options);
+      await workflowBuilderStageVercelOutputMock(options);
     }
   },
 }));
@@ -238,7 +234,7 @@ describe("buildApplication", () => {
         2,
       )}\n`,
     );
-    expect(workflowBuilderBuildVercelOutputMock).not.toHaveBeenCalled();
+    expect(workflowBuilderStageVercelOutputMock).not.toHaveBeenCalled();
     expect(runVercelBuildPrewarmMock).not.toHaveBeenCalled();
     await expect(
       readFile(join(appRoot, ".eve", "compile", "compiled-agent-manifest.json"), "utf8"),
@@ -461,7 +457,7 @@ describe("buildApplication", () => {
     )?.[1]?.outputDir;
     expect(flowOutputDir).toEqual(expect.stringContaining(join(appRoot, ".eve", "builds")));
     expect(workflowBuilderConstructors).toHaveLength(1);
-    expect(workflowBuilderBuildVercelOutputMock).toHaveBeenCalledWith(
+    expect(workflowBuilderStageVercelOutputMock).toHaveBeenCalledWith(
       expect.objectContaining({
         flowNitroOutputDir: flowOutputDir,
         measure: expect.any(Function),
@@ -525,9 +521,11 @@ describe("buildApplication", () => {
     expect(profile.phases).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "sandbox.prewarm" }),
-        expect.objectContaining({ name: "workflow.build" }),
         expect.objectContaining({ name: "workflow.function.stage" }),
       ]),
+    );
+    expect(profile.phases).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "workflow.build" })]),
     );
 
     const summary = JSON.parse(
@@ -538,7 +536,7 @@ describe("buildApplication", () => {
     expect((summary.agent as { name: string }).name).toBe("scenario-test-agent");
   });
 
-  it("waits for sandbox prewarm before bundling either Vercel function surface", async () => {
+  it("keeps the last-good output when sandbox prewarm fails after bundling", async () => {
     vi.stubEnv("VERCEL", "1");
     const appRoot = await createScratchDirectory("eve-build-application-vercel-prewarm-failure-");
     const outputDir = join(appRoot, ".vercel", "output");
@@ -563,15 +561,54 @@ describe("buildApplication", () => {
     );
 
     expect(createdNitros).toHaveLength(2);
-    expect(buildNitroMock).not.toHaveBeenCalled();
-    expect(workflowBuilderBuildVercelOutputMock).not.toHaveBeenCalled();
+    expect(buildNitroMock).toHaveBeenCalledTimes(2);
+    expect(workflowBuilderStageVercelOutputMock).not.toHaveBeenCalled();
     for (const nitro of createdNitros) {
       expect(nitro.close).toHaveBeenCalledOnce();
     }
     await expect(readFile(outputMarkerPath, "utf8")).resolves.toBe("last-good-output\n");
   });
 
-  it("bundles the Vercel app and flow surfaces concurrently after prewarm", async () => {
+  it("bundles Vercel surfaces while sandbox prewarm is running", async () => {
+    vi.stubEnv("VERCEL", "1");
+    const appRoot = await createScratchDirectory("eve-build-application-vercel-prewarm-overlap-");
+    const prewarmStarted = Promise.withResolvers<void>();
+    const releasePrewarm = Promise.withResolvers<void>();
+    const releaseSurfaceCreation = Promise.withResolvers<void>();
+    const surfacesCreated = Promise.withResolvers<void>();
+    let createdSurfaceCount = 0;
+
+    prepareProductionApplicationHostMock.mockImplementationOnce(prepareHostBuildWorkspace);
+    createProductionApplicationNitroMock.mockImplementation(
+      async (_preparedHost: PreparedApplicationHost, options: { outputDir: string }) => {
+        await releaseSurfaceCreation.promise;
+        createdSurfaceCount += 1;
+        if (createdSurfaceCount === 2) {
+          surfacesCreated.resolve();
+        }
+        return createNitroStub(options.outputDir);
+      },
+    );
+    runVercelBuildPrewarmMock.mockImplementationOnce(async () => {
+      prewarmStarted.resolve();
+      await releasePrewarm.promise;
+    });
+
+    const { buildApplication } = await import("#internal/nitro/host/build-application.js");
+    const build = buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
+
+    await prewarmStarted.promise;
+    expect(createProductionApplicationNitroMock).toHaveBeenCalledTimes(2);
+    releaseSurfaceCreation.resolve();
+    await surfacesCreated.promise;
+    await vi.waitFor(() => expect(buildNitroMock).toHaveBeenCalledTimes(2));
+
+    releasePrewarm.resolve();
+    await expect(build).resolves.toBe(join(appRoot, ".vercel", "output"));
+    expect(buildNitroMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("bundles the Vercel app and flow surfaces concurrently", async () => {
     vi.stubEnv("VERCEL", "1");
     const appRoot = await createScratchDirectory("eve-build-application-vercel-concurrent-");
     const firstBundleStarted = Promise.withResolvers<void>();
@@ -618,7 +655,7 @@ describe("buildApplication", () => {
 
     expect(outputDir).toBe(join(appRoot, ".vercel", "output"));
     expect(runVercelBuildPrewarmMock).not.toHaveBeenCalled();
-    expect(workflowBuilderBuildVercelOutputMock).toHaveBeenCalledTimes(1);
+    expect(workflowBuilderStageVercelOutputMock).toHaveBeenCalledTimes(1);
   });
 
   it("normalizes eve function output behind a non-Next host service", async () => {

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -55,6 +55,14 @@ async function measureBuildPhase<T>(
   return profiler === undefined ? operation() : profiler.measure(name, operation);
 }
 
+async function settleBuildOperation<T>(operation: Promise<T>): Promise<PromiseSettledResult<T>> {
+  const [result] = await Promise.allSettled([operation]);
+  if (result === undefined) {
+    throw new Error("Expected build operation result.");
+  }
+  return result;
+}
+
 function isPathInside(directoryPath: string, candidatePath: string): boolean {
   const relativePath = relative(directoryPath, candidatePath);
   return (
@@ -327,7 +335,7 @@ async function emitVercelWorkflowFunctions(input: {
   });
   const runtime = await readVercelServerRuntime(input.outputDir);
 
-  await builder.buildVercelOutput({
+  await builder.stageVercelOutput({
     flowNitroOutputDir: input.flowNitroOutputDir,
     measure(phase, operation) {
       return measureBuildPhase(input.profiler, `workflow.${phase}`, operation);
@@ -572,15 +580,12 @@ async function buildApplicationInWorkspace(
       preparedHost.compileResult.project.agentRoot,
     ),
   );
-  const nitroSurfaces = await createVercelNitroSurfaces(preparedHost, workspace, profiler);
-
-  try {
-    // Run sandbox prewarm before emitting the workflow functions so a
-    // prewarm failure aborts the build before we spend time bundling either
-    // Vercel function surface. Both Nitro candidates are cheap to create and
-    // can then bundle concurrently after prewarm succeeds.
-    if (!options.skipVercelSandboxPrewarm) {
-      await measureBuildPhase(profiler, "sandbox.prewarm", () =>
+  // These operations share no mutable output, and publication still waits for
+  // all of them so a prewarm failure cannot replace the last-good build.
+  const nitroSurfacesPromise = createVercelNitroSurfaces(preparedHost, workspace, profiler);
+  const sandboxPrewarmPromise = options.skipVercelSandboxPrewarm
+    ? Promise.resolve(false)
+    : measureBuildPhase(profiler, "sandbox.prewarm", () =>
         runVercelBuildPrewarm({
           appRoot: preparedHost.appRoot,
           compiledArtifactsSource: createDiskRuntimeCompiledArtifactsSource(
@@ -597,8 +602,29 @@ async function buildApplicationInWorkspace(
           },
         }),
       );
+  const sandboxPrewarmResultPromise = settleBuildOperation(sandboxPrewarmPromise);
+  let nitroSurfaces: VercelNitroSurfaces;
+
+  try {
+    nitroSurfaces = await nitroSurfacesPromise;
+  } catch (error) {
+    await sandboxPrewarmResultPromise;
+    throw error;
+  }
+
+  try {
+    const [nitroBuildResult, sandboxPrewarmResult] = await Promise.all([
+      settleBuildOperation(buildVercelNitroSurfaces(nitroSurfaces, profiler)),
+      sandboxPrewarmResultPromise,
+    ]);
+    if (nitroBuildResult.status === "rejected") {
+      throw nitroBuildResult.reason;
     }
-    const flowNitroOutputDir = await buildVercelNitroSurfaces(nitroSurfaces, profiler);
+    if (sandboxPrewarmResult.status === "rejected") {
+      throw sandboxPrewarmResult.reason;
+    }
+
+    const flowNitroOutputDir = nitroBuildResult.value;
     await measureBuildPhase(profiler, "workflow.emit", () =>
       emitVercelWorkflowFunctions({
         agentName: preparedHost.compileResult.manifest.config.name,

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -129,6 +129,7 @@ function createPreparedHost(): PreparedDevelopmentApplicationHost {
       manifest: {
         channels: [],
         config: {},
+        connections: [],
         sandbox: null,
         subagents: [],
       },

--- a/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
@@ -528,6 +528,20 @@ describe("WorkflowBundleBuilder", () => {
       await expect(readFile(join(staleStepFunctionDir, "index.js"), "utf8")).rejects.toThrow();
       await expect(readFile(join(staleWebhookFunctionDir, "index.js"), "utf8")).rejects.toThrow();
       await expect(lstat(intermediateWorkflowOutputDir)).rejects.toThrow();
+
+      builder.buildCalls = 0;
+      measuredPhases.length = 0;
+      await builder.stageVercelOutput({
+        flowNitroOutputDir,
+        measure: async (phase, operation) => {
+          measuredPhases.push(phase);
+          return await operation();
+        },
+        outputDir,
+        runtime: "nodejs24.x",
+      });
+      expect(builder.buildCalls).toBe(0);
+      expect(measuredPhases).toEqual(["function.stage"]);
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }

--- a/packages/eve/src/internal/workflow-bundle/builder.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.ts
@@ -55,6 +55,13 @@ type VercelWorkflowOutputMeasure = <T>(
   operation: () => Promise<T>,
 ) => Promise<T>;
 
+interface VercelWorkflowOutputOptions {
+  readonly flowNitroOutputDir: string;
+  readonly measure?: VercelWorkflowOutputMeasure;
+  readonly outputDir: string;
+  readonly runtime?: string;
+}
+
 const runUnmeasuredVercelWorkflowOutputPhase = async <T>(
   _phase: VercelWorkflowOutputPhase,
   operation: () => Promise<T>,
@@ -367,14 +374,15 @@ export class WorkflowBundleBuilder {
     return manifestJson;
   }
 
-  async buildVercelOutput(options: {
-    flowNitroOutputDir: string;
-    measure?: VercelWorkflowOutputMeasure;
-    outputDir: string;
-    runtime?: string;
-  }): Promise<void> {
+  async buildVercelOutput(options: VercelWorkflowOutputOptions): Promise<void> {
     const measure = options.measure ?? runUnmeasuredVercelWorkflowOutputPhase;
     await measure("build", () => this.build());
+
+    await this.stageVercelOutput(options);
+  }
+
+  async stageVercelOutput(options: VercelWorkflowOutputOptions): Promise<void> {
+    const measure = options.measure ?? runUnmeasuredVercelWorkflowOutputPhase;
 
     const workflowGeneratedDir = join(
       options.outputDir,


### PR DESCRIPTION
## Summary

- run sandbox template prewarm concurrently with Vercel surface setup and isolated app/flow bundling
- keep publication gated on successful prewarm and both bundles, preserving the last-good production output on failure
- stage the workflow function from artifacts already generated for the flow surface instead of rebuilding them

## Benchmark

Exact local CI target: `e2e/fixtures/agent-tools-sandbox`, deployable Vercel mode with `sandbox.prewarm` included. Seven steady-state samples improved from a 798.1 ms median to 581.4 ms (-216.7 ms, -27.2%). Shared-runner CI remains the authoritative comparison.

## Validation

- 4,792 eve unit tests passed (1 skipped)
- focused scenario suites passed (39 tests)
- eve typecheck and invariant guard passed
- prewarm-failure scenario confirms staged work never replaces the last-good output
