### PR TITLE
Fix dev snapshots for physical node_modules installs

### DIFF
--- a/.changeset/calm-dodos-mount.md
+++ b/.changeset/calm-dodos-mount.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `eve dev` snapshots for extensions installed as physical `node_modules` directories, making dependency handling consistent across npm, Yarn, and pnpm layouts.

--- a/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
@@ -155,6 +155,85 @@ describe("development generation artifacts", () => {
     expect(tool.default.execute()).toBe("configured");
   });
 
+  it("materializes a mounted extension from a physical installed directory", async () => {
+    const packageName = "@acme/physical-extension";
+    const app = await scenarioApp({
+      dependencies: {
+        [packageName]: "1.0.0",
+      },
+      files: {
+        "agent/agent.mjs": 'export default { model: "openai/gpt-5.4" };\n',
+        "agent/extensions/physical.mjs": `export { default } from ${JSON.stringify(packageName)};\n`,
+        "agent/instructions.md": "Use the available tools.",
+      },
+      name: "physical-extension-generation",
+    });
+    const packageRoot = join(app.appRoot, "node_modules", "@acme", "physical-extension");
+    await mkdir(join(packageRoot, "extension", "tools"), { recursive: true });
+    await writeFile(
+      join(packageRoot, "package.json"),
+      `${JSON.stringify({
+        eve: { extension: { dist: "extension" } },
+        exports: "./extension/extension.mjs",
+        name: packageName,
+        type: "module",
+        version: "1.0.0",
+      })}\n`,
+    );
+    await writeFile(
+      join(packageRoot, "extension", "_manifest.json"),
+      `${JSON.stringify({
+        kind: "eve-extension",
+        formatVersion: 1,
+        builtWithEve: "0.0.0-test",
+        requires: { extension: 1, tool: 1 },
+      })}\n`,
+    );
+    await writeFile(
+      join(packageRoot, "extension", "extension.mjs"),
+      'import { defineExtension } from "eve/extension";\nexport default defineExtension();\n',
+    );
+    await writeFile(
+      join(packageRoot, "extension", "tools", "read_marker.mjs"),
+      [
+        "export default {",
+        '  description: "Read the extension marker.",',
+        '  execute: () => "physical-extension-original",',
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await mkdir(join(app.appRoot, "node_modules"), { recursive: true });
+    await symlink(resolvePackageRoot(), join(app.appRoot, "node_modules", "eve"), "junction");
+
+    const compileResult = await compileAgent({ startPath: app.appRoot });
+    const snapshot = await stageDevelopmentGeneration(compileResult);
+    const snapshotPackageRoot = join(
+      snapshot.runtimeAppRoot,
+      "node_modules",
+      "@acme",
+      "physical-extension",
+    );
+
+    await expect(realpath(snapshotPackageRoot)).resolves.toBe(await realpath(packageRoot));
+    await rm(packageRoot, { force: true, recursive: true });
+
+    const moduleMap = await loadCompiledModuleMapFromAuthoredSource({
+      compiledArtifactsSource: createAuthoredSourceRuntimeCompiledArtifactsSource(
+        snapshot.runtimeAppRoot,
+      ),
+    });
+    const toolSourceId = compileResult.manifest.tools.find((tool) =>
+      tool.sourceId.startsWith("ext:physical:"),
+    )?.sourceId;
+    expect(toolSourceId).toBeDefined();
+    const tool = moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules[toolSourceId!] as {
+      default: { execute(): string };
+    };
+
+    expect(tool.default.execute()).toBe("physical-extension-original");
+  });
+
   it("executes dynamic imports after the original bundled dependency is removed", async () => {
     const evaluationMarker = "__eveGenerationDynamicImportEvaluated__";
     const globals = globalThis as Record<string, unknown>;

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -1,5 +1,14 @@
 import { existsSync } from "node:fs";
-import { lstat, mkdir, readdir, readFile, symlink, utimes, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -258,6 +267,50 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(join(snapshot.runtimeAppRoot, ".generated"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, "build"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, "dist"))).toBe(false);
+  });
+
+  it("mounts declared physical dependency directories into source snapshots", async () => {
+    const appRoot = await createScratchDirectory("eve-dev-runtime-physical-dependency-");
+    const agentRoot = join(appRoot, "agent");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+    const installedPackageRoot = join(appRoot, "node_modules", "@acme", "extension");
+    const undeclaredPackageRoot = join(appRoot, "node_modules", "undeclared-package");
+
+    await mkdir(agentRoot, { recursive: true });
+    await mkdir(installedPackageRoot, { recursive: true });
+    await mkdir(undeclaredPackageRoot, { recursive: true });
+    await mkdir(compileDirectoryPath, { recursive: true });
+    await writeFile(
+      join(appRoot, "package.json"),
+      `${JSON.stringify({
+        dependencies: { "@acme/extension": "1.0.0" },
+        type: "module",
+      })}\n`,
+    );
+    await writeFile(join(agentRoot, "agent.ts"), "export const answer = 42;\n");
+    await writeFile(
+      join(installedPackageRoot, "package.json"),
+      '{"name":"@acme/extension","version":"1.0.0"}\n',
+    );
+    await writeFile(join(undeclaredPackageRoot, "package.json"), '{"name":"undeclared-package"}\n');
+    await writeFile(
+      join(compileDirectoryPath, "compiled-agent-manifest.json"),
+      `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`,
+    );
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+    const snapshotPackageRoot = join(snapshot.runtimeAppRoot, "node_modules", "@acme", "extension");
+
+    await expect(lstat(snapshotPackageRoot).then((stats) => stats.isSymbolicLink())).resolves.toBe(
+      true,
+    );
+    await expect(realpath(snapshotPackageRoot)).resolves.toBe(await realpath(installedPackageRoot));
+    expect(existsSync(join(snapshot.runtimeAppRoot, "node_modules", "undeclared-package"))).toBe(
+      false,
+    );
   });
 
   it("stops copying at nested git repository boundaries", async () => {

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -55,7 +55,7 @@ export async function copyDevelopmentSourceSnapshot(
   }
 
   await rewriteSnapshotTsConfigAbsoluteExtends(plan);
-  await createSnapshotSymlinks(plan);
+  await createSnapshotDependencyMounts(plan);
   await ensureRuntimePackageJson(plan);
   await validateDevelopmentSourceSnapshot(plan);
 }
@@ -292,20 +292,20 @@ function rewriteTsConfigExtendsSpecifier(input: {
   });
 }
 
-async function createSnapshotSymlinks(plan: DevelopmentSourceSnapshotPlan): Promise<void> {
-  for (const symlinkEntry of plan.symlinks) {
-    const snapshotLinkPath = toSnapshotPathForPlan(plan, symlinkEntry.linkPath);
-    const targetPath =
-      symlinkEntry.targetKind === "local"
-        ? toSnapshotPathForPlan(plan, symlinkEntry.targetPath)
-        : symlinkEntry.targetPath;
-    const relativeTarget =
-      symlinkEntry.targetKind === "local"
-        ? relative(dirname(snapshotLinkPath), targetPath) || "."
-        : targetPath;
+async function createSnapshotDependencyMounts(plan: DevelopmentSourceSnapshotPlan): Promise<void> {
+  for (const dependencyMount of plan.dependencyMounts) {
+    const snapshotMountPath = toSnapshotPathForPlan(plan, dependencyMount.mountPath);
+    const sourcePath =
+      dependencyMount.sourceKind === "workspace"
+        ? toSnapshotPathForPlan(plan, dependencyMount.sourcePath)
+        : dependencyMount.sourcePath;
+    const mountTarget =
+      dependencyMount.sourceKind === "workspace"
+        ? relative(dirname(snapshotMountPath), sourcePath) || "."
+        : sourcePath;
 
-    await mkdir(dirname(snapshotLinkPath), { recursive: true });
-    await symlink(relativeTarget, snapshotLinkPath, "junction");
+    await mkdir(dirname(snapshotMountPath), { recursive: true });
+    await symlink(mountTarget, snapshotMountPath, "junction");
   }
 }
 

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot.ts
@@ -39,31 +39,31 @@ export interface DevelopmentSourceSnapshotPlan {
   readonly appRoot: string;
   readonly copyFiles: readonly string[];
   readonly copyRoots: readonly string[];
+  readonly dependencyMounts: readonly DevelopmentSourceSnapshotDependencyMount[];
   readonly runtimeAppRoot: string;
   readonly snapshotRoot: string;
   readonly snapshotSourceRoot: string;
   readonly sourceRoot: string;
-  readonly symlinks: readonly DevelopmentSourceSnapshotSymlink[];
   readonly tsconfigPaths: readonly string[];
   readonly watchPaths: readonly string[];
 }
 
-export interface DevelopmentSourceSnapshotSymlink {
-  readonly linkPath: string;
-  readonly targetKind: "external" | "local";
-  readonly targetPath: string;
+export interface DevelopmentSourceSnapshotDependencyMount {
+  readonly mountPath: string;
+  readonly sourceKind: "installed" | "workspace";
+  readonly sourcePath: string;
 }
 
 interface SnapshotPlanState {
   readonly appRoot: string;
   readonly copyFiles: Set<string>;
   readonly copyRoots: Set<string>;
+  readonly dependencyMountsByPath: Map<string, DevelopmentSourceSnapshotDependencyMount>;
   readonly localRootsToProcess: string[];
   readonly processedLocalRoots: Set<string>;
   readonly snapshotRoot: string;
   readonly snapshotSourceRoot: string;
   readonly sourceRoot: string;
-  readonly symlinksByLinkPath: Map<string, DevelopmentSourceSnapshotSymlink>;
   readonly tsconfigPaths: Set<string>;
 }
 
@@ -79,12 +79,12 @@ export async function createDevelopmentSourceSnapshotPlan(input: {
     appRoot,
     copyFiles: new Set(),
     copyRoots: new Set(),
+    dependencyMountsByPath: new Map(),
     localRootsToProcess: [appRoot],
     processedLocalRoots: new Set(),
     snapshotRoot,
     snapshotSourceRoot,
     sourceRoot,
-    symlinksByLinkPath: new Map(),
     tsconfigPaths: new Set(),
   };
 
@@ -110,7 +110,7 @@ export async function createDevelopmentSourceSnapshotPlan(input: {
     state.copyRoots.add(resolvedLocalRoot);
 
     await addTsConfigDependenciesForRoot(state, resolvedLocalRoot);
-    await addDependencySymlinksForRoot(state, resolvedLocalRoot);
+    await addDependencyMountsForRoot(state, resolvedLocalRoot);
   }
 
   const copyRoots = normalizeCopyRoots([...state.copyRoots]);
@@ -120,15 +120,15 @@ export async function createDevelopmentSourceSnapshotPlan(input: {
   const tsconfigPaths = [...state.tsconfigPaths]
     .filter((path) => isPathInsideOrEqual(path, sourceRoot))
     .sort((left, right) => left.localeCompare(right));
-  const symlinks = [...state.symlinksByLinkPath.values()].sort((left, right) =>
-    left.linkPath.localeCompare(right.linkPath),
+  const dependencyMounts = [...state.dependencyMountsByPath.values()].sort((left, right) =>
+    left.mountPath.localeCompare(right.mountPath),
   );
   const watchPaths = createWatchPaths({
     appRoot,
     copyFiles,
     copyRoots,
+    dependencyMounts,
     sourceRoot,
-    symlinks,
     tsconfigPaths,
   });
 
@@ -136,11 +136,11 @@ export async function createDevelopmentSourceSnapshotPlan(input: {
     appRoot,
     copyFiles,
     copyRoots,
+    dependencyMounts,
     runtimeAppRoot: toSnapshotPath({ sourcePath: appRoot, sourceRoot, snapshotSourceRoot }),
     snapshotRoot,
     snapshotSourceRoot,
     sourceRoot,
-    symlinks,
     tsconfigPaths,
     watchPaths,
   };
@@ -220,7 +220,7 @@ async function addTsConfigDependenciesForRoot(
   }
 }
 
-async function addDependencySymlinksForRoot(
+async function addDependencyMountsForRoot(
   state: SnapshotPlanState,
   packageRoot: string,
 ): Promise<void> {
@@ -228,58 +228,60 @@ async function addDependencySymlinksForRoot(
 
   for (const dependencyName of dependencyNames) {
     for (const nodeModulesRoot of [packageRoot, state.sourceRoot]) {
-      const linkPath = joinNodeModulesPackagePath(nodeModulesRoot, dependencyName);
-      await addDependencySymlink(state, linkPath);
+      const mountPath = joinNodeModulesPackagePath(nodeModulesRoot, dependencyName);
+      await addDependencyMount(state, mountPath);
     }
   }
 }
 
-async function addDependencySymlink(state: SnapshotPlanState, linkPath: string): Promise<void> {
-  let linkStats: Awaited<ReturnType<typeof lstat>>;
+async function addDependencyMount(state: SnapshotPlanState, mountPath: string): Promise<void> {
+  let mountStats: Awaited<ReturnType<typeof lstat>>;
 
   try {
-    linkStats = await lstat(linkPath);
+    mountStats = await lstat(mountPath);
   } catch {
     return;
   }
 
-  if (!linkStats.isSymbolicLink()) {
+  if (!mountStats.isDirectory() && !mountStats.isSymbolicLink()) {
     return;
   }
 
-  const targetPathCandidates = await resolveSymlinkTargetPathCandidates(linkPath);
-  const localTargetPath = targetPathCandidates.find((candidate) =>
+  // Installation topology does not express ownership: npm and hoisted Yarn
+  // use directories where pnpm uses links for the same installed package.
+  const sourcePathCandidates = await resolveDependencySourcePathCandidates(mountPath);
+  const workspaceSourcePath = sourcePathCandidates.find((candidate) =>
     isAuthoredSourcePath(candidate, state.sourceRoot),
   );
 
-  if (localTargetPath !== undefined) {
-    await addLocalDependencySymlink({
-      linkPath,
+  if (workspaceSourcePath !== undefined) {
+    await addWorkspaceDependencyMount({
+      mountPath,
       state,
-      targetPath: localTargetPath,
+      sourcePath: workspaceSourcePath,
     });
     return;
   }
 
-  const externalTargetPath = targetPathCandidates.find((candidate) => existsSync(candidate));
+  const installedSourcePath = sourcePathCandidates.find((candidate) => existsSync(candidate));
 
-  if (externalTargetPath === undefined) {
+  if (installedSourcePath === undefined) {
     return;
   }
 
-  state.symlinksByLinkPath.set(resolve(linkPath), {
-    linkPath: resolve(linkPath),
-    targetKind: "external",
-    targetPath: externalTargetPath,
+  state.dependencyMountsByPath.set(resolve(mountPath), {
+    mountPath: resolve(mountPath),
+    sourceKind: "installed",
+    sourcePath: installedSourcePath,
   });
 }
 
-async function addLocalDependencySymlink(input: {
-  readonly linkPath: string;
+async function addWorkspaceDependencyMount(input: {
+  readonly mountPath: string;
   readonly state: SnapshotPlanState;
-  readonly targetPath: string;
+  readonly sourcePath: string;
 }): Promise<void> {
-  const packageRoot = await resolveNearestPackageRoot(input.targetPath, input.state.sourceRoot);
+  const packageRoot = await resolveNearestPackageRoot(input.sourcePath, input.state.sourceRoot);
 
   if (packageRoot === undefined || !isAuthoredSourcePath(packageRoot, input.state.sourceRoot)) {
     return;
@@ -288,27 +290,27 @@ async function addLocalDependencySymlink(input: {
   const { state } = input;
 
   enqueueLocalRoot(state, packageRoot);
-  state.symlinksByLinkPath.set(resolve(input.linkPath), {
-    linkPath: resolve(input.linkPath),
-    targetKind: "local",
-    targetPath: packageRoot,
+  state.dependencyMountsByPath.set(resolve(input.mountPath), {
+    mountPath: resolve(input.mountPath),
+    sourceKind: "workspace",
+    sourcePath: packageRoot,
   });
 }
 
-async function resolveSymlinkTargetPathCandidates(linkPath: string): Promise<string[]> {
+async function resolveDependencySourcePathCandidates(mountPath: string): Promise<string[]> {
   const candidates = new Set<string>();
 
   try {
-    const declaredTarget = await readlink(linkPath);
-    candidates.add(resolve(dirname(linkPath), declaredTarget));
+    const declaredTarget = await readlink(mountPath);
+    candidates.add(resolve(dirname(mountPath), declaredTarget));
   } catch {
     // Continue to canonical target fallback below.
   }
 
   try {
-    candidates.add(await realpath(linkPath));
+    candidates.add(await realpath(mountPath));
   } catch {
-    // Broken symlinks are ignored by the caller.
+    // Broken dependency entries are ignored by the caller.
   }
 
   return [...candidates];
@@ -536,8 +538,8 @@ function createWatchPaths(input: {
   readonly appRoot: string;
   readonly copyFiles: readonly string[];
   readonly copyRoots: readonly string[];
+  readonly dependencyMounts: readonly DevelopmentSourceSnapshotDependencyMount[];
   readonly sourceRoot: string;
-  readonly symlinks: readonly DevelopmentSourceSnapshotSymlink[];
   readonly tsconfigPaths: readonly string[];
 }): string[] {
   const watchPaths = new Set<string>([
@@ -552,9 +554,9 @@ function createWatchPaths(input: {
     }
   }
 
-  for (const symlink of input.symlinks) {
-    if (symlink.targetKind === "local" && symlink.targetPath !== input.appRoot) {
-      watchPaths.add(symlink.targetPath);
+  for (const mount of input.dependencyMounts) {
+    if (mount.sourceKind === "workspace" && mount.sourcePath !== input.appRoot) {
+      watchPaths.add(mount.sourcePath);
     }
   }
 


### PR DESCRIPTION
### Description

Fix `eve dev` snapshots that fail to resolve extension modules when npm, Yarn, or a hoisted install stores dependencies as physical `node_modules` directories. The snapshot planner now mounts declared dependencies independently of package-manager topology: workspace dependencies are copied and linked inside the snapshot, while installed packages are exposed as build inputs so ordinary dependencies are bundled and configured externals retain runtime resolution. Existing pnpm symlink behavior remains covered.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts` (18 tests)
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/dev-generation-artifacts.scenario.test.ts` (8 tests)
- `pnpm --filter eve typecheck`
- `pnpm exec oxlint` on the changed TypeScript files
- `pnpm guard:invariants`
- `pnpm --filter eve build`
- Manually ran the local CLI against an npm-installed `@upstash/agentkit-eve-extension` project and confirmed `eve dev` reached the interactive UI

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)