### PR TITLE
docs: style KERNEL brand in uppercase

### DIFF
--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -229,9 +229,10 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
   },
   {
     slug: "kernel",
-    name: "Kernel",
+    name: "KERNEL",
     kind: "extension",
-    tagline: "Add a Kernel cloud browser and browser automation skills to an eve agent.",
+    tagline:
+      "Let your eve agent use the Internet with KERNEL browser infra, o11y, and stealth. Integrated natively with Vercel Connect and AI Gateway.",
     surfaces: { scaffoldable: false, gallery: true },
   },
   {


### PR DESCRIPTION
## Summary

- style KERNEL in uppercase across its integration catalog entry and setup copy
- preserve lowercase package names, URLs, filenames, and tool namespaces
- update relevant test descriptions

## Testing

- `cd apps/docs && ../../node_modules/.bin/vitest run lib/integrations`
- `cd packages/eve-catalog && ../../node_modules/.bin/vitest run --config vitest.config.ts`
- docs and catalog TypeScript checks