### PR TITLE
test(eve): prompt exact skill slug in sandbox/redeploy

### DIFF
--- a/e2e/fixtures/agent-tools-sandbox/evals/sandbox/redeploy.eval.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/sandbox/redeploy.eval.ts
@@ -136,7 +136,7 @@ export default defineEval({
       // advertised and usable.
       const adopted = t.newSession();
       const skill = await adopted.send(
-        "Please use the deploy note skill and follow its instructions exactly.",
+        `Load the \`${SKILL_NAME}\` skill and follow its instructions exactly.`,
       );
       skill.expectOk();
       skill.loadedSkill(SKILL_NAME);


### PR DESCRIPTION
## What

At t4, `sandbox/redeploy` asked a fresh session to "use the deploy note skill". Prompted with that natural phrase, the model called `load_skill` with the human name `"deploy note"` (space) instead of the `deploy-note` slug, so `loadedSkill("deploy-note")` missed. That accounts for **~2/3 (10/15)** of this eval's observed flakes. Fix: name the exact hyphenated skill id.

## Not addressed here (logged separately)

The other **~1/3 (5/15)** used the correct `deploy-note` slug yet still failed — in all 5, both `loadedSkill` and the `SKILL_TOKEN` message assertion failed, so the skill genuinely did not load in the fresh session. That's a separate **post-redeploy skill-materialization/timing issue**: the added skill is in the manifest (`waitForAliasToServe` gates on that) but isn't reliably loadable in a new session's sandbox. This prompt change doesn't touch it.

## Note

`sandbox/redeploy` is a redeploy-tagged eval that only runs in CI's redeploy step (needs `EVE_E2E_REDEPLOY_ALIAS` + rebuild/redeploy), so it isn't locally verifiable. Surfaced during a broader e2e flake investigation; agent-tools-sandbox is ~13% of test-specific flakes and `sandbox/redeploy` is 88% of that fixture's flakes.