### PR TITLE
docs(eve): instrumentation - prevent dropped Workflow spans

### DIFF
--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -21,8 +21,16 @@ The two configurable surfaces send AI SDK spans to your OpenTelemetry backend. W
 
 ## Define instrumentation
 
+Install the OpenTelemetry wrapper, your exporter, and the trace SDK used to
+select the span processor:
+
+```bash
+npm install @braintrust/otel @opentelemetry/sdk-trace-base@^2 @vercel/otel
+```
+
 ```ts title="agent/instrumentation.ts"
 import { BraintrustExporter } from "@braintrust/otel";
+import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { defineInstrumentation } from "eve/instrumentation";
 import { registerOTel } from "@vercel/otel";
 
@@ -30,10 +38,14 @@ export default defineInstrumentation({
   setup: ({ agentName }) =>
     registerOTel({
       serviceName: agentName,
-      traceExporter: new BraintrustExporter({
-        parent: `project_name:${agentName}`,
-        filterAISpans: true,
-      }),
+      spanProcessors: [
+        new SimpleSpanProcessor(
+          new BraintrustExporter({
+            parent: `project_name:${agentName}`,
+            filterAISpans: true,
+          }),
+        ),
+      ],
     }),
 });
 ```
@@ -45,6 +57,14 @@ Export the result of `defineInstrumentation` as the default export.
 Use the `setup` callback to register your OTel provider (for example `registerOTel` from `@vercel/otel`). The framework invokes it at server startup with the resolved agent name. `context.agentName` is resolved at compile time from your project (the package's `name`, falling back to the app directory name), so you never hard-code a service name.
 
 Any OTel-compatible backend works (Braintrust, Raindrop, Arize, Honeycomb, Datadog, Jaeger). Install the exporter package you need and configure it in the callback.
+
+On Vercel Workflow and other serverless runtimes, use a `SimpleSpanProcessor`
+as shown above. Passing a custom `traceExporter` to `registerOTel` wraps it in
+a `BatchSpanProcessor`; completed spans can remain buffered behind a timer when
+the instance freezes outside a normal HTTP request lifecycle. A simple processor
+starts export as each span ends instead. Install
+`@opentelemetry/sdk-trace-base` directly and keep it on the OpenTelemetry 2.x
+line required by `@vercel/otel`.
 
 Three more fields control what the AI SDK records inside those spans (see the AI SDK's [telemetry reference](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)):
 


### PR DESCRIPTION
## Summary

- recommend `SimpleSpanProcessor` for OpenTelemetry export from Vercel Workflow and other serverless runtimes
- update the published `instrumentation.ts` example to provide an explicit simple processor
- document the required direct `@opentelemetry/sdk-trace-base` 2.x dependency

## Why

Passing a custom `traceExporter` to `registerOTel` selects a `BatchSpanProcessor`.
An eve turn runs inside Vercel Workflow rather than an ordinary HTTP request
lifecycle, so a serverless instance can freeze while completed spans are still
waiting for the processor's batch timer.

This documents the safe app-owned remedy already proven in the issue: start
export as each span ends with `SimpleSpanProcessor`. It intentionally avoids
framework-level provider discovery and forced flushing, which would couple eve
to provider ownership and lifecycle details that authored instrumentation
currently controls.

## Validation

- `pnpm docs:check`
- `pnpm fmt docs/guides/instrumentation.md`
- `pnpm lint`
- verified the current `@vercel/otel` peer contract requires
  `@opentelemetry/sdk-trace-base` 2.x

Closes #679
