### PR TITLE
feat(eve): extension build contribution manifest and beta peer range

### DIFF
--- a/.changeset/eager-planets-carry.md
+++ b/.changeset/eager-planets-carry.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve extension build` now writes a `dist/_ext-manifest.json` contribution manifest stamped with the building eve version and a contract version for each capability the extension uses. `eve extension init` scaffolds the eve peer range as `>=<installed-version> <1` so beta extensions declare their compatibility floor.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -79,7 +79,7 @@ Point `eve.extension` at the source directory and run `eve extension build` (wir
   "type": "module",
   "eve": { "extension": "./extension" },
   "files": ["extension", "dist"],
-  "peerDependencies": { "eve": "^x" },
+  "peerDependencies": { "eve": ">=0.24.6 <1" },
   "dependencies": { "zod": "^3" },
   "scripts": { "build": "eve extension build", "prepare": "eve extension build" },
 }
@@ -100,11 +100,11 @@ Author the source with `moduleResolution: "bundler"` — eve compiles it, so rel
 }
 ```
 
-`eve extension build` compiles the package's entry points to plain JavaScript with type declarations — the mount factory (`dist/index.mjs`) and the tool re-exports overrides use (`dist/tools`) — and fills the `exports` map so you never hand-list it. Compiling is what lets an installed extension load directly; local and workspace packages also work without publishing.
+`eve extension build` compiles the package's entry points to plain JavaScript with type declarations — the mount factory (`dist/index.mjs`) and the tool re-exports overrides use (`dist/tools`) — writes a `dist/_ext-manifest.json` describing the contributions, and fills the `exports` map so you never hand-list it. The manifest stamps the eve version the extension was built with and a contract version for each capability it uses (tools, skills, connections, …), so consumers can validate compatibility without recompiling. Compiling is what lets an installed extension load directly; local and workspace packages also work without publishing.
 
 ### Dependencies
 
-`eve` is a **peer** dependency: one eve lives in the consuming app and the extension's `eve/*` imports resolve to it. Declare the eve versions your extension supports as the peer range (`"eve": "^1"`) — eve enforces it when the extension is mounted, failing the build with a clear error if the app's eve is out of range, rather than surfacing a confusing compile break. Everything else the extension imports (SDKs, `zod`, …) goes in `dependencies`; each extension resolves its own versions. The consumer recompiles the extension's contributions from source, so `files` must ship both `extension/` (that source) and `dist/` (the compiled entry points).
+`eve` is a **peer** dependency: one eve lives in the consuming app and the extension's `eve/*` imports resolve to it. Declare the eve versions your extension supports as the peer range — while eve is in beta, new scaffolds accept versions from the installed eve release up to 1.0 (for example `">=0.24.6 <1"`). eve enforces the range when the extension is mounted, failing the build with a clear error if the app's eve is out of range, rather than surfacing a confusing compile break. Everything else the extension imports (SDKs, `zod`, …) goes in `dependencies`; each extension resolves its own versions. The consumer recompiles the extension's contributions from source, so `files` must ship both `extension/` (that source) and `dist/` (the compiled entry points).
 
 Those deps resolve from `node_modules` under `eve dev`/`eve eval` and are bundled into the deployable by the consuming agent's `eve build`. A dependency that can't be bundled (a native addon) must be listed in the **consuming agent's** `build.externalDependencies` — an extension can't declare build config, so note it in your README.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,7 +73,7 @@ See [Extensions](/docs/extensions) for authoring and mount details.
 eve extension build
 ```
 
-Builds the current package as an extension: compiles the mount factory and tool re-exports into `dist/`, and fills the package `exports` map. Requires `package.json#eve.extension`.
+Builds the current package as an extension: compiles the mount factory and tool re-exports into `dist/`, writes a `dist/_ext-manifest.json` contribution manifest with compatibility stamps, and fills the package `exports` map. Requires `package.json#eve.extension`.
 
 ## `eve info`
 

--- a/e2e/fixtures/gadget-extension/package.json
+++ b/e2e/fixtures/gadget-extension/package.json
@@ -30,7 +30,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "eve": "*"
+    "eve": ">=0.24.6 <1"
   },
   "eve": {
     "extension": "./extension"

--- a/e2e/fixtures/gizmo-extension/package.json
+++ b/e2e/fixtures/gizmo-extension/package.json
@@ -29,7 +29,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "eve": "*"
+    "eve": ">=0.24.6 <1"
   },
   "eve": {
     "extension": "./extension"

--- a/packages/eve/src/cli/commands/extension-build.integration.test.ts
+++ b/packages/eve/src/cli/commands/extension-build.integration.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -42,11 +43,18 @@ describe("runExtensionBuildCommand", () => {
           name: "@acme/crm",
           type: "module",
           eve: { extension: "./extension" },
+          peerDependencies: { eve: ">=0.1.0 <1" },
         },
         null,
         2,
       )}\n`,
       "utf8",
+    );
+    await mkdir(join(root, "node_modules"), { recursive: true });
+    await symlink(
+      dirname(createRequire(import.meta.url).resolve("eve/package.json")),
+      join(root, "node_modules", "eve"),
+      "dir",
     );
     await mkdir(join(root, "extension"), { recursive: true });
     await writeFile(

--- a/packages/eve/src/cli/commands/extension-init.integration.test.ts
+++ b/packages/eve/src/cli/commands/extension-init.integration.test.ts
@@ -108,7 +108,7 @@ describe("runExtensionInitCommand", () => {
       scripts?: Record<string, string>;
     };
     expect(packageJson.eve?.extension).toBe("./extension");
-    expect(packageJson.peerDependencies?.eve).toBe("^0.6.0");
+    expect(packageJson.peerDependencies?.eve).toBe(">=0.6.0 <1");
     expect(packageJson.devDependencies?.eve).toBe("^0.6.0");
     expect(packageJson.dependencies?.zod).toBe("4.0.0");
     expect(packageJson.dependencies?.ai).toBeUndefined();

--- a/packages/eve/src/compiler/extension-artifact.test.ts
+++ b/packages/eve/src/compiler/extension-artifact.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXTENSION_ARTIFACT_KIND,
+  EXTENSION_ARTIFACT_VERSION,
+  parseExtensionArtifact,
+  serializeExtensionArtifact,
+  type ExtensionArtifact,
+} from "#compiler/extension-artifact.js";
+
+function sampleArtifact(): ExtensionArtifact {
+  return {
+    kind: EXTENSION_ARTIFACT_KIND,
+    version: EXTENSION_ARTIFACT_VERSION,
+    eveVersion: "1.2.3",
+    packageName: "@acme/crm",
+    packageNamespace: "acme-crm",
+    capabilityVersions: { tool: 1, config: 1, state: 1 },
+    contributions: {
+      tools: [
+        {
+          description: "Search the CRM.",
+          inputSchema: null,
+          name: "search",
+          logicalPath: "tools/search.ts",
+          sourceId: "tools/search.ts",
+          sourceKind: "module",
+        },
+      ],
+      dynamicTools: [],
+      hooks: [],
+      skills: [],
+      dynamicSkills: [],
+      dynamicInstructions: [],
+      connections: [],
+      instructionFragments: [],
+    },
+  };
+}
+
+describe("extension artifact serialization", () => {
+  it("round-trips a serialized artifact back to a deep-equal value", () => {
+    const artifact = sampleArtifact();
+    const parsed = parseExtensionArtifact(
+      serializeExtensionArtifact(artifact),
+      "dist/_ext-manifest.json",
+    );
+    expect(parsed).toEqual(artifact);
+  });
+
+  it("rejects malformed JSON with the artifact path named", () => {
+    expect(() => parseExtensionArtifact("{ not json", "dist/_ext-manifest.json")).toThrow(
+      /dist\/_ext-manifest\.json/,
+    );
+  });
+
+  it("rejects an artifact whose kind is wrong", () => {
+    const artifact = { ...sampleArtifact(), kind: "not-an-artifact" };
+    expect(() =>
+      parseExtensionArtifact(JSON.stringify(artifact), "dist/_ext-manifest.json"),
+    ).toThrow();
+  });
+
+  it("names the building eve when a recognizable artifact fails the schema", () => {
+    // A recognizable artifact with an unknown field models the build-version
+    // skew case: built by a different eve whose schema this eve cannot read.
+    const artifact = { ...sampleArtifact(), futureField: true };
+    expect(() =>
+      parseExtensionArtifact(JSON.stringify(artifact), "dist/_ext-manifest.json"),
+    ).toThrow(/not readable by this version of eve.*built with eve 1\.2\.3.*eve extension build/s);
+  });
+});

--- a/packages/eve/src/compiler/extension-artifact.ts
+++ b/packages/eve/src/compiler/extension-artifact.ts
@@ -1,0 +1,173 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { z } from "#compiled/zod/index.js";
+
+import {
+  compiledConnectionDefinitionSchema,
+  compiledDynamicInstructionsDefinitionSchema,
+  compiledDynamicSkillDefinitionSchema,
+  compiledDynamicToolDefinitionSchema,
+  compiledHookDefinitionSchema,
+  compiledSkillSourceSchema,
+  compiledToolDefinitionSchema,
+  type CompiledConnectionDefinition,
+  type CompiledDynamicInstructionsDefinition,
+  type CompiledDynamicSkillDefinition,
+  type CompiledDynamicToolDefinition,
+  type CompiledHookDefinition,
+  type CompiledSkillDefinition,
+  type CompiledToolDefinition,
+} from "#compiler/manifest.js";
+import { formatValidationError } from "#runtime/validation.js";
+
+/** Stable kind emitted for a source-free extension's compiled artifact. */
+export const EXTENSION_ARTIFACT_KIND = "eve-extension-artifact";
+
+/** Current source-free extension artifact schema version. */
+export const EXTENSION_ARTIFACT_VERSION = 1;
+
+/** Filename `eve extension build` writes the artifact to, under `dist/`. */
+export const EXTENSION_ARTIFACT_FILENAME = "_ext-manifest.json";
+
+/**
+ * The per-extension slice of compiled contributions carried by the artifact.
+ *
+ * Names are the extension's own **base** names (no `<ns>__` prefix) and each
+ * `logicalPath` is relative to the extension's source root, exactly as
+ * authored. A consuming agent's compile prefixes the names with its mount
+ * namespace and rebases the logical paths onto its own agent root.
+ */
+export interface ExtensionArtifactContributions {
+  readonly tools: readonly CompiledToolDefinition[];
+  readonly dynamicTools: readonly CompiledDynamicToolDefinition[];
+  readonly hooks: readonly CompiledHookDefinition[];
+  readonly skills: readonly CompiledSkillDefinition[];
+  readonly dynamicSkills: readonly CompiledDynamicSkillDefinition[];
+  readonly dynamicInstructions: readonly CompiledDynamicInstructionsDefinition[];
+  readonly connections: readonly CompiledConnectionDefinition[];
+  readonly instructionFragments: readonly string[];
+}
+
+/**
+ * Contribution manifest `eve extension build` stamps into
+ * `dist/_ext-manifest.json`.
+ *
+ * It is the serialized equivalent of what discovery + compile derive by
+ * walking and executing the extension's source, recorded at build time so a
+ * consumer can validate compatibility — and eventually compose the extension —
+ * without recompiling it.
+ */
+export interface ExtensionArtifact {
+  readonly kind: typeof EXTENSION_ARTIFACT_KIND;
+  readonly version: typeof EXTENSION_ARTIFACT_VERSION;
+  /** eve version the extension was built with. */
+  readonly eveVersion: string;
+  readonly packageName: string;
+  /** Package-derived namespace baked into the shipped modules' state/config scope. */
+  readonly packageNamespace: string;
+  /** Contract version of each capability the extension uses, checked on consume. */
+  readonly capabilityVersions: Record<string, number>;
+  readonly contributions: ExtensionArtifactContributions;
+}
+
+const extensionArtifactContributionsSchema = z
+  .object({
+    tools: z.array(compiledToolDefinitionSchema),
+    dynamicTools: z.array(compiledDynamicToolDefinitionSchema),
+    hooks: z.array(compiledHookDefinitionSchema),
+    skills: z.array(compiledSkillSourceSchema),
+    dynamicSkills: z.array(compiledDynamicSkillDefinitionSchema),
+    dynamicInstructions: z.array(compiledDynamicInstructionsDefinitionSchema),
+    connections: z.array(compiledConnectionDefinitionSchema),
+    instructionFragments: z.array(z.string()),
+  })
+  .strict();
+
+/**
+ * Zod schema for the versioned source-free extension artifact.
+ */
+export const extensionArtifactSchema: z.ZodType<ExtensionArtifact> = z
+  .object({
+    kind: z.literal(EXTENSION_ARTIFACT_KIND),
+    version: z.literal(EXTENSION_ARTIFACT_VERSION),
+    eveVersion: z.string(),
+    packageName: z.string(),
+    packageNamespace: z.string(),
+    capabilityVersions: z.record(z.string(), z.number().int().nonnegative()),
+    contributions: extensionArtifactContributionsSchema,
+  })
+  .strict();
+
+/**
+ * Serializes an extension artifact to the `dist/_ext-manifest.json` bytes.
+ */
+export function serializeExtensionArtifact(artifact: ExtensionArtifact): string {
+  return `${JSON.stringify(artifact, null, 2)}\n`;
+}
+
+/**
+ * Writes the artifact to `<distDir>/_ext-manifest.json`.
+ */
+export async function writeExtensionArtifact(
+  distDir: string,
+  artifact: ExtensionArtifact,
+): Promise<void> {
+  await writeFile(
+    join(distDir, EXTENSION_ARTIFACT_FILENAME),
+    serializeExtensionArtifact(artifact),
+    "utf8",
+  );
+}
+
+/**
+ * Reads and validates an extension artifact from a `_ext-manifest.json` path.
+ * Throws a descriptive error when the file is missing or malformed.
+ */
+export async function readExtensionArtifact(artifactPath: string): Promise<ExtensionArtifact> {
+  let raw: string;
+  try {
+    raw = await readFile(artifactPath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `Could not read extension artifact "${artifactPath}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return parseExtensionArtifact(raw, artifactPath);
+}
+
+/**
+ * Parses and validates artifact JSON text, naming the source path in errors.
+ */
+export function parseExtensionArtifact(raw: string, artifactPath: string): ExtensionArtifact {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Extension artifact "${artifactPath}" is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const parsed = extensionArtifactSchema.safeParse(json);
+  if (!parsed.success) {
+    // A recognizable artifact failing the strict schema is almost always
+    // build-version skew, so name the eve that built it.
+    const record =
+      typeof json === "object" && json !== null ? (json as Record<string, unknown>) : undefined;
+    if (record?.kind === EXTENSION_ARTIFACT_KIND) {
+      const builtWith =
+        typeof record.eveVersion === "string" && record.eveVersion.length > 0
+          ? ` It was built with eve ${record.eveVersion}.`
+          : "";
+      throw new Error(
+        `Extension artifact "${artifactPath}" is not readable by this version of eve.${builtWith} ` +
+          `Rebuild the extension with \`eve extension build\` under a compatible eve, or align your eve version. ` +
+          `${formatValidationError(parsed.error)}`,
+      );
+    }
+    throw new Error(
+      `Extension artifact "${artifactPath}" is not a valid eve extension artifact. ${formatValidationError(parsed.error)}`,
+    );
+  }
+  return parsed.data;
+}

--- a/packages/eve/src/compiler/extension-capabilities.test.ts
+++ b/packages/eve/src/compiler/extension-capabilities.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXTENSION_CAPABILITY_VERSIONS,
+  validateExtensionCapabilities,
+} from "#compiler/extension-capabilities.js";
+
+describe("validateExtensionCapabilities", () => {
+  it("returns no mismatches when every stamped version matches the current eve", () => {
+    expect(
+      validateExtensionCapabilities({
+        tool: EXTENSION_CAPABILITY_VERSIONS.tool,
+        config: EXTENSION_CAPABILITY_VERSIONS.config,
+        state: EXTENSION_CAPABILITY_VERSIONS.state,
+      }),
+    ).toEqual([]);
+  });
+
+  it("reports a mismatch when a stamped capability version differs", () => {
+    expect(
+      validateExtensionCapabilities({
+        tool: EXTENSION_CAPABILITY_VERSIONS.tool + 1,
+        state: EXTENSION_CAPABILITY_VERSIONS.state,
+      }),
+    ).toEqual([
+      {
+        kind: "tool",
+        built: EXTENSION_CAPABILITY_VERSIONS.tool + 1,
+        current: EXTENSION_CAPABILITY_VERSIONS.tool,
+      },
+    ]);
+  });
+
+  it("reports an unknown capability as current version 0 so the consumer fails", () => {
+    expect(validateExtensionCapabilities({ ["future-capability" as never]: 1 })).toEqual([
+      { kind: "future-capability", built: 1, current: 0 },
+    ]);
+  });
+
+  it("ignores capabilities the extension did not stamp", () => {
+    expect(validateExtensionCapabilities({})).toEqual([]);
+  });
+});

--- a/packages/eve/src/compiler/extension-capabilities.ts
+++ b/packages/eve/src/compiler/extension-capabilities.ts
@@ -1,0 +1,77 @@
+/**
+ * Per-capability contract versions used to gate source-free extension
+ * distribution.
+ *
+ * A source-free extension ships a compiled artifact instead of its TypeScript
+ * source, so the consumer no longer typechecks the extension's contributions
+ * against its own eve. In place of that typecheck, `eve extension build` stamps
+ * the version of each capability the extension uses, and the consumer's build
+ * validates those stamps against its own eve — failing with a clear "rebuild the
+ * extension" message on any mismatch (see {@link validateExtensionCapabilities}).
+ *
+ * Each entry is the contract version of one capability kind. Bump a kind's
+ * version whenever a change to that capability would break an already-built
+ * extension — for example a change to a compiled definition's shape, the runtime
+ * binding a contribution relies on, or the state/config scoping baked into the
+ * shipped `.mjs`. A mismatch is loud and actionable rather than a runtime crash.
+ */
+export const EXTENSION_CAPABILITY_VERSIONS = {
+  tool: 1,
+  dynamicTool: 1,
+  connection: 1,
+  hook: 1,
+  skill: 1,
+  dynamicSkill: 1,
+  instructions: 1,
+  dynamicInstructions: 1,
+  /** `defineExtension` config binding through the string-keyed registry. */
+  config: 1,
+  /** `defineState` durable-state scoping baked into the shipped modules. */
+  state: 1,
+} as const;
+
+/** One capability kind an extension can contribute or depend on. */
+export type ExtensionCapabilityKind = keyof typeof EXTENSION_CAPABILITY_VERSIONS;
+
+/**
+ * Capability versions an extension recorded at its own build. Partial because an
+ * extension stamps only the capabilities it actually uses.
+ */
+export type ExtensionCapabilityVersions = Partial<Record<ExtensionCapabilityKind, number>>;
+
+/**
+ * A capability whose stamped version disagrees with the consumer's eve.
+ */
+export interface ExtensionCapabilityMismatch {
+  readonly kind: ExtensionCapabilityKind;
+  /** Version the extension was built against. */
+  readonly built: number;
+  /** Version the consumer's eve currently provides. */
+  readonly current: number;
+}
+
+/**
+ * Compares an extension's stamped capability versions against the versions the
+ * running eve provides, returning every mismatch. An empty array means the
+ * artifact is compatible. Unknown capability keys (a newer extension using a
+ * capability this eve does not know) are reported with `current: 0` so the
+ * consumer fails rather than silently ignoring them.
+ */
+export function validateExtensionCapabilities(
+  stamped: ExtensionCapabilityVersions,
+): ExtensionCapabilityMismatch[] {
+  const mismatches: ExtensionCapabilityMismatch[] = [];
+  for (const [kind, built] of Object.entries(stamped)) {
+    if (built === undefined) {
+      continue;
+    }
+    const current =
+      kind in EXTENSION_CAPABILITY_VERSIONS
+        ? EXTENSION_CAPABILITY_VERSIONS[kind as ExtensionCapabilityKind]
+        : 0;
+    if (current !== built) {
+      mismatches.push({ kind: kind as ExtensionCapabilityKind, built, current });
+    }
+  }
+  return mismatches;
+}

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -455,7 +455,7 @@ const compiledSkillBaseFields = {
   logicalPath: z.string(),
 };
 
-const compiledSkillSourceSchema: z.ZodType<CompiledSkillDefinition> = z.discriminatedUnion(
+export const compiledSkillSourceSchema: z.ZodType<CompiledSkillDefinition> = z.discriminatedUnion(
   "sourceKind",
   [
     z
@@ -536,7 +536,7 @@ const compiledWorkspaceResourceRootSchema = z
   })
   .strict();
 
-const compiledConnectionDefinitionSchema = z
+export const compiledConnectionDefinitionSchema = z
   .object({
     connectionName: z.string(),
     description: z.string(),
@@ -572,7 +572,7 @@ const compiledConnectionDefinitionSchema = z
   })
   .strict();
 
-const compiledToolDefinitionSchema = z
+export const compiledToolDefinitionSchema = z
   .object({
     description: z.string(),
     exportName: z.string().optional(),
@@ -585,7 +585,7 @@ const compiledToolDefinitionSchema = z
   })
   .strict();
 
-const compiledDynamicToolDefinitionSchema: z.ZodType<CompiledDynamicToolDefinition> = z
+export const compiledDynamicToolDefinitionSchema: z.ZodType<CompiledDynamicToolDefinition> = z
   .object({
     eventNames: z.array(z.string()).readonly(),
     exportName: z.string().optional(),
@@ -597,7 +597,7 @@ const compiledDynamicToolDefinitionSchema: z.ZodType<CompiledDynamicToolDefiniti
   })
   .strict();
 
-const compiledDynamicSkillDefinitionSchema: z.ZodType<CompiledDynamicSkillDefinition> = z
+export const compiledDynamicSkillDefinitionSchema: z.ZodType<CompiledDynamicSkillDefinition> = z
   .object({
     eventNames: z.array(z.string()).readonly(),
     exportName: z.string().optional(),
@@ -609,7 +609,7 @@ const compiledDynamicSkillDefinitionSchema: z.ZodType<CompiledDynamicSkillDefini
   })
   .strict();
 
-const compiledDynamicInstructionsDefinitionSchema: z.ZodType<CompiledDynamicInstructionsDefinition> =
+export const compiledDynamicInstructionsDefinitionSchema: z.ZodType<CompiledDynamicInstructionsDefinition> =
   z
     .object({
       eventNames: z.array(z.string()).readonly(),
@@ -621,7 +621,7 @@ const compiledDynamicInstructionsDefinitionSchema: z.ZodType<CompiledDynamicInst
     })
     .strict();
 
-const compiledHookDefinitionSchema: z.ZodType<CompiledHookDefinition> = z
+export const compiledHookDefinitionSchema: z.ZodType<CompiledHookDefinition> = z
   .object({
     exportName: z.string().optional(),
     logicalPath: z.string(),

--- a/packages/eve/src/compiler/normalize-extension.ts
+++ b/packages/eve/src/compiler/normalize-extension.ts
@@ -53,55 +53,95 @@ export async function compileExtensionContributions(input: {
   const { mount, consumerAgentRoot } = input;
   const options = { externalDependencies: input.externalDependencies };
 
-  const base = await composeManifestContributions({
+  const { base } = await produceBaseContributions({
     manifest: mount.manifest,
-    namespace: mount.namespace,
-    consumerAgentRoot,
-    options,
-    sourceIdScope: `ext:${mount.namespace}`,
     role: "extension",
+    namespace: mount.namespace,
+    options,
+  });
+
+  const extensionContributions = namespaceContributions({
+    base,
+    namespace: mount.namespace,
+    sourceRoot: mount.sourceRoot,
+    consumerAgentRoot,
+    sourceIdScope: `ext:${mount.namespace}`,
   });
 
   if (mount.overrides === undefined) {
-    return base.contributions;
+    return extensionContributions;
   }
 
   // Overrides are consumer-authored files, so they are NOT extension-scoped. The
   // `ext-override:` prefix keeps their module-map keys distinct from the
   // extension's own `ext:<ns>:` modules while deliberately not matching the
   // loader's `^ext:<ns>:` scope pattern, so dev and prod both treat them unscoped.
-  const overrides = await composeManifestContributions({
+  const overridesBase = await produceBaseContributions({
     manifest: mount.overrides,
-    namespace: mount.namespace,
-    consumerAgentRoot,
-    options,
-    sourceIdScope: `ext-override:${mount.namespace}`,
     role: "override",
+    namespace: mount.namespace,
+    options,
+  });
+  const overrideContributions = namespaceContributions({
+    base: overridesBase.base,
+    namespace: mount.namespace,
+    sourceRoot: mount.overrides.agentRoot,
+    consumerAgentRoot,
+    sourceIdScope: `ext-override:${mount.namespace}`,
   });
 
   // Consumer overrides win: list them first so first-registration-wins dedup
   // keeps the override over the extension's same-named contribution.
-  const merged = mergeContributions(overrides.contributions, base.contributions);
+  const merged = mergeContributions(overrideContributions, extensionContributions);
 
+  const prefix = `${mount.namespace}__`;
   return applyOverrideDisables({
     merged,
-    disables: overrides.disabledToolTargets,
-    extensionToolNames: new Set(base.contributions.tools.map((tool) => tool.name)),
-    extensionDynamicToolSlugs: new Set(base.contributions.dynamicTools.map((tool) => tool.slug)),
+    disables: overridesBase.disabledToolTargets.map((disable) => ({
+      name: `${prefix}${disable.name}`,
+      logicalPath: disable.logicalPath,
+    })),
+    extensionToolNames: new Set(extensionContributions.tools.map((tool) => tool.name)),
+    extensionDynamicToolSlugs: new Set(
+      extensionContributions.dynamicTools.map((tool) => tool.slug),
+    ),
     namespace: mount.namespace,
   });
 }
 
+/**
+ * Compiles an extension's own source tree into **base-named** contributions
+ * (no mount prefix, no rebase, no source-id scope), used by `eve extension
+ * build` to serialize the extension artifact. Rejects the same
+ * extension-illegal contributions the consumer compile path rejects.
+ */
+export async function produceExtensionArtifactContributions(input: {
+  readonly manifest: AgentSourceManifest;
+  readonly externalDependencies: readonly string[];
+}): Promise<CompiledExtensionContributions> {
+  const { base } = await produceBaseContributions({
+    manifest: input.manifest,
+    role: "extension",
+    namespace: input.manifest.agentId,
+    options: { externalDependencies: input.externalDependencies },
+  });
+  return base;
+}
+
 export interface DisabledToolTarget {
-  /** Namespaced target, e.g. `crm__search`. */
+  /** Base (un-prefixed) contribution name, e.g. `search`. */
   readonly name: string;
   /** Override-relative authored path, e.g. `tools/search.ts`, for diagnostics. */
   readonly logicalPath: string;
 }
 
-interface ComposedContributions {
-  readonly contributions: CompiledExtensionContributions;
+interface ComposedBaseContributions {
+  readonly base: CompiledExtensionContributions;
   readonly disabledToolTargets: readonly DisabledToolTarget[];
+}
+
+interface ComposeOptions {
+  readonly externalDependencies: readonly string[];
 }
 
 /**
@@ -147,29 +187,20 @@ export function applyOverrideDisables(input: {
   };
 }
 
-interface ComposeOptions {
-  readonly externalDependencies: readonly string[];
-}
-
 /**
- * Compiles one agent-shaped manifest into namespaced extension contributions
- * rebased onto the consumer's agent root. Used for both the extension's own
- * source tree and a directory mount's consumer override slots.
+ * Compiles one agent-shaped manifest into **base-named** extension
+ * contributions (no mount prefix, no rebase, no source-id scope). Used for both
+ * the extension's own source tree and a directory mount's consumer override
+ * slots; the caller applies namespacing via {@link namespaceContributions}.
  */
-async function composeManifestContributions(input: {
+async function produceBaseContributions(input: {
   readonly manifest: AgentSourceManifest;
-  readonly namespace: string;
-  readonly consumerAgentRoot: string;
-  readonly options: ComposeOptions;
-  readonly sourceIdScope: string;
   readonly role: "extension" | "override";
-}): Promise<ComposedContributions> {
-  const { manifest, namespace, consumerAgentRoot, options, sourceIdScope, role } = input;
+  readonly namespace: string;
+  readonly options: ComposeOptions;
+}): Promise<ComposedBaseContributions> {
+  const { manifest, role, namespace, options } = input;
   const sourceRoot = manifest.agentRoot;
-  const prefix = `${namespace}__`;
-  const scopeSourceId = (sourceId: string): string => `${sourceIdScope}:${sourceId}`;
-  const rebase = (logicalPath: string): string =>
-    relativePath(consumerAgentRoot, joinPath(sourceRoot, logicalPath)).replaceAll("\\", "/");
 
   const tools: CompiledToolDefinition[] = [];
   const dynamicTools: CompiledDynamicToolDefinition[] = [];
@@ -177,20 +208,9 @@ async function composeManifestContributions(input: {
   for (const source of manifest.tools) {
     const entry = await compileToolEntry(sourceRoot, source, options);
     if (entry.kind === "tool") {
-      tools.push({
-        ...entry.definition,
-        name: `${prefix}${entry.definition.name}`,
-        sourceId: scopeSourceId(entry.definition.sourceId),
-        logicalPath: rebase(entry.definition.logicalPath),
-      });
+      tools.push(entry.definition);
     } else if (entry.kind === "dynamic-tool") {
-      dynamicTools.push({
-        ...entry.definition,
-        slug: `${prefix}${entry.definition.slug}`,
-        extensionNamespace: namespace,
-        sourceId: scopeSourceId(entry.definition.sourceId),
-        logicalPath: rebase(entry.definition.logicalPath),
-      });
+      dynamicTools.push(entry.definition);
     } else if (entry.kind === "workflow-tool") {
       throw new Error(
         `${describeExtensionSource(role, namespace, source.logicalPath)} enables the Workflow tool, ` +
@@ -202,54 +222,26 @@ async function composeManifestContributions(input: {
           `but an extension cannot disable framework tools — that is the consuming agent's to own. Remove it.`,
       );
     } else {
-      disabledToolTargets.push({ name: `${prefix}${entry.name}`, logicalPath: source.logicalPath });
+      disabledToolTargets.push({ name: entry.name, logicalPath: source.logicalPath });
     }
   }
 
-  const hooks: CompiledHookDefinition[] = manifest.hooks.map((source) => {
-    const hook = compileHookEntry(source);
-    return {
-      ...hook,
-      slug: `${prefix}${hook.slug}`,
-      sourceId: scopeSourceId(hook.sourceId),
-      logicalPath: rebase(hook.logicalPath),
-    };
-  });
+  const hooks: CompiledHookDefinition[] = manifest.hooks.map((source) => compileHookEntry(source));
 
   const skills: CompiledSkillDefinition[] = [];
   const dynamicSkills: CompiledDynamicSkillDefinition[] = [];
   for (const source of manifest.skills) {
     const entry = await compileSkillSource(sourceRoot, source, options);
     if (entry.kind === "skill") {
-      skills.push({
-        ...entry.definition,
-        name: `${prefix}${entry.definition.name}`,
-        sourceId: scopeSourceId(entry.definition.sourceId),
-        logicalPath: rebase(entry.definition.logicalPath),
-      });
+      skills.push(entry.definition);
     } else {
-      dynamicSkills.push({
-        ...entry.definition,
-        slug: `${prefix}${entry.definition.slug}`,
-        extensionNamespace: namespace,
-        sourceId: scopeSourceId(entry.definition.sourceId),
-        logicalPath: rebase(entry.definition.logicalPath),
-      });
+      dynamicSkills.push(entry.definition);
     }
   }
 
-  const connections: CompiledConnectionDefinition[] = (
-    await Promise.all(
-      manifest.connections.map((source) =>
-        compileConnectionDefinition(sourceRoot, source, options),
-      ),
-    )
-  ).map((connection) => ({
-    ...connection,
-    connectionName: `${prefix}${connection.connectionName}`,
-    sourceId: scopeSourceId(connection.sourceId),
-    logicalPath: rebase(connection.logicalPath),
-  }));
+  const connections: CompiledConnectionDefinition[] = await Promise.all(
+    manifest.connections.map((source) => compileConnectionDefinition(sourceRoot, source, options)),
+  );
 
   const dynamicInstructions: CompiledDynamicInstructionsDefinition[] = [];
   const instructionFragments: string[] = [];
@@ -258,17 +250,12 @@ async function composeManifestContributions(input: {
     if (entry.kind === "instructions") {
       instructionFragments.push(entry.definition.markdown);
     } else {
-      dynamicInstructions.push({
-        ...entry.definition,
-        slug: `${prefix}${entry.definition.slug}`,
-        sourceId: scopeSourceId(entry.definition.sourceId),
-        logicalPath: rebase(entry.definition.logicalPath),
-      });
+      dynamicInstructions.push(entry.definition);
     }
   }
 
   return {
-    contributions: {
+    base: {
       tools,
       dynamicTools,
       hooks,
@@ -279,6 +266,74 @@ async function composeManifestContributions(input: {
       instructionFragments,
     },
     disabledToolTargets,
+  };
+}
+
+/**
+ * Namespaces a set of base contributions into one mounted extension's composed
+ * shape: prefixes every model-facing name with `<ns>__`, tags dynamic resolvers
+ * with the mount namespace, scopes each source id, and rebases each
+ * module-backed `logicalPath` onto the consumer's agent root.
+ */
+function namespaceContributions(input: {
+  readonly base: CompiledExtensionContributions;
+  readonly namespace: string;
+  readonly sourceRoot: string;
+  readonly consumerAgentRoot: string;
+  readonly sourceIdScope: string;
+}): CompiledExtensionContributions {
+  const { base, namespace, sourceRoot, consumerAgentRoot, sourceIdScope } = input;
+  const prefix = `${namespace}__`;
+  const scopeSourceId = (sourceId: string): string => `${sourceIdScope}:${sourceId}`;
+  const rebase = (logicalPath: string): string =>
+    relativePath(consumerAgentRoot, joinPath(sourceRoot, logicalPath)).replaceAll("\\", "/");
+
+  return {
+    tools: base.tools.map((tool) => ({
+      ...tool,
+      name: `${prefix}${tool.name}`,
+      sourceId: scopeSourceId(tool.sourceId),
+      logicalPath: rebase(tool.logicalPath),
+    })),
+    dynamicTools: base.dynamicTools.map((tool) => ({
+      ...tool,
+      slug: `${prefix}${tool.slug}`,
+      extensionNamespace: namespace,
+      sourceId: scopeSourceId(tool.sourceId),
+      logicalPath: rebase(tool.logicalPath),
+    })),
+    hooks: base.hooks.map((hook) => ({
+      ...hook,
+      slug: `${prefix}${hook.slug}`,
+      sourceId: scopeSourceId(hook.sourceId),
+      logicalPath: rebase(hook.logicalPath),
+    })),
+    skills: base.skills.map((skill) => ({
+      ...skill,
+      name: `${prefix}${skill.name}`,
+      sourceId: scopeSourceId(skill.sourceId),
+      logicalPath: rebase(skill.logicalPath),
+    })),
+    dynamicSkills: base.dynamicSkills.map((skill) => ({
+      ...skill,
+      slug: `${prefix}${skill.slug}`,
+      extensionNamespace: namespace,
+      sourceId: scopeSourceId(skill.sourceId),
+      logicalPath: rebase(skill.logicalPath),
+    })),
+    dynamicInstructions: base.dynamicInstructions.map((instruction) => ({
+      ...instruction,
+      slug: `${prefix}${instruction.slug}`,
+      sourceId: scopeSourceId(instruction.sourceId),
+      logicalPath: rebase(instruction.logicalPath),
+    })),
+    connections: base.connections.map((connection) => ({
+      ...connection,
+      connectionName: `${prefix}${connection.connectionName}`,
+      sourceId: scopeSourceId(connection.sourceId),
+      logicalPath: rebase(connection.logicalPath),
+    })),
+    instructionFragments: [...base.instructionFragments],
   };
 }
 

--- a/packages/eve/src/internal/nitro/host/build-extension.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-extension.integration.test.ts
@@ -23,6 +23,7 @@ describe("extension build config", () => {
     expect(config).not.toBeNull();
     expect(config?.packageName).toBe("@acme/crm");
     expect(config?.shortName).toBe("crm");
+    expect(config?.runtimeDependencies).toEqual([]);
   });
 
   it("returns null for a regular agent app without eve.extension", async () => {

--- a/packages/eve/src/internal/nitro/host/build-extension.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-extension.scenario.test.ts
@@ -53,6 +53,36 @@ describe("extension build output", () => {
     expect(toolsIndex).toContain("Search the CRM"); // the tool source was inlined
   });
 
+  it("stamps the contribution manifest with capability versions", async () => {
+    const root = await createExtensionPackage();
+    const config = await tryReadExtensionBuildConfig(root);
+    const outDir = await buildExtensionPackage(root, config!);
+
+    const artifact = JSON.parse(await readFile(join(outDir, "_ext-manifest.json"), "utf8")) as {
+      kind: string;
+      version: number;
+      eveVersion: string;
+      packageName: string;
+      packageNamespace: string;
+      capabilityVersions: Record<string, number>;
+      contributions: { tools: { name: string; description: string; logicalPath: string }[] };
+    };
+
+    expect(artifact.kind).toBe("eve-extension-artifact");
+    expect(artifact.version).toBe(1);
+    expect(artifact.eveVersion).toMatch(/^\d+\.\d+\.\d+/);
+    expect(artifact.packageName).toBe("@acme/crm");
+    expect(artifact.packageNamespace).toBe("acme-crm");
+    // `config` and `state` always stamp; `tool` stamps because one ships.
+    expect(artifact.capabilityVersions).toEqual({ config: 1, state: 1, tool: 1 });
+    expect(artifact.contributions.tools).toHaveLength(1);
+    expect(artifact.contributions.tools[0]).toMatchObject({
+      name: "crm_search",
+      description: "Search the CRM.",
+      logicalPath: "tools/crm_search.ts",
+    });
+  });
+
   it("emits declaration barrels resolving into the shipped source", async () => {
     const root = await createExtensionPackage();
     const config = await tryReadExtensionBuildConfig(root);

--- a/packages/eve/src/internal/nitro/host/build-extension.ts
+++ b/packages/eve/src/internal/nitro/host/build-extension.ts
@@ -1,11 +1,25 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
+import {
+  EXTENSION_CAPABILITY_VERSIONS,
+  type ExtensionCapabilityKind,
+} from "#compiler/extension-capabilities.js";
+import {
+  writeExtensionArtifact,
+  EXTENSION_ARTIFACT_KIND,
+  EXTENSION_ARTIFACT_VERSION,
+} from "#compiler/extension-artifact.js";
+import {
+  produceExtensionArtifactContributions,
+  type CompiledExtensionContributions,
+} from "#compiler/normalize-extension.js";
 import { discoverAgent } from "#discover/discover-agent.js";
 import { packageStateNamespace } from "#discover/extensions.js";
 import { discoverFlatModuleSource, readSortedDirectoryEntries } from "#discover/grammar.js";
 import { createDiskProjectSource } from "#discover/project-source.js";
 import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "#discover/filesystem.js";
+import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { bundleAuthoredModuleCode } from "#internal/authored-module-loader.js";
 
 /**
@@ -19,6 +33,12 @@ export interface ExtensionBuildConfig {
   readonly packageName: string;
   /** Short name a consumer mounts by (`@acme/crm` → `crm`). */
   readonly shortName: string;
+  /**
+   * Package names the extension declares as dependencies (regular, optional,
+   * or peer). Compiling contribution metadata loads the extension's modules,
+   * and declared packages stay external during that load.
+   */
+  readonly runtimeDependencies: readonly string[];
 }
 
 /**
@@ -29,7 +49,13 @@ export async function tryReadExtensionBuildConfig(
   rootDir: string,
 ): Promise<ExtensionBuildConfig | null> {
   const appRoot = resolve(rootDir);
-  let pkg: { name?: unknown; eve?: { extension?: unknown } };
+  let pkg: {
+    name?: unknown;
+    eve?: { extension?: unknown };
+    dependencies?: Record<string, unknown>;
+    optionalDependencies?: Record<string, unknown>;
+    peerDependencies?: Record<string, unknown>;
+  };
   try {
     pkg = JSON.parse(await readFile(join(appRoot, "package.json"), "utf8")) as typeof pkg;
   } catch {
@@ -48,6 +74,13 @@ export async function tryReadExtensionBuildConfig(
     sourceRoot: resolve(appRoot, extensionRoot),
     packageName,
     shortName,
+    runtimeDependencies: [
+      ...new Set([
+        ...Object.keys(pkg.dependencies ?? {}),
+        ...Object.keys(pkg.optionalDependencies ?? {}),
+        ...Object.keys(pkg.peerDependencies ?? {}),
+      ]),
+    ].sort(),
   };
 }
 
@@ -178,9 +211,53 @@ export async function buildExtensionPackage(
     scopeNamespace,
   });
 
+  const contributions = await produceExtensionArtifactContributions({
+    manifest,
+    externalDependencies: config.runtimeDependencies,
+  });
+  await writeExtensionArtifact(outDir, {
+    kind: EXTENSION_ARTIFACT_KIND,
+    version: EXTENSION_ARTIFACT_VERSION,
+    eveVersion: resolveInstalledPackageInfo().version,
+    packageName: config.packageName,
+    packageNamespace: scopeNamespace,
+    capabilityVersions: deriveCapabilityVersions(contributions),
+    contributions,
+  });
+
   await ensureExtensionExports(appRoot);
 
   return outDir;
+}
+
+/**
+ * Stamps the contract version of every capability the extension uses.
+ * `config` and `state` are always stamped: the mount factory can bind config
+ * and any shipped module may scope durable state, so their contracts always
+ * apply. Other capabilities are stamped only when the extension contributes
+ * at least one of them.
+ */
+function deriveCapabilityVersions(
+  contributions: CompiledExtensionContributions,
+): Record<string, number> {
+  const versions: Record<string, number> = {
+    config: EXTENSION_CAPABILITY_VERSIONS.config,
+    state: EXTENSION_CAPABILITY_VERSIONS.state,
+  };
+  const stamp = (kind: ExtensionCapabilityKind, present: boolean): void => {
+    if (present) {
+      versions[kind] = EXTENSION_CAPABILITY_VERSIONS[kind];
+    }
+  };
+  stamp("tool", contributions.tools.length > 0);
+  stamp("dynamicTool", contributions.dynamicTools.length > 0);
+  stamp("hook", contributions.hooks.length > 0);
+  stamp("connection", contributions.connections.length > 0);
+  stamp("skill", contributions.skills.length > 0);
+  stamp("dynamicSkill", contributions.dynamicSkills.length > 0);
+  stamp("instructions", contributions.instructionFragments.length > 0);
+  stamp("dynamicInstructions", contributions.dynamicInstructions.length > 0);
+  return versions;
 }
 
 /** One `export { <name> } from "<specifier>"` line an entrypoint barrel emits. */

--- a/packages/eve/src/setup/scaffold/create/extension.ts
+++ b/packages/eve/src/setup/scaffold/create/extension.ts
@@ -37,10 +37,22 @@ function renderTemplate(content: string, ctx: ExtensionTemplateContext): string 
   return content
     .replaceAll("__EVE_INIT_APP_NAME__", ctx.appName)
     .replaceAll("__EVE_INIT_PACKAGE_VERSION__", formatEveDependencySpecifier(ctx.eveVersion))
+    .replaceAll("__EVE_INIT_PEER_VERSION__", formatExtensionEvePeerSpecifier(ctx.eveVersion))
     .replaceAll("__EVE_INIT_ZOD_VERSION__", ctx.zodPackageVersion)
     .replaceAll("__EVE_INIT_TYPESCRIPT_VERSION__", ctx.typescriptPackageVersion)
     .replaceAll("__EVE_INIT_TYPES_NODE_VERSION__", ctx.nodeTypesVersion)
     .replaceAll("__EVE_INIT_NODE_ENGINE__", ctx.nodeEngine);
+}
+
+/**
+ * Gives beta extensions the installed eve version as their compatibility floor
+ * while allowing later pre-1.0 releases. Non-registry specifiers are preserved
+ * for local and tarball-based scaffolding.
+ */
+export function formatExtensionEvePeerSpecifier(versionOrSpecifier: string): string {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/.test(versionOrSpecifier)
+    ? `>=${versionOrSpecifier} <1`
+    : versionOrSpecifier;
 }
 
 /**
@@ -73,7 +85,7 @@ function packageJsonTemplate(includeRootOnlyFields: boolean): string {
       typescript: "__EVE_INIT_TYPESCRIPT_VERSION__",
     },
     peerDependencies: {
-      eve: "__EVE_INIT_PACKAGE_VERSION__",
+      eve: "__EVE_INIT_PEER_VERSION__",
     },
   };
 

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -754,7 +754,7 @@ describe("scaffoldExtensionProject", () => {
       name: "demo-extension",
       eve: { extension: "./extension" },
       files: ["extension", "dist"],
-      peerDependencies: { eve: "^0.25.0" },
+      peerDependencies: { eve: ">=0.25.0 <1" },
       dependencies: { zod: "4.4.3" },
       scripts: {
         build: "eve extension build",

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -30,7 +31,20 @@ const PACKAGE_NAME = "@acme/installed-crm";
 const EXT_TREE: Readonly<Record<string, string>> = {
   "extension/extension.ts": [
     'import { defineExtension } from "eve/extension";',
-    'const config = { "~standard": { version: 1, vendor: "scenario", validate: (value) => ({ value }) } };',
+    "",
+    "interface CrmConfig {",
+    "  apiKey: string;",
+    "}",
+    "",
+    "const config = {",
+    '  "~standard": {',
+    "    version: 1,",
+    '    vendor: "scenario",',
+    "    validate: (value: unknown) => ({ value: value as CrmConfig }),",
+    "    types: undefined as { input: CrmConfig; output: CrmConfig } | undefined,",
+    "  },",
+    "} as const;",
+    "",
     "export default defineExtension({ config });",
     "",
   ].join("\n"),
@@ -62,8 +76,14 @@ async function buildInstalledExtensionFiles(): Promise<Record<string, string>> {
   tempRoots.push(extRoot);
   await writeFile(
     join(extRoot, "package.json"),
-    `${JSON.stringify({ name: PACKAGE_NAME, type: "module", eve: { extension: "./extension" } }, null, 2)}\n`,
+    `${JSON.stringify({ name: PACKAGE_NAME, type: "module", eve: { extension: "./extension" }, peerDependencies: { eve: ">=0.1.0 <1" } }, null, 2)}\n`,
     "utf8",
+  );
+  await mkdir(join(extRoot, "node_modules"), { recursive: true });
+  await symlink(
+    dirname(createRequire(import.meta.url).resolve("eve/package.json")),
+    join(extRoot, "node_modules", "eve"),
+    "dir",
   );
   await mkdir(join(extRoot, "extension", "tools"), { recursive: true });
   for (const [path, contents] of Object.entries(EXT_TREE)) {
@@ -71,21 +91,29 @@ async function buildInstalledExtensionFiles(): Promise<Record<string, string>> {
   }
 
   const config = await tryReadExtensionBuildConfig(extRoot);
-  await buildExtensionPackage(extRoot, config!);
+  const distDir = await buildExtensionPackage(extRoot, config!);
 
-  // `eve build` writes dist/ (compiled entrypoints + declarations) and the
-  // exports map into package.json; ship those plus the extension/ source verbatim.
-  const packaged = [
-    "package.json",
-    "dist/index.mjs",
-    "dist/index.d.ts",
-    "dist/tools/index.mjs",
-    "dist/tools/index.d.ts",
-    ...Object.keys(EXT_TREE),
-  ];
-  const files: Record<string, string> = {};
-  for (const path of packaged) {
+  // package.json is read after the build because the build rewrites its
+  // `exports` map; the consumer resolves the mount entry through it.
+  const files: Record<string, string> = {
+    [`node_modules/${PACKAGE_NAME}/package.json`]: await readFile(
+      join(extRoot, "package.json"),
+      "utf8",
+    ),
+  };
+  for (const path of Object.keys(EXT_TREE)) {
     files[`node_modules/${PACKAGE_NAME}/${path}`] = await readFile(join(extRoot, path), "utf8");
+  }
+  for (const entry of await readdir(distDir, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const absolutePath = join(entry.parentPath, entry.name);
+    const distRelativePath = relative(distDir, absolutePath).replaceAll("\\", "/");
+    files[`node_modules/${PACKAGE_NAME}/dist/${distRelativePath}`] = await readFile(
+      absolutePath,
+      "utf8",
+    );
   }
   return files;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9447,7 +9447,7 @@ packages:
   gadget-extension@file:e2e/fixtures/gadget-extension:
     resolution: {directory: e2e/fixtures/gadget-extension, type: directory}
     peerDependencies:
-      eve: '*'
+      eve: '>=0.24.6 <1'
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -9528,7 +9528,7 @@ packages:
   gizmo-extension@file:e2e/fixtures/gizmo-extension:
     resolution: {directory: e2e/fixtures/gizmo-extension, type: directory}
     peerDependencies:
-      eve: '*'
+      eve: '>=0.24.6 <1'
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}


### PR DESCRIPTION
First slice of source-free extension distribution (splitting up `cgowrie/source-free-extensions`) — the **producer side only**. Consumers keep recompiling extension source; nothing reads the new artifact yet.

## What's in this PR

**`eve extension build` stamps a contribution manifest.** The build now writes `dist/_ext-manifest.json`: the extension's compiled contribution metadata (base names, authored logical paths, descriptions, JSON schemas) plus two compatibility stamps:

- `eveVersion` — the eve the extension was built with.
- `capabilityVersions` — a hand-maintained contract version per capability the extension uses (`EXTENSION_CAPABILITY_VERSIONS`). `config` and `state` always stamp (the mount factory can bind config and any module may scope state); the rest stamp only when the extension ships one.

Producing the manifest compiles the extension's contributions (loading its modules), so `tryReadExtensionBuildConfig` now collects declared dependency names and keeps them external during that load.

**`eve extension init` scaffolds the peer range as `>=<installed-version> <1`.** The installed eve becomes the beta extension's compatibility floor while allowing later pre-1.0 releases (`formatExtensionEvePeerSpecifier`); non-registry specifiers pass through for local/tarball scaffolds.

**Refactor:** `composeManifestContributions` splits into `produceBaseContributions` (base names, no rebase) + `namespaceContributions`, so the build can serialize base-named contributions via the new `produceExtensionArtifactContributions`. Consumer composition behavior is unchanged (existing normalize-extension tests untouched and green).

**e2e inclusivity:** gizmo/gadget fixtures adopt the scaffolded peer-range shape, so the existing e2e matrix (workspace + store-installed consumption, from #898) now exercises the artifact-emitting build and a real peer range end to end.

## Not in this PR (later slices)

Source-free discovery/composition (consuming `_ext-manifest.json` without source), the graph-bundled dist + declaration emit, dist-only fixtures/staging, and the consumer-side compatibility checks that read these stamps.

## Verification

- New unit tests: `extension-artifact.test.ts` (round-trip, malformed input, version-skew error), `extension-capabilities.test.ts`; new scenario assertion for the stamped manifest contents.
- `mounted-extension-installed` scenario ships the full recursive `dist/` (now including the manifest) and stays green — consumers still compile source.
- Full unit (4866) + integration (478) suites, typecheck, lint, guard, docs:check pass.
- Local e2e boot-checks: `dist-extensions` and `extensions` fixtures build with the artifact-emitting producer, boot, and `eve build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)