### PR TITLE
fix(eve): handle Vercel team pagination and CLI upgrades

### DIFF
--- a/.changeset/smart-chefs-upgrade.md
+++ b/.changeset/smart-chefs-upgrade.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Load up to 100 Vercel teams per page and use the authenticated API continuation that matches Vercel's emitted cursor, avoiding repeated-page loops for accounts with many teams. When an outdated CLI lacks the required list options, the TUI can upgrade it with the native upgrader and now retains a concise error if that upgrade fails.

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -80,8 +80,12 @@ function run(input: {
   flows: TuiSetupFlows;
   renderer?: TuiSetupCommandRenderer;
   initialModelStep?: "provider";
+  upgradeChoice?: "upgrade" | "later";
 }) {
-  const fake = createFakePrompter({});
+  const { upgradeChoice } = input;
+  const fake = createFakePrompter(
+    upgradeChoice === undefined ? {} : { single: () => upgradeChoice },
+  );
   const commandInput: TuiSetupCommandInput = {
     command: input.command,
     appRoot: APP_ROOT,
@@ -230,6 +234,93 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "model", flows })).resolves.toEqual({
       message: "/model dismissed.",
       preserveFlowDiagnostics: false,
+    });
+  });
+
+  it("prompts to upgrade an old Vercel CLI when setup reports it unsupported", async () => {
+    const flows = fakeFlows({
+      runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(async () => {
+        throw new HumanActionRequiredError({
+          kind: "vercel-cli-upgrade",
+          command: "vercel upgrade",
+          reason: "The installed Vercel CLI does not support the required team-list options.",
+        });
+      }),
+      runInstallVercelCliFlow: vi.fn<TuiSetupFlows["runInstallVercelCliFlow"]>(async () => ({
+        kind: "installed",
+      })),
+    });
+
+    await expect(run({ command: "model", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
+      message: "Upgraded the Vercel CLI. Retry /model.",
+      preserveFlowDiagnostics: false,
+    });
+    expect(flows.runInstallVercelCliFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appRoot: APP_ROOT,
+        upgrade: true,
+      }),
+    );
+  });
+
+  it("gives the manual upgrade command when the old-CLI prompt is declined", async () => {
+    const flows = fakeFlows({
+      runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(async () => {
+        throw new HumanActionRequiredError({
+          kind: "vercel-cli-upgrade",
+          command: "vercel upgrade",
+          reason: "The installed Vercel CLI does not support the required team-list options.",
+        });
+      }),
+    });
+
+    await expect(run({ command: "model", flows, upgradeChoice: "later" })).resolves.toEqual({
+      message: "The Vercel CLI needs an update — run `vercel upgrade`, then retry /model.",
+      preserveFlowDiagnostics: true,
+    });
+    expect(flows.runInstallVercelCliFlow).not.toHaveBeenCalled();
+  });
+
+  it("prints a thrown upgrade error with the manual command", async () => {
+    const flows = fakeFlows({
+      runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(async () => {
+        throw new HumanActionRequiredError({
+          kind: "vercel-cli-upgrade",
+          command: "vercel upgrade",
+          reason: "The installed Vercel CLI does not support the required team-list options.",
+        });
+      }),
+      runInstallVercelCliFlow: vi.fn<TuiSetupFlows["runInstallVercelCliFlow"]>(async () => {
+        throw new Error("package manager failed");
+      }),
+    });
+
+    await expect(run({ command: "model", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
+      message:
+        "Couldn't upgrade the Vercel CLI (package manager failed) — run `vercel upgrade`, then retry /model.",
+      preserveFlowDiagnostics: true,
+    });
+  });
+
+  it("prints the native CLI failure reason with the manual command", async () => {
+    const flows = fakeFlows({
+      runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(async () => {
+        throw new HumanActionRequiredError({
+          kind: "vercel-cli-upgrade",
+          command: "vercel upgrade",
+          reason: "The installed Vercel CLI does not support the required team-list options.",
+        });
+      }),
+      runInstallVercelCliFlow: vi.fn<TuiSetupFlows["runInstallVercelCliFlow"]>(async () => ({
+        kind: "failed",
+        reason: "ERR_PNPM_NO_GLOBAL_BIN_DIR Unable to find the global bin directory",
+      })),
+    });
+
+    await expect(run({ command: "model", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
+      message:
+        "Couldn't upgrade the Vercel CLI (ERR_PNPM_NO_GLOBAL_BIN_DIR Unable to find the global bin directory) — run `vercel upgrade`, then retry /model.",
+      preserveFlowDiagnostics: true,
     });
   });
 

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -316,6 +316,12 @@ async function executeSetupCommand(
         preserveFlowDiagnostics: command !== "model",
       };
     }
+    const upgrade = await vercelCliUpgradeOutcome(error, command, flows, {
+      appRoot,
+      prompter,
+      signal,
+    });
+    if (upgrade !== undefined) return upgrade;
     // Provisioning steps (link, deploy, Slack) throw a Vercel human action when
     // `whoami` fails or a scope is denied. Route it to the in-TUI fix instead of
     // dumping the raw "Human action required" message.
@@ -329,12 +335,102 @@ async function executeSetupCommand(
 }
 
 /**
+ * Offers to upgrade an old Vercel CLI when setup reports an unsupported
+ * capability. This prompt is intentionally at the TUI boundary: shared setup
+ * callers retain the structured human action, while an interactive command can
+ * perform the recovery in place after the user opts in.
+ */
+async function vercelCliUpgradeOutcome(
+  error: unknown,
+  command: string,
+  flows: TuiSetupFlows,
+  input: { appRoot: string; prompter: Prompter; signal: AbortSignal },
+): Promise<TuiSetupCommandResult | undefined> {
+  if (!(error instanceof HumanActionRequiredError) || error.action.kind !== "vercel-cli-upgrade") {
+    return undefined;
+  }
+
+  let choice: "upgrade" | "later";
+  try {
+    choice = await input.prompter.select({
+      message: "Your Vercel CLI needs an update to list your teams. Upgrade now?",
+      options: [
+        {
+          value: "upgrade",
+          label: "Upgrade Vercel CLI",
+          description: "Run the Vercel CLI's native upgrader",
+        },
+        { value: "later", label: "Not now" },
+      ],
+      initialValue: "upgrade",
+    });
+  } catch {
+    choice = "later";
+  }
+
+  if (choice === "later") {
+    return {
+      message: `The Vercel CLI needs an update — run \`vercel upgrade\`, then retry /${command}.`,
+      preserveFlowDiagnostics: true,
+    };
+  }
+
+  let result: InstallVercelCliResult;
+  try {
+    result = await flows.runInstallVercelCliFlow({
+      appRoot: input.appRoot,
+      prompter: input.prompter,
+      signal: input.signal,
+      upgrade: true,
+    });
+  } catch (error) {
+    return {
+      message: vercelCliUpgradeFailureMessage(command, errorMessage(error)),
+      preserveFlowDiagnostics: true,
+    };
+  }
+  switch (result.kind) {
+    case "installed":
+      return {
+        message: `Upgraded the Vercel CLI. Retry /${command}.`,
+        preserveFlowDiagnostics: false,
+      };
+    case "failed":
+      return {
+        message: vercelCliUpgradeFailureMessage(command, result.reason),
+        preserveFlowDiagnostics: true,
+      };
+    case "cancelled":
+      return {
+        message: `Vercel CLI upgrade cancelled — run \`vercel upgrade\`, then retry /${command}.`,
+        preserveFlowDiagnostics: true,
+      };
+    case "already":
+      return {
+        message: `The Vercel CLI is already up to date. Retry /${command}.`,
+        preserveFlowDiagnostics: false,
+      };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const compact = message.replace(/\s+/gu, " ").trim();
+  return compact.length <= 240 ? compact : `${compact.slice(0, 239)}…`;
+}
+
+function vercelCliUpgradeFailureMessage(command: string, reason?: string): string {
+  const detail = reason === undefined || reason === "" ? "" : ` (${reason})`;
+  return `Couldn't upgrade the Vercel CLI${detail} — run \`vercel upgrade\`, then retry /${command}.`;
+}
+
+/**
  * Translates a Vercel {@link HumanActionRequiredError} into the in-TUI routing
  * message, or `undefined` for anything else. One translator so every path that
  * can surface a provisioning action — the command catch, the `/channels`
  * partial-success result, and the deploy-and-chat continuation — routes
- * `vercel-login`, `vercel-forbidden`, and `vercel-cli-missing` the same way
- * rather than leaking the raw error text.
+ * login, forbidden-scope, and CLI recovery actions the same way rather than
+ * leaking the raw error text.
  */
 function vercelActionOutcome(error: unknown, command: string): TuiSetupCommandResult | undefined {
   if (!(error instanceof HumanActionRequiredError)) return undefined;
@@ -351,6 +447,8 @@ function vercelActionMessage(kind: string, command: string): string | undefined 
       return `Vercel denied access to that team — run /vc:login to re-authenticate (for example to complete SSO), or pick a team you can access, then retry /${command}.`;
     case "vercel-cli-missing":
       return `The Vercel CLI isn't installed — run /vc:install to install it, then retry /${command}.`;
+    case "vercel-cli-upgrade":
+      return `The Vercel CLI needs an update — run \`vercel upgrade\`, then retry /${command}.`;
     default:
       return undefined;
   }

--- a/packages/eve/src/setup/flows/install-vercel-cli.test.ts
+++ b/packages/eve/src/setup/flows/install-vercel-cli.test.ts
@@ -22,11 +22,16 @@ function detectPnpm(): InstallVercelCliDeps["detectPackageManager"] {
 function run(
   deps: Partial<InstallVercelCliDeps>,
   spawnPackageManager?: InstallVercelCliDeps["spawnPackageManager"],
+  upgrade = false,
 ) {
   const { prompter } = createFakePrompter({});
-  const merged: Partial<InstallVercelCliDeps> = { detectPackageManager: detectPnpm(), ...deps };
+  const merged: Partial<InstallVercelCliDeps> = {
+    detectPackageManager: detectPnpm(),
+    runVercel: vi.fn(async () => true),
+    ...deps,
+  };
   if (spawnPackageManager !== undefined) merged.spawnPackageManager = spawnPackageManager;
-  return runInstallVercelCliFlow({ appRoot: APP_ROOT, prompter, deps: merged });
+  return runInstallVercelCliFlow({ appRoot: APP_ROOT, prompter, deps: merged, upgrade });
 }
 
 describe("runInstallVercelCliFlow", () => {
@@ -54,6 +59,67 @@ describe("runInstallVercelCliFlow", () => {
       ["add", "-g", "vercel@latest"],
       expect.objectContaining({}),
     );
+  });
+
+  it("uses the active Vercel CLI's native upgrader instead of the project's manager", async () => {
+    const detectPackageManager = vi.fn<InstallVercelCliDeps["detectPackageManager"]>(
+      async (): Promise<DetectedPackageManager> => ({ kind: "yarn", source: "lockfile" }),
+    );
+    const runVercel = vi.fn<InstallVercelCliDeps["runVercel"]>(async () => true);
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
+      async () => true,
+    );
+
+    await expect(
+      run(
+        {
+          getVercelAuthStatus: statusProbe("authenticated"),
+          detectPackageManager,
+          runVercel,
+        },
+        spawnPackageManager,
+        true,
+      ),
+    ).resolves.toEqual({ kind: "installed" });
+    expect(runVercel).toHaveBeenCalledWith(
+      ["upgrade"],
+      expect.objectContaining({
+        cwd: APP_ROOT,
+        nonInteractive: true,
+      }),
+    );
+    expect(detectPackageManager).not.toHaveBeenCalled();
+    expect(spawnPackageManager).not.toHaveBeenCalled();
+  });
+
+  it("reports the useful stderr line when the native upgrade exits non-zero", async () => {
+    await expect(
+      run(
+        {
+          getVercelAuthStatus: statusProbe("authenticated"),
+          runVercel: vi.fn(async (_args, options) => {
+            options.onOutput?.({
+              stream: "stderr",
+              text: "Error: Cannot find module 'path/posix'",
+            });
+            options.onOutput?.({
+              stream: "stderr",
+              text: "    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:889:15)",
+            });
+            options.onOutput?.({
+              stream: "stderr",
+              text: "vercel upgrade exited with code 1.",
+            });
+            return false;
+          }),
+        },
+        undefined,
+        true,
+      ),
+    ).resolves.toEqual({
+      kind: "failed",
+      reason: "Error: Cannot find module 'path/posix'",
+    });
   });
 
   it("reports failed when the install exits non-zero", async () => {

--- a/packages/eve/src/setup/flows/install-vercel-cli.ts
+++ b/packages/eve/src/setup/flows/install-vercel-cli.ts
@@ -1,6 +1,6 @@
 import { createPromptCommandOutput } from "#setup/cli/index.js";
 import { detectPackageManager, type PackageManagerKind } from "#setup/package-manager.js";
-import { spawnPackageManager } from "#setup/primitives/index.js";
+import { runVercel, spawnPackageManager } from "#setup/primitives/index.js";
 import { getVercelAuthStatus } from "#setup/vercel-project.js";
 
 import type { Prompter } from "../prompter.js";
@@ -12,7 +12,7 @@ export type InstallVercelCliResult =
   /** The package manager installed it and it now resolves. */
   | { kind: "installed" }
   /** The install exited non-zero, or the CLI still isn't on PATH afterward. */
-  | { kind: "failed" }
+  | { kind: "failed"; reason?: string }
   /** The user interrupted (Ctrl-C / Esc) before the install finished. */
   | { kind: "cancelled" };
 
@@ -20,12 +20,14 @@ export type InstallVercelCliResult =
 export interface InstallVercelCliDeps {
   getVercelAuthStatus: typeof getVercelAuthStatus;
   detectPackageManager: typeof detectPackageManager;
+  runVercel: typeof runVercel;
   spawnPackageManager: typeof spawnPackageManager;
 }
 
 const defaultDeps: InstallVercelCliDeps = {
   getVercelAuthStatus,
   detectPackageManager,
+  runVercel,
   spawnPackageManager,
 };
 
@@ -42,6 +44,28 @@ function globalInstallArguments(kind: PackageManagerKind): string[] {
   }
 }
 
+const MAX_UPGRADE_FAILURE_LENGTH = 240;
+
+/** Picks one useful stderr line without exposing a whole stack trace in the TUI outcome. */
+function summarizeUpgradeFailure(stderr: readonly string[]): string | undefined {
+  const lines = stderr
+    .map((line) => line.trim().replace(/\s+/gu, " "))
+    .filter(
+      (line) =>
+        line !== "" &&
+        line !== "}" &&
+        !line.startsWith("at ") &&
+        !/^vercel upgrade exited with code \d+\.$/u.test(line),
+    );
+  const detail =
+    lines.find((line) => /^(?:error\b|err_|.*\b(?:cannot|failed|could not)\b)/iu.test(line)) ??
+    lines.at(-1);
+  if (detail === undefined) return undefined;
+  return detail.length <= MAX_UPGRADE_FAILURE_LENGTH
+    ? detail
+    : `${detail.slice(0, MAX_UPGRADE_FAILURE_LENGTH - 1)}…`;
+}
+
 /**
  * THE INSTALL FLOW for the dev TUI's `/vc:install`: the fix command for the
  * "Vercel CLI not found" diagnostic, so every diagnostic has a matching
@@ -49,11 +73,15 @@ function globalInstallArguments(kind: PackageManagerKind): string[] {
  * global install with the project's package manager, streaming output to the
  * rail, then re-probes. A global install can exit clean yet leave the binary
  * off PATH (pnpm/yarn global bins commonly aren't), so success is confirmed by
- * the re-probe, not the exit code alone.
+ * the re-probe, not the exit code alone. `upgrade` invokes the active Vercel
+ * CLI's native upgrader so it can update the installation that owns that
+ * executable, independent of the project's package manager.
  */
 export async function runInstallVercelCliFlow(input: {
   appRoot: string;
   prompter: Prompter;
+  /** Reinstall the latest CLI even when an existing binary resolves. */
+  upgrade?: boolean;
   signal?: AbortSignal;
   deps?: Partial<InstallVercelCliDeps>;
 }): Promise<InstallVercelCliResult> {
@@ -66,26 +94,55 @@ export async function runInstallVercelCliFlow(input: {
     return status !== "cli-missing";
   };
 
-  if (await withSpinner(prompter, "Checking for the Vercel CLI…", probe)) {
+  if (!input.upgrade && (await withSpinner(prompter, "Checking for the Vercel CLI…", probe))) {
     signal?.throwIfAborted();
     return { kind: "already" };
   }
   signal?.throwIfAborted();
 
-  const manager = await deps.detectPackageManager(appRoot);
-  const ok = await withSpinner(prompter, `Installing the Vercel CLI with ${manager.kind}…`, () =>
-    deps.spawnPackageManager(manager.kind, appRoot, globalInstallArguments(manager.kind), {
-      onOutput,
-      signal,
-      // A global install never prompts; closing stdin keeps it from contending
-      // with the TUI's raw-mode key consumer.
-      nonInteractive: true,
-    }),
-  );
+  let ok: boolean;
+  let failureReason: string | undefined;
+  if (input.upgrade) {
+    const stderr: string[] = [];
+    ok = await withSpinner(prompter, "Upgrading the Vercel CLI…", async () => {
+      const upgraded = await deps.runVercel(["upgrade"], {
+        cwd: appRoot,
+        onOutput: (line) => {
+          onOutput(line);
+          if (line.stream === "stderr") stderr.push(line.text);
+        },
+        signal,
+        nonInteractive: true,
+      });
+      if (!upgraded) failureReason = summarizeUpgradeFailure(stderr);
+      return upgraded;
+    });
+  } else {
+    const manager = await deps.detectPackageManager(appRoot);
+    ok = await withSpinner(prompter, `Installing the Vercel CLI with ${manager.kind}…`, () =>
+      deps.spawnPackageManager(manager.kind, appRoot, globalInstallArguments(manager.kind), {
+        onOutput,
+        signal,
+        // A global install never prompts; closing stdin keeps it from contending
+        // with the TUI's raw-mode key consumer.
+        nonInteractive: true,
+      }),
+    );
+  }
   if (signal?.aborted === true) return { kind: "cancelled" };
-  if (!ok) return { kind: "failed" };
+  if (!ok) {
+    return failureReason === undefined
+      ? { kind: "failed" }
+      : { kind: "failed", reason: failureReason };
+  }
 
   const present = await withSpinner(prompter, "Verifying the Vercel CLI…", probe);
   signal?.throwIfAborted();
-  return present ? { kind: "installed" } : { kind: "failed" };
+  if (present) return { kind: "installed" };
+  return input.upgrade
+    ? {
+        kind: "failed",
+        reason: "The Vercel CLI could not be found after the upgrade completed.",
+      }
+    : { kind: "failed" };
 }

--- a/packages/eve/src/setup/vercel-project-api.test.ts
+++ b/packages/eve/src/setup/vercel-project-api.test.ts
@@ -34,10 +34,7 @@ describe("listTeams", () => {
       )
       .mockResolvedValueOnce(
         captured({
-          teams: [
-            { name: "Current", slug: "current", current: true },
-            { name: "Other", slug: "other", current: false },
-          ],
+          teams: [{ name: "Other", slug: "other" }],
           pagination: { next: null },
         }),
       );
@@ -47,8 +44,13 @@ describe("listTeams", () => {
       { name: "Other", slug: "other", current: false },
     ]);
     expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
+      1,
+      ["teams", "ls", "--format", "json", "--limit", "100"],
+      { cwd: "/repo", signal: undefined },
+    );
+    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
       2,
-      ["teams", "ls", "--format", "json", "--next", "20"],
+      ["api", "/v2/teams?limit=100&until=20"],
       { cwd: "/repo", signal: undefined },
     );
   });
@@ -56,7 +58,22 @@ describe("listTeams", () => {
   it("rejects a repeated pagination cursor", async () => {
     mockedCaptureVercel.mockResolvedValue(captured({ teams: [], pagination: { next: 20 } }));
 
-    await expect(listTeams("/repo")).rejects.toThrow("repeated pagination cursor");
+    await expect(listTeams("/repo")).rejects.toThrow(
+      "Vercel returned a repeated pagination cursor",
+    );
+  });
+
+  it("requests a CLI upgrade when the team-list flags are unsupported", async () => {
+    mockedCaptureVercel.mockResolvedValue(failed("Error: unknown or unexpected option: --limit"));
+
+    await expect(listTeams("/repo")).rejects.toMatchObject({
+      name: "HumanActionRequiredError",
+      action: {
+        kind: "vercel-cli-upgrade",
+        command: "vercel upgrade",
+        reason: expect.stringContaining("does not support"),
+      },
+    });
   });
 
   it("rejects an invalid entry instead of returning a partial page", async () => {

--- a/packages/eve/src/setup/vercel-project-api.ts
+++ b/packages/eve/src/setup/vercel-project-api.ts
@@ -48,6 +48,16 @@ const VercelTeamPageSchema = z
   })
   .transform((data) => ({ items: data.teams, next: data.pagination?.next ?? undefined }));
 
+const VercelApiTeamPageSchema = z
+  .object({
+    teams: z.array(VercelTeamListEntrySchema.omit({ current: true })),
+    pagination: VercelPaginationSchema.optional(),
+  })
+  .transform((data) => ({
+    items: data.teams.map((team) => ({ ...team, current: false })),
+    next: data.pagination?.next ?? undefined,
+  }));
+
 const VercelProjectPageSchema = z
   .object({
     projects: z.array(VercelProjectListEntrySchema),
@@ -66,7 +76,7 @@ export function parseVercelJson(stdout: string, description: string): unknown {
 
 /**
  * Drains a cursor-paginated Vercel list, deduping by `key`. A repeated cursor
- * means Vercel paged us in a circle — bail rather than loop forever.
+ * means the API paged us in a circle — bail rather than loop forever.
  */
 async function drainPages<T>(
   label: string,
@@ -78,7 +88,10 @@ async function drainPages<T>(
   let next: number | undefined;
   while (true) {
     const page = await fetchPage(next);
-    for (const item of page.items) items.set(key(item), item);
+    for (const item of page.items) {
+      const itemKey = key(item);
+      if (!items.has(itemKey)) items.set(itemKey, item);
+    }
     if (page.next === undefined) return [...items.values()];
     if (cursors.has(page.next)) {
       throw new Error(`Vercel returned a repeated pagination cursor for ${label}.`);
@@ -99,21 +112,62 @@ export function requireVercelTeamAccess(failure: VercelCaptureFailure): never {
   });
 }
 
+const VERCEL_TEAM_PAGE_LIMIT = 100;
+
+function isUnsupportedTeamListFailure(failure: VercelCaptureFailure): boolean {
+  const output = `${failure.stderr}\n${failure.stdout}`;
+  return /(?:unknown|unexpected|invalid).*(?:--format|--limit)/iu.test(output);
+}
+
+function requireVercelCliUpgrade(failure: VercelCaptureFailure): never {
+  throw new HumanActionRequiredError({
+    kind: "vercel-cli-upgrade",
+    command: "vercel upgrade",
+    reason: `The installed Vercel CLI does not support the team-list options eve needs. ${failure.message} Upgrade it and retry.`,
+  });
+}
+
+async function captureTeamPage(
+  projectRoot: string,
+  options: VercelProjectOperationOptions,
+  args: string[],
+): Promise<string> {
+  const result = await captureVercel(args, { cwd: projectRoot, signal: options.signal });
+  options.signal?.throwIfAborted();
+  if (!result.ok) {
+    if (isForbiddenApiFailure(result.failure)) requireVercelTeamAccess(result.failure);
+    if (isUnsupportedTeamListFailure(result.failure)) requireVercelCliUpgrade(result.failure);
+    throw new Error(`Could not list Vercel teams. ${result.failure.message}`);
+  }
+  return result.stdout;
+}
+
 async function fetchTeamPage(
   projectRoot: string,
   options: VercelProjectOperationOptions,
   next: number | undefined,
 ): Promise<VercelPage<VercelTeamListEntry>> {
-  const args = ["teams", "ls", "--format", "json"];
-  if (next !== undefined) args.push("--next", String(next));
-  const result = await captureVercel(args, { cwd: projectRoot, signal: options.signal });
-  options.signal?.throwIfAborted();
-  if (!result.ok) {
-    if (isForbiddenApiFailure(result.failure)) requireVercelTeamAccess(result.failure);
-    throw new Error(`Could not list Vercel teams. ${result.failure.message}`);
+  if (next === undefined) {
+    const stdout = await captureTeamPage(projectRoot, options, [
+      "teams",
+      "ls",
+      "--format",
+      "json",
+      "--limit",
+      String(VERCEL_TEAM_PAGE_LIMIT),
+    ]);
+    const parsed = VercelTeamPageSchema.safeParse(parseVercelJson(stdout, "teams"));
+    if (!parsed.success) throw new Error("Could not read teams from Vercel CLI JSON output.");
+    return parsed.data;
   }
-  const parsed = VercelTeamPageSchema.safeParse(parseVercelJson(result.stdout, "teams"));
-  if (!parsed.success) throw new Error("Could not read teams from Vercel CLI JSON output.");
+
+  // The teams command currently sends its `--next` value as an API `next`
+  // parameter, while the teams API consumes the emitted timestamp as `until`.
+  // Use the CLI's authenticated API passthrough for continuation pages.
+  const path = `/v2/teams?limit=${VERCEL_TEAM_PAGE_LIMIT}&until=${next}`;
+  const stdout = await captureTeamPage(projectRoot, options, ["api", path]);
+  const parsed = VercelApiTeamPageSchema.safeParse(parseVercelJson(stdout, "teams"));
+  if (!parsed.success) throw new Error("Could not read teams from Vercel API JSON output.");
   return parsed.data;
 }
 


### PR DESCRIPTION
### Description

- Request the Vercel CLI maximum of 100 teams on the first page.
- Follow additional team pages through the authenticated `vercel api` command using the API's `until` cursor, avoiding the repeated-page loop caused by `teams ls --next`.
- Prompt to upgrade only when an older Vercel CLI does not support the required team-list flags.
- Run upgrades through native `vercel upgrade`, preserving the package manager that owns the active installation, and surface a concise stderr reason if the upgrade fails.

### How did you test your changes?

- `pnpm --filter eve typecheck`
- `pnpm test:unit` (5,269 passed, 1 skipped)
- `pnpm guard:invariants`
- Focused TUI, install-flow, and Vercel pagination unit tests (61 passed)
- Real Vercel CLI 56.5.0 validation: eve loaded all 25 available scopes, retained the current scope, and completed without a repeated cursor

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
