### PR TITLE
docs: add GitHub Tools eve extension integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -649,6 +649,68 @@ The reporter reads \`JETTY_API_TOKEN\` and \`JETTY_COLLECTION\`, sends each eval
 
 Jetty trajectories persist agent inputs and outputs. Redact PII before grading, put sensitive grader parameters in Jetty's \`secretParams\` rather than \`initParams\`, and treat trajectory storage like any other logging surface. See the [Jetty eve extension documentation](https://github.com/jettyio/jetty-sdk/tree/main/packages/eve#readme) for all experiment settings and the [worked example](https://github.com/jettyio/jetty-sdk/tree/main/examples/eve-jetty) for the complete grading loop.`,
   },
+  "github-tools": {
+    logo: "github",
+    docsHref: "https://github-tools.com/frameworks/eve#eve-extension",
+    keywords: [
+      "github",
+      "repositories",
+      "pull requests",
+      "issues",
+      "code review",
+      "ci",
+      "vercel connect",
+      "approval",
+    ],
+    install: `Install the GitHub Tools extension and Vercel Connect client:
+
+\`\`\`bash
+npm install @github-tools/eve-extension @vercel/connect
+\`\`\`
+
+The extension provides the GitHub toolset as a versioned eve package. Use a Vercel Connect connector for short-lived, scoped GitHub tokens, or omit \`@vercel/connect\` and authenticate with a GitHub token.`,
+    quickStart: `Create and attach a GitHub connector to the Vercel project that runs your agent:
+
+\`\`\`bash
+vercel link
+vercel connect create github --name my-connector
+vercel connect attach github/my-connector --yes
+vercel env pull
+\`\`\`
+
+Then mount the extension under \`agent/extensions/\`:
+
+\`\`\`ts title="agent/extensions/github.ts"
+import githubExtension from "@github-tools/eve-extension";
+
+export default githubExtension({
+  connector: "github/my-connector",
+  preset: "maintainer",
+  requireApproval: {
+    mergePullRequest: true,
+  },
+});
+\`\`\`
+
+The filename supplies the \`github\` namespace, so tools appear as \`github__listPullRequests\`, \`github__createIssue\`, and \`github__addPullRequestComment\`. The preset automatically limits the connector token to the scopes its tools need.`,
+    configure: `Choose one or more presets to limit the available tools: \`code-review\`, \`issue-triage\`, \`repo-explorer\`, \`ci-ops\`, or \`maintainer\`. Every write tool requires approval by default, while read tools do not. Use \`requireApproval\` to apply \`always\`, \`once\`, or an input-dependent policy to individual tools:
+
+\`\`\`ts title="agent/extensions/github.ts"
+import githubExtension from "@github-tools/eve-extension";
+
+export default githubExtension({
+  connector: "github/my-connector",
+  preset: ["code-review", "issue-triage"],
+  requireApproval: {
+    addPullRequestComment: "once",
+    mergePullRequest: true,
+    createIssue: ({ toolInput }) => toolInput?.owner !== "my-org",
+  },
+});
+\`\`\`
+
+For local or non-Vercel deployments, omit \`connector\` and set \`GITHUB_TOKEN\`; the extension also accepts an explicit \`token\`. Prefer fine-grained credentials, expose only the presets the agent needs, and keep approval enabled for writes. See the [GitHub Tools eve documentation](https://github-tools.com/frameworks/eve#eve-extension) for token authentication, per-tool overrides, commit attribution, and the complete tool catalog.`,
+  },
   "agent-browser": {
     logo: "agent-browser",
     docsHref:

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -55,6 +55,18 @@ describe("integration discovery", () => {
     expect(integrationSearchText(jetty!)).toContain("grading");
   });
 
+  it("renders the GitHub Tools extension setup", () => {
+    const githubTools = getIntegration("github-tools");
+    expect(githubTools).toBeDefined();
+
+    const markdown = integrationMarkdown(githubTools!);
+    expect(markdown).toContain("npm install @github-tools/eve-extension");
+    expect(markdown).toContain('connector: "github/my-connector"');
+    expect(markdown).toContain('preset: "maintainer"');
+    expect(markdown).toContain("github__addPullRequestComment");
+    expect(integrationSearchText(githubTools!)).toContain("code review");
+  });
+
   it("renders every connection setup variant", () => {
     const notion = getIntegration("notion");
     expect(notion).toBeDefined();

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -77,6 +77,12 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("jetty")?.connection).toBeUndefined();
   });
 
+  it("exposes GitHub Tools as an extension distinct from the GitHub channel", () => {
+    expect(getIntegrationEntry("github")?.kind).toBe("channel");
+    expect(getIntegrationEntry("github-tools")?.kind).toBe("extension");
+    expect(getIntegrationEntry("github-tools")?.connection).toBeUndefined();
+  });
+
   it("uses Browser Use's streamable HTTP MCP endpoint", () => {
     expect(getIntegrationEntry("browser-use")!.connection!.mcp!.url).toBe(
       "https://api.browser-use.com/v3/mcp",

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -186,6 +186,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "github-tools",
+    name: "GitHub Tools",
+    kind: "extension",
+    tagline: "Add scoped GitHub tools with Vercel Connect authentication and approval rules.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "jetty",
     name: "Jetty",
     kind: "extension",


### PR DESCRIPTION
## Summary

- add GitHub Tools to the catalog as an eve extension distinct from the GitHub channel
- document Vercel Connect authentication, presets, approval rules, and token fallback
- add integration discovery and catalog coverage

<img width="1124" height="1106" alt="image" src="https://github.com/user-attachments/assets/87784423-772c-4605-9c15-e116996144f4" />

## Testing

- `cd apps/docs && ../../node_modules/.bin/vitest run lib/integrations`
- `cd packages/eve-catalog && ../../node_modules/.bin/vitest run --config vitest.config.ts`
- docs and catalog TypeScript checks