### PR TITLE
fix(eve): show tool count in info output

### DIFF
--- a/.changeset/quiet-tools-count.md
+++ b/.changeset/quiet-tools-count.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show the number of discovered authored tools in the human-readable `eve info` output.

--- a/packages/eve/src/cli/commands/info.test.ts
+++ b/packages/eve/src/cli/commands/info.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { COMPILE_METADATA_KIND, COMPILE_METADATA_VERSION } from "#compiler/artifacts.js";
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
@@ -11,8 +11,11 @@ import {
   ROOT_COMPILED_AGENT_NODE_ID,
 } from "#compiler/manifest.js";
 import { getApplicationInfo } from "#internal/application/paths.js";
+import { inspectApplication } from "#services/inspect-application.js";
 
-import { buildApplicationInfoJson } from "./info.js";
+import { buildApplicationInfoJson, printApplicationInfo } from "./info.js";
+
+vi.mock("#services/inspect-application.js", () => ({ inspectApplication: vi.fn() }));
 
 const MESSAGING = {
   createSessionRoutePath: "/eve/v1/session",
@@ -199,5 +202,21 @@ describe("buildApplicationInfoJson", () => {
     expect(json.schedules).toEqual([]);
     expect(json.appRoot).toBe(APP_ROOT);
     expect(json.messaging.stream).toBe("/eve/v1/session/:id/stream");
+  });
+});
+
+describe("printApplicationInfo", () => {
+  test("includes the authored tool count in text output", async () => {
+    vi.mocked(inspectApplication).mockResolvedValue({
+      application: getApplicationInfo(APP_ROOT),
+      compiledState: makeCompiledState(),
+      messaging: MESSAGING,
+    });
+    const output: string[] = [];
+
+    await printApplicationInfo({ log: (message) => output.push(message) }, APP_ROOT);
+
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatch(/Tools\s+1 tool/);
   });
 });

--- a/packages/eve/src/cli/commands/info.ts
+++ b/packages/eve/src/cli/commands/info.ts
@@ -178,6 +178,10 @@ export async function printApplicationInfo(
         value: pluralize(compiledState.manifest.skills.length, "skill"),
       },
       {
+        label: "Tools",
+        value: pluralize(compiledState.manifest.tools.length, "tool"),
+      },
+      {
         label: "Subagents",
         value: pluralize(compiledState.manifest.subagents.length, "subagent"),
       },


### PR DESCRIPTION
### Description

The human-readable `eve info` output does not report number of discovered tools, even though the JSON output includes them.

This was noticed when completing the "Your First Tool" section of the eve course: https://vercel.com/academy/building-agents-with-eve/your-first-tool.

Adds a compact authored-tool count beside the skills count. This confirms discovery without making the summary noisy for agents with many tools.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/info.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build`
- Invoked the built CLI against an agent with one authored tool and confirmed it renders `Tools         1 tool`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
