### PR TITLE
fix(eve): dynamic tools - refresh session scope after redeploy

### DIFF
--- a/.changeset/quick-tools-redeploy.md
+++ b/.changeset/quick-tools-redeploy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Refresh session-scoped dynamic tools when an existing production session moves to a new Vercel deployment, so added, removed, and reordered tools use the current build.

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -14,18 +14,22 @@ vi.mock("#context/build-callback-context.js", () => ({
 }));
 
 // Import after mock so the module picks up the mock
-const { replayDynamicSessionTools, dispatchDynamicToolEvent } =
-  await import("#context/dynamic-tool-lifecycle.js");
+const {
+  replayDynamicSessionTools,
+  dispatchDynamicToolEvent,
+  refreshDynamicSessionToolsForRuntimeRevision,
+} = await import("#context/dynamic-tool-lifecycle.js");
 const { buildDynamicTools } = await import("#context/build-dynamic-tools.js");
 
 import { ContextContainer } from "#context/container.js";
 import {
   SessionIdKey,
   SessionDynamicToolMetadataKey,
+  SessionDynamicToolRuntimeRevisionKey,
   TurnDynamicToolMetadataKey,
 } from "#context/keys.js";
 import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
-import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { createSessionStartedEvent, type HandleMessageStreamEvent } from "#protocol/message.js";
 
 // Re-implement the naming logic here to test it independently
 // (the production function is unexported — testing via the public behavior)
@@ -499,6 +503,90 @@ function createReplayableTool(
 }
 
 describe("dispatchDynamicToolEvent", () => {
+  it("replaces session tools with the current deployment's resolver output", async () => {
+    const ctx = createCtx();
+    const oldResolver = createResolver("old", ["session.started"], () => ({
+      old_tool: createReplayableTool("old deployment"),
+    }));
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [oldResolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_old");
+
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["old_tool"]);
+
+    const newResolver = createResolver("new", ["session.started"], () => ({
+      new_tool: createReplayableTool("new deployment"),
+    }));
+
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx,
+      resolvers: [newResolver],
+      messages: [],
+      event: createSessionStartedEvent(),
+      runtimeRevision: "deployment:dpl_new",
+    });
+
+    expect(ctx.get(SessionDynamicToolRuntimeRevisionKey)).toBe("deployment:dpl_new");
+    expect(ctx.get(SessionDynamicToolMetadataKey)?.map((tool) => tool.name)).toEqual(["new_tool"]);
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["new_tool"]);
+  });
+
+  it("does not re-run session resolvers within the same deployment", async () => {
+    const ctx = createCtx();
+    const handler = vi.fn(() => ({
+      current_tool: createReplayableTool(),
+    }));
+    const resolver = createResolver("current", ["session.started"], handler);
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
+
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: createSessionStartedEvent(),
+      runtimeRevision: "deployment:dpl_current",
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("clears removed session resolvers on a new runtime revision", async () => {
+    const ctx = createCtx();
+    const oldResolver = createResolver("old", ["session.started"], () => ({
+      old_tool: createReplayableTool(),
+    }));
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [oldResolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_old");
+
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx,
+      resolvers: [],
+      messages: [],
+      event: createSessionStartedEvent(),
+      runtimeRevision: "deployment:dpl_new",
+    });
+
+    expect(ctx.get(SessionDynamicToolMetadataKey)).toEqual([]);
+    expect(ctx.get(SessionDynamicToolRuntimeRevisionKey)).toBe("deployment:dpl_new");
+  });
+
   it("leaves unsupported connection input schemas for the MCP server to validate", async () => {
     const ctx = createCtx();
     const inputSchema = {

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -3,7 +3,7 @@ import type { ModelMessage } from "ai";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { ApprovalContext } from "#public/definitions/approval.js";
 import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
-import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import type { HandleMessageStreamEvent, SessionStartedStreamEvent } from "#protocol/message.js";
 import {
   ALLOWED_DYNAMIC_TOOL_EVENTS,
   isBrandedToolEntry,
@@ -21,6 +21,7 @@ import type { ContextContainer } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
+  SessionDynamicToolRuntimeRevisionKey,
   TurnDynamicToolMetadataKey,
   LiveStepToolsKey,
 } from "#context/keys.js";
@@ -339,7 +340,12 @@ export async function dispatchDynamicToolEvent(input: {
   if (!ALLOWED_DYNAMIC_TOOL_EVENTS.has(event.type)) return;
 
   const matching = resolvers.filter((r) => r.eventNames.includes(event.type));
-  if (matching.length === 0) return;
+  if (matching.length === 0) {
+    if (event.type === "session.started") {
+      ctx.set(SessionDynamicToolMetadataKey, []);
+    }
+    return;
+  }
 
   const { metadata, liveTools } = await resolveToolsFromEvent(ctx, matching, event, messages);
 
@@ -356,8 +362,41 @@ export async function dispatchDynamicToolEvent(input: {
   const durableKey = durableKeyForEvent(event.type);
   if (durableKey === undefined) return;
 
+  if (event.type === "session.started") {
+    ctx.set(SessionDynamicToolMetadataKey, metadata);
+    return;
+  }
+
   const slugs = new Set(matching.map((r) => r.slug));
   const existing = ctx.get(durableKey) ?? [];
   const kept = existing.filter((m) => !slugs.has(m.resolverSlug));
   ctx.set(durableKey, [...kept, ...metadata]);
+}
+
+/**
+ * Re-resolves session-scoped dynamic tools when a durable session reaches a
+ * different runtime revision. The refresh is internal: lifecycle consumers
+ * still observe exactly one `session.started` event for the session.
+ */
+export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
+  readonly ctx: ContextContainer;
+  readonly resolvers: readonly ResolvedDynamicToolResolver[];
+  readonly event: SessionStartedStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  readonly runtimeRevision: string;
+}): Promise<void> {
+  if (input.ctx.get(SessionDynamicToolRuntimeRevisionKey) === input.runtimeRevision) {
+    return;
+  }
+
+  const matching = input.resolvers.filter((resolver) =>
+    resolver.eventNames.includes("session.started"),
+  );
+  const { metadata } =
+    matching.length === 0
+      ? { metadata: [] }
+      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
+
+  input.ctx.set(SessionDynamicToolMetadataKey, metadata);
+  input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);
 }

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -138,6 +138,14 @@ export const SessionDynamicToolMetadataKey = new ContextKey<readonly DurableDyna
 );
 
 /**
+ * Runtime revision that last resolved session-scoped dynamic tools.
+ * Used to refresh their durable metadata after a deploy or development rebuild.
+ */
+export const SessionDynamicToolRuntimeRevisionKey = new ContextKey<string>(
+  "eve.sessionDynamicToolRuntimeRevision",
+);
+
+/**
  * Turn-scoped dynamic tool metadata (from `turn.started`).
  * Replaced each turn.
  */

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -100,7 +100,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
  * Builds a {@link RuntimeIdentity} from the resolved runtime agent node
  * and the current eve package installation.
  */
-function buildRuntimeIdentity(node: ResolvedRuntimeAgentNode): RuntimeIdentity {
+export function buildRuntimeIdentity(node: ResolvedRuntimeAgentNode): RuntimeIdentity {
   const packageInfo = resolveInstalledPackageInfo();
 
   const identity: RuntimeIdentity = {

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -4,7 +4,14 @@ import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js"
 import type { DeliverPayload, SubagentInputRequestHookPayload } from "#channel/types.js";
 import { ContextContainer } from "#context/container.js";
 import { ContextKey } from "#context/key.js";
-import { AuthKey, ContinuationTokenKey, ModeKey, SessionIdKey } from "#context/keys.js";
+import {
+  AuthKey,
+  ContinuationTokenKey,
+  ModeKey,
+  SessionDynamicToolMetadataKey,
+  SessionDynamicToolRuntimeRevisionKey,
+  SessionIdKey,
+} from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { serializeContext } from "#context/serialize.js";
 import {
@@ -25,6 +32,7 @@ import {
 import { createTurnWorkflowInput } from "#execution/durable-session-migrations/turn-workflow.js";
 import { projectToDurableSession } from "#execution/session.js";
 import { createExecutionNodeStep } from "#execution/node-step.js";
+import { defineTool } from "#public/definitions/tool.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
@@ -101,6 +109,11 @@ function createTestWritable(
 }
 
 vi.mock("./node-step.js", () => ({
+  buildRuntimeIdentity: vi.fn(() => ({
+    agentId: "test-agent",
+    eveVersion: "0.0.0-test",
+    modelId: "test-model",
+  })),
   createExecutionNodeStep: vi.fn(),
 }));
 
@@ -980,6 +993,115 @@ describe("turnStep", () => {
         }),
       }),
     });
+  });
+
+  it("refreshes session-scoped dynamic tools from the current deployment", async () => {
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_new");
+    const handler = vi.fn(() => ({
+      current_tool: defineTool({
+        description: "Current deployment tool",
+        inputSchema: { type: "object" },
+        execute: async () => ({ ok: true }),
+      }),
+    }));
+    const dynamicToolResolver = {
+      eventNames: ["session.started"],
+      events: { "session.started": handler },
+      logicalPath: "agent/tools/current.ts",
+      slug: "current",
+      sourceId: "test:current",
+      sourceKind: "module",
+    } as never;
+    const compiledArtifactsSource = { kind: "bundled" } as const;
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: {
+        config: {},
+        dynamicToolResolvers: [dynamicToolResolver],
+      },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (session): Promise<StepResult> => ({
+        next: { done: true, output: "ok" },
+        session,
+      });
+    });
+
+    const session = createStubSession({
+      state: {
+        "eve.harness.emission": {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: "",
+        },
+      },
+    });
+    installSessionStoreMocks([session]);
+
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, null);
+    ctx.set(BundleKey, compiledBundle);
+    ctx.set(ChannelKey, threadContextAdapter);
+    ctx.set(ContinuationTokenKey, "http:thread-context");
+    ctx.set(ModeKey, "conversation");
+    ctx.set(SessionIdKey, "session-1");
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_old");
+    ctx.set(SessionDynamicToolMetadataKey, [
+      {
+        closureVars: {},
+        description: "Stale deployment tool",
+        entryKey: "old_tool",
+        executeStepFnName: "eve:dynamic-tool//old",
+        inputSchema: { type: "object" },
+        name: "old_tool",
+        resolverSlug: "old",
+      },
+    ]);
+
+    const result = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "follow up" }],
+      },
+      parentWritable: createTestWritable(),
+      serializedContext: serializeContext(ctx),
+      sessionState: createStubSessionState({
+        emissionState: {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: "",
+        },
+      }),
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(result.serializedContext[SessionDynamicToolRuntimeRevisionKey.name]).toBe(
+      "deployment:dpl_new",
+    );
+    expect(result.serializedContext[SessionDynamicToolMetadataKey.name]).toEqual([
+      expect.objectContaining({
+        name: "current_tool",
+        resolverSlug: "current",
+      }),
+    ]);
   });
 
   it("clears pending authorization after a matching callback resumes the turn", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -5,8 +5,16 @@ import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
 import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-lifecycle.js";
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
 import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
-import { dispatchDynamicToolEvent } from "#context/dynamic-tool-lifecycle.js";
-import { AuthKey, CapabilitiesKey, ModeKey } from "#context/keys.js";
+import {
+  dispatchDynamicToolEvent,
+  refreshDynamicSessionToolsForRuntimeRevision,
+} from "#context/dynamic-tool-lifecycle.js";
+import {
+  AuthKey,
+  CapabilitiesKey,
+  ModeKey,
+  SessionDynamicToolRuntimeRevisionKey,
+} from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
@@ -33,6 +41,7 @@ import type { RunMode } from "#shared/run-mode.js";
 import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
 import {
   createAuthorizationCompletedEvent,
+  createSessionStartedEvent,
   encodeMessageStreamEvent,
   type HandleMessageStreamEvent,
   timestampHandleMessageStreamEvent,
@@ -57,13 +66,14 @@ import {
   type TurnStepInput,
   type TurnWorkflowDispatchInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
-import { createExecutionNodeStep } from "#execution/node-step.js";
+import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
 import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
+import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
 import {
   createWorkflowRuntime,
   requestWorkflowTurnCancellation,
@@ -255,11 +265,30 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     };
   }
 
-  const writer = input.parentWritable.getWriter();
   const hookRegistry = bundle.hookRegistry;
   const dynamicInstructionsResolvers = bundle.resolvedAgent.dynamicInstructionsResolvers ?? [];
   const dynamicSkillResolvers = bundle.resolvedAgent.dynamicSkillResolvers ?? [];
   const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
+  const runtimeIdentity = buildRuntimeIdentity(bundle.graph.root);
+  const deploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
+  const dynamicToolRuntimeRevision = deploymentId
+    ? `deployment:${deploymentId}`
+    : await resolveRuntimeCompiledArtifactsVersionedCacheKey(bundle.compiledArtifactsSource);
+  const sessionStarted = getHarnessEmissionState(initialSession.state).sessionStarted;
+
+  if (!sessionStarted) {
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, dynamicToolRuntimeRevision);
+  } else {
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx,
+      resolvers: dynamicToolResolvers,
+      event: createSessionStartedEvent({ runtime: runtimeIdentity }),
+      messages: initialSession.history,
+      runtimeRevision: dynamicToolRuntimeRevision,
+    });
+  }
+
+  const writer = input.parentWritable.getWriter();
 
   const emit = async (event: HandleMessageStreamEvent): Promise<HandleMessageStreamEvent> => {
     const toEmit = await callAdapterEventHandler(adapter, event, adapterCtx);


### PR DESCRIPTION
## Summary

- persist the runtime revision that last resolved session-scoped dynamic tools
- re-run only those resolvers before model execution when an existing session reaches a new Vercel deployment or development build
- atomically replace durable tool metadata so added, removed, and reordered tools all come from the current runtime
- keep the refresh internal so hooks and stream consumers still observe exactly one `session.started` event

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/context/dynamic-tool-lifecycle.test.ts src/execution/node-step.test.ts src/execution/workflow-steps.test.ts`
- `pnpm --filter eve build`
- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`

Closes #1087
