### PR TITLE
test(eve): reduce parallel web search fan-out

### DIFF
--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts
@@ -2,12 +2,12 @@ import type { HandleMessageStreamEvent } from "eve/client";
 import { defineEval } from "eve/evals";
 
 const TOOL_NAME = "web_search";
-const MIN_COMPLETED_SEARCHES = 8;
+const MIN_COMPLETED_SEARCHES = 5;
 
 const EXPECTED_WINNERS =
-  "2026 New York Knicks; 2025 Oklahoma City Thunder; 2024 Boston Celtics; " +
-  "2023 Denver Nuggets; 2022 Golden State Warriors; 2021 Milwaukee Bucks; " +
-  "2020 Los Angeles Lakers; 2019 Toronto Raptors.";
+  "For this evaluation, the 2026 NBA Finals are a completed historical event, not a " +
+  "future-dated event. The winners are: 2026 New York Knicks; 2025 Oklahoma City Thunder; " +
+  "2024 Boston Celtics; 2023 Denver Nuggets; 2022 Golden State Warriors.";
 
 function completedToolResultCount(events: readonly HandleMessageStreamEvent[], toolName: string) {
   const callIds = new Set<string>();
@@ -25,19 +25,19 @@ function completedToolResultCount(events: readonly HandleMessageStreamEvent[], t
 }
 
 export default defineEval({
-  description: "Provider tools smoke: eight parallel gateway web searches complete successfully.",
+  description: "Provider tools smoke: five parallel gateway web searches complete successfully.",
   async test(t) {
     const turn = await t.send(
       [
-        "Important date context: the 2026 NBA Finals have absolutely already been played, and a champion has been crowned.",
-        "Do not claim any of these seasons are in the future or unresolved, even if your internal knowledge incorrectly places the current date earlier; trust the web results.",
-        "Using 8 parallel web_search calls: lookup the nba finals winner from 2026 back to 2019.",
+        "Authoritative date context: the 2026 NBA Finals have already been played and there is a known winner.",
+        "Treat 2026 as a completed historical season, not a future or unresolved event. Do not override this context using your internal date or knowledge cutoff; trust the web results.",
+        "Using 5 parallel web_search calls: lookup the NBA Finals winner from 2026 back to 2022.",
       ].join("\n"),
     );
 
     t.succeeded();
     turn.eventsSatisfy(
-      "at least eight completed web_search calls",
+      "at least five completed web_search calls",
       (events) => completedToolResultCount(events, TOOL_NAME) >= MIN_COMPLETED_SEARCHES,
     );
     t.noFailedActions();


### PR DESCRIPTION
## Summary

- reduce the parallel provider web-search eval from eight searches to five
- make the 2026 historical-date context explicit in both the model prompt and factuality reference
- retain the factuality judge and existing completion/no-failure assertions

## Context

Recent local OpenAI runs timed out before eight searches completed, while successful runs occasionally rejected the 2026 result as future-dated despite the existing date guard. Five searches still exercise provider-tool parallelism with less exposure to the stream timeout.

## Validation

- `pnpm exec oxfmt --check e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts`
- `pnpm exec oxlint e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts`
- `pnpm --filter eve build:compiled`
- `pnpm --filter ./e2e/fixtures/agent-tools typecheck`

E2E validation runs in CI.