### PR TITLE
test(eve): disambiguate recursive-root-only child prompt

### DIFF
--- a/e2e/fixtures/agent-subagents/evals/recursive-root-only.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/recursive-root-only.eval.ts
@@ -10,8 +10,8 @@ export default defineEval({
       [
         "Use the built-in agent subagent exactly once.",
         "Give the child this task:",
-        "If a built-in agent tool is visible, call it once and return RECURSIVE_AGENT_WAS_VISIBLE.",
-        `If no built-in agent tool is visible, return exactly ${CHILD_TOKEN}.`,
+        "If a built-in tool named `agent` is visible, call it once and return RECURSIVE_AGENT_WAS_VISIBLE.",
+        `If no built-in tool named \`agent\` is visible, return exactly ${CHILD_TOKEN}.`,
         `After the child returns, reply with its exact output and no other token.`,
       ].join(" "),
     );


### PR DESCRIPTION
## What

`agent-subagents/recursive-root-only` verifies the built-in recursive `agent` tool is exposed only to the root session. It does so by having a child subagent introspect its tools and relay a sentinel token. The child prompt asked whether "a built-in **agent tool**" is visible — ambiguous wording. The child legitimately has sibling subagent/framework tools (`echo-marker`, `parallel`, `ask_question`, …), and opus occasionally counted those as "an agent tool", relaying `RECURSIVE_AGENT_WAS_VISIBLE` and failing the eval.

Fix: name the exact tool — **"a built-in tool named `agent`"** — so only the recursive delegation tool (`AGENT_TOOL_NAME = "agent"`, `runtime/framework-tools/agent.ts`) counts, not the siblings.

## Evidence / honesty

- The tool name is verified: `AGENT_TOOL_NAME = "agent"` (model-visible), registered model-facing in `execution/node-step.ts`; siblings are named by directory (`echo-marker`), never `agent`.
- **No real capability leak**: across ~196 opus runs the child never invoked a nested `agent` tool even when it hallucinated visibility (`agentCalls` stayed 1). The runtime gating is correct and covered deterministically by `node-step.test.ts` (subagent nodes lack the tool) and `workflow-steps.test.ts` (`RECURSIVE_AGENT_ROOT_ONLY` enforcement).
- The flake is **rare on current models** (~1 in ~196 opus; 0 on gpt-5.6-sol); the historical failures were pre-matrix. The base rate is too low to statistically prove this wording reduces failures, but it removes the known ambiguity at zero risk. Candidate wording ran 130/130 clean.