### PR TITLE
fix(eve): Update Linear `AgentSession` GQL schema

### DIFF
--- a/packages/eve/src/public/channels/linear/api.ts
+++ b/packages/eve/src/public/channels/linear/api.ts
@@ -7,6 +7,26 @@ import { parseJsonObject, type JsonObject } from "#shared/json.js";
 
 export type LinearFetch = typeof fetch;
 
+/**
+ * Selection set for an Agent Session, shared by the create-on-issue and
+ * create-on-comment mutations. Linear's schema exposes the session's
+ * associations only as nested relations (`appUser`, `comment`, `issue`,
+ * `sourceComment`); the flat `*Id` scalars were removed, so selecting them
+ * returns HTTP 400. There is no `organization` relation on `AgentSession`.
+ */
+const AGENT_SESSION_FIELDS = `
+  fragment AgentSessionFields on AgentSession {
+    id
+    appUser { id }
+    comment { id }
+    creator { id }
+    issue { id identifier title url }
+    sourceComment { id }
+    status
+    url
+  }
+`;
+
 /** Transport options for Linear GraphQL calls. */
 export interface LinearApiOptions {
   /** Defaults to `https://api.linear.app/graphql`. */
@@ -212,19 +232,11 @@ export async function createLinearAgentSessionOnIssue(input: {
         agentSessionCreateOnIssue(input: $input) {
           success
           agentSession {
-            id
-            appUserId
-            commentId
-            creator { id }
-            issue { id identifier title url }
-            issueId
-            organizationId
-            sourceCommentId
-            status
-            url
+            ...AgentSessionFields
           }
         }
       }
+      ${AGENT_SESSION_FIELDS}
     `,
     queryName: "AgentSessionCreateOnIssue",
     variables: {
@@ -260,19 +272,11 @@ export async function createLinearAgentSessionOnComment(input: {
         agentSessionCreateOnComment(input: $input) {
           success
           agentSession {
-            id
-            appUserId
-            commentId
-            creator { id }
-            issue { id identifier title url }
-            issueId
-            organizationId
-            sourceCommentId
-            status
-            url
+            ...AgentSessionFields
           }
         }
       }
+      ${AGENT_SESSION_FIELDS}
     `,
     queryName: "AgentSessionCreateOnComment",
     variables: {
@@ -336,25 +340,33 @@ function normalizeAgentSessionRecord(value: unknown): LinearAgentSessionRecord {
     throw new Error("linearChannel: Linear Agent Session response was malformed.");
   }
 
-  const creator = isObject(value.creator) ? value.creator : undefined;
   const issue = normalizeIssue(value.issue);
   const record: LinearAgentSessionRecord = { id: value.id };
-  if (typeof value.appUserId === "string") record.appUserId = value.appUserId;
-  if (typeof value.commentId === "string" || value.commentId === null) {
-    record.commentId = value.commentId;
-  }
-  if (typeof creator?.id === "string" || creator === undefined) {
-    record.creatorId = typeof creator?.id === "string" ? creator.id : null;
-  }
+  const appUserId = relationId(value.appUser);
+  if (typeof appUserId === "string") record.appUserId = appUserId;
+  const commentId = relationId(value.comment);
+  if (commentId !== undefined) record.commentId = commentId;
+  const creatorId = relationId(value.creator);
+  if (creatorId !== undefined) record.creatorId = creatorId;
   if (issue !== undefined) record.issue = issue;
-  if (typeof value.issueId === "string" || value.issueId === null) record.issueId = value.issueId;
-  if (typeof value.organizationId === "string") record.organizationId = value.organizationId;
-  if (typeof value.sourceCommentId === "string" || value.sourceCommentId === null) {
-    record.sourceCommentId = value.sourceCommentId;
-  }
+  const issueId = relationId(value.issue);
+  if (issueId !== undefined) record.issueId = issueId;
+  const sourceCommentId = relationId(value.sourceComment);
+  if (sourceCommentId !== undefined) record.sourceCommentId = sourceCommentId;
   if (typeof value.status === "string") record.status = value.status;
   if (typeof value.url === "string" || value.url === null) record.url = value.url;
   return record;
+}
+
+/**
+ * Reads the `id` from a nested Linear relation selected as `{ id }`. Returns
+ * `null` when the relation is present but null (Linear's representation of an
+ * absent association), and `undefined` when the field was not returned.
+ */
+function relationId(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (isObject(value) && typeof value.id === "string") return value.id;
+  return undefined;
 }
 
 function normalizeAgentActivityRecord(value: unknown): LinearAgentActivityRecord | null {

--- a/packages/eve/src/public/channels/linear/api.ts
+++ b/packages/eve/src/public/channels/linear/api.ts
@@ -7,13 +7,7 @@ import { parseJsonObject, type JsonObject } from "#shared/json.js";
 
 export type LinearFetch = typeof fetch;
 
-/**
- * Selection set for an Agent Session, shared by the create-on-issue and
- * create-on-comment mutations. Linear's schema exposes the session's
- * associations only as nested relations (`appUser`, `comment`, `issue`,
- * `sourceComment`); the flat `*Id` scalars were removed, so selecting them
- * returns HTTP 400. There is no `organization` relation on `AgentSession`.
- */
+/** Shared Agent Session selection for the create-on-issue and create-on-comment mutations. */
 const AGENT_SESSION_FIELDS = `
   fragment AgentSessionFields on AgentSession {
     id
@@ -82,7 +76,6 @@ export interface LinearAgentSessionRecord {
     url?: string;
   } | null;
   issueId?: string | null;
-  organizationId?: string;
   sourceCommentId?: string | null;
   status?: string;
   url?: string | null;

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -470,8 +470,6 @@ describe("linearChannel default event handlers", () => {
             agentSession: {
               id: "agent_session_2",
               issue: { id: "issue_1", identifier: "EVE-123", title: "Linear work" },
-              issueId: "issue_1",
-              organizationId: "org_1",
               url: "https://linear.app/acme/agent-session/agent_session_2",
             },
             success: true,
@@ -504,7 +502,7 @@ describe("linearChannel default event handlers", () => {
         agentSessionId: "agent_session_2",
         issueId: "issue_1",
         issueIdentifier: "EVE-123",
-        organizationId: "org_1",
+        organizationId: null,
       }),
     });
   });

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -426,7 +426,8 @@ function stateFromAgentSession(
     issueIdentifier: session.issue?.identifier ?? null,
     issueTitle: session.issue?.title ?? null,
     issueUrl: session.issue?.url ?? null,
-    organizationId: session.organizationId ?? null,
+    // Only the webhook session ref carries an organization id.
+    organizationId: "organizationId" in session ? (session.organizationId ?? null) : null,
     pendingToolCallMessage: null,
     sourceCommentId: session.sourceCommentId ?? null,
   };


### PR DESCRIPTION
### Description

The [Linear GQL schema](https://raw.githubusercontent.com/linear/linear/master/packages/sdk/src/schema.graphql) for `AgentSession` changed from the hardcoded schema in our integration. Updates to match.

Worth flagging that `AgentSession` no longer returns an organization ID; this field was treated as nullable anyway.

### How did you test your changes?

Ran eve agent locally w/ changes, no longer seeing GQL error. Updated unit test.


