### PR TITLE
feat(eve): wire lifecycle bridge per model attempt

### DIFF
--- a/packages/eve/src/harness/otel-integration.ts
+++ b/packages/eve/src/harness/otel-integration.ts
@@ -1,5 +1,5 @@
 import { OpenTelemetry } from "#compiled/@ai-sdk/otel/index.js";
-import { registerTelemetry } from "ai";
+import { registerTelemetry, type Telemetry } from "ai";
 
 let registered = false;
 
@@ -16,9 +16,10 @@ export function ensureOtelIntegration(): void {
     return;
   }
   registered = true;
-  registerTelemetry(
-    new OpenTelemetry({
-      runtimeContext: true,
-    }),
-  );
+  registerTelemetry(createOtelIntegration());
+}
+
+/** Creates the existing OTel integration for explicit per-call composition. */
+export function createOtelIntegration(): Telemetry {
+  return new OpenTelemetry({ runtimeContext: true });
 }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -51,6 +51,7 @@ import {
   setTurnUsageState,
 } from "#harness/turn-tag-state.js";
 import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
+import { createInstrumentationHooks } from "#harness/instrumentation-lifecycle.js";
 import {
   CONDITIONAL_DELIVERY_INSTRUCTION,
   EMPTY_DELIVERY_SENTINEL,
@@ -68,7 +69,17 @@ vi.mock("ai", () => ({
   tool: vi.fn((t: unknown) => t),
 }));
 
+const { existingOtelIntegration, mockCreateAiSdkHookBridge } = vi.hoisted(() => ({
+  existingOtelIntegration: { onStart: vi.fn() },
+  mockCreateAiSdkHookBridge: vi.fn((..._args: unknown[]) => ({ onStart: vi.fn() })),
+}));
+
+vi.mock("./ai-sdk-hook-bridge.js", () => ({
+  createAiSdkHookBridge: (...args: unknown[]) => mockCreateAiSdkHookBridge(...args),
+}));
+
 vi.mock("./otel-integration.js", () => ({
+  createOtelIntegration: vi.fn(() => existingOtelIntegration),
   ensureOtelIntegration: vi.fn(),
 }));
 
@@ -3827,6 +3838,7 @@ describe("createToolLoopHarness", () => {
         },
       });
       const config: ToolLoopHarnessConfig = {
+        instrumentationHooks: createInstrumentationHooks([]),
         mode: "conversation",
         resolveModel: vi.fn().mockResolvedValue("anthropic/claude-opus-4.7"),
         tools: new Map([
@@ -3857,6 +3869,10 @@ describe("createToolLoopHarness", () => {
       // The second agent was constructed for the retry.
       expect(constructedCalls.count()).toBe(2);
       expect(resolveRuntimeContext).toHaveBeenCalledTimes(2);
+      expect(mockCreateAiSdkHookBridge.mock.calls.map(([attempt]) => attempt)).toEqual([
+        expect.objectContaining({ attemptIndex: 0 }),
+        expect.objectContaining({ attemptIndex: 1 }),
+      ]);
 
       // The retry succeeded — the session parked normally instead of
       // emitting any failure cascade.
@@ -8814,7 +8830,7 @@ describe("createToolLoopHarness", () => {
 
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
         runtimeContext?: Record<string, unknown>;
-        telemetry?: { isEnabled?: boolean };
+        telemetry?: { integrations?: unknown; isEnabled?: boolean };
       };
       const runtimeContext = agentCall?.runtimeContext;
       expect(runtimeContext).toBeDefined();
@@ -8822,6 +8838,81 @@ describe("createToolLoopHarness", () => {
       expect(runtimeContext?.["eve.version"]).not.toBe("");
       expect(runtimeContext?.["eve.session.id"]).toBe("test-session");
       expect(agentCall?.telemetry?.isEnabled).toBe(true);
+      expect(agentCall?.telemetry?.integrations).toBeUndefined();
+    });
+
+    it("injects one provider-neutral bridge when lifecycle hooks opt in", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+      const hooks = createInstrumentationHooks([]);
+      const config = createTestConfig("conversation", undefined, {
+        instrumentationHooks: hooks,
+      });
+
+      const runStep = createToolLoopHarness(config);
+      await runStep(createTestSession(), { message: "hi" });
+
+      expect(mockCreateAiSdkHookBridge).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          attemptId: "test-session:turn_0:0:0",
+          attemptIndex: 0,
+          sessionId: "test-session",
+          stepIndex: 0,
+          turnId: "turn_0",
+        }),
+        hooks,
+      );
+      const bridge = mockCreateAiSdkHookBridge.mock.results[0]!.value;
+      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
+        telemetry?: {
+          integrations?: unknown[];
+          recordInputs?: boolean;
+          recordOutputs?: boolean;
+        };
+      };
+      expect(agentCall.telemetry).toMatchObject({
+        integrations: [bridge],
+        recordInputs: true,
+        recordOutputs: true,
+      });
+    });
+
+    it("composes lifecycle hooks with existing authored OTel", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+      mockGetInstrumentationConfig.mockReturnValue({ recordInputs: true, recordOutputs: false });
+      const hooks = createInstrumentationHooks([]);
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", undefined, {
+          instrumentationHooks: hooks,
+        }),
+      );
+
+      await runStep(createTestSession(), { message: "hi" });
+
+      const bridge = mockCreateAiSdkHookBridge.mock.results[0]!.value;
+      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
+        telemetry?: {
+          integrations?: unknown[];
+          recordInputs?: boolean;
+          recordOutputs?: boolean;
+        };
+      };
+      expect(agentCall.telemetry).toMatchObject({
+        integrations: [bridge, existingOtelIntegration],
+        recordInputs: true,
+        recordOutputs: false,
+      });
     });
 
     it("merges step-started runtime context before emitting step.started", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -10,6 +10,7 @@ import {
   type ModelMessage,
   type ProviderMetadata,
   type SystemModelMessage,
+  type Telemetry,
   type TelemetryOptions,
   ToolLoopAgent,
   type ToolSet,
@@ -101,7 +102,9 @@ import {
   extractToolApprovalInputRequests,
 } from "#harness/input-extraction.js";
 import { createToolResultMessagePartFromToolError } from "#harness/action-result-helpers.js";
+import { activeTurnId } from "#harness/active-turn-id.js";
 import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-context.js";
+import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
 import {
   consumeDeferredStepInput,
   getApprovedTools,
@@ -143,7 +146,7 @@ import {
   hasEmptyDeliverySentinel,
 } from "#shared/empty-delivery.js";
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
-import { ensureOtelIntegration } from "#harness/otel-integration.js";
+import { createOtelIntegration, ensureOtelIntegration } from "#harness/otel-integration.js";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
 import {
   applyLastToolCacheBreakpoint,
@@ -245,8 +248,9 @@ function enrichTelemetry(
   authored: InstrumentationDefinition | undefined,
   agentName: string | undefined,
   runtimeContext?: Readonly<Record<string, unknown>>,
+  bridgeIntegration?: Telemetry,
 ): TelemetryOptions | undefined {
-  if (authored === undefined) {
+  if (authored === undefined && bridgeIntegration === undefined) {
     return undefined;
   }
 
@@ -258,11 +262,17 @@ function enrichTelemetry(
   }
 
   return {
-    functionId: authored.functionId ?? agentName,
+    functionId: authored?.functionId ?? agentName,
     includeRuntimeContext,
+    integrations:
+      bridgeIntegration === undefined
+        ? undefined
+        : authored === undefined
+          ? [bridgeIntegration]
+          : [bridgeIntegration, createOtelIntegration()],
     isEnabled: true,
-    recordInputs: authored.recordInputs ?? true,
-    recordOutputs: authored.recordOutputs ?? true,
+    recordInputs: authored?.recordInputs ?? true,
+    recordOutputs: authored?.recordOutputs ?? true,
   };
 }
 
@@ -801,7 +811,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       trailingUserNote?: string;
     };
 
-    const runSingleModelCall = async (opts: ModelCallOptions): Promise<HarnessStepResult> => {
+    const runSingleModelCall = async (
+      opts: ModelCallOptions & { readonly attemptIndex: number },
+    ): Promise<HarnessStepResult> => {
       const { instructions, telemetryRuntimeContext = {} } =
         opts.preparedInput ?? prepareModelCallInput(opts.extraSystemNote);
       // Label the reissued call's telemetry; without this a retry is only
@@ -875,6 +887,23 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
       const effectiveTools = marker ? applyLastToolCacheBreakpoint(modelTools, marker) : modelTools;
 
+      const instrumentationHooks = config.instrumentationHooks;
+      const instrumentationTurnId = activeTurnId(emissionState);
+      const bridgeIntegration =
+        instrumentationHooks === undefined
+          ? undefined
+          : createAiSdkHookBridge(
+              {
+                attemptId: `${session.sessionId}:${instrumentationTurnId}:${emissionState.stepIndex}:${opts.attemptIndex}`,
+                attemptIndex: opts.attemptIndex,
+                functionId: telemetryConfig?.functionId ?? agentName,
+                sessionId: session.sessionId,
+                stepIndex: emissionState.stepIndex,
+                turnId: instrumentationTurnId,
+              },
+              instrumentationHooks,
+            );
+
       const hooks = buildStepHooks({
         cachePath,
         emit,
@@ -905,7 +934,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         reasoning: session.agent.reasoning,
         runtimeContext: telemetryRuntimeContext,
         stopWhen: isStepCount(1),
-        telemetry: enrichTelemetry(telemetryConfig, agentName, telemetryRuntimeContext),
+        telemetry: enrichTelemetry(
+          telemetryConfig,
+          agentName,
+          telemetryRuntimeContext,
+          bridgeIntegration,
+        ),
         toolApproval: buildToolApproval(modelTools),
         tools: effectiveTools,
       };
@@ -996,11 +1030,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       return executeModelCall().catch(rethrowNoOutputAsEmptyResponse);
     };
 
+    let nextModelAttemptIndex = 0;
     const runOneModelCall = async (opts: ModelCallOptions): Promise<HarnessStepResult> =>
       runModelCallWithRetries(
         (attempt) =>
           runSingleModelCall({
             ...opts,
+            attemptIndex: nextModelAttemptIndex++,
             preparedInput: attempt === 1 ? opts.preparedInput : undefined,
             suppressStepStartedEmission: attempt === 1 ? opts.suppressStepStartedEmission : true,
           }),

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -12,6 +12,7 @@ import type { JsonObject } from "#shared/json.js";
 import type { InternalToolDefinition } from "#shared/tool-definition.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { InstrumentationHooks } from "#harness/instrumentation-lifecycle.js";
 
 /**
  * Serializable tool definition stored on the session.
@@ -240,6 +241,11 @@ export interface ToolLoopHarnessConfig {
    */
   readonly workflowMaxSubagents?: number;
   readonly handleEvent?: HandleEventFn;
+  /**
+   * Internal lifecycle hooks injected into each actual model attempt.
+   * Omitted in production until an instrumentation runtime opts in.
+   */
+  readonly instrumentationHooks?: InstrumentationHooks;
   /**
    * Execution mode for the current harness.
    *


### PR DESCRIPTION
## Summary

Phase 2 of local observability, stacked on #1169.

This PR adds the optional runtime insertion point for the provider-neutral AI SDK lifecycle bridge:

- Adds optional `instrumentationHooks` to the tool-loop harness
- Creates one bridge for every actual model attempt
- Assigns monotonic attempt identities across transient and recovery retries
- Passes the bridge through AI SDK’s per-call `telemetry.integrations`
- Composes the existing `@ai-sdk/otel` integration when authored instrumentation is active
- Leaves telemetry options unchanged when instrumentation hooks are absent

## Scope

This PR does **not** register hooks, add an OTel provider, or emit/persist traces. Runtime behavior remains unchanged unless internal instrumentation hooks are explicitly injected.

Production continues using the existing global `@ai-sdk/otel` path without a per-call override.

## Testing

- Harness telemetry remains unchanged by default
- One bridge is created per model attempt
- Recovery retries receive distinct attempt indexes
- Authored OTel and lifecycle integrations compose
- Existing recording flags remain backwards compatible
- `pnpm --filter eve typecheck`
- Unit tests
- Build, lint, formatting, and invariants