### PR TITLE
feat(eve): attach user information to turn events

### DIFF
--- a/.changeset/tiny-turn-authors.md
+++ b/.changeset/tiny-turn-authors.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Include normalized authenticated user IDs on `turn.started` events and OpenTelemetry turn/model-call attributes so consumers can show durable per-turn authorship.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -37,7 +37,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | Event                     | Meaning                                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `session.started`         | A durable session was created.                                                                                   |
-| `turn.started`            | A new turn began.                                                                                                |
+| `turn.started`            | A new turn began. Includes an optional normalized user id for the authenticated caller.                          |
 | `message.received`        | An inbound user message was accepted; carries flattened text plus structured text/file parts.                    |
 | `step.started`            | A model step began.                                                                                              |
 | `actions.requested`       | The model requested one or more actions, including tool calls; calls stream before execution.                    |

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -37,7 +37,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | Event                     | Meaning                                                                                                          |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `session.started`         | A durable session was created.                                                                                   |
-| `turn.started`            | A new turn began. Includes an optional normalized user id for the authenticated caller.                          |
+| `turn.started`            | A new turn began.                                                                                                |
 | `message.received`        | An inbound user message was accepted; carries flattened text plus structured text/file parts.                    |
 | `step.started`            | A model step began.                                                                                              |
 | `actions.requested`       | The model requested one or more actions, including tool calls; calls stream before execution.                    |

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -115,6 +115,8 @@ ai.eve.turn  {eve.session.id}
 
 eve creates the `ai.eve.turn` parent span per turn and passes enriched telemetry to the AI SDK so model calls and tool executions are traced automatically. Session, turn, step, and channel context is injected as the framework half of the runtime context (`eve.version`, `eve.session.id`, `eve.environment`, `eve.turn.id`, `eve.turn.sequence`, `eve.step.index`, `eve.channel.kind`) and rides onto the spans alongside any values your `events["step.started"]` callback returns under `runtimeContext`.
 
+When the current caller is an authenticated user, eve adds `eve.user.id` to the turn span and model-call runtime context. The same normalized user id is persisted on `turn.started.data.user` for durable turn-level authorship. Service, runtime, bot, anonymous, and unknown principals are omitted, and arbitrary auth attributes are never exported.
+
 ## Workflow run tags
 
 Separately from OpenTelemetry, eve tags every workflow run with reserved `$eve.*` attributes. These live on the Vercel Workflow run, queryable in the Workflow dashboard, not on OTel spans, and you do not configure them: they are framework-owned and emitted automatically on every session, turn, and subagent run, whether or not an `instrumentation.ts` file is present. Authored code cannot set or override the `$eve.` namespace.

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v1.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v1.ts
@@ -1,0 +1,9 @@
+import { defineDynamic } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started"() {
+      return null;
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v1.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v1.ts
@@ -1,0 +1,9 @@
+import { defineDynamic } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started"() {
+      return null;
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v3.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v3.ts
@@ -1,0 +1,9 @@
+import { defineDynamic } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started"() {
+      return null;
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v2.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v2.ts
@@ -1,0 +1,9 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "turn.started"(event) {
+      console.info(event.data.turnId, event.data.sequence);
+    },
+  },
+});

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v2.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v2.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 2,
+  "sha256": "db4ceef6a53d7700aaf02bf33f1a19733cab2f41e7952b05664dd52c2a7f6ce5",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v2.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v2.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 2,
+  "sha256": "db4ceef6a53d7700aaf02bf33f1a19733cab2f41e7952b05664dd52c2a7f6ce5",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v4.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v4.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 4,
+  "sha256": "03468cf5f6dd0bf4d37ad3a5b16edd03e5565b3ae83266733add8960897b7163",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v3.json
+++ b/packages/eve/extension-contracts/reports/hook/v3.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 3,
+  "sha256": "48a62424bc279d7ece88bb32ab49dc855c06754ea86c9a8d5486d8120fe5b3e1",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,13 +22,13 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: { current: 2, supported: [1, 2], dropped: {} },
-  dynamicTool: { current: 3, supported: [1, 2, 3], dropped: {} },
+  dynamicTool: { current: 4, supported: [1, 2, 3, 4], dropped: {} },
   connection: { current: 2, supported: [1, 2], dropped: {} },
-  hook: { current: 2, supported: [1, 2], dropped: {} },
+  hook: { current: 3, supported: [1, 2, 3], dropped: {} },
   skill: { current: 1, supported: [1], dropped: {} },
-  dynamicSkill: { current: 1, supported: [1], dropped: {} },
+  dynamicSkill: { current: 2, supported: [1, 2], dropped: {} },
   instructions: { current: 1, supported: [1], dropped: {} },
-  dynamicInstructions: { current: 1, supported: [1], dropped: {} },
+  dynamicInstructions: { current: 2, supported: [1, 2], dropped: {} },
   config: { current: 1, supported: [1], dropped: {} },
   state: { current: 2, supported: [1, 2], dropped: {} },
 } as const satisfies Record<string, ExtensionCapabilityContract>;

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   emitStreamContent,
+  emitTurnPreamble,
   getHarnessEmissionState,
   type HarnessEmissionState,
   setHarnessEmissionState,
@@ -123,6 +124,29 @@ describe("setHarnessEmissionState", () => {
     const retrieved = getHarnessEmissionState(session.state);
 
     expect(retrieved).toEqual(state);
+  });
+});
+
+describe("emitTurnPreamble", () => {
+  it("attaches the current user snapshot to turn.started", async () => {
+    const emit = createEmitStub();
+
+    await emitTurnPreamble(
+      emit,
+      { message: "hello" },
+      { sequence: 2, sessionStarted: true, stepIndex: 0, turnId: "" },
+      undefined,
+      { id: "slack:T1:U1" },
+    );
+
+    expect(emit).toHaveBeenNthCalledWith(1, {
+      data: {
+        sequence: 2,
+        turnId: "turn_2",
+        user: { id: "slack:T1:U1" },
+      },
+      type: "turn.started",
+    });
   });
 });
 

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -10,7 +10,11 @@ import type {
 type ToolResponsePart = Extract<ModelMessage, { role: "tool" }>["content"][number];
 type InlineToolResultPart = Extract<ToolResponsePart, { type: "tool-result" }>;
 
-import type { AssistantStepFinishReason, RuntimeIdentity } from "#protocol/message.js";
+import type {
+  AssistantStepFinishReason,
+  RuntimeIdentity,
+  TurnUserIdentity,
+} from "#protocol/message.js";
 import {
   createActionsRequestedEvent,
   createActionResultEvent,
@@ -140,6 +144,7 @@ export async function emitTurnPreamble(
   input: StepInput,
   state: HarnessEmissionState,
   runtimeIdentity?: RuntimeIdentity,
+  user?: TurnUserIdentity,
 ): Promise<HarnessEmissionState> {
   const turnId = `turn_${state.sequence}`;
 
@@ -147,7 +152,7 @@ export async function emitTurnPreamble(
     await emitFn(createSessionStartedEvent({ runtime: runtimeIdentity }));
   }
 
-  await emitFn(createTurnStartedEvent({ sequence: state.sequence, turnId }));
+  await emitFn(createTurnStartedEvent({ sequence: state.sequence, turnId, user }));
 
   if (input.message !== undefined) {
     await emitFn(

--- a/packages/eve/src/harness/instrumentation-runtime-context.test.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.test.ts
@@ -68,6 +68,33 @@ describe("buildTelemetryRuntimeContext", () => {
     expect(build()).toEqual(FRAMEWORK_KEYS);
   });
 
+  it("emits current user identity without arbitrary auth attributes", () => {
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, {
+      attributes: { email: "ada@example.com" },
+      authenticator: "slack-webhook",
+      principalId: "slack:T1:U1",
+      principalType: "user",
+    });
+
+    expect(contextStorage.run(ctx, () => build())).toEqual({
+      ...FRAMEWORK_KEYS,
+      "eve.user.id": "slack:T1:U1",
+    });
+  });
+
+  it("omits service principals from user identity", () => {
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, {
+      attributes: {},
+      authenticator: "slack-webhook",
+      principalId: "slack:T1:bot:B1",
+      principalType: "service",
+    });
+
+    expect(contextStorage.run(ctx, () => build())).toEqual(FRAMEWORK_KEYS);
+  });
+
   it("merges authored step.started runtime context beneath framework keys", () => {
     const runtimeContext = build({
       authored: { events: { "step.started": () => ({ runtimeContext: { team: "platform" } }) } },

--- a/packages/eve/src/harness/instrumentation-runtime-context.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.ts
@@ -11,6 +11,7 @@ import {
 } from "#context/keys.js";
 import type { HarnessEmissionState } from "#harness/emission.js";
 import type { HarnessSession } from "#harness/types.js";
+import { toObservableUserIdentity } from "#runtime/sessions/observable-user.js";
 import {
   normalizeInstrumentationChannelKind,
   resolveInstrumentationProjection,
@@ -55,8 +56,9 @@ export function buildTelemetryRuntimeContext(
   const authoredRuntimeContext = resolveStepStartedRuntimeContext(input);
   const context = contextStorage.getStore();
   const projection = context?.get(ChannelInstrumentationKey);
+  const currentUser = toObservableUserIdentity(context?.get(AuthKey));
 
-  return {
+  const runtimeContext: Record<string, unknown> = {
     ...authoredRuntimeContext,
     "eve.channel.kind": normalizeInstrumentationChannelKind(projection?.kind),
     "eve.environment": input.environment,
@@ -66,6 +68,10 @@ export function buildTelemetryRuntimeContext(
     "eve.turn.sequence": String(input.emissionState.sequence),
     "eve.version": input.eveVersion,
   };
+  if (currentUser !== undefined) {
+    runtimeContext["eve.user.id"] = currentUser.id;
+  }
+  return runtimeContext;
 }
 
 function buildInstrumentationStepStartedInput(

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -8824,6 +8824,45 @@ describe("createToolLoopHarness", () => {
       expect(agentCall?.telemetry?.isEnabled).toBe(true);
     });
 
+    it("emits current user identity on turn.started and model runtime context", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+
+      mockGetInstrumentationConfig.mockReturnValue({});
+      const { emit, events } = createEventCollector();
+      const ctx = new ContextContainer();
+      ctx.set(AuthKey, {
+        attributes: { email: "ada@example.com" },
+        authenticator: "slack-webhook",
+        principalId: "slack:T1:U1",
+        principalType: "user",
+      });
+
+      await contextStorage.run(ctx, () =>
+        createToolLoopHarness(createTestConfig("conversation", emit))(createTestSession(), {
+          message: "hi",
+        }),
+      );
+
+      const turnStarted = events.find((event) => event.type === "turn.started");
+      expect(turnStarted).toMatchObject({
+        data: { user: { id: "slack:T1:U1" } },
+      });
+      expect(JSON.stringify(turnStarted)).not.toContain("ada@example.com");
+
+      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
+        runtimeContext?: Record<string, unknown>;
+      };
+      expect(agentCall.runtimeContext).toMatchObject({
+        "eve.user.id": "slack:T1:U1",
+      });
+    });
+
     it("merges step-started runtime context before emitting step.started", async () => {
       setupMockAgent({
         finishReason: "stop",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -85,6 +85,7 @@ import {
   enforceSessionTokenLimit,
 } from "#harness/session-limit-enforcement.js";
 import { setEveAttributes } from "#runtime/attributes/emit.js";
+import { toObservableUserIdentity } from "#runtime/sessions/observable-user.js";
 import {
   advanceStep,
   emitFailedStep,
@@ -516,6 +517,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     turnSpan?: Span,
   ): Promise<StepResult> {
     let session = initialSession;
+    const currentUser = toObservableUserIdentity(contextStorage.getStore()?.get(AuthKey));
+    if (turnSpan && currentUser !== undefined) {
+      turnSpan.setAttribute("eve.user.id", currentUser.id);
+    }
 
     // Store the turn span context on the session so continuation steps
     // can restore the parent trace across step boundaries.
@@ -572,7 +577,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           preambleStepInput ?? {},
           emissionState,
           config.runtimeIdentity,
+          currentUser,
         );
+        turnSpan?.setAttribute("eve.turn.id", emissionState.turnId);
         emissionState = await emitTurnEpilogue(
           emit,
           emissionState,
@@ -614,12 +621,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         preambleStepInput ?? {},
         emissionState,
         config.runtimeIdentity,
+        currentUser,
       );
       session = setHarnessEmissionState(session, emissionState);
 
-      if (turnSpan) {
-        turnSpan.setAttribute("eve.turn.id", emissionState.turnId);
-      }
+      turnSpan?.setAttribute("eve.turn.id", emissionState.turnId);
     }
 
     session = pending.session;

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -13,6 +13,7 @@ import {
   createSessionWaitingEvent,
   createStepStartedEvent,
   createTurnCancelledEvent,
+  createTurnStartedEvent,
   encodeMessageStreamEvent,
   timestampHandleMessageStreamEvent,
 } from "#protocol/message.js";
@@ -20,7 +21,7 @@ import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 
 describe("message stream protocol", () => {
   it("pins the stream version for timed session events", () => {
-    expect(EVE_MESSAGE_STREAM_VERSION).toBe("19");
+    expect(EVE_MESSAGE_STREAM_VERSION).toBe("20");
   });
 
   it("publishes the channel-local continuation token on session.waiting", () => {
@@ -30,6 +31,27 @@ describe("message stream protocol", () => {
         wait: "next-user-message",
       },
       type: "session.waiting",
+    });
+  });
+
+  it("creates turn.started events with optional user identity", () => {
+    expect(
+      createTurnStartedEvent({
+        sequence: 2,
+        turnId: "turn_2",
+        user: { id: "slack:T1:U1" },
+      }),
+    ).toEqual({
+      data: {
+        sequence: 2,
+        turnId: "turn_2",
+        user: { id: "slack:T1:U1" },
+      },
+      type: "turn.started",
+    });
+    expect(createTurnStartedEvent({ sequence: 2, turnId: "turn_2" })).toEqual({
+      data: { sequence: 2, turnId: "turn_2" },
+      type: "turn.started",
     });
   });
 

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -18,7 +18,7 @@ export const EVE_STREAM_TAIL_INDEX_HEADER = "x-eve-stream-tail-index";
 export const EVE_STREAM_VERSION_HEADER = "x-eve-stream-version";
 export const EVE_MESSAGE_STREAM_CONTENT_TYPE = "application/x-ndjson; charset=utf-8";
 export const EVE_MESSAGE_STREAM_FORMAT = "ndjson";
-export const EVE_MESSAGE_STREAM_VERSION = "19";
+export const EVE_MESSAGE_STREAM_VERSION = "20";
 
 /**
  * eve-owned finish reason for one completed assistant step.
@@ -152,6 +152,12 @@ export interface SessionStartedStreamEvent {
   type: "session.started";
 }
 
+/** Authenticated user identity attached to a turn. */
+export interface TurnUserIdentity {
+  /** Stable canonical identity key. */
+  readonly id: string;
+}
+
 /**
  * Stream event emitted when one runtime turn starts.
  */
@@ -159,6 +165,7 @@ export interface TurnStartedStreamEvent {
   data: {
     sequence: number;
     turnId: string;
+    user?: TurnUserIdentity;
   };
   type: "turn.started";
 }
@@ -688,12 +695,17 @@ export function createSessionStartedEvent(input?: {
 export function createTurnStartedEvent(input: {
   readonly sequence: number;
   readonly turnId: string;
+  readonly user?: TurnUserIdentity;
 }): TurnStartedStreamEvent {
+  const data: TurnStartedStreamEvent["data"] = {
+    sequence: input.sequence,
+    turnId: input.turnId,
+  };
+  if (input.user !== undefined) {
+    data.user = input.user;
+  }
   return {
-    data: {
-      sequence: input.sequence,
-      turnId: input.turnId,
-    },
+    data,
     type: "turn.started",
   };
 }


### PR DESCRIPTION
### Description

Adds the authenticated user's stable ID to each `turn.started` event and to OpenTelemetry turn/model-call attributes as `eve.user.id`. This enables tracking per-turn authorship, including shared conversations where later turns may come from different users.

### Testing

-  Unit tests for `turn.started` event 
- Validated events were modified in deployed Slack agent
