### PR TITLE
fix(eve): channels - reject inactive HTTP continuations

### DIFF
--- a/.changeset/calm-sessions-continue.md
+++ b/.changeset/calm-sessions-continue.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Return an HTTP conflict when an explicit session continuation is no longer active instead of silently starting a different session.

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -77,6 +77,12 @@ type BaseSendOptions = {
   auth: SessionAuthContext | null;
   callback?: SessionCallback;
   continuationToken: string;
+  /**
+   * Whether a failed continuation may start a new session. Defaults to `true`.
+   * Disable this when the caller requires the continuation token to retain its
+   * existing session identity.
+   */
+  fallbackToNewSession?: boolean;
   mode?: RunMode;
   /**
    * Human-readable title for a newly started workflow session. Defaults to

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -50,6 +50,22 @@ describe("createSendFn", () => {
     warn.mockRestore();
   });
 
+  it("rejects instead of starting a session when fallback is disabled", async () => {
+    const noSession = new RuntimeNoActiveSessionError("test:token");
+    const runtime = createRuntime(noSession);
+    const send = createSendFn(runtime, ADAPTER, "test");
+
+    await expect(
+      send("hello", {
+        auth: null,
+        continuationToken: "token",
+        fallbackToNewSession: false,
+      }),
+    ).rejects.toBe(noSession);
+    expect(runtime.deliver).toHaveBeenCalledTimes(1);
+    expect(runtime.run).not.toHaveBeenCalled();
+  });
+
   it("warns and falls back to a new session when delivery fails unexpectedly", async () => {
     const runtime = createRuntime(new Error("boom"));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -27,6 +27,8 @@ export function createSendFn<TState = undefined>(
     const title = (options as { title?: string }).title;
     const rawToken = (options as { continuationToken: string }).continuationToken;
     const continuationToken = `${channelName}:${rawToken}`;
+    const fallbackToNewSession =
+      (options as { fallbackToNewSession?: boolean }).fallbackToNewSession ?? true;
 
     const {
       message: rawMessage,
@@ -47,6 +49,10 @@ export function createSendFn<TState = undefined>(
 
       return createSession(sessionId, rawToken, runtime);
     } catch (error) {
+      if (!fallbackToNewSession) {
+        throw error;
+      }
+
       // No-active-session is the expected resume-or-start signal. The
       // failure itself is logged in `deliver`; this only records the fallback.
       if (!isRuntimeNoActiveSessionError(error)) {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -20,6 +20,7 @@ import {
   type Session as RuntimeSession,
 } from "#context/keys.js";
 import { createMessageCompletedEvent } from "#protocol/message.js";
+import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 
 /**
  * Unit coverage for the inbound HTTP route's message-body parser and
@@ -1123,6 +1124,28 @@ describe("eveChannel — continue session HITL (inputResponses)", () => {
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
     expect(payload.message).toBe("yes please");
     expect(payload.inputResponses).toEqual([{ requestId: "req-1", optionId: "approve" }]);
+  });
+
+  it("returns a conflict instead of forking an inactive continuation", async () => {
+    const handler = createEveContinueHandler({ auth: none() });
+    handler.send.mockRejectedValue(new RuntimeNoActiveSessionError("eve:missing"));
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({
+        continuationToken: "missing",
+        message: "continue this session",
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Session is no longer active.",
+      ok: false,
+    });
+    expect(handler.send).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fallbackToNewSession: false }),
+    );
   });
 
   it("converts clientContext on continue-session requests", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -9,6 +9,7 @@ import {
   readAgentInfoRouteResponse,
   readRouteAgent,
 } from "#internal/nitro/routes/channel-route-context.js";
+import { isRuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import {
   EVE_MESSAGE_STREAM_CONTENT_TYPE,
   EVE_MESSAGE_STREAM_FORMAT,
@@ -291,18 +292,30 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           dispatchAuth = messageResult.auth;
         }
 
-        const session = await send(
-          {
-            inputResponses: body.inputResponses,
-            message: body.message,
-            context,
-            outputSchema: body.outputSchema,
-          },
-          {
-            auth: dispatchAuth,
-            continuationToken: body.continuationToken,
-          },
-        );
+        let session;
+        try {
+          session = await send(
+            {
+              inputResponses: body.inputResponses,
+              message: body.message,
+              context,
+              outputSchema: body.outputSchema,
+            },
+            {
+              auth: dispatchAuth,
+              continuationToken: body.continuationToken,
+              fallbackToNewSession: false,
+            },
+          );
+        } catch (error) {
+          if (!isRuntimeNoActiveSessionError(error)) {
+            throw error;
+          }
+          return Response.json(
+            { error: "Session is no longer active.", ok: false },
+            { status: 409 },
+          );
+        }
 
         return Response.json(
           {


### PR DESCRIPTION
Closes #942.

## What changed

- add a documented `fallbackToNewSession` send option, preserving the existing default
- disable fallback for the explicit HTTP continuation route
- translate a missing active continuation into a `409` response instead of creating a sibling session
- cover both the send primitive and public route contract

## Why

`POST /eve/v1/session/:sessionId` carries an explicit continuation token and session identity. Falling back to a new run when that token is inactive can return success for a different session, which makes the caller's continuation request silently fork.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/channel/send.test.ts src/public/channels/eve.test.ts`
- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve typecheck`
