### PR TITLE
fix(eve): build - preserve ESM globals beside suffixed shims

### DIFF
--- a/.changeset/fair-files-shim.md
+++ b/.changeset/fair-files-shim.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent bundler-suffixed CommonJS compatibility variables from suppressing the Node ESM globals that eve bundles need at startup.

--- a/packages/eve/src/internal/node-esm-compat-banner.test.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.test.ts
@@ -65,6 +65,21 @@ describe("buildNodeEsmCompatBanner", () => {
     expect(banner).not.toContain("const require");
   });
 
+  it("does not treat bundler-suffixed bindings as compatibility globals", () => {
+    const chunk = [
+      "const __filename$1 = '/x/file.js';",
+      "const __dirname$1 = '/x';",
+      "const require$1 = () => {};",
+      'export const value = "noop";',
+    ].join("\n");
+
+    const banner = buildNodeEsmCompatBanner(chunk, { includeRequire: true });
+
+    expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
+    expect(banner).toContain("const __dirname = __eveDirname(__filename);");
+    expect(banner).toContain("const require = __eveCreateRequire(import.meta.url);");
+  });
+
   it("ignores nested declarations inside functions", () => {
     const chunk = [
       "function inner() {",

--- a/packages/eve/src/internal/node-esm-compat-banner.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.ts
@@ -27,19 +27,19 @@ const BANNER_LINES: readonly BannerLine[] = [
   {
     importLine: 'import { fileURLToPath as __eveFileURLToPath } from "node:url";',
     declarationLine: "const __filename = __eveFileURLToPath(import.meta.url);",
-    bindingPattern: /^(?:const|let|var)\s+__filename\b/m,
+    bindingPattern: /^(?:const|let|var)\s+__filename(?![\w$])/m,
   },
   {
     importLine: 'import { dirname as __eveDirname } from "node:path";',
     declarationLine: "const __dirname = __eveDirname(__filename);",
-    bindingPattern: /^(?:const|let|var)\s+__dirname\b/m,
+    bindingPattern: /^(?:const|let|var)\s+__dirname(?![\w$])/m,
   },
 ];
 
 const REQUIRE_LINE: BannerLine = {
   importLine: 'import { createRequire as __eveCreateRequire } from "node:module";',
   declarationLine: "const require = __eveCreateRequire(import.meta.url);",
-  bindingPattern: /^(?:const|let|var)\s+require\b/m,
+  bindingPattern: /^(?:const|let|var)\s+require(?![\w$])/m,
 };
 
 /**


### PR DESCRIPTION
Closes #935.

## What changed

- require an exact JavaScript identifier boundary when detecting existing `__filename`, `__dirname`, and `require` bindings
- keep emitting the compatibility globals when Rolldown has only emitted suffixed bindings such as `__filename$1`
- add regression coverage for all three suffixed binding names

## Why

The previous `\b` boundary also matched before `$`, so a renamed shim could suppress eve's real `__filename` declaration while leaving `__dirname` dependent on it. That produced a startup-fatal dangling reference in Node ESM bundles.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/node-esm-compat-banner.test.ts`
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
