### PR TITLE
feat(eve): the loop core — runSession/runTurn/next drive the turn workflow

### DIFF
--- a/packages/eve/src/core/index.ts
+++ b/packages/eve/src/core/index.ts
@@ -1,0 +1,3 @@
+export { runSession } from "#core/session-program.js";
+export { runTurn } from "#core/turn-program.js";
+export { next } from "#core/turn-step.js";

--- a/packages/eve/src/core/programs.test.ts
+++ b/packages/eve/src/core/programs.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+
+import { runSession, runTurn } from "#core/index.js";
+import { TASK_MODE_WAIT_ERROR_MESSAGE } from "#core/turn-program.js";
+import { DURABLE_SESSION_VERSION } from "#execution/durable-session-store.js";
+import type {
+  ChildResults,
+  Delivery,
+  Generated,
+  GenerateInput,
+  LoopBackend,
+  LoopRequest,
+  SessionState,
+  TerminalOutcome,
+  TurnHandle,
+  TurnOutcome,
+  TurnProgramInput,
+} from "#core/types.js";
+
+describe("runTurn", () => {
+  it("advances through continue steps, checkpointing each, and settles done", async () => {
+    const backend = new ScriptedBackend([
+      { kind: "continue", state: state("s1") },
+      {
+        kind: "finish",
+        output: "final",
+        state: state("s2"),
+        usage: { cacheReadTokens: 0, cacheWriteTokens: 0, inputTokens: 1, outputTokens: 2 },
+      },
+    ]);
+
+    const outcome = await runTurn(backend, turnInput({ mode: "task" }));
+
+    expect(outcome).toMatchObject({ kind: "done", output: "final" });
+    expect(outcome.state.durable.sessionId).toBe("s2");
+    // Checkpoint fires after the continue step only; terminal state travels
+    // in the outcome.
+    expect(backend.checkpoints.map((s) => s.durable.sessionId)).toEqual(["s1"]);
+    // The first step receives the delivery; continuation steps receive none.
+    expect(backend.generateCalls.map((call) => call.input?.kind)).toEqual(["deliver", undefined]);
+  });
+
+  it("parks a conversation waiting for public input", async () => {
+    const backend = new ScriptedBackend([
+      {
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        kind: "waiting",
+        state: state("s1"),
+      },
+    ]);
+
+    await expect(runTurn(backend, turnInput({ mode: "conversation" }))).resolves.toMatchObject({
+      kind: "waiting",
+    });
+  });
+
+  it("rejects an unparkable task-mode wait", async () => {
+    const backend = new ScriptedBackend([
+      {
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        kind: "waiting",
+        state: state("s1"),
+      },
+    ]);
+
+    await expect(runTurn(backend, turnInput({ mode: "task" }))).rejects.toThrow(
+      TASK_MODE_WAIT_ERROR_MESSAGE,
+    );
+  });
+
+  it.each([
+    {
+      name: "a pending authorization",
+      waiting: { hasPendingAuthorization: true, hasPendingInputBatch: false },
+    },
+    {
+      name: "a pending input batch with requestInput capability",
+      waiting: { hasPendingAuthorization: false, hasPendingInputBatch: true },
+    },
+  ])("parks a task-mode wait for $name", async ({ waiting }) => {
+    const backend = new ScriptedBackend([{ ...waiting, kind: "waiting", state: state("s1") }]);
+
+    await expect(
+      runTurn(backend, turnInput({ capabilities: { requestInput: true }, mode: "task" })),
+    ).resolves.toMatchObject({ kind: "waiting" });
+  });
+
+  it("settles an observed cancellation as a cancelled outcome, not a failure", async () => {
+    const backend = new ScriptedBackend([{ kind: "cancelled", state: state("s1") }]);
+
+    await expect(runTurn(backend, turnInput({ mode: "conversation" }))).resolves.toMatchObject({
+      kind: "cancelled",
+    });
+    expect(backend.checkpoints).toHaveLength(0);
+  });
+
+  it("spawns every child before waiting and folds results back in as the next input", async () => {
+    const requests: LoopRequest[] = [
+      { key: "subagent-call:a:1", kind: "subagent" },
+      { key: "subagent-call:b:2", kind: "subagent" },
+    ];
+    const results: ChildResults = [
+      { callId: "call-a", kind: "subagent-result", output: "A", subagentName: "a" },
+      { callId: "call-b", kind: "subagent-result", output: "B", subagentName: "b" },
+    ];
+    const backend = new ScriptedBackend(
+      [
+        { kind: "requests", requests, state: state("s1") },
+        { kind: "finish", output: "after-children", state: state("s2") },
+      ],
+      { childResults: results },
+    );
+
+    const outcome = await runTurn(backend, turnInput({ mode: "task" }));
+
+    expect(outcome).toMatchObject({ kind: "done", output: "after-children" });
+    expect(backend.spawnedRequests).toEqual([requests]);
+    expect(backend.spawnOrder).toEqual(["spawn", "wait"]);
+    // The folded results arrive as the second generation's input.
+    expect(backend.generateCalls[1]?.input).toMatchObject({
+      kind: "runtime-action-result",
+    });
+  });
+
+  it("continues with no input when the child wait observes a cancellation", async () => {
+    const backend = new ScriptedBackend(
+      [
+        {
+          kind: "requests",
+          requests: [{ key: "subagent-call:a:1", kind: "subagent" }],
+          state: state("s1"),
+        },
+        { kind: "cancelled", state: state("s2") },
+      ],
+      { childResults: "cancelled" },
+    );
+
+    await expect(runTurn(backend, turnInput({ mode: "conversation" }))).resolves.toMatchObject({
+      kind: "cancelled",
+    });
+    expect(backend.generateCalls[1]?.input).toBeUndefined();
+  });
+
+  it("hands each step a monotonically increasing ordinal", async () => {
+    const backend = new ScriptedBackend([
+      { kind: "continue", state: state("s1") },
+      { kind: "continue", state: state("s2") },
+      { kind: "finish", output: "done", state: state("s3") },
+    ]);
+
+    await runTurn(backend, turnInput({ mode: "task" }));
+
+    expect(backend.generateOrdinals).toEqual([0, 1, 2]);
+  });
+});
+
+describe("runSession", () => {
+  it("dispatches a turn per delivery and finishes exactly once on done", async () => {
+    const turns: TurnOutcome[] = [
+      { kind: "waiting", state: state("s1") },
+      { kind: "done", output: "bye", state: state("s2") },
+    ];
+    const backend = new ScriptedBackend([], {
+      deliveries: [delivery("follow-up")],
+      turns,
+    });
+
+    const outcome = await runSession(backend, {
+      capabilities: undefined,
+      initialDelivery: delivery("hello"),
+      mode: "conversation",
+      state: state("s0"),
+    });
+
+    expect(outcome).toEqual({ isError: undefined, output: "bye", usage: undefined });
+    expect(backend.finished).toEqual([outcome]);
+    expect(backend.turnDeliveries.map((d) => d.requestId)).toEqual(["hello", "follow-up"]);
+    // The waiting turn's state threads into the next turn's input.
+    expect(backend.turnStates.map((s) => s.durable.sessionId)).toEqual(["s0", "s1"]);
+  });
+
+  it("parks through a cancelled turn and resumes on the next delivery", async () => {
+    const backend = new ScriptedBackend([], {
+      deliveries: [delivery("after-cancel")],
+      turns: [
+        { kind: "cancelled", state: state("s1") },
+        { kind: "done", output: "recovered", state: state("s2") },
+      ],
+    });
+
+    await expect(
+      runSession(backend, {
+        capabilities: undefined,
+        initialDelivery: delivery("hello"),
+        mode: "conversation",
+        state: state("s0"),
+      }),
+    ).resolves.toMatchObject({ output: "recovered" });
+  });
+});
+
+function state(sessionId: string): SessionState {
+  return {
+    durable: {
+      continuationToken: `token:${sessionId}`,
+      emissionState: { sequence: 0, sessionStarted: true, stepIndex: 0, turnId: "" },
+      hasProxyInputRequests: false,
+      sessionId,
+      version: DURABLE_SESSION_VERSION,
+    },
+    serializedContext: { sessionId },
+  };
+}
+
+function delivery(requestId: string): Delivery {
+  return { kind: "deliver", payloads: [{ message: requestId }], requestId };
+}
+
+function turnInput(input: {
+  readonly capabilities?: TurnProgramInput["capabilities"];
+  readonly mode: TurnProgramInput["mode"];
+}): TurnProgramInput {
+  return {
+    capabilities: input.capabilities,
+    delivery: delivery("initial"),
+    mode: input.mode,
+    state: state("s0"),
+  };
+}
+
+class ScriptedBackend implements LoopBackend {
+  readonly checkpoints: SessionState[] = [];
+  readonly finished: TerminalOutcome[] = [];
+  readonly generateCalls: GenerateInput[] = [];
+  readonly generateOrdinals: number[] = [];
+  readonly spawnedRequests: (readonly LoopRequest[])[] = [];
+  readonly spawnOrder: string[] = [];
+  readonly turnDeliveries: Delivery[] = [];
+  readonly turnStates: SessionState[] = [];
+  readonly #childResults: ChildResults;
+  readonly #deliveries: Delivery[];
+  readonly #script: Generated[];
+  readonly #turns: TurnOutcome[];
+
+  constructor(
+    script: readonly Generated[],
+    options: {
+      readonly childResults?: ChildResults;
+      readonly deliveries?: readonly Delivery[];
+      readonly turns?: readonly TurnOutcome[];
+    } = {},
+  ) {
+    this.#childResults = options.childResults ?? [];
+    this.#deliveries = [...(options.deliveries ?? [])];
+    this.#script = [...script];
+    this.#turns = [...(options.turns ?? [])];
+  }
+
+  async checkpoint(state: SessionState): Promise<void> {
+    this.checkpoints.push(state);
+  }
+
+  async generate(input: GenerateInput): Promise<Generated> {
+    this.generateCalls.push(input);
+    this.generateOrdinals.push(this.generateCalls.length - 1);
+    const scripted = this.#script.shift();
+    if (scripted === undefined) throw new Error("Scripted backend ran out of generations.");
+    return scripted;
+  }
+
+  async spawnChildren(state: SessionState, requests: readonly LoopRequest[]) {
+    this.spawnedRequests.push(requests);
+    this.spawnOrder.push("spawn");
+    return {
+      handle: {
+        wait: async () => {
+          this.spawnOrder.push("wait");
+          return { results: this.#childResults, state };
+        },
+      },
+      state,
+    };
+  }
+
+  async finish(outcome: TerminalOutcome): Promise<void> {
+    this.finished.push(outcome);
+  }
+
+  async receive(): Promise<Delivery> {
+    const next = this.#deliveries.shift();
+    if (next === undefined) throw new Error("Scripted backend ran out of deliveries.");
+    return next;
+  }
+
+  spawnTurn(input: TurnProgramInput): TurnHandle {
+    this.turnDeliveries.push(input.delivery as Delivery);
+    this.turnStates.push(input.state);
+    return {
+      wait: async () => {
+        const next = this.#turns.shift();
+        if (next === undefined) throw new Error("Scripted backend ran out of turns.");
+        return next;
+      },
+    };
+  }
+}

--- a/packages/eve/src/core/session-program.ts
+++ b/packages/eve/src/core/session-program.ts
@@ -1,0 +1,41 @@
+import type { Delivery, LoopBackend, SessionProgramInput, TerminalOutcome } from "#core/types.js";
+
+/**
+ * Drives one session: dispatch a turn per delivery until a turn completes
+ * the session, then publish the terminal outcome exactly once through
+ * `finish`. A waiting or cancelled turn parks the session; the next
+ * delivery arrives through `receive`, which owns buffering, coalescing,
+ * and descendant routing below the port.
+ */
+export async function runSession(
+  backend: LoopBackend,
+  input: SessionProgramInput,
+): Promise<TerminalOutcome> {
+  let state = input.state;
+  let delivery: Delivery | undefined = input.initialDelivery;
+
+  while (true) {
+    const received = delivery ?? (await backend.receive(state));
+    delivery = undefined;
+
+    const turn = await backend
+      .spawnTurn({
+        capabilities: input.capabilities,
+        delivery: received,
+        mode: input.mode,
+        state,
+      })
+      .wait();
+    state = turn.state;
+
+    if (turn.kind === "done") {
+      const outcome: TerminalOutcome = {
+        isError: turn.isError,
+        output: turn.output,
+        usage: turn.usage,
+      };
+      await backend.finish(outcome);
+      return outcome;
+    }
+  }
+}

--- a/packages/eve/src/core/turn-program.ts
+++ b/packages/eve/src/core/turn-program.ts
@@ -1,0 +1,53 @@
+import { next } from "#core/turn-step.js";
+import type { TurnBackend, TurnInput, TurnOutcome, TurnProgramInput } from "#core/types.js";
+
+export const TASK_MODE_WAIT_ERROR_MESSAGE =
+  "Task mode cannot wait for follow-up input (`next: null`).";
+
+/**
+ * Drives one logical turn through its named phases.
+ *
+ * **Initiate**: the delivery becomes the first step's input. **Advance**:
+ * one {@link next} call per step, checkpointing after every non-final
+ * step so the driver always holds the latest state. **Settle**: gate an
+ * unparkable task-mode wait, then map the completed step onto the turn's
+ * outcome. Cancellation surfaces as a value, never as a failure.
+ */
+export async function runTurn(backend: TurnBackend, input: TurnProgramInput): Promise<TurnOutcome> {
+  let state = input.state;
+  let stepInput: TurnInput | undefined = input.delivery;
+  let stepOrdinal = 0;
+
+  while (true) {
+    const step = await next(backend, { input: stepInput, state, stepOrdinal: stepOrdinal++ });
+    state = step.state;
+
+    if (!step.done) {
+      await backend.checkpoint(state);
+      stepInput = step.nextInput;
+      continue;
+    }
+
+    if (step.kind === "waiting") {
+      const canPark =
+        step.hasPendingAuthorization ||
+        (step.hasPendingInputBatch && input.capabilities?.requestInput === true) ||
+        input.mode === "conversation";
+      if (!canPark) throw new Error(TASK_MODE_WAIT_ERROR_MESSAGE);
+
+      return { authorizationNames: step.authorizationNames, kind: "waiting", state };
+    }
+
+    if (step.kind === "cancelled") {
+      return { kind: "cancelled", state };
+    }
+
+    return {
+      isError: step.isError,
+      kind: "done",
+      output: step.output,
+      state,
+      usage: step.usage,
+    };
+  }
+}

--- a/packages/eve/src/core/turn-step.ts
+++ b/packages/eve/src/core/turn-step.ts
@@ -1,0 +1,57 @@
+import type { StepInput, StepResult, TurnDependencies } from "#core/types.js";
+
+/**
+ * Runs one step of intra-turn work: one generation plus the resolution of
+ * its immediate requests. Reads top to bottom: generate; a finish, a wait,
+ * or an observed cancellation completes the step; unresolved child requests
+ * spawn — every child before anything else — and their results fold back
+ * in request order as the next step's input.
+ */
+export async function next(dependencies: TurnDependencies, input: StepInput): Promise<StepResult> {
+  const generated = await dependencies.generate({ input: input.input, state: input.state });
+
+  if (generated.kind === "finish") {
+    return {
+      done: true,
+      isError: generated.isError,
+      kind: "done",
+      output: generated.output,
+      state: generated.state,
+      usage: generated.usage,
+    };
+  }
+
+  if (generated.kind === "waiting") {
+    return {
+      authorizationNames: generated.authorizationNames,
+      done: true,
+      hasPendingAuthorization: generated.hasPendingAuthorization,
+      hasPendingInputBatch: generated.hasPendingInputBatch,
+      kind: "waiting",
+      state: generated.state,
+    };
+  }
+
+  if (generated.kind === "cancelled") {
+    return { done: true, kind: "cancelled", state: generated.state };
+  }
+
+  if (generated.kind === "requests") {
+    const spawned = await dependencies.spawnChildren(generated.state, generated.requests);
+    const settled = await spawned.handle.wait();
+
+    // A cancellation observed mid-wait continues with no input: the next
+    // generation observes the aborted turn and completes via `cancelled`.
+    if (settled.results === "cancelled") {
+      return { done: false, nextInput: undefined, state: settled.state };
+    }
+
+    return {
+      done: false,
+      nextInput: { kind: "runtime-action-result", results: settled.results },
+      state: settled.state,
+    };
+  }
+
+  return { done: false, nextInput: undefined, state: generated.state };
+}

--- a/packages/eve/src/core/types.ts
+++ b/packages/eve/src/core/types.ts
@@ -1,0 +1,175 @@
+import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+import type { RuntimeActionResult } from "#runtime/actions/types.js";
+import type { RunMode } from "#shared/run-mode.js";
+import type { TokenUsage } from "#shared/token-usage.js";
+
+/**
+ * The loop-domain session state: one value carrying both durable cursors
+ * that previously threaded every execution boundary separately. The single
+ * commit verb for it is {@link TurnBackend.checkpoint}.
+ */
+export interface SessionState {
+  readonly durable: DurableSessionState;
+  readonly serializedContext: Record<string, unknown>;
+}
+
+/** One turn-facing input: a public delivery or folded-back child results. */
+export type TurnInput = HookPayload;
+
+/** One public delivery, as the session program receives it. */
+export type Delivery = DeliverHookPayload;
+
+export interface GenerateInput {
+  readonly input: TurnInput | undefined;
+  readonly state: SessionState;
+}
+
+/**
+ * A request the model left unresolved at the end of a generation. Requests
+ * are identified by their runtime-action key; the durable representation of
+ * the open exchange (the pending batch holding the assistant response
+ * outside provider history) lives in `state` and travels with it.
+ */
+export interface LoopRequest {
+  readonly key: string;
+  readonly kind: "subagent" | "workflow-interrupt";
+}
+
+/**
+ * The classified outcome of one generation plus its inline tool execution.
+ *
+ * `waiting` carries the park classification the settle phase needs;
+ * `requests` carries unresolved child work; `cancelled` reports an observed
+ * turn abort as a value so the engine never treats it as a failure.
+ */
+export type Generated =
+  | { readonly kind: "continue"; readonly state: SessionState }
+  | {
+      readonly isError?: boolean;
+      readonly kind: "finish";
+      readonly output: unknown;
+      readonly state: SessionState;
+      readonly usage?: TokenUsage;
+    }
+  | {
+      readonly authorizationNames?: readonly string[];
+      readonly hasPendingAuthorization: boolean;
+      readonly hasPendingInputBatch: boolean;
+      readonly kind: "waiting";
+      readonly state: SessionState;
+    }
+  | {
+      readonly kind: "requests";
+      readonly requests: readonly LoopRequest[];
+      readonly state: SessionState;
+    }
+  | { readonly kind: "cancelled"; readonly state: SessionState };
+
+/**
+ * Results of one spawned child batch, in request order, or the sentinel
+ * for a turn cancellation observed during the wait.
+ */
+export type ChildResults = readonly RuntimeActionResult[] | "cancelled";
+
+export interface ChildrenHandle {
+  wait(): Promise<{ readonly results: ChildResults; readonly state: SessionState }>;
+}
+
+/**
+ * Capabilities one intra-turn step may use. Loop mechanics — checkpoint,
+ * receive, finish, spawnTurn — are statically invisible to a step.
+ */
+export interface TurnDependencies {
+  generate(input: GenerateInput): Promise<Generated>;
+  spawnChildren(
+    state: SessionState,
+    requests: readonly LoopRequest[],
+  ): Promise<{ readonly handle: ChildrenHandle; readonly state: SessionState }>;
+}
+
+/** The slice of the port the turn program drives. */
+export interface TurnBackend extends TurnDependencies {
+  checkpoint(state: SessionState): Promise<void>;
+}
+
+/** Everything the loop can do, enumerable in one place. */
+export interface LoopBackend extends TurnBackend {
+  finish(outcome: TerminalOutcome): Promise<void>;
+  receive(state: SessionState): Promise<Delivery>;
+  spawnTurn(input: TurnProgramInput): TurnHandle;
+}
+
+export interface StepInput {
+  readonly input: TurnInput | undefined;
+  readonly state: SessionState;
+  readonly stepOrdinal: number;
+}
+
+/**
+ * One step's result in the iterator protocol's shape: `done: false`
+ * continues the turn loop (carrying the next step's input, e.g. folded
+ * child results), `done: true` carries the turn's completion.
+ */
+export type StepResult =
+  | {
+      readonly done: false;
+      readonly nextInput: TurnInput | undefined;
+      readonly state: SessionState;
+    }
+  | {
+      readonly done: true;
+      readonly isError?: boolean;
+      readonly kind: "done";
+      readonly output: unknown;
+      readonly state: SessionState;
+      readonly usage?: TokenUsage;
+    }
+  | {
+      readonly authorizationNames?: readonly string[];
+      readonly done: true;
+      readonly hasPendingAuthorization: boolean;
+      readonly hasPendingInputBatch: boolean;
+      readonly kind: "waiting";
+      readonly state: SessionState;
+    }
+  | { readonly done: true; readonly kind: "cancelled"; readonly state: SessionState };
+
+export interface TurnProgramInput {
+  readonly capabilities: SessionCapabilities | undefined;
+  readonly delivery: TurnInput | undefined;
+  readonly mode: RunMode;
+  readonly state: SessionState;
+}
+
+export type TurnOutcome =
+  | {
+      readonly isError?: boolean;
+      readonly kind: "done";
+      readonly output: unknown;
+      readonly state: SessionState;
+      readonly usage?: TokenUsage;
+    }
+  | {
+      readonly authorizationNames?: readonly string[];
+      readonly kind: "waiting";
+      readonly state: SessionState;
+    }
+  | { readonly kind: "cancelled"; readonly state: SessionState };
+
+export interface TurnHandle {
+  wait(): Promise<TurnOutcome>;
+}
+
+export interface TerminalOutcome {
+  readonly isError?: boolean;
+  readonly output: unknown;
+  readonly usage?: TokenUsage;
+}
+
+export interface SessionProgramInput {
+  readonly capabilities: SessionCapabilities | undefined;
+  readonly initialDelivery: Delivery;
+  readonly mode: RunMode;
+  readonly state: SessionState;
+}

--- a/packages/eve/src/execution/turn-loop-backend.ts
+++ b/packages/eve/src/execution/turn-loop-backend.ts
@@ -1,0 +1,273 @@
+import { getWorkflowMetadata } from "#compiled/@workflow/core/index.js";
+
+import type { DeliverHookPayload } from "#channel/types.js";
+import type {
+  ChildResults,
+  ChildrenHandle,
+  Generated,
+  GenerateInput,
+  LoopRequest,
+  SessionState,
+  TurnBackend,
+} from "#core/types.js";
+import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
+import { dispatchWorkflowRuntimeActionsStep } from "#execution/dispatch-workflow-runtime-actions-step.js";
+import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
+import type { TurnCancellationControl } from "#execution/turn-cancellation-control.js";
+import type { TurnInboxPayload } from "#execution/turn-control-protocol.js";
+import type { TurnExecutionCursor } from "#execution/turn-execution-cursor.js";
+import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
+import { turnStep } from "#execution/workflow-steps.js";
+import { resolveRuntimeActionResultsForKeys } from "#harness/runtime-actions.js";
+import type { RuntimeActionResult } from "#runtime/actions/types.js";
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+
+/**
+ * The Workflow engine's {@link TurnBackend}: `generate` is one durable
+ * `turnStep`, `checkpoint` relays state to the driver through the turn
+ * control protocol, and `spawnChildren` dispatches the pending child batch
+ * and services the turn inbox — result demultiplexing, the public-delivery
+ * handshake, proxied subagent HITL events, and the cancellation race all
+ * stay below the port.
+ */
+export class TurnLoopBackend implements TurnBackend {
+  readonly #bufferedDeliveries: DeliverHookPayload[];
+  readonly #cancellation: TurnCancellationControl | undefined;
+  readonly #cursor: TurnExecutionCursor;
+  readonly #inboxToken: string;
+  readonly #iterator: AsyncIterator<TurnInboxPayload>;
+  // Delivery request ids stay unique across every wait in this turn. A
+  // forwarded delivery left unconsumed when one wait resolves would
+  // otherwise reuse a later wait's id and be mis-accepted as that wait's
+  // response.
+  #deliveryRequestSeq = 0;
+
+  constructor(input: {
+    readonly bufferedDeliveries: DeliverHookPayload[];
+    readonly cancellation: TurnCancellationControl | undefined;
+    readonly cursor: TurnExecutionCursor;
+    readonly inboxToken: string;
+    readonly iterator: AsyncIterator<TurnInboxPayload>;
+  }) {
+    this.#bufferedDeliveries = input.bufferedDeliveries;
+    this.#cancellation = input.cancellation;
+    this.#cursor = input.cursor;
+    this.#inboxToken = input.inboxToken;
+    this.#iterator = input.iterator;
+  }
+
+  async checkpoint(state: SessionState): Promise<void> {
+    await this.#cursor.adopt({
+      serializedContext: state.serializedContext,
+      sessionState: state.durable,
+    });
+  }
+
+  async generate(input: GenerateInput): Promise<Generated> {
+    const result = await turnStep(
+      this.#cursor.createStepInput(input.input, this.#cancellation?.signal),
+    );
+    const state = toSessionState(result);
+
+    if (result.action === "cancelled") {
+      return { kind: "cancelled", state };
+    }
+
+    if (result.action === "done") {
+      return {
+        isError: result.isError,
+        kind: "finish",
+        output: result.output ?? "",
+        state,
+        usage: result.usage,
+      };
+    }
+
+    if (result.action === "dispatch-workflow-runtime-actions") {
+      return {
+        kind: "requests",
+        requests: toLoopRequests("workflow-interrupt", result.pendingRuntimeActionKeys),
+        state,
+      };
+    }
+
+    if (result.action === "park") {
+      if (result.pendingRuntimeActionKeys !== undefined) {
+        return {
+          kind: "requests",
+          requests: toLoopRequests("subagent", result.pendingRuntimeActionKeys),
+          state,
+        };
+      }
+      return {
+        authorizationNames: result.authorizationNames,
+        hasPendingAuthorization: result.hasPendingAuthorization,
+        hasPendingInputBatch: result.hasPendingInputBatch,
+        kind: "waiting",
+        state,
+      };
+    }
+
+    return { kind: "continue", state };
+  }
+
+  async spawnChildren(
+    state: SessionState,
+    requests: readonly LoopRequest[],
+  ): Promise<{ readonly handle: ChildrenHandle; readonly state: SessionState }> {
+    await this.checkpoint(state);
+
+    const dispatch =
+      requests[0]?.kind === "workflow-interrupt"
+        ? dispatchWorkflowRuntimeActionsStep
+        : dispatchRuntimeActionsStep;
+    const dispatched = await dispatch({
+      callbackBaseUrl: resolveWorkflowCallbackBaseUrl(getWorkflowMetadata().url),
+      parentContinuationToken: this.#inboxToken,
+      parentWritable: this.#cursor.parentWritable,
+      serializedContext: this.#cursor.serializedContext,
+      sessionState: this.#cursor.sessionState,
+    });
+    await this.#cursor.adopt(dispatched);
+
+    const pendingActionKeys = requests.map((request) => request.key);
+    return {
+      handle: {
+        wait: async () => {
+          const results = await this.#waitForRuntimeActionResults(
+            pendingActionKeys,
+            dispatched.results,
+          );
+          return { results, state: this.#currentState() };
+        },
+      },
+      state: this.#currentState(),
+    };
+  }
+
+  #currentState(): SessionState {
+    return {
+      durable: this.#cursor.sessionState,
+      serializedContext: this.#cursor.serializedContext,
+    };
+  }
+
+  #nextDeliveryRequestId(): string {
+    return `${this.#inboxToken}:delivery:${String(this.#deliveryRequestSeq++)}`;
+  }
+
+  // `"cancelled"` stays a sentinel rather than a `RuntimeActionResult`
+  // variant: that union is the schema-validated wire type projected into
+  // harness resume calls, while cancellation is a control-flow outcome of
+  // this wait that never leaves the workflow.
+  async #waitForRuntimeActionResults(
+    pendingActionKeys: readonly string[],
+    initialResults: readonly RuntimeActionResult[],
+  ): Promise<ChildResults> {
+    let pendingDeliveryRequest: string | undefined;
+    const results: RuntimeActionResult[] = [...initialResults];
+
+    while (true) {
+      const ready = resolveRuntimeActionResultsForKeys({
+        pendingKeys: pendingActionKeys,
+        results,
+      });
+      if (ready !== undefined) {
+        if (pendingDeliveryRequest !== undefined) {
+          // The entry may already be racing public input against this wait.
+          // Cancellation keeps that input available for the next parent turn.
+          await this.#cursor.send({
+            kind: "turn-delivery-cancelled",
+            requestId: pendingDeliveryRequest,
+          });
+        }
+        return ready;
+      }
+
+      if (this.#cursor.sessionState.hasProxyInputRequests && pendingDeliveryRequest === undefined) {
+        pendingDeliveryRequest = this.#nextDeliveryRequestId();
+        await this.#cursor.send({
+          continuationToken: this.#cursor.sessionState.continuationToken,
+          inboxToken: this.#inboxToken,
+          kind: "turn-delivery-request",
+          requestId: pendingDeliveryRequest,
+        });
+      }
+
+      const nextPromise = this.#iterator.next();
+      // When a cancel wins the race, the dangling inbox `next()` is dropped
+      // by disposal in teardown; pre-attach a handler so a late rejection
+      // never surfaces as unhandled.
+      nextPromise.catch(() => {});
+      const next = await (this.#cancellation === undefined
+        ? nextPromise
+        : Promise.race([nextPromise, this.#cancellation.requested]));
+      if (next === "cancel") {
+        if (pendingDeliveryRequest !== undefined) {
+          // Release the raced public input back to the driver so it stays
+          // available for the next turn.
+          await this.#cursor.send({
+            kind: "turn-delivery-cancelled",
+            requestId: pendingDeliveryRequest,
+          });
+        }
+        return "cancelled";
+      }
+      if (next.done) throw new Error("Turn inbox closed before runtime actions completed.");
+
+      const value = next.value;
+      if (value.kind === "runtime-action-result") {
+        results.push(...value.results);
+        continue;
+      }
+
+      if (
+        value.kind === "subagent-input-request" ||
+        value.kind === "subagent-authorization-event"
+      ) {
+        const proxyResult = await runProxySubagentEventStep({
+          hookPayload: value,
+          parentWritable: this.#cursor.parentWritable,
+          serializedContext: this.#cursor.serializedContext,
+          sessionState: this.#cursor.sessionState,
+        });
+        await this.#cursor.adopt(proxyResult);
+        continue;
+      }
+
+      // Only `driver-delivery` reaches the inbox for public input: children
+      // resume it with results/HITL, and the driver relays public deliveries
+      // through the request handshake. A stale, non-matching request id means
+      // the turn already resolved and the driver re-buffered the delivery.
+      if (value.kind === "driver-delivery" && value.requestId === pendingDeliveryRequest) {
+        await this.#cursor.send({ kind: "turn-delivery-accepted", requestId: value.requestId });
+        pendingDeliveryRequest = undefined;
+
+        const remainder = await routeDeliverToChildren({
+          auth: value.delivery.auth,
+          parentWritable: this.#cursor.parentWritable,
+          payloads: value.delivery.payloads,
+          sessionState: this.#cursor.sessionState,
+        });
+        if (remainder !== undefined) {
+          this.#bufferedDeliveries.push({ ...value.delivery, payloads: [remainder] });
+        }
+      }
+    }
+  }
+}
+
+function toLoopRequests(
+  kind: LoopRequest["kind"],
+  keys: readonly string[],
+): readonly LoopRequest[] {
+  return keys.map((key) => ({ key, kind }));
+}
+
+function toSessionState(result: {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): SessionState {
+  return { durable: result.sessionState, serializedContext: result.serializedContext };
+}

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -1,10 +1,9 @@
-import { createHook, getWorkflowMetadata } from "#compiled/@workflow/core/index.js";
+import { createHook } from "#compiled/@workflow/core/index.js";
 
 import type { DeliverHookPayload } from "#channel/types.js";
+import { runTurn, TASK_MODE_WAIT_ERROR_MESSAGE } from "#core/turn-program.js";
 import { cancelDescendantTurnsStep } from "#execution/cancel-descendant-turns-step.js";
 import { sendTurnControlStep, type TurnInboxPayload } from "#execution/turn-control-protocol.js";
-import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
-import { dispatchWorkflowRuntimeActionsStep } from "#execution/dispatch-workflow-runtime-actions-step.js";
 import {
   migrateTurnWorkflowInput,
   type TurnStepInput,
@@ -12,21 +11,15 @@ import {
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
-import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
-import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import {
   createTurnCancellationControl,
   type TurnCancellationControl,
 } from "#execution/turn-cancellation-control.js";
 import { TurnExecutionCursor } from "#execution/turn-execution-cursor.js";
-import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
+import { TurnLoopBackend } from "#execution/turn-loop-backend.js";
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
 import { turnStep } from "#execution/workflow-steps.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
-import { resolveRuntimeActionResultsForKeys } from "#harness/runtime-actions.js";
-import type { RuntimeActionResult } from "#runtime/actions/types.js";
-
-const TASK_MODE_WAIT_ERROR_MESSAGE = "Task mode cannot wait for follow-up input (`next: null`).";
 
 // A cancelled turn settles by parking the session, so the cancel hook is
 // only claimed where a park can land: conversation sessions always accept
@@ -72,14 +65,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
     serializedContext: input.stepInput.serializedContext,
     sessionState: input.stepInput.sessionState,
   });
-  // Delivery request ids stay unique across every wait in this turn. A forwarded
-  // delivery left unconsumed when one wait resolves would otherwise reuse a later
-  // wait's id and be mis-accepted as that wait's response.
-  let deliveryRequestSeq = 0;
-  const nextDeliveryRequestId = (): string =>
-    `${inbox.token}:delivery:${String(deliveryRequestSeq++)}`;
   const bufferedDeliveries: DeliverHookPayload[] = [];
-  let nextStepInput = input.stepInput.input;
   let ownsInbox = false;
   let cancellation: TurnCancellationControl | undefined;
 
@@ -104,111 +90,75 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
       });
     }
 
-    while (true) {
-      const result = await turnStep(cursor.createStepInput(nextStepInput, cancellation?.signal));
+    const backend = new TurnLoopBackend({
+      bufferedDeliveries,
+      cancellation,
+      cursor,
+      inboxToken: inbox.token,
+      iterator,
+    });
 
-      if (result.action === "cancelled") {
-        // No `canPark` check here: that gate rejects model-authored waits
-        // (`next: null`) in task mode, whereas a cancelled turn parks by
-        // design and its parkability was already established when the
-        // cancel hook was claimed (`canSettleCancelledTurnAsPark`). The
-        // epilogue runs in the driver (`settleCancelledTurnStep`), not as
-        // a step in this run, where queued cancel wakes could re-dispatch
-        // it.
-        await cancelDescendantTurnsStep({
-          serializedContext: cursor.serializedContext,
-          sessionState: cursor.sessionState,
-        });
-        await cancellation?.dispose();
-        await cursor.finish(
-          { sessionState: cursor.sessionState },
-          { cancelled: true, kind: "park" },
-          bufferedDeliveries,
-        );
-        return;
-      }
+    const outcome = await runTurn(backend, {
+      capabilities: input.capabilities,
+      delivery: input.stepInput.input,
+      mode: input.mode,
+      state: {
+        durable: input.stepInput.sessionState,
+        serializedContext: input.stepInput.serializedContext,
+      },
+    });
 
-      if (result.action === "done") {
-        await cancellation?.dispose();
-        await cursor.finish(
-          result,
-          {
-            kind: "done",
-            output: result.output ?? "",
-            isError: result.isError,
-            usage: result.usage,
-          },
-          bufferedDeliveries,
-        );
-        return;
-      }
-
-      // A pending runtime-action batch (model-driven `park` or dynamic-workflow
-      // interrupt) is resolved in-line so the turn stays alive across the wait;
-      // the two arms differ only in their dispatch path.
-      const pendingActionKeys =
-        result.action === "dispatch-workflow-runtime-actions" || result.action === "park"
-          ? result.pendingRuntimeActionKeys
-          : undefined;
-
-      if (pendingActionKeys !== undefined) {
-        await cursor.adopt(result);
-        const dispatch =
-          result.action === "dispatch-workflow-runtime-actions"
-            ? dispatchWorkflowRuntimeActionsStep
-            : dispatchRuntimeActionsStep;
-        const dispatchResult = await dispatch({
-          callbackBaseUrl: resolveWorkflowCallbackBaseUrl(getWorkflowMetadata().url),
-          parentContinuationToken: inbox.token,
-          parentWritable: cursor.parentWritable,
-          serializedContext: cursor.serializedContext,
-          sessionState: cursor.sessionState,
-        });
-        await cursor.adopt(dispatchResult);
-
-        const results = await waitForRuntimeActionResults({
-          bufferedDeliveries,
-          cancellation,
-          cursor,
-          inboxToken: inbox.token,
-          initialResults: dispatchResult.results,
-          iterator,
-          nextDeliveryRequestId,
-          pendingActionKeys,
-        });
-        if (results === "cancelled") {
-          // The next turnStep observes the aborted signal and settles
-          // through the `cancelled` arm above.
-          nextStepInput = undefined;
-          continue;
-        }
-        nextStepInput = { kind: "runtime-action-result", results };
-        continue;
-      }
-
-      if (result.action === "park") {
-        const canPark =
-          result.hasPendingAuthorization ||
-          (result.hasPendingInputBatch && input.capabilities?.requestInput === true) ||
-          input.mode === "conversation";
-
-        if (!canPark) throw new Error(TASK_MODE_WAIT_ERROR_MESSAGE);
-
-        await cancellation?.dispose();
-        await cursor.finish(
-          result,
-          {
-            authorizationNames: result.authorizationNames,
-            kind: "park",
-          },
-          bufferedDeliveries,
-        );
-        return;
-      }
-
-      await cursor.adopt(result);
-      nextStepInput = undefined;
+    if (outcome.kind === "cancelled") {
+      // No `canPark` check here: that gate rejects model-authored waits
+      // (`next: null`) in task mode, whereas a cancelled turn parks by
+      // design and its parkability was already established when the
+      // cancel hook was claimed (`canSettleCancelledTurnAsPark`). The
+      // epilogue runs in the driver (`settleCancelledTurnStep`), not as
+      // a step in this run, where queued cancel wakes could re-dispatch
+      // it.
+      await cancelDescendantTurnsStep({
+        serializedContext: cursor.serializedContext,
+        sessionState: cursor.sessionState,
+      });
+      await cancellation?.dispose();
+      await cursor.finish(
+        { sessionState: cursor.sessionState },
+        { cancelled: true, kind: "park" },
+        bufferedDeliveries,
+      );
+      return;
     }
+
+    await cancellation?.dispose();
+
+    if (outcome.kind === "done") {
+      await cursor.finish(
+        {
+          serializedContext: outcome.state.serializedContext,
+          sessionState: outcome.state.durable,
+        },
+        {
+          kind: "done",
+          output: outcome.output,
+          isError: outcome.isError,
+          usage: outcome.usage,
+        },
+        bufferedDeliveries,
+      );
+      return;
+    }
+
+    await cursor.finish(
+      {
+        serializedContext: outcome.state.serializedContext,
+        sessionState: outcome.state.durable,
+      },
+      {
+        authorizationNames: outcome.authorizationNames,
+        kind: "park",
+      },
+      bufferedDeliveries,
+    );
   } catch (error) {
     await cursor.send({ error: normalizeSerializableError(error), kind: "turn-error" });
     throw error;
@@ -220,109 +170,6 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
     // run's teardown; this backstop covers the error path.
     if (cancellation !== undefined) await cancellation.dispose();
     if (ownsInbox) await disposeHook(inbox);
-  }
-}
-
-// `"cancelled"` stays a sentinel rather than a `RuntimeActionResult`
-// variant: that union is the schema-validated wire type projected into
-// harness resume calls, while cancellation is a control-flow outcome of
-// this wait that never leaves the workflow.
-async function waitForRuntimeActionResults(input: {
-  readonly bufferedDeliveries: DeliverHookPayload[];
-  readonly cancellation: TurnCancellationControl | undefined;
-  readonly cursor: TurnExecutionCursor;
-  readonly inboxToken: string;
-  readonly initialResults: readonly RuntimeActionResult[];
-  readonly iterator: AsyncIterator<TurnInboxPayload>;
-  readonly nextDeliveryRequestId: () => string;
-  readonly pendingActionKeys: readonly string[];
-}): Promise<readonly RuntimeActionResult[] | "cancelled"> {
-  let pendingDeliveryRequest: string | undefined;
-  const results: RuntimeActionResult[] = [...input.initialResults];
-
-  while (true) {
-    const ready = resolveRuntimeActionResultsForKeys({
-      pendingKeys: input.pendingActionKeys,
-      results,
-    });
-    if (ready !== undefined) {
-      if (pendingDeliveryRequest !== undefined) {
-        // The entry may already be racing public input against this wait.
-        // Cancellation keeps that input available for the next parent turn.
-        await input.cursor.send({
-          kind: "turn-delivery-cancelled",
-          requestId: pendingDeliveryRequest,
-        });
-      }
-      return ready;
-    }
-
-    if (input.cursor.sessionState.hasProxyInputRequests && pendingDeliveryRequest === undefined) {
-      pendingDeliveryRequest = input.nextDeliveryRequestId();
-      await input.cursor.send({
-        continuationToken: input.cursor.sessionState.continuationToken,
-        inboxToken: input.inboxToken,
-        kind: "turn-delivery-request",
-        requestId: pendingDeliveryRequest,
-      });
-    }
-
-    const nextPromise = input.iterator.next();
-    // When a cancel wins the race, the dangling inbox `next()` is dropped
-    // by disposal in teardown; pre-attach a handler so a late rejection
-    // never surfaces as unhandled.
-    nextPromise.catch(() => {});
-    const next = await (input.cancellation === undefined
-      ? nextPromise
-      : Promise.race([nextPromise, input.cancellation.requested]));
-    if (next === "cancel") {
-      if (pendingDeliveryRequest !== undefined) {
-        // Release the raced public input back to the driver so it stays
-        // available for the next turn.
-        await input.cursor.send({
-          kind: "turn-delivery-cancelled",
-          requestId: pendingDeliveryRequest,
-        });
-      }
-      return "cancelled";
-    }
-    if (next.done) throw new Error("Turn inbox closed before runtime actions completed.");
-
-    const value = next.value;
-    if (value.kind === "runtime-action-result") {
-      results.push(...value.results);
-      continue;
-    }
-
-    if (value.kind === "subagent-input-request" || value.kind === "subagent-authorization-event") {
-      const proxyResult = await runProxySubagentEventStep({
-        hookPayload: value,
-        parentWritable: input.cursor.parentWritable,
-        serializedContext: input.cursor.serializedContext,
-        sessionState: input.cursor.sessionState,
-      });
-      await input.cursor.adopt(proxyResult);
-      continue;
-    }
-
-    // Only `driver-delivery` reaches the inbox for public input: children
-    // resume it with results/HITL, and the driver relays public deliveries
-    // through the request handshake. A stale, non-matching request id means
-    // the turn already resolved and the driver re-buffered the delivery.
-    if (value.kind === "driver-delivery" && value.requestId === pendingDeliveryRequest) {
-      await input.cursor.send({ kind: "turn-delivery-accepted", requestId: value.requestId });
-      pendingDeliveryRequest = undefined;
-
-      const remainder = await routeDeliverToChildren({
-        auth: value.delivery.auth,
-        parentWritable: input.cursor.parentWritable,
-        payloads: value.delivery.payloads,
-        sessionState: input.cursor.sessionState,
-      });
-      if (remainder !== undefined) {
-        input.bufferedDeliveries.push({ ...value.delivery, payloads: [remainder] });
-      }
-    }
   }
 }
 


### PR DESCRIPTION
The loop becomes programs over a port, and the turn workflow becomes its first production consumer — the contract and the thing that uses it, in one diff. Stacked on #1011 (the engine-neutral step extraction this builds on).

## What

- `packages/eve/src/core/` — the production mirror of the research prototype's `core/`: `index.ts` exports exactly `runSession`, `runTurn`, `next`; `types.ts` is the closed contract; the three program modules are plain async code with no engine vocabulary. `SessionState` wraps the two durable cursors (`DurableSessionState` + `serializedContext`) behind a single `checkpoint(state)` verb. `TurnDependencies` (`generate`, `spawnChildren`) is the slice a step may use — `checkpoint`/`receive`/`finish`/`spawnTurn` are statically invisible to it. `next` is the pi-shaped step body: generate; a finish, wait, or observed cancellation completes the step; unresolved child requests spawn before anything else and fold back in request order. `runTurn` drives initiate/advance/settle with the task-mode park gate in settle. `programs.test.ts` pins it all against a scripted backend.
- `execution/turn-loop-backend.ts` — the Workflow engine's `TurnBackend`: `generate` is one durable `turnStep`; `checkpoint` relays through the cursor's control protocol; `spawnChildren` dispatches the pending batch and owns the turn-inbox pump (result demux, public-delivery handshake, proxied subagent HITL, cancellation race), moved verbatim from the old wait loop.
- `execution/turn-workflow.ts` — `runTurnOwnedWorkflow` stops being the loop: hook claims → backend → `await runTurn` → map `TurnOutcome` onto the existing terminal control payloads. The while-loop, park classification, and child fold-back are gone from the adapter. The legacy driver path is untouched.

## The load-bearing property

The driver-facing wire is byte-identical — control payloads, delivery-handshake ids, cancel-settles-as-park ordering, dispose ordering. An old pinned driver dispatching `turnWorkflow@latest` keeps working. The proof: **zero test files modified**. The 1,084-line turn-workflow suite, every cancellation integration suite, the full unit (5,203) and integration (535) tiers, and the turn-cancellation + bundle-discovery scenarios all pass as-is.

## Deviations from the prototype, on purpose

Two, both downstream of protecting the 9,453-line tool-loop suite: `generate` returns updated `SessionState` (the harness keeps owning balanced-history algebra and executes plain tools inline in the stream), and children spawn as one batch handle because production dispatch is one durable step. `next`'s per-tool arm activates in a later PR when tools move out of `streamText`. The session half (`workflowEntry` → `runSession`) is the next PR; `runSession` ships now with scripted-backend tests so the contract is complete.

No live-model smoke in this environment (no fixture credentials); the cancellation scenario runs a real subprocess through the new loop end to end.