### PR TITLE
feat(eve): create minimal MCP server utility

### DIFF
--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -313,6 +313,7 @@
     "@chat-adapter/state-memory": "4.34.0",
     "@chat-adapter/twilio": "4.34.0",
     "@clack/core": "1.3.1",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@nuxt/kit": "^4.0.0",
     "@standard-schema/spec": "1.1.0",
     "@sveltejs/kit": "^2.0.0",

--- a/packages/eve/scripts/vendor-compiled/@modelcontextprotocol/sdk.mjs
+++ b/packages/eve/scripts/vendor-compiled/@modelcontextprotocol/sdk.mjs
@@ -1,0 +1,25 @@
+import { loadDeclaration } from "../_shared.mjs";
+
+export default {
+  packageName: "@modelcontextprotocol/sdk",
+  compiledPath: "@modelcontextprotocol/sdk",
+  chunkGroup: "workflow",
+  entries: [
+    {
+      entry: "dist/esm/server/index.js",
+      outputPath: "server",
+      declaration: await loadDeclaration("@modelcontextprotocol/server.d.ts"),
+    },
+    {
+      entry: "dist/esm/server/webStandardStreamableHttp.js",
+      outputPath: "web-standard-streamable-http",
+      declaration: await loadDeclaration("@modelcontextprotocol/web-standard-streamable-http.d.ts"),
+    },
+    {
+      entry: "dist/esm/types.js",
+      outputPath: "types",
+      declaration: await loadDeclaration("@modelcontextprotocol/types.d.ts"),
+    },
+  ],
+  platform: "neutral",
+};

--- a/packages/eve/scripts/vendor-compiled/declarations/@modelcontextprotocol/server.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@modelcontextprotocol/server.d.ts
@@ -1,0 +1,30 @@
+export interface McpSdkRequest {
+  readonly params?: Readonly<Record<string, unknown>>;
+}
+
+export interface McpRequestHandlerExtra {
+  readonly signal: AbortSignal;
+}
+
+export declare class Server {
+  constructor(
+    info: { readonly name: string; readonly version: string },
+    options?: {
+      readonly capabilities?: Readonly<Record<string, unknown>>;
+    },
+  );
+  connect(transport: WebStandardTransport): Promise<void>;
+  close(): Promise<void>;
+  setRequestHandler<Request extends McpSdkRequest, Result>(
+    schema: McpRequestSchema<Request>,
+    handler: (request: Request, extra: McpRequestHandlerExtra) => Result | Promise<Result>,
+  ): void;
+}
+
+interface McpRequestSchema<Request extends McpSdkRequest> {
+  readonly __request?: Request;
+}
+
+interface WebStandardTransport {
+  handleRequest(request: Request): Promise<Response>;
+}

--- a/packages/eve/scripts/vendor-compiled/declarations/@modelcontextprotocol/types.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@modelcontextprotocol/types.d.ts
@@ -1,0 +1,17 @@
+export interface CallToolRequest {
+  readonly params: {
+    readonly arguments?: Readonly<Record<string, unknown>>;
+    readonly name: string;
+  };
+}
+
+export interface ListToolsRequest {
+  readonly params?: Readonly<Record<string, unknown>>;
+}
+
+interface McpRequestSchema<Request> {
+  readonly __request?: Request;
+}
+
+export declare const CallToolRequestSchema: McpRequestSchema<CallToolRequest>;
+export declare const ListToolsRequestSchema: McpRequestSchema<ListToolsRequest>;

--- a/packages/eve/scripts/vendor-compiled/declarations/@modelcontextprotocol/web-standard-streamable-http.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@modelcontextprotocol/web-standard-streamable-http.d.ts
@@ -1,0 +1,7 @@
+export declare class WebStandardStreamableHTTPServerTransport {
+  constructor(options?: {
+    readonly enableJsonResponse?: boolean;
+    readonly sessionIdGenerator?: undefined;
+  });
+  handleRequest(request: Request): Promise<Response>;
+}

--- a/packages/eve/scripts/vendor-compiled/index.mjs
+++ b/packages/eve/scripts/vendor-compiled/index.mjs
@@ -15,6 +15,7 @@ import chatAdapterSlack from "./@chat-adapter/slack.mjs";
 import chatAdapterStateMemory from "./@chat-adapter/state-memory.mjs";
 import chatAdapterTwilio from "./@chat-adapter/twilio.mjs";
 
+import modelContextProtocolSdk from "./@modelcontextprotocol/sdk.mjs";
 import opentelemetryApi from "./@opentelemetry/api.mjs";
 import standardSchemaSpec from "./@standard-schema/spec.mjs";
 import vercelDetectAgent from "./@vercel/detect-agent.mjs";
@@ -62,6 +63,7 @@ export const MODULES = [
   jsonSchema,
   marked,
   mcp,
+  modelContextProtocolSdk,
   openai,
   opentelemetryApi,
   otel,

--- a/packages/eve/src/internal/mcp/protected-resource.test.ts
+++ b/packages/eve/src/internal/mcp/protected-resource.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createMcpAuthChallenge,
+  createMcpProtectedResourceMetadata,
+} from "#internal/mcp/protected-resource.js";
+
+describe("MCP protected-resource authentication", () => {
+  it("builds RFC 9728 metadata", () => {
+    expect(
+      createMcpProtectedResourceMetadata({
+        authorizationServers: ["https://issuer.example"],
+        resource: "https://agent.example/mcp",
+        scopesSupported: ["agent:invoke"],
+      }),
+    ).toEqual({
+      authorization_servers: ["https://issuer.example"],
+      resource: "https://agent.example/mcp",
+      scopes_supported: ["agent:invoke"],
+    });
+  });
+
+  it("challenges with the metadata URL", () => {
+    const response = createMcpAuthChallenge(
+      "https://agent.example/.well-known/oauth-protected-resource",
+    );
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe(
+      'Bearer resource_metadata="https://agent.example/.well-known/oauth-protected-resource"',
+    );
+  });
+});

--- a/packages/eve/src/internal/mcp/protected-resource.ts
+++ b/packages/eve/src/internal/mcp/protected-resource.ts
@@ -1,0 +1,37 @@
+export interface McpProtectedResourceMetadataOptions {
+  readonly authorizationServers: readonly string[];
+  readonly resource: string;
+  readonly scopesSupported?: readonly string[];
+}
+
+/** Creates RFC 9728 protected-resource metadata for an MCP endpoint. */
+export function createMcpProtectedResourceMetadata(
+  options: McpProtectedResourceMetadataOptions,
+): Readonly<Record<string, unknown>> {
+  const metadata: Record<string, unknown> = {
+    authorization_servers: options.authorizationServers,
+    resource: options.resource,
+  };
+  if (options.scopesSupported !== undefined) {
+    metadata.scopes_supported = options.scopesSupported;
+  }
+  return metadata;
+}
+
+/** Creates the MCP OAuth bearer challenge used to discover resource metadata. */
+export function createMcpAuthChallenge(resourceMetadataUrl: string): Response {
+  return Response.json(
+    { error: "unauthorized", error_description: "A bearer access token is required." },
+    {
+      headers: {
+        "cache-control": "no-store",
+        "www-authenticate": `Bearer resource_metadata="${escapeChallenge(resourceMetadataUrl)}"`,
+      },
+      status: 401,
+    },
+  );
+}
+
+function escapeChallenge(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}

--- a/packages/eve/src/internal/mcp/sdk-vendor-conformance.test.ts
+++ b/packages/eve/src/internal/mcp/sdk-vendor-conformance.test.ts
@@ -1,0 +1,39 @@
+import type { Server as UpstreamServer } from "@modelcontextprotocol/sdk/server/index.js";
+import type { WebStandardStreamableHTTPServerTransport as UpstreamTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type {
+  CallToolRequest as UpstreamCallToolRequest,
+  ListToolsRequest as UpstreamListToolsRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Server as VendoredServer } from "#compiled/@modelcontextprotocol/sdk/server.js";
+import type { WebStandardStreamableHTTPServerTransport as VendoredTransport } from "#compiled/@modelcontextprotocol/sdk/web-standard-streamable-http.js";
+import type {
+  CallToolRequest as VendoredCallToolRequest,
+  ListToolsRequest as VendoredListToolsRequest,
+} from "#compiled/@modelcontextprotocol/sdk/types.js";
+
+import { describe, expect, it } from "vitest";
+
+type IsAssignable<Source, Target> = [Source] extends [Target] ? true : false;
+
+type ConformanceAssertions = readonly [
+  IsAssignable<
+    ConstructorParameters<typeof VendoredServer>,
+    ConstructorParameters<typeof UpstreamServer>
+  >,
+  IsAssignable<UpstreamTransport, Parameters<VendoredServer["connect"]>[0]>,
+  IsAssignable<UpstreamServer["close"], VendoredServer["close"]>,
+  IsAssignable<
+    ConstructorParameters<typeof VendoredTransport>,
+    ConstructorParameters<typeof UpstreamTransport>
+  >,
+  IsAssignable<UpstreamTransport["handleRequest"], VendoredTransport["handleRequest"]>,
+  IsAssignable<UpstreamCallToolRequest, VendoredCallToolRequest>,
+  IsAssignable<UpstreamListToolsRequest, VendoredListToolsRequest>,
+];
+
+describe("vendored MCP SDK declarations", () => {
+  it("remain assignable from the installed SDK surface", () => {
+    const assertions: ConformanceAssertions = [true, true, true, true, true, true, true];
+    expect(assertions).not.toContain(false);
+  });
+});

--- a/packages/eve/src/internal/mcp/streamable-http-server.test.ts
+++ b/packages/eve/src/internal/mcp/streamable-http-server.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionAuthContext } from "#channel/types.js";
+import {
+  createMcpStreamableHttpServer,
+  MCP_PROTOCOL_VERSION,
+  McpServerToolError,
+} from "#internal/mcp/streamable-http-server.js";
+
+const auth: SessionAuthContext = {
+  attributes: {},
+  authenticator: "test",
+  principalId: "alice",
+  principalType: "user",
+};
+
+function request(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("https://agent.example/mcp", {
+    body: JSON.stringify(body),
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      ...headers,
+    },
+    method: "POST",
+  });
+}
+
+function server() {
+  const call = vi.fn(async (input: unknown) => ({
+    content: [{ text: JSON.stringify(input), type: "text" as const }],
+  }));
+  return {
+    call,
+    handle: createMcpStreamableHttpServer({
+      authenticate: async () => auth,
+      name: "eve-test",
+      tools: [
+        {
+          call,
+          definition: {
+            description: "Echoes input.",
+            inputSchema: { type: "object" },
+            name: "echo",
+          },
+        },
+      ],
+      version: "0.0.0",
+    }),
+  };
+}
+
+function initialize(handle: (request: Request) => Promise<Response>): Promise<Response> {
+  return handle(
+    request({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "eve-test-client", version: "0.0.0" },
+        protocolVersion: MCP_PROTOCOL_VERSION,
+      },
+    }),
+  );
+}
+
+describe("stateless MCP Streamable HTTP server", () => {
+  it("negotiates initialize and advertises tools", async () => {
+    const { handle } = server();
+    const initialized = await initialize(handle);
+    expect(await initialized.json()).toMatchObject({
+      id: 1,
+      result: {
+        capabilities: { tools: { listChanged: false } },
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        serverInfo: { name: "eve-test", version: "0.0.0" },
+      },
+    });
+    expect(initialized.headers.get("mcp-session-id")).toBeNull();
+
+    const listed = await handle(request({ id: 2, jsonrpc: "2.0", method: "tools/list" }));
+    expect(await listed.json()).toMatchObject({ result: { tools: [{ name: "echo" }] } });
+  });
+
+  it("calls tools with authenticated context and SDK cancellation", async () => {
+    const { call, handle } = server();
+    const response = await handle(
+      request({
+        id: "call-1",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { arguments: { value: 42 }, name: "echo" },
+      }),
+    );
+    expect(await response.json()).toMatchObject({
+      id: "call-1",
+      result: { content: [{ text: '{"value":42}', type: "text" }] },
+    });
+    expect(call).toHaveBeenCalledWith(
+      { value: 42 },
+      expect.objectContaining({ auth, signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("returns stable structured tool errors", async () => {
+    const handle = createMcpStreamableHttpServer({
+      authenticate: async () => auth,
+      name: "test",
+      tools: [
+        {
+          async call() {
+            throw new McpServerToolError("invalid_arguments", "value is required.");
+          },
+          definition: { inputSchema: { type: "object" }, name: "fail" },
+        },
+      ],
+      version: "0",
+    });
+
+    const response = await handle(
+      request({
+        id: 4,
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { arguments: {}, name: "fail" },
+      }),
+    );
+    expect(await response.json()).toMatchObject({
+      result: {
+        content: [{ text: '{"code":"invalid_arguments","message":"value is required."}' }],
+        isError: true,
+        structuredContent: { code: "invalid_arguments", message: "value is required." },
+      },
+    });
+  });
+
+  it("returns JSON-RPC errors and acknowledges notifications", async () => {
+    const { handle } = server();
+    const unknown = await handle(request({ id: 3, jsonrpc: "2.0", method: "unknown" }));
+    expect(await unknown.json()).toMatchObject({
+      error: { code: -32601, message: "Method not found" },
+      id: 3,
+      jsonrpc: "2.0",
+    });
+
+    const notification = await handle(
+      request({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    );
+    expect(notification.status).toBe(202);
+    expect(await notification.text()).toBe("");
+  });
+
+  it("authenticates before transport handling", async () => {
+    const challenge = new Response(null, {
+      headers: {
+        "www-authenticate":
+          'Bearer resource_metadata="https://agent.example/.well-known/oauth-protected-resource"',
+      },
+      status: 401,
+    });
+    const handle = createMcpStreamableHttpServer({
+      authenticate: async () => challenge,
+      name: "test",
+      tools: [],
+      version: "0",
+    });
+
+    const unauthorized = await handle(request("not relevant"));
+    expect(unauthorized.status).toBe(401);
+    expect(unauthorized.headers.get("www-authenticate")).toContain("resource_metadata=");
+  });
+
+  it("enforces Streamable HTTP media types", async () => {
+    const response = await server().handle(
+      request({ id: 1, jsonrpc: "2.0", method: "ping" }, { accept: "application/json" }),
+    );
+
+    expect(response.status).toBe(406);
+    expect(await response.json()).toMatchObject({ error: { code: -32000 } });
+  });
+
+  it("rejects duplicate tool names at construction", () => {
+    const tool = {
+      call: async () => ({ content: [] }),
+      definition: { inputSchema: {}, name: "duplicate" },
+    };
+    expect(() =>
+      createMcpStreamableHttpServer({
+        authenticate: async () => auth,
+        name: "test",
+        tools: [tool, tool],
+        version: "0",
+      }),
+    ).toThrow("MCP tool names must be unique");
+  });
+});

--- a/packages/eve/src/internal/mcp/streamable-http-server.ts
+++ b/packages/eve/src/internal/mcp/streamable-http-server.ts
@@ -1,0 +1,146 @@
+import {
+  CallToolRequestSchema,
+  type CallToolRequest,
+  ListToolsRequestSchema,
+} from "#compiled/@modelcontextprotocol/sdk/types.js";
+import { Server } from "#compiled/@modelcontextprotocol/sdk/server.js";
+import { WebStandardStreamableHTTPServerTransport } from "#compiled/@modelcontextprotocol/sdk/web-standard-streamable-http.js";
+
+import type { SessionAuthContext } from "#channel/types.js";
+
+export const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+export interface McpToolDefinition {
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+  readonly outputSchema?: Readonly<Record<string, unknown>>;
+}
+
+/** Stable structured tool failure surfaced to MCP clients. */
+export class McpServerToolError extends Error {
+  readonly code: string;
+  readonly data?: Readonly<Record<string, unknown>>;
+
+  constructor(code: string, message: string, data?: Readonly<Record<string, unknown>>) {
+    super(message);
+    this.name = "McpServerToolError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export interface McpCallToolResult {
+  readonly content: readonly McpContent[];
+  readonly isError?: boolean;
+  readonly structuredContent?: Readonly<Record<string, unknown>>;
+}
+
+export type McpContent =
+  | { readonly type: "text"; readonly text: string }
+  | { readonly type: "resource_link"; readonly name: string; readonly uri: string };
+
+export interface McpServerTool {
+  readonly definition: McpToolDefinition;
+  call(
+    input: unknown,
+    context: { readonly auth: SessionAuthContext; readonly signal: AbortSignal },
+  ): Promise<McpCallToolResult>;
+}
+
+export interface McpStreamableHttpServerOptions {
+  readonly name: string;
+  readonly version: string;
+  readonly tools: readonly McpServerTool[];
+  authenticate(request: Request): Promise<SessionAuthContext | Response>;
+}
+
+/**
+ * Creates a stateless MCP Streamable HTTP request handler.
+ *
+ * Each request gets a fresh SDK server and transport because the transport
+ * deliberately does not issue `Mcp-Session-Id` or retain process-local state.
+ */
+export function createMcpStreamableHttpServer(
+  options: McpStreamableHttpServerOptions,
+): (request: Request) => Promise<Response> {
+  const tools = new Map(options.tools.map((tool) => [tool.definition.name, tool]));
+  if (tools.size !== options.tools.length) throw new Error("MCP tool names must be unique.");
+
+  return async (request) => {
+    const auth = await options.authenticate(request);
+    if (auth instanceof Response) return auth;
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: undefined,
+    });
+    const server = createServer(options, tools, auth);
+    await server.connect(transport);
+
+    try {
+      return await transport.handleRequest(request);
+    } finally {
+      await server.close();
+    }
+  };
+}
+
+function createServer(
+  options: Pick<McpStreamableHttpServerOptions, "name" | "version">,
+  tools: ReadonlyMap<string, McpServerTool>,
+  auth: SessionAuthContext,
+): Server {
+  const server = new Server(
+    { name: options.name, version: options.version },
+    { capabilities: { tools: { listChanged: false } } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [...tools.values()].map((tool) => tool.definition),
+  }));
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request, extra) => await callTool(request, extra.signal, auth, tools),
+  );
+
+  return server;
+}
+
+async function callTool(
+  request: CallToolRequest,
+  signal: AbortSignal,
+  auth: SessionAuthContext,
+  tools: ReadonlyMap<string, McpServerTool>,
+): Promise<McpCallToolResult> {
+  const tool = tools.get(request.params.name);
+  if (tool === undefined) {
+    return toolError(
+      new McpServerToolError("unknown_tool", `Unknown tool: ${request.params.name}`),
+    );
+  }
+
+  try {
+    return await tool.call(request.params.arguments ?? {}, { auth, signal });
+  } catch (error) {
+    return toolError(normalizeToolError(error));
+  }
+}
+
+function normalizeToolError(error: unknown): McpServerToolError {
+  if (error instanceof McpServerToolError) return error;
+  return new McpServerToolError("internal_error", "Tool call failed.");
+}
+
+function toolError(error: McpServerToolError): McpCallToolResult {
+  const value: { code: string; data?: Readonly<Record<string, unknown>>; message: string } = {
+    code: error.code,
+    message: error.message,
+  };
+  if (error.data !== undefined) value.data = error.data;
+  return {
+    content: [{ type: "text", text: JSON.stringify(value) }],
+    isError: true,
+    structuredContent: value,
+  };
+}

--- a/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
@@ -173,6 +173,19 @@ describe("compiled vendor assets", () => {
     expect(runtimeRunDts).toContain("from '../_workflow-serde.js'");
   });
 
+  it("preserves the MCP SDK runtime exports used by eve", async () => {
+    const [server, transport, types] = await Promise.all([
+      import("#compiled/@modelcontextprotocol/sdk/server.js"),
+      import("#compiled/@modelcontextprotocol/sdk/web-standard-streamable-http.js"),
+      import("#compiled/@modelcontextprotocol/sdk/types.js"),
+    ]);
+
+    expect(server.Server).toBeTypeOf("function");
+    expect(transport.WebStandardStreamableHTTPServerTransport).toBeTypeOf("function");
+    expect(types.CallToolRequestSchema).toBeDefined();
+    expect(types.ListToolsRequestSchema).toBeDefined();
+  });
+
   it("vendors the Workflow world targets selected by generated Nitro plugins", async () => {
     const [localWorld, vercelWorld] = await Promise.all([
       readFile(join(COMPILED_VENDOR_ROOT, "@workflow/world-local/index.js"), "utf8"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1134,6 +1134,9 @@ importers:
       '@clack/core':
         specifier: 1.3.1
         version: 1.3.1
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(supports-color@10.2.2)(zod@4.4.3)
       '@nuxt/kit':
         specifier: ^4.0.0
         version: 4.4.6(magicast@0.5.3)
@@ -2605,6 +2608,12 @@ packages:
       tailwindcss:
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -2901,6 +2910,16 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/zstd@7.0.0':
     resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
@@ -9273,6 +9292,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@3.2.0:
     resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
     engines: {node: ^8.12.0 || >=9.7.0}
@@ -9298,6 +9321,12 @@ packages:
     engines: {node: '>=22.13.0'}
     peerDependencies:
       ai: ^6.0.0 || ^7.0.0-beta.0
+
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -9908,6 +9937,10 @@ packages:
   hls.js@1.6.16:
     resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -10363,6 +10396,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -11962,10 +11998,6 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
 
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
@@ -14996,6 +15028,10 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
 
+  '@hono/node-server@1.19.14(hono@4.12.31)':
+    dependencies:
+      hono: 4.12.31
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -15306,6 +15342,28 @@ snapshots:
   '@microsoft/tsdoc@0.16.0': {}
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.31)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.6.0(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
+      hono: 4.12.31
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -22213,6 +22271,10 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@3.2.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -22259,6 +22321,14 @@ snapshots:
     dependencies:
       ai: 7.0.34(zod@4.4.3)
 
+  express-rate-limit@8.6.0(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1(supports-color@10.2.2)
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
@@ -22282,7 +22352,7 @@ snapshots:
       parseurl: 1.3.3
       proxy-addr: 2.0.7
       qs: 6.15.2
-      range-parser: 1.2.1
+      range-parser: 1.3.0
       router: 2.2.0(supports-color@10.2.2)
       send: 1.2.1(supports-color@10.2.2)
       serve-static: 2.2.1(supports-color@10.2.2)
@@ -23064,6 +23134,8 @@ snapshots:
 
   hls.js@1.6.16: {}
 
+  hono@4.12.31: {}
+
   hookable@5.5.3: {}
 
   hookable@6.1.1: {}
@@ -23496,6 +23568,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -26070,8 +26144,6 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
   radix3@1.1.2: {}
-
-  range-parser@1.2.1: {}
 
   range-parser@1.3.0: {}
 


### PR DESCRIPTION
### Description

Here, we vendor the official mcp sdk (`modelcontextprotocol/sdk`) and use it to create a minimal MCP server that provides the necessary generic MCP capabilities (tool calls, etc.).

<!-- Write a short summary of the problem and solution. -->

### How did you test your changes?

<!-- Include the commands you ran and any manual coverage. -->

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)