### PR TITLE
test(evals): compare documentation snapshots

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -79,6 +79,19 @@ experiments without executing a coding agent with:
 pnpm eval agent-000-create-greeting-tool --dry
 ```
 
+Compare the working tree's documentation against a Git ref with:
+
+```sh
+pnpm eval agent-000-create-greeting-tool --compare origin/main
+```
+
+Comparison runs use the current built eve runtime for both snapshots, changing
+only the package docs and installable eve skill. This isolates documentation
+changes from framework-code changes. The six resulting experiments are
+namespaced as `reference-*` and `current-*`; the summary prints both values and
+their signed deltas. Each `result.json` records the snapshot ref, SHA, dirty
+state, and treatment under `analysis.documentationEval`.
+
 Set `EVE_SKIP_PACK=1` to reuse `evals/.tarballs/eve.tgz` while iterating on a
 fixture. Do not use it after changing eve code or docs.
 
@@ -107,7 +120,7 @@ evals/
 ├── package.json        # private pnpm workspace package
 ├── run.js              # local package packer and experiment generator
 ├── evals/agent-*/     # committed starter projects, prompts, and graders
-├── lib/setup.ts       # installs local eve and writes treatment guidance
+├── lib/               # sandbox setup, comparison packaging, and reporting
 ├── experiments/       # generated per run, ignored
 ├── .tarballs/         # generated local package, ignored
 └── results/           # generated results and transcripts, ignored

--- a/evals/lib/comparison.js
+++ b/evals/lib/comparison.js
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+export function currentSnapshot(root) {
+  return {
+    snapshot: "current",
+    gitRef: "HEAD",
+    gitSha: git(root, ["rev-parse", "HEAD"]),
+    dirty: git(root, ["status", "--porcelain"]) !== "",
+  };
+}
+
+export function resolveReference(root, gitRef) {
+  try {
+    return {
+      snapshot: "reference",
+      gitRef,
+      gitSha: git(root, ["rev-parse", "--verify", "--end-of-options", `${gitRef}^{commit}`]),
+      dirty: false,
+    };
+  } catch {
+    throw new Error(`Unable to resolve comparison Git ref: ${gitRef}`);
+  }
+}
+
+/** Builds a package containing current runtime code and documentation from a Git ref. */
+export function prepareReferencePackage({ root, tarballPath, outputPath, reference }) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "eve-eval-compare-"));
+  const archivePath = path.join(temporaryRoot, "reference.tar");
+  const referenceRoot = path.join(temporaryRoot, "reference");
+  const packageRoot = path.join(temporaryRoot, "package");
+  fs.mkdirSync(referenceRoot);
+  fs.mkdirSync(packageRoot);
+
+  try {
+    execFileSync(
+      "git",
+      [
+        "archive",
+        "--format=tar",
+        `--output=${archivePath}`,
+        reference.gitSha,
+        "docs",
+        "skills/eve/SKILL.md",
+      ],
+      { cwd: root },
+    );
+    execFileSync("tar", ["-xf", archivePath, "-C", referenceRoot]);
+    execFileSync("tar", ["-xzf", tarballPath, "-C", packageRoot]);
+
+    const extractedPackage = path.join(packageRoot, "package");
+    fs.rmSync(path.join(extractedPackage, "docs"), { recursive: true, force: true });
+    fs.cpSync(path.join(referenceRoot, "docs"), path.join(extractedPackage, "docs"), {
+      recursive: true,
+    });
+
+    const outputDirectory = path.dirname(outputPath);
+    const output = execFileSync(
+      "npm",
+      ["pack", "--ignore-scripts", "--silent", "--pack-destination", outputDirectory],
+      { cwd: extractedPackage, encoding: "utf8" },
+    );
+    const produced = output.trim().split("\n").pop();
+    if (produced === undefined) {
+      throw new Error("npm pack did not report a reference tarball path.");
+    }
+    fs.rmSync(outputPath, { force: true });
+    fs.renameSync(path.join(outputDirectory, produced), outputPath);
+
+    return {
+      skillPath: path.join(referenceRoot, "skills/eve/SKILL.md"),
+      cleanup: () => fs.rmSync(temporaryRoot, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/evals/lib/report.js
+++ b/evals/lib/report.js
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const usageFields = [
+  "totalTokens",
+  "totalInputTokens",
+  "inputTokens",
+  "cacheCreationInputTokens",
+  "cacheReadInputTokens",
+  "outputTokens",
+];
+
+function mean(values) {
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function formatInteger(value) {
+  return Math.round(value).toLocaleString("en-US");
+}
+
+function formatDelta(value, formatter = formatInteger) {
+  if (value === 0) return formatter(0);
+  return `${value > 0 ? "+" : "-"}${formatter(Math.abs(value))}`;
+}
+
+function printTable(headers, rows) {
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index].length)),
+  );
+  const formatRow = (row) =>
+    row
+      .map((cell, index) =>
+        index <= (headers[0] === "Snapshot" ? 1 : 0)
+          ? cell.padEnd(widths[index])
+          : cell.padStart(widths[index]),
+      )
+      .join("  ");
+
+  console.log(formatRow(headers));
+  console.log(widths.map((width) => "-".repeat(width)).join("  "));
+  for (const row of rows) console.log(formatRow(row));
+}
+
+function summarize(results) {
+  const passed = results.filter((result) => result.status === "passed").length;
+  const usages = results
+    .map((result) => result.analysis?.tokenUsage)
+    .filter((usage) => usage !== undefined);
+  const usage =
+    usages.length === 0
+      ? undefined
+      : Object.fromEntries(
+          usageFields.map((field) => [field, mean(usages.map((entry) => entry[field]))]),
+        );
+
+  return {
+    passed,
+    runs: results.length,
+    accuracy: (passed / results.length) * 100,
+    duration: mean(results.map((result) => result.duration)),
+    usageRuns: usages.length,
+    usage,
+  };
+}
+
+function resultRow(label, treatment, summary, comparison) {
+  const prefix = comparison ? [label, treatment] : [treatment];
+  const usage = summary.usage;
+  return [
+    ...prefix,
+    `${summary.passed}/${summary.runs} (${Math.round(summary.accuracy)}%)`,
+    `${summary.usageRuns}/${summary.runs}`,
+    ...usageFields.map((field) => (usage === undefined ? "—" : formatInteger(usage[field]))),
+    `${summary.duration.toFixed(1)}s`,
+  ];
+}
+
+function deltaRow(treatment, reference, current) {
+  return [
+    "Δ",
+    treatment,
+    `${formatDelta(current.accuracy - reference.accuracy, (value) => value.toFixed(0))} pp`,
+    "—",
+    ...usageFields.map((field) => {
+      if (reference.usage === undefined || current.usage === undefined) return "—";
+      return formatDelta(current.usage[field] - reference.usage[field]);
+    }),
+    `${formatDelta(current.duration - reference.duration, (value) => value.toFixed(1))}s`,
+  ];
+}
+
+export function buildComparisonRows(treatments, summaries) {
+  const rows = [];
+  for (const treatment of treatments) {
+    const reference = summaries.get(`reference-${treatment}`);
+    const current = summaries.get(`current-${treatment}`);
+    if (reference !== undefined) rows.push(resultRow("reference", treatment, reference, true));
+    if (current !== undefined) rows.push(resultRow("current", treatment, current, true));
+    if (reference !== undefined && current !== undefined) {
+      rows.push(deltaRow(treatment, reference, current));
+    }
+  }
+  return rows;
+}
+
+export function printResultSummary({ resultFiles, resultsDir, experiments, comparison }) {
+  if (resultFiles.length === 0) return;
+
+  const resultsByExperiment = new Map();
+  for (const resultFile of resultFiles) {
+    const experiment = path.relative(resultsDir, resultFile).split(path.sep)[0];
+    const results = resultsByExperiment.get(experiment) ?? [];
+    results.push(JSON.parse(fs.readFileSync(resultFile, "utf8")));
+    resultsByExperiment.set(experiment, results);
+  }
+
+  const summaries = new Map();
+  for (const experiment of experiments) {
+    const results = resultsByExperiment.get(experiment.suffix);
+    if (results !== undefined) summaries.set(experiment.suffix, summarize(results));
+  }
+
+  const metricHeaders = [
+    "Accuracy",
+    "Token runs",
+    "Total",
+    "Input",
+    "Uncached",
+    "Cache write",
+    "Cache read",
+    "Output",
+    "Duration",
+  ];
+
+  console.log("\nEvaluation summary (token counts are means per reported run):");
+  if (!comparison) {
+    const rows = experiments.flatMap((experiment) => {
+      const summary = summaries.get(experiment.suffix);
+      return summary === undefined
+        ? []
+        : [resultRow("current", experiment.treatment, summary, false)];
+    });
+    printTable(["Variant", ...metricHeaders], rows);
+    return;
+  }
+
+  const treatments = new Set(experiments.map((experiment) => experiment.treatment));
+  const rows = buildComparisonRows(treatments, summaries);
+  printTable(["Snapshot", "Variant", ...metricHeaders], rows);
+}

--- a/evals/lib/report.test.js
+++ b/evals/lib/report.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import { buildComparisonRows } from "./report.js";
+
+const usage = (totalTokens) => ({
+  totalTokens,
+  totalInputTokens: totalTokens - 10,
+  inputTokens: 20,
+  cacheCreationInputTokens: 30,
+  cacheReadInputTokens: totalTokens - 60,
+  outputTokens: 10,
+});
+
+describe("buildComparisonRows", () => {
+  test("shows reference, current, and signed deltas", () => {
+    const summaries = new Map([
+      [
+        "reference-baseline",
+        {
+          passed: 1,
+          runs: 2,
+          accuracy: 50,
+          duration: 12,
+          usageRuns: 2,
+          usage: usage(1_000),
+        },
+      ],
+      [
+        "current-baseline",
+        {
+          passed: 2,
+          runs: 2,
+          accuracy: 100,
+          duration: 10.5,
+          usageRuns: 2,
+          usage: usage(900),
+        },
+      ],
+    ]);
+
+    expect(buildComparisonRows(["baseline"], summaries)).toEqual([
+      [
+        "reference",
+        "baseline",
+        "1/2 (50%)",
+        "2/2",
+        "1,000",
+        "990",
+        "20",
+        "30",
+        "940",
+        "10",
+        "12.0s",
+      ],
+      ["current", "baseline", "2/2 (100%)", "2/2", "900", "890", "20", "30", "840", "10", "10.5s"],
+      ["Δ", "baseline", "+50 pp", "—", "-100", "-100", "0", "0", "-100", "0", "-1.5s"],
+    ]);
+  });
+});

--- a/evals/lib/setup.ts
+++ b/evals/lib/setup.ts
@@ -2,16 +2,25 @@ import { readFileSync } from "node:fs";
 
 import type { Sandbox } from "@vercel/agent-eval";
 
-/** Installs the locally built eve package in an authoring-eval sandbox. */
-export async function installEve(sandbox: Sandbox): Promise<void> {
-  const tarballPath = process.env.EVE_EVAL_TARBALL;
-  if (tarballPath === undefined) {
-    throw new Error("EVE_EVAL_TARBALL is not set. Run evals with `pnpm eval`.");
-  }
+type EvalSnapshot = "current" | "reference";
 
+function snapshotPath(snapshot: EvalSnapshot, kind: "SKILL" | "TARBALL"): string {
+  const variable = snapshot === "reference" ? `EVE_EVAL_REFERENCE_${kind}` : `EVE_EVAL_${kind}`;
+  const value = process.env[variable];
+  if (value === undefined) {
+    throw new Error(`${variable} is not set. Run evals with \`pnpm eval\`.`);
+  }
+  return value;
+}
+
+/** Installs the locally built eve package in an authoring-eval sandbox. */
+export async function installEve(
+  sandbox: Sandbox,
+  snapshot: EvalSnapshot = "current",
+): Promise<void> {
   await sandbox.writeFiles({
     // @ts-expect-error The runtime accepts Buffer even though the upstream type only names string.
-    "eve.tgz": readFileSync(tarballPath),
+    "eve.tgz": readFileSync(snapshotPath(snapshot, "TARBALL")),
   });
   const result = await sandbox.runCommand("npm", ["install", "./eve.tgz"]);
   if (result.exitCode !== 0) {
@@ -37,11 +46,15 @@ package docs are unavailable, use https://eve.dev/docs as a fallback.
 }
 
 /** Installs the repository's eve skill for the configured Claude Code agent. */
-export async function writeEveSkill(sandbox: Sandbox): Promise<void> {
+export async function writeEveSkill(
+  sandbox: Sandbox,
+  snapshot: EvalSnapshot = "current",
+): Promise<void> {
+  const skillPath =
+    snapshot === "reference"
+      ? snapshotPath(snapshot, "SKILL")
+      : new URL("../../skills/eve/SKILL.md", import.meta.url);
   await sandbox.writeFiles({
-    ".claude/skills/eve/SKILL.md": readFileSync(
-      new URL("../../skills/eve/SKILL.md", import.meta.url),
-      "utf8",
-    ),
+    ".claude/skills/eve/SKILL.md": readFileSync(skillPath, "utf8"),
   });
 }

--- a/evals/lib/token-usage.test.ts
+++ b/evals/lib/token-usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { parseTokenUsage } from "./token-usage.js";
+import { createResultHook, parseTokenUsage } from "./token-usage.js";
 
 describe("parseTokenUsage", () => {
   test("aggregates usage across coding-agent turns", () => {
@@ -41,5 +41,25 @@ describe("parseTokenUsage", () => {
   test("returns undefined when the transcript has no usage", () => {
     expect(parseTokenUsage(undefined)).toBeUndefined();
     expect(parseTokenUsage(JSON.stringify({ type: "tool_result" }))).toBeUndefined();
+  });
+
+  test("records documentation snapshot metadata without token usage", async () => {
+    const metadata = {
+      treatment: "agents-md",
+      snapshot: "reference" as const,
+      gitRef: "origin/main",
+      gitSha: "abc123",
+      dirty: false,
+    };
+    const output = await createResultHook(metadata)({
+      runData: {
+        transcript: undefined,
+        result: { analysis: {}, status: "passed" },
+      },
+    } as never);
+
+    expect(output).toMatchObject({
+      result: { analysis: { documentationEval: metadata } },
+    });
   });
 });

--- a/evals/lib/token-usage.ts
+++ b/evals/lib/token-usage.ts
@@ -10,6 +10,15 @@ export interface TokenUsage {
   totalTokens: number;
 }
 
+/** Documentation snapshot and treatment recorded with an eval result. */
+export interface EvalResultMetadata {
+  treatment: string;
+  snapshot: "current" | "reference";
+  gitRef: string;
+  gitSha: string;
+  dirty: boolean;
+}
+
 function tokenCount(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
@@ -55,19 +64,20 @@ export function parseTokenUsage(transcript: string | undefined): TokenUsage | un
   };
 }
 
-/** Persists coding-model token usage with each agent-eval run result. */
-export const recordTokenUsage: RunCompleteHook = ({ runData }) => {
-  const tokenUsage = parseTokenUsage(runData.transcript);
-  if (tokenUsage === undefined) return;
+/** Persists comparison metadata and coding-model usage with each result. */
+export function createResultHook(metadata?: EvalResultMetadata): RunCompleteHook {
+  return ({ runData }) => {
+    const tokenUsage = parseTokenUsage(runData.transcript);
+    const analysis: Record<string, unknown> = { ...runData.result.analysis };
+    if (metadata !== undefined) analysis.documentationEval = metadata;
+    if (tokenUsage !== undefined) analysis.tokenUsage = tokenUsage;
 
-  return {
-    ...runData,
-    result: {
-      ...runData.result,
-      analysis: {
-        ...runData.result.analysis,
-        tokenUsage,
+    return {
+      ...runData,
+      result: {
+        ...runData.result,
+        analysis,
       },
-    },
+    };
   };
-};
+}

--- a/evals/run.js
+++ b/evals/run.js
@@ -8,29 +8,35 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
+import { currentSnapshot, prepareReferencePackage, resolveReference } from "./lib/comparison.js";
+import { printResultSummary } from "./lib/report.js";
+
 const evalsDir = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(evalsDir, "..");
 const fixturesDir = path.join(evalsDir, "evals");
 const experimentsDir = path.join(evalsDir, "experiments");
 const tarballDir = path.join(evalsDir, ".tarballs");
 const tarballPath = path.join(tarballDir, "eve.tgz");
+const referenceTarballPath = path.join(tarballDir, "eve-reference.tgz");
 const resultsDir = path.join(evalsDir, "results");
 
 const variants = [
   {
     suffix: "baseline",
     imports: `import { installEve } from '../lib/setup.js'`,
-    setup: `await installEve(sandbox)`,
+    setup: (snapshot) => `await installEve(sandbox, '${snapshot}')`,
   },
   {
     suffix: "agents-md",
     imports: `import { installEve, writeAgentsMd } from '../lib/setup.js'`,
-    setup: `await installEve(sandbox)\n    await writeAgentsMd(sandbox)`,
+    setup: (snapshot) =>
+      `await installEve(sandbox, '${snapshot}')\n    await writeAgentsMd(sandbox)`,
   },
   {
     suffix: "eve-skill",
     imports: `import { installEve, writeEveSkill } from '../lib/setup.js'`,
-    setup: `await installEve(sandbox)\n    await writeEveSkill(sandbox)`,
+    setup: (snapshot) =>
+      `await installEve(sandbox, '${snapshot}')\n    await writeEveSkill(sandbox, '${snapshot}')`,
   },
 ];
 
@@ -49,15 +55,31 @@ function pack() {
   fs.renameSync(producedPath, tarballPath);
 }
 
-function writeExperiments(evalName) {
+function createExperiments(comparison) {
+  const snapshots = comparison
+    ? [comparison.reference, comparison.current]
+    : [currentSnapshot(root)];
+
+  return snapshots.flatMap((snapshot) =>
+    variants.map((variant) => ({
+      ...variant,
+      snapshot: snapshot.snapshot,
+      suffix: comparison ? `${snapshot.snapshot}-${variant.suffix}` : variant.suffix,
+      treatment: variant.suffix,
+      metadata: { ...snapshot, treatment: variant.suffix },
+    })),
+  );
+}
+
+function writeExperiments(evalName, experiments) {
   fs.rmSync(experimentsDir, { recursive: true, force: true });
   fs.mkdirSync(experimentsDir, { recursive: true });
 
   const evalsField = evalName === null ? "" : `\n  evals: ${JSON.stringify(evalName)},`;
-  for (const variant of variants) {
+  for (const experiment of experiments) {
     const source = `import type { ExperimentConfig } from '@vercel/agent-eval'
-${variant.imports}
-import { recordTokenUsage } from '../lib/token-usage.js'
+${experiment.imports}
+import { createResultHook } from '../lib/token-usage.js'
 
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/claude-code',
@@ -68,15 +90,15 @@ const config: ExperimentConfig = {
   earlyExit: true,
   timeout: 720,
   sandbox: 'auto',
-  onRunComplete: recordTokenUsage,
+  onRunComplete: createResultHook(${JSON.stringify(experiment.metadata)}),
   setup: async (sandbox) => {
-    ${variant.setup}
+    ${experiment.setup(experiment.snapshot)}
   },
 }
 
 export default config
 `;
-    fs.writeFileSync(path.join(experimentsDir, `${variant.suffix}.ts`), source);
+    fs.writeFileSync(path.join(experimentsDir, `${experiment.suffix}.ts`), source);
   }
 }
 
@@ -95,107 +117,10 @@ function listResultFiles() {
     .map((resultPath) => path.join(resultsDir, resultPath));
 }
 
-function mean(values) {
-  return values.reduce((total, value) => total + value, 0) / values.length;
-}
-
-function formatInteger(value) {
-  return Math.round(value).toLocaleString("en-US");
-}
-
-function printTable(headers, rows) {
-  const widths = headers.map((header, index) =>
-    Math.max(header.length, ...rows.map((row) => row[index].length)),
-  );
-  const formatRow = (row) =>
-    row
-      .map((cell, index) =>
-        index === 0 ? cell.padEnd(widths[index]) : cell.padStart(widths[index]),
-      )
-      .join("  ");
-
-  console.log(formatRow(headers));
-  console.log(widths.map((width) => "-".repeat(width)).join("  "));
-  for (const row of rows) console.log(formatRow(row));
-}
-
-function printResultSummary(resultFiles) {
-  if (resultFiles.length === 0) return;
-
-  const resultsByVariant = new Map();
-  for (const resultFile of resultFiles) {
-    const variant = path.relative(resultsDir, resultFile).split(path.sep)[0];
-    const result = JSON.parse(fs.readFileSync(resultFile, "utf8"));
-    const results = resultsByVariant.get(variant) ?? [];
-    results.push(result);
-    resultsByVariant.set(variant, results);
-  }
-
-  const rows = [];
-  for (const variant of variants) {
-    const results = resultsByVariant.get(variant.suffix);
-    if (results === undefined) continue;
-
-    const passed = results.filter((result) => result.status === "passed").length;
-    const accuracy = `${passed}/${results.length} (${Math.round((passed / results.length) * 100)}%)`;
-    const duration = `${mean(results.map((result) => result.duration)).toFixed(1)}s`;
-    const usages = results
-      .map((result) => result.analysis?.tokenUsage)
-      .filter((usage) => usage !== undefined);
-
-    if (usages.length === 0) {
-      rows.push([
-        variant.suffix,
-        accuracy,
-        `0/${results.length}`,
-        "—",
-        "—",
-        "—",
-        "—",
-        "—",
-        "—",
-        duration,
-      ]);
-      continue;
-    }
-
-    const usage = (field) => formatInteger(mean(usages.map((entry) => entry[field])));
-    rows.push([
-      variant.suffix,
-      accuracy,
-      `${usages.length}/${results.length}`,
-      usage("totalTokens"),
-      usage("totalInputTokens"),
-      usage("inputTokens"),
-      usage("cacheCreationInputTokens"),
-      usage("cacheReadInputTokens"),
-      usage("outputTokens"),
-      duration,
-    ]);
-  }
-
-  console.log("\nEvaluation summary (token counts are means per reported run):");
-  printTable(
-    [
-      "Variant",
-      "Accuracy",
-      "Token runs",
-      "Total",
-      "Input",
-      "Uncached",
-      "Cache write",
-      "Cache read",
-      "Output",
-      "Duration",
-    ],
-    rows,
-  );
-}
-
 function printUsage(options = {}) {
   const write = options.error ? console.error : console.log;
-  write("Usage: pnpm --filter evals eval <eval-name> [--dry]");
-  write("       pnpm --filter evals eval --all [--dry]");
+  write("Usage: pnpm --filter evals eval <eval-name> [--compare <git-ref>] [--dry]");
+  write("       pnpm --filter evals eval --all [--compare <git-ref>] [--dry]");
 }
 
 function parseArguments() {
@@ -204,6 +129,7 @@ function parseArguments() {
     allowPositionals: true,
     options: {
       all: { type: "boolean" },
+      compare: { type: "string" },
       dry: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },
@@ -233,7 +159,12 @@ function parseArguments() {
     throw new Error(`Unknown eval: ${evalName}`);
   }
 
-  return { all: values.all ?? false, dry: values.dry ?? false, evalName };
+  return {
+    all: values.all ?? false,
+    compare: values.compare,
+    dry: values.dry ?? false,
+    evalName,
+  };
 }
 
 function main() {
@@ -244,11 +175,6 @@ function main() {
     console.error("packages/eve/dist not found. Run `pnpm --filter eve build` first.");
     process.exit(1);
   }
-  if (!fs.existsSync(path.join(root, "packages/eve/docs"))) {
-    console.error("packages/eve/docs not found. Run `pnpm --filter eve build` first.");
-    process.exit(1);
-  }
-
   if (process.env.EVE_SKIP_PACK === "1" && fs.existsSync(tarballPath)) {
     console.log("> Reusing existing tarball (EVE_SKIP_PACK=1)");
   } else {
@@ -266,24 +192,62 @@ function main() {
     }
   }
 
-  writeExperiments(evalName);
+  const comparison =
+    argv.compare === undefined
+      ? undefined
+      : {
+          current: currentSnapshot(root),
+          reference: resolveReference(root, argv.compare),
+        };
+  const experiments = createExperiments(comparison);
+
+  if (comparison !== undefined) {
+    const referenceSha = comparison.reference.gitSha.slice(0, 12);
+    const currentSha = comparison.current.gitSha.slice(0, 12);
+    const dirty = comparison.current.dirty ? " + uncommitted changes" : "";
+    console.log(
+      `> Comparing docs from ${comparison.reference.gitRef} (${referenceSha}) to HEAD (${currentSha}${dirty})`,
+    );
+  }
+
+  writeExperiments(evalName, experiments);
   fs.mkdirSync(resultsDir, { recursive: true });
+  const treatments = variants.map((variant) => variant.suffix).join(" + ");
   console.log(
     evalName === null
-      ? "> Running all evals (baseline + agents-md + eve-skill)"
-      : `> Running ${evalName} (baseline + agents-md + eve-skill)`,
+      ? `> Running all evals (${treatments})`
+      : `> Running ${evalName} (${treatments})`,
   );
 
   const agentEvalArgs = argv.dry
     ? ["status"]
-    : ["run", ...variants.map((variant) => variant.suffix), "--force"];
+    : ["run", ...experiments.map((experiment) => experiment.suffix), "--force"];
+  const comparisonAssets =
+    comparison === undefined
+      ? undefined
+      : prepareReferencePackage({
+          root,
+          tarballPath,
+          outputPath: referenceTarballPath,
+          reference: comparison.reference,
+        });
   const executable = path.join(evalsDir, "node_modules/.bin/agent-eval");
   const existingResults = new Set(listResultFiles());
-  const result = spawnSync(executable, agentEvalArgs, {
-    cwd: evalsDir,
-    stdio: "inherit",
-    env: { ...process.env, EVE_EVAL_TARBALL: tarballPath },
-  });
+  const env = { ...process.env, EVE_EVAL_TARBALL: tarballPath };
+  if (comparisonAssets !== undefined) {
+    env.EVE_EVAL_REFERENCE_SKILL = comparisonAssets.skillPath;
+    env.EVE_EVAL_REFERENCE_TARBALL = referenceTarballPath;
+  }
+  let result;
+  try {
+    result = spawnSync(executable, agentEvalArgs, {
+      cwd: evalsDir,
+      stdio: "inherit",
+      env,
+    });
+  } finally {
+    comparisonAssets?.cleanup();
+  }
 
   if (result.error) {
     console.error(`Failed to run ${executable}: ${result.error.message}`);
@@ -292,7 +256,12 @@ function main() {
     }
     process.exit(1);
   }
-  printResultSummary(listResultFiles().filter((resultFile) => !existingResults.has(resultFile)));
+  printResultSummary({
+    resultFiles: listResultFiles().filter((resultFile) => !existingResults.has(resultFile)),
+    resultsDir,
+    experiments,
+    comparison: comparison !== undefined,
+  });
   process.exit(result.status ?? 1);
 }
 


### PR DESCRIPTION
### Description

Stacked on #998.

Add `--compare <git-ref>` to the documentation evaluation harness so a working-tree documentation change can be measured against a reference snapshot:

```sh
pnpm eval agent-000-create-greeting-tool --compare origin/main
```

The comparison keeps the current built eve runtime constant and replaces only the packaged `docs/` tree and installable eve skill for the reference experiments. It runs each snapshot through the same `baseline`, `agents-md`, and `eve-skill` treatments, namespaces results as `reference-*` and `current-*`, and prints signed accuracy, token, and duration deltas.

Each result records the treatment, snapshot, Git ref, SHA, and dirty state under `analysis.documentationEval`.

### How did you test your changes?

- `pnpm exec oxfmt --check evals`
- `pnpm exec oxlint evals/run.js evals/lib/*.js evals/lib/*.ts`
- `pnpm --filter evals test`
- `pnpm --filter evals typecheck`
- `pnpm guard:invariants`
- `pnpm check:deps`
- `EVE_SKIP_PACK=1 pnpm --filter evals eval agent-000-create-greeting-tool --dry`
- `EVE_SKIP_PACK=1 pnpm --filter evals eval agent-000-create-greeting-tool --compare HEAD --dry`
- `pnpm --filter evals eval agent-000-create-greeting-tool --compare HEAD --dry` (full uncached package derivation; no model calls)

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not applicable; internal tooling only)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
