### PR TITLE
fix(eve): build - analyze dynamic tool captures from syntax

### DIFF
--- a/.changeset/quiet-dynamic-captures.md
+++ b/.changeset/quiet-dynamic-captures.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Analyze dynamic tool closure references from the syntax tree so object keys and string contents cannot become invalid runtime captures.

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-ast-references.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-ast-references.ts
@@ -1,0 +1,140 @@
+/** Rolldown AST subset consumed by the dynamic-tool transform. */
+export type DynamicToolAstNode = {
+  argument?: DynamicToolAstNode | null;
+  arguments?: DynamicToolAstNode[];
+  async?: boolean;
+  body?:
+    | DynamicToolAstNode
+    | DynamicToolAstNode[]
+    | { body?: DynamicToolAstNode[]; type?: string; start?: number; end?: number };
+  callee?: DynamicToolAstNode;
+  computed?: boolean;
+  declaration?: DynamicToolAstNode | null;
+  declarations?: DynamicToolAstNode[];
+  end?: number;
+  expression?: DynamicToolAstNode | null;
+  id?: { name?: string; start?: number; end?: number } | null;
+  init?: DynamicToolAstNode | null;
+  key?: DynamicToolAstNode | null;
+  kind?: string;
+  left?: DynamicToolAstNode | null;
+  method?: boolean;
+  name?: string;
+  params?: DynamicToolAstNode[];
+  properties?: DynamicToolAstNode[];
+  right?: DynamicToolAstNode | null;
+  start?: number;
+  type?: string;
+  value?: DynamicToolAstNode | unknown;
+};
+
+/**
+ * Collects identifiers used as runtime references in a function body AST.
+ */
+export function collectReferencedIdentifierNames(node: DynamicToolAstNode): Set<string> {
+  const names = new Set<string>();
+
+  const visit = (
+    current: DynamicToolAstNode,
+    parent: DynamicToolAstNode | undefined,
+    parentKey: string | undefined,
+    ancestors: readonly DynamicToolAstNode[],
+  ): void => {
+    if (
+      current.type === "Identifier" &&
+      current.name &&
+      isIdentifierReference(parent, parentKey, ancestors)
+    ) {
+      names.add(current.name);
+    }
+
+    const nextAncestors = [...ancestors, current];
+    for (const [key, value] of Object.entries(current)) {
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (isAstNode(child)) {
+            visit(child, current, key, nextAncestors);
+          }
+        }
+      } else if (isAstNode(value)) {
+        visit(value, current, key, nextAncestors);
+      }
+    }
+  };
+
+  visit(node, undefined, undefined, []);
+  return names;
+}
+
+function isIdentifierReference(
+  parent: DynamicToolAstNode | undefined,
+  parentKey: string | undefined,
+  ancestors: readonly DynamicToolAstNode[],
+): boolean {
+  if (!parent || !parentKey) return false;
+
+  if (
+    parentKey === "typeAnnotation" ||
+    parentKey === "returnType" ||
+    parentKey === "typeParameters" ||
+    parentKey === "typeArguments" ||
+    ancestors.some((ancestor) => ancestor.type?.startsWith("TS"))
+  ) {
+    return false;
+  }
+
+  if (
+    (parent.type === "MemberExpression" ||
+      parent.type === "OptionalMemberExpression" ||
+      parent.type === "Property" ||
+      parent.type === "MethodDefinition" ||
+      parent.type === "PropertyDefinition") &&
+    parentKey === "key"
+  ) {
+    return parent.computed === true;
+  }
+
+  if (
+    (parent.type === "MemberExpression" || parent.type === "OptionalMemberExpression") &&
+    parentKey === "property"
+  ) {
+    return parent.computed === true;
+  }
+
+  if (
+    (parent.type === "VariableDeclarator" && parentKey === "id") ||
+    ((parent.type === "FunctionExpression" ||
+      parent.type === "ArrowFunctionExpression" ||
+      parent.type === "FunctionDeclaration") &&
+      (parentKey === "id" || parentKey === "params")) ||
+    (parent.type === "CatchClause" && parentKey === "param") ||
+    ((parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
+      parentKey === "id") ||
+    ((parent.type === "LabeledStatement" ||
+      parent.type === "BreakStatement" ||
+      parent.type === "ContinueStatement") &&
+      parentKey === "label")
+  ) {
+    return false;
+  }
+
+  if (
+    parent.type === "ObjectPattern" ||
+    parent.type === "ArrayPattern" ||
+    ancestors.some(
+      (ancestor) => ancestor.type === "ObjectPattern" || ancestor.type === "ArrayPattern",
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isAstNode(value: unknown): value is DynamicToolAstNode {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as DynamicToolAstNode).type === "string"
+  );
+}

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-ast-references.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-ast-references.ts
@@ -28,107 +28,136 @@ export type DynamicToolAstNode = {
   value?: DynamicToolAstNode | unknown;
 };
 
+type IdentifierContext = "binding" | "reference";
+
 /**
  * Collects identifiers used as runtime references in a function body AST.
  */
 export function collectReferencedIdentifierNames(node: DynamicToolAstNode): Set<string> {
   const names = new Set<string>();
 
-  const visit = (
-    current: DynamicToolAstNode,
-    parent: DynamicToolAstNode | undefined,
-    parentKey: string | undefined,
-    ancestors: readonly DynamicToolAstNode[],
-  ): void => {
-    if (
-      current.type === "Identifier" &&
-      current.name &&
-      isIdentifierReference(parent, parentKey, ancestors)
-    ) {
+  const visit = (current: DynamicToolAstNode, context: IdentifierContext): void => {
+    if (current.type?.startsWith("TS")) {
+      if (isRuntimeTypeScriptExpression(current) && current.expression) {
+        visit(current.expression, "reference");
+      }
+      return;
+    }
+
+    if (current.type === "Identifier" && current.name && context === "reference") {
       names.add(current.name);
     }
 
-    const nextAncestors = [...ancestors, current];
     for (const [key, value] of Object.entries(current)) {
+      const childContext = getChildContext(current, key, context);
+      if (!childContext) continue;
+
       if (Array.isArray(value)) {
         for (const child of value) {
           if (isAstNode(child)) {
-            visit(child, current, key, nextAncestors);
+            visit(child, childContext);
           }
         }
       } else if (isAstNode(value)) {
-        visit(value, current, key, nextAncestors);
+        visit(value, childContext);
       }
     }
   };
 
-  visit(node, undefined, undefined, []);
+  visit(node, "reference");
   return names;
 }
 
-function isIdentifierReference(
-  parent: DynamicToolAstNode | undefined,
-  parentKey: string | undefined,
-  ancestors: readonly DynamicToolAstNode[],
-): boolean {
-  if (!parent || !parentKey) return false;
-
+function getChildContext(
+  parent: DynamicToolAstNode,
+  parentKey: string,
+  context: IdentifierContext,
+): IdentifierContext | null {
   if (
     parentKey === "typeAnnotation" ||
     parentKey === "returnType" ||
     parentKey === "typeParameters" ||
-    parentKey === "typeArguments" ||
-    ancestors.some((ancestor) => ancestor.type?.startsWith("TS"))
+    parentKey === "typeArguments"
   ) {
-    return false;
+    return null;
+  }
+
+  if (parent.type === "VariableDeclarator" && parentKey === "id") {
+    return "binding";
   }
 
   if (
-    (parent.type === "MemberExpression" ||
-      parent.type === "OptionalMemberExpression" ||
-      parent.type === "Property" ||
-      parent.type === "MethodDefinition" ||
-      parent.type === "PropertyDefinition") &&
-    parentKey === "key"
+    (parent.type === "FunctionExpression" ||
+      parent.type === "ArrowFunctionExpression" ||
+      parent.type === "FunctionDeclaration") &&
+    (parentKey === "id" || parentKey === "params")
   ) {
-    return parent.computed === true;
+    return "binding";
+  }
+
+  if (
+    (parent.type === "CatchClause" && parentKey === "param") ||
+    ((parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
+      parentKey === "id")
+  ) {
+    return "binding";
+  }
+
+  if (parent.type === "Property" && parentKey === "key") {
+    return parent.computed === true ? "reference" : null;
+  }
+
+  if (parent.type === "Property" && parentKey === "value") {
+    return context;
+  }
+
+  if (parent.type === "AssignmentPattern") {
+    return parentKey === "right" ? "reference" : context;
+  }
+
+  if (
+    (parent.type === "ObjectPattern" ||
+      parent.type === "ArrayPattern" ||
+      parent.type === "RestElement") &&
+    (parentKey === "properties" || parentKey === "elements" || parentKey === "argument")
+  ) {
+    return context;
   }
 
   if (
     (parent.type === "MemberExpression" || parent.type === "OptionalMemberExpression") &&
     parentKey === "property"
   ) {
-    return parent.computed === true;
+    return parent.computed === true ? "reference" : null;
   }
 
   if (
-    (parent.type === "VariableDeclarator" && parentKey === "id") ||
-    ((parent.type === "FunctionExpression" ||
-      parent.type === "ArrowFunctionExpression" ||
-      parent.type === "FunctionDeclaration") &&
-      (parentKey === "id" || parentKey === "params")) ||
-    (parent.type === "CatchClause" && parentKey === "param") ||
-    ((parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
-      parentKey === "id") ||
-    ((parent.type === "LabeledStatement" ||
+    (parent.type === "MethodDefinition" || parent.type === "PropertyDefinition") &&
+    parentKey === "key"
+  ) {
+    return parent.computed === true ? "reference" : null;
+  }
+
+  if (
+    (parent.type === "LabeledStatement" ||
       parent.type === "BreakStatement" ||
       parent.type === "ContinueStatement") &&
-      parentKey === "label")
+    parentKey === "label"
   ) {
-    return false;
+    return null;
   }
 
-  if (
-    parent.type === "ObjectPattern" ||
-    parent.type === "ArrayPattern" ||
-    ancestors.some(
-      (ancestor) => ancestor.type === "ObjectPattern" || ancestor.type === "ArrayPattern",
-    )
-  ) {
-    return false;
-  }
+  return "reference";
+}
 
-  return true;
+function isRuntimeTypeScriptExpression(node: DynamicToolAstNode): boolean {
+  return (
+    node.type === "TSAsExpression" ||
+    node.type === "TSInstantiationExpression" ||
+    node.type === "TSNonNullExpression" ||
+    node.type === "TSSatisfiesExpression" ||
+    node.type === "TSTypeAssertion"
+  );
 }
 
 function isAstNode(value: unknown): value is DynamicToolAstNode {

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -271,6 +271,61 @@ export default defineDynamic({
     expect(readStepFn).not.toBe(writeStepFn);
   });
 
+  it("does not capture object keys or text from string literals", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const tools = {};
+
+      tools.probe_alpha = defineTool({
+        description: "probe alpha",
+        inputSchema: { type: "object" },
+        execute({ q }) {
+          return { url: "/x/" + q, note: "answer from app tools only" };
+        },
+      });
+
+      {
+        const url = "https://example.com";
+        const cred = { a: 1 };
+        tools.probe_beta = defineTool({
+          description: "probe beta",
+          inputSchema: { type: "object" },
+          execute() {
+            return { target: url, cred };
+          },
+        });
+      }
+
+      return tools;
+    },
+  },
+});
+`;
+
+    const { callHandler } = await transformAndEval("tools/reference-analysis.ts", source);
+    const tools = await callHandler();
+    const alpha = tools.probe_alpha as Record<string, unknown>;
+    const beta = tools.probe_beta as Record<string, unknown>;
+
+    expect(alpha.__closureVars).toEqual({});
+    expect((alpha.execute as Function)({ q: "one" })).toEqual({
+      note: "answer from app tools only",
+      url: "/x/one",
+    });
+    expect(beta.__closureVars).toEqual({
+      cred: { a: 1 },
+      url: "https://example.com",
+    });
+    expect((beta.execute as Function)()).toEqual({
+      cred: { a: 1 },
+      target: "https://example.com",
+    });
+  });
+
   it("async execute preserves await semantics", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -326,6 +326,107 @@ export default defineDynamic({
     });
   });
 
+  it("captures computed keys and defaults inside binding patterns", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const fallback = "missing";
+      const field = "value";
+      return {
+        tool: defineTool({
+          description: "T",
+          inputSchema: { type: "object" },
+          execute(input) {
+            const { [field]: value = fallback } = input;
+            return value;
+          },
+        }),
+      };
+    },
+  },
+});
+`;
+
+    const { callHandler } = await transformAndEval("tools/binding-patterns.ts", source);
+    const tools = await callHandler();
+    const tool = tools.tool as Record<string, unknown>;
+    const execute = tool.execute as Function;
+
+    expect(tool.__closureVars).toEqual({
+      fallback: "missing",
+      field: "value",
+    });
+    expect(execute({})).toBe("missing");
+    expect(execute({ value: "present" })).toBe("present");
+  });
+
+  it("captures a direct identifier in an arrow expression body", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const result = "captured";
+      return {
+        tool: defineTool({
+          description: "T",
+          inputSchema: { type: "object" },
+          execute: () => result,
+        }),
+      };
+    },
+  },
+});
+`;
+
+    const { callHandler } = await transformAndEval("tools/identifier-expression.ts", source);
+    const tools = await callHandler();
+    const tool = tools.tool as Record<string, unknown>;
+
+    expect(tool.__closureVars).toEqual({ result: "captured" });
+    expect((tool.execute as Function)()).toBe("captured");
+  });
+
+  it("captures runtime references inside TypeScript expressions", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const TypeName = "type-only";
+      const asserted = "asserted";
+      const nonNull = "non-null";
+      const satisfied = "satisfied";
+      return {
+        tool: defineTool({
+          description: "T",
+          inputSchema: { type: "object" },
+          execute() {
+            return [
+              asserted as TypeName,
+              nonNull!,
+              satisfied satisfies TypeName,
+            ];
+          },
+        }),
+      };
+    },
+  },
+});
+`;
+
+    const result = await transformDynamicToolExecute("tools/typescript-expressions.ts", source);
+
+    expect(result).not.toBeNull();
+    expect(result!.code).toContain("const { asserted, nonNull, satisfied } = __vars");
+    expect(result!.code).not.toContain("const { TypeName, asserted, nonNull, satisfied } = __vars");
+  });
+
   it("async execute preserves await semantics", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -80,6 +80,8 @@ interface ExecuteInfo {
   params: string;
   /** Body source (block statement including braces) */
   body: string;
+  /** Function body AST used to identify actual identifier references */
+  bodyNode: AstNode;
   /** Scope entries from nested functions between handler and this execute */
   nestedScopes: readonly ScopeEntry[];
 }
@@ -382,18 +384,22 @@ function walkForExecuteProps(
         if (isFn || isMethod) {
           const params = extractFnParams(source, fn);
           const body = extractFnBody(source, fn);
+          const bodyNode = fn.body as AstNode | undefined;
           const isAsync = fn.async === true;
 
-          results.push({
-            propStart: prop.start,
-            propEnd: prop.end,
-            fnSource: source.slice(fn.start, fn.end),
-            isAsync,
-            params,
-            body,
-            hoistedName: `__eve_dynamic_exec_${transformCounter++}`,
-            nestedScopes,
-          });
+          if (bodyNode) {
+            results.push({
+              propStart: prop.start,
+              propEnd: prop.end,
+              fnSource: source.slice(fn.start, fn.end),
+              isAsync,
+              params,
+              body,
+              bodyNode,
+              hoistedName: `__eve_dynamic_exec_${transformCounter++}`,
+              nestedScopes,
+            });
+          }
         }
       }
     }
@@ -494,7 +500,7 @@ function applyTransform(source: string, handlers: HandlerInfo[]): { code: string
       // Only capture vars the execute body actually references. This
       // avoids TDZ errors when the execute is inside a nested function
       // that runs before later handler-level declarations are initialized.
-      const bodyText = exec.body;
+      const referencedNames = collectReferencedIdentifierNames(exec.bodyNode);
 
       // Exclude names that collide with the execute function's own
       // parameters — the hoisted function already has those as formal
@@ -503,8 +509,7 @@ function applyTransform(source: string, handlers: HandlerInfo[]): { code: string
       const execParamNames = extractExecuteParamNames(exec.params);
 
       const allVars = deduped.filter(
-        (name) =>
-          !execParamNames.has(name) && new RegExp(`\\b${escapeForRegex(name)}\\b`).test(bodyText),
+        (name) => !execParamNames.has(name) && referencedNames.has(name),
       );
 
       const varsObj = allVars.length > 0 ? `{ ${allVars.join(", ")} }` : "{}";
@@ -615,8 +620,108 @@ function findProperty(obj: AstNode, name: string): AstNode | undefined {
   );
 }
 
-function escapeForRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function collectReferencedIdentifierNames(node: AstNode): Set<string> {
+  const names = new Set<string>();
+
+  const visit = (
+    current: AstNode,
+    parent: AstNode | undefined,
+    parentKey: string | undefined,
+    ancestors: readonly AstNode[],
+  ): void => {
+    if (
+      current.type === "Identifier" &&
+      current.name &&
+      isIdentifierReference(parent, parentKey, ancestors)
+    ) {
+      names.add(current.name);
+    }
+
+    const nextAncestors = [...ancestors, current];
+    for (const [key, value] of Object.entries(current)) {
+      if (Array.isArray(value)) {
+        for (const child of value) {
+          if (isAstNode(child)) {
+            visit(child, current, key, nextAncestors);
+          }
+        }
+      } else if (isAstNode(value)) {
+        visit(value, current, key, nextAncestors);
+      }
+    }
+  };
+
+  visit(node, undefined, undefined, []);
+  return names;
+}
+
+function isIdentifierReference(
+  parent: AstNode | undefined,
+  parentKey: string | undefined,
+  ancestors: readonly AstNode[],
+): boolean {
+  if (!parent || !parentKey) return false;
+
+  if (
+    parentKey === "typeAnnotation" ||
+    parentKey === "returnType" ||
+    parentKey === "typeParameters" ||
+    parentKey === "typeArguments" ||
+    ancestors.some((ancestor) => ancestor.type?.startsWith("TS"))
+  ) {
+    return false;
+  }
+
+  if (
+    (parent.type === "MemberExpression" ||
+      parent.type === "OptionalMemberExpression" ||
+      parent.type === "Property" ||
+      parent.type === "MethodDefinition" ||
+      parent.type === "PropertyDefinition") &&
+    parentKey === "key"
+  ) {
+    return parent.computed === true;
+  }
+
+  if (
+    (parent.type === "MemberExpression" || parent.type === "OptionalMemberExpression") &&
+    parentKey === "property"
+  ) {
+    return parent.computed === true;
+  }
+
+  if (
+    (parent.type === "VariableDeclarator" && parentKey === "id") ||
+    ((parent.type === "FunctionExpression" ||
+      parent.type === "ArrowFunctionExpression" ||
+      parent.type === "FunctionDeclaration") &&
+      (parentKey === "id" || parentKey === "params")) ||
+    (parent.type === "CatchClause" && parentKey === "param") ||
+    ((parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
+      parentKey === "id") ||
+    ((parent.type === "LabeledStatement" ||
+      parent.type === "BreakStatement" ||
+      parent.type === "ContinueStatement") &&
+      parentKey === "label")
+  ) {
+    return false;
+  }
+
+  if (
+    parent.type === "ObjectPattern" ||
+    parent.type === "ArrayPattern" ||
+    ancestors.some(
+      (ancestor) => ancestor.type === "ObjectPattern" || ancestor.type === "ArrayPattern",
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isAstNode(value: unknown): value is AstNode {
+  return value !== null && typeof value === "object" && typeof (value as AstNode).type === "string";
 }
 
 /**

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -26,32 +26,10 @@
  */
 
 import { parseWithNitroRolldownAst } from "#internal/bundler/nitro-rolldown.js";
-
-type AstNode = {
-  argument?: AstNode | null;
-  arguments?: AstNode[];
-  async?: boolean;
-  body?: AstNode | AstNode[] | { body?: AstNode[]; type?: string; start?: number; end?: number };
-  callee?: AstNode;
-  computed?: boolean;
-  declaration?: AstNode | null;
-  declarations?: AstNode[];
-  end?: number;
-  expression?: AstNode | null;
-  id?: { name?: string; start?: number; end?: number } | null;
-  init?: AstNode | null;
-  key?: AstNode | null;
-  kind?: string;
-  left?: AstNode | null;
-  method?: boolean;
-  name?: string;
-  params?: AstNode[];
-  properties?: AstNode[];
-  right?: AstNode | null;
-  start?: number;
-  type?: string;
-  value?: AstNode | unknown;
-};
+import {
+  collectReferencedIdentifierNames,
+  type DynamicToolAstNode as AstNode,
+} from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
 
 interface HandlerInfo {
   /** The handler function AST node */
@@ -618,110 +596,6 @@ function findProperty(obj: AstNode, name: string): AstNode | undefined {
     (p) =>
       p.type === "Property" && !p.computed && p.key?.type === "Identifier" && p.key.name === name,
   );
-}
-
-function collectReferencedIdentifierNames(node: AstNode): Set<string> {
-  const names = new Set<string>();
-
-  const visit = (
-    current: AstNode,
-    parent: AstNode | undefined,
-    parentKey: string | undefined,
-    ancestors: readonly AstNode[],
-  ): void => {
-    if (
-      current.type === "Identifier" &&
-      current.name &&
-      isIdentifierReference(parent, parentKey, ancestors)
-    ) {
-      names.add(current.name);
-    }
-
-    const nextAncestors = [...ancestors, current];
-    for (const [key, value] of Object.entries(current)) {
-      if (Array.isArray(value)) {
-        for (const child of value) {
-          if (isAstNode(child)) {
-            visit(child, current, key, nextAncestors);
-          }
-        }
-      } else if (isAstNode(value)) {
-        visit(value, current, key, nextAncestors);
-      }
-    }
-  };
-
-  visit(node, undefined, undefined, []);
-  return names;
-}
-
-function isIdentifierReference(
-  parent: AstNode | undefined,
-  parentKey: string | undefined,
-  ancestors: readonly AstNode[],
-): boolean {
-  if (!parent || !parentKey) return false;
-
-  if (
-    parentKey === "typeAnnotation" ||
-    parentKey === "returnType" ||
-    parentKey === "typeParameters" ||
-    parentKey === "typeArguments" ||
-    ancestors.some((ancestor) => ancestor.type?.startsWith("TS"))
-  ) {
-    return false;
-  }
-
-  if (
-    (parent.type === "MemberExpression" ||
-      parent.type === "OptionalMemberExpression" ||
-      parent.type === "Property" ||
-      parent.type === "MethodDefinition" ||
-      parent.type === "PropertyDefinition") &&
-    parentKey === "key"
-  ) {
-    return parent.computed === true;
-  }
-
-  if (
-    (parent.type === "MemberExpression" || parent.type === "OptionalMemberExpression") &&
-    parentKey === "property"
-  ) {
-    return parent.computed === true;
-  }
-
-  if (
-    (parent.type === "VariableDeclarator" && parentKey === "id") ||
-    ((parent.type === "FunctionExpression" ||
-      parent.type === "ArrowFunctionExpression" ||
-      parent.type === "FunctionDeclaration") &&
-      (parentKey === "id" || parentKey === "params")) ||
-    (parent.type === "CatchClause" && parentKey === "param") ||
-    ((parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
-      parentKey === "id") ||
-    ((parent.type === "LabeledStatement" ||
-      parent.type === "BreakStatement" ||
-      parent.type === "ContinueStatement") &&
-      parentKey === "label")
-  ) {
-    return false;
-  }
-
-  if (
-    parent.type === "ObjectPattern" ||
-    parent.type === "ArrayPattern" ||
-    ancestors.some(
-      (ancestor) => ancestor.type === "ObjectPattern" || ancestor.type === "ArrayPattern",
-    )
-  ) {
-    return false;
-  }
-
-  return true;
-}
-
-function isAstNode(value: unknown): value is AstNode {
-  return value !== null && typeof value === "object" && typeof (value as AstNode).type === "string";
 }
 
 /**


### PR DESCRIPTION
Closes #1086.

## What changed

- replace source-text regex matching with AST-based identifier-reference collection for lifted dynamic tool functions
- exclude object keys, non-computed member names, binding positions, labels, and TypeScript-only syntax from closure captures
- preserve real computed/reference expressions and existing inner-scope shadowing behavior
- add an end-to-end transform regression matching the reported multi-tool TDZ failure

## Why

Scanning the function body as text treated names inside object keys and string literals as free variables. A later block-scoped declaration with the same name then appeared in the generated capture object before initialization, throwing during `session.started` and silently removing every tool from the resolver.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/workflow-bundle/dynamic-tool-transform.test.ts`
- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve typecheck`
