### PR TITLE
chore(docs): update @vercel/geistdocs to 1.13.0

### DIFF
--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -31,19 +31,20 @@ html[data-scrolled] body:has([data-home-route]) header {
   border-bottom-color: var(--ds-gray-alpha-400) !important;
 }
 
-/* Align docs content with navbar on mobile. */
-#nd-page {
-  @apply max-md:px-6;
-}
-
 /*
  * On mobile the sticky MobileDocsBar abuts the navbar via a negative top
  * margin, which would otherwise overlap and clip the page breadcrumb rendered
  * above it. Hide the breadcrumb on mobile so the bar sits flush under the
  * navbar; it stays visible on desktop, where the bar is hidden.
  */
-#nd-page > .text-fd-muted-foreground:first-child {
-  @apply max-md:hidden;
+@container (max-width: 960px) {
+  #nd-page {
+    @apply px-6;
+  }
+
+  #nd-page > .text-fd-muted-foreground:first-child {
+    @apply hidden;
+  }
 }
 
 /* TOC and footer links use gray-1000. */

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,7 +21,7 @@
     "@vercel/agent-readability": "0.4.0",
     "@vercel/analytics": "2.0.1",
     "@vercel/eve-catalog": "workspace:*",
-    "@vercel/geistdocs": "1.12.0",
+    "@vercel/geistdocs": "1.13.0",
     "@vercel/speed-insights": "2.0.0",
     "@vgpu/core": "0.0.7",
     "@vgpu/render": "0.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eve-catalog
       '@vercel/geistdocs':
-        specifier: 1.12.0
-        version: 1.12.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.3.0-preview.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: 1.13.0
+        version: 1.13.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.3.0-preview.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(d14575c04eef7e2c3094b0145364aa47)
@@ -7209,8 +7209,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.19':
     resolution: {integrity: sha512-dA1ZWZHruRjFbLToqjcPHUyh5J7/Cl3qGFDge87ghAInuy/aXfalApzFbw61OIopGx0SSsIYi/8kbpJ+SbQ6ZQ==}
 
-  '@vercel/geistdocs@1.12.0':
-    resolution: {integrity: sha512-IsULtetIzQGC1pu+DWAP6C4sNBnt/pw1FCqU2Fa+swZlakS0Xx7JyQ3reh2x0MK6uKncLAY8c75nlwhY2eyILg==}
+  '@vercel/geistdocs@1.13.0':
+    resolution: {integrity: sha512-vhFr1ocyT0WL+/fSiKIkMvkcMk7Tz4CI8tzH571rAjpuVMgP1L/l7RGGmqiGizPng8vFFTXT5NBLXaDuq5hm/A==}
     hasBin: true
     peerDependencies:
       next: 16.2.6
@@ -19177,7 +19177,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.12.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.3.0-preview.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vercel/geistdocs@1.13.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.3.0-preview.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(unified@11.0.5)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
## Summary

- update the eve docs app to `@vercel/geistdocs` 1.13.0
- align docs content spacing and breadcrumb visibility with the new container-responsive sidebar

https://github.com/user-attachments/assets/8f7ffacf-c3b0-44ab-a79d-5e3e00be791a


## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter eve-docs build`
- `pnpm exec oxfmt --check apps/docs/app/styles/geistdocs.css apps/docs/package.json pnpm-lock.yaml`

Upstream release: https://github.com/vercel/geistdocs/pull/160