### PR TITLE
feat(eve): export SessionNotReadyError for route auth readiness

### DIFF
--- a/.changeset/session-not-ready-auth-error.md
+++ b/.changeset/session-not-ready-auth-error.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Export `SessionNotReadyError` and `createReadinessResponse` from `eve/channels/auth` so route auth can return a typed, retryable `425` readiness failure.

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -71,13 +71,17 @@ Put your own providers ahead of the catch-all helpers. `localDev()` is the final
 To reject with a precise status instead of skipping, throw:
 
 ```ts
-import { ForbiddenError, UnauthenticatedError } from "eve/channels/auth";
+import { ForbiddenError, SessionNotReadyError, UnauthenticatedError } from "eve/channels/auth";
 
 throw new UnauthenticatedError({
   code: "authentication_required",
   message: "Sign in to continue.",
 }); // 401
 throw new ForbiddenError({ message: "Not allowed on this workspace." }); // 403
+throw new SessionNotReadyError({
+  message: "Session projection is still catching up.",
+  retryAfterSeconds: 1,
+}); // 425 — native clients retry this status
 ```
 
 Any other thrown error follows the normal channel failure path. When building a custom channel on `defineChannel`, call `routeAuth(request, auth)` from `eve/channels/auth` to reuse the same walk semantics.
@@ -195,7 +199,7 @@ export default defineChannel({
 });
 ```
 
-`UnauthenticatedError` and `ForbiddenError` wrap this builder (status `401` / `403`). Throw those from an `AuthFn` that `routeAuth` walks. Call `createUnauthorizedResponse` directly only when you're returning a `Response` from a hand-rolled route.
+`UnauthenticatedError`, `ForbiddenError`, and `SessionNotReadyError` wrap the framework response builders (`401` / `403` / `425`). Throw those from an `AuthFn` that `routeAuth` walks. Call `createUnauthorizedResponse` or `createReadinessResponse` directly only when you're returning a `Response` from a hand-rolled route.
 
 ## Network policy
 

--- a/packages/eve/src/client/open-stream.test.ts
+++ b/packages/eve/src/client/open-stream.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ClientError } from "#client/client-error.js";
+import { openStreamBody } from "#client/open-stream.js";
+
+const STREAM_INPUT = {
+  host: "https://example.com",
+  resolveHeaders: async () => new Headers(),
+  sessionId: "session_1",
+  startIndex: 0,
+} as const;
+
+function createNdjsonBody(events: readonly unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const payload = events.map((event) => `${JSON.stringify(event)}\n`).join("");
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload));
+      controller.close();
+    },
+  });
+}
+
+describe("openStreamBody", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("retries 425 readiness failures before succeeding", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(
+          JSON.stringify({
+            code: "session_not_ready",
+            error: "Session projection is still catching up.",
+            ok: false,
+          }),
+          {
+            headers: { "cache-control": "no-store" },
+            status: 425,
+          },
+        );
+      }
+
+      return new Response(createNdjsonBody([{ type: "session.waiting", data: {} }]), {
+        status: 200,
+      });
+    });
+
+    const bodyPromise = openStreamBody(STREAM_INPUT);
+    await vi.advanceTimersByTimeAsync(250);
+    const body = await bodyPromise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(body).toBeInstanceOf(ReadableStream);
+  });
+
+  it("does not retry non-retryable auth failures", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: "forbidden",
+          error: "Not allowed.",
+          ok: false,
+        }),
+        { status: 403 },
+      ),
+    );
+
+    await expect(openStreamBody(STREAM_INPUT)).rejects.toBeInstanceOf(ClientError);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("stops retrying when the caller aborts", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+
+      return new Response(
+        JSON.stringify({
+          code: "session_not_ready",
+          error: "Session projection is still catching up.",
+          ok: false,
+        }),
+        { status: 425 },
+      );
+    });
+
+    await expect(
+      openStreamBody({
+        ...STREAM_INPUT,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -7,6 +7,7 @@ import { withVercelOidcProjectResolver } from "#runtime/governance/auth/vercel-o
 import {
   type AuthFn,
   createIpAllowList,
+  createReadinessResponse,
   createUnauthorizedResponse,
   extractBearerToken,
   ForbiddenError,
@@ -17,6 +18,7 @@ import {
   none,
   placeholderAuth,
   routeAuth,
+  SessionNotReadyError,
   type UnauthorizedChallenge,
   UnauthenticatedError,
   vercelOidc,
@@ -271,6 +273,55 @@ describe("createUnauthorizedResponse", () => {
   });
 });
 
+describe("createReadinessResponse", () => {
+  it("emits a default 425 with cache-control: no-store", async () => {
+    const response = createReadinessResponse();
+
+    expect(response.status).toBe(425);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.has("retry-after")).toBe(false);
+    await expect(response.json()).resolves.toEqual({
+      code: "session_not_ready",
+      error: "The requested session is not ready yet.",
+      ok: false,
+    });
+  });
+
+  it("emits a bounded Retry-After hint when requested", async () => {
+    const response = createReadinessResponse({
+      message: "Session projection is still catching up.",
+      retryAfterSeconds: 1,
+    });
+
+    expect(response.status).toBe(425);
+    expect(response.headers.get("retry-after")).toBe("1");
+    await expect(response.json()).resolves.toEqual({
+      code: "session_not_ready",
+      error: "Session projection is still catching up.",
+      ok: false,
+    });
+  });
+});
+
+describe("SessionNotReadyError", () => {
+  it("carries a structured 425 readiness response", async () => {
+    const error = new SessionNotReadyError({
+      message: "Session projection is still catching up.",
+      retryAfterSeconds: 1,
+    });
+
+    expect(error.message).toBe("Session projection is still catching up.");
+    expect(error.response.status).toBe(425);
+    expect(error.response.headers.get("cache-control")).toBe("no-store");
+    expect(error.response.headers.get("retry-after")).toBe("1");
+    await expect(error.response.json()).resolves.toEqual({
+      code: "session_not_ready",
+      error: "Session projection is still catching up.",
+      ok: false,
+    });
+  });
+});
+
 describe("UnauthenticatedError", () => {
   it("carries a structured 401 auth response", async () => {
     const error = new UnauthenticatedError({ message: "Sign in." });
@@ -482,6 +533,33 @@ describe("routeAuth", () => {
       await expect(result.json()).resolves.toEqual({
         code: "forbidden",
         error: "custom auth rejection",
+        ok: false,
+      });
+    }
+    expect(never).not.toHaveBeenCalled();
+  });
+
+  it("returns a session-not-ready response immediately and stops the walk", async () => {
+    const never = vi.fn(() => SAMPLE_CONTEXT);
+
+    const result = await routeAuth(makeRequest(), [
+      () => {
+        throw new SessionNotReadyError({
+          message: "Session projection is still catching up.",
+          retryAfterSeconds: 1,
+        });
+      },
+      never,
+    ]);
+
+    expect(result).toBeInstanceOf(Response);
+    if (result instanceof Response) {
+      expect(result.status).toBe(425);
+      expect(result.headers.get("cache-control")).toBe("no-store");
+      expect(result.headers.get("retry-after")).toBe("1");
+      await expect(result.json()).resolves.toEqual({
+        code: "session_not_ready",
+        error: "Session projection is still catching up.",
         ok: false,
       });
     }

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -403,6 +403,53 @@ export interface UnauthorizedResponseOptions {
 }
 
 /**
+ * Options accepted by {@link createReadinessResponse}.
+ */
+export interface ReadinessResponseOptions {
+  /**
+   * Machine-readable error code returned in the JSON body. Defaults to
+   * `"session_not_ready"`.
+   */
+  readonly code?: string;
+  /**
+   * Human-readable error message returned in the JSON body.
+   */
+  readonly message?: string;
+  /**
+   * Optional bounded `Retry-After` hint in seconds for callers that retry
+   * readiness failures.
+   */
+  readonly retryAfterSeconds?: number;
+}
+
+/**
+ * Builds a JSON readiness failure response for authenticated callers whose
+ * route dependency is not queryable yet: HTTP `425`, `cache-control: no-store`,
+ * and a `{ ok: false, code, error }` body.
+ */
+export function createReadinessResponse(opts: ReadinessResponseOptions = {}): Response {
+  const code = opts.code ?? "session_not_ready";
+  const message = opts.message ?? "The requested session is not ready yet.";
+  const headers = new Headers({ "cache-control": "no-store" });
+
+  if (opts.retryAfterSeconds !== undefined) {
+    headers.set("retry-after", String(opts.retryAfterSeconds));
+  }
+
+  return Response.json(
+    {
+      code,
+      error: message,
+      ok: false,
+    },
+    {
+      headers,
+      status: 425,
+    },
+  );
+}
+
+/**
  * Builds a JSON failure response shaped like the framework's other auth
  * failures: `cache-control: no-store`, one `www-authenticate` header per
  * challenge, and a `{ ok: false, code, error }` body.
@@ -482,6 +529,26 @@ export class ForbiddenError extends Error {
 }
 
 /**
+ * Options accepted by {@link SessionNotReadyError}.
+ */
+export type SessionNotReadyErrorOptions = ReadinessResponseOptions;
+
+/**
+ * Error thrown by auth callbacks when the caller is authenticated but a route
+ * dependency is not queryable yet. `routeAuth` catches it and returns its
+ * `425` response so native clients can perform their bounded retry.
+ */
+export class SessionNotReadyError extends Error {
+  readonly response: Response;
+
+  constructor(opts: SessionNotReadyErrorOptions = {}) {
+    super(opts.message ?? "The requested session is not ready yet.");
+    this.name = "SessionNotReadyError";
+    this.response = createReadinessResponse(opts);
+  }
+}
+
+/**
  * Route auth callback. Returned value semantics inside {@link routeAuth}:
  *
  * - A {@link SessionAuthContext} accepts the request and halts the walk.
@@ -489,8 +556,9 @@ export class ForbiddenError extends Error {
  *
  * If every entry skips (including the empty `[]` case), the walker returns a
  * 401. To reject with a specific response, throw an
- * {@link UnauthenticatedError} or {@link ForbiddenError}. To accept anonymous
- * traffic, include {@link none} as the final entry.
+ * {@link UnauthenticatedError}, {@link ForbiddenError}, or
+ * {@link SessionNotReadyError}. To accept anonymous traffic, include
+ * {@link none} as the final entry.
  */
 export type AuthFn<TEvent = Request> = (
   event: TEvent,


### PR DESCRIPTION
## Summary

Closes #724.

Route auth had no public way to signal "caller is authenticated, but this session isn't readable yet." Apps had to duck-type a private `Response` to get HTTP 425, which the native stream opener already retries.

This adds:

- `createReadinessResponse()` — framework-shaped `425` with `cache-control: no-store`, code `session_not_ready`, optional `Retry-After`
- `SessionNotReadyError` — throw from an `AuthFn`; `routeAuth` returns the response and stops the walk (same pattern as `ForbiddenError`)
- Unit tests for the new error, `routeAuth` preservation, and `openStreamBody` 425 retry / abort behavior
- Auth guide + changeset

No new transport or client retry logic — the client already treats 425 as retryable.

## Test plan

```bash
cd packages/eve
CI=true pnpm run build:compiled
CI=true pnpm exec vitest run --config vitest.unit.config.ts \
  src/public/channels/auth.test.ts \
  src/client/open-stream.test.ts
node ../../scripts/check-docs.mjs
```

- [x] Auth tests cover `createReadinessResponse`, `SessionNotReadyError`, and `routeAuth` 425 termination
- [x] `open-stream.test.ts` covers 425 retry, non-retryable 403, and abort-before-fetch
- [x] `docs:check` passes
