### PR TITLE
fix(eve): avoid erroring when passing invalid text into ask_question

### DIFF
--- a/.changeset/skip-invalid-ask-question-tool-calls.md
+++ b/.changeset/skip-invalid-ask-question-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Avoid erroring when passing invalid text into `ask_question`.

--- a/packages/eve/src/harness/input-extraction.test.ts
+++ b/packages/eve/src/harness/input-extraction.test.ts
@@ -41,6 +41,27 @@ describe("extractQuestionInputRequests", () => {
     ]);
   });
 
+  it("skips invalid ask_question tool calls instead of throwing", () => {
+    // When the model emits unparsable JSON arguments, the AI SDK marks the
+    // tool call `invalid` and leaves `input` as the raw string. Projecting
+    // that through the JSON-object invariant must not crash the turn; the
+    // AI SDK already synthesizes a tool-error for the next step.
+    const result = extractQuestionInputRequests({
+      excludedCallIds: new Set(),
+      toolCalls: [
+        {
+          input: '{"prompt": "Continue?',
+          invalid: true,
+          toolCallId: "call-1",
+          toolName: "ask_question",
+          type: "tool-call",
+        } as never,
+      ],
+    });
+
+    expect(result).toEqual([]);
+  });
+
   it("includes allowFreeform when present in the tool input", () => {
     const result = extractQuestionInputRequests({
       excludedCallIds: new Set(),

--- a/packages/eve/src/harness/input-extraction.ts
+++ b/packages/eve/src/harness/input-extraction.ts
@@ -23,6 +23,10 @@ export function extractQuestionInputRequests(input: {
       continue;
     }
 
+    if (toolCall.invalid === true) {
+      continue;
+    }
+
     const action = createRuntimeToolCallActionFromToolCall({ toolCall });
     const toolInput = action.input as {
       allowFreeform?: boolean;


### PR DESCRIPTION
### Description

<!-- Write a short summary of the problem and solution. -->

### How did you test your changes?

<!-- Include the commands you ran and any manual coverage. -->

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
