### PR TITLE
fix(eve): include subagents and schedules in eve info

### DIFF
--- a/.changeset/info-subagents-schedules.md
+++ b/.changeset/info-subagents-schedules.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve info` now reports discovered subagents and schedules in both the human table and the `--json` output, matching what the CLI reference already documented. Previously both surfaces silently omitted them even though discovery resolved them correctly.

--- a/packages/eve/src/cli/commands/info.test.ts
+++ b/packages/eve/src/cli/commands/info.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, test } from "vitest";
 
 import { COMPILE_METADATA_KIND, COMPILE_METADATA_VERSION } from "#compiler/artifacts.js";
 import type { CompileAgentResult } from "#compiler/compile-agent.js";
-import { createCompiledAgentManifest, type CompiledChannelEntry } from "#compiler/manifest.js";
+import {
+  createCompiledAgentManifest,
+  createCompiledAgentNodeManifest,
+  type CompiledChannelEntry,
+  type CompiledScheduleDefinition,
+  type CompiledSubagentNode,
+  ROOT_COMPILED_AGENT_NODE_ID,
+} from "#compiler/manifest.js";
 import { getApplicationInfo } from "#internal/application/paths.js";
 
 import { buildApplicationInfoJson } from "./info.js";
@@ -16,7 +23,45 @@ const MESSAGING = {
 const APP_ROOT = "/virtual/app";
 const AGENT_ROOT = "/virtual/app/agent";
 
-function makeCompiledState(): CompileAgentResult {
+function makeSchedule(name: string): CompiledScheduleDefinition {
+  return {
+    cron: "0 9 * * *",
+    hasRun: false,
+    logicalPath: `schedules/${name}.md`,
+    markdown: `# ${name}`,
+    name,
+    sourceId: `schedules/${name}.md`,
+    sourceKind: "markdown",
+  };
+}
+
+function makeSubagent(name: string): CompiledSubagentNode {
+  return {
+    agent: createCompiledAgentNodeManifest({
+      agentRoot: `${AGENT_ROOT}/subagents/${name}`,
+      appRoot: APP_ROOT,
+      config: {
+        model: {
+          id: "anthropic/claude-sonnet-5",
+          routing: { kind: "gateway", target: "anthropic" },
+        },
+        name,
+      },
+    }),
+    description: `${name} subagent description`,
+    entryPath: `subagents/${name}/agent.ts`,
+    logicalPath: `subagents/${name}`,
+    name,
+    nodeId: name,
+    rootPath: `subagents/${name}`,
+    sourceId: `subagents/${name}/agent.ts`,
+    sourceKind: "module",
+  };
+}
+
+function makeCompiledState(
+  options: { subagents?: CompiledSubagentNode[]; schedules?: CompiledScheduleDefinition[] } = {},
+): CompileAgentResult {
   const channels: CompiledChannelEntry[] = [
     {
       kind: "channel",
@@ -60,6 +105,12 @@ function makeCompiledState(): CompileAgentResult {
         sourceKind: "module",
       },
     ],
+    schedules: options.schedules ?? [],
+    subagentEdges: (options.subagents ?? []).map((subagent) => ({
+      childNodeId: subagent.nodeId,
+      parentNodeId: ROOT_COMPILED_AGENT_NODE_ID,
+    })),
+    subagents: options.subagents ?? [],
   });
   const digest = { path: "x", sha256: "y" };
   return {
@@ -104,6 +155,8 @@ describe("buildApplicationInfoJson", () => {
     expect(json.model).toBe("anthropic/claude-sonnet-5");
     expect(json.tools).toEqual(["create_ticket"]);
     expect(json.skills).toEqual([]);
+    expect(json.subagents).toEqual([]);
+    expect(json.schedules).toEqual([]);
     expect(json.diagnostics).toEqual({ errors: 0, warnings: 0 });
     expect(json.channels).toEqual([
       { name: "slack", kind: "slack", method: "POST", urlPath: "/eve/v1/slack" },
@@ -111,6 +164,20 @@ describe("buildApplicationInfoJson", () => {
     ]);
     expect(json.messaging.create).toBe("/eve/v1/session");
     expect(json.artifacts?.compiledManifest).toContain("compiled-agent-manifest.json");
+  });
+
+  test("projects subagents and schedules into the JSON contract when present", () => {
+    const json = buildApplicationInfoJson({
+      application: getApplicationInfo(APP_ROOT),
+      compiledState: makeCompiledState({
+        schedules: [makeSchedule("morning-digest"), makeSchedule("weekly-report")],
+        subagents: [makeSubagent("research")],
+      }),
+      messaging: MESSAGING,
+    });
+
+    expect(json.subagents).toEqual(["research"]);
+    expect(json.schedules).toEqual(["morning-digest", "weekly-report"]);
   });
 
   test("reports an unavailable contract when the project is not compiled", () => {
@@ -128,6 +195,8 @@ describe("buildApplicationInfoJson", () => {
     expect(json.channels).toEqual([]);
     expect(json.tools).toEqual([]);
     expect(json.skills).toEqual([]);
+    expect(json.subagents).toEqual([]);
+    expect(json.schedules).toEqual([]);
     expect(json.appRoot).toBe(APP_ROOT);
     expect(json.messaging.stream).toBe("/eve/v1/session/:id/stream");
   });

--- a/packages/eve/src/cli/commands/info.ts
+++ b/packages/eve/src/cli/commands/info.ts
@@ -22,6 +22,8 @@ export interface ApplicationInfoJson {
   instructions: string | null;
   skills: string[];
   tools: string[];
+  subagents: string[];
+  schedules: string[];
   channels: { name: string; kind: string | null; method: string | null; urlPath: string | null }[];
   messaging: { create: string; continue: string; stream: string };
   artifacts: {
@@ -55,6 +57,8 @@ export function buildApplicationInfoJson(inspection: ApplicationInspection): App
     instructions: compiledState?.manifest.instructions?.logicalPath ?? null,
     skills: (compiledState?.manifest.skills ?? []).map((skill) => skill.name),
     tools: (compiledState?.manifest.tools ?? []).map((tool) => tool.name),
+    subagents: (compiledState?.manifest.subagents ?? []).map((subagent) => subagent.name),
+    schedules: (compiledState?.manifest.schedules ?? []).map((schedule) => schedule.name),
     channels: (compiledState?.manifest.channels ?? []).map((channel) =>
       channel.kind === "channel"
         ? {
@@ -172,6 +176,14 @@ export async function printApplicationInfo(
       {
         label: "Skills",
         value: pluralize(compiledState.manifest.skills.length, "skill"),
+      },
+      {
+        label: "Subagents",
+        value: pluralize(compiledState.manifest.subagents.length, "subagent"),
+      },
+      {
+        label: "Schedules",
+        value: pluralize(compiledState.manifest.schedules.length, "schedule"),
       },
     );
     artifactRows.unshift(


### PR DESCRIPTION
### Description

`docs/reference/cli.md` says `eve info` prints "discovered tools, skills, subagents, schedules, channels, routes, artifact paths, and discovery diagnostics", but `buildApplicationInfoJson` in `packages/eve/src/cli/commands/info.ts` only projected skills and tools. The compiled manifest exposes `manifest.subagents` and `manifest.schedules` (the same fields `build-vercel-agent-summary.ts` reads), yet `eve info` never read them. Both `--json` and the human table dropped subagents and schedules from every app that has them.

### Change

- `ApplicationInfoJson` gains `subagents: string[]` and `schedules: string[]`, projected from `manifest.subagents` / `manifest.schedules` like skills and tools already are.
- The human table gains `Subagents` and `Schedules` rows next to `Skills`, via the existing `pluralize` helper.
- No doc change: `cli.md` already documented this; the code was behind it.

### How did you test your changes?

- `pnpm test:unit`: extended `info.test.ts` to assert `subagents` and `schedules` populate when present and stay `[]` when absent (3 pass)
- `pnpm typecheck`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from CONTRIBUTING.md
- [x] I added tests and documentation where relevant (docs already correct)
- [x] I added a changeset if this touches the published eve package
- [x] DCO sign-off passes for every commit (git commit --signoff)
