### PR TITLE
feat(eve): fetch, include displayname with session workflow tags

### DIFF
--- a/.changeset/tiny-turn-authors.md
+++ b/.changeset/tiny-turn-authors.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Include normalized authenticated user IDs on `turn.started` events and OpenTelemetry turn/model-call attributes so consumers can show durable per-turn authorship.
+Include normalized authenticated user IDs and optional display names in session attributes, `turn.started` events, and OpenTelemetry turn/model-call attributes. Built-in message channels provide presentation names when available, with accepted Slack messages using cached profile lookup when webhook payloads omit the name.

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -300,7 +300,7 @@ export default eveChannel({
 });
 ```
 
-Keep `principalId` stable for the same person, and include an `issuer` when the same app may accept users from multiple identity providers. The connection token cache keys user credentials by issuer and principal id so two providers cannot accidentally share a grant.
+Keep `principalId` stable for the same person, and include an `issuer` when the same app may accept users from multiple identity providers. The connection token cache keys user credentials by issuer and principal id so two providers cannot accidentally share a grant. To give observability UIs a mutable presentation label, set a string `display_name` auth attribute. eve may also use standard `name` or `preferred_username` attributes when `display_name` is absent; none of these labels are identity keys.
 
 Built-in platform channels that identify a human sender, such as Slack, Discord, Teams, Telegram, Twilio, Linear, and GitHub, attach a user principal for that sender by default. A Slack mention, DM, or button click can therefore authorize a user-scoped connection for the Slack user who sent it without adding a separate browser-session auth function.
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -115,7 +115,7 @@ ai.eve.turn  {eve.session.id}
 
 eve creates the `ai.eve.turn` parent span per turn and passes enriched telemetry to the AI SDK so model calls and tool executions are traced automatically. Session, turn, step, and channel context is injected as the framework half of the runtime context (`eve.version`, `eve.session.id`, `eve.environment`, `eve.turn.id`, `eve.turn.sequence`, `eve.step.index`, `eve.channel.kind`) and rides onto the spans alongside any values your `events["step.started"]` callback returns under `runtimeContext`.
 
-When the current caller is an authenticated user, eve adds `eve.user.id` to the turn span and model-call runtime context. The same normalized user id is persisted on `turn.started.data.user` for durable turn-level authorship. Service, runtime, bot, anonymous, and unknown principals are omitted, and arbitrary auth attributes are never exported.
+When the current caller is an authenticated user, eve adds `eve.user.id` and optional `eve.user.name` to the turn span and model-call runtime context. The same normalized identity is persisted on `turn.started.data.user` for durable turn-level authorship. Service, runtime, bot, anonymous, and unknown principals are omitted, and arbitrary auth attributes are never exported. Names are mutable presentation snapshots; use the id as the canonical key.
 
 ## Workflow run tags
 
@@ -132,6 +132,7 @@ Structural tags describe each run's place in the tree:
 - `$eve.trigger`: the channel kind that started the run
 - `$eve.title`: truncated title derived from the first user message
 - `$eve.user_id`: stable id of the authenticated user who started a top-level session (session runs only)
+- `$eve.user_name`: optional, mutable presentation label for that user (session runs only)
 
 Per-turn usage tags are written on each step of a turn, accumulating cumulative totals (last write wins):
 

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v2.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v2.json
@@ -2,6 +2,6 @@
   "kind": "eve-extension-capability-contract",
   "capability": "dynamicInstructions",
   "epoch": 2,
-  "sha256": "db4ceef6a53d7700aaf02bf33f1a19733cab2f41e7952b05664dd52c2a7f6ce5",
+  "sha256": "728726c51b9e187e02d2df06ad6c3089133ec752659753702b79e970fbd02b00",
   "exports": ["defineDynamic"]
 }

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v2.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v2.json
@@ -2,6 +2,6 @@
   "kind": "eve-extension-capability-contract",
   "capability": "dynamicSkill",
   "epoch": 2,
-  "sha256": "db4ceef6a53d7700aaf02bf33f1a19733cab2f41e7952b05664dd52c2a7f6ce5",
+  "sha256": "728726c51b9e187e02d2df06ad6c3089133ec752659753702b79e970fbd02b00",
   "exports": ["defineDynamic"]
 }

--- a/packages/eve/extension-contracts/reports/dynamicTool/v4.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v4.json
@@ -2,7 +2,7 @@
   "kind": "eve-extension-capability-contract",
   "capability": "dynamicTool",
   "epoch": 4,
-  "sha256": "03468cf5f6dd0bf4d37ad3a5b16edd03e5565b3ae83266733add8960897b7163",
+  "sha256": "be786991f3cdc0d5f0f3bdeb8118e003d5890bb7487e3206ed3c499bba153747",
   "exports": [
     "DynamicToolEntry",
     "DynamicToolEvents",

--- a/packages/eve/extension-contracts/reports/hook/v3.json
+++ b/packages/eve/extension-contracts/reports/hook/v3.json
@@ -2,6 +2,6 @@
   "kind": "eve-extension-capability-contract",
   "capability": "hook",
   "epoch": 3,
-  "sha256": "48a62424bc279d7ece88bb32ab49dc855c06754ea86c9a8d5486d8120fe5b3e1",
+  "sha256": "b3436d628cee2ad404df354691c02fc78e370a4b85f1401570b0cfc0ee13dc84",
   "exports": ["defineHook"]
 }

--- a/packages/eve/src/execution/eve-workflow-attributes.test.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.test.ts
@@ -15,7 +15,7 @@ import {
 import { AuthKey, ChannelRequestIdKey, InitiatorAuthKey } from "#context/keys.js";
 
 const userAuth = {
-  attributes: { email: "ada@example.com" },
+  attributes: { display_name: "Ada Lovelace", email: "ada@example.com" },
   authenticator: "slack-webhook",
   principalId: "slack:T1:U1",
   principalType: "user",
@@ -193,6 +193,7 @@ describe("buildSessionAttributes", () => {
 
     expect(attrs).toMatchObject({
       "$eve.user_id": "slack:T1:U1",
+      "$eve.user_name": "Ada Lovelace",
     });
     expect(JSON.stringify(attrs)).not.toContain("ada@example.com");
   });

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -23,6 +23,7 @@
  * - `$eve.trigger`      — channel adapter kind (session/subagent rows)
  * - `$eve.title`        — truncated session title from the first user message
  * - `$eve.user_id`      — stable id of the user starting a top-level session
+ * - `$eve.user_name`    — optional display label for that user
  * - `$eve.channel_request_id` — inbound channel request id
  */
 
@@ -134,18 +135,30 @@ export function readChannelRequestId(
   return isNonEmptyString(channelRequestId) ? channelRequestId : undefined;
 }
 
-function readInitiatingUserId(serializedContext: Record<string, unknown>): string | undefined {
+function readInitiatingUserAuth(
+  serializedContext: Record<string, unknown>,
+): SessionAuthContext | null | undefined {
   const initiator = serializedContext[InitiatorAuthKey.name] as
     | SessionAuthContext
     | null
     | undefined;
-  const auth =
-    initiator === undefined
-      ? (serializedContext[AuthKey.name] as SessionAuthContext | null | undefined)
-      : initiator;
-  return auth?.principalType === "user" && auth.principalId.length > 0
-    ? auth.principalId
-    : undefined;
+  return initiator === undefined
+    ? (serializedContext[AuthKey.name] as SessionAuthContext | null | undefined)
+    : initiator;
+}
+
+function buildUserAttributes(
+  auth: SessionAuthContext | null | undefined,
+): Record<string, EveAttributeValue> {
+  const user = toObservableUserIdentity(auth);
+  if (user === undefined) return {};
+  const attributes: Record<string, EveAttributeValue> = {
+    "$eve.user_id": user.id,
+  };
+  if (user.displayName !== undefined) {
+    attributes["$eve.user_name"] = user.displayName;
+  }
+  return attributes;
 }
 
 /**
@@ -224,8 +237,8 @@ export function buildSessionAttributes(input: {
   readonly serializedContext: Record<string, unknown>;
 }): Record<string, EveAttributeValue> {
   return {
+    ...buildUserAttributes(readInitiatingUserAuth(input.serializedContext)),
     "$eve.channel_request_id": readChannelRequestId(input.serializedContext),
-    "$eve.user_id": readInitiatingUserId(input.serializedContext),
     "$eve.type": "session",
     "$eve.trigger": readChannelKind(input.serializedContext),
     "$eve.title": deriveSessionTitle(input.inputMessage),

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -136,14 +136,14 @@ describe("emitTurnPreamble", () => {
       { message: "hello" },
       { sequence: 2, sessionStarted: true, stepIndex: 0, turnId: "" },
       undefined,
-      { id: "slack:T1:U1" },
+      { id: "slack:T1:U1", name: "Ada Lovelace" },
     );
 
     expect(emit).toHaveBeenNthCalledWith(1, {
       data: {
         sequence: 2,
         turnId: "turn_2",
-        user: { id: "slack:T1:U1" },
+        user: { id: "slack:T1:U1", name: "Ada Lovelace" },
       },
       type: "turn.started",
     });

--- a/packages/eve/src/harness/instrumentation-runtime-context.test.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.test.ts
@@ -71,7 +71,7 @@ describe("buildTelemetryRuntimeContext", () => {
   it("emits current user identity without arbitrary auth attributes", () => {
     const ctx = new ContextContainer();
     ctx.set(AuthKey, {
-      attributes: { email: "ada@example.com" },
+      attributes: { display_name: "Ada Lovelace", email: "ada@example.com" },
       authenticator: "slack-webhook",
       principalId: "slack:T1:U1",
       principalType: "user",
@@ -80,6 +80,7 @@ describe("buildTelemetryRuntimeContext", () => {
     expect(contextStorage.run(ctx, () => build())).toEqual({
       ...FRAMEWORK_KEYS,
       "eve.user.id": "slack:T1:U1",
+      "eve.user.name": "Ada Lovelace",
     });
   });
 

--- a/packages/eve/src/harness/instrumentation-runtime-context.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.ts
@@ -70,6 +70,9 @@ export function buildTelemetryRuntimeContext(
   };
   if (currentUser !== undefined) {
     runtimeContext["eve.user.id"] = currentUser.id;
+    if (currentUser.displayName !== undefined) {
+      runtimeContext["eve.user.name"] = currentUser.displayName;
+    }
   }
   return runtimeContext;
 }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -8837,7 +8837,7 @@ describe("createToolLoopHarness", () => {
       const { emit, events } = createEventCollector();
       const ctx = new ContextContainer();
       ctx.set(AuthKey, {
-        attributes: { email: "ada@example.com" },
+        attributes: { display_name: "Ada Lovelace", email: "ada@example.com" },
         authenticator: "slack-webhook",
         principalId: "slack:T1:U1",
         principalType: "user",
@@ -8851,7 +8851,7 @@ describe("createToolLoopHarness", () => {
 
       const turnStarted = events.find((event) => event.type === "turn.started");
       expect(turnStarted).toMatchObject({
-        data: { user: { id: "slack:T1:U1" } },
+        data: { user: { id: "slack:T1:U1", name: "Ada Lovelace" } },
       });
       expect(JSON.stringify(turnStarted)).not.toContain("ada@example.com");
 
@@ -8860,6 +8860,7 @@ describe("createToolLoopHarness", () => {
       };
       expect(agentCall.runtimeContext).toMatchObject({
         "eve.user.id": "slack:T1:U1",
+        "eve.user.name": "Ada Lovelace",
       });
     });
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -520,6 +520,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const currentUser = toObservableUserIdentity(contextStorage.getStore()?.get(AuthKey));
     if (turnSpan && currentUser !== undefined) {
       turnSpan.setAttribute("eve.user.id", currentUser.id);
+      if (currentUser.displayName !== undefined) {
+        turnSpan.setAttribute("eve.user.name", currentUser.displayName);
+      }
     }
 
     // Store the turn span context on the session so continuation steps
@@ -577,7 +580,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           preambleStepInput ?? {},
           emissionState,
           config.runtimeIdentity,
-          currentUser,
+          currentUser === undefined
+            ? undefined
+            : { id: currentUser.id, name: currentUser.displayName },
         );
         turnSpan?.setAttribute("eve.turn.id", emissionState.turnId);
         emissionState = await emitTurnEpilogue(
@@ -621,7 +626,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         preambleStepInput ?? {},
         emissionState,
         config.runtimeIdentity,
-        currentUser,
+        currentUser === undefined
+          ? undefined
+          : { id: currentUser.id, name: currentUser.displayName },
       );
       session = setHarnessEmissionState(session, emissionState);
 

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -39,13 +39,13 @@ describe("message stream protocol", () => {
       createTurnStartedEvent({
         sequence: 2,
         turnId: "turn_2",
-        user: { id: "slack:T1:U1" },
+        user: { id: "slack:T1:U1", name: "Ada Lovelace" },
       }),
     ).toEqual({
       data: {
         sequence: 2,
         turnId: "turn_2",
-        user: { id: "slack:T1:U1" },
+        user: { id: "slack:T1:U1", name: "Ada Lovelace" },
       },
       type: "turn.started",
     });

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -152,10 +152,12 @@ export interface SessionStartedStreamEvent {
   type: "session.started";
 }
 
-/** Authenticated user identity attached to a turn. */
+/** Authenticated user snapshot attached to a turn. */
 export interface TurnUserIdentity {
   /** Stable canonical identity key. */
   readonly id: string;
+  /** Mutable presentation label. Never use as an identity key. */
+  readonly name?: string;
 }
 
 /**

--- a/packages/eve/src/public/channels/slack/auth.ts
+++ b/packages/eve/src/public/channels/slack/auth.ts
@@ -39,6 +39,7 @@ export function buildSlackAuthContext(input: SlackAuthContextInput): SessionAuth
   };
   if (input.userName) attributes.user_name = input.userName;
   if (input.fullName) attributes.full_name = input.fullName;
+  if (input.fullName ?? input.userName) attributes.display_name = input.fullName ?? input.userName!;
   if (input.teamId) attributes.team_id = input.teamId;
 
   return {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -24,6 +24,7 @@ import {
   SLACK_SECTION_TEXT_MAX_LENGTH,
 } from "#public/channels/slack/limits.js";
 import { defaultSlackAuth } from "#public/channels/slack/index.js";
+import { clearSlackUserProfileCacheForTests } from "#public/channels/slack/user-profile.js";
 import {
   constrainAuthorizationRequired,
   slackChannel,
@@ -1034,6 +1035,7 @@ describe("slackChannel() inbound mention pipeline", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    clearSlackUserProfileCacheForTests();
     process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
     fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
@@ -1262,6 +1264,54 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(message).toContain("sender_id: U01");
     expect(message).toContain("message_ts:");
     expect(options.title).toBe("hello");
+  });
+
+  it("enriches accepted Slack user auth with a cached profile lookup", async () => {
+    fetchMock.mockImplementation(async (request: string | URL | Request) => {
+      if (String(request).includes("users.info")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: {
+              name: "ada",
+              profile: { display_name: "Ada L.", real_name: "Ada Lovelace" },
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
+
+    const first = await firePost(channel, buildSignedRequest(buildMentionBody({ ts: "1.1" })));
+    const second = await firePost(channel, buildSignedRequest(buildMentionBody({ ts: "1.2" })));
+
+    expect(first.send.mock.calls[0]?.[1]).toMatchObject({
+      auth: { attributes: { display_name: "Ada L." } },
+    });
+    expect(second.send.mock.calls[0]?.[1]).toMatchObject({
+      auth: { attributes: { display_name: "Ada L." } },
+    });
+    expect(
+      fetchMock.mock.calls.filter(([request]) => String(request).includes("users.info")),
+    ).toHaveLength(1);
+  });
+
+  it("does not look up profiles for ignored messages", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onAppMention: () => null,
+    });
+
+    const { body } = buildMentionBody();
+    await firePost(channel, buildSignedRequest({ body }));
+
+    expect(fetchMock.mock.calls.some(([request]) => String(request).includes("users.info"))).toBe(
+      false,
+    );
   });
 
   it("uses only this app's reply as the incremental thread context boundary", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -48,6 +48,7 @@ import {
   type LoadThreadContextMessagesOptions,
 } from "#public/channels/slack/thread.js";
 import { slackUserIdFromAuthContext } from "#public/channels/slack/auth.js";
+import { enrichSlackUserAuth } from "#public/channels/slack/user-profile.js";
 import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#public/channels/slack/constants.js";
 import { handleInteractionPost } from "#public/channels/slack/interactions.js";
 import {
@@ -1167,6 +1168,11 @@ async function deliverSlackMessage(input: {
   // This runs in the webhook's `waitUntil` task; an unguarded throw would
   // reject silently into the dispatch `allSettled` ("no response, no logs").
   try {
+    const enrichedAuthPromise = enrichSlackUserAuth({
+      auth: input.result.auth,
+      botToken: input.credentials?.botToken,
+      teamId: message.teamId,
+    });
     const priorMessages =
       input.threadContext === undefined
         ? []
@@ -1193,12 +1199,14 @@ async function deliverSlackMessage(input: {
 
     const channelContext = input.result.context ?? [];
 
+    const auth = await enrichedAuthPromise;
+
     await input.send(
       channelContext.length === 0
         ? { message: turnMessage }
         : { message: turnMessage, context: channelContext },
       {
-        auth: input.result.auth,
+        auth,
         continuationToken: slackContinuationToken(message.channelId, message.threadTs),
         state: {
           channelId: message.channelId,

--- a/packages/eve/src/public/channels/slack/user-profile.ts
+++ b/packages/eve/src/public/channels/slack/user-profile.ts
@@ -1,0 +1,116 @@
+import type { SessionAuthContext } from "#channel/types.js";
+import { callSlackApi, type SlackBotToken } from "#public/channels/slack/api.js";
+import { isObject } from "#shared/guards.js";
+
+const SUCCESS_TTL_MS = 15 * 60 * 1_000;
+const FAILURE_TTL_MS = 60 * 1_000;
+
+interface CachedDisplayName {
+  readonly displayName: string | undefined;
+  readonly expiresAt: number;
+}
+
+const profileCache = new Map<string, CachedDisplayName>();
+const pendingProfiles = new Map<string, Promise<string | undefined>>();
+
+/** Clears process-local Slack profile state between tests. */
+export function clearSlackUserProfileCacheForTests(): void {
+  profileCache.clear();
+  pendingProfiles.clear();
+}
+
+/**
+ * Best-effort enrichment for accepted Slack webhook auth. Profile lookup starts
+ * only after the authored inbound handler accepts the message, and warm-process
+ * results are cached by workspace and user.
+ */
+export async function enrichSlackUserAuth(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly botToken: SlackBotToken | undefined;
+  readonly teamId: string | undefined;
+}): Promise<SessionAuthContext | null> {
+  const { auth } = input;
+  if (
+    auth?.authenticator !== "slack-webhook" ||
+    auth.principalType !== "user" ||
+    typeof auth.attributes.display_name === "string"
+  ) {
+    return auth;
+  }
+
+  const userId = auth.attributes.user_id;
+  if (typeof userId !== "string" || userId.length === 0) return auth;
+
+  const displayName = await resolveSlackUserDisplayName({
+    botToken: input.botToken,
+    teamId: input.teamId,
+    userId,
+  });
+  if (displayName === undefined) return auth;
+
+  return {
+    ...auth,
+    attributes: {
+      ...auth.attributes,
+      display_name: displayName,
+    },
+  };
+}
+
+async function resolveSlackUserDisplayName(input: {
+  readonly botToken: SlackBotToken | undefined;
+  readonly teamId: string | undefined;
+  readonly userId: string;
+}): Promise<string | undefined> {
+  const key = `${input.teamId ?? "slack"}:${input.userId}`;
+  const cached = profileCache.get(key);
+  if (cached !== undefined && cached.expiresAt > Date.now()) return cached.displayName;
+
+  const pending = pendingProfiles.get(key);
+  if (pending !== undefined) return pending;
+
+  const request = fetchSlackUserDisplayName(input)
+    .then((displayName) => {
+      profileCache.set(key, {
+        displayName,
+        expiresAt: Date.now() + (displayName === undefined ? FAILURE_TTL_MS : SUCCESS_TTL_MS),
+      });
+      return displayName;
+    })
+    .finally(() => pendingProfiles.delete(key));
+  pendingProfiles.set(key, request);
+  return request;
+}
+
+async function fetchSlackUserDisplayName(input: {
+  readonly botToken: SlackBotToken | undefined;
+  readonly userId: string;
+}): Promise<string | undefined> {
+  try {
+    const response = await callSlackApi({
+      body: { user: input.userId },
+      botToken: input.botToken,
+      operation: "users.info",
+    });
+    if (response.ok !== true || !isObject(response.user)) return undefined;
+
+    const profile = isObject(response.user.profile) ? response.user.profile : undefined;
+    return firstNonEmptyString(
+      profile?.display_name,
+      profile?.real_name,
+      response.user.real_name,
+      response.user.name,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return undefined;
+}

--- a/packages/eve/src/runtime/sessions/observable-user.test.ts
+++ b/packages/eve/src/runtime/sessions/observable-user.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { toObservableUserIdentity } from "#runtime/sessions/observable-user.js";
+
+describe("toObservableUserIdentity", () => {
+  it("projects the stable id and optional display name", () => {
+    expect(
+      toObservableUserIdentity({
+        attributes: { display_name: "Ada Lovelace", email: "ada@example.com" },
+        authenticator: "slack-webhook",
+        issuer: "slack:T1",
+        principalId: "slack:T1:U1",
+        principalType: "user",
+      }),
+    ).toEqual({ displayName: "Ada Lovelace", id: "slack:T1:U1" });
+  });
+
+  it("omits non-user and missing identities", () => {
+    expect(toObservableUserIdentity(null)).toBeUndefined();
+    expect(
+      toObservableUserIdentity({
+        attributes: {},
+        authenticator: "app",
+        principalId: "eve:app",
+        principalType: "runtime",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/eve/src/runtime/sessions/observable-user.ts
+++ b/packages/eve/src/runtime/sessions/observable-user.ts
@@ -1,0 +1,27 @@
+import type { SessionAuthContext } from "#channel/types.js";
+
+/** User identity safe for framework-owned observability projections. */
+export interface ObservableUserIdentity {
+  readonly displayName?: string;
+  readonly id: string;
+}
+
+/**
+ * Projects authenticated user identity without exposing arbitrary auth claims
+ * or attributes. Non-user principals are intentionally omitted.
+ */
+export function toObservableUserIdentity(
+  auth: SessionAuthContext | null | undefined,
+): ObservableUserIdentity | undefined {
+  if (auth?.principalType !== "user" || auth.principalId.length === 0) {
+    return undefined;
+  }
+
+  const displayName =
+    auth.attributes.display_name ?? auth.attributes.name ?? auth.attributes.preferred_username;
+  return {
+    displayName:
+      typeof displayName === "string" && displayName.length > 0 ? displayName : undefined,
+    id: auth.principalId,
+  };
+}


### PR DESCRIPTION
### Description

Anticipating a desire to display users in the agent runs UX, this PR explores adding display names alongside the canonical user IDs introduced earlier in this stack. Display names flow through session workflow attributes, `turn.started` events, and OpenTelemetry attributes.

For Slack messages, we perform a `users.info` lookup after the message is accepted, since incoming events don't contain user info. Results are cached in memory per workspace/user.

## Test Plan

- Unit tests
- Tested in deployed Slack agent