### PR TITLE
feat(docs): add Mattermost integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -502,7 +502,7 @@ Credentials come from the \`createMessengerAdapter\` config or the adapter's env
   "chat-sdk-mattermost": {
     logo: "mattermost",
     docsHref: "/docs/channels/chat-sdk",
-    badge: "Chat SDK",
+    badge: "Community",
     keywords: ["chat sdk", "mattermost", "self hosted chat", "team messaging", "websocket"],
     install: `Install eve, Chat SDK, the Mattermost adapter, and a state adapter:
 

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -347,7 +347,7 @@ import { createGoogleChatAdapter } from "@chat-adapter/gchat";
 import { createMemoryState } from "@chat-adapter/state-memory";
 import { chatSdkChannel } from "eve/channels/chat-sdk";
 
-export const { bot, channel, send } = chatSdkChannel({
+export const { bot, channel } = chatSdkChannel({
   userName: "My Agent",
   adapters: { gchat: createGoogleChatAdapter() },
   state: createMemoryState(),
@@ -355,11 +355,19 @@ export const { bot, channel, send } = chatSdkChannel({
 
 bot.onNewMention(async (thread, message) => {
   await thread.subscribe();
-  await send(message.text, { thread });
+  await channel.receive({
+    message: message.text,
+    target: { adapterName: "mattermost", threadId: thread.id },
+    auth: null,
+  });
 });
 
 bot.onSubscribedMessage(async (thread, message) => {
-  await send(message.text, { thread });
+  await channel.receive({
+    message: message.text,
+    target: { adapterName: "mattermost", threadId: thread.id },
+    auth: null,
+  });
 });
 
 export default channel;
@@ -490,6 +498,54 @@ export default channel;
 
 Credentials come from the \`createMessengerAdapter\` config or the adapter's environment variables; see the [Messenger adapter docs](https://chat-sdk.dev/adapters/official/messenger).`,
     configure: `The adapter mounts its webhook at \`/eve/v1/messenger\`. Point your Messenger webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
+  },
+  "chat-sdk-mattermost": {
+    logo: "mattermost",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Chat SDK",
+    keywords: ["chat sdk", "mattermost", "self hosted chat", "team messaging", "websocket"],
+    install: `Install eve, Chat SDK, the Mattermost adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat chat-adapter-mattermost @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. The adapter is community-maintained.`,
+    quickStart: `Create \`agent/channels/mattermost.ts\`:
+
+\`\`\`ts
+// agent/channels/mattermost.ts
+import { createMattermostAdapter } from "chat-adapter-mattermost";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    mattermost: createMattermostAdapter({
+      baseUrl: process.env.MATTERMOST_BASE_URL!,
+      botToken: process.env.MATTERMOST_BOT_TOKEN!,
+    }),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+await bot.initialize();
+
+export default channel;
+\`\`\`
+
+See the [Mattermost adapter documentation](https://chat-sdk.dev/adapters/community/mattermost) for all supported events and credentials.`,
+    configure: `Create a Mattermost bot account and set \`MATTERMOST_BASE_URL\` and \`MATTERMOST_BOT_TOKEN\`. The community adapter uses REST plus a WebSocket gateway, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. Mattermost and the adapter require Node.js 20 or newer. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
 };
 

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -8,6 +8,7 @@ import {
   SiDatadog,
   SiEgnyte,
   SiGooglechat,
+  SiMattermost,
   SiHuggingface,
   SiMake,
   SiMessenger,
@@ -310,6 +311,8 @@ export const ticketTailorLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const mattermostLogo = (props: LogoProps) => <SiMattermost color="default" {...props} />;
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -382,6 +385,7 @@ export const logos = {
   zapier: zapierLogo,
   zomato: zomatoLogo,
 
+  mattermost: mattermostLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -172,6 +172,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-mattermost",
+    name: "Mattermost",
+    kind: "channel",
+    tagline: "Mattermost posts, reactions, files, and actions via a community Chat SDK adapter.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
## Summary
- add Mattermost to the integrations catalog
- document setup through eve's Chat SDK channel
- use the official Mattermost vector mark

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`
