### PR TITLE
feat(eve): add slack-specific response instructions around mention syntax

### DIFF
--- a/.changeset/fuzzy-slack-mentions.md
+++ b/.changeset/fuzzy-slack-mentions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack turns now tell the agent to format user mentions as `<@USER_ID>` so generated replies notify the intended user instead of displaying a bare ID.

--- a/packages/eve/src/public/channels/slack/model-context.test.ts
+++ b/packages/eve/src/public/channels/slack/model-context.test.ts
@@ -42,6 +42,11 @@ describe("Slack model context", () => {
 
     expect(block).toBe(
       [
+        "<slack_context>",
+        "response_medium: slack",
+        "response_instructions: Reply for Slack in concise Markdown. To mention a user from a Slack user ID, use `<@USER_ID>`; never use `@USER_ID`.",
+        "</slack_context>",
+        "",
         "<slack_message>",
         "sender_type: user",
         "sender_id: U_CURRENT",

--- a/packages/eve/src/public/channels/slack/model-context.ts
+++ b/packages/eve/src/public/channels/slack/model-context.ts
@@ -1,6 +1,10 @@
 import type { SlackThreadMessage } from "#public/channels/slack/api.js";
 import type { SlackInboundContext } from "#public/channels/slack/inbound.js";
 
+const SLACK_RESPONSE_INSTRUCTIONS =
+  "Reply for Slack in concise Markdown. To mention a user from a Slack user ID, use " +
+  "`<@USER_ID>`; never use `@USER_ID`.";
+
 interface SlackModelMessageInput {
   readonly channelId?: string;
   readonly content: string;
@@ -32,12 +36,18 @@ export function formatSlackModelMessage(input: SlackModelMessageInput): string {
   ].join("\n");
 }
 
-/** Renders the triggering inbound Slack message as one attributed block. */
+/** Renders the triggering inbound Slack message with response guidance and attribution. */
 export function formatSlackInboundMessage(
   context: SlackInboundContext,
   message: { readonly markdown: string; readonly ts: string },
 ): string {
-  return formatSlackModelMessage({
+  const responseContext = [
+    "<slack_context>",
+    "response_medium: slack",
+    `response_instructions: ${SLACK_RESPONSE_INSTRUCTIONS}`,
+    "</slack_context>",
+  ].join("\n");
+  const attributedMessage = formatSlackModelMessage({
     channelId: context.channelId,
     content: message.markdown,
     senderId: context.userId || undefined,
@@ -46,6 +56,7 @@ export function formatSlackInboundMessage(
     threadTs: context.threadTs,
     ts: message.ts,
   });
+  return `${responseContext}\n\n${attributedMessage}`;
 }
 
 /**


### PR DESCRIPTION
### Description

We already have some platform-specific response instructions for Teams, Telegram etc. Adds instructions for Slack which includes tips on @-mentioning a user using the `<@USER_ID>` syntax Slack requires, since in the wild eve has done this incorrectly (sending bare `@USER_ID`).

### How did you test your changes?

deployed manually, tested that eve @-ed me properly, unit test



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>