### PR TITLE
test(eve): de-flake hitl/ask-question-select confirmation assertion

### DIFF
--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/ask-question-select.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/ask-question-select.eval.ts
@@ -14,6 +14,7 @@ export default defineEval({
         "Set prompt to: 'Pick a color.'",
         'Provide exactly two options: - id "red", label "Red" - id "blue", label "Blue"',
         "Do not answer the question yourself, wait for my response.",
+        "After I respond, reply confirming the color I chose by name.",
       ].join("\n"),
     );
 


### PR DESCRIPTION
## What

`agent-tools-hitl/hitl/ask-question-select` intermittently fails on `openai-sol`:

```
messageIncludes(/\bblue\b/i): assistant messages did not include /\bblue\b/i; got: Thanks.
```

The eval parks on `ask_question` (select red/blue), responds `blue`, then asserts the reply mentions "blue". The **park/resume flow works** (`requireInputRequest` + `respondAll` + `succeeded` all pass) — the failure is purely that the model's free-form post-resume acknowledgment was "Thanks." instead of echoing the choice. An over-strict content assertion on model prose.

## Fix

Instruct the model to confirm the chosen color by name after responding, so the assertion reliably reflects the resumed selection instead of depending on incidental phrasing. Keeps the assertion's value (verifies the selected value propagated through resume) while removing the model-nondeterminism flake. Same philosophy as the web-search cutoff guards (#893): prompt the model toward the behavior the assertion checks.

## Context

Surfaced during a broader e2e flake investigation. `agent-tools-hitl` is ~10% of test-specific e2e flakes over the week of 07-09→15; this is its first characterized cause. Separate root cause from the web-search cutoff refusals in #893, hence a separate PR.