### PR TITLE
fix(eve): follow durable event streams across connection cuts

### DIFF
--- a/.changeset/follow-until-boundary.md
+++ b/.changeset/follow-until-boundary.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+The client now reconnects durable event streams from their last cursor, so long turns continue across transient connection cuts without replaying events. Stream retries are now managed internally, interrupted sessions remain resumable, and `maxReconnectAttempts` has been removed from `ClientOptions`, `EveAgentStoreInit`, and the React, Svelte, and Vue `UseEveAgentOptions` APIs.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -110,7 +110,7 @@ Custom channel routes request the same cancellation without knowing the session 
 
 ## Reconnect and rewind
 
-The stream is durable. Every event is recorded before a step completes, so the whole stream is replayable. A nonnegative `startIndex` is an absolute event count: use it to pick up where you dropped off or pass `0` to rewind to the start.
+The stream is durable. Every event is recorded before a step completes, so consumers can reconnect from their cursor when an HTTP connection ends. A nonnegative `startIndex` is an absolute event count: use it to pick up where you dropped off or pass `0` to rewind to the start.
 
 ```bash
 curl "http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream?startIndex=<count>"

--- a/docs/guides/client/overview.mdx
+++ b/docs/guides/client/overview.mdx
@@ -9,7 +9,7 @@ For browser chat UIs, start with [`useEveAgent`](../frontend/overview). For wire
 
 ## Create a client
 
-A `Client` binds one host, auth policy, header policy, and stream reconnection budget:
+A `Client` binds one host, auth policy, and header policy:
 
 ```ts
 import { Client } from "eve/client";

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -103,16 +103,7 @@ If you support refresh while an authorization prompt is pending, keep the sessio
 
 ## Reconnection
 
-The client reconnects after transient stream disconnects. It resumes from the number of events already consumed in the current session:
-
-```ts
-const client = new Client({
-  host: "https://agent.example.com",
-  maxReconnectAttempts: 5,
-});
-```
-
-`maxReconnectAttempts` is per turn. The default is `3`.
+HTTP connections can end before a run does. The client reconnects from the number of events already consumed, so long turns continue without replaying events. It stops at a turn boundary, when aborted, or when the stream can no longer make progress.
 
 ## Open a stream manually
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -193,10 +193,7 @@ const agent = useEveAgent({
 });
 ```
 
-Two more options tune turn behavior:
-
-- `optimistic` (default `true`): projects submitted user messages into `data` before eve confirms them with a `message.received` event. These are reducer-facing projection events only. `events` stays the authoritative eve stream.
-- `maxReconnectAttempts` (default `3`): stream reconnection budget per turn.
+The `optimistic` option (default `true`) projects submitted user messages into `data` before eve confirms them with a `message.received` event. These are reducer-facing projection events only. `events` stays the authoritative eve stream.
 
 ## Custom reducer
 
@@ -256,7 +253,7 @@ const agent = useEveAgent({
 
 Store the full `session` object (`sessionId`, `continuationToken`, `streamIndex`), not a single field. The session cursor lets eve continue the durable conversation; the event log lets your UI render historical messages without replaying the whole stream. A database-backed chat app should usually persist stream events as they arrive with `onEvent` and then save a final snapshot in `onFinish`.
 
-For multiple chat threads, keep one saved event log and session cursor per thread. `agent`, `host`, `reducer`, `session`, `initialEvents`, `initialSession`, `auth`, `headers`, `maxReconnectAttempts`, and `optimistic` are read when the hook creates its store, so remount the chat component when switching threads, for example with `key={chat.id}`.
+For multiple chat threads, keep one saved event log and session cursor per thread. `agent`, `host`, `reducer`, `session`, `initialEvents`, `initialSession`, `auth`, `headers`, and `optimistic` are read when the hook creates its store, so remount the chat component when switching threads, for example with `key={chat.id}`.
 
 If the user can refresh or navigate immediately after pressing send, create your app-level chat row and store the pending user message before calling `send()`. After the request starts, persist the session state as soon as it contains a `sessionId`, then reconnect an interrupted in-flight turn with `session.stream({ startIndex: savedEvents.length })` from the lower-level client.
 

--- a/docs/guides/frontend/use-eve-agent-svelte.mdx
+++ b/docs/guides/frontend/use-eve-agent-svelte.mdx
@@ -167,10 +167,7 @@ const agent = useEveAgent({
 });
 ```
 
-Two more options tune turn behavior:
-
-- `optimistic` (default `true`): projects submitted user messages into `data` before eve confirms them with a `message.received` event. These are reducer-facing projection events only; `events` stays the authoritative eve stream.
-- `maxReconnectAttempts` (default `3`): stream reconnection budget per turn.
+The `optimistic` option (default `true`) projects submitted user messages into `data` before eve confirms them with a `message.received` event. These are reducer-facing projection events only; `events` stays the authoritative eve stream.
 
 ## Custom reducer
 

--- a/docs/guides/frontend/use-eve-agent-vue.mdx
+++ b/docs/guides/frontend/use-eve-agent-vue.mdx
@@ -180,10 +180,7 @@ const agent = useEveAgent({
 });
 ```
 
-Two more options tune turn behavior:
-
-- `optimistic` (default `true`): projects submitted user messages into `data` before eve confirms them with a `message.received` event. These are reducer-facing projection events only; `events` stays the authoritative eve stream.
-- `maxReconnectAttempts` (default `3`): stream reconnection budget per turn.
+The `optimistic` option (default `true`) projects submitted user messages into `data` before eve confirms them with a `message.received` event. These are reducer-facing projection events only; `events` stays the authoritative eve stream.
 
 ## Custom reducer
 

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -665,6 +665,71 @@ describe("EveTUIRunner terminal-failure recovery", () => {
     expect(notices).toHaveLength(1);
     expect(notices[0]).toContain("new session");
   });
+
+  it("preserves the session and posts a notice when the stream ends without a boundary", async () => {
+    const notices: string[] = [];
+    const prompts: Array<string | undefined> = ["run something long", undefined];
+
+    const strandedSession = sessionYielding([{ type: "turn.started", data: {} }]);
+    const client = stubClient();
+    const sessionFactory = vi.spyOn(client, "session");
+
+    const runner = new EveTUIRunner({
+      client,
+      name: "Weather Agent",
+      renderer: {
+        readPrompt: vi.fn(async () => prompts.shift()),
+        renderNotice: (text) => notices.push(text),
+        renderStream: vi.fn(async (result) => {
+          for await (const event of result.events as AsyncIterable<unknown>) {
+            void event;
+          }
+        }),
+      },
+      session: strandedSession,
+    });
+
+    await runner.run();
+
+    expect(sessionFactory).not.toHaveBeenCalled();
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain("Lost");
+    expect(notices[0]).not.toContain("new session");
+  });
+
+  it("starts a fresh session when the user interrupts a turn mid-stream", async () => {
+    const notices: string[] = [];
+    const prompts: Array<string | undefined> = ["run something long", undefined];
+
+    const interruptedSession = sessionYielding([{ type: "turn.started", data: {} }]);
+    const replacementSession = sessionYielding([]);
+    const client = stubClient();
+    const sessionFactory = vi.spyOn(client, "session").mockReturnValue(replacementSession);
+
+    const runner = new EveTUIRunner({
+      client,
+      name: "Weather Agent",
+      renderer: {
+        readPrompt: vi.fn(async () => prompts.shift()),
+        renderNotice: (text) => notices.push(text),
+        renderStream: vi.fn(async (result) => {
+          for await (const event of result.events as AsyncIterable<unknown>) {
+            void event;
+            result.abort?.();
+            break;
+          }
+        }),
+      },
+      session: interruptedSession,
+    });
+
+    await runner.run();
+
+    expect(sessionFactory).toHaveBeenCalledTimes(1);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain("new session");
+    expect(notices[0]).toContain("may still be running");
+  });
 });
 
 describe("EveTUIRunner delayed dev build errors", () => {

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -124,6 +124,7 @@ export type AgentTUIStreamEvent =
   | { type: "finish"; usage?: AgentTUIStreamUsage };
 
 export type AgentTUITurnState = {
+  aborted?: boolean;
   boundaryEvent?: "session.completed" | "session.failed" | "session.waiting";
   pendingApprovals: AgentTUIToolApprovalRequest[];
   pendingQuestions: InputRequest[];
@@ -829,7 +830,16 @@ export class EveTUIRunner {
           }
 
           if (result.turnState && result.turnState.boundaryEvent === undefined) {
-            this.#sessionFailed = true;
+            if (result.turnState.aborted) {
+              this.#sessionFailed = true;
+            } else {
+              const strandedSessionId = this.#session.state.sessionId;
+              this.#renderer.renderNotice?.(
+                strandedSessionId
+                  ? `Lost the event stream — the turn may still be running on the server (session ${strandedSessionId}). Your next message resumes this session; use /cancel to stop the turn.`
+                  : "Lost the connection to the running turn.",
+              );
+            }
           }
           break;
         }
@@ -849,15 +859,17 @@ export class EveTUIRunner {
       pendingInputResponses = undefined;
       prompt = undefined;
 
-      // The active session died terminally this turn (session.failed or a
-      // dead-socket transport error). Replace it with a fresh one so the next
-      // prompt isn't sent into a dead session, but keep the transcript on
-      // screen. Server-side context is gone with the old session.
+      // The session ended terminally this turn (session.failed, a dispatch
+      // failure, or a user interrupt). Replace it with a fresh one so the
+      // next prompt isn't sent into a dead session, but keep the transcript
+      // on screen. Server-side context is gone with the old session.
       if (this.#sessionFailed) {
         this.#sessionFailed = false;
         this.#startNewSession();
         this.#renderer.renderNotice?.(
-          "Session ended — started a new session. Earlier context was cleared.",
+          result.turnState?.aborted
+            ? "Stopped following the turn and started a new session. Earlier context was cleared; the interrupted turn may still be running on the server."
+            : "Session ended — started a new session. Earlier context was cleared.",
         );
       }
     }
@@ -1019,7 +1031,10 @@ export class EveTUIRunner {
   ): AgentTUIStreamResult {
     const turnState = createTurnState();
     return {
-      abort,
+      abort: () => {
+        turnState.aborted = true;
+        abort();
+      },
       events: eveEventsToTUIStream({
         events,
         pendingInputRequests: this.#pendingInputRequests,
@@ -2119,6 +2134,7 @@ async function* errorOnlyTUIStream(input: {
 
 function createTurnState(): AgentTUITurnState {
   return {
+    aborted: false,
     pendingApprovals: [],
     pendingQuestions: [],
     sawSessionFailure: false,

--- a/packages/eve/src/client/client.ts
+++ b/packages/eve/src/client/client.ts
@@ -29,7 +29,6 @@ export class Client {
   readonly #auth: ClientAuth | undefined;
   readonly #headers: HeadersValue | undefined;
   readonly #host: string;
-  readonly #maxReconnectAttempts: number;
   readonly #preserveCompletedSessions: boolean;
   readonly #redirect: ClientRedirectPolicy | undefined;
 
@@ -37,7 +36,6 @@ export class Client {
     this.#host = options.host;
     this.#auth = options.auth;
     this.#headers = options.headers;
-    this.#maxReconnectAttempts = options.maxReconnectAttempts ?? 3;
     this.#preserveCompletedSessions = options.preserveCompletedSessions ?? false;
     this.#redirect = options.redirect;
   }
@@ -136,7 +134,6 @@ export class Client {
     return new ClientSession(
       {
         host: this.#host,
-        maxReconnectAttempts: this.#maxReconnectAttempts,
         preserveCompletedSessions: this.#preserveCompletedSessions,
         redirect: this.#redirect,
         resolveHeaders: (perRequest) => this.#resolveHeaders(perRequest),

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -54,7 +54,7 @@ export interface EveAgentStoreCallbacks<TData> {
  * Configuration for constructing an {@link EveAgentStore}.
  *
  * Requires a {@link EveAgentReducer | reducer}, plus either connection options
- * (`host`, `auth`, `headers`, `maxReconnectAttempts`, `initialSession`) for a
+ * (`host`, `auth`, `headers`, `initialSession`) for a
  * store-owned session or an existing {@link ClientSession} via `session`.
  *
  * `optimistic` (default `true`) projects submitted user messages before the
@@ -68,7 +68,6 @@ export interface EveAgentStoreInit<TData> {
   readonly host?: string;
   readonly initialEvents?: readonly HandleMessageStreamEvent[];
   readonly initialSession?: SessionState;
-  readonly maxReconnectAttempts?: number;
   readonly optimistic?: boolean;
   readonly reducer: EveAgentReducer<TData>;
   readonly session?: ClientSession;
@@ -118,7 +117,6 @@ export class EveAgentStore<TData> {
             auth: init.auth,
             headers: init.headers,
             host: init.host ?? "",
-            maxReconnectAttempts: init.maxReconnectAttempts,
           }).session(init.initialSession);
     this.#events = [...(init.initialEvents ?? [])];
     this.#projectionEvents = [...this.#events];

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -6,15 +6,19 @@ import type { ClientRedirectPolicy } from "#client/types.js";
 import { createClientUrl } from "#client/url.js";
 
 const STREAM_OPEN_RETRY_ATTEMPTS = 12;
-const STREAM_OPEN_RETRY_DELAY_MS = 250;
+const STREAM_OPEN_RETRY_BASE_DELAY_MS = 250;
+const STREAM_OPEN_RETRY_MAX_DELAY_MS = 5_000;
 const STREAM_OPEN_RETRYABLE_STATUS = new Set([404, 409, 425, 500, 502, 503, 504]);
 
+const STREAM_RECONNECT_BASE_DELAY_MS = 250;
+const STREAM_RECONNECT_MAX_DELAY_MS = 4_000;
+const STREAM_MAX_IDLE_RECONNECTS = 5;
+
 /**
- * Internal configuration for opening a durable event stream.
+ * Internal configuration for following a durable event stream.
  */
-interface OpenStreamInput {
+interface FollowStreamInput {
   readonly host: string;
-  readonly maxReconnectAttempts: number;
   readonly resolveHeaders: () => Promise<Headers>;
   readonly redirect?: ClientRedirectPolicy;
   readonly sessionId: string;
@@ -22,58 +26,83 @@ interface OpenStreamInput {
   readonly startIndex: number;
 }
 
-type OpenStreamBodyInput = Omit<OpenStreamInput, "maxReconnectAttempts">;
-
 /**
- * Opens a durable NDJSON event stream with automatic reconnection on socket
- * disconnection. Used by {@link ClientSession.stream}.
+ * Follows a session's durable event stream from an absolute cursor,
+ * transparently reconnecting whenever the transport ends.
+ *
+ * Transport endings reconnect from the advanced cursor. Progress resets the
+ * idle budget; repeated empty streams eventually stop the follow. Callers own
+ * boundary handling. Negative tail-relative cursors use one connection because
+ * they cannot be advanced safely.
  */
-export async function* openStreamIterable(
-  input: OpenStreamInput,
+export async function* followStreamIterable(
+  input: FollowStreamInput,
 ): AsyncGenerator<HandleMessageStreamEvent> {
   let startIndex = input.startIndex;
-  // A relative tail cursor cannot be advanced safely after a disconnect
-  // without first resolving it to an absolute stream index.
-  let remainingReconnectAttempts = input.startIndex < 0 ? 0 : input.maxReconnectAttempts;
+  let reconnectDelayMs = STREAM_RECONNECT_BASE_DELAY_MS;
+  let idleReconnects = 0;
+  let initialConnection = true;
 
   while (true) {
-    const body = await openStreamBody({ ...input, startIndex });
+    let body: ReadableStream<Uint8Array>;
+    try {
+      body = await openStreamBody({ ...input, startIndex });
+    } catch (error) {
+      if (input.signal?.aborted) {
+        return;
+      }
+      throw error;
+    }
 
-    let disconnected = false;
-
+    let deliveredEvent = false;
     try {
       for await (const event of readNdjsonStream(body)) {
         startIndex += 1;
+        deliveredEvent = true;
+        reconnectDelayMs = STREAM_RECONNECT_BASE_DELAY_MS;
+        idleReconnects = 0;
         yield event;
       }
     } catch (error) {
       if (!isStreamDisconnectError(error)) {
         throw error;
       }
-      disconnected = true;
     }
 
-    // Only reconnect on socket disconnection, not clean EOF or a
-    // caller-initiated abort.
-    if (!disconnected || input.signal?.aborted || remainingReconnectAttempts <= 0) {
+    if (input.signal?.aborted || input.startIndex < 0) {
       return;
     }
 
-    remainingReconnectAttempts -= 1;
+    if (
+      !deliveredEvent &&
+      !initialConnection &&
+      (idleReconnects += 1) >= STREAM_MAX_IDLE_RECONNECTS
+    ) {
+      return;
+    }
+
+    initialConnection = false;
+    await sleep(reconnectDelayMs, input.signal);
+    if (input.signal?.aborted) {
+      return;
+    }
+    reconnectDelayMs = Math.min(reconnectDelayMs * 2, STREAM_RECONNECT_MAX_DELAY_MS);
   }
 }
 
 /**
- * Opens one stream response body, retrying transient network errors and the
- * short propagation window where a just-acknowledged session may not yet be
+ * Opens one stream response body, retrying transient failures with capped
+ * exponential backoff (~35s total): brief network outages and the short
+ * propagation window where a just-acknowledged session may not yet be
  * readable from the stream route.
  */
 export async function openStreamBody(
-  input: OpenStreamBodyInput,
+  input: FollowStreamInput,
 ): Promise<ReadableStream<Uint8Array>> {
   let lastStatus: number | undefined;
   let lastBody: string | undefined;
   let lastHeaders: Headers | undefined;
+  let retryDelayMs = STREAM_OPEN_RETRY_BASE_DELAY_MS;
 
   for (let attempt = 0; attempt < STREAM_OPEN_RETRY_ATTEMPTS; attempt += 1) {
     const url = createClientUrl(
@@ -98,7 +127,8 @@ export async function openStreamBody(
       ) {
         throw error;
       }
-      await sleep(STREAM_OPEN_RETRY_DELAY_MS);
+      await sleep(retryDelayMs, input.signal);
+      retryDelayMs = Math.min(retryDelayMs * 2, STREAM_OPEN_RETRY_MAX_DELAY_MS);
       continue;
     }
 
@@ -118,13 +148,27 @@ export async function openStreamBody(
     }
 
     if (attempt < STREAM_OPEN_RETRY_ATTEMPTS - 1) {
-      await sleep(STREAM_OPEN_RETRY_DELAY_MS);
+      await sleep(retryDelayMs, input.signal);
+      retryDelayMs = Math.min(retryDelayMs * 2, STREAM_OPEN_RETRY_MAX_DELAY_MS);
     }
   }
 
   throw new ClientError(lastStatus ?? 0, lastBody ?? "Failed to open message stream.", lastHeaders);
 }
 
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/packages/eve/src/client/session-utils.ts
+++ b/packages/eve/src/client/session-utils.ts
@@ -15,7 +15,8 @@ export function createInitialSessionState(): SessionState {
  *
  * When the boundary event is `session.waiting`, the session is preserved for
  * the next message. For `session.completed` and `session.failed`, the session
- * resets so the next call starts a new conversation.
+ * resets so the next call starts a new conversation. Without a boundary, the
+ * session stays resumable from its advanced cursor.
  */
 export function advanceSession(input: {
   readonly continuationToken?: string;
@@ -36,6 +37,14 @@ export function advanceSession(input: {
         boundaryEvent?.type === "session.waiting"
           ? boundaryEvent.data.continuationToken
           : (input.continuationToken ?? input.session.continuationToken),
+      sessionId: input.sessionId,
+      streamIndex,
+    };
+  }
+
+  if (boundaryEvent === undefined) {
+    return {
+      continuationToken: input.continuationToken ?? input.session.continuationToken,
       sessionId: input.sessionId,
       streamIndex,
     };

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -10,7 +10,6 @@ afterEach(() => {
 function createSession(
   state: SessionState = { streamIndex: 0 },
   options: {
-    readonly maxReconnectAttempts?: number;
     readonly preserveCompletedSessions?: boolean;
     readonly redirect?: "error" | "follow" | "manual";
     readonly resolveHeaders?: () => Promise<Headers>;
@@ -18,13 +17,34 @@ function createSession(
 ) {
   const context: ConstructorParameters<typeof ClientSession>[0] = {
     host: "https://eve.test",
-    maxReconnectAttempts: options.maxReconnectAttempts ?? 0,
     preserveCompletedSessions: options.preserveCompletedSessions ?? false,
     redirect: options.redirect,
     resolveHeaders: options.resolveHeaders ?? (async () => new Headers()),
   };
 
   return new ClientSession(context, state);
+}
+
+/**
+ * Consumes an event stream under fake timers, flushing reconnect backoff
+ * sleeps so tests exercising many disconnects stay fast.
+ */
+async function collectEventTypes(events: AsyncIterable<{ type: string }>): Promise<string[]> {
+  const eventTypes: string[] = [];
+  let settled = false;
+  const consumed = (async () => {
+    for await (const event of events) {
+      eventTypes.push(event.type);
+    }
+  })().finally(() => {
+    settled = true;
+  });
+
+  while (!settled) {
+    await vi.advanceTimersByTimeAsync(1_000);
+  }
+  await consumed;
+  return eventTypes;
 }
 
 function createAcceptedResponse() {
@@ -389,10 +409,7 @@ describe("ClientSession", () => {
         }),
       );
     });
-    const session = createSession(
-      { sessionId: "session_1", streamIndex: 0 },
-      { maxReconnectAttempts: 3 },
-    );
+    const session = createSession({ sessionId: "session_1", streamIndex: 0 });
 
     for await (const _event of session.stream({ startIndex: -1 })) {
       // Drain until the simulated disconnect.
@@ -444,19 +461,112 @@ describe("ClientSession", () => {
         },
       ]);
     });
-    const session = createSession(undefined, { maxReconnectAttempts: 2 });
+    const session = createSession();
 
-    const eventTypes: string[] = [];
-    for await (const event of await session.send("first")) {
-      eventTypes.push(event.type);
+    vi.useFakeTimers();
+    try {
+      const eventTypes = await collectEventTypes(await session.send("first"));
+      expect(eventTypes).toEqual(["turn.started", "session.waiting"]);
+    } finally {
+      vi.useRealTimers();
     }
 
-    expect(eventTypes).toEqual(["turn.started", "session.waiting"]);
     expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(streamUrls.map((url) => new URL(url).searchParams.get("startIndex"))).toEqual([
       null,
       "1",
       "1",
     ]);
+  });
+
+  it("preserves the session cursor when a turn stream is aborted mid-flight", async () => {
+    const encoder = new TextEncoder();
+    const abortController = new AbortController();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createAcceptedResponse();
+      }
+
+      const signal = init?.signal;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(`${JSON.stringify({ type: "turn.started", data: {} })}\n`),
+            );
+            signal?.addEventListener("abort", () => {
+              controller.error(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          },
+        }),
+      );
+    });
+    const session = createSession();
+
+    const eventTypes: string[] = [];
+    for await (const event of await session.send({
+      message: "first",
+      signal: abortController.signal,
+    })) {
+      eventTypes.push(event.type);
+      abortController.abort();
+    }
+
+    expect(eventTypes).toEqual(["turn.started"]);
+    expect(session.state).toEqual({
+      continuationToken: "eve:test",
+      sessionId: "session_1",
+      streamIndex: 1,
+    });
+  });
+
+  it("keeps session.stream() boundary-blind across subsequent turns", async () => {
+    const streamStartIndices: Array<string | null> = [];
+    let streamRequest = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request) => {
+      const url =
+        typeof request === "string" ? request : request instanceof URL ? request.href : request.url;
+      streamStartIndices.push(new URL(url).searchParams.get("startIndex"));
+      streamRequest += 1;
+
+      if (streamRequest === 1) {
+        return createStreamResponse([
+          {
+            type: "session.waiting",
+            data: { continuationToken: "eve:first", wait: "next-user-message" },
+          },
+        ]);
+      }
+
+      return createStreamResponse([{ type: "turn.started", data: {} }]);
+    });
+    const session = createSession({ sessionId: "session_1", streamIndex: 0 });
+    const abortController = new AbortController();
+
+    vi.useFakeTimers();
+    try {
+      const eventTypes: string[] = [];
+      let settled = false;
+      const consumed = (async () => {
+        for await (const event of session.stream({ signal: abortController.signal })) {
+          eventTypes.push(event.type);
+          if (event.type === "turn.started") abortController.abort();
+        }
+      })().finally(() => {
+        settled = true;
+      });
+      while (!settled) await vi.advanceTimersByTimeAsync(1_000);
+      await consumed;
+      expect(eventTypes).toEqual(["session.waiting", "turn.started"]);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(streamStartIndices).toEqual([null, "1"]);
+    expect(session.state).toEqual({
+      continuationToken: "eve:first",
+      sessionId: "session_1",
+      streamIndex: 2,
+    });
   });
 });

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -8,8 +8,7 @@ import {
 } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { MessageResponse } from "#client/message-response.js";
-import { isStreamDisconnectError, readNdjsonStream } from "#client/ndjson.js";
-import { openStreamBody, openStreamIterable } from "#client/open-stream.js";
+import { followStreamIterable } from "#client/open-stream.js";
 import { advanceSession } from "#client/session-utils.js";
 import { serializeOutputSchema } from "#shared/tool-schema.js";
 import { createClientUrl } from "#client/url.js";
@@ -31,7 +30,6 @@ const DELIVER_RETRY_DELAY_MS = 200;
  */
 interface SessionContext {
   readonly host: string;
-  readonly maxReconnectAttempts: number;
   readonly preserveCompletedSessions: boolean;
   readonly redirect?: ClientRedirectPolicy;
   resolveHeaders(perRequest?: Readonly<Record<string, string>>): Promise<Headers>;
@@ -147,10 +145,9 @@ export class ClientSession {
    * Opens this session's event stream for the current session ID.
    *
    * Resumes from the session's stored stream cursor unless `options.startIndex`
-   * overrides it. Negative indices read relative to the current tail and do
-   * not reconnect or advance the stored absolute cursor. Other streams
-   * reconnect on transient socket disconnects, up to the client's
-   * `maxReconnectAttempts`.
+   * overrides it. The stream reconnects from its cursor when the connection
+   * ends. Negative indices read relative to the current tail on one connection
+   * and do not advance the stored absolute cursor.
    *
    * @throws {Error} If the session has no session ID (no message has been sent
    *   yet).
@@ -217,7 +214,7 @@ export class ClientSession {
   }
 
   // ---------------------------------------------------------------------------
-  // Internal: event stream with reconnection
+  // Internal: event stream consumption
   // ---------------------------------------------------------------------------
 
   async *#createEventStream(
@@ -229,51 +226,20 @@ export class ClientSession {
     const events: HandleMessageStreamEvent[] = [];
 
     try {
-      let currentStreamIndex = initialState.sessionId === sessionId ? initialState.streamIndex : 0;
-      let remainingReconnectAttempts = this.#context.maxReconnectAttempts;
+      for await (const event of followStreamIterable({
+        host: this.#context.host,
+        resolveHeaders: () => this.#context.resolveHeaders(input.headers),
+        redirect: this.#context.redirect,
+        sessionId,
+        signal: input.signal,
+        startIndex: initialState.sessionId === sessionId ? initialState.streamIndex : 0,
+      })) {
+        events.push(event);
+        yield event;
 
-      while (true) {
-        const body = await this.#openStreamBody(
-          sessionId,
-          currentStreamIndex,
-          input.signal,
-          input.headers,
-        );
-
-        let foundBoundary = false;
-
-        try {
-          for await (const event of readNdjsonStream(body)) {
-            events.push(event);
-            currentStreamIndex += 1;
-            yield event;
-
-            if (isCurrentTurnBoundaryEvent(event)) {
-              foundBoundary = true;
-              break;
-            }
-          }
-        } catch (error) {
-          if (!isStreamDisconnectError(error)) {
-            throw error;
-          }
-        }
-
-        if (foundBoundary) {
+        if (isCurrentTurnBoundaryEvent(event)) {
           break;
         }
-
-        // A caller-initiated abort is a stop signal, not a transient socket
-        // disconnect — do not reconnect.
-        if (input.signal?.aborted) {
-          break;
-        }
-
-        if (remainingReconnectAttempts <= 0) {
-          break;
-        }
-
-        remainingReconnectAttempts -= 1;
       }
     } finally {
       this.#state = advanceSession({
@@ -286,22 +252,6 @@ export class ClientSession {
     }
   }
 
-  async #openStreamBody(
-    sessionId: string,
-    startIndex: number,
-    signal?: AbortSignal,
-    headers?: Readonly<Record<string, string>>,
-  ): Promise<ReadableStream<Uint8Array>> {
-    return await openStreamBody({
-      host: this.#context.host,
-      resolveHeaders: () => this.#context.resolveHeaders(headers),
-      redirect: this.#context.redirect,
-      sessionId,
-      signal,
-      startIndex,
-    });
-  }
-
   async *#streamAndAdvance(
     sessionId: string,
     options?: StreamOptions,
@@ -311,9 +261,8 @@ export class ClientSession {
     const events: HandleMessageStreamEvent[] = [];
 
     try {
-      for await (const event of openStreamIterable({
+      for await (const event of followStreamIterable({
         host: this.#context.host,
-        maxReconnectAttempts: this.#context.maxReconnectAttempts,
         resolveHeaders: () => this.#context.resolveHeaders(),
         redirect: this.#context.redirect,
         sessionId,

--- a/packages/eve/src/client/stream-follow.integration.test.ts
+++ b/packages/eve/src/client/stream-follow.integration.test.ts
@@ -1,0 +1,135 @@
+import { createServer, type Server } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Client } from "./client.js";
+import { followStreamIterable } from "./open-stream.js";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+});
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("Expected a TCP address.");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function startIndexOf(url: string | undefined): number {
+  return Number(new URL(url ?? "", "http://127.0.0.1").searchParams.get("startIndex") ?? "0");
+}
+
+function follow(host: string) {
+  return followStreamIterable({
+    host,
+    resolveHeaders: () => Promise.resolve(new Headers()),
+    sessionId: "s",
+    startIndex: 0,
+  });
+}
+
+describe("stream following over real sockets", () => {
+  it("stays attached across abrupt drops and clean closes until the boundary event", async () => {
+    const log = [
+      { type: "step.started", data: {} },
+      { type: "step.completed", data: {} },
+      { type: "step.started", data: {} },
+      { type: "step.completed", data: {} },
+      { type: "step.started", data: {} },
+      { type: "session.waiting", data: { wait: "next-user-message", continuationToken: "eve:x" } },
+    ];
+    let connections = 0;
+    const host = await listen(
+      createServer((req, res) => {
+        connections += 1;
+        const index = startIndexOf(req.url);
+        res.writeHead(200, { "content-type": "application/x-ndjson" });
+        res.write(`${JSON.stringify(log[index])}\n`);
+
+        if (index % 2 === 0) {
+          setTimeout(() => req.socket.destroy(), 80);
+        } else {
+          res.end();
+        }
+      }),
+    );
+
+    const client = new Client({ host });
+    const session = client.session({ sessionId: "s1", streamIndex: 0 });
+
+    const received: string[] = [];
+    for await (const event of session.stream()) {
+      received.push(event.type);
+      if (event.type === "session.waiting") {
+        break;
+      }
+    }
+
+    expect(received).toEqual([
+      "step.started",
+      "step.completed",
+      "step.started",
+      "step.completed",
+      "step.started",
+      "session.waiting",
+    ]);
+    expect(connections).toBe(6);
+    expect(session.state).toMatchObject({ sessionId: "s1", streamIndex: 6 });
+  });
+
+  it("gives up after the idle-reconnect budget when a settled run's stream ends boundary-less", async () => {
+    let connections = 0;
+    const host = await listen(
+      createServer((_req, res) => {
+        connections += 1;
+        res.writeHead(200, { "content-type": "application/x-ndjson" });
+        setTimeout(() => res.end(), 10);
+      }),
+    );
+
+    const received: string[] = [];
+    for await (const event of follow(host)) {
+      received.push(event.type);
+    }
+
+    expect(received).toEqual([]);
+    expect(connections).toBe(6);
+  }, 20_000);
+
+  it("never abandons a progressing turn: any event resets the idle budget", async () => {
+    const events = ["step.started", "step.completed", "step.started", "session.completed"];
+    const idlesServed = new Map<number, number>();
+    let connections = 0;
+    const host = await listen(
+      createServer((req, res) => {
+        connections += 1;
+        const index = startIndexOf(req.url);
+        res.writeHead(200, { "content-type": "application/x-ndjson" });
+        const served = idlesServed.get(index) ?? 0;
+        if (index < events.length && served >= 2) {
+          res.end(`${JSON.stringify({ type: events[index], data: {} })}\n`);
+        } else {
+          idlesServed.set(index, served + 1);
+          setTimeout(() => res.end(), 10);
+        }
+      }),
+    );
+
+    const received: string[] = [];
+    for await (const event of follow(host)) {
+      received.push(event.type);
+      if (event.type === "session.completed") break;
+    }
+
+    expect(received).toEqual(events);
+    expect(connections).toBe(3 * events.length);
+  }, 30_000);
+});

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -96,13 +96,6 @@ export interface ClientOptions {
   readonly redirect?: ClientRedirectPolicy;
 
   /**
-   * Maximum number of stream reconnection attempts per message turn.
-   *
-   * @default 3
-   */
-  readonly maxReconnectAttempts?: number;
-
-  /**
    * Keep a session's continuation token after a normal `session.completed`
    * boundary.
    *

--- a/packages/eve/src/react/use-eve-agent.ts
+++ b/packages/eve/src/react/use-eve-agent.ts
@@ -77,7 +77,6 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
   readonly host?: string;
   readonly initialEvents?: readonly HandleMessageStreamEvent[];
   readonly initialSession?: SessionState;
-  readonly maxReconnectAttempts?: number;
   /**
    * Project submitted user messages before eve confirms them with a
    * `message.received` stream event.
@@ -110,7 +109,7 @@ export function useEveAgent<TData>(
  * infer `TData`.
  *
  * Session-shaping options (`host`, `reducer`, `session`, `initialEvents`,
- * `initialSession`, `auth`, `headers`, `maxReconnectAttempts`, `optimistic`) are
+ * `initialSession`, `auth`, `headers`, `optimistic`) are
  * read once when the store is created; remount to change them. Lifecycle
  * callbacks (`onError`, `onEvent`, `onFinish`, `onSessionChange`, `prepareSend`)
  * refresh on every render.
@@ -128,7 +127,6 @@ export function useEveAgent<TData>(
       host: resolveEveAgentHost({ agent: options.agent, host: options.host }),
       initialEvents: options.initialEvents,
       initialSession: options.initialSession,
-      maxReconnectAttempts: options.maxReconnectAttempts,
       optimistic: options.optimistic,
       reducer,
       session: options.session,

--- a/packages/eve/src/svelte/use-eve-agent.ts
+++ b/packages/eve/src/svelte/use-eve-agent.ts
@@ -95,12 +95,6 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
   /** Seed session identity and stream cursor for resuming a prior conversation. */
   readonly initialSession?: SessionState;
   /**
-   * Maximum number of stream reconnection attempts per turn.
-   *
-   * @default 3
-   */
-  readonly maxReconnectAttempts?: number;
-  /**
    * Project submitted user messages before eve confirms them with a
    * `message.received` stream event. Optimistic events are reducer-facing
    * projection only and never appear in `events`, which stays the
@@ -209,7 +203,6 @@ export function useEveAgent<TData>(
     host: resolveEveAgentHost({ agent: options.agent, host: options.host }),
     initialEvents: options.initialEvents,
     initialSession: options.initialSession,
-    maxReconnectAttempts: options.maxReconnectAttempts,
     optimistic: options.optimistic,
     reducer,
     session: options.session,

--- a/packages/eve/src/vue/use-eve-agent.ts
+++ b/packages/eve/src/vue/use-eve-agent.ts
@@ -92,8 +92,6 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
   readonly initialEvents?: readonly HandleMessageStreamEvent[];
   /** Prior session cursor to resume from on mount. */
   readonly initialSession?: SessionState;
-  /** Maximum SSE reconnection attempts per turn. @default 3 */
-  readonly maxReconnectAttempts?: number;
   /**
    * Project submitted user messages before eve confirms them with a
    * `message.received` stream event.
@@ -148,7 +146,6 @@ export function useEveAgent<TData>(
     host: resolveEveAgentHost({ agent: options.agent, host: options.host }),
     initialEvents: options.initialEvents,
     initialSession: options.initialSession,
-    maxReconnectAttempts: options.maxReconnectAttempts,
     optimistic: options.optimistic,
     reducer,
     session: options.session,

--- a/packages/eve/test/client.test.ts
+++ b/packages/eve/test/client.test.ts
@@ -832,6 +832,11 @@ describe("Session.stream", () => {
     const collected: HandleMessageStreamEvent[] = [];
     for await (const event of session.stream()) {
       collected.push(event);
+      // stream() follows the durable log across transport ends; the boundary
+      // event is the caller's stop signal.
+      if (event.type === "session.waiting") {
+        break;
+      }
     }
 
     expect(collected).toEqual(events);

--- a/packages/eve/test/tui-client/tui-connection-auth-states.ts
+++ b/packages/eve/test/tui-client/tui-connection-auth-states.ts
@@ -42,7 +42,6 @@ class FakeSession extends ClientSession {
     super(
       {
         host: "http://fake.invalid",
-        maxReconnectAttempts: 0,
         preserveCompletedSessions: false,
         resolveHeaders: async () => new Headers(),
       },


### PR DESCRIPTION
### Description

High-level changes here:

- Refactors stream following logic to be shared between send() / stream() (previously these treated stream interruptions subtly differently depending on if it was a clean EOF vs. a disconnect error)
- Removes the `maxReconnectAttempts` option from the public API, as the reconnection logic was changed to be more predictable / stable, described below
    - note that there are a wide variety of potentially-useful-to-configure parameters beyond just the raw count of reconnection attempts (e.g. backoff params). my take is that we should either expose all of them or none of them, and exposing none is fine for now, given reasonable defaults.

**Previous State of the World**

- the max duration of the stream-serving function in an eve deployment is set to the default value (300s), whereas turn workflows are allowed to last as long as the plan's maximum (300-800s).
- this means that, during a long running (>300s) turn, if you are following the stream (using either send() or stream()), it is expected that there will be EOFs / disconnect errors that we will need to handle / interpret as something other than "the external work is done". Other infra / transient issues can also cause these issues, not just standard function shutdowns, but just noting that these cuts are _guaranteed_ to occur once you hit a certain length.
- the previous logic was to have a "reconnect budget" (defaulting to 3) that would be eaten up as these issues occurred. once the budget was depleted, we would completely lose the session from the tailer, and present this to the user (in the TUI, at least) that the session was completely lost
    - notably, this budget was never reset during the turn. i.e. if we had an interrupt at the beginning of a turn, then reconnected, then got successful messages after that, then disconnected again, etc., these would all drain the reconnection budget even though the underlying workflow was clearly still alive
- in reality, work was still ongoing (if slow), but the user was left in a frustrating / somewhat unrecoverable state

**New State of the World**

- When the stream follower hits a 'cut' (EOF/steam disconnect error), it will reconnect, but it will reset its reconnection budget if it gets a new event (which proves that the underlying workflow is still alive)
- It will only truly end tracking if it hits 5 reconnect errors in a row without receiving a new event
  - if the underlying workflow run is truly dead but with no boundary event, the fn will return a clean EOF ~instantly, meaning given the exp backoff it's around 8 seconds of delay to fully give up on the stream. note that this should be a quite rare case (workflow dying with no terminal event), so this seems acceptable
- If this happens but the stream is actually alive (which should be rarer now), in the dev TUI, we give the user a more informative message and default to reconnecting to the in-progress session on the next message rather than forcing them to abandon the session entirely

### How did you test your changes?

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)