### PR TITLE
fix(eve): honor post-step turn cancellation

### DIFF
--- a/.changeset/steady-turns-cancel.md
+++ b/.changeset/steady-turns-cancel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Honor a turn cancellation that arrives as a durable step returns instead of publishing the step as completed.

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -296,6 +296,46 @@ describe("turnWorkflow", () => {
     expect(resumeHookMock.mock.calls.filter((call) => call[1]?.kind === "turn-error")).toEqual([]);
   });
 
+  it("honors cancellation observed while a durable turn step returns", async () => {
+    const sessionState = createSessionState();
+    installInbox([], { cancelPayloads: [{}] });
+    vi.mocked(turnStep).mockImplementationOnce(async (stepInput) => {
+      await vi.waitFor(() => expect(stepInput.abortSignal?.aborted).toBe(true));
+      return {
+        action: "done",
+        output: "must not complete",
+        serializedContext: { state: "done" },
+        sessionState,
+      };
+    });
+
+    const { input } = createInput({
+      driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
+      sessionState,
+    });
+    await turnWorkflow(input);
+
+    expect(cancelDescendantTurnsStep).toHaveBeenCalledWith({
+      serializedContext: { state: "start" },
+      sessionState,
+    });
+    expect(resumeHookMock).toHaveBeenCalledWith("turn-token", {
+      action: {
+        cancelled: true,
+        kind: "park",
+        serializedContext: { state: "start" },
+        sessionState,
+      },
+      kind: "turn-result",
+    });
+    expect(resumeHookMock).not.toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({
+        action: expect.objectContaining({ kind: "done" }),
+      }),
+    );
+  });
+
   it("runs uncancellable when the session cancel token is claimed by another run", async () => {
     const sessionState = createSessionState();
     installInbox([], { cancelConflict: { runId: "wrun_stale_prior_turn" } });

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -106,8 +106,15 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
 
     while (true) {
       const result = await turnStep(cursor.createStepInput(nextStepInput, cancellation?.signal));
+      const pendingActionKeys =
+        result.action === "dispatch-workflow-runtime-actions" || result.action === "park"
+          ? result.pendingRuntimeActionKeys
+          : undefined;
 
-      if (result.action === "cancelled") {
+      if (
+        result.action === "cancelled" ||
+        (cancellation?.signal.aborted === true && pendingActionKeys === undefined)
+      ) {
         // No `canPark` check here: that gate rejects model-authored waits
         // (`next: null`) in task mode, whereas a cancelled turn parks by
         // design and its parkability was already established when the
@@ -146,11 +153,6 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
       // A pending runtime-action batch (model-driven `park` or dynamic-workflow
       // interrupt) is resolved in-line so the turn stays alive across the wait;
       // the two arms differ only in their dispatch path.
-      const pendingActionKeys =
-        result.action === "dispatch-workflow-runtime-actions" || result.action === "park"
-          ? result.pendingRuntimeActionKeys
-          : undefined;
-
       if (pendingActionKeys !== undefined) {
         await cursor.adopt(result);
         const dispatch =


### PR DESCRIPTION
## Summary

- re-check the durable cancel signal after `turnStep()` returns
- prevent a `done` or ordinary step result from crossing an already-observed cancellation boundary
- preserve the existing requirement to adopt and dispatch pending runtime actions before cancellation cascades
- add deterministic regression coverage for the post-step race

## Context

Follow-up to #483 and the turn-cancellation implementation. The cancel hook aborts a durable signal, but `runTurnOwnedWorkflow()` currently checks only `result.action === "cancelled"`. A step that finishes concurrently with the hook can therefore publish `done` after cancellation was observed.

The pending-runtime-action exception is intentional. Existing coverage requires dispatch state to be adopted before descendant cancellation; an unconditional signal check would regress that guarantee.

## Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve test:unit` — 474 files passed; 4,891 tests passed; 1 skipped
- `pnpm exec oxlint packages/eve/src/execution/turn-workflow.ts packages/eve/src/execution/turn-workflow.test.ts`
- `git diff --check`

The commit is GitHub-verified and includes the required DCO sign-off.