### PR TITLE
fix(eve): keep delivery context out of history

### DIFF
--- a/.changeset/fair-mails-rest.md
+++ b/.changeset/fair-mails-rest.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Apply channel delivery context only to its active turn instead of persisting it as user-authored conversation history, while keeping caller-supplied client context as transient user-role model input.

--- a/packages/eve/src/channel/adapter.test.ts
+++ b/packages/eve/src/channel/adapter.test.ts
@@ -99,6 +99,10 @@ describe("ChannelAdapter helpers", () => {
     expect(defaultDeliverResult({ context })).toEqual({ context });
   });
 
+  it("defaultDeliverResult rejects clientContext-only payloads", () => {
+    expect(defaultDeliverResult({ clientContext: ["selected word: jazz"] })).toBeUndefined();
+  });
+
   it("defaultDeliverResult returns undefined when the payload is empty", () => {
     expect(defaultDeliverResult({})).toBeUndefined();
   });

--- a/packages/eve/src/channel/adapter.test.ts
+++ b/packages/eve/src/channel/adapter.test.ts
@@ -71,12 +71,14 @@ describe("ChannelAdapter helpers", () => {
     });
   });
 
-  it("defaultDeliverResult forwards context with message payloads", () => {
+  it("defaultDeliverResult keeps client and channel context separate", () => {
+    const clientContext = ["selected word: jazz"];
     const context = ["thread background"];
 
-    expect(defaultDeliverResult({ message: "hi", context })).toEqual({
+    expect(defaultDeliverResult({ clientContext, message: "hi", context })).toEqual({
       inputResponses: undefined,
       message: "hi",
+      clientContext,
       context,
     });
   });

--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -205,10 +205,7 @@ export function defaultDeliverResult(payload: DeliverPayload): StepInput | undef
     };
   }
 
-  if (
-    (payload.clientContext !== undefined && payload.clientContext.length > 0) ||
-    (payload.context !== undefined && payload.context.length > 0)
-  ) {
+  if (payload.context !== undefined && payload.context.length > 0) {
     return {
       clientContext: payload.clientContext,
       context: payload.context,

--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -190,6 +190,7 @@ export function defaultDeliverResult(payload: DeliverPayload): StepInput | undef
     return {
       inputResponses: payload.inputResponses,
       message: payload.message,
+      clientContext: payload.clientContext,
       context: payload.context,
       outputSchema: payload.outputSchema,
     };
@@ -198,13 +199,21 @@ export function defaultDeliverResult(payload: DeliverPayload): StepInput | undef
   if (payload.inputResponses !== undefined && payload.inputResponses.length > 0) {
     return {
       inputResponses: payload.inputResponses,
+      clientContext: payload.clientContext,
       context: payload.context,
       outputSchema: payload.outputSchema,
     };
   }
 
-  if (payload.context !== undefined && payload.context.length > 0) {
-    return { context: payload.context, outputSchema: payload.outputSchema };
+  if (
+    (payload.clientContext !== undefined && payload.clientContext.length > 0) ||
+    (payload.context !== undefined && payload.context.length > 0)
+  ) {
+    return {
+      clientContext: payload.clientContext,
+      context: payload.context,
+      outputSchema: payload.outputSchema,
+    };
   }
 
   if (payload.outputSchema !== undefined) {

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -38,9 +38,15 @@ export interface SendPayload {
   readonly message?: string | UserContent;
   readonly inputResponses?: readonly InputResponse[];
   /**
-   * Context strings contributed by the channel. eve appends each entry
-   * as a `role: "user"` message to `session.history` before the delivery
-   * message and persists it across the session.
+   * Caller-authored client or page context. eve presents each entry as a
+   * transient user-role message for this turn and never persists it to
+   * durable conversation history.
+   */
+  readonly clientContext?: readonly string[];
+  /**
+   * Context strings contributed by the channel. eve applies each entry as
+   * instructions for this turn without adding it to durable conversation
+   * history.
    */
   readonly context?: readonly string[];
   /**

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -83,6 +83,32 @@ describe("createSendFn", () => {
     expect(runtime.run).not.toHaveBeenCalled();
   });
 
+  it("rejects clientContext-only input when no active session exists", async () => {
+    const runtime = createRuntime(new RuntimeNoActiveSessionError("test:token"));
+    const send = createSendFn(runtime, ADAPTER, "test");
+
+    await expect(
+      send({ clientContext: ["selected word: jazz"] }, { auth: null, continuationToken: "token" }),
+    ).rejects.toThrow(/Cannot start a session/);
+    expect(runtime.run).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["trusted context", { context: ["reply in the current channel"] }],
+    [
+      "an output schema",
+      { outputSchema: { properties: {}, required: [], type: "object" as const } },
+    ],
+  ])("starts a new session from %s without a message", async (_label, input) => {
+    const runtime = createRuntime(new RuntimeNoActiveSessionError("test:token"));
+    const send = createSendFn(runtime, ADAPTER, "test");
+
+    await send(input, { auth: null, continuationToken: "token" });
+
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runtime.run).mock.calls[0]![0].input).toMatchObject(input);
+  });
+
   it("keeps client and channel context separate through deliver and run payloads", async () => {
     const clientContext = ["selected word: jazz"];
     const context = ["thread background"];

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -83,7 +83,8 @@ describe("createSendFn", () => {
     expect(runtime.run).not.toHaveBeenCalled();
   });
 
-  it("forwards context through deliver and run payloads", async () => {
+  it("keeps client and channel context separate through deliver and run payloads", async () => {
+    const clientContext = ["selected word: jazz"];
     const context = ["thread background"];
     const deliverRuntime: Runtime = {
       cancelTurn: vi.fn(),
@@ -94,7 +95,10 @@ describe("createSendFn", () => {
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test");
-    await deliverSend({ message: "hello", context }, { auth: null, continuationToken: "token" });
+    await deliverSend(
+      { clientContext, message: "hello", context },
+      { auth: null, continuationToken: "token" },
+    );
 
     expect(deliverRuntime.deliver).toHaveBeenCalledWith({
       auth: null,
@@ -102,6 +106,7 @@ describe("createSendFn", () => {
       payload: {
         inputResponses: undefined,
         message: "hello",
+        clientContext,
         context,
       },
     });
@@ -109,10 +114,14 @@ describe("createSendFn", () => {
 
     const runRuntime = createRuntime(new RuntimeNoActiveSessionError("test:token"));
     const runSend = createSendFn(runRuntime, ADAPTER, "test");
-    await runSend({ message: "hello", context }, { auth: null, continuationToken: "token" });
+    await runSend(
+      { clientContext, message: "hello", context },
+      { auth: null, continuationToken: "token" },
+    );
 
     expect(vi.mocked(runRuntime.run).mock.calls[0]![0].input).toEqual({
       message: "hello",
+      clientContext,
       context,
     });
   });

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -31,6 +31,7 @@ export function createSendFn<TState = undefined>(
     const {
       message: rawMessage,
       inputResponses,
+      clientContext,
       context,
       outputSchema,
     } = normalizeSendInput(input);
@@ -41,7 +42,7 @@ export function createSendFn<TState = undefined>(
         auth,
         continuationToken,
         requestId: metadata.requestId,
-        payload: { inputResponses, message, context, outputSchema },
+        payload: { inputResponses, message, clientContext, context, outputSchema },
       };
       const { sessionId } = await runtime.deliver(deliverInput);
 
@@ -73,7 +74,7 @@ export function createSendFn<TState = undefined>(
       channelName,
       callback,
       continuationToken,
-      input: { message: message ?? "", context, outputSchema },
+      input: { message: message ?? "", clientContext, context, outputSchema },
       mode,
       requestId: metadata.requestId,
       title,

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -63,6 +63,16 @@ export function createSendFn<TState = undefined>(
       );
     }
 
+    if (
+      message === undefined &&
+      (context === undefined || context.length === 0) &&
+      outputSchema === undefined
+    ) {
+      throw new Error(
+        "Cannot start a session without a message, trusted context, or output schema.",
+      );
+    }
+
     const sessionAdapter = state
       ? { ...adapter, state: { ...adapter.state, ...(state as Record<string, unknown>) } }
       : adapter;

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -113,6 +113,7 @@ export type EventEmitFn = (event: HandleMessageStreamEvent) => Promise<void>;
 export interface DeliverPayload {
   readonly inputResponses?: readonly InputResponse[];
   readonly message?: string | UserContent;
+  readonly clientContext?: readonly string[];
   readonly context?: readonly string[];
   readonly outputSchema?: JsonObject;
   readonly [key: string]: unknown;
@@ -307,6 +308,7 @@ export interface RunInput {
   readonly initiatorAuth?: SessionAuthContext | null;
   readonly input: {
     readonly message: string | UserContent;
+    readonly clientContext?: readonly string[];
     readonly context?: readonly string[];
     readonly outputSchema?: JsonObject;
   };

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -130,10 +130,11 @@ export type SendTurnInput<TOutput = unknown> = string | SendTurnPayload<TOutput>
  */
 export interface SendTurnPayload<TOutput = unknown> {
   /**
-   * Ephemeral client/page context for the next model call only.
+   * Ephemeral client/page context for the active turn only.
    *
    * Strings are rendered as user-role model context messages. Objects are
-   * JSON-serialized into one user-role model context message. Client context
+   * JSON-serialized into one user-role model context message. It remains
+   * available across internal model continuations for that turn. Client context
    * rides along with a message or HITL response; it does not dispatch a turn by
    * itself and is never persisted to durable session history.
    */

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -129,7 +129,7 @@ describe("workflowEntry", () => {
     });
 
     const result = await workflowEntry({
-      input: { message: "hello there" },
+      input: { clientContext: ["selected word: jazz"], message: "hello there" },
       serializedContext: createSerializedContext(),
     });
 
@@ -145,7 +145,13 @@ describe("workflowEntry", () => {
         completionToken: expect.any(String),
         delivery: {
           kind: "deliver",
-          payloads: [{ message: "hello there", context: undefined }],
+          payloads: [
+            {
+              clientContext: ["selected word: jazz"],
+              message: "hello there",
+              context: undefined,
+            },
+          ],
         },
         serializedContext: expect.objectContaining({
           "eve.continuationToken": "http:test",

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -110,6 +110,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
         payloads: [
           {
             message: input.input.message,
+            clientContext: input.input.clientContext,
             context: input.input.context,
             outputSchema: input.input.outputSchema,
           },

--- a/packages/eve/src/harness/compact-step-input.ts
+++ b/packages/eve/src/harness/compact-step-input.ts
@@ -1,0 +1,33 @@
+import type { StepInput } from "#harness/types.js";
+
+type CompactableStepInput = StepInput & { readonly messageConsumed?: boolean };
+
+/** Drops empty optional fields before a step input is persisted for replay. */
+export function compactStepInput(input: CompactableStepInput | undefined): CompactableStepInput {
+  if (input === undefined) {
+    return {};
+  }
+
+  const result: { -readonly [K in keyof CompactableStepInput]?: CompactableStepInput[K] } = {};
+
+  if ((input.clientContext?.length ?? 0) > 0) {
+    result.clientContext = input.clientContext;
+  }
+  if ((input.context?.length ?? 0) > 0) {
+    result.context = input.context;
+  }
+  if ((input.inputResponses?.length ?? 0) > 0) {
+    result.inputResponses = input.inputResponses;
+  }
+  if (input.message !== undefined) {
+    result.message = input.message;
+  }
+  if (input.messageConsumed === true) {
+    result.messageConsumed = true;
+  }
+  if (input.outputSchema !== undefined) {
+    result.outputSchema = input.outputSchema;
+  }
+
+  return result;
+}

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -8,6 +8,7 @@ import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import { resolveTextToResponses } from "#channel/resolve-text.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
+import { compactStepInput } from "#harness/compact-step-input.js";
 import {
   isSessionLimitContinuationRequest,
   resolveSessionLimitContinuation,
@@ -211,9 +212,13 @@ export function resolvePendingInput(input: {
   // in isolation; `consumeDeferredStepInput` replays them on the next step.
   if (resolvesApprovalBatch) {
     const deferredInput: {
+      clientContext?: StepInput["clientContext"];
       context?: StepInput["context"];
       message?: StepInput["message"];
     } = {};
+    if ((resolvedStepInput?.clientContext?.length ?? 0) > 0) {
+      deferredInput.clientContext = resolvedStepInput?.clientContext;
+    }
     if ((resolvedStepInput?.context?.length ?? 0) > 0) {
       deferredInput.context = resolvedStepInput?.context;
     }
@@ -221,11 +226,16 @@ export function resolvePendingInput(input: {
       deferredInput.message = resolvedStepInput.message;
     }
 
-    if (deferredInput.context !== undefined || deferredInput.message !== undefined) {
+    if (
+      deferredInput.clientContext !== undefined ||
+      deferredInput.context !== undefined ||
+      deferredInput.message !== undefined
+    ) {
       session = queueDeferredStepInput(session, deferredInput);
 
       return {
         consumedMessage: resolvedStepInput?.messageConsumed,
+        deferredClientContext: deferredInput.clientContext === undefined ? undefined : true,
         deferredContext: deferredInput.context === undefined ? undefined : true,
         deferredMessage: deferredInput.message === undefined ? undefined : true,
         limitContinuation,
@@ -268,40 +278,6 @@ function resolveTextMessageInput(
   });
 }
 
-function compactStepInput(
-  input: (StepInput & { readonly messageConsumed?: boolean }) | undefined,
-): StepInput & { readonly messageConsumed?: boolean } {
-  if (input === undefined) {
-    return {};
-  }
-
-  const result: {
-    context?: StepInput["context"];
-    inputResponses?: StepInput["inputResponses"];
-    message?: StepInput["message"];
-    messageConsumed?: boolean;
-    outputSchema?: StepInput["outputSchema"];
-  } = {};
-
-  if ((input.context?.length ?? 0) > 0) {
-    result.context = input.context;
-  }
-  if ((input.inputResponses?.length ?? 0) > 0) {
-    result.inputResponses = input.inputResponses;
-  }
-  if (input.message !== undefined) {
-    result.message = input.message;
-  }
-  if (input.messageConsumed === true) {
-    result.messageConsumed = true;
-  }
-  if (input.outputSchema !== undefined) {
-    result.outputSchema = input.outputSchema;
-  }
-
-  return result;
-}
-
 function hasUnansweredApproval(input: {
   readonly pendingBatch: PendingInputBatch;
   readonly responses: readonly InputResponse[];
@@ -314,6 +290,7 @@ function hasUnansweredApproval(input: {
 
 type ResolvePendingInputResult = {
   readonly consumedMessage?: boolean;
+  readonly deferredClientContext?: boolean;
   readonly deferredContext?: boolean;
   readonly deferredMessage?: boolean;
   /**

--- a/packages/eve/src/harness/messages.test.ts
+++ b/packages/eve/src/harness/messages.test.ts
@@ -55,13 +55,15 @@ describe("coalesceTurnInputs", () => {
     });
   });
 
-  it("preserves context from both payloads in order", () => {
+  it("preserves client and channel context independently in order", () => {
     const result = coalesceTurnInputs(
       {
+        clientContext: ["client-a"],
         message: "hello",
         context: ["from-channel"],
       },
       {
+        clientContext: ["client-b"],
         inputResponses: [{ requestId: "r1", text: "yes" }],
         context: ["from-hook"],
       },
@@ -70,6 +72,7 @@ describe("coalesceTurnInputs", () => {
     expect(result).toEqual({
       inputResponses: [{ requestId: "r1", text: "yes" }],
       message: "hello",
+      clientContext: ["client-a", "client-b"],
       context: ["from-channel", "from-hook"],
     });
   });

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -20,6 +20,10 @@ export function coalesceTurnInputs(a: StepInput, b: StepInput): StepInput {
     a: a.message,
     b: b.message,
   });
+  const clientContext = coalesceContext({
+    a: a.clientContext,
+    b: b.clientContext,
+  });
   const context = coalesceContext({
     a: a.context,
     b: b.context,
@@ -29,6 +33,7 @@ export function coalesceTurnInputs(a: StepInput, b: StepInput): StepInput {
   const result: {
     inputResponses?: readonly InputResponse[];
     message?: string | UserContent;
+    clientContext?: readonly string[];
     context?: readonly string[];
     outputSchema?: StepInput["outputSchema"];
   } = {};
@@ -39,6 +44,10 @@ export function coalesceTurnInputs(a: StepInput, b: StepInput): StepInput {
 
   if (message !== undefined) {
     result.message = message;
+  }
+
+  if (clientContext !== undefined) {
+    result.clientContext = clientContext;
   }
 
   if (context !== undefined) {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -42,6 +42,7 @@ import {
   setPendingInputBatch,
 } from "#harness/input-requests.js";
 import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
+import { getTurnClientContext, getTurnDeliveryContext } from "#harness/turn-delivery-context.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import { TurnCancelledError } from "#harness/turn-cancellation.js";
@@ -6837,6 +6838,8 @@ describe("createToolLoopHarness", () => {
       role: "user",
     });
     expect(secondResult.session.history).not.toContainEqual({ content: context, role: "user" });
+    expect(getTurnClientContext(secondResult.session)).toEqual([]);
+    expect(getTurnDeliveryContext(secondResult.session)).toEqual([]);
   });
 
   it("deferred message lands as last non-system message after explicit approval denial", async () => {
@@ -7041,9 +7044,15 @@ describe("createToolLoopHarness", () => {
       },
     });
 
-    const result = await runStep(session, { message: "Choose for me." });
+    const result = await runStep(session, {
+      clientContext: ["selected issue text"],
+      context: ["channel instruction"],
+      message: "Choose for me.",
+    });
 
     expect(result.next).toBeNull();
+    expect(getTurnClientContext(result.session)).toEqual([]);
+    expect(getTurnDeliveryContext(result.session)).toEqual([]);
     expect(events.some((event) => event.type === "actions.requested")).toBe(false);
     expect(events.find((event) => event.type === "input.requested")).toEqual({
       data: {
@@ -9091,6 +9100,7 @@ describe("createToolLoopHarness", () => {
         { role: "user", content: "Hi" },
         { role: "assistant", content: "ok" },
       ]);
+      expect(getTurnDeliveryContext(result.session)).toEqual([]);
     });
 
     it("keeps public client context as a turn-scoped user overlay", async () => {
@@ -9163,6 +9173,7 @@ describe("createToolLoopHarness", () => {
       expect(dynamicModelMessages[0]).toContainEqual({ role: "user", content: clientContext });
       expect(dynamicToolMessages[0]).toContainEqual({ role: "user", content: clientContext });
       expect(first.session.history).not.toContainEqual({ role: "user", content: clientContext });
+      expect(getTurnClientContext(first.session)).toEqual([clientContext]);
 
       setupMockAgent(defaultModelResult());
       expect(typeof first.next).toBe("function");
@@ -9177,6 +9188,7 @@ describe("createToolLoopHarness", () => {
       expect(dynamicModelMessages[1]).toContainEqual({ role: "user", content: clientContext });
       expect(dynamicToolMessages[1]).toContainEqual({ role: "user", content: clientContext });
       expect(second.session.history).not.toContainEqual({ role: "user", content: clientContext });
+      expect(getTurnClientContext(second.session)).toEqual([]);
 
       setupMockAgent(defaultModelResult());
       await contextStorage.run(ctx, () =>

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -7338,7 +7338,35 @@ describe("createToolLoopHarness", () => {
       ],
     });
 
-    await runStep(session, { message: "Hi" });
+    const result = await runStep(session, {
+      clientContext: ["selected PR text"],
+      context: ["trusted channel instruction"],
+      message: "Hi",
+    });
+
+    expect(shouldCompact).toHaveBeenCalledWith(
+      [
+        { content: "old message", role: "user" },
+        { content: "old reply", role: "assistant" },
+        { content: "Hi", role: "user" },
+        { content: "selected PR text", role: "user" },
+        { content: "trusted channel instruction", role: "system" },
+      ],
+      expect.objectContaining({ threshold: 100_000 }),
+    );
+    expect(vi.mocked(compactMessages).mock.calls[0]?.[0]).toEqual([
+      { content: "old message", role: "user" },
+      { content: "old reply", role: "assistant" },
+      { content: "Hi", role: "user" },
+    ]);
+    expect(result.session.history).not.toContainEqual({
+      content: "selected PR text",
+      role: "user",
+    });
+    expect(result.session.history).not.toContainEqual({
+      content: "trusted channel instruction",
+      role: "system",
+    });
 
     expect(getCompatibilityEventTypes(events)).toEqual([
       "session.started",
@@ -7584,6 +7612,29 @@ describe("createToolLoopHarness", () => {
       lastKnownInputTokens: 321,
       lastKnownPromptMessageCount: 1,
     });
+  });
+
+  it("does not checkpoint provider token counts that include transient context", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Hello!", role: "assistant" }] },
+      text: "Hello!",
+      toolCalls: [],
+      toolResults: [],
+      usage: { inputTokens: 321 },
+    });
+
+    const result = await createToolLoopHarness(createTestConfig("conversation"))(
+      createTestSession(),
+      {
+        clientContext: ["selected PR text"],
+        context: ["trusted channel instruction"],
+        message: "Hi",
+      },
+    );
+
+    expect(result.session.compaction.lastKnownInputTokens).toBeUndefined();
+    expect(result.session.compaction.lastKnownPromptMessageCount).toBeUndefined();
   });
 
   it("invokes onCompaction callback after compaction", async () => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -43,6 +43,8 @@ import {
 } from "#harness/input-requests.js";
 import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { getTurnClientContext, getTurnDeliveryContext } from "#harness/turn-delivery-context.js";
+import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
+import { WORKFLOW_RUNTIME_ACTION_INTERRUPT_KIND } from "#harness/workflow-runtime-action-state.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import { TurnCancelledError } from "#harness/turn-cancellation.js";
@@ -92,6 +94,12 @@ vi.mock("./compaction.js", () => ({
     }),
   ),
   shouldCompact: vi.fn().mockReturnValue(false),
+}));
+
+const mockGetWorkflowSandboxInterrupt = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("#shared/workflow-sandbox.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#shared/workflow-sandbox.js")>()),
+  getWorkflowSandboxInterrupt: (...args: unknown[]) => mockGetWorkflowSandboxInterrupt(...args),
 }));
 
 afterEach(() => {
@@ -9251,6 +9259,88 @@ describe("createToolLoopHarness", () => {
       });
       expect(dynamicModelMessages[2]).not.toContainEqual({ role: "user", content: clientContext });
       expect(dynamicToolMessages[2]).not.toContainEqual({ role: "user", content: clientContext });
+    });
+
+    it("keeps transient context while a workflow child is parked", async () => {
+      setupMockAgent(defaultModelResult());
+      const interruptId = "workflow-call:tool-1:interrupt";
+      const toolCallId = "workflow-call:tool-1";
+      const interruptPayload = {
+        kind: WORKFLOW_RUNTIME_ACTION_INTERRUPT_KIND,
+        runtimeAction: {
+          kind: "subagent-call" as const,
+          nodeId: "workers",
+          subagentName: "worker",
+        },
+        toolInput: { message: "delegate" },
+        toolName: "delegate",
+      };
+      const continuation = {
+        auth: {
+          alg: "HMAC-SHA256" as const,
+          expiresAtMs: 2,
+          issuedAtMs: 1,
+          nonce: "nonce",
+          signature: "signature",
+        },
+        determinism: {
+          dateNowMs: 1,
+          randomSeed: "00000000000000000000000000000000",
+        },
+        js: "return delegate({ message: 'delegate' })",
+        ledger: [
+          {
+            inputJson: JSON.stringify({ message: "delegate" }),
+            interruptId,
+            interruptPayload,
+            kind: "tool" as const,
+            name: "delegate",
+            status: "interrupted" as const,
+            toolCallId,
+          },
+        ],
+        outerToolCallId: "workflow-call",
+        version: 1 as const,
+      };
+      mockGetWorkflowSandboxInterrupt.mockResolvedValueOnce({
+        continuation,
+        input: { message: "delegate" },
+        interruptId,
+        outerToolCallId: continuation.outerToolCallId,
+        payload: interruptPayload,
+        toolCallId,
+        toolName: "delegate",
+        type: "code-mode-interrupt",
+      });
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", undefined, {
+          tools: createDelegationToolMap(),
+          workflow: true,
+        }),
+      );
+      const clientContext = "selected issue text";
+      const deliveryContext = "reply in the current channel";
+
+      const result = await runStep(
+        createTestSession({
+          state: {
+            "eve.harness.workflowContinuationSecurity": {
+              signingKey: "a".repeat(43),
+              version: 1,
+            },
+          },
+        }),
+        {
+          clientContext: [clientContext],
+          context: [deliveryContext],
+          message: "Delegate this",
+        },
+      );
+
+      expect(result.next).toBeNull();
+      expect(getPendingWorkflowInterrupt(result.session.state)).toBeDefined();
+      expect(getTurnClientContext(result.session)).toEqual([clientContext]);
+      expect(getTurnDeliveryContext(result.session)).toEqual([deliveryContext]);
     });
 
     it("routes role:system durable history into instructions, not messages", async () => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -6730,7 +6730,7 @@ describe("createToolLoopHarness", () => {
     ]);
   });
 
-  it("keeps channel context after the approval-response model call", async () => {
+  it("applies channel context after the approval-response model call", async () => {
     setupMockAgent({
       finishReason: "stop",
       response: { messages: [{ content: "Approved.", role: "assistant" }] },
@@ -6791,8 +6791,10 @@ describe("createToolLoopHarness", () => {
     });
     const harness = createToolLoopHarness(config);
     const context = "<linear_context>issue metadata</linear_context>";
+    const clientContext = "Client context:\napproval modal open";
 
     const firstResult = await harness(createPendingBashApprovalSession(), {
+      clientContext: [clientContext],
       context: [context],
       inputResponses: [{ requestId: "approval-1", optionId: "approve" }],
     });
@@ -6800,6 +6802,7 @@ describe("createToolLoopHarness", () => {
     const firstMessages = readGenerateMessages(0);
     expect(typeof firstResult.next).toBe("function");
     expect(firstMessages.at(-1)?.role).toBe("tool");
+    expect(firstMessages).not.toContainEqual({ content: clientContext, role: "user" });
     expect(firstMessages).not.toContainEqual({ content: context, role: "user" });
     expect((await readPreparedMessages(0)).at(-1)).toMatchObject({
       providerOptions: {
@@ -6813,14 +6816,27 @@ describe("createToolLoopHarness", () => {
     const secondMessages = readGenerateMessages(1);
     expect(secondResult.next).toBeNull();
     expect(secondMessages.slice(0, firstMessages.length)).toEqual(firstMessages);
-    expect(secondMessages.at(-1)).toEqual({ content: context, role: "user" });
+    expect(secondMessages.at(-2)).toEqual({ content: "Approved.", role: "assistant" });
+    expect(secondMessages.at(-1)).toEqual({ content: clientContext, role: "user" });
+    expect(vi.mocked(ToolLoopAgent).mock.calls[1]?.[0].instructions).toEqual({
+      content: `You are a test assistant.\n\n${context}`,
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      },
+      role: "system",
+    });
     expect((await readPreparedMessages(1)).at(-1)).toMatchObject({
-      content: context,
+      content: clientContext,
       providerOptions: {
         anthropic: { cacheControl: { type: "ephemeral" } },
       },
       role: "user",
     });
+    expect(secondResult.session.history).not.toContainEqual({
+      content: clientContext,
+      role: "user",
+    });
+    expect(secondResult.session.history).not.toContainEqual({ content: context, role: "user" });
   });
 
   it("deferred message lands as last non-system message after explicit approval denial", async () => {
@@ -9037,8 +9053,9 @@ describe("createToolLoopHarness", () => {
       };
       const instance = vi.mocked(ToolLoopAgent).mock.results.at(-1)?.value as {
         generate: ReturnType<typeof vi.fn>;
+        stream: ReturnType<typeof vi.fn>;
       };
-      const call = instance.generate.mock.calls[0]?.[0] as {
+      const call = (instance.generate.mock.calls[0]?.[0] ?? instance.stream.mock.calls[0]?.[0]) as {
         messages: Array<{ role: string; content: unknown }>;
       };
       return { instructions: settings.instructions, messages: call.messages };
@@ -9054,20 +9071,123 @@ describe("createToolLoopHarness", () => {
       };
     }
 
-    it("appends context strings as user messages", async () => {
+    it("applies delivery context as turn-scoped instructions", async () => {
       setupMockAgent(defaultModelResult());
       const runStep = createToolLoopHarness(createTestConfig("conversation"));
       const session = createTestSession();
 
-      await runStep(session, {
+      const result = await runStep(session, {
         message: "Hi",
         context: ["ephemeral-context"],
       });
 
-      const { messages } = getLastAgentSettings();
-      const contextMessage = messages.find((m) => m.content === "ephemeral-context");
-      expect(contextMessage).toBeDefined();
-      expect(contextMessage!.role).toBe("user");
+      const { instructions, messages } = getLastAgentSettings();
+      expect(instructions).toEqual({
+        role: "system",
+        content: "You are a test assistant.\n\nephemeral-context",
+      });
+      expect(messages).not.toContainEqual({ role: "user", content: "ephemeral-context" });
+      expect(result.session.history).toEqual([
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "ok" },
+      ]);
+    });
+
+    it("keeps public client context as a turn-scoped user overlay", async () => {
+      const dynamicModelMessages: ModelMessage[][] = [];
+      const dynamicToolMessages: ModelMessage[][] = [];
+      const emit: HarnessEmitFn = async (event, messages) => {
+        if (event.type === "step.started" && messages !== undefined) {
+          dynamicToolMessages.push([...messages]);
+        }
+      };
+      const dispatchDynamicModelEvent: NonNullable<
+        ToolLoopHarnessConfig["dispatchDynamicModelEvent"]
+      > = vi.fn(async ({ ctx, fallback, messages }) => {
+        dynamicModelMessages.push([...messages]);
+        ctx.setVirtualContext(LiveStepDynamicModelSelectionKey, {
+          model: {} as LanguageModel,
+          reference: fallback,
+        });
+      });
+      setupMockAgent({
+        finishReason: "tool-calls",
+        response: {
+          messages: [
+            {
+              content: [
+                { input: { a: 1, b: 2 }, toolCallId: "call-1", toolName: "add", type: "tool-call" },
+              ],
+              role: "assistant",
+            },
+            {
+              content: [
+                { output: "42", toolCallId: "call-1", toolName: "add", type: "tool-result" },
+              ],
+              role: "tool",
+            },
+          ],
+        },
+        text: "",
+        toolCalls: [
+          { input: { a: 1, b: 2 }, toolCallId: "call-1", toolName: "add", type: "tool-call" },
+        ],
+        toolResults: [
+          {
+            input: { a: 1, b: 2 },
+            output: "42",
+            toolCallId: "call-1",
+            toolName: "add",
+            type: "tool-result",
+          },
+        ],
+      });
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", emit, { dispatchDynamicModelEvent }),
+      );
+      const ctx = new ContextContainer();
+      const session = createTestSession();
+      const clientContext = "Client context:\nselection: jazz";
+
+      const first = await contextStorage.run(ctx, () =>
+        runStep(session, {
+          clientContext: [clientContext],
+          message: "Use the selected word",
+        }),
+      );
+      expect(getLastAgentSettings().instructions).toBe("You are a test assistant.");
+      expect(getLastAgentSettings().messages).toContainEqual({
+        role: "user",
+        content: clientContext,
+      });
+      expect(dynamicModelMessages[0]).toContainEqual({ role: "user", content: clientContext });
+      expect(dynamicToolMessages[0]).toContainEqual({ role: "user", content: clientContext });
+      expect(first.session.history).not.toContainEqual({ role: "user", content: clientContext });
+
+      setupMockAgent(defaultModelResult());
+      expect(typeof first.next).toBe("function");
+      const second = await contextStorage.run(ctx, () =>
+        (first.next as typeof runStep)(first.session),
+      );
+      expect(getLastAgentSettings().instructions).toBe("You are a test assistant.");
+      expect(getLastAgentSettings().messages).toContainEqual({
+        role: "user",
+        content: clientContext,
+      });
+      expect(dynamicModelMessages[1]).toContainEqual({ role: "user", content: clientContext });
+      expect(dynamicToolMessages[1]).toContainEqual({ role: "user", content: clientContext });
+      expect(second.session.history).not.toContainEqual({ role: "user", content: clientContext });
+
+      setupMockAgent(defaultModelResult());
+      await contextStorage.run(ctx, () =>
+        runStep(second.session, { message: "Start the next turn" }),
+      );
+      expect(getLastAgentSettings().messages).not.toContainEqual({
+        role: "user",
+        content: clientContext,
+      });
+      expect(dynamicModelMessages[2]).not.toContainEqual({ role: "user", content: clientContext });
+      expect(dynamicToolMessages[2]).not.toContainEqual({ role: "user", content: clientContext });
     });
 
     it("routes role:system durable history into instructions, not messages", async () => {
@@ -9088,21 +9208,70 @@ describe("createToolLoopHarness", () => {
       expect(messages.at(-1)).toEqual({ role: "user", content: "Hi" });
     });
 
-    it("persists context strings in session history as user messages", async () => {
-      setupMockAgent(defaultModelResult());
+    it("keeps delivery context through internal steps without leaking it into the next turn", async () => {
+      setupMockAgent({
+        finishReason: "tool-calls",
+        response: {
+          messages: [
+            {
+              content: [
+                { input: { a: 1, b: 2 }, toolCallId: "call-1", toolName: "add", type: "tool-call" },
+              ],
+              role: "assistant",
+            },
+            {
+              content: [
+                { output: "42", toolCallId: "call-1", toolName: "add", type: "tool-result" },
+              ],
+              role: "tool",
+            },
+          ],
+        },
+        text: "",
+        toolCalls: [
+          { input: { a: 1, b: 2 }, toolCallId: "call-1", toolName: "add", type: "tool-call" },
+        ],
+        toolResults: [
+          {
+            input: { a: 1, b: 2 },
+            output: "42",
+            toolCallId: "call-1",
+            toolName: "add",
+            type: "tool-result",
+          },
+        ],
+      });
       const runStep = createToolLoopHarness(createTestConfig("conversation"));
       const session = createTestSession();
 
-      const result = await runStep(session, {
-        message: "Hi",
-        context: ["background-context"],
+      const first = await runStep(session, {
+        message: "Add 1 and 2",
+        context: ["current-turn-only"],
+      });
+      expect(getLastAgentSettings().instructions).toEqual({
+        role: "system",
+        content: "You are a test assistant.\n\ncurrent-turn-only",
       });
 
-      expect(result.session.history).toEqual([
-        { role: "user", content: "background-context" },
-        { role: "user", content: "Hi" },
-        { role: "assistant", content: "ok" },
-      ]);
+      setupMockAgent(defaultModelResult());
+      expect(typeof first.next).toBe("function");
+      const second = await (first.next as typeof runStep)(first.session);
+      expect(getLastAgentSettings().instructions).toEqual({
+        role: "system",
+        content: "You are a test assistant.\n\ncurrent-turn-only",
+      });
+      expect(second.session.history).not.toContainEqual({
+        role: "user",
+        content: "current-turn-only",
+      });
+
+      setupMockAgent(defaultModelResult());
+      await runStep(second.session, { message: "Start the next turn" });
+      expect(getLastAgentSettings().instructions).toBe("You are a test assistant.");
+      expect(getLastAgentSettings().messages).not.toContainEqual({
+        role: "user",
+        content: "current-turn-only",
+      });
     });
 
     it("leaves instructions unchanged when no context is provided", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -112,6 +112,7 @@ import { getInstrumentationConfig } from "#harness/instrumentation-config.js";
 import { resolveAssistantStepText } from "#harness/messages.js";
 import {
   buildTurnClientContextView,
+  clearTurnContext,
   getTurnDeliveryContext,
   setTurnClientContext,
   setTurnDeliveryContext,
@@ -508,10 +509,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const executeStep = () => executeStepBody(initialSession, input, turnSpan);
 
     try {
-      if (parentContext) {
-        return await otelContext.with(parentContext, executeStep);
-      }
-      return await executeStep();
+      const result = parentContext
+        ? await otelContext.with(parentContext, executeStep)
+        : await executeStep();
+      return typeof result.next === "function"
+        ? result
+        : { ...result, session: clearTurnContext(result.session) };
     } finally {
       turnSpan?.end();
     }

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -112,6 +112,7 @@ import { getInstrumentationConfig } from "#harness/instrumentation-config.js";
 import { resolveAssistantStepText } from "#harness/messages.js";
 import {
   buildTurnClientContextView,
+  buildTurnContextAccountingView,
   clearTurnContext,
   getTurnDeliveryContext,
   setTurnClientContext,
@@ -702,8 +703,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // Runs before `agent.stream()` so the compacted messages flow through
     // `messages` (which the harness uses to rebuild session history).
     const attributionHeaders = buildGatewayAttributionHeaders(model, config.runtimeIdentity);
+    const accountingMessages = buildTurnContextAccountingView(session, messages);
 
     ({ messages, session } = await maybeCompact({
+      accountingMessages,
       abortSignal: config.abortSignal,
       emit,
       emissionState,
@@ -1309,6 +1312,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       result,
       runStep,
       session,
+      hasTransientContext: buildTurnContextAccountingView(session, []).length > 0,
     });
   }
 
@@ -1797,8 +1801,9 @@ async function handleStepResult(input: {
   readonly result: HarnessStepResult;
   readonly runStep: StepFn;
   readonly session: HarnessSession;
+  readonly hasTransientContext: boolean;
 }): Promise<StepResult> {
-  const { config, emit, promptMessages, result, runStep } = input;
+  const { config, emit, hasTransientContext, promptMessages, result, runStep } = input;
   let { emissionState, session } = input;
 
   const resolvedStepOutput = resolveAssistantStepText(result.response.messages, result.text);
@@ -1840,7 +1845,12 @@ async function handleStepResult(input: {
 
   const baseSession: HarnessSession = {
     ...session,
-    compaction: createNextCompactionConfig(session.compaction, promptMessages, result),
+    compaction: createNextCompactionConfig(
+      session.compaction,
+      promptMessages,
+      result,
+      hasTransientContext,
+    ),
   };
 
   const workflowContinuationSecurity =
@@ -2375,6 +2385,7 @@ function createNextCompactionConfig(
   current: CompactionConfig,
   promptMessages: readonly ModelMessage[],
   result: HarnessStepResult,
+  hasTransientContext: boolean,
 ): CompactionConfig {
   const next: {
     lastKnownInputTokens?: number;
@@ -2386,7 +2397,13 @@ function createNextCompactionConfig(
     threshold: current.threshold,
   };
 
-  if (result.usage?.inputTokens !== undefined) {
+  // A provider count that includes ephemeral context cannot seed the next
+  // durable-history checkpoint: that context may disappear or move relative
+  // to newly appended messages. Fall back to full prompt estimation instead.
+  if (hasTransientContext) {
+    next.lastKnownInputTokens = undefined;
+    next.lastKnownPromptMessageCount = undefined;
+  } else if (result.usage?.inputTokens !== undefined) {
     next.lastKnownInputTokens = result.usage.inputTokens;
     next.lastKnownPromptMessageCount = promptMessages.length;
   }
@@ -2404,6 +2421,7 @@ function createNextCompactionConfig(
  * harness uses to rebuild `session.history` after the step.
  */
 async function maybeCompact(input: {
+  readonly accountingMessages: readonly ModelMessage[];
   readonly abortSignal?: AbortSignal;
   readonly emit?: ToolLoopHarnessConfig["handleEvent"];
   readonly emissionState: ReturnType<typeof getHarnessEmissionState>;
@@ -2419,7 +2437,7 @@ async function maybeCompact(input: {
   let messages = input.messages;
   const session = input.session;
 
-  if (!shouldCompact(messages, session.compaction)) {
+  if (!shouldCompact(input.accountingMessages, session.compaction)) {
     return { messages, session };
   }
 
@@ -2437,7 +2455,7 @@ async function maybeCompact(input: {
         sequence: emissionState.sequence,
         sessionId: session.sessionId,
         turnId: emissionState.turnId,
-        usageInputTokens: getInputTokenCount(messages, session.compaction),
+        usageInputTokens: getInputTokenCount(input.accountingMessages, session.compaction),
       }),
     );
   }

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -513,7 +513,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       const result = parentContext
         ? await otelContext.with(parentContext, executeStep)
         : await executeStep();
-      return typeof result.next === "function"
+      return typeof result.next === "function" ||
+        getPendingWorkflowInterrupt(result.session.state) !== undefined
         ? result
         : { ...result, session: clearTurnContext(result.session) };
     } finally {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -110,6 +110,12 @@ import {
 import { convertStaleResponsesToUserMessage } from "#harness/stale-input-responses.js";
 import { getInstrumentationConfig } from "#harness/instrumentation-config.js";
 import { resolveAssistantStepText } from "#harness/messages.js";
+import {
+  buildTurnClientContextView,
+  getTurnDeliveryContext,
+  setTurnClientContext,
+  setTurnDeliveryContext,
+} from "#harness/turn-delivery-context.js";
 import { normalizeProviderToolHistory } from "#harness/provider-tool-history.js";
 import {
   type AuthorizationSignal,
@@ -619,6 +625,21 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = pending.session;
     let messages: ModelMessage[] = pending.messages;
 
+    if (
+      hasStepInput(effectiveStepInput) ||
+      effectiveStepInput?.clientContext !== undefined ||
+      effectiveStepInput?.context !== undefined
+    ) {
+      session = setTurnClientContext(
+        session,
+        pending.deferredClientContext === true ? undefined : effectiveStepInput?.clientContext,
+      );
+      session = setTurnDeliveryContext(
+        session,
+        pending.deferredContext === true ? undefined : effectiveStepInput?.context,
+      );
+    }
+
     // A resolved session-limit continuation prompt grants a fresh token
     // budget or ends the session; see session-limit-enforcement.
     const continuation = await applySessionLimitContinuation({
@@ -632,12 +653,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       return continuation.result;
     }
     session = continuation.session;
-
-    if (effectiveStepInput?.context !== undefined && pending.deferredContext !== true) {
-      for (const entry of effectiveStepInput.context) {
-        messages.push({ content: entry, role: "user" });
-      }
-    }
 
     if (
       effectiveStepInput?.message !== undefined &&
@@ -666,7 +681,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           turnId: emissionState.turnId,
         }),
         fallback: session.agent.dynamicModelDefaultReference ?? session.agent.modelReference,
-        messages,
+        messages: buildTurnClientContextView(session, messages),
       });
     }
     const resolvedModel = await resolveActiveRuntimeModel({
@@ -730,6 +745,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         nonSystemMessages.push(entry);
       }
     }
+    for (const entry of getTurnDeliveryContext(session)) {
+      systemMessages.push({ role: "system", content: entry });
+    }
     if (ctx !== undefined) {
       systemMessages.push(...buildDynamicInstructionMessages(ctx));
       const skillAnnouncement = ctx.get(PendingSkillAnnouncementKey);
@@ -741,7 +759,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       systemMessages.push({ role: "system", content: CONDITIONAL_DELIVERY_INSTRUCTION });
     }
 
-    const modelMessages = nonSystemMessages;
+    const modelMessages = buildTurnClientContextView(session, nonSystemMessages);
 
     const prepareModelCallInput = (extraSystemNote?: string) => {
       const extraSystemEntry: SystemModelMessage[] = extraSystemNote
@@ -1015,7 +1033,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // Emit step.started before building the toolset so dynamic tool
     // resolvers subscribed to step.started write to LiveStepToolsKey.
     if (emit) {
-      await emitStepStarted(emit, emissionState, messages);
+      await emitStepStarted(emit, emissionState, buildTurnClientContextView(session, messages));
     }
 
     // Workflow continuations replay the sandbox after step.started so nested

--- a/packages/eve/src/harness/turn-delivery-context.ts
+++ b/packages/eve/src/harness/turn-delivery-context.ts
@@ -21,6 +21,17 @@ export function buildTurnClientContextView(
   ];
 }
 
+/** Builds the full active-turn prompt view used only for token accounting. */
+export function buildTurnContextAccountingView(
+  session: HarnessSession,
+  messages: readonly ModelMessage[],
+): ModelMessage[] {
+  return [
+    ...buildTurnClientContextView(session, messages),
+    ...getTurnDeliveryContext(session).map((content) => ({ role: "system" as const, content })),
+  ];
+}
+
 /** Replaces the active turn's caller context without adding it to model history. */
 export function setTurnClientContext(
   session: HarnessSession,

--- a/packages/eve/src/harness/turn-delivery-context.ts
+++ b/packages/eve/src/harness/turn-delivery-context.ts
@@ -1,0 +1,68 @@
+import type { ModelMessage } from "ai";
+
+import type { HarnessSession } from "#harness/types.js";
+
+const TURN_DELIVERY_CONTEXT_KEY = "eve.harness.turnDeliveryContext";
+const TURN_CLIENT_CONTEXT_KEY = "eve.harness.turnClientContext";
+
+/** Returns caller-authored context attached to the active turn. */
+export function getTurnClientContext(session: HarnessSession): readonly string[] {
+  return (session.state?.[TURN_CLIENT_CONTEXT_KEY] as readonly string[] | undefined) ?? [];
+}
+
+/** Builds an ephemeral resolver/model view with caller context overlaid as user messages. */
+export function buildTurnClientContextView(
+  session: HarnessSession,
+  messages: readonly ModelMessage[],
+): ModelMessage[] {
+  return [
+    ...messages,
+    ...getTurnClientContext(session).map((content) => ({ role: "user" as const, content })),
+  ];
+}
+
+/** Replaces the active turn's caller context without adding it to model history. */
+export function setTurnClientContext(
+  session: HarnessSession,
+  context: readonly string[] | undefined,
+): HarnessSession {
+  return setStoredContext(session, TURN_CLIENT_CONTEXT_KEY, context);
+}
+
+/** Returns the channel context attached to the active turn. */
+export function getTurnDeliveryContext(session: HarnessSession): readonly string[] {
+  return (session.state?.[TURN_DELIVERY_CONTEXT_KEY] as readonly string[] | undefined) ?? [];
+}
+
+/** Replaces the active turn's channel context without adding it to model history. */
+export function setTurnDeliveryContext(
+  session: HarnessSession,
+  context: readonly string[] | undefined,
+): HarnessSession {
+  return setStoredContext(session, TURN_DELIVERY_CONTEXT_KEY, context);
+}
+
+function setStoredContext(
+  session: HarnessSession,
+  key: string,
+  context: readonly string[] | undefined,
+): HarnessSession {
+  const current = (session.state?.[key] as readonly string[] | undefined) ?? [];
+  const next = context ?? [];
+
+  if (current.length === 0 && next.length === 0) {
+    return session;
+  }
+
+  const state = { ...session.state };
+  if (next.length > 0) {
+    state[key] = next;
+  } else {
+    delete state[key];
+  }
+
+  return {
+    ...session,
+    state: Object.keys(state).length > 0 ? state : undefined,
+  };
+}

--- a/packages/eve/src/harness/turn-delivery-context.ts
+++ b/packages/eve/src/harness/turn-delivery-context.ts
@@ -42,6 +42,11 @@ export function setTurnDeliveryContext(
   return setStoredContext(session, TURN_DELIVERY_CONTEXT_KEY, context);
 }
 
+/** Clears context that must not survive the active turn. */
+export function clearTurnContext(session: HarnessSession): HarnessSession {
+  return setTurnDeliveryContext(setTurnClientContext(session, undefined), undefined);
+}
+
 function setStoredContext(
   session: HarnessSession,
   key: string,

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -123,9 +123,14 @@ export interface StepInput {
   readonly inputResponses?: readonly InputResponse[];
   readonly message?: string | UserContent;
   /**
-   * Context strings from the channel delivery. Each entry is appended
-   * as a `role: "user"` message to `session.history` before the
-   * delivery message. Populated by channels via `SendPayload.context`.
+   * Caller-authored client or page context. Each entry applies as a transient
+   * user-role model message for this turn without entering durable history.
+   */
+  readonly clientContext?: readonly string[];
+  /**
+   * Context strings from the channel delivery. Each entry applies as
+   * instructions for this turn without entering durable conversation
+   * history. Populated by channels via `SendPayload.context`.
    */
   readonly context?: readonly string[];
   /**

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -112,7 +112,8 @@ export interface RuntimeIdentity {
  * array (mixing `text`, `image`, and `file` parts). Clients pass
  * multimodal attachments with the same shape AI SDK's `useChat`
  * `sendMessage({ files })` produces. `clientContext` is one-turn
- * client/page context; the channel converts it into internal model context.
+ * client/page context; the channel converts it into transient user-role model
+ * context that is never persisted to durable session history.
  */
 export type HandleMessageRequestBody =
   | {

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -190,7 +190,13 @@ describe("discordChannel() inbound route", () => {
 
   it("dispatches verified application commands with Discord auth and state", async () => {
     const { privateKey, publicKeyHex } = testKeys();
-    const channel = discordChannel({ credentials: { publicKey: publicKeyHex } });
+    const channel = discordChannel({
+      credentials: { publicKey: publicKeyHex },
+      onCommand: (_ctx, interaction) => ({
+        auth: defaultDiscordAuth(interaction),
+        context: ["trusted Discord hook instruction"],
+      }),
+    });
 
     const { response, send } = await firePost(
       channel,
@@ -201,8 +207,12 @@ describe("discordChannel() inbound route", () => {
     await expect(response.json()).resolves.toEqual({ type: 5 });
     expect(send).toHaveBeenCalledTimes(1);
     const [payload, options] = send.mock.calls[0]!;
-    expect((payload as { context: string[] }).context[0]).toContain("<discord_context>");
-    expect(String((payload as { message: string }).message)).toContain("hello discord");
+    expect(payload).toMatchObject({
+      clientContext: [expect.stringContaining("<discord_context>")],
+      context: ["trusted Discord hook instruction"],
+      message: expect.stringContaining("hello discord"),
+    });
+    expect((payload as { context: string[] }).context[0]).not.toContain("<discord_context>");
     expect(options).toMatchObject({
       auth: {
         authenticator: "discord-interaction",

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -209,10 +209,14 @@ describe("discordChannel() inbound route", () => {
     const [payload, options] = send.mock.calls[0]!;
     expect(payload).toMatchObject({
       clientContext: [expect.stringContaining("<discord_context>")],
-      context: ["trusted Discord hook instruction"],
+      context: [expect.stringContaining("<discord_delivery>"), "trusted Discord hook instruction"],
       message: expect.stringContaining("hello discord"),
     });
-    expect((payload as { context: string[] }).context[0]).not.toContain("<discord_context>");
+    expect((payload as { clientContext: string[] }).clientContext[0]).not.toContain(
+      "response_medium",
+    );
+    expect((payload as { context: string[] }).context[0]).toContain("response_medium: discord");
+    expect((payload as { context: string[] }).context.join("\n")).not.toContain("user_id: U01");
     expect(options).toMatchObject({
       auth: {
         authenticator: "discord-interaction",

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -300,7 +300,11 @@ describe("discordChannel() inbound route", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ type: 6 });
     expect(send).toHaveBeenCalledWith(
-      { inputResponses: [{ optionId: "approve", requestId: "call_1" }] },
+      {
+        clientContext: [expect.stringContaining("<discord_context>")],
+        context: [expect.stringContaining("<discord_delivery>")],
+        inputResponses: [{ optionId: "approve", requestId: "call_1" }],
+      },
       expect.objectContaining({
         auth: null,
         continuationToken: "C01:M01",
@@ -372,7 +376,11 @@ describe("discordChannel() inbound route", () => {
       type: 4,
     });
     expect(submit.send).toHaveBeenCalledWith(
-      { inputResponses: [{ requestId: "call_1", text: "freeform answer" }] },
+      {
+        clientContext: [expect.stringContaining("<discord_context>")],
+        context: [expect.stringContaining("<discord_delivery>")],
+        inputResponses: [{ requestId: "call_1", text: "freeform answer" }],
+      },
       expect.objectContaining({
         continuationToken: "C01:M01",
       }),

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -33,6 +33,7 @@ import {
   DISCORD_INTERACTION_RESPONSE_TYPE,
   DISCORD_INTERACTION_TYPE,
   formatDiscordContextBlock,
+  formatDiscordDeliveryContext,
   parseDiscordInteraction,
   type DiscordCommandInteraction,
   type DiscordComponentInteraction,
@@ -594,7 +595,7 @@ async function dispatchCommand(input: {
     await input.send(
       {
         clientContext: [contextBlock],
-        context: input.result.context,
+        context: [formatDiscordDeliveryContext(), ...(input.result.context ?? [])],
         message: turnMessage,
       },
       {

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -32,8 +32,8 @@ import {
   commandInteractionMessage,
   DISCORD_INTERACTION_RESPONSE_TYPE,
   DISCORD_INTERACTION_TYPE,
-  formatDiscordContextBlock,
   formatDiscordDeliveryContext,
+  formatDiscordInteractionContextBlock,
   parseDiscordInteraction,
   type DiscordCommandInteraction,
   type DiscordComponentInteraction,
@@ -583,14 +583,7 @@ async function dispatchCommand(input: {
   readonly state: DiscordChannelState;
 }): Promise<void> {
   const turnMessage = commandInteractionMessage(input.interaction);
-  const contextBlock = formatDiscordContextBlock({
-    channelId: input.interaction.channelId,
-    commandName: input.interaction.commandName,
-    guildId: input.interaction.guildId,
-    interactionId: input.interaction.id,
-    userId: input.interaction.user.id,
-    username: input.interaction.user.username,
-  });
+  const contextBlock = formatDiscordInteractionContextBlock(input.interaction);
   try {
     await input.send(
       {
@@ -620,7 +613,11 @@ async function dispatchInputResponses(input: {
 }): Promise<void> {
   try {
     await input.send(
-      { inputResponses: input.inputResponses },
+      {
+        clientContext: [formatDiscordInteractionContextBlock(input.interaction)],
+        context: [formatDiscordDeliveryContext()],
+        inputResponses: input.inputResponses,
+      },
       {
         auth: null,
         continuationToken: discordContinuationToken(

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -102,7 +102,7 @@ export interface DiscordReceiveTarget {
  * interaction without dispatching the agent.
  * - `auth`: session auth context for the dispatched turn, or `null` for anonymous.
  * - `ephemeral`: when `true`, the deferred reply is visible only to the invoking user.
- * - `context`: model-visible context lines appended after the Discord context block.
+ * - `context`: trusted model instructions authored by the hook.
  */
 export type DiscordCommandResult = {
   readonly auth: SessionAuthContext | null;
@@ -590,13 +590,12 @@ async function dispatchCommand(input: {
     userId: input.interaction.user.id,
     username: input.interaction.user.username,
   });
-  const channelContext = input.result.context ?? [];
-
   try {
     await input.send(
       {
+        clientContext: [contextBlock],
+        context: input.result.context,
         message: turnMessage,
-        context: [contextBlock, ...channelContext],
       },
       {
         auth: input.result.auth,

--- a/packages/eve/src/public/channels/discord/inbound.test.ts
+++ b/packages/eve/src/public/channels/discord/inbound.test.ts
@@ -3,8 +3,25 @@ import { describe, expect, it } from "vitest";
 import {
   commandInteractionMessage,
   formatDiscordContextBlock,
+  formatDiscordDeliveryContext,
   parseDiscordInteraction,
 } from "#public/channels/discord/inbound.js";
+
+describe("Discord context rendering", () => {
+  it("separates provider metadata from fixed delivery instructions", () => {
+    const context = formatDiscordContextBlock({
+      channelId: "C01",
+      interactionId: "I01",
+      userId: "U01",
+    });
+    const delivery = formatDiscordDeliveryContext();
+
+    expect(context).toContain("user_id: U01");
+    expect(context).not.toContain("response_medium");
+    expect(delivery).toContain("response_medium: discord");
+    expect(delivery).not.toContain("user_id: U01");
+  });
+});
 
 describe("parseDiscordInteraction", () => {
   it("parses an application command interaction", () => {

--- a/packages/eve/src/public/channels/discord/inbound.ts
+++ b/packages/eve/src/public/channels/discord/inbound.ts
@@ -160,6 +160,21 @@ export function formatDiscordContextBlock(context: DiscordInboundContext): strin
   return lines.join("\n");
 }
 
+/** Renders provider metadata shared by command and interactive-resume turns. */
+export function formatDiscordInteractionContextBlock(interaction: DiscordInteraction): string {
+  return formatDiscordContextBlock({
+    channelId: interaction.channelId,
+    commandName:
+      interaction.type === DISCORD_INTERACTION_TYPE.APPLICATION_COMMAND
+        ? interaction.commandName
+        : undefined,
+    guildId: interaction.guildId,
+    interactionId: interaction.id,
+    userId: interaction.user.id,
+    username: interaction.user.username,
+  });
+}
+
 /** Renders trusted, channel-authored Discord delivery instructions. */
 export function formatDiscordDeliveryContext(): string {
   return [

--- a/packages/eve/src/public/channels/discord/inbound.ts
+++ b/packages/eve/src/public/channels/discord/inbound.ts
@@ -145,12 +145,10 @@ export function commandInteractionMessage(interaction: DiscordCommandInteraction
   return optionText ? `/${interaction.commandName} ${optionText}` : `/${interaction.commandName}`;
 }
 
-/** Renders one {@link DiscordInboundContext} as a deterministic context block. */
+/** Renders provider-authored Discord metadata as user context. */
 export function formatDiscordContextBlock(context: DiscordInboundContext): string {
   const lines = [
     "<discord_context>",
-    "response_medium: discord",
-    `response_instructions: ${DISCORD_RESPONSE_INSTRUCTIONS}`,
     `user_id: ${context.userId}`,
     ...(context.username ? [`username: ${context.username}`] : []),
     `channel_id: ${context.channelId}`,
@@ -160,6 +158,16 @@ export function formatDiscordContextBlock(context: DiscordInboundContext): strin
     "</discord_context>",
   ];
   return lines.join("\n");
+}
+
+/** Renders trusted, channel-authored Discord delivery instructions. */
+export function formatDiscordDeliveryContext(): string {
+  return [
+    "<discord_delivery>",
+    "response_medium: discord",
+    `response_instructions: ${DISCORD_RESPONSE_INSTRUCTIONS}`,
+    "</discord_delivery>",
+  ].join("\n");
 }
 
 function parseCommandInteraction(raw: Record<string, unknown>): DiscordCommandInteraction | null {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -422,7 +422,8 @@ describe("eveChannel — onMessage", () => {
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
     expect(payload).toEqual({
       message: "What word is selected?",
-      context: ["Client context:\nselection: jazz", "Authenticated caller profile: enterprise"],
+      clientContext: ["Client context:\nselection: jazz"],
+      context: ["Authenticated caller profile: enterprise"],
     });
     const options = handler.send.mock.calls[0]?.[1] as SendOptions;
     expect(options.auth).toEqual(ACCEPTED_AUTH);
@@ -528,10 +529,8 @@ describe("eveChannel — onMessage", () => {
     expect(response.status).toBe(200);
     expect(onMessage).toHaveBeenCalledTimes(1);
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
-    expect(payload.context).toEqual([
-      "Client context:\napproval modal open",
-      "Authenticated continuation context",
-    ]);
+    expect(payload.clientContext).toEqual(["Client context:\napproval modal open"]);
+    expect(payload.context).toEqual(["Authenticated continuation context"]);
     expect(payload.inputResponses).toEqual([{ requestId: "req-1", optionId: "approve" }]);
     const options = handler.send.mock.calls[0]?.[1] as SendOptions;
     expect(options.auth).toEqual(ACCEPTED_AUTH);
@@ -709,7 +708,7 @@ describe("eveChannel — create session (text)", () => {
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
     expect(payload).toEqual({
       message: "What word is selected?",
-      context: ['Client context:\n{"selectedWord":"jazz"}'],
+      clientContext: ['Client context:\n{"selectedWord":"jazz"}'],
     });
   });
 
@@ -764,7 +763,7 @@ describe("eveChannel — create session (text)", () => {
     expect(response.status).toBe(202);
     expect(handler.send).toHaveBeenCalledTimes(1);
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
-    expect(payload.context).toEqual([
+    expect(payload.clientContext).toEqual([
       "Client context:\nroute: /editor",
       "Client context:\nselection: jazz",
     ]);
@@ -1120,7 +1119,7 @@ describe("eveChannel — continue session HITL (inputResponses)", () => {
     expect(handler.send).toHaveBeenCalledTimes(1);
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
     expect(payload.message).toBe("yes please");
-    expect(payload.context).toEqual(["Client context:\napproval modal open"]);
+    expect(payload.clientContext).toEqual(["Client context:\napproval modal open"]);
   });
 
   it("forwards outputSchema with a continue-session message", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -217,9 +217,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         if (!messageResult.dispatch) return droppedMessageResponse();
 
         const token = `eve:${crypto.randomUUID()}`;
-        const context = mergeContext(body.context, messageResult.context);
-
-        const session = await send(createSendPayload(body, context), {
+        const session = await send(createSendPayload(body, messageResult.context), {
           auth: messageResult.auth,
           callback: body.callback,
           continuationToken: token,
@@ -275,7 +273,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         const policyRejection = checkUploadPolicy(body, uploadPolicy);
         if (policyRejection !== null) return policyRejection;
 
-        let context = body.context;
+        let context: readonly string[] | undefined;
         let dispatchAuth: SessionAuthContext | null = sessionAuth;
         if (body.message !== undefined) {
           const messageResult = await resolveOnMessage({
@@ -287,7 +285,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           });
           if (messageResult instanceof Response) return messageResult;
           if (!messageResult.dispatch) return droppedMessageResponse();
-          context = mergeContext(body.context, messageResult.context);
+          context = messageResult.context;
           dispatchAuth = messageResult.auth;
         }
 
@@ -295,6 +293,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           {
             inputResponses: body.inputResponses,
             message: body.message,
+            clientContext: body.clientContext,
             context,
             outputSchema: body.outputSchema,
           },
@@ -515,7 +514,7 @@ interface ParsedCreateBody {
   callback?: SessionCallback;
   message: string | UserContent;
   mode?: RunMode;
-  context?: readonly string[];
+  clientContext?: readonly string[];
   outputSchema?: JsonObject;
 }
 
@@ -523,8 +522,8 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
   const message = parseMessageField(payload.message);
   if (message instanceof Response) return message;
 
-  const context = parseClientContextField(payload.clientContext);
-  if (context instanceof Response) return context;
+  const clientContext = parseClientContextField(payload.clientContext);
+  if (clientContext instanceof Response) return clientContext;
 
   const callback = parseCallbackField(payload.callback);
   if (callback instanceof Response) return callback;
@@ -542,14 +541,14 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     );
   }
 
-  return { callback, message, mode, context, outputSchema };
+  return { callback, clientContext, message, mode, outputSchema };
 }
 
 interface ParsedContinueBody {
   message?: string | UserContent;
   continuationToken: string;
   inputResponses?: readonly InputResponse[];
-  context?: readonly string[];
+  clientContext?: readonly string[];
   outputSchema?: JsonObject;
 }
 
@@ -572,8 +571,8 @@ function parseContinueBody(payload: Record<string, unknown>): ParsedContinueBody
   const inputResponses = parseInputResponses(payload.inputResponses);
   if (inputResponses instanceof Response) return inputResponses;
 
-  const context = parseClientContextField(payload.clientContext);
-  if (context instanceof Response) return context;
+  const clientContext = parseClientContextField(payload.clientContext);
+  if (clientContext instanceof Response) return clientContext;
 
   const outputSchema = parseOutputSchemaField(payload.outputSchema);
   if (outputSchema instanceof Response) return outputSchema;
@@ -588,7 +587,7 @@ function parseContinueBody(payload: Record<string, unknown>): ParsedContinueBody
     );
   }
 
-  return { message, continuationToken, inputResponses, context, outputSchema };
+  return { clientContext, message, continuationToken, inputResponses, outputSchema };
 }
 
 interface ParsedCancelTurnBody {
@@ -631,23 +630,32 @@ async function parseCancelTurnBody(req: Request): Promise<ParsedCancelTurnBody |
 
 function createSendPayload(
   body: ParsedCreateBody,
-  context = body.context,
+  context?: readonly string[],
 ):
   | string
   | UserContent
   | {
       readonly message: string | UserContent;
+      readonly clientContext?: readonly string[];
       readonly context?: readonly string[];
       readonly outputSchema?: JsonObject;
     } {
-  if (context === undefined && body.outputSchema === undefined) {
+  if (
+    body.clientContext === undefined &&
+    context === undefined &&
+    body.outputSchema === undefined
+  ) {
     return body.message;
   }
   const payload: {
     message: string | UserContent;
+    clientContext?: readonly string[];
     context?: readonly string[];
     outputSchema?: JsonObject;
   } = { message: body.message };
+  if (body.clientContext !== undefined) {
+    payload.clientContext = body.clientContext;
+  }
   if (context !== undefined) {
     payload.context = context;
   }
@@ -822,15 +830,6 @@ function parseInputResponses(value: unknown): readonly InputResponse[] | Respons
     );
   }
   return inputResponses;
-}
-
-function mergeContext(
-  existing: readonly string[] | undefined,
-  added: readonly string[] | undefined,
-): readonly string[] | undefined {
-  if (existing === undefined) return added;
-  if (added === undefined) return existing;
-  return [...existing, ...added];
 }
 
 const CLIENT_CONTEXT_PREFIX = "Client context:\n";

--- a/packages/eve/src/public/channels/github/dispatch.ts
+++ b/packages/eve/src/public/channels/github/dispatch.ts
@@ -20,10 +20,7 @@ import {
   type GitHubUser,
   type GitHubWorkflowRunWebhookEvent,
 } from "#public/channels/github/inbound.js";
-import {
-  buildGitHubPullRequestContext,
-  mergeGitHubContext,
-} from "#public/channels/github/pr-context.js";
+import { buildGitHubPullRequestContext } from "#public/channels/github/pr-context.js";
 import {
   continuationTokenFromState,
   stateFromCiEvent,
@@ -233,12 +230,14 @@ async function dispatchWebhookEventTurn(input: {
 
   await sendGitHubTurn({
     auth: result.auth,
+    clientContext: await buildPullRequestContext(
+      input.config,
+      input.state,
+      input.event.delivery.id,
+    ),
+    context: result.context,
     event: input.event,
     message: input.message,
-    context: mergeGitHubContext({
-      github: await buildPullRequestContext(input.config, input.state, input.event.delivery.id),
-      hook: result.context,
-    }),
     send: input.send,
     state: input.state,
   });
@@ -268,13 +267,15 @@ async function dispatchCommentTurn(input: {
 
   await sendGitHubTurn({
     auth: result.auth,
+    clientContext: await buildPullRequestContext(
+      input.config,
+      input.state,
+      input.event.delivery.id,
+    ),
     commentUrl: input.commentUrl,
+    context: result.context,
     event: input.event,
     message,
-    context: mergeGitHubContext({
-      github: await buildPullRequestContext(input.config, input.state, input.event.delivery.id),
-      hook: result.context,
-    }),
     send: input.send,
     state: input.state,
   });
@@ -296,11 +297,12 @@ async function runInboundHandler(input: {
 
 async function sendGitHubTurn(input: {
   readonly auth: SessionAuthContext | null;
+  readonly clientContext?: readonly string[];
   readonly commentUrl?: string;
+  readonly context?: readonly string[];
   readonly event: GitHubTurnEvent;
   readonly logMessage?: string;
   readonly message: string;
-  readonly context: readonly string[] | undefined;
   readonly send: SendFn<GitHubChannelState>;
   readonly state: GitHubChannelState;
 }): Promise<void> {
@@ -318,8 +320,9 @@ async function sendGitHubTurn(input: {
   try {
     await input.send(
       {
-        message: turnMessage,
+        clientContext: input.clientContext,
         context: input.context,
+        message: turnMessage,
       },
       {
         auth: input.auth,

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -404,8 +404,8 @@ describe("githubChannel", () => {
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://github.test/repos/vercel/eve/pulls/7");
     const [payload] = send.mock.calls[0]!;
-    expect(payload.context?.[0]).toContain("title: Add GitHub context");
-    expect(payload.context?.[0]).toContain("head_sha: head-sha");
+    expect(payload.clientContext?.[0]).toContain("title: Add GitHub context");
+    expect(payload.clientContext?.[0]).toContain("head_sha: head-sha");
   });
 
   it("dispatches inline review comments to the review-thread token", async () => {
@@ -514,7 +514,7 @@ describe("githubChannel", () => {
       credentials: { appId: "test-app", webhookSecret: SECRET },
       onPullRequest(ctx, pullRequest) {
         hook(ctx.conversation, pullRequest);
-        return { auth: defaultGitHubAuth(ctx) };
+        return { auth: defaultGitHubAuth(ctx), context: ["trusted hook instruction"] };
       },
     });
 
@@ -547,6 +547,8 @@ describe("githubChannel", () => {
     expect(send).toHaveBeenCalledTimes(1);
     const [payload, options] = send.mock.calls[0]!;
     expect(payload.message).toContain("Pull request opened: #7 Add webhook PR handling");
+    expect(payload.clientContext?.[0]).toContain("title: Add GitHub context");
+    expect(payload.context).toEqual(["trusted hook instruction"]);
     expect(options).toMatchObject({
       continuationToken: "repo:123:pull:7",
       state: {

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -99,7 +99,7 @@ export interface GitHubEventContext extends GitHubChannelContext, ChannelSession
 /**
  * Result of a GitHub inbound hook. Return `null` to acknowledge without
  * dispatching; return `{ auth }` to dispatch. Optional `context` strings are
- * added as `role: "user"` messages before the dispatched turn.
+ * applied as instructions for the dispatched turn.
  */
 export type GitHubInboundResult = {
   readonly auth: SessionAuthContext | null;

--- a/packages/eve/src/public/channels/github/pr-context.ts
+++ b/packages/eve/src/public/channels/github/pr-context.ts
@@ -75,8 +75,8 @@ export interface GitHubPullRequestContextInput {
  * Builds bounded, one-shot pull-request background for a GitHub turn: PR
  * metadata plus the changed-file diff (noisy files excluded from the patch).
  *
- * The returned strings are intended for `SendPayload.context`; each is appended
- * as a `role: "user"` message to session history before the delivery message.
+ * The returned strings are intended for `SendPayload.context`; each applies as
+ * instructions for the dispatched turn without entering conversation history.
  */
 export async function buildGitHubPullRequestContext(
   input: GitHubPullRequestContextInput,

--- a/packages/eve/src/public/channels/github/pr-context.ts
+++ b/packages/eve/src/public/channels/github/pr-context.ts
@@ -75,8 +75,9 @@ export interface GitHubPullRequestContextInput {
  * Builds bounded, one-shot pull-request background for a GitHub turn: PR
  * metadata plus the changed-file diff (noisy files excluded from the patch).
  *
- * The returned strings are intended for `SendPayload.context`; each applies as
- * instructions for the dispatched turn without entering conversation history.
+ * The returned strings are intended for `SendPayload.clientContext`; each
+ * applies as user-role context for the dispatched turn without entering
+ * conversation history.
  */
 export async function buildGitHubPullRequestContext(
   input: GitHubPullRequestContextInput,
@@ -133,17 +134,6 @@ export async function buildGitHubPullRequestContext(
       lines.join("\n"),
     ].join("\n"),
   ];
-}
-
-/** Merges channel-generated PR context before hook-provided context. */
-export function mergeGitHubContext(input: {
-  readonly github?: readonly string[];
-  readonly hook?: readonly string[];
-}): readonly string[] | undefined {
-  const github = input.github ?? [];
-  const hook = input.hook ?? [];
-  if (github.length === 0 && hook.length === 0) return undefined;
-  return [...github, ...hook];
 }
 
 function withPinnedPullRequestShas(

--- a/packages/eve/src/public/channels/linear/inbound.ts
+++ b/packages/eve/src/public/channels/linear/inbound.ts
@@ -157,7 +157,7 @@ export function messageFromLinearAgentSessionEvent(event: LinearAgentSessionEven
   return "Linear agent session started.";
 }
 
-/** Formats Linear issue/session context as an eve context block. */
+/** Formats caller-provided Linear issue/session metadata as an eve context block. */
 export function formatLinearContextBlock(event: LinearAgentSessionEvent): string {
   const session = event.agentSession;
   const issue = session.issue;
@@ -173,10 +173,16 @@ export function formatLinearContextBlock(event: LinearAgentSessionEvent): string
     `issue_url: ${issue?.url ?? ""}`,
     `comment_id: ${session.commentId ?? ""}`,
     `source_comment_id: ${session.sourceCommentId ?? ""}`,
-    "response_medium: linear_agent_activity",
     "</linear_context>",
   ];
   return lines.join("\n");
+}
+
+/** Renders trusted, channel-authored Linear delivery instructions. */
+export function formatLinearDeliveryContext(): string {
+  return ["<linear_delivery>", "response_medium: linear_agent_activity", "</linear_delivery>"].join(
+    "\n",
+  );
 }
 
 function readAgentSession(value: unknown): LinearAgentSessionRef | null {

--- a/packages/eve/src/public/channels/linear/index.ts
+++ b/packages/eve/src/public/channels/linear/index.ts
@@ -31,6 +31,7 @@ export {
 } from "#public/channels/linear/hitl.js";
 export {
   formatLinearContextBlock,
+  formatLinearDeliveryContext,
   linearContinuationToken,
   messageFromLinearAgentSessionEvent,
   parseLinearWebhookEvent,

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -164,8 +164,8 @@ describe("linearChannel inbound Agent Session events", () => {
     expect(send).toHaveBeenCalledTimes(1);
     const [payload, options] = send.mock.calls[0]!;
     expect(payload.message).toBe("Please handle this issue.");
-    expect(payload.context[0]).toContain("<linear_context>");
-    expect(payload.context[0]).toContain("issue_identifier: EVE-123");
+    expect(payload.clientContext[0]).toContain("<linear_context>");
+    expect(payload.clientContext[0]).toContain("issue_identifier: EVE-123");
     expect(options).toMatchObject({
       auth: {
         authenticator: "linear-agent-webhook",

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -166,6 +166,8 @@ describe("linearChannel inbound Agent Session events", () => {
     expect(payload.message).toBe("Please handle this issue.");
     expect(payload.clientContext[0]).toContain("<linear_context>");
     expect(payload.clientContext[0]).toContain("issue_identifier: EVE-123");
+    expect(payload.clientContext[0]).not.toContain("response_medium");
+    expect(payload.context[0]).toContain("response_medium: linear_agent_activity");
     expect(options).toMatchObject({
       auth: {
         authenticator: "linear-agent-webhook",

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -157,7 +157,7 @@ export interface LinearChannelEvents {
 /**
  * Result of an inbound Linear hook. Return `null` to acknowledge without
  * dispatching; return `{ auth }` to dispatch. Optional `context` strings are
- * added as `role: "user"` messages before the dispatched turn.
+ * applied as instructions for the dispatched turn.
  */
 export type LinearInboundResult = {
   readonly auth: SessionAuthContext | null;

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -352,11 +352,8 @@ async function dispatchAgentSession(input: {
 
   await input.send(
     {
-      context: [
-        formatLinearContextBlock(event),
-        ...event.previousComments,
-        ...(result.context ?? []),
-      ],
+      clientContext: [formatLinearContextBlock(event), ...event.previousComments],
+      context: result.context,
       inputResponses,
       message: messageFromLinearAgentSessionEvent(event),
     },

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -17,6 +17,7 @@ import { createDefaultEvents, defaultOnAgentSession } from "#public/channels/lin
 import { resolveLinearPromptInputResponses } from "#public/channels/linear/hitl.js";
 import {
   formatLinearContextBlock,
+  formatLinearDeliveryContext,
   linearContinuationToken,
   messageFromLinearAgentSessionEvent,
   parseLinearWebhookEvent,
@@ -353,7 +354,7 @@ async function dispatchAgentSession(input: {
   await input.send(
     {
       clientContext: [formatLinearContextBlock(event), ...event.previousComments],
-      context: result.context,
+      context: [formatLinearDeliveryContext(), ...(result.context ?? [])],
       inputResponses,
       message: messageFromLinearAgentSessionEvent(event),
     },

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -295,8 +295,8 @@ export interface SlackInteractionUser {
 /**
  * Result of an `onAppMention` or `onDirectMessage` callback. Return an
  * object (auth may be `null`) to dispatch a turn, or `null` to drop the
- * inbound message. `context` strings are appended as user messages to
- * session history before the delivery message.
+ * inbound message. `context` strings apply as turn instructions without
+ * entering conversation history.
  */
 export type SlackMentionResult = {
   readonly auth: SessionAuthContext | null;

--- a/packages/eve/src/public/channels/teams/inbound.test.ts
+++ b/packages/eve/src/public/channels/teams/inbound.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatTeamsContextBlock,
+  formatTeamsDeliveryContext,
   parseTeamsActivity,
   teamsThreadRootActivityId,
 } from "#public/channels/teams/inbound.js";
@@ -58,8 +59,9 @@ describe("Teams inbound parsing", () => {
       userName: "Ada",
     });
     expect(block).toContain("<teams_context>");
-    expect(block).toContain("response_medium: microsoft_teams");
+    expect(block).not.toContain("response_medium");
     expect(block).toContain("user_id: U1");
+    expect(formatTeamsDeliveryContext()).toContain("response_medium: microsoft_teams");
   });
 });
 

--- a/packages/eve/src/public/channels/teams/inbound.ts
+++ b/packages/eve/src/public/channels/teams/inbound.ts
@@ -130,15 +130,12 @@ export function teamsThreadRootActivityId(
 }
 
 /**
- * Renders one {@link TeamsInboundContext} as a `<teams_context>` block of
- * `key: value` lines for the model. Optional fields (user name, conversation
- * type, tenant, team, channel) are omitted when absent; field order is stable.
+ * Renders provider-authored Teams metadata as a `<teams_context>` user-context
+ * block. Optional fields are omitted when absent; field order is stable.
  */
 export function formatTeamsContextBlock(context: TeamsInboundContext): string {
   const lines = [
     "<teams_context>",
-    "response_medium: microsoft_teams",
-    `response_instructions: ${TEAMS_RESPONSE_INSTRUCTIONS}`,
     `user_id: ${context.userId}`,
     ...(context.userName ? [`user_name: ${context.userName}`] : []),
     `conversation_id: ${context.conversationId}`,
@@ -151,6 +148,16 @@ export function formatTeamsContextBlock(context: TeamsInboundContext): string {
     "</teams_context>",
   ];
   return lines.join("\n");
+}
+
+/** Renders trusted, channel-authored Teams delivery instructions. */
+export function formatTeamsDeliveryContext(): string {
+  return [
+    "<teams_delivery>",
+    "response_medium: microsoft_teams",
+    `response_instructions: ${TEAMS_RESPONSE_INSTRUCTIONS}`,
+    "</teams_delivery>",
+  ].join("\n");
 }
 
 function parseMessageActivity(raw: Record<string, unknown>): TeamsMessageActivity | null {

--- a/packages/eve/src/public/channels/teams/inbound.ts
+++ b/packages/eve/src/public/channels/teams/inbound.ts
@@ -150,6 +150,23 @@ export function formatTeamsContextBlock(context: TeamsInboundContext): string {
   return lines.join("\n");
 }
 
+/** Renders provider metadata shared by message and interactive-resume turns. */
+export function formatTeamsActivityContextBlock(
+  activity: TeamsMessageActivity | TeamsInvokeActivity,
+): string {
+  return formatTeamsContextBlock({
+    activityId: activity.id,
+    channelId: activity.teamsChannelId,
+    conversationId: activity.conversation.id,
+    conversationType: activity.conversationType,
+    scope: activity.scope,
+    teamId: activity.teamId,
+    tenantId: activity.tenantId,
+    userId: activity.from.id,
+    userName: activity.from.name,
+  });
+}
+
 /** Renders trusted, channel-authored Teams delivery instructions. */
 export function formatTeamsDeliveryContext(): string {
   return [

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -139,7 +139,11 @@ describe("teamsChannel", () => {
 
     expect(await response.json()).toMatchObject({ statusCode: 200 });
     expect(send).toHaveBeenCalledWith(
-      { inputResponses: [{ optionId: "approve", requestId: "REQ" }] },
+      {
+        clientContext: [expect.stringContaining("<teams_context>")],
+        context: [expect.stringContaining("<teams_delivery>")],
+        inputResponses: [{ optionId: "approve", requestId: "REQ" }],
+      },
       expect.objectContaining({
         auth: expect.objectContaining({ subject: "AAD_USER" }),
         continuationToken: "TENANT:CONV:THREAD_ROOT",
@@ -169,7 +173,11 @@ describe("teamsChannel", () => {
 
     expect(onMessage).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledWith(
-      { inputResponses: [{ optionId: "deny", requestId: "REQ" }] },
+      {
+        clientContext: [expect.stringContaining("<teams_context>")],
+        context: [expect.stringContaining("<teams_delivery>")],
+        inputResponses: [{ optionId: "deny", requestId: "REQ" }],
+      },
       expect.objectContaining({ continuationToken: "TENANT:CONV:THREAD_ROOT" }),
     );
   });

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -79,6 +79,7 @@ describe("teamsChannel", () => {
             principalId: "USER",
             principalType: "user",
           },
+          context: ["trusted Teams hook instruction"],
         };
       },
     });
@@ -98,7 +99,11 @@ describe("teamsChannel", () => {
         serviceUrl: "https://smba.example.test/teams",
       },
     });
-    expect(send.mock.calls[0]![0].context[0]).toContain("<teams_context>");
+    expect(send.mock.calls[0]![0]).toMatchObject({
+      clientContext: [expect.stringContaining("<teams_context>")],
+      context: ["trusted Teams hook instruction"],
+    });
+    expect(send.mock.calls[0]![0].context[0]).not.toContain("<teams_context>");
   });
 
   it("default dispatch ignores unmentioned group messages", async () => {

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -101,9 +101,11 @@ describe("teamsChannel", () => {
     });
     expect(send.mock.calls[0]![0]).toMatchObject({
       clientContext: [expect.stringContaining("<teams_context>")],
-      context: ["trusted Teams hook instruction"],
+      context: [expect.stringContaining("<teams_delivery>"), "trusted Teams hook instruction"],
     });
-    expect(send.mock.calls[0]![0].context[0]).not.toContain("<teams_context>");
+    expect(send.mock.calls[0]![0].clientContext[0]).not.toContain("response_medium");
+    expect(send.mock.calls[0]![0].context[0]).toContain("response_medium: microsoft_teams");
+    expect(send.mock.calls[0]![0].context.join("\n")).not.toContain("user_id: USER");
   });
 
   it("default dispatch ignores unmentioned group messages", async () => {

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -45,12 +45,11 @@ import {
   teamsInvokeResponse,
 } from "#public/channels/teams/hitl.js";
 import {
-  formatTeamsContextBlock,
+  formatTeamsActivityContextBlock,
   formatTeamsDeliveryContext,
   parseTeamsActivity,
   teamsThreadRootActivityId,
   type TeamsActivity,
-  type TeamsInboundContext,
   type TeamsInvokeActivity,
   type TeamsMessageActivity,
 } from "#public/channels/teams/inbound.js";
@@ -573,21 +572,10 @@ async function dispatchMessage(input: {
 
   const fileParts = collectTeamsFileParts(input.activity.attachments, input.filesPolicy);
   const turnMessage = buildTeamsTurnMessage(input.activity.text, fileParts);
-  const inboundContext: TeamsInboundContext = {
-    activityId: input.activity.id,
-    channelId: input.activity.teamsChannelId,
-    conversationId: input.activity.conversation.id,
-    conversationType: input.activity.conversationType,
-    scope: input.activity.scope,
-    teamId: input.activity.teamId,
-    tenantId: input.activity.tenantId,
-    userId: input.activity.from.id,
-    userName: input.activity.from.name,
-  };
   try {
     await input.send(
       {
-        clientContext: [formatTeamsContextBlock(inboundContext)],
+        clientContext: [formatTeamsActivityContextBlock(input.activity)],
         context: [formatTeamsDeliveryContext(), ...(result.context ?? [])],
         message: turnMessage,
       },
@@ -649,7 +637,11 @@ async function dispatchInputResponses(input: {
   if (result === null) return;
   try {
     await input.send(
-      { inputResponses },
+      {
+        clientContext: [formatTeamsActivityContextBlock(input.activity)],
+        context: [formatTeamsDeliveryContext()],
+        inputResponses,
+      },
       {
         auth: result.auth,
         continuationToken: resolveInputContinuationToken(input.activity, state),

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -46,6 +46,7 @@ import {
 } from "#public/channels/teams/hitl.js";
 import {
   formatTeamsContextBlock,
+  formatTeamsDeliveryContext,
   parseTeamsActivity,
   teamsThreadRootActivityId,
   type TeamsActivity,
@@ -587,7 +588,7 @@ async function dispatchMessage(input: {
     await input.send(
       {
         clientContext: [formatTeamsContextBlock(inboundContext)],
-        context: result.context,
+        context: [formatTeamsDeliveryContext(), ...(result.context ?? [])],
         message: turnMessage,
       },
       {

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -128,6 +128,7 @@ export interface TeamsReceiveTarget {
 /** Result of an inbound Teams message hook. Return `null` to acknowledge without dispatching. */
 export type TeamsInboundResult = {
   readonly auth: SessionAuthContext | null;
+  /** Trusted model instructions authored by the hook. */
   readonly context?: readonly string[];
 } | null;
 
@@ -582,13 +583,12 @@ async function dispatchMessage(input: {
     userId: input.activity.from.id,
     userName: input.activity.from.name,
   };
-  const channelContext = result.context ?? [];
-
   try {
     await input.send(
       {
+        clientContext: [formatTeamsContextBlock(inboundContext)],
+        context: result.context,
         message: turnMessage,
-        context: [formatTeamsContextBlock(inboundContext), ...channelContext],
       },
       {
         auth: result.auth,

--- a/packages/eve/src/public/channels/telegram/inbound.test.ts
+++ b/packages/eve/src/public/channels/telegram/inbound.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatTelegramContextBlock,
+  formatTelegramDeliveryContext,
   parseTelegramUpdate,
 } from "#public/channels/telegram/inbound.js";
 
@@ -110,7 +111,8 @@ describe("Telegram context rendering", () => {
         userId: "42",
         username: "ada",
       }),
-    ).toContain("<telegram_context>\nresponse_medium: telegram");
+    ).toContain("<telegram_context>\nchat_id: -1001");
+    expect(formatTelegramDeliveryContext()).toContain("response_medium: telegram");
   });
 
   it("renders chat and actor identity into the block", () => {

--- a/packages/eve/src/public/channels/telegram/inbound.ts
+++ b/packages/eve/src/public/channels/telegram/inbound.ts
@@ -138,6 +138,24 @@ export function formatTelegramContextBlock(context: TelegramInboundContext): str
   return lines.join("\n");
 }
 
+/** Renders provider metadata for an interactive callback resume. */
+export function formatTelegramCallbackContext(
+  query: TelegramCallbackQuery,
+  botUsername: string | undefined,
+): string {
+  if (!query.message) throw new Error("Telegram callback context requires a message.");
+  return formatTelegramContextBlock({
+    botUsername,
+    chatId: query.message.chat.id,
+    chatTitle: query.message.chat.title,
+    chatType: query.message.chat.type,
+    messageId: query.message.messageId,
+    messageThreadId: query.message.messageThreadId,
+    userId: query.from.id,
+    username: query.from.username,
+  });
+}
+
 /** Renders trusted, channel-authored Telegram delivery instructions. */
 export function formatTelegramDeliveryContext(): string {
   return [

--- a/packages/eve/src/public/channels/telegram/inbound.ts
+++ b/packages/eve/src/public/channels/telegram/inbound.ts
@@ -118,15 +118,11 @@ export function parseTelegramUpdate(value: unknown): TelegramUpdate | null {
 }
 
 /**
- * Renders one {@link TelegramInboundContext} as a deterministic
- * `<telegram_context>` block with fixed response instructions and the chat and
- * user identity fields.
+ * Renders provider-authored Telegram chat and user metadata as user context.
  */
 export function formatTelegramContextBlock(context: TelegramInboundContext): string {
   const lines = [
     "<telegram_context>",
-    "response_medium: telegram",
-    `response_instructions: ${TELEGRAM_RESPONSE_INSTRUCTIONS}`,
     `chat_id: ${context.chatId}`,
     `chat_type: ${context.chatType}`,
     ...(context.chatTitle ? [`chat_title: ${context.chatTitle}`] : []),
@@ -140,6 +136,16 @@ export function formatTelegramContextBlock(context: TelegramInboundContext): str
     "</telegram_context>",
   ];
   return lines.join("\n");
+}
+
+/** Renders trusted, channel-authored Telegram delivery instructions. */
+export function formatTelegramDeliveryContext(): string {
+  return [
+    "<telegram_delivery>",
+    "response_medium: telegram",
+    `response_instructions: ${TELEGRAM_RESPONSE_INSTRUCTIONS}`,
+    "</telegram_delivery>",
+  ].join("\n");
 }
 
 function parseTelegramMessage(value: unknown): TelegramMessage | null {

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -165,10 +165,17 @@ describe("telegramChannel() inbound route", () => {
     const [payload, options] = send.mock.calls[0]!;
     expect(payload).toMatchObject({
       clientContext: [expect.stringContaining("<telegram_context>")],
-      context: ["trusted Telegram hook instruction"],
+      context: [
+        expect.stringContaining("<telegram_delivery>"),
+        "trusted Telegram hook instruction",
+      ],
       message: expect.stringContaining("hello"),
     });
-    expect((payload as { context: string[] }).context[0]).not.toContain("<telegram_context>");
+    expect((payload as { clientContext: string[] }).clientContext[0]).not.toContain(
+      "response_medium",
+    );
+    expect((payload as { context: string[] }).context[0]).toContain("response_medium: telegram");
+    expect((payload as { context: string[] }).context.join("\n")).not.toContain("chat_id: 42");
     expect(options).toMatchObject({
       auth: {
         authenticator: "telegram-webhook",
@@ -312,6 +319,7 @@ describe("telegramChannel() deliver hook", () => {
     expect(
       await adapter.deliver!(
         {
+          clientContext: ["telegram metadata"],
           inputResponses: [
             { optionId: "selected", requestId: "telegram_callback:eve:0" },
             { requestId: "telegram_reply:55", text: "because" },
@@ -324,6 +332,7 @@ describe("telegramChannel() deliver hook", () => {
         { optionId: "approve", requestId: "call_1" },
         { requestId: "call_2", text: "because" },
       ],
+      clientContext: ["telegram metadata"],
       context: undefined,
     });
   });
@@ -335,12 +344,13 @@ describe("telegramChannel() deliver hook", () => {
     expect(
       await adapter.deliver!(
         {
+          clientContext: ["telegram metadata"],
           inputResponses: [{ requestId: "telegram_reply:55", text: "hello" }],
           message: "hello",
         },
         ctx,
       ),
-    ).toEqual({ message: "hello", context: undefined });
+    ).toEqual({ clientContext: ["telegram metadata"], message: "hello", context: undefined });
   });
 });
 

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -240,7 +240,11 @@ describe("telegramChannel() inbound route", () => {
     });
 
     expect(send).toHaveBeenCalledWith(
-      { inputResponses: [{ optionId: "selected", requestId: "telegram_callback:eve:0" }] },
+      {
+        clientContext: [expect.stringContaining("<telegram_context>")],
+        context: [expect.stringContaining("<telegram_delivery>")],
+        inputResponses: [{ optionId: "selected", requestId: "telegram_callback:eve:0" }],
+      },
       expect.objectContaining({
         auth: null,
         continuationToken: "-1001::55",

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -7,7 +7,11 @@ import { isHttpRouteDefinition } from "#channel/routes.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { SessionKey } from "#context/keys.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
-import { telegramChannel, type TelegramChannelState } from "#public/channels/telegram/index.js";
+import {
+  defaultTelegramAuth,
+  telegramChannel,
+  type TelegramChannelState,
+} from "#public/channels/telegram/index.js";
 
 const SECRET = "telegram-secret";
 
@@ -140,6 +144,10 @@ describe("telegramChannel() inbound route", () => {
     const channel = telegramChannel({
       api: { fetch: fakeTelegramFetch() },
       credentials: { botToken: "bot-token", webhookSecretToken: SECRET },
+      onMessage: (_ctx, message) => ({
+        auth: defaultTelegramAuth(message),
+        context: ["trusted Telegram hook instruction"],
+      }),
     });
 
     const { response, send } = await firePost(channel, {
@@ -155,8 +163,12 @@ describe("telegramChannel() inbound route", () => {
     expect(response.status).toBe(200);
     expect(send).toHaveBeenCalledTimes(1);
     const [payload, options] = send.mock.calls[0]!;
-    expect((payload as { context: string[] }).context[0]).toContain("<telegram_context>");
-    expect(String((payload as { message: string }).message)).toContain("hello");
+    expect(payload).toMatchObject({
+      clientContext: [expect.stringContaining("<telegram_context>")],
+      context: ["trusted Telegram hook instruction"],
+      message: expect.stringContaining("hello"),
+    });
+    expect((payload as { context: string[] }).context[0]).not.toContain("<telegram_context>");
     expect(options).toMatchObject({
       auth: {
         authenticator: "telegram-webhook",

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -107,6 +107,7 @@ export interface TelegramReceiveTarget {
 /** Result of an inbound Telegram message hook. Return `null` to drop the update. */
 export type TelegramInboundResult = {
   readonly auth: SessionAuthContext | null;
+  /** Trusted model instructions authored by the hook. */
   readonly context?: readonly string[];
 } | null;
 
@@ -505,8 +506,6 @@ async function dispatchMessage(input: {
     userId: input.message.from?.id,
     username: input.message.from?.username,
   });
-  const channelContext = result.context ?? [];
-
   const replyText = input.message.text || input.message.caption;
   const replyInputResponses =
     input.message.replyToMessage?.from?.isBot === true && replyText.trim().length > 0
@@ -521,9 +520,10 @@ async function dispatchMessage(input: {
   try {
     await input.send(
       {
+        clientContext: [contextBlock],
+        context: result.context,
         inputResponses: replyInputResponses,
         message: turnMessage,
-        context: [contextBlock, ...channelContext],
       },
       {
         auth: result.auth,

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -37,6 +37,7 @@ import {
 } from "#public/channels/telegram/hitl.js";
 import {
   formatTelegramContextBlock,
+  formatTelegramDeliveryContext,
   parseTelegramUpdate,
   type TelegramCallbackQuery,
   type TelegramChatType,
@@ -521,7 +522,7 @@ async function dispatchMessage(input: {
     await input.send(
       {
         clientContext: [contextBlock],
-        context: result.context,
+        context: [formatTelegramDeliveryContext(), ...(result.context ?? [])],
         inputResponses: replyInputResponses,
         message: turnMessage,
       },
@@ -601,17 +602,24 @@ function attachTelegramDeliver(channel: TelegramChannel): void {
     if (responses.some(isTelegramSyntheticResponse)) {
       const resolved = resolveTelegramInputResponses(ctx.state, responses);
       if (resolved.length > 0) {
-        return { inputResponses: resolved, context: payload.context };
+        return {
+          clientContext: payload.clientContext,
+          context: payload.context,
+          inputResponses: resolved,
+        };
       }
       if (payload.message !== undefined) {
-        return { message: payload.message, context: payload.context };
+        return {
+          clientContext: payload.clientContext,
+          context: payload.context,
+          message: payload.message,
+        };
       }
       return undefined;
     }
     return defaultDeliverResult(payload);
   };
 }
-
 function stateFromMessage(
   message: TelegramMessage,
   config: TelegramChannelConfig,

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -37,6 +37,7 @@ import {
 } from "#public/channels/telegram/hitl.js";
 import {
   formatTelegramContextBlock,
+  formatTelegramCallbackContext,
   formatTelegramDeliveryContext,
   parseTelegramUpdate,
   type TelegramCallbackQuery,
@@ -536,7 +537,6 @@ async function dispatchMessage(input: {
     log.error("message delivery failed", { error });
   }
 }
-
 async function dispatchCallbackQuery(input: {
   readonly config: TelegramChannelConfig;
   readonly query: TelegramCallbackQuery;
@@ -546,7 +546,6 @@ async function dispatchCallbackQuery(input: {
   const telegram: TelegramContext = {
     telegram: buildTelegramHandle({ config: input.config, state }),
   };
-
   if (input.query.data?.startsWith(TELEGRAM_HITL_CALLBACK_PREFIX) === true) {
     try {
       await telegram.telegram.answerCallbackQuery({
@@ -556,11 +555,12 @@ async function dispatchCallbackQuery(input: {
     } catch (error) {
       log.warn("Telegram callback-query acknowledgement failed", { error });
     }
-
     if (!input.query.message || !state.chatId) return;
     try {
       await input.send(
         {
+          clientContext: [formatTelegramCallbackContext(input.query, input.config.botUsername)],
+          context: [formatTelegramDeliveryContext()],
           inputResponses: [telegramCallbackInputResponse(input.query.data)],
         },
         {

--- a/packages/eve/src/public/channels/twilio/inbound.ts
+++ b/packages/eve/src/public/channels/twilio/inbound.ts
@@ -112,13 +112,11 @@ export function parseTwilioVoiceTranscription(
   };
 }
 
-/** Renders a deterministic `<twilio_context>` block for the model. */
+/** Renders provider-authored identity metadata for the model as user context. */
 export function formatTwilioContextBlock(context: TwilioInboundContext): string {
   const lines = [
     "<twilio_context>",
     `channel: ${context.channel}`,
-    "response_medium: sms",
-    `response_instructions: ${TWILIO_SMS_RESPONSE_INSTRUCTIONS}`,
     `from: ${context.from}`,
     ...(context.to ? [`to: ${context.to}`] : []),
     ...(context.messageSid ? [`message_sid: ${context.messageSid}`] : []),
@@ -126,4 +124,14 @@ export function formatTwilioContextBlock(context: TwilioInboundContext): string 
     "</twilio_context>",
   ];
   return lines.join("\n");
+}
+
+/** Renders trusted, channel-authored SMS delivery instructions for the model. */
+export function formatTwilioDeliveryContext(): string {
+  return [
+    "<twilio_delivery>",
+    "response_medium: sms",
+    `response_instructions: ${TWILIO_SMS_RESPONSE_INSTRUCTIONS}`,
+    "</twilio_delivery>",
+  ].join("\n");
 }

--- a/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
@@ -209,13 +209,20 @@ describe("twilioChannel() inbound text pipeline", () => {
     expect(await response.text()).toBe("<Response></Response>");
     expect(send).toHaveBeenCalledTimes(1);
     const [payload, options] = send.mock.calls[0]!;
-    const { message, context } = payload as { message: string; context: string[] };
-    const contextBlock = context[0]!;
-    expect(contextBlock).toContain("<twilio_context>");
-    expect(contextBlock).toContain("channel: text");
-    expect(contextBlock).toContain("response_medium: sms");
-    expect(contextBlock).toContain("Reply for SMS in plain text.");
-    expect(contextBlock).toContain("avoid Markdown formatting");
+    const { clientContext, context, message } = payload as {
+      clientContext: string[];
+      context: string[];
+      message: string;
+    };
+    expect(clientContext[0]).toContain("<twilio_context>");
+    expect(clientContext[0]).toContain("channel: text");
+    expect(clientContext[0]).toContain("from: +15551234567");
+    expect(clientContext[0]).not.toContain("response_medium");
+    expect(context[0]).toContain("<twilio_delivery>");
+    expect(context[0]).toContain("response_medium: sms");
+    expect(context[0]).toContain("Reply for SMS in plain text.");
+    expect(context[0]).toContain("avoid Markdown formatting");
+    expect(context[0]).not.toContain("+15551234567");
     expect(message).toBe("hello");
     expect(options).toMatchObject({
       auth: {
@@ -523,11 +530,17 @@ describe("twilioChannel() voice pipeline", () => {
     expect(await response.text()).toContain("Thanks. I&apos;ll follow up by text.");
     expect(send).toHaveBeenCalledTimes(1);
     const [payload, options] = send.mock.calls[0]!;
-    const { message, context } = payload as { message: string; context: string[] };
-    const contextBlock = context[0]!;
-    expect(contextBlock).toContain("channel: voice");
-    expect(contextBlock).toContain("response_medium: sms");
-    expect(contextBlock).toContain("Reply for SMS in plain text.");
+    const { clientContext, context, message } = payload as {
+      clientContext: string[];
+      context: string[];
+      message: string;
+    };
+    expect(clientContext[0]).toContain("channel: voice");
+    expect(clientContext[0]).toContain("call_sid: CA123");
+    expect(clientContext[0]).not.toContain("response_medium");
+    expect(context[0]).toContain("response_medium: sms");
+    expect(context[0]).toContain("Reply for SMS in plain text.");
+    expect(context[0]).not.toContain("CA123");
     expect(message).toBe("book a table");
     expect(options).toMatchObject({
       continuationToken: "+15551234567:+15557654321",

--- a/packages/eve/src/public/channels/twilio/twilioChannel.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.ts
@@ -23,6 +23,7 @@ import {
 } from "#public/channels/twilio/defaults.js";
 import {
   formatTwilioContextBlock,
+  formatTwilioDeliveryContext,
   parseTwilioTextMessage,
   parseTwilioVoiceCall,
   parseTwilioVoiceTranscription,
@@ -560,8 +561,9 @@ async function dispatchText(input: {
   try {
     await input.send(
       {
+        clientContext: [contextBlock],
+        context: [formatTwilioDeliveryContext()],
         message: message.body,
-        context: [contextBlock],
       },
       {
         auth: result.auth,
@@ -637,8 +639,9 @@ async function dispatchVoiceTranscription(input: {
   try {
     await input.send(
       {
+        clientContext: [contextBlock],
+        context: [formatTwilioDeliveryContext()],
         message: transcription.text,
-        context: [contextBlock],
       },
       {
         auth: result.auth,

--- a/packages/eve/src/runtime/agent/mock-model-fixtures.ts
+++ b/packages/eve/src/runtime/agent/mock-model-fixtures.ts
@@ -77,11 +77,11 @@ export function resolveMockFixtureToken(prompt: BootstrapPrompt): string | null 
     .map((message) => getPromptContentText(message.content))
     .join("\n");
   // The current turn's user batch participates last so instruction- and
-  // skill-delivered fixture directives always win. Scanning user text makes
-  // per-turn context (clientContext entries, channel context strings) and
-  // exact-reply prompts deterministically provable in smoke evals. Only the
-  // trailing user messages count: directives from earlier turns must not
-  // leak into later replies.
+  // skill-delivered fixture directives always win. Scanning system and user
+  // text makes channel instructions, clientContext entries, and exact-reply
+  // prompts deterministically provable in smoke evals. Only trailing user
+  // messages count: directives from earlier turns must not leak into later
+  // replies.
   const searchableTexts = [
     ...getLoadedSkillResultTexts(prompt),
     systemText,


### PR DESCRIPTION
## Problem

Delivery context was being persisted into durable user history. The first repair removed that leak, but the public caller-controlled overlay and trusted channel instructions still crossed roles, built-in channels mixed provider metadata with framework-authored delivery instructions, and transient context was omitted from compaction accounting.

## Solution

Keep the authority and lifetime split explicit:

- `clientContext` is transient user-role context for caller- and provider-authored data.
- `context` is transient system-role context for hook- and framework-authored instructions.
- GitHub PR, Linear, Discord, Teams, Telegram, and Twilio provider metadata now travels through `clientContext`; fixed channel response instructions remain trusted `context`.
- Both overlays survive immediate internal continuations, including deferred approval, parked workflow children, and Telegram synthetic reply/HITL delivery. Terminal turns and parks waiting for a new external user turn clear them.
- Discord, Teams, and Telegram interactive resumes reconstruct current callback/provider metadata and fixed delivery instructions without persisting or inventing stale hook context.
- Dynamic model/tool resolvers and model calls see the same active-turn client context.
- Compaction decisions account for both transient roles, but the summarizer and `session.history` receive durable messages only. Provider token checkpoints are not persisted when their count includes transient context.
- New user input replaces or clears both overlays; actual delivery messages remain durable user history.
- `clientContext` without a message or input response cannot dispatch an existing session or synthesize a new model turn. Explicit trusted-context-only and output-schema starts remain supported.

No policy framework, trust registry, fallback, compatibility layer, or file-length allowlist was added.

## Proof

- provider-role red witness: 4 files, 5 failed / 57 passed across Discord, Teams, Telegram, and Twilio
- delivery/synthetic red witness: 3 files, 5 failed / 38 passed across Discord, Teams, and Telegram
- interactive-resume red witness: 3 files, 5 failed / 38 passed across Discord, Teams, and Telegram
- client-context-only adapter red witness: 1 failed / 11 passed
- no-session start + parked workflow red witness: 2 failed / 4,862 passed, 1 skipped
- Linear trusted-delivery red witness: 1 failed / 7 passed
- focused compaction + channel bundle: 5 files, 218/218
- focused delivery/synthetic bundle: 6 files, 60/60
- focused final lifecycle bundle: 3 files, 177/177
- `pnpm lint`
- `pnpm fmt`
- `pnpm guard:invariants`
- `pnpm check:deps`
- `pnpm docs:check`
- `pnpm typecheck`: 32/32 tasks
- `pnpm test:unit`: 470 files, 4,866 passed, 1 skipped
- `pnpm test:integration`: 66 files, 478 passed
- exact-head autoreview on `254fa4291b9af63b404cfc2eaefa2d45faca4aaf` against `origin/main`: clean, no actionable findings

## Self-review

Traced public parsing, new-session and resumed delivery, workflow serialization and child parking, adapter coalescing, stale and active HITL paths, dynamic model/tool resolver inputs, internal tool-loop continuation, compaction, model roles, durable history reconstruction, built-in provider metadata, fixed channel instructions, and next-turn replacement. No accepted findings remain.

Related: REMI-1190
