### PR TITLE
feat(eve): Update teams to add `isSubscribed`, `isBotMentioned` utility

### DIFF
--- a/.changeset/calm-threads-continue.md
+++ b/.changeset/calm-threads-continue.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Added `isBotMentioned()` and `isSubscribed()` helpers to the Slack and Microsoft Teams `onMessage` hooks for custom routing that can continue active conversations without repeated mentions.
+Added a Slack `onMessage` hook with `isBotMentioned()` and `isSubscribed()` helpers for custom message routing.

--- a/.changeset/calm-threads-continue.md
+++ b/.changeset/calm-threads-continue.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Added a Slack `onMessage` hook with `isBotMentioned()` and `isSubscribed()` helpers for custom message routing.
+Added `isBotMentioned()` and `isSubscribed()` helpers to the Slack and Microsoft Teams `onMessage` hooks for custom routing that can continue active conversations without repeated mentions.

--- a/.changeset/gentle-teams-continue.md
+++ b/.changeset/gentle-teams-continue.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Added an `isSubscribed()` helper to the Microsoft Teams `onMessage` hook for custom routing that can continue conversations without repeated mentions.

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -28,7 +28,7 @@ By default the channel mounts at `POST /eve/v1/teams`. Point your Azure Bot or T
 
 The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
 
-For example, use the contextual `isBotMentioned()` and `isSubscribed()` helpers to continue active threads without requiring another mention:
+For example, use the contextual `isSubscribed()` helper to continue active threads without requiring another mention:
 
 ```ts
 import { defaultTeamsAuth, teamsChannel } from "eve/channels/teams";
@@ -37,7 +37,7 @@ export default teamsChannel({
   async onMessage(ctx, message) {
     if (message.from.role === "bot" || message.from.id === message.recipient.id) return null;
     const isDirectMessage = message.scope === "personal";
-    return isDirectMessage || ctx.isBotMentioned() || (await ctx.isSubscribed())
+    return isDirectMessage || message.isBotMentioned || (await ctx.isSubscribed())
       ? { auth: defaultTeamsAuth(message) }
       : null;
   },

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -28,7 +28,7 @@ By default the channel mounts at `POST /eve/v1/teams`. Point your Azure Bot or T
 
 The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
 
-Use the contextual `isBotMentioned()` and `isSubscribed()` helpers to continue active threads without requiring another mention:
+For example, use the contextual `isBotMentioned()` and `isSubscribed()` helpers to continue active threads without requiring another mention:
 
 ```ts
 import { defaultTeamsAuth, teamsChannel } from "eve/channels/teams";
@@ -44,7 +44,7 @@ export default teamsChannel({
 });
 ```
 
-`isSubscribed()` checks whether the message's Teams conversation and root activity identify an active eve session.
+`isSubscribed()` checks whether the conversation has previously involved the agent.
 
 ### Delivery
 

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -28,16 +28,23 @@ By default the channel mounts at `POST /eve/v1/teams`. Point your Azure Bot or T
 
 The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
 
+Use the contextual `isBotMentioned()` and `isSubscribed()` helpers to continue active threads without requiring another mention:
+
 ```ts
 import { defaultTeamsAuth, teamsChannel } from "eve/channels/teams";
 
 export default teamsChannel({
-  onMessage(ctx, message) {
-    if (message.scope !== "personal" && !message.isBotMentioned) return null;
-    return { auth: defaultTeamsAuth(message) };
+  async onMessage(ctx, message) {
+    if (message.from.role === "bot" || message.from.id === message.recipient.id) return null;
+    const isDirectMessage = message.scope === "personal";
+    return isDirectMessage || ctx.isBotMentioned() || (await ctx.isSubscribed())
+      ? { auth: defaultTeamsAuth(message) }
+      : null;
   },
 });
 ```
+
+`isSubscribed()` checks whether the message's Teams conversation and root activity identify an active eve session.
 
 ### Delivery
 

--- a/packages/eve/src/public/channels/teams/defaults.ts
+++ b/packages/eve/src/public/channels/teams/defaults.ts
@@ -51,6 +51,7 @@ export async function defaultOnMessage(
   ctx: TeamsContext,
   message: TeamsMessageActivity,
 ): Promise<TeamsInboundResult> {
+  if (message.from.role === "bot" || message.from.id === message.recipient.id) return null;
   if (message.scope !== "personal" && !message.isBotMentioned) return null;
   await ctx.thread.startTyping();
   return { auth: defaultTeamsAuth(message) };

--- a/packages/eve/src/public/channels/teams/index.ts
+++ b/packages/eve/src/public/channels/teams/index.ts
@@ -22,6 +22,7 @@ export {
   type TeamsContext,
   type TeamsEventContext,
   type TeamsHandle,
+  type TeamsInboundMessageContext,
   type TeamsInboundResult,
   type TeamsInboundResultOrPromise,
   type TeamsInputResponseResult,

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -14,6 +14,11 @@ function asCompiled<T = unknown>(channel: unknown): CompiledChannel<T> {
 async function firePost(
   channel: unknown,
   body: Record<string, unknown>,
+  overrides: {
+    readonly resolveActiveSession?: (options: {
+      readonly continuationToken: string;
+    }) => Promise<{ readonly sessionId: string } | undefined>;
+  } = {},
 ): Promise<{
   readonly response: Response;
   readonly send: ReturnType<typeof vi.fn>;
@@ -40,7 +45,7 @@ async function firePost(
     }),
     {
       getSession: vi.fn(),
-      resolveActiveSession: async () => undefined,
+      resolveActiveSession: overrides.resolveActiveSession ?? vi.fn().mockResolvedValue(undefined),
       cancel: vi.fn(),
       params: {},
       receive: vi.fn(),
@@ -108,6 +113,69 @@ describe("teamsChannel", () => {
     raw.entities = [];
 
     const { send } = await firePost(channel, raw);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("exposes mention and subscription helpers to onMessage", async () => {
+    const observed: Array<{ mentioned: boolean; subscribed: boolean }> = [];
+    const resolveActiveSession = vi.fn().mockResolvedValue({ sessionId: "SESSION" });
+    const channel = teamsChannel({
+      credentials: { webhookVerifier: () => true },
+      async onMessage(ctx) {
+        observed.push({
+          mentioned: ctx.isBotMentioned(),
+          subscribed: await ctx.isSubscribed(),
+        });
+        return null;
+      },
+    });
+    const raw = messageActivity({ conversationType: "channel" });
+    raw.entities = [];
+    raw.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
+
+    await firePost(channel, raw, { resolveActiveSession });
+
+    expect(observed).toEqual([{ mentioned: false, subscribed: true }]);
+    expect(resolveActiveSession).toHaveBeenCalledWith({
+      continuationToken: "TENANT:CONV:THREAD_ROOT",
+    });
+  });
+
+  it("allows a mention-or-subscription onMessage policy", async () => {
+    const channel = teamsChannel({
+      credentials: { webhookVerifier: () => true },
+      async onMessage(ctx) {
+        return ctx.isBotMentioned() || (await ctx.isSubscribed()) ? { auth: null } : null;
+      },
+    });
+    const raw = messageActivity({ conversationType: "channel" });
+    raw.entities = [];
+    raw.conversation = { conversationType: "channel", id: "CONV;messageid=THREAD_ROOT" };
+
+    const { send } = await firePost(channel, raw, {
+      resolveActiveSession: vi.fn().mockResolvedValue({ sessionId: "SESSION" }),
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes bot-authored messages to onMessage", async () => {
+    const onMessage = vi.fn((_ctx: unknown, _message: unknown) => null);
+    const channel = teamsChannel({
+      credentials: { webhookVerifier: () => true },
+      onMessage,
+    });
+    const raw = messageActivity({ conversationType: "channel" });
+    raw.entities = [];
+    raw.from = { id: "OTHER_BOT", name: "Other bot", role: "bot" };
+
+    const { send } = await firePost(channel, raw);
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ from: expect.objectContaining({ id: "OTHER_BOT", role: "bot" }) }),
+    );
     expect(send).not.toHaveBeenCalled();
   });
 

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -116,6 +116,16 @@ describe("teamsChannel", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("default dispatch ignores bot-authored personal messages", async () => {
+    const channel = teamsChannel({ credentials: { webhookVerifier: () => true } });
+    const raw = messageActivity({ conversationType: "personal" });
+    raw.from = { id: "OTHER_BOT", name: "Other bot", role: "bot" };
+
+    const { send } = await firePost(channel, raw);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("exposes mention and subscription helpers to onMessage", async () => {
     const observed: Array<{ mentioned: boolean; subscribed: boolean }> = [];
     const resolveActiveSession = vi.fn().mockResolvedValue({ sessionId: "SESSION" });

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -126,16 +126,13 @@ describe("teamsChannel", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("exposes mention and subscription helpers to onMessage", async () => {
-    const observed: Array<{ mentioned: boolean; subscribed: boolean }> = [];
+  it("exposes the subscription helper to onMessage", async () => {
+    const observed: boolean[] = [];
     const resolveActiveSession = vi.fn().mockResolvedValue({ sessionId: "SESSION" });
     const channel = teamsChannel({
       credentials: { webhookVerifier: () => true },
       async onMessage(ctx) {
-        observed.push({
-          mentioned: ctx.isBotMentioned(),
-          subscribed: await ctx.isSubscribed(),
-        });
+        observed.push(await ctx.isSubscribed());
         return null;
       },
     });
@@ -145,7 +142,7 @@ describe("teamsChannel", () => {
 
     await firePost(channel, raw, { resolveActiveSession });
 
-    expect(observed).toEqual([{ mentioned: false, subscribed: true }]);
+    expect(observed).toEqual([true]);
     expect(resolveActiveSession).toHaveBeenCalledWith({
       continuationToken: "TENANT:CONV:THREAD_ROOT",
     });
@@ -154,8 +151,8 @@ describe("teamsChannel", () => {
   it("allows a mention-or-subscription onMessage policy", async () => {
     const channel = teamsChannel({
       credentials: { webhookVerifier: () => true },
-      async onMessage(ctx) {
-        return ctx.isBotMentioned() || (await ctx.isSubscribed()) ? { auth: null } : null;
+      async onMessage(ctx, message) {
+        return message.isBotMentioned || (await ctx.isSubscribed()) ? { auth: null } : null;
       },
     });
     const raw = messageActivity({ conversationType: "channel" });

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -70,8 +70,6 @@ export interface TeamsContext {
 
 /** Message-scoped context handed to `teamsChannel({ onMessage })`. */
 export interface TeamsInboundMessageContext extends TeamsContext {
-  /** Returns whether the inbound activity explicitly mentions this bot. */
-  isBotMentioned(): boolean;
   /** Returns whether this message belongs to a thread with an active eve session. */
   isSubscribed(): Promise<boolean>;
 }
@@ -580,7 +578,6 @@ async function dispatchMessage(input: {
   const continuationToken = stateToken(state);
   const ctx: TeamsInboundMessageContext = {
     ...binding,
-    isBotMentioned: () => input.activity.isBotMentioned,
     isSubscribed: async () =>
       (await input.resolveActiveSession({ continuationToken })) !== undefined,
   };

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -62,10 +62,18 @@ const log = createLogger("teams.channel");
 type EventData<T extends HandleMessageStreamEvent["type"]> =
   Extract<HandleMessageStreamEvent, { type: T }> extends { data: infer D } ? D : undefined;
 
-/** Pre-dispatch Teams context passed to inbound message and invoke hooks. */
+/** Pre-dispatch Teams context passed to invoke hooks. */
 export interface TeamsContext {
   readonly teams: TeamsHandle;
   readonly thread: TeamsThread;
+}
+
+/** Message-scoped context handed to `teamsChannel({ onMessage })`. */
+export interface TeamsInboundMessageContext extends TeamsContext {
+  /** Returns whether the inbound activity explicitly mentions this bot. */
+  isBotMentioned(): boolean;
+  /** Returns whether this message belongs to a thread with an active eve session. */
+  isSubscribed(): Promise<boolean>;
 }
 
 /** Channel-owned Teams context returned by `context()`. */
@@ -188,7 +196,10 @@ export interface TeamsChannelConfig {
   readonly route?: string;
 
   /** Inbound message hook. Defaults to user-scoped auth and mention-gated dispatch outside personal chats. */
-  onMessage?(ctx: TeamsContext, message: TeamsMessageActivity): TeamsInboundResultOrPromise;
+  onMessage?(
+    ctx: TeamsInboundMessageContext,
+    message: TeamsMessageActivity,
+  ): TeamsInboundResultOrPromise;
 
   /** Authorizes HITL card submissions. Defaults to the submitting Teams user. */
   onInputResponse?(
@@ -284,48 +295,52 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
     },
 
     routes: [
-      POST<TeamsChannelState>(config.route ?? "/eve/v1/teams", async (req, { send, waitUntil }) => {
-        const body = await verifyInbound(req, config.credentials);
-        if (body === null) return new Response("unauthorized", { status: 401 });
+      POST<TeamsChannelState>(
+        config.route ?? "/eve/v1/teams",
+        async (req, { resolveActiveSession, send, waitUntil }) => {
+          const body = await verifyInbound(req, config.credentials);
+          if (body === null) return new Response("unauthorized", { status: 401 });
 
-        let raw: JsonObject;
-        try {
-          raw = parseJsonObject(JSON.parse(body) as unknown);
-        } catch (error) {
-          log.warn("inbound Teams body is not valid JSON", { error });
+          let raw: JsonObject;
+          try {
+            raw = parseJsonObject(JSON.parse(body) as unknown);
+          } catch (error) {
+            log.warn("inbound Teams body is not valid JSON", { error });
+            return teamsOk();
+          }
+
+          const activity = parseTeamsActivity(raw);
+          if (activity === null) return teamsOk();
+
+          if (activity.type === "message") {
+            waitUntil(
+              isTeamsInputResponseActivity(activity)
+                ? dispatchInputResponses({ activity, config, onInputResponse, send })
+                : dispatchMessage({
+                    activity,
+                    config,
+                    filesPolicy,
+                    onMessage,
+                    resolveActiveSession,
+                    send,
+                  }),
+            );
+            return teamsOk();
+          }
+
+          if (activity.type === "invoke") {
+            return handleInvoke({
+              activity,
+              config,
+              onInputResponse,
+              send,
+              waitUntil,
+            });
+          }
+
           return teamsOk();
-        }
-
-        const activity = parseTeamsActivity(raw);
-        if (activity === null) return teamsOk();
-
-        if (activity.type === "message") {
-          waitUntil(
-            isTeamsInputResponseActivity(activity)
-              ? dispatchInputResponses({ activity, config, onInputResponse, send })
-              : dispatchMessage({
-                  activity,
-                  config,
-                  filesPolicy,
-                  onMessage,
-                  send,
-                }),
-          );
-          return teamsOk();
-        }
-
-        if (activity.type === "invoke") {
-          return handleInvoke({
-            activity,
-            config,
-            onInputResponse,
-            send,
-            waitUntil,
-          });
-        }
-
-        return teamsOk();
-      }),
+        },
+      ),
     ],
 
     async receive(input, { send }) {
@@ -555,10 +570,20 @@ async function dispatchMessage(input: {
   readonly config: TeamsChannelConfig;
   readonly filesPolicy: TeamsFilesPolicy;
   readonly onMessage: NonNullable<TeamsChannelConfig["onMessage"]>;
+  readonly resolveActiveSession: (options: {
+    readonly continuationToken: string;
+  }) => Promise<{ readonly sessionId: string } | undefined>;
   readonly send: SendFn<TeamsChannelState>;
 }): Promise<void> {
   const state = stateFromActivity(input.activity);
-  const ctx = buildTeamsBinding({ config: input.config, state });
+  const binding = buildTeamsBinding({ config: input.config, state });
+  const continuationToken = stateToken(state);
+  const ctx: TeamsInboundMessageContext = {
+    ...binding,
+    isBotMentioned: () => input.activity.isBotMentioned,
+    isSubscribed: async () =>
+      (await input.resolveActiveSession({ continuationToken })) !== undefined,
+  };
 
   let result: TeamsInboundResult;
   try {
@@ -592,7 +617,7 @@ async function dispatchMessage(input: {
       },
       {
         auth: result.auth,
-        continuationToken: stateToken(state),
+        continuationToken,
         state,
       },
     );


### PR DESCRIPTION
## Summary

Equivalent to #1046 for Teams. Provides users with context tools for checking e.g. subscribed status

```ts
import { defaultTeamsAuth, teamsChannel } from "eve/channels/teams";

export default teamsChannel({
  async onMessage(ctx, message) {
    if (message.from.role === "bot" || message.from.id === message.recipient.id) return null;
    const isDirectMessage = message.scope === "personal";
    return isDirectMessage || ctx.isBotMentioned() || (await ctx.isSubscribed())
      ? { auth: defaultTeamsAuth(message) }
      : null;
  },
});
```

## Test Plan

Unit tests; tested with deployed teams bot.