### PR TITLE
fix(eve): enqueue newline on NDJSON stream open

### DIFF
--- a/.changeset/calm-streams-start.md
+++ b/.changeset/calm-streams-start.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit an initial NDJSON whitespace byte when opening a session event stream so clients and proxies receive the response body before the first durable event.

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -369,6 +369,22 @@ describe("eveChannel — events", () => {
 });
 
 describe("eveChannel — stream cursor", () => {
+  it("establishes the NDJSON body before the first durable event", async () => {
+    const handler = createEveStreamHandler({ auth: none() });
+    const response = await handler.fetch("https://eve.test/eve/v1/session/test-session-id/stream");
+    const reader = response.body!.getReader();
+
+    const firstChunk = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Timed out waiting for the NDJSON response body")), 25),
+      ),
+    ]);
+    await reader.cancel();
+
+    expect(new TextDecoder().decode(firstChunk.value)).toBe("\n");
+  });
+
   it("forwards negative tail-relative start indices", async () => {
     const handler = createEveStreamHandler({ auth: none() });
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -897,6 +897,9 @@ function serializeAsNdjson(events: ReadableStream<unknown>): ReadableStream<Uint
   const encoder = new TextEncoder();
   return events.pipeThrough(
     new TransformStream<unknown, Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("\n"));
+      },
       transform(event, controller) {
         controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
       },


### PR DESCRIPTION
### Description

resolves: https://github.com/vercel/eve/issues/943

<!-- Write a short summary of the problem and solution. -->

### How did you test your changes?

<!-- Include the commands you ran and any manual coverage. -->

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)