### PR TITLE
docs: use Kernel eve extension integration

### DIFF
--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -29,15 +29,16 @@ describe("Browser Use connection setup", () => {
   });
 });
 
-describe("Kernel connection setup", () => {
-  it("uses the named Connect connector created for Kernel's MCP service", () => {
+describe("Kernel extension setup", () => {
+  it("uses Kernel's eve extension with Vercel Connect", () => {
     const integration = getIntegration("kernel")!;
-    const setup = buildConnectionSetup(integration);
 
-    expect(setup.variants["mcp:user"]).toContain('auth: connect("mcp.onkernel.com/kernel")');
-    expect(buildConnectionConfigure(integration)).toContain(
-      "vercel connect create mcp.onkernel.com --name kernel",
+    expect(integration.type).toBe("extension");
+    expect(integration.install).toContain("npm install @onkernel/eve-extension");
+    expect(integration.quickStart).toContain(
+      'kernel({ connect: "mcp.onkernel.com/eve-extension" })',
     );
+    expect(integration.configure).toContain("KERNEL_API_KEY");
   });
 });
 

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -494,6 +494,49 @@ Credentials come from the \`createMessengerAdapter\` config or the adapter's env
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {
+  kernel: {
+    logo: "kernel",
+    docsHref: "https://www.kernel.sh/docs/integrations/vercel/eve-extension",
+    keywords: [
+      "browser",
+      "browser automation",
+      "cloud browser",
+      "playwright",
+      "mcp",
+      "managed auth",
+      "vercel connect",
+    ],
+    install: `Install the Kernel extension for eve:
+
+\`\`\`bash
+npm install @onkernel/eve-extension
+\`\`\`
+
+The extension requires Node.js 24 or later and eve 0.25 or later. It mounts Kernel's hosted MCP browser tools and a \`browse\` skill without requiring you to maintain browser tool code.`,
+    quickStart: `Create and attach a Kernel connector with [Vercel Connect](https://vercel.com/connect):
+
+\`\`\`bash
+vercel connect create mcp.onkernel.com --name eve-extension
+vercel connect attach mcp.onkernel.com/eve-extension
+\`\`\`
+
+Then mount the extension under \`agent/extensions/\`:
+
+\`\`\`ts title="agent/extensions/kernel.ts"
+import kernel from "@onkernel/eve-extension";
+
+export default kernel({ connect: "mcp.onkernel.com/eve-extension" });
+\`\`\`
+
+The filename supplies the \`kernel\` namespace. The extension adds browser management, Playwright, computer control, managed auth, profiles, proxies, and replay tools under \`kernel__browser__*\`, along with the \`browse\` skill.`,
+    configure: `For a personal or single-tenant agent, you can authenticate with a Kernel API key instead. Set \`KERNEL_API_KEY\`, then mount the extension with its default configuration:
+
+\`\`\`ts title="agent/extensions/kernel.ts"
+export { default } from "@onkernel/eve-extension";
+\`\`\`
+
+The default mount can execute JavaScript in the browser VM and reuse authenticated browser sessions. For team or multi-tenant agents, prefer Vercel Connect so each user authenticates separately, and add an approval gate by overriding the extension's \`browser\` connection. See the [Kernel eve extension guide](https://www.kernel.sh/docs/integrations/vercel/eve-extension) for API-key configuration, connection overrides, the complete tool list, and security guidance.`,
+  },
   "agent-browser": {
     logo: "agent-browser",
     docsHref:
@@ -551,16 +594,6 @@ The extension also supports inline screenshots, session naming, proxies, and pro
  * note.
  */
 const connectionPresentations: Record<string, ConnectionPresentation> = {
-  kernel: {
-    logo: "kernel",
-    docsHref: "https://www.kernel.sh/docs/reference/mcp-server/",
-    keywords: ["mcp", "browser", "browser automation", "playwright", "cloud browser"],
-    authModes: ["user"],
-    connector: "mcp.onkernel.com/kernel",
-    connectorService: "mcp.onkernel.com",
-    configureNote:
-      "Kernel's MCP server can launch browsers, execute Playwright, and manage recordings. Add approval gates or tool filters before allowing unattended browser actions.",
-  },
   "browser-use": {
     logo: "browser-use",
     docsHref: "https://docs.browser-use.com/cloud/guides/mcp-server",

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -62,10 +62,9 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("linear")!.connection!.mcp!.url).toBe("https://mcp.linear.app/mcp");
   });
 
-  it("uses Kernel's streamable HTTP MCP endpoint", () => {
-    expect(getIntegrationEntry("kernel")!.connection!.mcp!.url).toBe(
-      "https://mcp.onkernel.com/mcp",
-    );
+  it("exposes Kernel as an extension", () => {
+    expect(getIntegrationEntry("kernel")?.kind).toBe("extension");
+    expect(getIntegrationEntry("kernel")?.connection).toBeUndefined();
   });
 
   it("uses Browser Use's streamable HTTP MCP endpoint", () => {

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -181,14 +181,9 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
   {
     slug: "kernel",
     name: "Kernel",
-    kind: "connection",
-    tagline: "Launch cloud browsers and automate web interactions through Kernel's MCP server.",
+    kind: "extension",
+    tagline: "Add a Kernel cloud browser and browser automation skills to an eve agent.",
     surfaces: { scaffoldable: false, gallery: true },
-    connection: {
-      description:
-        "Kernel: launch and automate cloud browsers, run Playwright, and inspect replays.",
-      mcp: { url: "https://mcp.onkernel.com/mcp" },
-    },
   },
   {
     slug: "browser-use",


### PR DESCRIPTION
## Summary

- present Kernel as an eve extension instead of a raw MCP connection
- document installation and authentication with Vercel Connect or a Kernel API key
- link to Kernel’s extension guide and update integration coverage

<img width="1156" height="1220" alt="image" src="https://github.com/user-attachments/assets/376e7978-679b-4ead-9248-5b307ea6bba7" />

## Testing

- `pnpm --filter eve-docs exec vitest run lib/integrations`
- `pnpm --filter @vercel/eve-catalog test:unit`