### PR TITLE
fix(eve): retry transient stream open failures

### DIFF
--- a/.changeset/calm-stream-reconnects.md
+++ b/.changeset/calm-stream-reconnects.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Retry transient network failures while reopening client session streams so active turns remain attached.

--- a/packages/eve/src/client/ndjson.ts
+++ b/packages/eve/src/client/ndjson.ts
@@ -19,6 +19,7 @@ export function isStreamDisconnectError(error: unknown): boolean {
     error.name === "AbortError" ||
     error.message === "terminated" ||
     errorCode === "UND_ERR_SOCKET" ||
+    (error instanceof TypeError && /^(?:failed to fetch|fetch failed)$/i.test(error.message)) ||
     /abort|cancel|disconnect|premature close|socket|terminated/i.test(error.message)
   );
 }

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -64,8 +64,9 @@ export async function* openStreamIterable(
 }
 
 /**
- * Opens one stream response body, retrying the short propagation window where
- * a just-acknowledged session may not yet be readable from the stream route.
+ * Opens one stream response body, retrying transient network errors and the
+ * short propagation window where a just-acknowledged session may not yet be
+ * readable from the stream route.
  */
 export async function openStreamBody(
   input: OpenStreamBodyInput,
@@ -82,11 +83,24 @@ export async function openStreamBody(
     );
 
     const headers = await input.resolveHeaders();
-    const response = await fetch(url, {
-      headers,
-      redirect: input.redirect,
-      signal: input.signal ?? null,
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers,
+        redirect: input.redirect,
+        signal: input.signal ?? null,
+      });
+    } catch (error) {
+      if (
+        input.signal?.aborted ||
+        !isStreamDisconnectError(error) ||
+        attempt === STREAM_OPEN_RETRY_ATTEMPTS - 1
+      ) {
+        throw error;
+      }
+      await sleep(STREAM_OPEN_RETRY_DELAY_MS);
+      continue;
+    }
 
     if (response.ok) {
       if (!response.body) {

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -400,4 +400,63 @@ describe("ClientSession", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
   });
+
+  it("retries a transient fetch failure while reopening an active turn stream", async () => {
+    const encoder = new TextEncoder();
+    const streamUrls: string[] = [];
+    let streamRequest = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createAcceptedResponse();
+      }
+
+      streamUrls.push(
+        typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
+      );
+      streamRequest += 1;
+
+      if (streamRequest === 1) {
+        let emitted = false;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (!emitted) {
+                emitted = true;
+                controller.enqueue(
+                  encoder.encode(`${JSON.stringify({ type: "turn.started", data: {} })}\n`),
+                );
+                return;
+              }
+              controller.error(new Error("socket disconnected"));
+            },
+          }),
+        );
+      }
+
+      if (streamRequest === 2) {
+        throw new TypeError("fetch failed");
+      }
+
+      return createStreamResponse([
+        {
+          type: "session.waiting",
+          data: { continuationToken: "eve:test", wait: "next-user-message" },
+        },
+      ]);
+    });
+    const session = createSession(undefined, { maxReconnectAttempts: 2 });
+
+    const eventTypes: string[] = [];
+    for await (const event of await session.send("first")) {
+      eventTypes.push(event.type);
+    }
+
+    expect(eventTypes).toEqual(["turn.started", "session.waiting"]);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(streamUrls.map((url) => new URL(url).searchParams.get("startIndex"))).toEqual([
+      null,
+      "1",
+      "1",
+    ]);
+  });
 });


### PR DESCRIPTION
## What

- retry Node's transient `TypeError: fetch failed` while opening or reopening a durable client stream
- keep the same stream cursor across the failed open
- add a session-level regression and patch changeset

## Why

During local `eve dev`, a turn delivered tool events and kept running, but one stream reopen failed with `TypeError: fetch failed`. The client did not classify that error as a disconnect, and `openStreamBody` only retried temporary HTTP responses. The exception reached the TUI, which printed the error and replaced the session because it never received a durable session boundary. The server-side turn remained active.

The retry belongs in `openStreamBody` beside its existing 404, 409, and 5xx propagation retries. Caller aborts and non-network exceptions still fail immediately. The regression consumes one event, disconnects the stream, fails the first reopen, and verifies that the client resumes at the same `startIndex`.
