### PR TITLE
feat(docs): add Zalo integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -491,6 +491,49 @@ export default channel;
 Credentials come from the \`createMessengerAdapter\` config or the adapter's environment variables; see the [Messenger adapter docs](https://chat-sdk.dev/adapters/official/messenger).`,
     configure: `The adapter mounts its webhook at \`/eve/v1/messenger\`. Point your Messenger webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
   },
+  "chat-sdk-zalo": {
+    logo: "zalo",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Chat SDK",
+    keywords: ["chat sdk", "zalo", "vietnam", "zalo bot platform", "messaging"],
+    install: `Install eve, Chat SDK, the Zalo adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat chat-adapter-zalo @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. The adapter is community-maintained.`,
+    quickStart: `Create \`agent/channels/zalo.ts\`:
+
+\`\`\`ts
+// agent/channels/zalo.ts
+import { createZaloAdapter } from "chat-adapter-zalo";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    zalo: createZaloAdapter(),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+export default channel;
+\`\`\`
+
+See the [Zalo adapter documentation](https://chat-sdk.dev/adapters/community/zalo) for all supported events and credentials.`,
+    configure: `Create a bot at [bot.zapps.me](https://bot.zapps.me), set the adapter’s Zalo credentials, and point the Zalo webhook at \`/eve/v1/zalo\`. This community adapter supports buffered streaming, automatic chunking, typing indicators, and webhook signature verification. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+  },
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -494,7 +494,7 @@ Credentials come from the \`createMessengerAdapter\` config or the adapter's env
   "chat-sdk-zalo": {
     logo: "zalo",
     docsHref: "/docs/channels/chat-sdk",
-    badge: "Chat SDK",
+    badge: "Community",
     keywords: ["chat sdk", "zalo", "vietnam", "zalo bot platform", "messaging"],
     install: `Install eve, Chat SDK, the Zalo adapter, and a state adapter:
 

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -8,6 +8,7 @@ import {
   SiDatadog,
   SiEgnyte,
   SiGooglechat,
+  SiZalo,
   SiHuggingface,
   SiMake,
   SiMessenger,
@@ -310,6 +311,8 @@ export const ticketTailorLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const zaloLogo = (props: LogoProps) => <SiZalo color="default" {...props} />;
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -382,6 +385,7 @@ export const logos = {
   zapier: zapierLogo,
   zomato: zomatoLogo,
 
+  zalo: zaloLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -172,6 +172,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-zalo",
+    name: "Zalo",
+    kind: "channel",
+    tagline: "Zalo Bot Platform conversations via a community Chat SDK adapter.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
## Summary
- add Zalo to the integrations catalog
- document setup through eve's Chat SDK channel
- use the official Zalo vector mark

<img width="918" height="872" alt="image" src="https://github.com/user-attachments/assets/867fb884-f6b1-40a6-9b1e-9ca78a0589c7" />

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`
