### PR TITLE
fix(docs): expose integrations in llms.txt

### DIFF
--- a/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
@@ -1,10 +1,11 @@
 import { createDocsMarkdownRoute } from "@vercel/geistdocs/routes/llms";
 import { geistdocsSource } from "@/lib/geistdocs/source";
+import { integrationSource } from "@/lib/integrations/source";
 
 export const revalidate = false;
 
 const markdownRoute = createDocsMarkdownRoute({
-  source: geistdocsSource,
+  sources: [geistdocsSource, integrationSource],
 });
 
 export const GET = markdownRoute.GET;

--- a/apps/docs/app/[lang]/llms.txt/route.ts
+++ b/apps/docs/app/[lang]/llms.txt/route.ts
@@ -1,10 +1,11 @@
 import { createLlmsRoute } from "@vercel/geistdocs/routes/llms";
 import { geistdocsSource } from "@/lib/geistdocs/source";
+import { integrationSource } from "@/lib/integrations/source";
 
 export const revalidate = false;
 
 const llmsRoute = createLlmsRoute({
-  sources: [geistdocsSource],
+  sources: [geistdocsSource, integrationSource],
 });
 
 export const GET = llmsRoute.GET;

--- a/apps/docs/app/[lang]/sitemap.md/route.ts
+++ b/apps/docs/app/[lang]/sitemap.md/route.ts
@@ -1,13 +1,14 @@
 import { createSitemapMarkdownRoute } from "@vercel/geistdocs/routes/sitemap";
 import { config } from "@/lib/geistdocs/config";
 import { geistdocsSource } from "@/lib/geistdocs/source";
+import { integrationSource } from "@/lib/integrations/source";
 
 export const revalidate = false;
 export const dynamic = "error";
 
 const sitemapRoute = createSitemapMarkdownRoute({
   config,
-  sources: [{ source: geistdocsSource }],
+  sources: [{ source: geistdocsSource }, { source: integrationSource }],
 });
 
 export const GET = sitemapRoute.GET;

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getIntegration, integrations } from "./data";
-import { integrationPaths, integrationSearchText } from "./discovery";
+import { integrationMarkdown, integrationPaths, integrationSearchText } from "./discovery";
 
 describe("integration discovery", () => {
   it("includes the landing page and every detail page in crawler paths", () => {
@@ -20,5 +20,25 @@ describe("integration discovery", () => {
     expect(integrationSearchText(slack!)).toContain("Slack");
     expect(integrationSearchText(slack!)).toContain("Channel");
     expect(integrationSearchText(slack!)).toContain("messaging");
+  });
+
+  it("renders hand-authored setup as agent-readable Markdown", () => {
+    const slack = getIntegration("slack");
+    expect(slack).toBeDefined();
+
+    const markdown = integrationMarkdown(slack!);
+    expect(markdown).toContain("## Install");
+    expect(markdown).toContain("## Quick start");
+    expect(markdown).toContain("eve channels add slack");
+  });
+
+  it("renders every connection setup variant", () => {
+    const notion = getIntegration("notion");
+    expect(notion).toBeDefined();
+
+    const markdown = integrationMarkdown(notion!);
+    expect(markdown).toContain("### MCP · User");
+    expect(markdown).toContain("### OpenAPI · User");
+    expect(markdown).toContain("agent/connections/notion.ts");
   });
 });

--- a/apps/docs/lib/integrations/discovery.ts
+++ b/apps/docs/lib/integrations/discovery.ts
@@ -1,9 +1,29 @@
-import { type Integration, integrations } from "./data";
+import {
+  buildConnectionConfigure,
+  buildConnectionInstall,
+  buildConnectionSetup,
+} from "./connection-setup";
+import { type Integration, authModeLabel, integrations, protocolLabel } from "./data";
 
 const typeLabel: Record<Integration["type"], string> = {
   channel: "Channel",
   connection: "Connection",
   extension: "Extension",
+};
+
+const section = (title: string, content: string): string => `## ${title}\n\n${content}`;
+
+const connectionQuickStart = (integration: Integration): string => {
+  const setup = buildConnectionSetup(integration);
+
+  return setup.protocols
+    .flatMap((protocol) =>
+      setup.authModes.map((authMode) => {
+        const content = setup.variants[`${protocol}:${authMode}`] ?? "";
+        return `### ${protocolLabel[protocol]} · ${authModeLabel[authMode]}\n\n${content}`;
+      }),
+    )
+    .join("\n\n");
 };
 
 /** Plain text used by the advanced search index for one integration. */
@@ -14,6 +34,36 @@ export const integrationSearchText = (integration: Integration): string =>
     integration.tagline,
     ...(integration.keywords ?? []),
   ].join("\n");
+
+/** Markdown representation shared by integration discovery and agent-readable routes. */
+export const integrationMarkdown = (integration: Integration): string => {
+  const isConnection = integration.connection !== undefined;
+  const install = isConnection ? buildConnectionInstall(integration) : (integration.install ?? "");
+  const quickStart = isConnection
+    ? connectionQuickStart(integration)
+    : (integration.quickStart ?? "");
+  const configure = isConnection
+    ? buildConnectionConfigure(integration)
+    : (integration.configure ?? "");
+
+  return [
+    `${typeLabel[integration.type]} integration for eve. ${integration.tagline}`,
+    section("Install", install),
+    section("Quick start", quickStart),
+    section("Configure", configure),
+    `[Read the full ${typeLabel[integration.type].toLowerCase()} documentation](${integration.docsHref})`,
+  ].join("\n\n");
+};
+
+/** Markdown landing page for agent-readable integration discovery. */
+export const integrationsIndexMarkdown = (): string =>
+  [
+    "Browse every third-party service eve connects to, including extensions, messaging channels, and tool connections over MCP or OpenAPI.",
+    ...integrations.map(
+      (integration) =>
+        `- [${integration.name}](/integrations/${integration.slug}): ${integration.tagline}`,
+    ),
+  ].join("\n\n");
 
 /** Public integration paths included in crawler-facing sitemaps. */
 export const integrationPaths = (): string[] => [

--- a/apps/docs/lib/integrations/source.ts
+++ b/apps/docs/lib/integrations/source.ts
@@ -1,6 +1,6 @@
 import { createSource, type FumadocsCollection } from "@vercel/geistdocs/source";
 import { config } from "@/lib/geistdocs/config";
-import { integrationSearchText } from "./discovery";
+import { integrationMarkdown, integrationSearchText, integrationsIndexMarkdown } from "./discovery";
 import { integrations } from "./data";
 
 const structuredData = (content: string) => ({
@@ -28,10 +28,12 @@ const integrationFiles = [
       excludeFrom: ["search" as const],
       type: "directory",
       structuredData: structuredData("Integrations for eve."),
-      getText: async () => "Integrations for eve.",
+      getText: async () => integrationsIndexMarkdown(),
     },
   },
   ...integrations.map((integration) => {
+    const markdown = integrationMarkdown(integration);
+
     return {
       type: "page" as const,
       path: `${integration.slug}.md`,
@@ -42,7 +44,7 @@ const integrationFiles = [
         type: integration.type,
         keywords: integration.keywords,
         structuredData: structuredData(integrationSearchText(integration)),
-        getText: async () => integration.tagline,
+        getText: async () => markdown,
       },
     };
   }),

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -9,8 +9,9 @@ const proxy = createProxy({
 });
 
 export const config = {
-  // Matcher ignoring `/_next/`, `/api/`, public static assets, favicon, sitemap, robots, etc.
+  // llms.txt needs the locale rewrite even though the general matcher ignores static extensions.
   matcher: [
+    "/llms.txt",
     "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|eve\\.tgz$|.*\\.(?!mdx?$)[^/]+$).*)",
   ],
 };


### PR DESCRIPTION
### Description

Package-backed integration pages were also absent from the docs site's agent-readable surfaces. This adds the integration source to:

- the combined `llms.txt` corpus;
- the semantic `sitemap.md` index; and
- individual `llms.mdx/integrations/<slug>` Markdown routes.

Each integration document includes its type, tagline, install steps, every applicable quick-start variant, configuration guidance, and canonical reference link. The integration index remains available to agent/crawler surfaces while staying excluded from the command menu.

This also fixes the advertised public `/llms.txt` URL. The general proxy matcher ignores static file extensions, so `.txt` bypassed the default-language rewrite and returned 500 while `/en/llms.txt` worked. `/llms.txt` is now an explicit proxy match.

### How did you test your changes?

- `pnpm --filter eve-docs test:unit`
- `pnpm exec tsc --project apps/docs/tsconfig.json --noEmit`
- `pnpm --filter eve-docs build`
- `pnpm lint`
- `pnpm docs:check`
- `pnpm guard:invariants`
- Started the production build locally and confirmed 200 responses with integration content from `/llms.txt`, `/sitemap.md`, and `/llms.mdx/integrations/slack`.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (docs site only; no changeset needed)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
