### PR TITLE
feat(docs): add Kapso integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -799,6 +799,53 @@ export default channel;
 See the [Linq adapter documentation](https://chat-sdk.dev/adapters/vendor-official/linq) for supported events, capabilities, and credentials.`,
     configure: `Create a Linq account, set \`LINQ_API_KEY\` and \`LINQ_WEBHOOK_SECRET\`, then point its signed webhook at \`/eve/v1/linq\`. Linq supports iMessage and SMS DMs and group chats, media, buffered streaming, and tapbacks. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
+  "chat-sdk-kapso": {
+    logo: "kapso",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Provider official",
+    keywords: ["chat sdk", "kapso", "whatsapp", "meta", "business", "buttons", "media"],
+    install: `Install eve, Chat SDK, the Kapso adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat @kapso/chat-adapter @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. This adapter is built and maintained by Kapso.`,
+    quickStart: `Create \`agent/channels/kapso.ts\`:
+
+\`\`\`ts
+// agent/channels/kapso.ts
+import { createKapsoAdapter } from "@kapso/chat-adapter";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    kapso: createKapsoAdapter({
+      kapsoApiKey: process.env.KAPSO_API_KEY!,
+      phoneNumberId: process.env.KAPSO_PHONE_NUMBER_ID!,
+      webhookSecret: process.env.KAPSO_WEBHOOK_SECRET!,
+    }),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+export default channel;
+\`\`\`
+
+See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) for supported events, capabilities, and credentials.`,
+    configure: `Connect a WhatsApp number in Kapso, set \`KAPSO_API_KEY\`, \`KAPSO_PHONE_NUMBER_ID\`, and \`KAPSO_WEBHOOK_SECRET\`, then point the Kapso webhook at \`/eve/v1/kapso\`. Use this provider-managed option when you do not want to integrate directly with the WhatsApp Cloud API. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+  },
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -376,6 +376,12 @@ export const linqLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const kapsoLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M5 4h3v6.7L14.2 4H18l-7 7.5L18.5 20h-4L8 12.6V20H5V4Z" fill="currentColor" />
+  </svg>
+);
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -518,6 +524,7 @@ export const logos = {
   novu: novuLogo,
   liveblocks: liveblocksLogo,
   linq: linqLogo,
+  kapso: kapsoLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -377,8 +377,16 @@ export const linqLogo = (props: LogoProps) => (
 );
 
 export const kapsoLogo = (props: LogoProps) => (
-  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
-    <path d="M5 4h3v6.7L14.2 4H18l-7 7.5L18.5 20h-4L8 12.6V20H5V4Z" fill="currentColor" />
+  <svg fill="none" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path fill="#100e0d" d="M0 0h32v32H0z" />
+    <path
+      fill="#ededed"
+      d="M9 7h3l1 7 1.172-1.531L15.75 10.5c.51-.65 1.02-1.3 1.547-1.969C19 7 19 7 23 7c0 2 0 2-2.5 4.625L18 14c1.258 3.482 2.773 6.065 5 9v2c-2.312-.187-2.312-.187-5-1-1.687-2.563-1.687-2.563-3-5h-2l-1 6H9z"
+    />
+    <path
+      fill="#e4e4e4"
+      d="M15 14h2c1.508 1.898 1.508 1.898 3.125 4.375l1.633 2.46C23 23 23 23 23 25c-2.312-.187-2.312-.187-5-1-1.687-2.5-1.687-2.5-3-5l-2-1z"
+    />
   </svg>
 );
 

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -214,6 +214,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-kapso",
+    name: "Kapso",
+    kind: "channel",
+    tagline: "Managed WhatsApp conversations, media, buttons, and history through Kapso.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
## Summary
- add Kapso to the integrations gallery
- document the vendor-official Chat SDK adapter setup
- include provider and supported-surface search keywords

<img width="971" height="964" alt="image" src="https://github.com/user-attachments/assets/be6b3c36-dc45-4be1-bf9a-8f1a9effb63f" />

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`