### PR TITLE
docs: use pnpm for extension installs

### DIFF
--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -34,7 +34,7 @@ describe("Kernel extension setup", () => {
     const integration = getIntegration("kernel")!;
 
     expect(integration.type).toBe("extension");
-    expect(integration.install).toContain("npm install @onkernel/eve-extension");
+    expect(integration.install).toContain("pnpm add @onkernel/eve-extension");
     expect(integration.quickStart).toContain(
       'kernel({ connect: "mcp.onkernel.com/eve-extension" })',
     );

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -663,7 +663,7 @@ const extensionPresentations: Record<string, ExtensionPresentation> = {
     install: `Install the Browserbase extension for eve:
 
 \`\`\`bash
-npm install @browserbasehq/eve
+pnpm add @browserbasehq/eve
 \`\`\`
 
 The extension requires Node.js 24 or later. A Browserbase API key covers both cloud browser sessions and Stagehand inference through Browserbase Model Gateway, so you do not need a separate model-provider key.`,
@@ -716,7 +716,7 @@ Browserbase uses keep-alive sessions and eve's durable per-session state to reco
     install: `Install the Kernel extension for eve:
 
 \`\`\`bash
-npm install @onkernel/eve-extension
+pnpm add @onkernel/eve-extension
 \`\`\`
 
 The extension requires Node.js 24 or later and eve 0.25 or later. It mounts Kernel's hosted MCP browser tools and a \`browse\` skill without requiring you to maintain browser tool code.`,
@@ -760,7 +760,7 @@ The default mount can execute JavaScript in the browser VM and reuse authenticat
     install: `Install the Jetty extension for eve:
 
 \`\`\`bash
-npm install @jetty/eve
+pnpm add @jetty/eve
 \`\`\`
 
 The extension requires Node.js 24 or later and eve 0.25 or later. It can ingest every completed turn as a durable Jetty trajectory, grade turns inline, steer experiments from their grades, and report native \`eve eval\` results.`,
@@ -819,7 +819,7 @@ Jetty trajectories persist agent inputs and outputs. Redact PII before grading, 
     install: `Install the GitHub Tools extension and Vercel Connect client:
 
 \`\`\`bash
-npm install @github-tools/eve-extension @vercel/connect
+pnpm add @github-tools/eve-extension @vercel/connect
 \`\`\`
 
 The extension provides the GitHub toolset as a versioned eve package. Use a Vercel Connect connector for short-lived, scoped GitHub tokens, or omit \`@vercel/connect\` and authenticate with a GitHub token.`,
@@ -884,7 +884,7 @@ For local or non-Vercel deployments, omit \`connector\` and set \`GITHUB_TOKEN\`
     install: `Install the agent-browser extension for eve:
 
 \`\`\`bash
-npm install @agent-browser/eve
+pnpm add @agent-browser/eve
 \`\`\`
 
 The extension installs agent-browser automatically on first use and runs it inside the agent's sandbox. It requires a sandbox backend with real process execution, such as Vercel Sandbox, Docker, or microsandbox.`,

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -37,7 +37,7 @@ describe("integration discovery", () => {
     expect(browserbase).toBeDefined();
 
     const markdown = integrationMarkdown(browserbase!);
-    expect(markdown).toContain("npm install @browserbasehq/eve");
+    expect(markdown).toContain("pnpm add @browserbasehq/eve");
     expect(markdown).toContain('import browserbase from "@browserbasehq/eve"');
     expect(markdown).toContain("BROWSERBASE_API_KEY");
     expect(integrationSearchText(browserbase!)).toContain("Stagehand");
@@ -48,7 +48,7 @@ describe("integration discovery", () => {
     expect(jetty).toBeDefined();
 
     const markdown = integrationMarkdown(jetty!);
-    expect(markdown).toContain("npm install @jetty/eve");
+    expect(markdown).toContain("pnpm add @jetty/eve");
     expect(markdown).toContain('import jetty from "@jetty/eve"');
     expect(markdown).toContain('import { Jetty } from "@jetty/eve/reporter"');
     expect(markdown).toContain("JETTY_API_TOKEN");
@@ -60,7 +60,7 @@ describe("integration discovery", () => {
     expect(githubTools).toBeDefined();
 
     const markdown = integrationMarkdown(githubTools!);
-    expect(markdown).toContain("npm install @github-tools/eve-extension");
+    expect(markdown).toContain("pnpm add @github-tools/eve-extension");
     expect(markdown).toContain('connector: "github/my-connector"');
     expect(markdown).toContain('preset: "maintainer"');
     expect(markdown).toContain("github__addPullRequestComment");

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -148,10 +148,10 @@ A mount gives the publisher's contributions a namespace. Updating the package up
 
 ### Install the package
 
-Install the extension in the consumer's agent project:
+Install the extension with the package manager already used by the consumer's agent project. Fresh eve projects use pnpm:
 
 ```bash
-npm install @acme/crm
+pnpm add @acme/crm
 ```
 
 ### Mount it


### PR DESCRIPTION
## Summary

- use `pnpm add` in extension integration install examples
- clarify that consumers should use their project’s existing package manager
- align the extension guide with fresh eve projects, which default to pnpm

## Testing

- `cd apps/docs && ../../node_modules/.bin/vitest run lib/integrations`
- `node ./scripts/check-docs.mjs`
- `node ./scripts/check-doc-snippets.mjs`
- `node ./scripts/check-doc-mdx.mjs`