### PR TITLE
fix(eve): sandbox prewarm - reclaim orphaned locks

### DIFF
--- a/.changeset/nice-spiders-wait.md
+++ b/.changeset/nice-spiders-wait.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reclaim sandbox prewarm locks immediately when their same-host owner process has exited, while preserving live and unverifiable owners and safely isolating reclaimed lock directories.

--- a/packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts
@@ -21,12 +21,40 @@ const recoveryIntentRename = vi.hoisted(() => ({
   calls: 0,
   failures: 0,
 }));
+const lockRename = vi.hoisted(() => ({
+  tombstoneCalls: 0,
+}));
+const ownerWrite = vi.hoisted(() => ({
+  removeLockOnNextWrite: false,
+}));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:fs/promises")>();
 
   return {
     ...original,
+    async writeFile(...input: Parameters<typeof original.writeFile>) {
+      const path = String(input[0]);
+
+      if (
+        ownerWrite.removeLockOnNextWrite &&
+        /[\\/]owner\.json$/.test(path) &&
+        !path.includes(".recovery")
+      ) {
+        ownerWrite.removeLockOnNextWrite = false;
+        // Stands in for a reclaimer moving the directory away between the
+        // claiming mkdir and the ownership write.
+        await original.rm(path.replace(/[\\/]owner\.json$/, ""), {
+          force: true,
+          recursive: true,
+        });
+        throw Object.assign(new Error("injected lock disappearance"), {
+          code: "ENOENT",
+        });
+      }
+
+      return original.writeFile(...input);
+    },
     async rm(...input: Parameters<typeof original.rm>) {
       if (recoveryIntentRemoval.failNext && String(input[0]).includes(".recovery.released-")) {
         recoveryIntentRemoval.failNext = false;
@@ -55,6 +83,10 @@ vi.mock("#shared/rename-with-retry.js", async (importOriginal) => {
   return {
     ...original,
     async renameWithTransientBusyRetry(sourcePath: string, destinationPath: string) {
+      if (destinationPath.includes(".tombstone-")) {
+        lockRename.tombstoneCalls += 1;
+      }
+
       if (sourcePath.includes("intent-") && destinationPath.includes(".recovery.released-")) {
         recoveryIntentRename.calls += 1;
         if (recoveryIntentRename.failures > 0) {
@@ -82,6 +114,8 @@ afterEach(() => {
   recoveryIntentRemoval.failNext = false;
   recoveryIntentRename.calls = 0;
   recoveryIntentRename.failures = 0;
+  lockRename.tombstoneCalls = 0;
+  ownerWrite.removeLockOnNextWrite = false;
 });
 
 function resolveLockPath(appRoot: string): string {
@@ -396,6 +430,38 @@ describe("sandbox template prewarm locks", () => {
     await withSandboxTemplatePrewarmLock(input, async () => {});
 
     expect(recoveryIntentRename.calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("retries when the lock directory disappears before ownership is recorded", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-lost-claim-");
+    ownerWrite.removeLockOnNextWrite = true;
+    let ran = false;
+
+    await withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {
+      ran = true;
+    });
+
+    expect(ran).toBe(true);
+    expect(ownerWrite.removeLockOnNextWrite).toBe(false);
+  });
+
+  it("moves reclaimed and released locks with the transient-busy rename", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-reclaim-rename-");
+    const lockPath = await writeLock(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: DEAD_PID,
+    });
+
+    await waitForFixtureLock(appRoot);
+
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    const reclaimCalls = lockRename.tombstoneCalls;
+    expect(reclaimCalls).toBeGreaterThanOrEqual(1);
+
+    await withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {});
+
+    expect(lockRename.tombstoneCalls).toBeGreaterThan(reclaimCalls);
   });
 
   it("reclaims stale locks whose owner cannot be verified", async () => {

--- a/packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts
+++ b/packages/eve/src/execution/sandbox/template-prewarm-lock.integration.test.ts
@@ -1,0 +1,596 @@
+import { mkdir, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  waitForSandboxTemplatePrewarmLock,
+  withSandboxTemplatePrewarmLock,
+} from "#execution/sandbox/template-prewarm-lock.js";
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+const tombstoneRemoval = vi.hoisted(() => ({
+  release: undefined as (() => void) | undefined,
+  started: undefined as (() => void) | undefined,
+}));
+const recoveryIntentRemoval = vi.hoisted(() => ({
+  failNext: false,
+}));
+const recoveryIntentRename = vi.hoisted(() => ({
+  calls: 0,
+  failures: 0,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs/promises")>();
+
+  return {
+    ...original,
+    async rm(...input: Parameters<typeof original.rm>) {
+      if (recoveryIntentRemoval.failNext && String(input[0]).includes(".recovery.released-")) {
+        recoveryIntentRemoval.failNext = false;
+        throw Object.assign(new Error("injected recovery intent cleanup failure"), {
+          code: "EBUSY",
+        });
+      }
+
+      if (String(input[0]).includes(".tombstone-") && tombstoneRemoval.started !== undefined) {
+        const onStarted = tombstoneRemoval.started;
+        tombstoneRemoval.started = undefined;
+        onStarted();
+        await new Promise<void>((resolve) => {
+          tombstoneRemoval.release = resolve;
+        });
+      }
+
+      return original.rm(...input);
+    },
+  };
+});
+
+vi.mock("#shared/rename-with-retry.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("#shared/rename-with-retry.js")>();
+
+  return {
+    ...original,
+    async renameWithTransientBusyRetry(sourcePath: string, destinationPath: string) {
+      if (sourcePath.includes("intent-") && destinationPath.includes(".recovery.released-")) {
+        recoveryIntentRename.calls += 1;
+        if (recoveryIntentRename.failures > 0) {
+          recoveryIntentRename.failures -= 1;
+          throw Object.assign(new Error("injected recovery intent rename failure"), {
+            code: "EBUSY",
+          });
+        }
+      }
+
+      return original.renameWithTransientBusyRetry(sourcePath, destinationPath);
+    },
+  };
+});
+
+const BACKEND_NAME = "docker";
+const DEAD_PID = 2_147_483_647;
+const TEMPLATE_KEY = "template-abc";
+const createScratchDirectory = useTemporaryDirectories();
+
+afterEach(() => {
+  tombstoneRemoval.release?.();
+  tombstoneRemoval.release = undefined;
+  tombstoneRemoval.started = undefined;
+  recoveryIntentRemoval.failNext = false;
+  recoveryIntentRename.calls = 0;
+  recoveryIntentRename.failures = 0;
+});
+
+function resolveLockPath(appRoot: string): string {
+  return join(
+    appRoot,
+    ".eve",
+    "sandbox-cache",
+    "template-locks",
+    BACKEND_NAME,
+    `${TEMPLATE_KEY}.lock`,
+  );
+}
+
+function resolveRecoveryRoot(appRoot: string): string {
+  return `${resolveLockPath(appRoot)}.recovery`;
+}
+
+function createLockInput(appRoot: string) {
+  return {
+    appRoot,
+    backendName: BACKEND_NAME,
+    templateKey: TEMPLATE_KEY,
+  };
+}
+
+async function writeLock(
+  appRoot: string,
+  owner: Readonly<Record<string, unknown>> | string,
+  options: { readonly ageMs?: number } = {},
+): Promise<string> {
+  const lockPath = resolveLockPath(appRoot);
+
+  await mkdir(lockPath, { recursive: true });
+  await writeFile(
+    join(lockPath, "owner.json"),
+    typeof owner === "string" ? owner : `${JSON.stringify(owner)}\n`,
+    "utf8",
+  );
+
+  if (options.ageMs !== undefined) {
+    const modifiedAt = new Date(Date.now() - options.ageMs);
+    await utimes(lockPath, modifiedAt, modifiedAt);
+  }
+
+  return lockPath;
+}
+
+async function writeRecoveryIntent(
+  appRoot: string,
+  owner: Readonly<Record<string, unknown>> | string,
+  options: { readonly ageMs?: number; readonly name?: string } = {},
+): Promise<string> {
+  const recoveryPath = join(
+    resolveRecoveryRoot(appRoot),
+    options.name ?? `intent-${Math.random().toString(36).slice(2)}`,
+  );
+
+  await mkdir(recoveryPath, { recursive: true });
+  await writeFile(
+    join(recoveryPath, "owner.json"),
+    typeof owner === "string" ? owner : `${JSON.stringify(owner)}\n`,
+    "utf8",
+  );
+
+  if (options.ageMs !== undefined) {
+    const modifiedAt = new Date(Date.now() - options.ageMs);
+    await utimes(recoveryPath, modifiedAt, modifiedAt);
+  }
+
+  return recoveryPath;
+}
+
+async function releaseFixtureLock(appRoot: string): Promise<void> {
+  await rm(resolveLockPath(appRoot), { force: true, recursive: true });
+}
+
+async function waitForFixtureLock(appRoot: string): Promise<void> {
+  await waitForSandboxTemplatePrewarmLock(createLockInput(appRoot));
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  const pending = Symbol("pending");
+  let timer: NodeJS.Timeout | undefined;
+
+  try {
+    const result = await Promise.race([
+      promise.then(() => true),
+      new Promise<typeof pending>((resolve) => {
+        timer = setTimeout(() => resolve(pending), timeoutMs);
+      }),
+    ]);
+
+    return result !== pending;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+describe("sandbox template prewarm locks", () => {
+  it("records the owning hostname and pid", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-owner-");
+    let owner: unknown;
+
+    await withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {
+      owner = JSON.parse(await readFile(join(resolveLockPath(appRoot), "owner.json"), "utf8"));
+    });
+
+    expect(owner).toMatchObject({
+      hostname: hostname(),
+      pid: process.pid,
+    });
+  });
+
+  it("reclaims a fresh lock whose same-host owner is definitively dead", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-dead-");
+    const lockPath = await writeLock(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: DEAD_PID,
+    });
+    const waiter = waitForFixtureLock(appRoot);
+    const settled = await settlesWithin(waiter, 2_000);
+
+    if (!settled) {
+      await releaseFixtureLock(appRoot);
+    }
+    await waiter;
+
+    expect(settled).toBe(true);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves a same-host live owner even after the unknown-owner stale window", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-live-");
+    const waiter = waitForFixtureLockAfterWrite(
+      appRoot,
+      {
+        createdAt: new Date().toISOString(),
+        hostname: hostname(),
+        pid: process.pid,
+      },
+      { ageMs: 20 * 60 * 1000 },
+    );
+
+    expect(await settlesWithin(waiter, 750)).toBe(false);
+    await releaseFixtureLock(appRoot);
+    await waiter;
+  });
+
+  it("preserves a fresh owner recorded on another host", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-foreign-");
+    const waiter = waitForFixtureLockAfterWrite(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: "another-host.invalid",
+      pid: DEAD_PID,
+    });
+
+    expect(await settlesWithin(waiter, 750)).toBe(false);
+    await releaseFixtureLock(appRoot);
+    await waiter;
+  });
+
+  it("preserves a fresh lock with malformed owner metadata", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-malformed-");
+    const waiter = waitForFixtureLockAfterWrite(appRoot, "{not-json");
+
+    expect(await settlesWithin(waiter, 750)).toBe(false);
+    await releaseFixtureLock(appRoot);
+    await waiter;
+  });
+
+  it("does not acquire the main lock while a live recovery lease exists", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-recovery-");
+    const recoveryPath = await writeRecoveryIntent(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: process.pid,
+      token: "recovery-owner",
+    });
+
+    const contender = withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {});
+    expect(await settlesWithin(contender, 750)).toBe(false);
+
+    await rm(recoveryPath, { force: true, recursive: true });
+    await contender;
+  });
+
+  it("reclaims a recovery lease whose same-host owner is definitively dead", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-dead-recovery-");
+    const recoveryPath = await writeRecoveryIntent(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: DEAD_PID,
+      token: "dead-recovery-owner",
+    });
+
+    await withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {});
+
+    await expect(stat(recoveryPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reclaims stale recovery intents with unverifiable owners", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-stale-recovery-");
+    const malformedPath = await writeRecoveryIntent(appRoot, "{not-json", {
+      ageMs: 11 * 60 * 1000,
+      name: "intent-malformed",
+    });
+    const foreignPath = await writeRecoveryIntent(
+      appRoot,
+      {
+        createdAt: new Date().toISOString(),
+        hostname: "another-host.invalid",
+        pid: DEAD_PID,
+        token: "foreign-recovery-owner",
+      },
+      {
+        ageMs: 11 * 60 * 1000,
+        name: "intent-foreign",
+      },
+    );
+
+    await withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {});
+
+    await expect(stat(malformedPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(foreignPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps the main lock blocked until every live recovery intent is gone", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-recovery-barrier-");
+    const owner = {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: process.pid,
+    };
+    const firstRecoveryPath = await writeRecoveryIntent(appRoot, owner, {
+      name: "intent-first",
+    });
+    const secondRecoveryPath = await writeRecoveryIntent(appRoot, owner, {
+      name: "intent-second",
+    });
+
+    const contender = withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {});
+    expect(await settlesWithin(contender, 750)).toBe(false);
+
+    await rm(firstRecoveryPath, { force: true, recursive: true });
+    expect(await settlesWithin(contender, 750)).toBe(false);
+
+    await rm(secondRecoveryPath, { force: true, recursive: true });
+    await contender;
+  });
+
+  it("does not remove a newer intent while stale-intent cleanup is delayed", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-recovery-generation-");
+    await writeRecoveryIntent(
+      appRoot,
+      {
+        createdAt: new Date().toISOString(),
+        hostname: hostname(),
+        pid: DEAD_PID,
+        token: "dead-recovery-owner",
+      },
+      { name: "intent-dead" },
+    );
+    let markRemovalStarted: (() => void) | undefined;
+    const removalStarted = new Promise<void>((resolve) => {
+      markRemovalStarted = resolve;
+    });
+    tombstoneRemoval.started = markRemovalStarted;
+
+    const firstContender = withSandboxTemplatePrewarmLock(createLockInput(appRoot), async () => {});
+    await removalStarted;
+
+    const liveRecoveryPath = await writeRecoveryIntent(
+      appRoot,
+      {
+        createdAt: new Date().toISOString(),
+        hostname: hostname(),
+        pid: process.pid,
+        token: "live-recovery-owner",
+      },
+      { name: "intent-live" },
+    );
+    const secondContender = withSandboxTemplatePrewarmLock(
+      createLockInput(appRoot),
+      async () => {},
+    );
+
+    tombstoneRemoval.release?.();
+    tombstoneRemoval.release = undefined;
+    expect(await settlesWithin(Promise.all([firstContender, secondContender]), 750)).toBe(false);
+    await expect(stat(liveRecoveryPath)).resolves.toBeDefined();
+
+    await rm(liveRecoveryPath, { force: true, recursive: true });
+    await Promise.all([firstContender, secondContender]);
+  });
+
+  it("does not leave a completed intent blocking when its cleanup fails", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-recovery-cleanup-");
+    const input = createLockInput(appRoot);
+    recoveryIntentRemoval.failNext = true;
+
+    await withSandboxTemplatePrewarmLock(input, async () => {});
+    await withSandboxTemplatePrewarmLock(input, async () => {});
+  });
+
+  it("retries a transient failure while moving a completed intent", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-recovery-rename-");
+    const input = createLockInput(appRoot);
+    recoveryIntentRename.failures = 1;
+
+    await withSandboxTemplatePrewarmLock(input, async () => {});
+    await withSandboxTemplatePrewarmLock(input, async () => {});
+
+    expect(recoveryIntentRename.calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("reclaims stale locks whose owner cannot be verified", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-stale-");
+    const lockPath = await writeLock(appRoot, "{not-json", {
+      ageMs: 11 * 60 * 1000,
+    });
+
+    await waitForFixtureLock(appRoot);
+
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("holds successors out while reclaimed-lock cleanup is delayed", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-successor-");
+    const input = createLockInput(appRoot);
+    const lockPath = await writeLock(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: DEAD_PID,
+    });
+    let markRemovalStarted: (() => void) | undefined;
+    const removalStarted = new Promise<void>((resolve) => {
+      markRemovalStarted = resolve;
+    });
+    tombstoneRemoval.started = markRemovalStarted;
+
+    const reclaim = waitForFixtureLock(appRoot);
+    await removalStarted;
+
+    let enterSuccessor: (() => void) | undefined;
+    const successorEntered = new Promise<void>((resolve) => {
+      enterSuccessor = resolve;
+    });
+    let releaseSuccessor: (() => void) | undefined;
+    const holdSuccessor = new Promise<void>((resolve) => {
+      releaseSuccessor = resolve;
+    });
+    const successor = withSandboxTemplatePrewarmLock(input, async () => {
+      enterSuccessor?.();
+      await holdSuccessor;
+    });
+
+    expect(await settlesWithin(successorEntered, 750)).toBe(false);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    tombstoneRemoval.release?.();
+    tombstoneRemoval.release = undefined;
+    await successorEntered;
+    await expect(stat(lockPath)).resolves.toBeDefined();
+
+    releaseSuccessor?.();
+    await Promise.all([reclaim, successor]);
+  });
+
+  it("does not release a successor when a reclaimed owner finishes late", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-late-owner-");
+    const input = createLockInput(appRoot);
+    const lockPath = resolveLockPath(appRoot);
+    let markFirstEntered: (() => void) | undefined;
+    const firstEntered = new Promise<void>((resolve) => {
+      markFirstEntered = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = withSandboxTemplatePrewarmLock(input, async () => {
+      markFirstEntered?.();
+      await holdFirst;
+    });
+    await firstEntered;
+
+    const firstOwner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    await writeFile(
+      join(lockPath, "owner.json"),
+      `${JSON.stringify({ ...firstOwner, hostname: "another-host.invalid" })}\n`,
+    );
+    const staleAt = new Date(Date.now() - 11 * 60 * 1000);
+    await utimes(lockPath, staleAt, staleAt);
+
+    let markSuccessorEntered: (() => void) | undefined;
+    const successorEntered = new Promise<void>((resolve) => {
+      markSuccessorEntered = resolve;
+    });
+    let releaseSuccessor: (() => void) | undefined;
+    const holdSuccessor = new Promise<void>((resolve) => {
+      releaseSuccessor = resolve;
+    });
+    const successor = withSandboxTemplatePrewarmLock(input, async () => {
+      markSuccessorEntered?.();
+      await holdSuccessor;
+    });
+    await successorEntered;
+
+    releaseFirst?.();
+    await first;
+    await expect(stat(lockPath)).resolves.toBeDefined();
+
+    releaseSuccessor?.();
+    await successor;
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("holds successors out while an owner release is delayed", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-release-");
+    const input = createLockInput(appRoot);
+    const lockPath = resolveLockPath(appRoot);
+    let markFirstEntered: (() => void) | undefined;
+    const firstEntered = new Promise<void>((resolve) => {
+      markFirstEntered = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = withSandboxTemplatePrewarmLock(input, async () => {
+      markFirstEntered?.();
+      await holdFirst;
+    });
+    await firstEntered;
+
+    let markRemovalStarted: (() => void) | undefined;
+    const removalStarted = new Promise<void>((resolve) => {
+      markRemovalStarted = resolve;
+    });
+    tombstoneRemoval.started = markRemovalStarted;
+    releaseFirst?.();
+    await removalStarted;
+
+    let markSuccessorEntered: (() => void) | undefined;
+    const successorEntered = new Promise<void>((resolve) => {
+      markSuccessorEntered = resolve;
+    });
+    let releaseSuccessor: (() => void) | undefined;
+    const holdSuccessor = new Promise<void>((resolve) => {
+      releaseSuccessor = resolve;
+    });
+    const successor = withSandboxTemplatePrewarmLock(input, async () => {
+      markSuccessorEntered?.();
+      await holdSuccessor;
+    });
+
+    expect(await settlesWithin(successorEntered, 750)).toBe(false);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    tombstoneRemoval.release?.();
+    tombstoneRemoval.release = undefined;
+    await first;
+    await successorEntered;
+    await expect(stat(lockPath)).resolves.toBeDefined();
+
+    releaseSuccessor?.();
+    await successor;
+  });
+
+  it("serializes simultaneous reclaimers without deleting a successor lock", async () => {
+    const appRoot = await createScratchDirectory("eve-prewarm-lock-race-");
+    const input = createLockInput(appRoot);
+    await writeLock(appRoot, {
+      createdAt: new Date().toISOString(),
+      hostname: hostname(),
+      pid: DEAD_PID,
+    });
+    let activeCallbacks = 0;
+    let callbackCount = 0;
+    let maximumActiveCallbacks = 0;
+
+    const run = async () => {
+      await withSandboxTemplatePrewarmLock(input, async () => {
+        callbackCount += 1;
+        activeCallbacks += 1;
+        maximumActiveCallbacks = Math.max(maximumActiveCallbacks, activeCallbacks);
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        activeCallbacks -= 1;
+      });
+    };
+
+    await Promise.all([run(), run()]);
+
+    expect(callbackCount).toBe(2);
+    expect(maximumActiveCallbacks).toBe(1);
+    const lockParent = dirname(resolveLockPath(appRoot));
+    expect((await readdir(lockParent)).filter((name) => name.includes(".tombstone-"))).toEqual([]);
+  });
+});
+
+async function waitForFixtureLockAfterWrite(
+  appRoot: string,
+  owner: Readonly<Record<string, unknown>> | string,
+  options?: { readonly ageMs?: number },
+): Promise<void> {
+  await writeLock(appRoot, owner, options);
+  await waitForFixtureLock(appRoot);
+}

--- a/packages/eve/src/execution/sandbox/template-prewarm-lock.ts
+++ b/packages/eve/src/execution/sandbox/template-prewarm-lock.ts
@@ -1,11 +1,27 @@
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 
 import { resolveSandboxCacheDirectory } from "#internal/application/paths.js";
+import { renameWithTransientBusyRetry } from "#shared/rename-with-retry.js";
 
 const LOCK_POLL_MS = 250;
 const LOCK_TIMEOUT_MS = 15 * 60 * 1000;
-const STALE_LOCK_MS = 30 * 60 * 1000;
+const RECOVERY_HEARTBEAT_MS = 30_000;
+// Unknown owners need time to finish, but their fallback must become
+// reclaimable before a waiter reaches its timeout.
+const UNKNOWN_OWNER_STALE_MS = 10 * 60 * 1000;
+
+interface PrewarmLockOwner {
+  readonly createdAt?: string;
+  readonly hostname?: string;
+  readonly pid?: number;
+  readonly token?: string;
+}
+
+type PrewarmLockOwnerLiveness = "alive" | "dead" | "foreign" | "unknown";
+type PrewarmLockReclaimReason = "dead" | "stale";
 
 export interface SandboxTemplatePrewarmLockInput {
   readonly appRoot: string;
@@ -25,11 +41,11 @@ export async function withSandboxTemplatePrewarmLock<T>(
   callback: () => Promise<T>,
 ): Promise<T> {
   const lockPath = resolveSandboxTemplatePrewarmLockPath(input);
-  await acquireLock(lockPath);
+  const ownerToken = await acquireLock(lockPath);
   try {
     return await callback();
   } finally {
-    await rm(lockPath, { force: true, recursive: true }).catch(() => {});
+    await releaseOwnedLockDirectory(lockPath, ownerToken).catch(() => {});
   }
 }
 
@@ -42,22 +58,46 @@ function resolveSandboxTemplatePrewarmLockPath(input: SandboxTemplatePrewarmLock
   );
 }
 
-async function acquireLock(lockPath: string): Promise<void> {
+async function acquireLock(lockPath: string): Promise<string> {
   const startedAt = Date.now();
   for (;;) {
     await mkdir(dirname(lockPath), { recursive: true });
+
+    if (await waitForRecoveryIntents(lockPath, startedAt)) {
+      continue;
+    }
+
     try {
       await mkdir(lockPath);
-      await writeFile(
-        join(lockPath, "owner.json"),
-        `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`,
-      );
-      return;
     } catch (error) {
       if (!isFileExistsError(error)) {
         throw error;
       }
       await waitForExistingLock(lockPath, startedAt, undefined);
+      continue;
+    }
+
+    if ((await listRecoveryIntentPaths(lockPath)).length > 0) {
+      await removeLockDirectory(lockPath).catch(() => {});
+      await waitForRecoveryIntents(lockPath, startedAt);
+      continue;
+    }
+
+    const ownerToken = randomUUID();
+    try {
+      await writeFile(
+        join(lockPath, "owner.json"),
+        `${JSON.stringify({
+          createdAt: new Date().toISOString(),
+          hostname: hostname(),
+          pid: process.pid,
+          token: ownerToken,
+        } satisfies PrewarmLockOwner)}\n`,
+      );
+      return ownerToken;
+    } catch (error) {
+      await removeLockDirectory(lockPath).catch(() => {});
+      throw error;
     }
   }
 }
@@ -69,6 +109,10 @@ async function waitForLockRelease(
   const startedAt = Date.now();
   let nextLogAt = startedAt + 10_000;
   for (;;) {
+    if (await waitForRecoveryIntents(lockPath, startedAt)) {
+      continue;
+    }
+
     try {
       await stat(lockPath);
     } catch (error) {
@@ -106,27 +150,353 @@ async function waitForExistingLock(
     return;
   }
 
-  const lockAgeMs = Date.now() - lockStat.mtimeMs;
-  if (lockAgeMs > STALE_LOCK_MS) {
-    log?.("removing stale sandbox template prewarm lock");
-    await rm(lockPath, { force: true, recursive: true }).catch(() => {});
-    return;
+  const reclaimReason = resolveReclaimReason(
+    await resolvePrewarmLockOwnerLiveness(lockPath),
+    Date.now() - lockStat.mtimeMs,
+  );
+
+  if (reclaimReason !== undefined) {
+    const reclaimedReason = await tryReclaimLock(lockPath);
+
+    if (reclaimedReason === "dead") {
+      log?.("removing sandbox template prewarm lock held by a dead process");
+    } else if (reclaimedReason === "stale") {
+      log?.("removing stale sandbox template prewarm lock");
+    }
+    if (reclaimedReason !== undefined) {
+      return;
+    }
   }
 
-  const elapsedMs = Date.now() - startedAt;
-  if (elapsedMs > LOCK_TIMEOUT_MS) {
-    throw new Error(
-      `Timed out waiting for sandbox template prewarm lock "${lockPath}" after ${LOCK_TIMEOUT_MS}ms.`,
-    );
-  }
-
+  throwIfLockWaitTimedOut(lockPath, startedAt);
   await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
 }
 
+function resolveReclaimReason(
+  liveness: PrewarmLockOwnerLiveness,
+  lockAgeMs: number,
+): PrewarmLockReclaimReason | undefined {
+  if (liveness === "dead") {
+    return "dead";
+  }
+
+  if (liveness !== "alive" && lockAgeMs > UNKNOWN_OWNER_STALE_MS) {
+    return "stale";
+  }
+
+  return undefined;
+}
+
+async function tryReclaimLock(lockPath: string): Promise<PrewarmLockReclaimReason | undefined> {
+  const releaseRecovery = await createRecoveryIntent(lockPath);
+
+  try {
+    return await reclaimLockWhileRecoveryIsHeld(lockPath);
+  } finally {
+    await releaseRecovery();
+  }
+}
+
+async function reclaimLockWhileRecoveryIsHeld(
+  lockPath: string,
+): Promise<PrewarmLockReclaimReason | undefined> {
+  // Re-read immediately before the atomic claim so another waiter never acts
+  // on owner metadata observed before a replacement lock was acquired.
+  const lockStat = await stat(lockPath).catch((error: unknown) => {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  });
+
+  if (lockStat === null) {
+    return undefined;
+  }
+
+  const reclaimReason = resolveReclaimReason(
+    await resolvePrewarmLockOwnerLiveness(lockPath),
+    Date.now() - lockStat.mtimeMs,
+  );
+
+  if (reclaimReason === undefined) {
+    return undefined;
+  }
+
+  const tombstonePath = `${lockPath}.tombstone-${process.pid}-${randomUUID()}`;
+
+  try {
+    await rename(lockPath, tombstonePath);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+
+  // Delete only the claimed path. Every outstanding recovery intent keeps
+  // successors from acquiring the original name until cleanup completes.
+  await rm(tombstonePath, { force: true, recursive: true }).catch(() => {});
+  return reclaimReason;
+}
+
+async function createRecoveryIntent(lockPath: string): Promise<() => Promise<void>> {
+  const recoveryRoot = resolveRecoveryRoot(lockPath);
+  const ownerToken = randomUUID();
+  const recoveryPath = join(recoveryRoot, `intent-${ownerToken}`);
+
+  await mkdir(recoveryRoot, { recursive: true });
+  await mkdir(recoveryPath);
+
+  try {
+    await writeFile(
+      join(recoveryPath, "owner.json"),
+      `${JSON.stringify({
+        createdAt: new Date().toISOString(),
+        hostname: hostname(),
+        pid: process.pid,
+        token: ownerToken,
+      } satisfies PrewarmLockOwner)}\n`,
+    );
+  } catch (error) {
+    await removeRecoveryIntent(recoveryPath).catch(() => {});
+    throw error;
+  }
+
+  return createRecoveryIntentRelease(recoveryPath);
+}
+
+function createRecoveryIntentRelease(recoveryPath: string): () => Promise<void> {
+  let releaseRequested = false;
+  let activeRelease: Promise<void> | undefined;
+  let releaseRetryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const heartbeat = () => {
+    const now = new Date();
+    void utimes(recoveryPath, now, now).catch(() => {});
+  };
+  const scheduleReleaseRetry = () => {
+    if (releaseRetryTimer !== undefined) {
+      return;
+    }
+
+    releaseRetryTimer = setTimeout(() => {
+      releaseRetryTimer = undefined;
+      void attemptRelease().catch(() => {});
+    }, LOCK_POLL_MS);
+    releaseRetryTimer.unref();
+  };
+  const attemptRelease = (): Promise<void> => {
+    if (activeRelease !== undefined) {
+      return activeRelease;
+    }
+
+    const attempt = removeRecoveryIntent(recoveryPath);
+    activeRelease = attempt;
+    void attempt.then(
+      () => {
+        clearInterval(timer);
+        if (releaseRetryTimer !== undefined) {
+          clearTimeout(releaseRetryTimer);
+          releaseRetryTimer = undefined;
+        }
+        activeRelease = undefined;
+      },
+      () => {
+        activeRelease = undefined;
+        heartbeat();
+        scheduleReleaseRetry();
+      },
+    );
+    return attempt;
+  };
+  const timer = setInterval(() => {
+    if (releaseRequested) {
+      void attemptRelease().catch(() => {});
+    } else {
+      heartbeat();
+    }
+  }, RECOVERY_HEARTBEAT_MS);
+  timer.unref();
+
+  return async () => {
+    releaseRequested = true;
+    await attemptRelease().catch(() => {});
+  };
+}
+
+async function waitForRecoveryIntents(lockPath: string, startedAt: number): Promise<boolean> {
+  const recoveryPaths = await listRecoveryIntentPaths(lockPath);
+  if (recoveryPaths.length === 0) {
+    return false;
+  }
+
+  await Promise.all(
+    recoveryPaths.map(async (recoveryPath) => {
+      const recoveryStat = await stat(recoveryPath).catch((error: unknown) => {
+        if (isNotFoundError(error)) {
+          return null;
+        }
+        throw error;
+      });
+      if (recoveryStat === null) {
+        return;
+      }
+
+      const reclaimReason = resolveReclaimReason(
+        await resolvePrewarmLockOwnerLiveness(recoveryPath),
+        Date.now() - recoveryStat.mtimeMs,
+      );
+      if (reclaimReason !== undefined) {
+        // Intent paths contain a random generation and are never reused, so a
+        // delayed cleaner can only remove the generation it inspected.
+        await removeRecoveryIntent(recoveryPath).catch(() => {});
+      }
+    }),
+  );
+
+  if ((await listRecoveryIntentPaths(lockPath)).length === 0) {
+    return false;
+  }
+
+  throwIfLockWaitTimedOut(resolveRecoveryRoot(lockPath), startedAt);
+  await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+  return true;
+}
+
+async function releaseOwnedLockDirectory(lockPath: string, ownerToken: string): Promise<void> {
+  const releaseRecovery = await createRecoveryIntent(lockPath);
+  try {
+    await removeOwnedLockDirectory(lockPath, ownerToken);
+  } finally {
+    await releaseRecovery();
+  }
+}
+
+async function removeOwnedLockDirectory(lockPath: string, ownerToken: string): Promise<void> {
+  const owner = await readPrewarmLockOwner(lockPath);
+  if (owner?.token !== ownerToken) {
+    return;
+  }
+
+  await removeLockDirectory(lockPath);
+}
+
+async function removeLockDirectory(lockPath: string): Promise<void> {
+  const tombstonePath = `${lockPath}.tombstone-${process.pid}-${randomUUID()}`;
+
+  try {
+    await rename(lockPath, tombstonePath);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  await rm(tombstonePath, { force: true, recursive: true }).catch(() => {});
+}
+
+async function removeRecoveryIntent(recoveryPath: string): Promise<void> {
+  const releasedPath = `${dirname(recoveryPath)}.released-${process.pid}-${randomUUID()}`;
+
+  try {
+    await renameWithTransientBusyRetry(recoveryPath, releasedPath);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  // The intent stops blocking as soon as it leaves the recovery root. Cleanup
+  // failure cannot wedge future lock acquisitions.
+  await rm(releasedPath, { force: true, recursive: true }).catch(() => {});
+}
+
+function resolveRecoveryRoot(lockPath: string): string {
+  return `${lockPath}.recovery`;
+}
+
+async function listRecoveryIntentPaths(lockPath: string): Promise<string[]> {
+  const recoveryRoot = resolveRecoveryRoot(lockPath);
+
+  try {
+    return (await readdir(recoveryRoot))
+      .filter((entry) => entry.startsWith("intent-") && !entry.includes(".tombstone-"))
+      .map((entry) => join(recoveryRoot, entry));
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function throwIfLockWaitTimedOut(lockPath: string, startedAt: number): void {
+  if (Date.now() - startedAt <= LOCK_TIMEOUT_MS) {
+    return;
+  }
+
+  throw new Error(
+    `Timed out waiting for sandbox template prewarm lock "${lockPath}" after ${LOCK_TIMEOUT_MS}ms.`,
+  );
+}
+
+async function resolvePrewarmLockOwnerLiveness(
+  lockPath: string,
+): Promise<PrewarmLockOwnerLiveness> {
+  const owner = await readPrewarmLockOwner(lockPath);
+
+  if (owner === undefined || owner.hostname === undefined) {
+    return "unknown";
+  }
+
+  if (owner.hostname !== hostname()) {
+    return "foreign";
+  }
+
+  if (typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid <= 0) {
+    return "unknown";
+  }
+
+  try {
+    process.kill(owner.pid, 0);
+    return "alive";
+  } catch (error) {
+    if (hasErrorCode(error, "ESRCH")) {
+      return "dead";
+    }
+
+    if (hasErrorCode(error, "EPERM")) {
+      return "alive";
+    }
+
+    return "unknown";
+  }
+}
+
+async function readPrewarmLockOwner(lockPath: string): Promise<PrewarmLockOwner | undefined> {
+  try {
+    const value: unknown = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8"));
+
+    if (typeof value !== "object" || value === null) {
+      return undefined;
+    }
+
+    return value as PrewarmLockOwner;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
 function isFileExistsError(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+  return hasErrorCode(error, "EEXIST");
 }
 
 function isNotFoundError(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+  return hasErrorCode(error, "ENOENT");
 }

--- a/packages/eve/src/execution/sandbox/template-prewarm-lock.ts
+++ b/packages/eve/src/execution/sandbox/template-prewarm-lock.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, readdir, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -96,6 +96,14 @@ async function acquireLock(lockPath: string): Promise<string> {
       );
       return ownerToken;
     } catch (error) {
+      if (isNotFoundError(error)) {
+        // A reclaimer moved this directory away between the claim and the
+        // ownership write, so the claim never took effect. Retry rather than
+        // failing the prewarm.
+        throwIfLockWaitTimedOut(lockPath, startedAt);
+        continue;
+      }
+
       await removeLockDirectory(lockPath).catch(() => {});
       throw error;
     }
@@ -225,7 +233,7 @@ async function reclaimLockWhileRecoveryIsHeld(
   const tombstonePath = `${lockPath}.tombstone-${process.pid}-${randomUUID()}`;
 
   try {
-    await rename(lockPath, tombstonePath);
+    await renameWithTransientBusyRetry(lockPath, tombstonePath);
   } catch (error) {
     if (isNotFoundError(error)) {
       return undefined;
@@ -385,7 +393,7 @@ async function removeLockDirectory(lockPath: string): Promise<void> {
   const tombstonePath = `${lockPath}.tombstone-${process.pid}-${randomUUID()}`;
 
   try {
-    await rename(lockPath, tombstonePath);
+    await renameWithTransientBusyRetry(lockPath, tombstonePath);
   } catch (error) {
     if (isNotFoundError(error)) {
       return;


### PR DESCRIPTION
Closes #432.

## What changed

- record hostname, PID, and a generation token in sandbox prewarm lock ownership metadata
- immediately reclaim definitively dead same-host owners and stale unverifiable owners while preserving live owners
- serialize every reclaim and owner release behind unique, never-reused recovery intents
- keep successors out until every in-flight mutation has settled, so delayed reclaimers and late owners cannot remove replacement locks
- heartbeat active intents, reclaim abandoned intents, and retry transient Windows rename failures without leaving a permanent barrier
- atomically move completed intents outside the barrier before best-effort cleanup

## Verification

- lock integration suite: 17 passed, covering dead/live/foreign/malformed owners, simultaneous reclaimers, delayed cleanup, late owner release, multiple recovery generations, abandoned intents, cleanup failure, and transient rename failure
- related unit suite: 4 passed
- independent concurrency review: no blocker after three adversarial race audits
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck` (32/32 tasks)
- `pnpm guard:invariants`
- `git diff --check`
- signed commit with DCO