### PR TITLE
feat(eve): support credentialed client requests

### DIFF
--- a/.changeset/fuzzy-cats-include.md
+++ b/.changeset/fuzzy-cats-include.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a `credentials` option to the eve client and `useEveAgent` for cross-origin cookie authentication.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -102,7 +102,9 @@ Post to `/eve/v1/session/:sessionId/reset` to terminally retire that session. Re
 The eve channel leaves CORS untouched by default. Pass `cors: true` to enable
 permissive browser CORS with preflight handling, or pass an options object to
 narrow origins, methods, and headers. Route auth still runs on the actual
-session requests.
+session requests. Credentialed cross-origin requests require a specific
+frontend origin and `credentials: true`; do not use the wildcard origin for
+credentialed requests.
 
 Enable or narrow CORS only when browser clients call the channel directly:
 
@@ -114,6 +116,7 @@ export default eveChannel({
   auth: [vercelOidc(), localDev()],
   cors: {
     origin: "https://app.example.com",
+    credentials: true,
     methods: ["GET", "POST"],
     allowedHeaders: ["authorization", "content-type"],
   },

--- a/docs/guides/client/overview.mdx
+++ b/docs/guides/client/overview.mdx
@@ -9,7 +9,7 @@ For browser chat UIs, start with [`useEveAgent`](../frontend/overview). For wire
 
 ## Create a client
 
-A `Client` binds one host, auth policy, and header policy:
+A `Client` binds one host and request policy for auth, headers, credentials, and redirects:
 
 ```ts
 import { Client } from "eve/client";
@@ -96,6 +96,19 @@ const client = new Client({
 ```
 
 Set `redirect` to `"manual"` or `"error"` on credential-bearing clients so fetch cannot forward custom authorization headers to another origin. The policy applies to inspection requests, custom fetches, session creation, and event streams.
+
+For cross-origin cookie authentication, set `credentials: "include"`. The policy applies to every request, session-control operation, and stream reconnect. A raw `Client.fetch()` call can override it for that request:
+
+```ts
+const client = new Client({
+  host: "https://agent.example.com",
+  credentials: "include",
+});
+
+await client.fetch("/custom", { credentials: "omit" });
+```
+
+The agent's [eve channel CORS policy](../../channels/eve#cors) must also allow credentials and the calling origin.
 
 Per-request headers can be attached to an individual turn:
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -301,7 +301,7 @@ then save a final snapshot in `onFinish`.
 
 `initialEvents` must be an ordered prefix of the same session's stream, but its endpoint does not have to line up exactly with where the stream resumes. Every event carries a stable [`meta.id`](/docs/concepts/sessions-runs-and-streaming#the-event-envelope), and the store drops any event whose id it has already applied — so a saved log that overlaps the replayed prefix renders once, and `onEvent` only fires for events your UI has not seen.
 
-For multiple chat threads, keep one saved event log and session cursor per thread. `agent`, `host`, `reducer`, `session`, `initialEvents`, `initialSession`, `auth`, `headers`, `optimistic`, and `resume` are read when the hook creates its store, so remount the chat component when switching threads, for example with `key={chat.id}`.
+For multiple chat threads, keep one saved event log and session cursor per thread. `agent`, `host`, `reducer`, `session`, `initialEvents`, `initialSession`, `auth`, `credentials`, `headers`, `optimistic`, and `resume` are read when the hook creates its store, so remount the chat component when switching threads, for example with `key={chat.id}`.
 
 Pass `resume: true` with `initialSession` to rebuild the projection from the durable stream after mount. If the stream ends at an in-flight turn, the binding stays attached until that turn reaches its boundary. If the stream already ends at a settled session boundary, replay stops at the history tail.
 
@@ -326,6 +326,17 @@ const agent = useEveAgent({
   },
 });
 ```
+
+For cross-origin cookie authentication, pass `credentials: "include"`:
+
+```tsx
+const agent = useEveAgent({
+  host: "https://agent.example.com",
+  credentials: "include",
+});
+```
+
+The agent's [eve channel CORS policy](../../channels/eve#cors) must name the frontend origin and set `credentials: true`. The channel still needs an authentication policy that verifies the application session.
 
 When a framework integration mounts multiple named agents, pass `agent` instead of `host`:
 

--- a/docs/guides/frontend/use-eve-agent-svelte.mdx
+++ b/docs/guides/frontend/use-eve-agent-svelte.mdx
@@ -110,7 +110,7 @@ Call `agent.cancel()` to stop the durable server-side turn while the binding rem
 
 ## Custom host and credentials
 
-Pass `host`, `auth`, or `headers` to the binding using the same options as the other frontend bindings. See [Custom hosts and headers](./overview#custom-hosts-and-headers).
+Pass `host`, `auth`, `credentials`, or `headers` to the binding using the same options as the other frontend bindings. See [Custom hosts and headers](./overview#custom-hosts-and-headers).
 
 ## Attach page context per turn
 

--- a/docs/guides/frontend/use-eve-agent-vue.mdx
+++ b/docs/guides/frontend/use-eve-agent-vue.mdx
@@ -112,7 +112,7 @@ Call `cancel()` to stop the durable server-side turn while the composable remain
 
 ## Custom host and credentials
 
-Pass `host`, `auth`, or `headers` to the composable using the same options as the other frontend bindings. See [Custom hosts and headers](./overview#custom-hosts-and-headers).
+Pass `host`, `auth`, `credentials`, or `headers` to the composable using the same options as the other frontend bindings. See [Custom hosts and headers](./overview#custom-hosts-and-headers).
 
 ## Attach page context per turn
 

--- a/packages/eve/src/client/client.test.ts
+++ b/packages/eve/src/client/client.test.ts
@@ -100,6 +100,40 @@ describe("Client request policy", () => {
     }
   });
 
+  it("applies its credentials policy to info, health, raw fetch, and sessions", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json(AGENT_INFO))
+      .mockResolvedValueOnce(Response.json({ ok: true, status: "ready", workflowId: "wf" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        Response.json({ sessionId: "session_1", status: "accepted" }, { status: 202 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(`${JSON.stringify({ data: {}, type: "session.completed" })}\n`),
+      );
+    const client = new Client({ credentials: "include", host: "https://eve.test" });
+
+    await client.info();
+    await client.health();
+    await client.fetch("/custom");
+    await (await client.sessions.create({ message: "hello" })).response.result();
+
+    expect(fetchMock.mock.calls).toHaveLength(5);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init?.credentials).toBe("include");
+    }
+  });
+
+  it("allows a raw fetch to override its credentials policy", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null));
+    const client = new Client({ credentials: "include", host: "https://eve.test" });
+
+    await client.fetch("/custom", { credentials: "omit" });
+
+    expect(fetchMock.mock.calls[0]?.[1]?.credentials).toBe("omit");
+  });
+
   it("expands vercelOidc auth into the bearer and trusted-oidc headers", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/eve/src/client/client.ts
+++ b/packages/eve/src/client/client.ts
@@ -4,12 +4,12 @@ import { encodeBasicCredentials } from "#internal/http/basic-auth.js";
 import { AgentInfoResultSchema } from "#client/agent-info-schema.js";
 import { ClientError } from "#client/client-error.js";
 import { ClientSessions } from "#client/sessions.js";
+import { applyClientRequestPolicy, type ClientRequestPolicy } from "#client/request-policy.js";
 import { createClientUrl } from "#client/url.js";
 import type {
   AgentInfoResult,
   ClientAuth,
   ClientOptions,
-  ClientRedirectPolicy,
   HeadersValue,
   HealthResult,
   TokenValue,
@@ -27,7 +27,7 @@ export class Client {
   readonly #auth: ClientAuth | undefined;
   readonly #headers: HeadersValue | undefined;
   readonly #host: string;
-  readonly #redirect: ClientRedirectPolicy | undefined;
+  readonly #requestPolicy: ClientRequestPolicy;
   /** Explicit create/attach surface for ID-addressed sessions. */
   readonly sessions: ClientSessions;
 
@@ -35,10 +35,13 @@ export class Client {
     this.#host = options.host;
     this.#auth = options.auth;
     this.#headers = options.headers;
-    this.#redirect = options.redirect;
+    this.#requestPolicy = {
+      credentials: options.credentials,
+      redirect: options.redirect,
+    };
     this.sessions = new ClientSessions({
       host: this.#host,
-      redirect: this.#redirect,
+      requestPolicy: this.#requestPolicy,
       resolveHeaders: (perRequest) => this.#resolveHeaders(perRequest),
     });
   }
@@ -51,7 +54,7 @@ export class Client {
   async health(): Promise<HealthResult> {
     const url = createClientUrl(this.#host, EVE_HEALTH_ROUTE_PATH);
     const headers = await this.#resolveHeaders();
-    const response = await fetch(url, withRedirectPolicy({ headers }, this.#redirect));
+    const response = await fetch(url, applyClientRequestPolicy({ headers }, this.#requestPolicy));
 
     if (!response.ok) {
       const body = await response.text();
@@ -112,7 +115,7 @@ export class Client {
   async fetch(path: string, init: RequestInit = {}): Promise<Response> {
     const url = createClientUrl(this.#host, path);
     const headers = await this.#resolveHeaders(headersInitToRecord(init.headers));
-    return await fetch(url, withRedirectPolicy({ ...init, headers }, this.#redirect));
+    return await fetch(url, applyClientRequestPolicy({ ...init, headers }, this.#requestPolicy));
   }
 
   // ---------------------------------------------------------------------------
@@ -204,11 +207,4 @@ function headersInitToRecord(
 ): Readonly<Record<string, string>> {
   if (headers === undefined) return {};
   return Object.fromEntries(new Headers(headers).entries());
-}
-
-function withRedirectPolicy(
-  init: RequestInit,
-  redirect: ClientRedirectPolicy | undefined,
-): RequestInit {
-  return redirect === undefined ? init : { ...init, redirect };
 }

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -19,6 +19,7 @@ import { toError } from "#shared/errors.js";
 import type {
   CancelSessionResult,
   ClientAuth,
+  ClientCredentialsPolicy,
   HeadersValue,
   SendTurnPayload,
   ClientSessionState,
@@ -72,7 +73,7 @@ export interface EveAgentStoreCallbacks<TData> {
  * Configuration for constructing an {@link EveAgentStore}.
  *
  * Requires a {@link EveAgentReducer | reducer}, plus either connection options
- * (`host`, `auth`, `headers`, `initialSession`) for a
+ * (`host`, `auth`, `credentials`, `headers`, `initialSession`) for a
  * store-owned session or an existing {@link ClientSession} via `session`.
  *
  * `optimistic` (default `true`) projects submitted user messages before the
@@ -84,6 +85,7 @@ export interface EveAgentStoreCallbacks<TData> {
  */
 export interface EveAgentStoreInit<TData> {
   readonly auth?: ClientAuth;
+  readonly credentials?: ClientCredentialsPolicy;
   readonly headers?: HeadersValue;
   readonly host?: string;
   /** Ordered prefix of the session stream used to rehydrate projected state. */
@@ -155,6 +157,7 @@ export class EveAgentStore<TData> {
       ? undefined
       : new Client({
           auth: init.auth,
+          credentials: init.credentials,
           headers: init.headers,
           host: init.host ?? "",
         });

--- a/packages/eve/src/client/index.ts
+++ b/packages/eve/src/client/index.ts
@@ -47,6 +47,7 @@ export type {
   ClearResult,
   CompactResult,
   ClientAuth,
+  ClientCredentialsPolicy,
   ClientOptions,
   ClientRedirectPolicy,
   HeadersValue,

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -3,8 +3,8 @@ import { EVE_STREAM_TAIL_INDEX_HEADER } from "#protocol/message.js";
 import { createEveSessionStreamRoutePath } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { isStreamDisconnectError, readNdjsonStream } from "#client/ndjson.js";
+import { applyClientRequestPolicy, type ClientRequestPolicy } from "#client/request-policy.js";
 import type {
-  ClientRedirectPolicy,
   ResolvedStreamReconnectPolicy as StreamReconnectPolicyOptions,
   StreamReconnectPolicy,
   StreamReconnectRetryPolicy,
@@ -84,7 +84,7 @@ interface FollowStreamInput {
   /** @internal Test override for reconnecting an open stream that stops producing bytes. */
   readonly streamReadIdleTimeoutMs?: number;
   readonly resolveHeaders: () => Promise<Headers>;
-  readonly redirect?: ClientRedirectPolicy;
+  readonly requestPolicy: ClientRequestPolicy;
   readonly sessionId: string;
   readonly signal?: AbortSignal;
   readonly startIndex: number;
@@ -247,12 +247,17 @@ export async function openStreamBody(
       : connectionController.signal;
     let response: Response;
     try {
-      response = await fetch(url, {
-        cache: "no-store",
-        headers,
-        redirect: input.redirect,
-        signal,
-      });
+      response = await fetch(
+        url,
+        applyClientRequestPolicy(
+          {
+            cache: "no-store",
+            headers,
+            signal,
+          },
+          input.requestPolicy,
+        ),
+      );
     } catch (error) {
       if (
         input.signal?.aborted ||

--- a/packages/eve/src/client/request-policy.ts
+++ b/packages/eve/src/client/request-policy.ts
@@ -1,0 +1,27 @@
+import type { ClientCredentialsPolicy, ClientRedirectPolicy } from "#client/types.js";
+
+/** Client-wide fetch policy shared by all requests for one client. */
+export interface ClientRequestPolicy {
+  readonly credentials?: ClientCredentialsPolicy;
+  readonly redirect?: ClientRedirectPolicy;
+}
+
+/** Applies client-wide fetch policy to one request. */
+export function applyClientRequestPolicy(
+  init: RequestInit,
+  policy: ClientRequestPolicy,
+): RequestInit {
+  const resolved = { ...init };
+
+  if (resolved.credentials === undefined && policy.credentials !== undefined) {
+    resolved.credentials = policy.credentials;
+  }
+
+  // Redirect policy remains client-owned so credential-bearing headers cannot
+  // follow a redirect that the client configuration forbids.
+  if (policy.redirect !== undefined) {
+    resolved.redirect = policy.redirect;
+  }
+
+  return resolved;
+}

--- a/packages/eve/src/client/session-controls.ts
+++ b/packages/eve/src/client/session-controls.ts
@@ -1,8 +1,8 @@
 import { ClientError } from "#client/client-error.js";
+import { applyClientRequestPolicy, type ClientRequestPolicy } from "#client/request-policy.js";
 import type {
   CancelSessionResult,
   ClearResult,
-  ClientRedirectPolicy,
   CompactResult,
   ResetResult,
 } from "#client/types.js";
@@ -20,7 +20,7 @@ import {
 
 interface SessionControlContext {
   readonly host: string;
-  readonly redirect?: ClientRedirectPolicy;
+  readonly requestPolicy: ClientRequestPolicy;
   resolveHeaders(): Promise<Headers>;
 }
 
@@ -122,13 +122,13 @@ async function postJson(input: {
   headers.set("content-type", "application/json");
   const response = await fetch(
     createClientUrl(input.context.host, input.path),
-    withRedirectPolicy(
+    applyClientRequestPolicy(
       {
         body: input.body === undefined ? undefined : JSON.stringify(input.body),
         headers,
         method: "POST",
       },
-      input.context.redirect,
+      input.context.requestPolicy,
     ),
   );
   const text = await response.text();
@@ -138,8 +138,4 @@ async function postJson(input: {
   } catch {
     throw new Error(`${input.operation} route returned invalid JSON (${response.status}).`);
   }
-}
-
-function withRedirectPolicy(init: RequestInit, redirect?: ClientRedirectPolicy): RequestInit {
-  return redirect === undefined ? init : { ...init, redirect };
 }

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ClientError } from "#client/client-error.js";
 import { ClientSession } from "#client/session.js";
-import type { ClientSessionState } from "#client/types.js";
+import type { ClientCredentialsPolicy, ClientSessionState } from "#client/types.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -11,13 +11,14 @@ afterEach(() => {
 function createSession(
   state: ClientSessionState = { sessionId: "session_1", streamIndex: 0 },
   options: {
+    readonly credentials?: ClientCredentialsPolicy;
     readonly redirect?: "error" | "follow" | "manual";
     readonly resolveHeaders?: () => Promise<Headers>;
   } = {},
 ) {
   const context: ConstructorParameters<typeof ClientSession>[0] = {
     host: "https://eve.test",
-    redirect: options.redirect,
+    requestPolicy: { credentials: options.credentials, redirect: options.redirect },
     resolveHeaders: options.resolveHeaders ?? (async () => new Headers()),
   };
 
@@ -77,6 +78,37 @@ function createBoundedStreamResponse(events: readonly unknown[]) {
 }
 
 describe("ClientSession", () => {
+  it("applies its credentials policy to sends, streams, and session controls", async () => {
+    const credentials: Array<ClientCredentialsPolicy | undefined> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+      credentials.push(init?.credentials);
+      const pathname = new URL(String(request)).pathname;
+      if (pathname.endsWith("/stream")) {
+        return createStreamResponse([{ data: {}, type: "session.completed" }]);
+      }
+      if (pathname.endsWith("/reset")) {
+        return Response.json({
+          ok: true,
+          previousSessionId: "session_1",
+          status: "reset",
+        });
+      }
+      return Response.json(
+        { ok: true, sessionId: "session_1", status: "accepted" },
+        { status: 202 },
+      );
+    });
+    const session = createSession(undefined, { credentials: "include" });
+
+    await (await session.send("hello")).result();
+    await session.cancel();
+    await session.clear();
+    await session.compact();
+    await session.reset();
+
+    expect(credentials).toEqual(["include", "include", "include", "include", "include", "include"]);
+  });
+
   it("cancels an accepted turn before its stream settles with freshly resolved auth", async () => {
     let headerResolution = 0;
     const requests: Array<{ headers: Headers; method: string; url: string }> = [];

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -4,6 +4,7 @@ import { EVE_SESSION_ROUTE_PATH, createEveSessionRoutePath } from "#protocol/rou
 import { ClientError } from "#client/client-error.js";
 import { MessageResponse } from "#client/message-response.js";
 import { followStreamIterable } from "#client/open-stream.js";
+import { applyClientRequestPolicy, type ClientRequestPolicy } from "#client/request-policy.js";
 import {
   cancelClientSession,
   clearClientSession,
@@ -18,7 +19,6 @@ import type {
   ClearResult,
   ClientSessionState,
   CompactResult,
-  ClientRedirectPolicy,
   RespondTurnOptions,
   ResetResult,
   SendTurnInput,
@@ -34,7 +34,7 @@ import type {
  */
 export interface ClientSessionContext {
   readonly host: string;
-  readonly redirect?: ClientRedirectPolicy;
+  readonly requestPolicy: ClientRequestPolicy;
   resolveHeaders(perRequest?: Readonly<Record<string, string>>): Promise<Headers>;
 }
 
@@ -248,7 +248,7 @@ export class ClientSession {
       host: this.#context.host,
       keepAlive: input.keepAlive,
       resolveHeaders: () => this.#context.resolveHeaders(input.headers),
-      redirect: this.#context.redirect,
+      requestPolicy: this.#context.requestPolicy,
       sessionId: this.#state.sessionId,
       signal: input.signal,
       startIndex: input.startIndex,
@@ -282,13 +282,18 @@ async function postTurn(
 
   const headers = await context.resolveHeaders(input.headers);
   headers.set("content-type", "application/json");
-  const response = await fetch(createClientUrl(context.host, path), {
-    body: JSON.stringify(body),
-    headers,
-    method: "POST",
-    redirect: context.redirect,
-    signal: input.signal ?? null,
-  });
+  const response = await fetch(
+    createClientUrl(context.host, path),
+    applyClientRequestPolicy(
+      {
+        body: JSON.stringify(body),
+        headers,
+        method: "POST",
+        signal: input.signal ?? null,
+      },
+      context.requestPolicy,
+    ),
+  );
   if (!response.ok) {
     const responseBody = await response.text();
     throw new ClientError(response.status, responseBody, response.headers);

--- a/packages/eve/src/client/stream-follow.integration.test.ts
+++ b/packages/eve/src/client/stream-follow.integration.test.ts
@@ -31,6 +31,7 @@ function follow(host: string, options?: { follow?: boolean }) {
   return followStreamIterable({
     follow: options?.follow,
     host,
+    requestPolicy: {},
     resolveHeaders: () => Promise.resolve(new Headers()),
     sessionId: "s",
     startIndex: 0,
@@ -114,6 +115,7 @@ describe("stream following over real sockets", () => {
     const received: string[] = [];
     for await (const event of followStreamIterable({
       host,
+      requestPolicy: {},
       resolveHeaders: () => Promise.resolve(new Headers()),
       sessionId: "s",
       startIndex: 0,

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -68,6 +68,9 @@ export const VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER = "x-vercel-trusted-oidc-idp-t
 /** Redirect modes supported by the configured fetch implementation. */
 export type ClientRedirectPolicy = NonNullable<RequestInit["redirect"]>;
 
+/** Browser credentials modes supported by the configured fetch implementation. */
+export type ClientCredentialsPolicy = NonNullable<RequestInit["credentials"]>;
+
 /**
  * Configuration for creating a new {@link Client}.
  */
@@ -90,6 +93,13 @@ export interface ClientOptions {
    * that need to be refreshed alongside the bearer credential).
    */
   readonly headers?: HeadersValue;
+
+  /**
+   * Browser credentials mode for every client request. Cross-origin cookies
+   * also require a matching server CORS policy. {@link Client.fetch} may
+   * override this value per call.
+   */
+  readonly credentials?: ClientCredentialsPolicy;
 
   /**
    * Redirect policy for every request, including streams. Overrides a

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -225,6 +225,7 @@ describe("useEveAgent", () => {
 
     function TestComponent() {
       helpers = useEveAgent({
+        credentials: "include",
         onEvent(event) {
           lifecycle.push(`event:${event.type}`);
           seenEvents.push(event);
@@ -257,6 +258,7 @@ describe("useEveAgent", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")).toBe(true);
     expect(lifecycle[0]).toBe("session:0");
     expect(seenEvents).toEqual(stampTestEvents(events));
     expect(seenSessions).toEqual([

--- a/packages/eve/src/react/use-eve-agent.ts
+++ b/packages/eve/src/react/use-eve-agent.ts
@@ -17,6 +17,7 @@ import type { UserContent } from "ai";
 import type {
   CancelSessionResult,
   ClientAuth,
+  ClientCredentialsPolicy,
   HeadersValue,
   RespondTurnOptions,
   SendTurnOptions,
@@ -71,7 +72,7 @@ export interface UseEveAgentHelpers<TData> extends UseEveAgentSnapshot<TData> {
  * remount the component to point at a different host, reducer, or session.
  * Lifecycle callbacks update on every render.
  *
- * For credentials or headers that must change without remounting, pass function
+ * For auth tokens or headers that must change without remounting, pass function
  * values to `auth` or `headers`; the client resolves those before each request.
  */
 export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData> {
@@ -83,6 +84,8 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
    */
   readonly agent?: string;
   readonly auth?: ClientAuth;
+  /** Browser credentials mode for every request made by the auto-created client. */
+  readonly credentials?: ClientCredentialsPolicy;
   readonly headers?: HeadersValue;
   /**
    * Base URL for eve client requests. Do not combine with `agent`.
@@ -159,6 +162,7 @@ export function useEveAgent<TData>(
     const reducer = options.reducer ?? (defaultMessageReducer() as EveAgentReducer<TData>);
     storeRef.current = new EveAgentStore({
       auth: options.auth,
+      credentials: options.credentials,
       headers: options.headers,
       host: resolveEveAgentHost({ agent: options.agent, host: options.host }),
       initialEvents: options.initialEvents,

--- a/packages/eve/src/svelte/use-eve-agent.test.ts
+++ b/packages/eve/src/svelte/use-eve-agent.test.ts
@@ -117,12 +117,14 @@ describe("useEveAgent (Svelte rune binding)", () => {
       createMessageReceivedEvent({ message: "Hello", sequence: 0, turnId: "turn_1" }),
       createSessionWaitingEvent(),
     ];
-    vi.spyOn(globalThis, "fetch")
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(createStartedMessageResponse("session_1", "http:session_1"))
       .mockResolvedValueOnce(createEagerStreamResponse(events));
     const seenEvents: UnstampedMessageStreamEvent[] = [];
 
     const agent = useEveAgent({
+      credentials: "include",
       onEvent(event) {
         seenEvents.push(event);
       },
@@ -131,5 +133,6 @@ describe("useEveAgent (Svelte rune binding)", () => {
     await agent.send("Hello");
 
     expect(seenEvents).toEqual(stampTestEvents(events));
+    expect(fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")).toBe(true);
   });
 });

--- a/packages/eve/src/svelte/use-eve-agent.ts
+++ b/packages/eve/src/svelte/use-eve-agent.ts
@@ -16,6 +16,7 @@ import type { ClientSession } from "#client/session.js";
 import type {
   CancelSessionResult,
   ClientAuth,
+  ClientCredentialsPolicy,
   HeadersValue,
   RespondTurnOptions,
   SendTurnOptions,
@@ -79,7 +80,7 @@ export interface UseEveAgentReturn<TData> {
  * Configuration for a Svelte eve agent session.
  *
  * Read once when `useEveAgent` creates its store; create a new binding to
- * change host, reducer, or session. To rotate credentials or headers without
+ * change host, reducer, or session. To rotate auth tokens or headers without
  * recreating the binding, pass function values to `auth` or `headers`, which
  * the client resolves before each HTTP request.
  */
@@ -92,10 +93,12 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
    */
   readonly agent?: string;
   /**
-   * Credentials for the auto-created session. Pass function values to refresh
+   * Authentication for the auto-created session. Pass function values to refresh
    * per request. Ignored when `session` is supplied.
    */
   readonly auth?: ClientAuth;
+  /** Browser credentials mode for every request made by the auto-created client. */
+  readonly credentials?: ClientCredentialsPolicy;
   /**
    * Custom headers for the auto-created session. Pass a function to resolve
    * fresh values per request. Ignored when `session` is supplied.
@@ -131,7 +134,7 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
   readonly resume?: boolean;
   /**
    * Pre-built client session to bind to. When omitted, the binding creates its
-   * own session from `auth`, `headers`, and `host`.
+   * own session from `auth`, `credentials`, `headers`, and `host`.
    */
   readonly session?: ClientSession;
 }
@@ -237,6 +240,7 @@ export function useEveAgent<TData>(
   const reducer = options.reducer ?? (defaultMessageReducer() as EveAgentReducer<TData>);
   const store = new EveAgentStore<TData>({
     auth: options.auth,
+    credentials: options.credentials,
     headers: options.headers,
     host: resolveEveAgentHost({ agent: options.agent, host: options.host }),
     initialEvents: options.initialEvents,

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -392,12 +392,13 @@ describe("useEveAgent (Vue composable wiring)", () => {
     ];
 
     const startResponse = createDeferred<Response>();
-    vi.spyOn(globalThis, "fetch")
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
       .mockReturnValueOnce(startResponse.promise)
       .mockResolvedValueOnce(createEagerStreamResponse(events));
 
     const scope = effectScope();
-    const agent = scope.run(() => useEveAgent());
+    const agent = scope.run(() => useEveAgent({ credentials: "include" }));
     if (agent === undefined) throw new Error("effect scope did not run");
 
     expect(agent.status.value).toBe("ready");
@@ -411,6 +412,7 @@ describe("useEveAgent (Vue composable wiring)", () => {
     await sendPromise;
 
     expect(agent.status.value).toBe("ready");
+    expect(fetchMock.mock.calls.every(([, init]) => init?.credentials === "include")).toBe(true);
     expect(agent.data.value).toEqual(
       completedTurnData({
         assistantMessage: "Hi there.",

--- a/packages/eve/src/vue/use-eve-agent.ts
+++ b/packages/eve/src/vue/use-eve-agent.ts
@@ -17,6 +17,7 @@ import type { MessageStreamEvent } from "#protocol/message.js";
 import type {
   CancelSessionResult,
   ClientAuth,
+  ClientCredentialsPolicy,
   HeadersValue,
   RespondTurnOptions,
   SendTurnOptions,
@@ -78,7 +79,7 @@ export interface UseEveAgentReturn<TData> {
  *
  * Session configuration is read once when the composable creates its internal
  * store; to change the host, reducer, or session, remount the component. For
- * credentials or headers that must change without remounting, pass function
+ * auth tokens or headers that must change without remounting, pass function
  * values to `auth` or `headers`; the client resolves those before each request.
  *
  * Lifecycle callbacks (`onError`, `onEvent`, `onFinish`, `onSessionChange`,
@@ -95,6 +96,8 @@ export interface UseEveAgentOptions<TData> extends EveAgentStoreCallbacks<TData>
   readonly agent?: string;
   /** Authentication configuration; a function value is resolved per request. */
   readonly auth?: ClientAuth;
+  /** Browser credentials mode for every request made by the auto-created client. */
+  readonly credentials?: ClientCredentialsPolicy;
   /** Custom headers; a function value is resolved per request. */
   readonly headers?: HeadersValue;
   /**
@@ -166,6 +169,7 @@ export function useEveAgent<TData>(
 
   const store = new EveAgentStore<TData>({
     auth: options.auth,
+    credentials: options.credentials,
     headers: options.headers,
     host: resolveEveAgentHost({ agent: options.agent, host: options.host }),
     initialEvents: options.initialEvents,

--- a/packages/eve/test/tui-client/tui-connection-auth-states.ts
+++ b/packages/eve/test/tui-client/tui-connection-auth-states.ts
@@ -43,6 +43,7 @@ class FakeSession extends ClientSession {
     super(
       {
         host: "http://fake.invalid",
+        requestPolicy: {},
         resolveHeaders: async () => new Headers(),
       },
       { sessionId: "fake-session", streamIndex: 0 },


### PR DESCRIPTION
## Summary

Cross-origin browser clients could not send cookie credentials through `Client` or `useEveAgent`. This adds a client-wide `credentials` policy, applies it to health and info requests, raw fetches, session sends, every session control, streams, and reconnects, and exposes it through the React, Vue, and Svelte bindings. Raw `Client.fetch()` calls may override credentials per request; the configured redirect policy remains client-owned.

```tsx
const agent = useEveAgent({
  host: "https://agent.example.com",
  credentials: "include",
});
```

## Validation

- Focused client and frontend unit coverage: 82 tests passed
- Real-socket stream integration coverage: 7 tests passed
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm fmt`
- `pnpm lint` (one pre-existing warning in `teamsChannel.test.ts`)
- `pnpm guard:invariants`
- TUI TypeScript compilation and the formerly failing auth-state smoke passed; the later packed-install smoke was interrupted after repeated TLS certificate retries from the internal npm registry and is left to CI

## Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

## Diff size

**Docs** — 6 files · `+37 / -5`

Documents the client and frontend API, matching credentialed CORS policy, framework-specific options, and release note.

**Implementation** — 11 files · `+100 / -45`

Centralizes request policy and threads it through the current client, session lifecycle, reconnect loop, and React, Vue, and Svelte bindings.

**Tests** — 7 files · `+81 / -5`

Covers request precedence, every request and control path, stream propagation, all frontend bindings, and the TUI fake-session contract.
