### PR TITLE
feat(eve): background tasks - inert task mode (slice 1)

### DIFF
--- a/.changeset/spicy-planets-brake.md
+++ b/.changeset/spicy-planets-brake.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add the inert task-mode foundation for background tasks (Slice 1 of the background-tasks plan): durable MCP-aligned task records owned by per-task actor runs, guarded notification fan-out to session-driver callback endpoints, and driver-side routing that wakes a parked session with a terminal task outcome or re-emits an `input_required` task's requests without running a turn. Nothing user-facing elects background execution yet — the creation path is internal-only.

--- a/packages/eve/src/execution/deliver-payloads.test.ts
+++ b/packages/eve/src/execution/deliver-payloads.test.ts
@@ -6,7 +6,34 @@ const SECOND_MESSAGE = "Proceed after the synthetic health check passes.";
 const FIRST_CALLBACK_CONTEXT = "Release policy: use the synthetic staging environment only.";
 const SECOND_CALLBACK_CONTEXT = "Release policy: wait for the synthetic health check.";
 
+const TASK_NOTIFICATION_A = {
+  kind: "task.terminal" as const,
+  task: {
+    createdAt: "2026-07-23T00:00:00.000Z",
+    lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+    result: "a",
+    status: "completed" as const,
+    taskId: "task_a",
+    ttlMs: null,
+  },
+};
+
+const TASK_NOTIFICATION_B = {
+  ...TASK_NOTIFICATION_A,
+  task: { ...TASK_NOTIFICATION_A.task, result: "b", taskId: "task_b" },
+};
+
 describe("coalesceDeliverPayloads", () => {
+  it("concat-merges task notifications instead of last-write-wins", () => {
+    const result = coalesceDeliverPayloads([
+      { taskNotifications: [TASK_NOTIFICATION_A] },
+      { message: "hello", taskNotifications: [TASK_NOTIFICATION_B] },
+    ]);
+
+    expect(result.taskNotifications).toEqual([TASK_NOTIFICATION_A, TASK_NOTIFICATION_B]);
+    expect(result.message).toBe("hello");
+  });
+
   it("preserves messages and authored callback context in arrival order", () => {
     const result = coalesceDeliverPayloads([
       {

--- a/packages/eve/src/execution/deliver-payloads.ts
+++ b/packages/eve/src/execution/deliver-payloads.ts
@@ -1,6 +1,8 @@
 import type { DeliverPayload } from "#channel/types.js";
+import { TASK_NOTIFICATIONS_PAYLOAD_KEY } from "#execution/tasks/delivery.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
 import type { StepInput } from "#harness/types.js";
+import type { TaskNotification } from "#runtime/tasks/types.js";
 
 const COALESCED_DELIVER_FIELDS = ["context", "inputResponses", "message", "outputSchema"] as const;
 
@@ -10,6 +12,7 @@ export function coalesceDeliverPayloads(payloads: readonly DeliverPayload[]): De
   if (payloads.length === 1) return payloads[0] ?? {};
 
   const merged: Record<string, unknown> = {};
+  const taskNotifications: TaskNotification[] = [];
   let turnInput: StepInput = {};
 
   for (const payload of payloads) {
@@ -18,11 +21,22 @@ export function coalesceDeliverPayloads(payloads: readonly DeliverPayload[]): De
         merged[key] = value;
       }
     }
+    // Concat-merged rather than last-write-wins: two coalesced
+    // notifications must not clobber each other. The reserved field is
+    // deliberately undeclared on the public payload type — it rides the
+    // index signature (`#execution/tasks/delivery.js`).
+    const notifications = payload[TASK_NOTIFICATIONS_PAYLOAD_KEY];
+    if (Array.isArray(notifications)) {
+      taskNotifications.push(...(notifications as TaskNotification[]));
+    }
     turnInput = coalesceTurnInputs(turnInput, payload);
   }
 
   for (const field of COALESCED_DELIVER_FIELDS) {
     delete merged[field];
+  }
+  if (taskNotifications.length > 0) {
+    merged[TASK_NOTIFICATIONS_PAYLOAD_KEY] = taskNotifications;
   }
 
   return Object.assign(merged, turnInput);

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -32,6 +32,12 @@ import type {
   RuntimeSubagentCallActionRequest,
   RuntimeSubagentResultActionResult,
 } from "#runtime/actions/types.js";
+import { readBackgroundElection } from "#runtime/tasks/election.js";
+import { toCreateTaskResult } from "#runtime/tasks/types.js";
+import { createEveCallbackRoutePath } from "#protocol/routes.js";
+import { createTask } from "#execution/tasks/service.js";
+import { createWorkflowCallbackUrl } from "#execution/workflow-callback-url.js";
+import { addLiveTask } from "#harness/task-state.js";
 import {
   createDurableSessionState,
   type DurableSessionState,
@@ -111,6 +117,47 @@ export async function dispatchRuntimeActionsStep(input: {
         });
         results.push(createRecursiveAgentRootOnlyResult(action));
         continue;
+      }
+
+      if (action.kind === "subagent-call" || action.kind === "remote-agent-call") {
+        const election = readBackgroundElection(batch.taskElections?.[action.callId]);
+        if (election !== undefined) {
+          // Background election: create the task record, register the
+          // session's driver endpoint, and terminalize the call position
+          // with the CreateTaskResult placeholder. No child is started in
+          // Slice 1 (inert mode) — the executor arrives with Slice 2.
+          const callbackUrl =
+            input.callbackBaseUrl === undefined || session.continuationToken.length === 0
+              ? undefined
+              : createWorkflowCallbackUrl(
+                  input.callbackBaseUrl,
+                  createEveCallbackRoutePath(session.continuationToken),
+                );
+          const record = await createTask({
+            createdBy:
+              initiatorAuth === null
+                ? null
+                : {
+                    authenticator: initiatorAuth.authenticator,
+                    principalId: initiatorAuth.principalId,
+                  },
+            endpoints: callbackUrl === undefined ? [] : [{ url: callbackUrl }],
+            sessionId: session.sessionId,
+            ttlMs: election.ttlMs,
+          });
+          nextSession = addLiveTask(nextSession, {
+            taskId: record.task.taskId,
+            taskRunId: record.taskRunId,
+          });
+          results.push({
+            callId: action.callId,
+            kind: "subagent-result",
+            output: toCreateTaskResult(record.task),
+            subagentName:
+              action.kind === "subagent-call" ? action.subagentName : action.remoteAgentName,
+          });
+          continue;
+        }
       }
 
       let childSessionId: string;

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -19,7 +19,11 @@ import { AGENT_TOOL_DESCRIPTION, AGENT_TOOL_NAME } from "#runtime/framework-tool
 import { ROOT_RUNTIME_AGENT_NODE_ID, type ResolvedRuntimeAgentNode } from "#runtime/graph.js";
 
 import type { PreparedRuntimeTool } from "#runtime/sessions/turn.js";
-import { SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+import {
+  SUBAGENT_TOOL_INPUT_SCHEMA,
+  SUBAGENT_TOOL_INPUT_SCHEMA_WITH_TASK,
+} from "#runtime/subagents/registry.js";
+import { isInternalBackgroundTaskElectionEnabled } from "#runtime/tasks/election.js";
 import { findRegisteredRuntimeTool } from "#runtime/tools/registry.js";
 import type { ResolvedToolDefinition } from "#runtime/types.js";
 import { preserveFrameworkStateOnCompaction } from "#execution/compaction.js";
@@ -181,15 +185,19 @@ export function createNodeHarnessTools(input: {
     !input.node.agent.disabledFrameworkTools.includes(AGENT_TOOL_NAME) &&
     !tools.has(AGENT_TOOL_NAME)
   ) {
+    // Slice 1 internal gate: the env flag is the only elector until the
+    // Slice 2 `task:` combinators land (`#runtime/tasks/election.js`).
+    const taskElection = isInternalBackgroundTaskElectionEnabled();
+    const runtimeAction: HarnessToolDefinition["runtimeAction"] = {
+      kind: "subagent-call",
+      nodeId: input.node.nodeId,
+      subagentName: AGENT_TOOL_NAME,
+    };
     tools.set(AGENT_TOOL_NAME, {
       description: AGENT_TOOL_DESCRIPTION,
-      inputSchema: SUBAGENT_TOOL_INPUT_SCHEMA,
+      inputSchema: taskElection ? SUBAGENT_TOOL_INPUT_SCHEMA_WITH_TASK : SUBAGENT_TOOL_INPUT_SCHEMA,
       name: AGENT_TOOL_NAME,
-      runtimeAction: {
-        kind: "subagent-call",
-        nodeId: input.node.nodeId,
-        subagentName: AGENT_TOOL_NAME,
-      },
+      runtimeAction: taskElection ? { ...runtimeAction, taskSupport: "optional" } : runtimeAction,
     });
   }
 

--- a/packages/eve/src/execution/route-child-delivery.ts
+++ b/packages/eve/src/execution/route-child-delivery.ts
@@ -1,31 +1,38 @@
 import type { DeliverPayload, SessionAuthContext } from "#channel/types.js";
 import { coalesceDeliverPayloads } from "#execution/deliver-payloads.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { payloadCarriesTaskNotifications } from "#execution/tasks/delivery.js";
 import { routeProxiedDeliverStep } from "#execution/workflow-steps.js";
 
 /**
  * Coalesces inbound deliver payloads and routes any descendant-bound input
- * responses down to the owning child, returning the parent-local remainder
- * (or `undefined` when the whole payload routed away).
+ * responses down to the owning child and task notifications through the
+ * task arms, returning the parent-local remainder (or `undefined` when the
+ * whole payload routed away).
  *
- * Short-circuits via `hasProxyInputRequests` so the common no-active-descendant
- * path skips a durable step boundary. Lives in its own non-step module so both
- * the driver and the active turn can share it (a `"use step"` module cannot
- * re-export plain helpers into a workflow body).
+ * Short-circuits when no descendant subagent is active and no task
+ * notification is aboard so the common path skips a durable step boundary.
+ * Lives in its own non-step module so both the driver and the active turn
+ * can share it (a `"use step"` module cannot re-export plain helpers into
+ * a workflow body).
  */
 export async function routeDeliverToChildren(input: {
   readonly auth?: SessionAuthContext | null;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly payloads: readonly DeliverPayload[];
+  readonly serializedContext?: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<DeliverPayload | undefined> {
   const payload = coalesceDeliverPayloads(input.payloads);
-  if (!input.sessionState.hasProxyInputRequests) return payload;
+  if (!input.sessionState.hasProxyInputRequests && !payloadCarriesTaskNotifications(payload)) {
+    return payload;
+  }
 
   const routed = await routeProxiedDeliverStep({
     auth: input.auth,
     parentWritable: input.parentWritable,
     payload,
+    serializedContext: input.serializedContext,
     sessionState: input.sessionState,
   });
   return routed.remainder;

--- a/packages/eve/src/execution/tasks/commands.test.ts
+++ b/packages/eve/src/execution/tasks/commands.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyTaskTransition,
+  taskCommandHookPayloadSchema,
+  taskErrorFromToolOutput,
+} from "#execution/tasks/commands.js";
+import type { TaskRecord } from "#execution/tasks/store.js";
+import type { InputRequest } from "#runtime/input/types.js";
+import type { DetailedTask } from "#runtime/tasks/types.js";
+
+const NOW = "2026-07-23T01:00:00.000Z";
+
+const inputRequest: InputRequest = {
+  action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "get_weather" },
+  prompt: "Allow?",
+  requestId: "req_1",
+};
+
+function createRecord(task?: Partial<DetailedTask>): TaskRecord {
+  return {
+    endpoints: [{ url: "https://caller.example/eve/v1/callback/tok" }],
+    sessionId: "session_1",
+    task: {
+      createdAt: "2026-07-23T00:00:00.000Z",
+      lastUpdatedAt: "2026-07-23T00:00:00.000Z",
+      status: "working",
+      taskId: "task_1",
+      ttlMs: null,
+      ...task,
+    } as DetailedTask,
+    taskRunId: "run_1",
+  };
+}
+
+function apply(record: TaskRecord, command: Parameters<typeof applyTaskTransition>[0]["command"]) {
+  return applyTaskTransition({ command, commandId: "cmd_1", now: NOW, record });
+}
+
+describe("applyTaskTransition", () => {
+  it("completes a working task with the result inline", () => {
+    const applied = apply(createRecord(), { kind: "complete", result: { ok: true } });
+
+    expect(applied.notificationKind).toBe("task.terminal");
+    expect(applied.record.task).toMatchObject({
+      lastUpdatedAt: NOW,
+      result: { ok: true },
+      status: "completed",
+    });
+    expect(applied.record.lastCommandId).toBe("cmd_1");
+  });
+
+  it("fails a working task with a structured error and no result", () => {
+    const applied = apply(createRecord(), {
+      error: { data: { code: 500 }, message: "boom" },
+      kind: "fail",
+    });
+
+    expect(applied.notificationKind).toBe("task.terminal");
+    expect(applied.record.task).toMatchObject({ error: { message: "boom" }, status: "failed" });
+    expect("result" in applied.record.task).toBe(false);
+  });
+
+  it("cancels a working task", () => {
+    const applied = apply(createRecord(), { kind: "cancel" });
+    expect(applied.notificationKind).toBe("task.terminal");
+    expect(applied.record.task.status).toBe("cancelled");
+  });
+
+  it("transitions working → input_required carrying the live requests", () => {
+    const applied = apply(createRecord(), {
+      inputRequests: [inputRequest],
+      kind: "require-input",
+    });
+
+    expect(applied.notificationKind).toBe("task.status");
+    expect(applied.record.task).toMatchObject({
+      inputRequests: [inputRequest],
+      status: "input_required",
+    });
+  });
+
+  it("routes update responses and returns to working", () => {
+    const awaiting = apply(createRecord(), {
+      inputRequests: [inputRequest],
+      kind: "require-input",
+    }).record;
+
+    const applied = applyTaskTransition({
+      command: { inputResponses: [{ optionId: "approve", requestId: "req_1" }], kind: "update" },
+      commandId: "cmd_2",
+      now: NOW,
+      record: awaiting,
+    });
+
+    expect(applied.notificationKind).toBe("task.status");
+    expect(applied.record.task.status).toBe("working");
+    expect("inputRequests" in applied.record.task).toBe(false);
+    expect(applied.record.inputResponses).toEqual([{ optionId: "approve", requestId: "req_1" }]);
+  });
+
+  it("no-ops update outside input_required but still acknowledges", () => {
+    const applied = apply(createRecord(), {
+      inputResponses: [{ requestId: "req_1", text: "yes" }],
+      kind: "update",
+    });
+
+    expect(applied.notificationKind).toBeUndefined();
+    expect(applied.record.task.status).toBe("working");
+    expect(applied.record.inputResponses).toBeUndefined();
+    expect(applied.record.lastCommandId).toBe("cmd_1");
+  });
+
+  it("emits task.progress for a status message on a working task only", () => {
+    const progressed = apply(createRecord(), {
+      kind: "set-status-message",
+      statusMessage: "halfway",
+    });
+    expect(progressed.notificationKind).toBe("task.progress");
+    expect(progressed.record.task.statusMessage).toBe("halfway");
+
+    const awaiting = apply(createRecord(), {
+      inputRequests: [inputRequest],
+      kind: "require-input",
+    }).record;
+    const ignored = applyTaskTransition({
+      command: { kind: "set-status-message", statusMessage: "late" },
+      commandId: "cmd_3",
+      now: NOW,
+      record: awaiting,
+    });
+    expect(ignored.notificationKind).toBeUndefined();
+    expect(ignored.record.task.status).toBe("input_required");
+  });
+
+  it("keeps terminal states final — cancelled is sticky under a later complete", () => {
+    const cancelled = apply(createRecord(), { kind: "cancel" }).record;
+    const applied = applyTaskTransition({
+      command: { kind: "complete", result: "too late" },
+      commandId: "cmd_4",
+      now: NOW,
+      record: cancelled,
+    });
+
+    expect(applied.notificationKind).toBeUndefined();
+    expect(applied.record.task.status).toBe("cancelled");
+    expect(applied.record.lastCommandId).toBe("cmd_4");
+  });
+});
+
+describe("taskCommandHookPayloadSchema", () => {
+  it("accepts a well-formed payload and rejects malformed ones", () => {
+    expect(
+      taskCommandHookPayloadSchema.safeParse({
+        command: { kind: "cancel" },
+        commandId: "cmd_1",
+        kind: "task-command",
+      }).success,
+    ).toBe(true);
+    expect(
+      taskCommandHookPayloadSchema.safeParse({ command: { kind: "explode" }, kind: "task-command" })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe("taskErrorFromToolOutput", () => {
+  it("uses a string output as the message", () => {
+    expect(taskErrorFromToolOutput("it broke")).toEqual({ message: "it broke" });
+  });
+
+  it("preserves structured output under data", () => {
+    expect(taskErrorFromToolOutput({ reason: "quota" })).toEqual({
+      data: { reason: "quota" },
+      message: "Tool execution failed.",
+    });
+  });
+});

--- a/packages/eve/src/execution/tasks/commands.ts
+++ b/packages/eve/src/execution/tasks/commands.ts
@@ -1,0 +1,204 @@
+/**
+ * Task transition commands and the pure transition function.
+ *
+ * Every write to a task record is a command resumed onto the owning
+ * actor's hook (`#execution/tasks/workflow.js`); the actor applies
+ * {@link applyTaskTransition} single-writer, so legality — terminal
+ * states are final, `cancelled` is sticky, `update` requires
+ * `input_required` — is enforced in exactly one place and transition
+ * bursts are ordered.
+ */
+import { z } from "#compiled/zod/index.js";
+
+import { inputRequestSchema, inputResponseSchema } from "#runtime/input/types.js";
+import {
+  isTerminalStatus,
+  type DetailedTask,
+  type TaskNotificationKind,
+} from "#runtime/tasks/types.js";
+import type { TaskRecord } from "#execution/tasks/store.js";
+import { jsonValueSchema } from "#shared/json-schemas.js";
+import type { JsonValue } from "#shared/json.js";
+
+/**
+ * One transition command addressed to a task actor.
+ */
+export type TaskCommand = z.infer<typeof taskCommandSchema>;
+
+const taskErrorSchema = z
+  .object({
+    data: jsonValueSchema.optional(),
+    message: z.string(),
+  })
+  .strict();
+
+/**
+ * Zod schema for one task transition command.
+ */
+export const taskCommandSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("cancel") }).strict(),
+  z.object({ kind: z.literal("complete"), result: jsonValueSchema }).strict(),
+  z.object({ error: taskErrorSchema, kind: z.literal("fail") }).strict(),
+  z
+    .object({ inputRequests: z.array(inputRequestSchema), kind: z.literal("require-input") })
+    .strict(),
+  z.object({ kind: z.literal("set-status-message"), statusMessage: z.string() }).strict(),
+  z.object({ inputResponses: z.array(inputResponseSchema), kind: z.literal("update") }).strict(),
+]);
+
+/**
+ * The hook payload a task actor consumes. `commandId` is echoed back on
+ * the written snapshot (`TaskRecord.lastCommandId`) so senders can poll
+ * for their command's application.
+ */
+export type TaskCommandHookPayload = z.infer<typeof taskCommandHookPayloadSchema>;
+
+/**
+ * Zod schema for one task-command hook payload. The actor validates
+ * every resumed payload and ignores anything malformed.
+ */
+export const taskCommandHookPayloadSchema = z
+  .object({
+    command: taskCommandSchema,
+    commandId: z.string(),
+    kind: z.literal("task-command"),
+  })
+  .strict();
+
+/**
+ * Token of a task actor's command hook.
+ */
+export function taskCommandHookToken(taskId: string): string {
+  return `${taskId}:commands`;
+}
+
+/**
+ * Result of applying one command: the next record snapshot, plus the
+ * notification kind to fan out (absent for no-op commands).
+ */
+export interface TaskTransitionResult {
+  readonly notificationKind?: TaskNotificationKind;
+  readonly record: TaskRecord;
+}
+
+/**
+ * Applies one command to a record. Pure — timestamps are inputs.
+ *
+ * Illegal commands (any command on a terminal task, `update` outside
+ * `input_required`, `set-status-message` outside `working`) are no-ops
+ * that still acknowledge the command id, so senders always observe
+ * their command settled and read the unchanged record.
+ */
+export function applyTaskTransition(input: {
+  readonly command: TaskCommand;
+  readonly commandId: string;
+  readonly now: string;
+  readonly record: TaskRecord;
+}): TaskTransitionResult {
+  const { command, commandId, now, record } = input;
+  const acknowledge = (next?: {
+    readonly inputResponses?: readonly z.infer<typeof inputResponseSchema>[];
+    readonly notificationKind?: TaskNotificationKind;
+    readonly task?: DetailedTask;
+  }): TaskTransitionResult => {
+    const nextRecord: TaskRecord = {
+      ...record,
+      lastCommandId: commandId,
+      task: next?.task ?? record.task,
+    };
+    const result: { notificationKind?: TaskNotificationKind; record: TaskRecord } = {
+      record:
+        next?.inputResponses === undefined
+          ? nextRecord
+          : { ...nextRecord, inputResponses: next.inputResponses },
+    };
+    if (next?.notificationKind !== undefined) {
+      result.notificationKind = next.notificationKind;
+    }
+    return result;
+  };
+
+  if (isTerminalStatus(record.task.status)) {
+    return acknowledge();
+  }
+
+  const base = baseTask(record.task, now);
+
+  switch (command.kind) {
+    case "cancel":
+      return acknowledge({
+        notificationKind: "task.terminal",
+        task: { ...base, status: "cancelled" },
+      });
+    case "complete":
+      return acknowledge({
+        notificationKind: "task.terminal",
+        task: { ...base, result: command.result, status: "completed" },
+      });
+    case "fail":
+      return acknowledge({
+        notificationKind: "task.terminal",
+        task: { ...base, error: command.error, status: "failed" },
+      });
+    case "require-input":
+      return acknowledge({
+        notificationKind: "task.status",
+        task: { ...base, inputRequests: command.inputRequests, status: "input_required" },
+      });
+    case "set-status-message":
+      if (record.task.status !== "working") {
+        return acknowledge();
+      }
+      return acknowledge({
+        notificationKind: "task.progress",
+        task: { ...base, status: "working", statusMessage: command.statusMessage },
+      });
+    case "update":
+      if (record.task.status !== "input_required") {
+        return acknowledge();
+      }
+      return acknowledge({
+        inputResponses: [...(record.inputResponses ?? []), ...command.inputResponses],
+        notificationKind: "task.status",
+        task: { ...base, status: "working" },
+      });
+  }
+}
+
+/**
+ * Projects an error-shaped tool output into the task `error` payload:
+ * `message` from the output when it is a string, the original output
+ * preserved under `data` otherwise.
+ */
+export function taskErrorFromToolOutput(output: JsonValue): { data?: JsonValue; message: string } {
+  if (typeof output === "string") {
+    return { message: output };
+  }
+  return { data: output, message: "Tool execution failed." };
+}
+
+function baseTask(
+  task: DetailedTask,
+  now: string,
+): Omit<DetailedTask, "status" | "result" | "error" | "inputRequests"> {
+  const base: {
+    createdAt: string;
+    lastUpdatedAt: string;
+    pollIntervalMs?: number;
+    statusMessage?: string;
+    taskId: string;
+    ttlMs: number | null;
+  } = {
+    createdAt: task.createdAt,
+    lastUpdatedAt: now,
+    taskId: task.taskId,
+    ttlMs: task.ttlMs,
+  };
+  if (task.statusMessage !== undefined) {
+    base.statusMessage = task.statusMessage;
+  }
+  if (task.pollIntervalMs !== undefined) {
+    base.pollIntervalMs = task.pollIntervalMs;
+  }
+  return base;
+}

--- a/packages/eve/src/execution/tasks/delivery.test.ts
+++ b/packages/eve/src/execution/tasks/delivery.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeliverPayload } from "#channel/types.js";
+import {
+  formatTaskOutcomeMessage,
+  payloadCarriesTaskNotifications,
+  readTaskNotifications,
+  sanitizeInboundDeliverPayload,
+  splitTaskNotifications,
+} from "#execution/tasks/delivery.js";
+import type { TaskNotification } from "#runtime/tasks/types.js";
+
+const notification: TaskNotification = {
+  kind: "task.terminal",
+  task: {
+    createdAt: "2026-07-23T00:00:00.000Z",
+    lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+    result: { ok: true },
+    status: "completed",
+    taskId: "task_1",
+    ttlMs: null,
+  },
+};
+
+describe("payloadCarriesTaskNotifications", () => {
+  it("detects the reserved field structurally", () => {
+    expect(payloadCarriesTaskNotifications({ taskNotifications: [notification] })).toBe(true);
+    expect(payloadCarriesTaskNotifications({ taskNotifications: [] })).toBe(false);
+    expect(payloadCarriesTaskNotifications({ message: "hi" })).toBe(false);
+  });
+});
+
+describe("readTaskNotifications", () => {
+  it("validates entries and drops malformed ones", () => {
+    const payload: DeliverPayload = {
+      taskNotifications: [notification, { kind: "task.terminal", task: { taskId: "broken" } }],
+    };
+    expect(readTaskNotifications(payload)).toEqual([notification]);
+  });
+});
+
+describe("splitTaskNotifications", () => {
+  it("returns the payload untouched when the field is absent", () => {
+    const payload = { message: "hi" };
+    expect(splitTaskNotifications(payload)).toEqual({ notifications: [], rest: payload });
+  });
+
+  it("splits notifications from a mixed payload", () => {
+    const { notifications, rest } = splitTaskNotifications({
+      message: "hi",
+      taskNotifications: [notification],
+    });
+    expect(notifications).toEqual([notification]);
+    expect(rest).toEqual({ message: "hi" });
+  });
+
+  it("returns rest undefined for a pure task payload", () => {
+    const { notifications, rest } = splitTaskNotifications({
+      taskNotifications: [notification],
+    });
+    expect(notifications).toEqual([notification]);
+    expect(rest).toBeUndefined();
+  });
+});
+
+describe("sanitizeInboundDeliverPayload", () => {
+  it("strips the reserved field and preserves everything else", () => {
+    expect(
+      sanitizeInboundDeliverPayload({
+        adapterMetadata: { deliverySequence: 1 },
+        message: "hi",
+        taskNotifications: [notification],
+      }),
+    ).toEqual({ adapterMetadata: { deliverySequence: 1 }, message: "hi" });
+  });
+
+  it("returns clean payloads by reference", () => {
+    const payload = { message: "hi" };
+    expect(sanitizeInboundDeliverPayload(payload)).toBe(payload);
+  });
+});
+
+describe("formatTaskOutcomeMessage", () => {
+  it("carries the result inline for completed tasks", () => {
+    const message = formatTaskOutcomeMessage(notification.task);
+    expect(message).toContain("task_1");
+    expect(message).toContain("completed");
+    expect(JSON.parse(message.split("\n")[1] ?? "")).toEqual({
+      result: { ok: true },
+      status: "completed",
+      taskId: "task_1",
+    });
+  });
+
+  it("carries the error inline for failed tasks", () => {
+    const message = formatTaskOutcomeMessage({
+      createdAt: "2026-07-23T00:00:00.000Z",
+      error: { message: "boom" },
+      lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+      status: "failed",
+      taskId: "task_2",
+      ttlMs: null,
+    });
+    expect(JSON.parse(message.split("\n")[1] ?? "")).toEqual({
+      error: { message: "boom" },
+      status: "failed",
+      taskId: "task_2",
+    });
+  });
+});

--- a/packages/eve/src/execution/tasks/delivery.ts
+++ b/packages/eve/src/execution/tasks/delivery.ts
@@ -1,0 +1,108 @@
+/**
+ * Task-notification deliver-payload helpers.
+ *
+ * A task notification enters a session as an ordinary `deliver` hook
+ * payload carrying the reserved `taskNotifications` field — the
+ * driver's wake vocabulary stays `deliver`-only and discrimination
+ * happens in step bodies. The field is framework-owned: it is stripped
+ * from inbound public deliveries at the runtime ingress and from
+ * adapter-visible payloads in the turn step, so only the callback
+ * route (a capability URL) and framework code can inject it.
+ *
+ * This module is pure and driver-body-safe: no logging, no node
+ * built-ins (`route-child-delivery.js` is compiled into the pinned
+ * driver bundle).
+ */
+import type { DeliverPayload } from "#channel/types.js";
+import {
+  taskNotificationSchema,
+  type DetailedTask,
+  type TaskNotification,
+} from "#runtime/tasks/types.js";
+import type { JsonObject } from "#shared/json.js";
+
+/** Reserved deliver-payload field carrying task notifications. */
+export const TASK_NOTIFICATIONS_PAYLOAD_KEY = "taskNotifications";
+
+/**
+ * Returns true when a payload carries at least one task notification.
+ * Structural check only — validation happens at read.
+ */
+export function payloadCarriesTaskNotifications(payload: DeliverPayload): boolean {
+  const raw = payload[TASK_NOTIFICATIONS_PAYLOAD_KEY];
+  return Array.isArray(raw) && raw.length > 0;
+}
+
+/**
+ * Reads and validates the task notifications on a payload. Malformed
+ * entries are dropped — the wire crosses deployments and versions.
+ */
+export function readTaskNotifications(payload: DeliverPayload): readonly TaskNotification[] {
+  const raw = payload[TASK_NOTIFICATIONS_PAYLOAD_KEY];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const notifications: TaskNotification[] = [];
+  for (const entry of raw) {
+    const parsed = taskNotificationSchema.safeParse(entry);
+    if (parsed.success) {
+      notifications.push(parsed.data);
+    }
+  }
+  return notifications;
+}
+
+/**
+ * Splits the reserved field off a payload. `rest` is `undefined` when
+ * nothing else remains on the payload — the caller then has no
+ * parent-local remainder to run a turn with.
+ */
+export function splitTaskNotifications(payload: DeliverPayload): {
+  readonly notifications: readonly TaskNotification[];
+  readonly rest: DeliverPayload | undefined;
+} {
+  if (!(TASK_NOTIFICATIONS_PAYLOAD_KEY in payload)) {
+    return { notifications: [], rest: payload };
+  }
+  const { [TASK_NOTIFICATIONS_PAYLOAD_KEY]: _stripped, ...rest } = payload;
+  return {
+    notifications: readTaskNotifications(payload),
+    rest: Object.keys(rest).length > 0 ? rest : undefined,
+  };
+}
+
+/**
+ * Strips the reserved field from an inbound public delivery so a
+ * channel caller can never forge a task notification (half of the
+ * initiator-binding invariant; the other half is principal comparison
+ * at routing).
+ */
+export function sanitizeInboundDeliverPayload(payload: DeliverPayload): DeliverPayload {
+  if (!(TASK_NOTIFICATIONS_PAYLOAD_KEY in payload)) {
+    return payload;
+  }
+  const { [TASK_NOTIFICATIONS_PAYLOAD_KEY]: _stripped, ...rest } = payload;
+  return rest;
+}
+
+/**
+ * Projects a terminal task into the system-authored turn input the
+ * model sees. The outcome enters as new input — the original call
+ * position was terminalized with the placeholder at election.
+ */
+export function formatTaskOutcomeMessage(task: DetailedTask): string {
+  const outcome: Record<string, JsonObject[string]> = {
+    status: task.status,
+    taskId: task.taskId,
+  };
+  if (task.status === "completed") {
+    outcome.result = task.result;
+  }
+  if (task.status === "failed") {
+    outcome.error = task.error;
+  }
+  if (task.statusMessage !== undefined) {
+    outcome.statusMessage = task.statusMessage;
+  }
+  return `Background task ${task.taskId} is now ${task.status}.\n${JSON.stringify(outcome)}`;
+}

--- a/packages/eve/src/execution/tasks/notifications.integration.test.ts
+++ b/packages/eve/src/execution/tasks/notifications.integration.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resumeHook, start } from "#internal/workflow/runtime.js";
+
+import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { filterEventsByType } from "#internal/testing/events.js";
+import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
+import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { taskCommandHookToken, type TaskCommandHookPayload } from "#execution/tasks/commands.js";
+import { workflowEntry } from "#execution/workflow-entry.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import type { RouteContext } from "#public/definitions/channel.js";
+import { handleSessionCallbackRequest } from "#runtime/session-callback-route.js";
+import type { InputRequest } from "#runtime/input/types.js";
+
+/**
+ * End-to-end Slice 1 coverage: background election → placeholder →
+ * park → executor transition → loopback notification POST through the
+ * real callback route → driver wake → the two routing arms.
+ *
+ * The internal env gate (`EVE_INTERNAL_BACKGROUND_TASK_ELECTION`) is
+ * the Slice 1 elector; the test plays the executor by resuming the
+ * task actor's command hook directly.
+ */
+
+interface CapturedCallbackPost {
+  readonly body: { kind?: string };
+  readonly status: number;
+  readonly url: string;
+}
+
+function installLoopbackCallbackFetch(): CapturedCallbackPost[] {
+  const original = globalThis.fetch;
+  const posts: CapturedCallbackPost[] = [];
+  vi.stubGlobal(
+    "fetch",
+    async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const target = String(url);
+      const match = /\/eve\/v1\/callback\/([^/?]+)/.exec(target);
+      if (match?.[1] === undefined) {
+        return original(url as never, init as never);
+      }
+      const token = decodeURIComponent(match[1]);
+      const response = await handleSessionCallbackRequest(
+        new Request(target, { body: init?.body, headers: init?.headers, method: "POST" }),
+        createRouteContext({ token }),
+      );
+      posts.push({
+        body: JSON.parse(String(init?.body)) as { kind?: string },
+        status: response.status,
+        url: target,
+      });
+      return response;
+    },
+  );
+  return posts;
+}
+
+function createRouteContext(params: Record<string, string>): RouteContext {
+  return {
+    agent: {
+      async cancelTurn() {
+        throw new Error("unexpected cancelTurn");
+      },
+      async deliver() {
+        throw new Error("unexpected deliver");
+      },
+      async getEventStream() {
+        throw new Error("unexpected getEventStream");
+      },
+      async run() {
+        throw new Error("unexpected run");
+      },
+    },
+    params,
+    requestIp: null,
+    waitUntil() {},
+  };
+}
+
+function buildSerializedContext(overrides: { continuationToken: string }): Record<string, unknown> {
+  return {
+    "eve.auth": {
+      attributes: {},
+      authenticator: "test-idp",
+      principalId: "user-initiator",
+      principalType: "user",
+    },
+    "eve.bundle": { source: createBundledRuntimeCompiledArtifactsSource() },
+    "eve.channel": { kind: "http", state: {} },
+    "eve.continuationToken": overrides.continuationToken,
+    "eve.mode": "conversation",
+  };
+}
+
+async function waitForPosts(posts: readonly CapturedCallbackPost[], count: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (posts.length < count) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${count} callback POSTs (saw ${posts.length}).`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function sendTaskCommand(taskId: string, payload: TaskCommandHookPayload): Promise<void> {
+  // The actor creates its hook right before its first snapshot; retry
+  // briefly in case the hook's persistence trails the snapshot read.
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await resumeHook(taskCommandHookToken(taskId), payload);
+      return;
+    } catch (error) {
+      if (attempt >= 20) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+}
+
+function extractTaskId(events: readonly HandleMessageStreamEvent[]): string {
+  for (const event of filterEventsByType(events, "action.result")) {
+    const result = (event.data as { result?: { output?: { taskId?: unknown } } }).result;
+    if (typeof result?.output?.taskId === "string") {
+      return result.output.taskId;
+    }
+  }
+  throw new Error("Expected an action.result event carrying a CreateTaskResult placeholder.");
+}
+
+interface CapturedEventStream {
+  dispose(): void;
+  nextUntil(
+    label: string,
+    predicate: (event: HandleMessageStreamEvent) => boolean,
+  ): Promise<HandleMessageStreamEvent[]>;
+}
+
+function captureEvents(run: { readable: ReadableStream<Uint8Array> }): CapturedEventStream {
+  const reader = run.readable.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let disposed = false;
+
+  const readUntil = async (
+    predicate: (event: HandleMessageStreamEvent) => boolean,
+  ): Promise<HandleMessageStreamEvent[]> => {
+    const events: HandleMessageStreamEvent[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error("Workflow stream closed before reaching the expected event.");
+      }
+      buffer += decoder.decode(value);
+      for (
+        let newlineIndex = buffer.indexOf("\n");
+        newlineIndex !== -1;
+        newlineIndex = buffer.indexOf("\n")
+      ) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line.length === 0) {
+          continue;
+        }
+        const event = JSON.parse(line) as HandleMessageStreamEvent;
+        events.push(event);
+        if (predicate(event)) {
+          return events;
+        }
+      }
+    }
+  };
+
+  return {
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      reader.releaseLock();
+    },
+    async nextUntil(label, predicate) {
+      if (disposed) {
+        throw new Error("CapturedEventStream: stream already disposed.");
+      }
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          readUntil(predicate),
+          new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error(`Timed out waiting for ${label}.`)),
+              15_000,
+            );
+          }),
+        ]);
+      } finally {
+        if (timeout !== undefined) clearTimeout(timeout);
+      }
+    },
+  };
+}
+
+const taskInputRequest: InputRequest = {
+  action: { callId: "call_task_hitl", input: {}, kind: "tool-call", toolName: "pick_region" },
+  prompt: "Which region should the research cover?",
+  requestId: "req_task_region",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("task notifications integration", () => {
+  it("elects background, parks, and wakes with the terminal outcome as input", async () => {
+    vi.stubEnv("EVE_INTERNAL_BACKGROUND_TASK_ELECTION", "1");
+    const posts = installLoopbackCallbackFetch();
+    const runtime = createTestRuntime({ agent: { name: "task-notify-complete" } });
+    const continuationToken = "http:task-notify-complete";
+
+    await runtime.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "Delegate to a background subagent: research penguins" },
+          serializedContext: buildSerializedContext({ continuationToken }),
+        },
+      ]);
+      const stream = captureEvents(run);
+
+      try {
+        const firstTurn = await stream.nextUntil(
+          "election turn",
+          (event) => event.type === "session.waiting",
+        );
+
+        // The call position was terminalized with the placeholder: the
+        // turn ended with the work "still running" and no child events.
+        const taskId = extractTaskId(firstTurn);
+        expect(taskId).toMatch(/^task_/);
+        expect(filterEventsByType(firstTurn, "subagent.called")).toHaveLength(0);
+        expect(filterEventsByType(firstTurn, "subagent.completed")).toHaveLength(0);
+        expect(posts).toHaveLength(0);
+
+        await waitForHook({ runId: run.runId }, { token: continuationToken });
+
+        // The test acts as the executor: terminal transition → notify.
+        await sendTaskCommand(taskId, {
+          command: { kind: "complete", result: { answer: 42 } },
+          commandId: "cmd-complete-1",
+          kind: "task-command",
+        });
+
+        const wakeTurn = await stream.nextUntil(
+          "terminal wake turn",
+          (event) => event.type === "session.waiting",
+        );
+
+        // The parked driver woke on the loopback POST and ran a turn
+        // with the outcome as new input.
+        expect(posts).toHaveLength(1);
+        expect(posts[0]).toMatchObject({ body: { kind: "task.terminal" }, status: 202 });
+        expect(
+          wakeTurn.some(
+            (event) =>
+              event.type === "message.completed" && event.data.message?.includes(taskId) === true,
+          ),
+        ).toBe(true);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  }, 30_000);
+
+  it("re-emits input_required without a turn and routes the late answer via updateTask", async () => {
+    vi.stubEnv("EVE_INTERNAL_BACKGROUND_TASK_ELECTION", "1");
+    const posts = installLoopbackCallbackFetch();
+    const runtime = createTestRuntime({ agent: { name: "task-notify-input" } });
+    const continuationToken = "http:task-notify-input";
+
+    await runtime.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "Delegate to a background subagent: research volcanoes" },
+          serializedContext: buildSerializedContext({ continuationToken }),
+        },
+      ]);
+      const stream = captureEvents(run);
+
+      try {
+        const firstTurn = await stream.nextUntil(
+          "election turn",
+          (event) => event.type === "session.waiting",
+        );
+        const taskId = extractTaskId(firstTurn);
+        await waitForHook({ runId: run.runId }, { token: continuationToken });
+
+        // Executor needs input: input_required is consumed by the
+        // routing step — input.requested re-emitted, no model turn.
+        await sendTaskCommand(taskId, {
+          command: { inputRequests: [taskInputRequest], kind: "require-input" },
+          commandId: "cmd-require-1",
+          kind: "task-command",
+        });
+
+        const untilRequested = await stream.nextUntil(
+          "re-emitted input.requested",
+          (event) => event.type === "input.requested",
+        );
+        expect(filterEventsByType(untilRequested, "turn.started")).toHaveLength(0);
+        const requested = untilRequested.at(-1);
+        if (requested?.type !== "input.requested") {
+          throw new Error("Expected the stream to end on input.requested.");
+        }
+        expect(requested.data).toMatchObject({
+          requests: [{ prompt: taskInputRequest.prompt, requestId: taskInputRequest.requestId }],
+        });
+
+        // The user answers in the parent conversation. Step-0 routes
+        // the response to updateTask — the model never sees it, so no
+        // reply turn runs (a stale-converted response would produce
+        // one). The task transitions back to working, whose wake is
+        // consumed silently; the later terminal wake is the next turn.
+        await resumeHook(continuationToken, {
+          kind: "deliver",
+          payloads: [
+            { inputResponses: [{ optionId: "approve", requestId: taskInputRequest.requestId }] },
+          ],
+        });
+
+        // The update's task.status notification is the observable proof
+        // the answer routed through updateTask; wait for it before the
+        // executor completes, or the completion races the answer turn.
+        await waitForPosts(posts, 2);
+        expect(posts[1]).toMatchObject({ body: { kind: "task.status" }, status: 202 });
+
+        await sendTaskCommand(taskId, {
+          command: { kind: "complete", result: "research complete" },
+          commandId: "cmd-complete-2",
+          kind: "task-command",
+        });
+
+        const wakeTurn = await stream.nextUntil(
+          "terminal wake turn",
+          (event) => event.type === "session.waiting",
+        );
+
+        // Exactly one model turn between the answer and the terminal
+        // wake — the answer itself never woke the model.
+        expect(filterEventsByType(wakeTurn, "turn.started")).toHaveLength(1);
+        expect(
+          wakeTurn.some(
+            (event) =>
+              event.type === "message.completed" && event.data.message?.includes(taskId) === true,
+          ),
+        ).toBe(true);
+
+        // require-input and the update both notify task.status; the
+        // completion notifies task.terminal.
+        expect(posts.map((post) => post.body.kind)).toEqual([
+          "task.status",
+          "task.status",
+          "task.terminal",
+        ]);
+        expect(posts.every((post) => post.status === 202)).toBe(true);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  }, 30_000);
+});

--- a/packages/eve/src/execution/tasks/notify.test.ts
+++ b/packages/eve/src/execution/tasks/notify.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { notifyTaskEndpoints } from "#execution/tasks/notify.js";
+import type { StoredNotificationEndpoint } from "#execution/tasks/store.js";
+import type { TaskNotification } from "#runtime/tasks/types.js";
+
+const notification: TaskNotification = {
+  kind: "task.terminal",
+  task: {
+    createdAt: "2026-07-23T00:00:00.000Z",
+    lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+    result: "done",
+    status: "completed",
+    taskId: "task_1",
+    ttlMs: null,
+  },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubFetch(handler: (url: string) => Response | Error): ReturnType<typeof vi.fn> {
+  const mock = vi.fn(async (url: string | URL | Request) => {
+    const result = handler(String(url));
+    if (result instanceof Error) {
+      throw result;
+    }
+    return result;
+  });
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+describe("notifyTaskEndpoints", () => {
+  it("POSTs the envelope to routed endpoints", async () => {
+    const fetchMock = stubFetch(() => new Response(null, { status: 202 }));
+
+    const endpoints: StoredNotificationEndpoint[] = [{ url: "https://caller.example/cb/a" }];
+    const result = await notifyTaskEndpoints({ endpoints, notification });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://caller.example/cb/a");
+    expect(init.method).toBe("POST");
+    expect(init.redirect).toBe("error");
+    expect(JSON.parse(String(init.body))).toEqual(notification);
+    expect(result).toEqual(endpoints);
+  });
+
+  it("skips dead endpoints and kinds outside the endpoint's routes", async () => {
+    const fetchMock = stubFetch(() => new Response(null, { status: 202 }));
+
+    await notifyTaskEndpoints({
+      endpoints: [
+        { dead: true, url: "https://caller.example/cb/dead" },
+        { routes: ["task.progress"], url: "https://caller.example/cb/progress-only" },
+      ],
+      notification,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not route task.created or task.progress by default", async () => {
+    const fetchMock = stubFetch(() => new Response(null, { status: 202 }));
+
+    await notifyTaskEndpoints({
+      endpoints: [{ url: "https://caller.example/cb/a" }],
+      notification: {
+        kind: "task.created",
+        task: { ...notification.task, status: "working" } as TaskNotification["task"],
+      },
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("marks an endpoint dead on 404 without failing the batch", async () => {
+    const fetchMock = stubFetch((url) =>
+      url.endsWith("/gone")
+        ? new Response(null, { status: 404 })
+        : new Response(null, { status: 202 }),
+    );
+
+    const result = await notifyTaskEndpoints({
+      endpoints: [
+        { url: "https://caller.example/cb/gone" },
+        { url: "https://caller.example/cb/live" },
+      ],
+      notification,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result[0]).toEqual({ dead: true, url: "https://caller.example/cb/gone" });
+    expect(result[1]).toEqual({ url: "https://caller.example/cb/live" });
+  });
+
+  it("drops on network failure and non-OK statuses without throwing or marking dead", async () => {
+    stubFetch((url) =>
+      url.endsWith("/down") ? new Error("connection refused") : new Response(null, { status: 500 }),
+    );
+
+    const endpoints: StoredNotificationEndpoint[] = [
+      { url: "https://caller.example/cb/down" },
+      { url: "https://caller.example/cb/error" },
+    ];
+
+    await expect(notifyTaskEndpoints({ endpoints, notification })).resolves.toEqual(endpoints);
+  });
+});

--- a/packages/eve/src/execution/tasks/notify.ts
+++ b/packages/eve/src/execution/tasks/notify.ts
@@ -1,0 +1,93 @@
+/**
+ * Guarded task-notification fan-out.
+ *
+ * One POST per routed endpoint per transition, each endpoint guarded
+ * independently: a gone subscriber (HTTP 404 from the callback route)
+ * is marked dead and never retried; any other delivery failure is
+ * logged and dropped. A notification send never throws — delivery is
+ * best-effort and must never fail the task (unlike the terminal
+ * session callback, which throws to hand retry to the orchestrator).
+ */
+import { createLogger } from "#internal/logging.js";
+import { DEFAULT_NOTIFICATION_ROUTES, type TaskNotification } from "#runtime/tasks/types.js";
+import type { StoredNotificationEndpoint } from "#execution/tasks/store.js";
+
+const TASK_NOTIFY_TIMEOUT_MS = 30_000;
+const log = createLogger("execution.task-notify");
+
+/**
+ * Delivers one notification to every live, routed endpoint.
+ *
+ * Returns the endpoint list with delivery state updated (gone
+ * subscribers marked `dead`); the caller persists it on the next
+ * record snapshot.
+ */
+export async function notifyTaskEndpoints(input: {
+  readonly endpoints: readonly StoredNotificationEndpoint[];
+  readonly notification: TaskNotification;
+}): Promise<readonly StoredNotificationEndpoint[]> {
+  const results: StoredNotificationEndpoint[] = [];
+
+  for (const endpoint of input.endpoints) {
+    if (endpoint.dead === true) {
+      results.push(endpoint);
+      continue;
+    }
+
+    const routes = endpoint.routes ?? DEFAULT_NOTIFICATION_ROUTES;
+    if (!routes.includes(input.notification.kind)) {
+      results.push(endpoint);
+      continue;
+    }
+
+    results.push(await deliver(endpoint, input.notification));
+  }
+
+  return results;
+}
+
+async function deliver(
+  endpoint: StoredNotificationEndpoint,
+  notification: TaskNotification,
+): Promise<StoredNotificationEndpoint> {
+  try {
+    const response = await fetch(endpoint.url, {
+      body: JSON.stringify(notification),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+      // Do not follow redirects: a callback host could otherwise
+      // 3xx-bounce the framework to an internal/metadata address.
+      redirect: "error",
+      signal: AbortSignal.timeout(TASK_NOTIFY_TIMEOUT_MS),
+    });
+
+    if (response.status === 404) {
+      // The callback route answers 404 when the hook behind the token is
+      // gone — the subscriber no longer exists. Mark dead, never retry.
+      log.debug("task notification endpoint gone; marking dead", {
+        kind: notification.kind,
+        taskId: notification.task.taskId,
+      });
+      return { ...endpoint, dead: true };
+    }
+
+    if (!response.ok) {
+      log.warn("task notification delivery failed; dropping", {
+        kind: notification.kind,
+        status: response.status,
+        taskId: notification.task.taskId,
+      });
+    }
+
+    return endpoint;
+  } catch (error) {
+    log.warn("task notification delivery failed; dropping", {
+      error,
+      kind: notification.kind,
+      taskId: notification.task.taskId,
+    });
+    return endpoint;
+  }
+}

--- a/packages/eve/src/execution/tasks/routing.test.ts
+++ b/packages/eve/src/execution/tasks/routing.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionAuthContext } from "#channel/types.js";
+import type { DurableSession } from "#execution/durable-session-store.js";
+import { routeTaskNotifications } from "#execution/tasks/routing.js";
+import type { TaskRecord } from "#execution/tasks/store.js";
+import type { HarnessEmissionState } from "#harness/emission.js";
+import type { InputRequest } from "#runtime/input/types.js";
+import type { TaskNotification } from "#runtime/tasks/types.js";
+
+const readTaskRecordMock = vi.fn();
+const updateTaskMock = vi.fn();
+
+vi.mock("#execution/tasks/store.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#execution/tasks/store.js")>()),
+  readTaskRecord: (input: unknown) => readTaskRecordMock(input),
+}));
+
+vi.mock("#execution/tasks/service.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#execution/tasks/service.js")>()),
+  updateTask: (handle: unknown, responses: unknown) => updateTaskMock(handle, responses),
+}));
+
+const emissionState: HarnessEmissionState = {
+  sequence: 7,
+  sessionStarted: true,
+  stepIndex: 2,
+  turnId: "turn_1",
+};
+
+const inputRequest: InputRequest = {
+  action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "get_weather" },
+  prompt: "Allow get_weather?",
+  requestId: "req_1",
+};
+
+function createDurableSession(liveTasks: Record<string, string>): DurableSession {
+  return {
+    agent: { system: "" },
+    continuationToken: "http:session",
+    history: [],
+    sessionId: "session_1",
+    state: Object.keys(liveTasks).length > 0 ? { "eve.runtime.liveTasks": liveTasks } : undefined,
+  };
+}
+
+function terminalNotification(taskId: string): TaskNotification {
+  return {
+    kind: "task.terminal",
+    task: {
+      createdAt: "2026-07-23T00:00:00.000Z",
+      lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+      result: "done",
+      status: "completed",
+      taskId,
+      ttlMs: null,
+    },
+  };
+}
+
+function inputRequiredNotification(taskId: string): TaskNotification {
+  return {
+    kind: "task.status",
+    task: {
+      createdAt: "2026-07-23T00:00:00.000Z",
+      inputRequests: [inputRequest],
+      lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+      status: "input_required",
+      taskId,
+      ttlMs: null,
+    },
+  };
+}
+
+function captureWritable(): { chunks: Uint8Array[]; writable: WritableStream<Uint8Array> } {
+  const chunks: Uint8Array[] = [];
+  return {
+    chunks,
+    writable: new WritableStream<Uint8Array>({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    }),
+  };
+}
+
+function decodeEvents(chunks: readonly Uint8Array[]): { type: string; data?: unknown }[] {
+  const text = chunks.map((chunk) => new TextDecoder().decode(chunk)).join("");
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as { type: string; data?: unknown });
+}
+
+beforeEach(() => {
+  readTaskRecordMock.mockReset();
+  updateTaskMock.mockReset();
+});
+
+describe("routeTaskNotifications", () => {
+  it("keeps terminal notifications on the remainder", async () => {
+    const { writable } = captureWritable();
+    const notification = terminalNotification("task_a");
+
+    const remainder = await routeTaskNotifications({
+      durableSession: createDurableSession({ task_a: "run_a" }),
+      emissionState,
+      parentWritable: writable,
+      payload: { taskNotifications: [notification] },
+    });
+
+    expect(remainder).toEqual({ taskNotifications: [notification] });
+  });
+
+  it("consumes input_required and re-emits input.requested without a turn", async () => {
+    const { chunks, writable } = captureWritable();
+
+    const remainder = await routeTaskNotifications({
+      durableSession: createDurableSession({ task_a: "run_a" }),
+      emissionState,
+      parentWritable: writable,
+      payload: { taskNotifications: [inputRequiredNotification("task_a")] },
+    });
+
+    expect(remainder).toBeUndefined();
+    const events = decodeEvents(chunks);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      data: { requests: [inputRequest], sequence: 7, stepIndex: 2, turnId: "turn_1" },
+      type: "input.requested",
+    });
+  });
+
+  it("drops notifications for tasks not on the live index", async () => {
+    const { chunks, writable } = captureWritable();
+
+    const remainder = await routeTaskNotifications({
+      durableSession: createDurableSession({}),
+      emissionState,
+      parentWritable: writable,
+      payload: { taskNotifications: [terminalNotification("task_unknown")] },
+    });
+
+    expect(remainder).toBeUndefined();
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("rejects cross-principal authenticated deliveries", async () => {
+    const { writable } = captureWritable();
+    readTaskRecordMock.mockResolvedValue({
+      createdBy: { authenticator: "test", principalId: "user_owner" },
+      endpoints: [],
+      sessionId: "session_1",
+      task: terminalNotification("task_a").task,
+      taskRunId: "run_a",
+    } satisfies TaskRecord);
+
+    const intruder: SessionAuthContext = {
+      attributes: {},
+      authenticator: "test",
+      principalId: "user_intruder",
+      principalType: "user",
+    };
+
+    const remainder = await routeTaskNotifications({
+      auth: intruder,
+      durableSession: createDurableSession({ task_a: "run_a" }),
+      emissionState,
+      parentWritable: writable,
+      payload: { taskNotifications: [terminalNotification("task_a")] },
+    });
+
+    expect(remainder).toBeUndefined();
+    expect(readTaskRecordMock).toHaveBeenCalledWith({ taskRunId: "run_a" });
+  });
+
+  it("passes same-principal authenticated deliveries", async () => {
+    const { writable } = captureWritable();
+    readTaskRecordMock.mockResolvedValue({
+      createdBy: { authenticator: "test", principalId: "user_owner" },
+      endpoints: [],
+      sessionId: "session_1",
+      task: terminalNotification("task_a").task,
+      taskRunId: "run_a",
+    } satisfies TaskRecord);
+
+    const owner: SessionAuthContext = {
+      attributes: {},
+      authenticator: "test",
+      principalId: "user_owner",
+      principalType: "user",
+    };
+
+    const remainder = await routeTaskNotifications({
+      auth: owner,
+      durableSession: createDurableSession({ task_a: "run_a" }),
+      emissionState,
+      parentWritable: writable,
+      payload: { taskNotifications: [terminalNotification("task_a")] },
+    });
+
+    expect(remainder?.taskNotifications).toHaveLength(1);
+  });
+
+  it("splits a coalesced task + public payload: task resolves, message remains", async () => {
+    const { chunks, writable } = captureWritable();
+
+    const remainder = await routeTaskNotifications({
+      durableSession: createDurableSession({ task_a: "run_a" }),
+      emissionState,
+      parentWritable: writable,
+      payload: {
+        message: "unrelated public message",
+        taskNotifications: [inputRequiredNotification("task_a")],
+      },
+    });
+
+    expect(remainder).toEqual({ message: "unrelated public message" });
+    expect(decodeEvents(chunks)).toHaveLength(1);
+  });
+
+  it("routes late responses to live input_required tasks and returns the rest", async () => {
+    readTaskRecordMock.mockResolvedValue({
+      endpoints: [],
+      sessionId: "session_1",
+      task: inputRequiredNotification("task_a").task,
+      taskRunId: "run_a",
+    } satisfies TaskRecord);
+    updateTaskMock.mockResolvedValue(undefined);
+
+    const { routeLateResponsesToLiveTasks } = await import("#execution/tasks/routing.js");
+    const { remaining } = await routeLateResponsesToLiveTasks({
+      inputResponses: [
+        { optionId: "approve", requestId: "req_1" },
+        { requestId: "req_other", text: "unrelated" },
+      ],
+      state: { "eve.runtime.liveTasks": { task_a: "run_a" } },
+    });
+
+    expect(updateTaskMock).toHaveBeenCalledWith({ taskId: "task_a", taskRunId: "run_a" }, [
+      { optionId: "approve", requestId: "req_1" },
+    ]);
+    expect(remaining).toEqual([{ requestId: "req_other", text: "unrelated" }]);
+  });
+
+  it("falls back to the stale path when updateTask rejects", async () => {
+    readTaskRecordMock.mockResolvedValue({
+      endpoints: [],
+      sessionId: "session_1",
+      task: inputRequiredNotification("task_a").task,
+      taskRunId: "run_a",
+    } satisfies TaskRecord);
+    updateTaskMock.mockRejectedValue(new Error("task settled"));
+
+    const { routeLateResponsesToLiveTasks } = await import("#execution/tasks/routing.js");
+    const { remaining } = await routeLateResponsesToLiveTasks({
+      inputResponses: [{ optionId: "approve", requestId: "req_1" }],
+      state: { "eve.runtime.liveTasks": { task_a: "run_a" } },
+    });
+
+    expect(remaining).toEqual([{ optionId: "approve", requestId: "req_1" }]);
+  });
+
+  it("leaves responses untouched when no live task awaits input", async () => {
+    readTaskRecordMock.mockResolvedValue({
+      endpoints: [],
+      sessionId: "session_1",
+      task: terminalNotification("task_a").task,
+      taskRunId: "run_a",
+    } satisfies TaskRecord);
+
+    const { routeLateResponsesToLiveTasks } = await import("#execution/tasks/routing.js");
+    const responses = [{ optionId: "approve", requestId: "req_1" }];
+    const { remaining } = await routeLateResponsesToLiveTasks({
+      inputResponses: responses,
+      state: { "eve.runtime.liveTasks": { task_a: "run_a" } },
+    });
+
+    expect(updateTaskMock).not.toHaveBeenCalled();
+    expect(remaining).toEqual(responses);
+  });
+
+  it("consumes progress and created kinds silently", async () => {
+    const { chunks, writable } = captureWritable();
+
+    const remainder = await routeTaskNotifications({
+      durableSession: createDurableSession({ task_a: "run_a" }),
+      emissionState,
+      parentWritable: writable,
+      payload: {
+        taskNotifications: [
+          {
+            kind: "task.progress",
+            task: {
+              createdAt: "2026-07-23T00:00:00.000Z",
+              lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+              status: "working",
+              statusMessage: "halfway",
+              taskId: "task_a",
+              ttlMs: null,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(remainder).toBeUndefined();
+    expect(chunks).toHaveLength(0);
+  });
+});

--- a/packages/eve/src/execution/tasks/routing.ts
+++ b/packages/eve/src/execution/tasks/routing.ts
@@ -1,0 +1,225 @@
+/**
+ * Routing-step discrimination for task-notification deliver payloads.
+ *
+ * A notification never wakes the model directly; the two arms mirror
+ * the driver's existing routing outcomes:
+ *
+ * - **terminal** (`completed` | `failed` | `cancelled`) — kept on the
+ *   remainder, so the caller runs a turn with the outcome as input.
+ * - **`input_required`** — consumed here: the record's live requests
+ *   are re-emitted on the parent stream as `input.requested` without
+ *   running a turn (the driver-level analog of the turn-level subagent
+ *   HITL proxy). The eventual answer routes back through the step-0
+ *   late-response check (`tasks/update` semantics).
+ *
+ * Everything else (`task.created`, `task.progress`, non-wake status
+ * changes) is consumed silently. Notifications for unknown tasks — not
+ * on the session's live-task index — are dropped, as are deliveries
+ * whose authenticated principal mismatches the task's creator.
+ */
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import type { DeliverPayload, SessionAuthContext } from "#channel/types.js";
+import { deserializeContext } from "#context/serialize.js";
+import type { DurableSession } from "#execution/durable-session-store.js";
+import {
+  splitTaskNotifications,
+  TASK_NOTIFICATIONS_PAYLOAD_KEY,
+} from "#execution/tasks/delivery.js";
+import { updateTask, type TaskHandle } from "#execution/tasks/service.js";
+import { readTaskRecord } from "#execution/tasks/store.js";
+import type { HarnessEmissionState } from "#harness/emission.js";
+import { getLiveTasks } from "#harness/task-state.js";
+import type { SessionStateMap } from "#harness/types.js";
+import type { InputResponse } from "#runtime/input/types.js";
+import { createLogger } from "#internal/logging.js";
+import {
+  createInputRequestedEvent,
+  encodeMessageStreamEvent,
+  timestampHandleMessageStreamEvent,
+} from "#protocol/message.js";
+import { isTerminalStatus, type TaskNotification } from "#runtime/tasks/types.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+
+const log = createLogger("execution.task-routing");
+
+/**
+ * Discriminates the task notifications on a payload and returns the
+ * parent-local remainder (`undefined` when nothing actionable is left —
+ * the caller's existing no-turn arm).
+ */
+export async function routeTaskNotifications(input: {
+  readonly auth?: SessionAuthContext | null;
+  readonly durableSession: DurableSession;
+  readonly emissionState: HarnessEmissionState;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly payload: DeliverPayload;
+  readonly serializedContext?: Record<string, unknown>;
+}): Promise<DeliverPayload | undefined> {
+  const { notifications, rest } = splitTaskNotifications(input.payload);
+  const liveTasks = getLiveTasks(input.durableSession.state);
+  const kept: TaskNotification[] = [];
+
+  for (const notification of notifications) {
+    const taskRunId = liveTasks.get(notification.task.taskId);
+    if (taskRunId === undefined) {
+      log.debug("dropping notification for unknown task", {
+        kind: notification.kind,
+        taskId: notification.task.taskId,
+      });
+      continue;
+    }
+
+    if (!(await deliveryPrincipalMatches({ auth: input.auth, taskRunId }))) {
+      log.warn("dropping cross-principal task delivery", {
+        kind: notification.kind,
+        taskId: notification.task.taskId,
+      });
+      continue;
+    }
+
+    if (isTerminalStatus(notification.task.status)) {
+      kept.push(notification);
+      continue;
+    }
+
+    if (notification.task.status === "input_required") {
+      await emitTaskInputRequested({
+        emissionState: input.emissionState,
+        notification,
+        parentWritable: input.parentWritable,
+        serializedContext: input.serializedContext,
+      });
+      continue;
+    }
+
+    // task.created / task.progress / non-wake status changes carry no
+    // parent-local action; the record already holds the state.
+  }
+
+  if (kept.length === 0) {
+    return rest;
+  }
+  return { ...rest, [TASK_NOTIFICATIONS_PAYLOAD_KEY]: kept };
+}
+
+/**
+ * Step-0 late-response routing (`tasks/update` semantics): responses
+ * whose `requestId` matches a live `input_required` task's inline
+ * requests route to `updateTask` and never reach the model step — so
+ * they run before stale conversion by construction, and a late answer
+ * executes instead of degrading to advisory text. Everything else is
+ * returned for today's paths unchanged.
+ */
+export async function routeLateResponsesToLiveTasks(input: {
+  readonly inputResponses: readonly InputResponse[];
+  readonly state: SessionStateMap | undefined;
+}): Promise<{ readonly remaining: readonly InputResponse[] }> {
+  const liveTasks = getLiveTasks(input.state);
+  if (liveTasks.size === 0 || input.inputResponses.length === 0) {
+    return { remaining: input.inputResponses };
+  }
+
+  const handleByRequestId = new Map<string, TaskHandle>();
+  for (const [taskId, taskRunId] of liveTasks) {
+    const record = await readTaskRecord({ taskRunId });
+    if (record.task.status !== "input_required") {
+      continue;
+    }
+    for (const request of record.task.inputRequests) {
+      handleByRequestId.set(request.requestId, { taskId, taskRunId });
+    }
+  }
+
+  const remaining: InputResponse[] = [];
+  const routed = new Map<string, { handle: TaskHandle; responses: InputResponse[] }>();
+  for (const response of input.inputResponses) {
+    const handle = handleByRequestId.get(response.requestId);
+    if (handle === undefined) {
+      remaining.push(response);
+      continue;
+    }
+    const group = routed.get(handle.taskId);
+    if (group === undefined) {
+      routed.set(handle.taskId, { handle, responses: [response] });
+    } else {
+      group.responses.push(response);
+    }
+  }
+
+  for (const group of routed.values()) {
+    try {
+      await updateTask(group.handle, group.responses);
+    } catch (error) {
+      // The task settled or left input_required between read and send;
+      // fall back to today's stale path for these responses.
+      log.warn("late response routing failed; falling back to stale path", {
+        error,
+        taskId: group.handle.taskId,
+      });
+      remaining.push(...group.responses);
+    }
+  }
+
+  return { remaining };
+}
+
+/**
+ * Tasks are bound to the auth context that created them: an
+ * authenticated delivery must match the creator's principal. Loopback
+ * notification POSTs carry no auth and pass — forgery through public
+ * channels is blocked upstream by ingress sanitization.
+ */
+async function deliveryPrincipalMatches(input: {
+  readonly auth?: SessionAuthContext | null;
+  readonly taskRunId: string;
+}): Promise<boolean> {
+  if (input.auth === undefined || input.auth === null) {
+    return true;
+  }
+  const record = await readTaskRecord({ taskRunId: input.taskRunId });
+  if (record.createdBy === undefined || record.createdBy === null) {
+    return true;
+  }
+  return record.createdBy.principalId === input.auth.principalId;
+}
+
+/**
+ * Re-emits an `input_required` task's live requests on the parent
+ * stream as the session's own `input.requested`, through the channel
+ * adapter when a context is available. Coordinates come from the
+ * session's emission state — no turn runs and no state advances.
+ */
+async function emitTaskInputRequested(input: {
+  readonly emissionState: HarnessEmissionState;
+  readonly notification: TaskNotification;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext?: Record<string, unknown>;
+}): Promise<void> {
+  const task = input.notification.task;
+  if (task.status !== "input_required" || task.inputRequests.length === 0) {
+    return;
+  }
+
+  const event = createInputRequestedEvent({
+    requests: task.inputRequests,
+    sequence: input.emissionState.sequence,
+    stepIndex: input.emissionState.stepIndex,
+    turnId: input.emissionState.turnId,
+  });
+
+  const writer = input.parentWritable.getWriter();
+  try {
+    if (input.serializedContext === undefined) {
+      await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(event)));
+      return;
+    }
+    const ctx = await deserializeContext(input.serializedContext);
+    const adapter = ctx.require(ChannelKey);
+    const adapterCtx = buildAdapterContext(adapter, ctx);
+    const transformed = await callAdapterEventHandler(adapter, event, adapterCtx);
+    await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(transformed)));
+  } finally {
+    writer.releaseLock();
+  }
+}

--- a/packages/eve/src/execution/tasks/service.integration.test.ts
+++ b/packages/eve/src/execution/tasks/service.integration.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTestRuntime } from "#internal/testing/app-harness.js";
+import {
+  cancelTask,
+  completeTask,
+  createTask,
+  getTask,
+  requireTaskInput,
+  setTaskStatusMessage,
+  updateTask,
+  type TaskHandle,
+} from "#execution/tasks/service.js";
+import { readTaskRecord } from "#execution/tasks/store.js";
+import type { InputRequest } from "#runtime/input/types.js";
+import type { TaskNotification } from "#runtime/tasks/types.js";
+import { getRun } from "#internal/workflow/runtime.js";
+
+const inputRequest: InputRequest = {
+  action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "get_weather" },
+  prompt: "Allow get_weather?",
+  requestId: "req_1",
+};
+
+interface CapturedPost {
+  readonly notification: TaskNotification;
+  readonly url: string;
+}
+
+function stubNotificationSink(statusFor: (url: string) => number): CapturedPost[] {
+  const posts: CapturedPost[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      posts.push({
+        notification: JSON.parse(String(init?.body)) as TaskNotification,
+        url: String(url),
+      });
+      return new Response(null, { status: statusFor(String(url)) });
+    }),
+  );
+  return posts;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("task actor integration", () => {
+  it("creates, completes, and stays readable after the actor run settles", async () => {
+    const runtime = createTestRuntime({ agent: { name: "task-actor-complete" } });
+
+    await runtime.run(async () => {
+      const posts = stubNotificationSink(() => 202);
+
+      const record = await createTask({
+        createdBy: { authenticator: "test", principalId: "user_1" },
+        endpoints: [{ url: "https://caller.example/eve/v1/callback/tok-1" }],
+        sessionId: "session_1",
+        ttlMs: null,
+      });
+      const handle: TaskHandle = { taskId: record.task.taskId, taskRunId: record.taskRunId };
+
+      expect(record.task.status).toBe("working");
+      expect(record.task.taskId).toMatch(/^task_/);
+      expect(record.task.taskId).not.toContain(record.taskRunId);
+
+      const completed = await completeTask(handle, { answer: 42 });
+      expect(completed).toMatchObject({ result: { answer: 42 }, status: "completed" });
+
+      // The actor run settles on terminal; the record must remain
+      // readable cross-run after completion.
+      await expect(getRun(record.taskRunId).returnValue).resolves.toMatchObject({
+        status: "completed",
+      });
+      await expect(getTask(handle)).resolves.toMatchObject({
+        result: { answer: 42 },
+        status: "completed",
+      });
+
+      // task.created is not routed by default; the terminal is.
+      expect(posts.map((post) => post.notification.kind)).toEqual(["task.terminal"]);
+      expect(posts[0]?.url).toBe("https://caller.example/eve/v1/callback/tok-1");
+      expect(posts[0]?.notification.task).toMatchObject({ status: "completed" });
+    });
+  });
+
+  it("routes input_required round-trips through updateTask", async () => {
+    const runtime = createTestRuntime({ agent: { name: "task-actor-input" } });
+
+    await runtime.run(async () => {
+      const posts = stubNotificationSink(() => 202);
+
+      const record = await createTask({
+        endpoints: [{ url: "https://caller.example/eve/v1/callback/tok-2" }],
+        sessionId: "session_2",
+        ttlMs: null,
+      });
+      const handle: TaskHandle = { taskId: record.task.taskId, taskRunId: record.taskRunId };
+
+      const awaiting = await requireTaskInput(handle, [inputRequest]);
+      expect(awaiting).toMatchObject({ inputRequests: [inputRequest], status: "input_required" });
+
+      const resumed = await updateTask(handle, [{ optionId: "approve", requestId: "req_1" }]);
+      expect(resumed.status).toBe("working");
+
+      const stored = await readTaskRecord({ taskRunId: handle.taskRunId });
+      expect(stored.inputResponses).toEqual([{ optionId: "approve", requestId: "req_1" }]);
+
+      await expect(updateTask(handle, [{ requestId: "req_1", text: "again" }])).rejects.toThrow(
+        /not "input_required"/,
+      );
+
+      expect(posts.map((post) => post.notification.kind)).toEqual(["task.status", "task.status"]);
+
+      await completeTask(handle, "done");
+    });
+  });
+
+  it("keeps cancellation sticky and settles late commands against the terminal record", async () => {
+    const runtime = createTestRuntime({ agent: { name: "task-actor-cancel" } });
+
+    await runtime.run(async () => {
+      stubNotificationSink(() => 202);
+
+      const record = await createTask({
+        endpoints: [],
+        sessionId: "session_3",
+        ttlMs: 60_000,
+      });
+      const handle: TaskHandle = { taskId: record.task.taskId, taskRunId: record.taskRunId };
+      expect(record.task.ttlMs).toBe(60_000);
+
+      const cancelled = await cancelTask(handle);
+      expect(cancelled.status).toBe("cancelled");
+
+      // Terminal is final: a late completion resolves against the
+      // settled record instead of transitioning it.
+      const afterComplete = await completeTask(handle, "too late");
+      expect(afterComplete.status).toBe("cancelled");
+
+      // cancelTask on a terminal task is a read, not a transition.
+      await expect(cancelTask(handle)).resolves.toMatchObject({ status: "cancelled" });
+    });
+  });
+
+  it("marks gone subscribers dead after a 404 and never retries them", async () => {
+    const runtime = createTestRuntime({ agent: { name: "task-actor-gone" } });
+
+    await runtime.run(async () => {
+      const posts = stubNotificationSink((url) => (url.includes("gone") ? 404 : 202));
+
+      const record = await createTask({
+        endpoints: [
+          { url: "https://caller.example/eve/v1/callback/gone" },
+          { url: "https://caller.example/eve/v1/callback/live" },
+        ],
+        sessionId: "session_4",
+        ttlMs: null,
+      });
+      const handle: TaskHandle = { taskId: record.task.taskId, taskRunId: record.taskRunId };
+
+      await setTaskStatusMessage(handle, "progress is not routed by default");
+      await requireTaskInput(handle, [inputRequest]);
+
+      const afterStatus = await readTaskRecord({ taskRunId: handle.taskRunId });
+      expect(afterStatus.endpoints).toEqual([
+        { dead: true, url: "https://caller.example/eve/v1/callback/gone" },
+        { url: "https://caller.example/eve/v1/callback/live" },
+      ]);
+
+      await completeTask(handle, "done");
+
+      // First transition hit both endpoints; the dead one is skipped
+      // for the terminal event.
+      const urls = posts.map((post) => post.url);
+      expect(urls.filter((url) => url.includes("gone"))).toHaveLength(1);
+      expect(urls.filter((url) => url.includes("live"))).toHaveLength(2);
+    });
+  });
+});

--- a/packages/eve/src/execution/tasks/service.ts
+++ b/packages/eve/src/execution/tasks/service.ts
@@ -1,0 +1,216 @@
+/**
+ * Task operations, mirroring the MCP tasks extension's semantics.
+ *
+ * Caller-facing operations (`getTask`, `updateTask`, `cancelTask`) and
+ * executor-side transitions (`completeTask`, `failTask`,
+ * `requireTaskInput`, `setTaskStatusMessage`) are all expressed against
+ * the owning actor run: reads are cross-run tail reads, writes are
+ * commands resumed onto the actor's hook and acknowledged via
+ * `lastCommandId` on the next snapshot.
+ */
+import { HookNotFoundError } from "#compiled/@workflow/errors/index.js";
+
+import type { InputRequest, InputResponse } from "#runtime/input/types.js";
+import { isTerminalStatus, type DetailedTask } from "#runtime/tasks/types.js";
+import {
+  taskCommandHookToken,
+  type TaskCommand,
+  type TaskCommandHookPayload,
+} from "#execution/tasks/commands.js";
+import {
+  awaitTaskRecord,
+  readTaskRecord,
+  type StoredNotificationEndpoint,
+  type TaskCreatedBy,
+  type TaskRecord,
+} from "#execution/tasks/store.js";
+import { taskWorkflow } from "#execution/tasks/workflow.js";
+import { resumeHook, start } from "#internal/workflow/runtime.js";
+import type { JsonValue } from "#shared/json.js";
+
+const COMMAND_SEND_RETRY_DELAY_MS = 100;
+const COMMAND_SEND_TIMEOUT_MS = 10_000;
+
+/**
+ * Addresses one task: the minted public id plus the owning actor run.
+ * The run id is store-internal (kept on the live-task index and the
+ * record itself); only `taskId` ever appears on streams.
+ */
+export interface TaskHandle {
+  readonly taskId: string;
+  readonly taskRunId: string;
+}
+
+/**
+ * Mints a task id: high-entropy, never derived from a session id or
+ * token.
+ */
+export function mintTaskId(): string {
+  return `task_${crypto.randomUUID()}`;
+}
+
+/**
+ * Creates a task: mints the id, starts the owning actor run, and waits
+ * for the initial `working` snapshot so the record observably exists
+ * before the caller projects the placeholder.
+ */
+export async function createTask(input: {
+  readonly createdBy?: TaskCreatedBy | null;
+  readonly endpoints: readonly StoredNotificationEndpoint[];
+  readonly sessionId: string;
+  readonly ttlMs: number | null;
+}): Promise<TaskRecord> {
+  const taskId = mintTaskId();
+  const run = await start(taskWorkflow, [
+    {
+      createdBy: input.createdBy,
+      endpoints: input.endpoints,
+      sessionId: input.sessionId,
+      taskId,
+      ttlMs: input.ttlMs,
+    },
+  ]);
+  return await awaitTaskRecord({ taskRunId: run.runId });
+}
+
+/**
+ * Reads one task (`tasks/get` semantics).
+ */
+export async function getTask(handle: TaskHandle): Promise<DetailedTask> {
+  const record = await readTaskRecord({ taskRunId: handle.taskRunId });
+  return record.task;
+}
+
+/**
+ * Routes input responses to an `input_required` task (`tasks/update`
+ * semantics): records the responses and transitions back to `working`.
+ * Throws when the task is not awaiting input.
+ */
+export async function updateTask(
+  handle: TaskHandle,
+  inputResponses: readonly InputResponse[],
+): Promise<DetailedTask> {
+  const current = await readTaskRecord({ taskRunId: handle.taskRunId });
+  if (current.task.status !== "input_required") {
+    throw new Error(
+      `Cannot update task ${handle.taskId}: status is "${current.task.status}", not "input_required".`,
+    );
+  }
+  const record = await sendTaskCommand(handle, {
+    inputResponses: [...inputResponses],
+    kind: "update",
+  });
+  return record.task;
+}
+
+/**
+ * Cancels a task (`tasks/cancel` semantics): cooperative and sticky.
+ * A task already terminal is returned unchanged — terminal states are
+ * final.
+ */
+export async function cancelTask(handle: TaskHandle): Promise<DetailedTask> {
+  const current = await readTaskRecord({ taskRunId: handle.taskRunId });
+  if (isTerminalStatus(current.task.status)) {
+    return current.task;
+  }
+  const record = await sendTaskCommand(handle, { kind: "cancel" });
+  return record.task;
+}
+
+/**
+ * Executor-side terminal success: `result` is the JSON output a sync
+ * invocation would have placed at the call position.
+ */
+export async function completeTask(handle: TaskHandle, result: JsonValue): Promise<DetailedTask> {
+  const record = await sendTaskCommand(handle, { kind: "complete", result });
+  return record.task;
+}
+
+/**
+ * Executor-side terminal failure.
+ */
+export async function failTask(
+  handle: TaskHandle,
+  error: { readonly data?: JsonValue; readonly message: string },
+): Promise<DetailedTask> {
+  const record = await sendTaskCommand(handle, { error, kind: "fail" });
+  return record.task;
+}
+
+/**
+ * Executor-side transition to `input_required` with the live requests
+ * inline on the record.
+ */
+export async function requireTaskInput(
+  handle: TaskHandle,
+  inputRequests: readonly InputRequest[],
+): Promise<DetailedTask> {
+  const record = await sendTaskCommand(handle, {
+    inputRequests: [...inputRequests],
+    kind: "require-input",
+  });
+  return record.task;
+}
+
+/**
+ * Executor-side progress: sets `statusMessage` (emits `task.progress`,
+ * unrouted by default).
+ */
+export async function setTaskStatusMessage(
+  handle: TaskHandle,
+  statusMessage: string,
+): Promise<DetailedTask> {
+  const record = await sendTaskCommand(handle, { kind: "set-status-message", statusMessage });
+  return record.task;
+}
+
+/**
+ * Resumes one command onto the actor's hook and waits for the actor to
+ * acknowledge it on a snapshot.
+ *
+ * `HookNotFoundError` is ambiguous — the hook may not exist *yet*
+ * (create race) or not exist *anymore* (task settled, hook disposed).
+ * The record disambiguates: terminal → settled, return as-is (the
+ * command would be a legality no-op anyway); otherwise retry briefly.
+ */
+async function sendTaskCommand(handle: TaskHandle, command: TaskCommand): Promise<TaskRecord> {
+  const commandId = crypto.randomUUID();
+  const payload: TaskCommandHookPayload = { command, commandId, kind: "task-command" };
+  const deadline = Date.now() + COMMAND_SEND_TIMEOUT_MS;
+
+  for (;;) {
+    try {
+      await resumeHook(taskCommandHookToken(handle.taskId), payload);
+      break;
+    } catch (error) {
+      if (!HookNotFoundError.is(error)) {
+        throw error;
+      }
+      const record = await readTaskRecord({ taskRunId: handle.taskRunId });
+      if (isTerminalStatus(record.task.status)) {
+        return record;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out sending command to task ${handle.taskId}: command hook never became available.`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, COMMAND_SEND_RETRY_DELAY_MS));
+    }
+  }
+
+  try {
+    return await awaitTaskRecord({
+      predicate: (record) => record.lastCommandId === commandId,
+      taskRunId: handle.taskRunId,
+    });
+  } catch (error) {
+    // A command that raced the actor's terminal exit is never applied;
+    // the settled record is the authoritative answer.
+    const record = await readTaskRecord({ taskRunId: handle.taskRunId });
+    if (isTerminalStatus(record.task.status)) {
+      return record;
+    }
+    throw error;
+  }
+}

--- a/packages/eve/src/execution/tasks/store.ts
+++ b/packages/eve/src/execution/tasks/store.ts
@@ -1,0 +1,194 @@
+/**
+ * Read side of the task-record store.
+ *
+ * Each background task is owned by a dedicated `taskWorkflow` actor run
+ * (`#execution/tasks/workflow.js`): the actor is the record's single
+ * writer and appends one full snapshot to its own `eve.task` stream per
+ * applied transition. Workflow-run streams are write-local but
+ * read-global, so any step — the routing step, the turn step, tests —
+ * reads the current record with a cross-run tail read; all writes go
+ * through the actor's command hook instead
+ * (`#execution/tasks/service.js`).
+ */
+import { z } from "#compiled/zod/index.js";
+
+import { inputResponseSchema, type InputResponse } from "#runtime/input/types.js";
+import {
+  detailedTaskSchema,
+  taskNotificationKindSchema,
+  type DetailedTask,
+  type TaskNotificationKind,
+} from "#runtime/tasks/types.js";
+import { getRun } from "#internal/workflow/runtime.js";
+
+/** Stream namespace the task actor writes record snapshots to. */
+export const TASK_STREAM_NAMESPACE = "eve.task";
+
+const TASK_RECORD_READ_TIMEOUT_MS = 10_000;
+const TASK_RECORD_POLL_INTERVAL_MS = 50;
+
+/**
+ * A stored notification endpoint.
+ *
+ * Extends the public contract with store-internal delivery state:
+ * `dead` marks a gone subscriber (never retried), `routes` is the
+ * per-endpoint kind filter (absent = `DEFAULT_NOTIFICATION_ROUTES`).
+ * Endpoints are capabilities and never leave the store.
+ */
+export interface StoredNotificationEndpoint {
+  readonly dead?: boolean;
+  readonly routes?: readonly TaskNotificationKind[];
+  readonly url: string;
+}
+
+/**
+ * Zod schema for one stored notification endpoint.
+ */
+export const storedNotificationEndpointSchema: z.ZodType<StoredNotificationEndpoint> = z
+  .object({
+    dead: z.boolean().optional(),
+    routes: z.array(taskNotificationKindSchema).optional(),
+    url: z.string(),
+  })
+  .strict();
+
+/**
+ * Principal binding recorded at task creation (invariant: tasks are
+ * bound to the auth context that created them).
+ */
+export interface TaskCreatedBy {
+  readonly authenticator: string;
+  readonly principalId: string;
+}
+
+const taskCreatedBySchema: z.ZodType<TaskCreatedBy> = z
+  .object({
+    authenticator: z.string(),
+    principalId: z.string(),
+  })
+  .strict();
+
+/**
+ * One full task-record snapshot as written by the actor.
+ *
+ * `task` is the public `DetailedTask`; everything else is store-internal
+ * (endpoints, principal binding, recorded input responses, and the id
+ * of the last applied command — the acknowledgment senders poll for).
+ */
+export interface TaskRecord {
+  readonly createdBy?: TaskCreatedBy | null;
+  readonly endpoints: readonly StoredNotificationEndpoint[];
+  readonly inputResponses?: readonly InputResponse[];
+  readonly lastCommandId?: string;
+  readonly sessionId: string;
+  readonly task: DetailedTask;
+  readonly taskRunId: string;
+}
+
+/**
+ * Zod schema for one task-record snapshot.
+ */
+export const taskRecordSchema: z.ZodType<TaskRecord> = z
+  .object({
+    createdBy: taskCreatedBySchema.nullable().optional(),
+    endpoints: z.array(storedNotificationEndpointSchema),
+    inputResponses: z.array(inputResponseSchema).optional(),
+    lastCommandId: z.string().optional(),
+    sessionId: z.string(),
+    task: detailedTaskSchema,
+    taskRunId: z.string(),
+  })
+  .strict();
+
+/**
+ * Reads the latest task-record snapshot from the actor run's stream.
+ *
+ * Blocks until the first snapshot exists (the create race), up to
+ * `timeoutMs`. Works from any step and from tests — the read is
+ * cross-run.
+ */
+export async function readTaskRecord(input: {
+  readonly taskRunId: string;
+  readonly timeoutMs?: number;
+}): Promise<TaskRecord> {
+  const timeoutMs = input.timeoutMs ?? TASK_RECORD_READ_TIMEOUT_MS;
+  const stream = getRun<unknown>(input.taskRunId).getReadable<unknown>({
+    namespace: TASK_STREAM_NAMESPACE,
+    startIndex: -1,
+  });
+  const reader = stream.getReader();
+  let cancelReason = "eve task record tail read failed";
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      reader.read().then((read) => ({ kind: "read" as const, read })),
+      new Promise<{ readonly kind: "timeout" }>((resolve) => {
+        timeout = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+      }),
+    ]);
+
+    if (result.kind === "timeout") {
+      cancelReason = `eve task record tail read timed out after ${timeoutMs}ms`;
+      throw new Error(
+        `Timed out reading task record from run ${input.taskRunId} after ${timeoutMs}ms.`,
+      );
+    }
+
+    if (result.read.done || result.read.value === undefined) {
+      cancelReason = "eve task record tail read returned no snapshot";
+      throw new Error(`No task record snapshot found for run ${input.taskRunId}.`);
+    }
+
+    cancelReason = "eve task record tail read complete";
+    return taskRecordSchema.parse(result.read.value);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+    await reader.cancel(cancelReason).catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Polls the actor's stream until a snapshot satisfies `predicate`.
+ *
+ * Used by command senders to observe their own command applied
+ * (`lastCommandId` acknowledgment) — the actor is the single writer, so
+ * a satisfying snapshot is authoritative.
+ */
+export async function awaitTaskRecord(input: {
+  readonly predicate?: (record: TaskRecord) => boolean;
+  readonly taskRunId: string;
+  readonly timeoutMs?: number;
+}): Promise<TaskRecord> {
+  const timeoutMs = input.timeoutMs ?? TASK_RECORD_READ_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(
+        `Timed out awaiting task record for run ${input.taskRunId} after ${timeoutMs}ms.`,
+      );
+    }
+
+    const record = await readTaskRecord({ taskRunId: input.taskRunId, timeoutMs: remaining });
+    if (input.predicate === undefined || input.predicate(record)) {
+      return record;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, TASK_RECORD_POLL_INTERVAL_MS));
+  }
+}
+
+/**
+ * Public projection of a record read: the `DetailedTask` alone.
+ */
+export async function readDetailedTask(input: {
+  readonly taskRunId: string;
+  readonly timeoutMs?: number;
+}): Promise<DetailedTask> {
+  const record = await readTaskRecord(input);
+  return record.task;
+}

--- a/packages/eve/src/execution/tasks/workflow-steps.ts
+++ b/packages/eve/src/execution/tasks/workflow-steps.ts
@@ -1,0 +1,125 @@
+/**
+ * Steps of the task actor (`#execution/tasks/workflow.js`).
+ *
+ * Both steps run inside the actor run, so `getWritable` targets the
+ * actor's own `eve.task` stream — the single place record snapshots
+ * are written.
+ */
+import { getWritable } from "#compiled/@workflow/core/index.js";
+
+import { createLogger } from "#internal/logging.js";
+import { applyTaskTransition, taskCommandHookPayloadSchema } from "#execution/tasks/commands.js";
+import { TASK_STREAM_NAMESPACE, type TaskRecord } from "#execution/tasks/store.js";
+import { notifyTaskEndpoints } from "#execution/tasks/notify.js";
+import type { TaskCreatedBy, StoredNotificationEndpoint } from "#execution/tasks/store.js";
+
+const log = createLogger("execution.task-workflow");
+
+/**
+ * Writes the initial `working` snapshot and emits `task.created`.
+ *
+ * The first snapshot is written before any notification is attempted so
+ * `createTask` can observe the record as soon as the actor starts.
+ */
+export async function initializeTaskStep(input: {
+  readonly createdBy?: TaskCreatedBy | null;
+  readonly endpoints: readonly StoredNotificationEndpoint[];
+  readonly sessionId: string;
+  readonly taskId: string;
+  readonly taskRunId: string;
+  readonly ttlMs: number | null;
+}): Promise<TaskRecord> {
+  "use step";
+
+  const now = new Date().toISOString();
+  const base: TaskRecord = {
+    endpoints: input.endpoints,
+    sessionId: input.sessionId,
+    task: {
+      createdAt: now,
+      lastUpdatedAt: now,
+      status: "working",
+      taskId: input.taskId,
+      ttlMs: input.ttlMs,
+    },
+    taskRunId: input.taskRunId,
+  };
+  const record: TaskRecord =
+    input.createdBy === undefined ? base : { ...base, createdBy: input.createdBy };
+
+  await writeTaskSnapshot(record);
+
+  const endpoints = await notifyTaskEndpoints({
+    endpoints: record.endpoints,
+    notification: { kind: "task.created", task: record.task },
+  });
+
+  return await persistEndpointUpdates(record, endpoints);
+}
+
+/**
+ * Validates and applies one command hook payload, persists the next
+ * snapshot, and fans out the transition's notification.
+ *
+ * Malformed payloads are logged and ignored — a bad sender must not
+ * fail the actor run.
+ */
+export async function applyTaskCommandStep(input: {
+  readonly payload: unknown;
+  readonly record: TaskRecord;
+}): Promise<TaskRecord> {
+  "use step";
+
+  const parsed = taskCommandHookPayloadSchema.safeParse(input.payload);
+  if (!parsed.success) {
+    log.warn("ignoring malformed task command payload", {
+      taskId: input.record.task.taskId,
+    });
+    return input.record;
+  }
+
+  const applied = applyTaskTransition({
+    command: parsed.data.command,
+    commandId: parsed.data.commandId,
+    now: new Date().toISOString(),
+    record: input.record,
+  });
+
+  await writeTaskSnapshot(applied.record);
+
+  if (applied.notificationKind === undefined) {
+    return applied.record;
+  }
+
+  const endpoints = await notifyTaskEndpoints({
+    endpoints: applied.record.endpoints,
+    notification: { kind: applied.notificationKind, task: applied.record.task },
+  });
+
+  return await persistEndpointUpdates(applied.record, endpoints);
+}
+
+async function persistEndpointUpdates(
+  record: TaskRecord,
+  endpoints: readonly StoredNotificationEndpoint[],
+): Promise<TaskRecord> {
+  if (endpoints === record.endpoints) {
+    return record;
+  }
+  const changed = endpoints.some((endpoint, index) => endpoint !== record.endpoints[index]);
+  if (!changed) {
+    return record;
+  }
+  const next: TaskRecord = { ...record, endpoints };
+  await writeTaskSnapshot(next);
+  return next;
+}
+
+async function writeTaskSnapshot(record: TaskRecord): Promise<void> {
+  const writer = getWritable<TaskRecord>({ namespace: TASK_STREAM_NAMESPACE }).getWriter();
+  try {
+    await writer.write(record);
+  } finally {
+    writer.releaseLock();
+  }
+}

--- a/packages/eve/src/execution/tasks/workflow.ts
+++ b/packages/eve/src/execution/tasks/workflow.ts
@@ -1,0 +1,69 @@
+/**
+ * The task actor: one durable workflow run per background task.
+ *
+ * The actor owns the task record single-writer. It writes the initial
+ * `working` snapshot, then loops on its command hook
+ * (`taskCommandHookToken(taskId)`): each resumed command is validated
+ * and applied under the transition legality rules
+ * (`#execution/tasks/commands.js`), the new snapshot is appended to the
+ * actor's own `eve.task` stream, and the transition's notification is
+ * fanned out to the registered endpoints. The run returns when the
+ * record reaches a terminal status — terminal states are final by
+ * construction, and a command resumed after the hook is disposed
+ * surfaces `HookNotFoundError` to the sender (the task is settled).
+ *
+ * Readers never talk to the actor: they tail-read its stream cross-run
+ * (`#execution/tasks/store.js`).
+ */
+import { createHook, getWorkflowMetadata } from "#compiled/@workflow/core/index.js";
+
+import { taskCommandHookToken } from "#execution/tasks/commands.js";
+import { disposeHook } from "#execution/hook-ownership.js";
+import type { TaskCreatedBy, StoredNotificationEndpoint } from "#execution/tasks/store.js";
+import { applyTaskCommandStep, initializeTaskStep } from "#execution/tasks/workflow-steps.js";
+import { isTerminalStatus, type DetailedTask } from "#runtime/tasks/types.js";
+
+/**
+ * Start input of one task actor run.
+ */
+export interface TaskWorkflowInput {
+  readonly createdBy?: TaskCreatedBy | null;
+  readonly endpoints: readonly StoredNotificationEndpoint[];
+  readonly sessionId: string;
+  readonly taskId: string;
+  readonly ttlMs: number | null;
+}
+
+/**
+ * Runs one background task's record to a terminal status.
+ */
+export async function taskWorkflow(input: TaskWorkflowInput): Promise<DetailedTask> {
+  "use workflow";
+
+  const { workflowRunId: taskRunId } = getWorkflowMetadata();
+  const hook = createHook<unknown>({ token: taskCommandHookToken(input.taskId) });
+  const iterator = hook[Symbol.asyncIterator]();
+
+  try {
+    let record = await initializeTaskStep({
+      createdBy: input.createdBy,
+      endpoints: input.endpoints,
+      sessionId: input.sessionId,
+      taskId: input.taskId,
+      taskRunId,
+      ttlMs: input.ttlMs,
+    });
+
+    while (!isTerminalStatus(record.task.status)) {
+      const next = await iterator.next();
+      if (next.done) {
+        break;
+      }
+      record = await applyTaskCommandStep({ payload: next.value, record });
+    }
+
+    return record.task;
+  } finally {
+    await disposeHook(hook);
+  }
+}

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -317,6 +317,7 @@ async function waitForRuntimeActionResults(input: {
         auth: value.delivery.auth,
         parentWritable: input.cursor.parentWritable,
         payloads: value.delivery.payloads,
+        serializedContext: input.cursor.serializedContext,
         sessionState: input.cursor.sessionState,
       });
       if (remainder !== undefined) {

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -288,6 +288,7 @@ async function runDriverLoop(input: {
         auth: nextDeliver.auth,
         parentWritable: input.driverWritable,
         payloads: nextDeliver.payloads,
+        serializedContext: action.serializedContext,
         sessionState: action.sessionState,
       });
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -41,6 +41,7 @@ import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { buildRunContext } from "#execution/runtime-context.js";
 import { parseNdjsonStream } from "#execution/ndjson-stream.js";
+import { sanitizeInboundDeliverPayload } from "#execution/tasks/delivery.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import {
   sessionCancelHookToken,
@@ -178,7 +179,9 @@ export function createWorkflowRuntime(config: {
       const hookPayload: Extract<HookPayload, { kind: "deliver" }> = {
         auth: input.auth,
         kind: "deliver",
-        payloads: [input.payload],
+        // Channel callers can never forge a task notification; the
+        // reserved field only enters through the callback route.
+        payloads: [sanitizeInboundDeliverPayload(input.payload)],
         requestId: input.requestId,
       };
       try {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -12,6 +12,7 @@ import {
 import {
   AuthKey,
   CapabilitiesKey,
+  InitiatorAuthKey,
   ModeKey,
   SessionDynamicToolRuntimeRevisionKey,
 } from "#context/keys.js";
@@ -68,6 +69,14 @@ import {
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
+import {
+  formatTaskOutcomeMessage,
+  payloadCarriesTaskNotifications,
+  splitTaskNotifications,
+} from "#execution/tasks/delivery.js";
+import { routeLateResponsesToLiveTasks, routeTaskNotifications } from "#execution/tasks/routing.js";
+import { hasLiveTasks, removeLiveTaskFromState } from "#harness/task-state.js";
+import { isTerminalStatus, type DetailedTask } from "#runtime/tasks/types.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
@@ -203,10 +212,49 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     }
   }
 
+  // Task notifications: strip the reserved field before the adapter
+  // deliver loop (adapters never see it). Terminal outcomes clear the
+  // live-task index here — the only index writer besides election —
+  // and project into turn input below.
+  const taskOutcomes: DetailedTask[] = [];
+  let sawTaskNotifications = false;
+  if (input.input?.kind === "deliver") {
+    const strippedPayloads: DeliverPayload[] = [];
+    for (const payload of input.input.payloads) {
+      const { notifications, rest } = splitTaskNotifications(payload);
+      if (notifications.length > 0) {
+        sawTaskNotifications = true;
+      }
+      for (const notification of notifications) {
+        if (isTerminalStatus(notification.task.status)) {
+          taskOutcomes.push(notification.task);
+          durableSession = {
+            ...durableSession,
+            state: removeLiveTaskFromState(durableSession.state, notification.task.taskId),
+          };
+        }
+      }
+      if (rest !== undefined) {
+        strippedPayloads.push(rest);
+      }
+    }
+    if (sawTaskNotifications) {
+      input = { ...input, input: { ...input.input, payloads: strippedPayloads } };
+    }
+  }
+
   // Apply deliver-time auth ferried via `resumeHook` (initial-turn
   // input has no auth; it was seeded by buildRunContext).
   if (input.input?.kind === "deliver" && input.input.auth !== undefined) {
     ctx.set(AuthKey, input.input.auth ?? null);
+  } else if (
+    input.input?.kind === "deliver" &&
+    sawTaskNotifications &&
+    input.input.auth === undefined
+  ) {
+    // A task delivery carries no channel auth (loopback POST); the
+    // re-alived session runs under the principal that started it.
+    ctx.set(AuthKey, ctx.get(InitiatorAuthKey) ?? null);
   }
 
   const initialSession = hydrateDurableSession({
@@ -237,6 +285,38 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   } else if (input.input?.kind === "runtime-action-result") {
     recordSubagentUsageSpans(input.input.results);
     resolved = { runtimeActionResults: input.input.results };
+  }
+
+  // Terminal task outcomes enter as new input — the call position was
+  // terminalized with the placeholder at election (never completed by
+  // the result).
+  if (taskOutcomes.length > 0) {
+    resolved = coalesceTurnInputs(resolved ?? {}, {
+      message: taskOutcomes.map(formatTaskOutcomeMessage).join("\n\n"),
+    });
+  }
+
+  // Step-0 late responses: answers to a live input_required task route
+  // to `updateTask` and never reach the model step, so they run before
+  // stale conversion by construction. `resolved` drops to `undefined`
+  // when nothing else remains — the no-turn re-park arm below.
+  if (
+    input.input?.kind === "deliver" &&
+    resolved?.inputResponses !== undefined &&
+    resolved.inputResponses.length > 0 &&
+    hasLiveTasks(durableSession.state)
+  ) {
+    const { remaining } = await routeLateResponsesToLiveTasks({
+      inputResponses: resolved.inputResponses,
+      state: durableSession.state,
+    });
+    if (remaining.length !== resolved.inputResponses.length) {
+      const { inputResponses: _routed, ...restInput } = resolved;
+      resolved = remaining.length > 0 ? { ...restInput, inputResponses: remaining } : restInput;
+      if (Object.values(resolved).every((value) => value === undefined)) {
+        resolved = undefined;
+      }
+    }
   }
 
   // Pin adapter-state mutations back onto ctx so they survive the
@@ -545,13 +625,16 @@ export interface RoutedDeliverResult {
 
 /**
  * Splits an inbound deliver payload into parent-local and
- * proxied-child buckets and forwards the child buckets via
- * `resumeHook`. Read-only: never appends a snapshot.
+ * proxied-child buckets, forwards the child buckets via `resumeHook`,
+ * and discriminates any task notifications aboard the parent-local
+ * remainder (`#execution/tasks/routing.js`). Read-only on the session:
+ * never appends a snapshot.
  */
 export async function routeProxiedDeliverStep(input: {
   readonly auth?: SessionAuthContext | null;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly payload: DeliverPayload;
+  readonly serializedContext?: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<RoutedDeliverResult> {
   "use step";
@@ -570,7 +653,19 @@ export async function routeProxiedDeliverStep(input: {
     });
   }
 
-  return { remainder: routed.forSelf };
+  let remainder = routed.forSelf;
+  if (remainder !== undefined && payloadCarriesTaskNotifications(remainder)) {
+    remainder = await routeTaskNotifications({
+      auth: input.auth,
+      durableSession,
+      emissionState: input.sessionState.emissionState,
+      parentWritable: input.parentWritable,
+      payload: remainder,
+      serializedContext: input.serializedContext,
+    });
+  }
+
+  return { remainder };
 }
 
 /** Starts a per-turn child workflow for the current driver session. */

--- a/packages/eve/src/harness/execute-tool.ts
+++ b/packages/eve/src/harness/execute-tool.ts
@@ -14,6 +14,13 @@ export type HarnessRuntimeActionDefinition = {
   readonly nodeId: string;
   readonly remoteAgentName?: string;
   readonly subagentName: string;
+  /**
+   * Background-task election gate. When `"optional"`, a `task` field on
+   * the call input elects background execution
+   * (`#runtime/tasks/election.js`). Internal until the Slice 2 `task:`
+   * combinators land — no authoring surface writes it yet.
+   */
+  readonly taskSupport?: "optional";
 };
 
 /**

--- a/packages/eve/src/harness/runtime-actions.test.ts
+++ b/packages/eve/src/harness/runtime-actions.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  collectTaskElections,
+  createRuntimeActionRequestFromToolCall,
   getPendingRuntimeActionBatch,
   recordPendingSubagentChild,
   resolvePendingRuntimeActions,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
 import { getSessionTokenUsage, setTurnUsageState } from "#harness/turn-tag-state.js";
-import type { HarnessSession } from "#harness/types.js";
+import type { HarnessSession, HarnessToolMap } from "#harness/types.js";
 
 function createParkedSession(): HarnessSession {
   const base: HarnessSession = {
@@ -103,6 +105,138 @@ describe("resolvePendingRuntimeActions", () => {
       inputTokens: 1_000,
       outputTokens: 100,
     });
+  });
+});
+
+describe("task election gating", () => {
+  const toolCall = (input: Record<string, unknown>) =>
+    ({
+      input,
+      toolCallId: "call-1",
+      toolName: "agent",
+      type: "tool-call" as const,
+    }) as Parameters<typeof createRuntimeActionRequestFromToolCall>[0]["toolCall"];
+
+  const toolsWith = (taskSupport?: "optional"): HarnessToolMap => {
+    const runtimeAction = {
+      kind: "subagent-call" as const,
+      nodeId: "subagents/agent",
+      subagentName: "agent",
+    };
+    return new Map([
+      [
+        "agent",
+        {
+          description: "delegate",
+          inputSchema: { jsonSchema: { type: "object" } } as never,
+          name: "agent",
+          runtimeAction:
+            taskSupport === undefined ? runtimeAction : { ...runtimeAction, taskSupport },
+        },
+      ],
+    ]);
+  };
+
+  it("records a valid election when the definition declares taskSupport", () => {
+    const elections = collectTaskElections({
+      toolCalls: [toolCall({ message: "go", task: { ttlMs: 60_000 } })],
+      tools: toolsWith("optional"),
+    });
+
+    expect(elections).toEqual({ "call-1": { ttlMs: 60_000 } });
+  });
+
+  it("keeps the action request itself election-free", () => {
+    const action = createRuntimeActionRequestFromToolCall({
+      toolCall: toolCall({ message: "go", task: { ttlMs: 60_000 } }),
+      tools: toolsWith("optional"),
+    });
+
+    expect("task" in action).toBe(false);
+  });
+
+  it("never records an election for an undeclared tool, whatever the model sent", () => {
+    const elections = collectTaskElections({
+      toolCalls: [toolCall({ message: "go", task: {} })],
+      tools: toolsWith(undefined),
+    });
+
+    expect(elections).toBeUndefined();
+  });
+
+  it("ignores malformed task fields", () => {
+    const elections = collectTaskElections({
+      toolCalls: [toolCall({ message: "go", task: { ttlMs: "forever" } })],
+      tools: toolsWith("optional"),
+    });
+
+    expect(elections).toBeUndefined();
+  });
+
+  it("stores elections on the pending batch", () => {
+    const session = setPendingRuntimeActionBatch({
+      actions: [],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      responseMessages: [],
+      session: createParkedSession(),
+      taskElections: { "call-1": { ttlMs: null } },
+    });
+
+    expect(getPendingRuntimeActionBatch(session.state)?.taskElections).toEqual({
+      "call-1": { ttlMs: null },
+    });
+  });
+});
+
+describe("placeholder result events", () => {
+  it("suppresses subagent.completed for CreateTaskResult placeholders", async () => {
+    const session = createParkedSession();
+    const emit = vi.fn();
+
+    const resolved = await resolvePendingRuntimeActions({
+      emit,
+      session,
+      stepInput: {
+        runtimeActionResults: [
+          {
+            callId: "call-1",
+            kind: "subagent-result",
+            output: {
+              createdAt: "2026-07-23T00:00:00.000Z",
+              lastUpdatedAt: "2026-07-23T00:00:00.000Z",
+              status: "working",
+              taskId: "task_1",
+              ttlMs: null,
+            },
+            subagentName: "researcher",
+          },
+        ],
+      },
+    });
+
+    expect(resolved.outcome).toBe("resolved");
+    const emitted = emit.mock.calls.map(([event]) => (event as { type: string }).type);
+    expect(emitted).not.toContain("subagent.completed");
+    expect(emitted).toContain("action.result");
+  });
+
+  it("still emits subagent.completed for real subagent outputs", async () => {
+    const session = createParkedSession();
+    const emit = vi.fn();
+
+    await resolvePendingRuntimeActions({
+      emit,
+      session,
+      stepInput: {
+        runtimeActionResults: [
+          { callId: "call-1", kind: "subagent-result", output: "done", subagentName: "researcher" },
+        ],
+      },
+    });
+
+    expect(emit.mock.calls.map(([event]) => (event as { type: string }).type)).toContain(
+      "subagent.completed",
+    );
   });
 });
 

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -3,6 +3,8 @@ import type { ModelMessage, ToolSet, TypedToolCall } from "ai";
 import { createActionResultEvent, type HandleMessageStreamEvent } from "#protocol/message.js";
 import { getRuntimeActionRequestKey, getRuntimeActionResultKey } from "#runtime/actions/keys.js";
 import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
+import { taskElectionSchema, type TaskElection } from "#runtime/tasks/election.js";
+import { isCreateTaskResultShaped } from "#runtime/tasks/types.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { clearProxyInputRequestsForChild } from "#harness/proxy-input-requests.js";
 import {
@@ -40,6 +42,10 @@ interface PendingRuntimeActionEventMetadata {
  * `childContinuationTokens` lets the harness clear local proxy-input entries
  * on result resolution. `childSessionIds` lets the turn workflow cancel every
  * successfully adopted local or remote child before dropping the batch.
+ * `taskElections` records, per `callId`, a validated background election
+ * read off the call input — kept on the batch (session-internal state)
+ * rather than the action request, whose type is part of the extension
+ * capability contracts.
  */
 export interface PendingRuntimeActionBatch {
   readonly actions: readonly RuntimeActionRequest[];
@@ -47,6 +53,7 @@ export interface PendingRuntimeActionBatch {
   readonly childSessionIds?: Readonly<Record<string, string>>;
   readonly event: PendingRuntimeActionEventMetadata;
   readonly responseMessages: readonly ModelMessage[];
+  readonly taskElections?: Readonly<Record<string, TaskElection>>;
 }
 
 /**
@@ -106,13 +113,16 @@ export function setPendingRuntimeActionBatch(input: {
   readonly event: PendingRuntimeActionEventMetadata;
   readonly responseMessages: readonly ModelMessage[];
   readonly session: HarnessSession;
+  readonly taskElections?: Readonly<Record<string, TaskElection>>;
 }): HarnessSession {
-  const state = { ...input.session.state };
-  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = {
+  const batch: PendingRuntimeActionBatch = {
     actions: [...input.actions],
     event: input.event,
     responseMessages: [...input.responseMessages],
-  } satisfies PendingRuntimeActionBatch;
+  };
+  const state = { ...input.session.state };
+  state[PENDING_RUNTIME_ACTION_BATCH_KEY] =
+    input.taskElections === undefined ? batch : { ...batch, taskElections: input.taskElections };
 
   return { ...input.session, state };
 }
@@ -259,7 +269,13 @@ export async function resolvePendingRuntimeActions(input: {
 
   if (input.emit !== undefined) {
     for (const result of readyResults) {
-      if (result.kind === "subagent-result" && result.isError !== true) {
+      if (
+        result.kind === "subagent-result" &&
+        result.isError !== true &&
+        // A background-election placeholder is not a completion — the
+        // work just started; task lifecycle events cover it instead.
+        !isCreateTaskResultShaped(result.output)
+      ) {
         await input.emit({
           data: {
             callId: result.callId,
@@ -414,6 +430,35 @@ export function createRuntimeActionRequestFromToolCall(input: {
     kind: "tool-call",
     toolName: input.toolCall.toolName,
   };
+}
+
+/**
+ * Collects valid `task` elections off the batch's call inputs, keyed by
+ * `callId` — only for tools whose definition declares `taskSupport`.
+ * Undeclared tools never surface an election, whatever the model sent.
+ */
+export function collectTaskElections(input: {
+  readonly toolCalls: readonly TypedToolCall<ToolSet>[];
+  readonly tools: HarnessToolMap;
+}): Readonly<Record<string, TaskElection>> | undefined {
+  const elections: Record<string, TaskElection> = {};
+
+  for (const toolCall of input.toolCalls) {
+    const definition = input.tools.get(toolCall.toolName);
+    if (definition?.runtimeAction?.taskSupport !== "optional") {
+      continue;
+    }
+    const resolvedInput = resolveToolCallInputObject(toolCall.input, {
+      callId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+    });
+    const parsed = taskElectionSchema.safeParse(resolvedInput.task);
+    if (parsed.success) {
+      elections[toolCall.toolCallId] = parsed.data;
+    }
+  }
+
+  return Object.keys(elections).length > 0 ? elections : undefined;
 }
 
 /**

--- a/packages/eve/src/harness/task-state.test.ts
+++ b/packages/eve/src/harness/task-state.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addLiveTask,
+  getLiveTasks,
+  hasLiveTasks,
+  removeLiveTask,
+  removeLiveTaskFromState,
+} from "#harness/task-state.js";
+import type { HarnessSession } from "#harness/types.js";
+
+function createSession(state?: Record<string, unknown>): HarnessSession {
+  return {
+    agent: {
+      modelReference: { id: "test-model" },
+      system: "",
+      tools: [],
+    },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "parent-token",
+    history: [],
+    sessionId: "parent-session",
+    state,
+  };
+}
+
+describe("live-task index", () => {
+  it("starts empty", () => {
+    const session = createSession();
+    expect(getLiveTasks(session.state).size).toBe(0);
+    expect(hasLiveTasks(session.state)).toBe(false);
+  });
+
+  it("adds and removes tasks", () => {
+    let session = addLiveTask(createSession(), { taskId: "task_a", taskRunId: "run_1" });
+    session = addLiveTask(session, { taskId: "task_b", taskRunId: "run_2" });
+
+    expect(getLiveTasks(session.state).get("task_a")).toBe("run_1");
+    expect(getLiveTasks(session.state).get("task_b")).toBe("run_2");
+    expect(hasLiveTasks(session.state)).toBe(true);
+
+    session = removeLiveTask(session, "task_a");
+    expect([...getLiveTasks(session.state).keys()]).toEqual(["task_b"]);
+  });
+
+  it("is idempotent on duplicate adds and missing removes", () => {
+    const added = addLiveTask(createSession(), { taskId: "task_a", taskRunId: "run_1" });
+    expect(addLiveTask(added, { taskId: "task_a", taskRunId: "run_1" })).toBe(added);
+
+    const untouched = removeLiveTask(added, "task_missing");
+    expect(untouched).toBe(added);
+  });
+
+  it("elides the state key when the last task is removed", () => {
+    const session = removeLiveTask(
+      addLiveTask(createSession(), { taskId: "task_a", taskRunId: "run_1" }),
+      "task_a",
+    );
+    expect(session.state).toBeUndefined();
+    expect(hasLiveTasks(session.state)).toBe(false);
+  });
+
+  it("preserves unrelated state entries", () => {
+    const session = addLiveTask(createSession({ "eve.other": 1 }), {
+      taskId: "task_a",
+      taskRunId: "run_1",
+    });
+    const cleared = removeLiveTask(session, "task_a");
+    expect(cleared.state).toEqual({ "eve.other": 1 });
+  });
+
+  it("removes at the state level, preserving unrelated keys and eliding when empty", () => {
+    const session = addLiveTask(createSession({ "eve.other": 1 }), {
+      taskId: "task_a",
+      taskRunId: "run_1",
+    });
+
+    const untouched = removeLiveTaskFromState(session.state, "task_missing");
+    expect(untouched).toBe(session.state);
+
+    const cleared = removeLiveTaskFromState(session.state, "task_a");
+    expect(cleared).toEqual({ "eve.other": 1 });
+    expect(
+      removeLiveTaskFromState({ "eve.runtime.liveTasks": { task_a: "run_1" } }, "task_a"),
+    ).toBe(undefined);
+  });
+
+  it("ignores malformed stored values", () => {
+    const session = createSession({ "eve.runtime.liveTasks": ["task_a"] });
+    expect(getLiveTasks(session.state).size).toBe(0);
+    expect(hasLiveTasks(session.state)).toBe(false);
+  });
+});

--- a/packages/eve/src/harness/task-state.ts
+++ b/packages/eve/src/harness/task-state.ts
@@ -1,0 +1,108 @@
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+
+const LIVE_TASKS_KEY = "eve.runtime.liveTasks";
+
+/**
+ * Returns the session's live (non-terminal) background tasks as a
+ * fresh `taskId → taskRunId` map. Never returns a live reference so
+ * accidental mutation cannot corrupt session state.
+ *
+ * The index is a session-state pointer map only; task records
+ * themselves are owned by their actor runs (`#execution/tasks/store.js`)
+ * so they stay writable while the session is parked. Both index
+ * writers — the dispatch step at election and the turn step at
+ * terminal consumption — sit on the threaded session-state path. The
+ * run id is store-internal and never appears on streams.
+ */
+export function getLiveTasks(state: SessionStateMap | undefined): ReadonlyMap<string, string> {
+  return new Map(Object.entries(readMap(state)));
+}
+
+/**
+ * Returns true when the session has at least one live background task.
+ */
+export function hasLiveTasks(state: SessionStateMap | undefined): boolean {
+  for (const _ of Object.keys(readMap(state))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Adds a task to the live-task index. Idempotent per task id.
+ */
+export function addLiveTask(
+  session: HarnessSession,
+  entry: { readonly taskId: string; readonly taskRunId: string },
+): HarnessSession {
+  const current = readMap(session.state);
+  if (current[entry.taskId] === entry.taskRunId) {
+    return session;
+  }
+  return writeMap(session, { ...current, [entry.taskId]: entry.taskRunId });
+}
+
+/**
+ * Removes a task from the live-task index. Called when a terminal
+ * task notification is consumed. Idempotent.
+ */
+export function removeLiveTask(session: HarnessSession, taskId: string): HarnessSession {
+  const state = removeLiveTaskFromState(session.state, taskId);
+  return state === session.state ? session : { ...session, state };
+}
+
+/**
+ * State-level form of {@link removeLiveTask} for callers holding a
+ * `SessionStateMap` rather than a full session (e.g. the turn step
+ * before hydration). Returns the same reference when nothing changed.
+ */
+export function removeLiveTaskFromState(
+  state: SessionStateMap | undefined,
+  taskId: string,
+): SessionStateMap | undefined {
+  const current = readMap(state);
+  if (!(taskId in current)) {
+    return state;
+  }
+  const next = { ...current };
+  delete next[taskId];
+
+  const nextState = { ...state };
+  if (Object.keys(next).length === 0) {
+    delete nextState[LIVE_TASKS_KEY];
+    return Object.keys(nextState).length > 0 ? nextState : undefined;
+  }
+  nextState[LIVE_TASKS_KEY] = next;
+  return nextState;
+}
+
+function readMap(state: SessionStateMap | undefined): Readonly<Record<string, string>> {
+  const raw = state?.[LIVE_TASKS_KEY];
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "string") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function writeMap(session: HarnessSession, entries: Record<string, string>): HarnessSession {
+  const state = { ...session.state };
+
+  if (Object.keys(entries).length === 0) {
+    delete state[LIVE_TASKS_KEY];
+    return {
+      ...session,
+      state: Object.keys(state).length > 0 ? state : undefined,
+    };
+  }
+
+  state[LIVE_TASKS_KEY] = entries;
+  return { ...session, state };
+}

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -153,6 +153,7 @@ import {
 } from "#harness/prompt-cache.js";
 import { resolveFrameworkToolFromUpstreamType } from "#harness/provider-tools.js";
 import {
+  collectTaskElections,
   createRuntimeActionRequestFromToolCall,
   resolvePendingRuntimeActions,
   setPendingRuntimeActionBatch,
@@ -1877,7 +1878,7 @@ async function handleStepResult(input: {
     session: baseSession,
     tools: config.tools,
   });
-  const pendingRuntimeActions = ((result.toolCalls ?? []) as TypedToolCall<ToolSet>[])
+  const runtimeActionToolCalls = ((result.toolCalls ?? []) as TypedToolCall<ToolSet>[])
     .filter((toolCall) => !invalidInputToolCallIds.has(toolCall.toolCallId))
     .filter((toolCall) => config.tools.get(toolCall.toolName)?.runtimeAction !== undefined)
     .filter((toolCall) => {
@@ -1890,13 +1891,13 @@ async function handleStepResult(input: {
         toolName: toolCall.toolName,
       });
       return false;
-    })
-    .map((toolCall) =>
-      createRuntimeActionRequestFromToolCall({
-        toolCall,
-        tools: advertisedRuntimeActionTools,
-      }),
-    );
+    });
+  const pendingRuntimeActions = runtimeActionToolCalls.map((toolCall) =>
+    createRuntimeActionRequestFromToolCall({
+      toolCall,
+      tools: advertisedRuntimeActionTools,
+    }),
+  );
 
   if (pendingRuntimeActions.length > 0) {
     // Stamp the live emission state onto the parked session so the
@@ -1917,6 +1918,10 @@ async function handleStepResult(input: {
           },
           responseMessages,
           session: { ...baseSession, history: [...promptMessages] },
+          taskElections: collectTaskElections({
+            toolCalls: runtimeActionToolCalls,
+            tools: advertisedRuntimeActionTools,
+          }),
         }),
         emissionState,
       ),

--- a/packages/eve/src/runtime/agent/mock-model-adapter.ts
+++ b/packages/eve/src/runtime/agent/mock-model-adapter.ts
@@ -207,6 +207,7 @@ function createSkillLoadResult(
 
 const SUBAGENT_TOOL_NAME = "agent";
 const SUBAGENT_DELEGATION_DIRECTIVE = /\bdelegate\s+to\s+a\s+subagent\s*:\s*(.+)$/iu;
+const BACKGROUND_DELEGATION_DIRECTIVE = /\bdelegate\s+to\s+a\s+background\s+subagent\s*:\s*(.+)$/iu;
 const PARALLEL_AUTHORED_TOOLS_DIRECTIVE = /^call tools in parallel:\s*(.+)$/imu;
 
 function createParallelAuthoredToolCallsResult(
@@ -270,7 +271,8 @@ function createSubagentDelegationResult(
     return null;
   }
 
-  const directive = SUBAGENT_DELEGATION_DIRECTIVE.exec(lastUserMessage);
+  const backgroundDirective = BACKGROUND_DELEGATION_DIRECTIVE.exec(lastUserMessage);
+  const directive = backgroundDirective ?? SUBAGENT_DELEGATION_DIRECTIVE.exec(lastUserMessage);
 
   if (directive?.[1] === undefined) {
     return null;
@@ -282,7 +284,10 @@ function createSubagentDelegationResult(
     return null;
   }
 
-  const toolInput = { message: directive[1].trim() };
+  const toolInput =
+    backgroundDirective === null
+      ? { message: directive[1].trim() }
+      : { message: directive[1].trim(), task: {} };
 
   return createToolCallGenerateResult({
     input: toolInput,

--- a/packages/eve/src/runtime/session-callback-route.test.ts
+++ b/packages/eve/src/runtime/session-callback-route.test.ts
@@ -136,6 +136,73 @@ describe("session callback route", () => {
     });
   });
 
+  it("resumes a task notification as a deliver payload", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+
+    const notification = {
+      kind: "task.terminal",
+      task: {
+        createdAt: "2026-07-23T00:00:00.000Z",
+        lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+        result: { ok: true },
+        status: "completed",
+        taskId: "task_1",
+        ttlMs: null,
+      },
+    };
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify(notification),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).toHaveBeenCalledWith("tok123", {
+      kind: "deliver",
+      payloads: [{ taskNotifications: [notification] }],
+    });
+  });
+
+  it("rejects a malformed task notification with 400 without resuming", async () => {
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({ kind: "task.terminal", task: { taskId: "task_1" } }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 for a task notification whose hook is gone", async () => {
+    resumeHookMock.mockRejectedValue(new Error("no hook"));
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          kind: "task.status",
+          task: {
+            createdAt: "2026-07-23T00:00:00.000Z",
+            inputRequests: [],
+            lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+            status: "input_required",
+            taskId: "task_1",
+            ttlMs: null,
+          },
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
   it("drops malformed usage but still resumes the result", async () => {
     resumeHookMock.mockResolvedValue(undefined);
 

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -3,6 +3,7 @@ import { EVE_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
 import type { ChannelMethod, RouteContext } from "#public/definitions/channel.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
+import { taskNotificationSchema } from "#runtime/tasks/types.js";
 import type { JsonValue } from "#shared/json.js";
 import { tokenUsageSchema, type TokenUsage } from "#shared/token-usage.js";
 
@@ -68,6 +69,10 @@ export async function handleSessionCallbackRequest(
     return Response.json({ error: "Invalid JSON body.", ok: false }, { status: 400 });
   }
 
+  if (isTaskNotificationBody(body)) {
+    return await resumeTaskNotification(token, body);
+  }
+
   const result = projectSessionCallbackResult(body);
   if (result instanceof Response) {
     return result;
@@ -77,6 +82,39 @@ export async function handleSessionCallbackRequest(
     await resumeHook(token, {
       kind: "runtime-action-result",
       results: [result],
+    });
+  } catch {
+    return Response.json({ error: "Session callback not pending.", ok: false }, { status: 404 });
+  }
+
+  return Response.json({ ok: true }, { status: 202 });
+}
+
+function isTaskNotificationBody(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { kind?: unknown }).kind === "string" &&
+    (value as { kind: string }).kind.startsWith("task.")
+  );
+}
+
+/**
+ * Resumes a task notification as an ordinary `deliver` payload so the
+ * target's driver — which skips every non-`deliver` hook payload while
+ * parked — wakes and routes it. The 404 arm is the gone-subscriber
+ * signal the notify fan-out consumes to mark an endpoint dead.
+ */
+async function resumeTaskNotification(token: string, body: unknown): Promise<Response> {
+  const parsed = taskNotificationSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid task notification body.", ok: false }, { status: 400 });
+  }
+
+  try {
+    await resumeHook(token, {
+      kind: "deliver",
+      payloads: [{ taskNotifications: [parsed.data] }],
     });
   } catch {
     return Response.json({ error: "Session callback not pending.", ok: false }, { status: 404 });

--- a/packages/eve/src/runtime/subagents/registry.ts
+++ b/packages/eve/src/runtime/subagents/registry.ts
@@ -1,6 +1,7 @@
 import { z } from "#compiled/zod/index.js";
 
 import { RuntimeRegistry, RuntimeRegistryError } from "#internal/runtime-registry.js";
+import { taskElectionSchema } from "#runtime/tasks/election.js";
 import type { PreparedRuntimeDelegationTool } from "#runtime/sessions/turn.js";
 import type { ResolvedRuntimeDelegationNode } from "#runtime/types.js";
 import { serializeInputSchema } from "#shared/tool-schema.js";
@@ -36,6 +37,20 @@ export const SUBAGENT_TOOL_INPUT_SCHEMA = z.strictObject({
     .looseObject({})
     .describe(
       "Only provide a non-empty JSON Schema when the caller explicitly requests structured output; otherwise omit this field. The subagent must match a provided schema, and that structured output becomes the tool result.",
+    )
+    .optional(),
+});
+
+/**
+ * {@link SUBAGENT_TOOL_INPUT_SCHEMA} augmented with the background
+ * `task` election field. Lowered only when a tool's election gate is on
+ * (`taskSupport`) — declared here so the augmentation matches the
+ * request-side contract (`#runtime/tasks/election.js`).
+ */
+export const SUBAGENT_TOOL_INPUT_SCHEMA_WITH_TASK = SUBAGENT_TOOL_INPUT_SCHEMA.extend({
+  task: taskElectionSchema
+    .describe(
+      "Provide to run this delegation as a background task: the call returns a task placeholder immediately and the outcome arrives later as new input.",
     )
     .optional(),
 });

--- a/packages/eve/src/runtime/tasks/election.ts
+++ b/packages/eve/src/runtime/tasks/election.ts
@@ -1,0 +1,52 @@
+import { z } from "#compiled/zod/index.js";
+
+/**
+ * Background-election input carried on a tool call.
+ *
+ * Presence of the `task` field on a call elects background execution;
+ * the shape mirrors the MCP tasks extension's request-side augmentation
+ * (`ttlMs` is the only negotiable field today, `null` = unlimited
+ * retention).
+ */
+export type TaskElection = z.infer<typeof taskElectionSchema>;
+
+/**
+ * Zod schema for the `task` election field on a tool call.
+ */
+export const taskElectionSchema = z
+  .object({
+    ttlMs: z.number().nullable().optional(),
+  })
+  .strict();
+
+const INTERNAL_TASK_ELECTION_ENV = "EVE_INTERNAL_BACKGROUND_TASK_ELECTION";
+
+/**
+ * Internal Slice 1 gate: enables background election on the built-in
+ * `agent` tool (`taskSupport: "optional"` plus the `task` input field).
+ * Exists only so integration coverage can exercise the creation path
+ * before any public elector ships — the Slice 2 `task:` combinators
+ * replace it. Never document or rely on it.
+ */
+export function isInternalBackgroundTaskElectionEnabled(): boolean {
+  return process.env[INTERNAL_TASK_ELECTION_ENV] === "1";
+}
+
+/**
+ * Normalizes one recorded background election (`ttlMs` defaulted to
+ * `null`), or `undefined` when the call carried none. Elections are
+ * recorded per `callId` on the pending runtime-action batch
+ * (`PendingRuntimeActionBatch.taskElections`) — never on the action
+ * request, whose type is part of the extension capability contracts.
+ * This is the single seam later slices extend: subagent combinators
+ * (Slice 2) and authored-tool `task:` declarations (Slice 3) both
+ * surface elections through this reader.
+ */
+export function readBackgroundElection(
+  election: TaskElection | undefined,
+): { readonly ttlMs: number | null } | undefined {
+  if (election === undefined) {
+    return undefined;
+  }
+  return { ttlMs: election.ttlMs ?? null };
+}

--- a/packages/eve/src/runtime/tasks/types.test.ts
+++ b/packages/eve/src/runtime/tasks/types.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import type { InputRequest } from "#runtime/input/types.js";
+import { readBackgroundElection, taskElectionSchema } from "#runtime/tasks/election.js";
+import {
+  DEFAULT_NOTIFICATION_ROUTES,
+  detailedTaskSchema,
+  isTerminalStatus,
+  taskNotificationSchema,
+  toCreateTaskResult,
+  type DetailedTask,
+  type Task,
+} from "#runtime/tasks/types.js";
+
+const baseTask = {
+  createdAt: "2026-07-23T00:00:00.000Z",
+  lastUpdatedAt: "2026-07-23T00:00:01.000Z",
+  taskId: "task_5c1c19f3-9f7d-4a8e-9a9e-0f2f9f6d4b1a",
+  ttlMs: null,
+} as const;
+
+const inputRequest: InputRequest = {
+  action: {
+    callId: "call_1",
+    input: { city: "Lisbon" },
+    kind: "tool-call",
+    toolName: "get_weather",
+  },
+  prompt: "Allow get_weather?",
+  requestId: "req_1",
+};
+
+describe("detailedTaskSchema", () => {
+  it("round-trips every status variant", () => {
+    const variants: DetailedTask[] = [
+      { ...baseTask, status: "working" },
+      { ...baseTask, inputRequests: [inputRequest], status: "input_required" },
+      { ...baseTask, result: { ok: true }, status: "completed" },
+      { ...baseTask, error: { data: { code: 500 }, message: "boom" }, status: "failed" },
+      { ...baseTask, status: "cancelled" },
+    ];
+    for (const variant of variants) {
+      expect(detailedTaskSchema.parse(variant)).toEqual(variant);
+    }
+  });
+
+  it("rejects variant payloads on the wrong status", () => {
+    expect(
+      detailedTaskSchema.safeParse({ ...baseTask, result: "late", status: "failed" }).success,
+    ).toBe(false);
+    expect(
+      detailedTaskSchema.safeParse({ ...baseTask, inputRequests: [], status: "working" }).success,
+    ).toBe(false);
+  });
+
+  it("requires the variant payload where the contract demands one", () => {
+    expect(detailedTaskSchema.safeParse({ ...baseTask, status: "completed" }).success).toBe(false);
+    expect(detailedTaskSchema.safeParse({ ...baseTask, status: "failed" }).success).toBe(false);
+    expect(detailedTaskSchema.safeParse({ ...baseTask, status: "input_required" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("taskNotificationSchema", () => {
+  it("round-trips an envelope carrying the full snapshot", () => {
+    const notification = {
+      kind: "task.terminal",
+      task: { ...baseTask, result: "done", status: "completed" },
+    };
+    expect(taskNotificationSchema.parse(notification)).toEqual(notification);
+  });
+
+  it("rejects unknown kinds", () => {
+    expect(
+      taskNotificationSchema.safeParse({
+        kind: "task.deleted",
+        task: { ...baseTask, status: "working" },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("isTerminalStatus", () => {
+  it("marks exactly completed, failed, and cancelled as terminal", () => {
+    expect(isTerminalStatus("completed")).toBe(true);
+    expect(isTerminalStatus("failed")).toBe(true);
+    expect(isTerminalStatus("cancelled")).toBe(true);
+    expect(isTerminalStatus("working")).toBe(false);
+    expect(isTerminalStatus("input_required")).toBe(false);
+  });
+});
+
+describe("DEFAULT_NOTIFICATION_ROUTES", () => {
+  it("routes only wake-worthy kinds", () => {
+    expect(DEFAULT_NOTIFICATION_ROUTES).toEqual(["task.status", "task.terminal"]);
+  });
+});
+
+describe("toCreateTaskResult", () => {
+  it("projects the flat placeholder shape", () => {
+    const task: Task = { ...baseTask, status: "working" };
+    expect(toCreateTaskResult(task)).toEqual({
+      createdAt: baseTask.createdAt,
+      lastUpdatedAt: baseTask.lastUpdatedAt,
+      status: "working",
+      taskId: baseTask.taskId,
+      ttlMs: null,
+    });
+  });
+
+  it("keeps optional fields only when present", () => {
+    const task: Task = {
+      ...baseTask,
+      pollIntervalMs: 2_000,
+      status: "working",
+      statusMessage: "starting",
+    };
+    expect(toCreateTaskResult(task)).toMatchObject({
+      pollIntervalMs: 2_000,
+      statusMessage: "starting",
+    });
+  });
+});
+
+describe("readBackgroundElection", () => {
+  it("returns undefined when no election was recorded", () => {
+    expect(readBackgroundElection(undefined)).toBeUndefined();
+  });
+
+  it("normalizes an empty election to unlimited retention", () => {
+    expect(readBackgroundElection({})).toEqual({ ttlMs: null });
+  });
+
+  it("passes an explicit ttl through", () => {
+    expect(readBackgroundElection({ ttlMs: 60_000 })).toEqual({ ttlMs: 60_000 });
+  });
+
+  it("rejects unknown election fields at the schema", () => {
+    expect(taskElectionSchema.safeParse({ retainForever: true }).success).toBe(false);
+  });
+});

--- a/packages/eve/src/runtime/tasks/types.ts
+++ b/packages/eve/src/runtime/tasks/types.ts
@@ -1,0 +1,238 @@
+import { z } from "#compiled/zod/index.js";
+
+import { inputRequestSchema } from "#runtime/input/types.js";
+import type { JsonObject } from "#shared/json.js";
+import { jsonValueSchema } from "#shared/json-schemas.js";
+
+/**
+ * Lifecycle status of a task, in the MCP tasks extension's vocabulary.
+ *
+ * `completed`, `failed`, and `cancelled` are terminal and final: once a
+ * task reaches one of them it never transitions again (`cancelled` is
+ * sticky even if execution later runs to completion).
+ */
+export type TaskStatus = z.infer<typeof taskStatusSchema>;
+
+/**
+ * Zod schema for a task status.
+ */
+export const taskStatusSchema = z.enum([
+  "working",
+  "input_required",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+const taskBaseShape = {
+  createdAt: z.string(),
+  lastUpdatedAt: z.string(),
+  pollIntervalMs: z.number().optional(),
+  statusMessage: z.string().optional(),
+  taskId: z.string(),
+  ttlMs: z.number().nullable(),
+};
+
+/**
+ * The base task record: an identifiable container for an asynchronous,
+ * long-running unit of work.
+ *
+ * Shape mirrors the MCP tasks extension's `Task` object exactly:
+ * `taskId` is minted and high-entropy (never a session id or token),
+ * timestamps are ISO 8601, and `ttlMs: null` means unlimited retention.
+ */
+export type Task = z.infer<typeof taskSchema>;
+
+/**
+ * Zod schema for the base task record.
+ */
+export const taskSchema = z
+  .object({
+    ...taskBaseShape,
+    status: taskStatusSchema,
+  })
+  .strict();
+
+const workingTaskSchema = z
+  .object({
+    ...taskBaseShape,
+    status: z.literal("working"),
+  })
+  .strict();
+
+const inputRequiredTaskSchema = z
+  .object({
+    ...taskBaseShape,
+    inputRequests: z.array(inputRequestSchema),
+    status: z.literal("input_required"),
+  })
+  .strict();
+
+const completedTaskSchema = z
+  .object({
+    ...taskBaseShape,
+    result: jsonValueSchema,
+    status: z.literal("completed"),
+  })
+  .strict();
+
+const failedTaskSchema = z
+  .object({
+    ...taskBaseShape,
+    error: z
+      .object({
+        data: jsonValueSchema.optional(),
+        message: z.string(),
+      })
+      .strict(),
+    status: z.literal("failed"),
+  })
+  .strict();
+
+const cancelledTaskSchema = z
+  .object({
+    ...taskBaseShape,
+    status: z.literal("cancelled"),
+  })
+  .strict();
+
+/**
+ * Status-detailed task record, discriminated on `status`.
+ *
+ * Mirrors the extension's `DetailedTask`: `input_required` carries its
+ * live input requests inline, `completed` carries the JSON `result` a
+ * sync invocation would have placed at the call position, and `failed`
+ * carries a structured `error` (never a `result`). The record is the
+ * single source of truth for status, pending input, and outcome — there
+ * is no separate result-retrieval operation.
+ */
+export type DetailedTask = z.infer<typeof detailedTaskSchema>;
+
+/**
+ * Zod schema for a status-detailed task record.
+ */
+export const detailedTaskSchema = z.discriminatedUnion("status", [
+  workingTaskSchema,
+  inputRequiredTaskSchema,
+  completedTaskSchema,
+  failedTaskSchema,
+  cancelledTaskSchema,
+]);
+
+/**
+ * Event kinds a task notification can carry.
+ *
+ * - `task.created` — record created at background election.
+ * - `task.progress` — `statusMessage` changed; status still `working`.
+ * - `task.status` — non-terminal status transition.
+ * - `task.terminal` — `completed` | `failed` | `cancelled`, outcome
+ *   inline on the snapshot.
+ */
+export type TaskNotificationKind = z.infer<typeof taskNotificationKindSchema>;
+
+/**
+ * Zod schema for a task notification kind.
+ */
+export const taskNotificationKindSchema = z.enum([
+  "task.created",
+  "task.progress",
+  "task.status",
+  "task.terminal",
+]);
+
+/**
+ * One task notification: an explicit event kind plus the full
+ * `DetailedTask` snapshot.
+ *
+ * Mirrors `notifications/tasks` params, which carry the whole record
+ * rather than a delta — consumers never reconstruct state from event
+ * history.
+ */
+export type TaskNotification = z.infer<typeof taskNotificationSchema>;
+
+/**
+ * Zod schema for one task notification envelope.
+ */
+export const taskNotificationSchema = z
+  .object({
+    kind: taskNotificationKindSchema,
+    task: detailedTaskSchema,
+  })
+  .strict();
+
+/**
+ * A stored notification endpoint: a POST target for task notifications,
+ * as `/eve/v1/callback/:token` today — local and remote alike.
+ *
+ * Endpoint URLs are capabilities (the token is embedded in the URL):
+ * they are stored, never emitted on streams or surfaced to the model.
+ */
+export interface NotificationEndpoint {
+  readonly url: string;
+}
+
+/**
+ * Notification kinds delivered to an endpoint that registered without a
+ * per-endpoint filter.
+ *
+ * Deliberately narrow — wake-worthy only: the default registered
+ * endpoint is the caller's session driver, and a delivery wakes it (and
+ * may run a turn), so progress chatter must not route there. A passive
+ * observer that wants the full feed overrides this on registration.
+ */
+export const DEFAULT_NOTIFICATION_ROUTES: readonly TaskNotificationKind[] = [
+  "task.status",
+  "task.terminal",
+];
+
+/**
+ * Returns true when a status is terminal (`completed` | `failed` |
+ * `cancelled`). Terminal states are final.
+ */
+export function isTerminalStatus(status: TaskStatus): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+/**
+ * Returns true when a value is shaped like the `CreateTaskResult`
+ * placeholder — used to tell a background-election placeholder apart
+ * from a real tool outcome (e.g. to suppress `subagent.completed` for
+ * work that just started).
+ */
+export function isCreateTaskResultShaped(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.taskId === "string" &&
+    taskStatusSchema.safeParse(candidate.status).success &&
+    typeof candidate.createdAt === "string" &&
+    typeof candidate.lastUpdatedAt === "string" &&
+    (candidate.ttlMs === null || typeof candidate.ttlMs === "number")
+  );
+}
+
+/**
+ * Projects a task into the flat `CreateTaskResult`-shaped placeholder
+ * placed at the tool-call position on background election.
+ *
+ * The model sees this in place of the tool result; the real outcome
+ * enters as new input when the task's terminal notification arrives.
+ */
+export function toCreateTaskResult(task: Task): JsonObject {
+  const result: Record<string, JsonObject[string]> = {
+    createdAt: task.createdAt,
+    lastUpdatedAt: task.lastUpdatedAt,
+    status: task.status,
+    taskId: task.taskId,
+    ttlMs: task.ttlMs,
+  };
+  if (task.statusMessage !== undefined) {
+    result.statusMessage = task.statusMessage;
+  }
+  if (task.pollIntervalMs !== undefined) {
+    result.pollIntervalMs = task.pollIntervalMs;
+  }
+  return result;
+}


### PR DESCRIPTION
Part of https://github.com/vercel/eve/issues/1084. Implements Slice 1 of [`research/background-tasks.md`](https://github.com/vercel/eve/pull/1085): the task contract and both protocols (caller and callee) land end-to-end with **no public electors**. Nothing user-facing changes; the creation path is exercised through an internal env gate, with unit and integration coverage only.

## What

- `runtime/tasks/` — the MCP-aligned contract: `Task`/`DetailedTask`, the `TaskNotification` envelope, `DEFAULT_NOTIFICATION_ROUTES` (wake-worthy kinds only), the `CreateTaskResult` placeholder, and the election seam Slices 2/3 extend.
- `execution/tasks/` — the callee side: a per-task **actor run** owning the record, a pure transition function (terminal-is-final, cancelled sticky, `update` requires `input_required`), cross-run reads, guarded notification fan-out, and the `getTask`/`updateTask`/`cancelTask` service.
- Caller wiring — election in the dispatch step (placeholder at the call position, no child started), a `task.*` arm on the callback route that resumes the driver with `kind: "deliver"`, routing-step discrimination (terminal → run a turn with the outcome as input; `input_required` → re-emit `input.requested`, no turn), and step-0 routing of late answers to `updateTask` before stale conversion.
- `harness/task-state.ts` — the live-task index (`taskId → actor run id`) on session state, next to `proxyInputRequests`.

## The task actor

The doc says records "live on the durable session state". That doesn't survive contact with the runtime: session state is threaded through step results, and the routing step — which handles notifications while the session is parked — returns only `{ remainder }` to the pinned driver. Transitions must also be writable from the callback path and (Slice 2) a child session. Workflow-run streams are write-local/read-global: `getWritable` only targets the current run, `getRun(id)` only reads.

So each task is a small dedicated workflow run: it loops on its own hook, applies each resumed command under the legality rules, appends a full snapshot to its own stream, fans out one POST per routed endpoint, and returns on terminal. Everyone else either tail-reads the stream or sends a command and polls for its `commandId` ack. Single-writer legality and ordered transition bursts fall out for free, and it matches the extension's receiver-owned record. The research doc needs a follow-up amendment for this (on the #1085 branch, not here).

## Election rides the batch, not the request

First cut added `task?: { ttlMs? }` to the action-request schemas. That silently changed four extension-capability contract epochs — `RuntimeActionRequest` is in their public closure (found by bisecting against `scripts/extension-capability-contracts.mjs`). An inert slice shouldn't bump extension contracts, so elections are recorded per `callId` on `PendingRuntimeActionBatch.taskElections`, which is session-internal. Authored-tool election (Slice 3) will change the public schema and take the epoch bump deliberately.

Same reasoning for the wire field: `taskNotifications` stays undeclared on the public `DeliverPayload` type and rides its index signature — it's framework-owned, stripped at public ingress and from adapter-visible payloads.

## "Does not register the action key" — mechanism

The doc's key-withholding is implemented as a pre-seeded result: the dispatch step returns the `CreateTaskResult`-shaped result for elected actions, so `waitForRuntimeActionResults` resolves the key instantly via `initialResults` and the turn ends with the work still running. Same observable contract, no epilogue/resolver surgery. Precedent: the recursive-agent-guard synthetic result. The placeholder also suppresses `subagent.completed` — the work just started.

## Invariants held

- Call positions are terminalized at election; outcomes enter as new input (asserted on history in the integration test).
- `NextDriverAction` untouched; the driver's wake vocabulary stays `deliver`-only. Discrimination lives in step bodies that run at latest.
- Task ids are minted (`task_` + UUID); endpoints and run ids never appear on streams.
- Deliveries with an authenticated principal that mismatches the task's creator are dropped at routing; task-delivery turns run under the initiator.
- Notification sends never throw; a 404 marks the endpoint dead, no retries.

## Testing

`execution/tasks/notifications.integration.test.ts` drives the whole wire through a real `workflowEntry` run: mock model elects via the internal gate, the test plays the executor by resuming the actor's hook, and notification POSTs go through the real callback route handler (loopback fetch stub). The sharpest assertion: after answering an `input_required` task in the parent conversation, exactly one model turn runs in the whole exchange — a stale-converted answer would produce two. Actor semantics (sticky cancellation, post-terminal reads, 404 dead-marking) are covered in `service.integration.test.ts`; everything else is unit-tested.

## Out of scope (Slice 2 per the doc)

Session-done cancellation of live tasks, descendant abort propagation, `task.*` lifecycle events on the parent stream, and the `sync()`/`defer()`/`background()` combinators. Known inert-mode edge: continuation-token rotation 404s a registered endpoint (dead-marked, notification dropped) — noted for the doc amendment.
