### PR TITLE
fix(eve): Reset client reconnect attempts on stream progress

### DIFF
--- a/.changeset/reconnect-budget-consecutive-failures.md
+++ b/.changeset/reconnect-budget-consecutive-failures.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Client event stream reconnection attempts now exhaust only on consecutive failures. Successful reconnection resets the reconnection counter.

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -52,6 +52,23 @@ function createStreamResponse(events: readonly unknown[]) {
   );
 }
 
+function createDisconnectingStreamResponse(events: readonly unknown[]) {
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (index < events.length) {
+          controller.enqueue(encoder.encode(`${JSON.stringify(events[index]!)}\n`));
+          index += 1;
+          return;
+        }
+        controller.error(new Error("socket disconnected"));
+      },
+    }),
+  );
+}
+
 describe("ClientSession", () => {
   it("cancels an accepted turn before its stream settles with freshly resolved auth", async () => {
     let headerResolution = 0;
@@ -458,5 +475,73 @@ describe("ClientSession", () => {
       "1",
       "1",
     ]);
+  });
+
+  it("resets the reconnect budget after forward progress", async () => {
+    const streamUrls: string[] = [];
+    const streams = [
+      () => createDisconnectingStreamResponse([{ type: "turn.started", data: {} }]),
+      () => createDisconnectingStreamResponse([{ type: "reasoning.appended", data: {} }]),
+      () => createDisconnectingStreamResponse([{ type: "step.completed", data: {} }]),
+      () =>
+        createStreamResponse([
+          {
+            type: "session.waiting",
+            data: { continuationToken: "eve:test", wait: "next-user-message" },
+          },
+        ]),
+    ];
+    let streamRequest = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createAcceptedResponse();
+      }
+      streamUrls.push(
+        typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
+      );
+      const handler = streams[streamRequest] ?? streams[streams.length - 1]!;
+      streamRequest += 1;
+      return handler();
+    });
+    const session = createSession(undefined, { maxReconnectAttempts: 1 });
+
+    const eventTypes: string[] = [];
+    for await (const event of await session.send("first")) {
+      eventTypes.push(event.type);
+    }
+
+    // Four opens far exceed the budget of 1; each progressing reconnect
+    // refreshed it, so the boundary is still reached.
+    expect(eventTypes).toEqual([
+      "turn.started",
+      "reasoning.appended",
+      "step.completed",
+      "session.waiting",
+    ]);
+    expect(streamUrls.length).toBe(4);
+  });
+
+  it("gives up after consecutive no-progress stream ends", async () => {
+    const streamUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createAcceptedResponse();
+      }
+      streamUrls.push(
+        typeof request === "string" ? request : request instanceof URL ? request.href : request.url,
+      );
+      return createStreamResponse([]);
+    });
+    const session = createSession(undefined, { maxReconnectAttempts: 2 });
+
+    const eventTypes: string[] = [];
+    for await (const event of await session.send("first")) {
+      eventTypes.push(event.type);
+    }
+
+    // A finished session reopens to a clean EOF; the initial open plus two
+    // budgeted reconnects give up rather than looping forever.
+    expect(eventTypes).toEqual([]);
+    expect(streamUrls.length).toBe(3);
   });
 });

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -230,6 +230,8 @@ export class ClientSession {
 
     try {
       let currentStreamIndex = initialState.sessionId === sessionId ? initialState.streamIndex : 0;
+      // Spent only on consecutive reconnects that deliver no events (see the
+      // reset below), so a turn that keeps making progress is never cut off.
       let remainingReconnectAttempts = this.#context.maxReconnectAttempts;
 
       while (true) {
@@ -240,6 +242,7 @@ export class ClientSession {
           input.headers,
         );
 
+        const streamIndexBeforeRead = currentStreamIndex;
         let foundBoundary = false;
 
         try {
@@ -269,11 +272,15 @@ export class ClientSession {
           break;
         }
 
-        if (remainingReconnectAttempts <= 0) {
+        // A reconnect that delivered events restores the full budget; one that
+        // delivered nothing spends an attempt, so a dead stream still gives up.
+        if (currentStreamIndex > streamIndexBeforeRead) {
+          remainingReconnectAttempts = this.#context.maxReconnectAttempts;
+        } else if (remainingReconnectAttempts <= 0) {
           break;
+        } else {
+          remainingReconnectAttempts -= 1;
         }
-
-        remainingReconnectAttempts -= 1;
       }
     } finally {
       this.#state = advanceSession({


### PR DESCRIPTION
### Description

The remaining reconnect attempts tracker was permanently decremented every time the client attempted to reconnect, even if that reconnection was successful/more data continued to stream through. Updates that logic to reset the counter every time data is successfully received so that it only ticks down on repeated, consecutive failures.

### How did you test your changes?

Couple new unit tests.
