### PR TITLE
fix(eve): (server) guarantee session event streams end in a terminal boundary event

### DIFF
--- a/.changeset/terminal-stream-framing.md
+++ b/.changeset/terminal-stream-framing.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Session event streams are now guaranteed to end in a terminal boundary event: when a settled workflow run's durable log ends without one (for example after a platform-level cancellation), the stream appends a synthesized `session.failed` or `session.completed` derived from the run status. The deployed app function's `maxDuration` is also raised to `"max"`, so long event streams are cut at the plan's maximum window instead of the platform default.

--- a/packages/eve/src/execution/terminal-framing.test.ts
+++ b/packages/eve/src/execution/terminal-framing.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createSessionStartedEvent,
+  createSessionWaitingEvent,
+  type HandleMessageStreamEvent,
+} from "#protocol/message.js";
+import { withTerminalFraming } from "#execution/terminal-framing.js";
+
+function streamOf(
+  events: readonly HandleMessageStreamEvent[],
+): ReadableStream<HandleMessageStreamEvent> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(event);
+      }
+      controller.close();
+    },
+  });
+}
+
+async function collect(
+  stream: ReadableStream<HandleMessageStreamEvent>,
+): Promise<HandleMessageStreamEvent[]> {
+  const events: HandleMessageStreamEvent[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    events.push(value);
+  }
+  return events;
+}
+
+const textEvent: HandleMessageStreamEvent = createSessionStartedEvent();
+const waitingEvent: HandleMessageStreamEvent = createSessionWaitingEvent("tok");
+
+describe("withTerminalFraming", () => {
+  it("passes a boundary-terminated stream through unchanged", async () => {
+    const framed = withTerminalFraming(streamOf([textEvent, waitingEvent]), {
+      getRunStatus: () => Promise.reject(new Error("must not be called")),
+      sessionId: "wrun_1",
+    });
+
+    await expect(collect(framed)).resolves.toEqual([textEvent, waitingEvent]);
+  });
+
+  it("synthesizes session.failed when a cancelled run's log ends without a boundary", async () => {
+    const framed = withTerminalFraming(streamOf([textEvent]), {
+      getRunStatus: () => Promise.resolve("cancelled"),
+      sessionId: "wrun_1",
+    });
+
+    const events = await collect(framed);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual(textEvent);
+    expect(events[1]).toMatchObject({
+      data: { code: "RUN_CANCELLED", sessionId: "wrun_1" },
+      type: "session.failed",
+    });
+  });
+
+  it("synthesizes session.failed when a failed run's log ends without a boundary", async () => {
+    const framed = withTerminalFraming(streamOf([textEvent]), {
+      getRunStatus: () => Promise.resolve("failed"),
+      sessionId: "wrun_1",
+    });
+
+    const events = await collect(framed);
+    expect(events.at(-1)).toMatchObject({
+      data: { code: "WORKFLOW_RUN_FAILED", sessionId: "wrun_1" },
+      type: "session.failed",
+    });
+  });
+
+  it("synthesizes session.completed for an empty slice of a completed run", async () => {
+    // A client reconnecting at the tail of a completed run reads zero events;
+    // the synthesized boundary is what stops it from reconnecting forever.
+    const framed = withTerminalFraming(streamOf([]), {
+      getRunStatus: () => Promise.resolve("completed"),
+      sessionId: "wrun_1",
+    });
+
+    const events = await collect(framed);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "session.completed" });
+  });
+
+  it("synthesizes nothing while the run is still live", async () => {
+    const framed = withTerminalFraming(streamOf([textEvent]), {
+      getRunStatus: () => Promise.resolve("running"),
+      sessionId: "wrun_1",
+    });
+
+    await expect(collect(framed)).resolves.toEqual([textEvent]);
+  });
+
+  it("ends cleanly when the status probe fails", async () => {
+    const framed = withTerminalFraming(streamOf([textEvent]), {
+      getRunStatus: () => Promise.reject(new Error("world unavailable")),
+      sessionId: "wrun_1",
+    });
+
+    await expect(collect(framed)).resolves.toEqual([textEvent]);
+  });
+
+  it("stamps the synthesized event with durable timing metadata", async () => {
+    const framed = withTerminalFraming(streamOf([]), {
+      getRunStatus: () => Promise.resolve("cancelled"),
+      sessionId: "wrun_1",
+    });
+
+    const [event] = await collect(framed);
+    expect((event as { meta?: { at?: string } }).meta?.at).toBeTypeOf("string");
+  });
+
+  it("forwards cancellation to the source stream", async () => {
+    let sourceCancelled = false;
+    const source = new ReadableStream<HandleMessageStreamEvent>({
+      cancel() {
+        sourceCancelled = true;
+      },
+    });
+
+    const framed = withTerminalFraming(source, {
+      getRunStatus: () => Promise.resolve("running"),
+      sessionId: "wrun_1",
+    });
+
+    await framed.cancel();
+    // pipeThrough propagates cancellation to its source asynchronously.
+    await expect.poll(() => sourceCancelled).toBe(true);
+  });
+});

--- a/packages/eve/src/execution/terminal-framing.ts
+++ b/packages/eve/src/execution/terminal-framing.ts
@@ -1,0 +1,86 @@
+import {
+  createSessionCompletedEvent,
+  createSessionFailedEvent,
+  isCurrentTurnBoundaryEvent,
+  timestampHandleMessageStreamEvent,
+  type HandleMessageStreamEvent,
+} from "#protocol/message.js";
+
+/**
+ * Guarantees a served session event stream ends in a turn-boundary event.
+ *
+ * The durable event log reaches EOF only once its workflow run settles, and
+ * every eve-owned settle path already writes a boundary event
+ * (`session.waiting` / `session.completed` / `session.failed`) as its last
+ * entry. The log can still end without one when the run is terminated from
+ * outside eve's code — a platform-level cancellation, run expiry, or a crash
+ * that also killed the failure emitter. In that case a boundary event is
+ * synthesized from the run's terminal status, so consumers can rely on a
+ * single rule: follow the stream until a boundary event.
+ *
+ * A stream that ends while the run is still live (which the durable log
+ * contract does not produce, but a defect might) is passed through untouched —
+ * synthesizing a terminal event for a live run would falsely end the session.
+ */
+export function withTerminalFraming(
+  events: ReadableStream<HandleMessageStreamEvent>,
+  input: {
+    /** Resolves the run's current status, e.g. `getRun(sessionId).status`. */
+    readonly getRunStatus: () => Promise<string>;
+    readonly sessionId: string;
+  },
+): ReadableStream<HandleMessageStreamEvent> {
+  let lastEvent: HandleMessageStreamEvent | undefined;
+
+  return events.pipeThrough(
+    new TransformStream<HandleMessageStreamEvent, HandleMessageStreamEvent>({
+      transform(event, controller) {
+        lastEvent = event;
+        controller.enqueue(event);
+      },
+      async flush(controller) {
+        if (lastEvent !== undefined && isCurrentTurnBoundaryEvent(lastEvent)) {
+          return;
+        }
+
+        const synthesized = await synthesizeTerminalBoundaryEvent(input);
+        if (synthesized !== undefined) {
+          controller.enqueue(timestampHandleMessageStreamEvent(synthesized));
+        }
+      },
+    }),
+  );
+}
+
+async function synthesizeTerminalBoundaryEvent(input: {
+  readonly getRunStatus: () => Promise<string>;
+  readonly sessionId: string;
+}): Promise<HandleMessageStreamEvent | undefined> {
+  let status: string;
+  try {
+    status = await input.getRunStatus();
+  } catch {
+    // The status probe failing must not poison the events already served;
+    // the stream simply ends and the client's reconnect asks again.
+    return undefined;
+  }
+
+  switch (status) {
+    case "completed":
+      return createSessionCompletedEvent();
+    case "failed":
+      return createSessionFailedEvent({
+        code: "WORKFLOW_RUN_FAILED",
+        message: "The session's workflow run failed before a terminal session event was recorded.",
+        sessionId: input.sessionId,
+      });
+    case "cancelled":
+      return createSessionFailedEvent({
+        code: "RUN_CANCELLED",
+        message: "The session's workflow run was cancelled.",
+        sessionId: input.sessionId,
+      });
+    default:
+      return undefined;
+  }
+}

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -41,6 +41,7 @@ import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { buildRunContext } from "#execution/runtime-context.js";
 import { parseNdjsonStream } from "#execution/ndjson-stream.js";
+import { withTerminalFraming } from "#execution/terminal-framing.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import {
   sessionCancelHookToken,
@@ -155,9 +156,7 @@ export function createWorkflowRuntime(config: {
 
       let events: ReadableStream<HandleMessageStreamEvent> | undefined;
       const getEvents = () => {
-        events ??= parseNdjsonStream<HandleMessageStreamEvent>(() =>
-          getRun(run.runId).getReadable(),
-        );
+        events ??= readSessionEventStream(run.runId);
         return events;
       };
 
@@ -201,9 +200,7 @@ export function createWorkflowRuntime(config: {
       sessionId: string,
       options?: GetEventStreamOptions,
     ): Promise<ReadableStream<HandleMessageStreamEvent>> {
-      return parseNdjsonStream<HandleMessageStreamEvent>(() =>
-        getRun(sessionId).getReadable({ startIndex: options?.startIndex }),
-      );
+      return readSessionEventStream(sessionId, options);
     },
 
     async resolveSession(continuationToken: string): Promise<{ sessionId: string } | undefined> {
@@ -221,6 +218,26 @@ export function createWorkflowRuntime(config: {
       }
     },
   };
+}
+
+/**
+ * Reads a session's durable event log as parsed stream events, framed so a
+ * settled run's stream always ends in a turn-boundary event (see
+ * {@link withTerminalFraming}).
+ */
+function readSessionEventStream(
+  sessionId: string,
+  options?: GetEventStreamOptions,
+): ReadableStream<HandleMessageStreamEvent> {
+  return withTerminalFraming(
+    parseNdjsonStream<HandleMessageStreamEvent>(() =>
+      getRun(sessionId).getReadable({ startIndex: options?.startIndex }),
+    ),
+    {
+      getRunStatus: () => getRun(sessionId).status,
+      sessionId,
+    },
+  );
 }
 
 /** Requests cancellation through a session's stable workflow hook. */

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -471,6 +471,14 @@ describe("buildApplication", () => {
     ).rejects.toThrow();
     expect(sharedFunctionStats.isDirectory()).toBe(true);
     expect(sharedFunctionStats.isSymbolicLink()).toBe(false);
+    const sharedFunctionConfig = JSON.parse(
+      await readFile(
+        join(appRoot, ".vercel", "output", "functions", "eve", "__server.func", ".vc-config.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(sharedFunctionConfig.maxDuration).toBe("max");
+    expect(sharedFunctionConfig.runtime).toBe("nodejs24.x");
     expect(nestedFunctionStats.isSymbolicLink()).toBe(true);
     await expect(
       realpath(join(appRoot, ".vercel", "output", "functions", "eve", "v1", "health.func")),
@@ -777,6 +785,13 @@ describe("buildApplication", () => {
 
     expect(rootFunctionStats.isSymbolicLink()).toBe(true);
     expect(sharedFunctionStats.isDirectory()).toBe(true);
+    const sharedFunctionConfig = JSON.parse(
+      await readFile(
+        join(appRoot, ".vercel", "output", "functions", "__server.func", ".vc-config.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(sharedFunctionConfig.maxDuration).toBe("max");
     await expect(
       readFile(
         join(appRoot, ".vercel", "output", "functions", "index.func", "_runtime.mjs"),

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -32,6 +32,7 @@ import { emitVercelAgentSummary } from "#internal/nitro/host/build-vercel-agent-
 import { tryReadExtensionBuildConfig } from "#internal/nitro/host/build-extension.js";
 import { copyHostMiddlewareFunctions } from "#internal/nitro/host/copy-host-middleware.js";
 import { prepareProductionApplicationHost } from "#internal/nitro/host/prepare-application-host.js";
+import { extendVercelServerFunctionMaxDuration } from "#internal/nitro/host/vercel-build-output-config.js";
 import { runVercelBuildPrewarm } from "#internal/nitro/host/vercel-build-prewarm.js";
 import type {
   ApplicationBuildOptions,
@@ -495,6 +496,9 @@ async function buildApplicationInWorkspace(
 
   try {
     await buildNitroOutput(nitro, profiler, "nitro.app");
+    await measureBuildPhase(profiler, "vercel.app-function.max-duration", () =>
+      extendVercelServerFunctionMaxDuration(workspace.publication.output.stagedDir),
+    );
     // Run sandbox prewarm before emitting the workflow functions so a
     // prewarm failure aborts the build before we spend time bundling
     // function output that we would never deploy.

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
@@ -1,3 +1,6 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 
@@ -15,4 +18,37 @@ export function createEveVercelOptions(enabled: boolean) {
       },
     },
   };
+}
+
+/**
+ * Raises the emitted app server function's `maxDuration` to the plan maximum.
+ *
+ * The app function serves long-lived session event streams, so its duration
+ * ceiling should match the workflow function's (patched to `"max"` in
+ * `workflow-bundle/builder.ts`) — otherwise streams are severed at the shorter
+ * platform default and clients reconnect more often than the plan requires.
+ * Nitro's typed `vercel.functions` option cannot express the Build Output
+ * API's literal `"max"`, so the emitted `.vc-config.json` is patched after the
+ * build instead. Missing output (a non-Vercel build) is left untouched.
+ */
+export async function extendVercelServerFunctionMaxDuration(outputDir: string): Promise<void> {
+  const configPath = join(outputDir, "functions", "__server.func", ".vc-config.json");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(configPath, "utf8"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return;
+  }
+
+  const config: Record<string, unknown> = { ...(parsed as Record<string, unknown>) };
+  config.maxDuration = "max";
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
 }


### PR DESCRIPTION
Server half of the stream-liveness fix (client half: #919).

A workflow run's durable event log can settle without a session boundary event when the run is terminated outside eve's own code paths — platform-level cancellation, run expiry, or the terminal-failure emitter itself dying. Consumers then can't tell "turn still running" from "run is gone" by transport behavior alone.

- **Terminal framing**: served event streams now append a synthesized `session.failed` / `session.completed` (derived from `getRun(id).status`) when a settled run's log ends without a boundary event. Implemented as a small `TransformStream.flush` wrapper (`execution/terminal-framing.ts`) on both stream-serving paths.
- **App function** **`maxDuration: "max"`**: the nitro `__server.func` that serves `GET /eve/v1/session/:id/stream` previously ran at the platform default (~300s), so every open stream was severed every ~5 minutes while the flow function ran at `"max"`. Patched post-build, same mechanism as the flow function.

Together with #919 this establishes the stream contract: _a settled run's stream always ends in a boundary event; everything else is a transport cut the client reconnects through._