### PR TITLE
fix(eve): hosted tracing - include eve internal dependency closure

### DIFF
--- a/.changeset/trace-eve-hosted-closure.md
+++ b/.changeset/trace-eve-hosted-closure.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent hosted functions from shipping an incomplete eve package when an external dependency imports an eve public subpath. Transitively traced eve packages now include their complete runtime closure instead of failing with `ERR_MODULE_NOT_FOUND`.

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -546,6 +546,9 @@ describe("application Nitro creation", () => {
 
     for (const call of createNitroMock.mock.calls.slice(0, 3)) {
       const traceDeps = call[0].traceDeps;
+      expect(call[0].traceOpts).toEqual({
+        nft: { readFile: expect.any(Function) },
+      });
       expect(traceDeps).toEqual(
         expect.arrayContaining(["@napi-rs/keyring", "sharp", "fixture-external"]),
       );

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -35,6 +35,7 @@ import type {
   PreparedApplicationHost,
   PreparedDevelopmentApplicationHost,
 } from "#internal/nitro/host/types.js";
+import { createEvePackageTraceOptions } from "#internal/nitro/host/eve-package-trace-options.js";
 import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
 import { applyWorkflowTransform } from "#internal/workflow-bundle/workflow-builders.js";
 import { transformDynamicToolExecute } from "#internal/workflow-bundle/dynamic-tool-transform.js";
@@ -841,6 +842,7 @@ export async function createProductionApplicationNitro(
     rootDir: preparedHost.appRoot,
     serverDir: false,
     traceDeps: bundler.tracedAppDependencies,
+    traceOpts: createEvePackageTraceOptions(),
     vercel: createEveVercelOptions(
       preset === "vercel" && includesApplicationSurface(options.surface),
     ),

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-options.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-options.integration.test.ts
@@ -1,0 +1,44 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { createEvePackageTraceOptions } from "#internal/nitro/host/eve-package-trace-options.js";
+
+describe("eve package trace options", () => {
+  it("presents package-internal imports to NFT as relative imports", async () => {
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "eve-package-trace-options-"));
+    const packageRoot = join(temporaryDirectory, "node_modules", "eve");
+    const connectionsRoot = join(packageRoot, "dist", "src", "public", "connections");
+    const entrypoint = join(connectionsRoot, "index.js");
+
+    try {
+      await mkdir(connectionsRoot, { recursive: true });
+      await writeFile(join(packageRoot, "package.json"), '{"name":"eve"}\n');
+      await writeFile(
+        entrypoint,
+        [
+          'export { error } from "#public/connections/errors.js";',
+          'export { z } from "#compiled/zod/index.js";',
+          'export { invalid } from "#../outside.js";',
+          "",
+        ].join("\n"),
+      );
+
+      await expect(createEvePackageTraceOptions().nft.readFile(entrypoint)).resolves.toBe(
+        [
+          'export { error } from "./errors.js";',
+          'export { z } from "../../compiled/zod/index.js";',
+          'export { invalid } from "#../outside.js";',
+          "",
+        ].join("\n"),
+      );
+      await expect(
+        createEvePackageTraceOptions().nft.readFile(connectionsRoot),
+      ).resolves.toBeNull();
+    } finally {
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-options.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-options.integration.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 
 import { describe, expect, it } from "vitest";
 
-import { createEvePackageTraceOptions } from "#internal/nitro/host/eve-package-trace-options.js";
+import {
+  createEvePackageTraceOptions,
+  createFileIoThrottle,
+} from "#internal/nitro/host/eve-package-trace-options.js";
 
 describe("eve package trace options", () => {
   it("presents package-internal imports to NFT as relative imports", async () => {
@@ -40,5 +43,55 @@ describe("eve package trace options", () => {
     } finally {
       await rm(temporaryDirectory, { force: true, recursive: true });
     }
+  });
+
+  it("reads each traced path from disk only once", async () => {
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "eve-package-trace-options-"));
+    const modulePath = join(temporaryDirectory, "module.js");
+
+    try {
+      await writeFile(modulePath, "export const first = 1;\n");
+
+      const { readFile: readTracedFile } = createEvePackageTraceOptions().nft;
+      await expect(readTracedFile(modulePath)).resolves.toBe("export const first = 1;\n");
+
+      await writeFile(modulePath, "export const second = 2;\n");
+
+      await expect(readTracedFile(modulePath)).resolves.toBe("export const first = 1;\n");
+    } finally {
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("file IO throttle", () => {
+  it("never exceeds the limit and still completes every operation", async () => {
+    const withFileIoSlot = createFileIoThrottle(4);
+    let active = 0;
+    let peakActive = 0;
+
+    const completed = await Promise.all(
+      Array.from({ length: 64 }, (_unused, index) =>
+        withFileIoSlot(async () => {
+          active += 1;
+          peakActive = Math.max(peakActive, active);
+          await new Promise((admit) => setTimeout(admit, 1));
+          active -= 1;
+          return index;
+        }),
+      ),
+    );
+
+    expect(peakActive).toBe(4);
+    expect(completed).toEqual(Array.from({ length: 64 }, (_unused, index) => index));
+  });
+
+  it("releases its slot when an operation rejects", async () => {
+    const withFileIoSlot = createFileIoThrottle(1);
+
+    await expect(
+      withFileIoSlot(() => Promise.reject(new Error("read failed"))),
+    ).rejects.toThrowError("read failed");
+    await expect(withFileIoSlot(() => Promise.resolve("readable"))).resolves.toBe("readable");
   });
 });

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-options.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-options.ts
@@ -3,6 +3,9 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 
+/** Matches NFT's own `fileIOConcurrency` default. */
+const FILE_IO_CONCURRENCY = 1024;
+
 function isPathWithin(path: string, root: string): boolean {
   const pathFromRoot = relative(root, path);
   return (
@@ -11,7 +14,43 @@ function isPathWithin(path: string, root: string): boolean {
   );
 }
 
-function createFindEvePackageRoot(): (path: string) => Promise<string | undefined> {
+/**
+ * Caps how many filesystem operations may be in flight at once.
+ *
+ * Returns a wrapper that admits an operation immediately when the limit has
+ * spare capacity and otherwise queues it. A finishing operation hands its slot
+ * directly to the next waiter, so the limit is never exceeded.
+ */
+export function createFileIoThrottle(
+  limit: number,
+): <T>(operation: () => Promise<T>) => Promise<T> {
+  let active = 0;
+  const waiting: (() => void)[] = [];
+
+  return async (operation) => {
+    if (active >= limit) {
+      // The releasing operation hands its slot over instead of decrementing.
+      await new Promise<void>((admit) => waiting.push(admit));
+    } else {
+      active += 1;
+    }
+
+    try {
+      return await operation();
+    } finally {
+      const admitNext = waiting.shift();
+      if (admitNext === undefined) {
+        active -= 1;
+      } else {
+        admitNext();
+      }
+    }
+  };
+}
+
+function createFindEvePackageRoot(
+  readSource: (path: string) => Promise<string>,
+): (path: string) => Promise<string | undefined> {
   const packageRootByDirectory = new Map<string, Promise<string | undefined>>();
 
   function findFromDirectory(directory: string): Promise<string | undefined> {
@@ -22,7 +61,7 @@ function createFindEvePackageRoot(): (path: string) => Promise<string | undefine
 
     const packageRoot = (async (): Promise<string | undefined> => {
       try {
-        const packageJson = JSON.parse(await readFile(join(directory, "package.json"), "utf8")) as {
+        const packageJson = JSON.parse(await readSource(join(directory, "package.json"))) as {
           name?: unknown;
         };
         if (packageJson.name === EVE_PACKAGE_NAME) {
@@ -51,12 +90,16 @@ function toRelativeImportSpecifier(importer: string, imported: string): string {
 }
 
 function createEveTraceFileReader(): (path: string) => Promise<string | null> {
-  const findEvePackageRoot = createFindEvePackageRoot();
+  const withFileIoSlot = createFileIoThrottle(FILE_IO_CONCURRENCY);
+  const readSource = (path: string): Promise<string> =>
+    withFileIoSlot(() => readFile(path, "utf8"));
+  const findEvePackageRoot = createFindEvePackageRoot(readSource);
+  const sourceByPath = new Map<string, Promise<string | null>>();
 
-  return async (path) => {
+  async function readTracedSource(path: string): Promise<string | null> {
     let source: string;
     try {
-      source = await readFile(path, "utf8");
+      source = await readSource(path);
     } catch (error) {
       if (
         error instanceof Error &&
@@ -84,6 +127,17 @@ function createEveTraceFileReader(): (path: string) => Promise<string | null> {
         ? `${quote}${toRelativeImportSpecifier(path, imported)}${quote}`
         : match;
     });
+  }
+
+  return (path) => {
+    const cachedSource = sourceByPath.get(path);
+    if (cachedSource !== undefined) {
+      return cachedSource;
+    }
+
+    const source = readTracedSource(path);
+    sourceByPath.set(path, source);
+    return source;
   };
 }
 
@@ -93,6 +147,10 @@ function createEveTraceFileReader(): (path: string) => Promise<string | null> {
  * NFT cannot match eve's embedded `#*.js` import-map wildcard. It can,
  * however, trace the equivalent relative specifiers. This virtual read only
  * changes what NFT analyzes; nf3 still copies the original package files.
+ *
+ * Supplying `readFile` replaces NFT's cached filesystem wholesale, so this
+ * reader has to memoize and throttle on its own: NFT re-reads the same
+ * manifests once per resolution and fans reads out with unbounded recursion.
  */
 export function createEvePackageTraceOptions(): {
   readonly nft: {

--- a/packages/eve/src/internal/nitro/host/eve-package-trace-options.ts
+++ b/packages/eve/src/internal/nitro/host/eve-package-trace-options.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
+
+function isPathWithin(path: string, root: string): boolean {
+  const pathFromRoot = relative(root, path);
+  return (
+    pathFromRoot.length === 0 ||
+    (pathFromRoot !== ".." && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot))
+  );
+}
+
+function createFindEvePackageRoot(): (path: string) => Promise<string | undefined> {
+  const packageRootByDirectory = new Map<string, Promise<string | undefined>>();
+
+  function findFromDirectory(directory: string): Promise<string | undefined> {
+    const cachedPackageRoot = packageRootByDirectory.get(directory);
+    if (cachedPackageRoot !== undefined) {
+      return cachedPackageRoot;
+    }
+
+    const packageRoot = (async (): Promise<string | undefined> => {
+      try {
+        const packageJson = JSON.parse(await readFile(join(directory, "package.json"), "utf8")) as {
+          name?: unknown;
+        };
+        if (packageJson.name === EVE_PACKAGE_NAME) {
+          return directory;
+        }
+      } catch {
+        // Keep walking: this directory either has no manifest or does not contain valid JSON.
+      }
+
+      const parentDirectory = dirname(directory);
+      return parentDirectory === directory ? undefined : findFromDirectory(parentDirectory);
+    })();
+    packageRootByDirectory.set(directory, packageRoot);
+    return packageRoot;
+  }
+
+  return (path) =>
+    path.split(/[\\/]/).includes(EVE_PACKAGE_NAME)
+      ? findFromDirectory(dirname(path))
+      : Promise.resolve(undefined);
+}
+
+function toRelativeImportSpecifier(importer: string, imported: string): string {
+  const relativePath = relative(dirname(importer), imported).replaceAll("\\", "/");
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function createEveTraceFileReader(): (path: string) => Promise<string | null> {
+  const findEvePackageRoot = createFindEvePackageRoot();
+
+  return async (path) => {
+    let source: string;
+    try {
+      source = await readFile(path, "utf8");
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        (error.code === "ENOENT" || error.code === "EISDIR")
+      ) {
+        return null;
+      }
+      throw error;
+    }
+
+    const packageRoot = await findEvePackageRoot(path);
+    if (packageRoot === undefined) {
+      return source;
+    }
+
+    const distSourceRoot = join(packageRoot, "dist", "src");
+    if (!isPathWithin(path, distSourceRoot)) {
+      return source;
+    }
+
+    return source.replace(/(["'])#([^"']+)\1/g, (match, quote: string, specifier: string) => {
+      const imported = resolve(distSourceRoot, specifier);
+      return isPathWithin(imported, distSourceRoot)
+        ? `${quote}${toRelativeImportSpecifier(path, imported)}${quote}`
+        : match;
+    });
+  };
+}
+
+/**
+ * Makes eve's package-internal imports visible to nf3's NFT tracer.
+ *
+ * NFT cannot match eve's embedded `#*.js` import-map wildcard. It can,
+ * however, trace the equivalent relative specifiers. This virtual read only
+ * changes what NFT analyzes; nf3 still copies the original package files.
+ */
+export function createEvePackageTraceOptions(): {
+  readonly nft: {
+    readonly readFile: (path: string) => Promise<string | null>;
+  };
+} {
+  return { nft: { readFile: createEveTraceFileReader() } };
+}

--- a/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
+++ b/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
@@ -608,6 +608,9 @@ describe("app runtime dependency tracing", () => {
       join(packageRoot, "package.json"),
       JSON.stringify(
         {
+          dependencies: {
+            eve: "1.0.0",
+          },
           exports: {
             ".": "./index.js",
           },
@@ -622,12 +625,44 @@ describe("app runtime dependency tracing", () => {
     await writeFile(
       join(packageRoot, "index.js"),
       [
+        'import { externalClosureMarker } from "eve/connections";',
         'export const label = "fixture-external-only-dep";',
         "export default {",
+        "  externalClosureMarker,",
         "  label,",
         "};",
         "",
       ].join("\n"),
+    );
+
+    const evePackageRoot = join(appRoot, "node_modules", "eve");
+    const eveConnectionsRoot = join(evePackageRoot, "dist", "src", "public", "connections");
+    await mkdir(eveConnectionsRoot, { recursive: true });
+    await writeFile(
+      join(evePackageRoot, "package.json"),
+      JSON.stringify(
+        {
+          exports: {
+            "./connections": "./dist/src/public/connections/index.js",
+          },
+          imports: {
+            "#*.js": "./dist/src/*.js",
+          },
+          name: "eve",
+          type: "module",
+          version: "1.0.0",
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      join(eveConnectionsRoot, "index.js"),
+      'export { externalClosureMarker } from "#public/connections/errors.js";\n',
+    );
+    await writeFile(
+      join(eveConnectionsRoot, "errors.js"),
+      'export const externalClosureMarker = "external-closure-present";\n',
     );
 
     const outputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
@@ -649,6 +684,22 @@ describe("app runtime dependency tracing", () => {
         "utf8",
       ),
     ).resolves.toContain('"name": "fixture-external-only-dep"');
+    await expect(
+      readFile(
+        join(
+          outputDir,
+          "server",
+          "node_modules",
+          "eve",
+          "dist",
+          "src",
+          "public",
+          "connections",
+          "errors.js",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain("external-closure-present");
     expect(serverModuleSource).toContain('"fixture-external-only-dep"');
     expect(serverModuleSource).not.toContain('export const label = "fixture-external-only-dep";');
   }, 30_000);


### PR DESCRIPTION
## Summary

- make nf3/NFT see eve package-internal imports through a virtual read transform
- leave recursive graph traversal to NFT instead of maintaining a custom parser
- cache package-root discovery and restrict rewrites to the traced eve `dist/src` tree
- verify the final hosted output contains the transitive eve module

## Verification

- trace-options integration test
- Nitro creation scenario: 16 tests
- hosted external-dependency output regression
- `pnpm --filter eve typecheck`
- targeted `oxlint` and `oxfmt --check`
- `pnpm guard:invariants`

Supersedes #1041 and #1048 while retaining Colton Padden as co-author.

Closes #842