### PR TITLE
fix(eve): emit approval-resumed tool failures

### DIFF
--- a/.changeset/quiet-tools-report.md
+++ b/.changeset/quiet-tools-report.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit a durable failed action result when an approval-resumed tool throws before its call appears in the current provider step.

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -536,6 +536,44 @@ describe("emitStreamContent action requests", () => {
     expect(providerResult.trailingInlineToolResultParts).toEqual([]);
   });
 
+  it("emits a failed action result when an approved tool throws on resume", async () => {
+    const emit = createEmitStub();
+
+    const result = await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        {
+          error: new Error("Approved execution failed"),
+          input: { query: "eve" },
+          toolCallId: "approved-call-1",
+          toolName: "web_search",
+          type: "tool-error",
+        },
+        { finishReason: "stop", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          result: {
+            callId: "approved-call-1",
+            isError: true,
+            kind: "tool-result",
+            output: "Approved execution failed",
+            toolName: "web_search",
+          },
+          status: "failed",
+        }),
+        type: "action.result",
+      }),
+    ]);
+    expect([...result.handledInlineToolResultCallIds]).toEqual(["approved-call-1"]);
+    expect(result.trailingInlineToolResultParts).toEqual([]);
+  });
+
   it("turns non-object tool call input into a failed tool result for the model", async () => {
     const tools = new Map<string, HarnessToolDefinition>([
       [

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -329,8 +329,7 @@ export function normalizeAssistantStepFinishReason(
 /**
  * Result of consuming one step's `fullStream`.
  *
- * Inline results avoid duplicate post-step events. Approval-resume
- * authorization results also route back to the park detector.
+ * Inline results avoid duplicate post-step events; authorization results route back to parking.
  */
 interface EmittedStreamContent {
   readonly emittedActionCallIds: ReadonlySet<string>;
@@ -346,8 +345,7 @@ interface StreamActionEmissionOptions {
 }
 
 /**
- * Consumes the AI SDK `fullStream` and emits real-time text and reasoning
- * events.
+ * Consumes the AI SDK `fullStream` and emits real-time text and reasoning events.
  *
  * Emits local tool events in source order. Provider calls that arrive in one
  * stream batch into one request event before their first result. A result
@@ -619,10 +617,12 @@ async function consumeStreamContent(
           await collectProviderToolCall(toolError);
           await providerActionBatch.flush();
           await emitActionResult(createRuntimeToolResultFromToolError(toolError));
-        } else if (emittedActionCallIds.has(toolError.toolCallId)) {
+        } else if (!handledInlineToolResultCallIds.has(toolError.toolCallId)) {
           await emitActionResult(createRuntimeToolResultFromToolError(toolError));
           handledInlineToolResultCallIds.add(toolError.toolCallId);
-          trailingInlineToolResultParts.push(createToolResultMessagePartFromToolError(toolError));
+          if (emittedActionCallIds.has(toolError.toolCallId)) {
+            trailingInlineToolResultParts.push(createToolResultMessagePartFromToolError(toolError));
+          }
         }
         break;
       }


### PR DESCRIPTION
## Summary

- emit a failed `action.result` when an approval-resumed local tool throws before its call appears in the current provider step
- retain the existing trailing model-result behavior only for calls emitted in the same step
- add a deterministic regression for the exact approved call id and deduplication boundary

## Context

Follow-up to #460 and #588. #588 fixed durable model-history persistence, but the public Eve event stream still drops this narrower approval-resume error branch because `emittedActionCallIds` only describes the current provider step.

This PR intentionally changes only event emission. AI SDK `responseMessages` remains authoritative for model history, so the resumed error does not add a duplicate trailing model result.

## Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve test:unit` — 474 files passed; 4,891 tests passed; 1 skipped
- `pnpm exec oxlint packages/eve/src/harness/emission.ts packages/eve/src/harness/emission.test.ts`
- `git diff --check`

The commit is GitHub-verified and includes the required DCO sign-off.