### PR TITLE
fix(eve): mount dependencies resolved above the app root into dev snapshots

### DIFF
--- a/.changeset/dev-snapshot-approot-aware-mounts.md
+++ b/.changeset/dev-snapshot-approot-aware-mounts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve dev` no longer fails at boot with `UNRESOLVED_IMPORT` when a mounted extension (or any dependency) resolves through a `node_modules` above the app root — npm/yarn workspace hoisting, intermediate monorepo levels, and bare `withEve` agent directories whose host app owns the install now materialize in the dev-runtime snapshot.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -313,6 +313,101 @@ describe("development runtime artifact snapshots", () => {
     );
   });
 
+  // https://github.com/vercel/eve/issues/1151 — hoisting-workspace expression.
+  it("mounts declared dependencies hoisted above the app root into source snapshots", async () => {
+    const workspaceRoot = await createScratchDirectory("eve-dev-runtime-hoisted-dependency-");
+    const appRoot = join(workspaceRoot, "agents", "support");
+    const agentRoot = join(appRoot, "agent");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+    const hoistedPackageRoot = join(workspaceRoot, "node_modules", "@acme", "extension");
+
+    await mkdir(agentRoot, { recursive: true });
+    await mkdir(hoistedPackageRoot, { recursive: true });
+    await mkdir(compileDirectoryPath, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      '{"private":true,"workspaces":["agents/*"]}\n',
+    );
+    await writeFile(
+      join(appRoot, "package.json"),
+      `${JSON.stringify({
+        dependencies: { "@acme/extension": "1.0.0" },
+        type: "module",
+      })}\n`,
+    );
+    await writeFile(join(agentRoot, "agent.ts"), "export const answer = 42;\n");
+    await writeFile(
+      join(hoistedPackageRoot, "package.json"),
+      '{"name":"@acme/extension","version":"1.0.0"}\n',
+    );
+    await writeFile(
+      join(compileDirectoryPath, "compiled-agent-manifest.json"),
+      `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`,
+    );
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+
+    // The compiled module map imports the dependency relative to the app's
+    // compile directory, escaping the app root toward the install location
+    // (`../../../../node_modules/@acme/extension/...`). Any correct snapshot
+    // must materialize the package somewhere inside the snapshot where that
+    // resolution can land: either mirroring the hoisted location relative to
+    // the snapshot source root, or flattened into the app root's own
+    // node_modules.
+    const acceptableMountLocations = [
+      join(snapshot.runtimeAppRoot, "node_modules", "@acme", "extension"),
+      join(snapshot.runtimeAppRoot, "..", "..", "node_modules", "@acme", "extension"),
+    ];
+    expect(acceptableMountLocations.some((location) => existsSync(location))).toBe(true);
+  });
+
+  // https://github.com/vercel/eve/issues/1151 — withEve bare-agent-dir expression:
+  // the agent root has no package.json of its own; the host app owns the
+  // dependency declaration and the install.
+  it("mounts host-declared dependencies for bare agent roots without a package.json", async () => {
+    const hostRoot = await createScratchDirectory("eve-dev-runtime-bare-agent-dependency-");
+    const appRoot = join(hostRoot, "agents", "research");
+    const compileDirectoryPath = join(appRoot, ".eve", "compile");
+    const hostPackageRoot = join(hostRoot, "node_modules", "@acme", "extension");
+
+    await mkdir(appRoot, { recursive: true });
+    await mkdir(hostPackageRoot, { recursive: true });
+    await mkdir(compileDirectoryPath, { recursive: true });
+    // The host boundary is a real workspace root marker so the snapshot's
+    // source-root walk resolves to it, exactly like a withEve app.
+    await writeFile(join(hostRoot, "pnpm-workspace.yaml"), "packages: []\n");
+    await writeFile(
+      join(hostRoot, "package.json"),
+      `${JSON.stringify({
+        dependencies: { "@acme/extension": "1.0.0" },
+        type: "module",
+      })}\n`,
+    );
+    await writeFile(join(appRoot, "agent.ts"), "export const answer = 42;\n");
+    await writeFile(
+      join(hostPackageRoot, "package.json"),
+      '{"name":"@acme/extension","version":"1.0.0"}\n',
+    );
+    await writeFile(
+      join(compileDirectoryPath, "compiled-agent-manifest.json"),
+      `${JSON.stringify({ agentRoot: appRoot, appRoot }, null, 2)}\n`,
+    );
+
+    const snapshot = await stageDevelopmentRuntimeArtifactsSnapshot({
+      paths: { compileDirectoryPath },
+      project: { appRoot },
+    } as CompileAgentResult);
+
+    const acceptableMountLocations = [
+      join(snapshot.runtimeAppRoot, "node_modules", "@acme", "extension"),
+      join(snapshot.runtimeAppRoot, "..", "..", "node_modules", "@acme", "extension"),
+    ];
+    expect(acceptableMountLocations.some((location) => existsSync(location))).toBe(true);
+  });
+
   it("stops copying at nested git repository boundaries", async () => {
     const appRoot = await createScratchDirectory("eve-dev-runtime-nested-git-");
     const agentRoot = join(appRoot, "agent");

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { lstat, readlink, realpath } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 
@@ -172,7 +172,10 @@ export function resolveDevelopmentSourceRoot(appRoot: string): string {
 
   while (true) {
     if (
-      SOURCE_ROOT_MARKER_NAMES.some((markerName) => existsSync(join(currentDirectory, markerName)))
+      SOURCE_ROOT_MARKER_NAMES.some((markerName) =>
+        existsSync(join(currentDirectory, markerName)),
+      ) ||
+      isWorkspaceManifestRoot(currentDirectory)
     ) {
       return currentDirectory;
     }
@@ -224,13 +227,93 @@ async function addDependencyMountsForRoot(
   state: SnapshotPlanState,
   packageRoot: string,
 ): Promise<void> {
-  const dependencyNames = await readPackageDependencyNames(packageRoot);
+  const declarationRoot = resolveDependencyDeclarationRoot(packageRoot, state.sourceRoot);
+  const dependencyNames = await readPackageDependencyNames(declarationRoot);
 
   for (const dependencyName of dependencyNames) {
-    for (const nodeModulesRoot of [packageRoot, state.sourceRoot]) {
+    for (const nodeModulesRoot of listAncestorNodeModulesRoots(packageRoot, state.sourceRoot)) {
       const mountPath = joinNodeModulesPackagePath(nodeModulesRoot, dependencyName);
       await addDependencyMount(state, mountPath);
     }
+  }
+}
+
+/**
+ * An app root without its own `package.json` (a bare `withEve` agent
+ * directory) resolves imports through the nearest owning package. Its
+ * dependency declarations live there, not at the app root (vercel/eve#1151).
+ */
+function resolveDependencyDeclarationRoot(packageRoot: string, sourceRoot: string): string {
+  let currentDirectory = resolve(packageRoot);
+  const boundary = resolve(sourceRoot);
+
+  while (isPathInsideOrEqual(currentDirectory, boundary)) {
+    if (existsSync(join(currentDirectory, "package.json"))) {
+      return currentDirectory;
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+
+    if (parentDirectory === currentDirectory) {
+      break;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+
+  return packageRoot;
+}
+
+/**
+ * Node resolution walks every ancestor `node_modules`. Mirror that walk up to
+ * the source boundary so hoisted installs — npm/yarn workspaces and
+ * intermediate monorepo levels — are materialized in the snapshot instead of
+ * only the package's own and the source root's `node_modules`
+ * (vercel/eve#1151).
+ */
+function listAncestorNodeModulesRoots(packageRoot: string, sourceRoot: string): string[] {
+  const boundary = resolve(sourceRoot);
+  const roots = new Set<string>();
+  let currentDirectory = resolve(packageRoot);
+
+  while (isPathInsideOrEqual(currentDirectory, boundary)) {
+    roots.add(currentDirectory);
+
+    const parentDirectory = dirname(currentDirectory);
+
+    if (parentDirectory === currentDirectory) {
+      break;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+
+  // A package root outside the boundary keeps the pre-existing two-point
+  // behavior: its own node_modules plus the source root's.
+  roots.add(resolve(packageRoot));
+  roots.add(boundary);
+
+  return [...roots];
+}
+
+/**
+ * npm and Yarn mark the workspace root only in `package.json` (`workspaces`),
+ * unlike pnpm's `pnpm-workspace.yaml`. Without recognizing it, a gitless npm
+ * workspace collapses the source root to the app root and hides the hoisted
+ * `node_modules` level from the snapshot (vercel/eve#1151).
+ */
+function isWorkspaceManifestRoot(directory: string): boolean {
+  const packageJsonPath = join(directory, "package.json");
+
+  if (!existsSync(packageJsonPath)) {
+    return false;
+  }
+
+  try {
+    const packageJson: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    return isObjectRecord(packageJson) && packageJson["workspaces"] !== undefined;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
Agents deployed as workspace packages — or as bare `withEve({ agents })` dirs — with a mounted extension kill `eve dev` at boot:

```
[UNRESOLVED_IMPORT] Could not resolve '../../../../node_modules/@example/playbook/dist/extension/tools/ping.mjs' in .eve/compile/module-map.mjs
```

`eve build` on the identical tree succeeds. Fixes #1151.

The compiled module map imports mounted extensions by a path relative to the agent's `.eve/compile`, and that path escapes the app root toward wherever Node resolved the package. The dev snapshot only materialized dependencies visible from exactly two `node_modules` levels — the app root's and the source root's — and only for names declared in the app root's own `package.json`. Three real layouts fall outside that:

- npm/yarn workspaces hoist the install to the workspace root; without `.git` or `pnpm-workspace.yaml` the source-root walk collapses to the app root and the hoisted level is invisible
- nested monorepos put the install at an intermediate level between app root and source root
- bare `withEve` agent dirs have no `package.json`, so no dependency names were read and nothing was mounted — every multi-agent Next app with an extension fails unconditionally

## What

- `listAncestorNodeModulesRoots` — walk every ancestor `node_modules` from the package root to the source boundary, mirroring Node resolution instead of the two-point sample
- `isWorkspaceManifestRoot` — a `package.json` declaring `workspaces` marks a source root, alongside `.git` / `pnpm-workspace.yaml`
- `resolveDependencyDeclarationRoot` — an app root without its own `package.json` reads dependency declarations from the nearest owning package
- two regression tests, one per expression, next to #967's — the sibling fix that covered installs physically inside the app root

The tests assert the contract rather than the layout: the dependency must be reachable inside the snapshot, either mirrored at its hoisted position or flattened into the app root's `node_modules` — a later placement change won't need to rewrite them.

The npm-workspace repro from #1151 boots to `server listening` against this build; on 0.27.1 it dies at the error above.
