### PR TITLE
docs: add Browserbase eve extension integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -494,6 +494,59 @@ Credentials come from the \`createMessengerAdapter\` config or the adapter's env
 };
 
 const extensionPresentations: Record<string, ExtensionPresentation> = {
+  browserbase: {
+    logo: "browserbase",
+    docsHref: "https://www.npmjs.com/package/@browserbasehq/eve",
+    keywords: [
+      "browser",
+      "browser automation",
+      "cloud browser",
+      "stagehand",
+      "search",
+      "fetch",
+      "web automation",
+    ],
+    install: `Install the Browserbase extension for eve:
+
+\`\`\`bash
+npm install @browserbasehq/eve
+\`\`\`
+
+The extension requires Node.js 24 or later. A Browserbase API key covers both cloud browser sessions and Stagehand inference through Browserbase Model Gateway, so you do not need a separate model-provider key.`,
+    quickStart: `Add your Browserbase API key to the agent's environment:
+
+\`\`\`bash title=".env.local"
+BROWSERBASE_API_KEY=bb_live_...
+\`\`\`
+
+Then mount the extension under \`agent/extensions/\`:
+
+\`\`\`ts title="agent/extensions/browserbase.ts"
+import browserbase from "@browserbasehq/eve";
+
+export default browserbase({
+  apiKey: process.env.BROWSERBASE_API_KEY!,
+});
+\`\`\`
+
+The filename supplies the \`browserbase\` namespace. The extension adds \`browserbase__search\`, \`browserbase__fetch\`, and persistent browser tools for creating sessions, navigating, observing, acting, extracting structured data, and running autonomous Stagehand tasks.`,
+    configure: `Use Search → Fetch → browser as an escalation path: search for sources first, fetch straightforward content without starting a session, and create a browser only when a page requires JavaScript or interaction.
+
+You can configure the Stagehand model, session timeout, and proxies:
+
+\`\`\`ts title="agent/extensions/browserbase.ts"
+import browserbase from "@browserbasehq/eve";
+
+export default browserbase({
+  apiKey: process.env.BROWSERBASE_API_KEY!,
+  model: "openai/gpt-5.4-mini",
+  sessionTimeoutSeconds: 900,
+  proxies: false,
+});
+\`\`\`
+
+Browserbase uses keep-alive sessions and eve's durable per-session state to reconnect across workflow steps and function invocations. Call \`browserbase__stop_session\` when the task finishes to release billable browser time. Keep API keys out of prompts, and add approval gates around sensitive or irreversible browser actions. See the [Browserbase extension package](https://www.npmjs.com/package/@browserbasehq/eve) for the complete tool and configuration reference.`,
+  },
   kernel: {
     logo: "kernel",
     docsHref: "https://www.kernel.sh/docs/integrations/vercel/eve-extension",

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -32,6 +32,17 @@ describe("integration discovery", () => {
     expect(markdown).toContain("eve channels add slack");
   });
 
+  it("renders the Browserbase extension setup", () => {
+    const browserbase = getIntegration("browserbase");
+    expect(browserbase).toBeDefined();
+
+    const markdown = integrationMarkdown(browserbase!);
+    expect(markdown).toContain("npm install @browserbasehq/eve");
+    expect(markdown).toContain('import browserbase from "@browserbasehq/eve"');
+    expect(markdown).toContain("BROWSERBASE_API_KEY");
+    expect(integrationSearchText(browserbase!)).toContain("Stagehand");
+  });
+
   it("renders every connection setup variant", () => {
     const notion = getIntegration("notion");
     expect(notion).toBeDefined();

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -324,6 +324,20 @@ export const messengerLogo = (props: LogoProps) => <SiMessenger color="default" 
 
 export const xLogo = (props: LogoProps) => <SiX {...props} />;
 
+export const browserbaseLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect fill="white" height="124" width="134" x="30" y="36" />
+    <path d="M111.168 116.901H83.168V109.901H111.168V116.901Z" fill="#FF4500" />
+    <path d="M111.168 86.208H83.168V79.208H111.168V86.208Z" fill="#FF4500" />
+    <path
+      clipRule="evenodd"
+      d="M200 200H0V0H200V200ZM55.4453 147.815H128.678L145.259 131.234V111.891L131.441 98.0723L142.495 87.0186V69.0557L125.914 52.4756H55.4453V147.815Z"
+      fill="#FF4500"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
 export const agentBrowserLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
     <rect height="16" rx="2" stroke="currentColor" strokeWidth="1.5" width="20" x="2" y="4" />
@@ -393,6 +407,7 @@ export const logos = {
   whatsapp: whatsappLogo,
   messenger: messengerLogo,
   x: xLogo,
+  browserbase: browserbaseLogo,
   "agent-browser": agentBrowserLogo,
 } as const;
 

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -67,6 +67,11 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("kernel")?.connection).toBeUndefined();
   });
 
+  it("exposes Browserbase as an extension", () => {
+    expect(getIntegrationEntry("browserbase")?.kind).toBe("extension");
+    expect(getIntegrationEntry("browserbase")?.connection).toBeUndefined();
+  });
+
   it("uses Browser Use's streamable HTTP MCP endpoint", () => {
     expect(getIntegrationEntry("browser-use")!.connection!.mcp!.url).toBe(
       "https://api.browser-use.com/v3/mcp",

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -179,6 +179,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "browserbase",
+    name: "Browserbase",
+    kind: "extension",
+    tagline: "Search, fetch, and automate the web with Browserbase and Stagehand.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "kernel",
     name: "Kernel",
     kind: "extension",


### PR DESCRIPTION
## Summary

- add Browserbase to the integration catalog as an eve extension
- document installation, authentication, Stagehand tools, and durable browser sessions
- add the Browserbase brand mark and integration discovery coverage

<img width="1004" height="1132" alt="image" src="https://github.com/user-attachments/assets/87b0be7a-7c78-44de-84ef-6e9d4c6537db" />

## Testing

- `cd apps/docs && ../../node_modules/.bin/vitest run lib/integrations`
- `cd packages/eve-catalog && ../../node_modules/.bin/vitest run --config vitest.config.ts`
- docs and catalog TypeScript checks