### PR TITLE
feat(eve): add loadingMessages and suggestedPrompts to slackChannel

### DIFF
--- a/.changeset/slack-assistant-config.md
+++ b/.changeset/slack-assistant-config.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`slackChannel` accepts two new assistant-thread options: `loadingMessages`, a set of rotating typing-indicator statuses replacing the default `"Thinking..."` / `"Working..."`, and `suggestedPrompts`, prompt chips applied when a user opens an assistant thread (static payload or per-thread resolver).

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -131,6 +131,27 @@ export default slackChannel({
 });
 ```
 
+### Assistant threads
+
+Two options tune the assistant/agent-thread experience:
+
+- `loadingMessages` replaces the default `Thinking…` / `Working…` typing statuses with a set Slack rotates through while the agent works. Progress statuses (reasoning snippets, action labels) still take over as the turn advances. Supplying your own `onAppMention`, `onDirectMessage`, or `events["turn.started"]` replaces the typing behavior along with the handler.
+- `suggestedPrompts` sets up to four suggested prompts when a user opens the conversation with the bot. Under Slack's current Agent messaging experience (`agent_view` manifest mode) they render at the top of the Messages tab, triggered by `app_home_opened`; under the legacy assistant experience they render inside the opened thread, triggered by `assistant_thread_started`. Both triggers are handled — subscribe the app to whichever event matches its manifest mode. Pass a static payload, or a resolver invoked per open (return `null` to skip). Requires the `assistant:write` scope.
+
+```ts
+export default slackChannel({
+  credentials: connectSlackCredentials("slack/my-agent"),
+  loadingMessages: ["Thinking...", "Digging through the archives..."],
+  suggestedPrompts: {
+    title: "Welcome! What can I do for you?",
+    prompts: [
+      { title: "Catch me up", message: "What did I miss today?" },
+      { title: "Draft a message", message: "Help me draft a message" },
+    ],
+  },
+});
+```
+
 ### Human-in-the-loop (HITL)
 
 HITL renders as Slack buttons and selects. When the user responds, the parked session (paused awaiting input) resumes.

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -249,11 +249,13 @@ export interface SlackThread {
 
   /**
    * Show a typing/status indicator in this thread via Slack's
-   * `assistant.threads.setStatus`. Called with no argument, clears the
-   * indicator (empty status). Failures are logged and swallowed: the
+   * `assistant.threads.setStatus`. Pass an array to have Slack rotate
+   * through the entries (`loading_messages`); the first entry doubles as
+   * the immediate status. Called with no argument (or an empty array),
+   * clears the indicator. Failures are logged and swallowed: the
    * indicator is a UX nicety, never a reason to fail a turn.
    */
-  startTyping(status?: string): Promise<void>;
+  startTyping(status?: string | readonly string[]): Promise<void>;
 
   /**
    * Fetch the latest replies in this thread into {@link recentMessages}
@@ -418,14 +420,16 @@ export function buildSlackBinding(input: {
     async startTyping(status) {
       if (!input.channelId || !currentThreadTs) return;
       try {
-        const normalizedStatus = status === undefined ? "" : truncateTypingStatus(status);
+        const statuses = (typeof status === "string" ? [status] : (status ?? []))
+          .map(truncateTypingStatus)
+          .filter((entry) => entry.length > 0);
         const body: Record<string, unknown> = {
           channel_id: input.channelId,
           thread_ts: currentThreadTs,
-          status: normalizedStatus,
+          status: statuses[0] ?? "",
         };
-        if (normalizedStatus.length > 0) {
-          body.loading_messages = [normalizedStatus];
+        if (statuses.length > 0) {
+          body.loading_messages = statuses;
         }
         const response = await request("assistant.threads.setStatus", body);
         if (response.ok !== true) {

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -58,16 +58,26 @@ export function defaultSlackAuth(
 }
 
 /**
+ * Builds the default inbound handler (shared by `onAppMention` and
+ * `onDirectMessage`): derives auth from the Slack actor and posts a
+ * typing indicator before the workflow runtime starts. `typingStatus`
+ * is the status to show — a string, or an array Slack rotates through
+ * (`slackChannel({ loadingMessages })`).
+ */
+export function createDefaultInboundHandler(
+  typingStatus: string | readonly string[],
+): (ctx: SlackContext, message: SlackMessage) => Promise<SlackMentionResult> {
+  return async (ctx, message) => {
+    await ctx.thread.startTyping(typingStatus);
+    return { auth: defaultSlackAuth(message, ctx) };
+  };
+}
+
+/**
  * Default `onAppMention` — derives auth from the Slack actor and posts
  * a `"Thinking…"` typing indicator before the workflow runtime starts.
  */
-export async function defaultOnAppMention(
-  ctx: SlackContext,
-  message: SlackMessage,
-): Promise<SlackMentionResult> {
-  await ctx.thread.startTyping("Thinking...");
-  return { auth: defaultSlackAuth(message, ctx) };
-}
+export const defaultOnAppMention = createDefaultInboundHandler("Thinking...");
 
 /**
  * Default `onDirectMessage` — derives auth from the Slack actor and
@@ -75,13 +85,7 @@ export async function defaultOnAppMention(
  * starts. Matches the default mention behavior; replace the option to
  * customize gating, auth derivation, or pre-dispatch side effects.
  */
-export async function defaultOnDirectMessage(
-  ctx: SlackContext,
-  message: SlackMessage,
-): Promise<SlackMentionResult> {
-  await ctx.thread.startTyping("Thinking...");
-  return { auth: defaultSlackAuth(message, ctx) };
-}
+export const defaultOnDirectMessage = createDefaultInboundHandler("Thinking...");
 
 /**
  * Reads the first non-empty line of a model-emitted message. The
@@ -145,13 +149,25 @@ function buildInputRequestPosts(
  * `authorization.required` handler owns the public link-free status,
  * which user overrides cannot express.
  */
-export const defaultEvents: SlackChannelInternalEvents = {
-  async "turn.started"(_event, channel, _ctx) {
+/**
+ * Builds the default `turn.started` handler: resets typing-related
+ * state and posts a typing indicator. `typingStatus` is the status to
+ * show — a string, or an array Slack rotates through
+ * (`slackChannel({ loadingMessages })`).
+ */
+export function createDefaultTurnStarted(
+  typingStatus: string | readonly string[],
+): NonNullable<SlackChannelInternalEvents["turn.started"]> {
+  return async (_event, channel, _ctx) => {
     channel.state.pendingToolCallMessage = null;
     channel.state.lastReasoningTypingAtMs = null;
     channel.state.lastReasoningTypingStatus = null;
-    await channel.thread.startTyping("Working...");
-  },
+    await channel.thread.startTyping(typingStatus);
+  };
+}
+
+export const defaultEvents: SlackChannelInternalEvents = {
+  "turn.started": createDefaultTurnStarted("Working..."),
 
   async "reasoning.appended"(event, channel, _ctx) {
     const line = firstNonEmptyLine(event.reasoningSoFar);

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -53,6 +53,13 @@ export {
 
 export { defaultSlackAuth } from "#public/channels/slack/defaults.js";
 
+export type {
+  SlackSuggestedPrompt,
+  SlackSuggestedPrompts,
+  SlackSuggestedPromptsContext,
+  SlackSuggestedPromptsInput,
+} from "#public/channels/slack/suggested-prompts.js";
+
 export {
   describeActionRequest,
   describeActionRequests,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1604,6 +1604,202 @@ describe("slackChannel() onEvent pipeline", () => {
   });
 });
 
+describe("slackChannel() assistant config (loadingMessages / suggestedPrompts)", () => {
+  const ORIGINAL_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SIGNING_SECRET === undefined) {
+      delete process.env.SLACK_SIGNING_SECRET;
+    } else {
+      process.env.SLACK_SIGNING_SECRET = ORIGINAL_SIGNING_SECRET;
+    }
+  });
+
+  const LOADING_MESSAGES = ["Thinking...", "Digging through the archives..."];
+
+  function buildAssistantThreadStartedBody(): string {
+    mentionCounter += 1;
+    return JSON.stringify({
+      type: "event_callback",
+      team_id: "T01",
+      event_id: `Ev${mentionCounter}`,
+      event_time: 1700000000,
+      event: {
+        type: "assistant_thread_started",
+        assistant_thread: {
+          user_id: "U01",
+          channel_id: "D01",
+          thread_ts: "1700000000.000001",
+          context: { channel_id: null, team_id: "T01", enterprise_id: null },
+        },
+        event_ts: "1700000000.000001",
+      },
+    });
+  }
+
+  it("default onAppMention rotates loadingMessages in the typing indicator", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      loadingMessages: LOADING_MESSAGES,
+    });
+
+    const { body } = buildMentionBody();
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    const typingCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("assistant.threads.setStatus"),
+    );
+    expect(typingCall).toBeDefined();
+    const sent = parseSlackRequestBody(typingCall![1] as RequestInit);
+    expect(sent.status).toBe("Thinking...");
+    expect(sent.loading_messages).toEqual(LOADING_MESSAGES);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("default turn.started rotates loadingMessages instead of 'Working...'", async () => {
+    const adapter = withState(
+      getAdapter(
+        slackChannel({
+          credentials: { botToken: "xoxb-test" },
+          loadingMessages: LOADING_MESSAGES,
+        }),
+      ),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("turn.started", { sequence: 0, stepIndex: 0, turnId: "t1" }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://slack.com/api/assistant.threads.setStatus");
+    const body = parseSlackRequestBody(init as RequestInit);
+    expect(body).toMatchObject({
+      status: "Thinking...",
+      loading_messages: LOADING_MESSAGES,
+    });
+  });
+
+  it("an empty loadingMessages array keeps the built-in defaults", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      loadingMessages: [],
+    });
+
+    const { body } = buildMentionBody();
+    await firePost(channel, buildSignedRequest({ body }));
+
+    const typingCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("assistant.threads.setStatus"),
+    );
+    const sent = parseSlackRequestBody(typingCall![1] as RequestInit);
+    expect(sent.status).toBe("Thinking...");
+    expect(sent.loading_messages).toEqual(["Thinking..."]);
+  });
+
+  it("applies suggestedPrompts when an assistant thread starts", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      suggestedPrompts: {
+        title: "Welcome!",
+        prompts: [{ title: "Catch me up", message: "What did I miss today?" }],
+      },
+    });
+
+    const { response, send } = await firePost(
+      channel,
+      buildSignedRequest({ body: buildAssistantThreadStartedBody() }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(send).not.toHaveBeenCalled();
+    const promptsCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("assistant.threads.setSuggestedPrompts"),
+    );
+    expect(promptsCall).toBeDefined();
+    const sent = parseSlackRequestBody(promptsCall![1] as RequestInit);
+    expect(sent).toMatchObject({
+      channel_id: "D01",
+      thread_ts: "1700000000.000001",
+      title: "Welcome!",
+      prompts: [{ title: "Catch me up", message: "What did I miss today?" }],
+    });
+  });
+
+  it("applies suggestedPrompts on app_home_opened for the Messages tab (agent_view)", async () => {
+    mentionCounter += 1;
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T01",
+      event_id: `Ev${mentionCounter}`,
+      event: { type: "app_home_opened", user: "U01", channel: "D01", tab: "messages" },
+    });
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      suggestedPrompts: { prompts: [{ title: "Catch me up", message: "What did I miss today?" }] },
+    });
+
+    const { response, send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(response.status).toBe(200);
+    expect(send).not.toHaveBeenCalled();
+    const promptsCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("assistant.threads.setSuggestedPrompts"),
+    );
+    expect(promptsCall).toBeDefined();
+    const sent = parseSlackRequestBody(promptsCall![1] as RequestInit);
+    expect(sent.channel_id).toBe("D01");
+    expect(sent).not.toHaveProperty("thread_ts");
+  });
+
+  it("assistant_thread_started also reaches onEvent when both are configured", async () => {
+    const onEvent = vi.fn();
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      suggestedPrompts: { prompts: [{ title: "Hi", message: "hello" }] },
+      onEvent,
+    });
+
+    await firePost(channel, buildSignedRequest({ body: buildAssistantThreadStartedBody() }));
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0]![1]).toMatchObject({ type: "assistant_thread_started" });
+    const promptsCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("assistant.threads.setSuggestedPrompts"),
+    );
+    expect(promptsCall).toBeDefined();
+  });
+
+  it("drops assistant_thread_started without dispatching when suggestedPrompts is unset", async () => {
+    const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
+
+    const { response, send, waitUntil } = await firePost(
+      channel,
+      buildSignedRequest({ body: buildAssistantThreadStartedBody() }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(send).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("slackChannel() HITL interaction pipeline", () => {
   const ORIGINAL_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET;
   const ORIGINAL_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -21,11 +21,18 @@ import {
   createSlackFetchFile,
 } from "#public/channels/slack/attachments.js";
 import {
+  createDefaultInboundHandler,
+  createDefaultTurnStarted,
   defaultEvents,
   defaultInputRequestedHandler,
   defaultOnAppMention,
   defaultOnDirectMessage,
 } from "#public/channels/slack/defaults.js";
+import {
+  applySuggestedPrompts,
+  isSuggestedPromptsTrigger,
+  type SlackSuggestedPrompts,
+} from "#public/channels/slack/suggested-prompts.js";
 import {
   type SlackEvent,
   type SlackInboundContext,
@@ -463,6 +470,33 @@ export interface SlackChannelConfig {
    */
   onEvent?(ctx: SlackContext, event: SlackEvent): void | Promise<void>;
 
+  /**
+   * Rotating typing-indicator messages shown while the agent works,
+   * replacing the default `"Thinking..."` / `"Working..."` statuses.
+   * Slack cycles through the entries via `assistant.threads.setStatus`
+   * `loading_messages`. Applies only to the default inbound and
+   * `turn.started` handlers — supplying your own `onAppMention`,
+   * `onDirectMessage`, or `events["turn.started"]` replaces the typing
+   * behavior along with the handler. Progress statuses (reasoning
+   * snippets, action labels) still take over as the turn advances.
+   */
+  readonly loadingMessages?: readonly string[];
+
+  /**
+   * Suggested prompts applied via
+   * `assistant.threads.setSuggestedPrompts` when a user opens the
+   * conversation with the bot. Under the current Agent messaging
+   * experience (`agent_view` manifest mode) the trigger is
+   * `app_home_opened` with `tab: "messages"` and the prompts render at
+   * the top of the Messages tab; under the legacy assistant experience
+   * the trigger is `assistant_thread_started` and the prompts render
+   * in the opened thread. Pass a static payload (max four prompts), or
+   * a resolver invoked per open (return `null` to skip). Requires the
+   * `assistant:write` scope and a subscription to the relevant event.
+   * Failures are logged and swallowed.
+   */
+  readonly suggestedPrompts?: SlackSuggestedPrompts;
+
   readonly events?: SlackChannelEvents;
 }
 
@@ -508,10 +542,26 @@ export interface SlackChannel extends Channel<
 export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
   const uploadPolicy = mergeUploadPolicy(config.uploadPolicy);
   const slackFetchFile = createSlackFetchFile({ botToken: config.credentials?.botToken });
-  const onAppMention = config.onAppMention ?? defaultOnAppMention;
-  const onDirectMessage = config.onDirectMessage ?? defaultOnDirectMessage;
+  const loadingMessages =
+    config.loadingMessages !== undefined && config.loadingMessages.length > 0
+      ? config.loadingMessages
+      : undefined;
+  const onAppMention =
+    config.onAppMention ??
+    (loadingMessages === undefined
+      ? defaultOnAppMention
+      : createDefaultInboundHandler(loadingMessages));
+  const onDirectMessage =
+    config.onDirectMessage ??
+    (loadingMessages === undefined
+      ? defaultOnDirectMessage
+      : createDefaultInboundHandler(loadingMessages));
   const authorizationRequiredOverride = config.events?.["authorization.required"];
-  const turnStartedHandler = config.events?.["turn.started"] ?? defaultEvents["turn.started"]!;
+  const turnStartedHandler =
+    config.events?.["turn.started"] ??
+    (loadingMessages === undefined
+      ? defaultEvents["turn.started"]!
+      : createDefaultTurnStarted(loadingMessages));
   const mergedEvents: SlackChannelInternalEvents = {
     ...defaultEvents,
     ...config.events,
@@ -586,6 +636,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
             onAppMention,
             onDirectMessage,
             onEvent: config.onEvent,
+            suggestedPrompts: config.suggestedPrompts,
             uploadPolicy,
             threadContext: config.threadContext,
             handledEvents,
@@ -694,6 +745,7 @@ async function handleEventPost(input: {
   readonly onAppMention: NonNullable<SlackChannelConfig["onAppMention"]>;
   readonly onDirectMessage: NonNullable<SlackChannelConfig["onDirectMessage"]>;
   readonly onEvent: SlackChannelConfig["onEvent"];
+  readonly suggestedPrompts: SlackSuggestedPrompts | undefined;
   readonly uploadPolicy: UploadPolicy;
   readonly threadContext: LoadThreadContextMessagesOptions | undefined;
   readonly credentials: SlackChannelCredentials | undefined;
@@ -716,7 +768,10 @@ async function handleEventPost(input: {
 
   const inboundPayload =
     payload.kind === "app_mention" || payload.kind === "direct_message" ? payload : null;
-  const slackEvent = input.onEvent === undefined ? null : slackEventFromWebhookPayload(payload);
+  const slackEvent =
+    input.onEvent === undefined && input.suggestedPrompts === undefined
+      ? null
+      : slackEventFromWebhookPayload(payload);
   if (inboundPayload === null && slackEvent === null) return new Response("ok");
 
   const eventId = inboundPayload === null ? slackEvent?.eventId : inboundPayload.eventId;
@@ -735,6 +790,26 @@ async function handleEventPost(input: {
 
   if (slackEvent !== null && input.onEvent !== undefined) {
     input.waitUntil(invokeOnEvent(input.onEvent, slackEvent, input.credentials));
+  }
+
+  if (
+    slackEvent !== null &&
+    input.suggestedPrompts !== undefined &&
+    isSuggestedPromptsTrigger(slackEvent)
+  ) {
+    const { slack } = buildSlackBinding({
+      botToken: input.credentials?.botToken,
+      channelId: slackEvent.channelId ?? "",
+      threadTs: slackEvent.threadTs ?? "",
+      teamId: slackEvent.teamId,
+    });
+    input.waitUntil(
+      applySuggestedPrompts({
+        suggestedPrompts: input.suggestedPrompts,
+        event: slackEvent,
+        request: (operation, body) => slack.request(operation, body),
+      }),
+    );
   }
 
   if (inboundPayload === null) return new Response("ok");

--- a/packages/eve/src/public/channels/slack/suggested-prompts.test.ts
+++ b/packages/eve/src/public/channels/slack/suggested-prompts.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SlackEvent } from "#public/channels/slack/inbound.js";
+import {
+  applySuggestedPrompts,
+  isSuggestedPromptsTrigger,
+  SLACK_MAX_SUGGESTED_PROMPTS,
+} from "#public/channels/slack/suggested-prompts.js";
+
+function buildEvent(type: string, inner: Record<string, unknown>): SlackEvent {
+  return {
+    type,
+    event: { type, ...inner },
+    teamId: "T01",
+    eventId: "Ev1",
+    eventTime: 1700000000,
+    channelId: undefined,
+    threadTs: undefined,
+  };
+}
+
+function buildThreadStartedEvent(): SlackEvent {
+  return buildEvent("assistant_thread_started", {
+    assistant_thread: {
+      user_id: "U01",
+      channel_id: "D01",
+      thread_ts: "1700000000.000001",
+      context: { channel_id: null, team_id: "T01", enterprise_id: null },
+    },
+  });
+}
+
+function buildAppHomeOpenedEvent(tab: string): SlackEvent {
+  return buildEvent("app_home_opened", { user: "U01", channel: "D01", tab });
+}
+
+const PROMPTS = [{ title: "Catch me up", message: "What did I miss today?" }];
+
+describe("isSuggestedPromptsTrigger", () => {
+  it("matches assistant_thread_started (legacy assistant_view)", () => {
+    expect(isSuggestedPromptsTrigger(buildThreadStartedEvent())).toBe(true);
+  });
+
+  it("matches app_home_opened on the Messages tab (agent_view)", () => {
+    expect(isSuggestedPromptsTrigger(buildAppHomeOpenedEvent("messages"))).toBe(true);
+  });
+
+  it("ignores app_home_opened on the Home tab", () => {
+    expect(isSuggestedPromptsTrigger(buildAppHomeOpenedEvent("home"))).toBe(false);
+  });
+
+  it("ignores unrelated events", () => {
+    expect(isSuggestedPromptsTrigger(buildEvent("reaction_added", {}))).toBe(false);
+  });
+});
+
+describe("applySuggestedPrompts", () => {
+  it("targets the assistant thread for assistant_thread_started", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+
+    await applySuggestedPrompts({
+      suggestedPrompts: { title: "Welcome!", prompts: PROMPTS },
+      event: buildThreadStartedEvent(),
+      request,
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("assistant.threads.setSuggestedPrompts", {
+      channel_id: "D01",
+      thread_ts: "1700000000.000001",
+      title: "Welcome!",
+      prompts: [{ title: "Catch me up", message: "What did I miss today?" }],
+    });
+  });
+
+  it("omits thread_ts for the agent_view Messages tab trigger", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+
+    await applySuggestedPrompts({
+      suggestedPrompts: { prompts: PROMPTS },
+      event: buildAppHomeOpenedEvent("messages"),
+      request,
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const body = request.mock.calls[0]![1] as Record<string, unknown>;
+    expect(body.channel_id).toBe("D01");
+    expect(body).not.toHaveProperty("thread_ts");
+    expect(body).not.toHaveProperty("title");
+  });
+
+  it("drops prompts beyond Slack's cap", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const prompts = Array.from({ length: 6 }, (_, index) => ({
+      title: `Prompt ${index}`,
+      message: `message ${index}`,
+    }));
+
+    await applySuggestedPrompts({
+      suggestedPrompts: { prompts },
+      event: buildAppHomeOpenedEvent("messages"),
+      request,
+    });
+
+    const body = request.mock.calls[0]![1] as { prompts: unknown[] };
+    expect(body.prompts).toHaveLength(SLACK_MAX_SUGGESTED_PROMPTS);
+  });
+
+  it("invokes a resolver with the conversation context", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const resolver = vi.fn().mockResolvedValue({ prompts: PROMPTS });
+
+    await applySuggestedPrompts({
+      suggestedPrompts: resolver,
+      event: buildThreadStartedEvent(),
+      request,
+    });
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver.mock.calls[0]![0]).toMatchObject({
+      channelId: "D01",
+      threadTs: "1700000000.000001",
+      userId: "U01",
+      teamId: "T01",
+      event: { type: "assistant_thread_started" },
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the API call when the resolver returns null", async () => {
+    const request = vi.fn();
+
+    await applySuggestedPrompts({
+      suggestedPrompts: () => null,
+      event: buildThreadStartedEvent(),
+      request,
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("skips the API call when prompts are empty", async () => {
+    const request = vi.fn();
+
+    await applySuggestedPrompts({
+      suggestedPrompts: { prompts: [] },
+      event: buildThreadStartedEvent(),
+      request,
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for a non-Messages app_home_opened tab", async () => {
+    const request = vi.fn();
+
+    await applySuggestedPrompts({
+      suggestedPrompts: { prompts: PROMPTS },
+      event: buildAppHomeOpenedEvent("home"),
+      request,
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("swallows a throwing resolver", async () => {
+    const request = vi.fn();
+
+    await expect(
+      applySuggestedPrompts({
+        suggestedPrompts: () => {
+          throw new Error("bad resolver");
+        },
+        event: buildThreadStartedEvent(),
+        request,
+      }),
+    ).resolves.toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejecting API call", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("network"));
+
+    await expect(
+      applySuggestedPrompts({
+        suggestedPrompts: { prompts: PROMPTS },
+        event: buildThreadStartedEvent(),
+        request,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does nothing when assistant_thread_started carries no assistant_thread", async () => {
+    const request = vi.fn();
+
+    await applySuggestedPrompts({
+      suggestedPrompts: { prompts: PROMPTS },
+      event: buildEvent("assistant_thread_started", {}),
+      request,
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/public/channels/slack/suggested-prompts.ts
+++ b/packages/eve/src/public/channels/slack/suggested-prompts.ts
@@ -1,0 +1,191 @@
+/**
+ * Suggested prompts for Slack assistant/agent conversations.
+ *
+ * The channel applies the configured prompts via
+ * `assistant.threads.setSuggestedPrompts` when the user opens the
+ * conversation. Which event signals that depends on the Slack app's
+ * manifest mode:
+ *
+ * - `agent_view` (current Agent messaging experience): `app_home_opened`
+ *   with `tab: "messages"`. Prompts render at the top of the Messages
+ *   tab and are not tied to a thread, so no `thread_ts` is sent.
+ * - `assistant_view` (legacy): `assistant_thread_started`. Prompts
+ *   render inside the newly opened assistant thread, targeted by
+ *   `thread_ts`.
+ *
+ * Configured via `slackChannel({ suggestedPrompts })`; requires the
+ * `assistant:write` scope and a subscription to the relevant event.
+ */
+
+import type { SlackApiResponse } from "#public/channels/slack/api.js";
+import type { SlackEvent } from "#public/channels/slack/inbound.js";
+
+import { createLogger, logError } from "#internal/logging.js";
+
+const log = createLogger("slack.suggested-prompts");
+
+/** Slack caps `assistant.threads.setSuggestedPrompts` at four prompts. */
+export const SLACK_MAX_SUGGESTED_PROMPTS = 4;
+
+/** One suggested prompt shown when the conversation opens. */
+export interface SlackSuggestedPrompt {
+  /** Short label rendered on the prompt. */
+  readonly title: string;
+  /** Message sent as the user's turn when the prompt is clicked. */
+  readonly message: string;
+}
+
+/** Suggested prompts payload applied when the conversation opens. */
+export interface SlackSuggestedPromptsInput {
+  /** Optional heading rendered above the prompt list. */
+  readonly title?: string;
+  /**
+   * Up to {@link SLACK_MAX_SUGGESTED_PROMPTS} prompts; extras are
+   * dropped with a warning.
+   */
+  readonly prompts: readonly SlackSuggestedPrompt[];
+}
+
+/**
+ * Context handed to a dynamic `suggestedPrompts` resolver, extracted
+ * from the triggering event.
+ */
+export interface SlackSuggestedPromptsContext {
+  /** DM channel the conversation lives in. */
+  readonly channelId: string;
+  /**
+   * Assistant thread root ts. Only present for the legacy
+   * `assistant_thread_started` trigger — under `agent_view` prompts
+   * apply to the whole Messages tab, not a thread.
+   */
+  readonly threadTs: string | undefined;
+  /** Slack user who opened the conversation. */
+  readonly userId: string | undefined;
+  /** Slack team id, when the envelope carried one. */
+  readonly teamId: string | undefined;
+  /** The normalized triggering event. */
+  readonly event: SlackEvent;
+}
+
+/**
+ * `slackChannel({ suggestedPrompts })` value: a static payload, or a
+ * resolver invoked each time a conversation opens. Return
+ * `null`/`undefined` from the resolver to skip that open.
+ */
+export type SlackSuggestedPrompts =
+  | SlackSuggestedPromptsInput
+  | ((
+      context: SlackSuggestedPromptsContext,
+    ) =>
+      | SlackSuggestedPromptsInput
+      | null
+      | undefined
+      | Promise<SlackSuggestedPromptsInput | null | undefined>);
+
+/**
+ * True when `event` signals a user opening the assistant/agent
+ * conversation, i.e. when the channel should apply suggested prompts.
+ */
+export function isSuggestedPromptsTrigger(event: SlackEvent): boolean {
+  return resolvePromptsTarget(event) !== null;
+}
+
+/**
+ * Resolves the configured prompts for one conversation-open event and
+ * applies them via `assistant.threads.setSuggestedPrompts`. Errors and
+ * not-ok responses are logged and swallowed: suggested prompts are a
+ * UX nicety, never a reason to fail the webhook.
+ */
+export async function applySuggestedPrompts(input: {
+  readonly suggestedPrompts: SlackSuggestedPrompts;
+  readonly event: SlackEvent;
+  readonly request: (operation: string, body: unknown) => Promise<SlackApiResponse>;
+}): Promise<void> {
+  const { event } = input;
+  const target = resolvePromptsTarget(event);
+  if (target === null) return;
+
+  try {
+    const resolved =
+      typeof input.suggestedPrompts === "function"
+        ? await input.suggestedPrompts({ ...target, teamId: event.teamId, event })
+        : input.suggestedPrompts;
+    if (!resolved || resolved.prompts.length === 0) return;
+
+    let prompts = resolved.prompts;
+    if (prompts.length > SLACK_MAX_SUGGESTED_PROMPTS) {
+      log.warn("suggested prompts exceed Slack's cap — extras dropped", {
+        configured: prompts.length,
+        cap: SLACK_MAX_SUGGESTED_PROMPTS,
+      });
+      prompts = prompts.slice(0, SLACK_MAX_SUGGESTED_PROMPTS);
+    }
+
+    const body: Record<string, unknown> = {
+      channel_id: target.channelId,
+      prompts: prompts.map((prompt) => ({
+        title: prompt.title,
+        message: prompt.message,
+      })),
+    };
+    if (target.threadTs !== undefined) body.thread_ts = target.threadTs;
+    if (resolved.title !== undefined) body.title = resolved.title;
+
+    const response = await input.request("assistant.threads.setSuggestedPrompts", body);
+    if (response.ok !== true) {
+      log.warn("assistant.threads.setSuggestedPrompts returned not-ok", {
+        error: response.error,
+        channel_id: target.channelId,
+      });
+    }
+  } catch (error) {
+    logError(log, "suggested prompts delivery failed", error, {
+      channelId: target.channelId,
+    });
+  }
+}
+
+interface PromptsTarget {
+  readonly channelId: string;
+  readonly threadTs: string | undefined;
+  readonly userId: string | undefined;
+}
+
+/**
+ * Extracts the prompts delivery target from a conversation-open event,
+ * or `null` when the event is not one (including `app_home_opened` for
+ * tabs other than Messages).
+ */
+function resolvePromptsTarget(event: SlackEvent): PromptsTarget | null {
+  if (event.type === "assistant_thread_started") {
+    const thread = event.event.assistant_thread;
+    if (typeof thread !== "object" || thread === null || Array.isArray(thread)) {
+      log.warn("assistant_thread_started event carried no assistant_thread", {
+        event_id: event.eventId,
+      });
+      return null;
+    }
+    const { channel_id, thread_ts, user_id } = thread as Record<string, unknown>;
+    if (typeof channel_id !== "string" || channel_id.length === 0) return null;
+    return {
+      channelId: channel_id,
+      threadTs: typeof thread_ts === "string" && thread_ts.length > 0 ? thread_ts : undefined,
+      userId: typeof user_id === "string" && user_id.length > 0 ? user_id : undefined,
+    };
+  }
+
+  if (event.type === "app_home_opened") {
+    // Under agent_view the Messages tab is the conversation surface;
+    // opening the Home (or About) tab is not a prompts trigger.
+    if (event.event.tab !== "messages") return null;
+    const { channel, user } = event.event;
+    if (typeof channel !== "string" || channel.length === 0) return null;
+    return {
+      channelId: channel,
+      threadTs: undefined,
+      userId: typeof user === "string" && user.length > 0 ? user : undefined,
+    };
+  }
+
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1228,7 +1228,7 @@ importers:
         version: 1.28.1
       '@workflow/core':
         specifier: 5.0.0-beta.35
-        version: 5.0.0-beta.35(@opentelemetry/api@1.9.1)(ws@8.21.0)
+        version: 5.0.0-beta.35(@opentelemetry/api@1.9.1)(ws@8.21.1)
       '@workflow/errors':
         specifier: 5.0.0-beta.11
         version: 5.0.0-beta.11
@@ -1252,7 +1252,7 @@ importers:
         version: 7.0.26(zod@4.4.3)
       autoevals:
         specifier: 0.0.132
-        version: 0.0.132(ws@8.21.0)
+        version: 0.0.132(ws@8.21.1)
       chat:
         specifier: 4.31.0
         version: 4.31.0(ai@7.0.26(zod@4.4.3))(zod@4.4.3)
@@ -11619,10 +11619,6 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -13534,18 +13530,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
@@ -15280,7 +15264,7 @@ snapshots:
       magicast: 0.5.3
       pathe: 2.0.3
       pkg-types: 2.3.1
-      semver: 7.8.5
+      semver: 7.8.4
 
   '@nuxt/devtools@3.2.4(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
@@ -15307,7 +15291,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      semver: 7.8.5
+      semver: 7.8.4
       simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
@@ -15349,7 +15333,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      semver: 7.8.5
+      semver: 7.8.4
       simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
@@ -18204,7 +18188,7 @@ snapshots:
       '@types/node': 25.9.1
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
-      ws: 8.21.0
+      ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19150,20 +19134,12 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
 
-  '@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0)':
-    dependencies:
-      '@vercel/oidc': 3.8.0
-    optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.972.49
-      ws: 8.21.0
-
   '@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1)':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       ws: 8.21.1
-    optional: true
 
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     dependencies:
@@ -19746,13 +19722,13 @@ snapshots:
 
   '@webgpu/types@0.1.71': {}
 
-  '@workflow/core@5.0.0-beta.35(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/core@5.0.0-beta.35(@opentelemetry/api@1.9.1)(ws@8.21.1)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
       '@standard-schema/spec': 1.0.0
       '@types/ms': 2.1.0
-      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0)
+      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1)
       '@workflow/errors': 5.0.0-beta.11
       '@workflow/serde': 5.0.0-beta.2
       '@workflow/utils': 5.0.0-beta.6
@@ -20061,7 +20037,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoevals@0.0.132(ws@8.21.0):
+  autoevals@0.0.132(ws@8.21.1):
     dependencies:
       ajv: 8.20.0
       compute-cosine-similarity: 1.1.0
@@ -20069,7 +20045,7 @@ snapshots:
       js-yaml: 4.1.1
       linear-sum-assignment: 1.0.9
       mustache: 4.2.0
-      openai: 6.39.1(ws@8.21.0)(zod@3.25.76)
+      openai: 6.39.1(ws@8.21.1)(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
@@ -24090,7 +24066,7 @@ snapshots:
       rollup: 4.62.2
       rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.62.2)
       scule: 1.3.0
-      semver: 7.8.5
+      semver: 7.8.4
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
@@ -24202,7 +24178,7 @@ snapshots:
       rollup: 4.62.2
       rollup-plugin-visualizer: 7.0.1(rolldown@1.1.0)(rollup@4.62.2)
       scule: 1.3.0
-      semver: 7.8.5
+      semver: 7.8.4
       serve-placeholder: 2.0.2
       serve-static: 2.2.1
       source-map: 0.7.6
@@ -24379,7 +24355,7 @@ snapshots:
       pkg-types: 2.3.1
       rou3: 0.8.1
       scule: 1.3.0
-      semver: 7.8.5
+      semver: 7.8.4
       std-env: 4.2.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
@@ -24515,7 +24491,7 @@ snapshots:
       pkg-types: 2.3.1
       rou3: 0.8.1
       scule: 1.3.0
-      semver: 7.8.5
+      semver: 7.8.4
       std-env: 4.2.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
@@ -24721,9 +24697,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.39.1(ws@8.21.0)(zod@3.25.76):
+  openai@6.39.1(ws@8.21.1)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.21.0
+      ws: 8.21.1
       zod: 3.25.76
 
   optionator@0.9.4:
@@ -25270,12 +25246,6 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.19:
-    dependencies:
-      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -27489,7 +27459,7 @@ snapshots:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.15
       rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -27738,8 +27708,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  ws@8.21.0: {}
 
   ws@8.21.1: {}
 


### PR DESCRIPTION
> Stacked on #928 (`feat/slack-onevent`) — `suggestedPrompts` reuses its `SlackEvent` normalization. Retarget to `main` once that merges.

Adds two assistant-experience options to `slackChannel`, mirroring the Chat SDK Slack adapter's `loadingMessages` and `suggestedPrompts` config — implemented channel-side on eve's own pipeline (eve doesn't run the adapter runtime):

```ts
import { slackChannel } from "eve/channels/slack";

export default slackChannel({
  loadingMessages: ["Thinking...", "Digging through the archives..."],
  suggestedPrompts: {
    title: "Welcome! What can I do for you?",
    prompts: [
      { title: "Catch me up", message: "What did I miss today?" },
      { title: "Draft a message", message: "Help me draft a message" },
    ],
  },
});
```

`suggestedPrompts` also takes a resolver for per-user/per-open prompts:

```ts
suggestedPrompts: async ({ userId, channelId }) => ({
  prompts: [{ title: "My open PRs", message: `List open PRs for <@${userId}>` }],
}),
```

## loadingMessages

Rotating typing-indicator statuses replacing the default `"Thinking..."` (inbound) and `"Working..."` (`turn.started`). eve already sends `loading_messages` to `assistant.threads.setStatus` — always as a single entry; `SlackThread.startTyping` now accepts a `readonly string[]` and passes the full set so Slack rotates through it. Progress statuses (reasoning snippets, action labels) still take over as the turn advances.

The default handlers are now built by exported factories (`createDefaultInboundHandler`, `createDefaultTurnStarted`); `defaultOnAppMention` / `defaultOnDirectMessage` / `defaultEvents` are unchanged aliases of the factories' defaults.

## suggestedPrompts

Applied via `assistant.threads.setSuggestedPrompts` when a user opens the conversation. Both manifest modes are handled:

- **`agent_view`** (current Agent messaging experience): triggered by `app_home_opened` with `tab: "messages"`; prompts render at the top of the Messages tab, no `thread_ts` sent.
- **`assistant_view`** (legacy): triggered by `assistant_thread_started`; prompts render in the opened thread, targeted by `thread_ts`.

Prompts are capped at Slack's limit of four (extras dropped with a warning). Requires the `assistant:write` scope and a subscription to the relevant event. Failures are logged and swallowed — prompts are a UX nicety, never a reason to fail the webhook.

## Effect on current behavior

- Neither option configured: behavior is unchanged, including the exact `setStatus` payloads sent today.
- `loadingMessages` applies only to the *default* inbound / `turn.started` handlers — supplying your own `onAppMention`, `onDirectMessage`, or `events["turn.started"]` replaces the typing behavior along with the handler, as before. An empty array is treated as unset.
- `suggestedPrompts` handling runs on the webhook side under `waitUntil()` after event-id dedup, alongside (never instead of) `onEvent`; conversation-open events still never dispatch a turn.

Includes docs (new "Assistant threads" section in `docs/channels/slack.mdx`), 12 unit tests for the suggested-prompts module plus 7 channel wiring tests, public type exports (`SlackSuggestedPrompt(s)`, context/input types), and a patch changeset.