### PR TITLE
feat(eve): Add ability to launch workflow sdk devserver alongside eve TUI

### DIFF
--- a/.changeset/quiet-ducks-observe.md
+++ b/.changeset/quiet-ducks-observe.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `eve dev --workflow-ui` to launch the Workflow SDK Web UI against the agent's local durable workflow store, with an optional `--workflow-ui-port` override.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -122,7 +122,7 @@ eve dev --tools full --assistant-response-stats tokens --context-size 200000
 | `--context-size <tokens>`           | a token count                                      | Model context window size, shown as a usage percentage. |
 | `--logs <mode>`                     | `all` / `stderr` / `sandbox` / `none`              | Which server and agent logs to show (default `stderr`). |
 
-Connection flags: `--host` and `--port` bind the local server, and `--no-ui` runs headless (also the automatic fallback when stdout is not a TTY). See the [CLI](../reference/cli) for the full flag list.
+Connection flags: `--host` and `--port` bind the local server, and `--no-ui` runs headless (also the automatic fallback when stdout is not a TTY). Pass `--workflow-ui` to start the Workflow SDK Web UI for inspecting local durable runs and steps; it defaults to `http://localhost:3456`, or use `--workflow-ui-port <port>`. See the [CLI](../reference/cli) for the full flag list.
 
 ## Remote: `eve dev <url>`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,6 +151,8 @@ Pass a bare URL and the UI connects to that server instead of booting a local on
 | `-u, --url <url>`                   | string | none               | Connect to an existing server URL instead of starting one                                 |
 | `-H, --header <header>`             | string | none               | Request header for a URL target, in `Name: value` form; repeat for multiple headers       |
 | `--no-ui`                           | flag   | UI on              | Start the server without an interactive UI                                                |
+| `--workflow-ui`                     | flag   | off                | Start the local Workflow SDK Web UI                                                       |
+| `--workflow-ui-port <port>`         | number | 3456               | Port for the Workflow SDK Web UI; also enables it                                         |
 | `--name <name>`                     | string | app folder name    | Title shown in the terminal UI                                                            |
 | `--input <text>`                    | string | none               | Pre-fill the prompt input; bare local `/model` starts onboarding                          |
 | `--tools <mode>`                    | enum   | `auto-collapsed`   | Tool-call rendering: `full` \| `collapsed` \| `auto-collapsed` \| `hidden`                |
@@ -162,6 +164,8 @@ Pass a bare URL and the UI connects to that server instead of booting a local on
 | `--logs <mode>`                     | enum   | `stderr`           | Server/agent logs to show: `all` \| `stderr` \| `sandbox` \| `none`                       |
 
 A fresh `eve init` passes `--input /model`. That bare local input starts onboarding: the TUI installs the Vercel CLI if needed, asks you to log in if needed, then opens `/model`. Other input stays editable in the prompt.
+
+Pass `--workflow-ui` to start the version-matched Workflow SDK observability UI against eve's local `.eve/.workflow-data` store. It runs at `http://localhost:3456` by default, does not open a browser automatically, and stops with `eve dev`. Use `--workflow-ui-port <port>` to choose another port; specifying the port also enables the UI. This option is local-only and cannot be combined with a URL target.
 
 For a URL target protected by HTTP Basic auth, put the credentials in the URL. Eve sends them as a Basic `Authorization` header and strips them from the server URL before connecting:
 

--- a/packages/eve/src/cli/dev/workflow-web-ui.ts
+++ b/packages/eve/src/cli/dev/workflow-web-ui.ts
@@ -1,0 +1,137 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { access } from "node:fs/promises";
+
+import { resolveLocalWorkflowWorldDataDirectory } from "#internal/workflow/local-world-data-directory.js";
+
+const WORKFLOW_CLI_VERSION = "5.0.0-beta.35";
+const STARTUP_TIMEOUT_MS = 60_000;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+
+/** A running Workflow SDK observability UI owned by `eve dev`. */
+export interface WorkflowWebUiHandle {
+  readonly url: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Starts the version-matched Workflow SDK Web UI against eve's local Workflow store.
+ *
+ * The UI runs in a child process so its Workflow global state cannot interfere with
+ * the parent-owned local world that survives development worker rebuilds.
+ */
+export async function startWorkflowWebUi(input: {
+  readonly appRoot: string;
+  readonly agentServerUrl: string;
+  readonly port: number;
+}): Promise<WorkflowWebUiHandle> {
+  const dataDir = resolveLocalWorkflowWorldDataDirectory(input.appRoot);
+  await access(dataDir);
+
+  const executable = process.platform === "win32" ? "npx.cmd" : "npx";
+  const child = spawn(
+    executable,
+    [
+      "--yes",
+      `workflow@${WORKFLOW_CLI_VERSION}`,
+      "web",
+      "--backend",
+      "local",
+      "--noBrowser",
+      "--webPort",
+      String(input.port),
+    ],
+    {
+      cwd: input.appRoot,
+      env: {
+        ...process.env,
+        WORKFLOW_DISABLE_BROWSER_OPEN: "1",
+        WORKFLOW_LOCAL_BASE_URL: new URL(input.agentServerUrl).origin,
+        WORKFLOW_LOCAL_DATA_DIR: dataDir,
+        WORKFLOW_LOCAL_RECOVER_ACTIVE_RUNS: "false",
+        WORKFLOW_TARGET_WORLD: "local",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  let output = "";
+  let spawnError: Error | undefined;
+  const collectOutput = (chunk: Buffer | string) => {
+    output = `${output}${String(chunk)}`.slice(-8_000);
+  };
+  child.on("error", (error) => {
+    spawnError = error;
+  });
+  child.stdout?.on("data", collectOutput);
+  child.stderr?.on("data", collectOutput);
+
+  const url = `http://localhost:${input.port}`;
+  try {
+    await waitUntilReady(
+      child,
+      url,
+      () => output,
+      () => spawnError,
+    );
+  } catch (error) {
+    await stopChild(child);
+    throw error;
+  }
+
+  return {
+    url,
+    close: async () => await stopChild(child),
+  };
+}
+
+async function waitUntilReady(
+  child: ChildProcess,
+  url: string,
+  readOutput: () => string,
+  readSpawnError: () => Error | undefined,
+): Promise<void> {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const spawnError = readSpawnError();
+    if (spawnError !== undefined) {
+      throw new Error(formatStartupError(`could not launch: ${spawnError.message}`, readOutput()));
+    }
+    if (child.exitCode !== null || child.signalCode !== null) {
+      const outcome =
+        child.exitCode !== null ? `code ${child.exitCode}` : `signal ${child.signalCode}`;
+      throw new Error(formatStartupError(`exited with ${outcome}`, readOutput()));
+    }
+    try {
+      const response = await fetch(url, {
+        method: "HEAD",
+        signal: AbortSignal.timeout(500),
+      });
+      if (response.ok) return;
+    } catch {
+      // The CLI may be downloading its pinned package or starting the server.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(formatStartupError("did not become ready within 60 seconds", readOutput()));
+}
+
+function formatStartupError(reason: string, output: string): string {
+  const detail = output.trim();
+  return detail.length === 0
+    ? `Workflow SDK Web UI ${reason}.`
+    : `Workflow SDK Web UI ${reason}.\n${detail}`;
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  child.kill("SIGTERM");
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+  const timedOut = new Promise<"timeout">((resolve) => {
+    setTimeout(() => resolve("timeout"), SHUTDOWN_TIMEOUT_MS);
+  });
+  if ((await Promise.race([closed, timedOut])) === "timeout") {
+    child.kill("SIGKILL");
+    await closed;
+  }
+}

--- a/packages/eve/src/cli/run-types.ts
+++ b/packages/eve/src/cli/run-types.ts
@@ -1,0 +1,91 @@
+import type { BuildHost } from "#cli/commands/build.js";
+import type { DevelopmentRequestHeaders } from "#cli/dev/url-target.js";
+import type { WorkflowWebUiHandle } from "#cli/dev/workflow-web-ui.js";
+import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
+import type {
+  AssistantResponseStatsMode,
+  LogDisplayMode,
+  TerminalPartDisplayMode,
+} from "#cli/dev/tui/types.js";
+import type {
+  DevelopmentServer,
+  DevelopmentServerOptions,
+  ProductionServerHandle,
+} from "#internal/nitro/host/types.js";
+
+export interface CliLogger {
+  error(message: string): void;
+  log(message: string): void;
+}
+
+export interface DevelopmentCliOptions {
+  assistantResponseStats?: AssistantResponseStatsMode;
+  connectionAuth?: TerminalPartDisplayMode;
+  contextSize?: number;
+  header?: DevelopmentRequestHeaders;
+  host?: string;
+  input?: string;
+  logs?: LogDisplayMode;
+  name?: string;
+  port?: number;
+  reasoning?: TerminalPartDisplayMode;
+  subagents?: TerminalPartDisplayMode;
+  tools?: TerminalPartDisplayMode;
+  ui?: boolean;
+  url?: string;
+  workflowUi?: boolean;
+  workflowUiPort?: number;
+}
+
+export interface ProductionCliOptions {
+  host?: string;
+  port?: number;
+}
+
+export interface EvalCliOptions {
+  json?: boolean;
+  junit?: string;
+  list?: boolean;
+  maxConcurrency?: string;
+  skipReport?: boolean;
+  strict?: boolean;
+  tag?: string[];
+  timeout?: string;
+  url?: string;
+  verbose?: boolean;
+}
+
+export interface CliRuntimeDependencies {
+  isCodingAgentLaunch(): Promise<boolean>;
+  isActiveDevelopmentServerForApp(input: {
+    readonly appRoot: string;
+    readonly serverUrl: string;
+  }): Promise<boolean>;
+  buildHost: BuildHost;
+  printApplicationInfo(
+    logger: CliLogger,
+    appRoot: string,
+    options?: { json?: boolean },
+  ): Promise<void>;
+  runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<void>;
+  runEvalCommand(
+    evalIds: readonly string[],
+    options: EvalCliOptions,
+    logger: CliLogger,
+  ): Promise<void>;
+  startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
+  startProductionHost(
+    appRoot: string,
+    options?: {
+      host?: string;
+      port?: number;
+    },
+  ): Promise<ProductionServerHandle>;
+  startWorkflowWebUi(input: {
+    readonly appRoot: string;
+    readonly agentServerUrl: string;
+    readonly port: number;
+  }): Promise<WorkflowWebUiHandle>;
+}
+
+export type CliRuntimeOverrides = Partial<CliRuntimeDependencies>;

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -328,6 +328,70 @@ describe("eve dev --logs", () => {
   });
 });
 
+describe("eve dev --workflow-ui", () => {
+  it("starts and closes the Workflow SDK Web UI with the local server", async () => {
+    const closeWorkflowUi = vi.fn(async () => {});
+    const startWorkflowWebUi = vi.fn(async () => ({
+      close: closeWorkflowUi,
+      url: "http://localhost:4567",
+    }));
+    const startHost = vi.fn(() => ({
+      start: async () => ({
+        kind: "started" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:4321/",
+      }),
+      close: async () => {},
+    }));
+
+    await runInteractiveDev(["dev", "--workflow-ui", "--workflow-ui-port", "4567"], {
+      startHost,
+      startWorkflowWebUi,
+    });
+
+    expect(startWorkflowWebUi).toHaveBeenCalledWith({
+      agentServerUrl: "http://127.0.0.1:4321/",
+      appRoot: "/canonical/app",
+      port: 4567,
+    });
+    expect(closeWorkflowUi).toHaveBeenCalledOnce();
+  });
+
+  it("treats an explicit Workflow UI port as enabling the UI", async () => {
+    const startWorkflowWebUi = vi.fn(async () => ({
+      close: async () => {},
+      url: "http://localhost:4567",
+    }));
+    const startHost = vi.fn(() => ({
+      start: async () => ({
+        kind: "started" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:4321/",
+      }),
+      close: async () => {},
+    }));
+
+    await runInteractiveDev(["dev", "--workflow-ui-port", "4567"], {
+      startHost,
+      startWorkflowWebUi,
+    });
+
+    expect(startWorkflowWebUi).toHaveBeenCalledOnce();
+  });
+
+  it("rejects port zero because the resolved UI URL must be known", async () => {
+    await expect(runInteractiveDev(["dev", "--workflow-ui-port", "0"])).rejects.toThrow(
+      "Workflow SDK Web UI port must be greater than 0",
+    );
+  });
+
+  it("rejects the Workflow UI flag for a remote target", async () => {
+    await expect(
+      runInteractiveDev(["dev", "--url", "https://example.com", "--workflow-ui"]),
+    ).rejects.toThrow("--workflow-ui requires eve dev to start a local server");
+  });
+});
+
 describe("eve dev boot progress", () => {
   it("passes one reporter through local startup and clears the row on failure", async () => {
     const writes: string[] = [];

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -1,5 +1,5 @@
 import { Command, CommanderError, InvalidArgumentError } from "#compiled/commander/index.js";
-import { registerBuildCommand, type BuildHost } from "#cli/commands/build.js";
+import { registerBuildCommand } from "#cli/commands/build.js";
 import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-progress.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
@@ -7,23 +7,23 @@ import { isCodingAgentLaunch } from "#cli/agent-detection.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerProjectCommands } from "#cli/commands/register-project-commands.js";
 import { resolveDevUiMode, resolveTuiDisplayOptions } from "#cli/dev/ui-options.js";
-import {
-  parseDevelopmentHeaderOption,
-  resolveDevelopmentUrlTarget,
-  type DevelopmentRequestHeaders,
-} from "#cli/dev/url-target.js";
+import { parseDevelopmentHeaderOption, resolveDevelopmentUrlTarget } from "#cli/dev/url-target.js";
 import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
+import type {
+  CliLogger,
+  CliRuntimeDependencies,
+  CliRuntimeOverrides,
+  DevelopmentCliOptions,
+  EvalCliOptions,
+  ProductionCliOptions,
+} from "#cli/run-types.js";
 import { LOG_DISPLAY_MODES, parseLogDisplayMode } from "#cli/dev/tui/log-display-mode.js";
 import { resolveTuiTitle, type DevelopmentTuiTarget } from "#cli/dev/tui/target.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";
 import { createLogger } from "#internal/logging.js";
-import type {
-  DevelopmentServer,
-  DevelopmentServerOptions,
-  ProductionServerHandle,
-} from "#internal/nitro/host/types.js";
+import type { DevelopmentServer, ProductionServerHandle } from "#internal/nitro/host/types.js";
 import type {
   AssistantResponseStatsMode,
   LogDisplayMode,
@@ -32,70 +32,6 @@ import type {
 import type { WorkflowWebUiHandle } from "#cli/dev/workflow-web-ui.js";
 
 export { resolveDevUiMode, resolveTuiDisplayOptions };
-
-interface CliLogger {
-  error(message: string): void;
-  log(message: string): void;
-}
-
-interface DevelopmentCliOptions {
-  assistantResponseStats?: AssistantResponseStatsMode;
-  connectionAuth?: TerminalPartDisplayMode;
-  contextSize?: number;
-  header?: DevelopmentRequestHeaders;
-  host?: string;
-  input?: string;
-  logs?: LogDisplayMode;
-  name?: string;
-  port?: number;
-  reasoning?: TerminalPartDisplayMode;
-  subagents?: TerminalPartDisplayMode;
-  tools?: TerminalPartDisplayMode;
-  ui?: boolean;
-  url?: string;
-  workflowUi?: boolean;
-  workflowUiPort?: number;
-}
-
-interface ProductionCliOptions {
-  host?: string;
-  port?: number;
-}
-
-interface CliRuntimeDependencies {
-  isCodingAgentLaunch(): Promise<boolean>;
-  isActiveDevelopmentServerForApp(input: {
-    readonly appRoot: string;
-    readonly serverUrl: string;
-  }): Promise<boolean>;
-  buildHost: BuildHost;
-  printApplicationInfo(
-    logger: CliLogger,
-    appRoot: string,
-    options?: { json?: boolean },
-  ): Promise<void>;
-  runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<void>;
-  runEvalCommand(
-    evalIds: readonly string[],
-    options: EvalCliOptions,
-    logger: CliLogger,
-  ): Promise<void>;
-  startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
-  startProductionHost(
-    appRoot: string,
-    options?: {
-      host?: string;
-      port?: number;
-    },
-  ): Promise<ProductionServerHandle>;
-  startWorkflowWebUi(input: {
-    readonly appRoot: string;
-    readonly agentServerUrl: string;
-    readonly port: number;
-  }): Promise<WorkflowWebUiHandle>;
-}
-
-type CliRuntimeOverrides = Partial<CliRuntimeDependencies>;
 
 const devBootLog = createLogger("dev.boot");
 
@@ -120,19 +56,6 @@ function createDevBootProgressReporter(
       }
     }
   };
-}
-
-interface EvalCliOptions {
-  json?: boolean;
-  junit?: string;
-  list?: boolean;
-  maxConcurrency?: string;
-  skipReport?: boolean;
-  strict?: boolean;
-  tag?: string[];
-  timeout?: string;
-  url?: string;
-  verbose?: boolean;
 }
 
 async function loadPrintApplicationInfo(): Promise<CliRuntimeDependencies["printApplicationInfo"]> {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -29,6 +29,7 @@ import type {
   LogDisplayMode,
   TerminalPartDisplayMode,
 } from "#cli/dev/tui/types.js";
+import type { WorkflowWebUiHandle } from "#cli/dev/workflow-web-ui.js";
 
 export { resolveDevUiMode, resolveTuiDisplayOptions };
 
@@ -52,6 +53,8 @@ interface DevelopmentCliOptions {
   tools?: TerminalPartDisplayMode;
   ui?: boolean;
   url?: string;
+  workflowUi?: boolean;
+  workflowUiPort?: number;
 }
 
 interface ProductionCliOptions {
@@ -85,6 +88,11 @@ interface CliRuntimeDependencies {
       port?: number;
     },
   ): Promise<ProductionServerHandle>;
+  startWorkflowWebUi(input: {
+    readonly appRoot: string;
+    readonly agentServerUrl: string;
+    readonly port: number;
+  }): Promise<WorkflowWebUiHandle>;
 }
 
 type CliRuntimeOverrides = Partial<CliRuntimeDependencies>;
@@ -150,6 +158,10 @@ async function loadStartProductionHost(): Promise<CliRuntimeDependencies["startP
   return (await import("#internal/nitro/host.js")).startProductionServer;
 }
 
+async function loadStartWorkflowWebUi(): Promise<CliRuntimeDependencies["startWorkflowWebUi"]> {
+  return (await import("#cli/dev/workflow-web-ui.js")).startWorkflowWebUi;
+}
+
 function shouldPrintCliBootBanner(actionCommand: Command): boolean {
   return (
     actionCommand.name() === "info" ||
@@ -202,6 +214,14 @@ function parsePortOption(value: string): number {
     throw new InvalidArgumentError(`Expected a port between 0 and 65535, received "${value}".`);
   }
 
+  return port;
+}
+
+function parseWorkflowUiPortOption(value: string): number {
+  const port = parsePortOption(value);
+  if (port === 0) {
+    throw new InvalidArgumentError("The Workflow SDK Web UI port must be greater than 0.");
+  }
   return port;
 }
 
@@ -404,6 +424,12 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       parseDevelopmentHeaderOption,
     )
     .option("--no-ui", "Start the server without an interactive UI")
+    .option("--workflow-ui", "Start the local Workflow SDK Web UI")
+    .option(
+      "--workflow-ui-port <port>",
+      "Port for the Workflow SDK Web UI (defaults to 3456)",
+      parseWorkflowUiPortOption,
+    )
     .option("--name <name>", "Title shown in the terminal UI (defaults to the app folder name)")
     .option("--input <text>", "Pre-fill the prompt input, or start onboarding with /model")
     .option(
@@ -452,6 +478,12 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       const mode = resolveDevUiMode({ options, interactive });
       if (options.input !== undefined && mode === "headless") {
         throw new InvalidArgumentError("--input requires the interactive UI.");
+      }
+      if (
+        remoteServerUrl !== undefined &&
+        (options.workflowUi === true || options.workflowUiPort !== undefined)
+      ) {
+        throw new InvalidArgumentError("--workflow-ui requires eve dev to start a local server.");
       }
       let existingLocalDevelopmentServer = false;
       if (remoteServerUrl !== undefined) {
@@ -526,14 +558,16 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
 
       let closed = false;
       let server: DevelopmentServer | undefined;
+      let workflowWebUi: WorkflowWebUiHandle | undefined;
       const closeServer = async () => {
-        if (closed || server === undefined) {
+        if (closed) {
           return;
         }
 
         closed = true;
+        await workflowWebUi?.close();
         // No-op when this instance attached to a server another process owns.
-        await server.close();
+        await server?.close();
       };
 
       try {
@@ -557,6 +591,36 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
               tone: "success",
             }),
           );
+        }
+
+        if (options.workflowUi === true || options.workflowUiPort !== undefined) {
+          buildProgress?.update("Starting Workflow SDK Web UI");
+          try {
+            const startWorkflowWebUi =
+              runtime.startWorkflowWebUi ?? (await loadStartWorkflowWebUi());
+            workflowWebUi = await startWorkflowWebUi({
+              agentServerUrl: handle.url,
+              appRoot: handle.appRoot,
+              port: options.workflowUiPort ?? 3456,
+            });
+            buildProgress?.stop();
+            logger.log(
+              renderCliTaggedLine(theme, {
+                message: `Workflow SDK Web UI at ${workflowWebUi.url}`,
+                tag: "dev",
+                tone: "success",
+              }),
+            );
+          } catch (error) {
+            buildProgress?.stop();
+            logger.error(
+              renderCliTaggedLine(theme, {
+                message: `Workflow SDK Web UI failed to start: ${error instanceof Error ? error.message : String(error)}`,
+                tag: "dev",
+                tone: "warning",
+              }),
+            );
+          }
         }
 
         if (mode === "headless") {


### PR DESCRIPTION

### Description

Adds a `--workflow-ui` flag to `npx eve dev` which spins up the Workflow SDK observability UI at `localhost:3456` configured for eve's use-case (`.eve/.workflow-data` as the local data dir etc)

<img width="1433" height="718" alt="Screenshot 2026-07-20 at 4 09 30 PM" src="https://github.com/user-attachments/assets/49f6a38f-c1f0-4600-aba6-849e3713f63c" />

### How did you test your changes?

Tested locally, small unit test
