### PR TITLE
feat(eve): reconcile Vercel framework preset on channels add web

### DIFF
--- a/.changeset/reconcile-host-framework-preset.md
+++ b/.changeset/reconcile-host-framework-preset.md
@@ -1,0 +1,7 @@
+---
+"eve": patch
+---
+
+`eve channels add web` now updates the Vercel Framework Preset when adding a
+Next.js web channel to an already-linked eve project to prevent deployment
+failures.

--- a/packages/eve/src/cli/commands/channels.ts
+++ b/packages/eve/src/cli/commands/channels.ts
@@ -3,6 +3,7 @@ import { isEveProject, listAuthoredChannels, type ChannelKind } from "#setup/sca
 import { interactiveAsker } from "#setup/ask.js";
 import { addChannels, type AddChannelsDeps } from "#setup/boxes/add-channels.js";
 import { deployProject, type DeployProjectDeps } from "#setup/boxes/deploy-project.js";
+import { reconcileHostFrameworkPreset } from "#setup/boxes/reconcile-host-framework-preset.js";
 import { selectChannels } from "#setup/boxes/select-channels.js";
 import {
   detectDeployment,
@@ -129,6 +130,10 @@ async function runAddChannelsFlow(
       ensureLinkedProject: "interactive-vercel-link",
       deps: dependencies.addChannelsDeps,
     }),
+    // A web (Next.js) channel added to an already-linked eve project may leave
+    // the project's Vercel Framework Preset on `eve`; switch it before deploying
+    // so the host app actually builds.
+    reconcileHostFrameworkPreset({ prompter }),
     deployProject({
       prompter,
       ensureLinkedProject: "interactive-vercel-link",

--- a/packages/eve/src/setup/boxes/reconcile-host-framework-preset.test.ts
+++ b/packages/eve/src/setup/boxes/reconcile-host-framework-preset.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+
+import type { Prompter } from "../prompter.js";
+import { runHeadless } from "../runner.js";
+import { createDefaultSetupState, type SetupState } from "../state.js";
+import type { OutputSink } from "../step.js";
+import {
+  reconcileHostFrameworkPreset,
+  type ReconcileHostFrameworkPresetDeps,
+} from "./reconcile-host-framework-preset.js";
+
+const silentSink: OutputSink = { write: () => {} };
+
+function createPrompter(): Prompter {
+  return createFakePrompter().prompter;
+}
+
+function fakeDeps(): ReconcileHostFrameworkPresetDeps {
+  return { syncHostFrameworkPreset: vi.fn(async () => {}) };
+}
+
+function stateWith(overrides: Partial<SetupState>): SetupState {
+  return {
+    ...createDefaultSetupState(),
+    projectPath: { kind: "resolved", inPlace: true, path: "/tmp/project" },
+    deploymentPending: true,
+    ...overrides,
+  };
+}
+
+describe("reconcileHostFrameworkPreset box", () => {
+  it("reconciles the preset when a web channel targets an already-linked project", async () => {
+    const prompter = createPrompter();
+    const deps = fakeDeps();
+    const state = stateWith({
+      channelSelection: ["web"],
+      project: { kind: "linked", projectId: "prj_demo" },
+    });
+
+    await runHeadless([reconcileHostFrameworkPreset({ prompter, deps })], state, silentSink);
+
+    expect(deps.syncHostFrameworkPreset).toHaveBeenCalledWith(
+      prompter,
+      "/tmp/project",
+      expect.anything(),
+      { signal: undefined },
+    );
+  });
+
+  it("skips when no web channel is selected", async () => {
+    const deps = fakeDeps();
+    const state = stateWith({
+      channelSelection: ["slack"],
+      project: { kind: "linked", projectId: "prj_demo" },
+    });
+
+    await runHeadless(
+      [reconcileHostFrameworkPreset({ prompter: createPrompter(), deps })],
+      state,
+      silentSink,
+    );
+
+    expect(deps.syncHostFrameworkPreset).not.toHaveBeenCalled();
+  });
+
+  it("skips when the project is not yet linked", async () => {
+    const deps = fakeDeps();
+    const state = stateWith({
+      channelSelection: ["web"],
+      project: { kind: "unresolved" },
+    });
+
+    await runHeadless(
+      [reconcileHostFrameworkPreset({ prompter: createPrompter(), deps })],
+      state,
+      silentSink,
+    );
+
+    expect(deps.syncHostFrameworkPreset).not.toHaveBeenCalled();
+  });
+
+  it("skips when no deploy will follow (deploymentPending is false)", async () => {
+    const deps = fakeDeps();
+    const state = stateWith({
+      channelSelection: ["web"],
+      project: { kind: "linked", projectId: "prj_demo" },
+      deploymentPending: false,
+    });
+
+    await runHeadless(
+      [reconcileHostFrameworkPreset({ prompter: createPrompter(), deps })],
+      state,
+      silentSink,
+    );
+
+    expect(deps.syncHostFrameworkPreset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/setup/boxes/reconcile-host-framework-preset.ts
+++ b/packages/eve/src/setup/boxes/reconcile-host-framework-preset.ts
@@ -1,0 +1,66 @@
+import { createPromptCommandOutput } from "#setup/cli/index.js";
+
+import { isProjectResolved } from "../project-resolution.js";
+import type { Prompter } from "../prompter.js";
+import { requireProjectPath, type SetupState } from "../state.js";
+import type { SetupBox } from "../step.js";
+import { syncHostFrameworkPreset } from "../vercel-project-framework.js";
+
+/** Injected for tests; defaults to the real framework-preset reconciliation. */
+export interface ReconcileHostFrameworkPresetDeps {
+  syncHostFrameworkPreset: typeof syncHostFrameworkPreset;
+}
+
+export interface ReconcileHostFrameworkPresetOptions {
+  /** Streams reconciliation progress and the applied-change note. */
+  prompter: Prompter;
+  deps?: ReconcileHostFrameworkPresetDeps;
+}
+
+/**
+ * Aligns an already-linked Vercel project's Framework Preset with a newly-added
+ * web (Next.js) channel before the deploy box runs. A project created as a
+ * standalone agent keeps the `eve` preset, which would build the agent instead
+ * of the host app; the command already deploys on the user's behalf, so this
+ * corrects the preset directly (no confirmation) and notes the change.
+ *
+ * Runs only for an already-linked project — an unlinked directory links later
+ * inside the deploy box, where a fresh `vercel link` detects the framework. All
+ * effects live in {@link syncHostFrameworkPreset}, a no-op when the preset
+ * already matches.
+ */
+export function reconcileHostFrameworkPreset(
+  options: ReconcileHostFrameworkPresetOptions,
+): SetupBox<SetupState, null, null> {
+  const deps = options.deps ?? { syncHostFrameworkPreset };
+
+  return {
+    id: "reconcile-host-framework-preset",
+
+    shouldRun(state) {
+      // Only reconcile ahead of a deploy this run: a stale preset only bites the
+      // deployment, and the deploy box gates on `deploymentPending` too, so a
+      // no-op channel add must not touch the Vercel setting.
+      return (
+        state.deploymentPending &&
+        state.channelSelection.includes("web") &&
+        isProjectResolved(state.project)
+      );
+    },
+
+    async gather(): Promise<null> {
+      return null;
+    },
+
+    async perform({ state, signal }): Promise<null> {
+      const projectRoot = requireProjectPath(state);
+      const onOutput = createPromptCommandOutput(options.prompter.log);
+      await deps.syncHostFrameworkPreset(options.prompter, projectRoot, onOutput, { signal });
+      return null;
+    },
+
+    apply(state): SetupState {
+      return state;
+    },
+  };
+}

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -10,6 +10,7 @@ import {
   isNextJsProject,
   listAuthoredChannels,
   normalizeSlackConnectorSlug,
+  resolveVercelHostFrameworkPreset,
   scaffoldBaseProject,
   scaffoldExtensionProject,
   type WebPackageVersions,
@@ -679,6 +680,42 @@ describe("hasVercelHostFramework", () => {
     );
 
     await expect(hasVercelHostFramework(projectRoot)).resolves.toBe(false);
+  });
+});
+
+describe("resolveVercelHostFrameworkPreset", () => {
+  test("reads as no host framework when package.json is missing", async () => {
+    const projectRoot = await createTempDir();
+
+    await expect(resolveVercelHostFrameworkPreset(projectRoot)).resolves.toBeUndefined();
+  });
+
+  test.each([
+    ["Next.js", { next: "16.2.6" }, "nextjs"],
+    ["Nuxt", { nuxt: "4.3.3" }, "nuxtjs"],
+    ["Nuxt 3", { nuxt3: "3.19.7" }, "nuxtjs"],
+    ["Nuxt edge", { "nuxt-edge": "3.0.0-rc.13" }, "nuxtjs"],
+    ["SvelteKit", { "@sveltejs/kit": "2.60.0" }, "sveltekit"],
+  ])("maps %s to its Vercel Framework Preset slug", async (_label, dependencies, preset) => {
+    const projectRoot = await createTempDir();
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ name: "demo", devDependencies: dependencies }),
+      "utf8",
+    );
+
+    await expect(resolveVercelHostFrameworkPreset(projectRoot)).resolves.toBe(preset);
+  });
+
+  test("returns undefined for a standalone eve project", async () => {
+    const projectRoot = await createTempDir();
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ name: "demo", dependencies: { eve: "0.25.0" } }),
+      "utf8",
+    );
+
+    await expect(resolveVercelHostFrameworkPreset(projectRoot)).resolves.toBeUndefined();
   });
 });
 

--- a/packages/eve/src/setup/scaffold/index.ts
+++ b/packages/eve/src/setup/scaffold/index.ts
@@ -21,6 +21,7 @@ export {
   isNextJsProject,
   listAuthoredChannels,
   normalizeSlackConnectorSlug,
+  resolveVercelHostFrameworkPreset,
   type ChannelKind,
   type ChannelMutationResult,
   type EnsureChannelOptions,

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -36,14 +36,6 @@ const DEFAULT_TYPES_REACT_PACKAGE_VERSION = "__TYPES_REACT_VERSION__";
 const DEFAULT_TYPES_REACT_DOM_PACKAGE_VERSION = "__TYPES_REACT_DOM_VERSION__";
 const CONNECT_PACKAGE_NAME = "@vercel/connect";
 const NEXT_PACKAGE_NAME = "next";
-const VERCEL_HOST_FRAMEWORK_PACKAGE_NAMES = [
-  "@sveltejs/kit",
-  NEXT_PACKAGE_NAME,
-  "nuxt",
-  "nuxt3",
-  "nuxt-edge",
-  "nuxt-nightly",
-] as const;
 const PACKAGE_DEPENDENCY_FIELDS = ["dependencies", "devDependencies"] as const;
 const USER_AUTHORED_CHANNEL_DIR = "agent/channels";
 const WEB_CHANNEL_PATH = "agent/channels/eve.ts";
@@ -128,12 +120,25 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Read and parse a project's `package.json` into a plain object, or `undefined`
+ * when it is missing or does not parse to a JSON object.
+ */
+async function readPackageJsonObject(
+  packageJsonPath: string,
+): Promise<Record<string, unknown> | undefined> {
+  if (!(await pathExists(packageJsonPath))) return undefined;
+
+  const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  return isJsonObject(parsed) ? parsed : undefined;
+}
+
 async function readDependencyVersion(
   packageJsonPath: string,
   dependencyName: string,
 ): Promise<string | undefined> {
-  const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
-  if (!isJsonObject(parsed) || !isJsonObject(parsed.dependencies)) return undefined;
+  const parsed = await readPackageJsonObject(packageJsonPath);
+  if (parsed === undefined || !isJsonObject(parsed.dependencies)) return undefined;
 
   const version = parsed.dependencies[dependencyName];
   return typeof version === "string" ? version : undefined;
@@ -156,22 +161,8 @@ async function hasPackageDependency(
   packageJsonPath: string,
   dependencyName: string,
 ): Promise<boolean> {
-  if (!(await pathExists(packageJsonPath))) return false;
-
-  const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
-  return isJsonObject(parsed) && packageJsonHasDependency(parsed, dependencyName);
-}
-
-async function hasAnyPackageDependency(
-  packageJsonPath: string,
-  dependencyNames: readonly string[],
-): Promise<boolean> {
-  if (!(await pathExists(packageJsonPath))) return false;
-
-  const parsed: unknown = JSON.parse(await readFile(packageJsonPath, "utf8"));
-  if (!isJsonObject(parsed)) return false;
-
-  return dependencyNames.some((dependencyName) => packageJsonHasDependency(parsed, dependencyName));
+  const parsed = await readPackageJsonObject(packageJsonPath);
+  return parsed !== undefined && packageJsonHasDependency(parsed, dependencyName);
 }
 
 /**
@@ -187,15 +178,44 @@ export async function isNextJsProject(projectRoot: string): Promise<boolean> {
 }
 
 /**
+ * Host-framework dependency → the Vercel Framework Preset slug it must deploy
+ * under (so the framework owns the top-level build and eve runs as a sibling).
+ * Single source of truth for which dependencies mark a host framework;
+ * {@link hasVercelHostFramework} derives from it.
+ */
+const VERCEL_HOST_FRAMEWORK_PRESETS: Readonly<Record<string, string>> = {
+  "@sveltejs/kit": "sveltekit",
+  [NEXT_PACKAGE_NAME]: "nextjs",
+  nuxt: "nuxtjs",
+  nuxt3: "nuxtjs",
+  "nuxt-edge": "nuxtjs",
+  "nuxt-nightly": "nuxtjs",
+};
+
+/**
+ * The Vercel Framework Preset slug for the host framework a project declares, or
+ * `undefined` when it declares none (a missing `package.json` reads as none).
+ */
+export async function resolveVercelHostFrameworkPreset(
+  projectRoot: string,
+): Promise<string | undefined> {
+  const parsed = await readPackageJsonObject(join(projectRoot, "package.json"));
+  if (parsed === undefined) return undefined;
+
+  for (const [dependencyName, preset] of Object.entries(VERCEL_HOST_FRAMEWORK_PRESETS)) {
+    if (packageJsonHasDependency(parsed, dependencyName)) return preset;
+  }
+  return undefined;
+}
+
+/**
  * Whether the root app declares a Vercel framework that should own the
  * top-level deployment while eve runs as a sibling service. These match Eve's
- * current framework integrations: Next.js, Nuxt, and SvelteKit.
+ * current framework integrations: Next.js, Nuxt, and SvelteKit. Derived from
+ * {@link resolveVercelHostFrameworkPreset} so the two share one dependency list.
  */
 export async function hasVercelHostFramework(projectRoot: string): Promise<boolean> {
-  return hasAnyPackageDependency(
-    join(projectRoot, "package.json"),
-    VERCEL_HOST_FRAMEWORK_PACKAGE_NAMES,
-  );
+  return (await resolveVercelHostFrameworkPreset(projectRoot)) !== undefined;
 }
 
 async function ensurePackageDependency(

--- a/packages/eve/src/setup/vercel-project-framework.test.ts
+++ b/packages/eve/src/setup/vercel-project-framework.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPromptCommandOutput } from "#setup/cli/index.js";
+import { captureVercel, type VercelCaptureResult } from "#setup/primitives/index.js";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { readProjectLink } from "./project-resolution.js";
+import { resolveVercelHostFrameworkPreset } from "./scaffold/index.js";
+import { syncHostFrameworkPreset } from "./vercel-project-framework.js";
+
+vi.mock("#setup/primitives/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("#setup/primitives/index.js")>();
+  return { ...original, captureVercel: vi.fn() };
+});
+
+vi.mock("./project-resolution.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./project-resolution.js")>();
+  return { ...original, readProjectLink: vi.fn() };
+});
+
+vi.mock("./scaffold/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./scaffold/index.js")>();
+  return { ...original, resolveVercelHostFrameworkPreset: vi.fn() };
+});
+
+const mockedCaptureVercel = vi.mocked(captureVercel);
+const mockedReadProjectLink = vi.mocked(readProjectLink);
+const mockedResolvePreset = vi.mocked(resolveVercelHostFrameworkPreset);
+
+const captured = (value: unknown): VercelCaptureResult => ({
+  ok: true,
+  stdout: typeof value === "string" ? value : JSON.stringify(value),
+});
+
+const LINK = { orgId: "team_demo", projectId: "prj_demo", projectName: "demo" };
+
+/** True when `captureVercel` received a project-framework PATCH to `framework`. */
+function patchedFrameworkTo(framework: string): boolean {
+  return mockedCaptureVercel.mock.calls.some(
+    ([args]) =>
+      Array.isArray(args) &&
+      args.includes("--method") &&
+      args.includes("PATCH") &&
+      args.includes(`framework=${framework}`),
+  );
+}
+
+const failed = (message: string): VercelCaptureResult => ({
+  ok: false,
+  failure: { stdout: "", stderr: message, message },
+});
+
+/** Answer the framework GET with `current`; succeed any PATCH. */
+function stubCurrentFramework(current: string | undefined): void {
+  mockedCaptureVercel.mockImplementation(async (args) => {
+    if (Array.isArray(args) && args.includes("--method")) return captured("{}");
+    return captured(current === undefined ? {} : { framework: current });
+  });
+}
+
+beforeEach(() => {
+  mockedCaptureVercel.mockReset();
+  mockedReadProjectLink.mockReset();
+  mockedResolvePreset.mockReset();
+  mockedReadProjectLink.mockResolvedValue(LINK);
+  stubCurrentFramework("eve");
+});
+
+describe("syncHostFrameworkPreset", () => {
+  it("no-ops when the project declares no host framework", async () => {
+    mockedResolvePreset.mockResolvedValue(undefined);
+    const { prompter, selectMessages } = createFakePrompter();
+
+    await syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {});
+
+    expect(mockedCaptureVercel).not.toHaveBeenCalled();
+    expect(selectMessages).toEqual([]);
+  });
+
+  it("no-ops when the directory is not linked to a Vercel project", async () => {
+    mockedResolvePreset.mockResolvedValue("nextjs");
+    mockedReadProjectLink.mockResolvedValue(undefined);
+    const { prompter, selectMessages } = createFakePrompter();
+
+    await syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {});
+
+    expect(mockedCaptureVercel).not.toHaveBeenCalled();
+    expect(selectMessages).toEqual([]);
+  });
+
+  it("no-ops when the linked preset already matches the host framework", async () => {
+    mockedResolvePreset.mockResolvedValue("nextjs");
+    stubCurrentFramework("nextjs");
+    const { prompter, selectMessages } = createFakePrompter();
+
+    await syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {});
+
+    expect(selectMessages).toEqual([]);
+    expect(patchedFrameworkTo("nextjs")).toBe(false);
+  });
+
+  it("switches a stale preset directly, without prompting, and notes the change", async () => {
+    mockedResolvePreset.mockResolvedValue("nextjs");
+    const { prompter, selectMessages } = createFakePrompter();
+
+    await syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {});
+
+    expect(selectMessages).toEqual([]);
+    expect(patchedFrameworkTo("nextjs")).toBe(true);
+    expect(prompter.log.info).toHaveBeenCalledWith(expect.stringContaining("Next.js"));
+    expect(prompter.log.warning).not.toHaveBeenCalled();
+  });
+
+  it("warns instead of throwing when the framework lookup fails", async () => {
+    mockedResolvePreset.mockResolvedValue("nextjs");
+    mockedCaptureVercel.mockResolvedValue(failed("network exploded"));
+    const { prompter, selectMessages } = createFakePrompter();
+
+    await expect(
+      syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {}),
+    ).resolves.toBeUndefined();
+
+    expect(selectMessages).toEqual([]);
+    expect(patchedFrameworkTo("nextjs")).toBe(false);
+    expect(prompter.log.warning).toHaveBeenCalledWith(expect.stringContaining("Framework Preset"));
+  });
+
+  it("re-throws instead of warning when the operation was aborted", async () => {
+    mockedResolvePreset.mockResolvedValue("nextjs");
+    mockedCaptureVercel.mockRejectedValue(new Error("The operation was aborted"));
+    const controller = new AbortController();
+    controller.abort();
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("aborted");
+
+    expect(prompter.log.warning).not.toHaveBeenCalled();
+  });
+
+  it("warns instead of throwing when applying the preset fails", async () => {
+    mockedResolvePreset.mockResolvedValue("nextjs");
+    mockedCaptureVercel.mockImplementation(async (args) => {
+      if (Array.isArray(args) && args.includes("--method")) return failed("patch denied");
+      return captured({ framework: "eve" });
+    });
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      syncHostFrameworkPreset(prompter, "/app", createPromptCommandOutput(prompter.log), {}),
+    ).resolves.toBeUndefined();
+
+    expect(prompter.log.info).not.toHaveBeenCalled();
+    expect(prompter.log.warning).toHaveBeenCalledWith(expect.stringContaining("Framework Preset"));
+  });
+});

--- a/packages/eve/src/setup/vercel-project-framework.ts
+++ b/packages/eve/src/setup/vercel-project-framework.ts
@@ -5,7 +5,9 @@ import * as fs from "node:fs/promises";
 import { extname, join } from "node:path";
 import { z } from "zod";
 
+import { readProjectLink } from "./project-resolution.js";
 import type { Prompter } from "./prompter.js";
+import { resolveVercelHostFrameworkPreset } from "./scaffold/index.js";
 import { isForbiddenApiFailure, normalizeVercelApiResult } from "./vercel-api-failure.js";
 import {
   parseVercelJson,
@@ -219,6 +221,78 @@ async function resolveDetectedFrameworkAction(
   if (importDetected) return "keep";
   if (options.headless) return "switch-to-eve";
   return confirmDetectedFramework(prompter, framework, integration);
+}
+
+function frameworkPresetLabel(preset: string): string {
+  return EVE_FRAMEWORK_INTEGRATIONS[preset]?.label ?? preset;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Best-effort alignment of a linked Vercel project's Framework Preset with the
+ * host framework the project declares on disk (e.g. Next.js).
+ *
+ * A project created as a standalone eve agent keeps the `eve` preset; adding a
+ * host framework via `eve channels add web` leaves it stale, so the deploy would
+ * build the agent instead of the host app. Since that command already deploys on
+ * the user's behalf, this switches the preset directly (no prompt) and notes the
+ * change. No host framework, an unlinked directory, or an already-correct preset
+ * is a no-op; a Vercel API failure warns rather than aborting the deploy.
+ */
+export async function syncHostFrameworkPreset(
+  prompter: Prompter,
+  projectRoot: string,
+  onOutput: ReturnType<typeof createPromptCommandOutput>,
+  options: VercelProjectOperationOptions,
+): Promise<void> {
+  const hostPreset = await resolveVercelHostFrameworkPreset(projectRoot);
+  if (hostPreset === undefined) return;
+
+  const link = await readProjectLink(projectRoot);
+  if (link === undefined) return;
+
+  const label = frameworkPresetLabel(hostPreset);
+
+  let current: string | undefined;
+  try {
+    current = await fetchProjectFramework(projectRoot, link.orgId, link.projectId, options);
+  } catch (error) {
+    // A cancel isn't an API failure — let it propagate; anything else is
+    // best-effort, so warn and skip instead of aborting the deploy.
+    if (options.signal?.aborted) throw error;
+    prompter.log.warning(
+      `Could not check this Vercel project's Framework Preset (${describeError(error)}). If it is not already ${label}, set it under Project Settings → Build and Deployment → Framework Settings before deploying.`,
+    );
+    return;
+  }
+  if (current === hostPreset) return;
+
+  const currentLabel = current === undefined ? undefined : frameworkPresetLabel(current);
+  const currentPhrase =
+    currentLabel === undefined ? "had no Framework Preset set" : `was set to "${currentLabel}"`;
+
+  try {
+    await setProjectFramework(
+      projectRoot,
+      link.orgId,
+      link.projectId,
+      hostPreset,
+      onOutput,
+      options,
+    );
+  } catch (error) {
+    if (options.signal?.aborted) throw error;
+    prompter.log.warning(
+      `${describeError(error)} Set this Vercel project's Framework Preset to ${label} (Project Settings → Build and Deployment → Framework Settings) before deploying, or the deployment will not build your ${label} app.`,
+    );
+    return;
+  }
+  prompter.log.info(
+    `This project uses ${label}, but its Vercel Framework Preset ${currentPhrase}; switched it to ${label} so the deployment builds your app.`,
+  );
 }
 
 export async function ensureCreatedProjectFramework(


### PR DESCRIPTION
### Description

In the flow where you: 1. `eve init` with no channels 2. `eve channels add web` to add a next.js project into the scaffolded repo, you end up hitting an error on deployment (No Output Directory named ".output" found).

This is because the linked Vercel project 

### How did you test your changes?

Added tests, and ran through the `eve init` / `eve channels add web` flow manually, confirmed deployment was successful.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
