### PR TITLE
feat(eve): dev TUI paints immediately with in-shell startup progress

### DIFF
--- a/.changeset/dev-tui-loads-immediately.md
+++ b/.changeset/dev-tui-loads-immediately.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve dev` now paints the interactive shell immediately when starting a local server, and reports build, agent connection, and active-run recovery as progress inside the shell instead of as console preamble. The prompt stays gated until startup finishes, and startup failures surface in the shell with their recovery context.

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -70,6 +70,7 @@ import {
   type SetupIssue,
 } from "./setup-issues.js";
 import type { SetupFlowRenderer } from "./setup-flow.js";
+import type { StartupStatusSnapshot } from "./startup-status.js";
 import type { RemoteDevelopmentTarget } from "./target.js";
 import type {
   AssistantResponseStatsMode,
@@ -284,6 +285,12 @@ export type AgentTUIRenderer = {
   setVercelStatus?(status: VercelStatusSnapshot): void;
   /** Sets the remote deployment badge and its current connection/authentication state. */
   setRemoteConnectionStatus?(status: RemoteConnectionSnapshot): void;
+  /**
+   * Shows deferrable startup progress (build, connection, active-run recovery)
+   * in the shell before controls are available, and clears it once ready.
+   * Renderers without a startup region ignore it.
+   */
+  setStartupStatus?(status: StartupStatusSnapshot): void;
   /**
    * Clears the rendered transcript and resets per-conversation display
    * state, leaving the UI interactive on a fresh screen. Used by the
@@ -603,6 +610,9 @@ export class EveTUIRunner {
   }
 
   #reportBeforeFirstPaint(): void {
+    // Deferrable startup work is done; hand the footer back to the header and
+    // prompt. No-op on renderers without a startup region.
+    this.#renderer.setStartupStatus?.({ kind: "ready" });
     const report = this.#onBootProgress;
     this.#onBootProgress = undefined;
     report?.({ type: "before-first-paint" });

--- a/packages/eve/src/cli/dev/tui/startup-status.test.ts
+++ b/packages/eve/src/cli/dev/tui/startup-status.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { startupStatusForBootPhase } from "./startup-status.js";
+
+describe("startupStatusForBootPhase", () => {
+  it("gives connection its own headline", () => {
+    expect(startupStatusForBootPhase("connecting to agent")).toEqual({
+      kind: "working",
+      label: "Connecting to agent",
+    });
+  });
+
+  it("gives active-run recovery its own headline", () => {
+    expect(startupStatusForBootPhase("recovering active runs")).toEqual({
+      kind: "working",
+      label: "Recovering active runs",
+    });
+  });
+
+  it("collapses build phases under one headline with the phase as detail", () => {
+    expect(startupStatusForBootPhase("compiling agent")).toEqual({
+      kind: "working",
+      label: "Building your agent",
+      detail: "compiling agent",
+    });
+  });
+});

--- a/packages/eve/src/cli/dev/tui/startup-status.ts
+++ b/packages/eve/src/cli/dev/tui/startup-status.ts
@@ -1,0 +1,41 @@
+/**
+ * Startup progress surfaced inside the dev TUI shell. The shell paints before
+ * the local server finishes booting; while deferrable startup work runs it
+ * shows one of these snapshots instead of the prompt, so build, connection, and
+ * active-run recovery report their progress in the shell rather than as console
+ * preamble.
+ */
+export type StartupStatusSnapshot =
+  | {
+      /** A startup task is in flight; the shell shows a spinner and this label. */
+      readonly kind: "working";
+      readonly label: string;
+      /** Optional secondary line, e.g. the active boot phase or a recovery count. */
+      readonly detail?: string;
+    }
+  | {
+      /** All deferrable startup work finished; the shell activates its controls. */
+      readonly kind: "ready";
+    }
+  | {
+      /** Startup failed; the shell shows the failure with recovery context. */
+      readonly kind: "failed";
+      readonly label: string;
+      /** What went wrong and, where possible, how to recover or retry. */
+      readonly detail?: string;
+    };
+
+/**
+ * Maps a measured boot phase name (see {@link devBootPhase}) to the label shown
+ * in the startup shell. Build phases collapse under one "Building your agent"
+ * headline with the phase as detail; connection has its own headline.
+ */
+export function startupStatusForBootPhase(phase: string): StartupStatusSnapshot {
+  if (phase === "connecting to agent") {
+    return { kind: "working", label: "Connecting to agent" };
+  }
+  if (phase === "recovering active runs") {
+    return { kind: "working", label: "Recovering active runs" };
+  }
+  return { kind: "working", label: "Building your agent", detail: phase };
+}

--- a/packages/eve/src/cli/dev/tui/target.ts
+++ b/packages/eve/src/cli/dev/tui/target.ts
@@ -1,19 +1,24 @@
 import { basename } from "node:path";
 
 interface DevelopmentTargetBase {
-  readonly serverUrl: string;
   /** Local workspace root for app files and the fallback Vercel project link. */
   readonly workspaceRoot: string;
 }
 
-/** A development TUI session backed by the local `eve dev` server. */
+/**
+ * A development TUI session backed by the local `eve dev` server. `serverUrl`
+ * is omitted when the server has not booted yet — the shell paints first and
+ * the URL is supplied by the deferred boot (see `RunDevelopmentTuiInput`).
+ */
 export interface LocalDevelopmentTarget extends DevelopmentTargetBase {
   readonly kind: "local";
+  readonly serverUrl?: string;
 }
 
 /** A development TUI session connected to an existing remote server. */
 export interface RemoteDevelopmentTarget extends DevelopmentTargetBase {
   readonly kind: "remote";
+  readonly serverUrl: string;
 }
 
 /** Local or remote server backing one development TUI session. */

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -101,6 +101,59 @@ function agentInfoWithModel(
   };
 }
 
+describe("TerminalRenderer startup status", () => {
+  it("paints a working startup label before any control is available", () => {
+    const { screen, input, renderer } = makeRenderer();
+    renderer.setStartupStatus({
+      kind: "working",
+      label: "Building your agent",
+      detail: "compiling agent",
+    });
+
+    const snapshot = screen.snapshot();
+    expect(snapshot).toContain("Building your agent");
+    expect(snapshot).toContain("compiling agent");
+    // No prompt yet, and the keyboard is not claimed so Ctrl+C still exits via
+    // SIGINT while startup work runs.
+    expect(snapshot).not.toContain("Type to chat");
+    expect(input.rawModes).toEqual([]);
+
+    renderer.shutdown();
+  });
+
+  it("shows a failed startup with its recovery context and keeps it in scrollback", () => {
+    const { screen, renderer } = makeRenderer();
+    renderer.setStartupStatus({
+      kind: "failed",
+      label: "The dev server failed to start.",
+      detail: "Port 3000 is already in use.",
+    });
+    expect(screen.snapshot()).toContain("The dev server failed to start.");
+
+    renderer.shutdown();
+    const snapshot = screen.snapshot();
+    expect(snapshot).toContain("The dev server failed to start.");
+    expect(snapshot).toContain("Port 3000 is already in use.");
+  });
+
+  it("clears the startup region and enables input once ready", async () => {
+    const { input, renderer } = makeRenderer();
+    renderer.setStartupStatus({ kind: "working", label: "Building your agent" });
+    expect(input.rawModes).toEqual([]);
+
+    renderer.setStartupStatus({ kind: "ready" });
+    const prompt = renderer.readPrompt({ title: "eve" });
+    // readPrompt is the first control; it claims the keyboard now that startup
+    // is done.
+    expect(input.rawModes).toEqual([true]);
+
+    input.type("hello");
+    input.enter();
+    await expect(prompt).resolves.toBe("hello");
+    renderer.shutdown();
+  });
+});
+
 describe("TerminalRenderer (inline scrollback)", () => {
   it("renders the brand line with the agent name and a tip", () => {
     const { screen, renderer } = makeRenderer();

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -100,6 +100,7 @@ import {
 } from "./line-editor.js";
 import { LiveRegion } from "./live-region.js";
 import { buildStatusLine } from "./status-line.js";
+import type { StartupStatusSnapshot } from "./startup-status.js";
 import { nextLogDisplayMode } from "./log-display-mode.js";
 import { createTheme, detectUnicode, type Theme } from "./theme.js";
 import {
@@ -356,6 +357,15 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #status: string = STATUS.processing;
   #title = "eve";
   #isInteractive = false;
+  /**
+   * Whether raw-mode keyboard input has been enabled. Deferred past the first
+   * paint so that while the shell shows startup progress (before any control is
+   * available) a Ctrl+C still raises SIGINT and exits cleanly, exactly as it
+   * did before the shell painted.
+   */
+  #inputEnabled = false;
+  /** Startup progress shown in place of the prompt until deferrable work finishes. */
+  #startupStatus?: StartupStatusSnapshot;
   #interrupted = false;
   #caretVisible = true;
   #spinnerIndex = 0;
@@ -1052,6 +1062,34 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
   setRemoteConnectionStatus(status: RemoteConnectionSnapshot): void {
     this.#remoteConnection = status;
+    this.#paint();
+  }
+
+  /**
+   * Shows deferrable startup progress in the shell footer in place of the
+   * prompt. `working` animates a spinner beside the label; `failed` pins the
+   * failure with its recovery context; `ready` clears the region so the normal
+   * prompt/header footer takes over. Paints the shell (deferring raw-mode input)
+   * on first call so the shell is visible before the local server finishes
+   * booting.
+   */
+  setStartupStatus(status: StartupStatusSnapshot): void {
+    if (status.kind === "ready") {
+      this.#startupStatus = undefined;
+      this.#stopTicker();
+      this.#paint();
+      return;
+    }
+
+    this.#startupStatus = status;
+    // Bootstrap the live region without claiming the keyboard: no control is
+    // available yet, so a Ctrl+C during startup should exit via SIGINT.
+    this.#start(undefined, false);
+    if (status.kind === "working") {
+      this.#startTicker();
+    } else {
+      this.#stopTicker();
+    }
     this.#paint();
   }
 
@@ -1993,18 +2031,26 @@ export class TerminalRenderer implements AgentTUIRenderer {
   // Lifecycle
   // ---------------------------------------------------------------------------
 
-  #start(options?: AgentTUISessionOptions) {
+  /**
+   * Bootstraps interactive rendering. `enableInput` defers raw-mode keyboard
+   * setup: the startup shell paints with it `false` so Ctrl+C keeps raising
+   * SIGINT until a real control (a prompt) needs the keyboard.
+   */
+  #start(options?: AgentTUISessionOptions, enableInput = true) {
     this.#title = options?.title ?? this.#title;
     this.#contextSize = options?.contextSize ?? this.#defaultContextSize;
 
-    if (this.#isInteractive) return;
+    if (!this.#isInteractive) {
+      this.#isInteractive = true;
+      this.#live.reset();
+      this.#live.hideCursor();
+      this.#installLogCapture();
+      this.#onResize = () => this.#paint();
+      this.#output.on("resize", this.#onResize);
+    }
 
-    this.#isInteractive = true;
-    this.#live.reset();
-    this.#live.hideCursor();
-    this.#installLogCapture();
-
-    if (this.#input.isTTY) {
+    if (enableInput && !this.#inputEnabled && this.#input.isTTY) {
+      this.#inputEnabled = true;
       this.#input.setRawMode?.(true);
       this.#input.resume();
       // Enable bracketed paste (DEC private mode 2004) so the terminal wraps
@@ -2014,9 +2060,6 @@ export class TerminalRenderer implements AgentTUIRenderer {
       // capture installed just above can't swallow the control sequence.
       this.#live.emitBracketedPaste(true);
     }
-
-    this.#onResize = () => this.#paint();
-    this.#output.on("resize", this.#onResize);
   }
 
   #stop() {
@@ -2030,6 +2073,17 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#logLevelHintActive = false;
 
     if (!this.#isInteractive) return;
+
+    // A startup failure is a footer element; commit it to scrollback so it
+    // survives teardown and the user keeps the failure and its recovery context.
+    if (this.#startupStatus?.kind === "failed") {
+      const status = this.#startupStatus;
+      this.#startupStatus = undefined;
+      const c = this.#theme.colors;
+      const lines = [`${c.red(this.#theme.glyph.warning)} ${c.red(status.label)}`];
+      if (status.detail !== undefined) lines.push(c.dim(status.detail));
+      this.#pushBlock({ kind: "notice", body: lines.join("\n"), live: false });
+    }
 
     // Commit any leading finalized blocks (e.g. freshly captured log lines)
     // before the live region is wiped, so they land in scrollback instead of
@@ -2045,12 +2099,13 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#removeLogCapture();
     this.#live.newline();
 
-    if (this.#input.isTTY) {
+    if (this.#inputEnabled && this.#input.isTTY) {
       // Disable bracketed paste, restoring the terminal to how we found it.
       this.#live.emitBracketedPaste(false);
       this.#input.setRawMode?.(false);
       this.#input.pause();
     }
+    this.#inputEnabled = false;
 
     if (this.#onResize) {
       this.#output.off("resize", this.#onResize);
@@ -2709,9 +2764,31 @@ export class TerminalRenderer implements AgentTUIRenderer {
     };
   }
 
+  /** Renders the startup progress region shown in place of the prompt. */
+  #startupRows(status: StartupStatusSnapshot, width: number): string[] {
+    if (status.kind === "ready") return [];
+    const c = this.#theme.colors;
+    const marker =
+      status.kind === "failed" ? c.red(this.#theme.glyph.warning) : c.cyan(this.#spinnerFrame());
+    const label = status.kind === "failed" ? c.red(status.label) : status.label;
+    const rows = [clip(`${marker} ${label}`, width)];
+    if (status.detail !== undefined) {
+      rows.push(clip(c.dim(`  ${status.detail}`), width));
+    }
+    return rows;
+  }
+
   #footerRows(width: number): string[] {
     const c = this.#theme.colors;
     const rows: string[] = [""];
+
+    // Startup progress owns the footer before any control is available. It
+    // replaces the prompt/idle line entirely so nothing invites input yet.
+    if (this.#startupStatus !== undefined) {
+      rows.push(...this.#startupRows(this.#startupStatus, width));
+      this.#pushStatusLine(rows, width);
+      return rows;
+    }
 
     const flow = this.#setupFlow;
     if (flow !== undefined) {

--- a/packages/eve/src/cli/dev/tui/tui.ts
+++ b/packages/eve/src/cli/dev/tui/tui.ts
@@ -1,5 +1,5 @@
 import { Client } from "#client/index.js";
-import type { DevBootProgressReporter } from "#internal/dev-boot-progress.js";
+import type { DeferredBootProgress } from "#internal/dev-boot-progress.js";
 import {
   resolveLocalDevelopmentClientOptions,
   resolveRemoteDevelopmentClientOptions,
@@ -18,8 +18,16 @@ import { promptCommandsFor } from "./prompt-commands.js";
 import { formatRemoteAuthChallengeMessage } from "./remote-auth-result.js";
 import { probeMcpConnection } from "./mcp-connection-status.js";
 import { EveTUIRunner, type EveTUIRunnerOptions } from "./runner.js";
+import { startupStatusForBootPhase } from "./startup-status.js";
 import { remoteHost, type DevelopmentTuiTarget, type RemoteDevelopmentTarget } from "./target.js";
+import { TerminalRenderer } from "./terminal-renderer.js";
 import type { TuiDisplayOptions } from "./types.js";
+
+/** The local server URL and app root resolved by a deferred `eve dev` boot. */
+export interface BootedLocalServer {
+  readonly serverUrl: string;
+  readonly appRoot: string;
+}
 
 export type { DevelopmentTuiTarget } from "./target.js";
 
@@ -33,8 +41,18 @@ export interface RunDevelopmentTuiInput extends TuiDisplayOptions {
    * `/model` starts fresh-agent onboarding. Applies to the first prompt only.
    */
   readonly initialInput?: string;
-  /** Reports local CLI boot phases. Omitted for remote and programmatic TUI runs. */
-  readonly onBootProgress?: DevBootProgressReporter;
+  /**
+   * Boots the local `eve dev` server after the shell has painted. When present,
+   * the shell renders first and this resolves the server URL; the boot phases it
+   * drives are shown inside the shell via {@link onBootProgress}. Omitted for
+   * remote sessions and when attaching to an already-running local server.
+   */
+  readonly bootServer?: () => Promise<BootedLocalServer>;
+  /**
+   * Local CLI boot-phase progress. The shell attaches its observer once painted
+   * so phases render inside it. Omitted for remote and programmatic TUI runs.
+   */
+  readonly onBootProgress?: DeferredBootProgress;
 }
 
 function prepareRemoteTarget(target: RemoteDevelopmentTarget) {
@@ -79,45 +97,92 @@ function prepareDevelopmentTarget(target: DevelopmentTuiTarget): PreparedDevelop
  * the inline error region rather than crashing the command.
  */
 export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<void> {
-  const { target, headers, initialInput, onBootProgress, ...display } = input;
+  const { target, headers, initialInput, onBootProgress, bootServer, ...display } = input;
   const prepared = prepareDevelopmentTarget(target);
-  const { serverUrl } = target;
   const headerOptions = headers === undefined ? {} : { headers };
+
+  // The renderer needs no client, so it is built and painted before the server
+  // boots. Boot phases stream into its startup region instead of the console.
+  const renderer = new TerminalRenderer({
+    tools: display.tools,
+    reasoning: display.reasoning,
+    subagents: display.subagents,
+    connectionAuth: display.connectionAuth,
+    assistantResponseStats: display.assistantResponseStats,
+    contextSize: display.contextSize,
+    logs: display.logs,
+    availablePromptCommands: promptCommandsFor(target.kind),
+  });
+
+  let serverUrl = target.serverUrl;
+  // Local sessions track the workspace root for OIDC/link resolution. A
+  // deferred boot yields the host's canonical root; otherwise fall back to the
+  // target's known workspace root.
+  let localAppRoot = prepared.kind === "local" ? prepared.target.workspaceRoot : undefined;
+  if (bootServer !== undefined) {
+    renderer.setStartupStatus({ kind: "working", label: "Building your agent" });
+    onBootProgress?.observe((event) => {
+      if (event.type === "phase-started") {
+        renderer.setStartupStatus(startupStatusForBootPhase(event.phase));
+      }
+    });
+    try {
+      const booted = await bootServer();
+      serverUrl = booted.serverUrl;
+      localAppRoot = booted.appRoot;
+    } catch (error) {
+      renderer.setStartupStatus({
+        kind: "failed",
+        label: "The dev server failed to start.",
+        detail: toErrorMessage(error),
+      });
+      onBootProgress?.observe(undefined);
+      renderer.shutdown();
+      throw error;
+    }
+  }
+
+  if (serverUrl === undefined) {
+    throw new Error("runDevelopmentTui requires a booted server URL or a bootServer.");
+  }
+  const resolvedServerUrl = serverUrl;
 
   const client = new Client(
     prepared.kind === "local"
       ? resolveLocalDevelopmentClientOptions({
           ...headerOptions,
-          serverUrl,
-          token: () => resolveLinkedDevelopmentOidcToken(prepared.target.workspaceRoot),
+          serverUrl: resolvedServerUrl,
+          token: () =>
+            resolveLinkedDevelopmentOidcToken(localAppRoot ?? prepared.target.workspaceRoot),
         })
       : resolveRemoteDevelopmentClientOptions({
           ...headerOptions,
-          serverUrl,
+          serverUrl: resolvedServerUrl,
           credentials: prepared.remote.credentials,
         }),
   );
 
   const options: EveTUIRunnerOptions = {
     ...display,
+    renderer,
     session: client.session(),
     client,
-    serverUrl,
+    serverUrl: resolvedServerUrl,
     promptCommandHandler: createPromptCommandHandler({ target }),
     availablePromptCommands: promptCommandsFor(target.kind),
     formatTransportError: (error) =>
       isVercelAuthChallenge(error)
-        ? formatRemoteAuthChallengeMessage(serverUrl)
+        ? formatRemoteAuthChallengeMessage(resolvedServerUrl)
         : toErrorMessage(error),
   };
   if (prepared.kind === "local") {
-    options.appRoot = prepared.target.workspaceRoot;
+    options.appRoot = localAppRoot ?? prepared.target.workspaceRoot;
     options.probeMcpConnection = probeMcpConnection;
   } else {
     options.remote = prepared.remote;
   }
   if (initialInput !== undefined) options.initialInput = initialInput;
-  if (onBootProgress !== undefined) options.onBootProgress = onBootProgress;
+  if (onBootProgress !== undefined) options.onBootProgress = onBootProgress.reporter;
 
   await new EveTUIRunner(options).run();
 }

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { resolveDevUiMode, resolveTuiDisplayOptions, runCli } from "#cli/run.js";
-import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
+import type { BootedLocalServer, RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
 import type { DevelopmentServerOptions } from "#internal/nitro/host/types.js";
 
 async function withInteractiveTerminal<T>(fn: () => Promise<T>): Promise<T> {
@@ -314,78 +314,79 @@ describe("eve dev --logs", () => {
 });
 
 describe("eve dev boot progress", () => {
-  it("passes one reporter through local startup and clears the row on failure", async () => {
-    const writes: string[] = [];
+  it("routes deferred boot phases to the shell observer and closes the server on failure", async () => {
     const close = vi.fn(async () => {});
     let hostReporter: DevelopmentServerOptions["onBootProgress"] = undefined;
-    let tuiReporter: RunDevelopmentTuiInput["onBootProgress"] = undefined;
-    const startHost = vi.fn((_appRoot: string, options?: DevelopmentServerOptions) => ({
-      start: async () => {
-        hostReporter = options?.onBootProgress;
-        hostReporter?.({ phase: "compiling agent", type: "phase-started" });
-        hostReporter?.({ elapsedMs: 1, phase: "compiling agent", type: "phase-finished" });
-        return {
-          kind: "started" as const,
-          appRoot: "/canonical/app",
-          url: "http://127.0.0.1:2000",
-        };
-      },
-      close,
-    }));
+    const start = vi.fn(async () => {
+      hostReporter?.({ phase: "compiling agent", type: "phase-started" });
+      hostReporter?.({ elapsedMs: 1, phase: "compiling agent", type: "phase-finished" });
+      return {
+        kind: "started" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:2000",
+      };
+    });
+    const startHost = vi.fn((_appRoot: string, options?: DevelopmentServerOptions) => {
+      hostReporter = options?.onBootProgress;
+      return { start, close };
+    });
+    // The shell (mocked here) attaches its observer, drives the boot, then fails.
+    const observed: string[] = [];
     const runDevelopmentTui = vi.fn(async (input: RunDevelopmentTuiInput) => {
-      tuiReporter = input.onBootProgress;
+      input.onBootProgress?.observe((event) => {
+        if (event.type === "phase-started") observed.push(event.phase);
+      });
+      await input.bootServer?.();
       throw new Error("TUI startup failed");
     });
-    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-      writes.push(String(chunk));
-      return true;
-    });
 
-    try {
-      await expect(
-        withInteractiveTerminal(() =>
-          runCli(["dev"], { error: () => {}, log: () => {} }, { runDevelopmentTui, startHost }),
-        ),
-      ).rejects.toThrow("TUI startup failed");
-    } finally {
-      stdoutWrite.mockRestore();
-    }
+    await expect(
+      withInteractiveTerminal(() =>
+        runCli(["dev"], { error: () => {}, log: () => {} }, { runDevelopmentTui, startHost }),
+      ),
+    ).rejects.toThrow("TUI startup failed");
 
     expect(hostReporter).toBeTypeOf("function");
-    expect(tuiReporter).toBe(hostReporter);
-    expect(writes.at(-1)).toBe("\r\u001B[K");
+    expect(start).toHaveBeenCalledOnce();
+    expect(observed).toEqual(["compiling agent"]);
     expect(close).toHaveBeenCalledOnce();
   });
 });
 
 describe("eve dev local server ownership", () => {
-  it("uses the host's canonical root and leaves an attached server running", async () => {
-    const startHost = vi.fn(() => ({
-      start: async () => ({
-        kind: "existing" as const,
-        appRoot: "/canonical/app",
-        url: "http://127.0.0.1:4321/",
-      }),
-      close: async () => {},
+  it("defers the boot to the shell and forwards the host's canonical handle", async () => {
+    const start = vi.fn(async () => ({
+      kind: "existing" as const,
+      appRoot: "/canonical/app",
+      url: "http://127.0.0.1:4321/",
     }));
-    const runDevelopmentTui = await runInteractiveDev(["dev"], { startHost });
-
-    expect(startHost).toHaveBeenCalledWith(expect.any(String), {
-      existing: "attach-if-unconfigured",
-      host: undefined,
-      onBootProgress: expect.any(Function),
-      port: undefined,
+    const startHost = vi.fn(() => ({ start, close: async () => {} }));
+    let booted: BootedLocalServer | undefined;
+    const runDevelopmentTui = vi.fn(async (input: RunDevelopmentTuiInput) => {
+      booted = await input.bootServer?.();
     });
-    expect(runDevelopmentTui).toHaveBeenCalledWith(
+    await withInteractiveTerminal(() =>
+      runCli(["dev"], { error: () => {}, log: () => {} }, { runDevelopmentTui, startHost }),
+    );
+
+    expect(startHost).toHaveBeenCalledWith(
+      expect.any(String),
       expect.objectContaining({
-        name: "App",
-        target: {
-          kind: "local",
-          serverUrl: "http://127.0.0.1:4321/",
-          workspaceRoot: "/canonical/app",
-        },
+        existing: "attach-if-unconfigured",
+        onBootProgress: expect.any(Function),
       }),
     );
+    // The target no longer carries a server URL; the shell resolves it by
+    // calling bootServer, which yields the host's canonical root and URL.
+    expect(runDevelopmentTui).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { kind: "local", workspaceRoot: expect.any(String) },
+        bootServer: expect.any(Function),
+        onBootProgress: expect.objectContaining({ observe: expect.any(Function) }),
+      }),
+    );
+    expect(booted).toEqual({ serverUrl: "http://127.0.0.1:4321/", appRoot: "/canonical/app" });
+    expect(start).toHaveBeenCalledOnce();
   });
 
   it("closes a server started for the interactive TUI", async () => {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -1,6 +1,11 @@
 import { Command, CommanderError, InvalidArgumentError } from "#compiled/commander/index.js";
 import { registerBuildCommand, type BuildHost } from "#cli/commands/build.js";
-import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-progress.js";
+import {
+  createDeferredBootProgress,
+  devBootPhase,
+  type DeferredBootProgress,
+  type DevBootProgressReporter,
+} from "#internal/dev-boot-progress.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
@@ -12,11 +17,10 @@ import {
   resolveDevelopmentUrlTarget,
   type DevelopmentRequestHeaders,
 } from "#cli/dev/url-target.js";
-import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
+import type { BootedLocalServer, RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
 import { LOG_DISPLAY_MODES, parseLogDisplayMode } from "#cli/dev/tui/log-display-mode.js";
 import { resolveTuiTitle, type DevelopmentTuiTarget } from "#cli/dev/tui/target.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
-import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";
 import { createLogger } from "#internal/logging.js";
 import type {
@@ -91,20 +95,21 @@ type CliRuntimeOverrides = Partial<CliRuntimeDependencies>;
 
 const devBootLog = createLogger("dev.boot");
 
-function createDevBootProgressReporter(
-  row: ReturnType<typeof startCliLiveRow> | undefined,
-): DevBootProgressReporter {
+/**
+ * Debug-logs boot phases. Boot progress is shown to the user inside the TUI
+ * shell (see the deferred boot progress observer); this only records timings for
+ * `eve dev`'s own diagnostics.
+ */
+function createDevBootProgressLogger(): DevBootProgressReporter {
   return (event) => {
     switch (event.type) {
       case "phase-started":
-        row?.update("Building your agent", event.phase);
         devBootLog.debug(event.phase);
         return;
       case "phase-finished":
         devBootLog.debug(`${event.phase} finished`, { ms: event.elapsedMs });
         return;
       case "before-first-paint":
-        row?.stop();
         return;
       default: {
         const exhaustive: never = event;
@@ -459,40 +464,35 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
           runtime.isActiveDevelopmentServerForApp ?? (await loadIsActiveDevelopmentServerForApp());
         existingLocalDevelopmentServer = await isActive({ appRoot, serverUrl: remoteServerUrl });
       }
-      const runInteractiveUi = async (
-        input: {
-          readonly appRoot?: string;
-          readonly serverUrl: string;
-        },
-        report?: DevBootProgressReporter,
-      ): Promise<void> => {
+      const runInteractiveUi = async (input: {
+        /** Known server URL (remote, or an already-running local server). */
+        readonly serverUrl?: string;
+        /** Boots the local server after the shell paints. */
+        readonly bootServer?: () => Promise<BootedLocalServer>;
+        /** Boot-phase progress routed into the shell's startup region. */
+        readonly bootProgress?: DeferredBootProgress;
+      }): Promise<void> => {
         const runDevelopmentTui = await devBootPhase(
           "loading interactive UI",
           async () => runtime.runDevelopmentTui ?? (await loadRunDevelopmentTui()),
-          report,
+          input.bootProgress?.reporter,
         );
         const display = resolveTuiDisplayOptions(options);
         const target: DevelopmentTuiTarget =
           remoteServerUrl === undefined || existingLocalDevelopmentServer
-            ? {
-                kind: "local",
-                serverUrl: input.serverUrl,
-                workspaceRoot: input.appRoot ?? appRoot,
-              }
-            : { kind: "remote", serverUrl: input.serverUrl, workspaceRoot: appRoot };
+            ? { kind: "local", workspaceRoot: appRoot, serverUrl: input.serverUrl }
+            : { kind: "remote", serverUrl: remoteServerUrl, workspaceRoot: appRoot };
         const title = resolveTuiTitle({ name: options.name, target });
         if (title !== undefined) display.name = title;
-        const tuiInput = {
+        const tuiInput: RunDevelopmentTuiInput = {
           target,
-          initialInput: options.input,
-          onBootProgress: report,
           ...display,
-        } satisfies RunDevelopmentTuiInput;
-        if (remoteTarget?.headers !== undefined) {
-          await runDevelopmentTui({ ...tuiInput, headers: remoteTarget.headers });
-        } else {
-          await runDevelopmentTui(tuiInput);
-        }
+          initialInput: options.input,
+          bootServer: input.bootServer,
+          onBootProgress: input.bootProgress,
+          headers: remoteTarget?.headers,
+        };
+        await runDevelopmentTui(tuiInput);
       };
 
       if (remoteServerUrl) {
@@ -518,12 +518,6 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
         return;
       }
 
-      // Print spacing before the live row; a later write would strand the row.
-      if (mode === "tui") logger.log("");
-      const buildProgress = mode === "tui" ? startCliLiveRow(logger) : undefined;
-      const onBootProgress = createDevBootProgressReporter(buildProgress);
-      buildProgress?.update("Building your agent");
-
       let closed = false;
       let server: DevelopmentServer | undefined;
       const closeServer = async () => {
@@ -538,18 +532,15 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
 
       try {
         const startHost = runtime.startHost ?? (await loadStartHost());
-        server = startHost(appRoot, {
-          existing: mode === "tui" ? "attach-if-unconfigured" : "reject",
-          host: options.host,
-          onBootProgress,
-          port: options.port,
-        });
-        const handle = await server.start();
 
-        // The terminal UI's header already shows the server URL, and startup
-        // no longer clears the screen, so the line would linger as noise.
-        // Headless consumers (scripts, scenario tests) still parse it.
-        if (mode !== "tui") {
+        if (mode === "headless") {
+          server = startHost(appRoot, {
+            existing: "reject",
+            host: options.host,
+            port: options.port,
+          });
+          const handle = await server.start();
+          // Headless consumers (scripts, scenario tests) parse this line.
           logger.log(
             renderCliTaggedLine(theme, {
               message: `server listening at ${handle.url}`,
@@ -557,9 +548,6 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
               tone: "success",
             }),
           );
-        }
-
-        if (mode === "headless") {
           // An explicit `--no-ui` is intentional and silent; a non-TTY
           // terminal that did not ask for headless gets a hint so the
           // missing UI is not mistaken for a hang.
@@ -573,14 +561,31 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
             );
           }
 
-          return await waitForShutdownSignal({
-            close: closeServer,
-          });
+          return await waitForShutdownSignal({ close: closeServer });
         }
 
-        await runInteractiveUi({ appRoot: handle.appRoot, serverUrl: handle.url }, onBootProgress);
+        // TUI: build the server but defer `start()` to the shell so the shell
+        // paints first and the boot phases stream into its startup region.
+        const bootProgress = createDeferredBootProgress();
+        const logProgress = createDevBootProgressLogger();
+        server = startHost(appRoot, {
+          existing: "attach-if-unconfigured",
+          host: options.host,
+          onBootProgress: (event) => {
+            logProgress(event);
+            bootProgress.reporter(event);
+          },
+          port: options.port,
+        });
+        const activeServer = server;
+        await runInteractiveUi({
+          bootServer: async () => {
+            const handle = await activeServer.start();
+            return { serverUrl: handle.url, appRoot: handle.appRoot };
+          },
+          bootProgress,
+        });
       } finally {
-        buildProgress?.stop();
         await closeServer();
       }
     });

--- a/packages/eve/src/internal/dev-boot-progress.ts
+++ b/packages/eve/src/internal/dev-boot-progress.ts
@@ -14,6 +14,30 @@ export type DevBootProgressEvent =
 
 export type DevBootProgressReporter = (event: DevBootProgressEvent) => void;
 
+/**
+ * A boot-progress reporter whose downstream observer can be attached after the
+ * reporter is already wired into the host. `eve dev` builds the server (which
+ * captures {@link reporter} in its options) before the TUI shell exists, then
+ * calls {@link observe} once the shell is ready so boot phases render inside it.
+ */
+export interface DeferredBootProgress {
+  /** The stable reporter handed to the host at construction. */
+  readonly reporter: DevBootProgressReporter;
+  /** Routes subsequent events to `sink`, or stops routing when `undefined`. */
+  observe(sink: DevBootProgressReporter | undefined): void;
+}
+
+/** Creates a {@link DeferredBootProgress} whose sink starts detached. */
+export function createDeferredBootProgress(): DeferredBootProgress {
+  let sink: DevBootProgressReporter | undefined;
+  return {
+    reporter: (event) => sink?.(event),
+    observe: (next) => {
+      sink = next;
+    },
+  };
+}
+
 /** Runs one measured boot phase and reports it to this invocation's observer. */
 export async function devBootPhase<T>(
   phase: string,

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -476,7 +476,16 @@ async function startNitroDevelopmentServer(
       },
       options.onBootProgress,
     );
-    await workflowWorld?.start();
+    // The parent world's start() runs quarantine-aware active-run recovery.
+    // Surface it as a boot phase so recovery reports its progress inside the
+    // shell instead of as console preamble.
+    await devBootPhase(
+      "recovering active runs",
+      async () => {
+        await workflowWorld?.start();
+      },
+      options.onBootProgress,
+    );
     startDevelopmentSandboxPrewarmInBackground({
       appRoot: preparedHost.appRoot,
       compiledArtifactsSource,


### PR DESCRIPTION
Closes #791

## Problem

`eve dev` performed startup work (build, agent connection, active-run recovery) before rendering the TUI shell, printing workflow-oriented preamble like `Building your agent connecting to agent[…]` and `Re-enqueued N active run(s)…`. Startup felt blocked and leaked internal details before the interface appeared.

## Solution

`eve dev` now paints the interactive shell immediately when starting a local server and defers the server `start()` to the shell, streaming startup progress into the shell's startup region instead of the console preamble:

- The shell renders before build, agent connection, and active-run recovery finish.
- Startup status appears inside the shell ("Building your agent", "Connecting to agent", "Recovering active runs"); the prompt stays gated until startup completes and explains what it is waiting for.
- The old console preamble (the `startCliLiveRow` "Building your agent" row and the `server listening at …` line) is removed for TUI mode.
- Startup failures surface in the shell with their recovery context.

Behavior preserved:
- Headless mode (`--no-ui` / non-TTY) still prints the machine-parsed `server listening at …` line for scripts and scenario tests.
- The remote/attach path (`eve dev <url>`) is unchanged: it still prints a single `↗ <local|remote> mode targeting <host>` line before the shell.

## Acceptance criteria

- [x] TUI shell renders before build/connection/recovery finish
- [x] Loading indicators and startup status appear inside the shell
- [x] No more workflow-oriented preamble for tasks represented in the shell
- [x] Controls gated on unfinished startup work stay unavailable and explain the wait
- [x] Controls activate as soon as prerequisites complete
- [x] Startup failures appear in the shell with recovery context
- [x] Active-run recovery and other startup guarantees remain intact

## Tests

- New unit tests: `startup-status.test.ts`, `terminal-renderer.test.ts`; updated `run.test.ts`
- Local: `pnpm typecheck`, `pnpm lint`, `pnpm guard:invariants`, and the full `eve` unit suite (4792 passed) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
