### PR TITLE
fix(application): fix package path resolution on Windows inside dev-host

### DIFF
--- a/.changeset/sweet-cameras-switch.md
+++ b/.changeset/sweet-cameras-switch.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+fix(application): resolve package path correctly on Windows when bundled by Nitro

--- a/packages/eve/src/internal/application/package.ts
+++ b/packages/eve/src/internal/application/package.ts
@@ -68,6 +68,25 @@ function isBuildOutputPackageRoot(directoryPath: string): boolean {
 }
 
 function resolvePackageBuildRoot(): string | null {
+  // Check if we are running in the source checkout of the eve monorepo.
+  // In the source tree, we want to return null so it resolves to src/ instead of dist/.
+  const currentFilePath = realpathSync(resolveCurrentModulePath()).replace(/\\/g, "/");
+  const isSourceCheckout = currentFilePath.toLowerCase().includes("/packages/eve/");
+
+  if (!isSourceCheckout) {
+    try {
+      // Attempt to locate the installed package root dynamically using require.resolve
+      const packageJsonPath = require.resolve("eve/package.json");
+      const packageRoot = dirname(packageJsonPath);
+      const distPath = join(packageRoot, "dist");
+      if (existsSync(distPath)) {
+        return distPath;
+      }
+    } catch {
+      // Fall back to filename-based directory traversal
+    }
+  }
+
   let currentDirectory = dirname(realpathSync(resolveCurrentModulePath()));
 
   while (true) {
@@ -110,6 +129,19 @@ function findNearestPackageRoot(startDirectory: string): string {
  * Resolves the installed eve package root.
  */
 export function resolvePackageRoot(): string {
+  const currentFilePath = realpathSync(resolveCurrentModulePath()).replace(/\\/g, "/");
+  const isSourceCheckout = currentFilePath.toLowerCase().includes("/packages/eve/");
+
+  if (!isSourceCheckout) {
+    try {
+      // Attempt to locate the installed package root dynamically using require.resolve
+      const packageJsonPath = require.resolve("eve/package.json");
+      return dirname(packageJsonPath);
+    } catch {
+      // Fall back to filename-based directory traversal
+    }
+  }
+
   // Canonicalize the current module path so workspace symlinks such as
   // app-local `node_modules/<package-name>` resolve back to the real package root.
   return findNearestPackageRoot(dirname(realpathSync(resolveCurrentModulePath())));


### PR DESCRIPTION
Closes #948 

### Description

When Nitro bundles the dev-host (`.eve/dev-hosts/.../index.mjs`), `resolveCurrentModulePath()` points to the bundled index file. If Node.js/V8 fails to resolve the source map back to `node_modules/eve/dist/...` (which typically happens on Windows due to slash normalization mismatches `/` vs `\`), `findNearestPackageRoot` crawls up from the dev-host directory and returns the client project root directory instead of the installed `eve` package root.
This PR resolves this issue by looking up the package root dynamically using `require.resolve('eve/package.json')`. It also includes monorepo source checkout detection (`isSourceCheckout`) to safely fallback to the original climbing behavior when running internal unit tests under Vitest.

### How did you test your changes?

1. Ran unit tests in the `eve` monorepo to verify no regressions: `pnpm --filter eve test:unit`.
2. Packed the package using `pnpm pack`.
3. Installed the `.tgz` package into a client Next.js agent project on Windows 11.
4. Ran `npx eve dev` and successfully created a session (the `authored-module-map-loader` resolution error is gone).

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
