### PR TITLE
feat(docs): add Novu integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -645,6 +645,58 @@ export default channel;
 See the [Sendblue adapter documentation](https://chat-sdk.dev/adapters/vendor-official/sendblue) for supported events, capabilities, and credentials.`,
     configure: `Set \`SENDBLUE_API_KEY\`, \`SENDBLUE_API_SECRET\`, and \`SENDBLUE_FROM_NUMBER\`, then point Sendblue webhooks at \`/eve/v1/sendblue\`. The adapter also supports tapbacks, typing indicators, delivery callbacks, and number lookup. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
+  "chat-sdk-novu": {
+    logo: "novu",
+    docsHref: "/docs/channels/chat-sdk",
+    badge: "Provider official",
+    keywords: [
+      "chat sdk",
+      "novu",
+      "slack",
+      "teams",
+      "whatsapp",
+      "telegram",
+      "email",
+      "multichannel",
+    ],
+    install: `Install eve, Chat SDK, the Novu adapter, and a state adapter:
+
+\`\`\`bash
+npm install eve@latest chat @novu/chat-sdk-adapter @chat-adapter/state-memory
+\`\`\`
+
+The in-memory state store is for local development. Use Redis or PostgreSQL in production. This adapter is built and maintained by Novu.`,
+    quickStart: `Create \`agent/channels/novu.ts\`:
+
+\`\`\`ts
+// agent/channels/novu.ts
+import { createNovuAdapter } from "@novu/chat-sdk-adapter";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { chatSdkChannel } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "My Agent",
+  adapters: {
+    novu: createNovuAdapter(),
+  },
+  state: createMemoryState(),
+});
+
+bot.onNewMention(async (thread, message) => {
+  await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onSubscribedMessage(async (thread, message) => {
+  await send(message.text, { thread });
+});
+
+export default channel;
+\`\`\`
+
+See the [Novu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/novu) for supported events, capabilities, and credentials.`,
+    configure: `Run \`npx novu connect --runtime chat-sdk\` to authenticate Novu, choose a channel, and create the required environment variables. Novu manages provider credentials, identity, delivery, and conversation history across its supported channels. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+  },
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -350,7 +350,10 @@ export const sendblueLogo = (props: LogoProps) => (
 
 export const novuLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
-    <path d="M4 20V4h3.2L17 15.3V4h3v16h-3.1L7 8.6V20H4Z" fill="currentColor" />
+    <path
+      d="M18.48 9.62a.72.72 0 0 1-1.235.503L8.007.68A12 12 0 0 1 18.48 1.898V9.62Zm3.36-4.49v4.49c0 3.656-4.44 5.466-6.996 2.853L4.909 2.319A11.98 11.98 0 0 0 0 12c0 2.555.799 4.924 2.16 6.87v-4.465c0-3.657 4.44-5.467 6.996-2.854l9.922 10.14A11.98 11.98 0 0 0 24 12c0-2.555-.799-4.924-2.16-6.87ZM6.755 13.9l9.22 9.425A12 12 0 0 1 5.52 22.102v-7.697a.72.72 0 0 1 1.235-.504Z"
+      fill="currentColor"
+    />
   </svg>
 );
 

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -348,6 +348,12 @@ export const sendblueLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const novuLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M4 20V4h3.2L17 15.3V4h3v16h-3.1L7 8.6V20H4Z" fill="currentColor" />
+  </svg>
+);
+
 export const googlechatLogo = (props: LogoProps) => <SiGooglechat color="default" {...props} />;
 
 export const whatsappLogo = (props: LogoProps) => <SiWhatsapp color="default" {...props} />;
@@ -487,6 +493,7 @@ export const logos = {
   zernio: zernioLogo,
   velt: veltLogo,
   sendblue: sendblueLogo,
+  novu: novuLogo,
   googlechat: googlechatLogo,
   whatsapp: whatsappLogo,
   messenger: messengerLogo,

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -193,6 +193,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "chat-sdk-novu",
+    name: "Novu",
+    kind: "channel",
+    tagline: "Reach Slack, Teams, WhatsApp, Telegram, and email through Novu.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
## Summary
- add Novu to the integrations gallery
- document the vendor-official Chat SDK adapter setup
- include provider and supported-surface search keywords

<img width="967" height="932" alt="image" src="https://github.com/user-attachments/assets/75607e59-4d3b-4c05-aa09-6a334d160871" />

## Validation
- `pnpm fmt`
- `pnpm --filter @vercel/eve-catalog test`