### PR TITLE
fix(eve): scope workflow tsconfig to package

### DIFF
--- a/.changeset/tidy-tools-ignore-host-tsconfig.md
+++ b/.changeset/tidy-tools-ignore-host-tsconfig.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep workflow bundling scoped to eve's package-local TypeScript configuration instead of inheriting an unrelated host workspace config.

--- a/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
@@ -27,6 +27,10 @@ class InspectableWorkflowBundleBuilder extends WorkflowBundleBuilder {
   get snapshot() {
     return this.config;
   }
+
+  resolveTsConfigPath(): Promise<string | undefined> {
+    return this.findTsConfigPath();
+  }
 }
 
 class StepEntryOnlyWorkflowBundleBuilder extends WorkflowBundleBuilder {
@@ -104,6 +108,34 @@ describe("WorkflowBundleBuilder", () => {
     expect(builder.snapshot.projectRoot).toBe(appRoot);
     expect(builder.snapshot.workingDir).toBe(rootDir);
     expect(builder.snapshot.dirs).toEqual([resolvePackageSourceDirectoryPath("src/execution")]);
+  });
+
+  it("does not inherit a tsconfig from outside the eve package", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-workflow-bundle-tsconfig-"));
+    const packageRoot = join(workspaceRoot, "node_modules", "eve");
+
+    try {
+      await mkdir(packageRoot, { recursive: true });
+      await writeFile(join(workspaceRoot, "tsconfig.json"), "{}\n");
+
+      const builder = new InspectableWorkflowBundleBuilder({
+        agentName: "test-agent",
+        appRoot: workspaceRoot,
+        compiledArtifactsBootstrapPath: join(workspaceRoot, "compiled-artifacts-bootstrap.js"),
+        outDir: join(workspaceRoot, ".eve", "workflows"),
+        rootDir: packageRoot,
+        watch: false,
+      });
+
+      await expect(builder.resolveTsConfigPath()).resolves.toBeUndefined();
+
+      const packageTsConfigPath = join(packageRoot, "tsconfig.json");
+      await writeFile(packageTsConfigPath, "{}\n");
+
+      await expect(builder.resolveTsConfigPath()).resolves.toBe(packageTsConfigPath);
+    } finally {
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
   });
 
   it("writes a Nitro-owned step registration entry", async () => {

--- a/packages/eve/src/internal/workflow-bundle/builder.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.ts
@@ -179,30 +179,20 @@ export class WorkflowBundleBuilder {
   }
 
   protected async findTsConfigPath(): Promise<string | undefined> {
-    let current = this.config.workingDir;
+    for (const filename of ["tsconfig.json", "jsconfig.json"]) {
+      const candidate = join(this.config.workingDir, filename);
 
-    while (true) {
-      for (const filename of ["tsconfig.json", "jsconfig.json"]) {
-        const candidate = join(current, filename);
-
-        try {
-          await readFile(candidate);
-          return candidate;
-        } catch (error) {
-          if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
-            throw error;
-          }
+      try {
+        await readFile(candidate);
+        return candidate;
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+          throw error;
         }
       }
-
-      const parent = dirname(current);
-
-      if (parent === current) {
-        return undefined;
-      }
-
-      current = parent;
     }
+
+    return undefined;
   }
 
   protected async getInputFiles(): Promise<string[]> {


### PR DESCRIPTION
### Description

Workflow bundles are built from eve-owned source under the installed `eve` package. However, `WorkflowBundleBuilder.findTsConfigPath()` currently walks above that package root. Because the published package does not include its source tsconfig, a nested workspace install can accidentally select the host workspace config. In a staged Vercel build that inherited path can point outside the authored package boundary and fail with:

```text
[TSCONFIG_ERROR] Failed to load tsconfig for ../../tsconfig.json: Tsconfig not found
```

Limit workflow tsconfig discovery to `WorkflowBundleBuilder`'s package root. Source checkouts still use `packages/eve/tsconfig.json`; published installs without a package-local config pass `tsconfig: false` instead of inheriting unrelated host configuration. This matches the package-local lookup already used by the authored-module loader.

The regression scenario covers both behaviors: an ancestor workspace config is ignored, while a package-local config is selected.

A public issue was not opened separately, so this draft PR is the initial discussion and reproduction artifact.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/workflow-bundle/builder.scenario.test.ts` — 9 passed
- `pnpm --filter eve typecheck`
- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve test:unit` — 5,245 passed, 1 skipped
- `pnpm --filter eve test:integration` — 536 passed
- `pnpm guard:invariants`
- `pnpm check:deps`
- `pnpm guard:fixtures`

`pnpm typecheck` was also attempted across the full workspace. It stopped in the existing `agent-model` fixture because `openai/gpt-5.6-sol` did not have known AI Gateway context-window metadata; the `eve` package typecheck passed independently.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted — this draft is the initial reproduction/discussion artifact
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
