### PR TITLE
feat(docs): includes integration entries in command+k search menu

### DIFF
--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,5 +1,9 @@
 import { createSearchRoute } from "@vercel/geistdocs/routes/search";
 import { config } from "@/lib/geistdocs/config";
 import { geistdocsSource } from "@/lib/geistdocs/source";
+import { integrationSource } from "@/lib/integrations/source";
 
-export const GET = createSearchRoute({ config, sources: [geistdocsSource] });
+export const GET = createSearchRoute({
+  config,
+  sources: [geistdocsSource, integrationSource],
+});

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getIntegration } from "./data";
+import { integrationSearchText } from "./discovery";
+
+describe("integration discovery", () => {
+  it("includes presentation keywords in searchable text", () => {
+    const slack = getIntegration("slack");
+    expect(slack).toBeDefined();
+
+    expect(integrationSearchText(slack!)).toContain("Slack");
+    expect(integrationSearchText(slack!)).toContain("Channel");
+    expect(integrationSearchText(slack!)).toContain("messaging");
+  });
+});

--- a/apps/docs/lib/integrations/discovery.ts
+++ b/apps/docs/lib/integrations/discovery.ts
@@ -1,0 +1,16 @@
+import type { Integration } from "./data";
+
+const typeLabel: Record<Integration["type"], string> = {
+  channel: "Channel",
+  connection: "Connection",
+  extension: "Extension",
+};
+
+/** Plain text used by the advanced search index for one integration. */
+export const integrationSearchText = (integration: Integration): string =>
+  [
+    integration.name,
+    typeLabel[integration.type],
+    integration.tagline,
+    ...(integration.keywords ?? []),
+  ].join("\n");

--- a/apps/docs/lib/integrations/source.ts
+++ b/apps/docs/lib/integrations/source.ts
@@ -1,0 +1,61 @@
+import { createSource, type FumadocsCollection } from "@vercel/geistdocs/source";
+import { config } from "@/lib/geistdocs/config";
+import { integrationSearchText } from "./discovery";
+import { integrations } from "./data";
+
+const structuredData = (content: string) => ({
+  headings: [],
+  contents: [{ heading: undefined, content }],
+});
+
+const integrationFiles = [
+  {
+    type: "meta" as const,
+    path: "meta.json",
+    data: {
+      title: "Integrations",
+      root: true,
+    },
+  },
+  {
+    type: "page" as const,
+    path: "index.md",
+    slugs: [],
+    data: {
+      title: "Integrations",
+      description:
+        "Browse every third-party service eve connects to, including channels and connections.",
+      excludeFrom: ["search" as const],
+      type: "directory",
+      structuredData: structuredData("Integrations for eve."),
+      getText: async () => "Integrations for eve.",
+    },
+  },
+  ...integrations.map((integration) => {
+    return {
+      type: "page" as const,
+      path: `${integration.slug}.md`,
+      slugs: [integration.slug],
+      data: {
+        title: integration.name,
+        description: integration.tagline,
+        type: integration.type,
+        keywords: integration.keywords,
+        structuredData: structuredData(integrationSearchText(integration)),
+        getText: async () => integration.tagline,
+      },
+    };
+  }),
+];
+
+const integrationDocs: FumadocsCollection = {
+  toFumadocsSource: () => ({ files: integrationFiles }),
+};
+
+export const integrationSource = createSource({
+  baseUrl: "/integrations",
+  config,
+  docs: integrationDocs,
+  id: "integrations",
+  label: "Integrations",
+});


### PR DESCRIPTION
### Description

The integrations gallery is populated from `@vercel/eve-catalog`, outside the Fumadocs collection that backs the command menu. As a result, searching for a catalog-only integration could not return its detail page.

This adds a synthetic Geistdocs source for the package-backed integrations and includes it in `/api/search`. Individual integrations are searchable by name, type, tagline, and presentation keywords; their results use an `Integrations` breadcrumb. The broad `/integrations` landing page is intentionally excluded so it does not compete with specific results.

<img width="696" height="314" alt="image" src="https://github.com/user-attachments/assets/8a26d069-c29a-4397-8336-de16c11f5834" />

### How did you test your changes?

- `pnpm --filter eve-docs test:unit`
- `pnpm exec tsc --project apps/docs/tsconfig.json --noEmit`
- `pnpm --filter eve-docs build`
- Queried the production search endpoint for catalog-only entries and confirmed results link to `/integrations/<slug>` with `breadcrumbs: ["Integrations"]`.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (docs site only; no changeset needed)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
