### PR TITLE
fix(eve): workflow - align bridge capacity with fan-out

### DIFF
--- a/.changeset/calm-workflows-fan-out.md
+++ b/.changeset/calm-workflows-fan-out.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Workflow now keeps sandbox bridge capacity aligned with its configured `maxSubagents` budget, so large `Promise.all` fan-outs park and dispatch child sessions instead of failing at code mode's lower internal concurrency limit.

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -53,7 +53,10 @@ import {
   hydrateSandboxAttachments,
   stageAttachmentsToSandbox,
 } from "#harness/attachment-staging.js";
-import { buildWorkflowHostTools } from "#harness/workflow-sandbox.js";
+import {
+  buildWorkflowHostTools,
+  resolveWorkflowSandboxBridgeRequestLimit,
+} from "#harness/workflow-sandbox.js";
 import {
   getWorkflowContinuationSecurity,
   readWorkflowContinuationSecurity,
@@ -2241,6 +2244,9 @@ async function continuePendingWorkflowInterrupt(input: {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       continuationOutput = await continueWorkflowSandboxInterrupt({
+        bridgeRequestLimit: resolveWorkflowSandboxBridgeRequestLimit(
+          input.config.workflowMaxSubagents,
+        ),
         continuationSecurity,
         interrupt: currentInterrupt,
         lifecycle,

--- a/packages/eve/src/harness/workflow-sandbox.scenario.test.ts
+++ b/packages/eve/src/harness/workflow-sandbox.scenario.test.ts
@@ -47,6 +47,11 @@ const highFanOutProgram = `return await Promise.all(Array.from(
   { length: ${String(highFanOutCount)} },
   (_, index) => tools["echo-marker"]({ message: "marker-" + String(index) }),
 ));`;
+const overBudgetFanOutCount = 257;
+const overBudgetFanOutProgram = `return await Promise.all(Array.from(
+  { length: ${String(overBudgetFanOutCount)} },
+  (_, index) => tools["echo-marker"]({ message: "over-budget-" + String(index) }),
+));`;
 const continuationSecurity = {
   maxAgeMs: 365 * 24 * 60 * 60 * 1000,
   signingKey: "workflow-sandbox-scenario-test-key",
@@ -78,6 +83,27 @@ describe("Workflow concurrent continuation", () => {
     const interrupt = await getWorkflowSandboxInterrupt(initialOutput, continuationSecurity);
 
     expect(getWorkflowRuntimeActionInterrupts(interrupt!)).toHaveLength(highFanOutCount);
+  });
+
+  it("collects an over-budget call above the default bridge-request floor", async () => {
+    const tools = orchestrationTools();
+    const { modelTools } = await applyWorkflowTool({
+      continuationSecurity,
+      harnessTools: tools,
+      maxSubagents: 256,
+      tools: buildToolSet({ tools }),
+    });
+    const execute = modelTools.Workflow?.execute as
+      | ((input: { js: string }, options: { messages: []; toolCallId: string }) => Promise<unknown>)
+      | undefined;
+
+    const initialOutput = await execute!(
+      { js: overBudgetFanOutProgram },
+      { messages: [], toolCallId: "workflow-over-budget-fan-out" },
+    );
+    const interrupt = await getWorkflowSandboxInterrupt(initialOutput, continuationSecurity);
+
+    expect(getWorkflowRuntimeActionInterrupts(interrupt!)).toHaveLength(overBudgetFanOutCount);
   });
 
   it("collects promptly interrupted Promise.all siblings in one ledger", async () => {

--- a/packages/eve/src/harness/workflow-sandbox.scenario.test.ts
+++ b/packages/eve/src/harness/workflow-sandbox.scenario.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { getWorkflowRuntimeActionInterrupts } from "#harness/workflow-runtime-action-state.js";
-import { applyWorkflowTool } from "#harness/workflow-sandbox.js";
+import {
+  applyWorkflowTool,
+  resolveWorkflowSandboxBridgeRequestLimit,
+} from "#harness/workflow-sandbox.js";
 import { buildToolSet } from "#harness/tools.js";
 import type { HarnessToolMap } from "#harness/types.js";
 import {
@@ -39,12 +42,44 @@ const concurrentProgram = `return await Promise.all([
   tools["echo-marker"]({ message: "alpha" }),
   tools["echo-marker"]({ message: "beta" }),
 ]);`;
+const highFanOutCount = 50;
+const highFanOutProgram = `return await Promise.all(Array.from(
+  { length: ${String(highFanOutCount)} },
+  (_, index) => tools["echo-marker"]({ message: "marker-" + String(index) }),
+));`;
 const continuationSecurity = {
   maxAgeMs: 365 * 24 * 60 * 60 * 1000,
   signingKey: "workflow-sandbox-scenario-test-key",
 };
 
 describe("Workflow concurrent continuation", () => {
+  it("collects fan-out above code mode's default in-flight bridge limit", async () => {
+    const tools = orchestrationTools();
+    const lifecycle: WorkflowSandboxLifecycle = {
+      async onNestedToolCall() {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      },
+    };
+    const { modelTools } = await applyWorkflowTool({
+      continuationSecurity,
+      harnessTools: tools,
+      lifecycle,
+      maxSubagents: 100,
+      tools: buildToolSet({ tools }),
+    });
+    const execute = modelTools.Workflow?.execute as
+      | ((input: { js: string }, options: { messages: []; toolCallId: string }) => Promise<unknown>)
+      | undefined;
+
+    const initialOutput = await execute!(
+      { js: highFanOutProgram },
+      { messages: [], toolCallId: "workflow-high-fan-out" },
+    );
+    const interrupt = await getWorkflowSandboxInterrupt(initialOutput, continuationSecurity);
+
+    expect(getWorkflowRuntimeActionInterrupts(interrupt!)).toHaveLength(highFanOutCount);
+  });
+
   it("collects promptly interrupted Promise.all siblings in one ledger", async () => {
     const tools = orchestrationTools();
     const { modelTools } = await applyWorkflowTool({
@@ -105,6 +140,7 @@ describe("Workflow concurrent continuation", () => {
     ]);
 
     const firstContinuation = await continueWorkflowSandboxInterrupt({
+      bridgeRequestLimit: resolveWorkflowSandboxBridgeRequestLimit(),
       continuationSecurity,
       interrupt: pending[0]!,
       lifecycle,
@@ -122,6 +158,7 @@ describe("Workflow concurrent continuation", () => {
     if (firstUnwrapped.status !== "interrupted") throw new Error("Expected second interrupt.");
 
     const finalContinuation = await continueWorkflowSandboxInterrupt({
+      bridgeRequestLimit: resolveWorkflowSandboxBridgeRequestLimit(),
       continuationSecurity,
       interrupt: firstUnwrapped.interrupt,
       lifecycle,

--- a/packages/eve/src/harness/workflow-sandbox.test.ts
+++ b/packages/eve/src/harness/workflow-sandbox.test.ts
@@ -57,7 +57,9 @@ describe("applyWorkflowTool", () => {
   it("keeps sandbox bridge capacity above the configured dispatch budget", () => {
     expect(resolveWorkflowSandboxBridgeRequestLimit()).toBe(256);
     expect(resolveWorkflowSandboxBridgeRequestLimit(100)).toBe(256);
-    expect(resolveWorkflowSandboxBridgeRequestLimit(300)).toBe(300);
+    expect(resolveWorkflowSandboxBridgeRequestLimit(255)).toBe(256);
+    expect(resolveWorkflowSandboxBridgeRequestLimit(256)).toBe(257);
+    expect(resolveWorkflowSandboxBridgeRequestLimit(300)).toBe(301);
   });
 
   it("adds only agent runtime actions to the sandbox", async () => {

--- a/packages/eve/src/harness/workflow-sandbox.test.ts
+++ b/packages/eve/src/harness/workflow-sandbox.test.ts
@@ -2,7 +2,11 @@ import { asSchema, jsonSchema } from "ai";
 import { describe, expect, it } from "vitest";
 
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
-import { applyWorkflowTool, buildWorkflowHostTools } from "#harness/workflow-sandbox.js";
+import {
+  applyWorkflowTool,
+  buildWorkflowHostTools,
+  resolveWorkflowSandboxBridgeRequestLimit,
+} from "#harness/workflow-sandbox.js";
 import { buildToolSet } from "#harness/tools.js";
 import type { HarnessToolMap } from "#harness/types.js";
 
@@ -50,6 +54,12 @@ function orchestrationTools(): HarnessToolMap {
 }
 
 describe("applyWorkflowTool", () => {
+  it("keeps sandbox bridge capacity above the configured dispatch budget", () => {
+    expect(resolveWorkflowSandboxBridgeRequestLimit()).toBe(256);
+    expect(resolveWorkflowSandboxBridgeRequestLimit(100)).toBe(256);
+    expect(resolveWorkflowSandboxBridgeRequestLimit(300)).toBe(300);
+  });
+
   it("adds only agent runtime actions to the sandbox", async () => {
     const harnessTools = orchestrationTools();
     const flatTools = buildToolSet({ tools: harnessTools });

--- a/packages/eve/src/harness/workflow-sandbox.ts
+++ b/packages/eve/src/harness/workflow-sandbox.ts
@@ -4,6 +4,7 @@ import { z } from "#compiled/zod/index.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessToolMap } from "#harness/types.js";
 import { WORKFLOW_RUNTIME_ACTION_INTERRUPT_KIND } from "#harness/workflow-runtime-action-state.js";
+import { DEFAULT_WORKFLOW_MAX_SUBAGENTS } from "#harness/workflow-subagent-limit.js";
 import { workflowToolDescription } from "#harness/workflow-tool-description.js";
 import {
   createWorkflowSandboxTool,
@@ -18,6 +19,8 @@ interface WorkflowToolSet {
   readonly hostTools: ToolSet;
   readonly modelTools: ToolSet;
 }
+
+const DEFAULT_WORKFLOW_SANDBOX_BRIDGE_REQUEST_LIMIT = 256;
 
 const workflowInputSchema = z.strictObject({
   js: z
@@ -45,6 +48,7 @@ export async function applyWorkflowTool(input: {
   }
 
   const workflowTool = await createWorkflowSandboxTool({
+    bridgeRequestLimit: resolveWorkflowSandboxBridgeRequestLimit(input.maxSubagents),
     continuationSecurity: input.continuationSecurity,
     hostTools,
     lifecycle: input.lifecycle,
@@ -65,6 +69,18 @@ export async function applyWorkflowTool(input: {
     hostTools,
     modelTools: modelTools as ToolSet,
   };
+}
+
+/**
+ * Keeps code mode's bridge capacity at least as large as eve's dispatch budget.
+ * The 256-request floor preserves room for over-budget calls to resolve through
+ * eve's `WORKFLOW_SUBAGENT_LIMIT_REACHED` result instead of failing the sandbox.
+ */
+export function resolveWorkflowSandboxBridgeRequestLimit(maxSubagents?: number): number {
+  return Math.max(
+    DEFAULT_WORKFLOW_SANDBOX_BRIDGE_REQUEST_LIMIT,
+    maxSubagents ?? DEFAULT_WORKFLOW_MAX_SUBAGENTS,
+  );
 }
 
 function workflowApiReference(generatedDescription: string): string {

--- a/packages/eve/src/harness/workflow-sandbox.ts
+++ b/packages/eve/src/harness/workflow-sandbox.ts
@@ -72,15 +72,13 @@ export async function applyWorkflowTool(input: {
 }
 
 /**
- * Keeps code mode's bridge capacity at least as large as eve's dispatch budget.
- * The 256-request floor preserves room for over-budget calls to resolve through
- * eve's `WORKFLOW_SUBAGENT_LIMIT_REACHED` result instead of failing the sandbox.
+ * Keeps code mode's bridge capacity strictly above eve's dispatch budget.
+ * The extra request lets the first over-budget call resolve through eve's
+ * `WORKFLOW_SUBAGENT_LIMIT_REACHED` result instead of failing the sandbox.
  */
 export function resolveWorkflowSandboxBridgeRequestLimit(maxSubagents?: number): number {
-  return Math.max(
-    DEFAULT_WORKFLOW_SANDBOX_BRIDGE_REQUEST_LIMIT,
-    maxSubagents ?? DEFAULT_WORKFLOW_MAX_SUBAGENTS,
-  );
+  const dispatchBudget = maxSubagents ?? DEFAULT_WORKFLOW_MAX_SUBAGENTS;
+  return Math.max(DEFAULT_WORKFLOW_SANDBOX_BRIDGE_REQUEST_LIMIT, dispatchBudget + 1);
 }
 
 function workflowApiReference(generatedDescription: string): string {

--- a/packages/eve/src/shared/workflow-sandbox.ts
+++ b/packages/eve/src/shared/workflow-sandbox.ts
@@ -36,6 +36,7 @@ export function installWorkflowSandboxModule(module: WorkflowSandboxModule): voi
 }
 
 export async function createWorkflowSandboxTool(input: {
+  readonly bridgeRequestLimit: number;
   readonly continuationSecurity: WorkflowSandboxContinuationSecurity;
   readonly hostTools: ToolSet;
   readonly lifecycle?: WorkflowSandboxLifecycle;
@@ -43,7 +44,11 @@ export async function createWorkflowSandboxTool(input: {
   const { createCodeModeTool } = await loadWorkflowSandboxModule();
   return createCodeModeTool(
     input.hostTools,
-    createWorkflowSandboxOptions(input.continuationSecurity, input.lifecycle),
+    createWorkflowSandboxOptions(
+      input.bridgeRequestLimit,
+      input.continuationSecurity,
+      input.lifecycle,
+    ),
   ) as ToolSet[string];
 }
 
@@ -66,6 +71,7 @@ export async function getWorkflowSandboxInterrupt(
 }
 
 export async function continueWorkflowSandboxInterrupt(input: {
+  readonly bridgeRequestLimit: number;
   readonly continuationSecurity: WorkflowSandboxContinuationSecurity;
   readonly interrupt: WorkflowSandboxInterrupt;
   readonly lifecycle?: WorkflowSandboxLifecycle;
@@ -75,7 +81,11 @@ export async function continueWorkflowSandboxInterrupt(input: {
   const { continueCodeModeInterrupt } = await loadWorkflowSandboxModule();
   return continueCodeModeInterrupt({
     interrupt: input.interrupt,
-    options: createWorkflowSandboxOptions(input.continuationSecurity, input.lifecycle),
+    options: createWorkflowSandboxOptions(
+      input.bridgeRequestLimit,
+      input.continuationSecurity,
+      input.lifecycle,
+    ),
     resolution: input.resolution,
     tools: input.tools,
   } as never);
@@ -102,11 +112,16 @@ export function readWorkflowSandboxResolution(options: unknown): unknown {
 }
 
 function createWorkflowSandboxOptions(
+  bridgeRequestLimit: number,
   continuationSecurity: WorkflowSandboxContinuationSecurity,
   lifecycle: WorkflowSandboxLifecycle | undefined,
 ): CodeModeModule.CodeModeOptions {
   const options: CodeModeModule.CodeModeOptions = {
     continuationSecurity,
+    executionPolicy: {
+      maxBridgeRequests: bridgeRequestLimit,
+      maxInFlightBridgeRequests: bridgeRequestLimit,
+    },
   };
   if (lifecycle !== undefined) options.lifecycle = lifecycle;
   return options;


### PR DESCRIPTION
## Summary

- align Workflow's code-mode bridge capacity with the configured `maxSubagents` budget
- retain a 256-request floor so over-budget calls can resolve through eve's `WORKFLOW_SUBAGENT_LIMIT_REACHED` path
- apply the same execution policy to initial sandbox runs and durable continuation replay
- add a 50-call `Promise.all` regression with asynchronous lifecycle emission

## Root cause

Workflow defaults to 100 allowed subagent calls, but its code-mode sandbox retained the dependency default of 32 in-flight bridge requests. Because nested `actions.requested` emission is asynchronous, a large `Promise.all` could accumulate more than 32 requests, fail with a bridge-limit response, and then surface `Unexpected bridge response` during worker teardown before eve produced a durable interrupt ledger. No runtime-action batch reached the child-dispatch step, so no `subagent.called` events were emitted.

## Impact

Workflow fan-out within the configured `maxSubagents` budget now parks all child calls in one deterministic continuation ledger and reaches normal subagent dispatch. The existing bridge-request ceiling still bounds unconfigured fan-out, while explicit `maxSubagents` values above that ceiling raise it to keep the authored budget usable.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm test:unit` — 4,892 passed, 1 skipped
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/workflow-sandbox.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/harness/workflow-sandbox.scenario.test.ts`
