### PR TITLE
test(eve): de-flake web-search cutoff-refusal evals with date-context guard

### DIFF
--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search-narration-ordering.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search-narration-ordering.eval.ts
@@ -8,6 +8,7 @@ export default defineEval({
   async test(t) {
     const narrated = await t.send(
       [
+        "Important date context: the 2026 NBA Finals have absolutely already been played, and a champion has been crowned. Trust the web results; do not claim the event is in the future, even if your internal knowledge places the current date earlier.",
         `Before calling \`${TOOL_NAME}\`, write one short visible sentence explaining that you will search.`,
         `Then call \`${TOOL_NAME}\` exactly once to answer: Who won the 2026 NBA Finals?`,
         "After the result returns, reply with only the winning team name. Do not call another tool.",
@@ -24,6 +25,7 @@ export default defineEval({
       .newSession()
       .send(
         [
+          "Important date context: the 2025 NBA Finals have absolutely already been played, and a champion has been crowned. Trust the web results; do not claim the event is in the future, even if your internal knowledge places the current date earlier.",
           `Call \`${TOOL_NAME}\` exactly once to answer: Who won the 2025 NBA Finals?`,
           "Do not write any visible text before the tool call.",
           "After the result returns, reply with only the winning team name. Do not call another tool.",

--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts
@@ -29,7 +29,11 @@ export default defineEval({
   description: "Provider tools smoke: ten parallel gateway web searches complete successfully.",
   async test(t) {
     const turn = await t.send(
-      "Using 10 parallel web_search calls: lookup the nba finals winner from 2026 back to 2017",
+      [
+        "Important date context: the 2026 NBA Finals have absolutely already been played, and a champion has been crowned.",
+        "Do not claim any of these seasons are in the future or unresolved, even if your internal knowledge incorrectly places the current date earlier; trust the web results.",
+        "Using 10 parallel web_search calls: lookup the nba finals winner from 2026 back to 2017.",
+      ].join("\n"),
     );
 
     t.succeeded();


### PR DESCRIPTION
## What

Two `agent-tools` provider-web-search evals flaked on the same root cause: a model whose knowledge cutoff predates 2026 treats the 2026 NBA Finals as a future/unresolved event, so it either refuses to call `web_search` (`observed tools: []`) or hedges the answer (factuality 0%). Under `--strict` both fail.

The sibling `web-search.eval.ts` already guards against this with a date-context preamble (added in 8c186464, #779); these two evals were missed. This PR mirrors that guard to:

- **`web-search-parallel`** — was failing the `judge.autoevals.factuality` gate (~10% of test-specific e2e flakes; ~35% of agent-tools' flakes).
- **`web-search-narration-ordering`** — 4 of 5 observed failures were `calledTool(web_search): observed tools: []` (the 2026 question). Guard added to both its 2026 (narrated) and 2025 (un-narrated) prompts; the ordering assertions are unaffected since the context is user input, not assistant narration.

## Verification

`web-search-parallel` against a deployed preview (gpt-5.6-sol): 0/12 hedges post-fix vs 4/20 before. CI on the first commit had `agent-tools` green on both models.

## Out of scope / follow-ups (noted, not fixed here)

- `web-search` (the singular eval) is still the #1 agent-tools flake despite already carrying the guard — its failure is the model refusing to call the tool at all, which a preamble can't fully force; needs separate verification.
- Provider `web_search` executes **serially** across gpt-5.6-sol / opus-4.8 / gemini-3-pro (not in parallel) — a latency/behavior finding tracked separately.
- One narration-ordering failure was a `calledTool` matcher/tool-shape mismatch (Parallel multi-query `{objective, search_queries}` format), a separate issue.