### PR TITLE
fix(eve): include per-agent route prefix in framework callback URLs

### DIFF
--- a/.changeset/multi-agent-callback-prefix.md
+++ b/.changeset/multi-agent-callback-prefix.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix connector authorization and remote-subagent result callbacks 404ing in multi-agent mode (`withEve({ agents })`). Framework-minted callback URLs now include the agent's public route prefix (`/eve/agents/<name>`), so after connecting a provider or when a remote subagent finishes, the parked turn resumes instead of the connect card re-prompting in a loop or the parent turn hanging.

--- a/packages/eve/src/channel/session-callback.test.ts
+++ b/packages/eve/src/channel/session-callback.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSessionCallback } from "#channel/session-callback.js";
+
+const BASE_CALLBACK = {
+  callId: "call-remote",
+  subagentName: "research",
+  token: "eve:parent-token",
+};
+
+describe("parseSessionCallback", () => {
+  it("accepts a bare single-agent callback url", () => {
+    const result = parseSessionCallback({
+      ...BASE_CALLBACK,
+      url: "https://caller.example.com/eve/v1/callback/eve%3Aparent-token",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a callback url carrying a per-agent public route prefix (multi-agent mode)", () => {
+    const result = parseSessionCallback({
+      ...BASE_CALLBACK,
+      url: "https://caller.example.com/eve/agents/researcher/eve/v1/callback/eve%3Aparent-token",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a callback url whose token segment does not match the token", () => {
+    const result = parseSessionCallback({
+      ...BASE_CALLBACK,
+      url: "https://caller.example.com/eve/agents/researcher/eve/v1/callback/someone-else",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a private/reserved callback host", () => {
+    const result = parseSessionCallback({
+      ...BASE_CALLBACK,
+      url: "http://169.254.169.254/eve/v1/callback/eve%3Aparent-token",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/eve/src/channel/session-callback.ts
+++ b/packages/eve/src/channel/session-callback.ts
@@ -70,12 +70,16 @@ export function parseSessionCallback(value: unknown): SessionCallbackParseResult
 }
 
 function readCallbackUrlToken(url: URL): string | null {
+  // In multi-agent mode the minted callback carries the agent's public route
+  // prefix (`/eve/agents/<name>/eve/v1/callback/<token>`), so match the callback
+  // segment anywhere in the path rather than anchoring it to the origin.
   const tokenPrefix = createEveCallbackRoutePath("");
-  if (!url.pathname.startsWith(tokenPrefix)) {
+  const markerIndex = url.pathname.lastIndexOf(tokenPrefix);
+  if (markerIndex === -1) {
     return null;
   }
 
-  const encodedToken = url.pathname.slice(tokenPrefix.length);
+  const encodedToken = url.pathname.slice(markerIndex + tokenPrefix.length);
   if (encodedToken.length === 0 || encodedToken.includes("/")) {
     return null;
   }

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -1,6 +1,7 @@
 import { EVE_SESSION_ID_HEADER } from "#protocol/message.js";
 import { CancelTurnResponseSchema } from "#protocol/cancel-turn.js";
 import { createEveCallbackRoutePath, createEveCancelTurnRoutePath } from "#protocol/routes.js";
+import { prefixFrameworkCallbackPath } from "#protocol/public-route-prefix.js";
 import type { CancelTurnResult } from "#channel/types.js";
 import { createWorkflowCallbackUrl } from "#execution/workflow-callback-url.js";
 import { formatSubagentInput } from "#execution/subagent-invocation.js";
@@ -43,7 +44,7 @@ export async function startRemoteAgentSession(input: {
         token: callbackToken,
         url: createWorkflowCallbackUrl(
           input.callbackBaseUrl,
-          createEveCallbackRoutePath(callbackToken),
+          prefixFrameworkCallbackPath(createEveCallbackRoutePath(callbackToken)),
         ),
       },
       message: formatRemoteAgentCallInputMessage({ action: input.action, remote: input.remote }),

--- a/packages/eve/src/execution/tool-auth.integration.test.ts
+++ b/packages/eve/src/execution/tool-auth.integration.test.ts
@@ -288,6 +288,57 @@ describe("tool-hosted authorization", () => {
     expect(result.challenges[0]?.hookUrl).toBe(receivedCallbackUrl);
   });
 
+  it("includes the per-agent public route prefix in the callback URL (multi-agent mode)", async () => {
+    let receivedCallbackUrl: string | undefined;
+    const inlineAuth: AuthorizationDefinition = {
+      principalType: "user",
+      vercelConnect: { connector: "mcp.notion.com/notion" },
+      async getToken(): Promise<TokenResult> {
+        throw requiredError();
+      },
+      async startAuthorization({ callbackUrl }) {
+        receivedCallbackUrl = callbackUrl;
+        return { challenge: { url: "https://idp.example/auth" } };
+      },
+      async completeAuthorization(): Promise<TokenResult> {
+        return { token: "after-signin" };
+      },
+    };
+    const tool = authoredTool({
+      name: "search_notion",
+      async execute(_input, ctx) {
+        return await ctx.getToken(inlineAuth);
+      },
+    });
+    const runtime = createTestRuntime({ tools: [tool] });
+
+    const previousPrefix = process.env.EVE_PUBLIC_ROUTE_PREFIX;
+    process.env.EVE_PUBLIC_ROUTE_PREFIX = "/eve/agents/researcher";
+    try {
+      const result = await runtime.runAsSession(
+        { sessionId: "session_prefixed_callback" },
+        async () => {
+          seedUserPrincipal();
+          loadContext().set(CallbackBaseUrlKey, "https://app.example");
+          return runtime.executeTool(tool, {});
+        },
+      );
+
+      expect(isAuthorizationSignal(result)).toBe(true);
+      if (!isAuthorizationSignal(result)) throw new Error("expected signal");
+      expect(result.challenges[0]?.hookUrl).toBe(
+        "https://app.example/eve/agents/researcher/eve/v1/connections/search_notion__mcp.notion.com_notion/callback/session_auth%3Aauth",
+      );
+      expect(receivedCallbackUrl).toBe(result.challenges[0]?.hookUrl);
+    } finally {
+      if (previousPrefix === undefined) {
+        delete process.env.EVE_PUBLIC_ROUTE_PREFIX;
+      } else {
+        process.env.EVE_PUBLIC_ROUTE_PREFIX = previousPrefix;
+      }
+    }
+  });
+
   it("parks the turn with a challenge when getToken throws Required", async () => {
     const auth: AuthorizationDefinition = {
       principalType: "user",

--- a/packages/eve/src/execution/workflow-callback-url.test.ts
+++ b/packages/eve/src/execution/workflow-callback-url.test.ts
@@ -35,6 +35,15 @@ describe("resolveVercelProductionCallbackBaseUrl", () => {
     );
   });
 
+  it("preserves a per-agent public route prefix folded into the callback path", () => {
+    expect(
+      createWorkflowCallbackUrl(
+        "https://app.example",
+        "/eve/agents/researcher/eve/v1/callback/eve%3Aparent-token",
+      ),
+    ).toBe("https://app.example/eve/agents/researcher/eve/v1/callback/eve%3Aparent-token");
+  });
+
   it("preserves existing callback query params when adding the Vercel bypass query param", () => {
     vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "secret");
 

--- a/packages/eve/src/harness/authorization.ts
+++ b/packages/eve/src/harness/authorization.ts
@@ -37,6 +37,7 @@ import type { ConnectionAuthorizationChallenge } from "#public/connections/error
 import type { AuthorizationCallback } from "#runtime/connections/types.js";
 import type { JsonValue } from "#public/types/json.js";
 import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
+import { prefixFrameworkCallbackPath } from "#protocol/public-route-prefix.js";
 
 const AUTHORIZATION_BRAND = "__eveAuthorization" as const;
 const AUTHORIZATION_PENDING_BRAND = "__eveAuthorizationPending" as const;
@@ -142,7 +143,7 @@ export function getHookUrl(name: string): string | undefined {
   const baseUrl = ctx.get(CallbackBaseUrlKey);
   if (!sessionId || !baseUrl) return undefined;
   const token = authHookToken(sessionId);
-  return `${baseUrl}${createEveConnectionCallbackRoutePath(name, token)}`;
+  return `${baseUrl}${prefixFrameworkCallbackPath(createEveConnectionCallbackRoutePath(name, token))}`;
 }
 
 export function isAuthorizationSignal(value: unknown): value is AuthorizationSignal {

--- a/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.scenario.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.scenario.test.ts
@@ -8,6 +8,7 @@ import { resolvePackageRoot } from "#internal/application/package.js";
 import {
   copyNitroFunctionDirectory,
   emitBundledWorkflowFunctionDirectory,
+  normalizeEveVercelFunctionOutput,
   retargetNitroFunctionDirectoryToWorkflowRoute,
 } from "#internal/workflow-bundle/vercel-workflow-output.js";
 
@@ -425,5 +426,60 @@ describe("emitBundledWorkflowFunctionDirectory", () => {
       "function",
     );
     await expect(response.text()).resolves.toBe("function");
+  });
+});
+
+describe("normalizeEveVercelFunctionOutput", () => {
+  async function seedEveFunction(): Promise<{
+    readonly configPath: string;
+    readonly outputDir: string;
+  }> {
+    const root = await mkdtemp(join(resolvePackageRoot(), ".eve-vercel-workflow-normalize-"));
+    temporaryDirectories.push(root);
+
+    const outputDir = join(root, "output");
+    const functionDir = join(outputDir, "functions", ".well-known", "workflow", "v1", "flow.func");
+    await mkdir(functionDir, { recursive: true });
+    const configPath = join(functionDir, ".vc-config.json");
+    await writeFile(
+      configPath,
+      `${JSON.stringify(
+        { environment: { NODE_OPTIONS: "--experimental-require-module" }, handler: "index.js" },
+        null,
+        2,
+      )}\n`,
+    );
+
+    return { configPath, outputDir };
+  }
+
+  async function readEnvironment(configPath: string): Promise<Record<string, unknown> | undefined> {
+    const config = JSON.parse(await readFile(configPath, "utf8")) as {
+      environment?: Record<string, unknown>;
+    };
+    return config.environment;
+  }
+
+  it("bakes the public route prefix into eve function environments for a named agent", async () => {
+    const { configPath, outputDir } = await seedEveFunction();
+
+    await normalizeEveVercelFunctionOutput(outputDir, {
+      servicePrefix: "/eve/agents/researcher",
+    });
+
+    expect(await readEnvironment(configPath)).toEqual({
+      NODE_OPTIONS: "--experimental-require-module",
+      EVE_PUBLIC_ROUTE_PREFIX: "/eve/agents/researcher",
+    });
+  });
+
+  it("leaves function environments untouched when there is no service prefix", async () => {
+    const { configPath, outputDir } = await seedEveFunction();
+
+    await normalizeEveVercelFunctionOutput(outputDir);
+
+    expect(await readEnvironment(configPath)).toEqual({
+      NODE_OPTIONS: "--experimental-require-module",
+    });
   });
 });

--- a/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.ts
+++ b/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.ts
@@ -18,6 +18,7 @@ import {
   isEveVercelFunctionPath,
   normalizeEveVercelRoutes,
 } from "#internal/workflow-bundle/eve-service-route-output.js";
+import { PUBLIC_ROUTE_PREFIX_ENV } from "#protocol/public-route-prefix.js";
 
 // just-bash and microsandbox are optional peer dependencies (the
 // opt-in local sandbox engines) loaded lazily from the application's
@@ -135,6 +136,81 @@ export async function normalizeEveVercelFunctionOutput(
   }
   await pruneNonEveFunctionEntries(functionsDir, functionsDir);
   await pruneNonEveVercelRoutes(outputDir, options.servicePrefix);
+
+  // Named agents mount under `/eve/agents/<name>/eve/v1/*`, but the request
+  // reaches the function with that prefix stripped — so the running function
+  // cannot recover its own public prefix. Bake it into the function's runtime
+  // environment so callback URLs minted mid-turn resolve back to the agent's
+  // own mount instead of a bare `/eve/v1/*` path nothing serves.
+  if (options.servicePrefix !== undefined && options.servicePrefix.length > 0) {
+    await injectEvePublicRoutePrefixEnv(functionsDir, options.servicePrefix);
+  }
+}
+
+async function injectEvePublicRoutePrefixEnv(
+  functionsDir: string,
+  publicRoutePrefix: string,
+  directoryPath: string = functionsDir,
+): Promise<void> {
+  let entries: Dirent<string>[];
+
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = join(directoryPath, entry.name);
+      const relativeFunctionPath = normalizeVercelOutputPath(relative(functionsDir, entryPath));
+
+      if (entry.name.endsWith(".func")) {
+        // Route aliases are symlinks onto the shared server function, which is
+        // patched through its own concrete directory — skip the aliases so we
+        // neither follow the link nor double-write.
+        if (!entry.isSymbolicLink() && isEveVercelFunctionPath(relativeFunctionPath)) {
+          await patchFunctionPublicRoutePrefixEnv(entryPath, publicRoutePrefix);
+        }
+        return;
+      }
+
+      if (entry.isDirectory()) {
+        await injectEvePublicRoutePrefixEnv(functionsDir, publicRoutePrefix, entryPath);
+      }
+    }),
+  );
+}
+
+async function patchFunctionPublicRoutePrefixEnv(
+  functionDir: string,
+  publicRoutePrefix: string,
+): Promise<void> {
+  const configPath = join(functionDir, ".vc-config.json");
+  let config: unknown;
+
+  try {
+    config = JSON.parse(await readFile(configPath, "utf8"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+
+  if (!isRecord(config)) {
+    return;
+  }
+
+  const environment = isRecord(config.environment) ? { ...config.environment } : {};
+  environment[PUBLIC_ROUTE_PREFIX_ENV] = publicRoutePrefix;
+  config.environment = environment;
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
 async function prepareSharedEveServerFunction(functionsDir: string): Promise<string | null> {

--- a/packages/eve/src/protocol/public-route-prefix.test.ts
+++ b/packages/eve/src/protocol/public-route-prefix.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  prefixFrameworkCallbackPath,
+  resolveEvePublicRoutePrefix,
+} from "#protocol/public-route-prefix.js";
+
+describe("resolveEvePublicRoutePrefix", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns an empty string when the env var is unset", () => {
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "");
+    expect(resolveEvePublicRoutePrefix()).toBe("");
+  });
+
+  it("returns an empty string when the env var is whitespace", () => {
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "   ");
+    expect(resolveEvePublicRoutePrefix()).toBe("");
+  });
+
+  it("returns the configured prefix", () => {
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "/eve/agents/researcher");
+    expect(resolveEvePublicRoutePrefix()).toBe("/eve/agents/researcher");
+  });
+
+  it("strips a trailing slash so it joins cleanly with an absolute path", () => {
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "/eve/agents/researcher/");
+    expect(resolveEvePublicRoutePrefix()).toBe("/eve/agents/researcher");
+  });
+});
+
+describe("prefixFrameworkCallbackPath", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prepends the prefix to a framework callback path", () => {
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "/eve/agents/researcher");
+    expect(prefixFrameworkCallbackPath("/eve/v1/callback/tok123")).toBe(
+      "/eve/agents/researcher/eve/v1/callback/tok123",
+    );
+  });
+
+  it("is a no-op for a single-agent mount (no prefix)", () => {
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "");
+    expect(prefixFrameworkCallbackPath("/eve/v1/callback/tok123")).toBe("/eve/v1/callback/tok123");
+  });
+});

--- a/packages/eve/src/protocol/public-route-prefix.ts
+++ b/packages/eve/src/protocol/public-route-prefix.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-agent public route prefix minted into framework-owned callback URLs.
+ *
+ * In multi-agent mode (`withEve({ agents })`) each named agent mounts under
+ * `/eve/agents/<name>/eve/v1/*`, and the Vercel route strips that prefix before
+ * the request reaches the service — so the running function only ever sees the
+ * bare `/eve/v1/*` path and cannot recover its own public prefix from the
+ * request. The build injects the prefix as {@link PUBLIC_ROUTE_PREFIX_ENV} into
+ * the workflow function's environment so callback URLs minted mid-turn resolve
+ * back to the agent's own mount instead of a bare `/eve/v1/*` path nothing
+ * serves.
+ *
+ * The prefix is empty for a single/unnamed agent (which IS mounted at bare
+ * `/eve/v1/*`), so both helpers are no-ops there.
+ */
+
+/**
+ * Environment variable carrying the current agent's public route prefix into
+ * the generated workflow function at runtime. Written by the Vercel function
+ * output writer; read by {@link resolveEvePublicRoutePrefix}.
+ */
+export const PUBLIC_ROUTE_PREFIX_ENV = "EVE_PUBLIC_ROUTE_PREFIX";
+
+/**
+ * Resolves the current agent's public route prefix (e.g. `/eve/agents/researcher`),
+ * or the empty string when the agent is mounted at the bare `/eve/v1/*` root.
+ */
+export function resolveEvePublicRoutePrefix(): string {
+  const prefix = process.env[PUBLIC_ROUTE_PREFIX_ENV]?.trim();
+  if (!prefix) {
+    return "";
+  }
+  return prefix.replace(/\/$/, "");
+}
+
+/**
+ * Prepends the current agent's public route prefix to a framework-owned
+ * callback path so the minted URL targets the agent's own mount.
+ *
+ * The path must be prefixed at mint time only — never in the shared
+ * `#protocol/routes.js` builders, which also register the receiving routes that
+ * run post-transform against the bare `/eve/v1/*` path.
+ */
+export function prefixFrameworkCallbackPath(path: string): string {
+  return `${resolveEvePublicRoutePrefix()}${path}`;
+}


### PR DESCRIPTION
Closes #839.

## Problem

In multi-agent mode (`withEve({ agents })`) each named agent mounts **only** under
`/eve/agents/<name>/eve/v1/*`. Two framework-minted callback URLs were built from the bare
deployment origin, dropping the per-agent prefix, so they 404:

- **Connection callback (OAuth)** — `getHookUrl` minted `<origin>/eve/v1/connections/<name>/callback/<token>`.
  After consent the browser landed on a path nothing serves → parked turn never resumed → connect
  card re-prompted in a loop.
- **Remote-subagent session callback** — `startRemoteAgentSession` minted `<origin>/eve/v1/callback/<token>`.
  The subagent finished, then its result POST 404'd → 3 retries → `run_failed` → parent turn hung.

Both share one root cause: the Vercel route strips the prefix (`request.path` → `/eve/v1/$1`) before
the request reaches the function, so callbacks minted mid-turn cannot reconstruct `/eve/agents/<name>`.

## Fix

Carry the per-agent public prefix into the workflow function's runtime environment at build, then
prepend it to framework callback **paths** at mint time.

- **`protocol/public-route-prefix.ts`** (new) — `resolveEvePublicRoutePrefix()` reads
  `EVE_PUBLIC_ROUTE_PREFIX`; `prefixFrameworkCallbackPath(path)` prepends it.
- **`normalizeEveVercelFunctionOutput`** bakes `environment.EVE_PUBLIC_ROUTE_PREFIX = servicePrefix`
  into eve-owned function `.vc-config.json` files. The value is the already-resolved `servicePrefix`
  (`build-application.ts`), so no new build-command export is needed. Runs only for named agents;
  single/unnamed output is byte-identical.
- **Mint sites** — `getHookUrl` (connection callback) and `startRemoteAgentSession` (session callback)
  prepend the prefix to the callback path.

The path must be prefixed at mint time only — never in the shared `#protocol/routes.js` builders,
which also register the **receiving** routes that run post-transform against the bare `/eve/v1/*`
path.

## Scope

Two related bugs in the same class are intentionally out of scope and tracked separately: the remote
create-session URL (`new URL` drops the base path) and the hosted-service file-tracing gap.

## Testing

- Unit: `public-route-prefix` helper; `createWorkflowCallbackUrl` preserves a prefixed absolute path.
- Integration: `getHookUrl` mints a prefixed URL when `EVE_PUBLIC_ROUTE_PREFIX` is set.
- Scenario: `normalizeEveVercelFunctionOutput` injects the env for a named agent and leaves single-agent
  output untouched.
- `pnpm fmt`, `pnpm lint`, `pnpm typecheck`, `pnpm guard:invariants` pass.

## Open question

`EVE_PUBLIC_ROUTE_PREFIX` is injected only into Vercel build output. If multi-agent `eve dev` also
mounts under `/eve/agents/<name>`, the dev server would need the same env; if dev serves a single
agent (no prefix), nothing to do. Flagging for reviewer input.
