### PR TITLE
fix(harness): classify undici stream-timeout terminations as transient network failures

### DIFF
--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -245,6 +245,15 @@ describe("classifyModelCallError", () => {
     const fetchFailed = new Error("fetch failed");
     expect(classifyModelCallError(fetchFailed)).toBe("retry");
 
+    // A stalled response stream killed by undici's body timeout: the
+    // provider accepted the request, went silent past the timeout, and
+    // undici terminated the fetch. Nothing about the request was wrong —
+    // repeating it is exactly right.
+    const bodyTimeout = Object.assign(new TypeError("terminated"), {
+      cause: Object.assign(new Error("Body Timeout Error"), { code: "UND_ERR_BODY_TIMEOUT" }),
+    });
+    expect(classifyModelCallError(bodyTimeout)).toBe("retry");
+
     // The old substring policy is gone: prose that merely mentions a
     // network token no longer forces a retry loop.
     expect(classifyModelCallError(new Error("network configuration invalid"))).toBe("recoverable");

--- a/packages/eve/src/harness/semantic-errors/rules/system.ts
+++ b/packages/eve/src/harness/semantic-errors/rules/system.ts
@@ -12,7 +12,9 @@ const NETWORK_ERROR_CODES = [
   "ENOTFOUND",
   "EPIPE",
   "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
   "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
   "UND_ERR_SOCKET",
 ] as const;
 
@@ -53,14 +55,18 @@ export const SYSTEM_RULES: readonly SemanticErrorRule[] = [
     // Exact-equality message fallback, verified empirically on Node 26:
     // a failed `fetch` rejects with a TypeError whose message is exactly
     // "fetch failed" (the coded cause is sometimes stripped in transit),
-    // and a peer-destroyed HTTP socket errors with exactly "socket hang
-    // up" (code ECONNRESET — the code rule above normally wins).
-    // Equality, never containment: a user error that merely mentions
-    // "fetch failed" must not be reclassified as a connectivity problem.
+    // a peer-destroyed HTTP socket errors with exactly "socket hang
+    // up" (code ECONNRESET — the code rule above normally wins), and a
+    // stream undici kills for exceeding its headers/body timeout rejects
+    // with a TypeError whose message is exactly "terminated" (cause
+    // BodyTimeoutError/HeadersTimeoutError — the coded rule wins when the
+    // cause survives). Equality, never containment: a user error that
+    // merely mentions "fetch failed" must not be reclassified as a
+    // connectivity problem.
     id: "network-request-failed",
     name: "Network request failed",
     tags: ["system", "transient"],
-    when: messageIs("fetch failed", "socket hang up"),
+    when: messageIs("fetch failed", "socket hang up", "terminated"),
     message: (link) => networkFailureMessage(link.message.trim()),
     hint: NETWORK_FAILURE_HINT,
   },

--- a/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
+++ b/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
@@ -152,6 +152,22 @@ describe("summarizeKnownError (catalog table)", () => {
       error: new TypeError("fetch failed"),
       id: "network-request-failed",
     },
+    {
+      // undici kills a response stream that exceeds its body timeout with
+      // `TypeError: terminated`, cause BodyTimeoutError (UND_ERR_BODY_TIMEOUT).
+      title: "stream killed by the undici body timeout",
+      error: new TypeError("terminated", {
+        cause: Object.assign(new Error("Body Timeout Error"), {
+          code: "UND_ERR_BODY_TIMEOUT",
+        }),
+      }),
+      id: "network-request-failed",
+    },
+    {
+      title: "bare stream termination without a structured code",
+      error: new TypeError("terminated"),
+      id: "network-request-failed",
+    },
   ];
 
   for (const testCase of cases) {


### PR DESCRIPTION
Fixes #1037.

## Problem

When a provider/proxy response stream stalls past undici's headers/body timeout, the fetch is killed with `TypeError: terminated` (cause `BodyTimeoutError` / `HeadersTimeoutError`, codes `UND_ERR_BODY_TIMEOUT` / `UND_ERR_HEADERS_TIMEOUT`). The semantic-error catalog recognizes neither the codes nor the message, so `classifyModelCallError` falls through to `"recoverable"` — and in task mode the harness fails the run outright with zero retries. A transient transport stall becomes a terminal run failure (hit in production behind a LiteLLM proxy; details in the issue).

## Fix

- Add `UND_ERR_BODY_TIMEOUT` and `UND_ERR_HEADERS_TIMEOUT` to `NETWORK_ERROR_CODES` in `semantic-errors/rules/system.ts` — the coded rule wins whenever the cause chain survives.
- Add `"terminated"` to the exact-equality message fallback, same stripped-cause rationale as `"fetch failed"` (undici's `Fetch.terminate` rejects with a `TypeError` whose message is exactly `terminated`). Equality, never containment.

Both signals now summarize as `network-request-failed` (tag `transient`) → `classifyModelCallError` returns `"retry"` and `runModelCallWithRetries` handles it like any other transient network failure.

## Tests

- `semantic-errors.test.ts`: coded shape (`terminated` + `UND_ERR_BODY_TIMEOUT` cause) and bare `TypeError: terminated` both classify as `network-request-failed`.
- `model-call-error.test.ts`: the body-timeout shape classifies `"retry"` alongside the existing structural-signal cases.

`pnpm vitest run` on both files: 71 passed.

Note on commit signature: this commit carries a DCO sign-off but is not yet GPG/SSH-signed — happy to re-sign and force-push once my signing key is set up, or feel free to squash-merge.