### PR TITLE
fix(eve): dev snapshots - exclude legacy workflow data

### DIFF
--- a/.changeset/quiet-snapshots-skip-workflow-data.md
+++ b/.changeset/quiet-snapshots-skip-workflow-data.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Development runtime snapshots no longer copy legacy root-level `.workflow-data` directories. Projects with large local workflow histories avoid redundant multi-gigabyte snapshot copies and related disk-space failures.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -238,6 +238,7 @@ describe("development runtime artifact snapshots", () => {
     await mkdir(join(appRoot, "node_modules", "heavy-package"), { recursive: true });
     await mkdir(join(appRoot, ".next", "cache"), { recursive: true });
     await mkdir(join(appRoot, ".generated", "compiled"), { recursive: true });
+    await mkdir(join(appRoot, ".workflow-data", "streams"), { recursive: true });
     await mkdir(join(appRoot, "build"), { recursive: true });
     await mkdir(join(appRoot, "dist"), { recursive: true });
     await mkdir(compileDirectoryPath, { recursive: true });
@@ -249,6 +250,7 @@ describe("development runtime artifact snapshots", () => {
     await writeFile(join(appRoot, "node_modules", "heavy-package", "index.js"), "export {}\n");
     await writeFile(join(appRoot, ".next", "cache", "webpack.bin"), "cache\n");
     await writeFile(join(appRoot, ".generated", "compiled", "bundle.js"), "generated\n");
+    await writeFile(join(appRoot, ".workflow-data", "streams", "events.bin"), "events\n");
     await writeFile(join(appRoot, "build", "server.js"), "build\n");
     await writeFile(join(appRoot, "dist", "index.js"), "dist\n");
     await writeFile(manifestPath, `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`);
@@ -265,6 +267,7 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(join(snapshot.runtimeAppRoot, ".env.example"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, ".next"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, ".generated"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".workflow-data"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, "build"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, "dist"))).toBe(false);
   });

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -24,6 +24,7 @@ const SNAPSHOT_SKIP_NAMES = new Set([
   ".output",
   ".turbo",
   ".vercel",
+  ".workflow-data",
   "node_modules",
 ]);
 const SNAPSHOT_APP_ROOT_SKIP_NAMES = new Set(["build", "dist"]);


### PR DESCRIPTION
## Summary

- exclude legacy root-level `.workflow-data` from development runtime source snapshots
- cover populated workflow stream data in the existing snapshot exclusion integration test
- keep the existing bounded snapshot retention policy unchanged

## Verification

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/nitro/dev-runtime-artifacts.integration.test.ts -t \"excludes generated output and dependency directories\"`
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`

Closes #963