### PR TITLE
ci: skip scenario tests for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,39 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      scenario: ${{ steps.filter.outputs.scenario }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether scenario tests are needed
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
+            echo "scenario=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          scenario=false
+          while IFS= read -r path; do
+            case "$path" in
+              apps/docs/* | .changeset/*) ;;
+              *) scenario=true; break ;;
+            esac
+          done < <(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")
+
+          echo "scenario=$scenario" >> "$GITHUB_OUTPUT"
+
   lint:
     runs-on: ubuntu-latest
 
@@ -122,6 +155,8 @@ jobs:
         run: pnpm test:integration
 
   test-scenario:
+    needs: changes
+    if: needs.changes.outputs.scenario == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -229,9 +229,9 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
   },
   {
     slug: "kernel",
-    name: "Kernel",
+    name: "KERNEL",
     kind: "extension",
-    tagline: "Add a Kernel cloud browser and browser automation skills to an eve agent.",
+    tagline: "Add a KERNEL cloud browser and browser automation tools to an eve agent.",
     surfaces: { scaffoldable: false, gallery: true },
   },
   {


### PR DESCRIPTION
## Summary
- detect whether a change includes runtime-affecting files
- skip the scenario build-and-test job for documentation-only changes
- default to running scenarios when the comparison cannot be resolved or a changed path is not explicitly documentation-only

## Validation
- `pnpm exec oxfmt --check .github/workflows/ci.yml`
- `git diff --check`