### PR TITLE
feat(eve): slack - add thread participant routing and self-loop guard

### DIFF
--- a/.changeset/fuzzy-bots-listen.md
+++ b/.changeset/fuzzy-bots-listen.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Added `thread.listParticipants()` for Slack thread routing. Messages posted by the installed Slack app are now ignored before reaching message hooks to prevent self-reply loops.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -54,7 +54,7 @@ VERCEL_USE_EXPERIMENTAL_FRAMEWORKS=1 vercel deploy --prod
 
 Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history.
 
-- `onMessage(ctx, message)` handles Slack `message` events. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies; check `message.author?.isBot` when bot messages should be ignored.
+- `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
 - `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.
 - `onDirectMessage(ctx, message)` handles only DMs and takes precedence over `onMessage`. Bot-authored messages and edits are filtered first; Slack requires `message.im` and `im:history`.
 
@@ -87,6 +87,22 @@ export default slackChannel({
 ```
 
 `isBotMentioned()` identifies an explicit mention. `isSubscribed()` checks whether the message belongs to a thread with an active eve session. For Vercel Connect, open **Advanced** when creating the connector and add `message.channels` under **Trigger Event Types** and `channels:history` under **Bot Scopes**. Private channels additionally need `message.groups` and `groups:history`.
+
+Use `ctx.thread.listParticipants()` when routing depends on who has joined the thread. It fetches the current thread and returns unique human Slack user ids in first-appearance order, so the first id is the starting author for a human-started thread. Bot and system messages are excluded:
+
+```ts
+async onMessage(ctx, message) {
+  if (!message.author || message.author.isBot) return null;
+
+  const participants = await ctx.thread.listParticipants();
+  const isGroupFollowUpFromStarter =
+    participants.length > 1 && participants[0] === message.author.userId;
+
+  return isGroupFollowUpFromStarter ? { auth: null } : null;
+}
+```
+
+Like `threadContext`, this helper calls `conversations.replies` and requires the matching Slack history scope.
 
 ### Other Events API callbacks
 

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -10,7 +10,31 @@ interface FetchCall {
   contentType: string | null;
 }
 
-function buildFetchMock(): { fetch: ReturnType<typeof vi.fn>; calls: FetchCall[] } {
+function buildFetchMock(
+  threadMessages: readonly Record<string, unknown>[] = [
+    {
+      text: "Hello from user",
+      ts: "1700000000.123456",
+      thread_ts: "1700000000.000001",
+      user: "U01",
+      files: [
+        {
+          id: "F1",
+          name: "report.csv",
+          mimetype: "text/csv",
+          url_private: "https://files.slack.com/a/b/report.csv",
+          size: 128,
+        },
+      ],
+    },
+    {
+      text: "Hello from bot",
+      ts: "1700000001.000000",
+      thread_ts: "1700000000.000001",
+      bot_id: "B01",
+    },
+  ],
+): { fetch: ReturnType<typeof vi.fn>; calls: FetchCall[] } {
   const calls: FetchCall[] = [];
   const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
@@ -44,29 +68,7 @@ function buildFetchMock(): { fetch: ReturnType<typeof vi.fn>; calls: FetchCall[]
       return new Response(
         JSON.stringify({
           ok: true,
-          messages: [
-            {
-              text: "Hello from user",
-              ts: "1700000000.123456",
-              thread_ts: "1700000000.000001",
-              user: "U01",
-              files: [
-                {
-                  id: "F1",
-                  name: "report.csv",
-                  mimetype: "text/csv",
-                  url_private: "https://files.slack.com/a/b/report.csv",
-                  size: 128,
-                },
-              ],
-            },
-            {
-              text: "Hello from bot",
-              ts: "1700000001.000000",
-              thread_ts: "1700000000.000001",
-              bot_id: "B01",
-            },
-          ],
+          messages: threadMessages,
         }),
         { headers: { "content-type": "application/json" } },
       );
@@ -445,6 +447,36 @@ describe("SlackThread.refresh", () => {
     expect("attachments" in firstMessage).toBe(false);
     expect("author" in firstMessage).toBe(false);
     expect("metadata" in firstMessage).toBe(false);
+  });
+});
+
+describe("SlackThread.listParticipants", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns unique human user ids in first-appearance order", async () => {
+    const mock = buildFetchMock([
+      { text: "root", ts: "1.0", user: "U01" },
+      { text: "bot reply", ts: "1.1", thread_ts: "1.0", user: "UAPP", bot_id: "B01" },
+      { text: "second person", ts: "1.2", thread_ts: "1.0", user: "U02" },
+      { text: "starter again", ts: "1.3", thread_ts: "1.0", user: "U01" },
+      { text: "system message", ts: "1.4", thread_ts: "1.0" },
+    ]);
+    vi.stubGlobal("fetch", mock.fetch);
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await expect(thread.listParticipants()).resolves.toEqual(["U01", "U02"]);
+
+    expect(thread.recentMessages).toHaveLength(5);
+    expect(
+      mock.calls.filter((call) => call.url === "https://slack.com/api/conversations.replies"),
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -210,6 +210,14 @@ export interface SlackThread {
   readonly recentMessages: readonly SlackThreadMessage[];
 
   /**
+   * Fetch the latest replies and return the unique human Slack user ids
+   * participating in this thread, ordered by first appearance. For a
+   * human-started thread, the first entry is the starting author. Bot and
+   * system messages are excluded.
+   */
+  listParticipants(): Promise<readonly string[]>;
+
+  /**
    * Post a reply to this thread.
    *
    * Bare-form shortcuts: `string` becomes `{ markdown }` (so `**bold**` /
@@ -387,6 +395,16 @@ export function buildSlackBinding(input: {
 
   const thread: SlackThread = {
     recentMessages: messages,
+    async listParticipants() {
+      await thread.refresh();
+      const participants = new Set<string>();
+      for (const message of messages) {
+        if (message.user !== undefined && message.botId === undefined) {
+          participants.add(message.user);
+        }
+      }
+      return [...participants];
+    },
     async post(rawMessage) {
       const message = normalizePostInput(rawMessage);
       const files = message.files ?? [];

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1423,25 +1423,80 @@ describe("slackChannel() onMessage", () => {
     );
   });
 
-  it("passes bot-authored messages to onMessage", async () => {
+  it("passes messages from other bots to onMessage", async () => {
     const onMessage = vi.fn((_ctx, _message: { author?: { isBot: boolean } }) => null);
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
       onMessage,
     });
-    const body = buildEventBody({
-      bot_id: "B01",
-      channel: "C01",
-      text: "automated",
-      ts: "1700000000.000200",
-      type: "message",
-      user: "U_BOT",
-    });
+    const body = buildEventBody(
+      {
+        app_id: "A_OTHER",
+        bot_id: "B_OTHER",
+        channel: "C01",
+        text: "automated",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_OTHER_BOT",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
 
     await firePost(channel, buildSignedRequest({ body }));
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(onMessage.mock.calls[0]![1].author?.isBot).toBe(true);
+  });
+
+  it.each([
+    [
+      "bot user id",
+      {
+        bot_id: "B01",
+        channel: "C01",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_BOT",
+      },
+    ],
+    [
+      "app id when user is absent",
+      {
+        app_id: "A01",
+        bot_id: "B01",
+        channel: "C01",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+      },
+    ],
+    [
+      "bot user id in a direct message",
+      {
+        bot_id: "B01",
+        channel: "D01",
+        channel_type: "im",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_BOT",
+      },
+    ],
+  ])("drops the app's own message identified by %s", async (_label, event) => {
+    const onMessage = vi.fn(() => ({ auth: null }));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
+      onMessage,
+    });
+    const body = buildEventBody(event, {
+      authorizations: [{ is_bot: true, user_id: "U_BOT" }],
+    });
+
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("gives specialized message hooks precedence", async () => {
@@ -1803,6 +1858,30 @@ describe("slackChannel() inbound direct message pipeline", () => {
     });
 
     const { body } = buildDirectMessageBody({ botId: "B01" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(onDirectMessage).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("filters the app's own DM by its authorized bot user id", async () => {
+    const onDirectMessage = vi.fn(() => ({ auth: null }));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onDirectMessage,
+    });
+    const body = buildEventBody(
+      {
+        channel: "D01",
+        channel_type: "im",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_BOT",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
+
     const { send } = await firePost(channel, buildSignedRequest({ body }));
 
     expect(onDirectMessage).not.toHaveBeenCalled();

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -69,9 +69,9 @@ type EventData<T extends HandleMessageStreamEvent["type"]> =
  * `onInteraction`. These hooks run on the inbound webhook side before the
  * runtime hydrates session state, so `state` is absent here.
  * {@link thread} owns thread-scoped operations (`post`, `postEphemeral`,
- * `startTyping`, `refresh`, `recentMessages`, `mentionUser`); {@link slack}
- * owns Slack identity (`channelId`, `threadTs`, `teamId`) plus the raw-API
- * escape hatch (`request`, `uploadFiles`).
+ * `startTyping`, `refresh`, `listParticipants`, `recentMessages`,
+ * `mentionUser`); {@link slack} owns Slack identity (`channelId`, `threadTs`,
+ * `teamId`) plus the raw-API escape hatch (`request`, `uploadFiles`).
  */
 export interface SlackContext {
   readonly thread: SlackThread;
@@ -791,7 +791,7 @@ async function handleEventPost(input: {
   if (payload.kind === "app_mention" || payload.kind === "direct_message") {
     const kind = payload.kind;
     const message = slackMessageFromWebhookPayload(payload);
-    if (message !== null) {
+    if (message !== null && !isSelfAuthoredSlackMessage(envelope, message)) {
       const dispatchMessageWith =
         (handler: NonNullable<SlackChannelConfig["onAppMention"]>) => () =>
           dispatchInboundMessage({
@@ -828,7 +828,7 @@ async function handleEventPost(input: {
 
   if (dispatch === null && config.onMessage !== undefined) {
     const message = parseMessageEvent(envelope);
-    if (message !== null) {
+    if (message !== null && !isSelfAuthoredSlackMessage(envelope, message)) {
       const botUserId = slackEventBotUserId(envelope);
       // Slack also emits message.channels for an app mention. The app_mention
       // callback owns that user action so the generic message is not duplicated.
@@ -850,7 +850,7 @@ async function handleEventPost(input: {
   }
 
   // Specialized handlers retain their bot/subtype filters. onMessage receives
-  // every structurally valid message event; onEvent remains the raw fallback.
+  // structurally valid messages except this app's own; onEvent is the raw fallback.
   const onEvent = config.onEvent;
   if (dispatch === null && onEvent !== undefined) {
     dispatch = () =>
@@ -882,6 +882,18 @@ async function handleEventPost(input: {
 
   input.waitUntil(dispatch());
   return new Response("ok");
+}
+
+function isSelfAuthoredSlackMessage(envelope: SlackEventEnvelope, message: SlackMessage): boolean {
+  const botUserId = slackEventBotUserId(envelope);
+  if (botUserId !== undefined && message.author?.userId === botUserId) {
+    return true;
+  }
+
+  // App-authored message events can omit `user`, so match Slack's app identity
+  // as a fallback. Other bots keep flowing to authored onMessage handlers.
+  const apiAppId = typeof envelope.api_app_id === "string" ? envelope.api_app_id : undefined;
+  return apiAppId !== undefined && message.raw.app_id === apiAppId;
 }
 
 async function dispatchSlackMessage(input: {


### PR DESCRIPTION
## Summary

- add `ctx.thread.listParticipants()` to return unique human Slack participants in first-appearance order
- prevent messages authored by the installed Slack app from reaching message hooks and triggering self-reply loops
- preserve `onMessage` delivery for messages authored by other bots
- document participant-based routing and self-message filtering

## Root cause

Once `message.channels` and `message.im` event delivery is enabled, Slack also sends events for messages posted by the installed app. eve previously forwarded those events to authored message hooks, allowing an agent response to recursively trigger another turn.

The inbound Slack boundary now identifies the installed app by its authorized bot user ID, with the event app ID as a fallback when Slack omits `user`, and drops only those self-authored messages.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack` (277 tests)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- targeted `oxlint` for the changed Slack source and tests
- `git diff --check`
