### PR TITLE
feat(docs): add WeChat / Weixin integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -347,7 +347,7 @@ import { createGoogleChatAdapter } from "@chat-adapter/gchat";
 import { createMemoryState } from "@chat-adapter/state-memory";
 import { chatSdkChannel } from "eve/channels/chat-sdk";
 
-export const { bot, channel, send } = chatSdkChannel({
+export const { bot, channel } = chatSdkChannel({
   userName: "My Agent",
   adapters: { gchat: createGoogleChatAdapter() },
   state: createMemoryState(),
@@ -355,11 +355,19 @@ export const { bot, channel, send } = chatSdkChannel({
 
 bot.onNewMention(async (thread, message) => {
   await thread.subscribe();
-  await send(message.text, { thread });
+  await channel.receive({
+    message: message.text,
+    target: { adapterName: "weixin", threadId: thread.id },
+    auth: null,
+  });
 });
 
 bot.onSubscribedMessage(async (thread, message) => {
-  await send(message.text, { thread });
+  await channel.receive({
+    message: message.text,
+    target: { adapterName: "weixin", threadId: thread.id },
+    auth: null,
+  });
 });
 
 export default channel;
@@ -490,6 +498,54 @@ export default channel;
 
 Credentials come from the \`createMessengerAdapter\` config or the adapter's environment variables; see the [Messenger adapter docs](https://chat-sdk.dev/adapters/official/messenger).`,
     configure: `The adapter mounts its webhook at \`/eve/v1/messenger\`. Point your Messenger webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
+  },
+  "chat-sdk-weixin": {
+    logo: "wechat",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Chat SDK",
+    keywords: ["chat sdk", "wechat", "weixin", "ilink", "china", "messaging"],
+    install: `Install eve, Chat SDK, the WeChat / Weixin adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat chat-adapter-weixin @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. The adapter is community-maintained.`,
+    quickStart: `Create \`agent/channels/weixin.ts\`:
+
+\`\`\`ts
+// agent/channels/weixin.ts
+import { createWeixinAdapter } from "chat-adapter-weixin";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    weixin: createWeixinAdapter({
+      accountId: process.env.WEIXIN_ACCOUNT_ID!,
+      token: process.env.WEIXIN_BOT_TOKEN!,
+    }),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+await bot.initialize();
+
+export default channel;
+\`\`\`
+
+See the [WeChat / Weixin adapter documentation](https://chat-sdk.dev/adapters/community/weixin) for all supported events and credentials.`,
+    configure: `Authenticate an iLink bot and set \`WEIXIN_ACCOUNT_ID\` and \`WEIXIN_BOT_TOKEN\`. The community adapter uses long polling rather than webhooks, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. Use durable state in production because the adapter stores its cursor, context tokens, dedupe markers, and thread history there. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
 };
 

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -502,7 +502,7 @@ Credentials come from the \`createMessengerAdapter\` config or the adapter's env
   "chat-sdk-weixin": {
     logo: "wechat",
     docsHref: "/docs/channels/chat-sdk",
-    badge: "Chat SDK",
+    badge: "Community",
     keywords: ["chat sdk", "wechat", "weixin", "ilink", "china", "messaging"],
     install: `Install eve, Chat SDK, the WeChat / Weixin adapter, and a state adapter:
 

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -8,6 +8,7 @@ import {
   SiDatadog,
   SiEgnyte,
   SiGooglechat,
+  SiWechat,
   SiHuggingface,
   SiMake,
   SiMessenger,
@@ -310,6 +311,8 @@ export const ticketTailorLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const wechatLogo = (props: LogoProps) => <SiWechat color="default" {...props} />;
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -382,6 +385,7 @@ export const logos = {
   zapier: zapierLogo,
   zomato: zomatoLogo,
 
+  wechat: wechatLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -172,6 +172,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-weixin",
+    name: "WeChat / Weixin",
+    kind: "channel",
+    tagline: "WeChat messages, media, and typing through the Weixin iLink Chat SDK adapter.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
## Summary

- add WeChat / Weixin to the integrations catalog
- document setup through eve's Chat SDK channel
- use the official WeChat / Weixin vector mark

<img width="892" height="945" alt="image" src="https://github.com/user-attachments/assets/4a731e23-1388-42c1-86ff-bbcf95a01868" />

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`
