### PR TITLE
fix(eve): security - keep workflow failures private

### DIFF
--- a/.changeset/private-workflow-failures.md
+++ b/.changeset/private-workflow-failures.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep raw outer workflow failure details in the private session trace instead of copying them into provider logs and Workflow telemetry.

--- a/packages/eve/src/execution/terminal-session-failure-step.ts
+++ b/packages/eve/src/execution/terminal-session-failure-step.ts
@@ -21,8 +21,8 @@ export async function emitTerminalSessionFailureStep(input: {
   "use step";
 
   // Cataloged failures replace the raw identity with the curated one; the
-  // `detail` dump stays attached so the local diagnostic log keeps the
-  // raw evidence while the transcript shows the actionable summary.
+  // `detail` dump stays attached to the private event so the session trace
+  // keeps the raw evidence while the transcript shows the actionable summary.
   const formatted = formatError(input.error);
   const summary = summarizeKnownError(input.error);
   let details = formatted;
@@ -43,9 +43,6 @@ export async function emitTerminalSessionFailureStep(input: {
     sessionId,
     errorId: typeof details.errorId === "string" ? details.errorId : undefined,
     code,
-    message,
-    hint: summary?.hint,
-    detail: typeof details.detail === "string" ? details.detail : undefined,
   });
 
   const event = createSessionFailedEvent({ code, details, message, sessionId });

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -337,7 +337,9 @@ describe("workflowEntry integration", () => {
             (event) => event.type === "message.completed" || event.type === "turn.started",
           ),
         ).toBe(false);
-        await expect(contender.returnValue).rejects.toThrow(/Hook token/);
+        await expect(contender.returnValue).rejects.toThrow(
+          /Agent workflow failed\. Inspect the private session trace for details\./,
+        );
 
         await resumeHook(continuationToken, {
           kind: "deliver",

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -182,11 +182,19 @@ describe("workflowEntry", () => {
         serializedContext: createSerializedContext(),
       }),
     ).rejects.toMatchObject({
-      conflictingRunId: "wrun_owner",
-      name: "HookConflictError",
-      token: "http:test",
+      message: "Agent workflow failed. Inspect the private session trace for details.",
+      name: "EveWorkflowFailure",
     });
 
+    expect(emitTerminalSessionFailureStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          conflictingRunId: "wrun_owner",
+          name: "HookConflictError",
+          token: "http:test",
+        }),
+      }),
+    );
     expect(dispatchTurnStep).not.toHaveBeenCalled();
     expect(dispose).toHaveBeenCalledOnce();
   });
@@ -218,12 +226,19 @@ describe("workflowEntry", () => {
         serializedContext: createSerializedContext(),
       }),
     ).rejects.toMatchObject({
-      conflictingRunId: undefined,
-      message: 'Hook token "http:test" is already in use',
-      name: "HookConflictError",
-      token: "http:test",
+      message: "Agent workflow failed. Inspect the private session trace for details.",
+      name: "EveWorkflowFailure",
     });
 
+    expect(emitTerminalSessionFailureStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'Hook token "http:test" is already in use',
+          name: "HookConflictError",
+          token: "http:test",
+        }),
+      }),
+    );
     expect(dispatchTurnStep).not.toHaveBeenCalled();
     expect(dispose).toHaveBeenCalledOnce();
   });
@@ -299,9 +314,16 @@ describe("workflowEntry", () => {
         input: { message: "delegate" },
         serializedContext,
       }),
-    ).rejects.toThrow("persistent recoverable failure");
+    ).rejects.toMatchObject({
+      message: "Agent workflow failed. Inspect the private session trace for details.",
+      name: "EveWorkflowFailure",
+    });
 
-    expect(emitTerminalSessionFailureStep).toHaveBeenCalledOnce();
+    expect(emitTerminalSessionFailureStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "persistent recoverable failure" }),
+      }),
+    );
     expect(fireSessionCallbackStep).toHaveBeenCalledOnce();
     expect(notifyDelegatedParentStep).toHaveBeenCalledOnce();
     expect(notifyDelegatedParentStep).toHaveBeenCalledWith({

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -32,6 +32,9 @@ import {
 } from "#execution/session-delivery-hook.js";
 import { readSerializedSubagentDepth } from "#harness/subagent-depth.js";
 
+const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
+  "Agent workflow failed. Inspect the private session trace for details.";
+
 // workflow-entry.ts is the durable workflow body — the bundler rejects
 // node built-ins here, so `internal/logging.ts` cannot be imported.
 // Error logging happens inside `emitTerminalSessionFailureStep`.
@@ -139,8 +142,14 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       result: createDelegatedSubagentErrorResult(input.serializedContext, error),
       serializedContext: input.serializedContext,
     });
-    throw error;
+    throw createSafeOuterWorkflowError();
   }
+}
+
+function createSafeOuterWorkflowError(): Error {
+  const error = new Error(SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE);
+  error.name = "EveWorkflowFailure";
+  return error;
 }
 
 async function runDriverLoop(input: {

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1193,10 +1193,12 @@ describe("emitTerminalSessionFailureStep", () => {
     // raw Errors to this shape (`normalizeSerializableError`) before
     // handing them into the step so they survive JSON serialization.
     const error = {
-      message: "attachment staging failed",
+      detail: "private attachment name: confidential.png",
+      message: "attachment staging failed for confidential.png",
       name: "EveAttachmentError",
       kind: "resolver-threw",
     };
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await emitTerminalSessionFailureStep({
       error,
@@ -1209,8 +1211,18 @@ describe("emitTerminalSessionFailureStep", () => {
       data: { code: string; message: string; details?: { errorId?: string } };
     };
     expect(data.code).toBe("EveAttachmentError");
-    expect(data.message).toContain("attachment staging failed");
+    expect(data.message).toContain("attachment staging failed for confidential.png");
     expect(typeof data.details?.errorId).toBe("string");
+
+    const providerLog = errorLog.mock.calls.find(([line]) =>
+      String(line).includes("workflow loop threw"),
+    );
+    expect(providerLog?.[1]).toEqual({
+      code: "EveAttachmentError",
+      errorId: data.details?.errorId,
+      sessionId: "session-terminal",
+    });
+    expect(JSON.stringify(providerLog)).not.toContain("confidential.png");
 
     // The terminal step must also write the event to the durable
     // stream so event-stream consumers see a canonical tail instead
@@ -1254,8 +1266,8 @@ describe("emitTerminalSessionFailureStep", () => {
     expect(data.message).toContain("ECONNREFUSED");
     expect(data.details?.semanticErrorId).toBe("network-request-failed");
     expect(data.details?.hint).toContain("Check your internet connection");
-    // The raw inspection stays attached so the diagnostic log keeps the
-    // evidence the curated message summarizes away.
+    // The raw inspection stays attached so the private session trace keeps
+    // the evidence the curated message summarizes away.
     expect(data.details?.detail).toContain("fetch failed");
   });
 


### PR DESCRIPTION
Closes #879.

## What changed

- remove raw workflow failure messages, hints, and detail dumps from the provider-facing terminal log
- keep the full normalized error in the private `session.failed` event, callback, and delegated-parent result
- replace the outer Workflow throw with a stable `EveWorkflowFailure` that contains no session-derived text
- add regressions proving private diagnostics remain intact while logs and the outer error are sanitized

## Why

Outer workflow failures can include user text, filenames, or tool arguments. Logging and rethrowing that raw error copied private session data into hosting logs and Workflow telemetry with a broader access boundary than the session trace.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/workflow-steps.test.ts src/execution/workflow-entry.test.ts`
- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve typecheck`
