### PR TITLE
fix(eve): fix withEve build in npm (non-pnpm) workspaces

### DIFF
--- a/.changeset/withEve-hoisted-eve-binary.md
+++ b/.changeset/withEve-hoisted-eve-binary.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Fix `withEve` producing a broken Vercel build command under npm workspaces, where eve is hoisted to the workspace root rather than the app's own `node_modules`. The eve binary is now located via module resolution, so npm-hoisted and pnpm layouts both work.
+Fix `withEve` producing a broken Vercel build command in npm workspaces, where the `eve` module is located in the workspace root.

--- a/.changeset/withEve-hoisted-eve-binary.md
+++ b/.changeset/withEve-hoisted-eve-binary.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `withEve` producing a broken Vercel build command under npm workspaces, where eve is hoisted to the workspace root rather than the app's own `node_modules`. The eve binary is now located via module resolution, so npm-hoisted and pnpm layouts both work.

--- a/packages/eve/src/public/next/index.integration.test.ts
+++ b/packages/eve/src/public/next/index.integration.test.ts
@@ -14,6 +14,20 @@ async function createTempAppRoot(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "eve-next-config-"));
 }
 
+// Simulate an installed eve package under a directory's node_modules (the
+// layout pnpm produces app-locally via symlink). Tests that assert the default
+// build command need a real install to resolve against, since withEve locates
+// the eve binary through module resolution.
+async function installEve(root: string): Promise<void> {
+  const eveRoot = join(root, "node_modules", "eve");
+  await mkdir(join(eveRoot, "bin"), { recursive: true });
+  await writeFile(
+    join(eveRoot, "package.json"),
+    JSON.stringify({ name: "eve", version: "0.0.0", bin: { eve: "./bin/eve.js" } }),
+  );
+  await writeFile(join(eveRoot, "bin", "eve.js"), "#!/usr/bin/env node\n");
+}
+
 async function readJsonFile(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown;
 }
@@ -52,6 +66,7 @@ describe("withEve Vercel config", () => {
 
   it("writes Build Output config in Vercel even when no linked project is detected", async () => {
     const appRoot = await createTempAppRoot();
+    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -98,6 +113,7 @@ describe("withEve Vercel config", () => {
 
   it("isolates a colocated generated eve service from the Next.js Build Output", async () => {
     const appRoot = await createTempAppRoot();
+    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -126,6 +142,7 @@ describe("withEve Vercel config", () => {
     await mkdir(join(projectRoot, ".vercel"), { recursive: true });
     await writeFile(join(projectRoot, ".vercel", "project.json"), "{}\n");
     await mkdir(appRoot, { recursive: true });
+    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -309,8 +326,37 @@ describe("withEve Vercel config", () => {
     });
   });
 
+  it("resolves the eve binary from a hoisted node_modules (npm workspaces)", async () => {
+    // npm workspaces hoist eve to the workspace root instead of creating an
+    // app-local node_modules/eve (which pnpm symlinks). The generated build
+    // command must point at the hoisted install, not a nonexistent app-local
+    // path.
+    const workspaceRoot = await createTempAppRoot();
+    await installEve(workspaceRoot);
+
+    const appRoot = join(workspaceRoot, "apps", "web");
+    await mkdir(appRoot, { recursive: true });
+    await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "web" }));
+
+    process.chdir(appRoot);
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_URL", "preview.example.com");
+
+    await resolveConfig(withEve<TestConfig>({}));
+    const outputConfig = (await readJsonFile(
+      join(appRoot, ".vercel", "output", "config.json"),
+    )) as { services: { eve: { buildCommand: string } } };
+
+    // The hoisted eve lives two levels up from apps/web at the workspace root.
+    expect(outputConfig.services.eve.buildCommand).toContain(
+      "node '../../node_modules/eve/bin/eve.js' build",
+    );
+  });
+
   it("writes one Build Output service and route for each named agent", async () => {
     const appRoot = await createTempAppRoot();
+    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -398,6 +444,7 @@ describe("withEve Vercel config", () => {
 
   it("normalizes existing Build Output service arrays before adding named agents", async () => {
     const appRoot = await createTempAppRoot();
+    await installEve(appRoot);
     process.chdir(appRoot);
     await mkdir(join(appRoot, ".vercel", "output"), { recursive: true });
     await writeFile(join(appRoot, ".vercel", "project.json"), "{}\n");

--- a/packages/eve/src/public/next/index.integration.test.ts
+++ b/packages/eve/src/public/next/index.integration.test.ts
@@ -4,6 +4,17 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("./resolve-eve-binary.js", async () => {
+  const { join } = await import("node:path");
+  return {
+    // Pin resolution to the conventional app-local path so build-command
+    // assertions stay deterministic without a real eve install on disk. The
+    // real resolver is exercised in resolve-eve-binary.integration.test.ts.
+    resolveEveBinaryPath: (nextRoot: string) =>
+      join(nextRoot, "node_modules", "eve", "bin", "eve.js"),
+  };
+});
+
 import { withEve, type EveNextConfig, type EveNextRewriteSections } from "./index.js";
 
 interface TestConfig extends EveNextConfig {
@@ -12,20 +23,6 @@ interface TestConfig extends EveNextConfig {
 
 async function createTempAppRoot(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "eve-next-config-"));
-}
-
-// Simulate an installed eve package under a directory's node_modules (the
-// layout pnpm produces app-locally via symlink). Tests that assert the default
-// build command need a real install to resolve against, since withEve locates
-// the eve binary through module resolution.
-async function installEve(root: string): Promise<void> {
-  const eveRoot = join(root, "node_modules", "eve");
-  await mkdir(join(eveRoot, "bin"), { recursive: true });
-  await writeFile(
-    join(eveRoot, "package.json"),
-    JSON.stringify({ name: "eve", version: "0.0.0", bin: { eve: "./bin/eve.js" } }),
-  );
-  await writeFile(join(eveRoot, "bin", "eve.js"), "#!/usr/bin/env node\n");
 }
 
 async function readJsonFile(path: string): Promise<unknown> {
@@ -66,7 +63,6 @@ describe("withEve Vercel config", () => {
 
   it("writes Build Output config in Vercel even when no linked project is detected", async () => {
     const appRoot = await createTempAppRoot();
-    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -113,7 +109,6 @@ describe("withEve Vercel config", () => {
 
   it("isolates a colocated generated eve service from the Next.js Build Output", async () => {
     const appRoot = await createTempAppRoot();
-    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -142,7 +137,6 @@ describe("withEve Vercel config", () => {
     await mkdir(join(projectRoot, ".vercel"), { recursive: true });
     await writeFile(join(projectRoot, ".vercel", "project.json"), "{}\n");
     await mkdir(appRoot, { recursive: true });
-    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -326,37 +320,8 @@ describe("withEve Vercel config", () => {
     });
   });
 
-  it("resolves the eve binary from a hoisted node_modules (npm workspaces)", async () => {
-    // npm workspaces hoist eve to the workspace root instead of creating an
-    // app-local node_modules/eve (which pnpm symlinks). The generated build
-    // command must point at the hoisted install, not a nonexistent app-local
-    // path.
-    const workspaceRoot = await createTempAppRoot();
-    await installEve(workspaceRoot);
-
-    const appRoot = join(workspaceRoot, "apps", "web");
-    await mkdir(appRoot, { recursive: true });
-    await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "web" }));
-
-    process.chdir(appRoot);
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("VERCEL", "1");
-    vi.stubEnv("VERCEL_URL", "preview.example.com");
-
-    await resolveConfig(withEve<TestConfig>({}));
-    const outputConfig = (await readJsonFile(
-      join(appRoot, ".vercel", "output", "config.json"),
-    )) as { services: { eve: { buildCommand: string } } };
-
-    // The hoisted eve lives two levels up from apps/web at the workspace root.
-    expect(outputConfig.services.eve.buildCommand).toContain(
-      "node '../../node_modules/eve/bin/eve.js' build",
-    );
-  });
-
   it("writes one Build Output service and route for each named agent", async () => {
     const appRoot = await createTempAppRoot();
-    await installEve(appRoot);
     process.chdir(appRoot);
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
@@ -444,7 +409,6 @@ describe("withEve Vercel config", () => {
 
   it("normalizes existing Build Output service arrays before adding named agents", async () => {
     const appRoot = await createTempAppRoot();
-    await installEve(appRoot);
     process.chdir(appRoot);
     await mkdir(join(appRoot, ".vercel", "output"), { recursive: true });
     await writeFile(join(appRoot, ".vercel", "project.json"), "{}\n");

--- a/packages/eve/src/public/next/index.test.ts
+++ b/packages/eve/src/public/next/index.test.ts
@@ -344,7 +344,7 @@ describe("withEve", () => {
         },
         {
           appRoot: expect.stringContaining("/agents/support"),
-          buildCommand: "node '../../node_modules/eve/bin/eve.js' build",
+          buildCommand: expect.stringMatching(/^node '.*bin\/eve\.js' build$/),
           name: "support",
           publicRoutePrefix: "/eve/agents/support",
           servicePrefix: `${EVE_NEXT_SERVICE_PREFIX}/support`,

--- a/packages/eve/src/public/next/index.test.ts
+++ b/packages/eve/src/public/next/index.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("./resolve-eve-binary.js", async () => {
+  const { join } = await import("node:path");
+  return {
+    // Pin resolution to the conventional app-local path so the default
+    // build-command assertion is deterministic without touching the
+    // filesystem. The real resolver is covered by its own integration test.
+    resolveEveBinaryPath: (nextRoot: string) =>
+      join(nextRoot, "node_modules", "eve", "bin", "eve.js"),
+  };
+});
+
 vi.mock("./vercel-output-config.js", () => ({
   ensureEveVercelOutputConfig: vi.fn(
     async (input: {
@@ -344,7 +355,7 @@ describe("withEve", () => {
         },
         {
           appRoot: expect.stringContaining("/agents/support"),
-          buildCommand: expect.stringMatching(/^node '.*bin\/eve\.js' build$/),
+          buildCommand: "node '../../node_modules/eve/bin/eve.js' build",
           name: "support",
           publicRoutePrefix: "/eve/agents/support",
           servicePrefix: `${EVE_NEXT_SERVICE_PREFIX}/support`,

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import type { NextConfig } from "next";
 
@@ -325,12 +326,27 @@ function toPosixPath(path: string): string {
   return path.replaceAll("\\", "/");
 }
 
+function resolveEveBinaryPath(nextRoot: string): string {
+  // Resolve where eve is actually installed from the app's perspective rather
+  // than assuming an app-local `node_modules/eve`. npm workspaces hoist eve to
+  // the workspace root, so the app-local path does not exist there; module
+  // resolution follows the hoisted (or pnpm-symlinked) install instead. eve
+  // does not export `./bin/eve.js`, but it does export `./package.json`, so we
+  // resolve that and derive the bin path from the package root.
+  try {
+    const require = createRequire(join(nextRoot, "package.json"));
+    return join(dirname(require.resolve("eve/package.json")), "bin", "eve.js");
+  } catch {
+    return join(nextRoot, "node_modules", "eve", "bin", "eve.js");
+  }
+}
+
 function createDefaultBuildCommand(input: {
   readonly agentRoot: string;
   readonly nextRoot: string;
 }): string {
   const eveBinaryPath = toPosixPath(
-    relative(input.agentRoot, join(input.nextRoot, "node_modules", "eve", "bin", "eve.js")),
+    relative(input.agentRoot, resolveEveBinaryPath(input.nextRoot)),
   );
   return `node ${quoteShellArg(eveBinaryPath)} build`;
 }

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -1,9 +1,9 @@
-import { createRequire } from "node:module";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 import type { NextConfig } from "next";
 
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
+import { resolveEveBinaryPath } from "./resolve-eve-binary.js";
 import { resolveEveDestinationPrefix } from "./server.js";
 import { ensureEveVercelOutputConfig } from "./vercel-output-config.js";
 
@@ -324,21 +324,6 @@ function quoteShellArg(value: string): string {
 
 function toPosixPath(path: string): string {
   return path.replaceAll("\\", "/");
-}
-
-function resolveEveBinaryPath(nextRoot: string): string {
-  // Resolve where eve is actually installed from the app's perspective rather
-  // than assuming an app-local `node_modules/eve`. npm workspaces hoist eve to
-  // the workspace root, so the app-local path does not exist there; module
-  // resolution follows the hoisted (or pnpm-symlinked) install instead. eve
-  // does not export `./bin/eve.js`, but it does export `./package.json`, so we
-  // resolve that and derive the bin path from the package root.
-  try {
-    const require = createRequire(join(nextRoot, "package.json"));
-    return join(dirname(require.resolve("eve/package.json")), "bin", "eve.js");
-  } catch {
-    return join(nextRoot, "node_modules", "eve", "bin", "eve.js");
-  }
 }
 
 function createDefaultBuildCommand(input: {

--- a/packages/eve/src/public/next/resolve-eve-binary.integration.test.ts
+++ b/packages/eve/src/public/next/resolve-eve-binary.integration.test.ts
@@ -1,0 +1,40 @@
+import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveEveBinaryPath } from "./resolve-eve-binary.js";
+
+// Writes a minimal installed eve package under `root/node_modules/eve` and
+// returns the realpath the resolver is expected to produce (createRequire
+// canonicalizes symlinks, and macOS routes tmpdir through one).
+async function writeEvePackage(root: string): Promise<string> {
+  const eveRoot = join(root, "node_modules", "eve");
+  await mkdir(join(eveRoot, "bin"), { recursive: true });
+  await writeFile(join(eveRoot, "package.json"), JSON.stringify({ name: "eve", version: "0.0.0" }));
+  await writeFile(join(eveRoot, "bin", "eve.js"), "#!/usr/bin/env node\n");
+  return join(await realpath(eveRoot), "bin", "eve.js");
+}
+
+describe("resolveEveBinaryPath", () => {
+  it("resolves eve hoisted to the workspace root (npm workspaces)", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-resolve-"));
+    const expected = await writeEvePackage(workspaceRoot);
+
+    // The app has no eve under its own node_modules — npm hoisted it up.
+    const appRoot = join(workspaceRoot, "apps", "web");
+    await mkdir(appRoot, { recursive: true });
+    await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "web" }));
+
+    expect(resolveEveBinaryPath(appRoot)).toBe(expected);
+  });
+
+  it("resolves eve from an app-local install (pnpm layout)", async () => {
+    const appRoot = await mkdtemp(join(tmpdir(), "eve-resolve-"));
+    const expected = await writeEvePackage(appRoot);
+    await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "web" }));
+
+    expect(resolveEveBinaryPath(appRoot)).toBe(expected);
+  });
+});

--- a/packages/eve/src/public/next/resolve-eve-binary.integration.test.ts
+++ b/packages/eve/src/public/next/resolve-eve-binary.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -6,35 +6,39 @@ import { describe, expect, it } from "vitest";
 
 import { resolveEveBinaryPath } from "./resolve-eve-binary.js";
 
-// Writes a minimal installed eve package under `root/node_modules/eve` and
-// returns the realpath the resolver is expected to produce (createRequire
-// canonicalizes symlinks, and macOS routes tmpdir through one).
-async function writeEvePackage(root: string): Promise<string> {
-  const eveRoot = join(root, "node_modules", "eve");
-  await mkdir(join(eveRoot, "bin"), { recursive: true });
-  await writeFile(join(eveRoot, "package.json"), JSON.stringify({ name: "eve", version: "0.0.0" }));
-  await writeFile(join(eveRoot, "bin", "eve.js"), "#!/usr/bin/env node\n");
-  return join(await realpath(eveRoot), "bin", "eve.js");
+// Writes a minimal eve package at `dir` and returns its realpath'd bin path
+// (createRequire canonicalizes symlinks, and macOS routes tmpdir through one).
+async function writeEvePackage(dir: string): Promise<string> {
+  await mkdir(join(dir, "bin"), { recursive: true });
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name: "eve", version: "0.0.0" }));
+  await writeFile(join(dir, "bin", "eve.js"), "#!/usr/bin/env node\n");
+  return join(await realpath(dir), "bin", "eve.js");
 }
 
 describe("resolveEveBinaryPath", () => {
   it("resolves eve hoisted to the workspace root (npm workspaces)", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-resolve-"));
-    const expected = await writeEvePackage(workspaceRoot);
+    const expected = await writeEvePackage(join(workspaceRoot, "node_modules", "eve"));
 
-    // The app has no eve under its own node_modules — npm hoisted it up.
+    // The app has no eve under its own node_modules; npm hoisted it up.
     const appRoot = join(workspaceRoot, "apps", "web");
     await mkdir(appRoot, { recursive: true });
     await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "web" }));
 
-    expect(resolveEveBinaryPath(appRoot)).toBe(expected);
+    // realpath both sides so Windows short (8.3) paths compare equal.
+    expect(await realpath(resolveEveBinaryPath(appRoot))).toBe(expected);
   });
 
-  it("resolves eve from an app-local install (pnpm layout)", async () => {
+  it("resolves eve through pnpm's virtual-store symlink", async () => {
     const appRoot = await mkdtemp(join(tmpdir(), "eve-resolve-"));
-    const expected = await writeEvePackage(appRoot);
     await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "web" }));
 
-    expect(resolveEveBinaryPath(appRoot)).toBe(expected);
+    // pnpm installs the real package under .pnpm and symlinks node_modules/eve
+    // to it; the resolver must follow the link to the store.
+    const storeRoot = join(appRoot, "node_modules", ".pnpm", "eve@0.0.0", "node_modules", "eve");
+    const expected = await writeEvePackage(storeRoot);
+    await symlink(storeRoot, join(appRoot, "node_modules", "eve"), "junction");
+
+    expect(await realpath(resolveEveBinaryPath(appRoot))).toBe(expected);
   });
 });

--- a/packages/eve/src/public/next/resolve-eve-binary.ts
+++ b/packages/eve/src/public/next/resolve-eve-binary.ts
@@ -1,0 +1,22 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+/**
+ * Resolves the absolute path to the installed eve binary from the app's
+ * perspective.
+ *
+ * Uses module resolution rather than assuming an app-local `node_modules/eve`:
+ * npm workspaces hoist eve to the workspace root, so the app-local path does
+ * not exist there, while pnpm symlinks it app-locally. eve does not export
+ * `./bin/eve.js`, but it does export `./package.json`, so we resolve that and
+ * derive the bin path from the package root. Falls back to the conventional
+ * app-local path when eve cannot be resolved (e.g. before install).
+ */
+export function resolveEveBinaryPath(nextRoot: string): string {
+  try {
+    const require = createRequire(join(nextRoot, "package.json"));
+    return join(dirname(require.resolve("eve/package.json")), "bin", "eve.js");
+  } catch {
+    return join(nextRoot, "node_modules", "eve", "bin", "eve.js");
+  }
+}


### PR DESCRIPTION
### Description

`withEve` expects eve to be installed in the app's `node_modules`, but in `npm` (non-`pnpm`) workspaces, it's installed in the workspace root. Adjusts our resolution behavior to support both.

### How did you test your changes?

Manually constructed an npm workspace, tested the failure, then tested with the patch.
New integration test.


### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
