### PR TITLE
fix(eve): stabilize terminal rendering

### DIFF
--- a/.changeset/tidy-terminal-rendering.md
+++ b/.changeset/tidy-terminal-rendering.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep the dev TUI prompt aligned with submitted messages, reflow the transcript after terminal resize, and strip complete ANSI sequences from captured output.

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -856,6 +856,49 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("aligns live input with the submitted user message", async () => {
+    const { screen, input, renderer } = makeRenderer();
+
+    const prompt = renderer.readPrompt();
+    input.type("hello");
+    const live = screen
+      .snapshot()
+      .split("\n")
+      .find((line) => line.includes("hello"));
+    input.enter();
+    await prompt;
+    const submitted = screen
+      .snapshot()
+      .split("\n")
+      .find((line) => line.includes("hello"));
+
+    expect(live?.indexOf("hello")).toBe(2);
+    expect(submitted?.indexOf("hello")).toBe(2);
+    renderer.shutdown();
+  });
+
+  it("reflows the transcript on resize without duplicating the live prompt", async () => {
+    const { screen, renderer } = makeRenderer();
+    await renderer.renderStream(
+      streamOf([
+        { type: "assistant-delta", id: "t1", delta: "a response that wraps at narrow widths" },
+        { type: "assistant-complete", id: "t1" },
+        { type: "finish" },
+      ]),
+      { submittedPrompt: "hello", continueSession: true },
+    );
+    void renderer.readPrompt();
+    const beforeResize = screen.rawOutput().length;
+
+    screen.resize(40, 20);
+
+    expect(screen.rawOutput().slice(beforeResize)).toContain("\x1b[3J");
+    expect(countOccurrences(screen.snapshot(), "❯")).toBe(1);
+    expect(screen.snapshot()).toContain("hello");
+    expect(screen.snapshot()).toContain("a response that wraps");
+    renderer.shutdown();
+  });
+
   it("starts the turn pulse as soon as the prompt is submitted", async () => {
     vi.useFakeTimers();
     try {
@@ -2612,7 +2655,7 @@ describe("TerminalRenderer command typeahead", () => {
     expect(snapshot).toContain("Show available commands");
     expect(snapshot).toContain("Configure the agent's model and provider");
     const promptLine = snapshot.split("\n").find((line) => line.includes("❯ /"));
-    expect(promptLine?.startsWith(" ❯ /")).toBe(true);
+    expect(promptLine?.startsWith("❯ /")).toBe(true);
 
     input.enter();
     // The highlighted default — /help leads the registry — is what a bare

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -2015,7 +2015,10 @@ export class TerminalRenderer implements AgentTUIRenderer {
       this.#live.emitBracketedPaste(true);
     }
 
-    this.#onResize = () => this.#paint();
+    this.#onResize = () => {
+      this.#rebuildCommittedTranscript();
+      this.#replayTranscript();
+    };
     this.#output.on("resize", this.#onResize);
   }
 
@@ -3213,8 +3216,8 @@ function promptInputRows({
   );
   const promptGlyph = c.cyan(theme.glyph.prompt);
   const ellipsis = c.dim(theme.glyph.ellipsis);
-  // Reserve the leading pad, gutter, and block cursor's trailing cell at end-of-line.
-  const budget = Math.max(1, width - 4);
+  // Reserve the gutter and block cursor's trailing cell at end-of-line.
+  const budget = Math.max(1, width - 3);
   const out: string[] = [];
   for (let r = top; r < top + visibleCount; r += 1) {
     const row = layout.rows[r]!;
@@ -3245,7 +3248,7 @@ function promptInputRows({
     } else {
       body = style(row.text);
     }
-    out.push(clip(` ${gutter} ${body}`, width));
+    out.push(clip(`${gutter} ${body}`, width));
   }
   out.push("");
   return out;

--- a/packages/eve/src/cli/dev/tui/terminal-text.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-text.test.ts
@@ -19,6 +19,12 @@ describe("stripTerminalControls", () => {
     expect(stripTerminalControls(input)).toBe("a\tb\ncdefghijk");
   });
 
+  it("removes complete CSI styling instead of exposing its printable suffix", () => {
+    expect(stripTerminalControls("Model changed to \x1b[1mopus\x1b[22m.")).toBe(
+      "Model changed to opus.",
+    );
+  });
+
   it("neutralizes OSC and DCS introducers", () => {
     const input = "\x1b]52;c;cGFzdGU=\x07copy \x1bPqpayload\x1b\\done \u009d0;title\u009c";
 

--- a/packages/eve/src/cli/dev/tui/terminal-text.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-text.ts
@@ -9,15 +9,16 @@ const extendedPictographicPattern = /\p{Extended_Pictographic}/u;
 const keycapPattern = /^[#*0-9]\u{fe0f}?\u{20e3}$/u;
 
 export function stripAnsi(input: string): string {
-  return stripTerminalControls(input.replaceAll(ansiPattern, ""));
+  return stripTerminalControls(input);
 }
 
 export function stripTerminalControls(input: string): string {
+  const text = input.replaceAll(ansiPattern, "");
   let output = "";
   let index = 0;
 
-  while (index < input.length) {
-    const codePoint = input.codePointAt(index);
+  while (index < text.length) {
+    const codePoint = text.codePointAt(index);
 
     if (codePoint == null) {
       break;


### PR DESCRIPTION
## What

- Align the live prompt with the submitted user message by removing the extra leading cell from prompt rows.
- Rebuild and replay committed transcript rows after a terminal resize so previous output wraps at the new width without duplicating the live prompt.
- Strip complete ANSI CSI sequences before filtering remaining terminal controls, preventing printable CSI suffixes from leaking into captured text.

The live input and submitted message previously used different left offsets. Resize only repainted the existing row model, so committed output kept its old wrapping. Terminal control filtering could also expose text such as `1m` and `22m` after removing the escape byte without consuming the full sequence.

These fixes stay at the renderer and terminal-text boundaries that own those behaviors. The init and local authoring changes remain in #850.
