### PR TITLE
perf(eve): trim ESM compatibility banners

### DIFF
--- a/.changeset/lean-esm-compat-banners.md
+++ b/.changeset/lean-esm-compat-banners.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Generate Node ESM compatibility source maps without per-line allocations and inject path globals only into chunks that reference them, reducing build time and hosted bundle size.

--- a/packages/eve/src/internal/node-esm-compat-banner.test.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("buildNodeEsmCompatBanner", () => {
   it("emits both path globals when the chunk declares neither", () => {
-    const banner = buildNodeEsmCompatBanner('console.log("noop");');
+    const banner = buildNodeEsmCompatBanner("export const value = __dirname;");
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
     expect(banner).toContain("const __dirname = __eveDirname(__filename);");
@@ -15,7 +15,9 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("includes the require shim when requested", () => {
-    const banner = buildNodeEsmCompatBanner('console.log("noop");', { includeRequire: true });
+    const banner = buildNodeEsmCompatBanner('export const value = require("noop");', {
+      includeRequire: true,
+    });
 
     expect(banner).toContain("const require = __eveCreateRequire(import.meta.url);");
   });
@@ -43,13 +45,17 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("emits only the missing path global", () => {
-    const chunk = ["var __dirname = somethingElse;", 'export const value = "noop";'].join("\n");
+    const chunk = ["var __dirname = somethingElse;", "export const value = __filename;"].join("\n");
 
     const banner = buildNodeEsmCompatBanner(chunk);
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
     expect(banner).not.toContain("const __dirname = __eveDirname(__filename);");
     expect(banner).not.toContain('from "node:path"');
+  });
+
+  it("emits nothing when the chunk does not use compatibility globals", () => {
+    expect(buildNodeEsmCompatBanner('export const value = "noop";')).toBe("");
   });
 
   it("omits the require shim when the chunk binds require", () => {
@@ -86,12 +92,12 @@ describe("buildNodeEsmCompatBanner", () => {
 describe("createNodeEsmCompatBannerPlugin", () => {
   it("prepends the banner to chunks that need it", () => {
     const plugin = createNodeEsmCompatBannerPlugin();
-    const code = 'export const value = "noop";';
+    const code = "export const value = __dirname;";
     const result = plugin.renderChunk(code, { fileName: "agent.mjs" });
 
     expect(result).not.toBeNull();
     expect(result?.code).toMatch(/^import \{ fileURLToPath as __eveFileURLToPath \}/);
-    expect(result?.code).toContain('export const value = "noop";');
+    expect(result?.code).toContain("export const value = __dirname;");
     expect(result?.map).toEqual({
       version: 3,
       sources: ["agent.mjs"],
@@ -103,7 +109,7 @@ describe("createNodeEsmCompatBannerPlugin", () => {
 
   it("maps original chunk lines after the prepended banner", () => {
     const plugin = createNodeEsmCompatBannerPlugin();
-    const code = ['const value = "noop";', "export { value };"].join("\n");
+    const code = ["const value = __dirname;", "export { value };"].join("\n");
     const result = plugin.renderChunk(code);
 
     expect(result?.map.mappings).toBe(";;;;AAAA;AACA");

--- a/packages/eve/src/internal/node-esm-compat-banner.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.ts
@@ -5,8 +5,8 @@
  * Bundle output that re-declares one of the CJS path globals at the top
  * level would otherwise collide with the banner, producing
  * `SyntaxError: Identifier '__dirname' has already been declared` at load
- * time. The banner builder omits any line whose binding the chunk already
- * provides.
+ * time. The banner builder includes only referenced globals and omits any
+ * line whose binding the chunk already provides.
  */
 interface NodeEsmCompatBannerOptions {
   /** Whether to expose a CommonJS `require` shim alongside the path globals. */
@@ -17,6 +17,7 @@ interface BannerLine {
   readonly importLine: string;
   readonly declarationLine: string;
   readonly bindingPattern: RegExp;
+  readonly usagePattern: RegExp;
 }
 
 // Match `const|let|var <name>` at the literal start of a line. Bundler
@@ -28,11 +29,13 @@ const BANNER_LINES: readonly BannerLine[] = [
     importLine: 'import { fileURLToPath as __eveFileURLToPath } from "node:url";',
     declarationLine: "const __filename = __eveFileURLToPath(import.meta.url);",
     bindingPattern: /^(?:const|let|var)\s+__filename\b/m,
+    usagePattern: /\b__(?:dir|file)name\b/,
   },
   {
     importLine: 'import { dirname as __eveDirname } from "node:path";',
     declarationLine: "const __dirname = __eveDirname(__filename);",
     bindingPattern: /^(?:const|let|var)\s+__dirname\b/m,
+    usagePattern: /\b__dirname\b/,
   },
 ];
 
@@ -40,6 +43,7 @@ const REQUIRE_LINE: BannerLine = {
   importLine: 'import { createRequire as __eveCreateRequire } from "node:module";',
   declarationLine: "const require = __eveCreateRequire(import.meta.url);",
   bindingPattern: /^(?:const|let|var)\s+require\b/m,
+  usagePattern: /\brequire\b/,
 };
 
 /**
@@ -48,7 +52,7 @@ const REQUIRE_LINE: BannerLine = {
  * level (e.g. `const __dirname = ...` emitted by an inlined module) are
  * skipped so the prepended banner never re-declares them.
  *
- * Returns an empty string when the chunk already provides every binding.
+ * Returns an empty string when the chunk needs no compatibility binding.
  */
 export function buildNodeEsmCompatBanner(
   code: string,
@@ -64,7 +68,7 @@ export function buildNodeEsmCompatBanner(
   const declarations: string[] = [];
 
   for (const line of lines) {
-    if (line.bindingPattern.test(code)) {
+    if (!line.usagePattern.test(code) || line.bindingPattern.test(code)) {
       continue;
     }
 
@@ -97,8 +101,9 @@ interface SourceMap {
 
 /**
  * Creates a bundler plugin that prepends the Node ESM compatibility
- * banner to each output chunk, skipping any banner line whose binding
- * the chunk already provides. Compatible with both Rollup and Rolldown.
+ * banner to each output chunk that references a compatibility global,
+ * skipping any line whose binding the chunk already provides. Compatible
+ * with both Rollup and Rolldown.
  */
 export function createNodeEsmCompatBannerPlugin(
   options: NodeEsmCompatBannerOptions = {},
@@ -133,44 +138,18 @@ function createPrependedLineSourceMap({
   source: string;
   sourceContent: string;
 }): SourceMap {
-  const originalLineCount = sourceContent.split("\n").length;
-  const lineMappings = Array.from({ length: originalLineCount }, (_, index) =>
-    encodeVlqFields(index === 0 ? [0, 0, 0, 0] : [0, 0, 1, 0]),
-  );
+  let originalLineCount = 1;
+  let newlineIndex = sourceContent.indexOf("\n");
+  while (newlineIndex !== -1) {
+    originalLineCount += 1;
+    newlineIndex = sourceContent.indexOf("\n", newlineIndex + 1);
+  }
 
   return {
     version: 3,
     sources: [source],
     sourcesContent: [sourceContent],
     names: [],
-    mappings: `${";".repeat(insertedLineCount)}${lineMappings.join(";")}`,
+    mappings: `${";".repeat(insertedLineCount)}AAAA${";AACA".repeat(originalLineCount - 1)}`,
   };
-}
-
-const BASE64_VLQ_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-const VLQ_BASE_SHIFT = 5;
-const VLQ_BASE = 1 << VLQ_BASE_SHIFT;
-const VLQ_BASE_MASK = VLQ_BASE - 1;
-const VLQ_CONTINUATION_BIT = VLQ_BASE;
-
-function encodeVlqFields(fields: readonly number[]): string {
-  return fields.map((field) => encodeVlqInteger(field)).join("");
-}
-
-function encodeVlqInteger(value: number): string {
-  let vlq = value < 0 ? (-value << 1) + 1 : value << 1;
-  let encoded = "";
-
-  do {
-    let digit = vlq & VLQ_BASE_MASK;
-    vlq >>>= VLQ_BASE_SHIFT;
-
-    if (vlq > 0) {
-      digit |= VLQ_CONTINUATION_BIT;
-    }
-
-    encoded += BASE64_VLQ_CHARS[digit];
-  } while (vlq > 0);
-
-  return encoded;
 }


### PR DESCRIPTION
## Summary

- inject Node ESM compatibility globals only into chunks that reference them
- generate the line-preserving source map with constant mappings instead of allocating and encoding every source line
- retain declaration-collision protection and exact source-map semantics

## Benchmark

On the same deployable `agent-tools-sandbox` benchmark with sandbox prewarm included, the stack improved from a 581.4 ms median to 527.8 ms (-53.6 ms, -9.2% for this layer; -33.9% from the original 798.1 ms baseline).

Compatibility banners fell from 59 chunks to 6. Total output decreased by 9,723 raw bytes and 3,749 gzip bytes.

## Validation

- 4,792 eve unit tests passed (1 skipped)
- focused unit and scenario suites passed (49 tests)
- eve typecheck and invariant guard passed
