### PR TITLE
fix(eve): sandbox - seed workspaces before bootstrap

### DIFF
--- a/.changeset/seed-sandboxes-before-bootstrap.md
+++ b/.changeset/seed-sandboxes-before-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Write authored sandbox workspace seed files before running bootstrap across the Vercel, Docker, microsandbox, and just-bash backends, so bootstrap can consume canonical workspace inputs and its outputs remain in the captured template.

--- a/packages/eve/src/execution/sandbox/bindings/docker.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker.integration.test.ts
@@ -221,6 +221,61 @@ describe("createDockerSandboxBackend prewarm", () => {
     expect(cleanup?.args.at(-1)).toBe(buildContainerName);
   });
 
+  it("writes seed files before bootstrap and commits bootstrap outputs", async () => {
+    const appRoot = await createScratchDirectory("eve-docker-sandbox-");
+    let seedWritten = false;
+    const { calls, cli } = createFakeDockerCli((args) => {
+      const command = args.at(-1) ?? "";
+      if (isImageInspect(args, TEMPLATE_IMAGE)) {
+        return { exitCode: 1, stderr: "No such image" };
+      }
+      if (args[0] === "exec" && args[1] === "-i" && command.includes("/workspace/seed.txt")) {
+        seedWritten = true;
+      }
+      if (
+        args[0] === "exec" &&
+        command.includes("if [ -e") &&
+        command.includes("/workspace/seed.txt")
+      ) {
+        return seedWritten ? { exitCode: 0, stdout: "authored seed" } : { exitCode: 43 };
+      }
+      return undefined;
+    });
+
+    await createEngine({ cli }).prewarm({
+      bootstrap: async ({ use }) => {
+        const sandbox = await use();
+        await expect(sandbox.readTextFile({ path: "/workspace/seed.txt" })).resolves.toBe(
+          "authored seed",
+        );
+        await sandbox.writeTextFile({
+          content: "bootstrap output",
+          path: "/workspace/bootstrap.txt",
+        });
+      },
+      runtimeContext: { appRoot },
+      seedFiles: [{ content: "authored seed", path: "/workspace/seed.txt" }],
+      templateKey: TEMPLATE_KEY,
+    });
+
+    const seedWriteIndex = calls.findIndex(
+      ({ args }) =>
+        args[0] === "exec" &&
+        args[1] === "-i" &&
+        (args.at(-1) ?? "").includes("/workspace/seed.txt"),
+    );
+    const bootstrapWriteIndex = calls.findIndex(
+      ({ args }) =>
+        args[0] === "exec" &&
+        args[1] === "-i" &&
+        (args.at(-1) ?? "").includes("/workspace/bootstrap.txt"),
+    );
+    const commitIndex = calls.findIndex(({ args }) => args[0] === "commit");
+    expect(seedWriteIndex).toBeGreaterThanOrEqual(0);
+    expect(seedWriteIndex).toBeLessThan(bootstrapWriteIndex);
+    expect(bootstrapWriteIndex).toBeLessThan(commitIndex);
+  });
+
   it("fails with an actionable error when the daemon is unreachable", async () => {
     const appRoot = await createScratchDirectory("eve-docker-sandbox-");
     const { cli } = createFakeDockerCli((args) => {

--- a/packages/eve/src/execution/sandbox/bindings/docker.ts
+++ b/packages/eve/src/execution/sandbox/bindings/docker.ts
@@ -142,6 +142,11 @@ export function createDockerSandboxBackend(
           (policy) => setDockerNetworkPolicy(cli, buildContainerName, policy),
         );
 
+        if (prewarmInput.seedFiles.length > 0) {
+          prewarmInput.log?.(`writing ${prewarmInput.seedFiles.length} seed file(s)`);
+        }
+        await writeSandboxSeedFiles(templateSession, prewarmInput.seedFiles);
+
         if (prewarmInput.bootstrap !== undefined) {
           prewarmInput.log?.("running sandbox bootstrap");
           await prewarmInput.bootstrap({
@@ -152,11 +157,6 @@ export function createDockerSandboxBackend(
               }),
           });
         }
-
-        if (prewarmInput.seedFiles.length > 0) {
-          prewarmInput.log?.(`writing ${prewarmInput.seedFiles.length} seed file(s)`);
-        }
-        await writeSandboxSeedFiles(templateSession, prewarmInput.seedFiles);
 
         // Quiesce before commit so the captured filesystem is stable.
         prewarmInput.log?.("stopping template build container");

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
@@ -472,6 +472,39 @@ describe("createLocalSandboxBackend with the just-bash engine", () => {
     expect(result.stdout.trim().split("\n")).toEqual(["/workspace/skills/weather.md"]);
   });
 
+  it("writes seed files before bootstrap and captures bootstrap outputs", async () => {
+    const appRoot = await createTemporaryCacheDirectory("seed-before-bootstrap");
+    const backend = createJustBashBackend();
+
+    await backend.prewarm({
+      bootstrap: async ({ use }) => {
+        const sandbox = await use();
+        await expect(sandbox.readTextFile({ path: "/workspace/seed.txt" })).resolves.toBe(
+          "authored seed",
+        );
+        await sandbox.writeTextFile({
+          content: "bootstrap output",
+          path: "/workspace/bootstrap.txt",
+        });
+      },
+      runtimeContext: { appRoot },
+      seedFiles: [{ content: "authored seed", path: "/workspace/seed.txt" }],
+      templateKey: "template-seed-before-bootstrap",
+    });
+
+    const handle = await backend.create({
+      runtimeContext: { appRoot },
+      sessionKey: "session-seed-before-bootstrap",
+      templateKey: "template-seed-before-bootstrap",
+    });
+    await expect(handle.session.readTextFile({ path: "/workspace/seed.txt" })).resolves.toBe(
+      "authored seed",
+    );
+    await expect(handle.session.readTextFile({ path: "/workspace/bootstrap.txt" })).resolves.toBe(
+      "bootstrap output",
+    );
+  });
+
   it("does not repair an existing session directory with later seed files", async () => {
     const appRoot = await createTemporaryCacheDirectory("seed-session");
     const backend = createJustBashBackend();

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.ts
@@ -92,6 +92,8 @@ export function createJustBashSandboxBackend(
       );
 
       try {
+        await writeSandboxSeedFiles(templateSession, prewarmInput.seedFiles);
+
         if (prewarmInput.bootstrap !== undefined) {
           prewarmInput.log?.("running sandbox bootstrap");
           await prewarmInput.bootstrap({
@@ -102,8 +104,6 @@ export function createJustBashSandboxBackend(
               }),
           });
         }
-
-        await writeSandboxSeedFiles(templateSession, prewarmInput.seedFiles);
 
         const captured = await templateSandbox.captureState();
         if (captured === null) {

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.test.ts
@@ -244,6 +244,39 @@ describe("prewarmMicrosandboxTemplate", () => {
     );
     expect(result).toEqual({ reused: false });
   });
+
+  it("writes seed files before bootstrap and snapshots bootstrap outputs", async () => {
+    const vm = createFakeMicrosandboxVm("template");
+    runtimeMocks.createPreparedMicrosandbox.mockResolvedValue(vm);
+
+    await prewarmMicrosandboxTemplate({
+      backendName: "microsandbox",
+      options: resolveMicrosandboxOptions({ image: MICROSANDBOX_DEFAULT_IMAGE }),
+      optionsHash: "options-hash",
+      prewarmInput: {
+        bootstrap: async ({ use }) => {
+          const sandbox = await use();
+          await expect(sandbox.readTextFile({ path: "/workspace/seed.txt" })).resolves.toBe(
+            "authored seed",
+          );
+          await sandbox.writeTextFile({
+            content: "bootstrap output",
+            path: "/workspace/bootstrap.txt",
+          });
+        },
+        runtimeContext: { appRoot: "/tmp/eve-app" },
+        seedFiles: [{ content: "authored seed", path: "/workspace/seed.txt" }],
+        templateKey: "template-key",
+      },
+    });
+
+    await expect(vm.readFileBytes("/workspace/bootstrap.txt")).resolves.toEqual(
+      Buffer.from("bootstrap output"),
+    );
+    expect(vm.writeFiles.mock.invocationCallOrder[1]).toBeLessThan(
+      vm.stopAndSnapshot.mock.invocationCallOrder[0]!,
+    );
+  });
 });
 
 function createFakeMicrosandboxVm(sessionKey: string) {
@@ -271,14 +304,14 @@ function createFakeMicrosandboxVm(sessionKey: string) {
     async spawn() {
       throw new Error("spawn is not used by this test.");
     },
-    async stopAndSnapshot() {},
-    async writeFiles(
-      nextFiles: ReadonlyArray<{ readonly content: Uint8Array; readonly path: string }>,
-    ) {
-      for (const file of nextFiles) {
-        files.set(file.path, Buffer.from(file.content));
-      }
-    },
+    stopAndSnapshot: vi.fn(async () => {}),
+    writeFiles: vi.fn(
+      async (nextFiles: ReadonlyArray<{ readonly content: Uint8Array; readonly path: string }>) => {
+        for (const file of nextFiles) {
+          files.set(file.path, Buffer.from(file.content));
+        }
+      },
+    ),
     async writeMetadata() {},
   };
 }

--- a/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.ts
+++ b/packages/eve/src/execution/sandbox/bindings/microsandbox-lifecycle.ts
@@ -118,6 +118,11 @@ export async function prewarmMicrosandboxTemplate(input: {
   );
 
   try {
+    if (input.prewarmInput.seedFiles.length > 0) {
+      input.prewarmInput.log?.(`writing ${input.prewarmInput.seedFiles.length} seed file(s)`);
+    }
+    await writeSandboxSeedFiles(templateSession, input.prewarmInput.seedFiles);
+
     if (input.prewarmInput.bootstrap !== undefined) {
       input.prewarmInput.log?.("running sandbox bootstrap");
       await input.prewarmInput.bootstrap({
@@ -132,11 +137,6 @@ export async function prewarmMicrosandboxTemplate(input: {
         },
       });
     }
-
-    if (input.prewarmInput.seedFiles.length > 0) {
-      input.prewarmInput.log?.(`writing ${input.prewarmInput.seedFiles.length} seed file(s)`);
-    }
-    await writeSandboxSeedFiles(templateSession, input.prewarmInput.seedFiles);
 
     input.prewarmInput.log?.("snapshotting template VM");
     await templateSandbox.stopAndSnapshot(snapshotName);

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -38,6 +38,7 @@ function createMockSandbox(input: {
   status?: string;
   tags?: Record<string, string>;
 }) {
+  const files = new Map<string, Buffer>();
   let tags = input.tags;
   return {
     currentSnapshotId: input.snapshotId ?? "",
@@ -47,7 +48,10 @@ function createMockSandbox(input: {
       unlink: vi.fn().mockResolvedValue(undefined),
     },
     name: input.name,
-    readFile: vi.fn<(file: { path: string }) => Promise<object | null>>().mockResolvedValue(null),
+    readFile: vi.fn(async (file: { path: string }): Promise<object | null> => {
+      const content = files.get(file.path);
+      return content === undefined ? null : Readable.from([content]);
+    }),
     runCommand: vi.fn().mockResolvedValue(createMockCommandResult()),
     snapshot: vi.fn().mockResolvedValue({ snapshotId: `${input.name}-snapshot` }),
     status: input.status ?? "running",
@@ -60,7 +64,13 @@ function createMockSandbox(input: {
         tags = params.tags;
       }
     }),
-    writeFiles: vi.fn().mockResolvedValue(undefined),
+    writeFiles: vi.fn(
+      async (nextFiles: ReadonlyArray<{ readonly content: Uint8Array; readonly path: string }>) => {
+        for (const file of nextFiles) {
+          files.set(file.path, Buffer.from(file.content));
+        }
+      },
+    ),
   };
 }
 
@@ -329,6 +339,44 @@ describe("createVercelSandbox", () => {
       }),
     );
     expect(files?.[0]?.content).toBeInstanceOf(Buffer);
+  });
+
+  it("writes seed files before bootstrap and snapshots bootstrap outputs", async () => {
+    const templateSandbox = createMockSandbox({ name: "template" });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn().mockResolvedValueOnce(templateSandbox),
+        get: vi.fn().mockResolvedValueOnce(null),
+      },
+    };
+    const backend = createTestVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await backend.prewarm({
+      bootstrap: async ({ use }) => {
+        const sandbox = await use();
+        await expect(sandbox.readTextFile({ path: "/workspace/seed.txt" })).resolves.toBe(
+          "authored seed",
+        );
+        await sandbox.writeTextFile({
+          content: "bootstrap output",
+          path: "/workspace/bootstrap.txt",
+        });
+      },
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      seedFiles: [{ content: "authored seed", path: "/workspace/seed.txt" }],
+      templateKey: "template-key",
+    });
+
+    const writes = vi.mocked(templateSandbox.writeFiles);
+    expect(writes.mock.calls.map(([files]) => files[0]?.path)).toEqual([
+      "/workspace/seed.txt",
+      "/workspace/bootstrap.txt",
+    ]);
+    expect(writes.mock.invocationCallOrder[1]).toBeLessThan(
+      vi.mocked(templateSandbox.snapshot).mock.invocationCallOrder[0]!,
+    );
   });
 
   it("reports a fresh build when no framework snapshot exists yet", async () => {

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -320,6 +320,8 @@ async function ensureTemplate(input: EnsureTemplateInput): Promise<EnsureTemplat
     createVercelNetworkPolicySetter(sandbox),
   );
 
+  await writeSandboxSeedFiles(templateSession, input.seedFiles);
+
   if (input.bootstrap !== undefined) {
     input.log?.("running sandbox bootstrap");
     await input.bootstrap({
@@ -334,8 +336,6 @@ async function ensureTemplate(input: EnsureTemplateInput): Promise<EnsureTemplat
       },
     });
   }
-
-  await writeSandboxSeedFiles(templateSession, input.seedFiles);
 
   const snapshot = await sandbox.snapshot();
   return {


### PR DESCRIPTION
## Summary

- write authored sandbox workspace seed files before invoking `bootstrap`
- apply the lifecycle ordering consistently to Vercel, Docker, microsandbox, and just-bash templates
- keep every backend's snapshot or image commit after bootstrap so bootstrap outputs remain in the reusable template
- add focused regression coverage for seed visibility and captured bootstrap outputs
- add an `eve` patch changeset

## Root cause

All four template builders prepared the base runtime, ran authored bootstrap code, and only then wrote `agent/sandbox/workspace/**` seed files. Template identity already included the authored seed contents, but bootstrap could not consume the files that selected that template.

The template lifecycle is now:

1. prepare the backend/base runtime
2. write authored workspace seed files
3. run authored bootstrap against that workspace
4. snapshot or commit the resulting template

## Backend coverage

- Vercel unit coverage verifies the seed is readable from bootstrap and the bootstrap write precedes `sandbox.snapshot()`.
- Docker integration coverage verifies the seed write precedes bootstrap and the bootstrap write precedes the image commit, using the mocked Docker CLI.
- microsandbox unit coverage verifies the seed is readable from bootstrap and the bootstrap write precedes `stopAndSnapshot()`.
- just-bash scenario coverage creates a session from the template and verifies that both the authored seed and bootstrap output were captured.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/vercel.test.ts src/execution/sandbox/bindings/microsandbox-lifecycle.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/sandbox/bindings/docker.integration.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/execution/sandbox/bindings/just-bash.scenario.test.ts`
- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`

Closes #959.
