### PR TITLE
fix(eve): harden delegated parent resume after subagent completion

### DIFF
--- a/packages/eve/src/execution/delegated-parent-notification.test.ts
+++ b/packages/eve/src/execution/delegated-parent-notification.test.ts
@@ -30,7 +30,7 @@ function createSuccessResult(): RuntimeSubagentResultActionResult {
   };
 }
 
-function createSerializedContext(): Record<string, unknown> {
+function createSerializedContext(state?: Record<string, unknown>): Record<string, unknown> {
   const bundle = {
     adapterRegistry: {
       adaptersByKind: new Map([[SUBAGENT_ADAPTER_KIND, SUBAGENT_ADAPTER]]),
@@ -44,7 +44,7 @@ function createSerializedContext(): Record<string, unknown> {
   ctx.set(BundleKey, bundle);
   ctx.set(ChannelKey, {
     ...SUBAGENT_ADAPTER,
-    state: {
+    state: state ?? {
       callId: "call-1",
       parentContinuationToken: "parent-tok",
       parentSessionId: "parent-session",
@@ -112,5 +112,35 @@ describe("notifyDelegatedParentStep", () => {
       kind: "runtime-action-result",
       results: [errorResult],
     });
+  });
+
+  it("throws when subagent adapter state is missing parentContinuationToken", async () => {
+    await expect(
+      notifyDelegatedParentStep({
+        result: createSuccessResult(),
+        serializedContext: createSerializedContext({
+          callId: "call-1",
+          parentContinuationToken: "",
+          parentSessionId: "parent-session",
+          subagentName: "research",
+        }),
+      }),
+    ).rejects.toThrow(/adapter state is invalid/);
+
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows resumeHook failures so the child run fails visibly", async () => {
+    const hookError = Object.assign(new Error("Hook not found"), {
+      name: "HookNotFoundError",
+    });
+    resumeHookMock.mockRejectedValue(hookError);
+
+    await expect(
+      notifyDelegatedParentStep({
+        result: createSuccessResult(),
+        serializedContext: createSerializedContext(),
+      }),
+    ).rejects.toBe(hookError);
   });
 });

--- a/packages/eve/src/execution/delegated-parent-notification.ts
+++ b/packages/eve/src/execution/delegated-parent-notification.ts
@@ -8,13 +8,21 @@
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { deserializeContext } from "#context/serialize.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { isSubagentAdapterState, SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
 import type { TokenUsage } from "#shared/token-usage.js";
+import { createErrorId, createLogger } from "#internal/logging.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
+
+const log = createLogger("execution.delegated-parent-notification");
 
 /**
  * Resumes the parent driver's hook with a delegated subagent result.
  * No-op for root sessions.
+ *
+ * Parent resume after a delegated child completes is **guaranteed** for
+ * well-formed subagent adapters: failures to resume are logged and
+ * rethrown so the child run fails visibly instead of leaving the parent
+ * parked on `${completionToken}:inbox` forever.
  *
  * `usage` — the completed child's session-total token spend — is
  * attached to success results so the caller can attribute the
@@ -38,18 +46,42 @@ export async function notifyDelegatedParentStep(input: {
     return;
   }
 
-  const parentContinuationToken = String(adapter.state?.parentContinuationToken ?? "");
-  if (parentContinuationToken === "") {
-    return;
+  if (!isSubagentAdapterState(adapter.state)) {
+    const errorId = createErrorId();
+    log.error("delegated child has invalid subagent adapter state; parent will not be notified", {
+      callId: input.result.callId,
+      errorId,
+      subagentName: input.result.subagentName,
+    });
+    throw new Error(
+      `Delegated subagent adapter state is invalid (errorId=${errorId}); ` +
+        "parent turn cannot be resumed with the subagent result.",
+    );
   }
 
+  const parentContinuationToken = adapter.state.parentContinuationToken;
   const result =
     input.usage === undefined || input.result.isError === true
       ? input.result
       : { ...input.result, usage: input.usage };
 
-  await resumeHook(parentContinuationToken, {
-    kind: "runtime-action-result",
-    results: [result],
-  });
+  try {
+    await resumeHook(parentContinuationToken, {
+      kind: "runtime-action-result",
+      results: [result],
+    });
+  } catch (error) {
+    const errorId = createErrorId();
+    const hookNotFound = error instanceof Error && error.name === "HookNotFoundError";
+    log.error("failed to resume parent hook with delegated subagent result", {
+      callId: adapter.state.callId,
+      errorId,
+      hookNotFound,
+      parentContinuationToken,
+      parentSessionId: adapter.state.parentSessionId,
+      subagentName: adapter.state.subagentName,
+      error,
+    });
+    throw error;
+  }
 }

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -319,6 +319,73 @@ describe("workflowEntry", () => {
     });
   });
 
+  it("preserves the original turn error when parent notify fails in the catch path", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      turnControls: [
+        {
+          error: { message: "persistent recoverable failure", name: "Error" },
+          kind: "turn-error",
+        },
+      ],
+    });
+    vi.mocked(notifyDelegatedParentStep).mockRejectedValueOnce(new Error("parent inbox gone"));
+
+    await expect(
+      workflowEntry({
+        input: { message: "delegate" },
+        serializedContext: createSerializedContext({
+          "eve.channel": {
+            kind: "subagent",
+            state: {
+              callId: "call-1",
+              parentContinuationToken: "parent-token",
+              subagentName: "researcher",
+            },
+          },
+        }),
+      }),
+    ).rejects.toThrow("persistent recoverable failure");
+  });
+
+  it("notifies the parent before marking a successful child session completed", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      turnControls: [turnResult({ action: "done", output: "child done", sessionState })],
+    });
+    const order: string[] = [];
+    vi.mocked(notifyDelegatedParentStep).mockImplementation(async () => {
+      order.push("notify");
+    });
+    vi.mocked(fireSessionCallbackStep).mockImplementation(async () => {
+      order.push("callback");
+    });
+
+    try {
+      await workflowEntry({
+        input: { message: "delegate" },
+        serializedContext: createSerializedContext({
+          "eve.channel": {
+            kind: "subagent",
+            state: {
+              callId: "call-1",
+              parentContinuationToken: "parent-token",
+              parentSessionId: "parent-session",
+              subagentName: "researcher",
+            },
+          },
+        }),
+      });
+
+      expect(order).toEqual(["notify", "callback"]);
+    } finally {
+      vi.mocked(notifyDelegatedParentStep).mockResolvedValue(undefined);
+      vi.mocked(fireSessionCallbackStep).mockResolvedValue(undefined);
+    }
+  });
+
   it("passes the resumed channel request id to the next turn", async () => {
     const sessionState = createBaseSessionState();
     vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -135,10 +135,17 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       serializedContext: input.serializedContext,
       status: "failed",
     });
-    await notifyDelegatedParentStep({
-      result: createDelegatedSubagentErrorResult(input.serializedContext, error),
-      serializedContext: input.serializedContext,
-    });
+    // Isolate parent-notify failures so a HookNotFound / resume error
+    // cannot replace the original exception (or skip rethrowing it).
+    // `notifyDelegatedParentStep` logs its own failures.
+    try {
+      await notifyDelegatedParentStep({
+        result: createDelegatedSubagentErrorResult(input.serializedContext, error),
+        serializedContext: input.serializedContext,
+      });
+    } catch {
+      // Parent may remain parked; the child already emitted session.failed.
+    }
     throw error;
   }
 }
@@ -315,18 +322,21 @@ async function finalizeDone(input: {
   const { output, serializedContext } = input.action;
   const failed = input.action.isError === true;
 
-  await fireSessionCallbackStep({
-    error: failed ? output : undefined,
-    output: failed ? undefined : output,
-    serializedContext,
-    status: failed ? "failed" : "completed",
-    usage: failed ? undefined : input.action.usage,
-  });
+  // Notify the parent *before* marking the child session completed so a
+  // failed `resumeHook` cannot leave clients observing a finished child
+  // while the parent stays parked on its turn inbox forever.
   await notifyDelegatedParentStep({
     result: failed
       ? createDelegatedSubagentErrorResult(serializedContext, output)
       : createDelegatedSubagentSuccessResult(serializedContext, output),
     serializedContext,
+    usage: failed ? undefined : input.action.usage,
+  });
+  await fireSessionCallbackStep({
+    error: failed ? output : undefined,
+    output: failed ? undefined : output,
+    serializedContext,
+    status: failed ? "failed" : "completed",
     usage: failed ? undefined : input.action.usage,
   });
   return { output };


### PR DESCRIPTION
## Summary

- Harden `notifyDelegatedParentStep`: validate subagent adapter state, structured-log `resumeHook` failures (including `HookNotFoundError`), and rethrow so the child fails visibly instead of silently leaving the parent parked on `${completionToken}:inbox`.
- Reorder `finalizeDone` to notify the parent **before** emitting child `session.completed`, so clients cannot observe a finished child while the parent turn never wakes.
- Isolate catch-path parent notify errors so a secondary `resumeHook` failure cannot replace/mask the original turn error.

Fixes #891

## Test plan

- [x] `pnpm exec vitest run --config vitest.unit.config.ts src/execution/delegated-parent-notification.test.ts src/execution/workflow-entry.test.ts` (24 passed)
- [ ] Reproduce local declared-subagent hang (parent stuck after `subagent.called`, child `session.completed`) and confirm resume failures now log + fail the child instead of silent parent hang
- [ ] Confirm successful delegation still emits `subagent.completed` + `action.result` + parent `session.waiting`


Made with [Cursor](https://cursor.com)