### PR TITLE
feat(eve): add agent-semantic OTel provider

### DIFF
--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -315,6 +315,7 @@
     "@chat-adapter/twilio": "4.34.0",
     "@clack/core": "1.3.1",
     "@nuxt/kit": "^4.0.0",
+    "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@standard-schema/spec": "1.1.0",
     "@sveltejs/kit": "^2.0.0",
     "@types/json-schema": "7.0.15",

--- a/packages/eve/src/harness/agent-otel-provider.test.ts
+++ b/packages/eve/src/harness/agent-otel-provider.test.ts
@@ -1,0 +1,218 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { describe, expect, it } from "vitest";
+
+import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
+import {
+  createAgentOtelProvider,
+  InMemoryAgentSessionContextStore,
+} from "#harness/agent-otel-provider.js";
+import {
+  createInstrumentationHooks,
+  type InstrumentationAttemptScope,
+  type InstrumentationHooks,
+} from "#harness/instrumentation-lifecycle.js";
+
+interface TestRuntime {
+  readonly exporter: InMemorySpanExporter;
+  readonly hooks: InstrumentationHooks;
+  readonly provider: BasicTracerProvider;
+}
+
+function createRuntime(): TestRuntime {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const hooks = createInstrumentationHooks([
+    createAgentOtelProvider({
+      frameworkVersion: "test",
+      sessionContexts: new InMemoryAgentSessionContextStore(),
+      tracer: provider.getTracer("eve.agent"),
+    }),
+  ]);
+  return { exporter, hooks, provider };
+}
+
+async function emitAttempt(input: {
+  readonly attemptIndex?: number;
+  readonly hooks: InstrumentationHooks;
+  readonly sessionId: string;
+  readonly toolError?: Error;
+  readonly turnId: string;
+  readonly turnSequence: number;
+}): Promise<void> {
+  const scope: InstrumentationAttemptScope = {
+    attemptId: `${input.sessionId}:${input.turnId}:0:${input.attemptIndex ?? 0}`,
+    attemptIndex: input.attemptIndex ?? 0,
+    functionId: "weather",
+    sessionId: input.sessionId,
+    stepIndex: 0,
+    turnId: input.turnId,
+  };
+  await input.hooks.publish({
+    agentName: "weather",
+    channelKind: "http",
+    rootSessionId: input.sessionId,
+    sessionId: input.sessionId,
+    type: "session.started",
+  });
+  await input.hooks.publish({
+    rootSessionId: input.sessionId,
+    sequence: input.turnSequence,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    type: "turn.started",
+  });
+
+  const bridge = createAiSdkHookBridge(scope, input.hooks);
+  Reflect.apply(bridge.onStart!, bridge, [
+    {
+      callId: "call-1",
+      instructions: "private prompt",
+      messages: [{ content: "private message", role: "user" }],
+      modelId: "claude-test",
+      operationId: "ai.streamText",
+      provider: "anthropic",
+    },
+  ]);
+  await Reflect.apply(bridge.onStepStart!, bridge, [{ callId: "call-1", stepNumber: 0 }]);
+  await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
+    { callId: "call-1", messages: [], modelId: "claude-test", provider: "anthropic" },
+  ]);
+  await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+    {
+      callId: "call-1",
+      content: [],
+      finishReason: "tool-calls",
+      performance: { responseTimeMs: 10 },
+      responseId: "response-1",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    },
+  ]);
+  await Reflect.apply(bridge.onToolExecutionStart!, bridge, [
+    {
+      callId: "call-1",
+      toolCall: { input: { secret: "value" }, toolCallId: "tool-1", toolName: "weather" },
+    },
+  ]);
+  await Reflect.apply(bridge.onToolExecutionEnd!, bridge, [
+    {
+      callId: "call-1",
+      messages: [],
+      toolCall: { input: {}, toolCallId: "tool-1", toolName: "weather" },
+      toolExecutionMs: 1,
+      toolOutput:
+        input.toolError === undefined
+          ? { output: { temperature: 72 }, type: "tool-result" }
+          : { error: input.toolError, type: "tool-error" },
+    },
+  ]);
+
+  await input.hooks.publish({ scope, type: "attempt.completed" });
+  await input.hooks.publish({
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    type: "turn.completed",
+  });
+  await input.hooks.publish({
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    type: "session.waiting",
+  });
+}
+
+function byName(spans: readonly ReadableSpan[], name: string): ReadableSpan[] {
+  return spans.filter((span) => span.name === name);
+}
+
+describe("createAgentOtelProvider", () => {
+  it("emits the agent hierarchy in one session trace", async () => {
+    const runtime = createRuntime();
+    await emitAttempt({
+      hooks: runtime.hooks,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const spans = runtime.exporter.getFinishedSpans();
+    const session = byName(spans, "agent.session")[0]!;
+    const turn = byName(spans, "agent.turn")[0]!;
+    const step = byName(spans, "agent.step")[0]!;
+    const action = byName(spans, "agent.action")[0]!;
+
+    expect(session.parentSpanContext).toBeUndefined();
+    expect(turn.parentSpanContext?.spanId).toBe(session.spanContext().spanId);
+    expect(step.parentSpanContext?.spanId).toBe(turn.spanContext().spanId);
+    expect(action.parentSpanContext?.spanId).toBe(step.spanContext().spanId);
+    expect(new Set(spans.map((span) => span.spanContext().traceId))).toHaveLength(1);
+    expect(turn.events.map((event) => event.name)).toEqual([
+      "turn.started",
+      "session.started",
+      "turn.completed",
+      "session.waiting",
+    ]);
+    expect(step.attributes).toMatchObject({
+      "agent.framework.name": "eve",
+      "agent.model.id": "claude-test",
+      "agent.model.provider": "anthropic",
+      "agent.root.session.id": "session-1",
+      "agent.usage.input_tokens": 10,
+      "agent.usage.output_tokens": 5,
+    });
+    expect(action.attributes).toMatchObject({
+      "agent.action.kind": "tool",
+      "agent.action.name": "weather",
+      "agent.framework.name": "eve",
+      "agent.root.session.id": "session-1",
+    });
+    expect(JSON.stringify(spans.map((span) => span.attributes))).not.toContain("private");
+  });
+
+  it("reuses one trace id across turns", async () => {
+    const runtime = createRuntime();
+    await emitAttempt({
+      hooks: runtime.hooks,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await emitAttempt({
+      hooks: runtime.hooks,
+      sessionId: "session-1",
+      turnId: "turn-2",
+      turnSequence: 1,
+    });
+    await runtime.provider.forceFlush();
+
+    const turns = byName(runtime.exporter.getFinishedSpans(), "agent.turn");
+    expect(turns).toHaveLength(2);
+    expect(turns[0]!.spanContext().traceId).toBe(turns[1]!.spanContext().traceId);
+    expect(
+      turns.flatMap((turn) => turn.events).filter((event) => event.name === "session.started"),
+    ).toHaveLength(1);
+  });
+
+  it("marks a failed action without failing its turn", async () => {
+    const runtime = createRuntime();
+    await emitAttempt({
+      hooks: runtime.hooks,
+      sessionId: "session-1",
+      toolError: new Error("tool failed"),
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const spans = runtime.exporter.getFinishedSpans();
+    expect(byName(spans, "agent.action")[0]!.status.code).toBe(SpanStatusCode.ERROR);
+    expect(byName(spans, "agent.turn")[0]!.status.code).toBe(SpanStatusCode.UNSET);
+  });
+});

--- a/packages/eve/src/harness/agent-otel-provider.test.ts
+++ b/packages/eve/src/harness/agent-otel-provider.test.ts
@@ -46,6 +46,7 @@ async function emitAttempt(input: {
   readonly runInContext: InstrumentationContextRunner;
   readonly sessionId: string;
   readonly toolError?: Error;
+  readonly turnAlreadyStarted?: boolean;
   readonly turnId: string;
   readonly turnSequence: number;
 }): Promise<void> {
@@ -57,20 +58,9 @@ async function emitAttempt(input: {
     stepIndex: 0,
     turnId: input.turnId,
   };
-  await input.hooks.publish({
-    agentName: "weather",
-    channelKind: "http",
-    rootSessionId: input.sessionId,
-    sessionId: input.sessionId,
-    type: "session.started",
-  });
-  await input.hooks.publish({
-    rootSessionId: input.sessionId,
-    sequence: input.turnSequence,
-    sessionId: input.sessionId,
-    turnId: input.turnId,
-    type: "turn.started",
-  });
+  if (input.turnAlreadyStarted !== true) {
+    await publishTurnStarted(input);
+  }
 
   const bridge = createAiSdkHookBridge(scope, input.hooks, input.runInContext);
   Reflect.apply(bridge.onStart!, bridge, [
@@ -132,6 +122,28 @@ async function emitAttempt(input: {
     sessionId: input.sessionId,
     turnId: input.turnId,
     type: "session.waiting",
+  });
+}
+
+async function publishTurnStarted(input: {
+  readonly hooks: InstrumentationHooks;
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly turnSequence: number;
+}): Promise<void> {
+  await input.hooks.publish({
+    agentName: "weather",
+    channelKind: "http",
+    rootSessionId: input.sessionId,
+    sessionId: input.sessionId,
+    type: "session.started",
+  });
+  await input.hooks.publish({
+    rootSessionId: input.sessionId,
+    sequence: input.turnSequence,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    type: "turn.started",
   });
 }
 
@@ -218,6 +230,38 @@ describe("createAgentOtelInstrumentation", () => {
     expect(
       turns.flatMap((turn) => turn.events).filter((event) => event.name === "session.started"),
     ).toHaveLength(1);
+  });
+
+  it("restores durable turn context when a replacement worker runs the attempt", async () => {
+    const stateStore = new InMemoryAgentTraceStateStore();
+    const firstRuntime = createRuntime(stateStore);
+    await publishTurnStarted({
+      hooks: firstRuntime.hooks,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await firstRuntime.provider.forceFlush();
+
+    const replacementRuntime = createRuntime(stateStore);
+    await emitAttempt({
+      hooks: replacementRuntime.hooks,
+      runInContext: replacementRuntime.runInContext,
+      sessionId: "session-1",
+      turnAlreadyStarted: true,
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await replacementRuntime.provider.forceFlush();
+
+    const turn = byName(firstRuntime.exporter.getFinishedSpans(), "agent.turn")[0]!;
+    const replacementSpans = replacementRuntime.exporter.getFinishedSpans();
+    const step = byName(replacementSpans, "agent.step")[0]!;
+    const action = byName(replacementSpans, "agent.action")[0]!;
+
+    expect(step.parentSpanContext?.spanId).toBe(turn.spanContext().spanId);
+    expect(action.parentSpanContext?.spanId).toBe(step.spanContext().spanId);
+    expect(step.spanContext().traceId).toBe(turn.spanContext().traceId);
   });
 
   it("marks a failed action without failing its turn", async () => {

--- a/packages/eve/src/harness/agent-otel-provider.test.ts
+++ b/packages/eve/src/harness/agent-otel-provider.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
 import {
   createAgentOtelProvider,
-  InMemoryAgentSessionContextStore,
+  InMemoryAgentTraceStateStore,
 } from "#harness/agent-otel-provider.js";
 import {
   createInstrumentationHooks,
@@ -24,7 +24,7 @@ interface TestRuntime {
   readonly provider: BasicTracerProvider;
 }
 
-function createRuntime(): TestRuntime {
+function createRuntime(stateStore = new InMemoryAgentTraceStateStore()): TestRuntime {
   const exporter = new InMemorySpanExporter();
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(exporter)],
@@ -32,7 +32,7 @@ function createRuntime(): TestRuntime {
   const hooks = createInstrumentationHooks([
     createAgentOtelProvider({
       frameworkVersion: "test",
-      sessionContexts: new InMemoryAgentSessionContextStore(),
+      stateStore,
       tracer: provider.getTracer("eve.agent"),
     }),
   ]);
@@ -145,17 +145,18 @@ describe("createAgentOtelProvider", () => {
     const spans = runtime.exporter.getFinishedSpans();
     const session = byName(spans, "agent.session")[0]!;
     const turn = byName(spans, "agent.turn")[0]!;
+    const turnTerminal = byName(spans, "agent.turn.terminal")[0]!;
     const step = byName(spans, "agent.step")[0]!;
     const action = byName(spans, "agent.action")[0]!;
 
     expect(session.parentSpanContext).toBeUndefined();
     expect(turn.parentSpanContext?.spanId).toBe(session.spanContext().spanId);
+    expect(turnTerminal.parentSpanContext?.spanId).toBe(turn.spanContext().spanId);
     expect(step.parentSpanContext?.spanId).toBe(turn.spanContext().spanId);
     expect(action.parentSpanContext?.spanId).toBe(step.spanContext().spanId);
     expect(new Set(spans.map((span) => span.spanContext().traceId))).toHaveLength(1);
-    expect(turn.events.map((event) => event.name)).toEqual([
-      "turn.started",
-      "session.started",
+    expect(turn.events.map((event) => event.name)).toEqual(["turn.started", "session.started"]);
+    expect(turnTerminal.events.map((event) => event.name)).toEqual([
       "turn.completed",
       "session.waiting",
     ]);
@@ -177,22 +178,30 @@ describe("createAgentOtelProvider", () => {
   });
 
   it("reuses one trace id across turns", async () => {
-    const runtime = createRuntime();
+    const stateStore = new InMemoryAgentTraceStateStore();
+    const firstRuntime = createRuntime(stateStore);
     await emitAttempt({
-      hooks: runtime.hooks,
+      hooks: firstRuntime.hooks,
       sessionId: "session-1",
       turnId: "turn-1",
       turnSequence: 0,
     });
+    await firstRuntime.provider.forceFlush();
+
+    // A new provider instance models resumption in another Workflow worker.
+    const secondRuntime = createRuntime(stateStore);
     await emitAttempt({
-      hooks: runtime.hooks,
+      hooks: secondRuntime.hooks,
       sessionId: "session-1",
       turnId: "turn-2",
       turnSequence: 1,
     });
-    await runtime.provider.forceFlush();
+    await secondRuntime.provider.forceFlush();
 
-    const turns = byName(runtime.exporter.getFinishedSpans(), "agent.turn");
+    const turns = [
+      ...byName(firstRuntime.exporter.getFinishedSpans(), "agent.turn"),
+      ...byName(secondRuntime.exporter.getFinishedSpans(), "agent.turn"),
+    ];
     expect(turns).toHaveLength(2);
     expect(turns[0]!.spanContext().traceId).toBe(turns[1]!.spanContext().traceId);
     expect(

--- a/packages/eve/src/harness/agent-otel-provider.test.ts
+++ b/packages/eve/src/harness/agent-otel-provider.test.ts
@@ -9,12 +9,13 @@ import { describe, expect, it } from "vitest";
 
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
 import {
-  createAgentOtelProvider,
+  createAgentOtelInstrumentation,
   InMemoryAgentTraceStateStore,
 } from "#harness/agent-otel-provider.js";
 import {
   createInstrumentationHooks,
   type InstrumentationAttemptScope,
+  type InstrumentationContextRunner,
   type InstrumentationHooks,
 } from "#harness/instrumentation-lifecycle.js";
 
@@ -22,6 +23,7 @@ interface TestRuntime {
   readonly exporter: InMemorySpanExporter;
   readonly hooks: InstrumentationHooks;
   readonly provider: BasicTracerProvider;
+  readonly runInContext: InstrumentationContextRunner;
 }
 
 function createRuntime(stateStore = new InMemoryAgentTraceStateStore()): TestRuntime {
@@ -29,19 +31,19 @@ function createRuntime(stateStore = new InMemoryAgentTraceStateStore()): TestRun
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(exporter)],
   });
-  const hooks = createInstrumentationHooks([
-    createAgentOtelProvider({
-      frameworkVersion: "test",
-      stateStore,
-      tracer: provider.getTracer("eve.agent"),
-    }),
-  ]);
-  return { exporter, hooks, provider };
+  const agentOtel = createAgentOtelInstrumentation({
+    frameworkVersion: "test",
+    stateStore,
+    tracer: provider.getTracer("eve.agent"),
+  });
+  const hooks = createInstrumentationHooks([agentOtel.hook]);
+  return { exporter, hooks, provider, runInContext: agentOtel.runInContext };
 }
 
 async function emitAttempt(input: {
   readonly attemptIndex?: number;
   readonly hooks: InstrumentationHooks;
+  readonly runInContext: InstrumentationContextRunner;
   readonly sessionId: string;
   readonly toolError?: Error;
   readonly turnId: string;
@@ -70,7 +72,7 @@ async function emitAttempt(input: {
     type: "turn.started",
   });
 
-  const bridge = createAiSdkHookBridge(scope, input.hooks);
+  const bridge = createAiSdkHookBridge(scope, input.hooks, input.runInContext);
   Reflect.apply(bridge.onStart!, bridge, [
     {
       callId: "call-1",
@@ -85,6 +87,7 @@ async function emitAttempt(input: {
   await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
     { callId: "call-1", messages: [], modelId: "claude-test", provider: "anthropic" },
   ]);
+  await bridge.executeLanguageModelCall!({ callId: "call-1", execute: async () => undefined });
   await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
     {
       callId: "call-1",
@@ -101,6 +104,11 @@ async function emitAttempt(input: {
       toolCall: { input: { secret: "value" }, toolCallId: "tool-1", toolName: "weather" },
     },
   ]);
+  await bridge.executeTool!({
+    callId: "call-1",
+    execute: async () => undefined,
+    toolCallId: "tool-1",
+  });
   await Reflect.apply(bridge.onToolExecutionEnd!, bridge, [
     {
       callId: "call-1",
@@ -131,11 +139,12 @@ function byName(spans: readonly ReadableSpan[], name: string): ReadableSpan[] {
   return spans.filter((span) => span.name === name);
 }
 
-describe("createAgentOtelProvider", () => {
+describe("createAgentOtelInstrumentation", () => {
   it("emits the agent hierarchy in one session trace", async () => {
     const runtime = createRuntime();
     await emitAttempt({
       hooks: runtime.hooks,
+      runInContext: runtime.runInContext,
       sessionId: "session-1",
       turnId: "turn-1",
       turnSequence: 0,
@@ -182,6 +191,7 @@ describe("createAgentOtelProvider", () => {
     const firstRuntime = createRuntime(stateStore);
     await emitAttempt({
       hooks: firstRuntime.hooks,
+      runInContext: firstRuntime.runInContext,
       sessionId: "session-1",
       turnId: "turn-1",
       turnSequence: 0,
@@ -192,6 +202,7 @@ describe("createAgentOtelProvider", () => {
     const secondRuntime = createRuntime(stateStore);
     await emitAttempt({
       hooks: secondRuntime.hooks,
+      runInContext: secondRuntime.runInContext,
       sessionId: "session-1",
       turnId: "turn-2",
       turnSequence: 1,
@@ -213,6 +224,7 @@ describe("createAgentOtelProvider", () => {
     const runtime = createRuntime();
     await emitAttempt({
       hooks: runtime.hooks,
+      runInContext: runtime.runInContext,
       sessionId: "session-1",
       toolError: new Error("tool failed"),
       turnId: "turn-1",

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -10,6 +10,7 @@ import {
 } from "@opentelemetry/api";
 
 import type {
+  InstrumentationAttemptScope,
   InstrumentationAttemptStartedEvent,
   InstrumentationAttemptTerminalEvent,
   InstrumentationModelCallTerminalEvent,
@@ -28,34 +29,72 @@ interface SpanState {
   readonly span: Span;
 }
 
-interface SessionMetadata {
+export interface AgentSessionTraceState {
   readonly agentName?: string;
   readonly channelKind?: string;
+  readonly context: SpanContext;
+  readonly pendingStarted: boolean;
   readonly rootSessionId: string;
 }
 
-/** Provider-owned storage for the trace context assigned to an eve session. */
-export interface AgentSessionContextStore {
-  get(sessionId: string): SpanContext | undefined;
-  set(sessionId: string, spanContext: SpanContext): void;
+export interface AgentTurnTraceState {
+  readonly context: SpanContext;
+  readonly rootSessionId: string;
+  readonly sequence: number;
+  readonly terminal?: {
+    readonly error?: unknown;
+    readonly type: InstrumentationTurnTerminalEvent["type"];
+  };
 }
 
-/** In-memory context storage used by tests and non-durable runtimes. */
-export class InMemoryAgentSessionContextStore implements AgentSessionContextStore {
-  readonly #contexts = new Map<string, SpanContext>();
+/** Provider-owned serializable storage for durable agent trace state. */
+export interface AgentTraceStateStore {
+  deleteSession(sessionId: string): void | PromiseLike<void>;
+  deleteTurn(sessionId: string, turnId: string): void | PromiseLike<void>;
+  getSession(
+    sessionId: string,
+  ): AgentSessionTraceState | undefined | PromiseLike<AgentSessionTraceState | undefined>;
+  getTurn(
+    sessionId: string,
+    turnId: string,
+  ): AgentTurnTraceState | undefined | PromiseLike<AgentTurnTraceState | undefined>;
+  setSession(sessionId: string, state: AgentSessionTraceState): void | PromiseLike<void>;
+  setTurn(sessionId: string, turnId: string, state: AgentTurnTraceState): void | PromiseLike<void>;
+}
 
-  get(sessionId: string): SpanContext | undefined {
-    return this.#contexts.get(sessionId);
+/** In-memory trace state used by tests and non-durable runtimes. */
+export class InMemoryAgentTraceStateStore implements AgentTraceStateStore {
+  readonly #sessions = new Map<string, AgentSessionTraceState>();
+  readonly #turns = new Map<string, AgentTurnTraceState>();
+
+  deleteSession(sessionId: string): void {
+    this.#sessions.delete(sessionId);
   }
 
-  set(sessionId: string, spanContext: SpanContext): void {
-    this.#contexts.set(sessionId, spanContext);
+  deleteTurn(sessionId: string, turnId: string): void {
+    this.#turns.delete(turnKey(sessionId, turnId));
+  }
+
+  getSession(sessionId: string): AgentSessionTraceState | undefined {
+    return this.#sessions.get(sessionId);
+  }
+
+  getTurn(sessionId: string, turnId: string): AgentTurnTraceState | undefined {
+    return this.#turns.get(turnKey(sessionId, turnId));
+  }
+
+  setSession(sessionId: string, state: AgentSessionTraceState): void {
+    this.#sessions.set(sessionId, state);
+  }
+
+  setTurn(sessionId: string, turnId: string, state: AgentTurnTraceState): void {
+    this.#turns.set(turnKey(sessionId, turnId), state);
   }
 }
 
 export interface AgentOtelProviderInput {
   readonly frameworkVersion: string;
-  readonly sessionContexts: AgentSessionContextStore;
+  readonly stateStore: AgentTraceStateStore;
   readonly tracer: Tracer;
 }
 
@@ -65,53 +104,57 @@ export function createAgentOtelProvider(
 ): InstrumentationProviderDefinition {
   const actions = new Map<string, SpanState>();
   const modelContexts = new Map<string, Context>();
-  const pendingSessionStarted = new Set<string>();
-  const sessionMetadata = new Map<string, SessionMetadata>();
-  const steps = new Map<string, SpanState>();
-  const turns = new Map<string, SpanState>();
+  // Attempt scopes are object identities retained by the bridge for one
+  // atomic invocation; WeakMap state cannot outlive an abandoned attempt.
+  const steps = new WeakMap<InstrumentationAttemptScope, SpanState>();
 
-  const onSessionStarted = (event: InstrumentationSessionStartedEvent): void => {
-    sessionMetadata.set(event.sessionId, event);
-    if (ensureSessionContext(event).created) pendingSessionStarted.add(event.sessionId);
+  const onSessionStarted = async (event: InstrumentationSessionStartedEvent): Promise<void> => {
+    await ensureSessionContext(event);
   };
 
-  const onTurnStarted = (event: InstrumentationTurnStartedEvent): void => {
-    const session = ensureSessionContext({
+  const onTurnStarted = async (event: InstrumentationTurnStartedEvent): Promise<void> => {
+    const session = await ensureSessionContext({
       agentName: undefined,
       channelKind: undefined,
       rootSessionId: event.rootSessionId,
       sessionId: event.sessionId,
       type: "session.started",
     });
-    const metadata = sessionMetadata.get(event.sessionId);
     const span = input.tracer.startSpan(
       "agent.turn",
       {
         attributes: {
           "agent.framework.name": "eve",
           "agent.framework.version": input.frameworkVersion,
-          "agent.name": metadata?.agentName,
+          "agent.name": session.agentName,
           "agent.root.session.id": event.rootSessionId,
           "agent.session.id": event.sessionId,
           "agent.turn.id": event.turnId,
           "agent.turn.sequence": event.sequence,
         },
       },
-      session.context,
+      contextFromSpanContext(session.context),
     );
     span.addEvent("turn.started");
-    if (pendingSessionStarted.delete(event.sessionId)) {
+    if (session.pendingStarted) {
       span.addEvent("session.started");
     }
-    turns.set(turnKey(event.sessionId, event.turnId), {
-      context: trace.setSpan(session.context, span),
-      span,
+    await input.stateStore.setSession(event.sessionId, {
+      ...session,
+      pendingStarted: false,
     });
+    await input.stateStore.setTurn(event.sessionId, event.turnId, {
+      context: span.spanContext(),
+      rootSessionId: event.rootSessionId,
+      sequence: event.sequence,
+    });
+    span.end();
   };
 
-  const onAttemptStarted = (event: InstrumentationAttemptStartedEvent): void => {
-    const turn = turns.get(turnKey(event.scope.sessionId, event.scope.turnId));
+  const onAttemptStarted = async (event: InstrumentationAttemptStartedEvent): Promise<void> => {
+    const turn = await input.stateStore.getTurn(event.scope.sessionId, event.scope.turnId);
     if (turn === undefined) return;
+    const turnContext = contextFromSpanContext(turn.context);
     const span = input.tracer.startSpan(
       "agent.step",
       {
@@ -126,52 +169,72 @@ export function createAgentOtelProvider(
           "agent.name": event.scope.functionId,
         },
       },
-      turn.context,
+      turnContext,
     );
     span.addEvent("step.started");
-    steps.set(event.scope.attemptId, {
-      context: trace.setSpan(turn.context, span),
+    steps.set(event.scope, {
+      context: trace.setSpan(turnContext, span),
       span,
     });
   };
 
   const onAttemptTerminal = (event: InstrumentationAttemptTerminalEvent): void => {
-    const step = steps.get(event.scope.attemptId);
+    const step = steps.get(event.scope);
     if (step === undefined) return;
     step.span.addEvent(event.type === "attempt.completed" ? "step.completed" : "step.failed");
     if (event.type === "attempt.failed") recordError(step.span, event.error);
     step.span.end();
-    steps.delete(event.scope.attemptId);
+    steps.delete(event.scope);
   };
 
-  const onTurnTerminal = (event: InstrumentationTurnTerminalEvent): void => {
-    const turn = turns.get(turnKey(event.sessionId, event.turnId));
+  const onTurnTerminal = async (event: InstrumentationTurnTerminalEvent): Promise<void> => {
+    const turn = await input.stateStore.getTurn(event.sessionId, event.turnId);
     if (turn === undefined) return;
-    turn.span.addEvent(event.type);
-    if (event.type === "turn.failed") recordError(turn.span, event.error);
+    await input.stateStore.setTurn(event.sessionId, event.turnId, {
+      ...turn,
+      terminal: { error: event.error, type: event.type },
+    });
   };
 
-  const onSessionTransition = (event: InstrumentationSessionTransitionEvent): void => {
+  const onSessionTransition = async (
+    event: InstrumentationSessionTransitionEvent,
+  ): Promise<void> => {
     if (event.turnId !== undefined) {
-      const key = turnKey(event.sessionId, event.turnId);
-      const turn = turns.get(key);
+      const turn = await input.stateStore.getTurn(event.sessionId, event.turnId);
       if (turn !== undefined) {
-        turn.span.addEvent(event.type);
-        turn.span.end();
-        turns.delete(key);
+        const span = input.tracer.startSpan(
+          "agent.turn.terminal",
+          {
+            attributes: {
+              "agent.root.session.id": turn.rootSessionId,
+              "agent.session.id": event.sessionId,
+              "agent.turn.id": event.turnId,
+              "agent.turn.sequence": turn.sequence,
+            },
+          },
+          contextFromSpanContext(turn.context),
+        );
+        if (turn.terminal !== undefined) {
+          span.addEvent(turn.terminal.type);
+          if (turn.terminal.type === "turn.failed") {
+            recordError(span, turn.terminal.error);
+          }
+        }
+        span.addEvent(event.type);
+        span.end();
+        await input.stateStore.deleteTurn(event.sessionId, event.turnId);
       }
     }
     // `session.waiting` is not terminal — the session may resume with a new
     // turn that still needs its metadata — so only release session-scoped
     // state on terminal transitions.
     if (event.type === "session.completed" || event.type === "session.failed") {
-      sessionMetadata.delete(event.sessionId);
-      pendingSessionStarted.delete(event.sessionId);
+      await input.stateStore.deleteSession(event.sessionId);
     }
   };
 
   const beforeModelCall = (event: InstrumentationModelCallStartedEvent): SpanState | undefined => {
-    const step = steps.get(event.scope.attemptId);
+    const step = steps.get(event.scope);
     if (step === undefined) return undefined;
     step.span.setAttribute("agent.model.id", event.source.modelId);
     step.span.setAttribute("agent.model.provider", event.source.provider);
@@ -190,7 +253,7 @@ export function createAgentOtelProvider(
   };
 
   const beforeToolCall = (event: InstrumentationToolCallStartedEvent): SpanState | undefined => {
-    const step = steps.get(event.scope.attemptId);
+    const step = steps.get(event.scope);
     if (step === undefined) return undefined;
     const span = input.tracer.startSpan(
       "agent.action",
@@ -226,12 +289,11 @@ export function createAgentOtelProvider(
     state.span.end();
   };
 
-  const ensureSessionContext = (
+  const ensureSessionContext = async (
     event: InstrumentationSessionStartedEvent,
-  ): { context: Context; created: boolean } => {
-    let spanContext = input.sessionContexts.get(event.sessionId);
-    let created = false;
-    if (spanContext === undefined) {
+  ): Promise<AgentSessionTraceState> => {
+    let state = await input.stateStore.getSession(event.sessionId);
+    if (state === undefined) {
       const marker = input.tracer.startSpan(
         "agent.session",
         {
@@ -247,15 +309,17 @@ export function createAgentOtelProvider(
         },
         ROOT_CONTEXT,
       );
-      spanContext = marker.spanContext();
-      input.sessionContexts.set(event.sessionId, spanContext);
+      state = {
+        agentName: event.agentName,
+        channelKind: event.channelKind,
+        context: marker.spanContext(),
+        pendingStarted: true,
+        rootSessionId: event.rootSessionId,
+      };
+      await input.stateStore.setSession(event.sessionId, state);
       marker.end();
-      created = true;
     }
-    return {
-      context: trace.setSpan(ROOT_CONTEXT, trace.wrapSpanContext(spanContext)),
-      created,
-    };
+    return state;
   };
 
   return {
@@ -289,6 +353,10 @@ export function createAgentOtelProvider(
 
 function turnKey(sessionId: string, turnId: string): string {
   return `${sessionId}:${turnId}`;
+}
+
+function contextFromSpanContext(spanContext: SpanContext): Context {
+  return trace.setSpan(ROOT_CONTEXT, trace.wrapSpanContext(spanContext));
 }
 
 function isSpanState(value: unknown): value is SpanState {

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -1,0 +1,308 @@
+import {
+  ROOT_CONTEXT,
+  SpanStatusCode,
+  context,
+  type Context,
+  type Span,
+  type SpanContext,
+  type Tracer,
+  trace,
+} from "@opentelemetry/api";
+
+import type {
+  InstrumentationAttemptStartedEvent,
+  InstrumentationAttemptTerminalEvent,
+  InstrumentationModelCallTerminalEvent,
+  InstrumentationModelCallStartedEvent,
+  InstrumentationProviderDefinition,
+  InstrumentationSessionStartedEvent,
+  InstrumentationSessionTransitionEvent,
+  InstrumentationToolCallStartedEvent,
+  InstrumentationToolCallTerminalEvent,
+  InstrumentationTurnStartedEvent,
+  InstrumentationTurnTerminalEvent,
+} from "#harness/instrumentation-lifecycle.js";
+
+interface SpanState {
+  readonly context: Context;
+  readonly span: Span;
+}
+
+interface SessionMetadata {
+  readonly agentName?: string;
+  readonly channelKind?: string;
+  readonly rootSessionId: string;
+}
+
+/** Provider-owned storage for the trace context assigned to an eve session. */
+export interface AgentSessionContextStore {
+  get(sessionId: string): SpanContext | undefined;
+  set(sessionId: string, spanContext: SpanContext): void;
+}
+
+/** In-memory context storage used by tests and non-durable runtimes. */
+export class InMemoryAgentSessionContextStore implements AgentSessionContextStore {
+  readonly #contexts = new Map<string, SpanContext>();
+
+  get(sessionId: string): SpanContext | undefined {
+    return this.#contexts.get(sessionId);
+  }
+
+  set(sessionId: string, spanContext: SpanContext): void {
+    this.#contexts.set(sessionId, spanContext);
+  }
+}
+
+export interface AgentOtelProviderInput {
+  readonly frameworkVersion: string;
+  readonly sessionContexts: AgentSessionContextStore;
+  readonly tracer: Tracer;
+}
+
+/** Creates the OTel lifecycle provider for eve's structural `agent.*` convention. */
+export function createAgentOtelProvider(
+  input: AgentOtelProviderInput,
+): InstrumentationProviderDefinition {
+  const actions = new Map<string, SpanState>();
+  const modelContexts = new Map<string, Context>();
+  const pendingSessionStarted = new Set<string>();
+  const sessionMetadata = new Map<string, SessionMetadata>();
+  const steps = new Map<string, SpanState>();
+  const turns = new Map<string, SpanState>();
+
+  const onSessionStarted = (event: InstrumentationSessionStartedEvent): void => {
+    sessionMetadata.set(event.sessionId, event);
+    if (ensureSessionContext(event).created) pendingSessionStarted.add(event.sessionId);
+  };
+
+  const onTurnStarted = (event: InstrumentationTurnStartedEvent): void => {
+    const session = ensureSessionContext({
+      agentName: undefined,
+      channelKind: undefined,
+      rootSessionId: event.rootSessionId,
+      sessionId: event.sessionId,
+      type: "session.started",
+    });
+    const metadata = sessionMetadata.get(event.sessionId);
+    const span = input.tracer.startSpan(
+      "agent.turn",
+      {
+        attributes: {
+          "agent.framework.name": "eve",
+          "agent.framework.version": input.frameworkVersion,
+          "agent.name": metadata?.agentName,
+          "agent.root.session.id": event.rootSessionId,
+          "agent.session.id": event.sessionId,
+          "agent.turn.id": event.turnId,
+          "agent.turn.sequence": event.sequence,
+        },
+      },
+      session.context,
+    );
+    span.addEvent("turn.started");
+    if (pendingSessionStarted.delete(event.sessionId)) {
+      span.addEvent("session.started");
+    }
+    turns.set(turnKey(event.sessionId, event.turnId), {
+      context: trace.setSpan(session.context, span),
+      span,
+    });
+  };
+
+  const onAttemptStarted = (event: InstrumentationAttemptStartedEvent): void => {
+    const turn = turns.get(turnKey(event.scope.sessionId, event.scope.turnId));
+    if (turn === undefined) return;
+    const span = input.tracer.startSpan(
+      "agent.step",
+      {
+        attributes: {
+          "agent.session.id": event.scope.sessionId,
+          "agent.framework.name": "eve",
+          "agent.framework.version": input.frameworkVersion,
+          "agent.root.session.id": event.scope.rootSessionId ?? event.scope.sessionId,
+          "agent.step.attempt": event.scope.attemptIndex,
+          "agent.step.index": event.scope.stepIndex,
+          "agent.turn.id": event.scope.turnId,
+          "agent.name": event.scope.functionId,
+        },
+      },
+      turn.context,
+    );
+    span.addEvent("step.started");
+    steps.set(event.scope.attemptId, {
+      context: trace.setSpan(turn.context, span),
+      span,
+    });
+  };
+
+  const onAttemptTerminal = (event: InstrumentationAttemptTerminalEvent): void => {
+    const step = steps.get(event.scope.attemptId);
+    if (step === undefined) return;
+    step.span.addEvent(event.type === "attempt.completed" ? "step.completed" : "step.failed");
+    if (event.type === "attempt.failed") recordError(step.span, event.error);
+    step.span.end();
+    steps.delete(event.scope.attemptId);
+  };
+
+  const onTurnTerminal = (event: InstrumentationTurnTerminalEvent): void => {
+    const turn = turns.get(turnKey(event.sessionId, event.turnId));
+    if (turn === undefined) return;
+    turn.span.addEvent(event.type);
+    if (event.type === "turn.failed") recordError(turn.span, event.error);
+  };
+
+  const onSessionTransition = (event: InstrumentationSessionTransitionEvent): void => {
+    if (event.turnId === undefined) return;
+    const key = turnKey(event.sessionId, event.turnId);
+    const turn = turns.get(key);
+    if (turn === undefined) return;
+    turn.span.addEvent(event.type);
+    turn.span.end();
+    turns.delete(key);
+  };
+
+  const beforeModelCall = (event: InstrumentationModelCallStartedEvent): SpanState | undefined => {
+    const step = steps.get(event.scope.attemptId);
+    if (step === undefined) return undefined;
+    step.span.setAttribute("agent.model.id", event.source.modelId);
+    step.span.setAttribute("agent.model.provider", event.source.provider);
+    modelContexts.set(event.id, step.context);
+    return step;
+  };
+
+  const afterModelCall = (event: InstrumentationModelCallTerminalEvent, state: unknown): void => {
+    modelContexts.delete(event.id);
+    if (!isSpanState(state)) return;
+    if (event.type === "model.call.failed") {
+      recordError(state.span, event.error);
+      return;
+    }
+    setUsage(state.span, event.source.usage);
+  };
+
+  const beforeToolCall = (event: InstrumentationToolCallStartedEvent): SpanState | undefined => {
+    const step = steps.get(event.scope.attemptId);
+    if (step === undefined) return undefined;
+    const span = input.tracer.startSpan(
+      "agent.action",
+      {
+        attributes: {
+          "agent.action.call_id": event.source.toolCall.toolCallId,
+          "agent.action.kind": "tool",
+          "agent.action.name": event.source.toolCall.toolName,
+          "agent.framework.name": "eve",
+          "agent.framework.version": input.frameworkVersion,
+          "agent.root.session.id": event.scope.rootSessionId ?? event.scope.sessionId,
+          "agent.session.id": event.scope.sessionId,
+          "agent.step.attempt": event.scope.attemptIndex,
+          "agent.step.index": event.scope.stepIndex,
+          "agent.turn.id": event.scope.turnId,
+        },
+      },
+      step.context,
+    );
+    const state = { context: trace.setSpan(step.context, span), span };
+    actions.set(event.id, state);
+    return state;
+  };
+
+  const afterToolCall = (event: InstrumentationToolCallTerminalEvent, state: unknown): void => {
+    actions.delete(event.id);
+    if (!isSpanState(state)) return;
+    if (event.type === "tool.call.failed") {
+      recordError(state.span, event.error);
+    } else if (event.source.toolOutput.type !== "tool-result") {
+      recordError(state.span, event.source.toolOutput.error);
+    }
+    state.span.end();
+  };
+
+  const ensureSessionContext = (
+    event: InstrumentationSessionStartedEvent,
+  ): { context: Context; created: boolean } => {
+    let spanContext = input.sessionContexts.get(event.sessionId);
+    let created = false;
+    if (spanContext === undefined) {
+      const marker = input.tracer.startSpan(
+        "agent.session",
+        {
+          attributes: {
+            "agent.channel.kind": event.channelKind,
+            "agent.framework.name": "eve",
+            "agent.framework.version": input.frameworkVersion,
+            "agent.name": event.agentName,
+            "agent.root.session.id": event.rootSessionId,
+            "agent.session.id": event.sessionId,
+          },
+          root: true,
+        },
+        ROOT_CONTEXT,
+      );
+      spanContext = marker.spanContext();
+      input.sessionContexts.set(event.sessionId, spanContext);
+      marker.end();
+      created = true;
+    }
+    return {
+      context: trace.setSpan(ROOT_CONTEXT, trace.wrapSpanContext(spanContext)),
+      created,
+    };
+  };
+
+  return {
+    events: {
+      "attempt.completed": onAttemptTerminal,
+      "attempt.failed": onAttemptTerminal,
+      "attempt.started": onAttemptStarted,
+      "model.call": { after: afterModelCall, before: beforeModelCall },
+      "session.completed": onSessionTransition,
+      "session.failed": onSessionTransition,
+      "session.started": onSessionStarted,
+      "session.waiting": onSessionTransition,
+      "tool.call": { after: afterToolCall, before: beforeToolCall },
+      "turn.cancelled": onTurnTerminal,
+      "turn.completed": onTurnTerminal,
+      "turn.failed": onTurnTerminal,
+      "turn.started": onTurnStarted,
+    },
+    executionContext: {
+      runModelCall(id, execute) {
+        const parent = modelContexts.get(id);
+        return parent === undefined ? execute() : context.with(parent, execute);
+      },
+      runToolCall(id, execute) {
+        const parent = actions.get(id)?.context;
+        return parent === undefined ? execute() : context.with(parent, execute);
+      },
+    },
+  };
+}
+
+function turnKey(sessionId: string, turnId: string): string {
+  return `${sessionId}:${turnId}`;
+}
+
+function isSpanState(value: unknown): value is SpanState {
+  return typeof value === "object" && value !== null && "context" in value && "span" in value;
+}
+
+function setUsage(
+  span: Span,
+  usage: { readonly inputTokens?: number; readonly outputTokens?: number },
+): void {
+  if (usage.inputTokens !== undefined) {
+    span.setAttribute("agent.usage.input_tokens", usage.inputTokens);
+  }
+  if (usage.outputTokens !== undefined) {
+    span.setAttribute("agent.usage.output_tokens", usage.outputTokens);
+  }
+}
+
+function recordError(span: Span, error: unknown): void {
+  if (error instanceof Error) {
+    span.recordException(error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+  } else {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+}

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -152,13 +152,22 @@ export function createAgentOtelProvider(
   };
 
   const onSessionTransition = (event: InstrumentationSessionTransitionEvent): void => {
-    if (event.turnId === undefined) return;
-    const key = turnKey(event.sessionId, event.turnId);
-    const turn = turns.get(key);
-    if (turn === undefined) return;
-    turn.span.addEvent(event.type);
-    turn.span.end();
-    turns.delete(key);
+    if (event.turnId !== undefined) {
+      const key = turnKey(event.sessionId, event.turnId);
+      const turn = turns.get(key);
+      if (turn !== undefined) {
+        turn.span.addEvent(event.type);
+        turn.span.end();
+        turns.delete(key);
+      }
+    }
+    // `session.waiting` is not terminal — the session may resume with a new
+    // turn that still needs its metadata — so only release session-scoped
+    // state on terminal transitions.
+    if (event.type === "session.completed" || event.type === "session.failed") {
+      sessionMetadata.delete(event.sessionId);
+      pendingSessionStarted.delete(event.sessionId);
+    }
   };
 
   const beforeModelCall = (event: InstrumentationModelCallStartedEvent): SpanState | undefined => {

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -113,8 +113,9 @@ export function createAgentOtelInstrumentation(
     InstrumentationAttemptScope,
     { readonly models: Map<string, Context>; readonly tools: Map<string, Context> }
   >();
-  // Attempt scopes are object identities retained by the bridge for one
-  // atomic invocation; WeakMap state cannot outlive an abandoned attempt.
+  // A serverless turn runs inside one `turnStep` "use step" invocation. If
+  // that worker is lost, Workflow retries the whole step from entry rather
+  // than resuming this callback sequence in a replacement process.
   const steps = new WeakMap<InstrumentationAttemptScope, SpanState>();
 
   const onSessionStarted = async (event: InstrumentationSessionStartedEvent): Promise<void> => {

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -350,13 +350,13 @@ export function createAgentOtelInstrumentation(
         "turn.started": onTurnStarted,
       },
     },
-    runInContext(operation, run) {
+    runInContext(operation, execute) {
       const contexts = executionContexts.get(operation.scope);
       const parent =
         operation.type === "model.call"
           ? contexts?.models.get(operation.id)
           : contexts?.tools.get(operation.id);
-      return parent === undefined ? run() : context.with(parent, run);
+      return parent === undefined ? execute() : context.with(parent, execute);
     },
   };
 

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -13,6 +13,7 @@ import type {
   InstrumentationAttemptScope,
   InstrumentationAttemptStartedEvent,
   InstrumentationAttemptTerminalEvent,
+  InstrumentationContextRunner,
   InstrumentationModelCallTerminalEvent,
   InstrumentationModelCallStartedEvent,
   InstrumentationProviderDefinition,
@@ -92,18 +93,26 @@ export class InMemoryAgentTraceStateStore implements AgentTraceStateStore {
   }
 }
 
-export interface AgentOtelProviderInput {
+export interface AgentOtelInstrumentationInput {
   readonly frameworkVersion: string;
   readonly stateStore: AgentTraceStateStore;
   readonly tracer: Tracer;
 }
 
-/** Creates the OTel lifecycle provider for eve's structural `agent.*` convention. */
-export function createAgentOtelProvider(
-  input: AgentOtelProviderInput,
-): InstrumentationProviderDefinition {
-  const actions = new Map<string, SpanState>();
-  const modelContexts = new Map<string, Context>();
+/** OTel event definition and its trusted framework context runner. */
+export interface AgentOtelInstrumentation {
+  readonly hook: InstrumentationProviderDefinition;
+  readonly runInContext: InstrumentationContextRunner;
+}
+
+/** Creates OTel instrumentation for eve's structural `agent.*` convention. */
+export function createAgentOtelInstrumentation(
+  input: AgentOtelInstrumentationInput,
+): AgentOtelInstrumentation {
+  const executionContexts = new WeakMap<
+    InstrumentationAttemptScope,
+    { readonly models: Map<string, Context>; readonly tools: Map<string, Context> }
+  >();
   // Attempt scopes are object identities retained by the bridge for one
   // atomic invocation; WeakMap state cannot outlive an abandoned attempt.
   const steps = new WeakMap<InstrumentationAttemptScope, SpanState>();
@@ -179,6 +188,7 @@ export function createAgentOtelProvider(
   };
 
   const onAttemptTerminal = (event: InstrumentationAttemptTerminalEvent): void => {
+    executionContexts.delete(event.scope);
     const step = steps.get(event.scope);
     if (step === undefined) return;
     step.span.addEvent(event.type === "attempt.completed" ? "step.completed" : "step.failed");
@@ -238,12 +248,12 @@ export function createAgentOtelProvider(
     if (step === undefined) return undefined;
     step.span.setAttribute("agent.model.id", event.source.modelId);
     step.span.setAttribute("agent.model.provider", event.source.provider);
-    modelContexts.set(event.id, step.context);
+    getExecutionContexts(event.scope).models.set(event.id, step.context);
     return step;
   };
 
   const afterModelCall = (event: InstrumentationModelCallTerminalEvent, state: unknown): void => {
-    modelContexts.delete(event.id);
+    executionContexts.get(event.scope)?.models.delete(event.id);
     if (!isSpanState(state)) return;
     if (event.type === "model.call.failed") {
       recordError(state.span, event.error);
@@ -274,12 +284,12 @@ export function createAgentOtelProvider(
       step.context,
     );
     const state = { context: trace.setSpan(step.context, span), span };
-    actions.set(event.id, state);
+    getExecutionContexts(event.scope).tools.set(event.id, state.context);
     return state;
   };
 
   const afterToolCall = (event: InstrumentationToolCallTerminalEvent, state: unknown): void => {
-    actions.delete(event.id);
+    executionContexts.get(event.scope)?.tools.delete(event.id);
     if (!isSpanState(state)) return;
     if (event.type === "tool.call.failed") {
       recordError(state.span, event.error);
@@ -323,32 +333,44 @@ export function createAgentOtelProvider(
   };
 
   return {
-    events: {
-      "attempt.completed": onAttemptTerminal,
-      "attempt.failed": onAttemptTerminal,
-      "attempt.started": onAttemptStarted,
-      "model.call": { after: afterModelCall, before: beforeModelCall },
-      "session.completed": onSessionTransition,
-      "session.failed": onSessionTransition,
-      "session.started": onSessionStarted,
-      "session.waiting": onSessionTransition,
-      "tool.call": { after: afterToolCall, before: beforeToolCall },
-      "turn.cancelled": onTurnTerminal,
-      "turn.completed": onTurnTerminal,
-      "turn.failed": onTurnTerminal,
-      "turn.started": onTurnStarted,
+    hook: {
+      events: {
+        "attempt.completed": onAttemptTerminal,
+        "attempt.failed": onAttemptTerminal,
+        "attempt.started": onAttemptStarted,
+        "model.call": { after: afterModelCall, before: beforeModelCall },
+        "session.completed": onSessionTransition,
+        "session.failed": onSessionTransition,
+        "session.started": onSessionStarted,
+        "session.waiting": onSessionTransition,
+        "tool.call": { after: afterToolCall, before: beforeToolCall },
+        "turn.cancelled": onTurnTerminal,
+        "turn.completed": onTurnTerminal,
+        "turn.failed": onTurnTerminal,
+        "turn.started": onTurnStarted,
+      },
     },
-    executionContext: {
-      runModelCall(id, execute) {
-        const parent = modelContexts.get(id);
-        return parent === undefined ? execute() : context.with(parent, execute);
-      },
-      runToolCall(id, execute) {
-        const parent = actions.get(id)?.context;
-        return parent === undefined ? execute() : context.with(parent, execute);
-      },
+    runInContext(operation, run) {
+      const contexts = executionContexts.get(operation.scope);
+      const parent =
+        operation.type === "model.call"
+          ? contexts?.models.get(operation.id)
+          : contexts?.tools.get(operation.id);
+      return parent === undefined ? run() : context.with(parent, run);
     },
   };
+
+  function getExecutionContexts(scope: InstrumentationAttemptScope): {
+    readonly models: Map<string, Context>;
+    readonly tools: Map<string, Context>;
+  } {
+    let state = executionContexts.get(scope);
+    if (state === undefined) {
+      state = { models: new Map(), tools: new Map() };
+      executionContexts.set(scope, state);
+    }
+    return state;
+  }
 }
 
 function turnKey(sessionId: string, turnId: string): string {

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -9,6 +9,7 @@ export interface InstrumentationAttemptScope {
   readonly attemptId: string;
   readonly attemptIndex: number;
   readonly functionId?: string;
+  readonly rootSessionId?: string;
   readonly sessionId: string;
   readonly stepIndex: number;
   readonly turnId: string;
@@ -19,6 +20,42 @@ export interface InstrumentationAttemptStartedEvent {
   readonly scope: InstrumentationAttemptScope;
   readonly operation: TelemetryEvent<"onStart">;
   readonly step: TelemetryEvent<"onStepStart">;
+}
+
+export interface InstrumentationSessionStartedEvent {
+  readonly type: "session.started";
+  readonly agentName?: string;
+  readonly channelKind?: string;
+  readonly rootSessionId: string;
+  readonly sessionId: string;
+}
+
+export interface InstrumentationSessionTransitionEvent {
+  readonly type: "session.completed" | "session.failed" | "session.waiting";
+  readonly error?: unknown;
+  readonly sessionId: string;
+  readonly turnId?: string;
+}
+
+export interface InstrumentationTurnStartedEvent {
+  readonly type: "turn.started";
+  readonly rootSessionId: string;
+  readonly sequence: number;
+  readonly sessionId: string;
+  readonly turnId: string;
+}
+
+export interface InstrumentationTurnTerminalEvent {
+  readonly type: "turn.cancelled" | "turn.completed" | "turn.failed";
+  readonly error?: unknown;
+  readonly sessionId: string;
+  readonly turnId: string;
+}
+
+export interface InstrumentationAttemptTerminalEvent {
+  readonly type: "attempt.completed" | "attempt.failed";
+  readonly error?: unknown;
+  readonly scope: InstrumentationAttemptScope;
 }
 
 export interface InstrumentationModelCallStartedEvent {
@@ -86,10 +123,36 @@ export interface InstrumentationProviderDefinition {
     readonly "attempt.started"?: (
       event: InstrumentationAttemptStartedEvent,
     ) => void | PromiseLike<void>;
+    readonly "attempt.completed"?: (
+      event: InstrumentationAttemptTerminalEvent,
+    ) => void | PromiseLike<void>;
+    readonly "attempt.failed"?: (
+      event: InstrumentationAttemptTerminalEvent,
+    ) => void | PromiseLike<void>;
+    readonly "session.completed"?: (
+      event: InstrumentationSessionTransitionEvent,
+    ) => void | PromiseLike<void>;
+    readonly "session.failed"?: (
+      event: InstrumentationSessionTransitionEvent,
+    ) => void | PromiseLike<void>;
+    readonly "session.started"?: (
+      event: InstrumentationSessionStartedEvent,
+    ) => void | PromiseLike<void>;
+    readonly "session.waiting"?: (
+      event: InstrumentationSessionTransitionEvent,
+    ) => void | PromiseLike<void>;
     readonly "tool.call"?: RelatedLifecycleHook<
       InstrumentationToolCallStartedEvent,
       InstrumentationToolCallTerminalEvent
     >;
+    readonly "turn.cancelled"?: (
+      event: InstrumentationTurnTerminalEvent,
+    ) => void | PromiseLike<void>;
+    readonly "turn.completed"?: (
+      event: InstrumentationTurnTerminalEvent,
+    ) => void | PromiseLike<void>;
+    readonly "turn.failed"?: (event: InstrumentationTurnTerminalEvent) => void | PromiseLike<void>;
+    readonly "turn.started"?: (event: InstrumentationTurnStartedEvent) => void | PromiseLike<void>;
   };
 }
 
@@ -106,7 +169,13 @@ export interface InstrumentationRelatedEventMap {
 
 export type InstrumentationRelatedEventName = keyof InstrumentationRelatedEventMap;
 
-export type InstrumentationPointEvent = InstrumentationAttemptStartedEvent;
+export type InstrumentationPointEvent =
+  | InstrumentationAttemptStartedEvent
+  | InstrumentationAttemptTerminalEvent
+  | InstrumentationSessionStartedEvent
+  | InstrumentationSessionTransitionEvent
+  | InstrumentationTurnStartedEvent
+  | InstrumentationTurnTerminalEvent;
 
 /** Trusted framework operation for activating context around AI SDK execution. */
 export type InstrumentationContextRunner = <T>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1173,6 +1173,9 @@ importers:
       '@nuxt/kit':
         specifier: ^4.0.0
         version: 4.4.6(magicast@0.5.3)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@standard-schema/spec':
         specifier: 1.1.0
         version: 1.1.0


### PR DESCRIPTION
## Summary

Phase 3 of local observability, stacked on #1191.

This PR adds the first lifecycle provider and defines eve’s agent-first OpenTelemetry semantics:

- Injected `Tracer`; no global OTel registration
- Provider-owned serializable session/turn trace-state store
- `SpanContext` restoration through `wrapSpanContext()`
- Zero-duration session and turn start markers
- Retrospective turn terminal markers
- `agent.step` and `agent.action` spans scoped to one atomic attempt
- Stable `agent.*` identity, framework, lineage, model, usage, and action attributes
- Tool/action failures remain localized to the action span
- Content is not captured

Only attempt/model/tool state that starts and terminates within one atomic invocation remains process-local. No live `Span` object is expected to survive a Workflow boundary.

The same provider can later run with a private local tracer or the global tracer configured by `@vercel/otel`.

## Scope

This PR does **not** register the provider, wire harness-native lifecycle events, persist the state store, call `registerOTel()`, or change production behavior. The provider is exercised only through real in-memory OTel tests.

## Testing

- Session root ignores ambient parent context
- Provider recreation restores session trace identity
- Multiple turns share one trace ID
- Turn, attempt, and action logical hierarchy
- Session event placement
- Structural attributes and no content capture
- Action failure does not fail the turn
- Provider-neutral bridge tests
- Tool-loop regression tests
- Package typecheck, build, lint, formatting, and invariants