### PR TITLE
fix(eve): harness - retry undici stream timeouts

### DIFF
--- a/.changeset/small-spiders-retry.md
+++ b/.changeset/small-spiders-retry.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Retry model calls when undici terminates a response stream after a headers or body timeout, so transient provider stalls no longer immediately fail task runs.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -245,9 +245,21 @@ describe("classifyModelCallError", () => {
     const fetchFailed = new Error("fetch failed");
     expect(classifyModelCallError(fetchFailed)).toBe("retry");
 
+    for (const code of ["UND_ERR_BODY_TIMEOUT", "UND_ERR_HEADERS_TIMEOUT"]) {
+      const timeout = new TypeError("request aborted", {
+        cause: Object.assign(new Error("undici timeout"), { code }),
+      });
+      expect(classifyModelCallError(timeout)).toBe("retry");
+    }
+
+    expect(classifyModelCallError(new TypeError("terminated"))).toBe("retry");
+
     // The old substring policy is gone: prose that merely mentions a
     // network token no longer forces a retry loop.
     expect(classifyModelCallError(new Error("network configuration invalid"))).toBe("recoverable");
+    expect(classifyModelCallError(new Error("provider terminated the request"))).toBe(
+      "recoverable",
+    );
   });
 
   it("falls back to recoverable for unknown errors so the session parks instead of dying", () => {

--- a/packages/eve/src/harness/semantic-errors/rules/system.ts
+++ b/packages/eve/src/harness/semantic-errors/rules/system.ts
@@ -12,7 +12,9 @@ const NETWORK_ERROR_CODES = [
   "ENOTFOUND",
   "EPIPE",
   "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
   "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
   "UND_ERR_SOCKET",
 ] as const;
 
@@ -53,14 +55,15 @@ export const SYSTEM_RULES: readonly SemanticErrorRule[] = [
     // Exact-equality message fallback, verified empirically on Node 26:
     // a failed `fetch` rejects with a TypeError whose message is exactly
     // "fetch failed" (the coded cause is sometimes stripped in transit),
-    // and a peer-destroyed HTTP socket errors with exactly "socket hang
-    // up" (code ECONNRESET — the code rule above normally wins).
-    // Equality, never containment: a user error that merely mentions
-    // "fetch failed" must not be reclassified as a connectivity problem.
+    // a peer-destroyed HTTP socket errors with exactly "socket hang up",
+    // and an undici headers/body timeout can surface as exactly
+    // "terminated" when its coded cause is stripped in transit. Equality,
+    // never containment: user errors that merely mention these messages
+    // must not be reclassified as connectivity problems.
     id: "network-request-failed",
     name: "Network request failed",
     tags: ["system", "transient"],
-    when: messageIs("fetch failed", "socket hang up"),
+    when: messageIs("fetch failed", "socket hang up", "terminated"),
     message: (link) => networkFailureMessage(link.message.trim()),
     hint: NETWORK_FAILURE_HINT,
   },

--- a/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
+++ b/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
@@ -152,6 +152,29 @@ describe("summarizeKnownError (catalog table)", () => {
       error: new TypeError("fetch failed"),
       id: "network-request-failed",
     },
+    {
+      title: "undici body timeout on the cause chain",
+      error: new TypeError("terminated", {
+        cause: Object.assign(new Error("Body Timeout Error"), {
+          code: "UND_ERR_BODY_TIMEOUT",
+        }),
+      }),
+      id: "network-request-failed",
+    },
+    {
+      title: "undici headers timeout on the cause chain",
+      error: new TypeError("request aborted", {
+        cause: Object.assign(new Error("Headers Timeout Error"), {
+          code: "UND_ERR_HEADERS_TIMEOUT",
+        }),
+      }),
+      id: "network-request-failed",
+    },
+    {
+      title: "bare undici termination without a structured code",
+      error: new TypeError("terminated"),
+      id: "network-request-failed",
+    },
   ];
 
   for (const testCase of cases) {
@@ -205,6 +228,7 @@ describe("summarizeKnownError (catalog table)", () => {
 
   it("requires exact message equality, never containment", () => {
     expect(summarizeKnownError(new Error("upstream fetch failed for user 42"))).toBeNull();
+    expect(summarizeKnownError(new Error("upstream terminated unexpectedly"))).toBeNull();
     expect(summarizeKnownError(new Error("network configuration invalid"))).toBeNull();
   });
 
@@ -225,6 +249,7 @@ describe("summary tags", () => {
       "transient",
     );
     expect(summarizeKnownError(new TypeError("fetch failed"))?.tags).toContain("transient");
+    expect(summarizeKnownError(new TypeError("terminated"))?.tags).toContain("transient");
   });
 });
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3213,6 +3213,65 @@ describe("createToolLoopHarness", () => {
     expect(eventTypes).not.toContain("session.failed");
   });
 
+  it("retries a model call after an undici body timeout", async () => {
+    vi.useFakeTimers();
+    const timeout = new TypeError("terminated", {
+      cause: Object.assign(new Error("Body Timeout Error"), {
+        code: "UND_ERR_BODY_TIMEOUT",
+      }),
+    });
+    const success = {
+      finishReason: "stop",
+      response: { messages: [{ content: "Recovered", role: "assistant" }] },
+      text: "Recovered",
+      toolCalls: [],
+      toolResults: [],
+    };
+    const modelCallMock = vi.fn();
+
+    vi.mocked(ToolLoopAgent).mockImplementation(function (
+      this: ToolLoopAgent,
+      settings: MockAgentSettings,
+    ) {
+      const { onStepFinish, prepareStep } = settings;
+      this.generate = modelCallMock.mockImplementation(async (options: { messages: unknown[] }) => {
+        if (prepareStep) {
+          await prepareStep({
+            context: undefined,
+            messages: options.messages,
+            model: {},
+            stepNumber: 0,
+            steps: [],
+          });
+        }
+        if (modelCallMock.mock.calls.length === 1) {
+          throw timeout;
+        }
+        if (onStepFinish) {
+          void Promise.resolve().then(() => onStepFinish(success));
+        }
+        return createMockGenerateResult(success);
+      });
+      this.stream = vi.fn();
+      return this;
+    } as MockAgentConstructor);
+
+    try {
+      const runStep = createToolLoopHarness(createTestConfig());
+      const pending = runStep(createTestSession(), { message: "Hi" });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+
+      expect(modelCallMock).toHaveBeenCalledTimes(2);
+      expect(result.session.history).toEqual([
+        { content: "Hi", role: "user" },
+        { content: "Recovered", role: "assistant" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not start a model call when the turn signal is already aborted", async () => {
     const abortController = new AbortController();
     const cancellation = new TurnCancelledError();


### PR DESCRIPTION
## Summary

- classify undici body and headers timeout codes as transient network failures
- recognize an exact bare `terminated` error when wrappers strip the structured cause
- verify the model harness retries the failed call and completes successfully

## Verification

- focused unit suite: 3 files, 230 tests
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `git diff --check`

Supersedes #1038 with signed commits and the required changeset.

Closes #1037