### PR TITLE
fix(eve): Fix incorrectly adjusting tool call names in Slack status as part of markdown stripping

### DIFF
--- a/.changeset/fuzzy-slack-status.md
+++ b/.changeset/fuzzy-slack-status.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve underscores in connection tool names shown by Slack typing status indicators.

--- a/packages/eve/src/public/channels/slack/limits.test.ts
+++ b/packages/eve/src/public/channels/slack/limits.test.ts
@@ -33,6 +33,18 @@ describe("truncateTypingStatus", () => {
     );
   });
 
+  it("preserves underscores within tool names", () => {
+    expect(truncateTypingStatus("kernel_browser_manage_browsers")).toBe(
+      "kernel_browser_manage_browsers",
+    );
+    expect(truncateTypingStatus("kernel__browser__manage_browsers")).toBe(
+      "kernel__browser__manage_browsers",
+    );
+    expect(truncateTypingStatus("Running kernel_browser_manage_browsers now")).toBe(
+      "Running kernel_browser_manage_browsers now",
+    );
+  });
+
   it("caps at the typing-status limit with a trailing ellipsis", () => {
     const long = "a".repeat(SLACK_TYPING_STATUS_MAX_LENGTH + 20);
     const result = truncateTypingStatus(long);

--- a/packages/eve/src/public/channels/slack/limits.ts
+++ b/packages/eve/src/public/channels/slack/limits.ts
@@ -129,6 +129,7 @@ function stripTypingStatusMarkdown(status: string): string {
     .replace(/\[([^\]]+)\]\([^)]+\)/gu, "$1")
     .replace(/`([^`]+)`/gu, "$1")
     .replace(/~~([^~]+)~~/gu, "$1")
-    .replace(/(\*\*|__)([^*_]+)\1/gu, "$2")
-    .replace(/(^|[^\p{L}\p{N}])([*_])([^*_]+)\2(?=$|[^\p{L}\p{N}])/gu, "$1$3");
+    .replace(/(^|[^\p{L}\p{N}])(\*\*|__)([^*_]+)\2(?=$|[^\p{L}\p{N}])/gu, "$1$3")
+    .replace(/(^|[^\p{L}\p{N}*])\*([^*_]+)\*(?=$|[^\p{L}\p{N}*])/gu, "$1$2")
+    .replace(/(^|[^\p{L}\p{N}_])_([^*_]+)_(?=$|[^\p{L}\p{N}_])/gu, "$1$2");
 }


### PR DESCRIPTION
### Description

Our markdown stripping logic incorrectly collapsed underscores in tool names. Regex now more carefully only looks at double underscores at the start/end of a text block.

### How did you test your changes?

Regression test.n



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>