### PR TITLE
fix(eve): Fix incorrect overwrite of bot text when a single turn emits many messages

### DIFF
--- a/.changeset/fix-multi-message-turn-reducer.md
+++ b/.changeset/fix-multi-message-turn-reducer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fixed the default chat message reducer dropping assistant text when a single turn produced more than one message — for example, text shown before an OAuth authorization prompt was overwritten by the text that followed it once authorization completed. Each message now renders in the order it arrived.

--- a/packages/eve/src/client/message-action-parts.ts
+++ b/packages/eve/src/client/message-action-parts.ts
@@ -1,0 +1,156 @@
+import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
+import type { InputRequest } from "#runtime/input/types.js";
+import type {
+  EveDynamicToolPart,
+  EveMessageInputRequest,
+  EveMessageToolMetadata,
+} from "#client/message-reducer-types.js";
+
+/**
+ * Normalized tool descriptor derived from a runtime action request or result.
+ *
+ * The default message reducer projects load-skill, subagent, remote-agent, and
+ * plain tool calls onto a single `dynamic-tool` UI part; this descriptor is the
+ * shared shape those variants collapse to before rendering.
+ */
+export interface ActionDescriptor {
+  readonly kind: "load-skill" | "subagent-call" | "tool-call";
+  readonly name: string;
+  readonly toolName: string;
+}
+
+/** Projects a runtime input request onto its UI-facing subset. */
+export function toMessageInputRequest(request: InputRequest): EveMessageInputRequest {
+  return {
+    allowFreeform: request.allowFreeform,
+    display: request.display,
+    options: request.options,
+    prompt: request.prompt,
+    requestId: request.requestId,
+  };
+}
+
+/** Builds tool metadata for a freshly projected tool part. */
+export function createToolMetadata(
+  descriptor: ActionDescriptor,
+  extra?: { readonly inputRequest?: EveMessageInputRequest },
+): EveMessageToolMetadata {
+  return {
+    eve: {
+      inputRequest: extra?.inputRequest,
+      kind: descriptor.kind,
+      name: descriptor.name,
+    },
+  };
+}
+
+/**
+ * Merges freshly derived tool metadata over any metadata already attached to a
+ * tool part, preferring the new values while preserving earlier request and
+ * response context.
+ */
+export function mergeToolMetadata(
+  current: EveMessageToolMetadata | undefined,
+  next: EveMessageToolMetadata,
+): EveMessageToolMetadata {
+  const kind = next.eve?.kind ?? current?.eve?.kind ?? "unknown";
+  const name = next.eve?.name ?? current?.eve?.name ?? "unknown";
+
+  return {
+    eve: {
+      ...current?.eve,
+      ...next.eve,
+      inputRequest: next.eve?.inputRequest ?? current?.eve?.inputRequest,
+      inputResponse: next.eve?.inputResponse ?? current?.eve?.inputResponse,
+      kind,
+      name,
+    },
+  };
+}
+
+/**
+ * Derives the approved-approval descriptor a resolved tool result carries
+ * forward, or `undefined` when the tool part never had an approval.
+ */
+export function approvedApproval(part: EveDynamicToolPart | undefined):
+  | {
+      readonly id: string;
+      readonly approved: true;
+      readonly reason?: string;
+      readonly isAutomatic?: boolean;
+    }
+  | undefined {
+  if (!part?.approval?.id) {
+    return undefined;
+  }
+  return {
+    approved: true,
+    id: part.approval.id,
+    isAutomatic: part.approval.isAutomatic,
+    reason: part.approval.reason,
+  };
+}
+
+/** Maps a runtime action request onto its normalized tool descriptor. */
+export function normalizeActionRequest(action: RuntimeActionRequest): ActionDescriptor {
+  switch (action.kind) {
+    case "load-skill":
+      return {
+        kind: "load-skill",
+        name: "load_skill",
+        toolName: "eve:load-skill",
+      };
+    case "tool-call":
+      return {
+        kind: "tool-call",
+        name: action.toolName,
+        toolName: action.toolName,
+      };
+    case "subagent-call":
+      return {
+        kind: "subagent-call",
+        name: action.subagentName,
+        toolName: `eve:subagent:${action.subagentName}`,
+      };
+    case "remote-agent-call":
+      return {
+        kind: "subagent-call",
+        name: action.remoteAgentName,
+        toolName: `eve:subagent:${action.remoteAgentName}`,
+      };
+  }
+}
+
+/** Maps a runtime action result onto its normalized tool descriptor. */
+export function normalizeActionResult(result: RuntimeActionResult): ActionDescriptor {
+  switch (result.kind) {
+    case "load-skill-result":
+      return {
+        kind: "load-skill",
+        name: result.name ?? "load_skill",
+        toolName: "eve:load-skill",
+      };
+    case "tool-result":
+      return {
+        kind: "tool-call",
+        name: result.toolName,
+        toolName: result.toolName,
+      };
+    case "subagent-result":
+      return {
+        kind: "subagent-call",
+        name: result.subagentName,
+        toolName: `eve:subagent:${result.subagentName}`,
+      };
+  }
+}
+
+/** Best-effort string rendering of an unknown tool output for error display. */
+export function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "Action failed.";
+  }
+}

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -651,6 +651,78 @@ describe("defaultMessageReducer", () => {
     ]);
   });
 
+  it("keeps multiple text runs within a single step as separate parts", () => {
+    // Regression test for https://github.com/vercel/eve/issues/436: a step can
+    // legitimately produce text, call tools, then produce more text. Keying
+    // text parts by stepIndex alone drops the first run and reorders the second
+    // ahead of the tool call.
+    const reducer = defaultMessageReducer();
+    let data = reducer.initial();
+
+    data = reducer.reduce(
+      data,
+      createMessageAppendedEvent({
+        messageDelta: "Checking Vienna",
+        messageSoFar: "Checking Vienna",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        finishReason: "tool-calls",
+        message: "Checking Vienna first.",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createActionsRequestedEvent({
+        actions: [
+          {
+            callId: "call_1",
+            input: { city: "Vienna" },
+            kind: "tool-call",
+            toolName: "get_weather",
+          },
+        ],
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageAppendedEvent({
+        messageDelta: "Now Berlin",
+        messageSoFar: "Now Berlin",
+        sequence: 3,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+    data = reducer.reduce(
+      data,
+      createMessageCompletedEvent({
+        message: "Now checking Berlin.",
+        sequence: 4,
+        stepIndex: 0,
+        turnId: "turn_0",
+      }),
+    );
+
+    const assistant = data.messages.find((message) => message.id === "turn_0:assistant");
+    expect(
+      assistant?.parts
+        .filter((part) => part.type === "text" || part.type === "dynamic-tool")
+        .map((part) => (part.type === "text" ? part.text : `tool:${part.toolCallId}`)),
+    ).toEqual(["Checking Vienna first.", "tool:call_1", "Now checking Berlin."]);
+  });
+
   it("finalizes partial streamed message and reasoning when the turn is cancelled", () => {
     const reducer = defaultMessageReducer();
     let data = reducer.reduce(

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -7,14 +7,20 @@ import type {
   EveAuthorizationPart,
   EveMessageData,
   EveDynamicToolPart,
-  EveMessageInputRequest,
   EveMessage,
   EveMessageMetadata,
   EveMessagePart,
-  EveMessageToolMetadata,
 } from "#client/message-reducer-types.js";
-import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
-import type { InputRequest, InputResponse } from "#runtime/input/types.js";
+import {
+  approvedApproval,
+  createToolMetadata,
+  mergeToolMetadata,
+  normalizeActionRequest,
+  normalizeActionResult,
+  stringifyUnknown,
+  toMessageInputRequest,
+} from "#client/message-action-parts.js";
+import type { InputResponse } from "#runtime/input/types.js";
 import type { AuthorizationCompletedStreamEvent, MessageReceivedPart } from "#protocol/message.js";
 
 export type {
@@ -31,12 +37,6 @@ export type {
 } from "#client/message-reducer-types.js";
 
 type EveAssistantMessage = EveMessage & { readonly role: "assistant" };
-
-interface ActionDescriptor {
-  readonly kind: "load-skill" | "subagent-call" | "tool-call";
-  readonly name: string;
-  readonly toolName: string;
-}
 
 /**
  * Creates a UIMessage-compatible eve reducer for chat and agent UIs.
@@ -591,128 +591,6 @@ function upsertMessage(data: EveMessageData, next: EveMessage): EveMessageData {
   };
 }
 
-function toMessageInputRequest(request: InputRequest): EveMessageInputRequest {
-  return {
-    allowFreeform: request.allowFreeform,
-    display: request.display,
-    options: request.options,
-    prompt: request.prompt,
-    requestId: request.requestId,
-  };
-}
-
-function createToolMetadata(
-  descriptor: ActionDescriptor,
-  extra?: { readonly inputRequest?: EveMessageInputRequest },
-): EveMessageToolMetadata {
-  return {
-    eve: {
-      inputRequest: extra?.inputRequest,
-      kind: descriptor.kind,
-      name: descriptor.name,
-    },
-  };
-}
-
-function mergeToolMetadata(
-  current: EveMessageToolMetadata | undefined,
-  next: EveMessageToolMetadata,
-): EveMessageToolMetadata {
-  const kind = next.eve?.kind ?? current?.eve?.kind ?? "unknown";
-  const name = next.eve?.name ?? current?.eve?.name ?? "unknown";
-
-  return {
-    eve: {
-      ...current?.eve,
-      ...next.eve,
-      inputRequest: next.eve?.inputRequest ?? current?.eve?.inputRequest,
-      inputResponse: next.eve?.inputResponse ?? current?.eve?.inputResponse,
-      kind,
-      name,
-    },
-  };
-}
-
-function approvedApproval(part: EveDynamicToolPart | undefined):
-  | {
-      readonly id: string;
-      readonly approved: true;
-      readonly reason?: string;
-      readonly isAutomatic?: boolean;
-    }
-  | undefined {
-  if (!part?.approval?.id) {
-    return undefined;
-  }
-  return {
-    approved: true,
-    id: part.approval.id,
-    isAutomatic: part.approval.isAutomatic,
-    reason: part.approval.reason,
-  };
-}
-
-function normalizeActionRequest(action: RuntimeActionRequest): ActionDescriptor {
-  switch (action.kind) {
-    case "load-skill":
-      return {
-        kind: "load-skill",
-        name: "load_skill",
-        toolName: "eve:load-skill",
-      };
-    case "tool-call":
-      return {
-        kind: "tool-call",
-        name: action.toolName,
-        toolName: action.toolName,
-      };
-    case "subagent-call":
-      return {
-        kind: "subagent-call",
-        name: action.subagentName,
-        toolName: `eve:subagent:${action.subagentName}`,
-      };
-    case "remote-agent-call":
-      return {
-        kind: "subagent-call",
-        name: action.remoteAgentName,
-        toolName: `eve:subagent:${action.remoteAgentName}`,
-      };
-  }
-}
-
-function normalizeActionResult(result: RuntimeActionResult): ActionDescriptor {
-  switch (result.kind) {
-    case "load-skill-result":
-      return {
-        kind: "load-skill",
-        name: result.name ?? "load_skill",
-        toolName: "eve:load-skill",
-      };
-    case "tool-result":
-      return {
-        kind: "tool-call",
-        name: result.toolName,
-        toolName: result.toolName,
-      };
-    case "subagent-result":
-      return {
-        kind: "subagent-call",
-        name: result.subagentName,
-        toolName: `eve:subagent:${result.subagentName}`,
-      };
-  }
-}
-
 function optimisticUserMessageId(submissionId: string): string {
   return `optimistic:${submissionId}:user`;
-}
-
-function stringifyUnknown(value: unknown): string {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return "Action failed.";
-  }
 }

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -107,7 +107,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
 
     case "reasoning.appended":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
-        upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        upsertRun(ensureStepStartPart(message, event.data.stepIndex), {
           state: "streaming",
           stepIndex: event.data.stepIndex,
           text: event.data.reasoningSoFar,
@@ -117,7 +117,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
 
     case "reasoning.completed":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
-        upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        upsertRun(ensureStepStartPart(message, event.data.stepIndex), {
           state: "done",
           stepIndex: event.data.stepIndex,
           text: event.data.reasoning,
@@ -238,7 +238,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
 
     case "message.appended":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
-        upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        upsertRun(ensureStepStartPart(message, event.data.stepIndex), {
           state: "streaming",
           stepIndex: event.data.stepIndex,
           text: event.data.messageSoFar,
@@ -252,7 +252,7 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
           return removeTextPart(message, event.data.stepIndex);
         }
 
-        return upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+        return upsertRun(ensureStepStartPart(message, event.data.stepIndex), {
           state: "done",
           stepIndex: event.data.stepIndex,
           text: event.data.message,
@@ -381,6 +381,41 @@ function upsertPart(message: EveAssistantMessage, next: EveMessagePart): EveAssi
     index === -1
       ? [...message.parts, next]
       : [...message.parts.slice(0, index), next, ...message.parts.slice(index + 1)];
+
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      status: next.type === "text" && next.state === "done" ? "complete" : "streaming",
+    },
+    parts,
+  };
+}
+
+type EveRunPart = Extract<EveMessagePart, { readonly type: "text" | "reasoning" }>;
+
+// Upserts a text/reasoning part, keeping multiple runs per step distinct: one
+// step can produce text, call tools, then produce more text (see
+// `MessageCompletedStreamEvent`), so a step-only key would collapse them.
+//
+// We find the latest same-step run of this type: while it is still streaming,
+// its snapshots replace it in place; once it is done (or there is none), `next`
+// begins a new run appended in arrival order.
+function upsertRun(message: EveAssistantMessage, next: EveRunPart): EveAssistantMessage {
+  let lastIndex = -1;
+  for (let index = message.parts.length - 1; index >= 0; index -= 1) {
+    const part = message.parts[index];
+    if (part?.type === next.type && part.stepIndex === next.stepIndex) {
+      lastIndex = index;
+      break;
+    }
+  }
+
+  const openRun =
+    lastIndex !== -1 && (message.parts[lastIndex] as EveRunPart).state === "streaming";
+  const parts = openRun
+    ? [...message.parts.slice(0, lastIndex), next, ...message.parts.slice(lastIndex + 1)]
+    : [...message.parts, next];
 
   return {
     ...message,


### PR DESCRIPTION
### Description


Addresses #436.

It's possible for a single turn to emit multiple messages, such as when an OAuth is triggered (which emits text -> triggers OAuth popup -> emits more text).

This PR adds a new resolver constructed slightly differently. It ensures that if the in-progress run is completed, a new text part will be added for a subsequent run rather than replacing the current part in-place. 

### How did you test your changes?

New unit test highlighting the single-turn, multiple-message case.
