### PR TITLE
feat(eve): slack - list thread participants

### DIFF
--- a/.changeset/fuzzy-bots-listen.md
+++ b/.changeset/fuzzy-bots-listen.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Added `thread.listParticipants()` for Slack thread routing based on the unique human participants in first-appearance order.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -88,6 +88,22 @@ export default slackChannel({
 
 `isBotMentioned()` identifies an explicit mention. `isSubscribed()` checks whether the message belongs to a thread with an active eve session. For Vercel Connect, open **Advanced** when creating the connector and add `message.channels` under **Trigger Event Types** and `channels:history` under **Bot Scopes**. Private channels additionally need `message.groups` and `groups:history`.
 
+Use `ctx.thread.listParticipants()` when routing depends on who has joined the thread. It fetches the current thread and returns unique human Slack user ids in first-appearance order, so the first id is the starting author for a human-started thread. Bot and system messages are excluded:
+
+```ts
+async onMessage(ctx, message) {
+  if (!message.author || message.author.isBot) return null;
+
+  const participants = await ctx.thread.listParticipants();
+  const isGroupFollowUpFromStarter =
+    participants.length > 1 && participants[0] === message.author.userId;
+
+  return isGroupFollowUpFromStarter ? { auth: null } : null;
+}
+```
+
+Like `threadContext`, this helper calls `conversations.replies` and requires the matching Slack history scope.
+
 ### Other Events API callbacks
 
 Use `onEvent` for subscribed events such as `reaction_added`, `team_join`, or `channel_created`. It receives the raw, open-ended Slack event and owns control flow. `ctx.receive(options)` is the current Slack channel's pre-bound form of the schedule API's `receive(slack, options)`: call it zero, one, or many times to start turns. Each call accepts `message`, `target`, and `auth`, and returns the resulting session.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -102,7 +102,7 @@ async onMessage(ctx, message) {
 }
 ```
 
-Like `threadContext`, this helper calls `conversations.replies` and requires the matching Slack history scope.
+Like `threadContext`, this helper calls `conversations.replies` and requires the matching Slack history scope. It observes at most the first 50 messages of the thread, and a failed fetch is logged and swallowed, so the returned list may be empty or stale — treat an unexpected empty list as "don't route" rather than "no participants".
 
 ### Other Events API callbacks
 

--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -10,7 +10,31 @@ interface FetchCall {
   contentType: string | null;
 }
 
-function buildFetchMock(): { fetch: ReturnType<typeof vi.fn>; calls: FetchCall[] } {
+function buildFetchMock(
+  threadMessages: readonly Record<string, unknown>[] = [
+    {
+      text: "Hello from user",
+      ts: "1700000000.123456",
+      thread_ts: "1700000000.000001",
+      user: "U01",
+      files: [
+        {
+          id: "F1",
+          name: "report.csv",
+          mimetype: "text/csv",
+          url_private: "https://files.slack.com/a/b/report.csv",
+          size: 128,
+        },
+      ],
+    },
+    {
+      text: "Hello from bot",
+      ts: "1700000001.000000",
+      thread_ts: "1700000000.000001",
+      bot_id: "B01",
+    },
+  ],
+): { fetch: ReturnType<typeof vi.fn>; calls: FetchCall[] } {
   const calls: FetchCall[] = [];
   const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input);
@@ -44,29 +68,7 @@ function buildFetchMock(): { fetch: ReturnType<typeof vi.fn>; calls: FetchCall[]
       return new Response(
         JSON.stringify({
           ok: true,
-          messages: [
-            {
-              text: "Hello from user",
-              ts: "1700000000.123456",
-              thread_ts: "1700000000.000001",
-              user: "U01",
-              files: [
-                {
-                  id: "F1",
-                  name: "report.csv",
-                  mimetype: "text/csv",
-                  url_private: "https://files.slack.com/a/b/report.csv",
-                  size: 128,
-                },
-              ],
-            },
-            {
-              text: "Hello from bot",
-              ts: "1700000001.000000",
-              thread_ts: "1700000000.000001",
-              bot_id: "B01",
-            },
-          ],
+          messages: threadMessages,
         }),
         { headers: { "content-type": "application/json" } },
       );
@@ -445,6 +447,36 @@ describe("SlackThread.refresh", () => {
     expect("attachments" in firstMessage).toBe(false);
     expect("author" in firstMessage).toBe(false);
     expect("metadata" in firstMessage).toBe(false);
+  });
+});
+
+describe("SlackThread.listParticipants", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns unique human user ids in first-appearance order", async () => {
+    const mock = buildFetchMock([
+      { text: "root", ts: "1.0", user: "U01" },
+      { text: "bot reply", ts: "1.1", thread_ts: "1.0", user: "UAPP", bot_id: "B01" },
+      { text: "second person", ts: "1.2", thread_ts: "1.0", user: "U02" },
+      { text: "starter again", ts: "1.3", thread_ts: "1.0", user: "U01" },
+      { text: "system message", ts: "1.4", thread_ts: "1.0" },
+    ]);
+    vi.stubGlobal("fetch", mock.fetch);
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-test",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: undefined,
+    });
+
+    await expect(thread.listParticipants()).resolves.toEqual(["U01", "U02"]);
+
+    expect(thread.recentMessages).toHaveLength(5);
+    expect(
+      mock.calls.filter((call) => call.url === "https://slack.com/api/conversations.replies"),
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -210,6 +210,14 @@ export interface SlackThread {
   readonly recentMessages: readonly SlackThreadMessage[];
 
   /**
+   * Fetch the latest replies and return the unique human Slack user ids
+   * participating in this thread, ordered by first appearance. For a
+   * human-started thread, the first entry is the starting author. Bot and
+   * system messages are excluded.
+   */
+  listParticipants(): Promise<readonly string[]>;
+
+  /**
    * Post a reply to this thread.
    *
    * Bare-form shortcuts: `string` becomes `{ markdown }` (so `**bold**` /
@@ -387,6 +395,16 @@ export function buildSlackBinding(input: {
 
   const thread: SlackThread = {
     recentMessages: messages,
+    async listParticipants() {
+      await thread.refresh();
+      const participants = new Set<string>();
+      for (const message of messages) {
+        if (message.user !== undefined && message.botId === undefined) {
+          participants.add(message.user);
+        }
+      }
+      return [...participants];
+    },
     async post(rawMessage) {
       const message = normalizePostInput(rawMessage);
       const files = message.files ?? [];

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -210,10 +210,15 @@ export interface SlackThread {
   readonly recentMessages: readonly SlackThreadMessage[];
 
   /**
-   * Fetch the latest replies and return the unique human Slack user ids
-   * participating in this thread, ordered by first appearance. For a
-   * human-started thread, the first entry is the starting author. Bot and
-   * system messages are excluded.
+   * Fetch the latest replies via {@link refresh} and return the unique
+   * human Slack user ids participating in this thread, ordered by first
+   * appearance. For a human-started thread, the first entry is the
+   * starting author. Bot messages and user-less system messages are
+   * excluded.
+   *
+   * Shares {@link refresh} semantics: it observes at most the first 50
+   * messages of the thread, and refresh failures are logged and swallowed,
+   * so the returned list may be empty or stale.
    */
   listParticipants(): Promise<readonly string[]>;
 

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -69,9 +69,9 @@ type EventData<T extends HandleMessageStreamEvent["type"]> =
  * `onInteraction`. These hooks run on the inbound webhook side before the
  * runtime hydrates session state, so `state` is absent here.
  * {@link thread} owns thread-scoped operations (`post`, `postEphemeral`,
- * `startTyping`, `refresh`, `recentMessages`, `mentionUser`); {@link slack}
- * owns Slack identity (`channelId`, `threadTs`, `teamId`) plus the raw-API
- * escape hatch (`request`, `uploadFiles`).
+ * `startTyping`, `refresh`, `listParticipants`, `recentMessages`,
+ * `mentionUser`); {@link slack} owns Slack identity (`channelId`, `threadTs`,
+ * `teamId`) plus the raw-API escape hatch (`request`, `uploadFiles`).
  */
 export interface SlackContext {
   readonly thread: SlackThread;


### PR DESCRIPTION
## Summary

- add `ctx.thread.listParticipants()` to the Slack channel context
- refresh the current thread and return unique human Slack user IDs in first-appearance order
- exclude bot and system messages
- document participant-based thread routing

## Impact

Slack agents can make routing decisions based on who has participated in a thread, including detecting when the starting author follows up after another person joins.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/api.test.ts` (23 tests)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- targeted `oxlint`
- `git diff --check`
