### PR TITLE
feat(setup): add interactive iMessage setup

### DIFF
--- a/.changeset/bright-messages-connect.md
+++ b/.changeset/bright-messages-connect.md
@@ -1,0 +1,6 @@
+---
+"eve": patch
+"@vercel/eve-catalog": patch
+---
+
+Add `eve channels add imessage`, which collects Photon project credentials separately, stores them in Vercel Connect, attaches the iMessage webhook route, and scaffolds the channel.

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -869,7 +869,7 @@ See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-offic
 npm install eve@latest chat @photon-ai/chat-adapter-imessage @chat-adapter/state-memory
 \`\`\`
 
-The in-memory state store is for local development. Use Redis or PostgreSQL in production. The adapter is vendor-official.`,
+Scaffold and provision this integration with \`eve channels add imessage\`, or install it manually below. The in-memory state store is for local development. Use Redis or PostgreSQL in production. The adapter is vendor-official.`,
     quickStart: `Create \`agent/channels/imessage.ts\`:
 
 \`\`\`ts
@@ -882,7 +882,6 @@ export const { bot, channel, send } = chatSdkChannel({
   userName: "My Agent",
   adapters: {
     imessage: createiMessageAdapter({
-      local: false,
       projectId: process.env.IMESSAGE_PROJECT_ID,
       projectSecret: process.env.IMESSAGE_PROJECT_SECRET,
     }),
@@ -903,7 +902,7 @@ export default channel;
 \`\`\`
 
 See the [Photon adapter documentation](https://chat-sdk.dev/adapters/vendor-official/photon) for all supported events and credentials.`,
-    configure: `Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Photon supports cloud, self-hosted, and local macOS deployments. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+    configure: `Set \`IMESSAGE_PROJECT_ID\` and \`IMESSAGE_PROJECT_SECRET\`, then point Photon’s signed webhook at \`/eve/v1/imessage\`. Photon supports cloud and self-hosted deployments. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-dial": {
     logo: "dial",

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -28,7 +28,7 @@ agent/
     intake.ts
 ```
 
-Scaffold a channel file with `eve channels add` (interactive), or pass a kind: `eve channels add slack` or `eve channels add web`. You can also author the file by hand.
+Scaffold a channel file with `eve channels add` (interactive), or pass a kind: `eve channels add imessage`, `eve channels add slack`, or `eve channels add web`. You can also author the file by hand.
 
 ## The eve HTTP channel (default)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,7 +20,7 @@ The `eve` binary (`bin: eve`) runs from your app root, and every command first l
 | `eve link`                    | Link the directory to a Vercel project and pull AI Gateway credentials                                                                                |
 | `eve deploy`                  | Deploy the agent to Vercel production (links first if needed)                                                                                         |
 | `eve eval`                    | Run evals against the local app or a remote target                                                                                                    |
-| `eve channels add [kind]`     | Scaffold a channel interactively, or by kind (`slack` \| `web`)                                                                                       |
+| `eve channels add [kind]`     | Scaffold a channel interactively, or by kind (`imessage` \| `slack` \| `web`)                                                                         |
 | `eve channels list`           | List user-authored channels                                                                                                                           |
 | `eve extension init [target]` | Create a new extension package                                                                                                                        |
 | `eve extension build`         | Build the current package as an extension                                                                                                             |
@@ -240,7 +240,7 @@ See [Evals](../evals/overview) for authoring evals.
 eve channels add [kind] [-f] [-y]
 ```
 
-Scaffolds a channel into `agent/channels/`. With no `kind` it prompts interactively; pass a `kind` (`slack` \| `web`) to scaffold one directly. When the Vercel CLI has an authenticated session, eve scaffolds the Vercel-integrated variant and asks whether to deploy after setup. Without one, Slack setup asks whether to set up Vercel Connect or use portable credentials. The portable variant reads `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` and adds both names to `.env.example`.
+Scaffolds a channel into `agent/channels/`. With no `kind` it prompts interactively; pass a `kind` (`imessage` \| `slack` \| `web`) to scaffold one directly. When the Vercel CLI has an authenticated session, eve scaffolds the Vercel-integrated variant and asks whether to deploy after setup. Without one, Slack setup asks whether to set up Vercel Connect or use portable credentials. The portable variant reads `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` and adds both names to `.env.example`. iMessage setup currently uses Photon and stores its project credentials in Vercel Connect.
 
 | Flag          | Type | Default | Description                                               |
 | ------------- | ---- | ------- | --------------------------------------------------------- |

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -81,8 +81,8 @@ export function connectionProtocols(connection: ConnectionIdentity): ConnectionP
  * carries only shared identity; the scaffolder and docs overlay their own
  * surface-specific data keyed by {@link IntegrationEntry.slug}.
  *
- * `surfaces.scaffoldable` reflects what the CLI can scaffold today: Slack and
- * Web Chat for channels, and every curated connection. The remaining
+ * `surfaces.scaffoldable` reflects what the CLI can scaffold today: iMessage,
+ * Slack, and Web Chat for channels, and every curated connection. The remaining
  * channels are runtime modules that are still configured by hand, so they
  * appear in the gallery but not the CLI picker.
  */
@@ -224,8 +224,8 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     slug: "chat-sdk-photon",
     name: "Photon",
     kind: "channel",
-    tagline: "Cloud, self-hosted, and local iMessage messaging through Photon.",
-    surfaces: { scaffoldable: false, gallery: true },
+    tagline: "Cloud and self-hosted iMessage messaging through Photon.",
+    surfaces: { scaffoldable: true, gallery: true },
   },
   {
     slug: "chat-sdk-dial",

--- a/packages/eve/src/cli/commands/channels.integration.test.ts
+++ b/packages/eve/src/cli/commands/channels.integration.test.ts
@@ -283,7 +283,9 @@ describe("runChannelsAddCommand", () => {
     );
 
     expect(detectDeployment).not.toHaveBeenCalled();
-    expect(logger.errors).toEqual(["Pass a channel kind: `eve channels add <slack|web>`."]);
+    expect(logger.errors).toEqual([
+      "Pass a channel kind: `eve channels add <imessage|slack|web>`.",
+    ]);
     expect(process.exitCode).toBe(1);
   });
 
@@ -588,6 +590,7 @@ describe("runChannelsAddCommand", () => {
         disabled: true,
         disabledReason: "POST /eve/v1/session already registered",
       }),
+      expect.objectContaining({ value: "imessage", disabled: undefined }),
       expect.objectContaining({
         value: "slack",
         disabled: true,

--- a/packages/eve/src/cli/commands/channels.ts
+++ b/packages/eve/src/cli/commands/channels.ts
@@ -2,6 +2,7 @@ import { isEveProject, listAuthoredChannels, type ChannelKind } from "#setup/sca
 
 import { interactiveAsker } from "#setup/ask.js";
 import type { AddChannelsDeps } from "#setup/boxes/add-channels.js";
+import { configurePhotonWebhook } from "#setup/boxes/configure-photon-webhook.js";
 import type { DeployProjectDeps } from "#setup/boxes/deploy-project.js";
 import {
   channelSetupEnvironment,
@@ -35,7 +36,7 @@ export interface CliLogger {
   log(message: string): void;
 }
 
-const KNOWN_CHANNEL_KINDS: readonly ChannelKind[] = ["slack", "web"];
+const KNOWN_CHANNEL_KINDS: readonly ChannelKind[] = ["imessage", "slack", "web"];
 
 function isChannelKind(value: string): value is ChannelKind {
   return KNOWN_CHANNEL_KINDS.includes(value as ChannelKind);
@@ -127,12 +128,17 @@ async function runAddChannelsFlow(
       presetChannels: kind === undefined ? undefined : [kind],
       disabledChannelReasons,
       validateSelection: async (selectedChannels) => {
-        if (!selectedChannels.includes("web") && !selectedChannels.includes("slack")) {
+        if (
+          !selectedChannels.includes("imessage") &&
+          !selectedChannels.includes("web") &&
+          !selectedChannels.includes("slack")
+        ) {
           return;
         }
         assertCanAddSelectedChannels(selectedChannels, await inspectRegistrations());
       },
     }),
+
   ];
 
   const sink: OutputSink = { write: (line) => prompter.log.message(line) };
@@ -153,6 +159,17 @@ async function runAddChannelsFlow(
     });
     if (result.kind === "cancelled") return;
     finalState = result.state;
+  }
+
+  if (finalState.channels.includes("imessage") && !finalState.photonWebhookConfigured) {
+    const configured = await runInteractive(
+      [configurePhotonWebhook({ asker: interactiveAsker(prompter), prompter })],
+      finalState,
+      sink,
+      { snapshot: snapshotSetupState },
+    );
+    if (configured.kind === "cancelled") return;
+    finalState = configured.state;
   }
 
   const addedVercelChannel =

--- a/packages/eve/src/setup/boxes/add-channels.test.ts
+++ b/packages/eve/src/setup/boxes/add-channels.test.ts
@@ -41,41 +41,51 @@ function makeBox(
 /** Default fakes: every effect succeeds and the slackbot attaches cleanly. */
 function createDeps() {
   return {
-    ensureChannel: vi.fn<AddChannelsDeps["ensureChannel"]>(async (options) =>
-      options.kind === "web"
-        ? {
-            kind: "web",
-            action: "created",
-            filesWritten: ["/tmp/project/app/page.tsx"],
-            filesSkipped: [],
-            packageJsonUpdated: [
-              {
-                path: "/tmp/project/package.json",
-                dependencies: ["next"],
-                devDependencies: [],
-                scripts: [],
-              },
-            ],
-          }
-        : {
-            kind: "slack",
-            action: "created",
-            filesWritten: ["/tmp/project/agent/channels/slack.ts"],
-            filesSkipped: [],
-            packageJsonUpdated:
-              options.slackCredentials === "environment"
-                ? []
-                : [
-                    {
-                      path: "/tmp/project/package.json",
-                      dependencies: ["@vercel/connect"],
-                      devDependencies: [],
-                      scripts: [],
-                    },
-                  ],
-            slackConnectorSlug: normalizeSlackConnectorSlug("my-agent"),
-          },
-    ),
+    ensureChannel: vi.fn<AddChannelsDeps["ensureChannel"]>(async (options) => {
+      if (options.kind === "web") {
+        return {
+          kind: "web",
+          action: "created",
+          filesWritten: ["/tmp/project/app/page.tsx"],
+          filesSkipped: [],
+          packageJsonUpdated: [
+            {
+              path: "/tmp/project/package.json",
+              dependencies: ["next"],
+              devDependencies: [],
+              scripts: [],
+            },
+          ],
+        };
+      }
+      if (options.kind === "imessage") {
+        return {
+          kind: "imessage",
+          action: "created",
+          filesWritten: ["/tmp/project/agent/channels/imessage.ts"],
+          filesSkipped: [],
+          packageJsonUpdated: [],
+        };
+      }
+      return {
+        kind: "slack",
+        action: "created",
+        filesWritten: ["/tmp/project/agent/channels/slack.ts"],
+        filesSkipped: [],
+        packageJsonUpdated:
+          options.slackCredentials === "environment"
+            ? []
+            : [
+                {
+                  path: "/tmp/project/package.json",
+                  dependencies: ["@vercel/connect"],
+                  devDependencies: [],
+                  scripts: [],
+                },
+              ],
+        slackConnectorSlug: normalizeSlackConnectorSlug("my-agent"),
+      };
+    }),
     deriveSlackConnectorSlug: vi.fn<AddChannelsDeps["deriveSlackConnectorSlug"]>(
       async (_projectRoot, hint) => normalizeSlackConnectorSlug(hint ?? "my-agent"),
     ),
@@ -86,6 +96,13 @@ function createDeps() {
       workspaceName: "Vercel",
     })),
     reconcileSlackUid: vi.fn<AddChannelsDeps["reconcileSlackUid"]>(async () => true),
+    provisionPhotonConnector: vi.fn<NonNullable<AddChannelsDeps["provisionPhotonConnector"]>>(
+      async () => ({ id: "scl_photon", uid: "spectrum.photon.codes/my-agent" }),
+    ),
+    readProjectLink: vi.fn<NonNullable<AddChannelsDeps["readProjectLink"]>>(async () => ({
+      orgId: "team_demo",
+      projectId: "prj_demo",
+    })),
     detectPackageManager: vi.fn<AddChannelsDeps["detectPackageManager"]>(async () => ({
       kind: "pnpm",
       source: "default",
@@ -171,6 +188,34 @@ describe("addChannels box", () => {
       force: undefined,
     });
     expect(next.channels).toEqual(["slack"]);
+  });
+
+  it("collects Photon credentials separately and provisions iMessage", async () => {
+    const deps = createDeps();
+    const prompter = createFakePrompter({
+      text: () => "project-id",
+      password: () => "project-secret",
+    }).prompter;
+    const box = makeBox({ prompter, deps });
+
+    const result = await runInteractive([box], resolvedState(["imessage"]), silentSink, snapshot);
+
+    expect(result.kind).toBe("done");
+    expect(deps.provisionPhotonConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: { projectId: "project-id", projectSecret: "project-secret" },
+        project: { orgId: "team_demo", projectId: "prj_demo" },
+        projectRoot: "/tmp/project",
+        slug: "my-agent",
+      }),
+    );
+    expect(deps.ensureChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: "/tmp/project",
+        kind: "imessage",
+        photonConnectorUid: "spectrum.photon.codes/my-agent",
+      }),
+    );
   });
 
   it("passes the web scaffold options through to ensureChannel", async () => {

--- a/packages/eve/src/setup/boxes/add-channels.ts
+++ b/packages/eve/src/setup/boxes/add-channels.ts
@@ -4,6 +4,7 @@ import {
   type ChannelKind,
   type EnsureChannelOptions,
   type EvePackageContract,
+  type PhotonProjectCredentials,
   type SlackConnectorSlug,
 } from "#setup/scaffold/index.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
@@ -18,9 +19,10 @@ import {
   isProjectResolved,
   mergeProjectResolution,
   projectResolutionFromDeployment,
+  readProjectLink,
   type ProjectResolution,
 } from "../project-resolution.js";
-import type { Asker } from "../ask.js";
+import { text, type Asker } from "../ask.js";
 import type { Prompter } from "../prompter.js";
 import {
   provisionSlackbot,
@@ -29,6 +31,7 @@ import {
   type ProvisionSlackbotResult,
 } from "../slackbot.js";
 import { hasVercelProject, requireProjectPath, type SetupState } from "../state.js";
+import { provisionPhotonConnector } from "../photon-connect.js";
 import { WizardCancelledError, type SetupBox } from "../step.js";
 
 const SLACK_REQUIRES_VERCEL =
@@ -126,6 +129,8 @@ export interface AddChannelsDeps {
   deriveSlackConnectorSlug: typeof deriveSlackConnectorSlug;
   provisionSlackbot: typeof provisionSlackbot;
   reconcileSlackUid: typeof reconcileSlackUid;
+  provisionPhotonConnector?: typeof provisionPhotonConnector;
+  readProjectLink?: typeof readProjectLink;
   detectPackageManager: typeof detectPackageManager;
   runPackageManagerInstall: typeof runPackageManagerInstall;
   runVercel: typeof runVercel;
@@ -179,7 +184,7 @@ export interface AddChannelsOptions {
    * a later `eve channels add slack` starts clean).
    */
   slackbotFailure?: "abort" | "warn-and-continue";
-  deps?: AddChannelsDeps;
+  deps?: Partial<AddChannelsDeps>;
 }
 
 /**
@@ -188,6 +193,7 @@ export interface AddChannelsOptions {
 export interface AddChannelsInput {
   headless: boolean;
   createSlackbot: boolean | undefined;
+  photonCredentials?: PhotonProjectCredentials;
 }
 
 /** Slackbot facts resolved by a successful Connect provision. */
@@ -209,6 +215,7 @@ export interface AddChannelsSlackbotFacts {
 export interface AddChannelsPayload {
   channelsAdded: ChannelKind[];
   webScaffolded: boolean;
+  imessageScaffolded: boolean;
   slackScaffolded: boolean;
   /**
    * Whether the post-scaffold dependency install succeeded. False both when no
@@ -219,6 +226,8 @@ export interface AddChannelsPayload {
   dependenciesInstalled: boolean;
   project: ProjectResolution;
   slackbot?: AddChannelsSlackbotFacts;
+  photonConnectorUid?: string;
+  photonConnectorId?: string;
 }
 
 function warnOverwrittenFiles(log: ChannelSetupLog, files: readonly string[] | undefined): void {
@@ -252,16 +261,19 @@ function warnCompetingNextConfigFiles(
 export function addChannels(
   options: AddChannelsOptions,
 ): SetupBox<SetupState, AddChannelsInput, AddChannelsPayload> {
-  const deps = options.deps ?? {
+  const deps = {
     ensureChannel,
     deriveSlackConnectorSlug,
     provisionSlackbot,
     reconcileSlackUid,
+    provisionPhotonConnector,
+    readProjectLink,
     detectPackageManager,
     runPackageManagerInstall,
     runVercel,
     detectDeployment,
-  };
+    ...options.deps,
+  } satisfies Required<AddChannelsDeps>;
 
   async function scaffoldSlackChannel(
     log: ChannelSetupLog,
@@ -385,12 +397,24 @@ export function addChannels(
     log.info("Next.js project detected. Skipping Web Chat scaffolding.");
   }
 
+  function assertVercelChannelProjectReady(state: Readonly<SetupState>, channelName: string): void {
+    if (options.ensureLinkedProject !== undefined) return;
+    if (!hasVercelProject(state)) {
+      throw new Error(
+        `${channelName} requires a Vercel project. Re-run and choose to deploy to Vercel to add ${channelName}.`,
+      );
+    }
+    if (!isProjectResolved(state.project)) {
+      throw new Error(
+        `Expected a linked Vercel project for ${channelName}, but none was resolved.`,
+      );
+    }
+  }
+
   function assertSlackProjectReady(state: Readonly<SetupState>): void {
     if (options.ensureLinkedProject !== undefined) return;
     if (!hasVercelProject(state)) throw new Error(SLACK_REQUIRES_VERCEL);
-    if (!isProjectResolved(state.project)) {
-      throw new Error("Expected a linked Vercel project for Slack, but none was resolved.");
-    }
+    assertVercelChannelProjectReady(state, "Slack");
   }
 
   async function provisionSlackbotWithControls(
@@ -539,6 +563,67 @@ export function addChannels(
     await scaffoldAttachedSlackChannel(log, state, projectPath, slug, payload, slackbot);
   }
 
+  async function addIMessageChannelToPayload(
+    log: ChannelSetupLog,
+    state: Readonly<SetupState>,
+    input: AddChannelsInput,
+    projectPath: string,
+    payload: AddChannelsPayload,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (!state.channelSelection.includes("imessage")) return;
+    assertVercelChannelProjectReady(state, "iMessage");
+    if (state.imessageScaffolded && state.photonConnectorUid !== undefined) {
+      payload.channelsAdded.push("imessage");
+      payload.photonConnectorUid = state.photonConnectorUid;
+      payload.photonConnectorId = state.photonConnectorId;
+      return;
+    }
+    if (!isProjectResolved(payload.project)) {
+      payload.project = await linkProjectForSlackbot(
+        log,
+        projectPath,
+        payload.project,
+        input.headless,
+        signal,
+      );
+    }
+    if (input.photonCredentials === undefined) {
+      throw new Error("Photon project credentials are required to add iMessage.");
+    }
+
+    const project = await deps.readProjectLink(projectPath);
+    if (project === undefined) {
+      throw new Error("Expected a linked Vercel project for iMessage, but none was resolved.");
+    }
+    const slug = await deps.deriveSlackConnectorSlug(projectPath, state.agentName);
+    const connector = await deps.provisionPhotonConnector({
+      credentials: input.photonCredentials,
+      log,
+      project,
+      projectRoot: projectPath,
+      slug,
+      signal,
+    });
+    signal?.throwIfAborted();
+    const result = await deps.ensureChannel({
+      projectRoot: projectPath,
+      kind: "imessage",
+      photonConnectorUid: connector.uid,
+      force: options.force,
+    });
+    warnOverwrittenFiles(log, result.filesOverwritten);
+    if (result.action === "created" || result.action === "overwritten") {
+      log.success("Scaffolded channel: imessage");
+    } else {
+      log.info('Channel "imessage" already exists. Skipping file creation.');
+    }
+    payload.imessageScaffolded = true;
+    payload.photonConnectorUid = connector.uid;
+    payload.photonConnectorId = connector.id;
+    payload.channelsAdded.push("imessage");
+  }
+
   async function installChannelDependencies(
     log: ChannelSetupLog,
     projectPath: string,
@@ -579,6 +664,7 @@ export function addChannels(
     const payload: AddChannelsPayload = {
       channelsAdded: [],
       webScaffolded: state.webScaffolded,
+      imessageScaffolded: state.imessageScaffolded,
       slackScaffolded: state.slackScaffolded,
       dependenciesChanged: false,
       dependenciesInstalled: false,
@@ -586,6 +672,7 @@ export function addChannels(
     };
     const packageManager = await deps.detectPackageManager(projectPath);
     await addWebChannelToPayload(log, state, projectPath, packageManager.kind, payload, signal);
+    await addIMessageChannelToPayload(log, state, input, projectPath, payload, signal);
     await addSlackChannelToPayload(log, state, input, projectPath, payload, signal);
     // A retry after a failed run can find durable channel files but no install;
     // recorded channels therefore always drive the dependency gate.
@@ -608,7 +695,39 @@ export function addChannels(
       ) {
         throw new Error(SLACK_HEADLESS_ERROR);
       }
-      return { headless, createSlackbot: options.presetCreateSlackbot };
+      // The preset short-circuits the question, exactly as the dual-face box did,
+      // so it stays a factory option rather than a withAnswers rung.
+      let photonCredentials: PhotonProjectCredentials | undefined;
+      if (state.channelSelection.includes("imessage")) {
+        if (headless) {
+          throw new Error(
+            "iMessage setup is interactive. Run `eve channels add imessage` from an interactive terminal.",
+          );
+        }
+        const projectId = await options.asker.ask(
+          text({
+            key: "photon-project-id",
+            message: "Photon project ID",
+            required: true,
+            validate: (value) => (value.trim() ? null : "Project ID is required"),
+          }),
+        );
+        const projectSecret = await options.asker.ask(
+          text({
+            key: "photon-project-secret",
+            message: "Photon project secret",
+            required: true,
+            sensitive: true,
+            validate: (value) => (value.trim() ? null : "Project secret is required"),
+          }),
+        );
+        photonCredentials = { projectId, projectSecret };
+      }
+      return {
+        headless,
+        createSlackbot: options.presetCreateSlackbot,
+        photonCredentials,
+      };
     },
 
     async perform({ state, input, signal }): Promise<AddChannelsPayload> {
@@ -635,6 +754,7 @@ export function addChannels(
         ...state,
         channels,
         webScaffolded: payload.webScaffolded,
+        imessageScaffolded: payload.imessageScaffolded,
         slackScaffolded: payload.slackScaffolded,
         deploymentPending: state.deploymentPending || payload.channelsAdded.length > 0,
         // Only manifest mutations invalidate an earlier dependency install.
@@ -642,6 +762,8 @@ export function addChannels(
           ? payload.dependenciesInstalled
           : state.deploymentDependenciesInstalled,
         project: mergeProjectResolution(state.project, payload.project),
+        photonConnectorUid: payload.photonConnectorUid ?? state.photonConnectorUid,
+        photonConnectorId: payload.photonConnectorId ?? state.photonConnectorId,
       };
       if (payload.slackbot === undefined) {
         return next;

--- a/packages/eve/src/setup/boxes/configure-photon-webhook.test.ts
+++ b/packages/eve/src/setup/boxes/configure-photon-webhook.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { interactiveAsker } from "../ask.js";
+import { runInteractive } from "../runner.js";
+import { createDefaultSetupState, snapshotSetupState } from "../state.js";
+import { configurePhotonWebhook } from "./configure-photon-webhook.js";
+
+const sink = { write: () => {} };
+
+describe("configurePhotonWebhook", () => {
+  test("shows the Connect trigger and saves the Photon secret", async () => {
+    const fake = createFakePrompter({ password: () => "whsec_test" });
+    const runVercel = vi.fn(async () => true);
+    const box = configurePhotonWebhook({
+      asker: interactiveAsker(fake.prompter),
+      prompter: fake.prompter,
+      deps: {
+        readProjectLink: vi.fn(async () => ({ orgId: "team_123", projectId: "prj_123" })),
+        runVercel,
+      },
+    });
+    const state = {
+      ...createDefaultSetupState(),
+      channels: ["imessage" as const],
+      photonConnectorId: "scl_photon",
+      projectPath: { kind: "resolved" as const, inPlace: true, path: "/tmp/agent" },
+    };
+
+    const result = await runInteractive([box], state, sink, { snapshot: snapshotSetupState });
+
+    expect(result.kind).toBe("done");
+    expect(fake.prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("https://connect.vercel.com/trigger/scl_photon"),
+      "Photon webhook",
+    );
+    expect(runVercel).toHaveBeenCalledWith(
+      ["env", "add", "IMESSAGE_WEBHOOK_SECRET", "production", "--force", "--scope", "team_123"],
+      expect.objectContaining({
+        cwd: "/tmp/agent",
+        nonInteractive: true,
+        stdin: "whsec_test",
+      }),
+    );
+    if (result.kind === "done") expect(result.state.photonWebhookConfigured).toBe(true);
+  });
+});

--- a/packages/eve/src/setup/boxes/configure-photon-webhook.ts
+++ b/packages/eve/src/setup/boxes/configure-photon-webhook.ts
@@ -1,0 +1,84 @@
+import { text, type Asker } from "../ask.js";
+import { createPromptCommandOutput } from "../cli/index.js";
+import type { Prompter } from "../prompter.js";
+import { runVercel } from "../primitives/run-vercel.js";
+import { requireProjectPath, type SetupState } from "../state.js";
+import type { SetupBox } from "../step.js";
+import { readProjectLink } from "../project-resolution.js";
+
+/** Dependencies for persisting the Photon webhook secret. */
+export interface ConfigurePhotonWebhookDeps {
+  readProjectLink: typeof readProjectLink;
+  runVercel: typeof runVercel;
+}
+
+/**
+ * Completes Photon setup after Connect has created the connector, when its
+ * stable trigger URL is available to register in the Photon dashboard.
+ */
+export function configurePhotonWebhook(options: {
+  asker: Asker;
+  prompter: Prompter;
+  deps?: Partial<ConfigurePhotonWebhookDeps>;
+}): SetupBox<SetupState, string | null, boolean> {
+  const deps: ConfigurePhotonWebhookDeps = {
+    readProjectLink,
+    runVercel,
+    ...options.deps,
+  };
+
+  return {
+    id: "configure-photon-webhook",
+
+    async gather({ state }) {
+      if (!state.channels.includes("imessage") || state.photonWebhookConfigured) return null;
+      if (state.photonConnectorId === undefined) {
+        throw new Error("Photon connector ID is missing; webhook setup cannot continue.");
+      }
+      options.prompter.note(
+        `Create a Photon webhook with this URL:\n\nhttps://connect.vercel.com/trigger/${state.photonConnectorId}\n\nThen copy the signing secret Photon shows.`,
+        "Photon webhook",
+      );
+      return options.asker.ask(
+        text({
+          key: "photon-webhook-secret",
+          message: "Photon webhook signing secret",
+          required: true,
+          sensitive: true,
+          validate: (value) => (value.trim() ? null : "Webhook signing secret is required"),
+        }),
+      );
+    },
+
+    async perform({ state, input, signal }) {
+      if (input === null) return state.photonWebhookConfigured;
+      const projectRoot = requireProjectPath(state);
+      const project = await deps.readProjectLink(projectRoot);
+      if (project === undefined) throw new Error("Expected a linked Vercel project for Photon.");
+      const saved = await deps.runVercel(
+        [
+          "env",
+          "add",
+          "IMESSAGE_WEBHOOK_SECRET",
+          "production",
+          "--force",
+          "--scope",
+          project.orgId,
+        ],
+        {
+          cwd: projectRoot,
+          nonInteractive: true,
+          onOutput: createPromptCommandOutput(options.prompter.log),
+          signal,
+          stdin: input,
+        },
+      );
+      if (!saved) throw new Error("Could not save the Photon webhook signing secret to Vercel.");
+      return true;
+    },
+
+    apply(state, configured) {
+      return configured ? { ...state, photonWebhookConfigured: true } : state;
+    },
+  };
+}

--- a/packages/eve/src/setup/channel-add-conflicts.ts
+++ b/packages/eve/src/setup/channel-add-conflicts.ts
@@ -8,6 +8,7 @@ import { discoverAgent } from "#discover/discover-agent.js";
 import { EVE_CREATE_SESSION_ROUTE_PATH } from "#protocol/routes.js";
 
 const SCAFFOLDED_WEB_CHANNEL_LOGICAL_PATH = "channels/eve.ts";
+const SCAFFOLDED_IMESSAGE_CHANNEL_LOGICAL_PATH = "channels/imessage.ts";
 const SCAFFOLDED_SLACK_CHANNEL_LOGICAL_PATH = "channels/slack.ts";
 
 /**
@@ -17,6 +18,7 @@ const SCAFFOLDED_SLACK_CHANNEL_LOGICAL_PATH = "channels/slack.ts";
 export interface ExistingChannelRegistrations {
   readonly disabledChannelReasons: DisabledChannelReasons;
   readonly webRouteOwners: readonly string[];
+  readonly imessageOwners: readonly string[];
   readonly slackOwners: readonly string[];
   /**
    * Whether the Next.js Web Chat app is already in place (the project depends
@@ -40,6 +42,7 @@ export async function inspectExistingChannelRegistrations(
     isNextJsProject(projectRoot),
   ]);
   const webRouteOwners = new Set<string>();
+  const imessageOwners = new Set<string>();
   const slackOwners = new Set<string>();
 
   for (const source of manifest.channels) {
@@ -55,6 +58,9 @@ export async function inspectExistingChannelRegistrations(
       if (definition.adapterKind === "slack") {
         slackOwners.add(source.logicalPath);
       }
+      if (definition.adapterKind === "chat-sdk" && definition.urlPath === "/eve/v1/imessage") {
+        imessageOwners.add(source.logicalPath);
+      }
     }
   }
 
@@ -64,6 +70,9 @@ export async function inspectExistingChannelRegistrations(
   ) {
     disabledChannelReasons.web = `POST ${EVE_CREATE_SESSION_ROUTE_PATH} already registered`;
   }
+  if (imessageOwners.size > 0) {
+    disabledChannelReasons.imessage = "iMessage channel already registered";
+  }
   if (slackOwners.size > 0) {
     disabledChannelReasons.slack = "Slack channel already registered";
   }
@@ -71,6 +80,7 @@ export async function inspectExistingChannelRegistrations(
   return {
     disabledChannelReasons,
     webRouteOwners: [...webRouteOwners],
+    imessageOwners: [...imessageOwners],
     slackOwners: [...slackOwners],
     webAppPresent,
   };
@@ -91,6 +101,17 @@ export function assertCanAddSelectedChannels(
     if (conflictingOwner !== undefined) {
       throw new Error(
         `Cannot scaffold Web Chat because agent/${conflictingOwner} already defines POST ${EVE_CREATE_SESSION_ROUTE_PATH}. Web Chat scaffolds the same eve session routes.`,
+      );
+    }
+  }
+
+  if (selectedChannels.includes("imessage")) {
+    const conflictingOwner = registrations.imessageOwners.find(
+      (logicalPath) => logicalPath !== SCAFFOLDED_IMESSAGE_CHANNEL_LOGICAL_PATH,
+    );
+    if (conflictingOwner !== undefined) {
+      throw new Error(
+        `Cannot scaffold iMessage because agent/${conflictingOwner} already defines the Photon webhook route.`,
       );
     }
   }

--- a/packages/eve/src/setup/channel-setup-imessage.ts
+++ b/packages/eve/src/setup/channel-setup-imessage.ts
@@ -1,0 +1,41 @@
+import { configurePhotonWebhook } from "./boxes/configure-photon-webhook.js";
+import type { ChannelSetupIntegration } from "./channel-setup-integration.js";
+import { runChannelSetup } from "./channel-setup-runner.js";
+import { runInteractive } from "./runner.js";
+import { snapshotSetupState } from "./state.js";
+import type { OutputSink } from "./step.js";
+
+/** iMessage's Photon provisioning, scaffold, and webhook configuration behavior. */
+export const IMESSAGE_CHANNEL_SETUP: ChannelSetupIntegration = {
+  kind: "imessage",
+  label: "iMessage",
+  hint: "Messages through Photon",
+  async setup(context) {
+    const scaffolded = await runChannelSetup(context, {});
+    if (scaffolded.kind === "cancelled") return scaffolded;
+
+    const deps = context.deps;
+    const box = configurePhotonWebhook({
+      asker: context.ui.asker,
+      prompter: context.ui.prompter,
+      ...(deps === undefined
+        ? {}
+        : {
+            deps: {
+              runVercel: deps.runVercel,
+              ...(deps.readProjectLink === undefined
+                ? {}
+                : { readProjectLink: deps.readProjectLink }),
+            },
+          }),
+    });
+    const sink: OutputSink = { write: (line) => context.ui.prompter.log.message(line) };
+    const configured = await runInteractive([box], scaffolded.state, sink, {
+      snapshot: snapshotSetupState,
+      signal: context.signal,
+    });
+    return configured.kind === "done"
+      ? { kind: "done", state: configured.state }
+      : { kind: "cancelled" };
+  },
+};

--- a/packages/eve/src/setup/channel-setup-integrations.ts
+++ b/packages/eve/src/setup/channel-setup-integrations.ts
@@ -1,3 +1,4 @@
+import { IMESSAGE_CHANNEL_SETUP } from "./channel-setup-imessage.js";
 import type { ChannelSetupIntegration } from "./channel-setup-integration.js";
 import { SLACK_CHANNEL_SETUP } from "./channel-setup-slack.js";
 import { WEB_CHANNEL_SETUP } from "./channel-setup-web.js";
@@ -7,6 +8,7 @@ import type { ChannelKind } from "./scaffold/index.js";
 export const CHANNEL_SETUP_INTEGRATIONS: readonly ChannelSetupIntegration[] = [
   WEB_CHANNEL_SETUP,
   SLACK_CHANNEL_SETUP,
+  IMESSAGE_CHANNEL_SETUP,
 ];
 
 /** Resolves a channel setup integration by its filesystem-facing kind. */

--- a/packages/eve/src/setup/flows/channels.test.ts
+++ b/packages/eve/src/setup/flows/channels.test.ts
@@ -30,6 +30,7 @@ const LINKED: DeploymentInfo = { state: "linked", projectId: "prj_1", orgId: "or
 const NO_REGISTRATIONS: ExistingChannelRegistrations = {
   disabledChannelReasons: {},
   webRouteOwners: [],
+  imessageOwners: [],
   slackOwners: [],
   webAppPresent: false,
 };

--- a/packages/eve/src/setup/flows/channels.ts
+++ b/packages/eve/src/setup/flows/channels.ts
@@ -79,7 +79,9 @@ function channelAlreadyAdded(
   registrations: ExistingChannelRegistrations,
   channel: ChannelKind,
 ): boolean {
-  return channel === "web" ? registrations.webAppPresent : registrations.slackOwners.length > 0;
+  if (channel === "web") return registrations.webAppPresent;
+  if (channel === "imessage") return registrations.imessageOwners.length > 0;
+  return registrations.slackOwners.length > 0;
 }
 
 function appendChannel(channels: readonly ChannelKind[], channel: ChannelKind): ChannelKind[] {

--- a/packages/eve/src/setup/scaffold/channels-catalog.test.ts
+++ b/packages/eve/src/setup/scaffold/channels-catalog.test.ts
@@ -28,8 +28,11 @@ describe("SCAFFOLDABLE_CHANNELS", () => {
     expect(eve?.kind).toBe("web");
   });
 
-  test("maps slack identity straight through", () => {
+  test("maps provider-backed channel identities to setup kinds", () => {
     const slack = SCAFFOLDABLE_CHANNELS.find((channel) => channel.slug === "slack");
+    const photon = SCAFFOLDABLE_CHANNELS.find((channel) => channel.slug === "chat-sdk-photon");
     expect(slack?.kind).toBe("slack");
+    expect(photon?.kind).toBe("imessage");
+    expect(photon?.requiresVercelProject).toBe(true);
   });
 });

--- a/packages/eve/src/setup/scaffold/channels-catalog.ts
+++ b/packages/eve/src/setup/scaffold/channels-catalog.ts
@@ -23,6 +23,8 @@ interface ChannelScaffold {
   label: string;
   /** Optional picker hint. */
   hint?: string;
+  /** Whether setup requires a linked Vercel project. */
+  requiresVercelProject?: boolean;
 }
 
 /**
@@ -34,6 +36,13 @@ interface ChannelScaffold {
  */
 const CHANNEL_SCAFFOLDS: readonly ChannelScaffold[] = [
   { slug: "eve", kind: "web", label: "Web Chat", hint: "Next.js app" },
+  {
+    slug: "chat-sdk-photon",
+    kind: "imessage",
+    label: "iMessage",
+    hint: "Connects Photon and deploys to Vercel",
+    requiresVercelProject: true,
+  },
   {
     slug: "slack",
     kind: "slack",
@@ -52,6 +61,8 @@ export interface ScaffoldableChannel {
   label: string;
   /** Optional picker hint. */
   hint?: string;
+  /** Whether setup requires a linked Vercel project. */
+  requiresVercelProject?: boolean;
 }
 
 function buildScaffoldableChannels(): ScaffoldableChannel[] {
@@ -75,6 +86,9 @@ function buildScaffoldableChannels(): ScaffoldableChannel[] {
     };
     if (scaffold.hint !== undefined) {
       channel.hint = scaffold.hint;
+    }
+    if (scaffold.requiresVercelProject !== undefined) {
+      channel.requiresVercelProject = scaffold.requiresVercelProject;
     }
     channels.push(channel);
   }

--- a/packages/eve/src/setup/state.ts
+++ b/packages/eve/src/setup/state.ts
@@ -154,6 +154,7 @@ export interface SetupState {
   /** Channels scaffolded so far in this run. */
   channels: ChannelKind[];
   webScaffolded: boolean;
+  imessageScaffolded: boolean;
   slackScaffolded: boolean;
   deploymentDependenciesInstalled: boolean;
   /** The linked Vercel project facts, from the link box or the on-disk `.vercel` link. */
@@ -162,6 +163,9 @@ export interface SetupState {
   slackbotCreated: boolean;
   slackbotAttached: boolean;
   slackConnectorUid: string | undefined;
+  photonConnectorUid: string | undefined;
+  photonConnectorId: string | undefined;
+  photonWebhookConfigured: boolean;
   /** Deep link that opens a DM compose with the bot ("chat with your agent"). */
   slackChatUrl: string | undefined;
   slackWorkspaceName: string | undefined;
@@ -171,6 +175,7 @@ export function createDefaultSetupState(): SetupState {
   return {
     channels: [],
     webScaffolded: false,
+    imessageScaffolded: false,
     slackScaffolded: false,
     deploymentDependenciesInstalled: false,
     project: { kind: "unresolved" },
@@ -178,6 +183,9 @@ export function createDefaultSetupState(): SetupState {
     slackbotCreated: false,
     slackbotAttached: false,
     slackConnectorUid: undefined,
+    photonConnectorUid: undefined,
+    photonConnectorId: undefined,
+    photonWebhookConfigured: false,
     slackChatUrl: undefined,
     slackWorkspaceName: undefined,
     agentName: "",


### PR DESCRIPTION
### Description

- add `imessage` to `eve channels add` and the dev TUI channel task list, using Photon as the initial provider
- prompt separately for Photon project ID and secret, provision the Connect connector, attach its trigger, scaffold the channel, and install dependencies
- document the new setup path and detect existing iMessage channel registrations

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/boxes/add-channels.test.ts src/setup/scaffold/channels-catalog.test.ts src/setup/flows/channels.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/channels.integration.test.ts`
- `pnpm --filter @vercel/eve-catalog test`
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm fmt`
- `pnpm lint`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)