### PR TITLE
fix(eve): tui - render IME composition text at the prompt caret

### DIFF
--- a/.changeset/tui-ime-cursor-park.md
+++ b/.changeset/tui-ime-cursor-park.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The `eve dev` TUI now parks the terminal's hardware cursor on the prompt's caret cell after every repaint, so IME composition (pre-edit) text — e.g. Chinese, Japanese, or Korean input — renders inline in the input box instead of staying invisible until committed.

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -796,6 +796,26 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("parks the hardware cursor on the prompt caret so IME composition renders inline", async () => {
+    const { screen, input, renderer } = makeRenderer();
+
+    const prompt = renderer.readPrompt();
+    input.type("漢字");
+    input.left(); // caret on 字
+
+    // Terminals draw IME pre-edit text at the hardware cursor position, so
+    // each paint must park the (hidden) cursor on the caret cell: the prompt
+    // row, past the two gutter cells and the wide 漢 (2 cells).
+    const lines = screen.snapshot().split("\n");
+    const promptLine = lines.findIndex((line) => line.includes("❯ 漢字"));
+    expect(promptLine).toBeGreaterThanOrEqual(0);
+    expect(screen.cursorPosition()).toEqual({ line: promptLine, column: 4 });
+
+    input.enter();
+    await prompt;
+    renderer.shutdown();
+  });
+
   it("recovers from an unterminated bracketed paste instead of wedging input", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -111,12 +111,13 @@ import {
   visibleLine,
   type LineState,
 } from "./line-editor.js";
-import { LiveRegion } from "#cli/ui/live-region.js";
+import { LiveRegion, type LiveCursor } from "#cli/ui/live-region.js";
 import { buildStatusLine } from "./status-line.js";
 import { nextLogDisplayMode } from "./log-display-mode.js";
 import { createTheme, detectUnicode, type Theme } from "./theme.js";
 import {
   clipVisible,
+  inputTextWidth,
   renderInputText,
   renderInputWithBlockCursor,
   stripAnsi,
@@ -398,6 +399,13 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #remoteConnection?: RemoteConnectionSnapshot;
   #inputText = "";
   #inputCursor = 0;
+  /**
+   * Caret cell of the focused footer input, relative to the footer's first
+   * row; set by {@link #footerRows} on each paint. The paint parks the hidden
+   * hardware cursor there so the terminal renders IME composition (pre-edit)
+   * text inline in the input instead of at the frame's tail.
+   */
+  #footerCaret?: { row: number; column: number };
   readonly #promptHistory = new PromptHistory();
   #inputActive = false;
   /**
@@ -3340,11 +3348,19 @@ export class TerminalRenderer implements AgentTUIRenderer {
       ),
       ...footer,
     ];
+    const cursor = this.#liveCursor(liveRows.length, footer.length);
     if (committed.length > 0) {
-      this.#live.flush(committed, liveRows);
+      this.#live.flush(committed, liveRows, cursor);
     } else {
-      this.#live.update(liveRows);
+      this.#live.update(liveRows, cursor);
     }
+  }
+
+  /** Translates the footer-relative caret cell into live-region coordinates. */
+  #liveCursor(liveRowCount: number, footerRowCount: number): LiveCursor | undefined {
+    const caret = this.#footerCaret;
+    if (caret === undefined) return undefined;
+    return { row: liveRowCount - footerRowCount + caret.row, column: caret.column };
   }
 
   #replayTranscript(): void {
@@ -3367,6 +3383,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#live.flush(
       [...this.#renderAgentHeaderRows(), ...this.#committedTranscriptRows],
       liveRows,
+      this.#liveCursor(liveRows.length, footer.length),
     );
   }
 
@@ -3489,6 +3506,9 @@ export class TerminalRenderer implements AgentTUIRenderer {
   }
 
   #footerRows(width: number): string[] {
+    // Recomputed per paint: only footers that render a focused text input
+    // (the prompt and its streaming draft) park the hardware cursor.
+    this.#footerCaret = undefined;
     const c = this.#theme.colors;
     const rows: string[] = [""];
 
@@ -3607,7 +3627,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
           ? ""
           : promptPlaceholder(Date.now() - this.#promptPlaceholderStartedAtMs);
       }
-      rows.push(...promptInputRows(promptRows));
+      const prompt = promptInputRows(promptRows);
+      this.#footerCaret = {
+        row: rows.length + prompt.caret.row,
+        column: prompt.caret.column,
+      };
+      rows.push(...prompt.rows);
       rows.push(...statusRows);
       return rows;
     }
@@ -3727,7 +3752,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
       inert: options.inert,
     };
     if (options.inert && this.#streamDraft.text.length === 0) prompt.placeholder = "";
-    rows.push(...promptInputRows(prompt));
+    const rendered = promptInputRows(prompt);
+    this.#footerCaret = {
+      row: rows.length + rendered.caret.row,
+      column: rendered.caret.column,
+    };
+    rows.push(...rendered.rows);
   }
 
   /** Appends the persistent bottom status line below the prompt when it has content. */
@@ -4137,6 +4167,13 @@ interface PromptInputRowsInput {
   inert?: boolean;
 }
 
+/** The rendered prompt rows plus the caret cell within them, for IME cursor parking. */
+interface PromptInputRender {
+  readonly rows: string[];
+  /** Caret cell: `row` indexes {@link rows}; `column` is the terminal column. */
+  readonly caret: { readonly row: number; readonly column: number };
+}
+
 /**
  * Renders the prompt buffer as terminal rows, followed by a blank row that keeps
  * the persistent status visually separate. The buffer can carry newlines from
@@ -4154,24 +4191,32 @@ function promptInputRows({
   maxRows,
   placeholder,
   inert,
-}: PromptInputRowsInput): string[] {
+}: PromptInputRowsInput): PromptInputRender {
   const c = theme.colors;
+  // The caret cell sits after the two gutter cells (mark + space) plus the
+  // visible text before it — the same cells `renderInputWithBlockCursor`
+  // paints, measured with the same tab expansion.
+  const caretColumn = (before: string) => 2 + inputTextWidth(before);
 
   if (text.length === 0 && placeholder !== undefined) {
     // The empty state trades the active `❯` for a quiet `›` and lets the
     // caret rest on the placeholder's first character, like the setup
     // panel's text fields.
+    const window = visibleLine(
+      { text: placeholder, cursor: 0 },
+      Math.max(1, width - 3),
+      theme.glyph.ellipsis,
+    );
     const body = renderInputWithBlockCursor({
-      ...visibleLine(
-        { text: placeholder, cursor: 0 },
-        Math.max(1, width - 3),
-        theme.glyph.ellipsis,
-      ),
+      ...window,
       visible: caretVisible,
       inverse: c.inverse,
       render: (segment) => c.dim(renderInputText(segment)),
     });
-    return [clip(`${c.dim(theme.glyph.promptIdle)} ${body}`, width), ""];
+    return {
+      rows: [clip(`${c.dim(theme.glyph.promptIdle)} ${body}`, width), ""],
+      caret: { row: 0, column: caretColumn(window.before) },
+    };
   }
 
   const style = (segment: string): string => {
@@ -4194,6 +4239,7 @@ function promptInputRows({
   // markers (`│`, `▲`).
   const budget = Math.max(1, width - 3);
   const out: string[] = [];
+  let caret = { row: 0, column: 2 };
   for (let r = top; r < top + visibleCount; r += 1) {
     const row = layout.rows[r]!;
     let gutter = r === 0 ? promptGlyph : " ";
@@ -4218,6 +4264,7 @@ function promptInputRows({
         inverse: c.inverse,
         render: style,
       });
+      caret = { row: out.length, column: caretColumn(before) };
       // The argument hint trails the caret only on a single-line command draft.
       if (ghost.length > 0 && layout.rows.length === 1) body += ghost;
     } else {
@@ -4226,7 +4273,7 @@ function promptInputRows({
     out.push(clip(`${gutter} ${body}`, width));
   }
   out.push("");
-  return out;
+  return { rows: out, caret };
 }
 
 /** Kind + title of the previously rendered block, for gap / run decisions. */

--- a/packages/eve/src/cli/dev/tui/test/mock-terminal.ts
+++ b/packages/eve/src/cli/dev/tui/test/mock-terminal.ts
@@ -121,6 +121,11 @@ export class MockScreen extends EventEmitter implements TerminalOutput {
     return this.#lines.join("\n");
   }
 
+  /** The emulated cursor cell after the last write, 0-based. */
+  cursorPosition() {
+    return { line: this.#cursorLine, column: this.#cursorColumn };
+  }
+
   rawOutput() {
     return this.#rawOutput;
   }

--- a/packages/eve/src/cli/ui/live-region.test.ts
+++ b/packages/eve/src/cli/ui/live-region.test.ts
@@ -38,4 +38,34 @@ describe("LiveRegion", () => {
     live.clear();
     expect(screen.snapshot()).toBe("");
   });
+
+  it("parks the hardware cursor on the caret cell", () => {
+    const { screen, live } = setup();
+    live.update(["header", "> input", "status"], { row: 1, column: 2 });
+    // The terminal draws IME composition text at the cursor position; a raw
+    // write standing in for that overlay must land on the caret cell.
+    screen.write("X");
+    expect(screen.snapshot()).toBe("header\n> Xnput\nstatus");
+  });
+
+  it("repaints in place after parking the cursor", () => {
+    const { screen, live } = setup();
+    live.update(["one", "two", "three"], { row: 0, column: 4 });
+    live.update(["uno", "dos"]);
+    expect(screen.snapshot()).toBe("uno\ndos");
+  });
+
+  it("commits rows after parking the cursor", () => {
+    const { screen, live } = setup();
+    live.update(["footer", "status"], { row: 0, column: 3 });
+    live.flush(["committed line"], ["footer", "status"], { row: 0, column: 3 });
+    expect(screen.snapshot()).toBe("committed line\nfooter\nstatus");
+  });
+
+  it("clamps an out-of-range park position to the live region", () => {
+    const { screen, live } = setup();
+    live.update(["only"], { row: 5, column: -2 });
+    screen.write("X");
+    expect(screen.snapshot()).toBe("Xnly");
+  });
 });

--- a/packages/eve/src/cli/ui/live-region.ts
+++ b/packages/eve/src/cli/ui/live-region.ts
@@ -36,6 +36,20 @@ export interface LiveRegionOutput {
   write(chunk: string): boolean;
 }
 
+/**
+ * Hardware-cursor park position within the live region, 0-based. Terminals
+ * anchor the IME composition (pre-edit) overlay to the cursor *position*
+ * regardless of its visibility, so parking the hidden cursor under the drawn
+ * block caret makes uncommitted IME text render inline in the focused input
+ * instead of at the frame's tail.
+ */
+export interface LiveCursor {
+  /** Row within the live region (0 = first live row). */
+  readonly row: number;
+  /** Terminal column of the caret cell. */
+  readonly column: number;
+}
+
 export interface LiveRegionOptions {
   /** Wrap each paint in synchronized-update markers to avoid flicker. */
   synchronized?: boolean;
@@ -46,6 +60,8 @@ export class LiveRegion {
   readonly #synchronized: boolean;
   /** Rows the live region currently occupies on screen. */
   #liveRowCount = 0;
+  /** Live-region row the hardware cursor was left on by the last write. */
+  #cursorRow = 0;
 
   constructor(output: LiveRegionOutput, options?: LiveRegionOptions) {
     this.#write = output.write.bind(output);
@@ -74,17 +90,19 @@ export class LiveRegion {
   /**
    * Repaints the live region in place from `liveRows`. Each row must already
    * be styled and fit within the terminal width (one row == one screen line).
+   * When `cursor` is given, the (hidden) hardware cursor parks on that cell so
+   * the terminal renders IME composition text at the focused input's caret.
    */
-  update(liveRows: readonly string[]): void {
-    this.#paint([], liveRows);
+  update(liveRows: readonly string[], cursor?: LiveCursor): void {
+    this.#paint([], liveRows, cursor);
   }
 
   /**
    * Commits `committedRows` to scrollback above the live region, then repaints
    * `liveRows`. Committed rows are permanent and scroll with the terminal.
    */
-  flush(committedRows: readonly string[], liveRows: readonly string[]): void {
-    this.#paint(committedRows, liveRows);
+  flush(committedRows: readonly string[], liveRows: readonly string[], cursor?: LiveCursor): void {
+    this.#paint(committedRows, liveRows, cursor);
   }
 
   /**
@@ -99,12 +117,14 @@ export class LiveRegion {
     }
     this.#write(`${this.#moveToTop()}${CLEAR_TO_END}`);
     this.#liveRowCount = 0;
+    this.#cursorRow = 0;
   }
 
   /** Clears the visible transcript and, where supported, terminal scrollback. */
   clearAll(): void {
     this.#write(`${CLEAR_SCROLLBACK}${CLEAR_SCREEN}${CURSOR_HOME}`);
     this.#liveRowCount = 0;
+    this.#cursorRow = 0;
   }
 
   /**
@@ -114,29 +134,51 @@ export class LiveRegion {
    */
   reset(): void {
     this.#liveRowCount = 0;
+    this.#cursorRow = 0;
   }
 
-  #paint(committedRows: readonly string[], liveRows: readonly string[]): void {
+  #paint(committedRows: readonly string[], liveRows: readonly string[], cursor?: LiveCursor): void {
     const body =
       this.#moveToTop() +
       CLEAR_TO_END +
       committedRows.map((row) => `${row}\n`).join("") +
       liveRows.join("\n");
 
-    this.#write(this.#synchronized ? `${SYNC_START}${body}${SYNC_END}` : body);
     this.#liveRowCount = liveRows.length;
+    this.#cursorRow = Math.max(0, liveRows.length - 1);
+    const park = cursor === undefined ? "" : this.#parkCursor(cursor);
+
+    this.#write(this.#synchronized ? `${SYNC_START}${body}${park}${SYNC_END}` : `${body}${park}`);
   }
 
   /**
-   * Cursor sequence that returns to column 0 of the first live row. The cursor
-   * sits at the end of the last live row after a paint, so move up
-   * `liveRowCount - 1` lines. CPL (`F`) treats a 0 parameter as 1, so a single
-   * (or empty) live region uses a bare carriage return instead.
+   * Cursor sequence that moves from the end of the freshly painted last live
+   * row to the caret cell, so the terminal's IME overlay anchors to the
+   * focused input. The cursor itself stays hidden — the renderer draws its
+   * own caret; only the position matters here.
+   */
+  #parkCursor(cursor: LiveCursor): string {
+    if (this.#liveRowCount === 0) return "";
+    const row = Math.min(Math.max(0, cursor.row), this.#liveRowCount - 1);
+    const column = Math.max(0, cursor.column);
+    this.#cursorRow = row;
+    // CPL (`F`) treats a 0 parameter as 1, so staying on the last row uses a
+    // bare carriage return; CUF (`C`) likewise only fires for column > 0.
+    const vertical =
+      this.#liveRowCount - 1 - row > 0 ? `${ESC}[${this.#liveRowCount - 1 - row}F` : "\r";
+    return column > 0 ? `${vertical}${ESC}[${column}C` : vertical;
+  }
+
+  /**
+   * Cursor sequence that returns to column 0 of the first live row from
+   * wherever the last paint left the hardware cursor (the end of the last
+   * live row, or a parked caret cell). CPL (`F`) treats a 0 parameter as 1,
+   * so a cursor already on the first row uses a bare carriage return.
    */
   #moveToTop(): string {
-    if (this.#liveRowCount <= 1) {
+    if (this.#cursorRow <= 0) {
       return "\r";
     }
-    return `${ESC}[${this.#liveRowCount - 1}F`;
+    return `${ESC}[${this.#cursorRow}F`;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/vercel/eve/issues/1114

## Problem

When typing with an IME (e.g. Chinese Zhuyin/Pinyin, Japanese, Korean) in the `eve dev` TUI prompt, the uncommitted composition (pre-edit) text was not displayed inside the input box — characters only appeared after the composition was committed.

Terminal emulators anchor the IME composition overlay to the **hardware cursor position**, but the TUI hides the hardware cursor and leaves it parked at the tail of the last painted row, so the pre-edit string rendered nowhere visible.

## Solution

Park the (hidden) hardware cursor on the prompt's caret cell after every repaint. Only the cursor *position* matters for the IME overlay — the cursor itself stays hidden, so the renderer's drawn block caret is unchanged visually.

- `LiveRegion.update()`/`flush()` accept an optional `LiveCursor` park position, emitted after the frame body (inside the synchronized-update markers). A new `#cursorRow` tracks where the cursor was left so the next repaint's move-to-top stays correct.
- `promptInputRows` now reports the caret cell (row + column, measured with the same tab-expansion and CJK-width rules as the painted cells), and the renderer translates it into live-region coordinates. The active prompt, the empty-placeholder prompt, and the inert streaming draft all park the cursor.
- The setup panel / question panel freeform inputs are unchanged in this PR and can be wired up the same way as a follow-up.

## Before & After

### Before

https://github.com/user-attachments/assets/9e22325e-1e56-4dac-a6f1-e5c2e2e059c5

### After

https://github.com/user-attachments/assets/3bef8512-0d46-46cc-8640-cc157a99dc2d

## Testing

- `LiveRegion` unit tests for cursor parking, clamping, and repaint-after-park.
- A renderer test that types CJK text (`漢字`) into the prompt and asserts the emulated hardware cursor lands on the caret cell (gutter + wide-character aware).
- `pnpm typecheck`, `pnpm lint`, `pnpm guard:invariants`, `pnpm test:unit` all pass.
- Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)