### PR TITLE
Emit Agent Run provenance

### DIFF
--- a/.changeset/verified-run-provenance.md
+++ b/.changeset/verified-run-provenance.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit verified channel and schedule provenance on top-level workflow runs while preserving the existing `$eve.trigger` attribute.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -128,7 +128,12 @@ Structural tags describe each run's place in the tree:
 - `$eve.root`: session id of the root session in the chain (group a whole tree with `$eve.root=<id>`)
 - `$eve.subagent`: compiled graph node id (subagent runs only)
 - `$eve.trigger`: the channel kind that started the run
+- `$eve.origin`: verified initiating boundary, either `channel` or `schedule` (session runs only)
+- `$eve.channel`: configured logical channel name for direct channel runs and schedules that target a channel (session runs only)
+- `$eve.schedule`: configured logical schedule name for scheduled runs (session runs only)
 - `$eve.title`: truncated title derived from the first user message
+
+`$eve.trigger` remains the channel adapter kind, so a scheduled handler that targets Slack still has Slack as its trigger. `$eve.origin` records that the schedule initiated the session, while `$eve.channel` and `$eve.schedule` identify the configured target and schedule. Eve omits provenance attributes when the initiation boundary or identity is unavailable; it does not infer or backfill them for older runs.
 
 Per-turn usage tags are written on each step of a turn, accumulating cumulative totals (last write wins):
 

--- a/packages/eve/src/channel/cross-channel-receive.ts
+++ b/packages/eve/src/channel/cross-channel-receive.ts
@@ -5,7 +5,7 @@ import { isCompiledChannel, type CompiledChannel } from "#channel/compiled-chann
 import type { InferReceiveTarget } from "#channel/receive-target.js";
 import { createSendFn } from "#channel/send.js";
 import type { Session } from "#channel/session.js";
-import type { Runtime, SessionAuthContext } from "#channel/types.js";
+import type { RunProvenance, Runtime, SessionAuthContext } from "#channel/types.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 
 /**
@@ -76,10 +76,12 @@ export function toCrossChannelTargets(
 export function createCrossChannelReceiveFn(
   runtime: Runtime,
   channels: readonly CrossChannelTarget[],
+  provenance?: Omit<RunProvenance, "channel">,
 ): CrossChannelReceiveFn {
   return async (channel, options) => {
     const targetChannel = resolveTargetByReference(channel, channels);
     return await invokeChannelReceive({
+      provenance,
       runtime,
       target: targetChannel,
       input: {
@@ -97,6 +99,7 @@ export function createCrossChannelReceiveFn(
 }
 
 interface InvokeChannelReceiveInput {
+  readonly provenance?: Omit<RunProvenance, "channel">;
   readonly runtime: Runtime;
   readonly target: Pick<CrossChannelTarget, "name" | "receive" | "adapter">;
   readonly input: {
@@ -121,7 +124,9 @@ export async function invokeChannelReceive(args: InvokeChannelReceiveInput): Pro
   if (!args.target.adapter) {
     throw new Error(args.describeMissingAdapter());
   }
-  const send = createSendFn(args.runtime, args.target.adapter, args.target.name);
+  const send = createSendFn(args.runtime, args.target.adapter, args.target.name, {
+    provenance: args.provenance,
+  });
   return await args.target.receive(args.input, { send });
 }
 

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -73,6 +73,10 @@ describe("ScheduleDispatcher", () => {
           input: { message: "Run heartbeat task." },
           mode: "task",
           auth: SCHEDULE_APP_AUTH,
+          provenance: {
+            origin: "schedule",
+            schedule: "heartbeat",
+          },
         }),
       );
       expect(SCHEDULE_ADAPTER.kind).toBe(SCHEDULE_ADAPTER_KIND);
@@ -129,6 +133,11 @@ describe("ScheduleDispatcher", () => {
           /^slack:C0123ABC:[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/,
         );
         expect(runInput.auth).toEqual(SCHEDULE_APP_AUTH);
+        expect(runInput.provenance).toEqual({
+          origin: "schedule",
+          channel: "slack",
+          schedule: "daily-digest",
+        });
       } finally {
         vi.unstubAllEnvs();
       }

--- a/packages/eve/src/channel/schedule.ts
+++ b/packages/eve/src/channel/schedule.ts
@@ -77,7 +77,11 @@ export class ScheduleDispatcher {
   async trigger(input: ScheduleDispatchInput): Promise<ScheduleDispatchResult> {
     const sessions: Session[] = [];
     const waitUntilTasks: Promise<unknown>[] = [];
-    const receive = createCrossChannelReceiveFn(this.runtime, toCrossChannelTargets(this.channels));
+    const receive = createCrossChannelReceiveFn(
+      this.runtime,
+      toCrossChannelTargets(this.channels),
+      { origin: "schedule", schedule: input.scheduleId },
+    );
 
     const args: ScheduleHandlerArgs = {
       appAuth: SCHEDULE_APP_AUTH,
@@ -94,7 +98,7 @@ export class ScheduleDispatcher {
     if (input.run) {
       await input.run(args);
     } else if (input.markdown !== undefined) {
-      const session = await this.runMarkdown(input.markdown);
+      const session = await this.runMarkdown(input.markdown, input.scheduleId);
       sessions.push(session);
     } else {
       throw new Error(
@@ -105,12 +109,13 @@ export class ScheduleDispatcher {
     return { sessions, waitUntilTasks };
   }
 
-  private async runMarkdown(markdown: string): Promise<Session> {
+  private async runMarkdown(markdown: string, scheduleId: string): Promise<Session> {
     const handle = await this.runtime.run({
       adapter: SCHEDULE_ADAPTER,
       auth: SCHEDULE_APP_AUTH,
       input: { message: markdown },
       mode: "task",
+      provenance: { origin: "schedule", schedule: scheduleId },
     });
     return createSession(handle.sessionId, handle.continuationToken, this.runtime);
   }

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -43,6 +43,10 @@ describe("createSendFn", () => {
     expect(session.id).toBe("mock-session-id");
     expect(runtime.deliver).toHaveBeenCalledTimes(1);
     expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runtime.run).mock.calls[0]![0].provenance).toEqual({
+      origin: "channel",
+      channel: "test",
+    });
     expect(log).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
 

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -1,7 +1,13 @@
 import type { FilePart, UserContent } from "ai";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
-import type { DeliverInput, RunInput, Runtime, SessionAuthContext } from "#channel/types.js";
+import type {
+  DeliverInput,
+  RunInput,
+  RunProvenance,
+  Runtime,
+  SessionAuthContext,
+} from "#channel/types.js";
 import { createSession, type Session } from "#channel/session.js";
 import type { SendFn, SendOptions, SendPayload } from "#channel/routes.js";
 import { isRuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
@@ -14,7 +20,10 @@ export function createSendFn<TState = undefined>(
   runtime: Runtime,
   adapter: ChannelAdapter<any>,
   channelName: string,
-  metadata: { readonly requestId?: string } = {},
+  metadata: {
+    readonly provenance?: Omit<RunProvenance, "channel">;
+    readonly requestId?: string;
+  } = {},
 ): SendFn<TState> {
   return async (
     input: string | UserContent | SendPayload,
@@ -75,6 +84,10 @@ export function createSendFn<TState = undefined>(
       continuationToken,
       input: { message: message ?? "", context, outputSchema },
       mode,
+      provenance: {
+        ...(metadata.provenance ?? { origin: "channel" }),
+        channel: channelName,
+      },
       requestId: metadata.requestId,
       title,
     };

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -253,6 +253,19 @@ export interface SessionCapabilities {
 // ---------------------------------------------------------------------------
 
 /**
+ * Framework-verified provenance for a top-level session.
+ *
+ * @internal Authored code must not infer or supply these values. Initiation
+ * boundaries stamp them before the runtime emits reserved `$eve.*` workflow
+ * attributes.
+ */
+export interface RunProvenance {
+  readonly origin: "channel" | "schedule";
+  readonly channel?: string;
+  readonly schedule?: string;
+}
+
+/**
  * Single input shape consumed by {@link Runtime.run} for both root runs
  * (started by routes) and delegated child runs (started by the
  * subagent tool wrapper).
@@ -280,6 +293,8 @@ export interface RunInput {
   readonly capabilities?: SessionCapabilities;
   /** Inbound channel request id used to correlate workflow attributes. */
   readonly requestId?: string;
+  /** Framework-owned provenance for top-level session instrumentation. */
+  readonly provenance?: RunProvenance;
   /**
    * Human-readable workflow title for top-level sessions. When omitted, the
    * runtime derives `$eve.title` from {@link input.message}.

--- a/packages/eve/src/execution/eve-workflow-attributes.test.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.test.ts
@@ -138,6 +138,24 @@ describe("deriveSessionTitle", () => {
 });
 
 describe("buildSessionAttributes", () => {
+  it("emits verified channel provenance without changing the trigger", () => {
+    const attrs = buildSessionAttributes({
+      inputMessage: "ship the thing please",
+      provenance: { origin: "channel", channel: "support/slack" },
+      serializedContext: slackChannelCtx,
+    });
+
+    expect(attrs).toEqual({
+      "$eve.channel": "support/slack",
+      "$eve.channel_request_id": undefined,
+      "$eve.origin": "channel",
+      "$eve.schedule": undefined,
+      "$eve.type": "session",
+      "$eve.trigger": "slack",
+      "$eve.title": "ship the thing please",
+    });
+  });
+
   it("emits type=session with trigger and derived title", () => {
     const attrs = buildSessionAttributes({
       inputMessage: "ship the thing please",
@@ -160,6 +178,9 @@ describe("buildSessionAttributes", () => {
 
     expect(attrs["$eve.trigger"]).toBeUndefined();
     expect(attrs["$eve.title"]).toBe("hi");
+    expect(attrs["$eve.origin"]).toBeUndefined();
+    expect(attrs["$eve.channel"]).toBeUndefined();
+    expect(attrs["$eve.schedule"]).toBeUndefined();
   });
 
   it("emits the channel request id when present", () => {

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -21,10 +21,14 @@
  * - `$eve.parent_turn`  — parent turn id that dispatched the subagent (subagent rows only)
  * - `$eve.subagent`     — active compiled graph node id (subagent rows only)
  * - `$eve.trigger`      — channel adapter kind (session/subagent rows)
+ * - `$eve.origin`       — verified initiating boundary (`channel` or `schedule`)
+ * - `$eve.channel`      — configured target channel name (session rows only)
+ * - `$eve.schedule`     — configured schedule name (session rows only)
  * - `$eve.title`        — truncated session title from the first user message
  * - `$eve.channel_request_id` — inbound channel request id
  */
 
+import type { RunProvenance } from "#channel/types.js";
 import { ChannelRequestIdKey } from "#context/keys.js";
 import type { EveAttributeValue } from "#runtime/attributes/normalize.js";
 import { isNonEmptyString } from "#shared/guards.js";
@@ -205,10 +209,18 @@ function collectMessageText(message: unknown): string | undefined {
  */
 export function buildSessionAttributes(input: {
   readonly inputMessage: unknown;
+  readonly provenance?: RunProvenance;
   readonly serializedContext: Record<string, unknown>;
 }): Record<string, EveAttributeValue> {
   return {
     "$eve.channel_request_id": readChannelRequestId(input.serializedContext),
+    ...(input.provenance
+      ? {
+          "$eve.channel": input.provenance.channel,
+          "$eve.origin": input.provenance.origin,
+          "$eve.schedule": input.provenance.schedule,
+        }
+      : {}),
     "$eve.type": "session",
     "$eve.trigger": readChannelKind(input.serializedContext),
     "$eve.title": deriveSessionTitle(input.inputMessage),

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -495,6 +495,11 @@ describe("workflowEntry integration", () => {
           attributes: normalizeEveAttributes(
             buildSessionAttributes({
               inputMessage: "session tag round-trip",
+              provenance: {
+                origin: "schedule",
+                channel: "slack",
+                schedule: "daily-digest",
+              },
               serializedContext,
             }),
           ),
@@ -511,6 +516,9 @@ describe("workflowEntry integration", () => {
 
         expect(attrs["$eve.type"]).toBe("session");
         expect(attrs["$eve.trigger"]).toBe("http");
+        expect(attrs["$eve.origin"]).toBe("schedule");
+        expect(attrs["$eve.channel"]).toBe("slack");
+        expect(attrs["$eve.schedule"]).toBe("daily-digest");
         expect(attrs["$eve.title"]).toContain("session tag round-trip");
         // Top-level sessions have no parent or subagent name on the root run.
         expect(attrs["$eve.parent"]).toBeUndefined();

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -289,6 +289,32 @@ describe("createWorkflowRuntime#run", () => {
     expect(startOptions.attributes["$eve.title"]).toBe("ship it");
   });
 
+  it("persists verified provenance without deriving it from the adapter trigger", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource);
+    startMock.mockResolvedValue({ runId: "driver-run" });
+
+    await buildRuntime(compiledArtifactsSource).run({
+      adapter,
+      auth: null,
+      input: { message: "post the digest" },
+      mode: "task",
+      provenance: {
+        origin: "schedule",
+        channel: "slack",
+        schedule: "daily-digest",
+      },
+    });
+
+    const [, , startOptions] = startMock.mock.calls[0]!;
+    expect(startOptions.attributes).toMatchObject({
+      "$eve.channel": "slack",
+      "$eve.origin": "schedule",
+      "$eve.schedule": "daily-digest",
+      "$eve.trigger": "http",
+    });
+  });
+
   it("serializes the channel request id into workflow context", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -119,6 +119,7 @@ export function createWorkflowRuntime(config: {
         parentLineage.sessionId === undefined
           ? buildSessionAttributes({
               inputMessage: input.title ?? input.input.message,
+              provenance: input.provenance,
               serializedContext,
             })
           : buildSubagentRootAttributes({

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -384,6 +384,10 @@ describe("dispatchChannelRequest", () => {
     expect(startedInput).not.toBe(runInput);
     expect(deliveredInput?.requestId).toBe("iad1::abc123-1710000000000-deadbeef");
     expect(startedInput?.requestId).toBe("iad1::abc123-1710000000000-deadbeef");
+    expect(startedInput?.provenance).toEqual({
+      origin: "channel",
+      channel: "internal",
+    });
     expect(deliverInput).not.toHaveProperty("requestId");
     expect(runInput).not.toHaveProperty("requestId");
   });

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
@@ -186,7 +186,7 @@ function buildRouteArgs(
   };
   const channel = bundle.channels.find((candidate) => candidate.name === channelName);
   const adapter = channel?.adapter ?? { kind: "channel" };
-  const agent = createRouteAgent(bundle.runtime, requestId);
+  const agent = createRouteAgent(bundle.runtime, channelName, requestId);
   const send = createSendFn(bundle.runtime, adapter, channelName, { requestId });
   const cancel = createCancelFn(bundle.runtime, channelName);
   const getSession = createGetSessionFn(bundle.runtime);
@@ -221,7 +221,11 @@ function buildRouteArgs(
   };
 }
 
-function createRouteAgent(runtime: Runtime, requestId: string | undefined): Agent {
+function createRouteAgent(
+  runtime: Runtime,
+  channelName: string,
+  requestId: string | undefined,
+): Agent {
   return {
     async cancelTurn(input) {
       return await runtime.cancelTurn(input);
@@ -234,7 +238,11 @@ function createRouteAgent(runtime: Runtime, requestId: string | undefined): Agen
       return await runtime.getEventStream(sessionId, options);
     },
     async run(input) {
-      const runInput: RunInput = { ...input, requestId }; // Avoid mutating a frozen caller input.
+      const runInput: RunInput = {
+        ...input,
+        provenance: { origin: "channel", channel: channelName },
+        requestId,
+      }; // Avoid mutating a frozen caller input.
       return await runtime.run(runInput);
     },
   };


### PR DESCRIPTION
- Emit verified `$eve.origin`, `$eve.channel`, and `$eve.schedule` attributes for new channel and scheduled sessions while preserving `$eve.trigger`.
- Carry schedule identity through markdown and channel-targeted schedule paths; leave legacy and missing provenance absent.
- Document the contract and cover direct, scheduled, persistence, and compatibility paths with focused tests.