### PR TITLE
feat(eve): add ability to unsubscribe eve from Slack threads (v3)

### DIFF
--- a/.changeset/slack-thread-unsubscribe.md
+++ b/.changeset/slack-thread-unsubscribe.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Added `resolveSubscription` to the Slack channel for durable thread subscription policy. Unsubscribed threads retain their eve session and history, ignore admitted messages before model execution, and resume when the policy returns `"subscribed"`.
+Added Slack `threadSubscription` configuration for following active threads and durably refining when the bot steps away. Unsubscribed threads retain their eve session and history while admitted messages are ignored before model execution.

--- a/.changeset/slack-thread-unsubscribe.md
+++ b/.changeset/slack-thread-unsubscribe.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Added `resolveSubscription` to the Slack channel for durable thread subscription policy. Unsubscribed threads retain their eve session and history, ignore admitted messages before model execution, and resume when the policy returns `"subscribed"`.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -88,6 +88,27 @@ export default slackChannel({
 
 `isBotMentioned()` identifies an explicit mention. `isSubscribed()` checks whether the message belongs to a thread with an active eve session. For Vercel Connect, open **Advanced** when creating the connector and add `message.channels` under **Trigger Event Types** and `channels:history` under **Bot Scopes**. Private channels additionally need `message.groups` and `groups:history`.
 
+Use `resolveSubscription` when the thread should stop dispatching messages while preserving its eve session and history. `onMessage` still runs at webhook ingress and decides whether to admit the message. For every admitted message, `resolveSubscription` runs inside the durable session after Slack channel state and `defineState` are hydrated. Return `"subscribed"` to dispatch the message to the agent, or `"unsubscribed"` to persist that state and ignore the message before it enters model history:
+
+```ts title="agent/channels/slack.ts"
+export default slackChannel({
+  credentials: connectSlackCredentials("slack/my-agent"),
+  async onMessage(ctx, message) {
+    if (message.author?.isBot) return null;
+    return ctx.isBotMentioned() || (await ctx.isSubscribed()) ? { auth: null } : null;
+  },
+  resolveSubscription({ current, isBotMentioned }, message) {
+    if (isBotMentioned) return "subscribed";
+    if (current === "unsubscribed") return current;
+
+    const mentionsSomeone = /<@[A-Z0-9]+(?:\|[^>]+)?>/.test(message.text);
+    return mentionsSomeone ? "unsubscribed" : current;
+  },
+});
+```
+
+The default resolver returns `"subscribed"` for an explicit bot mention and otherwise preserves the current state. A custom resolver controls resubscription, so preserve that explicit-mention behavior when users should be able to bring the bot back. Messages ignored as unsubscribed still wake the existing workflow long enough to hydrate and persist state, but they do not start an agent turn.
+
 Use `ctx.thread.listParticipants()` when routing depends on who has joined the thread. It fetches the current thread and returns unique human Slack user ids in first-appearance order, so the first id is the starting author for a human-started thread. Bot and system messages are excluded:
 
 ```ts

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -71,43 +71,37 @@ Only the first available handler runs. A message hook returning `null` drops the
 
 #### Continue conversations without repeated mentions
 
-Use `onMessage` to handle explicit mentions and continue replies in threads with an active eve session:
+By default, channel messages dispatch only when they explicitly mention the bot. Enable `threadSubscription` to also respond to human replies in threads with an active eve session:
 
 ```ts title="agent/channels/slack.ts"
 export default slackChannel({
   credentials: connectSlackCredentials("slack/my-agent"),
-  async onMessage(ctx, message) {
-    if (message.author?.isBot) return null;
-    const isDirectMessage = message.raw.channel_type === "im";
-    return isDirectMessage || ctx.isBotMentioned() || (await ctx.isSubscribed())
-      ? { auth: null }
-      : null;
-  },
+  threadSubscription: true,
 });
 ```
 
-`isBotMentioned()` identifies an explicit mention. `isSubscribed()` checks whether the message belongs to a thread with an active eve session. For Vercel Connect, open **Advanced** when creating the connector and add `message.channels` under **Trigger Event Types** and `channels:history` under **Bot Scopes**. Private channels additionally need `message.groups` and `groups:history`.
+For Vercel Connect, open **Advanced** when creating the connector and add `message.channels` under **Trigger Event Types** and `channels:history` under **Bot Scopes**. Private channels additionally need `message.groups` and `groups:history`.
 
-Use `resolveSubscription` when the thread should stop dispatching messages while preserving its eve session and history. `onMessage` still runs at webhook ingress and decides whether to admit the message. For every admitted message, `resolveSubscription` runs inside the durable session after Slack channel state and `defineState` are hydrated. Return `"subscribed"` to dispatch the message to the agent, or `"unsubscribed"` to persist that state and ignore the message before it enters model history:
+To refine when the bot remains subscribed, replace `true` with a resolver. The resolver runs inside the durable session after Slack channel state and `defineState` are hydrated. It receives the current state for every admitted message. Return `"subscribed"` to dispatch the message to the agent, or `"unsubscribed"` to persist that state and ignore the message before it enters model history:
 
 ```ts title="agent/channels/slack.ts"
 export default slackChannel({
   credentials: connectSlackCredentials("slack/my-agent"),
-  async onMessage(ctx, message) {
-    if (message.author?.isBot) return null;
-    return ctx.isBotMentioned() || (await ctx.isSubscribed()) ? { auth: null } : null;
-  },
-  resolveSubscription({ current, isBotMentioned }, message) {
-    if (isBotMentioned) return "subscribed";
-    if (current === "unsubscribed") return current;
+  threadSubscription: {
+    resolve({ current, isBotMentioned }, message) {
+      if (isBotMentioned) return "subscribed";
+      if (current === "unsubscribed") return current;
 
-    const mentionsSomeone = /<@[A-Z0-9]+(?:\|[^>]+)?>/.test(message.text);
-    return mentionsSomeone ? "unsubscribed" : current;
+      const mentionsSomeone = /<@[A-Z0-9]+(?:\|[^>]+)?>/.test(message.text);
+      return mentionsSomeone ? "unsubscribed" : current;
+    },
   },
 });
 ```
 
-The default resolver returns `"subscribed"` for an explicit bot mention and otherwise preserves the current state. A custom resolver controls resubscription, so preserve that explicit-mention behavior when users should be able to bring the bot back. Messages ignored as unsubscribed still wake the existing workflow long enough to hydrate and persist state, but they do not start an agent turn.
+With `threadSubscription: true`, explicit bot mentions subscribe the thread and other messages preserve its current state. A custom resolver controls resubscription, so preserve the explicit-mention branch when users should be able to bring the bot back. Messages ignored as unsubscribed still wake the existing workflow long enough to hydrate and persist state, but they do not start an agent turn.
+
+Use `onMessage` only when you need lower-level webhook-side admission, custom auth, or pre-dispatch behavior. `ctx.isBotMentioned()` identifies explicit mentions, while `ctx.isSubscribed()` is a point-in-time check for an active eve session; it does not read the durable `threadSubscription` state.
 
 Use `ctx.thread.listParticipants()` when routing depends on who has joined the thread. It fetches the current thread and returns unique human Slack user ids in first-appearance order, so the first id is the starting author for a human-started thread. Bot and system messages are excluded:
 

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -42,6 +42,8 @@ export interface RouteHandlerArgs<TState = undefined> {
 export interface SendPayload {
   readonly message?: string | UserContent;
   readonly inputResponses?: readonly InputResponse[];
+  /** @internal Channel-owned serializable data for durable delivery processing. */
+  readonly channelData?: unknown;
   /**
    * Context strings contributed by the channel. eve appends each entry
    * as a `role: "user"` message to `session.history` before the delivery

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -117,6 +117,31 @@ describe("createSendFn", () => {
     });
   });
 
+  it("forwards channel-owned delivery data through deliver and run inputs", async () => {
+    const channelData = { kind: "test-message", value: 1 };
+    const deliverRuntime: Runtime = {
+      cancelTurn: vi.fn(),
+      deliver: vi.fn().mockResolvedValue({ sessionId: "existing-session-id" }),
+      resolveSession: vi.fn(),
+      run: vi.fn().mockResolvedValue(createMockRunHandle()),
+      getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
+    };
+
+    const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test");
+    await deliverSend(
+      { channelData, message: "hello" },
+      { auth: null, continuationToken: "token" },
+    );
+    expect(vi.mocked(deliverRuntime.deliver).mock.calls[0]?.[0].payload.channelData).toEqual(
+      channelData,
+    );
+
+    const runRuntime = createRuntime(new RuntimeNoActiveSessionError("test:token"));
+    const runSend = createSendFn(runRuntime, ADAPTER, "test");
+    await runSend({ channelData, message: "hello" }, { auth: null, continuationToken: "token" });
+    expect(vi.mocked(runRuntime.run).mock.calls[0]?.[0].input.channelData).toEqual(channelData);
+  });
+
   it("adds channel request ids to deliver and run inputs when provided", async () => {
     const deliverRuntime: Runtime = {
       cancelTurn: vi.fn(),

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -31,6 +31,7 @@ export function createSendFn<TState = undefined>(
     const {
       message: rawMessage,
       inputResponses,
+      channelData,
       context,
       outputSchema,
     } = normalizeSendInput(input);
@@ -41,7 +42,7 @@ export function createSendFn<TState = undefined>(
         auth,
         continuationToken,
         requestId: metadata.requestId,
-        payload: { inputResponses, message, context, outputSchema },
+        payload: { inputResponses, channelData, message, context, outputSchema },
       };
       const { sessionId } = await runtime.deliver(deliverInput);
 
@@ -73,7 +74,7 @@ export function createSendFn<TState = undefined>(
       channelName,
       callback,
       continuationToken,
-      input: { message: message ?? "", context, outputSchema },
+      input: { channelData, message: message ?? "", context, outputSchema },
       mode,
       requestId: metadata.requestId,
       title,

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -307,6 +307,8 @@ export interface RunInput {
   readonly initiatorAuth?: SessionAuthContext | null;
   readonly input: {
     readonly message: string | UserContent;
+    /** @internal Channel-owned serializable data for durable delivery processing. */
+    readonly channelData?: unknown;
     readonly context?: readonly string[];
     readonly outputSchema?: JsonObject;
   };

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -109,6 +109,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
         kind: "deliver",
         payloads: [
           {
+            channelData: input.input.channelData,
             message: input.input.message,
             context: input.input.context,
             outputSchema: input.input.outputSchema,

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -39,6 +39,7 @@ export {
   type SlackSubscriptionContext,
   type SlackSubscriptionState,
   type SlackThread,
+  type SlackThreadSubscription,
   type SlackWebhookVerifier,
   type SlackWorkspaceHandle,
 } from "#public/channels/slack/slackChannel.js";

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -36,6 +36,8 @@ export {
   type SlackMentionResultOrPromise,
   type SlackReceiveTarget,
   type SlackSessionTarget,
+  type SlackSubscriptionContext,
+  type SlackSubscriptionState,
   type SlackThread,
   type SlackWebhookVerifier,
   type SlackWorkspaceHandle,

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -396,6 +396,7 @@ export async function handleInteractionPost(
             continuationToken,
             state: {
               channelId: interaction.channelId,
+              subscription: "subscribed",
               threadTs: interaction.threadTs,
               teamId: interaction.teamId ?? null,
               triggeringUserId: user.id,
@@ -557,6 +558,7 @@ async function handleViewSubmission(
           continuationToken: metadata.continuationToken,
           state: {
             channelId: metadata.channelId,
+            subscription: "subscribed",
             threadTs: metadata.threadTs,
             teamId,
             triggeringUserId,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1404,7 +1404,7 @@ describe("slackChannel() inbound mention pipeline", () => {
 });
 
 describe("slackChannel() onMessage", () => {
-  it("exposes mention and subscription helpers", async () => {
+  it("exposes mention and active-session helpers", async () => {
     const observed: Array<{ mentioned: boolean; subscribed: boolean }> = [];
     const onMessage = vi.fn(async (ctx) => {
       observed.push({
@@ -1467,6 +1467,83 @@ describe("slackChannel() onMessage", () => {
       expect.objectContaining({ message: expect.any(String) }),
       expect.objectContaining({ continuationToken: "C01:1700000000.000100" }),
     );
+  });
+
+  it("resolves admitted message subscription inside the hydrated session", async () => {
+    const resolveSubscription = vi.fn(() => "unsubscribed" as const);
+    const channel = slackChannel({ resolveSubscription });
+    const adapter = withState(getAdapter(channel), {
+      ...THREAD_STATE,
+      subscription: "subscribed",
+    });
+    const adapterCtx = buildAdapterContext(adapter, stubAccessor());
+    const message = {
+      attachments: [],
+      channelId: "C01",
+      markdown: "handoff to @someone",
+      raw: {},
+      teamId: "T01",
+      text: "handoff to <@U02>",
+      threadTs: "1700000000.000001",
+      ts: "1700000000.000002",
+    };
+
+    const result = await contextStorage.run(stubAlsContext, () =>
+      adapter.deliver!(
+        {
+          channelData: {
+            isBotMentioned: false,
+            kind: "slack-message",
+            message,
+          },
+          message: "attributed message",
+        },
+        adapterCtx,
+      ),
+    );
+
+    expect(result).toBeUndefined();
+    expect(adapterCtx.state.subscription).toBe("unsubscribed");
+    expect(resolveSubscription).toHaveBeenCalledWith(
+      { current: "subscribed", isBotMentioned: false },
+      message,
+      expect.objectContaining({ session: expect.any(Object) }),
+    );
+  });
+
+  it("resubscribes explicit mentions by default", async () => {
+    const adapter = withState(getAdapter(slackChannel()), {
+      ...THREAD_STATE,
+      subscription: "unsubscribed",
+    });
+    const adapterCtx = buildAdapterContext(adapter, stubAccessor());
+    const message = {
+      attachments: [],
+      channelId: "C01",
+      markdown: "@eve come back",
+      raw: {},
+      teamId: "T01",
+      text: "<@U_BOT> come back",
+      threadTs: "1700000000.000001",
+      ts: "1700000000.000002",
+    };
+
+    const result = await contextStorage.run(stubAlsContext, () =>
+      adapter.deliver!(
+        {
+          channelData: {
+            isBotMentioned: true,
+            kind: "slack-message",
+            message,
+          },
+          message: "attributed message",
+        },
+        adapterCtx,
+      ),
+    );
+
+    expect(result).toEqual({ message: "attributed message" });
+    expect(adapterCtx.state.subscription).toBe("subscribed");
   });
 
   it("passes messages from other bots to onMessage", async () => {
@@ -2559,6 +2636,7 @@ describe("slackChannel().receive", () => {
     expect(options.continuationToken).toBe("C123:1700000000.000001");
     expect(options.state).toEqual({
       channelId: "C123",
+      subscription: "subscribed",
       threadTs: "1700000000.000001",
       teamId: null,
       triggeringUserId: null,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1441,7 +1441,80 @@ describe("slackChannel() onMessage", () => {
     ]);
   });
 
-  it("allows a simple mention-or-subscription policy", async () => {
+  it("ignores ordinary thread replies by default", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
+    });
+    const reply = buildEventBody(
+      {
+        channel: "C01",
+        channel_type: "channel",
+        text: "continue",
+        thread_ts: "1700000000.000100",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U01",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
+
+    const { send } = await firePost(channel, buildSignedRequest({ body: reply }));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does not start a session from an ordinary reply when threadSubscription is enabled", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
+      threadSubscription: true,
+    });
+    const reply = buildEventBody(
+      {
+        channel: "C01",
+        channel_type: "channel",
+        text: "continue",
+        thread_ts: "1700000000.000100",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U01",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
+
+    const { send } = await firePost(channel, buildSignedRequest({ body: reply }), {
+      resolveActiveSession: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("follows active threads when threadSubscription is enabled", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
+      threadSubscription: true,
+    });
+    const reply = buildEventBody(
+      {
+        channel: "C01",
+        channel_type: "channel",
+        text: "continue",
+        thread_ts: "1700000000.000100",
+        ts: "1700000000.000200",
+        type: "message",
+        user: "U01",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
+
+    const { send } = await firePost(channel, buildSignedRequest({ body: reply }));
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) }),
+      expect.objectContaining({ continuationToken: "C01:1700000000.000100" }),
+    );
+  });
+
+  it("allows an advanced onMessage admission policy", async () => {
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test", signingSecret: SIGNING_SECRET },
       async onMessage(ctx) {
@@ -1470,8 +1543,8 @@ describe("slackChannel() onMessage", () => {
   });
 
   it("resolves admitted message subscription inside the hydrated session", async () => {
-    const resolveSubscription = vi.fn(() => "unsubscribed" as const);
-    const channel = slackChannel({ resolveSubscription });
+    const resolve = vi.fn(() => "unsubscribed" as const);
+    const channel = slackChannel({ threadSubscription: { resolve } });
     const adapter = withState(getAdapter(channel), {
       ...THREAD_STATE,
       subscription: "subscribed",
@@ -1504,7 +1577,7 @@ describe("slackChannel() onMessage", () => {
 
     expect(result).toBeUndefined();
     expect(adapterCtx.state.subscription).toBe("unsubscribed");
-    expect(resolveSubscription).toHaveBeenCalledWith(
+    expect(resolve).toHaveBeenCalledWith(
       { current: "subscribed", isBotMentioned: false },
       message,
       expect.objectContaining({ session: expect.any(Object) }),
@@ -2858,6 +2931,7 @@ describe("constrainAuthorizationRequired", () => {
     const request = vi.fn().mockResolvedValue({ ok: true });
     const state: SlackChannelState = {
       channelId: "C123",
+      subscription: "subscribed",
       threadTs: "111.222",
       teamId: null,
       triggeringUserId: "U777",

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -1,9 +1,12 @@
 import { parseSlackWebhookBody } from "#compiled/@chat-adapter/slack/webhook.js";
 
+import { defaultDeliverResult, type ChannelAdapter } from "#channel/adapter.js";
+import type { CompiledChannel } from "#channel/compiled-channel.js";
 import type { CrossChannelReceiveOptions } from "#channel/cross-channel-receive.js";
 import type { Session, SessionHandle } from "#channel/session.js";
 import type { CancelTurnResult, SessionAuthContext } from "#channel/types.js";
 import type { CardElement } from "#compiled/chat/index.js";
+import { buildCallbackContext } from "#context/build-callback-context.js";
 import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { ChannelSessionOps } from "#public/definitions/channel.js";
 
@@ -160,12 +163,48 @@ type SlackSessionFailedHandler = (
   channel: SlackEventContext,
 ) => void | Promise<void>;
 
+function defaultResolveSubscription(input: SlackSubscriptionContext): SlackSubscriptionState {
+  return input.isBotMentioned ? "subscribed" : input.current;
+}
+
+function readSlackMessageDeliveryData(value: unknown): SlackMessageDeliveryData | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const data = value as Partial<SlackMessageDeliveryData>;
+  if (
+    data.kind !== "slack-message" ||
+    typeof data.isBotMentioned !== "boolean" ||
+    typeof data.message !== "object" ||
+    data.message === null
+  ) {
+    return undefined;
+  }
+  return data as SlackMessageDeliveryData;
+}
+
 /**
  * JSON-serializable per-session state, stored verbatim across workflow
  * step boundaries. Anything written here must round-trip through
  * `JSON.stringify` / `JSON.parse`.
  */
+export type SlackSubscriptionState = "subscribed" | "unsubscribed";
+
+/** Input to a Slack channel's durable subscription resolver. */
+export interface SlackSubscriptionContext {
+  /** Subscription state persisted from the previous admitted message. */
+  readonly current: SlackSubscriptionState;
+  /** Whether this message explicitly mentions the installed bot. */
+  readonly isBotMentioned: boolean;
+}
+
+interface SlackMessageDeliveryData {
+  readonly isBotMentioned: boolean;
+  readonly kind: "slack-message";
+  readonly message: SlackMessage;
+}
+
 export interface SlackChannelState {
+  /** Whether admitted messages in this thread currently dispatch agent turns. */
+  subscription: SlackSubscriptionState;
   /** Slack channel id seeded by the inbound mention. */
   channelId: string | null;
   /** Slack thread root ts. */
@@ -337,7 +376,10 @@ export interface SlackInboundMessageContext extends SlackContext {
    * `"no_active_turn"` are successful outcomes.
    */
   cancel(options?: SlackCancelOptions): Promise<CancelTurnResult>;
-  /** Returns whether this message belongs to a thread with an active eve session. */
+  /**
+   * Returns whether this message belongs to a thread with an active eve session.
+   * This webhook-side lookup does not read the durable subscription state.
+   */
   isSubscribed(): Promise<boolean>;
   /** Returns whether the inbound event explicitly mentions this bot. */
   isBotMentioned(): boolean;
@@ -486,6 +528,18 @@ export interface SlackChannelConfig {
   readonly threadContext?: LoadThreadContextMessagesOptions;
 
   /**
+   * Resolves durable thread subscription after a message hook admits a message.
+   * Runs inside the owning eve session after Slack and `defineState` state are
+   * hydrated. A `"subscribed"` result dispatches the message to the agent; an
+   * `"unsubscribed"` result persists the state and ignores the message.
+   */
+  resolveSubscription?(
+    subscription: SlackSubscriptionContext,
+    message: SlackMessage,
+    ctx: SessionContext,
+  ): SlackSubscriptionState | Promise<SlackSubscriptionState>;
+
+  /**
    * Handles human-authored Slack messages. Specialized `onAppMention` and
    * `onDirectMessage` handlers take precedence for their event types. Other
    * channel messages are ignored when this hook is omitted.
@@ -608,6 +662,22 @@ export interface SlackChannel extends Channel<
   SlackInstrumentationMetadata
 > {}
 
+function defineSlackChannel(
+  definition: Parameters<
+    typeof defineChannel<
+      SlackChannelState,
+      SlackChannelContext,
+      SlackReceiveTarget,
+      SlackInstrumentationMetadata
+    >
+  >[0] & { readonly deliver: NonNullable<ChannelAdapter["deliver"]> },
+): SlackChannel {
+  const { deliver, ...baseDefinition } = definition;
+  const channel = defineChannel(baseDefinition) as SlackChannel &
+    CompiledChannel<SlackChannelState>;
+  return { ...channel, adapter: { ...channel.adapter, deliver } } as SlackChannel;
+}
+
 /**
  * Slack channel factory. Wires up the webhook route, mention dispatch,
  * interaction handling, and a baseline set of typing / error /
@@ -644,12 +714,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
   // Light weight dedup mechanism - not reliable across multiple invocations.
   const handledEvents = new Set<string>();
 
-  return defineChannel<
-    SlackChannelState,
-    SlackChannelContext,
-    SlackReceiveTarget,
-    SlackInstrumentationMetadata
-  >({
+  return defineSlackChannel({
     kindHint: "slack",
     state: {
       channelId: null as string | null,
@@ -660,6 +725,25 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       lastReasoningTypingAtMs: null,
       lastReasoningTypingStatus: null,
       pendingAuthMessageTs: {},
+      subscription: "subscribed",
+    },
+    deliver: async (payload, adapterCtx) => {
+      const delivery = readSlackMessageDeliveryData(payload.channelData);
+      if (delivery === undefined) return defaultDeliverResult(payload);
+
+      const current = adapterCtx.state.subscription as SlackSubscriptionState;
+      const subscription = await (config.resolveSubscription ?? defaultResolveSubscription)(
+        { current, isBotMentioned: delivery.isBotMentioned },
+        delivery.message,
+        buildCallbackContext(),
+      );
+      if (subscription !== "subscribed" && subscription !== "unsubscribed") {
+        throw new Error(
+          'slackChannel().resolveSubscription must return "subscribed" or "unsubscribed".',
+        );
+      }
+      adapterCtx.state.subscription = subscription;
+      return subscription === "subscribed" ? defaultDeliverResult(payload) : undefined;
     },
     fetchFile: slackFetchFile,
     metadata(state): SlackInstrumentationMetadata {
@@ -767,6 +851,7 @@ async function receiveOnSlack(
     continuationToken: slackContinuationToken(channelId, continuationThreadTs),
     state: {
       channelId,
+      subscription: "subscribed",
       threadTs: threadTs || null,
       teamId: deps.teamId ?? null,
       triggeringUserId: null,
@@ -990,19 +1075,18 @@ async function dispatchSlackMessage(input: {
     threadTs: input.message.threadTs,
     teamId: input.message.teamId,
   });
+  const isBotMentioned =
+    input.kind === "app_mention" ||
+    (input.botUserId !== undefined && input.message.text.includes(`<@${input.botUserId}>`));
   const ctx: SlackInboundMessageContext = {
     cancel: (options = {}) =>
       input.cancel({
         continuationToken,
         turnId: options.turnId,
       }),
-    isBotMentioned: () =>
-      input.kind === "app_mention" ||
-      (input.botUserId !== undefined && input.message.text.includes(`<@${input.botUserId}`)),
+    isBotMentioned: () => isBotMentioned,
     isSubscribed: async () =>
-      (await input.resolveActiveSession({
-        continuationToken,
-      })) !== undefined,
+      (await input.resolveActiveSession({ continuationToken })) !== undefined,
     slack,
     thread,
   };
@@ -1020,6 +1104,7 @@ async function dispatchSlackMessage(input: {
 
   await deliverSlackMessage({
     credentials: input.credentials,
+    isBotMentioned,
     kind: input.kind,
     message: input.message,
     result,
@@ -1111,6 +1196,7 @@ async function verifyInbound(
 
 async function deliverSlackMessage(input: {
   readonly credentials: SlackChannelCredentials | undefined;
+  readonly isBotMentioned: boolean;
   readonly kind: string;
   readonly message: SlackMessage;
   readonly result: Exclude<SlackInboundResult, null>;
@@ -1149,15 +1235,21 @@ async function deliverSlackMessage(input: {
 
     const channelContext = input.result.context ?? [];
 
+    const channelData: SlackMessageDeliveryData = {
+      isBotMentioned: input.isBotMentioned,
+      kind: "slack-message",
+      message: input.message,
+    };
     await input.send(
       channelContext.length === 0
-        ? { message: turnMessage }
-        : { message: turnMessage, context: channelContext },
+        ? { channelData, message: turnMessage }
+        : { channelData, message: turnMessage, context: channelContext },
       {
         auth: input.result.auth,
         continuationToken: slackContinuationToken(message.channelId, message.threadTs),
         state: {
           channelId: message.channelId,
+          subscription: "subscribed",
           threadTs: message.threadTs,
           teamId: message.teamId ?? null,
           triggeringUserId: inboundContext.userId || null,

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -31,6 +31,7 @@ import {
   defaultInputRequestedHandler,
   defaultOnAppMention,
   defaultOnDirectMessage,
+  defaultSlackAuth,
 } from "#public/channels/slack/defaults.js";
 import {
   parseMessageEvent,
@@ -167,6 +168,14 @@ function defaultResolveSubscription(input: SlackSubscriptionContext): SlackSubsc
   return input.isBotMentioned ? "subscribed" : input.current;
 }
 
+async function defaultSubscribedThreadMessage(
+  ctx: SlackInboundMessageContext,
+  message: SlackMessage,
+): Promise<SlackInboundResult> {
+  if (message.author?.isBot || !(await ctx.isSubscribed())) return null;
+  return { auth: defaultSlackAuth(message, ctx) };
+}
+
 function readSlackMessageDeliveryData(value: unknown): SlackMessageDeliveryData | undefined {
   if (typeof value !== "object" || value === null) return undefined;
   const data = value as Partial<SlackMessageDeliveryData>;
@@ -195,6 +204,18 @@ export interface SlackSubscriptionContext {
   /** Whether this message explicitly mentions the installed bot. */
   readonly isBotMentioned: boolean;
 }
+
+/** Durable Slack thread-following behavior. */
+export type SlackThreadSubscription =
+  | true
+  | {
+      /** Resolves the thread state for each message admitted at webhook ingress. */
+      resolve(
+        subscription: SlackSubscriptionContext,
+        message: SlackMessage,
+        ctx: SessionContext,
+      ): SlackSubscriptionState | Promise<SlackSubscriptionState>;
+    };
 
 interface SlackMessageDeliveryData {
   readonly isBotMentioned: boolean;
@@ -528,16 +549,12 @@ export interface SlackChannelConfig {
   readonly threadContext?: LoadThreadContextMessagesOptions;
 
   /**
-   * Resolves durable thread subscription after a message hook admits a message.
-   * Runs inside the owning eve session after Slack and `defineState` state are
-   * hydrated. A `"subscribed"` result dispatches the message to the agent; an
-   * `"unsubscribed"` result persists the state and ignores the message.
+   * Follows replies in threads that have an eve session. Pass `true` for the
+   * default behavior, or provide `resolve` to durably refine when the thread
+   * remains subscribed. The resolver runs after session state is hydrated;
+   * `"subscribed"` dispatches the message and `"unsubscribed"` ignores it.
    */
-  resolveSubscription?(
-    subscription: SlackSubscriptionContext,
-    message: SlackMessage,
-    ctx: SessionContext,
-  ): SlackSubscriptionState | Promise<SlackSubscriptionState>;
+  readonly threadSubscription?: SlackThreadSubscription;
 
   /**
    * Handles human-authored Slack messages. Specialized `onAppMention` and
@@ -732,14 +749,18 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       if (delivery === undefined) return defaultDeliverResult(payload);
 
       const current = adapterCtx.state.subscription as SlackSubscriptionState;
-      const subscription = await (config.resolveSubscription ?? defaultResolveSubscription)(
+      const resolveSubscription =
+        typeof config.threadSubscription === "object"
+          ? config.threadSubscription.resolve
+          : defaultResolveSubscription;
+      const subscription = await resolveSubscription(
         { current, isBotMentioned: delivery.isBotMentioned },
         delivery.message,
         buildCallbackContext(),
       );
       if (subscription !== "subscribed" && subscription !== "unsubscribed") {
         throw new Error(
-          'slackChannel().resolveSubscription must return "subscribed" or "unsubscribed".',
+          'slackChannel().threadSubscription.resolve must return "subscribed" or "unsubscribed".',
         );
       }
       adapterCtx.state.subscription = subscription;
@@ -978,7 +999,10 @@ async function handleEventPost(input: {
     }
   }
 
-  if (dispatch === null && config.onMessage !== undefined) {
+  if (
+    dispatch === null &&
+    (config.onMessage !== undefined || config.threadSubscription !== undefined)
+  ) {
     const message = parseMessageEvent(envelope);
     if (message !== null && !isSelfAuthoredSlackMessage({ appId, botUserId }, message)) {
       // Slack also emits message.channels for an app mention. The app_mention
@@ -990,7 +1014,7 @@ async function handleEventPost(input: {
             botUserId,
             cancel: input.cancel,
             credentials: config.credentials,
-            handler: config.onMessage!,
+            handler: config.onMessage ?? defaultSubscribedThreadMessage,
             kind: "channel_message",
             message,
             resolveActiveSession: input.resolveActiveSession,


### PR DESCRIPTION
## Summary

This exploratory PR adds durable Slack thread subscriptions using the existing per-session Slack channel state, without introducing another storage method or adding framework-level code (entirely internal to Slack state).

The API progresses from mention-only behavior, to following active threads, to a custom subscription lifecycle.

### 1. Respond only to explicit mentions

This remains the default:

```ts title="agent/channels/slack.ts"
export default slackChannel({
  credentials: connectSlackCredentials("slack/my-agent"),
});
```

### 2. Respond to replies in active threads

```ts title="agent/channels/slack.ts"
export default slackChannel({
  credentials: connectSlackCredentials("slack/my-agent"),
  threadSubscription: true,
});
```

Messages outside active eve threads remain ignored.

### 3. Refine when a thread remains subscribed

```ts title="agent/channels/slack.ts"
export default slackChannel({
  credentials: connectSlackCredentials("slack/my-agent"),
  threadSubscription: {
    resolve({ current, isBotMentioned }, message) {
      if (isBotMentioned) return "subscribed";
      if (current === "unsubscribed") return current;

      const mentionsSomeone = /<@[A-Z0-9]+(?:\|[^>]+)?>/.test(message.text);
      return mentionsSomeone ? "unsubscribed" : current;
    },
  },
});
```

The resolver runs inside the durable session after state is hydrated. Returning `"subscribed"` dispatches the message; returning `"unsubscribed"` persists the state and ignores it before model execution. Explicit mentions can resubscribe the same session while preserving its history and state.

<img width="492" height="1102" alt="Screenshot 2026-07-23 at 9 57 15 AM" src="https://github.com/user-attachments/assets/166641e6-5d9a-467e-b414-7ebdf302f0e8" />

## Test Plan

- Added unit tests for default, subscribed-thread, unsubscribe, and resubscribe behavior
- Manually verified the handoff behavior with a deployed Slack agent

