### PR TITLE
test(e2e): tolerate recovered fanout attempts

### DIFF
--- a/e2e/fixtures/agent-tools/evals/static-tools/fanout-authored.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/fanout-authored.eval.ts
@@ -1,11 +1,6 @@
 import { defineEval } from "eve/evals";
 
-import {
-  FANOUT_SIZE,
-  fanoutExecutionsReachBarrier,
-  fanoutRequestsPrecedeFirstResult,
-  fanoutRequestsUseExpectedLabels,
-} from "./fanout";
+import { FANOUT_SIZE, fanoutExecutionsReachBarrier } from "./fanout";
 
 const TOOL_NAME = "fanout-barrier";
 const LABELS = [
@@ -36,15 +31,9 @@ export default defineEval({
 
     t.succeeded();
     t.calledTool(TOOL_NAME, { count: FANOUT_SIZE });
-    t.noFailedActions();
-    turn.eventsSatisfy("ten authored requests precede the first authored result", (events) =>
-      fanoutRequestsPrecedeFirstResult({ events, toolName: TOOL_NAME }),
-    );
-    turn.eventsSatisfy("ten authored requests use their distinct labels", (events) =>
-      fanoutRequestsUseExpectedLabels({ events, labels: LABELS, toolName: TOOL_NAME }),
-    );
-    turn.eventsSatisfy("ten authored executions reach the concurrency barrier", (events) =>
-      fanoutExecutionsReachBarrier({ events, toolName: TOOL_NAME }),
+    turn.eventsSatisfy(
+      "ten distinctly labeled authored executions reach the concurrency barrier",
+      (events) => fanoutExecutionsReachBarrier({ events, labels: LABELS, toolName: TOOL_NAME }),
     );
   },
 });

--- a/e2e/fixtures/agent-tools/evals/static-tools/fanout.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/fanout.ts
@@ -2,86 +2,29 @@ import type { HandleMessageStreamEvent } from "eve/client";
 
 export const FANOUT_SIZE = 10;
 
-interface RequestedToolCall {
-  readonly callId: string;
-  readonly eventIndex: number;
-  readonly input: unknown;
-}
-
-/**
- * Checks the visible fan-out boundary: every requested call must have reached
- * the stream before the first matching result. This is the observable provider
- * contract; the provider's own network execution is outside eve's process.
- */
-export function fanoutRequestsPrecedeFirstResult(input: {
-  readonly events: readonly HandleMessageStreamEvent[];
-  readonly toolName: string;
-}): boolean {
-  const requests = requestedToolCalls(input);
-  const firstResultIndex = input.events.findIndex(
-    (event) =>
-      event.type === "action.result" &&
-      event.data.result.kind === "tool-result" &&
-      event.data.result.toolName === input.toolName,
-  );
-
-  return (
-    firstResultIndex >= 0 &&
-    requests.length === FANOUT_SIZE &&
-    new Set(requests.map((request) => request.callId)).size === FANOUT_SIZE &&
-    requests.every((request) => request.eventIndex < firstResultIndex)
-  );
-}
-
-export function fanoutRequestsUseExpectedLabels(input: {
+/** A serialized executor cannot release the fixture tool's concurrency barrier. */
+export function fanoutExecutionsReachBarrier(input: {
   readonly events: readonly HandleMessageStreamEvent[];
   readonly labels: readonly string[];
   readonly toolName: string;
 }): boolean {
-  const labels = requestedToolCalls(input)
-    .map((request) => readStringField(request.input, "label"))
-    .filter((label): label is string => label !== undefined);
-  const expectedLabels = new Set(input.labels);
-
-  return (
-    labels.length === FANOUT_SIZE &&
-    expectedLabels.size === FANOUT_SIZE &&
-    new Set(labels).size === FANOUT_SIZE &&
-    labels.every((label) => expectedLabels.has(label))
-  );
-}
-
-/** A serialized executor cannot release the fixture tool's concurrency barrier. */
-export function fanoutExecutionsReachBarrier(input: {
-  readonly events: readonly HandleMessageStreamEvent[];
-  readonly toolName: string;
-}): boolean {
-  const concurrentCallsAtRelease = input.events.flatMap((event) => {
+  const executions = input.events.flatMap((event) => {
     if (event.type !== "action.result" || event.data.result.kind !== "tool-result") return [];
     if (event.data.result.toolName !== input.toolName) return [];
 
     const count = readFiniteNumberField(event.data.result.output, "concurrentCallsAtRelease");
-    return count === undefined ? [] : [count];
+    const label = readStringField(event.data.result.output, "label");
+    return count === undefined || label === undefined ? [] : [{ count, label }];
   });
+  const expectedLabels = new Set(input.labels);
 
   return (
-    concurrentCallsAtRelease.length === FANOUT_SIZE &&
-    concurrentCallsAtRelease.every((count) => count === FANOUT_SIZE)
+    executions.length === FANOUT_SIZE &&
+    executions.every((execution) => execution.count === FANOUT_SIZE) &&
+    expectedLabels.size === FANOUT_SIZE &&
+    new Set(executions.map((execution) => execution.label)).size === FANOUT_SIZE &&
+    executions.every((execution) => expectedLabels.has(execution.label))
   );
-}
-
-function requestedToolCalls(input: {
-  readonly events: readonly HandleMessageStreamEvent[];
-  readonly toolName: string;
-}): RequestedToolCall[] {
-  return input.events.flatMap((event, eventIndex) => {
-    if (event.type !== "actions.requested") return [];
-
-    return event.data.actions.flatMap((action) => {
-      if (action.kind !== "tool-call" || action.toolName !== input.toolName) return [];
-      return [{ callId: action.callId, eventIndex, input: action.input }];
-    });
-  });
 }
 
 function readFiniteNumberField(value: unknown, field: string): number | undefined {


### PR DESCRIPTION
## Summary

- remove turn-wide fanout assertions that fail after a recoverable singleton attempt
- rely on the ten-party barrier to prove concurrent execution
- validate the successful barrier batch contains all ten expected labels exactly once

## Why singleton attempts occur

OpenAI occasionally returns a model step containing only the first valid `fanout-barrier` call even though the prompt requests ten calls in one step. Playground diagnostics observed the same singleton at all three boundaries: the AI SDK `fullStream`, `onStepFinish().toolCalls`, and the tool executor. This rules out eve dropping the other nine calls during event emission or execution.

The singleton then waits at the ten-party barrier, while the next model step cannot begin until that tool call settles. The timeout breaks that cycle and returns an error to the model, which usually retries with all ten calls in its next step. That retry proves the eve behavior this eval owns: ten distinctly labeled authored tools execute concurrently. The removed assertions instead judged the entire turn and failed because it also contained the recovered singleton.

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` in `e2e/fixtures/agent-tools`
- 100 sequential local `static-tools/fanout-authored` runs with `openai/gpt-5.6-sol`: 100 passed
- eight failed singleton barrier attempts were observed and recovered by a later valid ten-call batch
