### PR TITLE
fix(eve): bundle authored modules as one generation graph

### DIFF
--- a/.changeset/shared-authored-generation-graph.md
+++ b/.changeset/shared-authored-generation-graph.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Bundle authored modules in each development generation as one shared graph, avoiding repeated parsing and emission of dependencies for every tool.

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -2,11 +2,16 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 
+import type { CompiledAgentManifest } from "#compiler/manifest.js";
+import { createCompiledModuleMapSource } from "#compiler/module-map.js";
 import { createAuthoredAssetImportPlugin } from "#internal/authored-asset-import-plugin.js";
 import { assertNoWorkflowDirectivePrologue } from "#internal/authored-directive-prologue.js";
 import { createAuthoredModuleBundleError } from "#internal/authored-module-bundle.js";
 import { createAuthoredPackageTsConfigPathsPlugin } from "#internal/authored-package-tsconfig-paths.js";
-import { createFixedNamespaceScopePlugin } from "#internal/bundler/extension-scope-plugin.js";
+import {
+  createExtensionScopePlugin,
+  createFixedNamespaceScopePlugin,
+} from "#internal/bundler/extension-scope-plugin.js";
 import {
   CACHED_CHANNEL_PREFIX,
   RESOLVE_EXTENSIONS,
@@ -170,6 +175,85 @@ export async function bundleAuthoredModuleForGeneration(
   });
 
   return removeRolldownModuleRegionComments(code);
+}
+
+/**
+ * Bundles every runtime-authored module in one immutable generation graph.
+ * Shared dependencies are parsed and emitted once instead of once per authored
+ * entry.
+ */
+export async function bundleAuthoredModuleMapForGeneration(input: {
+  readonly manifest: CompiledAgentManifest;
+  readonly moduleMapPath: string;
+}): Promise<string> {
+  const packageRoot = resolveAuthoredPackageRoot(input.manifest.agentRoot);
+  const externalDependencies = normalizeExternalDependencies(
+    [input.manifest, ...input.manifest.subagents.map((subagent) => subagent.agent)].flatMap(
+      (node) => node.config.build?.externalDependencies ?? [],
+    ),
+  );
+  const moduleMapSource = createCompiledModuleMapSource({
+    manifest: input.manifest,
+    moduleMapPath: input.moduleMapPath,
+  });
+  const extensionScopePlugin = createExtensionScopePlugin(
+    input.manifest.extensionMounts.map((mount) => ({
+      packageNamespace: mount.packageNamespace,
+      sourceRoot: mount.sourceRoot,
+    })),
+  );
+  const plugins = [
+    createVirtualGenerationModuleMapPlugin({
+      id: input.moduleMapPath,
+      source: moduleMapSource,
+    }),
+    createAuthoredDirectiveGuardPlugin(),
+    extensionScopePlugin,
+    createAuthoredRelativeExtensionResolverPlugin({ extensions: RESOLVE_EXTENSIONS }),
+    createAuthoredAssetImportPlugin(),
+    createAuthoredPackageTsConfigPathsPlugin({
+      appPackageRoot: packageRoot,
+      extensions: RESOLVE_EXTENSIONS,
+    }),
+    createNodeEsmCompatBannerPlugin({ includeRequire: true }),
+    createGenerationPackageBoundaryPlugin({ externalDependencies, packageRoot }),
+  ].filter((plugin) => plugin !== null);
+
+  try {
+    const chunk = await buildSingleRolldownChunk("authored module map", {
+      cwd: packageRoot,
+      input: input.moduleMapPath,
+      platform: "node",
+      plugins,
+      resolve: {
+        extensions: [...RESOLVE_EXTENSIONS],
+      },
+      tsconfig: resolveAuthoredTsConfigPath(packageRoot),
+      output: {
+        comments: false,
+        format: "esm",
+        sourcemap: false,
+      },
+    });
+    return removeRolldownModuleRegionComments(chunk.code);
+  } catch (error) {
+    throw createAuthoredModuleBundleError(input.moduleMapPath, error);
+  }
+}
+
+function createVirtualGenerationModuleMapPlugin(input: {
+  readonly id: string;
+  readonly source: string;
+}): Record<string, unknown> {
+  return {
+    name: "eve-generation-module-map",
+    resolveId(id: string) {
+      return id === input.id ? id : undefined;
+    },
+    load(id: string) {
+      return id === input.id ? { code: input.source, moduleType: "js" as const } : undefined;
+    },
+  };
 }
 
 async function buildAuthoredModuleBundle(

--- a/packages/eve/src/internal/authored-module-map-loader.ts
+++ b/packages/eve/src/internal/authored-module-map-loader.ts
@@ -3,11 +3,15 @@ import { pathToFileURL } from "node:url";
 
 import type { CompiledAgentManifest, CompiledAgentNodeManifest } from "#compiler/manifest.js";
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
-import { collectModuleRefsForManifest, type CompiledModuleMap } from "#compiler/module-map.js";
+import {
+  collectModuleRefsForManifest,
+  compiledModuleMapSchema,
+  type CompiledModuleMap,
+} from "#compiler/module-map.js";
 import type { RuntimeDiskCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { loadCompiledManifest } from "#runtime/loaders/manifest.js";
+import { formatValidationError } from "#runtime/validation.js";
 import { loadAuthoredModuleNamespace } from "#internal/authored-module-loader.js";
-import { expectObjectRecord } from "#internal/authored-module.js";
 import { readMaterializedAuthoredModuleIndex } from "#internal/materialized-authored-modules.js";
 
 /**
@@ -48,6 +52,14 @@ async function hydrateCompiledModuleMapFromManifest(
   manifest: CompiledAgentManifest,
   runtimeAppRoot: string,
 ): Promise<CompiledModuleMap> {
+  const materializedIndex = await readMaterializedAuthoredModuleIndex(runtimeAppRoot);
+  if (materializedIndex !== undefined) {
+    return await loadMaterializedCompiledModuleMap({
+      moduleMapPath: materializedIndex.moduleMap,
+      runtimeAppRoot,
+    });
+  }
+
   const nodes: CompiledModuleMap["nodes"] = {};
   const nodeManifests: Array<{
     agentRoot: string;
@@ -76,22 +88,11 @@ async function hydrateCompiledModuleMapFromManifest(
       manifest.extensionMounts.map((mount) => [mount.mountSourceId, mount.packageNamespace]),
     ),
   };
-  const materializedIndex = await readMaterializedAuthoredModuleIndex(runtimeAppRoot);
-
   for (const nodeManifest of nodeManifests) {
-    const materializedModules = materializedIndex?.nodes[nodeManifest.nodeId]?.modules;
-    if (materializedIndex !== undefined && materializedModules === undefined) {
-      throw new Error(
-        `Materialized authored module index is missing node "${nodeManifest.nodeId}".`,
-      );
-    }
-
     nodes[nodeManifest.nodeId] = {
       modules: await hydrateCompiledNodeScope({
         agentRoot: nodeManifest.agentRoot,
         manifest: nodeManifest.manifest,
-        materializedModules,
-        runtimeAppRoot,
         scopeIndex,
       }),
     };
@@ -100,6 +101,27 @@ async function hydrateCompiledModuleMapFromManifest(
   return {
     nodes,
   };
+}
+
+async function loadMaterializedCompiledModuleMap(input: {
+  readonly moduleMapPath: string;
+  readonly runtimeAppRoot: string;
+}): Promise<CompiledModuleMap> {
+  const moduleMapPath = join(input.runtimeAppRoot, ".eve", "compile", input.moduleMapPath);
+  const moduleNamespace = (await import(
+    `${pathToFileURL(moduleMapPath).href}?generation=${encodeURIComponent(input.moduleMapPath)}`
+  )) as { readonly default?: unknown; readonly moduleMap?: unknown };
+  const parsed = compiledModuleMapSchema.safeParse(
+    moduleNamespace.moduleMap ?? moduleNamespace.default,
+  );
+
+  if (!parsed.success) {
+    throw new Error(
+      `Expected materialized authored module map "${moduleMapPath}" to export a valid compiled eve module map. ${formatValidationError(parsed.error)}`,
+    );
+  }
+
+  return parsed.data;
 }
 
 /**
@@ -117,8 +139,6 @@ function extensionNamespaceForSourceId(
 async function hydrateCompiledNodeScope(input: {
   agentRoot: string;
   manifest: CompiledAgentNodeManifest;
-  materializedModules?: Readonly<Record<string, string>>;
-  runtimeAppRoot: string;
   scopeIndex: ExtensionScopeIndex;
 }): Promise<CompiledModuleMap["nodes"][string]["modules"]> {
   const refs = collectModuleRefsForManifest(input.manifest).sort((left, right) =>
@@ -142,21 +162,6 @@ async function hydrateCompiledNodeScope(input: {
       container[EXT_CONFIG_SCOPE] = mountConfigScope;
     }
     try {
-      const materializedPath = input.materializedModules?.[ref.sourceId];
-      if (input.materializedModules !== undefined && materializedPath === undefined) {
-        throw new Error(`Materialized authored module index is missing source "${ref.sourceId}".`);
-      }
-
-      if (materializedPath !== undefined) {
-        modules[ref.sourceId] = expectObjectRecord(
-          await import(
-            `${pathToFileURL(join(input.runtimeAppRoot, ".eve", "compile", materializedPath)).href}?generation=${encodeURIComponent(materializedPath)}`
-          ),
-          `Expected materialized authored module "${ref.sourceId}" to export a namespace object.`,
-        );
-        continue;
-      }
-
       modules[ref.sourceId] = await loadAuthoredModuleNamespace(modulePath, {
         externalDependencies,
         extensionScopeNamespace,

--- a/packages/eve/src/internal/materialized-authored-modules.ts
+++ b/packages/eve/src/internal/materialized-authored-modules.ts
@@ -3,10 +3,12 @@ import { existsSync } from "node:fs";
 import { lstat, mkdir, readFile, readdir, readlink, writeFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 
-import type { CompiledAgentManifest, CompiledAgentNodeManifest } from "#compiler/manifest.js";
+import type { CompiledAgentManifest } from "#compiler/manifest.js";
 import { COMPILED_AGENT_MANIFEST_KIND, ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
-import { collectModuleRefsForManifest } from "#compiler/module-map.js";
-import { bundleAuthoredModuleForGeneration } from "#internal/authored-module-loader.js";
+import {
+  bundleAuthoredModuleForGeneration,
+  bundleAuthoredModuleMapForGeneration,
+} from "#internal/authored-module-loader.js";
 import { serializeCompiledManifestForFingerprint } from "#internal/compiled-manifest-fingerprint.js";
 
 const MATERIALIZED_MODULES_DIRECTORY = "authored-modules";
@@ -16,8 +18,8 @@ const INSTRUMENTATION_EXTENSIONS = [".ts", ".mts", ".js", ".mjs"] as const;
 export interface MaterializedAuthoredModuleIndex {
   readonly fingerprint: string;
   readonly instrumentation?: string;
-  readonly nodes: Readonly<Record<string, { readonly modules: Readonly<Record<string, string>> }>>;
-  readonly version: 1;
+  readonly moduleMap: string;
+  readonly version: 2;
 }
 
 export async function materializeAuthoredModules(input: {
@@ -26,8 +28,6 @@ export async function materializeAuthoredModules(input: {
   const compileRoot = join(input.runtimeAppRoot, ".eve", "compile");
   const manifest = await readCompiledManifest(join(compileRoot, "compiled-agent-manifest.json"));
   const modulesRoot = join(compileRoot, MATERIALIZED_MODULES_DIRECTORY);
-  const scopeIndex = createExtensionScopeIndex(manifest);
-  const nodes: Record<string, { modules: Record<string, string> }> = {};
   const fingerprint = createHash("sha256");
 
   await mkdir(modulesRoot, { recursive: true });
@@ -40,32 +40,19 @@ export async function materializeAuthoredModules(input: {
       }),
     )
     .update("\0");
-  for (const node of collectNodeManifests(manifest)) {
-    const modules: Record<string, string> = {};
+  const moduleMapCode = await bundleAuthoredModuleMapForGeneration({
+    manifest,
+    moduleMapPath: join(compileRoot, "module-map.mjs"),
+  });
+  const moduleMapFileName = createMaterializedModuleFileName(
+    ROOT_COMPILED_AGENT_NODE_ID,
+    "module-map",
+    moduleMapCode,
+  );
+  const moduleMapPath = join(MATERIALIZED_MODULES_DIRECTORY, moduleMapFileName);
 
-    for (const ref of collectModuleRefsForManifest(node.manifest).sort((left, right) =>
-      left.sourceId.localeCompare(right.sourceId),
-    )) {
-      const code = await bundleAuthoredModuleForGeneration(join(node.agentRoot, ref.logicalPath), {
-        externalDependencies: node.manifest.config.build?.externalDependencies ?? [],
-        extensionScopeNamespace: extensionNamespaceForSourceId(ref.sourceId, scopeIndex),
-      });
-      const fileName = createMaterializedModuleFileName(node.nodeId, ref.sourceId, code);
-
-      await writeFile(join(modulesRoot, fileName), code);
-      fingerprint
-        .update("module\0")
-        .update(node.nodeId)
-        .update("\0")
-        .update(ref.sourceId)
-        .update("\0")
-        .update(code)
-        .update("\0");
-      modules[ref.sourceId] = join(MATERIALIZED_MODULES_DIRECTORY, fileName);
-    }
-
-    nodes[node.nodeId] = { modules };
-  }
+  await writeFile(join(modulesRoot, moduleMapFileName), moduleMapCode);
+  fingerprint.update("module-map\0").update(moduleMapCode).update("\0");
 
   const instrumentation = resolveInstrumentationModule(manifest.agentRoot);
   let instrumentationPath: string | undefined;
@@ -93,12 +80,12 @@ export async function materializeAuthoredModules(input: {
   const index: {
     fingerprint: string;
     instrumentation?: string;
-    nodes: MaterializedAuthoredModuleIndex["nodes"];
-    version: 1;
+    moduleMap: string;
+    version: 2;
   } = {
     fingerprint: fingerprint.digest("hex"),
-    nodes,
-    version: 1,
+    moduleMap: moduleMapPath,
+    version: 2,
   };
   if (instrumentationPath !== undefined) {
     index.instrumentation = instrumentationPath;
@@ -119,54 +106,17 @@ export async function readMaterializedAuthoredModuleIndex(
     await readFile(indexPath, "utf8"),
   ) as Partial<MaterializedAuthoredModuleIndex>;
   if (
-    parsed.version !== 1 ||
+    parsed.version !== 2 ||
     typeof parsed.fingerprint !== "string" ||
     parsed.fingerprint.length === 0 ||
-    typeof parsed.nodes !== "object" ||
-    parsed.nodes === null ||
+    typeof parsed.moduleMap !== "string" ||
+    parsed.moduleMap.length === 0 ||
     (parsed.instrumentation !== undefined && typeof parsed.instrumentation !== "string")
   ) {
     throw new Error(`Invalid materialized authored module index at "${indexPath}".`);
   }
 
   return parsed as MaterializedAuthoredModuleIndex;
-}
-
-interface ExtensionScopeIndex {
-  readonly byMountNamespace: ReadonlyMap<string, string>;
-}
-
-function collectNodeManifests(manifest: CompiledAgentManifest): Array<{
-  readonly agentRoot: string;
-  readonly manifest: CompiledAgentNodeManifest;
-  readonly nodeId: string;
-}> {
-  return [
-    { agentRoot: manifest.agentRoot, manifest, nodeId: ROOT_COMPILED_AGENT_NODE_ID },
-    ...[...manifest.subagents]
-      .sort((left, right) => left.nodeId.localeCompare(right.nodeId))
-      .map((subagent) => ({
-        agentRoot: subagent.agent.agentRoot,
-        manifest: subagent.agent,
-        nodeId: subagent.nodeId,
-      })),
-  ];
-}
-
-function createExtensionScopeIndex(manifest: CompiledAgentManifest): ExtensionScopeIndex {
-  return {
-    byMountNamespace: new Map(
-      manifest.extensionMounts.map((mount) => [mount.namespace, mount.packageNamespace]),
-    ),
-  };
-}
-
-function extensionNamespaceForSourceId(
-  sourceId: string,
-  index: ExtensionScopeIndex,
-): string | undefined {
-  const match = sourceId.match(/^ext:([^:]+):/u);
-  return match === null ? undefined : index.byMountNamespace.get(match[1]!);
 }
 
 async function readCompiledManifest(path: string): Promise<CompiledAgentManifest> {

--- a/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { compileAgent } from "#compiler/compile-agent.js";
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import { loadCompiledModuleMapFromAuthoredSource } from "#internal/authored-module-map-loader.js";
+import { resolvePackageRoot } from "#internal/application/package.js";
 import {
   discardDevelopmentGeneration,
   stageDevelopmentGeneration,
@@ -16,6 +17,137 @@ import { useScenarioApp } from "#internal/testing/scenario-app.js";
 
 describe("development generation artifacts", () => {
   const scenarioApp = useScenarioApp();
+
+  it("materializes one shared module graph for every authored entry", async () => {
+    const sharedMarker = "eve-shared-generation-module-marker";
+    const app = await scenarioApp({
+      files: {
+        "agent/agent.mjs": 'export default { model: "openai/gpt-5.4" };\n',
+        "agent/instructions.md": "Use the available tools.",
+        "agent/lib/shared.mjs": `export const shared = ${JSON.stringify(sharedMarker)};\n`,
+        "agent/subagents/reader/agent.mjs": [
+          "export default {",
+          '  description: "Read the shared value.",',
+          '  model: "openai/gpt-5.4",',
+          "};",
+          "",
+        ].join("\n"),
+        "agent/subagents/reader/tools/read_shared.mjs": [
+          'import { shared } from "../../../lib/shared.mjs";',
+          'export default { description: "Read shared.", execute: () => shared };',
+          "",
+        ].join("\n"),
+        "agent/tools/first.mjs": [
+          'import { shared } from "../lib/shared.mjs";',
+          'export default { description: "First tool.", execute: () => shared };',
+          "",
+        ].join("\n"),
+        "agent/tools/second.mjs": [
+          'import { shared } from "../lib/shared.mjs";',
+          'export default { description: "Second tool.", execute: () => shared };',
+          "",
+        ].join("\n"),
+      },
+      name: "shared-generation-module-graph",
+    });
+
+    const compileResult = await compileAgent({ startPath: app.appRoot });
+    const snapshot = await stageDevelopmentGeneration(compileResult);
+    const compileRoot = join(snapshot.runtimeAppRoot, ".eve", "compile");
+    const index = JSON.parse(
+      await readFile(join(compileRoot, "authored-modules.json"), "utf8"),
+    ) as { readonly moduleMap?: string };
+    expect(index.moduleMap).toBeDefined();
+    const materializedFiles = await readdir(join(compileRoot, "authored-modules"));
+    const materializedCode = await Promise.all(
+      materializedFiles.map((fileName) =>
+        readFile(join(compileRoot, "authored-modules", fileName), "utf8"),
+      ),
+    );
+
+    expect(materializedFiles).toEqual([basename(index.moduleMap!)]);
+    expect(materializedCode.join("\n").split(sharedMarker)).toHaveLength(2);
+
+    const moduleMap = await loadCompiledModuleMapFromAuthoredSource({
+      compiledArtifactsSource: createAuthoredSourceRuntimeCompiledArtifactsSource(
+        snapshot.runtimeAppRoot,
+      ),
+    });
+    const subagent = compileResult.manifest.subagents[0];
+    const subagentToolSourceId = subagent?.agent.tools[0]?.sourceId;
+    expect(subagentToolSourceId).toBeDefined();
+    const subagentTool = moduleMap.nodes[subagent!.nodeId]?.modules[subagentToolSourceId!] as {
+      default: { execute(): string };
+    };
+    expect(subagentTool.default.execute()).toBe(sharedMarker);
+  });
+
+  it("preserves extension scope in a shared generation graph", async () => {
+    const packageName = "@acme/shared-graph-extension";
+    const app = await scenarioApp({
+      dependencies: {
+        [packageName]: "workspace:*",
+      },
+      files: {
+        "agent/agent.mjs": 'export default { model: "openai/gpt-5.4" };\n',
+        "agent/extensions/acme.mjs": [
+          `import extension from ${JSON.stringify(packageName)};`,
+          'export default extension({ label: "configured" });',
+          "",
+        ].join("\n"),
+        "agent/instructions.md": "Use the available tools.",
+        "packages/shared-graph-extension/extension/extension.mjs": [
+          'import { defineExtension } from "eve/extension";',
+          "const schema = {",
+          '  "~standard": { version: 1, vendor: "fixture", validate: (value) => ({ value }) },',
+          "};",
+          "export default defineExtension({ config: schema });",
+          "",
+        ].join("\n"),
+        "packages/shared-graph-extension/extension/tools/read_label.mjs": [
+          'import extension from "../extension.mjs";',
+          "export default {",
+          '  description: "Read extension config.",',
+          "  execute: () => extension.config.label,",
+          "};",
+          "",
+        ].join("\n"),
+        "packages/shared-graph-extension/package.json": `${JSON.stringify({
+          eve: { extension: "extension" },
+          exports: "./extension/extension.mjs",
+          name: packageName,
+          type: "module",
+        })}\n`,
+        "pnpm-workspace.yaml": "packages:\n  - packages/*\n",
+      },
+      name: "shared-generation-extension-scope",
+    });
+    const packageRoot = join(app.appRoot, "packages", "shared-graph-extension");
+    await mkdir(join(app.appRoot, "node_modules", "@acme"), { recursive: true });
+    await symlink(resolvePackageRoot(), join(app.appRoot, "node_modules", "eve"), "junction");
+    await symlink(
+      packageRoot,
+      join(app.appRoot, "node_modules", "@acme", "shared-graph-extension"),
+      "junction",
+    );
+
+    const compileResult = await compileAgent({ startPath: app.appRoot });
+    const snapshot = await stageDevelopmentGeneration(compileResult);
+    const moduleMap = await loadCompiledModuleMapFromAuthoredSource({
+      compiledArtifactsSource: createAuthoredSourceRuntimeCompiledArtifactsSource(
+        snapshot.runtimeAppRoot,
+      ),
+    });
+    const toolSourceId = compileResult.manifest.tools.find((tool) =>
+      tool.sourceId.startsWith("ext:acme:"),
+    )?.sourceId;
+    expect(toolSourceId).toBeDefined();
+    const tool = moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules[toolSourceId!] as {
+      default: { execute(): string };
+    };
+
+    expect(tool.default.execute()).toBe("configured");
+  });
 
   it("executes dynamic imports after the original bundled dependency is removed", async () => {
     const evaluationMarker = "__eveGenerationDynamicImportEvaluated__";

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.ts
@@ -5,7 +5,10 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
 import { copyDevelopmentSourceSnapshot } from "#internal/nitro/dev-runtime-source-snapshot-copy.js";
-import { createDevelopmentSourceSnapshotPlan } from "#internal/nitro/dev-runtime-source-snapshot.js";
+import {
+  createDevelopmentSourceSnapshotPlan,
+  toDevelopmentSourceSnapshotPath,
+} from "#internal/nitro/dev-runtime-source-snapshot.js";
 import {
   DEVELOPMENT_RUNTIME_ARTIFACTS_ACTIVATED_MARKER,
   pruneDevelopmentRuntimeArtifactsSnapshotDirectory,
@@ -104,6 +107,8 @@ export async function stageDevelopmentRuntimeArtifactsSnapshot(
         "compiled-agent-manifest.json",
       ),
       runtimeAppRoot: sourceSnapshotPlan.runtimeAppRoot,
+      snapshotSourceRoot: sourceSnapshotPlan.snapshotSourceRoot,
+      sourceRoot: sourceSnapshotPlan.sourceRoot,
     });
     await validateSnapshotCompiledManifestRoots({
       manifestPath: join(
@@ -332,11 +337,15 @@ async function rewriteSnapshotCompiledManifest(input: {
   readonly appRoot: string;
   readonly manifestPath: string;
   readonly runtimeAppRoot: string;
+  readonly snapshotSourceRoot: string;
+  readonly sourceRoot: string;
 }): Promise<void> {
   const manifest = JSON.parse(await readFile(input.manifestPath, "utf8")) as unknown;
   const rewritten = rewriteManifestRoots({
     appRoot: input.appRoot,
     runtimeAppRoot: input.runtimeAppRoot,
+    snapshotSourceRoot: input.snapshotSourceRoot,
+    sourceRoot: input.sourceRoot,
     value: manifest,
   });
 
@@ -346,6 +355,8 @@ async function rewriteSnapshotCompiledManifest(input: {
 function rewriteManifestRoots(input: {
   readonly appRoot: string;
   readonly runtimeAppRoot: string;
+  readonly snapshotSourceRoot: string;
+  readonly sourceRoot: string;
   readonly value: unknown;
 }): unknown {
   if (Array.isArray(input.value)) {
@@ -367,14 +378,41 @@ function rewriteManifestRoots(input: {
       continue;
     }
 
+    if (typeof value === "string" && key === "sourceRoot") {
+      rewritten[key] = rewritePathWithinSourceRoot({
+        path: value,
+        snapshotSourceRoot: input.snapshotSourceRoot,
+        sourceRoot: input.sourceRoot,
+      });
+      continue;
+    }
+
     rewritten[key] = rewriteManifestRoots({
       appRoot: input.appRoot,
       runtimeAppRoot: input.runtimeAppRoot,
+      snapshotSourceRoot: input.snapshotSourceRoot,
+      sourceRoot: input.sourceRoot,
       value,
     });
   }
 
   return rewritten;
+}
+
+function rewritePathWithinSourceRoot(input: {
+  readonly path: string;
+  readonly snapshotSourceRoot: string;
+  readonly sourceRoot: string;
+}): string {
+  if (!isPathInsideOrEqual(input.path, input.sourceRoot)) {
+    return input.path;
+  }
+
+  return toDevelopmentSourceSnapshotPath({
+    snapshotSourceRoot: input.snapshotSourceRoot,
+    sourcePath: input.path,
+    sourceRoot: input.sourceRoot,
+  });
 }
 
 function rewritePathWithinAppRoot(input: {


### PR DESCRIPTION
### Description

Fixes #820.

The issue's 50-tool reproduction takes 13,184 ms on eve 0.24.4. With this branch packed into that reproduction, cold startup is 2,303 ms. I ran the patched benchmark on Node 26 and changed only the fixture's model name to make it valid on current main.

Immutable development generations currently start one Rolldown build for every authored module. When 50 tools import the same protobuf dependency graph, Rolldown parses and emits that graph 50 times.

This change generates the compiler's module-map entry across the root agent and every subagent, then bundles that entry once. The materialized index points to one module-map artifact and the runtime imports it once. `codeSplitting: false` still comes from `buildSingleRolldownChunk`, so dynamic imports stay inside the immutable generation.

Workspace extension roots now point into the source snapshot. That lets the aggregate path-scoped extension plugin preserve config and state namespaces. Instrumentation remains separate because Nitro loads it as its own entry.

Compile-time discovery still uses the per-module evaluator. This PR changes immutable generation materialization, which is the repeated work measured in #820.

### How did you test your changes?

The generation artifact scenarios pass 7/7. They verify one emitted graph, one copy of a dependency shared across root and subagent tools, executable subagent modules, extension scoping, dynamic imports, configured externals, fingerprints, and directive rejection.

The development snapshot integration suite passes 17/17, and the eve package typecheck passes. The packed branch completes the issue reproduction in 2,303 ms.

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
