### PR TITLE
refactor(eve): extract the engine-neutral turn-step operation

### DIFF
--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -8,6 +8,7 @@ import type { HandleEventFn, HarnessToolMap, StepFn } from "#harness/types.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { createLogger } from "#internal/logging.js";
 import type { RuntimeIdentity } from "#protocol/message.js";
+import type { EveAttributeWriter } from "#runtime/attributes/normalize.js";
 import { UNSPECIFIED_INPUT_SCHEMA, toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
 import type { RunMode } from "#shared/run-mode.js";
 import {
@@ -60,6 +61,8 @@ export interface CreateExecutionNodeStepInput {
   readonly mode: RunMode;
   readonly modelResolutionScope: RuntimeModelResolutionScope;
   readonly node: ResolvedRuntimeAgentNode;
+  /** Runtime-owned writer for eve observability attributes. */
+  readonly writeEveAttributes?: EveAttributeWriter;
   /**
    * Effective `maxSubagents` cap configured by the experimental Workflow tool
    * definition and materialized on the session at creation.
@@ -93,6 +96,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     resolveModel,
     runtimeIdentity: buildRuntimeIdentity(input.node),
     tools,
+    writeEveAttributes: input.writeEveAttributes,
   });
 }
 

--- a/packages/eve/src/execution/turn-step-operation.ts
+++ b/packages/eve/src/execution/turn-step-operation.ts
@@ -1,0 +1,506 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { callAdapterEventHandler, defaultDeliverResult } from "#channel/adapter.js";
+import type { DeliverPayload, HookPayload } from "#channel/types.js";
+import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
+import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-lifecycle.js";
+import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
+import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
+import { dispatchDynamicToolEvent } from "#context/dynamic-tool-lifecycle.js";
+import { AuthKey, CapabilitiesKey, ModeKey } from "#context/keys.js";
+import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { runStep } from "#context/run-step.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import { getHarnessEmissionState } from "#harness/emission.js";
+import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellation.js";
+import { setChannelContext } from "#execution/channel-context.js";
+import { hasPendingInputBatch } from "#harness/input-requests.js";
+import { coalesceTurnInputs } from "#harness/messages.js";
+import {
+  getRuntimeActionKeysFromWorkflowInterrupt,
+  isWorkflowRuntimeActionInterrupt,
+} from "#harness/workflow-runtime-action-state.js";
+import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
+import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
+import type { HarnessSession, StepInput, StepResult } from "#harness/types.js";
+import { getTurnUsageState, toUsage } from "#harness/turn-tag-state.js";
+import type { TokenUsage } from "#shared/token-usage.js";
+import type { JsonObject } from "#shared/json.js";
+import type { RunMode } from "#shared/run-mode.js";
+import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
+import {
+  createAuthorizationCompletedEvent,
+  encodeMessageStreamEvent,
+  type HandleMessageStreamEvent,
+  timestampHandleMessageStreamEvent,
+} from "#protocol/message.js";
+import {
+  CallbackBaseUrlKey,
+  clearPendingAuthorization,
+  getPendingAuthorization,
+  PendingAuthorizationResultKey,
+  type AuthorizationResult,
+} from "#harness/authorization.js";
+import type { ConnectionAuthorizationChallenge } from "#public/connections/errors.js";
+import type { AuthorizationCallback } from "#runtime/connections/types.js";
+import {
+  createDurableSessionState,
+  type DurableSession,
+  type DurableSessionState,
+} from "#execution/durable-session-store.js";
+import { createExecutionNodeStep, type CreateRuntime } from "#execution/node-step.js";
+import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
+import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
+import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
+import type { EveAttributeWriter } from "#runtime/attributes/normalize.js";
+import { resolveSessionSkillRoot } from "#execution/workflow-skill-root.js";
+
+/**
+ * Result of one durable harness step, consumed by the turn workflow.
+ *
+ * `park` carries `hasPendingInputBatch`, `hasPendingAuthorization`, and
+ * `pendingRuntimeActionKeys` so the turn workflow can pick the right
+ * {@link import("#execution/next-driver-action.js").NextDriverAction}
+ * arm without re-reading the session.
+ *
+ * `cancelled` converts the harness's cancellation throw into a *returned*
+ * result so workflow-core never classifies the abort as a step failure or
+ * retries it; the epilogue runs in `settleCancelledTurnStep`.
+ */
+export type DurableStepResult =
+  | {
+      readonly action: "continue" | "done";
+      readonly output?: unknown;
+      readonly isError?: boolean;
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+      /** Session-total token usage; set on `done` when the session spent any. */
+      readonly usage?: TokenUsage;
+    }
+  | {
+      readonly action: "cancelled";
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+    }
+  | {
+      readonly action: "park";
+      readonly authorizationNames?: readonly string[];
+      readonly hasPendingAuthorization: boolean;
+      readonly hasPendingInputBatch: boolean;
+      readonly pendingRuntimeActionKeys?: readonly string[];
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+    }
+  | {
+      readonly action: "dispatch-workflow-runtime-actions";
+      readonly pendingRuntimeActionKeys: readonly string[];
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+    };
+
+/**
+ * Inputs for one harness step, with every engine-owned capability injected:
+ * the pre-read durable session, the resolved callback base URL, the runtime
+ * constructor for delegated child runs, and the observability attribute
+ * writer. The operation itself never touches a Workflow primitive.
+ */
+export interface TurnStepOperationInput {
+  /** Cancellation signal forwarded into the step. */
+  readonly abortSignal?: AbortSignal;
+  /** Callback base URL for tool-execution hooks, when the host knows one. */
+  readonly callbackBaseUrl: string | undefined;
+  /** Runtime constructor used to start delegated child runs. */
+  readonly createRuntime: CreateRuntime;
+  /** The durable session, pre-read by the host from `sessionState`. */
+  readonly durableSession: DurableSession;
+  readonly input: HookPayload | undefined;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+  /** Attribute sink, or `undefined` when the host has no attribute store. */
+  readonly writeEveAttributes: EveAttributeWriter | undefined;
+}
+
+/**
+ * Runs one atomic harness step: fold the delivery in, run the model with
+ * its tools, and classify the outcome into a {@link DurableStepResult}.
+ *
+ * Engine-neutral by construction — the caller owns the durable boundary
+ * (e.g. a Workflow `"use step"`), session reading, and retry policy.
+ */
+export async function executeTurnStepOperation(
+  rawInput: TurnStepOperationInput,
+): Promise<DurableStepResult> {
+  let input = rawInput;
+
+  let durableSession = rawInput.durableSession;
+  const ctx = await deserializeContext(input.serializedContext);
+  const adapter = ctx.require(ChannelKey);
+  const bundle = ctx.require(BundleKey);
+
+  // Populate the callback base URL so getHookUrl() works during tool
+  // execution. The host resolves it (eve's active local origin over
+  // engine metadata fallback); outside an engine context it is undefined
+  // and getHookUrl() returns undefined.
+  if (input.callbackBaseUrl !== undefined) {
+    ctx.set(CallbackBaseUrlKey, input.callbackBaseUrl);
+  }
+
+  // Authorization callback. If the delivery carries an
+  // `authorizationCallback` and there's a pending authorization on
+  // session state, extract it, build AuthorizationResult entries, and
+  // populate PendingAuthorizationResultKey so tools can complete auth.
+  // Strip the callback from the delivery so the adapter doesn't see it.
+  // Completion event names are collected here; emission happens after
+  // the `emit` function is created below.
+  const pendingAuth = getPendingAuthorization(durableSession.state);
+  let completedAuths:
+    | Array<{ name: string; authorization: ConnectionAuthorizationChallenge }>
+    | undefined;
+  if (pendingAuth && input.input?.kind === "deliver") {
+    const authResults: Array<{ name: string } & AuthorizationResult> = [];
+    const completed: Array<{ name: string; authorization: ConnectionAuthorizationChallenge }> = [];
+    const remainingPayloads: DeliverPayload[] = [];
+    for (const payload of input.input.payloads) {
+      const cb = payload["authorizationCallback"] as
+        | { connectionName: string; callback: AuthorizationCallback }
+        | undefined;
+      if (cb) {
+        const challenge = pendingAuth.challenges.find((c) => c.name === cb.connectionName);
+        if (challenge) {
+          authResults.push({
+            name: challenge.name,
+            resume: challenge.resume,
+            callback: cb.callback,
+            hookUrl: challenge.hookUrl,
+          });
+          completed.push({ name: challenge.name, authorization: challenge.challenge });
+        }
+      } else {
+        remainingPayloads.push(payload);
+      }
+    }
+    if (authResults.length > 0) {
+      ctx.set(PendingAuthorizationResultKey, authResults);
+      durableSession = {
+        ...durableSession,
+        state: clearPendingAuthorization(
+          durableSession.state,
+          authResults.map((result) => result.name),
+        ),
+      };
+      completedAuths = completed;
+      input =
+        remainingPayloads.length > 0
+          ? { ...input, input: { ...input.input, payloads: remainingPayloads } }
+          : { ...input, input: undefined };
+    }
+  }
+
+  // Apply deliver-time auth ferried via `resumeHook` (initial-turn
+  // input has no auth; it was seeded by buildRunContext).
+  if (input.input?.kind === "deliver" && input.input.auth !== undefined) {
+    ctx.set(AuthKey, input.input.auth ?? null);
+  }
+
+  const initialSession = hydrateDurableSession({
+    compactionOverrides: {
+      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+    },
+    durable: durableSession,
+    turnAgent: bundle.turnAgent,
+  });
+
+  const adapterCtx = buildAdapterContext(adapter, ctx);
+
+  // Run the adapter's deliver hook for each queued payload and
+  // coalesce the resulting StepInput values.
+  let resolved: StepInput | undefined;
+  if (input.input?.kind === "deliver") {
+    const results: StepInput[] = [];
+    for (const payload of input.input.payloads) {
+      const result = adapter.deliver
+        ? await adapter.deliver(payload, adapterCtx)
+        : defaultDeliverResult(payload);
+
+      if (result !== undefined && result !== null) {
+        results.push(result);
+      }
+    }
+    resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
+  } else if (input.input?.kind === "runtime-action-result") {
+    recordSubagentUsageSpans(input.input.results);
+    resolved = { runtimeActionResults: input.input.results };
+  }
+
+  // Pin adapter-state mutations back onto ctx so they survive the
+  // step boundary.
+  if (input.input?.kind === "deliver") {
+    const updatedAdapter = { ...adapter, state: { ...adapterCtx.state } };
+    setChannelContext(ctx, updatedAdapter);
+  }
+
+  // Adapter handled the delivery inline (e.g. a Slack interaction
+  // that only edits a message). Re-park without a model turn; skip
+  // the snapshot write when the session itself is unchanged.
+  if (input.input?.kind === "deliver" && resolved === undefined) {
+    const rekeyed = reconcileSessionContinuationToken(ctx, initialSession);
+    const nextSerializedContext = serializeContext(ctx);
+    const nextState =
+      rekeyed === initialSession
+        ? input.sessionState
+        : createDurableSessionState({ session: rekeyed });
+
+    return {
+      action: "park",
+      ...derivePendingState(rekeyed),
+      serializedContext: nextSerializedContext,
+      sessionState: nextState,
+    };
+  }
+
+  const writer = input.parentWritable.getWriter();
+  const hookRegistry = bundle.hookRegistry;
+  const dynamicInstructionsResolvers = bundle.resolvedAgent.dynamicInstructionsResolvers ?? [];
+  const dynamicSkillResolvers = bundle.resolvedAgent.dynamicSkillResolvers ?? [];
+  const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
+
+  const emit = async (event: HandleMessageStreamEvent): Promise<HandleMessageStreamEvent> => {
+    const toEmit = await callAdapterEventHandler(adapter, event, adapterCtx);
+    setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
+    await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(toEmit)));
+    return toEmit;
+  };
+
+  const handleEvent = async (
+    event: HandleMessageStreamEvent,
+    messages?: readonly import("ai").ModelMessage[],
+  ): Promise<void> => {
+    const emitted = await emit(event);
+    await dispatchStreamEventHooks({ ctx, registry: hookRegistry, event: emitted });
+    if (emitted.type !== "step.started") {
+      await dispatchDynamicModelEvent({
+        ctx,
+        dynamicModel: bundle.turnAgent.dynamicModel,
+        event: emitted,
+        fallback: bundle.turnAgent.model,
+        messages: messages ?? [],
+        scope: {
+          moduleMap: bundle.moduleMap,
+          nodeId: bundle.nodeId,
+        },
+      });
+    }
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: dynamicToolResolvers,
+      event: emitted,
+      messages: messages ?? [],
+    });
+    await dispatchDynamicSkillEvent({
+      ctx,
+      resolvers: dynamicSkillResolvers,
+      event: emitted,
+      messages: messages ?? [],
+    });
+    await dispatchDynamicInstructionEvent({
+      ctx,
+      resolvers: dynamicInstructionsResolvers,
+      event: emitted,
+      messages: messages ?? [],
+    });
+  };
+
+  const mode = ctx.require(ModeKey);
+
+  let stepResult: StepResult;
+  try {
+    // A signal already aborted at entry (cancellation during an in-line
+    // runtime-action wait) must settle before the park-resume stages run,
+    // or the pending batch would re-park and later re-dispatch.
+    throwIfTurnAborted(input.abortSignal);
+    stepResult = await runStep(ctx, initialSession, async (enrichedSession) => {
+      const schemaSession = resolveEffectiveOutputSchema({
+        agentOutputSchema: bundle.turnAgent.outputSchema,
+        input: resolved,
+        mode,
+        session: enrichedSession,
+      });
+      if (completedAuths) {
+        const emissionState = getHarnessEmissionState(schemaSession.state);
+        for (const { name, authorization } of completedAuths) {
+          await handleEvent(
+            createAuthorizationCompletedEvent({
+              authorization,
+              name,
+              outcome: "authorized",
+              sequence: emissionState.sequence,
+              stepIndex: emissionState.stepIndex,
+              turnId: emissionState.turnId,
+            }),
+          );
+        }
+      }
+
+      const capabilities = ctx.get(CapabilitiesKey);
+
+      const runHarnessStep = async (
+        lifecycleSession: HarnessSession,
+        stepInput: StepInput | undefined,
+      ): Promise<StepResult> => {
+        const skillRoot = await resolveSessionSkillRoot({
+          ctx,
+          turnAgent: bundle.turnAgent,
+        });
+        const refreshedSession = refreshSessionFromTurnAgent({
+          compactionOverrides: {
+            thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+          },
+          session: lifecycleSession,
+          skillRoot,
+          turnAgent: bundle.turnAgent,
+        });
+
+        const step = createExecutionNodeStep({
+          abortSignal: input.abortSignal,
+          capabilities,
+          createRuntime: input.createRuntime,
+          handleEvent,
+          mode,
+          modelResolutionScope: {
+            moduleMap: bundle.moduleMap,
+            nodeId: bundle.nodeId,
+          },
+          node: bundle.graph.root,
+          workflowMaxSubagents: refreshedSession.workflowMaxSubagents,
+          writeEveAttributes: input.writeEveAttributes,
+        });
+        return step(refreshedSession, stepInput);
+      };
+
+      return runHarnessStep(schemaSession, resolved);
+    });
+  } catch (error) {
+    if (!isTurnCancellation(error)) throw error;
+    writer.releaseLock();
+    return {
+      action: "cancelled",
+      serializedContext: input.serializedContext,
+      sessionState: input.sessionState,
+    };
+  }
+
+  // Re-stamp the in-memory session's continuation token in case a
+  // handler called `setContinuationToken(...)` (eg. Slack auto-anchor).
+  const rekeyed = reconcileSessionContinuationToken(ctx, stepResult.session);
+  const nextSerializedContext = serializeContext(ctx);
+  stepResult = { ...stepResult, session: rekeyed };
+
+  const nextState = createDurableSessionState({ session: stepResult.session });
+
+  if (
+    stepResult.next !== null &&
+    typeof stepResult.next === "object" &&
+    "done" in stepResult.next
+  ) {
+    await writer.close();
+    const sessionTotals = getTurnUsageState(stepResult.session.state)?.session;
+    return {
+      action: "done",
+      output: stepResult.next.output,
+      isError: stepResult.next.isError,
+      serializedContext: nextSerializedContext,
+      sessionState: nextState,
+      usage: sessionTotals === undefined ? undefined : toUsage(sessionTotals),
+    };
+  }
+
+  if (stepResult.next === null) {
+    writer.releaseLock();
+
+    const workflowInterrupt = getPendingWorkflowInterrupt(stepResult.session.state);
+    if (
+      workflowInterrupt !== undefined &&
+      isWorkflowRuntimeActionInterrupt(workflowInterrupt.interrupt)
+    ) {
+      return {
+        action: "dispatch-workflow-runtime-actions",
+        pendingRuntimeActionKeys: getRuntimeActionKeysFromWorkflowInterrupt(
+          workflowInterrupt.interrupt,
+        ),
+        serializedContext: nextSerializedContext,
+        sessionState: nextState,
+      };
+    }
+
+    return {
+      action: "park",
+      ...derivePendingState(stepResult.session),
+      serializedContext: nextSerializedContext,
+      sessionState: nextState,
+    };
+  }
+
+  writer.releaseLock();
+  return {
+    action: "continue",
+    serializedContext: nextSerializedContext,
+    sessionState: nextState,
+  };
+}
+
+/**
+ * Derives the pending-state fields the turn workflow needs to choose
+ * the right `NextDriverAction` arm at the park boundary.
+ */
+function derivePendingState(session: HarnessSession): {
+  readonly authorizationNames?: readonly string[];
+  readonly hasPendingAuthorization: boolean;
+  readonly hasPendingInputBatch: boolean;
+  readonly pendingRuntimeActionKeys?: readonly string[];
+} {
+  const batch = getPendingRuntimeActionBatch(session.state);
+  const pendingAuth = getPendingAuthorization(session.state);
+  const base = {
+    authorizationNames: pendingAuth?.challenges.map((c) => c.name),
+    hasPendingAuthorization: pendingAuth !== undefined,
+    hasPendingInputBatch: hasPendingInputBatch(session.state),
+  };
+  if (batch !== undefined) {
+    return {
+      ...base,
+      pendingRuntimeActionKeys: batch.actions.map((action) => getRuntimeActionRequestKey(action)),
+    };
+  }
+  return base;
+}
+
+/**
+ * Resolves the single output schema in effect for this turn, decoupling schema
+ * enforcement from {@link RunMode}: downstream the harness reads
+ * `session.outputSchema` unconditionally and never re-derives it from mode.
+ *
+ * A run-scoped (client-supplied) schema on the turn's {@link StepInput} always
+ * wins. With no run-scoped schema, a task run adopts the agent's declared
+ * return schema — its function-output contract, which only applies when the
+ * agent is invoked as a function (subagent / schedule / job), i.e. task mode.
+ * A conversation run with no run-scoped schema enforces nothing. Continuation
+ * steps (no new `StepInput`) preserve whatever is already in effect.
+ */
+export function resolveEffectiveOutputSchema(input: {
+  readonly agentOutputSchema: JsonObject | undefined;
+  readonly input: StepInput | undefined;
+  readonly mode: RunMode;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const { agentOutputSchema, input: stepInput, mode, session } = input;
+
+  if (stepInput?.outputSchema !== undefined) {
+    return { ...session, outputSchema: stepInput.outputSchema };
+  }
+
+  if (mode === "task" && session.outputSchema === undefined && agentOutputSchema !== undefined) {
+    return { ...session, outputSchema: agentOutputSchema };
+  }
+
+  return session;
+}

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -1,66 +1,19 @@
-import { buildAdapterContext } from "#channel/adapter-context.js";
-import { callAdapterEventHandler, defaultDeliverResult } from "#channel/adapter.js";
 import type { DeliverPayload, SessionAuthContext } from "#channel/types.js";
-import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
-import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-lifecycle.js";
-import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
-import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
-import { dispatchDynamicToolEvent } from "#context/dynamic-tool-lifecycle.js";
-import { AuthKey, CapabilitiesKey, ModeKey } from "#context/keys.js";
-import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
-import { runStep } from "#context/run-step.js";
-import { deserializeContext, serializeContext } from "#context/serialize.js";
-import { getHarnessEmissionState } from "#harness/emission.js";
-import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellation.js";
-import { setChannelContext } from "#execution/channel-context.js";
-import { hasPendingInputBatch } from "#harness/input-requests.js";
-import { coalesceTurnInputs } from "#harness/messages.js";
-import {
-  getRuntimeActionKeysFromWorkflowInterrupt,
-  isWorkflowRuntimeActionInterrupt,
-} from "#harness/workflow-runtime-action-state.js";
-import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
-import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
-import type { HarnessSession, StepInput, StepResult } from "#harness/types.js";
-import { getTurnUsageState, toUsage } from "#harness/turn-tag-state.js";
-import type { TokenUsage } from "#shared/token-usage.js";
-import type { JsonObject } from "#shared/json.js";
-import type { RunMode } from "#shared/run-mode.js";
-import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
-import {
-  createAuthorizationCompletedEvent,
-  encodeMessageStreamEvent,
-  type HandleMessageStreamEvent,
-  timestampHandleMessageStreamEvent,
-} from "#protocol/message.js";
-import {
-  CallbackBaseUrlKey,
-  clearPendingAuthorization,
-  getPendingAuthorization,
-  PendingAuthorizationResultKey,
-  type AuthorizationResult,
-} from "#harness/authorization.js";
-import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
-import type { ConnectionAuthorizationChallenge } from "#public/connections/errors.js";
-import type { AuthorizationCallback } from "#runtime/connections/types.js";
-import {
-  createDurableSessionState,
-  type DurableSessionState,
-  readDurableSession,
-} from "#execution/durable-session-store.js";
+import { type DurableSessionState, readDurableSession } from "#execution/durable-session-store.js";
 import {
   createTurnWorkflowInput,
   type TurnStepInput,
   type TurnWorkflowDispatchInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
-import { createExecutionNodeStep } from "#execution/node-step.js";
 import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
-import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
-import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
-import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
+import {
+  executeTurnStepOperation,
+  type DurableStepResult,
+} from "#execution/turn-step-operation.js";
 import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
-import { resolveSessionSkillRoot } from "#execution/workflow-skill-root.js";
+import { setEveAttributes } from "#runtime/attributes/emit.js";
+import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import {
   createWorkflowRuntime,
   startWorkflowPreferLatest,
@@ -68,433 +21,48 @@ import {
 } from "#execution/workflow-runtime.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 
-/**
- * Result of one durable harness step, consumed by the turn workflow.
- *
- * `park` carries `hasPendingInputBatch`, `hasPendingAuthorization`, and
- * `pendingRuntimeActionKeys` so the turn workflow can pick the right
- * {@link import("#execution/next-driver-action.js").NextDriverAction}
- * arm without re-reading the session.
- *
- * `cancelled` converts the harness's cancellation throw into a *returned*
- * result so workflow-core never classifies the abort as a step failure or
- * retries it; the epilogue runs in `settleCancelledTurnStep`.
- */
-export type DurableStepResult =
-  | {
-      readonly action: "continue" | "done";
-      readonly output?: unknown;
-      readonly isError?: boolean;
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-      /** Session-total token usage; set on `done` when the session spent any. */
-      readonly usage?: TokenUsage;
-    }
-  | {
-      readonly action: "cancelled";
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-    }
-  | {
-      readonly action: "park";
-      readonly authorizationNames?: readonly string[];
-      readonly hasPendingAuthorization: boolean;
-      readonly hasPendingInputBatch: boolean;
-      readonly pendingRuntimeActionKeys?: readonly string[];
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-    }
-  | {
-      readonly action: "dispatch-workflow-runtime-actions";
-      readonly pendingRuntimeActionKeys: readonly string[];
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-    };
-
-export type { TurnStepInput };
+export type { DurableStepResult, TurnStepInput };
+export { resolveEffectiveOutputSchema } from "#execution/turn-step-operation.js";
 
 /**
  * Runs one atomic harness step inside a durable `"use step"` boundary.
+ *
+ * The step body lives in the engine-neutral
+ * {@link import("#execution/turn-step-operation.js").executeTurnStepOperation};
+ * this shell owns what only the Workflow engine can supply: the durable
+ * commit boundary, the pre-read of legacy session state, the callback base
+ * URL from workflow metadata, the runtime constructor for delegated child
+ * runs, and the workflow-run attribute writer.
  */
 export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResult> {
   "use step";
 
-  let input = rawInput;
+  const durableSession = await readDurableSession(rawInput.sessionState);
 
-  let durableSession = await readDurableSession(input.sessionState);
-  const ctx = await deserializeContext(input.serializedContext);
-  const adapter = ctx.require(ChannelKey);
-  const bundle = ctx.require(BundleKey);
-
-  // Populate the callback base URL so getHookUrl() works during tool
-  // execution, preferring eve's active local origin over metadata fallback.
+  // Prefer eve's active local origin over metadata fallback so
+  // getHookUrl() works during tool execution.
+  let callbackBaseUrl: string | undefined;
   try {
     const { getWorkflowMetadata } = await import("#compiled/@workflow/core/index.js");
     const metadata = getWorkflowMetadata();
     if (typeof metadata.url === "string") {
-      ctx.set(CallbackBaseUrlKey, resolveWorkflowCallbackBaseUrl(metadata.url));
+      callbackBaseUrl = resolveWorkflowCallbackBaseUrl(metadata.url);
     }
   } catch {
     // Outside a workflow context (e.g. tests) — getHookUrl will return undefined.
   }
 
-  // Authorization callback. If the delivery carries an
-  // `authorizationCallback` and there's a pending authorization on
-  // session state, extract it, build AuthorizationResult entries, and
-  // populate PendingAuthorizationResultKey so tools can complete auth.
-  // Strip the callback from the delivery so the adapter doesn't see it.
-  // Completion event names are collected here; emission happens after
-  // the `emit` function is created below.
-  const pendingAuth = getPendingAuthorization(durableSession.state);
-  let completedAuths:
-    | Array<{ name: string; authorization: ConnectionAuthorizationChallenge }>
-    | undefined;
-  if (pendingAuth && input.input?.kind === "deliver") {
-    const authResults: Array<{ name: string } & AuthorizationResult> = [];
-    const completed: Array<{ name: string; authorization: ConnectionAuthorizationChallenge }> = [];
-    const remainingPayloads: DeliverPayload[] = [];
-    for (const payload of input.input.payloads) {
-      const cb = payload["authorizationCallback"] as
-        | { connectionName: string; callback: AuthorizationCallback }
-        | undefined;
-      if (cb) {
-        const challenge = pendingAuth.challenges.find((c) => c.name === cb.connectionName);
-        if (challenge) {
-          authResults.push({
-            name: challenge.name,
-            resume: challenge.resume,
-            callback: cb.callback,
-            hookUrl: challenge.hookUrl,
-          });
-          completed.push({ name: challenge.name, authorization: challenge.challenge });
-        }
-      } else {
-        remainingPayloads.push(payload);
-      }
-    }
-    if (authResults.length > 0) {
-      ctx.set(PendingAuthorizationResultKey, authResults);
-      durableSession = {
-        ...durableSession,
-        state: clearPendingAuthorization(
-          durableSession.state,
-          authResults.map((result) => result.name),
-        ),
-      };
-      completedAuths = completed;
-      input =
-        remainingPayloads.length > 0
-          ? { ...input, input: { ...input.input, payloads: remainingPayloads } }
-          : { ...input, input: undefined };
-    }
-  }
-
-  // Apply deliver-time auth ferried via `resumeHook` (initial-turn
-  // input has no auth; it was seeded by buildRunContext).
-  if (input.input?.kind === "deliver" && input.input.auth !== undefined) {
-    ctx.set(AuthKey, input.input.auth ?? null);
-  }
-
-  const initialSession = hydrateDurableSession({
-    compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
-    },
-    durable: durableSession,
-    turnAgent: bundle.turnAgent,
+  return await executeTurnStepOperation({
+    abortSignal: rawInput.abortSignal,
+    callbackBaseUrl,
+    createRuntime: createWorkflowRuntime,
+    durableSession,
+    input: rawInput.input,
+    parentWritable: rawInput.parentWritable,
+    serializedContext: rawInput.serializedContext,
+    sessionState: rawInput.sessionState,
+    writeEveAttributes: setEveAttributes,
   });
-
-  const adapterCtx = buildAdapterContext(adapter, ctx);
-
-  // Run the adapter's deliver hook for each queued payload and
-  // coalesce the resulting StepInput values.
-  let resolved: StepInput | undefined;
-  if (input.input?.kind === "deliver") {
-    const results: StepInput[] = [];
-    for (const payload of input.input.payloads) {
-      const result = adapter.deliver
-        ? await adapter.deliver(payload, adapterCtx)
-        : defaultDeliverResult(payload);
-
-      if (result !== undefined && result !== null) {
-        results.push(result);
-      }
-    }
-    resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
-  } else if (input.input?.kind === "runtime-action-result") {
-    recordSubagentUsageSpans(input.input.results);
-    resolved = { runtimeActionResults: input.input.results };
-  }
-
-  // Pin adapter-state mutations back onto ctx so they survive the
-  // step boundary.
-  if (input.input?.kind === "deliver") {
-    const updatedAdapter = { ...adapter, state: { ...adapterCtx.state } };
-    setChannelContext(ctx, updatedAdapter);
-  }
-
-  // Adapter handled the delivery inline (e.g. a Slack interaction
-  // that only edits a message). Re-park without a model turn; skip
-  // the snapshot write when the session itself is unchanged.
-  if (input.input?.kind === "deliver" && resolved === undefined) {
-    const rekeyed = reconcileSessionContinuationToken(ctx, initialSession);
-    const nextSerializedContext = serializeContext(ctx);
-    const nextState =
-      rekeyed === initialSession
-        ? input.sessionState
-        : createDurableSessionState({ session: rekeyed });
-
-    return {
-      action: "park",
-      ...derivePendingState(rekeyed),
-      serializedContext: nextSerializedContext,
-      sessionState: nextState,
-    };
-  }
-
-  const writer = input.parentWritable.getWriter();
-  const hookRegistry = bundle.hookRegistry;
-  const dynamicInstructionsResolvers = bundle.resolvedAgent.dynamicInstructionsResolvers ?? [];
-  const dynamicSkillResolvers = bundle.resolvedAgent.dynamicSkillResolvers ?? [];
-  const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
-
-  const emit = async (event: HandleMessageStreamEvent): Promise<HandleMessageStreamEvent> => {
-    const toEmit = await callAdapterEventHandler(adapter, event, adapterCtx);
-    setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
-    await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(toEmit)));
-    return toEmit;
-  };
-
-  const handleEvent = async (
-    event: HandleMessageStreamEvent,
-    messages?: readonly import("ai").ModelMessage[],
-  ): Promise<void> => {
-    const emitted = await emit(event);
-    await dispatchStreamEventHooks({ ctx, registry: hookRegistry, event: emitted });
-    if (emitted.type !== "step.started") {
-      await dispatchDynamicModelEvent({
-        ctx,
-        dynamicModel: bundle.turnAgent.dynamicModel,
-        event: emitted,
-        fallback: bundle.turnAgent.model,
-        messages: messages ?? [],
-        scope: {
-          moduleMap: bundle.moduleMap,
-          nodeId: bundle.nodeId,
-        },
-      });
-    }
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: dynamicToolResolvers,
-      event: emitted,
-      messages: messages ?? [],
-    });
-    await dispatchDynamicSkillEvent({
-      ctx,
-      resolvers: dynamicSkillResolvers,
-      event: emitted,
-      messages: messages ?? [],
-    });
-    await dispatchDynamicInstructionEvent({
-      ctx,
-      resolvers: dynamicInstructionsResolvers,
-      event: emitted,
-      messages: messages ?? [],
-    });
-  };
-
-  const mode = ctx.require(ModeKey);
-
-  let stepResult: StepResult;
-  try {
-    // A signal already aborted at entry (cancellation during an in-line
-    // runtime-action wait) must settle before the park-resume stages run,
-    // or the pending batch would re-park and later re-dispatch.
-    throwIfTurnAborted(input.abortSignal);
-    stepResult = await runStep(ctx, initialSession, async (enrichedSession) => {
-      const schemaSession = resolveEffectiveOutputSchema({
-        agentOutputSchema: bundle.turnAgent.outputSchema,
-        input: resolved,
-        mode,
-        session: enrichedSession,
-      });
-      if (completedAuths) {
-        const emissionState = getHarnessEmissionState(schemaSession.state);
-        for (const { name, authorization } of completedAuths) {
-          await handleEvent(
-            createAuthorizationCompletedEvent({
-              authorization,
-              name,
-              outcome: "authorized",
-              sequence: emissionState.sequence,
-              stepIndex: emissionState.stepIndex,
-              turnId: emissionState.turnId,
-            }),
-          );
-        }
-      }
-
-      const capabilities = ctx.get(CapabilitiesKey);
-
-      const runHarnessStep = async (
-        lifecycleSession: HarnessSession,
-        stepInput: StepInput | undefined,
-      ): Promise<StepResult> => {
-        const skillRoot = await resolveSessionSkillRoot({
-          ctx,
-          turnAgent: bundle.turnAgent,
-        });
-        const refreshedSession = refreshSessionFromTurnAgent({
-          compactionOverrides: {
-            thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
-          },
-          session: lifecycleSession,
-          skillRoot,
-          turnAgent: bundle.turnAgent,
-        });
-
-        const step = createExecutionNodeStep({
-          abortSignal: input.abortSignal,
-          capabilities,
-          createRuntime: createWorkflowRuntime,
-          handleEvent,
-          mode,
-          modelResolutionScope: {
-            moduleMap: bundle.moduleMap,
-            nodeId: bundle.nodeId,
-          },
-          node: bundle.graph.root,
-          workflowMaxSubagents: refreshedSession.workflowMaxSubagents,
-        });
-        return step(refreshedSession, stepInput);
-      };
-
-      return runHarnessStep(schemaSession, resolved);
-    });
-  } catch (error) {
-    if (!isTurnCancellation(error)) throw error;
-    writer.releaseLock();
-    return {
-      action: "cancelled",
-      serializedContext: input.serializedContext,
-      sessionState: input.sessionState,
-    };
-  }
-
-  // Re-stamp the in-memory session's continuation token in case a
-  // handler called `setContinuationToken(...)` (eg. Slack auto-anchor).
-  const rekeyed = reconcileSessionContinuationToken(ctx, stepResult.session);
-  const nextSerializedContext = serializeContext(ctx);
-  stepResult = { ...stepResult, session: rekeyed };
-
-  const nextState = createDurableSessionState({ session: stepResult.session });
-
-  if (
-    stepResult.next !== null &&
-    typeof stepResult.next === "object" &&
-    "done" in stepResult.next
-  ) {
-    await writer.close();
-    const sessionTotals = getTurnUsageState(stepResult.session.state)?.session;
-    return {
-      action: "done",
-      output: stepResult.next.output,
-      isError: stepResult.next.isError,
-      serializedContext: nextSerializedContext,
-      sessionState: nextState,
-      usage: sessionTotals === undefined ? undefined : toUsage(sessionTotals),
-    };
-  }
-
-  if (stepResult.next === null) {
-    writer.releaseLock();
-
-    const workflowInterrupt = getPendingWorkflowInterrupt(stepResult.session.state);
-    if (
-      workflowInterrupt !== undefined &&
-      isWorkflowRuntimeActionInterrupt(workflowInterrupt.interrupt)
-    ) {
-      return {
-        action: "dispatch-workflow-runtime-actions",
-        pendingRuntimeActionKeys: getRuntimeActionKeysFromWorkflowInterrupt(
-          workflowInterrupt.interrupt,
-        ),
-        serializedContext: nextSerializedContext,
-        sessionState: nextState,
-      };
-    }
-
-    return {
-      action: "park",
-      ...derivePendingState(stepResult.session),
-      serializedContext: nextSerializedContext,
-      sessionState: nextState,
-    };
-  }
-
-  writer.releaseLock();
-  return {
-    action: "continue",
-    serializedContext: nextSerializedContext,
-    sessionState: nextState,
-  };
-}
-
-/**
- * Derives the pending-state fields the turn workflow needs to choose
- * the right `NextDriverAction` arm at the park boundary.
- */
-function derivePendingState(session: HarnessSession): {
-  readonly authorizationNames?: readonly string[];
-  readonly hasPendingAuthorization: boolean;
-  readonly hasPendingInputBatch: boolean;
-  readonly pendingRuntimeActionKeys?: readonly string[];
-} {
-  const batch = getPendingRuntimeActionBatch(session.state);
-  const pendingAuth = getPendingAuthorization(session.state);
-  const base = {
-    authorizationNames: pendingAuth?.challenges.map((c) => c.name),
-    hasPendingAuthorization: pendingAuth !== undefined,
-    hasPendingInputBatch: hasPendingInputBatch(session.state),
-  };
-  if (batch !== undefined) {
-    return {
-      ...base,
-      pendingRuntimeActionKeys: batch.actions.map((action) => getRuntimeActionRequestKey(action)),
-    };
-  }
-  return base;
-}
-
-/**
- * Resolves the single output schema in effect for this turn, decoupling schema
- * enforcement from {@link RunMode}: downstream the harness reads
- * `session.outputSchema` unconditionally and never re-derives it from mode.
- *
- * A run-scoped (client-supplied) schema on the turn's {@link StepInput} always
- * wins. With no run-scoped schema, a task run adopts the agent's declared
- * return schema — its function-output contract, which only applies when the
- * agent is invoked as a function (subagent / schedule / job), i.e. task mode.
- * A conversation run with no run-scoped schema enforces nothing. Continuation
- * steps (no new `StepInput`) preserve whatever is already in effect.
- */
-export function resolveEffectiveOutputSchema(input: {
-  readonly agentOutputSchema: JsonObject | undefined;
-  readonly input: StepInput | undefined;
-  readonly mode: RunMode;
-  readonly session: HarnessSession;
-}): HarnessSession {
-  const { agentOutputSchema, input: stepInput, mode, session } = input;
-
-  if (stepInput?.outputSchema !== undefined) {
-    return { ...session, outputSchema: stepInput.outputSchema };
-  }
-
-  if (mode === "task" && session.outputSchema === undefined && agentOutputSchema !== undefined) {
-    return { ...session, outputSchema: agentOutputSchema };
-  }
-
-  return session;
 }
 
 export interface RoutedDeliverResult {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -83,7 +83,6 @@ import {
   applySessionLimitContinuation,
   enforceSessionTokenLimit,
 } from "#harness/session-limit-enforcement.js";
-import { setEveAttributes } from "#runtime/attributes/emit.js";
 import {
   advanceStep,
   emitFailedStep,
@@ -1255,8 +1254,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // runtime's last-write-wins per-key semantics mean only the running
     // total — not the per-step delta — should reach the dashboard.
     //
-    // Best-effort: `setEveAttributes` swallows runtime failures so a
-    // broken tag emit can never break the agent loop.
+    // Best-effort: the runtime-injected writer swallows runtime failures
+    // so a broken tag emit can never break the agent loop.
     const nextTurnUsage = accumulateTurnUsage({
       previous: getTurnUsageState(session.state),
       turnId: emissionState.turnId,
@@ -1268,7 +1267,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = setTurnUsageState(session, nextTurnUsage);
     // `formatLanguageModelGatewayId` requires `model.provider` to be a string;
     // mock models in tests omit it, so guard the lookup so a missing field
-    // becomes `undefined` and is dropped by `setEveAttributes` instead of
+    // becomes `undefined` and is dropped by the attribute writer instead of
     // throwing into the tool loop.
     let modelTag: string | undefined;
     try {
@@ -1276,7 +1275,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     } catch {
       modelTag = undefined;
     }
-    await setEveAttributes({
+    await config.writeEveAttributes?.({
       "$eve.model": modelTag,
       "$eve.input_tokens": nextTurnUsage.inputTokens,
       "$eve.output_tokens": nextTurnUsage.outputTokens,

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -7,6 +7,7 @@ import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import type { InputResponse } from "#runtime/input/types.js";
+import type { EveAttributeWriter } from "#runtime/attributes/normalize.js";
 import type { SandboxState } from "#sandbox/state.js";
 import type { JsonObject } from "#shared/json.js";
 import type { InternalToolDefinition } from "#shared/tool-definition.js";
@@ -279,4 +280,10 @@ export interface ToolLoopHarnessConfig {
    * definitions directly.
    */
   readonly tools: HarnessToolMap;
+  /**
+   * Runtime-owned writer for eve observability attributes. Optional so
+   * engines without an attribute store (or direct harness tests) run the
+   * loop without one; the harness never imports an engine emitter itself.
+   */
+  readonly writeEveAttributes?: EveAttributeWriter;
 }

--- a/packages/eve/src/runtime/attributes/normalize.ts
+++ b/packages/eve/src/runtime/attributes/normalize.ts
@@ -10,6 +10,9 @@ export const EVE_ATTRIBUTE_VALUE_MAX_BYTES = 256;
 /** Attribute value accepted by eve's internal attribute builders. */
 export type EveAttributeValue = string | number | undefined;
 
+/** Runtime-owned sink for eve observability attributes. */
+export type EveAttributeWriter = (attributes: Record<string, EveAttributeValue>) => Promise<void>;
+
 /**
  * Truncates a string to Workflow's UTF-8 byte budget without splitting
  * a surrogate pair.


### PR DESCRIPTION
First slice of the loop-decoupling migration (#513's research doc, migration steps 1–2): make `turnStep`'s body engine-neutral so the loop programs' `generate` effect can call it without touching a Workflow primitive.

## What

- `execution/turn-step-operation.ts` — `turnStep`'s body, moved verbatim, with every engine-owned capability injected: the pre-read durable session, the callback base URL (previously resolved via `getWorkflowMetadata` inside the body), the `createRuntime` constructor for delegated child runs, and a `writeEveAttributes` sink.
- `workflow-steps.ts#turnStep` — now a thin `"use step"` shell that supplies those four from the Workflow engine. `DurableStepResult` and `resolveEffectiveOutputSchema` move with the body and are re-exported for compatibility.
- The attribute seam removes the harness's last engine import: `tool-loop.ts` no longer calls `setEveAttributes` directly; the writer arrives through `ToolLoopHarnessConfig` → `node-step` → the operation input, and hosts without an attribute store omit it.

## Why this shape

The research contract puts the loop programs above a port and every engine word below it. `turnStep` was the one place plain loop code (`tool-loop`, `node-step`) was fused to engine calls; after this, the fusion is confined to a 30-line shell. The next PR lands the `src/core/` programs; the one after has `turnWorkflow` drive them, calling this operation as the generate effect.

## Scope

Zero behavior change, stacked on `rui/loop-interface-research`. The body is a verbatim move — review is easiest with whitespace-blind diff on `turn-step-operation.ts` against the old `workflow-steps.ts`. Full unit (5,192) and integration (535) tiers pass **unmodified**; `guard:invariants` clean. No changeset: no observable behavior changes.