### PR TITLE
fix(slack): drop external remote files from attachment collection

### DIFF
--- a/.changeset/slack-external-file-attachment.md
+++ b/.changeset/slack-external-file-attachment.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix the Slack channel crashing a whole turn when a thread contained a "remote file" — a Google Drive, Dropbox, or Box document shared via an external Slack integration (`mode: "external"`). These files' `url_private` points at the third-party service, not Slack, so downloading them with the Slack bot token failed (typically a 401), throwing an `AI_DownloadError` for every later mention in that thread. Remote files are now excluded from attachment collection across all three inbound paths (mention attachments, thread-history lookback, and the shared Chat SDK webhook payload).

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -407,6 +407,43 @@ describe("collectInboundFileParts", () => {
     expect(refresh).not.toHaveBeenCalled();
   });
 
+  it("drops external (Google Drive/Dropbox/etc.) remote files — their url_private points at the third-party service, not Slack, so fetching it with the bot token fails", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const thread = makeSlackThread({
+      refresh,
+      recentMessages: [
+        {
+          isMe: false,
+          raw: {
+            files: [
+              {
+                id: "F500",
+                name: "Q3 plan",
+                mimetype: "application/vnd.google-apps.spreadsheet",
+                url_private: "https://docs.google.com/spreadsheets/d/abc/edit",
+                mode: "external",
+              },
+              {
+                id: "F501",
+                mimetype: "text/csv",
+                url_private: "https://files.slack.com/a/b/real.csv",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const parts = await collectInboundFileParts({
+      mention: emptyMention,
+      thread,
+      policy: DEFAULT_UPLOAD_POLICY,
+    });
+
+    expect(parts).toHaveLength(1);
+    expect((parts[0]!.data as URL).href).toBe("https://files.slack.com/a/b/real.csv");
+  });
+
   it("returns an empty array when refresh throws", async () => {
     const refresh = vi.fn().mockRejectedValue(new Error("Slack 500"));
     const thread = makeSlackThread({ refresh });

--- a/packages/eve/src/public/channels/slack/attachments.ts
+++ b/packages/eve/src/public/channels/slack/attachments.ts
@@ -112,21 +112,31 @@ export async function collectInboundFileParts(input: {
   return [];
 }
 
+/**
+ * Drops Slack "remote files" (`mode: "external"` — Google Drive, Dropbox,
+ * Box, etc. shared via an external integration) before building attachment
+ * parts. Their `url_private` points at the third-party service, not Slack,
+ * so `createSlackFetchFile`'s bot-token auth doesn't apply and any generic
+ * download attempt fails (typically with a 401), taking down the whole
+ * turn over a file that was never Slack-hosted to begin with.
+ */
 function extractAttachmentsFromRaw(
   files: readonly Record<string, unknown>[] | undefined,
 ): SlackAttachment[] {
   if (!Array.isArray(files)) return [];
-  return files.map((file) => {
-    const mimeType = typeof file.mimetype === "string" ? file.mimetype : undefined;
-    return {
-      id: typeof file.id === "string" ? file.id : "",
-      type: inferAttachmentType(mimeType),
-      url: typeof file.url_private === "string" ? file.url_private : undefined,
-      name: typeof file.name === "string" ? file.name : undefined,
-      mimeType,
-      size: typeof file.size === "number" ? file.size : undefined,
-    };
-  });
+  return files
+    .filter((file) => file.mode !== "external")
+    .map((file) => {
+      const mimeType = typeof file.mimetype === "string" ? file.mimetype : undefined;
+      return {
+        id: typeof file.id === "string" ? file.id : "",
+        type: inferAttachmentType(mimeType),
+        url: typeof file.url_private === "string" ? file.url_private : undefined,
+        name: typeof file.name === "string" ? file.name : undefined,
+        mimeType,
+        size: typeof file.size === "number" ? file.size : undefined,
+      };
+    });
 }
 
 function inferAttachmentType(mimeType: string | undefined): "image" | "file" | "video" | "audio" {

--- a/packages/eve/src/public/channels/slack/inbound.test.ts
+++ b/packages/eve/src/public/channels/slack/inbound.test.ts
@@ -111,6 +111,38 @@ describe("parseAppMentionEvent", () => {
       size: 1024,
     });
   });
+
+  it("drops external (mode: external) files — Google Drive/Dropbox/etc. shared via a Slack integration, whose url_private points at the third-party service rather than Slack", () => {
+    const message = parseAppMentionEvent({
+      type: "event_callback",
+      event: {
+        type: "app_mention",
+        user: "U01",
+        text: "see this",
+        channel: "C01",
+        ts: "1.0",
+        files: [
+          {
+            id: "F1",
+            name: "Q3 plan",
+            mimetype: "application/vnd.google-apps.spreadsheet",
+            url_private: "https://docs.google.com/spreadsheets/d/abc/edit",
+            mode: "external",
+            external_type: "gsheet",
+          },
+          {
+            id: "F2",
+            name: "chart.png",
+            mimetype: "image/png",
+            url_private: "https://files.slack.com/a/chart.png",
+            size: 1024,
+          },
+        ],
+      },
+    });
+    expect(message?.attachments).toHaveLength(1);
+    expect(message?.attachments[0]?.id).toBe("F2");
+  });
 });
 
 describe("parseDirectMessageEvent", () => {
@@ -308,5 +340,46 @@ describe("parseDirectMessageEvent", () => {
         size: 2048,
       },
     ]);
+  });
+
+  it("drops external (mode: external) files from the shared Slack webhook payload path too", () => {
+    const payload = parseSlackWebhookBody(
+      JSON.stringify({
+        type: "event_callback",
+        team_id: "T01",
+        event: {
+          type: "message",
+          channel_type: "im",
+          subtype: "file_share",
+          user: "U01",
+          text: "here is a file",
+          channel: "D01",
+          ts: "1700000000.000100",
+          files: [
+            {
+              id: "F01",
+              mimetype: "application/vnd.google-apps.spreadsheet",
+              url_private: "https://docs.google.com/spreadsheets/d/abc/edit",
+              name: "Sheet",
+              mode: "external",
+              external_type: "gsheet",
+            },
+            {
+              id: "F02",
+              mimetype: "image/png",
+              url_private: "https://files.slack.com/F02/diagram.png",
+              name: "diagram.png",
+              size: 2048,
+            },
+          ],
+        },
+      }),
+    );
+    if (payload.kind !== "direct_message") throw new Error("expected direct_message");
+
+    const message = slackMessageFromWebhookPayload(payload);
+
+    expect(message?.attachments).toHaveLength(1);
+    expect(message?.attachments[0]?.id).toBe("F02");
   });
 });

--- a/packages/eve/src/public/channels/slack/inbound.ts
+++ b/packages/eve/src/public/channels/slack/inbound.ts
@@ -236,11 +236,17 @@ function parseAuthor(event: SlackAppMentionEvent | SlackMessageEvent): SlackAuth
   };
 }
 
+/**
+ * Drops Slack "remote files" (`mode: "external"` — Google Drive, Dropbox,
+ * Box, etc. shared via an external integration) before mapping. Their
+ * `url_private` points at the third-party service, not Slack, so no
+ * fetcher this channel owns can authenticate to it.
+ */
 function parseAttachments(
   files: readonly Record<string, unknown>[] | undefined,
 ): SlackAttachment[] {
   if (!Array.isArray(files)) return [];
-  return files.map(toAttachment);
+  return files.filter((file) => file.mode !== "external").map(toAttachment);
 }
 
 function toAttachment(file: Record<string, unknown>): SlackAttachment {
@@ -289,9 +295,10 @@ function parsePayloadAuthor(
   };
 }
 
+/** Same external-file exclusion as {@link parseAttachments}, applied to the shared Chat SDK's `SlackFile` shape (the original file's `mode` survives on `.raw`). */
 function parsePayloadAttachments(files: readonly SlackFile[] | undefined): SlackAttachment[] {
   if (!Array.isArray(files)) return [];
-  return files.map(toPayloadAttachment);
+  return files.filter((file) => file.raw.mode !== "external").map(toPayloadAttachment);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Slack "remote files" (`mode: "external"` — Google Drive/Dropbox/Box shared via an external Slack integration) carry a `url_private` pointing at the third-party service, not Slack. None of this channel's fetchers can authenticate to that URL, so downloading it (typically via a generic provider-side fetch when staging the FilePart) fails — usually a 401 — throwing `AI_DownloadError` and crashing the whole turn for every later mention in that thread.
- Filters `mode: "external"` files out of attachment collection across all three inbound paths: `extractAttachmentsFromRaw` (thread-history lookback), `parseAttachments` (legacy raw event envelope), and `parsePayloadAttachments` (shared Chat SDK webhook payload).
- Closes #855

## Test plan
- [x] New regression tests in `attachments.test.ts` and `inbound.test.ts`, one per inbound path — confirmed failing before the fix, passing after
- [x] `pnpm run test:unit` — 4844 passed, 1 skipped
- [x] `pnpm run typecheck` — clean
- [x] Changeset added (patch bump)