### PR TITLE
fix(eve): bound each step's combined tool output relative to the compaction threshold

### DIFF
--- a/.changeset/step-tool-output-budget.md
+++ b/.changeset/step-tool-output-budget.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Each model step's combined tool output is now bounded relative to the compaction threshold; oversized results are truncated with a note to the model, keeping at least ~20 steps between compactions.

--- a/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
@@ -3,15 +3,21 @@ import { mockModel, type MockModelRequest } from "eve/evals";
 
 import {
   COMPACTION_CHECKPOINT_TEXT,
+  OVERSIZED_TRUNCATION_MARKER,
   SECOND_CHECKPOINT_MARKER,
   TASK_PRESERVED_MARKER,
   TASK_TAIL_SENTINEL,
+  TRUNCATION_ANNOTATION_PREFIX,
 } from "../constants";
 
 const TEST_CONTEXT_WINDOW_TOKENS = 32_000;
 const MAX_TOOL_CALLS = 10;
 
-type RegressionCase = "redundant-tool-calls" | "stale-todo-work" | "task-survival";
+type RegressionCase =
+  | "redundant-tool-calls"
+  | "stale-todo-work"
+  | "task-survival"
+  | "oversized-step-truncation";
 
 let activeCase: RegressionCase | undefined;
 const checkpointAdvanceCallCounts = new Map<RegressionCase, number>();
@@ -77,15 +83,41 @@ const taskModel = mockModel({
       };
     }
 
+    if (regressionCase === "oversized-step-truncation") {
+      // The harness truncates the oversized result at attach time, so the
+      // annotation must be visible in the request — whether the result is
+      // still verbatim in recent history or reduced during compaction —
+      // before the model reports success.
+      if (request.messages.some((message) => message.text.includes(TRUNCATION_ANNOTATION_PREFIX))) {
+        return `Observed harness truncation: ${OVERSIZED_TRUNCATION_MARKER}`;
+      }
+
+      const emitCalls = toolCallCounts.get(regressionCase) ?? 0;
+      if (emitCalls >= MAX_TOOL_CALLS) {
+        return `Hard stop after ${MAX_TOOL_CALLS} calls: TRUNCATION_ANNOTATION_MISSING`;
+      }
+
+      toolCallCounts.set(regressionCase, emitCalls + 1);
+      return {
+        toolCalls: [
+          {
+            id: `emit-oversized-output-${emitCalls + 1}`,
+            input: {},
+            name: "emit-oversized-output",
+          },
+        ],
+      };
+    }
+
     const marker = completionMarker(regressionCase);
 
     // These are fixture markers, not compaction protocol fields. `marker` records the
     // regression work tool; `SECOND_CHECKPOINT_MARKER` records the test-only tool
     // whose output makes the harness cross the compaction threshold a second time.
     // Completion evidence is detected in any assistant message: compaction may
-    // leave it as a summarization checkpoint or as an eviction trail line, and
-    // the model must not repeat work in either case. User messages are
-    // excluded because the eval instructions themselves quote the markers.
+    // leave it as a summarization checkpoint or as a capped result, and the
+    // model must not repeat work in either case. User messages are excluded
+    // because the eval instructions themselves quote the markers.
     if (assistantEvidenceContains(request.messages, marker)) {
       if (assistantEvidenceContains(request.messages, SECOND_CHECKPOINT_MARKER)) {
         return `Done: ${marker}; ${SECOND_CHECKPOINT_MARKER}`;
@@ -164,10 +196,13 @@ function regressionCaseFromText(text: string): RegressionCase | undefined {
   if (text.includes("[case: redundant-tool-calls]")) return "redundant-tool-calls";
   if (text.includes("[case: stale-todo-work]")) return "stale-todo-work";
   if (text.includes("[case: task-survival]")) return "task-survival";
+  if (text.includes("[case: oversized-step-truncation]")) return "oversized-step-truncation";
   return undefined;
 }
 
-function completionMarker(regressionCase: Exclude<RegressionCase, "task-survival">): string {
+function completionMarker(
+  regressionCase: Exclude<RegressionCase, "oversized-step-truncation" | "task-survival">,
+): string {
   return regressionCase === "redundant-tool-calls"
     ? "REPOSITORY_INSPECTION_COMPLETE"
     : "SOURCE_ANALYSIS_COMPLETE";

--- a/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
@@ -1,5 +1,5 @@
 import { defineAgent } from "eve";
-import { mockModel, type MockModelRequest } from "eve/evals";
+import { mockModel, type MockModelRequest, type MockModelResponse } from "eve/evals";
 
 import {
   COMPACTION_CHECKPOINT_TEXT,
@@ -19,120 +19,119 @@ type RegressionCase =
   | "task-survival"
   | "oversized-step-truncation";
 
-let activeCase: RegressionCase | undefined;
-const checkpointAdvanceCallCounts = new Map<RegressionCase, number>();
-const toolCallCounts = new Map<RegressionCase, number>();
+/** Per-case call bookkeeping shared by every responder. */
+interface CaseState {
+  advanceCalls: number;
+  toolCalls: number;
+}
 
-let requestCount = 0;
+type CaseResponder = (request: MockModelRequest, state: CaseState) => MockModelResponse | string;
 
-const taskModel = mockModel({
-  modelId: "compaction-regression-task-model",
-  respond(request) {
-    // EVE_E2E_DUMP_CONTEXT=1 prints every request's messages — the context
-    // exactly as the model sees it, so compaction, capping, and replay are
-    // observable per step while iterating on these evals.
-    if (process.env.EVE_E2E_DUMP_CONTEXT) {
-      requestCount += 1;
-      console.log(`\n=== model request #${requestCount} (${request.messages.length} messages) ===`);
-      for (const message of request.messages) {
-        const text = message.text.replace(/\s+/g, " ");
-        console.log(`  [${message.role}] ${text.length} chars | ${text.slice(0, 160)}`);
-      }
+/**
+ * One responder per regression case. Adding a case means adding an entry
+ * here (plus its marker in {@link regressionCaseFromText}) — the dispatch
+ * and bookkeeping never change.
+ */
+const responders: Record<RegressionCase, CaseResponder> = {
+  "redundant-tool-calls": markerWorkCase(
+    "redundant-tool-calls",
+    "REPOSITORY_INSPECTION_COMPLETE",
+    (attempt) => ({
+      id: `inspect-repository-${attempt}`,
+      input: { scope: "repository" },
+      name: "inspect-repository",
+    }),
+  ),
+
+  "stale-todo-work": markerWorkCase("stale-todo-work", "SOURCE_ANALYSIS_COMPLETE", (attempt) => ({
+    id: `perform-source-analysis-${attempt}`,
+    input: { approach: `attempt-${attempt}` },
+    name: "perform-source-analysis",
+  })),
+
+  "task-survival": (request, state) => {
+    const compacted = request.messages.some(
+      (message) => message.role === "user" && message.text === COMPACTION_CHECKPOINT_TEXT,
+    );
+    if (compacted) {
+      // The harness must hand the model its verbatim task back after
+      // compaction — via the kept tail or the resumption replay. Losing it
+      // is the trace failure this case pins.
+      return request.userMessages.some((text) => text.includes(TASK_TAIL_SENTINEL))
+        ? `Task text still visible: ${TASK_PRESERVED_MARKER}`
+        : "Task text lost after compaction: TASK_LOST";
     }
 
-    const initialCase = findInitialCase(request);
-    if (initialCase !== undefined && activeCase !== initialCase) {
-      activeCase = initialCase;
-      checkpointAdvanceCallCounts.set(initialCase, 0);
-      toolCallCounts.set(initialCase, 0);
+    if (state.toolCalls >= MAX_TOOL_CALLS) {
+      return "Hard stop without a compaction: TASK_SURVIVAL_NO_COMPACTION";
     }
 
-    if (activeCase === undefined) {
-      throw new Error("Compaction regression task model received no case marker.");
+    state.toolCalls += 1;
+    return {
+      toolCalls: [
+        {
+          id: `inspect-repository-${state.toolCalls}`,
+          input: { scope: "repository" },
+          name: "inspect-repository",
+        },
+      ],
+    };
+  },
+
+  "oversized-step-truncation": (request, state) => {
+    // The harness truncates the oversized result at attach time, so the
+    // annotation must be visible in the request — whether the result is
+    // still verbatim in recent history or reduced during compaction —
+    // before the model reports success.
+    if (request.messages.some((message) => message.text.includes(TRUNCATION_ANNOTATION_PREFIX))) {
+      return `Observed harness truncation: ${OVERSIZED_TRUNCATION_MARKER}`;
     }
 
-    const regressionCase = activeCase;
-
-    if (regressionCase === "task-survival") {
-      const compacted = request.messages.some(
-        (message) => message.role === "user" && message.text === COMPACTION_CHECKPOINT_TEXT,
-      );
-      if (compacted) {
-        // The harness must hand the model its verbatim task back after
-        // compaction — via the kept tail or the resumption replay. Losing it
-        // is the trace failure this case pins.
-        return request.userMessages.some((text) => text.includes(TASK_TAIL_SENTINEL))
-          ? `Task text still visible: ${TASK_PRESERVED_MARKER}`
-          : "Task text lost after compaction: TASK_LOST";
-      }
-
-      const pressureCalls = toolCallCounts.get(regressionCase) ?? 0;
-      if (pressureCalls >= MAX_TOOL_CALLS) {
-        return "Hard stop without a compaction: TASK_SURVIVAL_NO_COMPACTION";
-      }
-
-      toolCallCounts.set(regressionCase, pressureCalls + 1);
-      return {
-        toolCalls: [
-          {
-            id: `inspect-repository-${pressureCalls + 1}`,
-            input: { scope: "repository" },
-            name: "inspect-repository",
-          },
-        ],
-      };
+    if (state.toolCalls >= MAX_TOOL_CALLS) {
+      return `Hard stop after ${MAX_TOOL_CALLS} calls: TRUNCATION_ANNOTATION_MISSING`;
     }
 
-    if (regressionCase === "oversized-step-truncation") {
-      // The harness truncates the oversized result at attach time, so the
-      // annotation must be visible in the request — whether the result is
-      // still verbatim in recent history or reduced during compaction —
-      // before the model reports success.
-      if (request.messages.some((message) => message.text.includes(TRUNCATION_ANNOTATION_PREFIX))) {
-        return `Observed harness truncation: ${OVERSIZED_TRUNCATION_MARKER}`;
-      }
+    state.toolCalls += 1;
+    return {
+      toolCalls: [
+        {
+          id: `emit-oversized-output-${state.toolCalls}`,
+          input: {},
+          name: "emit-oversized-output",
+        },
+      ],
+    };
+  },
+};
 
-      const emitCalls = toolCallCounts.get(regressionCase) ?? 0;
-      if (emitCalls >= MAX_TOOL_CALLS) {
-        return `Hard stop after ${MAX_TOOL_CALLS} calls: TRUNCATION_ANNOTATION_MISSING`;
-      }
-
-      toolCallCounts.set(regressionCase, emitCalls + 1);
-      return {
-        toolCalls: [
-          {
-            id: `emit-oversized-output-${emitCalls + 1}`,
-            input: {},
-            name: "emit-oversized-output",
-          },
-        ],
-      };
-    }
-
-    const marker = completionMarker(regressionCase);
-
-    // These are fixture markers, not compaction protocol fields. `marker` records the
-    // regression work tool; `SECOND_CHECKPOINT_MARKER` records the test-only tool
-    // whose output makes the harness cross the compaction threshold a second time.
-    // Completion evidence is detected in any assistant message: compaction may
-    // leave it as a summarization checkpoint or as a capped result, and the
-    // model must not repeat work in either case. User messages are excluded
-    // because the eval instructions themselves quote the markers.
+/**
+ * The shared protocol of the two marker-driven work cases: run the work tool
+ * until its completion marker is visible, then run the second-compaction
+ * trigger tool, then finish. Completion evidence is detected in any assistant
+ * message: compaction may leave it as a summarization checkpoint or as a
+ * capped result, and the model must not repeat work in either case. User
+ * messages are excluded because the eval instructions quote the markers.
+ */
+function markerWorkCase(
+  regressionCase: "redundant-tool-calls" | "stale-todo-work",
+  marker: string,
+  workToolCall: (attempt: number) => { id: string; input: object; name: string },
+): CaseResponder {
+  return (request, state) => {
     if (assistantEvidenceContains(request.messages, marker)) {
       if (assistantEvidenceContains(request.messages, SECOND_CHECKPOINT_MARKER)) {
         return `Done: ${marker}; ${SECOND_CHECKPOINT_MARKER}`;
       }
 
-      const advanceCalls = checkpointAdvanceCallCounts.get(regressionCase) ?? 0;
-      if (advanceCalls >= MAX_TOOL_CALLS) {
+      if (state.advanceCalls >= MAX_TOOL_CALLS) {
         return `Hard stop after ${MAX_TOOL_CALLS} checkpoint advances: ${marker}`;
       }
 
-      checkpointAdvanceCallCounts.set(regressionCase, advanceCalls + 1);
+      state.advanceCalls += 1;
       return {
         toolCalls: [
           {
-            id: `advance-checkpoint-${advanceCalls + 1}`,
+            id: `advance-checkpoint-${state.advanceCalls}`,
             input: { regressionCase },
             name: "advance-checkpoint",
           },
@@ -140,33 +139,40 @@ const taskModel = mockModel({
       };
     }
 
-    const completedCalls = toolCallCounts.get(regressionCase) ?? 0;
-    if (completedCalls >= MAX_TOOL_CALLS) {
+    if (state.toolCalls >= MAX_TOOL_CALLS) {
       return `Hard stop after ${MAX_TOOL_CALLS} calls: ${marker}`;
     }
 
-    const attempt = completedCalls + 1;
-    toolCallCounts.set(regressionCase, attempt);
+    state.toolCalls += 1;
+    return { toolCalls: [workToolCall(state.toolCalls)] };
+  };
+}
 
-    return regressionCase === "redundant-tool-calls"
-      ? {
-          toolCalls: [
-            {
-              id: `inspect-repository-${attempt}`,
-              input: { scope: "repository" },
-              name: "inspect-repository",
-            },
-          ],
-        }
-      : {
-          toolCalls: [
-            {
-              id: `perform-source-analysis-${attempt}`,
-              input: { approach: `attempt-${attempt}` },
-              name: "perform-source-analysis",
-            },
-          ],
-        };
+let activeCase: RegressionCase | undefined;
+const caseStates = new Map<RegressionCase, CaseState>();
+let requestCount = 0;
+
+const taskModel = mockModel({
+  modelId: "compaction-regression-task-model",
+  respond(request) {
+    dumpContextWhenEnabled(request);
+
+    const initialCase = findInitialCase(request);
+    if (initialCase !== undefined && activeCase !== initialCase) {
+      activeCase = initialCase;
+      caseStates.set(initialCase, { advanceCalls: 0, toolCalls: 0 });
+    }
+
+    if (activeCase === undefined) {
+      throw new Error("Compaction regression task model received no case marker.");
+    }
+
+    const state = caseStates.get(activeCase);
+    if (state === undefined) {
+      throw new Error(`Compaction regression task model has no state for ${activeCase}.`);
+    }
+
+    return responders[activeCase](request, state);
   },
 });
 
@@ -183,6 +189,21 @@ export default defineAgent({
   },
 });
 
+// EVE_E2E_DUMP_CONTEXT=1 prints every request's messages — the context
+// exactly as the model sees it, so compaction, capping, and replay are
+// observable per step while iterating on these evals.
+function dumpContextWhenEnabled(request: MockModelRequest): void {
+  if (!process.env.EVE_E2E_DUMP_CONTEXT) {
+    return;
+  }
+  requestCount += 1;
+  console.log(`\n=== model request #${requestCount} (${request.messages.length} messages) ===`);
+  for (const message of request.messages) {
+    const text = message.text.replace(/\s+/g, " ");
+    console.log(`  [${message.role}] ${text.length} chars | ${text.slice(0, 160)}`);
+  }
+}
+
 function findInitialCase(request: MockModelRequest): RegressionCase | undefined {
   for (const message of request.userMessages) {
     const regressionCase = regressionCaseFromText(message);
@@ -198,14 +219,6 @@ function regressionCaseFromText(text: string): RegressionCase | undefined {
   if (text.includes("[case: task-survival]")) return "task-survival";
   if (text.includes("[case: oversized-step-truncation]")) return "oversized-step-truncation";
   return undefined;
-}
-
-function completionMarker(
-  regressionCase: Exclude<RegressionCase, "oversized-step-truncation" | "task-survival">,
-): string {
-  return regressionCase === "redundant-tool-calls"
-    ? "REPOSITORY_INSPECTION_COMPLETE"
-    : "SOURCE_ANALYSIS_COMPLETE";
 }
 
 function assistantEvidenceContains(

--- a/e2e/fixtures/agent-compaction-regressions/agent/tools/emit-oversized-output.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/tools/emit-oversized-output.ts
@@ -1,0 +1,25 @@
+import { defineState } from "eve/context";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+const invocationCount = defineState("compaction-regression.emit-oversized-output", () => 0);
+
+// Large relative to the fixture's per-step tool budget (the degenerate-guard
+// 2,000 tokens ≈ 8,000 chars), so the harness must truncate it at attach time.
+const OVERSIZED_PAYLOAD = "oversized step output padding ".repeat(1_000);
+
+export default defineTool({
+  description:
+    "Compaction regression tool. Returns output larger than the per-step tool budget so the harness truncation is observable.",
+  inputSchema: z.object({}),
+  async execute() {
+    const attempt = invocationCount.get() + 1;
+    invocationCount.update(() => attempt);
+
+    return {
+      attempt,
+      completed: true,
+      payload: OVERSIZED_PAYLOAD,
+    };
+  },
+});

--- a/e2e/fixtures/agent-compaction-regressions/constants.ts
+++ b/e2e/fixtures/agent-compaction-regressions/constants.ts
@@ -12,3 +12,12 @@ export const TASK_PRESERVED_MARKER = "TASK_PRESERVED_AFTER_COMPACTION";
 
 /** Checkpoint marker the harness inserts when compaction summarizes. */
 export const COMPACTION_CHECKPOINT_TEXT = "Summary of our conversation so far:";
+
+/**
+ * Reported by the mock task model only after it has seen the harness
+ * per-step truncation annotation in its request messages.
+ */
+export const OVERSIZED_TRUNCATION_MARKER = "OVERSIZED_OUTPUT_TRUNCATION_OBSERVED";
+
+/** Prefix of the harness annotation on truncated per-step tool results. */
+export const TRUNCATION_ANNOTATION_PREFIX = "[Truncated by eve:";

--- a/e2e/fixtures/agent-compaction-regressions/evals/oversized-step-truncation.eval.ts
+++ b/e2e/fixtures/agent-compaction-regressions/evals/oversized-step-truncation.eval.ts
@@ -1,0 +1,25 @@
+import { defineEval } from "eve/evals";
+
+import { OVERSIZED_TRUNCATION_MARKER } from "../constants";
+
+export default defineEval({
+  description: "Oversized per-step tool output is truncated with a model-visible annotation.",
+  async test(t) {
+    const turn = await t.send(
+      [
+        "[case: oversized-step-truncation]",
+        "Call emit-oversized-output exactly once.",
+        "Its result is deliberately larger than the per-step tool budget.",
+        "Report OVERSIZED_OUTPUT_TRUNCATION_OBSERVED once the truncation annotation is visible.",
+      ].join("\n"),
+    );
+
+    turn.expectOk();
+    t.succeeded();
+    // One execution is enough: the harness truncates the result at attach time,
+    // and the mock model only reports the marker after seeing the annotation in
+    // its request messages.
+    t.calledTool("emit-oversized-output", { count: 1 });
+    t.messageIncludes(OVERSIZED_TRUNCATION_MARKER);
+  },
+});

--- a/packages/eve/src/execution/sandbox/truncate-output.ts
+++ b/packages/eve/src/execution/sandbox/truncate-output.ts
@@ -5,8 +5,13 @@
  * grep, glob, read_file, web_fetch) uses these helpers to enforce
  * consistent size limits inside its executor before the result enters
  * conversation history. Authored tools are expected to do the same —
- * bounding at the source keeps the contract simple: whatever `execute`
- * returns is what the model sees.
+ * bounding at the source keeps single results small and their truncation
+ * tool-aware.
+ *
+ * These caps bound one result. The harness additionally bounds each step's
+ * combined tool output relative to the compaction threshold
+ * (`harness/step-tool-budget.ts`), so several maximum-size results in one
+ * step cannot fill the context window in a handful of steps.
  */
 
 /**

--- a/packages/eve/src/harness/compaction.ts
+++ b/packages/eve/src/harness/compaction.ts
@@ -9,6 +9,7 @@ import {
   TRANSCRIPT_PAYLOAD_LIMIT,
 } from "#harness/compaction-prompt.js";
 import { estimateTokens } from "#harness/token-estimate.js";
+import { truncateToolResults } from "#harness/tool-result-truncation.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import type { CompactionConfig, ToolLoopHarnessConfig } from "#harness/types.js";
 
@@ -254,37 +255,12 @@ const CAPPED_RESULT_ANNOTATION =
  * tool_use/tool_result pairing untouched. The cap matches the transcript
  * payload clip, so a later summarization sees the same content the model
  * kept — capping never destroys material the summarizer would need, unlike
- * dropping results outright. The annotation leads the value so it survives
- * prefix-capped renderings.
+ * dropping results outright.
  */
-function capToolResults(messages: readonly ModelMessage[]): ModelMessage[] {
-  return messages.map((message) => {
-    if (message.role !== "tool" || typeof message.content === "string") {
-      return message;
-    }
-
-    let changed = false;
-    const content = message.content.map((part) => {
-      if (part.type !== "tool-result") {
-        return part;
-      }
-      const serialized = JSON.stringify(part.output) ?? "";
-      if (serialized.length <= TRANSCRIPT_PAYLOAD_LIMIT) {
-        return part;
-      }
-
-      changed = true;
-      return {
-        ...part,
-        output: {
-          type: "text" as const,
-          value: `${CAPPED_RESULT_ANNOTATION}\n\n${serialized.slice(0, TRANSCRIPT_PAYLOAD_LIMIT)}`,
-        },
-      };
-    });
-
-    return changed ? { ...message, content } : message;
-  });
+function capToolResults(messages: readonly ModelMessage[]): readonly ModelMessage[] {
+  return truncateToolResults(messages, CAPPED_RESULT_ANNOTATION, (_part, serialized) =>
+    serialized.length > TRANSCRIPT_PAYLOAD_LIMIT ? TRANSCRIPT_PAYLOAD_LIMIT : undefined,
+  );
 }
 
 /**

--- a/packages/eve/src/harness/step-tool-budget.test.ts
+++ b/packages/eve/src/harness/step-tool-budget.test.ts
@@ -1,0 +1,116 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+
+import {
+  applyStepToolBudget,
+  MIN_STEPS_BETWEEN_COMPACTIONS,
+  resolveStepToolBudget,
+} from "#harness/step-tool-budget.js";
+import { estimateTokens } from "#harness/token-estimate.js";
+
+function toolResultMessage(callId: string, value: string): ModelMessage {
+  return {
+    content: [
+      {
+        output: { type: "json", value: { content: value } },
+        toolCallId: callId,
+        toolName: "grep",
+        type: "tool-result",
+      },
+    ],
+    role: "tool",
+  };
+}
+
+describe("resolveStepToolBudget", () => {
+  it("derives the budget from the compaction threshold", () => {
+    expect(resolveStepToolBudget(180_000)).toBe(
+      Math.floor(180_000 / MIN_STEPS_BETWEEN_COMPACTIONS),
+    );
+  });
+
+  it("guards degenerate thresholds", () => {
+    // Deterministic test agents force compaction with thresholds in the
+    // hundreds; the guard keeps their small tool results untouched.
+    expect(resolveStepToolBudget(640)).toBe(2_000);
+  });
+});
+
+describe("applyStepToolBudget", () => {
+  it("returns the input reference-equal when the step is within budget", () => {
+    const messages: ModelMessage[] = [
+      { content: "run it", role: "user" },
+      toolResultMessage("call-1", "small result"),
+    ];
+
+    expect(applyStepToolBudget(messages, 2_000)).toBe(messages);
+  });
+
+  it("truncates the largest results first and annotates them", () => {
+    const large = toolResultMessage("call-1", "L".repeat(40_000));
+    const small = toolResultMessage("call-2", "s".repeat(1_000));
+    const messages: ModelMessage[] = [large, small];
+
+    const result = applyStepToolBudget(messages, 2_000);
+
+    expect(result).not.toBe(messages);
+    const [first, second] = result;
+    const firstPart = Array.isArray(first?.content) ? first.content[0] : undefined;
+    expect(firstPart?.type).toBe("tool-result");
+    expect(JSON.stringify(firstPart)).toContain("Truncated by eve");
+    // The small result was untouched — same reference.
+    expect(second).toBe(small);
+  });
+
+  it("keeps every tool_result paired with its call after truncation", () => {
+    const messages: ModelMessage[] = [
+      toolResultMessage("call-1", "a".repeat(30_000)),
+      toolResultMessage("call-2", "b".repeat(30_000)),
+      toolResultMessage("call-3", "c".repeat(30_000)),
+    ];
+
+    const result = applyStepToolBudget(messages, 3_000);
+
+    const ids: string[] = [];
+    for (const message of result) {
+      if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part.type === "tool-result") ids.push(part.toolCallId);
+        }
+      }
+    }
+    expect(ids).toEqual(["call-1", "call-2", "call-3"]);
+  });
+
+  it("brings a multi-result step down to roughly the budget", () => {
+    const messages: ModelMessage[] = [
+      toolResultMessage("call-1", "a".repeat(50_000)),
+      toolResultMessage("call-2", "b".repeat(50_000)),
+      toolResultMessage("call-3", "c".repeat(50_000)),
+    ];
+    const budget = 9_000;
+
+    const result = applyStepToolBudget(messages, budget);
+
+    // Within 2x of the budget: the estimate is a heuristic and each truncated
+    // result keeps a minimum readable prefix plus the annotation.
+    expect(estimateTokens(result)).toBeLessThan(budget * 2);
+    expect(estimateTokens(result)).toBeLessThan(estimateTokens(messages) / 2);
+  });
+
+  it("keeps a readable prefix even when the budget is dwarfed", () => {
+    const messages: ModelMessage[] = [toolResultMessage("call-1", "z".repeat(100_000))];
+
+    const result = applyStepToolBudget(messages, 2_000);
+
+    const part = Array.isArray(result[0]?.content) ? result[0].content[0] : undefined;
+    const output = part?.type === "tool-result" ? part.output : undefined;
+    const value =
+      typeof output === "object" && output !== null && "value" in output
+        ? String(output.value)
+        : "";
+    expect(value.length).toBeGreaterThanOrEqual(400);
+    expect(value).toContain("zzz");
+    expect(value).toContain("Truncated by eve");
+  });
+});

--- a/packages/eve/src/harness/step-tool-budget.ts
+++ b/packages/eve/src/harness/step-tool-budget.ts
@@ -1,0 +1,105 @@
+import type { ModelMessage } from "ai";
+
+import { estimateTokens } from "#harness/token-estimate.js";
+
+/**
+ * Target minimum number of model steps between compactions. The per-step
+ * tool-output budget is the compaction threshold divided by this count, so a
+ * step's combined tool results can never fill the context in fewer steps.
+ */
+export const MIN_STEPS_BETWEEN_COMPACTIONS = 20;
+
+// Only guards degenerate thresholds (tests force compaction with thresholds in
+// the hundreds); it binds when threshold < 40k and never for a real context
+// window. There is deliberately no larger floor: at production thresholds the
+// step cadence wins over keeping a single maximum-size tool result whole.
+const DEGENERATE_THRESHOLD_GUARD_TOKENS = 2_000;
+
+// Truncated results keep at least this much content so the model can see what
+// the tool returned and refine its next call instead of flying blind.
+const MIN_KEPT_CHARS = 400;
+
+const TRUNCATION_ANNOTATION =
+  "[Truncated by eve: this step's tool results exceeded the per-step context budget. Use narrower queries, smaller ranges, or offsets.]";
+
+/** Per-step tool-output budget (tokens) for a given compaction threshold. */
+export function resolveStepToolBudget(threshold: number): number {
+  return Math.max(
+    Math.floor(threshold / MIN_STEPS_BETWEEN_COMPACTIONS),
+    DEGENERATE_THRESHOLD_GUARD_TOKENS,
+  );
+}
+
+/**
+ * Bounds the combined size of one step's tool results to `budgetTokens`.
+ *
+ * Returns the input array unchanged (reference-equal) when the step is within
+ * budget. Otherwise the largest results are truncated first, each replaced by
+ * a text output carrying a content prefix plus an annotation steering the
+ * model toward narrower queries. Results are never dropped, so every tool_use
+ * keeps its paired tool_result.
+ */
+export function applyStepToolBudget(
+  messages: readonly ModelMessage[],
+  budgetTokens: number,
+): readonly ModelMessage[] {
+  const parts: { estimate: number; messageIndex: number; partIndex: number }[] = [];
+  for (const [messageIndex, message] of messages.entries()) {
+    if (message.role !== "tool" || typeof message.content === "string") {
+      continue;
+    }
+    for (const [partIndex, part] of message.content.entries()) {
+      if (part.type === "tool-result") {
+        parts.push({ estimate: estimateTokens(part.output), messageIndex, partIndex });
+      }
+    }
+  }
+
+  let total = parts.reduce((sum, part) => sum + part.estimate, 0);
+  if (total <= budgetTokens) {
+    return messages;
+  }
+
+  const truncations = new Map<string, number>();
+  for (const part of parts.toSorted((a, b) => b.estimate - a.estimate)) {
+    if (total <= budgetTokens) {
+      break;
+    }
+
+    const allowedTokens = Math.max(budgetTokens - (total - part.estimate), 0);
+    const keptChars = Math.max(Math.floor(allowedTokens * 4), MIN_KEPT_CHARS);
+    truncations.set(`${part.messageIndex}:${part.partIndex}`, keptChars);
+    total -= part.estimate - keptChars / 4;
+  }
+
+  return messages.map((message, messageIndex) => {
+    if (message.role !== "tool" || typeof message.content === "string") {
+      return message;
+    }
+
+    let changed = false;
+    const content = message.content.map((part, partIndex) => {
+      const keptChars = truncations.get(`${messageIndex}:${partIndex}`);
+      if (keptChars === undefined || part.type !== "tool-result") {
+        return part;
+      }
+
+      changed = true;
+      const serialized =
+        typeof part.output === "object" && part.output !== null
+          ? JSON.stringify(part.output)
+          : String(part.output);
+      // Annotation leads so the model reads the caveat before the content and
+      // so it survives prefix-capped renderings (compaction trail lines).
+      return {
+        ...part,
+        output: {
+          type: "text" as const,
+          value: `${TRUNCATION_ANNOTATION}\n\n${serialized.slice(0, keptChars)}`,
+        },
+      };
+    });
+
+    return changed ? { ...message, content } : message;
+  }) as readonly ModelMessage[];
+}

--- a/packages/eve/src/harness/step-tool-budget.ts
+++ b/packages/eve/src/harness/step-tool-budget.ts
@@ -1,6 +1,7 @@
 import type { ModelMessage } from "ai";
 
 import { estimateTokens } from "#harness/token-estimate.js";
+import { truncateToolResults, type ToolResultPart } from "#harness/tool-result-truncation.js";
 
 /**
  * Target minimum number of model steps between compactions. The per-step
@@ -16,7 +17,10 @@ export const MIN_STEPS_BETWEEN_COMPACTIONS = 20;
 const DEGENERATE_THRESHOLD_GUARD_TOKENS = 2_000;
 
 // Truncated results keep at least this much content so the model can see what
-// the tool returned and refine its next call instead of flying blind.
+// the tool returned and refine its next call instead of flying blind. With
+// many results in one step, these floors (plus annotations) can leave the
+// step somewhat above budget — the budget is a soft cadence target measured
+// on the estimateTokens ruler, not a hard cap.
 const MIN_KEPT_CHARS = 400;
 
 const TRUNCATION_ANNOTATION =
@@ -34,72 +38,41 @@ export function resolveStepToolBudget(threshold: number): number {
  * Bounds the combined size of one step's tool results to `budgetTokens`.
  *
  * Returns the input array unchanged (reference-equal) when the step is within
- * budget. Otherwise the largest results are truncated first, each replaced by
- * a text output carrying a content prefix plus an annotation steering the
- * model toward narrower queries. Results are never dropped, so every tool_use
- * keeps its paired tool_result.
+ * budget. Otherwise the largest results are truncated first, each keeping an
+ * annotated content prefix that steers the model toward narrower queries.
  */
 export function applyStepToolBudget(
   messages: readonly ModelMessage[],
   budgetTokens: number,
 ): readonly ModelMessage[] {
-  const parts: { estimate: number; messageIndex: number; partIndex: number }[] = [];
-  for (const [messageIndex, message] of messages.entries()) {
+  const parts: { estimate: number; part: ToolResultPart }[] = [];
+  for (const message of messages) {
     if (message.role !== "tool" || typeof message.content === "string") {
       continue;
     }
-    for (const [partIndex, part] of message.content.entries()) {
+    for (const part of message.content) {
       if (part.type === "tool-result") {
-        parts.push({ estimate: estimateTokens(part.output), messageIndex, partIndex });
+        parts.push({ estimate: estimateTokens(part.output), part });
       }
     }
   }
 
-  let total = parts.reduce((sum, part) => sum + part.estimate, 0);
+  let total = parts.reduce((sum, entry) => sum + entry.estimate, 0);
   if (total <= budgetTokens) {
     return messages;
   }
 
-  const truncations = new Map<string, number>();
-  for (const part of parts.toSorted((a, b) => b.estimate - a.estimate)) {
+  const keptCharsByPart = new Map<ToolResultPart, number>();
+  for (const entry of parts.toSorted((a, b) => b.estimate - a.estimate)) {
     if (total <= budgetTokens) {
       break;
     }
 
-    const allowedTokens = Math.max(budgetTokens - (total - part.estimate), 0);
+    const allowedTokens = Math.max(budgetTokens - (total - entry.estimate), 0);
     const keptChars = Math.max(Math.floor(allowedTokens * 4), MIN_KEPT_CHARS);
-    truncations.set(`${part.messageIndex}:${part.partIndex}`, keptChars);
-    total -= part.estimate - keptChars / 4;
+    keptCharsByPart.set(entry.part, keptChars);
+    total -= entry.estimate - keptChars / 4;
   }
 
-  return messages.map((message, messageIndex) => {
-    if (message.role !== "tool" || typeof message.content === "string") {
-      return message;
-    }
-
-    let changed = false;
-    const content = message.content.map((part, partIndex) => {
-      const keptChars = truncations.get(`${messageIndex}:${partIndex}`);
-      if (keptChars === undefined || part.type !== "tool-result") {
-        return part;
-      }
-
-      changed = true;
-      const serialized =
-        typeof part.output === "object" && part.output !== null
-          ? JSON.stringify(part.output)
-          : String(part.output);
-      // Annotation leads so the model reads the caveat before the content and
-      // so it survives prefix-capped renderings (compaction trail lines).
-      return {
-        ...part,
-        output: {
-          type: "text" as const,
-          value: `${TRUNCATION_ANNOTATION}\n\n${serialized.slice(0, keptChars)}`,
-        },
-      };
-    });
-
-    return changed ? { ...message, content } : message;
-  }) as readonly ModelMessage[];
+  return truncateToolResults(messages, TRUNCATION_ANNOTATION, (part) => keptCharsByPart.get(part));
 }

--- a/packages/eve/src/harness/tool-loop-compaction-accounting.test.ts
+++ b/packages/eve/src/harness/tool-loop-compaction-accounting.test.ts
@@ -362,4 +362,67 @@ describe("tool-loop structured compaction accounting", () => {
       )?.output,
     ).toEqual(largeOutput);
   });
+
+  it("truncates a step's oversized tool results at attach time with an annotation", async () => {
+    // ~50k estimated tokens against a threshold of 100k: the per-step budget
+    // (threshold / 20 = 5k tokens) binds, so the result enters history already
+    // truncated. History stays append-only — the truncated form is what was
+    // attached, nothing rewrites it later.
+    const largeOutput = { value: "x".repeat(200_000) };
+
+    setupMockAgentSequence([
+      {
+        finishReason: "tool-calls",
+        response: {
+          messages: [
+            {
+              content: [{ input: {}, toolCallId: "call-1", toolName: "add", type: "tool-call" }],
+              role: "assistant",
+            },
+            {
+              content: [
+                { output: largeOutput, toolCallId: "call-1", toolName: "add", type: "tool-result" },
+              ],
+              role: "tool",
+            },
+          ],
+        },
+        text: "",
+        toolCalls: [{ input: {}, toolCallId: "call-1", toolName: "add", type: "tool-call" }],
+        toolResults: [
+          { output: largeOutput, toolCallId: "call-1", toolName: "add", type: "tool-result" },
+        ],
+        usage: { inputTokens: 100 },
+      },
+      {
+        finishReason: "stop",
+        response: { messages: [{ content: "Done.", role: "assistant" }] },
+        text: "Done.",
+        toolCalls: [],
+        toolResults: [],
+      },
+    ]);
+
+    const runStep = createToolLoopHarness(createTestConfig());
+    const first = await runStep(
+      createTestSession({ compaction: { recentWindowSize: 10, threshold: 100_000 } }),
+      { message: "Read a big file" },
+    );
+
+    const toolResult = first.session.history.find(
+      (m) =>
+        m.role === "tool" &&
+        Array.isArray(m.content) &&
+        (m.content[0] as { toolCallId?: string }).toolCallId === "call-1",
+    );
+    expect(toolResult).toBeDefined();
+    const output = (
+      Array.isArray(toolResult?.content)
+        ? (toolResult.content[0] as { output?: unknown })
+        : undefined
+    )?.output as { type?: string; value?: string };
+    expect(output?.type).toBe("text");
+    expect(output?.value).toContain("Truncated by eve");
+    expect(output?.value?.length ?? 0).toBeLessThan(50_000);
+  });
 });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -74,6 +74,7 @@ import {
   resolveCompactionModel,
   shouldCompact,
 } from "#harness/compaction.js";
+import { applyStepToolBudget, resolveStepToolBudget } from "#harness/step-tool-budget.js";
 import {
   accumulateTurnUsage,
   getTurnUsageState,
@@ -1824,7 +1825,13 @@ async function handleStepResult(input: {
     messages: rawResponseMessages,
     providerExecutedOutcomeIds,
   });
-  const responseMessages = normalizedProviderHistory.messages;
+  // Bound the step's combined tool-result size before it enters durable
+  // history and compaction accounting. Stream events already emitted carry
+  // the full outputs; only what the model sees on later steps is bounded.
+  const responseMessages = applyStepToolBudget(
+    normalizedProviderHistory.messages,
+    resolveStepToolBudget(session.compaction.threshold),
+  );
 
   const baseSession: HarnessSession = {
     ...session,

--- a/packages/eve/src/harness/tool-result-truncation.test.ts
+++ b/packages/eve/src/harness/tool-result-truncation.test.ts
@@ -1,0 +1,55 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+
+import { truncateToolResults } from "#harness/tool-result-truncation.js";
+
+function toolMessage(callId: string, value: string): ModelMessage {
+  return {
+    content: [
+      {
+        output: { type: "json", value: { content: value } },
+        toolCallId: callId,
+        toolName: "grep",
+        type: "tool-result",
+      },
+    ],
+    role: "tool",
+  };
+}
+
+describe("truncateToolResults", () => {
+  it("returns the input reference-equal when the decider declines every part", () => {
+    const messages: ModelMessage[] = [{ content: "hi", role: "user" }, toolMessage("c1", "small")];
+
+    expect(truncateToolResults(messages, "[note]", () => undefined)).toBe(messages);
+  });
+
+  it("rewrites decided parts to annotation-led truncated text and keeps others by identity", () => {
+    const untouched = toolMessage("c1", "keep me");
+    const oversized = toolMessage("c2", "x".repeat(5_000));
+    const messages: ModelMessage[] = [untouched, oversized];
+
+    const result = truncateToolResults(messages, "[cut]", (_part, serialized) =>
+      serialized.length > 1_000 ? 100 : undefined,
+    );
+
+    expect(result).not.toBe(messages);
+    expect(result[0]).toBe(untouched);
+    const part = Array.isArray(result[1]?.content) ? result[1].content[0] : undefined;
+    expect(part?.type).toBe("tool-result");
+    const output = part?.type === "tool-result" ? part.output : undefined;
+    const value =
+      typeof output === "object" && output !== null && "value" in output
+        ? String(output.value)
+        : "";
+    expect(value.startsWith("[cut]\n\n")).toBe(true);
+    expect(value.length).toBeLessThan(200);
+    expect(part?.type === "tool-result" ? part.toolCallId : undefined).toBe("c2");
+  });
+
+  it("leaves a part untouched when the decided budget already covers it", () => {
+    const messages: ModelMessage[] = [toolMessage("c1", "tiny")];
+
+    expect(truncateToolResults(messages, "[cut]", () => 10_000)).toBe(messages);
+  });
+});

--- a/packages/eve/src/harness/tool-result-truncation.ts
+++ b/packages/eve/src/harness/tool-result-truncation.ts
@@ -1,0 +1,67 @@
+import type { ModelMessage } from "ai";
+
+type ModelMessageContentPart = Exclude<ModelMessage["content"], string>[number];
+
+/** Tool-result content part of a `role: "tool"` message. */
+export type ToolResultPart = Extract<ModelMessageContentPart, { type: "tool-result" }>;
+
+/** Canonical serialization used for measuring and truncating tool outputs. */
+export function serializeToolResultOutput(part: ToolResultPart): string {
+  return JSON.stringify(part.output) ?? "";
+}
+
+/**
+ * Rewrites tool-result outputs to an annotated truncated text form.
+ *
+ * `decideKeptChars` inspects each tool-result part (with its canonical
+ * serialization) and returns how many characters to keep, or `undefined` to
+ * leave the part untouched. Messages and untouched parts keep their identity,
+ * and the input array is returned reference-equal when nothing was truncated.
+ * Results are never dropped, so every tool_use keeps its paired tool_result.
+ *
+ * The annotation leads the value so the model reads the caveat before the
+ * content and so it survives prefix-capped renderings.
+ */
+export function truncateToolResults(
+  messages: readonly ModelMessage[],
+  annotation: string,
+  decideKeptChars: (part: ToolResultPart, serialized: string) => number | undefined,
+): readonly ModelMessage[] {
+  let anyTruncated = false;
+
+  const rewritten = messages.map((message) => {
+    if (message.role !== "tool" || typeof message.content === "string") {
+      return message;
+    }
+
+    let changed = false;
+    const content = message.content.map((part) => {
+      if (part.type !== "tool-result") {
+        return part;
+      }
+
+      const serialized = serializeToolResultOutput(part);
+      const keptChars = decideKeptChars(part, serialized);
+      if (keptChars === undefined || serialized.length <= keptChars) {
+        return part;
+      }
+
+      changed = true;
+      return {
+        ...part,
+        output: {
+          type: "text" as const,
+          value: `${annotation}\n\n${serialized.slice(0, keptChars)}`,
+        },
+      };
+    });
+
+    if (!changed) {
+      return message;
+    }
+    anyTruncated = true;
+    return { ...message, content };
+  });
+
+  return anyTruncated ? rewritten : messages;
+}


### PR DESCRIPTION
Stacked on #1003. Same production trace.

## Problem

Tool executors cap one result at 50 KiB, but nothing bounds a step. The traced model fired three max-size greps per step (~45k estimated tokens) and filled its threshold every ~11 steps. Per-step tool volume sets compaction cadence, and every compaction is a full prompt-cache rewrite — 28 in that turn.

## Fix

- New `harness/step-tool-budget.ts`: each step's combined tool output is bounded to `threshold / MIN_STEPS_BETWEEN_COMPACTIONS` (20). The limit is inferred from the compaction cutoff and the steps-per-window count; both are framework-owned for now — exposing the step count to agent authors is a deliberate non-goal of this PR.
- Applied at one choke point in `handleStepResult`, before results enter durable history and compaction accounting. Covers stream and generate paths. Already-emitted stream events keep full outputs; history stays append-only — the truncated form is what gets attached.
- Over budget: the largest results are truncated first, each replaced by an annotated text prefix telling the model to use narrower queries or offsets. Results are never dropped, so `tool_use`/`tool_result` pairing survives.
- The annotation leads the value, not trails it, so it survives prefix-capped renderings — after eviction reduces the result to a trail line, the model still sees `[Truncated by eve: …`.
- The budget wins over keeping a single max-size result whole: at a 180k threshold that is 9k tokens, so one 50 KiB grep gets cut. The only floor is a 2k-token guard so deterministic test agents (thresholds in the hundreds) don't truncate everything; it never binds above a 40k threshold.
- New `oversized-step-truncation` e2e case: the mock model reports its marker only after seeing the annotation in a request.
- Extracts `harness/tool-result-truncation.ts`, the serialize→clip→annotate kernel now shared with compaction's result capping — which is why `compaction.ts` appears in this diff: its `capToolResults` collapses to a three-line decider over the same kernel, removing a second copy that had already diverged on primitive-output serialization.


