### PR TITLE
fix(eve): add nf3 hook for recursive inclusion of `#...` imports

### DIFF
--- a/.changeset/full-eve-hosted-trace.md
+++ b/.changeset/full-eve-hosted-trace.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent hosted functions from shipping an incomplete eve package when an external dependency imports an eve public subpath. Transitively traced eve packages now include their complete runtime closure instead of failing with `ERR_MODULE_NOT_FOUND`.

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -546,6 +546,9 @@ describe("application Nitro creation", () => {
 
     for (const call of createNitroMock.mock.calls.slice(0, 3)) {
       const traceDeps = call[0].traceDeps;
+      expect(call[0].traceOpts).toEqual({
+        hooks: { traceResult: expect.any(Function) },
+      });
       expect(traceDeps).toEqual(
         expect.arrayContaining(["@napi-rs/keyring", "sharp", "fixture-external"]),
       );

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -36,6 +36,7 @@ import type {
   PreparedDevelopmentApplicationHost,
 } from "#internal/nitro/host/types.js";
 import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
+import { createEvePackageTraceHooks } from "#internal/nitro/host/eve-package-trace-hook.js";
 import { applyWorkflowTransform } from "#internal/workflow-bundle/workflow-builders.js";
 import { transformDynamicToolExecute } from "#internal/workflow-bundle/dynamic-tool-transform.js";
 import type { CompiledAgentManifest } from "#compiler/manifest.js";
@@ -841,6 +842,7 @@ export async function createProductionApplicationNitro(
     rootDir: preparedHost.appRoot,
     serverDir: false,
     traceDeps: bundler.tracedAppDependencies,
+    traceOpts: { hooks: createEvePackageTraceHooks() },
     vercel: createEveVercelOptions(
       preset === "vercel" && includesApplicationSurface(options.surface),
     ),

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-hook.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-hook.integration.test.ts
@@ -1,0 +1,45 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { createEvePackageTraceHooks } from "#internal/nitro/host/eve-package-trace-hook.js";
+
+describe("eve package trace hooks", () => {
+  it("adds the internal closure of traced public entrypoints", async () => {
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "eve-package-trace-hook-"));
+    const packageRoot = join(temporaryDirectory, "node_modules", "eve");
+    const connectionsRoot = join(packageRoot, "dist", "src", "public", "connections");
+    const entrypoint = join(connectionsRoot, "index.js");
+    const errorsPath = join(connectionsRoot, "errors.js");
+
+    try {
+      await mkdir(connectionsRoot, { recursive: true });
+      await writeFile(join(packageRoot, "package.json"), '{"name":"eve"}\n');
+      await writeFile(entrypoint, 'export { error } from "#public/connections/errors.js";\n');
+      await writeFile(errorsPath, 'export const error = "present";\n');
+      const traceEntrypoint = relative("/", entrypoint);
+      const traceErrorsPath = relative("/", errorsPath);
+      const traceResult = {
+        fileList: new Set([traceEntrypoint]),
+        reasons: new Map([
+          [
+            traceEntrypoint,
+            {
+              ignored: false,
+              parents: new Set<string>(),
+              type: ["dependency"],
+            },
+          ],
+        ]),
+      };
+
+      await createEvePackageTraceHooks().traceResult(traceResult);
+
+      expect(traceResult.fileList).toContain(traceErrorsPath);
+    } finally {
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-hook.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-hook.ts
@@ -1,0 +1,174 @@
+import { readFile, stat } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+
+import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
+
+interface MutableTraceResult {
+  readonly fileList: Set<string>;
+  readonly reasons: Map<
+    string,
+    {
+      ignored: boolean;
+      parents: Set<string>;
+      type: string[];
+    }
+  >;
+}
+
+function isMutableTraceResult(value: unknown): value is MutableTraceResult {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const result = value as { fileList?: unknown; reasons?: unknown };
+  return result.fileList instanceof Set && result.reasons instanceof Map;
+}
+
+function isPathWithin(path: string, root: string): boolean {
+  const pathFromRoot = relative(root, path);
+  return (
+    pathFromRoot.length === 0 ||
+    (!pathFromRoot.startsWith("..") && !pathFromRoot.split(/[\\/]/).includes(".."))
+  );
+}
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function findEvePackageRoot(path: string): Promise<string | undefined> {
+  if (!path.split(/[\\/]/).includes(EVE_PACKAGE_NAME)) {
+    return undefined;
+  }
+
+  let directory = dirname(path);
+  while (true) {
+    try {
+      const packageJson = JSON.parse(await readFile(join(directory, "package.json"), "utf8")) as {
+        name?: unknown;
+      };
+      if (packageJson.name === EVE_PACKAGE_NAME) {
+        return directory;
+      }
+    } catch {
+      // Keep walking: this directory either has no manifest or does not contain valid JSON.
+    }
+
+    const parentDirectory = dirname(directory);
+    if (parentDirectory === directory) {
+      return undefined;
+    }
+    directory = parentDirectory;
+  }
+}
+
+function parseStaticImportSpecifiers(source: string): string[] {
+  const staticImportPattern = /\b(?:import|export)\s*(?:[^;"']*?\s*from\s*)?["']([^"']+)["']/g;
+  const dynamicImportPattern = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+  return [
+    ...source.matchAll(staticImportPattern),
+    ...source.matchAll(dynamicImportPattern),
+  ].flatMap((match) => (match[1] === undefined ? [] : [match[1]]));
+}
+
+function resolveEveInternalImport(input: {
+  readonly distSourceRoot: string;
+  readonly importer: string;
+  readonly specifier: string;
+}): string | undefined {
+  if (input.specifier.startsWith("#")) {
+    return resolve(input.distSourceRoot, input.specifier.slice(1));
+  }
+
+  if (input.specifier.startsWith(".")) {
+    return resolve(dirname(input.importer), input.specifier);
+  }
+
+  return undefined;
+}
+
+async function collectEveInternalClosure(input: {
+  readonly distSourceRoot: string;
+  readonly entrypoints: readonly string[];
+}): Promise<Set<string>> {
+  const closure = new Set<string>();
+  const pending = [...input.entrypoints];
+
+  while (pending.length > 0) {
+    const path = pending.pop();
+    if (path === undefined || closure.has(path) || !isPathWithin(path, input.distSourceRoot)) {
+      continue;
+    }
+    if (!(await isFile(path))) {
+      continue;
+    }
+
+    closure.add(path);
+    const source = await readFile(path, "utf8");
+    for (const specifier of parseStaticImportSpecifiers(source)) {
+      const resolved = resolveEveInternalImport({
+        distSourceRoot: input.distSourceRoot,
+        importer: path,
+        specifier,
+      });
+      if (resolved !== undefined) {
+        pending.push(resolved);
+      }
+    }
+  }
+
+  return closure;
+}
+
+/**
+ * Extends nf3's trace with eve's package-internal import closure.
+ *
+ * nf3's vendored resolver cannot match eve's embedded `#*.js` import-map
+ * wildcard, so external packages that import an eve public subpath would
+ * otherwise ship only that entrypoint.
+ */
+export function createEvePackageTraceHooks(): {
+  readonly traceResult: (result: unknown) => Promise<void>;
+} {
+  return {
+    async traceResult(value: unknown): Promise<void> {
+      if (!isMutableTraceResult(value)) {
+        return;
+      }
+
+      const packageEntrypoints = new Map<string, string[]>();
+      for (const tracePath of value.fileList) {
+        const entrypoint = resolve("/", tracePath);
+        const packageRoot = await findEvePackageRoot(entrypoint);
+        if (packageRoot === undefined) {
+          continue;
+        }
+
+        const entrypoints = packageEntrypoints.get(packageRoot) ?? [];
+        entrypoints.push(entrypoint);
+        packageEntrypoints.set(packageRoot, entrypoints);
+      }
+
+      for (const [packageRoot, entrypoints] of packageEntrypoints) {
+        const closure = await collectEveInternalClosure({
+          distSourceRoot: join(packageRoot, "dist", "src"),
+          entrypoints,
+        });
+        for (const path of closure) {
+          const tracePath = relative("/", path);
+          value.fileList.add(tracePath);
+          value.reasons.set(tracePath, {
+            ignored: false,
+            parents: new Set(),
+            type: ["dependency"],
+          });
+        }
+      }
+    },
+  };
+}

--- a/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
+++ b/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
@@ -608,6 +608,9 @@ describe("app runtime dependency tracing", () => {
       join(packageRoot, "package.json"),
       JSON.stringify(
         {
+          dependencies: {
+            eve: "1.0.0",
+          },
           exports: {
             ".": "./index.js",
           },
@@ -622,12 +625,44 @@ describe("app runtime dependency tracing", () => {
     await writeFile(
       join(packageRoot, "index.js"),
       [
+        'import { externalClosureMarker } from "eve/connections";',
         'export const label = "fixture-external-only-dep";',
         "export default {",
+        "  externalClosureMarker,",
         "  label,",
         "};",
         "",
       ].join("\n"),
+    );
+
+    const evePackageRoot = join(appRoot, "node_modules", "eve");
+    const eveConnectionsRoot = join(evePackageRoot, "dist", "src", "public", "connections");
+    await mkdir(eveConnectionsRoot, { recursive: true });
+    await writeFile(
+      join(evePackageRoot, "package.json"),
+      JSON.stringify(
+        {
+          exports: {
+            "./connections": "./dist/src/public/connections/index.js",
+          },
+          imports: {
+            "#*.js": "./dist/src/*.js",
+          },
+          name: "eve",
+          type: "module",
+          version: "1.0.0",
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      join(eveConnectionsRoot, "index.js"),
+      'export { externalClosureMarker } from "#public/connections/errors.js";\n',
+    );
+    await writeFile(
+      join(eveConnectionsRoot, "errors.js"),
+      'export const externalClosureMarker = "external-closure-present";\n',
     );
 
     const outputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
@@ -649,6 +684,22 @@ describe("app runtime dependency tracing", () => {
         "utf8",
       ),
     ).resolves.toContain('"name": "fixture-external-only-dep"');
+    await expect(
+      readFile(
+        join(
+          outputDir,
+          "server",
+          "node_modules",
+          "eve",
+          "dist",
+          "src",
+          "public",
+          "connections",
+          "errors.js",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain("external-closure-present");
     expect(serverModuleSource).toContain('"fixture-external-only-dep"');
     expect(serverModuleSource).not.toContain('export const label = "fixture-external-only-dep";');
   }, 30_000);


### PR DESCRIPTION
Closes #842.

## Problem

Hosted builds trace packages listed in `agent.build.externalDependencies`. When an external package such as `@vercel/connect` imports `eve/connections` or `eve/channels/auth`, Nitro/nf3 discovers eve transitively and copies it into the function's `node_modules`.

nf3's vendored resolver cannot follow eve's embedded `#*.js` package-import wildcard. It emits only the public export entrypoints and silently omits their internal closure, so the function crashes at startup:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/var/task/node_modules/eve/dist/src/public/connections/errors.js'
imported from /var/task/node_modules/eve/dist/src/public/connections/index.js'
```

## Reproduction

I reproduced this on both `eve@0.24.3` and the latest published `eve@0.27.0` using a Next.js `withEve({ agents })` app. The affected agent configured:

```ts
build: { externalDependencies: ["@vercel/connect"] }
```

and an MCP connection importing `@vercel/connect/eve` and `eve/connections`. A second agent without configured externals served as the control.

The research agent failed with the exact missing `connections/errors.js` error; the control agent was healthy. A local hosted build independently emitted only public eve entrypoints and failed when importing the generated function entrypoint.

## Fix

Add an eve-owned nf3 `traceResult` hook. When nf3 traces an eve public entrypoint, the hook resolves eve's package-internal `#...` imports to `dist/src/...` and recursively adds their static internal and relative-import closure before nf3 copies trace files.

## Validation

I packed this exact branch as a local eve tarball and deployed it through the same failing multi-agent reproduction without publishing it. The previously failing research info route now succeeds and reports the authored Connect connection; the control agent remains healthy. The local generated function includes `connections/errors.js` and imports successfully.

Added integration coverage for a traced `eve/connections` entrypoint and scenario coverage that verifies hosted Nitro passes the eve trace hook to nf3.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/host/eve-package-trace-hook.integration.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/host/create-application-nitro.scenario.test.ts`
- `pnpm --filter eve typecheck`
- targeted `oxfmt` and `oxlint`
- `pnpm guard:invariants`
