### PR TITLE
feat(docs): add Dial integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -905,6 +905,53 @@ export default channel;
 See the [Photon adapter documentation](https://chat-sdk.dev/adapters/vendor-official/photon) for all supported events and credentials.`,
     configure: `Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Photon supports cloud, self-hosted, and local macOS deployments. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
+  "chat-sdk-dial": {
+    logo: "dial",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Provider official",
+    keywords: ["chat sdk", "dial", "sms", "mms", "imessage", "voice", "phone", "calls"],
+    install: `Install eve, Chat SDK, the Dial adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat @getdial/chat-sdk-adapter @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. This adapter is built and maintained by Dial.`,
+    quickStart: `Create \`agent/channels/dial.ts\`:
+
+\`\`\`ts
+// agent/channels/dial.ts
+import { createDialAdapter } from "@getdial/chat-sdk-adapter";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    dial: createDialAdapter({
+      apiKey: process.env.DIAL_API_KEY!,
+      fromNumberId: process.env.DIAL_FROM_NUMBER_ID!,
+      webhookSecret: process.env.DIAL_WEBHOOK_SECRET!,
+    }),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+export default channel;
+\`\`\`
+
+See the [Dial adapter documentation](https://chat-sdk.dev/adapters/vendor-official/dial) for supported events, capabilities, and credentials.`,
+    configure: `Create a Dial number, set \`DIAL_API_KEY\`, \`DIAL_FROM_NUMBER_ID\`, and \`DIAL_WEBHOOK_SECRET\`, then point its webhook at \`/eve/v1/dial\`. Dial maps each phone-number pair to a thread and delivers SMS, MMS, iMessage, and voice transcripts. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+  },
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -400,10 +400,14 @@ export const photonLogo = (props: LogoProps) => (
 );
 
 export const dialLogo = (props: LogoProps) => (
-  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg fill="none" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect fill="#2C2C2A" height="512" rx="102" width="512" />
+    <circle cx="256" cy="256" fill="#F1EFE8" r="56" />
     <path
-      d="M5 4h6.2C16.5 4 20 7.1 20 12s-3.5 8-8.8 8H5V4Zm3 2.8v10.4h3c3.7 0 6-1.9 6-5.2s-2.3-5.2-6-5.2H8Z"
-      fill="currentColor"
+      d="M256 101c85.6 0 155 69.4 155 155M256 411c-85.6 0-155-69.4-155-155"
+      stroke="#F1EFE8"
+      strokeLinecap="round"
+      strokeWidth="14"
     />
   </svg>
 );

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -399,6 +399,15 @@ export const photonLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const dialLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M5 4h6.2C16.5 4 20 7.1 20 12s-3.5 8-8.8 8H5V4Zm3 2.8v10.4h3c3.7 0 6-1.9 6-5.2s-2.3-5.2-6-5.2H8Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -543,6 +552,7 @@ export const logos = {
   linq: linqLogo,
   kapso: kapsoLogo,
   photon: photonLogo,
+  dial: dialLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -228,6 +228,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-dial",
+    name: "Dial",
+    kind: "channel",
+    tagline: "Give your agent a phone number for SMS, MMS, iMessage, and voice transcripts.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
## Summary
- add Dial to the integrations gallery
- document the vendor-official Chat SDK adapter setup
- include provider and supported-surface search keywords

<img width="1010" height="909" alt="image" src="https://github.com/user-attachments/assets/8787adc0-e426-4161-af85-0ae67262c065" />

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`