### PR TITLE
fix(eve): resolve internal imports during hosted tracing

### DIFF
--- a/.changeset/trace-eve-hosted-closure.md
+++ b/.changeset/trace-eve-hosted-closure.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent hosted functions from shipping an incomplete eve package when an external dependency imports an eve public subpath. Transitively traced eve packages now include their complete runtime closure instead of failing with `ERR_MODULE_NOT_FOUND`.

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -546,6 +546,9 @@ describe("application Nitro creation", () => {
 
     for (const call of createNitroMock.mock.calls.slice(0, 3)) {
       const traceDeps = call[0].traceDeps;
+      expect(call[0].traceOpts).toEqual({
+        nft: { readFile: expect.any(Function) },
+      });
       expect(traceDeps).toEqual(
         expect.arrayContaining(["@napi-rs/keyring", "sharp", "fixture-external"]),
       );

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -36,6 +36,7 @@ import type {
   PreparedDevelopmentApplicationHost,
 } from "#internal/nitro/host/types.js";
 import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
+import { createEvePackageTraceOptions } from "#internal/nitro/host/eve-package-trace-options.js";
 import { applyWorkflowTransform } from "#internal/workflow-bundle/workflow-builders.js";
 import { transformDynamicToolExecute } from "#internal/workflow-bundle/dynamic-tool-transform.js";
 import type { CompiledAgentManifest } from "#compiler/manifest.js";
@@ -841,6 +842,7 @@ export async function createProductionApplicationNitro(
     rootDir: preparedHost.appRoot,
     serverDir: false,
     traceDeps: bundler.tracedAppDependencies,
+    traceOpts: createEvePackageTraceOptions(),
     vercel: createEveVercelOptions(
       preset === "vercel" && includesApplicationSurface(options.surface),
     ),

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-options.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-options.integration.test.ts
@@ -1,0 +1,28 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { createEvePackageTraceOptions } from "#internal/nitro/host/eve-package-trace-options.js";
+
+describe("eve package trace options", () => {
+  it("presents package-internal imports to NFT as relative imports", async () => {
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "eve-package-trace-options-"));
+    const packageRoot = join(temporaryDirectory, "node_modules", "eve");
+    const connectionsRoot = join(packageRoot, "dist", "src", "public", "connections");
+    const entrypoint = join(connectionsRoot, "index.js");
+
+    try {
+      await mkdir(connectionsRoot, { recursive: true });
+      await writeFile(join(packageRoot, "package.json"), '{"name":"eve"}\n');
+      await writeFile(entrypoint, 'export { error } from "#public/connections/errors.js";\n');
+
+      await expect(createEvePackageTraceOptions().nft.readFile(entrypoint)).resolves.toBe(
+        'export { error } from "./errors.js";\n',
+      );
+    } finally {
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-options.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-options.ts
@@ -1,0 +1,85 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+
+import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
+
+function isPathWithin(path: string, root: string): boolean {
+  const pathFromRoot = relative(root, path);
+  return (
+    pathFromRoot.length === 0 ||
+    (!pathFromRoot.startsWith("..") && !pathFromRoot.split(/[\\/]/).includes(".."))
+  );
+}
+
+async function findEvePackageRoot(path: string): Promise<string | undefined> {
+  if (!path.split(/[\\/]/).includes(EVE_PACKAGE_NAME)) {
+    return undefined;
+  }
+
+  let directory = dirname(path);
+  while (true) {
+    try {
+      const packageJson = JSON.parse(await readFile(join(directory, "package.json"), "utf8")) as {
+        name?: unknown;
+      };
+      if (packageJson.name === EVE_PACKAGE_NAME) {
+        return directory;
+      }
+    } catch {
+      // Keep walking: this directory either has no manifest or does not contain valid JSON.
+    }
+
+    const parentDirectory = dirname(directory);
+    if (parentDirectory === directory) {
+      return undefined;
+    }
+    directory = parentDirectory;
+  }
+}
+
+function toRelativeImportSpecifier(importer: string, imported: string): string {
+  const relativePath = relative(dirname(importer), imported).replaceAll("\\", "/");
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+async function readEveTraceFile(path: string): Promise<string | null> {
+  let source: string;
+  try {
+    source = await readFile(path, "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  const packageRoot = await findEvePackageRoot(path);
+  if (packageRoot === undefined) {
+    return source;
+  }
+
+  const distSourceRoot = join(packageRoot, "dist", "src");
+  if (!isPathWithin(path, distSourceRoot)) {
+    return source;
+  }
+
+  return source.replace(/(["'])#([^"']+)\1/g, (_match, quote: string, specifier: string) => {
+    const imported = resolve(distSourceRoot, specifier);
+    return `${quote}${toRelativeImportSpecifier(path, imported)}${quote}`;
+  });
+}
+
+/**
+ * Makes eve's package-internal imports visible to nf3's NFT tracer.
+ *
+ * NFT cannot match eve's embedded `#*.js` import-map wildcard. It can,
+ * however, trace the equivalent relative specifiers. This virtual read only
+ * changes what NFT analyzes; nf3 still copies the original package files.
+ */
+export function createEvePackageTraceOptions(): {
+  readonly nft: {
+    readonly readFile: (path: string) => Promise<string | null>;
+  };
+} {
+  return { nft: { readFile: readEveTraceFile } };
+}

--- a/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
+++ b/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
@@ -608,6 +608,9 @@ describe("app runtime dependency tracing", () => {
       join(packageRoot, "package.json"),
       JSON.stringify(
         {
+          dependencies: {
+            eve: "1.0.0",
+          },
           exports: {
             ".": "./index.js",
           },
@@ -622,12 +625,44 @@ describe("app runtime dependency tracing", () => {
     await writeFile(
       join(packageRoot, "index.js"),
       [
+        'import { externalClosureMarker } from "eve/connections";',
         'export const label = "fixture-external-only-dep";',
         "export default {",
+        "  externalClosureMarker,",
         "  label,",
         "};",
         "",
       ].join("\n"),
+    );
+
+    const evePackageRoot = join(appRoot, "node_modules", "eve");
+    const eveConnectionsRoot = join(evePackageRoot, "dist", "src", "public", "connections");
+    await mkdir(eveConnectionsRoot, { recursive: true });
+    await writeFile(
+      join(evePackageRoot, "package.json"),
+      JSON.stringify(
+        {
+          exports: {
+            "./connections": "./dist/src/public/connections/index.js",
+          },
+          imports: {
+            "#*.js": "./dist/src/*.js",
+          },
+          name: "eve",
+          type: "module",
+          version: "1.0.0",
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      join(eveConnectionsRoot, "index.js"),
+      'export { externalClosureMarker } from "#public/connections/errors.js";\n',
+    );
+    await writeFile(
+      join(eveConnectionsRoot, "errors.js"),
+      'export const externalClosureMarker = "external-closure-present";\n',
     );
 
     const outputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
@@ -649,6 +684,22 @@ describe("app runtime dependency tracing", () => {
         "utf8",
       ),
     ).resolves.toContain('"name": "fixture-external-only-dep"');
+    await expect(
+      readFile(
+        join(
+          outputDir,
+          "server",
+          "node_modules",
+          "eve",
+          "dist",
+          "src",
+          "public",
+          "connections",
+          "errors.js",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain("external-closure-present");
     expect(serverModuleSource).toContain('"fixture-external-only-dep"');
     expect(serverModuleSource).not.toContain('export const label = "fixture-external-only-dep";');
   }, 30_000);


### PR DESCRIPTION
Alternative implementation to #1041 for #842.

## Problem

When a configured hosted external dependency imports an eve public subpath, Nitro/nf3 traces the external eve package into the function. NFT does not resolve eve's embedded `#*.js` package-import wildcard, so it includes the public entrypoint but omits eve-internal files that entrypoint imports. The deployed function then fails with `ERR_MODULE_NOT_FOUND`.

## Read-time approach

Provide NFT a virtual `readFile` implementation through Nitro's `traceOpts`.

For files inside the eve package NFT actually traced, the reader presents `#...` package imports as equivalent relative imports. NFT can then use its normal parser and graph traversal to discover the complete runtime closure. This only changes the source NFT analyzes; nf3 still copies the original package files unchanged.

Compared with #1041's post-trace closure hook, this approach leaves parsing and recursive graph traversal entirely to NFT.

## Validation

- Regression scenario traces a fixture external dependency that imports `eve/connections` and verifies its internal closure is copied.
- Integration coverage verifies aliases are virtually presented to NFT as relative imports from a separate installed eve package.
- Direct nf3 experiment traced the expected closure and successfully loaded both `eve/connections` and `eve/channels/auth`.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/host/eve-package-trace-options.integration.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/app-runtime-dependencies.scenario.test.ts -t "traces hosted external dependencies configured in agent.ts"`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/host/create-application-nitro.scenario.test.ts`
- `pnpm --filter eve typecheck`
- targeted `oxfmt` and `oxlint`
- `pnpm guard:invariants`
