### PR TITLE
test(evals): add customer support evaluation

### DIFF
--- a/evals/evals/agent-001-create-customer-support-tools/EVAL.ts
+++ b/evals/evals/agent-001-create-customer-support-tools/EVAL.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { expect, test } from "vitest";
+
+const root = process.cwd();
+const toolsDir = join(root, "agent", "tools");
+
+function readTool(name: string): string {
+  const toolPath = join(toolsDir, `${name}.ts`);
+  expect(existsSync(toolPath), `Expected ${toolPath} to exist`).toBe(true);
+  return readFileSync(toolPath, "utf8");
+}
+
+test("defines both tools at their path-derived names", () => {
+  for (const name of ["lookup_order", "issue_refund"]) {
+    const source = readTool(name);
+    expect(source).toMatch(/import\s*\{[^}]*defineTool[^}]*\}\s*from\s*["']eve\/tools["']/);
+    expect(source).toMatch(/export\s+default\s+defineTool\s*\(/);
+  }
+});
+
+test("looks up an order without requiring approval", () => {
+  const source = readTool("lookup_order");
+
+  expect(source).toMatch(/orderId\s*:\s*z\.string\s*\(/);
+  expect(source).toMatch(/status\s*:\s*["']paid["']/);
+  expect(source).toMatch(/total\s*:\s*125\b/);
+
+  const omitsApproval = !/\bapproval\s*:/.test(source);
+  const explicitlySkipsApproval =
+    /import\s*\{[^}]*never[^}]*\}\s*from\s*["']eve\/tools\/approval["']/.test(source) &&
+    /approval\s*:\s*never\s*\(\s*\)/.test(source);
+  expect(omitsApproval || explicitlySkipsApproval).toBe(true);
+});
+
+test("issues a refund only after approval", () => {
+  const source = readTool("issue_refund");
+
+  expect(source).toMatch(/orderId\s*:\s*z\.string\s*\(/);
+  expect(source).toMatch(/amount\s*:\s*z\.number\s*\(\s*\)\.positive\s*\(\s*\)/);
+  expect(source).toMatch(/status\s*:\s*["']refunded["']/);
+  expect(source).toMatch(/\bamount\b/);
+  expect(source).toMatch(/import\s*\{[^}]*always[^}]*\}\s*from\s*["']eve\/tools\/approval["']/);
+  expect(source).toMatch(/approval\s*:\s*always\s*\(\s*\)/);
+});
+
+test("instructs the agent to look up the order before refunding it", () => {
+  const instructions = readFileSync(join(root, "agent", "instructions.md"), "utf8");
+
+  expect(instructions).toMatch(/look\s*up|lookup/i);
+  expect(instructions).toMatch(/before[\s\S]*refund/i);
+  expect(instructions).toMatch(/approv/i);
+});

--- a/evals/evals/agent-001-create-customer-support-tools/PROMPT.md
+++ b/evals/evals/agent-001-create-customer-support-tools/PROMPT.md
@@ -1,0 +1,13 @@
+Turn this agent into a customer support assistant with two tools:
+
+- `lookup_order` accepts a required order ID and returns structured data with
+  the order ID, a `paid` status, and a total of `125`.
+- `issue_refund` accepts a required order ID and a positive refund amount, and
+  returns structured data with the order ID, amount, and a `refunded` status.
+
+Looking up an order must not require approval. Issuing a refund must require
+user approval before every execution. Enforce that in the tool definition, not
+only in the agent instructions.
+
+Update the instructions so the agent looks up an order before issuing a refund
+and explains that the refund requires approval. Ensure the project builds.

--- a/evals/evals/agent-001-create-customer-support-tools/agent/agent.ts
+++ b/evals/evals/agent-001-create-customer-support-tools/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "openai/gpt-5.4-mini",
+});

--- a/evals/evals/agent-001-create-customer-support-tools/agent/instructions.md
+++ b/evals/evals/agent-001-create-customer-support-tools/agent/instructions.md
@@ -1,0 +1,1 @@
+You are a concise customer support assistant. Use available tools when they directly address the user's request.

--- a/evals/evals/agent-001-create-customer-support-tools/package.json
+++ b/evals/evals/agent-001-create-customer-support-tools/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build"
+  },
+  "dependencies": {
+    "ai": "^7.0.0",
+    "eve": "^0.25.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "typescript": "^7.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/evals/evals/agent-001-create-customer-support-tools/tsconfig.json
+++ b/evals/evals/agent-001-create-customer-support-tools/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*"],
+  "exclude": ["node_modules", "dist", ".eve", ".output"]
+}


### PR DESCRIPTION
### Description

- Add a second documentation-authoring eval for a commonplace customer-support workflow.
- Exercise static tool authoring, structured inputs and outputs, and human approval policies.
- Accept both the implicit no-approval default and the equivalent explicit never() policy for read-only lookups.

### How did you test your changes?

```
Evaluation summary (token counts are means per reported run):
Variant      Accuracy  Token runs      Total      Input  Uncached  Cache write  Cache read  Output  Duration
---------  ----------  ----------  ---------  ---------  --------  -----------  ----------  ------  --------
baseline   1/1 (100%)         1/1  1,184,247  1,178,292    68,776      192,153     917,363   5,955    122.6s
agents-md  1/1 (100%)         1/1    988,234    982,240    11,455      135,365     835,420   5,994    118.1s
eve-skill  1/1 (100%)         1/1    881,469    876,207    21,724      136,677     717,806   5,262    105.7s
```

- Verified known-good implementations using both implicit and explicit lookup approval behavior pass all 4 grader assertions.
- Ran targeted formatting, lint, and eval-harness typechecking.
- Ran the eval harness unit tests and repository invariant guard.
- Confirmed the fixture is discovered for baseline, agents-md, and eve-skill experiments.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from CONTRIBUTING.md
- [x] I added tests and documentation where relevant
- [x] No changeset is needed because this is internal evaluation tooling
- [x] DCO sign-off passes for every commit