### PR TITLE
fix(eve): package resolution - resolve installed files from bundled hosts

### DIFF
--- a/.changeset/good-spoons-resolve.md
+++ b/.changeset/good-spoons-resolve.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Resolve package-owned runtime files from the installed eve package when generated host bundles execute outside its package root, including on Windows.

--- a/packages/eve/src/internal/application/package.integration.test.ts
+++ b/packages/eve/src/internal/application/package.integration.test.ts
@@ -1,0 +1,148 @@
+import { mkdir, realpath, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolvePackageLocationFromModulePath } from "#internal/application/package.js";
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+const createScratchDirectory = useTemporaryDirectories();
+
+async function writeFixtureFile(path: string, contents = ""): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, "utf8");
+}
+
+async function writePackageManifest(packageRoot: string, name: string): Promise<void> {
+  await writeFixtureFile(
+    join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        exports: {
+          "./package.json": "./package.json",
+        },
+        name,
+        version: "1.0.0",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function writeInstalledEvePackage(appRoot: string): Promise<string> {
+  const packageRoot = join(appRoot, "node_modules", "eve");
+
+  await writePackageManifest(packageRoot, "eve");
+  await mkdir(join(packageRoot, "dist"), { recursive: true });
+  return packageRoot;
+}
+
+async function writeBundle(appRoot: string): Promise<string> {
+  const bundlePath = join(appRoot, ".eve", "dev-hosts", "fixture", "nitro", "dev", "index.mjs");
+
+  await writeFixtureFile(bundlePath, "export {};\n");
+  return bundlePath;
+}
+
+describe("resolvePackageLocationFromModulePath", () => {
+  it("resolves an installed eve package from a bundle outside the package root", async () => {
+    const appRoot = await createScratchDirectory("eve-package-location-bundle-");
+    await writePackageManifest(appRoot, "consumer-app");
+    const packageRoot = await writeInstalledEvePackage(appRoot);
+    const bundlePath = await writeBundle(appRoot);
+    const canonicalPackageRoot = await realpath(packageRoot);
+
+    expect(resolvePackageLocationFromModulePath(bundlePath)).toEqual({
+      packageBuildRoot: join(canonicalPackageRoot, "dist"),
+      packageRoot: canonicalPackageRoot,
+    });
+  });
+
+  it("keeps source checkouts on package source files", async () => {
+    const packageRoot = await createScratchDirectory("eve-package-location-source-");
+    await writePackageManifest(packageRoot, "eve");
+    const modulePath = join(packageRoot, "src", "internal", "application", "package.ts");
+    await writeFixtureFile(modulePath, "export {};\n");
+    const canonicalPackageRoot = await realpath(packageRoot);
+
+    expect(resolvePackageLocationFromModulePath(modulePath)).toEqual({
+      packageBuildRoot: null,
+      packageRoot: canonicalPackageRoot,
+    });
+  });
+
+  it("keeps direct dist execution on built package files", async () => {
+    const packageRoot = await createScratchDirectory("eve-package-location-dist-");
+    await writePackageManifest(packageRoot, "eve");
+    await writeFixtureFile(
+      join(packageRoot, "src", "internal", "application", "package.ts"),
+      "export {};\n",
+    );
+    const modulePath = join(packageRoot, "dist", "src", "internal", "application", "package.js");
+    await writeFixtureFile(modulePath, "export {};\n");
+    const canonicalPackageRoot = await realpath(packageRoot);
+
+    expect(resolvePackageLocationFromModulePath(modulePath)).toEqual({
+      packageBuildRoot: join(canonicalPackageRoot, "dist"),
+      packageRoot: canonicalPackageRoot,
+    });
+  });
+
+  it("does not treat consumer directory names as source-checkout evidence", async () => {
+    const scratchRoot = await createScratchDirectory("eve-package-location-consumer-");
+    const appRoot = join(scratchRoot, "packages", "eve", "consumer");
+    await writePackageManifest(appRoot, "consumer-app");
+    const packageRoot = await writeInstalledEvePackage(appRoot);
+    const bundlePath = await writeBundle(appRoot);
+    const canonicalPackageRoot = await realpath(packageRoot);
+
+    expect(resolvePackageLocationFromModulePath(bundlePath)).toEqual({
+      packageBuildRoot: join(canonicalPackageRoot, "dist"),
+      packageRoot: canonicalPackageRoot,
+    });
+  });
+
+  it("falls back to a surrounding verified package when module resolution fails", async () => {
+    const packageRoot = await createScratchDirectory("eve-package-location-fallback-");
+    await writePackageManifest(packageRoot, "eve");
+    await mkdir(join(packageRoot, "dist"), { recursive: true });
+    const bundlePath = await writeBundle(packageRoot);
+    const canonicalPackageRoot = await realpath(packageRoot);
+
+    expect(
+      resolvePackageLocationFromModulePath(bundlePath, () => {
+        throw new Error("module resolution unavailable");
+      }),
+    ).toEqual({
+      packageBuildRoot: join(canonicalPackageRoot, "dist"),
+      packageRoot: canonicalPackageRoot,
+    });
+  });
+
+  it("rejects unrelated package roots when module resolution fails", async () => {
+    const appRoot = await createScratchDirectory("eve-package-location-missing-");
+    await writePackageManifest(appRoot, "consumer-app");
+    const bundlePath = await writeBundle(appRoot);
+
+    expect(() =>
+      resolvePackageLocationFromModulePath(bundlePath, () => {
+        throw new Error("module resolution unavailable");
+      }),
+    ).toThrowError(`Failed to resolve the eve package root from "${bundlePath}".`);
+  });
+
+  it("rejects a resolved manifest that does not identify eve", async () => {
+    const appRoot = await createScratchDirectory("eve-package-location-invalid-");
+    await writePackageManifest(appRoot, "consumer-app");
+    const bundlePath = await writeBundle(appRoot);
+    const unrelatedPackageRoot = join(appRoot, "node_modules", "not-eve");
+    await writePackageManifest(unrelatedPackageRoot, "not-eve");
+
+    expect(() =>
+      resolvePackageLocationFromModulePath(bundlePath, () =>
+        join(unrelatedPackageRoot, "package.json"),
+      ),
+    ).toThrowError(`Failed to resolve the eve package root from "${bundlePath}".`);
+  });
+});

--- a/packages/eve/src/internal/application/package.integration.test.ts
+++ b/packages/eve/src/internal/application/package.integration.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, realpath, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -7,6 +8,12 @@ import { resolvePackageLocationFromModulePath } from "#internal/application/pack
 import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
 
 const createScratchDirectory = useTemporaryDirectories();
+
+// Matches how the resolver canonicalizes paths. Windows temporary roots often
+// arrive as 8.3 short names, which only the native realpath expands.
+function canonicalize(path: string): string {
+  return realpathSync.native(path);
+}
 
 async function writeFixtureFile(path: string, contents = ""): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
@@ -51,7 +58,7 @@ describe("resolvePackageLocationFromModulePath", () => {
     await writePackageManifest(appRoot, "consumer-app");
     const packageRoot = await writeInstalledEvePackage(appRoot);
     const bundlePath = await writeBundle(appRoot);
-    const canonicalPackageRoot = await realpath(packageRoot);
+    const canonicalPackageRoot = canonicalize(packageRoot);
 
     expect(resolvePackageLocationFromModulePath(bundlePath)).toEqual({
       packageBuildRoot: join(canonicalPackageRoot, "dist"),
@@ -64,7 +71,7 @@ describe("resolvePackageLocationFromModulePath", () => {
     await writePackageManifest(packageRoot, "eve");
     const modulePath = join(packageRoot, "src", "internal", "application", "package.ts");
     await writeFixtureFile(modulePath, "export {};\n");
-    const canonicalPackageRoot = await realpath(packageRoot);
+    const canonicalPackageRoot = canonicalize(packageRoot);
 
     expect(resolvePackageLocationFromModulePath(modulePath)).toEqual({
       packageBuildRoot: null,
@@ -81,7 +88,7 @@ describe("resolvePackageLocationFromModulePath", () => {
     );
     const modulePath = join(packageRoot, "dist", "src", "internal", "application", "package.js");
     await writeFixtureFile(modulePath, "export {};\n");
-    const canonicalPackageRoot = await realpath(packageRoot);
+    const canonicalPackageRoot = canonicalize(packageRoot);
 
     expect(resolvePackageLocationFromModulePath(modulePath)).toEqual({
       packageBuildRoot: join(canonicalPackageRoot, "dist"),
@@ -95,7 +102,7 @@ describe("resolvePackageLocationFromModulePath", () => {
     await writePackageManifest(appRoot, "consumer-app");
     const packageRoot = await writeInstalledEvePackage(appRoot);
     const bundlePath = await writeBundle(appRoot);
-    const canonicalPackageRoot = await realpath(packageRoot);
+    const canonicalPackageRoot = canonicalize(packageRoot);
 
     expect(resolvePackageLocationFromModulePath(bundlePath)).toEqual({
       packageBuildRoot: join(canonicalPackageRoot, "dist"),
@@ -108,7 +115,7 @@ describe("resolvePackageLocationFromModulePath", () => {
     await writePackageManifest(packageRoot, "eve");
     await mkdir(join(packageRoot, "dist"), { recursive: true });
     const bundlePath = await writeBundle(packageRoot);
-    const canonicalPackageRoot = await realpath(packageRoot);
+    const canonicalPackageRoot = canonicalize(packageRoot);
 
     expect(
       resolvePackageLocationFromModulePath(bundlePath, () => {

--- a/packages/eve/src/internal/application/package.ts
+++ b/packages/eve/src/internal/application/package.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 
 let cachedPackageInfo: InstalledPackageInfo | undefined;
+let cachedPackageLocation: PackageLocation | undefined;
 // The package build stamps the published version into `dist` so bundled
 // deployments can still report package metadata without resolving package.json.
 const BUNDLED_FALLBACK_PACKAGE_VERSION: string = "__EVE_PACKAGE_VERSION__";
@@ -30,6 +31,11 @@ const FALLBACK_PACKAGE_INFO: InstalledPackageInfo = {
 interface InstalledPackageInfo {
   name: string;
   version: string;
+}
+
+interface PackageLocation {
+  packageBuildRoot: string | null;
+  packageRoot: string;
 }
 
 function resolveCurrentModulePath(): string {
@@ -61,58 +67,160 @@ function resolveCurrentModulePathFromStack(): string {
 
 const require = createRequire(resolveCurrentModulePath());
 
-function isBuildOutputPackageRoot(directoryPath: string): boolean {
-  return (
-    basename(directoryPath) === "dist" && existsSync(join(dirname(directoryPath), "package.json"))
-  );
-}
+function tryResolveVerifiedPackageRoot(packageJsonPath: string): string | undefined {
+  try {
+    const canonicalPackageJsonPath = realpathSync.native(packageJsonPath);
+    const packageInfo = tryReadInstalledPackageInfo(canonicalPackageJsonPath, EVE_PACKAGE_NAME);
 
-function resolvePackageBuildRoot(): string | null {
-  let currentDirectory = dirname(realpathSync(resolveCurrentModulePath()));
-
-  while (true) {
-    if (isBuildOutputPackageRoot(currentDirectory)) {
-      return currentDirectory;
-    }
-
-    const parentDirectory = dirname(currentDirectory);
-
-    if (parentDirectory === currentDirectory) {
-      return null;
-    }
-
-    currentDirectory = parentDirectory;
+    return packageInfo === undefined ? undefined : dirname(canonicalPackageJsonPath);
+  } catch {
+    return undefined;
   }
 }
 
-function findNearestPackageRoot(startDirectory: string): string {
+function findNearestVerifiedPackageRoot(startDirectory: string): string | undefined {
   let currentDirectory = startDirectory;
 
   while (true) {
-    if (
-      existsSync(join(currentDirectory, "package.json")) &&
-      !isBuildOutputPackageRoot(currentDirectory)
-    ) {
-      return currentDirectory;
+    const packageRoot = tryResolveVerifiedPackageRoot(join(currentDirectory, "package.json"));
+
+    if (packageRoot !== undefined) {
+      return packageRoot;
     }
 
     const parentDirectory = dirname(currentDirectory);
 
     if (parentDirectory === currentDirectory) {
-      throw new Error(`Failed to resolve package root from "${startDirectory}".`);
+      return undefined;
     }
 
     currentDirectory = parentDirectory;
   }
+}
+
+function tryResolveDirectBuildLocation(currentModulePath: string): PackageLocation | undefined {
+  let currentDirectory = dirname(currentModulePath);
+
+  while (true) {
+    if (basename(currentDirectory) === "dist") {
+      const packageRoot = tryResolveVerifiedPackageRoot(
+        join(dirname(currentDirectory), "package.json"),
+      );
+
+      if (packageRoot !== undefined) {
+        return {
+          packageBuildRoot: currentDirectory,
+          packageRoot,
+        };
+      }
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+
+    if (parentDirectory === currentDirectory) {
+      return undefined;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+}
+
+function isSourceCheckout(packageRoot: string): boolean {
+  // Published packages exclude `src`, so this marker distinguishes a checkout
+  // without depending on how its parent directories are named.
+  return existsSync(join(packageRoot, "src", "internal", "application", "package.ts"));
+}
+
+function tryCreatePackageLocation(packageRoot: string): PackageLocation | undefined {
+  if (isSourceCheckout(packageRoot)) {
+    return {
+      packageBuildRoot: null,
+      packageRoot,
+    };
+  }
+
+  const packageBuildRoot = join(packageRoot, "dist");
+
+  if (!existsSync(packageBuildRoot)) {
+    return undefined;
+  }
+
+  return {
+    packageBuildRoot,
+    packageRoot,
+  };
+}
+
+function resolveSelfPackageJsonPath(currentModulePath: string): string {
+  return createRequire(currentModulePath).resolve(`${EVE_PACKAGE_NAME}/package.json`);
+}
+
+/**
+ * Resolves eve's package location relative to an executing module.
+ *
+ * Direct source and build executions retain their package-local behavior.
+ * Bundled executions resolve the installed eve manifest through Node's module
+ * resolver instead of treating the bundle owner's manifest as eve's.
+ */
+export function resolvePackageLocationFromModulePath(
+  currentModulePath: string,
+  resolvePackageJsonPath: (currentModulePath: string) => string = resolveSelfPackageJsonPath,
+): PackageLocation {
+  const canonicalModulePath = realpathSync.native(currentModulePath);
+  const directBuildLocation = tryResolveDirectBuildLocation(canonicalModulePath);
+
+  if (directBuildLocation !== undefined) {
+    return directBuildLocation;
+  }
+
+  const nearestPackageRoot = findNearestVerifiedPackageRoot(dirname(canonicalModulePath));
+
+  if (nearestPackageRoot !== undefined && isSourceCheckout(nearestPackageRoot)) {
+    return {
+      packageBuildRoot: null,
+      packageRoot: nearestPackageRoot,
+    };
+  }
+
+  try {
+    const resolvedPackageRoot = tryResolveVerifiedPackageRoot(
+      resolvePackageJsonPath(canonicalModulePath),
+    );
+    const resolvedLocation =
+      resolvedPackageRoot === undefined ? undefined : tryCreatePackageLocation(resolvedPackageRoot);
+
+    if (resolvedLocation !== undefined) {
+      return resolvedLocation;
+    }
+  } catch {
+    // A verified package root surrounding the current module remains a safe
+    // fallback when module resolution is unavailable in generated output.
+  }
+
+  const fallbackLocation =
+    nearestPackageRoot === undefined ? undefined : tryCreatePackageLocation(nearestPackageRoot);
+
+  if (fallbackLocation !== undefined) {
+    return fallbackLocation;
+  }
+
+  throw new Error(`Failed to resolve the eve package root from "${currentModulePath}".`);
+}
+
+function resolvePackageLocation(): PackageLocation {
+  cachedPackageLocation ??= resolvePackageLocationFromModulePath(resolveCurrentModulePath());
+  return cachedPackageLocation;
+}
+
+function resolvePackageBuildRoot(): string | null {
+  return resolvePackageLocation().packageBuildRoot;
 }
 
 /**
  * Resolves the installed eve package root.
  */
 export function resolvePackageRoot(): string {
-  // Canonicalize the current module path so workspace symlinks such as
-  // app-local `node_modules/<package-name>` resolve back to the real package root.
-  return findNearestPackageRoot(dirname(realpathSync(resolveCurrentModulePath())));
+  return resolvePackageLocation().packageRoot;
 }
 
 function tryResolvePackageRoot(): string | undefined {


### PR DESCRIPTION
## Summary

- resolve the installed eve manifest through Node module resolution when generated hosts execute outside the package
- distinguish source checkouts and direct dist execution using verified package structure instead of pathname text
- reject unrelated consumer manifests and retain a verified-package fallback
- add real-filesystem regression coverage for bundled hosts and misleading `packages/eve` consumer paths

## Verification

- package-location integration tests: 7 passed
- related package unit tests: 8 passed
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`

Windows integration CI provides the native platform validation for the customer-reported failure.

Supersedes #949 while preserving its diagnosis and approach.

Closes #948