### PR TITLE
fix(eve): avoid broken Vercel team pagination

### DIFF
--- a/.changeset/bright-teams-limit.md
+++ b/.changeset/bright-teams-limit.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Request Vercel CLI's maximum 100-team page instead of following its broken default pagination path.

--- a/packages/eve/src/setup/vercel-project-api.test.ts
+++ b/packages/eve/src/setup/vercel-project-api.test.ts
@@ -24,42 +24,25 @@ beforeEach(() => {
 });
 
 describe("listTeams", () => {
-  it("drains every page and deduplicates by slug", async () => {
-    mockedCaptureVercel
-      .mockResolvedValueOnce(
-        captured({
-          teams: [{ name: "Current", slug: "current", current: true }],
-          pagination: { next: 20 },
-        }),
-      )
-      .mockResolvedValueOnce(
-        captured({
-          teams: [{ name: "Other", slug: "other" }],
-          pagination: { next: null },
-        }),
-      );
+  it("requests the maximum team page", async () => {
+    mockedCaptureVercel.mockResolvedValue(
+      captured({
+        teams: [
+          { name: "Current", slug: "current", current: true },
+          { name: "Other", slug: "other", current: false },
+        ],
+        pagination: { next: null },
+      }),
+    );
 
     await expect(listTeams("/repo")).resolves.toEqual([
       { name: "Current", slug: "current", current: true },
       { name: "Other", slug: "other", current: false },
     ]);
-    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
-      1,
+    expect(mockedCaptureVercel).toHaveBeenCalledOnce();
+    expect(mockedCaptureVercel).toHaveBeenCalledWith(
       ["teams", "ls", "--format", "json", "--limit", "100"],
       { cwd: "/repo", signal: undefined },
-    );
-    expect(mockedCaptureVercel).toHaveBeenNthCalledWith(
-      2,
-      ["api", "/v2/teams?limit=100&until=20"],
-      { cwd: "/repo", signal: undefined },
-    );
-  });
-
-  it("rejects a repeated pagination cursor", async () => {
-    mockedCaptureVercel.mockResolvedValue(captured({ teams: [], pagination: { next: 20 } }));
-
-    await expect(listTeams("/repo")).rejects.toThrow(
-      "Vercel returned a repeated pagination cursor",
     );
   });
 

--- a/packages/eve/src/setup/vercel-project-api.ts
+++ b/packages/eve/src/setup/vercel-project-api.ts
@@ -46,17 +46,7 @@ const VercelTeamPageSchema = z
     teams: z.array(VercelTeamListEntrySchema),
     pagination: VercelPaginationSchema.optional(),
   })
-  .transform((data) => ({ items: data.teams, next: data.pagination?.next ?? undefined }));
-
-const VercelApiTeamPageSchema = z
-  .object({
-    teams: z.array(VercelTeamListEntrySchema.omit({ current: true })),
-    pagination: VercelPaginationSchema.optional(),
-  })
-  .transform((data) => ({
-    items: data.teams.map((team) => ({ ...team, current: false })),
-    next: data.pagination?.next ?? undefined,
-  }));
+  .transform((data) => data.teams);
 
 const VercelProjectPageSchema = z
   .object({
@@ -71,33 +61,6 @@ export function parseVercelJson(stdout: string, description: string): unknown {
     return JSON.parse(stdout);
   } catch {
     throw new Error(`Could not parse ${description} JSON from Vercel CLI output.`);
-  }
-}
-
-/**
- * Drains a cursor-paginated Vercel list, deduping by `key`. A repeated cursor
- * means the API paged us in a circle — bail rather than loop forever.
- */
-async function drainPages<T>(
-  label: string,
-  key: (item: T) => string,
-  fetchPage: (next: number | undefined) => Promise<VercelPage<T>>,
-): Promise<T[]> {
-  const items = new Map<string, T>();
-  const cursors = new Set<number>();
-  let next: number | undefined;
-  while (true) {
-    const page = await fetchPage(next);
-    for (const item of page.items) {
-      const itemKey = key(item);
-      if (!items.has(itemKey)) items.set(itemKey, item);
-    }
-    if (page.next === undefined) return [...items.values()];
-    if (cursors.has(page.next)) {
-      throw new Error(`Vercel returned a repeated pagination cursor for ${label}.`);
-    }
-    cursors.add(page.next);
-    next = page.next;
   }
 }
 
@@ -142,45 +105,22 @@ async function captureTeamPage(
   return result.stdout;
 }
 
-async function fetchTeamPage(
-  projectRoot: string,
-  options: VercelProjectOperationOptions,
-  next: number | undefined,
-): Promise<VercelPage<VercelTeamListEntry>> {
-  if (next === undefined) {
-    const stdout = await captureTeamPage(projectRoot, options, [
-      "teams",
-      "ls",
-      "--format",
-      "json",
-      "--limit",
-      String(VERCEL_TEAM_PAGE_LIMIT),
-    ]);
-    const parsed = VercelTeamPageSchema.safeParse(parseVercelJson(stdout, "teams"));
-    if (!parsed.success) throw new Error("Could not read teams from Vercel CLI JSON output.");
-    return parsed.data;
-  }
-
-  // The teams command currently sends its `--next` value as an API `next`
-  // parameter, while the teams API consumes the emitted timestamp as `until`.
-  // Use the CLI's authenticated API passthrough for continuation pages.
-  const path = `/v2/teams?limit=${VERCEL_TEAM_PAGE_LIMIT}&until=${next}`;
-  const stdout = await captureTeamPage(projectRoot, options, ["api", path]);
-  const parsed = VercelApiTeamPageSchema.safeParse(parseVercelJson(stdout, "teams"));
-  if (!parsed.success) throw new Error("Could not read teams from Vercel API JSON output.");
-  return parsed.data;
-}
-
-/** Lists every Vercel scope available to the current CLI user. */
+/** Lists up to the maximum 100 Vercel scopes supported by the CLI. */
 export async function listTeams(
   projectRoot: string,
   options: VercelProjectOperationOptions = {},
 ): Promise<VercelTeamListEntry[]> {
-  return drainPages(
-    "Vercel teams",
-    (team) => team.slug,
-    (next) => fetchTeamPage(projectRoot, options, next),
-  );
+  const stdout = await captureTeamPage(projectRoot, options, [
+    "teams",
+    "ls",
+    "--format",
+    "json",
+    "--limit",
+    String(VERCEL_TEAM_PAGE_LIMIT),
+  ]);
+  const parsed = VercelTeamPageSchema.safeParse(parseVercelJson(stdout, "teams"));
+  if (!parsed.success) throw new Error("Could not read teams from Vercel CLI JSON output.");
+  return parsed.data;
 }
 
 async function fetchProjectPage(


### PR DESCRIPTION
### Description

- Remove the direct `vercel api` continuation fallback introduced in #1120.
- Request the Vercel CLI maximum of 100 teams in one `teams ls` call, avoiding its broken default 20-team continuation path.
- Keep the native `vercel upgrade` prompt for CLIs that do not support `--format json` and `--limit`.

### Upstream issue

Vercel CLI 56.5.0 passes the value from `teams ls --next` to its team client as `next`, which serializes it as a `next` query parameter on `GET /v2/teams`. That endpoint's documented cursor parameters are `since` and `until`; its emitted `pagination.next` value must be sent back as `until`. Because `next` is ignored, the CLI fetches the first page again and emits the same continuation cursor.

The CLI unit test exercises the flag only as telemetry and does not assert the outgoing query or second-page results, so the mismatch is not covered upstream.

### How did you test your changes?

- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- Focused TUI, install-flow, and Vercel team-list unit tests (60 passed)
- `pnpm --filter eve build`
- Built local eve against Vercel CLI 56.5.0: one `teams ls --limit 100` call returned all 25 available scopes and the current scope

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
