### PR TITLE
feat(docs): include integrations in sitemap.xml for use in crawling

### DIFF
--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 
 import { source } from "@/lib/geistdocs/source";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
+import { integrationPaths } from "@/lib/integrations/discovery";
 import { templateEntries } from "@/lib/templates/data";
 
 const baseUrl = getSiteOrigin();
@@ -42,6 +43,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly" as const,
       priority: 0.4,
       url: url(`/templates/${entry.slug}`),
+    })),
+    ...integrationPaths().map((path) => ({
+      changeFrequency: "weekly" as const,
+      priority: path === "/integrations" ? 0.5 : 0.4,
+      url: url(path),
     })),
     ...pages,
   ];

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { getIntegration } from "./data";
-import { integrationSearchText } from "./discovery";
+import { getIntegration, integrations } from "./data";
+import { integrationPaths, integrationSearchText } from "./discovery";
 
 describe("integration discovery", () => {
+  it("includes the landing page and every detail page in crawler paths", () => {
+    const paths = integrationPaths();
+
+    expect(paths[0]).toBe("/integrations");
+    expect(paths).toHaveLength(integrations.length + 1);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(paths).toContain("/integrations/slack");
+    expect(paths).toContain("/integrations/linear");
+  });
+
   it("includes presentation keywords in searchable text", () => {
     const slack = getIntegration("slack");
     expect(slack).toBeDefined();

--- a/apps/docs/lib/integrations/discovery.ts
+++ b/apps/docs/lib/integrations/discovery.ts
@@ -1,4 +1,4 @@
-import type { Integration } from "./data";
+import { type Integration, integrations } from "./data";
 
 const typeLabel: Record<Integration["type"], string> = {
   channel: "Channel",
@@ -14,3 +14,9 @@ export const integrationSearchText = (integration: Integration): string =>
     integration.tagline,
     ...(integration.keywords ?? []),
   ].join("\n");
+
+/** Public integration paths included in crawler-facing sitemaps. */
+export const integrationPaths = (): string[] => [
+  "/integrations",
+  ...integrations.map((integration) => `/integrations/${integration.slug}`),
+];


### PR DESCRIPTION
### Description

Integration detail pages are package-backed routes rather than Fumadocs pages, so the XML sitemap previously included docs and templates but omitted `/integrations` and every `/integrations/<slug>` page.

This derives the crawler-facing paths from the same integration catalog used by the gallery and adds the landing page plus every detail page to `sitemap.xml`. A unit test keeps sitemap coverage in sync as the catalog changes.

#### Why this improves crawling

The sitemap is a discovery mechanism; it does not itself render pages or guarantee indexing. We verified the other half of the crawler path separately:

- A production Next.js build reports the integration landing page and all 52 current detail routes as SSG HTML (`●`), rather than client-only pages.
- The generated initial HTML for `/integrations/slack` contains its title, description, navigation link, and Install/Quick start/Configure content without requiring client-side JavaScript.
- The integration gallery emits normal links to every detail route, and the shared layout permits `index, follow`.
- The generated XML sitemap contains 53 integration URLs: the landing page plus all 52 detail pages.

Together, the existing crawlable HTML and the new sitemap entries give crawlers both discoverable URLs and meaningful initial responses. Production indexing should still be confirmed with crawler/Search Console data after deployment.

### How did you test your changes?

- `pnpm --filter eve-docs test:unit`
- `pnpm --filter eve-docs build`
- Inspected `apps/docs/.next/server/app/sitemap.xml.body` for the integration landing and detail URLs.
- Inspected `apps/docs/.next/server/app/en/integrations/slack.html` for server-rendered metadata and setup content.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (docs site only; no changeset needed)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
