### PR TITLE
feat(eve): support extension mounts in subagents

### DIFF
--- a/.changeset/calm-agents-share.md
+++ b/.changeset/calm-agents-share.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow declared local subagents to mount extensions from their own `extensions/` slots. Each subagent can now opt into a complete reusable capability package without duplicating its definitions.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -256,6 +256,30 @@ When `eve dev` starts a consuming agent, it builds mounted, source-backed extens
 
 Production `eve build` expects the extension distribution to exist already. Keep `eve extension build` in the extension package's `build` and `prepare` scripts, as the scaffold does, and run workspace builds in dependency order so extensions build before their consuming agents.
 
+#### Share an extension with subagents
+
+Extension mounts belong to an agent node. To give the root agent and several declared subagents the same capabilities, mount the same package in each agent directory:
+
+```text
+agent/
+├── extensions/shared.ts
+└── subagents/
+    ├── researcher/
+    │   ├── agent.ts
+    │   └── extensions/shared.ts
+    └── reviewer/
+        ├── agent.ts
+        └── extensions/shared.ts
+```
+
+Each `shared.ts` contains the same mount:
+
+```ts
+export { default } from "@acme/shared-capabilities";
+```
+
+The extension's tools, connections, skills, instructions, and hooks remain defined once in the workspace package. Each agent node receives the complete extension surface under its local `shared__` namespace. Mounts are opt-in, so omit the file from any subagent that should not have those capabilities.
+
 ### Override a contribution
 
 Use a directory mount to replace or remove an extension contribution. Put the mount declaration in `extension.ts` and add overrides beside it:

--- a/docs/reference/project-layout.md
+++ b/docs/reference/project-layout.md
@@ -30,6 +30,7 @@ my-agent/
 │   ├── instrumentation.ts
 │   ├── channels/
 │   ├── connections/
+│   ├── extensions/
 │   ├── hooks/
 │   ├── skills/
 │   ├── lib/
@@ -53,6 +54,7 @@ The Subagents column states whether a local subagent (`subagents/<id>/`) can aut
 | `instrumentation.ts`                                    | Telemetry config                            | No        | OTel exporter and AI SDK span settings, auto-discovered and run before agent code. Root-only.                                                                                                                         |
 | `channels/`                                             | HTTP / messaging entrypoints                | No        | Root-only.                                                                                                                                                                                                            |
 | `connections/`                                          | External service connections (MCP, OpenAPI) | Yes       | One connection per file; name derived from filename.                                                                                                                                                                  |
+| `extensions/`                                           | Mounted reusable capability packages        | Yes       | One mount per file or directory; the mount path supplies the contribution namespace. See [Extensions](../extensions).                                                                                                 |
 | `hooks/`                                                | Lifecycle and stream-event subscribers      | Yes       | Module-backed only. Recursive directories supported.                                                                                                                                                                  |
 | `skills/`                                               | On-demand procedures and capability packs   | Yes       | Flat markdown, module-backed skills, or packaged skills. Seeded into `$HOME/.agents/skills/...`, with `/workspace/skills/...` as a fallback if `$HOME` is unavailable.                                                |
 | `lib/`                                                  | Shared authored helper code                 | Yes       | Import-only; not mounted into the workspace.                                                                                                                                                                          |
@@ -81,6 +83,7 @@ agent/subagents/researcher/
 ├── agent.ts
 ├── instructions.md
 ├── connections/
+├── extensions/
 ├── hooks/
 ├── skills/
 ├── lib/
@@ -93,7 +96,7 @@ Rules:
 
 - `agent.ts` is required, and must declare a `description`. The parent reads it on the lowered subagent tool to decide when to delegate.
 - `instructions.md` / `instructions.ts` is optional (unlike the root agent, where it is required).
-- `connections/`, `hooks/`, `skills/`, `lib/`, `sandbox/`, and `tools/` are all supported, discovered from the subagent's own directory.
+- `connections/`, `extensions/`, `hooks/`, `skills/`, `lib/`, `sandbox/`, and `tools/` are all supported, discovered from the subagent's own directory.
 - `channels/` and `schedules/` are not supported inside local subagents.
 - Nested subagents are supported.
 

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -53,6 +53,7 @@ Minimum files:
 agent/subagents/researcher/
 ├── agent.ts            # required (must export a description)
 ├── instructions.md     # or instructions.ts, optional
+├── extensions/         # optional, mounted capability packages
 ├── tools/              # optional, its own tools
 ├── skills/             # optional, its own skills
 ├── sandbox/            # optional, its own sandbox + workspace seed
@@ -63,11 +64,12 @@ agent/subagents/researcher/
 
 ## The isolation boundary
 
-A declared subagent inherits nothing from the root's authored slots. Discovery treats its directory as its own agent root, so it has only the instructions, tools, connections, skills, sandbox, hooks, and nested subagents authored under `agent/subagents/<id>/`. An absent slot falls back to the framework default, not to the root's version.
+A declared subagent inherits nothing from the root's authored slots. Discovery treats its directory as its own agent root, so it has only the instructions, extensions, tools, connections, skills, sandbox, hooks, and nested subagents authored under `agent/subagents/<id>/`. An absent slot falls back to the framework default, not to the root's version.
 
 | Slot         | Root built-in `agent` tool    | Declared subagent                      |
 | ------------ | ----------------------------- | -------------------------------------- |
 | Instructions | Inherited (copy of the agent) | Own `instructions.{md,ts}`, optional   |
+| Extensions   | Inherited (copy of the agent) | Own `extensions/` mounts               |
 | Tools        | Inherited except root-only    | Own `tools/`                           |
 | Connections  | Inherited                     | Own `connections/`                     |
 | Skills       | Inherited                     | Own `skills/`                          |
@@ -77,7 +79,7 @@ A declared subagent inherits nothing from the root's authored slots. Discovery t
 | Channels     | Root-only                     | Root-only                              |
 | Schedules    | Root-only                     | Root-only                              |
 
-For a declared subagent this means duplicating anything the child needs. When two subagents need the same procedure, copy the markdown under each `skills/` directory, or share typed helpers via `lib/`. The sandbox does not inherit from the parent; it falls back to the framework default unless the subagent authors `subagents/<id>/sandbox.ts` or seeds files via `subagents/<id>/sandbox/workspace/`.
+For a declared subagent this means explicitly adding anything the child needs. Mount the same [extension](./extensions) in several subagents when they should share a capability package without duplicating its definitions. For smaller implementation helpers, use `lib/`. The sandbox does not inherit from the parent; it falls back to the framework default unless the subagent authors `subagents/<id>/sandbox.ts` or seeds files via `subagents/<id>/sandbox/workspace/`.
 
 The root built-in `agent` tool is the exception. Its children share the root's sandbox and tools because they are copies of the same agent working on the same files.
 

--- a/e2e/fixtures/extensions/agent/subagents/extension-specialist/agent.ts
+++ b/e2e/fixtures/extensions/agent/subagents/extension-specialist/agent.ts
@@ -1,0 +1,8 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description:
+    "Extension specialist that runs the fixed E2E forecast with its mounted toolkit extension.",
+  model: process.env.EVE_E2E_MODEL ?? "openai/gpt-5.6-sol",
+  reasoning: "high",
+});

--- a/e2e/fixtures/extensions/agent/subagents/extension-specialist/extensions/toolkit.ts
+++ b/e2e/fixtures/extensions/agent/subagents/extension-specialist/extensions/toolkit.ts
@@ -1,0 +1,3 @@
+import toolkit from "toolkit-extension";
+
+export default toolkit({ apiKey: "sk-e2e-toolkit", tier: "pro" });

--- a/e2e/fixtures/extensions/agent/subagents/extension-specialist/instructions.md
+++ b/e2e/fixtures/extensions/agent/subagents/extension-specialist/instructions.md
@@ -1,0 +1,2 @@
+Call `toolkit__toolkit_forecast` exactly once with no arguments.
+After the tool returns, report its output verbatim and do not call another tool.

--- a/e2e/fixtures/extensions/evals/subagent-mount.eval.ts
+++ b/e2e/fixtures/extensions/evals/subagent-mount.eval.ts
@@ -1,0 +1,23 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "A subagent-mounted extension tool resolves its extension-owned lib dependency.",
+  async test(t) {
+    const parent = await t.start(
+      "Call the extension-specialist subagent exactly once. After it returns, report its result verbatim.",
+    );
+    const called = await parent.waitForEvent("subagent.called", {
+      data: { name: "extension-specialist" },
+    });
+    const child = t.target.watchTurn(called.data.childSessionId);
+    const [parentTurn, childTurn] = await Promise.all([parent.result(), child.result()]);
+
+    parentTurn.succeeded();
+    parentTurn.calledSubagent("extension-specialist", { count: 1, status: "completed" });
+    childTurn.succeeded();
+    childTurn.calledTool("toolkit__toolkit_forecast", {
+      count: 1,
+      output: { token: "toolkit-forecast-ok-9F4Q" },
+    });
+  },
+});

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -631,6 +631,38 @@ const compiledHookDefinitionSchema: z.ZodType<CompiledHookDefinition> = z
   })
   .strict();
 
+/** One mounted extension recorded on its owning compiled agent node. */
+export interface CompiledExtensionMount {
+  /** Mount-derived namespace that prefixes the extension's tool/skill names. */
+  readonly namespace: string;
+  readonly packageName: string;
+  /**
+   * Package-derived namespace that scopes the extension's durable state keys and
+   * config binding. Distinct from {@link namespace}: state stays keyed to the
+   * package so a consumer renaming the mount file cannot orphan persisted state.
+   */
+  readonly packageNamespace: string;
+  /**
+   * Absolute path to the extension's source root on disk. The extension-scope
+   * bundler plugin treats any module under this root as extension-owned and
+   * rewrites its `eve/context`/`eve/extension` imports to bake in the namespace.
+   */
+  readonly sourceRoot: string;
+  readonly mountSourceId: string;
+  readonly mountLogicalPath: string;
+}
+
+const compiledExtensionMountSchema: z.ZodType<CompiledExtensionMount> = z
+  .object({
+    namespace: z.string(),
+    packageName: z.string(),
+    packageNamespace: z.string(),
+    sourceRoot: z.string(),
+    mountSourceId: z.string(),
+    mountLogicalPath: z.string(),
+  })
+  .strict();
+
 /**
  * Zod schema for one non-recursive compiled authored agent payload.
  */
@@ -647,6 +679,7 @@ const compiledAgentNodeManifestSchema = z
     dynamicInstructions: z.array(compiledDynamicInstructionsDefinitionSchema).default([]),
     dynamicSkills: z.array(compiledDynamicSkillDefinitionSchema).default([]),
     dynamicTools: z.array(compiledDynamicToolDefinitionSchema).default([]),
+    extensionMounts: z.array(compiledExtensionMountSchema).default([]),
     hooks: z.array(compiledHookDefinitionSchema),
     sandbox: compiledSandboxDefinitionSchema.nullable(),
     sandboxWorkspaces: z.array(compiledSandboxWorkspaceSchema),
@@ -678,42 +711,6 @@ const compiledSubagentEdgeSchema: z.ZodType<CompiledSubagentEdge> = z
   .object({
     childNodeId: z.string(),
     parentNodeId: z.string(),
-  })
-  .strict();
-
-/**
- * One mounted extension recorded on the root compiled manifest. The runtime
- * evaluates {@link mountLogicalPath} at module-map load so the mount's factory
- * call binds the extension's config before any tool runs.
- */
-export interface CompiledExtensionMount {
-  /** Mount-derived namespace that prefixes the extension's tool/skill names. */
-  readonly namespace: string;
-  readonly packageName: string;
-  /**
-   * Package-derived namespace that scopes the extension's durable state keys and
-   * config binding. Distinct from {@link namespace}: state stays keyed to the
-   * package so a consumer renaming the mount file cannot orphan persisted state.
-   */
-  readonly packageNamespace: string;
-  /**
-   * Absolute path to the extension's source root on disk. The extension-scope
-   * bundler plugin treats any module under this root as extension-owned and
-   * rewrites its `eve/context`/`eve/extension` imports to bake in the namespace.
-   */
-  readonly sourceRoot: string;
-  readonly mountSourceId: string;
-  readonly mountLogicalPath: string;
-}
-
-const compiledExtensionMountSchema: z.ZodType<CompiledExtensionMount> = z
-  .object({
-    namespace: z.string(),
-    packageName: z.string(),
-    packageNamespace: z.string(),
-    sourceRoot: z.string(),
-    mountSourceId: z.string(),
-    mountLogicalPath: z.string(),
   })
   .strict();
 
@@ -765,6 +762,7 @@ export function createCompiledAgentNodeManifest(input: {
   readonly dynamicInstructions?: readonly CompiledDynamicInstructionsDefinition[];
   readonly dynamicSkills?: readonly CompiledDynamicSkillDefinition[];
   readonly dynamicTools?: readonly CompiledDynamicToolDefinition[];
+  readonly extensionMounts?: readonly CompiledExtensionMount[];
   readonly hooks?: readonly CompiledHookDefinition[];
   readonly remoteAgents?: readonly CompiledRemoteAgentNode[];
   readonly sandbox?: CompiledSandboxDefinition | null;
@@ -845,6 +843,7 @@ export function createCompiledAgentNodeManifest(input: {
     dynamicInstructions: [...(input.dynamicInstructions ?? [])],
     dynamicSkills: [...(input.dynamicSkills ?? [])],
     dynamicTools: [...(input.dynamicTools ?? [])],
+    extensionMounts: [...(input.extensionMounts ?? [])],
     hooks: [...(input.hooks ?? [])],
     remoteAgents: [...(input.remoteAgents ?? [])],
     sandbox: input.sandbox ?? null,
@@ -937,6 +936,16 @@ export function createCompiledAgentManifest(input: {
     subagents: [...(input.subagents ?? [])],
     version: COMPILED_AGENT_MANIFEST_VERSION,
   };
+}
+
+/** Collects extension mounts from the root and every flattened subagent node. */
+export function collectCompiledExtensionMounts(
+  manifest: CompiledAgentManifest,
+): CompiledExtensionMount[] {
+  return [
+    ...manifest.extensionMounts,
+    ...manifest.subagents.flatMap((subagent) => subagent.agent.extensionMounts),
+  ];
 }
 
 function cloneCompiledRuntimeModelReference(

--- a/packages/eve/src/compiler/module-map.ts
+++ b/packages/eve/src/compiler/module-map.ts
@@ -1,10 +1,6 @@
 import { z } from "#compiled/zod/index.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
-import type {
-  CompiledAgentManifest,
-  CompiledAgentNodeManifest,
-  CompiledExtensionMount,
-} from "#compiler/manifest.js";
+import type { CompiledAgentManifest, CompiledAgentNodeManifest } from "#compiler/manifest.js";
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
 
@@ -253,18 +249,13 @@ export function collectModuleRefsForManifest(
     });
   }
 
-  // Extension mount modules (root manifest only). Their top-level factory call
-  // binds config, so they must be evaluated at module-map load.
-  const extensionMounts = (manifest as { extensionMounts?: readonly CompiledExtensionMount[] })
-    .extensionMounts;
-  if (extensionMounts !== undefined) {
-    for (const mount of extensionMounts) {
-      moduleSourceRefs.set(mount.mountSourceId, {
-        sourceKind: "module",
-        logicalPath: mount.mountLogicalPath,
-        sourceId: mount.mountSourceId,
-      });
-    }
+  // Mount modules bind extension config when the owning node's module map loads.
+  for (const mount of manifest.extensionMounts) {
+    moduleSourceRefs.set(mount.mountSourceId, {
+      sourceKind: "module",
+      logicalPath: mount.mountLogicalPath,
+      sourceId: mount.mountSourceId,
+    });
   }
 
   // Authored system modules execute once at build time. The compiled markdown

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -48,23 +48,8 @@ export async function compileAgentManifest(
     subagents: manifest.subagents,
   });
 
-  const extensionMounts: CompiledExtensionMount[] = manifest.resolvedExtensions.map((mount) => {
-    const mountRef = manifest.extensions.find(
-      (entry) => mountRefNamespace(entry.logicalPath) === mount.namespace,
-    );
-    return {
-      namespace: mount.namespace,
-      packageName: mount.packageName,
-      packageNamespace: packageStateNamespace(mount.packageName),
-      sourceRoot: mount.sourceRoot,
-      mountSourceId: mountRef?.sourceId ?? `extensions/${mount.namespace}`,
-      mountLogicalPath: mountRef?.logicalPath ?? `extensions/${mount.namespace}`,
-    };
-  });
-
   return createCompiledAgentManifest({
     ...compiledNode,
-    extensionMounts,
     remoteAgents: subagentGraph.remoteAgents,
     subagentEdges: subagentGraph.edges,
     subagents: subagentGraph.nodes,
@@ -250,6 +235,7 @@ async function compileAgentNodeManifest(
     workflowTool,
     dynamicSkills,
     dynamicTools,
+    extensionMounts: compileExtensionMounts(manifest),
     hooks,
     sandbox:
       manifest.sandbox === null
@@ -268,6 +254,22 @@ async function compileAgentNodeManifest(
     skills,
     instructions: composedInstructions,
     tools,
+  });
+}
+
+function compileExtensionMounts(manifest: AgentSourceManifest): CompiledExtensionMount[] {
+  return manifest.resolvedExtensions.map((mount) => {
+    const mountRef = manifest.extensions.find(
+      (entry) => mountRefNamespace(entry.logicalPath) === mount.namespace,
+    );
+    return {
+      namespace: mount.namespace,
+      packageName: mount.packageName,
+      packageNamespace: packageStateNamespace(mount.packageName),
+      sourceRoot: mount.sourceRoot,
+      mountSourceId: mountRef?.sourceId ?? `extensions/${mount.namespace}`,
+      mountLogicalPath: mountRef?.logicalPath ?? `extensions/${mount.namespace}`,
+    };
   });
 }
 

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -319,6 +319,7 @@ function assertRemoteAgentDefinitionHasNoLocalPackageEntries(source: LocalSubage
   const manifest = source.manifest;
   const extraEntries = [
     manifest.connections.length > 0 ? "connections/" : undefined,
+    manifest.extensions.length > 0 ? "extensions/" : undefined,
     manifest.hooks.length > 0 ? "hooks/" : undefined,
     manifest.instructions.length > 0 ? "instructions" : undefined,
     manifest.lib.length > 0 ? "lib/" : undefined,

--- a/packages/eve/src/discover/agent.integration.test.ts
+++ b/packages/eve/src/discover/agent.integration.test.ts
@@ -1116,6 +1116,39 @@ describe("discoverAgent (memory)", () => {
     expect(nested?.message).toContain("extensions/inner");
   });
 
+  it("rejects an extension subagent that mounts another extension", async () => {
+    const project = buildMemoryAgentProject({
+      appFiles: {
+        "node_modules/@acme/crm/package.json": JSON.stringify({
+          name: "@acme/crm",
+          eve: { extension: { source: "source", dist: "extension" } },
+        }),
+        "node_modules/@acme/crm/extension/_manifest.json": EXTENSION_COMPATIBILITY_MANIFEST,
+        "node_modules/@acme/crm/extension/extension.ts": "export default {};\n",
+        "node_modules/@acme/crm/extension/tools/search.ts": "export default {};\n",
+        "node_modules/@acme/crm/extension/subagents/specialist/agent.ts": "export default {};\n",
+        "node_modules/@acme/crm/extension/subagents/specialist/extensions/inner.ts":
+          'export { default } from "@acme/inner";\n',
+      },
+      agentFiles: {
+        "extensions/crm.ts": 'export { default } from "@acme/crm";\n',
+        "instructions.md": "You are a precise assistant.",
+      },
+    });
+
+    const result = await discoverAgent({
+      agentRoot: project.agentRoot,
+      appRoot: project.appRoot,
+      source: project.source,
+    });
+
+    const nested = result.diagnostics.find(
+      (diagnostic) => diagnostic.code === DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
+    );
+    expect(nested).toBeDefined();
+    expect(nested?.message).toContain("extensions/inner");
+  });
+
   it("allows an agent-root tool whose name does not use a mounted namespace prefix", async () => {
     const project = buildMemoryAgentProject({
       appFiles: {

--- a/packages/eve/src/discover/discover-agent.ts
+++ b/packages/eve/src/discover/discover-agent.ts
@@ -5,28 +5,16 @@ import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discove
 import { discoverSubagents } from "#discover/discover-subagent.js";
 import {
   DISCOVER_EXTENSION_AGENT_CONFIG_UNSUPPORTED,
-  DISCOVER_EXTENSION_MOUNT_AMBIGUOUS,
-  DISCOVER_EXTENSION_MOUNT_MISSING_DECLARATION,
-  DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
-  DISCOVER_EXTENSION_OVERRIDE_OUTSIDE_MOUNT,
   DISCOVER_EXTENSION_SANDBOX_UNSUPPORTED,
   DISCOVER_EXTENSION_SCHEDULE_UNSUPPORTED,
-  locateExtensionMount,
-  mountNamespace,
 } from "#discover/extensions.js";
-import {
-  classifyAgentRootEntry,
-  normalizeLogicalPath,
-  SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS,
-} from "#discover/filesystem.js";
+import { classifyAgentRootEntry } from "#discover/filesystem.js";
 import {
   createChannelNameDiagnostic,
-  createExtensionNameDiagnostic,
   createHookNameDiagnostic,
   createToolNameDiagnostic,
   createUnsupportedRootDirectoryDiagnostics,
   DISCOVER_CHANNELS_DIRECTORY_INVALID,
-  DISCOVER_EXTENSIONS_DIRECTORY_INVALID,
   DISCOVER_HOOKS_DIRECTORY_INVALID,
   DISCOVER_TOOLS_DIRECTORY_INVALID,
   discoverFlatModuleSource,
@@ -39,15 +27,9 @@ import {
   type AgentSourceManifest,
   type CreateAgentSourceManifestInput,
   createAgentSourceManifest,
-  createModuleSourceRef,
-  type ExtensionSourceRef,
-  type ResolvedExtensionMount,
 } from "#discover/manifest.js";
-import {
-  createDiskProjectSource,
-  type ProjectSource,
-  type ProjectSourceEntry,
-} from "#discover/project-source.js";
+import { discoverMountedExtensions } from "#discover/mounted-extensions.js";
+import { createDiskProjectSource, type ProjectSource } from "#discover/project-source.js";
 import { discoverSandboxSource } from "#discover/sandbox.js";
 import { discoverScheduleSources } from "#discover/schedules.js";
 import { discoverSkills } from "#discover/skills.js";
@@ -219,18 +201,6 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
   });
   diagnostics.push(...hooksResult.diagnostics);
 
-  const extensionsResult = await discoverNamedSourceDirectory({
-    directoryName: "extensions",
-    invalidDirectoryCode: DISCOVER_EXTENSIONS_DIRECTORY_INVALID,
-    invalidDirectoryMessage: `Expected "${join(agentRoot, "extensions")}" to be a directory of extension mounts.`,
-    recursive: false,
-    rootEntries,
-    rootPath: agentRoot,
-    source,
-    validateSegment: createExtensionNameDiagnostic,
-  });
-  diagnostics.push(...extensionsResult.diagnostics);
-
   const skillsResult = await discoverSkills({
     agentRoot,
     source,
@@ -240,100 +210,29 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
   const subagentsResult = await discoverSubagents({
     agentRoot,
     appRoot,
+    discoverExtensionSourceTree: async (extensionInput) =>
+      await discoverAgent({ ...extensionInput, role: "extension" }),
+    resolveExtensionMounts: role === "agent",
     source,
   });
   diagnostics.push(...subagentsResult.diagnostics);
 
-  const mountCollection = await collectExtensionMounts({
+  const mountedExtensions = await discoverMountedExtensions({
     agentRoot,
-    fileMounts: extensionsResult.sources,
+    appRoot,
+    contributionSources: [
+      ...toolsResult.sources,
+      ...connectionsResult.connections,
+      ...skillsResult.skills,
+      ...schedulesResult.schedules,
+    ],
+    discoverExtensionSourceTree: async (extensionInput) =>
+      await discoverAgent({ ...extensionInput, role: "extension" }),
+    resolveMounts: role === "agent",
     rootEntries,
     source,
   });
-  diagnostics.push(...mountCollection.diagnostics);
-
-  // Overrides must be co-located in the mount directory. An agent-root
-  // contribution using a mounted extension's `<ns>__` composed-name prefix would
-  // shadow that extension from outside its mount directory, so reject it.
-  diagnostics.push(
-    ...detectRootNamespaceCollisions({
-      agentRoot,
-      namespaces: mountCollection.mounts.map((descriptor) => descriptor.namespace),
-      sources: [
-        ...toolsResult.sources,
-        ...connectionsResult.connections,
-        ...skillsResult.skills,
-        ...schedulesResult.schedules,
-      ],
-    }),
-  );
-
-  const resolvedExtensions: ResolvedExtensionMount[] = [];
-  if (role !== "agent") {
-    // Extensions cannot mount other extensions yet. Fail loudly instead of
-    // silently dropping the nested mount, and reserve the behavior so enabling
-    // it later is additive.
-    for (const descriptor of mountCollection.mounts) {
-      diagnostics.push(
-        createDiscoverErrorDiagnostic({
-          code: DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
-          message: `"${descriptor.mountRef.logicalPath}" mounts an extension from inside an extension, which is not supported yet. Extensions cannot mount other extensions; remove the "extensions/" slot.`,
-          sourcePath: join(agentRoot, descriptor.mountRef.logicalPath),
-        }),
-      );
-    }
-  } else {
-    for (const descriptor of mountCollection.mounts) {
-      const located = await locateExtensionMount({
-        source,
-        agentRoot,
-        appRoot,
-        mount: descriptor.mountRef,
-        namespace: descriptor.namespace,
-      });
-      diagnostics.push(...located.diagnostics);
-      if (located.location === undefined) {
-        continue;
-      }
-
-      const extensionResult = await discoverAgent({
-        agentRoot: located.location.sourceRoot,
-        appRoot: located.location.packageRoot,
-        source,
-        role: "extension",
-      });
-      diagnostics.push(...extensionResult.diagnostics);
-
-      // The mount directory's override slots discover as an agent-shaped source;
-      // its `extension.<ext>` declaration matches no slot, so it is ignored here.
-      let overrides: AgentSourceManifest | undefined;
-      if (descriptor.overridesRoot !== undefined) {
-        const overridesResult = await discoverAgent({
-          agentRoot: descriptor.overridesRoot,
-          appRoot,
-          source,
-          role: "extension",
-        });
-        diagnostics.push(...overridesResult.diagnostics);
-        overrides = overridesResult.manifest;
-      }
-
-      const resolved: { -readonly [K in keyof ResolvedExtensionMount]: ResolvedExtensionMount[K] } =
-        {
-          namespace: located.location.namespace,
-          specifier: located.location.specifier,
-          packageName: located.location.packageName,
-          packageRoot: located.location.packageRoot,
-          sourceRoot: located.location.sourceRoot,
-          manifest: extensionResult.manifest,
-        };
-      if (overrides !== undefined) {
-        resolved.overrides = overrides;
-      }
-
-      resolvedExtensions.push(resolved);
-    }
-  }
+  diagnostics.push(...mountedExtensions.diagnostics);
 
   const manifestInput: CreateAgentSourceManifestInput = {
     agentRoot,
@@ -342,8 +241,8 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
     connections: connectionsResult.connections,
     packageName,
     diagnostics,
-    extensions: mountCollection.mounts.map((descriptor) => descriptor.mountRef),
-    resolvedExtensions,
+    extensions: mountedExtensions.extensions,
+    resolvedExtensions: mountedExtensions.resolvedExtensions,
     hooks: hooksResult.sources,
     lib: libResult.lib,
     instructions: instructionsResult.instructions,
@@ -366,206 +265,6 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
     diagnostics,
     manifest,
   };
-}
-
-/**
- * One extension mount discovered under `agent/extensions/`, in either the flat
- * file form (`extensions/crm.ts`) or the directory form
- * (`extensions/crm/extension.ts` with optional override slots).
- */
-export interface ExtensionMountDescriptor {
-  /** Mount namespace prefixed onto every composed contribution. */
-  readonly namespace: string;
-  /** Module ref for the mount declaration the package specifier is read from. */
-  readonly mountRef: ExtensionSourceRef;
-  /**
-   * Absolute path to the mount directory when this is the directory form.
-   * Its override slots are discovered as an agent-shaped source. Absent for
-   * the flat file form.
-   */
-  readonly overridesRoot?: string;
-}
-
-/**
- * Discovers extension mount declarations without resolving or inspecting their
- * package distributions. Development uses this before building local mounts.
- */
-export async function discoverExtensionMountDeclarations(input: {
-  readonly agentRoot: string;
-  readonly source?: ProjectSource;
-}): Promise<{
-  diagnostics: DiscoverDiagnostic[];
-  mounts: ExtensionMountDescriptor[];
-}> {
-  const source = input.source ?? createDiskProjectSource();
-  const agentRoot = resolve(input.agentRoot);
-  const rootEntries = await readSortedDirectoryEntries(source, agentRoot);
-  const extensionsResult = await discoverNamedSourceDirectory({
-    directoryName: "extensions",
-    invalidDirectoryCode: DISCOVER_EXTENSIONS_DIRECTORY_INVALID,
-    invalidDirectoryMessage: `Expected "${join(agentRoot, "extensions")}" to be a directory of extension mounts.`,
-    recursive: false,
-    rootEntries,
-    rootPath: agentRoot,
-    source,
-    validateSegment: createExtensionNameDiagnostic,
-  });
-  const collection = await collectExtensionMounts({
-    agentRoot,
-    fileMounts: extensionsResult.sources,
-    rootEntries,
-    source,
-  });
-
-  return {
-    diagnostics: [...extensionsResult.diagnostics, ...collection.diagnostics],
-    mounts: collection.mounts,
-  };
-}
-
-/**
- * Collects extension mounts in both the flat file form and the directory form,
- * validating directory names and rejecting a namespace claimed by both forms.
- *
- * File mounts arrive pre-validated from {@link discoverNamedSourceDirectory}
- * (which, run non-recursively, ignores subdirectories); directory mounts are
- * gathered here by scanning the `extensions/` entries for subdirectories, each
- * of which must hold an `extension.<ext>` declaration.
- */
-async function collectExtensionMounts(input: {
-  readonly agentRoot: string;
-  readonly fileMounts: readonly ExtensionSourceRef[];
-  readonly rootEntries: readonly ProjectSourceEntry[];
-  readonly source: ProjectSource;
-}): Promise<{
-  diagnostics: DiscoverDiagnostic[];
-  mounts: ExtensionMountDescriptor[];
-}> {
-  const diagnostics: DiscoverDiagnostic[] = [];
-  const extensionsRoot = join(input.agentRoot, "extensions");
-
-  const fileDescriptors: ExtensionMountDescriptor[] = input.fileMounts.map((mountRef) => ({
-    namespace: mountNamespace(mountRef.logicalPath),
-    mountRef,
-  }));
-  const fileNamespaces = new Set(fileDescriptors.map((descriptor) => descriptor.namespace));
-
-  const extensionsEntry = input.rootEntries.find((entry) => entry.name === "extensions");
-  const directoryDescriptors: ExtensionMountDescriptor[] = [];
-  const ambiguousNamespaces = new Set<string>();
-
-  if (extensionsEntry?.isDirectory() === true) {
-    const entries = await readSortedDirectoryEntries(input.source, extensionsRoot);
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-
-      const namespace = entry.name;
-      const mountDir = join(extensionsRoot, namespace);
-      const nameDiagnostic = createExtensionNameDiagnostic(namespace, mountDir);
-      if (nameDiagnostic !== null) {
-        diagnostics.push(nameDiagnostic);
-        continue;
-      }
-
-      const declarationResult = discoverFlatModuleSource({
-        rootEntries: await readSortedDirectoryEntries(input.source, mountDir),
-        rootPath: mountDir,
-        slotName: "extension",
-      });
-      diagnostics.push(...declarationResult.diagnostics);
-
-      if (declarationResult.module === undefined) {
-        diagnostics.push(
-          createDiscoverErrorDiagnostic({
-            code: DISCOVER_EXTENSION_MOUNT_MISSING_DECLARATION,
-            message: `Extension mount directory "extensions/${namespace}/" must declare its mount in "extension.ts" (or another supported module extension).`,
-            sourcePath: mountDir,
-          }),
-        );
-        continue;
-      }
-
-      if (fileNamespaces.has(namespace)) {
-        ambiguousNamespaces.add(namespace);
-      }
-
-      directoryDescriptors.push({
-        namespace,
-        mountRef: createModuleSourceRef({
-          logicalPath: normalizeLogicalPath(
-            join("extensions", namespace, declarationResult.module.logicalPath),
-          ),
-        }),
-        overridesRoot: mountDir,
-      });
-    }
-  }
-
-  for (const namespace of ambiguousNamespaces) {
-    diagnostics.push(
-      createDiscoverErrorDiagnostic({
-        code: DISCOVER_EXTENSION_MOUNT_AMBIGUOUS,
-        message: `Extension namespace "${namespace}" is claimed by both a file mount ("extensions/${namespace}.ts") and a directory mount ("extensions/${namespace}/"). Keep only one.`,
-        sourcePath: extensionsRoot,
-      }),
-    );
-  }
-
-  const mounts = [...fileDescriptors, ...directoryDescriptors].filter(
-    (descriptor) => !ambiguousNamespaces.has(descriptor.namespace),
-  );
-
-  return { diagnostics, mounts };
-}
-
-/**
- * Flags agent-root contributions whose composed name uses a mounted extension's
- * `<ns>__` prefix. That prefix is reserved for the extension and its co-located
- * overrides, so a root-level `<ns>__…` file would override the extension from
- * outside its mount directory — rejected here.
- */
-function detectRootNamespaceCollisions(input: {
-  readonly agentRoot: string;
-  readonly namespaces: readonly string[];
-  readonly sources: ReadonlyArray<{ readonly logicalPath: string }>;
-}): DiscoverDiagnostic[] {
-  if (input.namespaces.length === 0) {
-    return [];
-  }
-
-  const diagnostics: DiscoverDiagnostic[] = [];
-  for (const source of input.sources) {
-    const name = rootContributionName(source.logicalPath);
-    const namespace = input.namespaces.find((candidate) => name.startsWith(`${candidate}__`));
-    if (namespace !== undefined) {
-      diagnostics.push(
-        createDiscoverErrorDiagnostic({
-          code: DISCOVER_EXTENSION_OVERRIDE_OUTSIDE_MOUNT,
-          message: `"${source.logicalPath}" uses the "${namespace}__" prefix reserved for the mounted extension "${namespace}". Override an extension's contributions inside its mount directory ("extensions/${namespace}/…"), not at the agent root.`,
-          sourcePath: join(input.agentRoot, source.logicalPath),
-        }),
-      );
-    }
-  }
-  return diagnostics;
-}
-
-/**
- * Derives a contribution's composed name from its slot-relative logical path:
- * the first path segment below the slot directory, minus any module extension
- * (`tools/crm__x.ts` → `crm__x`; `skills/crm__x/SKILL.md` → `crm__x`).
- */
-function rootContributionName(logicalPath: string): string {
-  const afterSlot = logicalPath.slice(logicalPath.indexOf("/") + 1);
-  const firstSegment = afterSlot.split("/")[0] ?? afterSlot;
-  for (const extension of SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS) {
-    if (firstSegment.toLowerCase().endsWith(extension)) {
-      return firstSegment.slice(0, firstSegment.length - extension.length);
-    }
-  }
-  return firstSegment;
 }
 
 /**

--- a/packages/eve/src/discover/discover-subagent.ts
+++ b/packages/eve/src/discover/discover-subagent.ts
@@ -28,6 +28,10 @@ import {
   type SubagentSourceRef,
 } from "#discover/manifest.js";
 import {
+  type DiscoverExtensionSourceTree,
+  discoverMountedExtensions,
+} from "#discover/mounted-extensions.js";
+import {
   createDiskProjectSource,
   type ProjectSource,
   type ProjectSourceEntry,
@@ -50,6 +54,8 @@ export const DISCOVER_SUBAGENTS_DIRECTORY_INVALID = "discover/subagents-director
 interface DiscoverSubagentsInput {
   agentRoot: string;
   appRoot: string;
+  discoverExtensionSourceTree: DiscoverExtensionSourceTree;
+  resolveExtensionMounts?: boolean;
   /**
    * Optional {@link ProjectSource} used for all filesystem reads. Defaults
    * to a disk-backed source so disk callers keep their current behaviour.
@@ -134,6 +140,8 @@ export async function discoverSubagents(
 
     const localSubagentResult = await discoverLocalSubagentPackage({
       appRoot: input.appRoot,
+      discoverExtensionSourceTree: input.discoverExtensionSourceTree,
+      resolveExtensionMounts: input.resolveExtensionMounts,
       source,
       subagentId: entry.name,
       subagentLogicalPath: join(subagentsLogicalPath, entry.name),
@@ -178,6 +186,8 @@ function discoverSingleFileSubagent(input: {
 
 async function discoverLocalSubagentPackage(input: {
   appRoot: string;
+  discoverExtensionSourceTree: DiscoverExtensionSourceTree;
+  resolveExtensionMounts?: boolean;
   source: ProjectSource;
   subagentId: string;
   subagentLogicalPath: string;
@@ -273,9 +283,26 @@ async function discoverLocalSubagentPackage(input: {
   });
   diagnostics.push(...skillsResult.diagnostics);
 
+  const mountedExtensions = await discoverMountedExtensions({
+    agentRoot: input.subagentRoot,
+    appRoot: input.appRoot,
+    contributionSources: [
+      ...toolsResult.sources,
+      ...connectionsResult.connections,
+      ...skillsResult.skills,
+    ],
+    discoverExtensionSourceTree: input.discoverExtensionSourceTree,
+    resolveMounts: input.resolveExtensionMounts ?? true,
+    rootEntries,
+    source: input.source,
+  });
+  diagnostics.push(...mountedExtensions.diagnostics);
+
   const subagentsResult = await discoverSubagents({
     agentRoot: input.subagentRoot,
     appRoot: input.appRoot,
+    discoverExtensionSourceTree: input.discoverExtensionSourceTree,
+    resolveExtensionMounts: input.resolveExtensionMounts,
     source: input.source,
   });
   diagnostics.push(...subagentsResult.diagnostics);
@@ -285,12 +312,14 @@ async function discoverLocalSubagentPackage(input: {
     appRoot: input.appRoot,
     connections: connectionsResult.connections,
     diagnostics,
+    extensions: mountedExtensions.extensions,
     hooks: hooksResult.sources,
     lib: libResult.lib,
     instructions: instructionsResult.instructions,
     sandbox: sandboxResult.sandbox,
     sandboxWorkspaces:
       sandboxResult.sandboxWorkspace === null ? [] : [sandboxResult.sandboxWorkspace],
+    resolvedExtensions: mountedExtensions.resolvedExtensions,
     skills: skillsResult.skills,
     tools: toolsResult.sources,
     subagents: subagentsResult.subagents,

--- a/packages/eve/src/discover/extension-mount-declarations.ts
+++ b/packages/eve/src/discover/extension-mount-declarations.ts
@@ -1,0 +1,218 @@
+import { join, resolve } from "node:path";
+
+import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discover/diagnostics.js";
+import {
+  DISCOVER_EXTENSION_MOUNT_AMBIGUOUS,
+  DISCOVER_EXTENSION_MOUNT_MISSING_DECLARATION,
+  mountNamespace,
+} from "#discover/extensions.js";
+import { normalizeLogicalPath } from "#discover/filesystem.js";
+import {
+  createExtensionNameDiagnostic,
+  DISCOVER_EXTENSIONS_DIRECTORY_INVALID,
+  discoverFlatModuleSource,
+  discoverNamedSourceDirectory,
+  readSortedDirectoryEntries,
+} from "#discover/grammar.js";
+import { createModuleSourceRef, type ExtensionSourceRef } from "#discover/manifest.js";
+import {
+  createDiskProjectSource,
+  type ProjectSource,
+  type ProjectSourceEntry,
+} from "#discover/project-source.js";
+
+/** One extension mount declaration and its optional co-located override root. */
+export interface ExtensionMountDescriptor {
+  /** Mount namespace prefixed onto every composed contribution. */
+  readonly namespace: string;
+  /** Module ref for the mount declaration the package specifier is read from. */
+  readonly mountRef: ExtensionSourceRef;
+  /** Absolute path to the directory-form mount when it carries overrides. */
+  readonly overridesRoot?: string;
+}
+
+/** One recursively discovered mount paired with the agent root that owns it. */
+export interface AgentExtensionMountDescriptor {
+  readonly agentRoot: string;
+  readonly mount: ExtensionMountDescriptor;
+}
+
+/**
+ * Discovers extension mount declarations without resolving their package
+ * distributions. Development uses this before building local mounts.
+ */
+export async function discoverExtensionMountDeclarations(input: {
+  readonly agentRoot: string;
+  readonly source?: ProjectSource;
+}): Promise<{
+  readonly diagnostics: DiscoverDiagnostic[];
+  readonly mounts: ExtensionMountDescriptor[];
+}> {
+  const source = input.source ?? createDiskProjectSource();
+  const agentRoot = resolve(input.agentRoot);
+  return await discoverExtensionMountDeclarationsFromEntries({
+    agentRoot,
+    rootEntries: await readSortedDirectoryEntries(source, agentRoot),
+    source,
+  });
+}
+
+/**
+ * Discovers mount declarations from the root agent and every directory-form
+ * local subagent without requiring extension distributions to exist yet.
+ */
+export async function discoverExtensionMountDeclarationsRecursively(input: {
+  readonly agentRoot: string;
+  readonly source?: ProjectSource;
+}): Promise<{
+  readonly diagnostics: DiscoverDiagnostic[];
+  readonly mounts: AgentExtensionMountDescriptor[];
+}> {
+  const source = input.source ?? createDiskProjectSource();
+  const diagnostics: DiscoverDiagnostic[] = [];
+  const mounts: AgentExtensionMountDescriptor[] = [];
+
+  async function visit(agentRoot: string): Promise<void> {
+    const declarations = await discoverExtensionMountDeclarations({ agentRoot, source });
+    diagnostics.push(...declarations.diagnostics);
+    mounts.push(
+      ...declarations.mounts.map((mount) => ({
+        agentRoot,
+        mount,
+      })),
+    );
+
+    const subagentsRoot = join(agentRoot, "subagents");
+    if ((await source.stat(subagentsRoot)) !== "directory") {
+      return;
+    }
+    const entries = await readSortedDirectoryEntries(source, subagentsRoot);
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        await visit(join(subagentsRoot, entry.name));
+      }
+    }
+  }
+
+  await visit(resolve(input.agentRoot));
+  return { diagnostics, mounts };
+}
+
+/** Discovers mount declarations using an agent root listing already in memory. */
+export async function discoverExtensionMountDeclarationsFromEntries(input: {
+  readonly agentRoot: string;
+  readonly rootEntries: readonly ProjectSourceEntry[];
+  readonly source: ProjectSource;
+}): Promise<{
+  readonly diagnostics: DiscoverDiagnostic[];
+  readonly mounts: ExtensionMountDescriptor[];
+}> {
+  const extensionsResult = await discoverNamedSourceDirectory({
+    directoryName: "extensions",
+    invalidDirectoryCode: DISCOVER_EXTENSIONS_DIRECTORY_INVALID,
+    invalidDirectoryMessage: `Expected "${join(input.agentRoot, "extensions")}" to be a directory of extension mounts.`,
+    recursive: false,
+    rootEntries: input.rootEntries,
+    rootPath: input.agentRoot,
+    source: input.source,
+    validateSegment: createExtensionNameDiagnostic,
+  });
+  const collection = await collectExtensionMounts({
+    agentRoot: input.agentRoot,
+    fileMounts: extensionsResult.sources,
+    rootEntries: input.rootEntries,
+    source: input.source,
+  });
+
+  return {
+    diagnostics: [...extensionsResult.diagnostics, ...collection.diagnostics],
+    mounts: collection.mounts,
+  };
+}
+
+async function collectExtensionMounts(input: {
+  readonly agentRoot: string;
+  readonly fileMounts: readonly ExtensionSourceRef[];
+  readonly rootEntries: readonly ProjectSourceEntry[];
+  readonly source: ProjectSource;
+}): Promise<{
+  readonly diagnostics: DiscoverDiagnostic[];
+  readonly mounts: ExtensionMountDescriptor[];
+}> {
+  const diagnostics: DiscoverDiagnostic[] = [];
+  const extensionsRoot = join(input.agentRoot, "extensions");
+  const fileDescriptors: ExtensionMountDescriptor[] = input.fileMounts.map((mountRef) => ({
+    namespace: mountNamespace(mountRef.logicalPath),
+    mountRef,
+  }));
+  const fileNamespaces = new Set(fileDescriptors.map((descriptor) => descriptor.namespace));
+  const extensionsEntry = input.rootEntries.find((entry) => entry.name === "extensions");
+  const directoryDescriptors: ExtensionMountDescriptor[] = [];
+  const ambiguousNamespaces = new Set<string>();
+
+  if (extensionsEntry?.isDirectory() === true) {
+    const entries = await readSortedDirectoryEntries(input.source, extensionsRoot);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const namespace = entry.name;
+      const mountDir = join(extensionsRoot, namespace);
+      const nameDiagnostic = createExtensionNameDiagnostic(namespace, mountDir);
+      if (nameDiagnostic !== null) {
+        diagnostics.push(nameDiagnostic);
+        continue;
+      }
+
+      const declarationResult = discoverFlatModuleSource({
+        rootEntries: await readSortedDirectoryEntries(input.source, mountDir),
+        rootPath: mountDir,
+        slotName: "extension",
+      });
+      diagnostics.push(...declarationResult.diagnostics);
+
+      if (declarationResult.module === undefined) {
+        diagnostics.push(
+          createDiscoverErrorDiagnostic({
+            code: DISCOVER_EXTENSION_MOUNT_MISSING_DECLARATION,
+            message: `Extension mount directory "extensions/${namespace}/" must declare its mount in "extension.ts" (or another supported module extension).`,
+            sourcePath: mountDir,
+          }),
+        );
+        continue;
+      }
+
+      if (fileNamespaces.has(namespace)) {
+        ambiguousNamespaces.add(namespace);
+      }
+
+      directoryDescriptors.push({
+        namespace,
+        mountRef: createModuleSourceRef({
+          logicalPath: normalizeLogicalPath(
+            join("extensions", namespace, declarationResult.module.logicalPath),
+          ),
+        }),
+        overridesRoot: mountDir,
+      });
+    }
+  }
+
+  for (const namespace of ambiguousNamespaces) {
+    diagnostics.push(
+      createDiscoverErrorDiagnostic({
+        code: DISCOVER_EXTENSION_MOUNT_AMBIGUOUS,
+        message: `Extension namespace "${namespace}" is claimed by both a file mount ("extensions/${namespace}.ts") and a directory mount ("extensions/${namespace}/"). Keep only one.`,
+        sourcePath: extensionsRoot,
+      }),
+    );
+  }
+
+  return {
+    diagnostics,
+    mounts: [...fileDescriptors, ...directoryDescriptors].filter(
+      (descriptor) => !ambiguousNamespaces.has(descriptor.namespace),
+    ),
+  };
+}

--- a/packages/eve/src/discover/filesystem.ts
+++ b/packages/eve/src/discover/filesystem.ts
@@ -62,6 +62,7 @@ export type AgentRootEntryKind =
 export type LocalSubagentEntryKind =
   | "agent-config-module"
   | "connections-directory"
+  | "extensions-directory"
   | "hooks-directory"
   | "ignored-directory"
   | "instructions-directory"
@@ -243,6 +244,10 @@ export function classifyLocalSubagentEntry(
 
     if (name === "connections") {
       return "connections-directory";
+    }
+
+    if (name === "extensions") {
+      return "extensions-directory";
     }
 
     if (name === "hooks") {

--- a/packages/eve/src/discover/manifest.ts
+++ b/packages/eve/src/discover/manifest.ts
@@ -195,8 +195,8 @@ export interface AgentSourceManifest {
   extensions: ExtensionSourceRef[];
   /**
    * Mounted extensions resolved to their packages and discovered source trees.
-   * Populated only for the agent root; extension trees do not mount further
-   * extensions (transitive mounting is a non-goal).
+   * Populated for the root agent and declared local subagents; extension trees
+   * do not mount further extensions (transitive mounting is a non-goal).
    */
   resolvedExtensions: ResolvedExtensionMount[];
   hooks: ModuleSourceRef[];

--- a/packages/eve/src/discover/mounted-extensions.ts
+++ b/packages/eve/src/discover/mounted-extensions.ts
@@ -1,0 +1,163 @@
+import { join } from "node:path";
+
+import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discover/diagnostics.js";
+import {
+  DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
+  DISCOVER_EXTENSION_OVERRIDE_OUTSIDE_MOUNT,
+  locateExtensionMount,
+} from "#discover/extensions.js";
+import {
+  discoverExtensionMountDeclarationsFromEntries,
+  type ExtensionMountDescriptor,
+} from "#discover/extension-mount-declarations.js";
+import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "#discover/filesystem.js";
+import type {
+  AgentSourceManifest,
+  ExtensionSourceRef,
+  ResolvedExtensionMount,
+} from "#discover/manifest.js";
+import type { ProjectSource, ProjectSourceEntry } from "#discover/project-source.js";
+
+/** Discovers an extension-owned agent-shaped source tree. */
+export type DiscoverExtensionSourceTree = (input: {
+  readonly agentRoot: string;
+  readonly appRoot: string;
+  readonly source: ProjectSource;
+}) => Promise<{
+  readonly diagnostics: DiscoverDiagnostic[];
+  readonly manifest: AgentSourceManifest;
+}>;
+
+/** Discovers and resolves the mounted extensions owned by one agent graph node. */
+export async function discoverMountedExtensions(input: {
+  readonly agentRoot: string;
+  readonly appRoot: string;
+  readonly contributionSources: ReadonlyArray<{ readonly logicalPath: string }>;
+  readonly discoverExtensionSourceTree: DiscoverExtensionSourceTree;
+  readonly resolveMounts: boolean;
+  readonly rootEntries: readonly ProjectSourceEntry[];
+  readonly source: ProjectSource;
+}): Promise<{
+  readonly diagnostics: DiscoverDiagnostic[];
+  readonly extensions: ExtensionSourceRef[];
+  readonly resolvedExtensions: ResolvedExtensionMount[];
+}> {
+  const declarations = await discoverExtensionMountDeclarationsFromEntries({
+    agentRoot: input.agentRoot,
+    rootEntries: input.rootEntries,
+    source: input.source,
+  });
+  const diagnostics = [...declarations.diagnostics];
+  const extensions = declarations.mounts.map((descriptor) => descriptor.mountRef);
+
+  diagnostics.push(
+    ...detectRootNamespaceCollisions({
+      agentRoot: input.agentRoot,
+      namespaces: declarations.mounts.map((descriptor) => descriptor.namespace),
+      sources: input.contributionSources,
+    }),
+  );
+
+  if (!input.resolveMounts) {
+    diagnostics.push(...createNestedMountDiagnostics(input.agentRoot, declarations.mounts));
+    return { diagnostics, extensions, resolvedExtensions: [] };
+  }
+
+  const resolvedExtensions: ResolvedExtensionMount[] = [];
+  for (const descriptor of declarations.mounts) {
+    const located = await locateExtensionMount({
+      source: input.source,
+      agentRoot: input.agentRoot,
+      appRoot: input.appRoot,
+      mount: descriptor.mountRef,
+      namespace: descriptor.namespace,
+    });
+    diagnostics.push(...located.diagnostics);
+    if (located.location === undefined) {
+      continue;
+    }
+
+    const extensionResult = await input.discoverExtensionSourceTree({
+      agentRoot: located.location.sourceRoot,
+      appRoot: located.location.packageRoot,
+      source: input.source,
+    });
+    diagnostics.push(...extensionResult.diagnostics);
+
+    let overrides: AgentSourceManifest | undefined;
+    if (descriptor.overridesRoot !== undefined) {
+      const overridesResult = await input.discoverExtensionSourceTree({
+        agentRoot: descriptor.overridesRoot,
+        appRoot: input.appRoot,
+        source: input.source,
+      });
+      diagnostics.push(...overridesResult.diagnostics);
+      overrides = overridesResult.manifest;
+    }
+
+    const resolved: { -readonly [K in keyof ResolvedExtensionMount]: ResolvedExtensionMount[K] } = {
+      namespace: located.location.namespace,
+      specifier: located.location.specifier,
+      packageName: located.location.packageName,
+      packageRoot: located.location.packageRoot,
+      sourceRoot: located.location.sourceRoot,
+      manifest: extensionResult.manifest,
+    };
+    if (overrides !== undefined) {
+      resolved.overrides = overrides;
+    }
+    resolvedExtensions.push(resolved);
+  }
+
+  return { diagnostics, extensions, resolvedExtensions };
+}
+
+function createNestedMountDiagnostics(
+  agentRoot: string,
+  mounts: readonly ExtensionMountDescriptor[],
+): DiscoverDiagnostic[] {
+  return mounts.map((descriptor) =>
+    createDiscoverErrorDiagnostic({
+      code: DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
+      message: `"${descriptor.mountRef.logicalPath}" mounts an extension from inside an extension, which is not supported yet. Extensions cannot mount other extensions; remove the "extensions/" slot.`,
+      sourcePath: join(agentRoot, descriptor.mountRef.logicalPath),
+    }),
+  );
+}
+
+function detectRootNamespaceCollisions(input: {
+  readonly agentRoot: string;
+  readonly namespaces: readonly string[];
+  readonly sources: ReadonlyArray<{ readonly logicalPath: string }>;
+}): DiscoverDiagnostic[] {
+  if (input.namespaces.length === 0) {
+    return [];
+  }
+
+  const diagnostics: DiscoverDiagnostic[] = [];
+  for (const source of input.sources) {
+    const name = rootContributionName(source.logicalPath);
+    const namespace = input.namespaces.find((candidate) => name.startsWith(`${candidate}__`));
+    if (namespace !== undefined) {
+      diagnostics.push(
+        createDiscoverErrorDiagnostic({
+          code: DISCOVER_EXTENSION_OVERRIDE_OUTSIDE_MOUNT,
+          message: `"${source.logicalPath}" uses the "${namespace}__" prefix reserved for the mounted extension "${namespace}". Override an extension's contributions inside its mount directory ("extensions/${namespace}/…"), not at the agent root.`,
+          sourcePath: join(input.agentRoot, source.logicalPath),
+        }),
+      );
+    }
+  }
+  return diagnostics;
+}
+
+function rootContributionName(logicalPath: string): string {
+  const afterSlot = logicalPath.slice(logicalPath.indexOf("/") + 1);
+  const firstSegment = afterSlot.split("/")[0] ?? afterSlot;
+  for (const extension of SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS) {
+    if (firstSegment.toLowerCase().endsWith(extension)) {
+      return firstSegment.slice(0, firstSegment.length - extension.length);
+    }
+  }
+  return firstSegment;
+}

--- a/packages/eve/src/discover/subagent.integration.test.ts
+++ b/packages/eve/src/discover/subagent.integration.test.ts
@@ -11,7 +11,72 @@ import {
   discoverSubagents,
 } from "#discover/discover-subagent.js";
 
+const discoverExtensionSourceTree = async (
+  input: Parameters<typeof discoverAgent>[0],
+): ReturnType<typeof discoverAgent> => await discoverAgent({ ...input, role: "extension" });
+const extensionCompatibilityManifest = JSON.stringify({
+  kind: "eve-extension",
+  formatVersion: 1,
+  builtWithEve: "0.0.0-test",
+  requires: { extension: 1, tool: 1 },
+});
+
 describe("discoverSubagents (memory)", () => {
+  it("discovers extension mounts owned by multiple local subagents", async () => {
+    const project = buildMemoryAgentProject({
+      appFiles: {
+        "node_modules/@acme/shared/package.json": JSON.stringify({
+          name: "@acme/shared",
+          eve: { extension: { dist: "extension" } },
+        }),
+        "node_modules/@acme/shared/extension/_manifest.json": extensionCompatibilityManifest,
+        "node_modules/@acme/shared/extension/tools/search.ts":
+          'throw new Error("extension modules should not execute during discovery");\n',
+      },
+      agentFiles: {
+        "instructions.md": "Route requests.",
+        "subagents/researcher/agent.ts":
+          'throw new Error("subagent modules should not execute during discovery");\n',
+        "subagents/researcher/extensions/shared.ts": 'export { default } from "@acme/shared";\n',
+        "subagents/reviewer/agent.ts":
+          'throw new Error("subagent modules should not execute during discovery");\n',
+        "subagents/reviewer/extensions/shared.ts": 'export { default } from "@acme/shared";\n',
+      },
+    });
+
+    const result = await discoverAgent({
+      agentRoot: project.agentRoot,
+      appRoot: project.appRoot,
+      source: project.source,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.manifest.subagents).toHaveLength(2);
+    for (const subagent of result.manifest.subagents) {
+      expect(subagent.manifest.extensions).toEqual([
+        {
+          logicalPath: "extensions/shared.ts",
+          sourceId: "extensions/shared.ts",
+          sourceKind: "module",
+        },
+      ]);
+      expect(subagent.manifest.resolvedExtensions).toHaveLength(1);
+      expect(subagent.manifest.resolvedExtensions[0]).toMatchObject({
+        namespace: "shared",
+        packageName: "@acme/shared",
+        manifest: {
+          tools: [
+            {
+              logicalPath: "tools/search.ts",
+              sourceId: "tools/search.ts",
+              sourceKind: "module",
+            },
+          ],
+        },
+      });
+    }
+  });
+
   it("discovers recursive local subagent packages through the agent manifest", async () => {
     const project = buildMemoryAgentProject({
       agentFiles: {
@@ -185,6 +250,7 @@ describe("discoverSubagents (memory)", () => {
     const result = await discoverSubagents({
       agentRoot: project.agentRoot,
       appRoot: project.appRoot,
+      discoverExtensionSourceTree,
       source: project.source,
     });
 
@@ -216,6 +282,7 @@ describe("discoverSubagents (memory)", () => {
     const result = await discoverSubagents({
       agentRoot: project.agentRoot,
       appRoot: project.appRoot,
+      discoverExtensionSourceTree,
       source: project.source,
     });
 
@@ -247,6 +314,7 @@ describe("discoverSubagents (memory)", () => {
     const result = await discoverSubagents({
       agentRoot: project.agentRoot,
       appRoot: project.appRoot,
+      discoverExtensionSourceTree,
       source: project.source,
     });
 
@@ -277,6 +345,7 @@ describe("discoverSubagents (memory)", () => {
     const result = await discoverSubagents({
       agentRoot: project.agentRoot,
       appRoot: project.appRoot,
+      discoverExtensionSourceTree,
       source: project.source,
     });
 
@@ -308,6 +377,7 @@ describe("discoverSubagents (memory)", () => {
     const result = await discoverSubagents({
       agentRoot: project.agentRoot,
       appRoot: project.appRoot,
+      discoverExtensionSourceTree,
       source: project.source,
     });
 

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
-import type { CompiledAgentManifest } from "#compiler/manifest.js";
+import { collectCompiledExtensionMounts, type CompiledAgentManifest } from "#compiler/manifest.js";
 import { createCompiledModuleMapSource } from "#compiler/module-map.js";
 import { createAuthoredAssetImportPlugin } from "#internal/authored-asset-import-plugin.js";
 import { assertNoWorkflowDirectivePrologue } from "#internal/authored-directive-prologue.js";
@@ -268,7 +268,7 @@ export async function bundleAuthoredModuleMapForGeneration(input: {
     moduleMapPath: input.moduleMapPath,
   });
   const extensionScopePlugin = createExtensionScopePlugin(
-    input.manifest.extensionMounts.map((mount) => ({
+    collectCompiledExtensionMounts(input.manifest).map((mount) => ({
       packageNamespace: mount.packageNamespace,
       sourceRoot: mount.sourceRoot,
     })),

--- a/packages/eve/src/internal/authored-module-map-loader.ts
+++ b/packages/eve/src/internal/authored-module-map-loader.ts
@@ -80,26 +80,29 @@ async function hydrateCompiledModuleMapFromManifest(
       })),
   ];
 
-  const scopeIndex: ExtensionScopeIndex = {
-    byMountNamespace: new Map(
-      manifest.extensionMounts.map((mount) => [mount.namespace, mount.packageNamespace]),
-    ),
-    byMountSourceId: new Map(
-      manifest.extensionMounts.map((mount) => [mount.mountSourceId, mount.packageNamespace]),
-    ),
-  };
   for (const nodeManifest of nodeManifests) {
     nodes[nodeManifest.nodeId] = {
       modules: await hydrateCompiledNodeScope({
         agentRoot: nodeManifest.agentRoot,
         manifest: nodeManifest.manifest,
-        scopeIndex,
+        scopeIndex: createExtensionScopeIndex(nodeManifest.manifest),
       }),
     };
   }
 
   return {
     nodes,
+  };
+}
+
+function createExtensionScopeIndex(manifest: CompiledAgentNodeManifest): ExtensionScopeIndex {
+  return {
+    byMountNamespace: new Map(
+      manifest.extensionMounts.map((mount) => [mount.namespace, mount.packageNamespace]),
+    ),
+    byMountSourceId: new Map(
+      manifest.extensionMounts.map((mount) => [mount.mountSourceId, mount.packageNamespace]),
+    ),
   };
 }
 

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -38,7 +38,7 @@ import type {
 import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
 import { applyWorkflowTransform } from "#internal/workflow-bundle/workflow-builders.js";
 import { transformDynamicToolExecute } from "#internal/workflow-bundle/dynamic-tool-transform.js";
-import type { CompiledAgentManifest } from "#compiler/manifest.js";
+import { collectCompiledExtensionMounts, type CompiledAgentManifest } from "#compiler/manifest.js";
 
 /**
  * Bare `workflow/*` specifiers that appear in pre-built workflow bundles.
@@ -648,7 +648,7 @@ function createApplicationNitroBundlerConfiguration(
     ).push(packageName);
   }
   const extensionScopePlugin = createExtensionScopePlugin(
-    (preparedHost.compileResult.manifest.extensionMounts ?? []).map((mount) => ({
+    collectCompiledExtensionMounts(preparedHost.compileResult.manifest).map((mount) => ({
       sourceRoot: mount.sourceRoot,
       packageNamespace: mount.packageNamespace,
     })),

--- a/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
+++ b/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
@@ -16,7 +16,8 @@ export async function computeDevelopmentHostFingerprint(
       externalDependencies: [
         ...new Set(agentNodes.flatMap((node) => node.config.build?.externalDependencies ?? [])),
       ].sort((left, right) => left.localeCompare(right)),
-      extensionScopes: (manifest.extensionMounts ?? [])
+      extensionScopes: agentNodes
+        .flatMap((node) => node.extensionMounts)
         .map((mount) => ({
           packageNamespace: mount.packageNamespace,
           sourceRoot: mount.sourceRoot,

--- a/packages/eve/src/internal/nitro/host/dev-workspace-extensions.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-workspace-extensions.integration.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { discoverExtensionMountDeclarations } from "#discover/discover-agent.js";
 import { locateExtensionMountPackage } from "#discover/extensions.js";
+import { discoverExtensionMountDeclarations } from "#discover/extension-mount-declarations.js";
 import { createDiskProjectSource } from "#discover/project-source.js";
 import { resolveDiscoveryProject } from "#discover/project.js";
 import {
@@ -156,6 +156,28 @@ describe("prepareDevelopmentWorkspaceExtensions", () => {
     });
 
     expect(mocks.buildExtensionPackage).toHaveBeenCalledTimes(2);
+  });
+
+  it("builds a workspace extension mounted only by a nested local subagent", async () => {
+    const appRoot = await createWorkspaceAgent(["alpha"]);
+    await rm(join(appRoot, "agent", "extensions", "alpha.ts"));
+    await writeText(
+      join(appRoot, "agent", "subagents", "researcher", "agent.ts"),
+      "export default {};\n",
+    );
+    await writeText(
+      join(appRoot, "agent", "subagents", "researcher", "extensions", "alpha.ts"),
+      'export { default } from "../../../../packages/alpha";\n',
+    );
+
+    const extensions = await prepareDevelopmentWorkspaceExtensions({ appRoot });
+
+    expect(extensions).toHaveLength(1);
+    expect(mocks.buildExtensionPackage).toHaveBeenCalledOnce();
+    expect(mocks.buildExtensionPackage).toHaveBeenCalledWith(
+      join(appRoot, "packages", "alpha"),
+      expect.objectContaining({ packageName: "@acme/alpha" }),
+    );
   });
 });
 

--- a/packages/eve/src/internal/nitro/host/dev-workspace-extensions.ts
+++ b/packages/eve/src/internal/nitro/host/dev-workspace-extensions.ts
@@ -1,11 +1,11 @@
 import { realpath, stat } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
 
-import {
-  discoverExtensionMountDeclarations,
-  type ExtensionMountDescriptor,
-} from "#discover/discover-agent.js";
 import { locateExtensionMountPackage } from "#discover/extensions.js";
+import {
+  discoverExtensionMountDeclarationsRecursively,
+  type ExtensionMountDescriptor,
+} from "#discover/extension-mount-declarations.js";
 import { createDiskProjectSource } from "#discover/project-source.js";
 import { resolveDiscoveryProject } from "#discover/project.js";
 import { resolveTsConfigDependencyPaths } from "#internal/application/tsconfig-dependencies.js";
@@ -40,18 +40,18 @@ export async function prepareDevelopmentWorkspaceExtensions(input: {
   const appRoot = resolve(input.appRoot);
   const project = await resolveDiscoveryProject(appRoot);
   const source = createDiskProjectSource();
-  const discovered = await discoverExtensionMountDeclarations({
+  const discovered = await discoverExtensionMountDeclarationsRecursively({
     agentRoot: project.agentRoot,
     source,
   });
   const workspaceSourceRoot = await toCanonicalPath(resolveDevelopmentSourceRoot(appRoot));
   const extensionsByPackageRoot = new Map<string, DevelopmentWorkspaceExtension>();
 
-  for (const mount of discovered.mounts) {
+  for (const discoveredMount of discovered.mounts) {
     const extension = await resolveWorkspaceExtension({
       appRoot,
-      agentRoot: project.agentRoot,
-      mount,
+      agentRoot: discoveredMount.agentRoot,
+      mount: discoveredMount.mount,
       source,
       workspaceSourceRoot,
     });

--- a/packages/eve/test/scenarios/mounted-extension-subagent.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-subagent.scenario.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import { compileAgent } from "../../src/compiler/compile-agent.js";
+import { loadCompiledModuleMapFromAuthoredSource } from "../../src/internal/authored-module-map-loader.js";
+import { useScenarioApp } from "../../src/internal/testing/scenario-app.js";
+import { createDiskRuntimeCompiledArtifactsSource } from "../../src/runtime/compiled-artifacts-source.js";
+import { loadCompiledManifest } from "../../src/runtime/loaders/manifest.js";
+import { resolveRuntimeAgentGraph } from "../../src/runtime/resolve-agent-graph.js";
+
+const scenarioApp = useScenarioApp();
+const compatibilityManifest = JSON.stringify({
+  kind: "eve-extension",
+  formatVersion: 1,
+  builtWithEve: "0.0.0-test",
+  requires: { config: 1, extension: 1, instructions: 1, skill: 1, tool: 1 },
+});
+
+describe("mounted extensions in local subagents", () => {
+  it("mounts one extension in the root and multiple declared subagents", async () => {
+    const app = await scenarioApp({
+      name: "mounted-extension-subagent",
+      installDependencies: true,
+      files: {
+        "agent/agent.mjs": 'export default { model: "openai/gpt-5.4" };\n',
+        "agent/instructions.md": "Route requests to specialists.\n",
+        "agent/extensions/shared.mjs": [
+          'import shared from "@acme/shared";',
+          'export default shared({ marker: "shared-config" });',
+          "",
+        ].join("\n"),
+        "agent/subagents/auditor/agent.mjs": [
+          "export default {",
+          '  description: "Audit an answer.",',
+          '  model: "openai/gpt-5.4",',
+          "};",
+          "",
+        ].join("\n"),
+        "agent/subagents/auditor/extensions/shared.mjs": [
+          'import shared from "@acme/shared";',
+          'export default shared({ marker: "shared-config" });',
+          "",
+        ].join("\n"),
+        "agent/subagents/researcher/agent.mjs": [
+          "export default {",
+          '  description: "Research a question.",',
+          '  model: "openai/gpt-5.4",',
+          "};",
+          "",
+        ].join("\n"),
+        "agent/subagents/researcher/extensions/shared.mjs": [
+          'import shared from "@acme/shared";',
+          'export default shared({ marker: "shared-config" });',
+          "",
+        ].join("\n"),
+        "agent/subagents/reviewer/agent.mjs": [
+          "export default {",
+          '  description: "Review an answer.",',
+          '  model: "openai/gpt-5.4",',
+          "};",
+          "",
+        ].join("\n"),
+        "agent/subagents/reviewer/extensions/shared.mjs": [
+          'import review from "@acme/review";',
+          'export default review({ marker: "review-config" });',
+          "",
+        ].join("\n"),
+        "node_modules/@acme/shared/package.json": `${JSON.stringify({
+          name: "@acme/shared",
+          type: "module",
+          eve: { extension: { dist: "extension" } },
+          exports: { ".": "./extension/extension.mjs" },
+        })}\n`,
+        "node_modules/@acme/shared/extension/_manifest.json": compatibilityManifest,
+        "node_modules/@acme/shared/extension/extension.mjs": [
+          'import { defineExtension } from "eve/extension";',
+          "const config = {",
+          '  "~standard": {',
+          "    version: 1,",
+          '    vendor: "scenario",',
+          "    validate: (value) => ({ value }),",
+          "  },",
+          "};",
+          "export default defineExtension({ config });",
+          "",
+        ].join("\n"),
+        "node_modules/@acme/shared/extension/instructions.md":
+          "Use the shared knowledge workflow.\n",
+        "node_modules/@acme/shared/extension/skills/guide/SKILL.md": [
+          "---",
+          "description: Follow the shared research guide.",
+          "---",
+          "",
+          "# Shared guide",
+          "",
+        ].join("\n"),
+        "node_modules/@acme/shared/extension/tools/search.mjs": [
+          'import { defineTool } from "eve/tools";',
+          'import extension from "../extension.mjs";',
+          "export default defineTool({",
+          '  description: "Search shared knowledge.",',
+          "  inputSchema: { type: 'object', properties: {}, additionalProperties: false },",
+          "  async execute() {",
+          '    return { marker: extension.config.marker, source: "shared-extension" };',
+          "  },",
+          "});",
+          "",
+        ].join("\n"),
+        "node_modules/@acme/review/package.json": `${JSON.stringify({
+          name: "@acme/review",
+          type: "module",
+          eve: { extension: { dist: "extension" } },
+          exports: { ".": "./extension/extension.mjs" },
+        })}\n`,
+        "node_modules/@acme/review/extension/_manifest.json": compatibilityManifest,
+        "node_modules/@acme/review/extension/extension.mjs": [
+          'import { defineExtension } from "eve/extension";',
+          "const config = {",
+          '  "~standard": {',
+          "    version: 1,",
+          '    vendor: "scenario",',
+          "    validate: (value) => ({ value }),",
+          "  },",
+          "};",
+          "export default defineExtension({ config });",
+          "",
+        ].join("\n"),
+        "node_modules/@acme/review/extension/instructions.md":
+          "Use the independent review workflow.\n",
+        "node_modules/@acme/review/extension/skills/guide/SKILL.md": [
+          "---",
+          "description: Follow the independent review guide.",
+          "---",
+          "",
+          "# Review guide",
+          "",
+        ].join("\n"),
+        "node_modules/@acme/review/extension/tools/search.mjs": [
+          'import { defineTool } from "eve/tools";',
+          'import extension from "../extension.mjs";',
+          "export default defineTool({",
+          '  description: "Review shared knowledge.",',
+          "  inputSchema: { type: 'object', properties: {}, additionalProperties: false },",
+          "  async execute() {",
+          '    return { marker: extension.config.marker, source: "review-extension" };',
+          "  },",
+          "});",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    await compileAgent({ startPath: app.appRoot });
+
+    const compiledArtifactsSource = createDiskRuntimeCompiledArtifactsSource(app.appRoot);
+    const [manifest, moduleMap] = await Promise.all([
+      loadCompiledManifest({ compiledArtifactsSource }),
+      loadCompiledModuleMapFromAuthoredSource({ compiledArtifactsSource }),
+    ]);
+    const graph = await resolveRuntimeAgentGraph({ manifest, moduleMap });
+
+    expect(manifest.extensionMounts).toHaveLength(1);
+    expect(manifest.subagents.map((subagent) => subagent.agent.extensionMounts.length)).toEqual([
+      1, 1, 1,
+    ]);
+
+    for (const [node, expected] of [
+      [graph.root, { marker: "shared-config", source: "shared-extension" }],
+      [
+        graph.nodesByNodeId.get("subagents/auditor"),
+        { marker: "shared-config", source: "shared-extension" },
+      ],
+      [
+        graph.nodesByNodeId.get("subagents/researcher"),
+        { marker: "shared-config", source: "shared-extension" },
+      ],
+      [
+        graph.nodesByNodeId.get("subagents/reviewer"),
+        { marker: "review-config", source: "review-extension" },
+      ],
+    ] as const) {
+      const tool = node?.agent.tools.find((entry) => entry.name === "shared__search");
+      expect(tool).toBeDefined();
+      expect(node?.agent.skills.some((skill) => skill.name === "shared__guide")).toBe(true);
+      await expect(tool?.execute?.({}, { messages: [], toolCallId: "call_1" })).resolves.toEqual(
+        expected,
+      );
+    }
+    expect(graph.root.agent.instructions?.markdown).toContain("Use the shared knowledge workflow.");
+    expect(graph.nodesByNodeId.get("subagents/reviewer")?.agent.instructions?.markdown).toContain(
+      "Use the independent review workflow.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- allow declared local subagents to discover and resolve their own `extensions/` mounts
- preserve mount ownership through compiled node manifests, module loading, production bundling, development fingerprints, and monorepo extension prebuilds
- document how root agents and multiple subagents can share one capability package, with a patch changeset and fixture-owned E2E coverage

This follows the workspace extension documentation merged in #1161.

## Testing

- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm exec oxlint <changed TypeScript files>`
- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter eve build:js`
- `pnpm --filter extensions exec tsc -p tsconfig.json --noEmit`
- focused unit tests: 18 passed
- focused integration tests: 53 passed after rebase
- mounted-extension subagent scenario: passed after rebase
- added `extensions/evals/subagent-mount.eval.ts`; it verifies a subagent-mounted tool resolves `extension/lib/brand` and runs in CI

The full unit suite completed with 5,366 passing tests; its only four failures were the CLI bootstrap guards rejecting local Node v22.14.0 because eve requires Node >=24.