### PR TITLE
test(eve): clarify stale-ask-question-selection judge criterion (both variants)

### DIFF
--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/stale-ask-question-selection-idle.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/stale-ask-question-selection-idle.eval.ts
@@ -49,7 +49,7 @@ export default defineEval({
     // a literal echo the model can rightly decline.
     t.judge.autoevals
       .closedQA(
-        "The reply acknowledges a late selection of the STALE-CANDIDATE-7Q4M option, either by applying it or by explaining that the question was already answered and the selection is no longer relevant.",
+        "The reply treats the message as a late response to an EARLIER question — either applying that earlier selection, or explaining that the earlier question was already answered or is no longer relevant (stale). Answer yes unless the reply ignores the message entirely or is unrelated to it.",
         { on: staleSelection.message },
       )
       .atLeast(0.5);

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/stale-ask-question-selection.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/stale-ask-question-selection.eval.ts
@@ -69,7 +69,7 @@ export default defineEval({
     // a literal echo the model can rightly decline.
     t.judge.autoevals
       .closedQA(
-        "The reply acknowledges a late selection of the STALE-CANDIDATE-7Q4M option, either by applying it or by explaining that the question was already answered and the selection is no longer relevant.",
+        "The reply treats the message as a late response to an EARLIER question — either applying that earlier selection, or explaining that the earlier question was already answered or is no longer relevant (stale). Answer yes unless the reply instead treats the message as the answer to the current pending question or ignores it entirely.",
         { on: staleSelection.message },
       )
       .atLeast(0.5);


### PR DESCRIPTION
## What

`hitl/stale-ask-question-selection`'s `closedQA` judge flipped a valid reply to 0 on **~22%** of runs. The root cause is the **judge, not the model**.

## Evidence

Instrumented repro (16 runs against a deployed preview) showed **16/16 replies correctly engage** with the stale selection — e.g. *"That response is stale and no longer relevant; the earlier prompt was already answered with 'Use current context.'"* Every reply satisfies the intended criterion, yet the real eval still scored 0% ~22% of the time. So the binary `closedQA` grader was intermittently answering "no" for good replies.

The likely trigger: the old criterion asked the grader to confirm the reply *"acknowledges a late selection of the STALE-CANDIDATE-7Q4M option"* — the option-specific phrasing made it flip for replies that engage in general terms ("stale / earlier prompt / already answered") without repeating the option text.

## Fix

Reword the criterion to match how models reliably respond: treat the message as a late response to an *earlier* question; apply it or explain it's already-answered/stale; answer "yes" unless the reply instead answers the current pending question or ignores it.

**Verified against a deployed preview: 0/15 flips post-change vs ~22% before.** The deterministic HITL mechanics (stale selection becomes a new user turn, fresh request ID, etc.) already pass and are unchanged — the judge was the only nondeterministic gate. Model behavior was never the problem, so no prompt/instruction change.