### PR TITLE
test(eve): restore parallel-order check in dynamic-workflow with tolerant count

### DIFF
--- a/e2e/fixtures/agent-subagents/evals/dynamic-workflow.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/dynamic-workflow.eval.ts
@@ -26,9 +26,14 @@ export default defineEval({
 
     t.succeeded();
     t.calledTool("Workflow", { input: isFanOutProgram, count: 1 });
+    // Parallel fan-out: both echo-marker subagents are called before either
+    // completes. subagent.completed can be emitted more than once if the
+    // resolution step re-runs before commit (benign duplicate — client state is
+    // built from callId-deduped action.result), so tolerate >=2 here; the exact
+    // distinct count is pinned by calledSubagent below.
     turn.eventOrder([
       { type: "subagent.called", data: { name: "echo-marker" }, count: 2 },
-      { type: "subagent.completed", data: { subagentName: "echo-marker" }, count: 2 },
+      { type: "subagent.completed", data: { subagentName: "echo-marker" }, count: (n) => n >= 2 },
     ]);
     t.calledSubagent("echo-marker", {
       output: /SUBAGENT_TOKEN=echo-marker-9F2X/,


### PR DESCRIPTION
## What

A prior change dropped the `subagent.completed` entry from `dynamic-workflow`'s `eventOrder` to stop a flake. That stopped the flake but also dropped the **parallel-vs-serial invariant**: `eventOrder` requires *both* `subagent.called` before *any* `subagent.completed`, so a serial fan-out would fail on ordering.

## Why the flake happens (root cause)

Intermittently, the workflow **re-executes the resolution step after the step has been called but before it commits**. The step's side-effects have already fired — including the streamed `subagent.completed` emit — and there is **no pre-commit step idempotency guard**, so on the re-execution the emit fires again. Result: 2 subagents produce 4 `subagent.completed` events (each completion emitted twice). The committed state (tool results / message) is correct — only the pre-commit streamed side-effect is duplicated.

## Fix (this PR — eval side)

Restore the `subagent.completed` entry but with a **count predicate (`n => n >= 2`)** instead of exactly `2`:
- keeps the parallel-order check (both called before any completed),
- tolerates the duplicate emit (4 ≥ 2),
- `calledSubagent("echo-marker", { output, count: 2 })` still pins the exact **distinct** completion count.

The duplicate is benign to product consumers: the client reducer doesn't handle `subagent.completed` and builds message state from `action.result` (upserted by `callId`); only the eval's raw-event counting was sensitive to it.

## Follow-up (runtime)

The underlying issue is the missing **pre-commit step idempotency guard** — a step re-executed before commit re-runs its side-effects. Tracked separately as a runtime fix (guard streamed side-effects so a pre-commit re-execution doesn't double-emit); the duplicates are currently benign, so this is latent hardening, not urgent.