### PR TITLE
feat(docs): add Photon integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -847,7 +847,7 @@ See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-offic
     configure: `Connect a WhatsApp number in Kapso, set \`KAPSO_API_KEY\`, \`KAPSO_PHONE_NUMBER_ID\`, and \`KAPSO_WEBHOOK_SECRET\`, then point the Kapso webhook at \`/eve/v1/kapso\`. Use this provider-managed option when you do not want to integrate directly with the WhatsApp Cloud API. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-photon": {
-    logo: "imessage",
+    logo: "photon",
     docsHref: "/docs/channels/chat-sdk",
     badge: "Provider official",
     keywords: [
@@ -903,7 +903,7 @@ export default channel;
 \`\`\`
 
 See the [Photon adapter documentation](https://chat-sdk.dev/adapters/vendor-official/photon) for all supported events and credentials.`,
-    configure: `Photon is the recommended adapter because it is dedicated to iMessage and supports cloud, self-hosted, and local macOS deployments. Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Other vendor-official choices are [Sendblue](https://chat-sdk.dev/adapters/vendor-official/sendblue) for iMessage/SMS/RCS, [Linq](https://chat-sdk.dev/adapters/vendor-official/linq) for iMessage/SMS, and [AgentPhone](https://chat-sdk.dev/adapters/vendor-official/agentphone) or [Dial](https://chat-sdk.dev/adapters/vendor-official/dial) when voice is part of the same agent. [Blooio](https://chat-sdk.dev/adapters/community/blooio) is a community option. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+    configure: `Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Photon supports cloud, self-hosted, and local macOS deployments. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
 };
 

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -846,6 +846,65 @@ export default channel;
 See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) for supported events, capabilities, and credentials.`,
     configure: `Connect a WhatsApp number in Kapso, set \`KAPSO_API_KEY\`, \`KAPSO_PHONE_NUMBER_ID\`, and \`KAPSO_WEBHOOK_SECRET\`, then point the Kapso webhook at \`/eve/v1/kapso\`. Use this provider-managed option when you do not want to integrate directly with the WhatsApp Cloud API. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
+  "chat-sdk-imessage": {
+    logo: "imessage",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Chat SDK",
+    keywords: [
+      "chat sdk",
+      "imessage",
+      "apple messages",
+      "sms",
+      "mms",
+      "rcs",
+      "photon",
+      "sendblue",
+      "linq",
+      "agentphone",
+      "dial",
+    ],
+    install: `Install eve, Chat SDK, the iMessage adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat @photon-ai/chat-adapter-imessage @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. The adapter is vendor-official.`,
+    quickStart: `Create \`agent/channels/imessage.ts\`:
+
+\`\`\`ts
+// agent/channels/imessage.ts
+import { createiMessageAdapter } from "@photon-ai/chat-adapter-imessage";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    imessage: createiMessageAdapter({
+      local: false,
+      projectId: process.env.IMESSAGE_PROJECT_ID,
+      projectSecret: process.env.IMESSAGE_PROJECT_SECRET,
+    }),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+export default channel;
+\`\`\`
+
+See the [iMessage adapter documentation](https://chat-sdk.dev/adapters/vendor-official/photon) for all supported events and credentials.`,
+    configure: `Photon is the recommended adapter because it is dedicated to iMessage and supports cloud, self-hosted, and local macOS deployments. Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Other vendor-official choices are [Sendblue](https://chat-sdk.dev/adapters/vendor-official/sendblue) for iMessage/SMS/RCS, [Linq](https://chat-sdk.dev/adapters/vendor-official/linq) for iMessage/SMS, and [AgentPhone](https://chat-sdk.dev/adapters/vendor-official/agentphone) or [Dial](https://chat-sdk.dev/adapters/vendor-official/dial) when voice is part of the same agent. [Blooio](https://chat-sdk.dev/adapters/community/blooio) is a community option. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+  },
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -846,7 +846,7 @@ export default channel;
 See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) for supported events, capabilities, and credentials.`,
     configure: `Connect a WhatsApp number in Kapso, set \`KAPSO_API_KEY\`, \`KAPSO_PHONE_NUMBER_ID\`, and \`KAPSO_WEBHOOK_SECRET\`, then point the Kapso webhook at \`/eve/v1/kapso\`. Use this provider-managed option when you do not want to integrate directly with the WhatsApp Cloud API. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
-  "chat-sdk-imessage": {
+  "chat-sdk-photon": {
     logo: "imessage",
     docsHref: "/docs/channels/chat-sdk",
     badge: "Chat SDK",
@@ -863,7 +863,7 @@ See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-offic
       "agentphone",
       "dial",
     ],
-    install: `Install eve, Chat SDK, the iMessage adapter, and a state adapter:
+    install: `Install eve, Chat SDK, the Photon adapter, and a state adapter:
 
 \`\`\`bash
 npm install eve@latest chat @photon-ai/chat-adapter-imessage @chat-adapter/state-memory
@@ -902,7 +902,7 @@ bot.onSubscribedMessage(async (thread, message) => {
 export default channel;
 \`\`\`
 
-See the [iMessage adapter documentation](https://chat-sdk.dev/adapters/vendor-official/photon) for all supported events and credentials.`,
+See the [Photon adapter documentation](https://chat-sdk.dev/adapters/vendor-official/photon) for all supported events and credentials.`,
     configure: `Photon is the recommended adapter because it is dedicated to iMessage and supports cloud, self-hosted, and local macOS deployments. Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Other vendor-official choices are [Sendblue](https://chat-sdk.dev/adapters/vendor-official/sendblue) for iMessage/SMS/RCS, [Linq](https://chat-sdk.dev/adapters/vendor-official/linq) for iMessage/SMS, and [AgentPhone](https://chat-sdk.dev/adapters/vendor-official/agentphone) or [Dial](https://chat-sdk.dev/adapters/vendor-official/dial) when voice is part of the same agent. [Blooio](https://chat-sdk.dev/adapters/community/blooio) is a community option. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
 };

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -849,7 +849,7 @@ See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-offic
   "chat-sdk-photon": {
     logo: "imessage",
     docsHref: "/docs/channels/chat-sdk",
-    badge: "Chat SDK",
+    badge: "Provider official",
     keywords: [
       "chat sdk",
       "imessage",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -9,6 +9,7 @@ import {
   SiEgnyte,
   SiGooglechat,
   SiHuggingface,
+  SiImessage,
   SiMake,
   SiMessenger,
   SiMiro,
@@ -390,6 +391,8 @@ export const kapsoLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const imessageLogo = (props: LogoProps) => <SiImessage color="default" {...props} />;
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -533,6 +536,7 @@ export const logos = {
   liveblocks: liveblocksLogo,
   linq: linqLogo,
   kapso: kapsoLogo,
+  imessage: imessageLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -9,7 +9,6 @@ import {
   SiEgnyte,
   SiGooglechat,
   SiHuggingface,
-  SiImessage,
   SiMake,
   SiMessenger,
   SiMiro,
@@ -391,7 +390,14 @@ export const kapsoLogo = (props: LogoProps) => (
   </svg>
 );
 
-export const imessageLogo = (props: LogoProps) => <SiImessage color="default" {...props} />;
+export const photonLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M6 3h7.2C17.4 3 20 5.4 20 9.1s-2.6 6.2-6.8 6.2H9V21H6V3Zm3 2.8v6.7h4c2.5 0 4-1.2 4-3.4 0-2.1-1.5-3.3-4-3.3H9Z"
+      fill="currentColor"
+    />
+  </svg>
+);
 
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
@@ -536,7 +542,7 @@ export const logos = {
   liveblocks: liveblocksLogo,
   linq: linqLogo,
   kapso: kapsoLogo,
-  imessage: imessageLogo,
+  photon: photonLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -391,9 +391,9 @@ export const kapsoLogo = (props: LogoProps) => (
 );
 
 export const photonLogo = (props: LogoProps) => (
-  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg fill="none" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
-      d="M6 3h7.2C17.4 3 20 5.4 20 9.1s-2.6 6.2-6.8 6.2H9V21H6V3Zm3 2.8v6.7h4c2.5 0 4-1.2 4-3.4 0-2.1-1.5-3.3-4-3.3H9Z"
+      d="m34 13-4 16h9l4-16h-9Zm-17 13-4 16h9l4-16h-9Zm16 10-4 16h9l4-16h-9Z"
       fill="currentColor"
     />
   </svg>

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -221,6 +221,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-imessage",
+    name: "iMessage",
+    kind: "channel",
+    tagline: "Reach iMessage conversations through a choice of Chat SDK adapters.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -221,10 +221,10 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
-    slug: "chat-sdk-imessage",
-    name: "iMessage",
+    slug: "chat-sdk-photon",
+    name: "Photon",
     kind: "channel",
-    tagline: "Reach iMessage conversations through a choice of Chat SDK adapters.",
+    tagline: "Cloud, self-hosted, and local iMessage messaging through Photon.",
     surfaces: { scaffoldable: false, gallery: true },
   },
   {


### PR DESCRIPTION
## Summary
- add Photon to the integrations catalog under its provider name
- make the integration discoverable through iMessage search keywords
- document cloud, self-hosted, and local setup through eve’s Chat SDK channel
- identify the adapter as provider-official and use a theme-aware provider mark

<img width="708" height="322" alt="image" src="https://github.com/user-attachments/assets/61ec17c3-638c-4545-baf1-c01d5ac2721a" />

<img width="992" height="1043" alt="image" src="https://github.com/user-attachments/assets/5d85ad6f-7c8f-472d-8280-59b19b20b80a" />

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`