### PR TITLE
fix(eve): channels - consolidate turn control ownership

### DIFF
--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -13,6 +13,7 @@
 import type { HookPayload, SessionCapabilities } from "#channel/types.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { RunMode } from "#shared/run-mode.js";
+import type { TurnSteeringState } from "#harness/types.js";
 
 import { runMigrationChain, type VersionMigration } from "./chain.js";
 import { turnWorkflowInputV0ToV1 } from "./turn-workflow-v0-to-v1.js";
@@ -22,8 +23,8 @@ export const TURN_WORKFLOW_INPUT_VERSION = 1;
 export interface TurnStepInput {
   /** Cancellation signal forwarded into the turn step. */
   readonly abortSignal?: AbortSignal;
-  /** Live signal set when replacement input is waiting at the next boundary. */
-  readonly steerSignal?: AbortSignal;
+  /** Replacement-input state observed at the next safe boundary. */
+  readonly steering?: TurnSteeringState;
   readonly input: HookPayload | undefined;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -4,7 +4,7 @@ import type { Runtime, SessionCapabilities } from "#channel/types.js";
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
-import type { HandleEventFn, HarnessToolMap, StepFn } from "#harness/types.js";
+import type { HandleEventFn, HarnessToolMap, StepFn, TurnSteeringState } from "#harness/types.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { createLogger } from "#internal/logging.js";
 import type { RuntimeIdentity } from "#protocol/message.js";
@@ -43,8 +43,8 @@ export type CreateRuntime = (config: {
 export interface CreateExecutionNodeStepInput {
   /** Cancellation signal forwarded to the tool-loop harness. */
   readonly abortSignal?: AbortSignal;
-  /** Signals replacement input waiting at the next safe harness boundary. */
-  readonly steerSignal?: AbortSignal;
+  /** Prevents settlement while replacement input is waiting. */
+  readonly steering?: TurnSteeringState;
   /**
    * Session-level capabilities propagated from the runtime. The
    * harness passes this through to `buildToolSet` so `ask_question`
@@ -93,7 +93,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     dispatchDynamicModelEvent: dispatchModelEvent,
     resolveModel,
     runtimeIdentity: buildRuntimeIdentity(input.node),
-    steerSignal: input.steerSignal,
+    steering: input.steering,
     tools,
   });
 }

--- a/packages/eve/src/execution/session-delivery-hook.test.ts
+++ b/packages/eve/src/execution/session-delivery-hook.test.ts
@@ -23,7 +23,7 @@ describe("createSessionDeliveryHook", () => {
       token: "replacement",
     });
     installHooks(oldHook, replacementHook);
-    const deliveryHook = createSessionDeliveryHook([]);
+    const deliveryHook = createSessionDeliveryHook(vi.fn());
 
     await deliveryHook.rekey("old");
     const pending = deliveryHook.next();
@@ -53,7 +53,7 @@ describe("createSessionDeliveryHook", () => {
       token: "replacement",
     });
     installHooks(oldHook, replacementHook);
-    const deliveryHook = createSessionDeliveryHook(bufferedDeliveries);
+    const deliveryHook = createSessionDeliveryHook((delivery) => bufferedDeliveries.push(delivery));
 
     await deliveryHook.rekey("old");
     await deliveryHook.rekey("replacement");
@@ -73,7 +73,7 @@ describe("createSessionDeliveryHook", () => {
       token: "candidate",
     });
     installHooks(oldHook, candidateHook);
-    const deliveryHook = createSessionDeliveryHook([]);
+    const deliveryHook = createSessionDeliveryHook(vi.fn());
 
     await deliveryHook.rekey("old");
     await expect(deliveryHook.rekey("candidate")).rejects.toMatchObject({
@@ -98,7 +98,7 @@ describe("createSessionDeliveryHook", () => {
     });
     const candidateHook = createMockHook({ token: "candidate" });
     installHooks(oldHook, candidateHook);
-    const deliveryHook = createSessionDeliveryHook([]);
+    const deliveryHook = createSessionDeliveryHook(vi.fn());
 
     await deliveryHook.rekey("old");
     await expect(deliveryHook.rekey("candidate")).rejects.toBe(failure);
@@ -118,7 +118,7 @@ describe("createSessionDeliveryHook", () => {
       createCursorHook({ committed: [], token: "replacement" }),
       createCursorHook({ committed: [], token: "third" }),
     );
-    const deliveryHook = createSessionDeliveryHook(bufferedDeliveries);
+    const deliveryHook = createSessionDeliveryHook((delivery) => bufferedDeliveries.push(delivery));
 
     await deliveryHook.rekey("old");
     await deliveryHook.rekey("replacement");
@@ -133,7 +133,7 @@ describe("createSessionDeliveryHook", () => {
   it("disposes without closing or settling a pending read", async () => {
     const hook = createMockHook({ token: "active" });
     installHooks(hook);
-    const deliveryHook = createSessionDeliveryHook([]);
+    const deliveryHook = createSessionDeliveryHook(vi.fn());
 
     await deliveryHook.rekey("active");
     void deliveryHook.next();

--- a/packages/eve/src/execution/session-delivery-hook.ts
+++ b/packages/eve/src/execution/session-delivery-hook.ts
@@ -40,7 +40,7 @@ export interface SessionDeliveryHookHandle extends SessionDeliveryHook {
  * to `hook_disposed` and receives `HookNotFoundError` from the Workflow SDK.
  */
 export function createSessionDeliveryHook(
-  bufferedDeliveries: DeliverHookPayload[],
+  onBufferedDelivery: (delivery: DeliverHookPayload) => void,
 ): SessionDeliveryHookHandle {
   let active: SessionDeliveryHookState | undefined;
   const retired: SessionDeliveryHookState[] = [];
@@ -114,7 +114,7 @@ export function createSessionDeliveryHook(
       if (read.result.done) {
         read.state.closed = true;
       } else if (read.result.value.kind === "deliver") {
-        bufferedDeliveries.push(read.result.value);
+        onBufferedDelivery(read.result.value);
       }
 
       arm(read.state);

--- a/packages/eve/src/execution/session-input-queue.test.ts
+++ b/packages/eve/src/execution/session-input-queue.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
+import { createSessionInputQueue } from "#execution/session-input-queue.js";
+
+const createHookMock = vi.fn();
+
+vi.mock("#compiled/@workflow/core/index.js", () => ({
+  createHook: (...args: unknown[]) => createHookMock(...args),
+}));
+
+describe("createSessionInputQueue", () => {
+  afterEach(() => {
+    createHookMock.mockReset();
+  });
+
+  it("preserves the ordering of remainders, returned input, and later queued input", async () => {
+    const queue = createSessionInputQueue();
+    queue.appendQueued(delivery("queued"));
+    queue.returnSteering({ ...delivery("steering"), turnPolicy: "steer" });
+    queue.prependReturned(delivery("returned"));
+    queue.prependTurnRemainders([{ ...delivery("remainder"), turnPolicy: "steer" }]);
+
+    const next = await queue.takeNextTurn();
+
+    expect(next?.payloads.map((payload) => payload.message)).toEqual([
+      "remainder",
+      "returned",
+      "queued",
+      "steering",
+    ]);
+    expect(next?.turnPolicy).toBe("queue");
+  });
+
+  it("converts returned steering to queue policy in one place", async () => {
+    const queue = createSessionInputQueue();
+    queue.returnSteering({ ...delivery("steering"), turnPolicy: "steer" });
+
+    await expect(queue.takeNextTurn()).resolves.toMatchObject({ turnPolicy: "queue" });
+  });
+
+  it("extracts only an explicitly addressed response from buffered input", async () => {
+    const queue = createSessionInputQueue();
+    const response: DeliverHookPayload = {
+      kind: "deliver",
+      payloads: [{ inputResponses: [{ requestId: "request-1", text: "approved" }] }],
+    };
+    queue.appendQueued(delivery("freeform"));
+    queue.appendQueued(response);
+
+    expect(queue.takeExplicitResponse()).toBe(response);
+    await expect(queue.takeNextTurn()).resolves.toEqual(delivery("freeform"));
+  });
+
+  it("skips commands and preserves live delivery order", async () => {
+    installHook([
+      { command: "resolve", kind: "session-command" },
+      delivery("first"),
+      delivery("second"),
+    ]);
+    const queue = createSessionInputQueue();
+    await queue.rekey("session-token");
+
+    const first = await queue.takeNextTurn();
+    const second = await queue.takeNextTurn();
+
+    expect(first?.payloads.map((payload) => payload.message)).toEqual(["first"]);
+    expect(second?.payloads.map((payload) => payload.message)).toEqual(["second"]);
+    await queue.dispose();
+  });
+
+  it("normalizes live steering when no active turn can accept it", async () => {
+    installHook([{ ...delivery("steering"), turnPolicy: "steer" }]);
+    const queue = createSessionInputQueue();
+    await queue.rekey("session-token");
+
+    await expect(queue.takeNextTurn()).resolves.toMatchObject({ turnPolicy: "queue" });
+    await queue.dispose();
+  });
+});
+
+function delivery(message: string): DeliverHookPayload {
+  return { kind: "deliver", payloads: [{ message }] };
+}
+
+function installHook(values: readonly HookPayload[]): void {
+  const reads = [...values];
+  createHookMock.mockReturnValue({
+    token: "session-token",
+    dispose: vi.fn(),
+    getConflict: vi.fn(async () => null),
+    [Symbol.asyncIterator]() {
+      return {
+        next: vi.fn(() => {
+          const value = reads.shift();
+          return value === undefined
+            ? new Promise<IteratorResult<HookPayload>>(() => {})
+            : Promise.resolve({ done: false, value });
+        }),
+      };
+    },
+  });
+}

--- a/packages/eve/src/execution/session-input-queue.ts
+++ b/packages/eve/src/execution/session-input-queue.ts
@@ -1,0 +1,100 @@
+import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
+import {
+  createSessionDeliveryHook,
+  type SessionDeliveryHookHandle,
+} from "#execution/session-delivery-hook.js";
+import { coalesceDeliveries } from "#harness/messages.js";
+
+/** Owns public hook admission and ordered input buffered by one session driver. */
+export interface SessionInputQueue {
+  appendQueued(delivery: DeliverHookPayload): void;
+  consumeAdmission(): void;
+  dispose(): Promise<void>;
+  nextAdmission(): Promise<IteratorResult<HookPayload>>;
+  prependReturned(delivery: DeliverHookPayload): void;
+  prependTurnRemainders(deliveries: readonly DeliverHookPayload[]): void;
+  rekey(token: string): Promise<void>;
+  returnSteering(delivery: DeliverHookPayload): void;
+  takeExplicitResponse(): DeliverHookPayload | undefined;
+  takeNextTurn(): Promise<DeliverHookPayload | null>;
+}
+
+/** Creates the single owner of a session driver's live and buffered input. */
+export function createSessionInputQueue(): SessionInputQueue {
+  const buffered: DeliverHookPayload[] = [];
+  const deliveryHook = createSessionDeliveryHook((delivery) =>
+    buffered.push(asQueuedDelivery(delivery)),
+  );
+
+  return createQueue(deliveryHook, buffered);
+}
+
+function createQueue(
+  deliveryHook: SessionDeliveryHookHandle,
+  buffered: DeliverHookPayload[],
+): SessionInputQueue {
+  return {
+    appendQueued(delivery): void {
+      if (delivery.turnPolicy === "steer") {
+        throw new Error("Steering input must use returnSteering() before entering the queue.");
+      }
+      buffered.push(delivery);
+    },
+    consumeAdmission: () => deliveryHook.consumeNext(),
+    dispose: () => deliveryHook.dispose(),
+    nextAdmission: () => deliveryHook.next(),
+    prependReturned(delivery): void {
+      buffered.unshift(asQueuedDelivery(delivery));
+    },
+    prependTurnRemainders(deliveries): void {
+      buffered.unshift(...deliveries.map(asQueuedDelivery));
+    },
+    rekey: (token) => deliveryHook.rekey(token),
+    returnSteering(delivery): void {
+      buffered.push(asQueuedDelivery(delivery));
+    },
+    takeExplicitResponse(): DeliverHookPayload | undefined {
+      const index = buffered.findIndex((delivery) =>
+        delivery.payloads.some((payload) => (payload.inputResponses?.length ?? 0) > 0),
+      );
+      if (index < 0) return undefined;
+      return buffered.splice(index, 1)[0];
+    },
+    async takeNextTurn(): Promise<DeliverHookPayload | null> {
+      if (buffered.length > 0) {
+        return coalesceDeliveries(buffered.splice(0));
+      }
+
+      while (true) {
+        const first = await deliveryHook.next();
+        deliveryHook.consumeNext();
+
+        if (first.done) return null;
+        if (first.value.kind !== "deliver") continue;
+
+        let coalesced = asQueuedDelivery(first.value);
+        while (true) {
+          const ready = await takeReadyPayload(deliveryHook.next());
+          if (ready === NO_READY_MESSAGE) break;
+
+          deliveryHook.consumeNext();
+          if (ready.done) break;
+          if (ready.value.kind !== "deliver") continue;
+          coalesced = coalesceDeliveries([coalesced, asQueuedDelivery(ready.value)]);
+        }
+        return coalesced;
+      }
+    },
+  };
+}
+
+function asQueuedDelivery(delivery: DeliverHookPayload): DeliverHookPayload {
+  return delivery.turnPolicy === "steer" ? { ...delivery, turnPolicy: "queue" } : delivery;
+}
+
+const NO_READY_MESSAGE = Symbol("no-ready-message");
+
+async function takeReadyPayload<T>(promise: Promise<T>): Promise<T | typeof NO_READY_MESSAGE> {
+  await Promise.resolve();
+  return await Promise.race([promise, Promise.resolve(NO_READY_MESSAGE)]);
+}

--- a/packages/eve/src/execution/turn-cancellation-control.ts
+++ b/packages/eve/src/execution/turn-cancellation-control.ts
@@ -1,10 +1,8 @@
-import { createHook } from "#compiled/@workflow/core/index.js";
-
-import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
 import {
   sessionCancelHookToken,
   type TurnCancelPayload,
 } from "#execution/turn-cancellation-token.js";
+import { createTurnHookInbox, type TurnHookInbox } from "#execution/turn-hook-inbox.js";
 import { TurnCancelledError } from "#harness/turn-cancellation.js";
 
 /**
@@ -35,53 +33,36 @@ export async function createTurnCancellationControl(input: {
   readonly expectedTurnId: string;
   readonly sessionId: string;
 }): Promise<TurnCancellationControl | undefined> {
-  const hook = createHook<TurnCancelPayload>({
+  const inbox = await createTurnHookInbox<TurnCancelPayload>({
+    conflict: "return-undefined",
     token: sessionCancelHookToken(input.sessionId),
   });
-  // Hook promises and iterators share one durable cursor. Create the
-  // iterator before claiming so conflict replay is consumed by
-  // getConflict(), not a later iterator read.
-  const iterator = hook[Symbol.asyncIterator]();
-
-  try {
-    await claimHookOwnership(hook);
-  } catch (error) {
-    if (isHookConflictError(error)) return undefined;
-    throw error;
-  }
+  if (inbox === undefined) return undefined;
 
   const controller = new AbortController();
   // The durable abort fires in the read's continuation so its call site
   // is reached deterministically on every replay.
-  const requested = consumeMatchingCancel(iterator, input.expectedTurnId).then(() => {
+  const requested = consumeMatchingCancel(inbox, input.expectedTurnId).then(() => {
     controller.abort(new TurnCancelledError());
     return "cancel" as const;
   });
 
-  let disposed = false;
   return {
     signal: controller.signal,
     requested,
-    async dispose(): Promise<void> {
-      if (disposed) return;
-      disposed = true;
-      // Never `iterator.return()`: it would await the pending durable
-      // read forever, leaving the run `running` and its hooks unswept.
-      await disposeHook(hook);
-    },
+    dispose: () => inbox.dispose(),
   };
 }
 
 // Mismatched turn guards are consumed as no-ops; each read is durable,
 // so the skip sequence replays deterministically.
 async function consumeMatchingCancel(
-  iterator: AsyncIterator<TurnCancelPayload>,
+  inbox: TurnHookInbox<TurnCancelPayload>,
   expectedTurnId: string,
 ): Promise<void> {
   while (true) {
-    const next = await iterator.next();
-    if (next.done) return await new Promise<never>(() => {});
-    if (matchesActiveTurn(next.value, expectedTurnId)) return;
+    const payload = await inbox.next();
+    if (matchesActiveTurn(payload, expectedTurnId)) return;
   }
 }
 

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -5,6 +5,7 @@ import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.js";
 import { forwardTurnSteeringStep } from "#execution/forward-turn-steering-step.js";
 import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
+import type { SessionInputQueue } from "#execution/session-input-queue.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
 
@@ -150,6 +151,82 @@ describe("TurnControlReceiver", () => {
     expect(action.kind).toBe("park");
   });
 
+  it("returns unacknowledged steering to the queue when the turn terminates", async () => {
+    const delivery: DeliverHookPayload = {
+      kind: "deliver",
+      payloads: [{ message: "change course" }],
+      turnPolicy: "steer",
+    };
+    let finish: (() => void) | undefined;
+    const forwarded = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    installControlHookFactory([
+      async () => ({
+        done: false,
+        value: { kind: "turn-steering-ready", steeringToken: "turn-steer" },
+      }),
+      async () => {
+        await forwarded;
+        return { done: false, value: parkResult() };
+      },
+    ]);
+    vi.mocked(forwardTurnSteeringStep).mockImplementationOnce(async () => finish?.());
+    const deliveryHook = createDeliveryHook({
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: delivery })
+        .mockImplementation(() => new Promise(() => {})),
+    });
+    const buffered: DeliverHookPayload[] = [];
+
+    await runReceiver(buffered, deliveryHook);
+
+    expect(buffered).toEqual([{ ...delivery, turnPolicy: "queue" }]);
+  });
+
+  it("keeps steering outstanding across a mismatched acknowledgement", async () => {
+    const delivery: DeliverHookPayload = {
+      kind: "deliver",
+      payloads: [{ message: "change course" }],
+      turnPolicy: "steer",
+    };
+    let acknowledge: (() => void) | undefined;
+    const forwarded = new Promise<void>((resolve) => {
+      acknowledge = resolve;
+    });
+    installControlHookFactory([
+      async () => ({
+        done: false,
+        value: { kind: "turn-steering-ready", steeringToken: "turn-steer" },
+      }),
+      async () => {
+        await forwarded;
+        return {
+          done: false,
+          value: { kind: "turn-steering-accepted", requestId: "stale-request" },
+        };
+      },
+      async () => ({
+        done: false,
+        value: { kind: "turn-steering-accepted", requestId: "turn-control:steer:0" },
+      }),
+      async () => ({ done: false, value: parkResult() }),
+    ]);
+    vi.mocked(forwardTurnSteeringStep).mockImplementationOnce(async () => acknowledge?.());
+    const deliveryHook = createDeliveryHook({
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: delivery })
+        .mockImplementation(() => new Promise(() => {})),
+    });
+    const buffered: DeliverHookPayload[] = [];
+
+    await runReceiver(buffered, deliveryHook);
+
+    expect(buffered).toEqual([]);
+  });
+
   it("keeps a delivery request active while forwarding steer input", async () => {
     const steeringDelivery: DeliverHookPayload = {
       kind: "deliver",
@@ -218,6 +295,65 @@ describe("TurnControlReceiver", () => {
     expect(action.kind).toBe("park");
   });
 
+  it("services a buffered response after an outstanding steer is accepted", async () => {
+    const steeringDelivery: DeliverHookPayload = {
+      kind: "deliver",
+      payloads: [{ message: "change course" }],
+      turnPolicy: "steer",
+    };
+    const response: DeliverHookPayload = {
+      kind: "deliver",
+      payloads: [{ inputResponses: [{ requestId: "req-1", text: "approved" }] }],
+    };
+    let steeringForwarded: (() => void) | undefined;
+    const forwardedSteering = new Promise<void>((resolve) => {
+      steeringForwarded = resolve;
+    });
+    let responseForwarded: (() => void) | undefined;
+    const forwardedResponse = new Promise<void>((resolve) => {
+      responseForwarded = resolve;
+    });
+    installControlHookFactory([
+      async () => ({
+        done: false,
+        value: { kind: "turn-steering-ready", steeringToken: "turn-steer" },
+      }),
+      async () => {
+        await forwardedSteering;
+        return { done: false, value: deliveryRequest("req-1") };
+      },
+      async () => ({
+        done: false,
+        value: { kind: "turn-steering-accepted", requestId: "turn-control:steer:0" },
+      }),
+      async () => {
+        await forwardedResponse;
+        return {
+          done: false,
+          value: { kind: "turn-delivery-accepted", requestId: "req-1" },
+        };
+      },
+      async () => ({ done: false, value: parkResult() }),
+    ]);
+    vi.mocked(forwardTurnSteeringStep).mockImplementationOnce(async () => steeringForwarded?.());
+    vi.mocked(forwardTurnDeliveryStep).mockImplementationOnce(async () => responseForwarded?.());
+    const deliveryHook = createDeliveryHook({
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: steeringDelivery })
+        .mockImplementation(() => new Promise(() => {})),
+    });
+    const buffered = [response];
+
+    await runReceiver(buffered, deliveryHook);
+
+    expect(forwardTurnDeliveryStep).toHaveBeenCalledWith({
+      inboxToken: "turn-inbox",
+      payload: { delivery: response, kind: "driver-delivery", requestId: "req-1" },
+    });
+    expect(buffered).toEqual([]);
+  });
+
   it("buffers queue input while the active turn continues", async () => {
     const delivery: DeliverHookPayload = {
       kind: "deliver",
@@ -273,8 +409,7 @@ function runReceiver(
   deliveryHook = createDeliveryHook(),
 ): ReturnType<TurnControlReceiver["waitForAction"]> {
   const receiver = new TurnControlReceiver({
-    bufferedDeliveries,
-    deliveryHook,
+    inputQueue: createInputQueue(bufferedDeliveries, deliveryHook),
     token: "turn-control",
   });
   return receiver.waitForAction().finally(() => receiver.dispose());
@@ -318,6 +453,37 @@ function createDeliveryHook(overrides: Partial<SessionDeliveryHook> = {}): Sessi
     next: vi.fn(() => new Promise<IteratorResult<HookPayload>>(() => {})),
     rekey: vi.fn(),
     ...overrides,
+  };
+}
+
+function createInputQueue(
+  buffered: DeliverHookPayload[],
+  deliveryHook: SessionDeliveryHook,
+): SessionInputQueue {
+  return {
+    appendQueued(delivery): void {
+      buffered.push(delivery);
+    },
+    consumeAdmission: () => deliveryHook.consumeNext(),
+    dispose: vi.fn(),
+    nextAdmission: () => deliveryHook.next(),
+    prependReturned(delivery): void {
+      buffered.unshift(delivery);
+    },
+    prependTurnRemainders(deliveries): void {
+      buffered.unshift(...deliveries);
+    },
+    rekey: (token) => deliveryHook.rekey(token),
+    returnSteering(delivery): void {
+      buffered.push({ ...delivery, turnPolicy: "queue" });
+    },
+    takeExplicitResponse(): DeliverHookPayload | undefined {
+      const index = buffered.findIndex((delivery) =>
+        delivery.payloads.some((payload) => (payload.inputResponses?.length ?? 0) > 0),
+      );
+      return index < 0 ? undefined : buffered.splice(index, 1)[0];
+    },
+    takeNextTurn: vi.fn(async () => null),
   };
 }
 

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -1,34 +1,37 @@
 import { createHook, type Hook } from "#compiled/@workflow/core/index.js";
 
-import type { DeliverHookPayload } from "#channel/types.js";
+import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.js";
 import { forwardTurnSteeringStep } from "#execution/forward-turn-steering-step.js";
 import { closeHookIterator, disposeHook } from "#execution/hook-ownership.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
-import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
+import type { SessionInputQueue } from "#execution/session-input-queue.js";
 import { rebuildSerializableError } from "#execution/workflow-errors.js";
 
 type DeliveryRequest = Extract<TurnControlPayload, { readonly kind: "turn-delivery-request" }>;
 
+interface OutstandingDelivery {
+  readonly delivery: DeliverHookPayload;
+  readonly requestId: string;
+}
+
 /** Owns one turn's driver-side control hook and public-delivery relay state. */
 export class TurnControlReceiver {
-  private readonly bufferedDeliveries: DeliverHookPayload[];
   private readonly control: Hook<TurnControlPayload>;
   private readonly controlIterator: AsyncIterator<TurnControlPayload>;
-  private readonly deliveryHook: SessionDeliveryHook;
-  private pendingControl: Promise<IteratorResult<TurnControlPayload>> | null = null;
+  private readonly inputQueue: SessionInputQueue;
+  private deliveryRequest: DeliveryRequest | undefined;
+  private outstandingDelivery: OutstandingDelivery | undefined;
+  private outstandingSteering: OutstandingDelivery | undefined;
+  private pendingControl: Promise<IteratorResult<TurnControlPayload>> | undefined;
   private steeringSequence = 0;
+  private steeringToken: string | undefined;
 
-  constructor(input: {
-    readonly bufferedDeliveries: DeliverHookPayload[];
-    readonly deliveryHook: SessionDeliveryHook;
-    readonly token: string;
-  }) {
-    this.bufferedDeliveries = input.bufferedDeliveries;
+  constructor(input: { readonly inputQueue: SessionInputQueue; readonly token: string }) {
     this.control = createHook<TurnControlPayload>({ token: input.token });
     this.controlIterator = this.control[Symbol.asyncIterator]();
-    this.deliveryHook = input.deliveryHook;
+    this.inputQueue = input.inputQueue;
   }
 
   /** Token passed to the turn workflow so it can publish control messages. */
@@ -42,218 +45,34 @@ export class TurnControlReceiver {
     await disposeHook(this.control);
   }
 
-  /** Services control messages until the active turn returns its terminal driver action. */
+  /** Services the active turn until it returns one terminal driver action. */
   async waitForAction(): Promise<NextDriverAction> {
     while (true) {
-      const payload = await this.nextControl(
-        "Turn control hook closed before delivering a result.",
-      );
-      if (payload.kind === "turn-steering-ready") {
-        return await this.waitForSteerableAction(payload.steeringToken);
-      }
-
-      const terminal = await this.handleControl(payload);
-      if (terminal !== undefined) return terminal;
-    }
-  }
-
-  private async waitForSteerableAction(steeringToken: string): Promise<NextDriverAction> {
-    while (true) {
-      const winner = await Promise.race([
-        this.getControlPromise().then((value) => ({ kind: "control" as const, value })),
-        this.deliveryHook.next().then((value) => ({ kind: "delivery" as const, value })),
-      ]);
-
-      if (winner.kind === "delivery") {
-        if (winner.value.done) {
-          throw new Error("Session delivery hook closed while a turn was active.");
-        }
-        const value = winner.value.value;
-        if (value.kind !== "deliver") {
-          this.deliveryHook.consumeNext();
-          continue;
-        }
-        if (value.turnPolicy !== "steer") {
-          this.deliveryHook.consumeNext();
-          this.bufferedDeliveries.push(value);
-          continue;
-        }
-
-        const terminal = await this.forwardSteering(value, steeringToken);
+      const event = await this.nextEvent();
+      if (event.kind === "control") {
+        const terminal = await this.handleControl(event.payload);
         if (terminal !== undefined) return terminal;
-        continue;
+      } else {
+        await this.handleAdmission(event.result);
       }
-
-      this.consumeControl();
-      if (winner.value.done) {
-        throw new Error("Turn control hook closed before delivering a result.");
-      }
-      const terminal = await this.handleControl(winner.value.value, steeringToken);
-      if (terminal !== undefined) return terminal;
     }
   }
 
-  private async handleControl(
-    payload: TurnControlPayload,
-    steeringToken?: string,
-  ): Promise<NextDriverAction | undefined> {
-    const terminal = this.readTerminalControl(payload);
-    if (terminal !== undefined) return terminal;
-
-    if (payload.kind === "turn-continuation-token") {
-      await this.deliveryHook.rekey(payload.continuationToken);
-      return undefined;
+  private canAdmitDelivery(): boolean {
+    if (this.outstandingDelivery !== undefined || this.outstandingSteering !== undefined) {
+      return false;
     }
-
-    if (payload.kind === "turn-delivery-request") {
-      return await this.serviceDeliveryRequest(payload, steeringToken);
-    }
-    return undefined;
-  }
-
-  private bufferTurnDeliveries(
-    payload: Extract<TurnControlPayload, { readonly kind: "turn-result" }>,
-  ): void {
-    if (payload.bufferedDeliveries !== undefined) {
-      this.bufferedDeliveries.unshift(...payload.bufferedDeliveries);
-    }
+    return this.steeringToken !== undefined || this.deliveryRequest !== undefined;
   }
 
   private consumeControl(): void {
-    this.pendingControl = null;
+    this.pendingControl = undefined;
   }
 
-  private getControlPromise(): Promise<IteratorResult<TurnControlPayload>> {
-    this.pendingControl ??= this.controlIterator.next();
-    return this.pendingControl;
-  }
+  private async forwardDelivery(delivery: DeliverHookPayload): Promise<void> {
+    const request = this.deliveryRequest;
+    if (request === undefined) return;
 
-  private async nextControl(
-    onClosed: string,
-  ): Promise<
-    Exclude<TurnControlPayload, { readonly kind: "turn-error" | "turn-continuation-token" }>
-  > {
-    while (true) {
-      const next = await this.getControlPromise();
-      this.consumeControl();
-      if (next.done) throw new Error(onClosed);
-      const payload = next.value;
-      if (payload.kind === "turn-error") throw rebuildSerializableError(payload.error);
-      if (payload.kind === "turn-continuation-token") {
-        await this.deliveryHook.rekey(payload.continuationToken);
-        continue;
-      }
-      return payload;
-    }
-  }
-
-  private readTerminalControl(payload: TurnControlPayload): NextDriverAction | undefined {
-    if (payload.kind === "turn-error") throw rebuildSerializableError(payload.error);
-    if (payload.kind !== "turn-result") return undefined;
-    this.bufferTurnDeliveries(payload);
-    return payload.action;
-  }
-
-  private async forwardSteering(
-    delivery: DeliverHookPayload,
-    steeringToken: string,
-  ): Promise<NextDriverAction | undefined> {
-    const requestId = `${this.control.token}:steer:${String(this.steeringSequence++)}`;
-    try {
-      await forwardTurnSteeringStep({
-        payload: { delivery, requestId },
-        steeringToken,
-      });
-    } catch (error) {
-      if (!(error instanceof Error && error.name === "HookNotFoundError")) throw error;
-      this.deliveryHook.consumeNext();
-      this.bufferedDeliveries.push({ ...delivery, turnPolicy: "queue" });
-      return undefined;
-    }
-
-    this.deliveryHook.consumeNext();
-    return await this.awaitForwardedSteering(requestId, delivery, steeringToken);
-  }
-
-  private async awaitForwardedSteering(
-    requestId: string,
-    outstanding: DeliverHookPayload,
-    steeringToken: string,
-  ): Promise<NextDriverAction | undefined> {
-    while (true) {
-      const payload = await this.nextControl(
-        "Turn control hook closed before resolving a steering delivery.",
-      );
-      if (payload.kind === "turn-steering-accepted" && payload.requestId === requestId) {
-        return undefined;
-      }
-      if (payload.kind === "turn-result") {
-        this.bufferedDeliveries.push({ ...outstanding, turnPolicy: "queue" });
-      }
-      const terminal = await this.handleControl(payload, steeringToken);
-      if (terminal !== undefined) return terminal;
-    }
-  }
-
-  private async serviceDeliveryRequest(
-    request: DeliveryRequest,
-    steeringToken?: string,
-  ): Promise<NextDriverAction | undefined> {
-    await this.deliveryHook.rekey(request.continuationToken);
-
-    // Only an explicitly addressed response may cross a request that was
-    // raised after the delivery was admitted. Freeform input already buffered
-    // for `queue` belongs to the next parent turn; input arriving after this
-    // request is armed may answer it below.
-    let delivery = takeExplicitInputResponse(this.bufferedDeliveries);
-    while (delivery === undefined) {
-      const winner = await Promise.race([
-        this.getControlPromise().then((value) => ({ kind: "control" as const, value })),
-        this.deliveryHook.next().then((value) => ({ kind: "delivery" as const, value })),
-      ]);
-
-      if (winner.kind === "control") {
-        this.consumeControl();
-        if (winner.value.done) {
-          throw new Error("Turn control hook closed during a delivery request.");
-        }
-        if (winner.value.value.kind === "turn-continuation-token") {
-          await this.deliveryHook.rekey(winner.value.value.continuationToken);
-          continue;
-        }
-        const terminal = this.readTerminalControl(winner.value.value);
-        if (terminal !== undefined) return terminal;
-        if (
-          winner.value.value.kind === "turn-delivery-cancelled" &&
-          winner.value.value.requestId === request.requestId
-        ) {
-          return undefined;
-        }
-        continue;
-      }
-
-      if (winner.value.done) {
-        throw new Error("Session delivery hook closed during a turn delivery request.");
-      }
-
-      const value = winner.value.value;
-      if (value.kind !== "deliver") {
-        this.deliveryHook.consumeNext();
-        continue;
-      }
-      if (value.turnPolicy === "steer" && steeringToken !== undefined) {
-        const terminal = await this.forwardSteering(value, steeringToken);
-        if (terminal !== undefined) return terminal;
-        continue;
-      }
-
-      this.deliveryHook.consumeNext();
-      delivery = value;
-    }
-
-    // Forwarding is provisional until the turn acknowledges it. If the inbox is
-    // already gone (the turn ended or was replaced), the turn's terminal or
-    // cancellation still re-buffers the delivery for the next parent turn.
     try {
       await forwardTurnDeliveryStep({
         inboxToken: request.inboxToken,
@@ -267,50 +86,166 @@ export class TurnControlReceiver {
       if (!(error instanceof Error && error.name === "HookNotFoundError")) throw error;
     }
 
-    return await this.awaitForwardedDelivery(request.requestId, delivery);
+    this.outstandingDelivery = { delivery, requestId: request.requestId };
   }
 
-  /**
-   * Waits for the active turn to resolve a forwarded delivery. The turn either
-   * accepts it (consumed) or releases it on cancellation or termination, in
-   * which case the delivery returns to the buffer ahead of the turn's own
-   * remainders so the next parent turn still observes it in arrival order.
-   */
-  private async awaitForwardedDelivery(
-    requestId: string,
-    outstanding: DeliverHookPayload,
-  ): Promise<NextDriverAction | undefined> {
-    while (true) {
-      const payload = await this.nextControl(
-        "Turn control hook closed before resolving a forwarded delivery.",
-      );
-
-      if (payload.kind === "turn-delivery-accepted") {
-        if (payload.requestId === requestId) return undefined;
-        continue;
-      }
-
-      if (payload.kind === "turn-delivery-cancelled" && payload.requestId === requestId) {
-        this.bufferedDeliveries.unshift(outstanding);
-        return undefined;
-      }
-
-      if (payload.kind === "turn-result") {
-        this.bufferedDeliveries.unshift(outstanding);
-      }
-
-      const terminal = this.readTerminalControl(payload);
-      if (terminal !== undefined) return terminal;
+  private async forwardBufferedResponse(): Promise<void> {
+    if (
+      this.deliveryRequest === undefined ||
+      this.outstandingDelivery !== undefined ||
+      this.outstandingSteering !== undefined
+    ) {
+      return;
     }
-  }
-}
 
-function takeExplicitInputResponse(
-  deliveries: DeliverHookPayload[],
-): DeliverHookPayload | undefined {
-  const index = deliveries.findIndex((delivery) =>
-    delivery.payloads.some((payload) => (payload.inputResponses?.length ?? 0) > 0),
-  );
-  if (index < 0) return undefined;
-  return deliveries.splice(index, 1)[0];
+    const buffered = this.inputQueue.takeExplicitResponse();
+    if (buffered !== undefined) await this.forwardDelivery(buffered);
+  }
+
+  private async forwardSteering(delivery: DeliverHookPayload): Promise<void> {
+    const steeringToken = this.steeringToken;
+    if (steeringToken === undefined) return;
+
+    const requestId = `${this.control.token}:steer:${String(this.steeringSequence++)}`;
+    try {
+      await forwardTurnSteeringStep({
+        payload: { delivery, requestId },
+        steeringToken,
+      });
+    } catch (error) {
+      if (!(error instanceof Error && error.name === "HookNotFoundError")) throw error;
+      this.inputQueue.consumeAdmission();
+      this.inputQueue.returnSteering(delivery);
+      return;
+    }
+
+    this.inputQueue.consumeAdmission();
+    this.outstandingSteering = { delivery, requestId };
+  }
+
+  private getControlPromise(): Promise<IteratorResult<TurnControlPayload>> {
+    this.pendingControl ??= this.controlIterator.next();
+    return this.pendingControl;
+  }
+
+  private async handleAdmission(result: IteratorResult<HookPayload>): Promise<void> {
+    if (result.done) {
+      throw new Error("Session delivery hook closed while a turn was active.");
+    }
+
+    const delivery = result.value;
+    if (delivery.kind !== "deliver") {
+      this.inputQueue.consumeAdmission();
+      return;
+    }
+
+    if (delivery.turnPolicy === "steer" && this.steeringToken !== undefined) {
+      await this.forwardSteering(delivery);
+      return;
+    }
+
+    if (this.deliveryRequest !== undefined) {
+      this.inputQueue.consumeAdmission();
+      await this.forwardDelivery(delivery);
+      return;
+    }
+
+    this.inputQueue.consumeAdmission();
+    this.inputQueue.appendQueued(delivery);
+  }
+
+  private async handleControl(payload: TurnControlPayload): Promise<NextDriverAction | undefined> {
+    if (payload.kind === "turn-error") {
+      throw rebuildSerializableError(payload.error);
+    }
+
+    if (payload.kind === "turn-result") {
+      if (this.outstandingDelivery !== undefined) {
+        this.inputQueue.prependReturned(this.outstandingDelivery.delivery);
+      }
+      if (this.outstandingSteering !== undefined) {
+        this.inputQueue.returnSteering(this.outstandingSteering.delivery);
+      }
+      if (payload.bufferedDeliveries !== undefined) {
+        this.inputQueue.prependTurnRemainders(payload.bufferedDeliveries);
+      }
+      this.deliveryRequest = undefined;
+      this.outstandingDelivery = undefined;
+      this.outstandingSteering = undefined;
+      return payload.action;
+    }
+
+    if (payload.kind === "turn-continuation-token") {
+      await this.inputQueue.rekey(payload.continuationToken);
+      return undefined;
+    }
+
+    if (payload.kind === "turn-steering-ready") {
+      this.steeringToken = payload.steeringToken;
+      return undefined;
+    }
+
+    if (payload.kind === "turn-steering-accepted") {
+      if (payload.requestId === this.outstandingSteering?.requestId) {
+        this.outstandingSteering = undefined;
+        await this.forwardBufferedResponse();
+      }
+      return undefined;
+    }
+
+    if (payload.kind === "turn-delivery-request") {
+      this.deliveryRequest = payload;
+      await this.inputQueue.rekey(payload.continuationToken);
+      await this.forwardBufferedResponse();
+      return undefined;
+    }
+
+    if (payload.kind === "turn-delivery-accepted") {
+      if (payload.requestId === this.outstandingDelivery?.requestId) {
+        this.deliveryRequest = undefined;
+        this.outstandingDelivery = undefined;
+      }
+      return undefined;
+    }
+
+    if (
+      payload.kind === "turn-delivery-cancelled" &&
+      payload.requestId === this.deliveryRequest?.requestId
+    ) {
+      if (payload.requestId === this.outstandingDelivery?.requestId) {
+        this.inputQueue.prependReturned(this.outstandingDelivery.delivery);
+        this.outstandingDelivery = undefined;
+      }
+      this.deliveryRequest = undefined;
+    }
+
+    return undefined;
+  }
+
+  private async nextEvent(): Promise<
+    | { readonly kind: "control"; readonly payload: TurnControlPayload }
+    | { readonly kind: "delivery"; readonly result: IteratorResult<HookPayload> }
+  > {
+    const control = this.getControlPromise().then((result) => ({
+      kind: "control" as const,
+      result,
+    }));
+    const winner = this.canAdmitDelivery()
+      ? await Promise.race([
+          control,
+          this.inputQueue.nextAdmission().then((result) => ({
+            kind: "delivery" as const,
+            result,
+          })),
+        ])
+      : await control;
+
+    if (winner.kind === "delivery") return winner;
+
+    this.consumeControl();
+    if (winner.result.done) {
+      throw new Error("Turn control hook closed before delivering a result.");
+    }
+    return { kind: "control", payload: winner.result.value };
+  }
 }

--- a/packages/eve/src/execution/turn-dispatch.test.ts
+++ b/packages/eve/src/execution/turn-dispatch.test.ts
@@ -4,6 +4,7 @@ import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.js";
 import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
+import type { SessionInputQueue } from "#execution/session-input-queue.js";
 import { dispatchAndAwaitTurn } from "#execution/turn-dispatch.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 
@@ -40,10 +41,9 @@ describe("dispatchAndAwaitTurn", () => {
     const deliveryHook = createDeliveryHook({ rekey: rekeyHook });
 
     await dispatchAndAwaitTurn({
-      bufferedDeliveries: [],
       controlToken: "turn-control",
       delivery: { kind: "deliver", payloads: [{ message: "start" }] },
-      deliveryHook,
+      inputQueue: createInputQueue([], deliveryHook),
       mode: "conversation",
       parentWritable: new WritableStream<Uint8Array>(),
       serializedContext: {},
@@ -73,10 +73,9 @@ describe("dispatchAndAwaitTurn", () => {
     const deliveryHook = createDeliveryHook({ rekey: rekeyHook });
 
     await dispatchAndAwaitTurn({
-      bufferedDeliveries: [],
       controlToken: "turn-control",
       delivery: { kind: "deliver", payloads: [{ message: "start" }] },
-      deliveryHook,
+      inputQueue: createInputQueue([], deliveryHook),
       mode: "conversation",
       parentWritable: new WritableStream<Uint8Array>(),
       serializedContext: {},
@@ -128,16 +127,16 @@ describe("dispatchAndAwaitTurn", () => {
     );
 
     const bufferedDeliveries: DeliverHookPayload[] = [];
+    const deliveryHook = createDeliveryHook({
+      next: async () => ({
+        done: false,
+        value: { kind: "deliver", payloads: [{ message: "later delivery" }] },
+      }),
+    });
     await dispatchAndAwaitTurn({
-      bufferedDeliveries,
       controlToken: "turn-control",
       delivery: { kind: "deliver", payloads: [{ message: "start" }] },
-      deliveryHook: createDeliveryHook({
-        next: async () => ({
-          done: false,
-          value: { kind: "deliver", payloads: [{ message: "later delivery" }] },
-        }),
-      }),
+      inputQueue: createInputQueue(bufferedDeliveries, deliveryHook),
       mode: "conversation",
       parentWritable: new WritableStream<Uint8Array>(),
       serializedContext: {},
@@ -174,10 +173,9 @@ describe("dispatchAndAwaitTurn", () => {
 
     const bufferedDeliveries: DeliverHookPayload[] = [delivery];
     const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries,
       controlToken: "turn-control",
       delivery: { kind: "deliver", payloads: [{ message: "start" }] },
-      deliveryHook: createDeliveryHook(),
+      inputQueue: createInputQueue(bufferedDeliveries, createDeliveryHook()),
       mode: "conversation",
       parentWritable: new WritableStream<Uint8Array>(),
       serializedContext: {},
@@ -199,10 +197,9 @@ describe("dispatchAndAwaitTurn", () => {
     ]);
 
     const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries: [],
       controlToken: "turn-control",
       delivery: { kind: "deliver", payloads: [{ message: "start" }] },
-      deliveryHook: createDeliveryHook(),
+      inputQueue: createInputQueue([], createDeliveryHook()),
       mode: "conversation",
       parentWritable: new WritableStream<Uint8Array>(),
       serializedContext: {},
@@ -224,6 +221,37 @@ function createDeliveryHook(overrides: Partial<SessionDeliveryHook> = {}): Sessi
     next: vi.fn(() => new Promise<IteratorResult<HookPayload>>(() => {})),
     rekey: vi.fn(),
     ...overrides,
+  };
+}
+
+function createInputQueue(
+  buffered: DeliverHookPayload[],
+  deliveryHook: SessionDeliveryHook,
+): SessionInputQueue {
+  return {
+    appendQueued(delivery): void {
+      buffered.push(delivery);
+    },
+    consumeAdmission: () => deliveryHook.consumeNext(),
+    dispose: vi.fn(),
+    nextAdmission: () => deliveryHook.next(),
+    prependReturned(delivery): void {
+      buffered.unshift(delivery);
+    },
+    prependTurnRemainders(deliveries): void {
+      buffered.unshift(...deliveries);
+    },
+    rekey: (token) => deliveryHook.rekey(token),
+    returnSteering(delivery): void {
+      buffered.push({ ...delivery, turnPolicy: "queue" });
+    },
+    takeExplicitResponse(): DeliverHookPayload | undefined {
+      const index = buffered.findIndex((delivery) =>
+        delivery.payloads.some((payload) => (payload.inputResponses?.length ?? 0) > 0),
+      );
+      return index < 0 ? undefined : buffered.splice(index, 1)[0];
+    },
+    takeNextTurn: vi.fn(async () => null),
   };
 }
 

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -1,8 +1,8 @@
-import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
+import type { HookPayload, SessionCapabilities } from "#channel/types.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
-import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
+import type { SessionInputQueue } from "#execution/session-input-queue.js";
 import { dispatchTurnStep } from "#execution/workflow-steps.js";
 import type { RunMode } from "#shared/run-mode.js";
 
@@ -22,19 +22,17 @@ export interface DispatchedTurn {
 
 /** Dispatches one turn and services its private-inbox control protocol until it terminates. */
 export async function dispatchAndAwaitTurn(input: {
-  readonly bufferedDeliveries: DeliverHookPayload[];
   readonly capabilities?: SessionCapabilities;
   readonly controlToken: string;
   readonly delivery: HookPayload;
-  readonly deliveryHook: SessionDeliveryHook;
+  readonly inputQueue: SessionInputQueue;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<DispatchedTurn> {
   const control = new TurnControlReceiver({
-    bufferedDeliveries: input.bufferedDeliveries,
-    deliveryHook: input.deliveryHook,
+    inputQueue: input.inputQueue,
     token: input.controlToken,
   });
 

--- a/packages/eve/src/execution/turn-execution-cursor.ts
+++ b/packages/eve/src/execution/turn-execution-cursor.ts
@@ -4,6 +4,7 @@ import { sendTurnControlStep } from "#execution/turn-control-protocol.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { TurnStepInput } from "#execution/durable-session-migrations/turn-workflow.js";
 import type { TokenUsage } from "#shared/token-usage.js";
+import type { TurnSteeringState } from "#harness/types.js";
 
 interface TurnTransition {
   readonly serializedContext?: Record<string, unknown>;
@@ -70,7 +71,7 @@ export class TurnExecutionCursor {
   createStepInput(
     input: HookPayload | undefined,
     abortSignal?: AbortSignal,
-    steerSignal?: AbortSignal,
+    steering?: TurnSteeringState,
   ): TurnStepInput {
     return {
       abortSignal,
@@ -78,7 +79,7 @@ export class TurnExecutionCursor {
       parentWritable: this.parentWritable,
       serializedContext: this.currentSerializedContext,
       sessionState: this.currentSessionState,
-      steerSignal,
+      steering,
     };
   }
 

--- a/packages/eve/src/execution/turn-hook-inbox.test.ts
+++ b/packages/eve/src/execution/turn-hook-inbox.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTurnHookInbox } from "#execution/turn-hook-inbox.js";
+
+const createHookMock = vi.fn();
+
+vi.mock("#compiled/@workflow/core/index.js", () => ({
+  createHook: (...args: unknown[]) => createHookMock(...args),
+}));
+
+describe("createTurnHookInbox", () => {
+  afterEach(() => {
+    createHookMock.mockReset();
+  });
+
+  it("creates the iterator before claiming ownership", async () => {
+    const order: string[] = [];
+    createHookMock.mockReturnValue({
+      token: "turn:signal",
+      dispose: vi.fn(),
+      getConflict: vi.fn(async () => {
+        order.push("claim");
+        return null;
+      }),
+      [Symbol.asyncIterator]() {
+        order.push("iterator");
+        return { next: vi.fn(() => new Promise(() => {})) };
+      },
+    });
+
+    await createTurnHookInbox({ conflict: "throw", token: "turn:signal" });
+
+    expect(order).toEqual(["iterator", "claim"]);
+  });
+
+  it("returns undefined for a tolerated ownership conflict", async () => {
+    const dispose = vi.fn();
+    createHookMock.mockReturnValue({
+      token: "session:cancel",
+      dispose,
+      getConflict: vi.fn(async () => ({ runId: "stale-run" })),
+      [Symbol.asyncIterator]() {
+        return { next: vi.fn(() => new Promise(() => {})) };
+      },
+    });
+
+    await expect(
+      createTurnHookInbox({ conflict: "return-undefined", token: "session:cancel" }),
+    ).resolves.toBeUndefined();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("throws an ownership conflict when the token must be unique", async () => {
+    createHookMock.mockReturnValue({
+      token: "turn:steer",
+      dispose: vi.fn(),
+      getConflict: vi.fn(async () => ({ runId: "owner" })),
+      [Symbol.asyncIterator]() {
+        return { next: vi.fn(() => new Promise(() => {})) };
+      },
+    });
+
+    await expect(
+      createTurnHookInbox({ conflict: "throw", token: "turn:steer" }),
+    ).rejects.toMatchObject({ name: "HookConflictError" });
+  });
+
+  it("shares one pending durable read and rearms after it resolves", async () => {
+    const next = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false, value: "first" })
+      .mockResolvedValueOnce({ done: false, value: "second" });
+    createHookMock.mockReturnValue({
+      token: "turn:signal",
+      dispose: vi.fn(),
+      getConflict: vi.fn(async () => null),
+      [Symbol.asyncIterator]() {
+        return { next };
+      },
+    });
+    const inbox = await createTurnHookInbox<string>({
+      conflict: "throw",
+      token: "turn:signal",
+    });
+
+    const first = inbox.next();
+    expect(inbox.next()).toBe(first);
+    await expect(first).resolves.toBe("first");
+    await expect(inbox.next()).resolves.toBe("second");
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it("disposes idempotently without closing the iterator", async () => {
+    const dispose = vi.fn();
+    const close = vi.fn();
+    createHookMock.mockReturnValue({
+      token: "turn:signal",
+      dispose,
+      getConflict: vi.fn(async () => null),
+      [Symbol.asyncIterator]() {
+        return { next: vi.fn(() => new Promise(() => {})), return: close };
+      },
+    });
+    const inbox = await createTurnHookInbox({ conflict: "throw", token: "turn:signal" });
+
+    await inbox.dispose();
+    await inbox.dispose();
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/execution/turn-hook-inbox.ts
+++ b/packages/eve/src/execution/turn-hook-inbox.ts
@@ -1,0 +1,62 @@
+import { createHook } from "#compiled/@workflow/core/index.js";
+
+import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
+
+/** Owns one replay-safe durable hook read at a time for an active turn. */
+export interface TurnHookInbox<T> {
+  readonly token: string;
+  next(): Promise<T>;
+  dispose(): Promise<void>;
+}
+
+export async function createTurnHookInbox<T>(input: {
+  readonly conflict: "throw";
+  readonly token: string;
+}): Promise<TurnHookInbox<T>>;
+export async function createTurnHookInbox<T>(input: {
+  readonly conflict: "return-undefined";
+  readonly token: string;
+}): Promise<TurnHookInbox<T> | undefined>;
+export async function createTurnHookInbox<T>(input: {
+  readonly conflict: "return-undefined" | "throw";
+  readonly token: string;
+}): Promise<TurnHookInbox<T> | undefined> {
+  const hook = createHook<T>({ token: input.token });
+  // Hook promises and iterators share one durable cursor. Create the iterator
+  // before claiming so conflict replay is consumed by getConflict(), not by a
+  // later data read.
+  const iterator = hook[Symbol.asyncIterator]();
+
+  try {
+    await claimHookOwnership(hook);
+  } catch (error) {
+    if (input.conflict === "return-undefined" && isHookConflictError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+
+  let disposed = false;
+  let pending: Promise<T> | undefined;
+
+  return {
+    token: hook.token,
+    next(): Promise<T> {
+      pending ??= iterator.next().then((result) => {
+        pending = undefined;
+        if (result.done) return new Promise<never>(() => {});
+        return result.value;
+      });
+      // Losing Promise.race arms may be abandoned during turn teardown.
+      pending.catch(() => {});
+      return pending;
+    },
+    async dispose(): Promise<void> {
+      if (disposed) return;
+      disposed = true;
+      // Never call iterator.return(): it waits for a pending durable read and
+      // can leave the workflow run alive indefinitely.
+      await disposeHook(hook);
+    },
+  };
+}

--- a/packages/eve/src/execution/turn-steering-control.ts
+++ b/packages/eve/src/execution/turn-steering-control.ts
@@ -1,22 +1,18 @@
-import { createHook } from "#compiled/@workflow/core/index.js";
-
 import type { TurnSteeringPayload } from "#execution/turn-control-protocol.js";
-import { claimHookOwnership, disposeHook } from "#execution/hook-ownership.js";
+import { createTurnHookInbox } from "#execution/turn-hook-inbox.js";
 
 /** Owns the active turn's durable steering inbox and step-boundary signal. */
 export interface TurnSteeringControl {
   readonly requested: Promise<TurnSteeringPayload>;
   readonly signal: AbortSignal;
   readonly token: string;
-  accept(options?: { readonly rearm?: boolean }): Promise<TurnSteeringPayload>;
+  accept(): Promise<TurnSteeringPayload>;
   dispose(): Promise<void>;
 }
 
 /** Creates the private, single-flight steering inbox for one active turn. */
 export async function createTurnSteeringControl(token: string): Promise<TurnSteeringControl> {
-  const hook = createHook<TurnSteeringPayload>({ token });
-  const iterator = hook[Symbol.asyncIterator]();
-  await claimHookOwnership(hook);
+  const inbox = await createTurnHookInbox<TurnSteeringPayload>({ conflict: "throw", token });
 
   let controller: AbortController;
   let requested: Promise<TurnSteeringPayload>;
@@ -24,12 +20,10 @@ export async function createTurnSteeringControl(token: string): Promise<TurnStee
 
   const arm = (): void => {
     controller = new AbortController();
-    requested = iterator.next().then((next) => {
-      if (next.done) return new Promise<never>(() => {});
+    requested = inbox.next().then((value) => {
       controller.abort();
-      return next.value;
+      return value;
     });
-    requested.catch(() => {});
   };
   arm();
 
@@ -40,16 +34,16 @@ export async function createTurnSteeringControl(token: string): Promise<TurnStee
     get signal() {
       return controller.signal;
     },
-    token: hook.token,
-    async accept(options) {
+    token: inbox.token,
+    async accept() {
       const value = await requested;
-      if (options?.rearm !== false) arm();
+      arm();
       return value;
     },
     async dispose() {
       if (disposed) return;
       disposed = true;
-      await disposeHook(hook);
+      await inbox.dispose();
     },
   };
 }

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -186,7 +186,10 @@ describe("turnWorkflow", () => {
 
     await turnWorkflow(input);
 
-    expect(vi.mocked(turnStep).mock.calls[0]?.[0].steerSignal?.aborted).toBe(true);
+    expect(vi.mocked(turnStep).mock.calls[0]?.[0].steering).toMatchObject({
+      pending: false,
+      signal: expect.objectContaining({ aborted: true }),
+    });
     expect(vi.mocked(turnStep).mock.calls[1]?.[0].input).toEqual(steeringDelivery);
     expect(resumeHookMock).toHaveBeenCalledWith("turn-token", {
       kind: "turn-steering-ready",
@@ -196,6 +199,63 @@ describe("turnWorkflow", () => {
       kind: "turn-steering-accepted",
       requestId: "steer-1",
     });
+  });
+
+  it("does not acknowledge steering that commits during terminal teardown", async () => {
+    const activeState = createSessionState({
+      emissionState: { sequence: 0, sessionStarted: true, stepIndex: 1, turnId: "turn_0" },
+    });
+    const steeringDelivery = {
+      kind: "deliver",
+      payloads: [{ message: "change course" }],
+      turnPolicy: "steer",
+    } as const;
+    const inbox = createInboxMock([]);
+    let resolveSteering:
+      | ((value: IteratorResult<{ delivery: typeof steeringDelivery; requestId: string }>) => void)
+      | undefined;
+    const pendingSteering = new Promise<
+      IteratorResult<{ delivery: typeof steeringDelivery; requestId: string }>
+    >((resolve) => {
+      resolveSteering = resolve;
+    });
+    const steeringHook = {
+      token: "turn-token:steer",
+      getConflict: vi.fn(async () => null),
+      dispose: vi.fn(async () => {
+        resolveSteering?.({
+          done: false,
+          value: { delivery: steeringDelivery, requestId: "steer-raced-terminal" },
+        });
+      }),
+      [Symbol.asyncIterator]() {
+        return { next: vi.fn(() => pendingSteering) };
+      },
+    };
+    createHookMock.mockImplementation((input: { token: string }) =>
+      input.token.endsWith(":steer") ? steeringHook : inbox.hook,
+    );
+    vi.mocked(turnStep).mockResolvedValueOnce({
+      action: "done",
+      output: "finished first",
+      serializedContext: { state: "done" },
+      sessionState: activeState,
+    });
+    const { input } = createInput({
+      driverCapabilities: { steering: true, turnInbox: true },
+      sessionState: activeState,
+    });
+
+    await turnWorkflow(input);
+
+    expect(resumeHookMock).not.toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({ kind: "turn-steering-accepted" }),
+    );
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({ bufferedDeliveries: undefined, kind: "turn-result" }),
+    );
   });
 
   it("parks when an authorization is pending", async () => {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -117,13 +117,13 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
     }
 
     while (true) {
-      const forcedSteering = pendingSteering.length === 0 ? undefined : new AbortController();
-      forcedSteering?.abort();
       const result = await turnStep(
         cursor.createStepInput(
           nextStepInput,
           cancellation?.signal,
-          forcedSteering?.signal ?? steering?.signal,
+          steering === undefined
+            ? undefined
+            : { pending: pendingSteering.length > 0, signal: steering.signal },
         ),
       );
 
@@ -139,7 +139,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
         // epilogue runs in the driver (`settleCancelledTurnStep`), not as
         // a step in this run, where queued cancel wakes could re-dispatch
         // it.
-        await settleSteeringAtTerminal(steering, cursor, bufferedDeliveries, pendingSteering);
+        await settleSteeringAtTerminal(steering, bufferedDeliveries, pendingSteering);
         await cancelDescendantTurnsStep({
           serializedContext: cursor.serializedContext,
           sessionState: cursor.sessionState,
@@ -154,7 +154,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
       }
 
       if (result.action === "done") {
-        await settleSteeringAtTerminal(steering, cursor, bufferedDeliveries, pendingSteering);
+        await settleSteeringAtTerminal(steering, bufferedDeliveries, pendingSteering);
         await cancellation?.dispose();
         await cursor.finish(
           result,
@@ -228,7 +228,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
 
         if (!canPark) throw new Error(TASK_MODE_WAIT_ERROR_MESSAGE);
 
-        await settleSteeringAtTerminal(steering, cursor, bufferedDeliveries, pendingSteering);
+        await settleSteeringAtTerminal(steering, bufferedDeliveries, pendingSteering);
         await cancellation?.dispose();
         await cursor.finish(
           result,
@@ -408,21 +408,12 @@ function takePendingSteering(deliveries: DeliverHookPayload[]): DeliverHookPaylo
 
 async function settleSteeringAtTerminal(
   steering: TurnSteeringControl | undefined,
-  cursor: TurnExecutionCursor,
   bufferedDeliveries: DeliverHookPayload[],
   pendingSteering: DeliverHookPayload[],
 ): Promise<void> {
-  if (steering !== undefined) {
-    await steering.dispose();
-    await Promise.resolve();
-    if (steering.signal.aborted) {
-      const accepted = await steering.accept({ rearm: false });
-      await cursor.send({ kind: "turn-steering-accepted", requestId: accepted.requestId });
-      pendingSteering.push(accepted.delivery);
-    }
-  }
+  await steering?.dispose();
   if (pendingSteering.length > 0) {
-    bufferedDeliveries.push({ ...takePendingSteering(pendingSteering), turnPolicy: "queue" });
+    bufferedDeliveries.push(takePendingSteering(pendingSteering));
   }
 }
 

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -1,13 +1,6 @@
 import { createHook, getWorkflowMetadata, getWritable } from "#compiled/@workflow/core/index.js";
 
-import type {
-  DeliverHookPayload,
-  DeliverPayload,
-  HookPayload,
-  RunInput,
-  SessionCapabilities,
-} from "#channel/types.js";
-import { coalesceDeliveries } from "#harness/messages.js";
+import type { DeliverPayload, HookPayload, RunInput, SessionCapabilities } from "#channel/types.js";
 import { readChannelRequestId, readRootSessionId } from "#execution/eve-workflow-attributes.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { DurableCompiledArtifactsSource } from "#runtime/durable-compiled-artifacts-source.js";
@@ -26,10 +19,7 @@ import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.j
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
 import { fireSessionCallbackStep } from "#execution/session-callback-step.js";
 import { disposeHook } from "#execution/hook-ownership.js";
-import {
-  createSessionDeliveryHook,
-  type SessionDeliveryHook,
-} from "#execution/session-delivery-hook.js";
+import { createSessionInputQueue } from "#execution/session-input-queue.js";
 import { readSerializedSubagentDepth } from "#harness/subagent-depth.js";
 
 // workflow-entry.ts is the durable workflow body — the bundler rejects
@@ -165,8 +155,7 @@ async function runDriverLoop(input: {
   const nextTurnControlToken = (): string =>
     `${input.sessionState.sessionId}:turn-control:${String(turnDispatchIndex++)}`;
 
-  const bufferedDeliveries: DeliverHookPayload[] = [];
-  const deliveryHook = createSessionDeliveryHook(bufferedDeliveries);
+  const inputQueue = createSessionInputQueue();
 
   // Control-hook disposal is deferred one turn — see DispatchedTurn.
   let disposeSettledTurnControl: (() => Promise<void>) | undefined;
@@ -176,11 +165,10 @@ async function runDriverLoop(input: {
     readonly sessionState: DurableSessionState;
   }): Promise<NextDriverAction> => {
     const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries,
       capabilities: input.capabilities,
       controlToken: nextTurnControlToken(),
       delivery: args.delivery,
-      deliveryHook,
+      inputQueue,
       mode: input.mode,
       parentWritable: input.driverWritable,
       serializedContext: args.serializedContext,
@@ -193,7 +181,7 @@ async function runDriverLoop(input: {
 
   try {
     if (input.sessionState.continuationToken) {
-      await deliveryHook.rekey(input.sessionState.continuationToken);
+      await inputQueue.rekey(input.sessionState.continuationToken);
     }
 
     let action: NextDriverAction = await runTurn({
@@ -241,7 +229,7 @@ async function runDriverLoop(input: {
 
       // Rekey to the parked turn's continuation token before awaiting the next
       // delivery — covers both the first turn's anchor and any later rekey.
-      await deliveryHook.rekey(action.sessionState.continuationToken);
+      await inputQueue.rekey(action.sessionState.continuationToken);
 
       if (action.authorizationNames && action.authorizationNames.length > 0) {
         const expected = action.authorizationNames.length;
@@ -266,10 +254,7 @@ async function runDriverLoop(input: {
         continue;
       }
 
-      const nextDeliver = await waitForNextDeliver({
-        bufferedDeliveries,
-        deliveryHook,
-      });
+      const nextDeliver = await inputQueue.takeNextTurn();
 
       if (nextDeliver === null) {
         return { output: "" };
@@ -300,7 +285,7 @@ async function runDriverLoop(input: {
     }
   } finally {
     await disposeSettledTurnControl?.();
-    await deliveryHook.dispose();
+    await inputQueue.dispose();
     // Dispose without closing the iterator: a session cancelled while
     // awaiting authorization can leave a durable read in flight, and an
     // async iterator only honors `return()` after that read settles.
@@ -330,57 +315,4 @@ async function finalizeDone(input: {
     usage: failed ? undefined : input.action.usage,
   });
   return { output };
-}
-
-async function waitForNextDeliver(input: {
-  readonly bufferedDeliveries: DeliverHookPayload[];
-  readonly deliveryHook: SessionDeliveryHook;
-}): Promise<DeliverHookPayload | null> {
-  if (input.bufferedDeliveries.length > 0) {
-    return coalesceDeliveries(input.bufferedDeliveries.splice(0));
-  }
-
-  while (true) {
-    const first = await input.deliveryHook.next();
-    input.deliveryHook.consumeNext();
-
-    if (first.done) {
-      return null;
-    }
-
-    if (first.value.kind !== "deliver") {
-      continue;
-    }
-
-    let coalesced = first.value;
-
-    while (true) {
-      const ready = await takeReadyPayload(input.deliveryHook.next());
-
-      if (ready === NO_READY_MESSAGE) {
-        break;
-      }
-
-      input.deliveryHook.consumeNext();
-
-      if (ready.done) {
-        break;
-      }
-
-      if (ready.value.kind !== "deliver") {
-        continue;
-      }
-
-      coalesced = coalesceDeliveries([coalesced, ready.value]);
-    }
-
-    return coalesced;
-  }
-}
-
-const NO_READY_MESSAGE = Symbol("no-ready-message");
-
-async function takeReadyPayload<T>(promise: Promise<T>): Promise<T | typeof NO_READY_MESSAGE> {
-  await Promise.resolve();
-  return await Promise.race([promise, Promise.resolve(NO_READY_MESSAGE)]);
 }

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -370,7 +370,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
             nodeId: bundle.nodeId,
           },
           node: bundle.graph.root,
-          steerSignal: input.steerSignal,
+          steering: input.steering,
           workflowMaxSubagents: refreshedSession.workflowMaxSubagents,
         });
         return step(refreshedSession, stepInput);

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -580,7 +580,9 @@ describe("createToolLoopHarness", () => {
     controller.abort();
     const { emit, events } = createEventCollector();
     const runStep = createToolLoopHarness(
-      createTestConfig("conversation", emit, { steerSignal: controller.signal }),
+      createTestConfig("conversation", emit, {
+        steering: { pending: false, signal: controller.signal },
+      }),
     );
     const session = setHarnessEmissionState(createTestSession(), {
       sequence: 0,
@@ -602,6 +604,31 @@ describe("createToolLoopHarness", () => {
     });
     expect(events.filter((event) => event.type === "message.received")).toHaveLength(1);
     expect(events.some((event) => event.type === "turn.started")).toBe(false);
+    expect(events.some((event) => event.type === "turn.completed")).toBe(false);
+  });
+
+  it("continues when steering was already pending before the step", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "old direction", role: "assistant" }] },
+      text: "old direction",
+      toolCalls: [],
+      toolResults: [],
+    });
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, { steering: { pending: true } }),
+    );
+    const session = setHarnessEmissionState(createTestSession(), {
+      sequence: 0,
+      sessionStarted: true,
+      stepIndex: 1,
+      turnId: "turn_0",
+    });
+
+    const result = await runStep(session, { message: "runtime result" });
+
+    expect(typeof result.next).toBe("function");
     expect(events.some((event) => event.type === "turn.completed")).toBe(false);
   });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1290,6 +1290,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
   return runStep;
 }
 
+function hasPendingSteering(steering: ToolLoopHarnessConfig["steering"]): boolean {
+  return steering?.pending === true || steering?.signal?.aborted === true;
+}
+
 function extractTokenUsageDelta(input: {
   readonly costUsd: number | undefined;
   readonly usage: HarnessStepResult["usage"] | undefined;
@@ -1925,7 +1929,7 @@ async function handleStepResult(input: {
         }),
       );
 
-      if (config.mode === "conversation" && config.steerSignal?.aborted !== true) {
+      if (config.mode === "conversation" && !hasPendingSteering(config.steering)) {
         emissionState = await emitTurnEpilogue(
           emit,
           emissionState,
@@ -1937,7 +1941,7 @@ async function handleStepResult(input: {
     }
 
     return {
-      next: config.steerSignal?.aborted === true ? runStep : null,
+      next: hasPendingSteering(config.steering) ? runStep : null,
       session: parkedSession,
     };
   }
@@ -1998,7 +2002,7 @@ async function handleStepResult(input: {
     (continuationMessages.at(-1)?.role === "tool" ||
       normalizedProviderHistory.outcomeEndsResponse ||
       hasDeferredStepInput(nextSession) ||
-      config.steerSignal?.aborted === true);
+      hasPendingSteering(config.steering));
   if (continueLoop) {
     if (emit) {
       emissionState = advanceStep(emissionState);

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -214,14 +214,22 @@ export type HandleEventFn = (
   messages?: readonly import("ai").ModelMessage[],
 ) => Promise<void>;
 
+/** Steering state observed by one active harness step. */
+export interface TurnSteeringState {
+  /** True when replacement input was already accepted before the step began. */
+  readonly pending: boolean;
+  /** Aborts when replacement input arrives while the step is running. */
+  readonly signal?: AbortSignal;
+}
+
 /**
  * Dependencies injected into the tool-loop harness at construction time.
  */
 export interface ToolLoopHarnessConfig {
   /** Cancellation signal for the active turn. */
   readonly abortSignal?: AbortSignal;
-  /** Signals that replacement input must be consumed before the turn settles. */
-  readonly steerSignal?: AbortSignal;
+  /** Prevents settlement while replacement input is waiting. */
+  readonly steering?: TurnSteeringState;
   /**
    * Session-level capabilities. The harness reads
    * {@link SessionCapabilities.requestInput} when assembling the

--- a/packages/eve/src/internal/testing/session-delivery-hook-workflow.ts
+++ b/packages/eve/src/internal/testing/session-delivery-hook-workflow.ts
@@ -1,8 +1,5 @@
 import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
-import {
-  createSessionDeliveryHook,
-  type SessionDeliveryHook,
-} from "#execution/session-delivery-hook.js";
+import { createSessionInputQueue, type SessionInputQueue } from "#execution/session-input-queue.js";
 
 export async function sessionDeliveryHookWorkflow(input: {
   readonly nextToken: string;
@@ -10,39 +7,34 @@ export async function sessionDeliveryHookWorkflow(input: {
 }): Promise<string[]> {
   "use workflow";
 
-  const bufferedDeliveries: DeliverHookPayload[] = [];
-  const deliveryHook = createSessionDeliveryHook(bufferedDeliveries);
+  const inputQueue = createSessionInputQueue();
 
   try {
-    await deliveryHook.rekey(input.token);
-    const pendingDelivery = deliveryHook.next();
-    await deliveryHook.rekey(input.nextToken);
+    await inputQueue.rekey(input.token);
+    const pendingDelivery = inputQueue.nextAdmission();
+    await inputQueue.rekey(input.nextToken);
 
     const messages: string[] = [];
-    collectMessages(await pendingDelivery, deliveryHook, messages);
+    collectMessages(await pendingDelivery, inputQueue, messages);
 
     while (messages.length < 2) {
-      const buffered = bufferedDeliveries.shift();
-      if (buffered !== undefined) {
-        appendMessages(buffered, messages);
-        continue;
-      }
-
-      collectMessages(await deliveryHook.next(), deliveryHook, messages);
+      const next = await inputQueue.takeNextTurn();
+      if (next === null) break;
+      appendMessages(next, messages);
     }
 
     return messages;
   } finally {
-    await deliveryHook.dispose();
+    await inputQueue.dispose();
   }
 }
 
 function collectMessages(
   result: IteratorResult<HookPayload>,
-  deliveryHook: SessionDeliveryHook,
+  inputQueue: SessionInputQueue,
   messages: string[],
 ): void {
-  deliveryHook.consumeNext();
+  inputQueue.consumeAdmission();
   if (!result.done && result.value.kind === "deliver") {
     appendMessages(result.value, messages);
   }

--- a/research/turn-cancellation-channel-ops.md
+++ b/research/turn-cancellation-channel-ops.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/483
 status: implemented
-last_updated: "2026-07-15"
+last_updated: "2026-07-16"
 ---
 
 # Active-turn control for channel authors
@@ -78,7 +78,7 @@ cancelling a newer turn.
 
 ```text
 public continuation hook
-  ├─ queue ───────────────► driver buffer ─────► next turn
+  ├─ queue ───────────────► session input queue ─────► next turn
   ├─ steer ─► private turn inbox ─► next safe step in active turn
   └─ resolve command ─────► session id ────────► cancel hook
 ```
@@ -86,6 +86,19 @@ public continuation hook
 The active turn acknowledges each forwarded steering delivery. This handshake
 is the ownership boundary that prevents completion, re-key, and hook-disposal
 races from dropping input or creating a second session.
+
+Cancellation and steering intentionally use separate hooks. Cancellation is
+session-addressed, one-shot, and claimed only when the turn can settle as
+waiting. Steering is repeatable and uses a unique per-turn token; its
+`turn-steering-ready` message proves that the active turn owns that token. The
+two controls share low-level hook mechanics but retain separate hard-cancel and
+soft-steering state.
+
+The session input queue owns live admission, buffering, ordering, and the sole
+transition from steer policy back to queue policy. The driver retains an
+unacknowledged forward; the turn owns only acknowledged steering. Therefore a
+terminal race needs no timing-based drain: the side that still owns the
+delivery returns it to the queue exactly once.
 
 ## HITL rules
 


### PR DESCRIPTION
Stacked on #834. This PR should merge after its base PR.

## Summary

- keep cancellation and steering on separate durable hooks while sharing replay-safe claim, read, and disposal mechanics
- replace overloaded steering abort state with explicit pending plus live-signal state and remove the terminal microtask drain
- centralize live admission, queue ordering, and steer-to-queue normalization in `SessionInputQueue`
- flatten `TurnControlReceiver` into one event loop with explicit request and provisional-forward ownership

## Control shape

```ts
steering: {
  pending: pendingSteering.length > 0,
  signal: steering.signal,
}
```

The driver owns a forwarded delivery until the active turn acknowledges its request id. If terminal settlement wins, the driver returns an unacknowledged delivery to the queue exactly once; the turn returns only steering it already accepted.

## Verification

- `pnpm fmt`
- `pnpm lint`
- `pnpm test:unit` — 4,870 passed, 1 skipped
- focused cancellation and session-delivery-hook integration tests — 11 passed
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`