### PR TITLE
fix(docs): improve integrations mobile layout

### DIFF
--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -52,11 +52,15 @@ export const Gallery = ({ integrations }: GalleryProps) => {
   return (
     <div className="flex min-w-0 flex-col gap-6">
       <div className="flex min-w-0 flex-col gap-3 min-[1024px]:flex-row min-[1024px]:items-center min-[1024px]:justify-between">
-        <div className="grid w-full grid-cols-2 gap-0.5 rounded-md border bg-background-100 p-1 sm:grid-cols-4 min-[1024px]:w-fit">
+        <div
+          aria-label="Integration type"
+          className="flex w-full gap-0.5 overflow-x-auto rounded-md border bg-background-100 p-1 [scrollbar-width:none] min-[1024px]:w-fit [&::-webkit-scrollbar]:hidden"
+          role="group"
+        >
           {FILTERS.map(({ value, label }) => (
             <button
               className={cn(
-                "rounded px-3 py-1 font-medium text-sm transition-colors",
+                "shrink-0 whitespace-nowrap rounded px-3 py-1 font-medium text-sm transition-colors",
                 filter === value
                   ? "bg-gray-100 text-gray-1000"
                   : "text-gray-900 hover:bg-gray-100/40 hover:text-gray-1000",

--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -50,9 +50,9 @@ export const Gallery = ({ integrations }: GalleryProps) => {
   }, [integrations, filter, query]);
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="inline-flex gap-0.5 rounded-md border bg-background-100 p-1">
+    <div className="flex min-w-0 flex-col gap-6">
+      <div className="flex min-w-0 flex-col gap-3 min-[1024px]:flex-row min-[1024px]:items-center min-[1024px]:justify-between">
+        <div className="grid w-full grid-cols-2 gap-0.5 rounded-md border bg-background-100 p-1 sm:grid-cols-4 min-[1024px]:w-fit">
           {FILTERS.map(({ value, label }) => (
             <button
               className={cn(
@@ -69,7 +69,7 @@ export const Gallery = ({ integrations }: GalleryProps) => {
             </button>
           ))}
         </div>
-        <InputGroup className="h-9 bg-background sm:w-64">
+        <InputGroup className="h-9 w-full bg-background min-[1024px]:w-64">
           <InputGroupAddon>
             <SearchIcon className="size-4 text-gray-700" />
           </InputGroupAddon>
@@ -88,7 +88,7 @@ export const Gallery = ({ integrations }: GalleryProps) => {
       )}
 
       {results.length > 0 ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid min-w-0 grid-cols-1 gap-4 min-[1024px]:grid-cols-2 min-[1200px]:grid-cols-3">
           {results.map((integration) => (
             <IntegrationCard integration={integration} key={integration.slug} />
           ))}

--- a/apps/docs/app/[lang]/integrations/components/integration-card.tsx
+++ b/apps/docs/app/[lang]/integrations/components/integration-card.tsx
@@ -20,11 +20,11 @@ export const IntegrationCard = ({ integration }: IntegrationCardProps) => {
       className="group flex flex-col gap-4 rounded-lg border bg-background-100 p-5 transition-colors hover:border-gray-400 hover:bg-gray-100"
       href={`/integrations/${integration.slug}`}
     >
-      <div className="flex items-center justify-between">
-        <span className="flex size-10 items-center justify-center rounded-md border bg-background text-gray-1000">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-background text-gray-1000">
           <Logo aria-hidden className="size-5" height={20} width={20} />
         </span>
-        <div className="flex items-center gap-1.5">
+        <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
           {integration.badge ? (
             <span className="rounded-full bg-teal-100 px-2 py-0.5 font-medium text-teal-900 text-xs">
               {integration.badge}
@@ -43,9 +43,11 @@ export const IntegrationCard = ({ integration }: IntegrationCardProps) => {
           </span>
         </div>
       </div>
-      <div className="flex flex-col gap-1">
-        <h3 className="font-medium text-base text-gray-1000 tracking-tight">{integration.name}</h3>
-        <p className="text-gray-900 text-sm leading-relaxed">{integration.tagline}</p>
+      <div className="flex min-w-0 flex-col gap-1">
+        <h3 className="break-words font-medium text-base text-gray-1000 tracking-tight">
+          {integration.name}
+        </h3>
+        <p className="break-words text-gray-900 text-sm leading-relaxed">{integration.tagline}</p>
       </div>
     </Link>
   );

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -15,8 +15,8 @@ export const metadata: Metadata = {
 export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
 
 const IntegrationsPage = () => (
-  <main className="mx-auto w-full max-w-[1080px] px-4 pb-32 sm:px-6">
-    <section className="flex flex-col items-center px-4 pt-24 pb-12 text-center">
+  <main className="mx-auto w-full min-w-0 max-w-[1080px] px-4 pb-32 sm:px-6">
+    <section className="flex min-w-0 flex-col items-center px-0 pt-24 pb-12 text-center sm:px-4">
       <h1 className="font-bold text-5xl text-gray-1000 tracking-tighter sm:text-6xl">
         Integrations
       </h1>


### PR DESCRIPTION
## Summary

- keep integration filters on one horizontally scrollable row on narrow screens
- stack the full-width search field below the filters on mobile and tablet
- keep the gallery single-column on narrow and tablet viewports
- let card badges and long text wrap instead of overflowing

## Verification

- `pnpm exec oxfmt --check apps/docs/app/[lang]/integrations/components/gallery.tsx`
- `pnpm --filter eve-docs build`
- browser-verified at 320px: filters remain on one line, the row scrolls horizontally, and the page has no horizontal overflow or console errors
- browser-verified gallery layout at 390px, 980px, and 1280px