### PR TITLE
feat(eve): forward end-user identity across remote agent hops

### DIFF
--- a/.changeset/remote-agent-auth-forwarding.md
+++ b/.changeset/remote-agent-auth-forwarding.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Remote agents can now forward the end user's identity across deployments. `defineRemoteAgent({ forwardAuth: true })` sends the dispatching turn's session principal (metadata only — never tokens) on the create-session request, and the receiving deployment opts in with `eveChannel({ acceptForwardedAuth })`, a predicate over the verified transport caller. Accepted forwarding replaces the session principal so per-user connections, local subagents, and chained remote hops see the original user; mismatches fail loud at the hop (403 / failed dispatch) instead of silently downgrading to the calling service's identity.

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -220,6 +220,26 @@ You do not have to keep `vercelOidc()` in the final policy. For a self-hosted ap
 
 Keep secret values (`ROUTE_AUTH_BASIC_PASSWORD`, signing keys) in environment variables. Route-auth secrets never land in compiled artifacts. The runtime re-materializes them from the authored channel definition at boot.
 
+## Accepting forwarded identity from another deployment
+
+A `defineRemoteAgent({ forwardAuth: true })` caller (see [Remote agents](./remote-agents#forwarding-the-caller-identity)) asserts its end user's principal on the create-session request as a `forwardedAuth` body field. By default every such assertion is rejected with `403` — accepting someone else's word for who the user is requires naming exactly which callers you trust. Do that with `acceptForwardedAuth` on `eveChannel`:
+
+```ts title="agent/channels/eve.ts"
+import { eveChannel } from "eve/channels/eve";
+import { vercelOidc, vercelSubject } from "eve/channels/auth";
+
+export default eveChannel({
+  auth: [vercelOidc()],
+  // Only the router deployment may assert a forwarded principal.
+  acceptForwardedAuth: ({ subject }) =>
+    subject === vercelSubject({ teamSlug: "acme", projectName: "router" }),
+});
+```
+
+The predicate authorizes the _verified transport caller_ (the route-auth result — who is asserting), not the forwarded identity (what is asserted). Match it precisely: a permissive predicate like `() => true` lets any caller that passes route auth assert any principal, including preview deployments of your own project when `vercelOidc()` is in the walk. `acceptForwardedAuth` exists only on your authored channel — the framework default channel never accepts forwarded auth, so a receiving deployment must author `agent/channels/eve.ts`.
+
+When the predicate accepts, the forwarded identity replaces the session principal: `ctx.session.auth.current` and `.initiator` carry the forwarded user exactly as if they had called your deployment directly, so user-scoped connections, local subagents, and further `forwardAuth` hops all see that user. The verified transport caller is recorded on the accepted contexts as the `eve:forwarded-by` attribute (always overwritten by the receiver, so a forwarder cannot falsify it), and the `202` response acknowledges acceptance with `forwardedAuth: "accepted"` — the sender requires that acknowledgment and fails its dispatch without it. Everything else fails loud: a forwarded body without `acceptForwardedAuth` configured or with a caller the predicate refuses is a `403`, and a malformed payload is a `400`. Only principal metadata is ever accepted — tokens and credentials never cross the hop.
+
 ## What reaches `ctx.session.auth`
 
 Inside runtime code, `ctx.session.auth` carries the result of the channel's route auth (the walk above) forward as the caller snapshot:

--- a/docs/guides/remote-agents.md
+++ b/docs/guides/remote-agents.md
@@ -25,6 +25,7 @@ export default defineRemoteAgent({
 | `url`          | `string \| (() => string \| Promise<string>)` | Yes      | n/a               | Base URL of the remote eve deployment to call. A string is baked at compile time; a function is resolved at runtime (see [Runtime URLs](#runtime-urls)). |
 | `description`  | `string`                                      | Yes      | n/a               | Model-visible delegation description.                                                                                                                    |
 | `auth`         | `OutboundAuthFn`                              | No       | none              | Outbound auth hook from `eve/agents/auth`.                                                                                                               |
+| `forwardAuth`  | `boolean`                                     | No       | `false`           | Forward the dispatching turn's session principal to the remote deployment (see [Forwarding the caller identity](#forwarding-the-caller-identity)).       |
 | `headers`      | `HeadersValue`                                | No       | none              | Static or lazily resolved request headers.                                                                                                               |
 | `path`         | `string`                                      | No       | `/eve/v1/session` | Route appended to `url` for the create-session request.                                                                                                  |
 | `outputSchema` | `StandardSchema \| JSON Schema`               | No       | none              | Structured return type the caller requires. Lowered to JSON Schema at compile time and enforced by the remote like any task-mode output schema.          |
@@ -59,6 +60,28 @@ A remote agent lowers to the same `{ message, outputSchema? }` tool shape as a l
 | `basic({ username, password })` | `Authorization: Basic …`                                                     |
 
 If you are calling another Vercel-deployed eve agent, reach for `vercelOidc()`. The remote verifies the OIDC token to authorize the caller. See [Auth & route protection](./auth-and-route-protection) for the receiving side.
+
+## Forwarding the caller identity
+
+Outbound auth authenticates your _deployment_ to the remote, so by default the remote session runs as your calling app — not as the end user who is talking to your agent. That breaks per-user workloads on the remote deployment, most directly per-user [Vercel Connect](./auth-and-route-protection#tool-and-connection-auth), which requires an authenticated `user` principal on the session.
+
+Set `forwardAuth: true` to forward the dispatching turn's session principal across the hop:
+
+```ts title="agent/subagents/site-ops.ts"
+import { defineRemoteAgent } from "eve";
+import { vercelOidc } from "eve/agents/auth";
+
+export default defineRemoteAgent({
+  url: "https://site-ops.example.com",
+  description: "Executes site operations as the requesting user.",
+  auth: vercelOidc(), // transport trust: authenticates *this* deployment
+  forwardAuth: true, // identity: asserts the current session principal
+});
+```
+
+The create-session request then carries the parent turn's `session.auth.current` and `session.auth.initiator` as a `forwardedAuth` body field. Only principal metadata crosses the wire — never tokens or credentials. The receiving deployment mints its own per-user credentials through its own connections.
+
+Forwarding is explicit on both sides. The receiver names which callers it trusts with `eveChannel({ acceptForwardedAuth })` (see [Auth & route protection](./auth-and-route-protection#accepting-forwarded-identity-from-another-deployment)) and acknowledges acceptance on the response. A receiver that rejects the assertion fails the dispatch with a 403, and a receiver that ignores the field (an older eve, or one without `acceptForwardedAuth`) fails the dispatch too — eve cancels the just-started remote session best-effort rather than letting it silently run as your app's service identity. When the dispatching turn has no auth at all, the field is omitted and the call proceeds on transport trust alone.
 
 ## How remote dispatch and callbacks work
 

--- a/packages/eve/src/channel/forwarded-auth.test.ts
+++ b/packages/eve/src/channel/forwarded-auth.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FORWARDED_BY_ATTRIBUTE,
+  parseForwardedAuth,
+  stampForwardedBy,
+} from "#channel/forwarded-auth.js";
+import type { SessionAuthContext } from "#channel/types.js";
+
+function slackUser(overrides: Partial<SessionAuthContext> = {}): SessionAuthContext {
+  return {
+    attributes: { user_id: "U123" },
+    authenticator: "slack-webhook",
+    issuer: "slack",
+    principalId: "slack:U123",
+    principalType: "user",
+    subject: "U123",
+    ...overrides,
+  };
+}
+
+describe("parseForwardedAuth", () => {
+  it("accepts a current-only payload", () => {
+    const result = parseForwardedAuth({ current: slackUser() });
+
+    expect(result).toEqual({ forwardedAuth: { current: slackUser() }, ok: true });
+  });
+
+  it("accepts a payload with a distinct initiator", () => {
+    const initiator = slackUser({ principalId: "slack:U999", subject: "U999" });
+    const result = parseForwardedAuth({ current: slackUser(), initiator });
+
+    expect(result).toEqual({
+      forwardedAuth: { current: slackUser(), initiator },
+      ok: true,
+    });
+  });
+
+  it("keeps authenticator and principalType open for channel-produced contexts", () => {
+    // The flagship use case: a Slack-authenticated user forwarded by a router
+    // deployment. The wire schema must not mirror the runtime enum schema.
+    const result = parseForwardedAuth({
+      current: {
+        attributes: {},
+        authenticator: "twilio-webhook",
+        principalId: "whatsapp:+15550001111",
+        principalType: "anonymous",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts string-array attribute values", () => {
+    const result = parseForwardedAuth({
+      current: slackUser({ attributes: { groups: ["eng", "ops"], team: "T1" } }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.forwardedAuth.current.attributes).toEqual({
+        groups: ["eng", "ops"],
+        team: "T1",
+      });
+    }
+  });
+
+  it("omits absent optional fields instead of writing undefined", () => {
+    const result = parseForwardedAuth({
+      current: {
+        attributes: {},
+        authenticator: "jwt-hmac",
+        principalId: "user-1",
+        principalType: "user",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(Object.keys(result.forwardedAuth.current)).not.toContain("issuer");
+      expect(Object.keys(result.forwardedAuth.current)).not.toContain("subject");
+    }
+  });
+
+  it.each([
+    ["a non-object", "forwarded"],
+    ["null", null],
+    ["an array", [slackUser()]],
+  ])("rejects %s payload", (_label, value) => {
+    const result = parseForwardedAuth(value);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a payload without current", () => {
+    const result = parseForwardedAuth({ initiator: slackUser() });
+
+    expect(result).toMatchObject({
+      message: expect.stringContaining("forwardedAuth.current"),
+      ok: false,
+    });
+  });
+
+  it("rejects unknown keys at the top level", () => {
+    const result = parseForwardedAuth({ current: slackUser(), token: "secret" });
+
+    expect(result).toMatchObject({
+      message: expect.stringContaining("Invalid forwardedAuth metadata"),
+      ok: false,
+    });
+  });
+
+  it("rejects unknown keys inside a context", () => {
+    const result = parseForwardedAuth({ current: { ...slackUser(), credential: "secret" } });
+
+    expect(result).toMatchObject({
+      message: expect.stringContaining("forwardedAuth.current"),
+      ok: false,
+    });
+  });
+
+  it("rejects an empty principalId", () => {
+    const result = parseForwardedAuth({ current: slackUser({ principalId: "" }) });
+
+    expect(result).toMatchObject({
+      message: expect.stringContaining("forwardedAuth.current.principalId"),
+      ok: false,
+    });
+  });
+
+  it("rejects non-string attribute values", () => {
+    const result = parseForwardedAuth({
+      current: slackUser({ attributes: { count: 3 } as never }),
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("stampForwardedBy", () => {
+  it("records the transport caller as an attribute", () => {
+    const stamped = stampForwardedBy(slackUser(), "router-app");
+
+    expect(stamped.attributes[FORWARDED_BY_ATTRIBUTE]).toBe("router-app");
+    expect(stamped.attributes.user_id).toBe("U123");
+    expect(stamped.principalId).toBe("slack:U123");
+  });
+
+  it("overwrites a sender-supplied forwarded-by value", () => {
+    const forged = slackUser({
+      attributes: { [FORWARDED_BY_ATTRIBUTE]: "someone-else" },
+    });
+
+    const stamped = stampForwardedBy(forged, "router-app");
+
+    expect(stamped.attributes[FORWARDED_BY_ATTRIBUTE]).toBe("router-app");
+  });
+
+  it("does not mutate the input context", () => {
+    const original = slackUser();
+
+    stampForwardedBy(original, "router-app");
+
+    expect(original.attributes[FORWARDED_BY_ATTRIBUTE]).toBeUndefined();
+  });
+});

--- a/packages/eve/src/channel/forwarded-auth.ts
+++ b/packages/eve/src/channel/forwarded-auth.ts
@@ -1,0 +1,128 @@
+import { z } from "#compiled/zod/index.js";
+
+import type { SessionAuthContext } from "#channel/types.js";
+
+/**
+ * Attribute key the receiving deployment stamps onto accepted forwarded auth
+ * contexts. Holds the verified transport caller's `principalId`, always
+ * overwriting any sender-supplied value — a forwarder must not be able to
+ * falsify the audit trail. On multi-hop chains the attribute names the most
+ * recent hop only.
+ */
+export const FORWARDED_BY_ATTRIBUTE = "eve:forwarded-by";
+
+/**
+ * Wire shape of the create-session `forwardedAuth` body field: the
+ * dispatching turn's session principals, asserted by a trusted forwarder.
+ * Only principal metadata crosses the wire — never tokens or credentials.
+ */
+export interface ForwardedAuth {
+  readonly current: SessionAuthContext;
+  readonly initiator?: SessionAuthContext;
+}
+
+export type ForwardedAuthParseResult =
+  | {
+      readonly forwardedAuth: ForwardedAuth;
+      readonly ok: true;
+    }
+  | {
+      readonly cause: unknown;
+      readonly message: string;
+      readonly ok: false;
+    };
+
+const attributeValueSchema = z.union([z.string(), z.array(z.string()).readonly()]);
+
+// Strict on keys, deliberately open on `authenticator` / `principalType`
+// values: forwarded principals originate from arbitrary channel auth on the
+// sending deployment (e.g. `authenticator: "slack-webhook"`), so the wire
+// schema must mirror the open public `SessionAuthContext` interface — not the
+// narrower runtime enums in `runtime/sessions/auth.ts`.
+const forwardedAuthContextSchema = z
+  .object({
+    attributes: z.record(z.string(), attributeValueSchema).readonly(),
+    authenticator: z.string().min(1),
+    issuer: z.string().min(1).optional(),
+    principalId: z.string().min(1),
+    principalType: z.string().min(1),
+    subject: z.string().min(1).optional(),
+  })
+  .strict();
+
+const forwardedAuthSchema = z
+  .object({
+    current: forwardedAuthContextSchema,
+    initiator: forwardedAuthContextSchema.optional(),
+  })
+  .strict();
+
+/**
+ * Parses the create-session `forwardedAuth` body field against the strict
+ * wire schema. Mirrors `parseSessionCallback` for `callback`: strict keys,
+ * formatted error strings, and no exceptions.
+ */
+export function parseForwardedAuth(value: unknown): ForwardedAuthParseResult {
+  const parsed = forwardedAuthSchema.safeParse(value);
+  if (parsed.success) {
+    const current = toSessionAuthContext(parsed.data.current);
+    return {
+      forwardedAuth:
+        parsed.data.initiator === undefined
+          ? { current }
+          : { current, initiator: toSessionAuthContext(parsed.data.initiator) },
+      ok: true,
+    };
+  }
+
+  return {
+    cause: parsed.error,
+    message: formatForwardedAuthParseError(parsed.error),
+    ok: false,
+  };
+}
+
+/**
+ * Returns a copy of `context` with {@link FORWARDED_BY_ATTRIBUTE} set to the
+ * verified transport caller's `principalId`, overwriting any sender-supplied
+ * value. Attributes never affect Connect token-cache keying (`principalKey`
+ * reads only issuer + id), so stamping is purely an audit trail.
+ */
+export function stampForwardedBy(
+  context: SessionAuthContext,
+  forwardedBy: string,
+): SessionAuthContext {
+  return {
+    ...context,
+    attributes: { ...context.attributes, [FORWARDED_BY_ATTRIBUTE]: forwardedBy },
+  };
+}
+
+function toSessionAuthContext(
+  parsed: z.infer<typeof forwardedAuthContextSchema>,
+): SessionAuthContext {
+  const context: {
+    -readonly [K in keyof SessionAuthContext]: SessionAuthContext[K];
+  } = {
+    attributes: parsed.attributes,
+    authenticator: parsed.authenticator,
+    principalId: parsed.principalId,
+    principalType: parsed.principalType,
+  };
+  if (parsed.issuer !== undefined) {
+    context.issuer = parsed.issuer;
+  }
+  if (parsed.subject !== undefined) {
+    context.subject = parsed.subject;
+  }
+  return context;
+}
+
+function formatForwardedAuthParseError(error: z.ZodError): string {
+  const messages = error.issues.map((issue) => {
+    const path =
+      issue.path.length === 0 ? "forwardedAuth" : `forwardedAuth.${issue.path.join(".")}`;
+    return `${path}: ${issue.message}`;
+  });
+  return `Invalid forwardedAuth metadata: ${messages.join("; ")}`;
+}

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -77,6 +77,13 @@ type BaseSendOptions = {
   auth: SessionAuthContext | null;
   callback?: SessionCallback;
   continuationToken: string;
+  /**
+   * The original (top-level) caller's auth for a newly started session,
+   * becoming `session.auth.initiator`. Defaults to {@link auth} when omitted
+   * (root session behavior). Ignored when the send resolves to an existing
+   * session, whose initiator never changes after start.
+   */
+  initiatorAuth?: SessionAuthContext | null;
   mode?: RunMode;
   /**
    * Human-readable title for a newly started workflow session. Defaults to

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -21,6 +21,7 @@ export function createSendFn<TState = undefined>(
     options: SendOptions<TState>,
   ): Promise<Session> => {
     const auth = (options as { auth: SessionAuthContext | null }).auth;
+    const initiatorAuth = (options as { initiatorAuth?: SessionAuthContext | null }).initiatorAuth;
     const callback = (options as { callback?: SendOptions<TState>["callback"] }).callback;
     const mode = (options as { mode?: SendOptions<TState>["mode"] }).mode ?? "conversation";
     const state = (options as { state?: TState }).state;
@@ -66,7 +67,9 @@ export function createSendFn<TState = undefined>(
       ? { ...adapter, state: { ...adapter.state, ...(state as Record<string, unknown>) } }
       : adapter;
 
-    const runInput: RunInput = {
+    const runInput: {
+      -readonly [K in keyof RunInput]: RunInput[K];
+    } = {
       adapter: sessionAdapter,
       auth,
       capabilities: mode === "conversation" ? { requestInput: true } : undefined,
@@ -78,6 +81,9 @@ export function createSendFn<TState = undefined>(
       requestId: metadata.requestId,
       title,
     };
+    if (initiatorAuth !== undefined) {
+      runInput.initiatorAuth = initiatorAuth;
+    }
     const handle = await runtime.run(runInput);
 
     return createSession(handle.sessionId, rawToken, runtime);

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -15,6 +15,7 @@ import {
   type ManifestCompileContext,
 } from "#compiler/normalize-helpers.js";
 import {
+  expectBoolean,
   expectObjectRecord,
   expectOnlyKnownKeys,
   expectString,
@@ -295,12 +296,18 @@ function normalizeRemoteAgentDefinition(
   const record = expectObjectRecord(value, message);
   expectOnlyKnownKeys(
     record,
-    ["auth", "description", "headers", "kind", "outputSchema", "path", "url"],
+    ["auth", "description", "forwardAuth", "headers", "kind", "outputSchema", "path", "url"],
     message,
   );
 
   if (record.kind !== "remote") {
     throw new Error(`${message} Expected "kind" to be "remote".`);
+  }
+
+  // `forwardAuth` rides the module-backed runtime definition (like `auth` and
+  // `headers`), so it is validated here but never baked into the manifest.
+  if (record.forwardAuth !== undefined) {
+    expectBoolean(record.forwardAuth, `${message} Expected "forwardAuth" to be a boolean.`);
   }
 
   return {

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -186,8 +186,10 @@ export async function dispatchRuntimeActionsStep(input: {
             });
             childSessionId = await startRemoteAgentSession({
               action,
+              auth,
               callbackBaseUrl: input.callbackBaseUrl,
               callbackToken: input.parentContinuationToken,
+              initiatorAuth,
               remote: resolvedRemote,
               session,
             });

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { SessionAuthContext } from "#channel/types.js";
 import {
   cancelRemoteAgentTurn,
   isRetryableRemoteAgentCancelError,
@@ -175,6 +176,185 @@ describe("startRemoteAgentSession", () => {
         }),
       }),
     );
+  });
+});
+
+describe("startRemoteAgentSession — forwarded auth", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const CURRENT_AUTH: SessionAuthContext = {
+    attributes: { user_id: "U123" },
+    authenticator: "slack-webhook",
+    issuer: "slack",
+    principalId: "slack:U123",
+    principalType: "user",
+    subject: "U123",
+  };
+
+  const INITIATOR_AUTH: SessionAuthContext = {
+    attributes: {},
+    authenticator: "slack-webhook",
+    issuer: "slack",
+    principalId: "slack:U999",
+    principalType: "user",
+    subject: "U999",
+  };
+
+  function acceptedResponse(): Response {
+    return new Response(
+      JSON.stringify({ forwardedAuth: "accepted", ok: true, sessionId: "remote-session" }),
+      { status: 202 },
+    );
+  }
+
+  function createSession() {
+    return {
+      agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+      compaction: { recentWindowSize: 10, threshold: 100000 },
+      continuationToken: "eve:parent-token",
+      history: [],
+      sessionId: "parent-session",
+    };
+  }
+
+  it("forwards the current and initiator principals when forwardAuth is set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(acceptedResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      startRemoteAgentSession({
+        action: createAction(),
+        auth: CURRENT_AUTH,
+        callbackBaseUrl: "https://caller.example.com",
+        initiatorAuth: INITIATOR_AUTH,
+        remote: { ...createRemoteAgent(), forwardAuth: true },
+        session: createSession(),
+      }),
+    ).resolves.toBe("remote-session");
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string).forwardedAuth).toEqual({
+      current: CURRENT_AUTH,
+      initiator: INITIATOR_AUTH,
+    });
+  });
+
+  it("omits the initiator when the dispatching turn has none", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(acceptedResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await startRemoteAgentSession({
+      action: createAction(),
+      auth: CURRENT_AUTH,
+      callbackBaseUrl: "https://caller.example.com",
+      initiatorAuth: null,
+      remote: { ...createRemoteAgent(), forwardAuth: true },
+      session: createSession(),
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string).forwardedAuth).toEqual({
+      current: CURRENT_AUTH,
+    });
+  });
+
+  it("omits the field and skips the ack when the turn has no auth", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, sessionId: "remote-session" }), { status: 202 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      startRemoteAgentSession({
+        action: createAction(),
+        auth: null,
+        callbackBaseUrl: "https://caller.example.com",
+        initiatorAuth: null,
+        remote: { ...createRemoteAgent(), forwardAuth: true },
+        session: createSession(),
+      }),
+    ).resolves.toBe("remote-session");
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).not.toHaveProperty(
+      "forwardedAuth",
+    );
+  });
+
+  it("does not forward when forwardAuth is unset even with auth in scope", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, sessionId: "remote-session" }), { status: 202 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      startRemoteAgentSession({
+        action: createAction(),
+        auth: CURRENT_AUTH,
+        callbackBaseUrl: "https://caller.example.com",
+        initiatorAuth: INITIATOR_AUTH,
+        remote: createRemoteAgent(),
+        session: createSession(),
+      }),
+    ).resolves.toBe("remote-session");
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).not.toHaveProperty(
+      "forwardedAuth",
+    );
+  });
+
+  it("fails the dispatch and cancels the orphan when the ack is missing", async () => {
+    // A pre-forwarding receiver ignores the unknown field, starts the session
+    // as the calling service, and responds without the acknowledgment.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, sessionId: "orphan-session" }), { status: 202 }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({ ok: true, sessionId: "orphan-session", status: "accepted" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      startRemoteAgentSession({
+        action: createAction(),
+        auth: CURRENT_AUTH,
+        callbackBaseUrl: "https://caller.example.com",
+        initiatorAuth: INITIATOR_AUTH,
+        remote: { ...createRemoteAgent(), forwardAuth: true },
+        session: createSession(),
+      }),
+    ).rejects.toThrow(/did not acknowledge forwarded auth/);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://remote.example.com/eve/v1/session/orphan-session/cancel",
+    );
+  });
+
+  it("fails the dispatch even when the orphan cancel fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, sessionId: "orphan-session" }), { status: 202 }),
+      )
+      .mockRejectedValueOnce(new TypeError("network unavailable"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      startRemoteAgentSession({
+        action: createAction(),
+        auth: CURRENT_AUTH,
+        callbackBaseUrl: "https://caller.example.com",
+        initiatorAuth: null,
+        remote: { ...createRemoteAgent(), forwardAuth: true },
+        session: createSession(),
+      }),
+    ).rejects.toThrow(/did not acknowledge forwarded auth/);
   });
 });
 

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -1,13 +1,17 @@
 import { EVE_SESSION_ID_HEADER } from "#protocol/message.js";
 import { CancelTurnResponseSchema } from "#protocol/cancel-turn.js";
 import { createEveCallbackRoutePath, createEveCancelTurnRoutePath } from "#protocol/routes.js";
-import type { CancelTurnResult } from "#channel/types.js";
+import type { CancelTurnResult, SessionAuthContext } from "#channel/types.js";
+import type { ForwardedAuth } from "#channel/forwarded-auth.js";
 import { createWorkflowCallbackUrl } from "#execution/workflow-callback-url.js";
 import { formatSubagentInput } from "#execution/subagent-invocation.js";
 import type { HarnessSession } from "#harness/types.js";
+import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types.js";
 import type { RuntimeSubagentRegistry } from "#runtime/subagents/registry.js";
 import type { ResolvedRuntimeRemoteAgentNode } from "#runtime/types.js";
+
+const log = createLogger("execution.remote-agent-dispatch");
 
 class RemoteAgentCancelRequestError extends Error {
   readonly retryable: boolean;
@@ -21,8 +25,12 @@ class RemoteAgentCancelRequestError extends Error {
 
 export async function startRemoteAgentSession(input: {
   readonly action: RuntimeRemoteAgentCallActionRequest;
+  /** The dispatching turn's session principal, forwarded when `remote.forwardAuth` is set. */
+  readonly auth?: SessionAuthContext | null;
   readonly callbackBaseUrl: string | undefined;
   readonly callbackToken?: string;
+  /** The root initiator's principal, forwarded alongside {@link auth}. */
+  readonly initiatorAuth?: SessionAuthContext | null;
   readonly remote: ResolvedRuntimeRemoteAgentNode;
   readonly session: HarnessSession;
 }): Promise<string> {
@@ -34,23 +42,40 @@ export async function startRemoteAgentSession(input: {
     throw new Error("Cannot dispatch remote agent without a callback base URL.");
   }
 
+  const forwardedAuth = buildForwardedAuthField(input);
+  const requestBody: {
+    callback: {
+      callId: string;
+      subagentName: string;
+      token: string;
+      url: string;
+    };
+    forwardedAuth?: ForwardedAuth;
+    message: string;
+    mode: "task";
+    outputSchema?: object;
+  } = {
+    callback: {
+      callId: input.action.callId,
+      subagentName: input.action.remoteAgentName,
+      token: callbackToken,
+      url: createWorkflowCallbackUrl(
+        input.callbackBaseUrl,
+        createEveCallbackRoutePath(callbackToken),
+      ),
+    },
+    message: formatRemoteAgentCallInputMessage({ action: input.action, remote: input.remote }),
+    mode: "task",
+    outputSchema:
+      (input.action.input.outputSchema as object | undefined) ?? input.remote.outputSchema,
+  };
+  if (forwardedAuth !== undefined) {
+    requestBody.forwardedAuth = forwardedAuth;
+  }
+
   const headers = await resolveRemoteAgentRequestHeaders(input.remote);
   const response = await fetch(createRemoteAgentSessionUrl(input.remote), {
-    body: JSON.stringify({
-      callback: {
-        callId: input.action.callId,
-        subagentName: input.action.remoteAgentName,
-        token: callbackToken,
-        url: createWorkflowCallbackUrl(
-          input.callbackBaseUrl,
-          createEveCallbackRoutePath(callbackToken),
-        ),
-      },
-      message: formatRemoteAgentCallInputMessage({ action: input.action, remote: input.remote }),
-      mode: "task",
-      outputSchema:
-        (input.action.input.outputSchema as object | undefined) ?? input.remote.outputSchema,
-    }),
+    body: JSON.stringify(requestBody),
     headers: {
       "content-type": "application/json",
       ...headers,
@@ -64,23 +89,76 @@ export async function startRemoteAgentSession(input: {
     );
   }
 
-  const sessionIdFromHeader = response.headers.get(EVE_SESSION_ID_HEADER);
-  if (sessionIdFromHeader !== null && sessionIdFromHeader.length > 0) {
-    return sessionIdFromHeader;
-  }
-
+  let responseBody: { readonly forwardedAuth?: unknown; readonly sessionId?: unknown } | undefined;
   try {
-    const body = (await response.json()) as { readonly sessionId?: unknown };
-    if (typeof body.sessionId === "string" && body.sessionId.length > 0) {
-      return body.sessionId;
-    }
+    responseBody = (await response.json()) as typeof responseBody;
   } catch {
-    // Fall through to the generic error below.
+    responseBody = undefined;
   }
 
-  throw new Error(
-    `Remote agent "${input.action.remoteAgentName}" create-session response did not include a session id.`,
-  );
+  const sessionIdFromHeader = response.headers.get(EVE_SESSION_ID_HEADER);
+  const sessionId =
+    sessionIdFromHeader !== null && sessionIdFromHeader.length > 0
+      ? sessionIdFromHeader
+      : typeof responseBody?.sessionId === "string" && responseBody.sessionId.length > 0
+        ? responseBody.sessionId
+        : undefined;
+
+  if (sessionId === undefined) {
+    throw new Error(
+      `Remote agent "${input.action.remoteAgentName}" create-session response did not include a session id.`,
+    );
+  }
+
+  // A pre-forwarding receiver silently drops unknown body fields and runs the
+  // session as the calling service — the exact silent downgrade forwarding
+  // rejects. Require the explicit acceptance acknowledgment, and best-effort
+  // cancel the already-started orphan before failing the dispatch.
+  if (forwardedAuth !== undefined && responseBody?.forwardedAuth !== "accepted") {
+    await cancelUnacknowledgedForwardedSession({ remote: input.remote, sessionId });
+    throw new Error(
+      `Remote agent "${input.action.remoteAgentName}" did not acknowledge forwarded auth. ` +
+        `The receiving deployment must configure eveChannel({ acceptForwardedAuth }) to accept a forwarded principal.`,
+    );
+  }
+
+  return sessionId;
+}
+
+function buildForwardedAuthField(input: {
+  readonly auth?: SessionAuthContext | null;
+  readonly initiatorAuth?: SessionAuthContext | null;
+  readonly remote: ResolvedRuntimeRemoteAgentNode;
+}): ForwardedAuth | undefined {
+  if (input.remote.forwardAuth !== true) {
+    return undefined;
+  }
+  // No current principal (the request was accepted with no credentials):
+  // proceed on transport trust alone, with no acknowledgment required.
+  if (input.auth === null || input.auth === undefined) {
+    return undefined;
+  }
+  const field: { current: SessionAuthContext; initiator?: SessionAuthContext } = {
+    current: input.auth,
+  };
+  if (input.initiatorAuth !== null && input.initiatorAuth !== undefined) {
+    field.initiator = input.initiatorAuth;
+  }
+  return field;
+}
+
+async function cancelUnacknowledgedForwardedSession(input: {
+  readonly remote: ResolvedRuntimeRemoteAgentNode;
+  readonly sessionId: string;
+}): Promise<void> {
+  try {
+    await cancelRemoteAgentTurn({ remote: input.remote, sessionId: input.sessionId });
+  } catch (error) {
+    logError(log, "failed to cancel the unacknowledged forwarded-auth session", error, {
+      remoteAgentName: input.remote.name,
+      sessionId: input.sessionId,
+    });
+  }
 }
 
 export async function cancelRemoteAgentTurn(input: {

--- a/packages/eve/src/public/channels/eve-forwarded-auth.integration.test.ts
+++ b/packages/eve/src/public/channels/eve-forwarded-auth.integration.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Integration coverage for forwarded auth across the create route and the
+ * runtime: an accepted `forwardedAuth` body becomes the run's session
+ * principal (`AuthKey` / `InitiatorAuthKey`, projected as
+ * `session.auth.current` / `.initiator`) and reaches
+ * `resolveConnectionPrincipal` as a `user` principal — the seam per-user
+ * Vercel Connect requires on the receiving deployment.
+ */
+
+import type { RouteHandlerArgs, SendFn, SendOptions } from "#channel/routes.js";
+import type { Session as ChannelSession } from "#channel/session.js";
+import type { RunInput, SessionAuthContext } from "#channel/types.js";
+import { contextStorage } from "#context/container.js";
+import { AuthKey, InitiatorAuthKey } from "#context/keys.js";
+import { buildRunContext } from "#execution/runtime-context.js";
+import { isConnectionAuthorizationFailedError } from "#public/connections/errors.js";
+import { principalKey, resolveConnectionPrincipal } from "#runtime/connections/principal.js";
+import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
+import { eveChannel, type EveChannelInput } from "#public/channels/eve.js";
+
+const ROUTER_CALLER: SessionAuthContext = {
+  attributes: {},
+  authenticator: "oidc",
+  issuer: "https://oidc.vercel.com/acme",
+  principalId: "https://oidc.vercel.com/acme:owner:acme:project:router:environment:production",
+  principalType: "service",
+  subject: "owner:acme:project:router:environment:production",
+};
+
+const FORWARDED_CURRENT: SessionAuthContext = {
+  attributes: { user_id: "U123" },
+  authenticator: "slack-webhook",
+  issuer: "slack",
+  principalId: "slack:U123",
+  principalType: "user",
+  subject: "U123",
+};
+
+const FORWARDED_INITIATOR: SessionAuthContext = {
+  attributes: {},
+  authenticator: "slack-webhook",
+  issuer: "slack",
+  principalId: "slack:U999",
+  principalType: "user",
+  subject: "U999",
+};
+
+function createEveCreateHandler(input: EveChannelInput) {
+  const channel = eveChannel(input);
+  const createRoute = channel.routes.find(
+    (route) => route.method === "POST" && route.path === "/eve/v1/session",
+  );
+  if (!createRoute) throw new Error("No create POST route found");
+
+  const mockSend = vi.fn<SendFn>().mockResolvedValue({
+    id: "receiver-session-id",
+    continuationToken: "eve:test",
+    async cancel() {
+      return { status: "no_active_turn" };
+    },
+    async getEventStream() {
+      return new ReadableStream();
+    },
+  } satisfies ChannelSession);
+
+  return {
+    send: mockSend,
+    async fetch(req: Request) {
+      const args: RouteHandlerArgs = {
+        send: mockSend,
+        resolveActiveSession: async () => undefined,
+        cancel: vi.fn(),
+        getSession: vi.fn(),
+        receive: vi.fn() as never,
+        params: {},
+        waitUntil: () => undefined,
+        requestIp: "127.0.0.1",
+      };
+      return (
+        createRoute as { handler: (req: Request, args: RouteHandlerArgs) => unknown }
+      ).handler(req, args) as Promise<Response>;
+    },
+  };
+}
+
+describe("eveChannel forwarded auth → runtime principal", () => {
+  it("seeds the forwarded principal into the run context and resolves a user Connect principal", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: (caller) => caller.principalId === ROUTER_CALLER.principalId,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(
+      new Request("https://receiver.example.com/eve/v1/session", {
+        body: JSON.stringify({
+          forwardedAuth: { current: FORWARDED_CURRENT, initiator: FORWARDED_INITIATOR },
+          message: "check my dashboards",
+          mode: "task",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ forwardedAuth: "accepted" });
+
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    const run: RunInput = {
+      adapter: { kind: "eve" },
+      auth: options.auth,
+      channelName: "eve",
+      continuationToken: "eve:test",
+      initiatorAuth: options.initiatorAuth,
+      input: { message: "check my dashboards" },
+      mode: "task",
+    };
+    const ctx = buildRunContext({ bundle: {} as CompiledBundle, run });
+
+    const current = ctx.get(AuthKey);
+    const initiator = ctx.get(InitiatorAuthKey);
+    expect(current).toMatchObject({
+      attributes: { "eve:forwarded-by": ROUTER_CALLER.principalId, user_id: "U123" },
+      principalId: "slack:U123",
+      principalType: "user",
+    });
+    expect(initiator).toMatchObject({
+      attributes: { "eve:forwarded-by": ROUTER_CALLER.principalId },
+      principalId: "slack:U999",
+      principalType: "user",
+    });
+
+    const principal = contextStorage.run(ctx, () =>
+      resolveConnectionPrincipal("datadog", {
+        getToken: async () => ({ token: "t" }),
+        principalType: "user",
+      }),
+    );
+
+    expect(principal).toEqual({
+      attributes: { "eve:forwarded-by": ROUTER_CALLER.principalId, user_id: "U123" },
+      id: "slack:U123",
+      issuer: "slack",
+      type: "user",
+    });
+    // The audit attribute never enters Connect token-cache keying.
+    expect(principalKey(principal)).toBe("user:slack:slack:U123");
+  });
+
+  it("resolves the transport service principal (and fails Connect) without forwarding", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    await handler.fetch(
+      new Request("https://receiver.example.com/eve/v1/session", {
+        body: JSON.stringify({ message: "check my dashboards", mode: "task" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    const ctx = buildRunContext({
+      bundle: {} as CompiledBundle,
+      run: {
+        adapter: { kind: "eve" },
+        auth: options.auth,
+        channelName: "eve",
+        continuationToken: "eve:test",
+        input: { message: "check my dashboards" },
+        mode: "task",
+      },
+    });
+
+    expect(ctx.get(AuthKey)).toEqual(ROUTER_CALLER);
+    expect(ctx.get(InitiatorAuthKey)).toEqual(ROUTER_CALLER);
+    const failure = (() => {
+      try {
+        contextStorage.run(ctx, () =>
+          resolveConnectionPrincipal("datadog", {
+            getToken: async () => ({ token: "t" }),
+            principalType: "user",
+          }),
+        );
+        return undefined;
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(isConnectionAuthorizationFailedError(failure)).toBe(true);
+    expect(failure).toMatchObject({ reason: "principal_required" });
+  });
+});

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -1377,3 +1377,228 @@ describe("eveChannel — cancel turn", () => {
     });
   });
 });
+
+describe("eveChannel — forwarded auth", () => {
+  const ROUTER_CALLER: SessionAuthContext = {
+    attributes: {},
+    authenticator: "oidc",
+    issuer: "https://oidc.vercel.com/acme",
+    principalId: "https://oidc.vercel.com/acme:owner:acme:project:router:environment:production",
+    principalType: "service",
+    subject: "owner:acme:project:router:environment:production",
+  };
+
+  const FORWARDED_CURRENT: SessionAuthContext = {
+    attributes: { user_id: "U123" },
+    authenticator: "slack-webhook",
+    issuer: "slack",
+    principalId: "slack:U123",
+    principalType: "user",
+    subject: "U123",
+  };
+
+  const FORWARDED_INITIATOR: SessionAuthContext = {
+    attributes: {},
+    authenticator: "slack-webhook",
+    issuer: "slack",
+    principalId: "slack:U999",
+    principalType: "user",
+    subject: "U999",
+  };
+
+  function forwardedRequest(forwardedAuth: unknown): Request {
+    return createJsonMessageRequest({ forwardedAuth, message: "hi", mode: "task" });
+  }
+
+  it("rejects a forwarded body when the channel has no acceptForwardedAuth", async () => {
+    const handler = createEveCreateHandler({ auth: () => ROUTER_CALLER });
+
+    const response = await handler.fetch(forwardedRequest({ current: FORWARDED_CURRENT }));
+
+    expect(response.status).toBe(403);
+    expect(handler.send).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "This deployment does not accept forwarded auth.",
+      ok: false,
+    });
+  });
+
+  it("rejects a caller the predicate refuses", async () => {
+    const acceptForwardedAuth = vi.fn(
+      (caller: SessionAuthContext) => caller.principalId === "someone-else",
+    );
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(forwardedRequest({ current: FORWARDED_CURRENT }));
+
+    expect(response.status).toBe(403);
+    expect(acceptForwardedAuth).toHaveBeenCalledWith(ROUTER_CALLER);
+    expect(handler.send).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Caller is not authorized to assert forwarded auth.",
+      ok: false,
+    });
+  });
+
+  it("rejects a malformed forwarded payload with 400", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(
+      forwardedRequest({ current: { ...FORWARDED_CURRENT, token: "secret" } }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(handler.send).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("Invalid forwardedAuth metadata"),
+      ok: false,
+    });
+  });
+
+  it("returns 500 when the authored predicate throws", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => {
+        throw new Error("boom");
+      },
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(forwardedRequest({ current: FORWARDED_CURRENT }));
+
+    expect(response.status).toBe(500);
+    expect(handler.send).not.toHaveBeenCalled();
+  });
+
+  it("replaces the session principal and acknowledges acceptance", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: (caller) => caller.principalId === ROUTER_CALLER.principalId,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(
+      forwardedRequest({ current: FORWARDED_CURRENT, initiator: FORWARDED_INITIATOR }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      forwardedAuth: "accepted",
+      ok: true,
+      sessionId: "test-session-id",
+    });
+
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    expect(options.auth).toEqual({
+      ...FORWARDED_CURRENT,
+      attributes: {
+        ...FORWARDED_CURRENT.attributes,
+        "eve:forwarded-by": ROUTER_CALLER.principalId,
+      },
+    });
+    expect(options.initiatorAuth).toEqual({
+      ...FORWARDED_INITIATOR,
+      attributes: {
+        ...FORWARDED_INITIATOR.attributes,
+        "eve:forwarded-by": ROUTER_CALLER.principalId,
+      },
+    });
+    expect(options.mode).toBe("task");
+  });
+
+  it("defaults the initiator to the forwarded current principal", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    await handler.fetch(forwardedRequest({ current: FORWARDED_CURRENT }));
+
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    expect(options.initiatorAuth).toEqual(options.auth);
+  });
+
+  it("overwrites a sender-supplied eve:forwarded-by attribute", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    await handler.fetch(
+      forwardedRequest({
+        current: {
+          ...FORWARDED_CURRENT,
+          attributes: { "eve:forwarded-by": "forged-value" },
+        },
+      }),
+    );
+
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    expect(options.auth?.attributes["eve:forwarded-by"]).toBe(ROUTER_CALLER.principalId);
+  });
+
+  it("exposes the stamped forwarded principal to onMessage as the caller", async () => {
+    const onMessage = vi.fn((ctx: Parameters<typeof defaultEveAuth>[0]) => {
+      expect(ctx.eve.caller?.principalId).toBe(FORWARDED_CURRENT.principalId);
+      expect(ctx.eve.caller?.attributes["eve:forwarded-by"]).toBe(ROUTER_CALLER.principalId);
+      return { auth: defaultEveAuth(ctx) };
+    });
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+      onMessage,
+    });
+
+    const response = await handler.fetch(forwardedRequest({ current: FORWARDED_CURRENT }));
+
+    expect(response.status).toBe(202);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    expect(options.auth?.principalId).toBe(FORWARDED_CURRENT.principalId);
+  });
+
+  it("omits the acknowledgment and initiatorAuth without a forwarded body", async () => {
+    const handler = createEveCreateHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.not.toHaveProperty("forwardedAuth");
+    const options = handler.send.mock.calls[0]?.[1] as SendOptions;
+    expect(options.auth).toEqual(ROUTER_CALLER);
+    expect(options).not.toHaveProperty("initiatorAuth");
+  });
+
+  it("rejects forwarded auth on the continue route", async () => {
+    const handler = createEveContinueHandler({
+      acceptForwardedAuth: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(
+      new Request("https://example.com/eve/v1/session/test-session-id", {
+        body: JSON.stringify({
+          continuationToken: "eve:test",
+          forwardedAuth: { current: FORWARDED_CURRENT },
+          message: "hi",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(handler.send).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Forwarded auth is only accepted on session creation.",
+      ok: false,
+    });
+  });
+});

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -2,6 +2,8 @@ import { type FilePart, type TextPart, type UserContent } from "ai";
 
 import type { CancelTurnResult, SessionAuthContext, SessionCallback } from "#channel/types.js";
 import type { CancelTurnResponse } from "#protocol/cancel-turn.js";
+import type { SendOptions } from "#channel/routes.js";
+import { parseForwardedAuth, stampForwardedBy } from "#channel/forwarded-auth.js";
 import { parseSessionCallback } from "#channel/session-callback.js";
 import { hasInternalRefScheme } from "#internal/attachments/url-refs.js";
 import { createLogger, logError } from "#internal/logging.js";
@@ -123,6 +125,23 @@ export interface EveChannelInput {
    */
   readonly auth: AuthFn<Request> | readonly AuthFn<Request>[];
   /**
+   * Authorizes which transport-authenticated callers may assert a forwarded
+   * principal on the create-session route (the `forwardedAuth` body field a
+   * `defineRemoteAgent({ forwardAuth: true })` sender emits). The predicate
+   * receives the *verified* route-auth caller — who is asserting, not what is
+   * asserted — and must match it precisely (for example
+   * `({ subject }) => subject === vercelSubject({ teamSlug, projectName })`).
+   * A permissive predicate lets any authenticated caller assert any
+   * principal.
+   *
+   * When accepted, the forwarded identity replaces the session principal
+   * (`session.auth.current` / `session.auth.initiator`) exactly as if that
+   * user had called this deployment directly, and the transport caller is
+   * recorded on the accepted contexts as the `eve:forwarded-by` attribute.
+   * Omit the option to reject every forwarded assertion with 403.
+   */
+  readonly acceptForwardedAuth?: (caller: SessionAuthContext) => boolean | Promise<boolean>;
+  /**
    * Attachment policy for inbound file parts. Omit for the framework default (25 MB cap, all media
    * types); `"disabled"` rejects every attachment; a partial config is merged onto the default. Violations reject with 413 (too large) or 415 (bad type).
    */
@@ -201,6 +220,13 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           return Response.json({ error: "Expected a JSON object.", ok: false }, { status: 400 });
         }
 
+        const forwarded = await resolveForwardedAuth({
+          caller: sessionAuth,
+          config: input,
+          payload: payload as Record<string, unknown>,
+        });
+        if (forwarded instanceof Response) return forwarded;
+
         const body = parseCreateBody(payload as Record<string, unknown>);
         if (body instanceof Response) return body;
 
@@ -208,7 +234,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         if (policyRejection !== null) return policyRejection;
 
         const messageResult = await resolveOnMessage({
-          auth: sessionAuth,
+          auth: forwarded === undefined ? sessionAuth : forwarded.current,
           config: input,
           message: body.message,
           request: req,
@@ -219,27 +245,41 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         const token = `eve:${crypto.randomUUID()}`;
         const context = mergeContext(body.context, messageResult.context);
 
-        const session = await send(createSendPayload(body, context), {
+        const sendOptions: SendOptions = {
           auth: messageResult.auth,
           callback: body.callback,
           continuationToken: token,
           mode: body.mode,
-        });
+        };
+        if (forwarded !== undefined) {
+          sendOptions.initiatorAuth = forwarded.initiator;
+        }
+        const session = await send(createSendPayload(body, context), sendOptions);
 
-        return Response.json(
-          {
-            continuationToken: session.continuationToken,
-            ok: true,
-            sessionId: session.id,
+        const createResponse: {
+          continuationToken: string;
+          forwardedAuth?: "accepted";
+          ok: boolean;
+          sessionId: string;
+        } = {
+          continuationToken: session.continuationToken,
+          ok: true,
+          sessionId: session.id,
+        };
+        if (forwarded !== undefined) {
+          // The acceptance acknowledgment the forwarding sender requires;
+          // its absence tells the sender a pre-forwarding receiver silently
+          // dropped the field.
+          createResponse.forwardedAuth = "accepted";
+        }
+
+        return Response.json(createResponse, {
+          headers: {
+            "cache-control": "no-store",
+            [EVE_SESSION_ID_HEADER]: session.id,
           },
-          {
-            headers: {
-              "cache-control": "no-store",
-              [EVE_SESSION_ID_HEADER]: session.id,
-            },
-            status: 202,
-          },
-        );
+          status: 202,
+        });
       }),
 
       POST("/eve/v1/session/:sessionId", async (req, { send, getSession, params }) => {
@@ -267,6 +307,15 @@ export function eveChannel(input: EveChannelInput): EveChannel {
 
         if (payload === null || typeof payload !== "object") {
           return Response.json({ error: "Expected a JSON object.", ok: false }, { status: 400 });
+        }
+
+        // Fail loud instead of silently running the delivery as the transport
+        // principal: forwarding is create-only today.
+        if ((payload as Record<string, unknown>).forwardedAuth !== undefined) {
+          return Response.json(
+            { error: "Forwarded auth is only accepted on session creation.", ok: false },
+            { status: 400 },
+          );
         }
 
         const body = parseContinueBody(payload as Record<string, unknown>);
@@ -502,6 +551,67 @@ async function resolveOnMessage(input: {
 
 function defaultOnMessage(ctx: EveMessageContext): Exclude<EveMessageResult, null> {
   return { auth: defaultEveAuth(ctx) };
+}
+
+interface AcceptedForwardedAuth {
+  readonly current: SessionAuthContext;
+  readonly initiator: SessionAuthContext;
+}
+
+/**
+ * Gates the create-session `forwardedAuth` body field. Returns `undefined`
+ * when the body carries no forwarded auth, the stamped accepted contexts when
+ * the transport caller may assert them, or the failure `Response` (403 when
+ * the channel or predicate rejects the caller, 400 on a malformed payload,
+ * 500 when the authored predicate throws).
+ */
+async function resolveForwardedAuth(input: {
+  readonly caller: SessionAuthContext;
+  readonly config: EveChannelInput;
+  readonly payload: Record<string, unknown>;
+}): Promise<AcceptedForwardedAuth | undefined | Response> {
+  const value = input.payload.forwardedAuth;
+  if (value === undefined) return undefined;
+
+  if (input.config.acceptForwardedAuth === undefined) {
+    return Response.json(
+      { error: "This deployment does not accept forwarded auth.", ok: false },
+      { status: 403 },
+    );
+  }
+
+  const parsed = parseForwardedAuth(value);
+  if (!parsed.ok) {
+    return Response.json({ error: parsed.message, ok: false }, { status: 400 });
+  }
+
+  let accepted: boolean;
+  try {
+    accepted = await input.config.acceptForwardedAuth(input.caller);
+  } catch (error) {
+    const errorId = logError(log, "acceptForwardedAuth handler failed", error, {
+      caller: input.caller.principalId,
+    });
+    return Response.json(
+      { error: "acceptForwardedAuth handler failed.", errorId, ok: false },
+      { status: 500 },
+    );
+  }
+  if (!accepted) {
+    return Response.json(
+      { error: "Caller is not authorized to assert forwarded auth.", ok: false },
+      { status: 403 },
+    );
+  }
+
+  // Stamp before `onMessage` runs: the attribute is the only window a custom
+  // `onMessage` has onto the transport caller once `caller` is replaced.
+  const current = stampForwardedBy(parsed.forwardedAuth.current, input.caller.principalId);
+  const initiator =
+    parsed.forwardedAuth.initiator === undefined
+      ? current
+      : stampForwardedBy(parsed.forwardedAuth.initiator, input.caller.principalId);
+  return { current, initiator };
 }
 
 function droppedMessageResponse(): Response {

--- a/packages/eve/src/public/definitions/remote-agent.ts
+++ b/packages/eve/src/public/definitions/remote-agent.ts
@@ -22,6 +22,20 @@ export interface RemoteAgentDefinition {
    * The parent agent reads this as the lowered subagent tool's description.
    */
   readonly description: string;
+  /**
+   * Forwards the dispatching turn's session principal to the remote
+   * deployment as the `forwardedAuth` create-session body field, so the
+   * remote session runs as the same end user as the parent (per-user
+   * Connect, local subagents, and further remote hops all see that
+   * principal). Defaults to `false` — forwarding identity to another
+   * deployment is an explicit decision, never ambient.
+   *
+   * Only principal metadata crosses the wire, never tokens or credentials.
+   * The receiver must opt in with `eveChannel({ acceptForwardedAuth })` and
+   * acknowledge acceptance; a missing acknowledgment fails the dispatch
+   * instead of silently running the session as the calling service.
+   */
+  readonly forwardAuth?: boolean;
   readonly headers?: HeadersValue;
   readonly kind: "remote";
   /**

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -352,6 +352,7 @@ async function resolveRuntimeRemoteAgent(input: {
   const resolvedRemoteAgent: {
     auth?: ResolvedRuntimeRemoteAgentNode["auth"];
     description: string;
+    forwardAuth?: boolean;
     headers?: HeadersValue;
     kind: "remote";
     logicalPath: string;
@@ -381,6 +382,10 @@ async function resolveRuntimeRemoteAgent(input: {
 
   if (typeof resolvedRecord.auth === "function") {
     resolvedRemoteAgent.auth = resolvedRecord.auth as ResolvedRuntimeRemoteAgentNode["auth"];
+  }
+
+  if (resolvedRecord.forwardAuth === true) {
+    resolvedRemoteAgent.forwardAuth = true;
   }
 
   const headers = resolveRemoteAgentHeaders(resolvedRecord.headers);

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -283,6 +283,7 @@ export type ResolvedRuntimeRemoteAgentNode = Readonly<
     Node & {
       auth?: OutboundAuthFn;
       description: string;
+      forwardAuth?: boolean;
       headers?: HeadersValue;
       kind: "remote";
       name: string;

--- a/packages/eve/test/scenarios/remote-agent-auth-forwarding.scenario.test.ts
+++ b/packages/eve/test/scenarios/remote-agent-auth-forwarding.scenario.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionAuthContext } from "../../src/channel/types.js";
+import { startRemoteAgentSession } from "../../src/execution/remote-agent-dispatch.js";
+import type { RuntimeRemoteAgentCallActionRequest } from "../../src/runtime/actions/types.js";
+import type { ResolvedRuntimeRemoteAgentNode } from "../../src/runtime/types.js";
+import {
+  type ScenarioAppDescriptor,
+  useScenarioApp,
+} from "../../src/internal/testing/scenario-app.js";
+import { startEveDev } from "./dev-server-harness.js";
+
+/**
+ * Locks the remote-agent auth-forwarding hop over a real HTTP boundary: the
+ * test process plays the router deployment (driving the real sender dispatch
+ * function) against a receiver dev server whose `eveChannel` configures
+ * `acceptForwardedAuth`. The receiver's `onMessage` asserts that the
+ * forwarded principal — not the transport caller — became the effective
+ * session caller, with the `eve:forwarded-by` audit attribute stamped from
+ * the verified transport principal.
+ */
+
+const scenarioApp = useScenarioApp();
+const SCENARIO_TIMEOUT_MS = 360_000;
+
+const ROUTER_TOKEN = "router-scenario-token";
+const STRANGER_TOKEN = "stranger-scenario-token";
+
+const RECEIVER_DESCRIPTOR: ScenarioAppDescriptor = {
+  files: {
+    "agent/agent.ts": `import { defineAgent } from "eve";
+
+export default defineAgent({ model: "openai/gpt-5.4-mini" });
+`,
+    "agent/channels/eve.ts": `import { eveChannel } from "eve/channels/eve";
+
+const PRINCIPALS = {
+  "Bearer ${ROUTER_TOKEN}": "router-app",
+  "Bearer ${STRANGER_TOKEN}": "stranger-app",
+};
+
+export default eveChannel({
+  auth(request) {
+    const principalId = PRINCIPALS[request.headers.get("authorization") ?? ""];
+    if (principalId === undefined) return null;
+    return {
+      attributes: {},
+      authenticator: "scenario-bearer",
+      principalId,
+      principalType: "service",
+    };
+  },
+  acceptForwardedAuth: (caller) => caller.principalId === "router-app",
+  onMessage(ctx) {
+    const caller = ctx.eve.caller;
+    if (
+      caller?.principalId !== "slack:U123" ||
+      caller.principalType !== "user" ||
+      caller.attributes["eve:forwarded-by"] !== "router-app"
+    ) {
+      throw new Error("Expected the stamped forwarded principal as the effective caller.");
+    }
+    return { auth: caller };
+  },
+});
+`,
+    "agent/instructions.md": "Reply tersely.\n",
+  },
+  installDependencies: true,
+  name: "forwarded-auth-receiver",
+};
+
+const FORWARDED_USER: SessionAuthContext = {
+  attributes: { user_id: "U123" },
+  authenticator: "slack-webhook",
+  issuer: "slack",
+  principalId: "slack:U123",
+  principalType: "user",
+  subject: "U123",
+};
+
+describe("remote agent auth forwarding", () => {
+  it(
+    "asserts the forwarded principal across the hop and rejects untrusted forwarders",
+    async () => {
+      const receiverApp = await scenarioApp(RECEIVER_DESCRIPTOR);
+      const receiver = await startEveDev(receiverApp.appRoot);
+
+      try {
+        // Accepted: the trusted transport principal asserts a forwarded user.
+        // The receiver acknowledges, and its onMessage (which throws on any
+        // other caller) proves the principal replacement happened.
+        const childSessionId = await startRemoteAgentSession({
+          action: createAction(),
+          auth: FORWARDED_USER,
+          callbackBaseUrl: "https://caller.example.com",
+          initiatorAuth: FORWARDED_USER,
+          remote: createRemote({ token: ROUTER_TOKEN, url: receiver.url }),
+          session: createParentSession(),
+        });
+        expect(childSessionId.length).toBeGreaterThan(0);
+
+        // The 202 response carries the acceptance acknowledgment.
+        const rawResponse = await fetch(new URL("/eve/v1/session", receiver.url), {
+          body: JSON.stringify({
+            forwardedAuth: { current: FORWARDED_USER },
+            message: "raw forwarded create",
+            mode: "task",
+          }),
+          headers: {
+            authorization: `Bearer ${ROUTER_TOKEN}`,
+            "content-type": "application/json",
+          },
+          method: "POST",
+        });
+        expect(rawResponse.status).toBe(202);
+        await expect(rawResponse.json()).resolves.toMatchObject({
+          forwardedAuth: "accepted",
+          ok: true,
+        });
+
+        // Mismatch: an authenticated caller outside the forwarder allow-list
+        // fails loud at the hop instead of downgrading to service identity.
+        await expect(
+          startRemoteAgentSession({
+            action: createAction(),
+            auth: FORWARDED_USER,
+            callbackBaseUrl: "https://caller.example.com",
+            initiatorAuth: FORWARDED_USER,
+            remote: createRemote({ token: STRANGER_TOKEN, url: receiver.url }),
+            session: createParentSession(),
+          }),
+        ).rejects.toThrow(/HTTP 403/);
+      } catch (error) {
+        throw new Error(
+          [`receiver stdout:\n${receiver.stdout()}`, `receiver stderr:\n${receiver.stderr()}`].join(
+            "\n\n",
+          ),
+          { cause: error },
+        );
+      } finally {
+        await receiver.stop();
+      }
+    },
+    SCENARIO_TIMEOUT_MS,
+  );
+});
+
+function createAction(): RuntimeRemoteAgentCallActionRequest {
+  return {
+    callId: "call-forwarded",
+    description: "Runtime action event description.",
+    input: { message: "check the site status" },
+    kind: "remote-agent-call",
+    name: "site-ops",
+    nodeId: "subagents/site-ops.ts",
+    remoteAgentName: "site-ops",
+  };
+}
+
+function createRemote(input: {
+  readonly token: string;
+  readonly url: string;
+}): ResolvedRuntimeRemoteAgentNode {
+  return {
+    auth: async () => ({ headers: { authorization: `Bearer ${input.token}` } }),
+    description: "Executes site operations as the requesting user.",
+    forwardAuth: true,
+    kind: "remote",
+    logicalPath: "subagents/site-ops.ts",
+    name: "site-ops",
+    nodeId: "subagents/site-ops.ts",
+    path: "/eve/v1/session",
+    sourceId: "subagents/site-ops.ts",
+    sourceKind: "module",
+    url: input.url,
+  };
+}
+
+function createParentSession() {
+  return {
+    agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "eve:parent-token",
+    history: [],
+    sessionId: "parent-session",
+  };
+}


### PR DESCRIPTION
## Summary

Implements the auth-forwarding plan from #608: a `defineRemoteAgent` hop can now carry the end user's principal to the receiving deployment, so per-user workloads split across deployments — most directly per-user Vercel Connect — keep working across the hop.

Closes #604.

> Stacked on #608 (the research plan). Merge that first; this PR then retargets to `main`.

## Design

**Sender — `defineRemoteAgent({ forwardAuth: true })`**
- Dispatch serializes the parent turn's `auth` / `initiatorAuth` (already in scope in `dispatch-runtime-actions-step.ts`) into a `forwardedAuth: { current, initiator? }` field on the create-session body. Omitted when the turn has no auth; only principal metadata crosses the wire — never tokens or credentials.
- The sender requires the receiver's `forwardedAuth: "accepted"` acknowledgment on the 202 response. A pre-forwarding receiver silently drops unknown body fields and would run the session as the calling service — the exact silent downgrade this design rejects — so a missing ack fails the dispatch after best-effort cancelling the already-started orphan session (its id is in hand; the existing cancel path is reused).
- The flag rides the module-backed runtime definition next to `auth` / `headers`; the compiled manifest node is unchanged.

**Receiver — `eveChannel({ acceptForwardedAuth })`**
- A predicate over the *verified transport principal* (the route-auth result): it authorizes who may forward, not what is forwarded. Because it runs on the already-authenticated principal, the Vercel OIDC current-project bypass can't leak into forwarder trust — the author must match explicitly (e.g. `({ subject }) => subject === vercelSubject({ teamSlug, projectName })`).
- The forwarded payload is validated by a new strict wire schema (`channel/forwarded-auth.ts`, beside `session-callback.ts`) that keeps `authenticator` / `principalType` open — a Slack-authenticated user (`authenticator: "slack-webhook"`) is the flagship case.
- Accepted forwarding replaces the session principal (`session.auth.current` / `.initiator` seed `RunInput.auth` / `.initiatorAuth`), so `resolveConnectionPrincipal` sees a `user` principal, local subagents inherit it, and further `forwardAuth` hops chain it. The verified transport caller is stamped as the `eve:forwarded-by` attribute (receiver-written, overwrites any sender-supplied value, stamped before `onMessage`); it never affects Connect token-cache keying.
- Fail loud, never fall back silently: field without the option → 403, predicate false → 403, malformed → 400, predicate throws → 500, `forwardedAuth` on the continue route → 400. The framework default channel never accepts forwarded auth.

## Tests

- **Unit**: wire schema matrix (open authenticator/principalType, strict keys, attribute shapes), stamping/overwrite, dispatch body construction (forwarded / initiator-omitted / null-auth-omitted / flag-unset), missing-ack failure + orphan cancel, full receiver gate matrix on the create and continue routes.
- **Integration**: create route → `buildRunContext` → forwarded principal seeds `AuthKey` / `InitiatorAuthKey` and resolves a `user` Connect principal (`principal_required` control without forwarding; `principalKey` unaffected by the audit attribute).
- **Scenario (real HTTP)**: a receiver dev server with `acceptForwardedAuth` configured, driven by the real sender dispatch function — trusted forwarder accepted + acknowledged with the receiver's `onMessage` asserting the stamped forwarded principal became the effective caller; untrusted forwarder → 403.

## Notes

- Patch changeset (both options are additive; no public API breaks).
- Docs updated in the same PR: `docs/guides/remote-agents.md` (sender) and `docs/guides/auth-and-route-protection.md` (receiver + trust-model warning).
- `pnpm fmt`, `lint`, `typecheck`, `guard:invariants`, `docs:check`, `test:unit`, `test:integration`, and the new scenario all pass locally.