### PR TITLE
fix(eve): fully trace configured external dependencies

### DIFF
--- a/.changeset/calm-traces-include.md
+++ b/.changeset/calm-traces-include.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fully include packages configured through `build.externalDependencies` in hosted output, including files accessed only through runtime resolution or filesystem lookup.

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -547,12 +547,12 @@ describe("application Nitro creation", () => {
     for (const call of createNitroMock.mock.calls.slice(0, 3)) {
       const traceDeps = call[0].traceDeps;
       expect(traceDeps).toEqual(
-        expect.arrayContaining(["@napi-rs/keyring", "sharp", "fixture-external"]),
+        expect.arrayContaining(["@napi-rs/keyring", "sharp*", "fixture-external*"]),
       );
-      expect(traceDeps.filter((dependencyName: string) => dependencyName === "sharp")).toHaveLength(
-        1,
-      );
-      expect(traceDeps).not.toContain("eve");
+      expect(
+        traceDeps.filter((dependencyName: string) => dependencyName === "sharp*"),
+      ).toHaveLength(1);
+      expect(traceDeps).not.toContain("eve*");
     }
   });
 
@@ -595,8 +595,8 @@ describe("application Nitro creation", () => {
     );
 
     const traceDeps = createNitroMock.mock.calls[0]?.[0].traceDeps;
-    expect(traceDeps).toEqual(expect.arrayContaining(["subagent-external", "sharp"]));
-    expect(traceDeps.filter((dependencyName: string) => dependencyName === "sharp")).toHaveLength(
+    expect(traceDeps).toEqual(expect.arrayContaining(["subagent-external*", "sharp*"]));
+    expect(traceDeps.filter((dependencyName: string) => dependencyName === "sharp*")).toHaveLength(
       1,
     );
   });
@@ -695,12 +695,12 @@ describe("application Nitro creation", () => {
 
     const traceDeps = createNitroMock.mock.calls[0]?.[0].traceDeps;
     expect(traceDeps).toEqual(
-      expect.arrayContaining(["@napi-rs/keyring", "sharp", "fixture-external"]),
+      expect.arrayContaining(["@napi-rs/keyring*", "sharp*", "fixture-external*"]),
     );
     expect(
-      traceDeps.filter((dependencyName: string) => dependencyName === "@napi-rs/keyring"),
+      traceDeps.filter((dependencyName: string) => dependencyName === "@napi-rs/keyring*"),
     ).toHaveLength(1);
-    expect(traceDeps.filter((dependencyName: string) => dependencyName === "sharp")).toHaveLength(
+    expect(traceDeps.filter((dependencyName: string) => dependencyName === "sharp*")).toHaveLength(
       1,
     );
   });

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -36,6 +36,7 @@ import type {
   PreparedDevelopmentApplicationHost,
 } from "#internal/nitro/host/types.js";
 import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
+import { createExternalDependencyTracePlugin } from "#internal/nitro/host/external-dependency-trace-plugin.js";
 import { applyWorkflowTransform } from "#internal/workflow-bundle/workflow-builders.js";
 import { transformDynamicToolExecute } from "#internal/workflow-bundle/dynamic-tool-transform.js";
 import type { CompiledAgentManifest } from "#compiler/manifest.js";
@@ -109,30 +110,47 @@ function manifestHasWebSocketChannel(manifest: CompiledAgentManifest): boolean {
   );
 }
 
-function collectHostedTraceDependencies(
-  preparedHost: PreparedApplicationHost,
-  configuredOptionalEnginePackages: readonly string[],
-): string[] {
+function collectConfiguredExternalDependencies(preparedHost: PreparedApplicationHost): string[] {
   const agentNodes = [
     preparedHost.compileResult.manifest,
     ...preparedHost.compileResult.manifest.subagents.map((subagent) => subagent.agent),
   ];
-  const configuredExternalDependencies = agentNodes.flatMap(
-    (node) => node.config.build?.externalDependencies ?? [],
+  return [
+    ...new Set(
+      agentNodes
+        .flatMap((node) => node.config.build?.externalDependencies ?? [])
+        .filter((dependencyName) => dependencyName !== EVE_PACKAGE_NAME),
+    ),
+  ];
+}
+
+function collectHostedTraceDependencies(
+  configuredExternalDependencies: readonly string[],
+  configuredOptionalEnginePackages: readonly string[],
+): string[] {
+  // Nitro's trailing `*` selector fully traces each configured package after
+  // createExternalDependencyTracePlugin registers it as a trace root.
+  const configuredFullTraceDependencies = configuredExternalDependencies.map(
+    (dependencyName) => `${dependencyName}*`,
   );
+  const configuredExternalDependencySet = new Set(configuredExternalDependencies);
   // Nitro already classifies known native and non-bundleable packages through
   // its nf3 database. traceDeps is only for eve-owned or author-configured
   // additions to that upstream policy.
   const merged = new Set<string>([
-    ...FRAMEWORK_HOSTED_EXTERNAL_PACKAGES,
+    ...FRAMEWORK_HOSTED_EXTERNAL_PACKAGES.filter(
+      (dependencyName) => !configuredExternalDependencySet.has(dependencyName),
+    ),
     // Optional engine packages (just-bash, microsandbox) join the
     // externalize-and-trace path only when the compiled sandbox config
     // selects their backend — the app's opt-in. Otherwise
     // createOptionalEngineDependencyPlugin pins them as plain externals
     // so a resolvable-but-unrequested install adds nothing to hosted
     // output.
-    ...configuredOptionalEnginePackages,
-    ...configuredExternalDependencies,
+    ...configuredOptionalEnginePackages.filter(
+      (dependencyName) => !configuredExternalDependencySet.has(dependencyName),
+    ),
+    ...configuredFullTraceDependencies,
   ]);
   return [...merged].filter((dependencyName) => dependencyName !== EVE_PACKAGE_NAME);
 }
@@ -653,15 +671,17 @@ function createApplicationNitroBundlerConfiguration(
       packageNamespace: mount.packageNamespace,
     })),
   );
+  const configuredExternalDependencies = collectConfiguredExternalDependencies(preparedHost);
   const nitroBundlerPlugins = [
     compiledSandboxBackendPrunePlugin,
     createOptionalEngineDependencyPlugin(unconfiguredOptionalEnginePackages),
+    createExternalDependencyTracePlugin(preparedHost.appRoot, configuredExternalDependencies),
     extensionScopePlugin,
   ].filter((plugin) => plugin !== null);
   const nitroRolldownConfig = createNitroBundlerConfig(nitroBundlerPlugins);
   const nitroRollupConfig = createNitroBundlerConfig(nitroBundlerPlugins);
   const tracedAppDependencies = collectHostedTraceDependencies(
-    preparedHost,
+    configuredExternalDependencies,
     configuredOptionalEnginePackages,
   );
 

--- a/packages/eve/src/internal/nitro/host/external-dependency-trace-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/external-dependency-trace-plugin.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, parse, resolve } from "node:path";
+
+interface PackageJson {
+  readonly exports?: string | Record<string, unknown>;
+}
+
+interface ResolvedModule {
+  readonly id: string;
+}
+
+interface BundlerPluginContext {
+  resolve(source: string, importer?: string): Promise<ResolvedModule | null>;
+}
+
+interface BundlerPluginShape {
+  readonly name: string;
+  buildStart(this: BundlerPluginContext): Promise<void>;
+}
+
+function packagePathSegments(packageName: string): string[] {
+  return packageName.startsWith("@") ? packageName.split("/", 2) : [packageName];
+}
+
+function findPackageJsonPath(appRoot: string, packageName: string): string | undefined {
+  const segments = packagePathSegments(packageName);
+  let directory = resolve(appRoot);
+  const { root } = parse(directory);
+
+  while (true) {
+    const candidate = join(directory, "node_modules", ...segments, "package.json");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    if (directory === root) {
+      return undefined;
+    }
+    directory = dirname(directory);
+  }
+}
+
+function resolveTraceSpecifier(packageName: string, packageJson: PackageJson): string | undefined {
+  if (packageJson.exports === undefined || typeof packageJson.exports === "string") {
+    return packageName;
+  }
+
+  const exportKeys = Object.keys(packageJson.exports);
+  if (!exportKeys.some((key) => key.startsWith("."))) {
+    return packageName;
+  }
+
+  const explicitExport = exportKeys.find((key) => key === "." || !key.includes("*"));
+  if (explicitExport === undefined) {
+    return undefined;
+  }
+
+  return explicitExport === "." ? packageName : `${packageName}/${explicitExport.slice(2)}`;
+}
+
+/**
+ * Seeds Nitro's dependency tracer without emitting or executing an import.
+ *
+ * `traceDeps` is a filter, not an unconditional trace root. Resolving one
+ * exported module from each configured package makes Nitro register the
+ * package with nf3; the matching `package*` trace selector then copies every
+ * package file, including assets accessed only through runtime filesystem
+ * lookup.
+ */
+export function createExternalDependencyTracePlugin(
+  appRoot: string,
+  packageNames: readonly string[],
+): BundlerPluginShape | null {
+  if (packageNames.length === 0) {
+    return null;
+  }
+
+  return {
+    name: "eve-external-dependency-trace-roots",
+    async buildStart() {
+      for (const packageName of packageNames) {
+        const packageJsonPath = findPackageJsonPath(appRoot, packageName);
+        if (packageJsonPath === undefined) {
+          throw new Error(
+            `Could not find external dependency "${packageName}". Add it to the application's dependencies before building.`,
+          );
+        }
+
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
+        const traceSpecifier = resolveTraceSpecifier(packageName, packageJson);
+        if (traceSpecifier === undefined || (await this.resolve(traceSpecifier)) === null) {
+          throw new Error(
+            `Could not resolve an exported module for external dependency "${packageName}".`,
+          );
+        }
+      }
+    },
+  };
+}

--- a/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
+++ b/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
@@ -443,7 +443,7 @@ describe("app runtime dependency tracing", () => {
     expect(existsSync(join(justBashOutputDir, "server", "node_modules", "just-bash"))).toBe(true);
   }, 120_000);
 
-  it("traces additional hosted build dependencies configured in agent.ts", async () => {
+  it("fully traces hosted dependencies accessed only through runtime resolution", async () => {
     const appRoot = await createScratchDirectory("eve-app-build-trace-dep-build-");
 
     await mkdir(join(appRoot, "agent", "tools"), {
@@ -482,12 +482,14 @@ describe("app runtime dependency tracing", () => {
     await writeFile(
       join(appRoot, "agent", "tools", "use_fixture_dep.ts"),
       [
-        'import fixtureTraceOnlyDep from "fixture-trace-only-dep";',
+        'import { createRequire } from "node:module";',
+        "",
+        "const require = createRequire(import.meta.url);",
         "",
         "export default {",
         '  description: "Use the fixture runtime dependency.",',
         "  execute() {",
-        "    return fixtureTraceOnlyDep;",
+        '    return require.resolve("fixture-trace-only-dep/entry");',
         "  },",
         "};",
         "",
@@ -504,7 +506,7 @@ describe("app runtime dependency tracing", () => {
       JSON.stringify(
         {
           exports: {
-            ".": "./index.js",
+            "./entry": "./index.js",
           },
           name: "fixture-trace-only-dep",
           type: "module",
@@ -524,6 +526,10 @@ describe("app runtime dependency tracing", () => {
         "",
       ].join("\n"),
     );
+    await mkdir(join(packageRoot, "assets"), {
+      recursive: true,
+    });
+    await writeFile(join(packageRoot, "assets", "fixture.txt"), "runtime-only asset\n");
 
     const outputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
     const serverModuleDirectory = join(outputDir, "server");
@@ -544,6 +550,19 @@ describe("app runtime dependency tracing", () => {
         "utf8",
       ),
     ).resolves.toContain('"name": "fixture-trace-only-dep"');
+    await expect(
+      readFile(
+        join(
+          outputDir,
+          "server",
+          "node_modules",
+          "fixture-trace-only-dep",
+          "assets",
+          "fixture.txt",
+        ),
+        "utf8",
+      ),
+    ).resolves.toBe("runtime-only asset\n");
     expect(serverModuleSource).toContain('"fixture-trace-only-dep"');
     expect(serverModuleSource).not.toContain('export const label = "fixture-trace-only-dep";');
   }, 30_000);


### PR DESCRIPTION
## Summary

- treat every `build.externalDependencies` entry as a full Nitro trace dependency
- seed Nitro's tracer by resolving an exported package module during `buildStart` without emitting or executing the import
- preserve runtime-only package assets, including packages with no root export
- add a patch changeset

This closes the gap exposed by e0's Geist font renderer: a package configured in `externalDependencies` could still be absent from hosted output when it was reached only through `createRequire().resolve(...)` and filesystem lookup.

## Verification

- focused hosted-output regression passes for a package with no root export, a runtime-only `require.resolve("pkg/subpath")`, and a sibling asset
- Nitro configuration scenarios pass for root agents, subagents, and deduplication
- changed files pass oxfmt, oxlint, and `git diff --check`

A full clean-install typecheck is left to PR CI because this machine has only ~2 GB free and the available shared worktree installs/generated vendor artifacts do not match current `main`.
