### PR TITLE
fix(eve): slack - prevent self-reply loops

### DIFF
--- a/.changeset/safe-slack-loops.md
+++ b/.changeset/safe-slack-loops.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Messages posted by the installed Slack app are now ignored before reaching message hooks to prevent self-reply loops.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -54,7 +54,7 @@ VERCEL_USE_EXPERIMENTAL_FRAMEWORKS=1 vercel deploy --prod
 
 Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history.
 
-- `onMessage(ctx, message)` handles Slack `message` events. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies; check `message.author?.isBot` when bot messages should be ignored.
+- `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
 - `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.
 - `onDirectMessage(ctx, message)` handles only DMs and takes precedence over `onMessage`. Bot-authored messages and edits are filtered first; Slack requires `message.im` and `im:history`.
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1423,25 +1423,80 @@ describe("slackChannel() onMessage", () => {
     );
   });
 
-  it("passes bot-authored messages to onMessage", async () => {
+  it("passes messages from other bots to onMessage", async () => {
     const onMessage = vi.fn((_ctx, _message: { author?: { isBot: boolean } }) => null);
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
       onMessage,
     });
-    const body = buildEventBody({
-      bot_id: "B01",
-      channel: "C01",
-      text: "automated",
-      ts: "1700000000.000200",
-      type: "message",
-      user: "U_BOT",
-    });
+    const body = buildEventBody(
+      {
+        app_id: "A_OTHER",
+        bot_id: "B_OTHER",
+        channel: "C01",
+        text: "automated",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_OTHER_BOT",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
 
     await firePost(channel, buildSignedRequest({ body }));
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(onMessage.mock.calls[0]![1].author?.isBot).toBe(true);
+  });
+
+  it.each([
+    [
+      "bot user id",
+      {
+        bot_id: "B01",
+        channel: "C01",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_BOT",
+      },
+    ],
+    [
+      "app id when user is absent",
+      {
+        app_id: "A01",
+        bot_id: "B01",
+        channel: "C01",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+      },
+    ],
+    [
+      "bot user id in a direct message",
+      {
+        bot_id: "B01",
+        channel: "D01",
+        channel_type: "im",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_BOT",
+      },
+    ],
+  ])("drops the app's own message identified by %s", async (_label, event) => {
+    const onMessage = vi.fn(() => ({ auth: null }));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
+      onMessage,
+    });
+    const body = buildEventBody(event, {
+      authorizations: [{ is_bot: true, user_id: "U_BOT" }],
+    });
+
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("gives specialized message hooks precedence", async () => {
@@ -1803,6 +1858,30 @@ describe("slackChannel() inbound direct message pipeline", () => {
     });
 
     const { body } = buildDirectMessageBody({ botId: "B01" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(onDirectMessage).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("filters the app's own DM by its authorized bot user id", async () => {
+    const onDirectMessage = vi.fn(() => ({ auth: null }));
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onDirectMessage,
+    });
+    const body = buildEventBody(
+      {
+        channel: "D01",
+        channel_type: "im",
+        text: "agent reply",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U_BOT",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
+
     const { send } = await firePost(channel, buildSignedRequest({ body }));
 
     expect(onDirectMessage).not.toHaveBeenCalled();

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -791,7 +791,7 @@ async function handleEventPost(input: {
   if (payload.kind === "app_mention" || payload.kind === "direct_message") {
     const kind = payload.kind;
     const message = slackMessageFromWebhookPayload(payload);
-    if (message !== null) {
+    if (message !== null && !isSelfAuthoredSlackMessage(envelope, message)) {
       const dispatchMessageWith =
         (handler: NonNullable<SlackChannelConfig["onAppMention"]>) => () =>
           dispatchInboundMessage({
@@ -828,7 +828,7 @@ async function handleEventPost(input: {
 
   if (dispatch === null && config.onMessage !== undefined) {
     const message = parseMessageEvent(envelope);
-    if (message !== null) {
+    if (message !== null && !isSelfAuthoredSlackMessage(envelope, message)) {
       const botUserId = slackEventBotUserId(envelope);
       // Slack also emits message.channels for an app mention. The app_mention
       // callback owns that user action so the generic message is not duplicated.
@@ -850,7 +850,7 @@ async function handleEventPost(input: {
   }
 
   // Specialized handlers retain their bot/subtype filters. onMessage receives
-  // every structurally valid message event; onEvent remains the raw fallback.
+  // structurally valid messages except this app's own; onEvent is the raw fallback.
   const onEvent = config.onEvent;
   if (dispatch === null && onEvent !== undefined) {
     dispatch = () =>
@@ -882,6 +882,18 @@ async function handleEventPost(input: {
 
   input.waitUntil(dispatch());
   return new Response("ok");
+}
+
+function isSelfAuthoredSlackMessage(envelope: SlackEventEnvelope, message: SlackMessage): boolean {
+  const botUserId = slackEventBotUserId(envelope);
+  if (botUserId !== undefined && message.author?.userId === botUserId) {
+    return true;
+  }
+
+  // App-authored message events can omit `user`, so match Slack's app identity
+  // as a fallback. Other bots keep flowing to authored onMessage handlers.
+  const apiAppId = typeof envelope.api_app_id === "string" ? envelope.api_app_id : undefined;
+  return apiAppId !== undefined && message.raw.app_id === apiAppId;
 }
 
 async function dispatchSlackMessage(input: {


### PR DESCRIPTION
## Summary

- drop messages authored by the installed Slack app before message hooks dispatch
- identify self-authored events by the authorized bot user ID, with the receiving app ID as a fallback
- continue delivering messages from other bots to authored `onMessage` handlers
- cover channel, user-less app, and direct-message event shapes

## Root cause

Enabling Slack message events also delivers events for messages posted by the installed app. eve previously forwarded those events back into message handlers, so an agent response could recursively start another turn.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/slackChannel.test.ts` (75 tests)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- targeted `oxlint`
- `git diff --check`
