### PR TITLE
fix(eve): provide auth context to dynamic tools

### DIFF
--- a/.changeset/bright-mice-resolve.md
+++ b/.changeset/bright-mice-resolve.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Provide dynamic tools with the full auth-capable `ToolContext`, including `ctx.getToken(provider)` and `ctx.requireAuth(provider)`, across live execution and durable replay.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -25,6 +25,8 @@ their `defineDynamic` export is a build error.
 
 Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. The wrapper stamps them so their `execute` functions survive workflow step boundaries.
 
+Dynamic tool executors receive the same `ToolContext` as static authored tools, including inline provider auth through `ctx.getToken(provider)` and `ctx.requireAuth(provider)`.
+
 The example below builds one tool per warehouse table. A map return names each tool by its bare key, so the model sees `orders`, `users`, and so on.
 
 ```ts title="agent/tools/query.ts"

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -6,7 +6,7 @@ import {
   LiveStepToolsKey,
 } from "#context/keys.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
-import { buildBaseToolContext } from "#context/build-base-tool-context.js";
+import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 import { createLogger } from "#internal/logging.js";
 import type { ApprovalContext, ApprovalStatus } from "#public/definitions/approval.js";
 import { toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
@@ -49,8 +49,10 @@ function replayTools(metadata: readonly DurableDynamicToolMetadata[]): HarnessTo
 
     tools.push({
       description: m.description,
-      execute: (input: unknown, options) =>
-        stepFn(m.closureVars, input, buildBaseToolContext({ options, toolName: m.name })),
+      execute: createToolExecuteWithAuth({
+        scope: m.name,
+        execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
+      }),
       inputSchema: toInputSchema(m.inputSchema),
       name: m.name,
       approval: buildReplayedApproval(m),

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import type { ApprovalContext } from "#public/definitions/approval.js";
-import { defineTool } from "#public/definitions/tool.js";
+import { defineTool, type ToolContext } from "#public/definitions/tool.js";
 import { serializeOutputSchema, type ToolSchema } from "#shared/tool-schema.js";
 
 vi.mock("#context/build-callback-context.js", () => ({
@@ -612,6 +612,33 @@ describe("dispatchDynamicToolEvent", () => {
     });
   });
 
+  it("provides inline auth to a step-scoped tool", async () => {
+    const ctx = createCtx();
+    const getToken = vi.fn(async () => ({ token: "step-token" }));
+    const auth = { getToken, principalType: "app" as const };
+    const resolver = createResolver("oauth", ["step.started"], () => ({
+      probe: defineTool({
+        description: "resolve auth",
+        inputSchema: { type: "object" },
+        execute: async (_input, toolCtx) => {
+          const { token } = await toolCtx.getToken(auth);
+          return { token };
+        },
+      }),
+    }));
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("step.started"),
+    });
+
+    const tool = buildDynamicTools(ctx)[0]!;
+    await expect(tool.execute!({}, executeOptions)).resolves.toEqual({ token: "step-token" });
+    expect(getToken).toHaveBeenCalledOnce();
+  });
+
   it("replaces tools from the same resolver slug (last write wins)", async () => {
     const ctx = createCtx();
     let callCount = 0;
@@ -773,10 +800,55 @@ describe("dispatchDynamicToolEvent", () => {
       const tools = buildDynamicTools(ctx);
       expect(tools).toHaveLength(1);
       expect(tools[0]!.name).toBe("query");
-      expect(tools[0]!.execute!({}, executeOptions)).toEqual({
+      await expect(tools[0]!.execute!({}, executeOptions)).resolves.toEqual({
         input: {},
         toolName: "query",
       });
+    } finally {
+      registry.delete(stepId);
+    }
+  });
+
+  it("provides inline auth to a replayed session-scoped tool", async () => {
+    const ctx = createCtx();
+    const stepId = "eve:dynamic-tool//__eve_dispatch_auth_rehydrate_test";
+    const getToken = vi.fn(async () => ({ token: "replayed-token" }));
+    const auth = { getToken, principalType: "app" as const };
+    const stepFn = vi.fn(async (_vars: unknown, _input: unknown, toolCtx: unknown) => {
+      const { token } = await (toolCtx as ToolContext).getToken(auth);
+      return { token };
+    });
+    const registrySym = Symbol.for("@workflow/core//registeredSteps");
+    const registry = getOrCreateStepRegistry(registrySym);
+    registry.set(stepId, stepFn);
+
+    try {
+      const resolver = createResolver("oauth", ["session.started"], () => {
+        const entry = defineTool({
+          description: "resolve replayed auth",
+          inputSchema: { type: "object" },
+          execute: async () => ({ ok: true }),
+        });
+        Object.assign(entry, {
+          __executeStepFn: { stepId },
+          __closureVars: {},
+        });
+        return { probe: entry };
+      });
+
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        messages: [],
+        event: makeEvent("session.started"),
+      });
+      ctx.clearVirtualContext();
+
+      const tool = buildDynamicTools(ctx)[0]!;
+      await expect(tool.execute!({}, executeOptions)).resolves.toEqual({
+        token: "replayed-token",
+      });
+      expect(getToken).toHaveBeenCalledOnce();
     } finally {
       registry.delete(stepId);
     }

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -17,7 +17,6 @@ import {
   toOutputSchema,
 } from "#shared/tool-schema.js";
 import { toErrorMessage } from "#shared/errors.js";
-import { buildBaseToolContext } from "#context/build-base-tool-context.js";
 import type { ContextContainer } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
@@ -27,6 +26,7 @@ import {
 } from "#context/keys.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
+import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 
 const log = createLogger("dynamic-tools");
 
@@ -37,11 +37,11 @@ const log = createLogger("dynamic-tools");
 function toHarnessToolDefinition(name: string, entry: DynamicToolEntry): HarnessToolDefinition {
   return {
     description: entry.description,
-    execute: (input: unknown, options) =>
-      entry.execute(
-        input as Record<string, unknown>,
-        buildBaseToolContext({ options, toolName: name }),
-      ),
+    execute: createToolExecuteWithAuth({
+      scope: name,
+      execute: (input, ctx) =>
+        entry.execute(input as Record<string, unknown>, ctx as Parameters<typeof entry.execute>[1]),
+    }),
     inputSchema: toInputSchema(entry.inputSchema),
     name,
     approval: entry.approval,
@@ -116,8 +116,10 @@ export function replayDynamicSessionTools(
 
     tools.push({
       description: m.description,
-      execute: (input: unknown, options) =>
-        stepFn(m.closureVars, input, buildBaseToolContext({ options, toolName: m.name })),
+      execute: createToolExecuteWithAuth({
+        scope: m.name,
+        execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
+      }),
       inputSchema: toInputSchema(m.inputSchema),
       name: m.name,
       outputSchema: toOutputSchema(m.outputSchema),

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -5,17 +5,10 @@ import type {
   PublicToolOutputSchema,
   ToolModelOutput,
 } from "#shared/tool-definition.js";
-import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { Approval } from "#public/definitions/approval.js";
+import type { ToolContext } from "#public/definitions/tool.js";
 import type { SessionAuth } from "#context/keys.js";
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
-
-type ToolContext = SessionContext & {
-  /** Aborts when the active turn is cancelled. */
-  readonly abortSignal: AbortSignal;
-  /** Final runtime name of the current tool. */
-  readonly toolName: string;
-};
 
 /**
  * Stream event types allowed for dynamic tool resolvers. Dispatch


### PR DESCRIPTION
## Summary

- route live dynamic-tool execution through the same auth-capable wrapper used by static authored tools
- preserve `ctx.getToken()` and `ctx.requireAuth()` when session/turn-scoped dynamic tools are replayed from durable metadata
- align the public dynamic-tool executor context type with `ToolContext`
- document the auth behavior and add a patch changeset

## Root cause

Dynamic tools were wrapped with `buildBaseToolContext`, which only provides the base session/tool fields. Static authored tools use `createToolExecuteWithAuth`, which augments that context with inline provider auth. The live dynamic path and both durable replay paths therefore omitted `getToken` and `requireAuth` at runtime.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm test`
- focused dynamic lifecycle regression suite: 41 tests passed

Fixes #946
