### PR TITLE
fix(eve): keep approvals pending across a same-step runtime action

### DIFF
--- a/.changeset/hitl-runtime-action-collision.md
+++ b/.changeset/hitl-runtime-action-collision.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+A model step that requests a tool approval (or question) and a subagent or remote-agent call in the same response no longer drops the approval. The harness now parks on both: the input request surfaces immediately, the delegation runs, and when its result arrives the turn re-parks on the still-pending approval instead of calling the model with a dangling tool call (`AI_MissingToolResultsError`).

--- a/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/agent.ts
@@ -1,7 +1,42 @@
 import { e2eAgentConfig } from "@eve-e2e/config";
 import { defineAgent } from "eve";
+import type { MockModelRequest, MockModelResponse } from "eve/evals";
+
+const COLLISION_MARKER = "MIXED-PARK-COMPLETE-7K2M";
+
+function respond(request: MockModelRequest): MockModelResponse | string {
+  if (request.lastUserMessage?.includes(COLLISION_MARKER) !== true) {
+    return `Mock reply: ${request.lastUserMessage ?? ""}`;
+  }
+
+  const gateResults = request.toolResults.filter((result) => result.name === "collision-gate");
+  const subagentResults = request.toolResults.filter((result) => result.name === "collision-child");
+
+  if (gateResults.length === 0 && subagentResults.length === 0) {
+    return {
+      toolCalls: [
+        {
+          id: "collision-gate-call",
+          input: { marker: COLLISION_MARKER },
+          name: "collision-gate",
+        },
+        {
+          id: "collision-child-call",
+          input: { message: `Return ${COLLISION_MARKER}.` },
+          name: "collision-child",
+        },
+      ],
+    };
+  }
+
+  if (gateResults.length === 1 && subagentResults.length === 1) {
+    return COLLISION_MARKER;
+  }
+
+  throw new Error("Mixed runtime-action step resumed before both tool results were available.");
+}
 
 export default defineAgent({
-  ...e2eAgentConfig(),
+  ...e2eAgentConfig({ mock: respond }),
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/collision-child/agent.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/collision-child/agent.ts
@@ -1,0 +1,7 @@
+import { e2eSubagentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description: "Return the marker from the request without calling any tools.",
+  ...e2eSubagentConfig(),
+});

--- a/e2e/fixtures/agent-subagents-hitl/agent/subagents/collision-child/instructions.md
+++ b/e2e/fixtures/agent-subagents-hitl/agent/subagents/collision-child/instructions.md
@@ -1,0 +1,1 @@
+Return the marker from the request without calling any tools.

--- a/e2e/fixtures/agent-subagents-hitl/agent/tools/collision-gate.ts
+++ b/e2e/fixtures/agent-subagents-hitl/agent/tools/collision-gate.ts
@@ -1,0 +1,10 @@
+import { defineTool } from "eve/tools";
+import { always } from "eve/tools/approval";
+import { z } from "zod";
+
+export default defineTool({
+  description: "Return a marker after explicit approval.",
+  inputSchema: z.object({ marker: z.string() }),
+  approval: always(),
+  execute: ({ marker }) => ({ marker }),
+});

--- a/e2e/fixtures/agent-subagents-hitl/evals/mixed-runtime-action-approval.eval.ts
+++ b/e2e/fixtures/agent-subagents-hitl/evals/mixed-runtime-action-approval.eval.ts
@@ -1,0 +1,42 @@
+import { defineEval } from "eve/evals";
+
+const COLLISION_MARKER = "MIXED-PARK-COMPLETE-7K2M";
+
+/**
+ * Regression coverage for https://github.com/vercel/eve/issues/1201.
+ *
+ * One model step requests an approval-gated tool and a subagent together.
+ * The child may finish first, but the root turn must retain the approval and
+ * re-park instead of resuming the model with an unanswered tool call.
+ */
+export default defineEval({
+  description: "A root approval and subagent call from one model step both survive parking.",
+  async test(t) {
+    const parked = await t.send(
+      [
+        `Call the collision-gate tool with marker "${COLLISION_MARKER}" and the collision-child subagent in the same assistant response.`,
+        "Do not wait for one call before making the other.",
+        `After both results arrive, reply with exactly ${COLLISION_MARKER}.`,
+      ].join("\n"),
+    );
+
+    parked.calledTool("collision-gate", { count: 1, status: "pending" });
+    parked.calledSubagent("collision-child", { count: 1, status: "completed" });
+    parked.eventOrder([
+      { type: "actions.requested" },
+      { type: "input.requested" },
+      { type: "subagent.completed" },
+      { type: "session.waiting" },
+    ]);
+    t.requireInputRequest({ display: "confirmation", toolName: "collision-gate" });
+
+    const resumed = await t.respondAll("approve");
+    resumed.expectOk();
+    resumed.messageIncludes(COLLISION_MARKER);
+
+    t.succeeded();
+    t.noFailedActions();
+    t.calledTool("collision-gate", { count: 1, status: "completed" });
+    t.calledSubagent("collision-child", { count: 1, status: "completed" });
+  },
+});

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -1335,6 +1335,117 @@ describe("createToolLoopHarness", () => {
     ]);
   });
 
+  it("parks on both batches when one step carries a runtime action and an approval", async () => {
+    const gateToolCall = {
+      input: { action: "run" },
+      toolCallId: "gate-1",
+      toolName: "add",
+      type: "tool-call" as const,
+    };
+    const delegateToolCall = {
+      input: { message: "probe" },
+      toolCallId: "delegate-1",
+      toolName: "delegate",
+      type: "tool-call" as const,
+    };
+    setupMockAgent({
+      content: [
+        gateToolCall,
+        { approvalId: "approval-1", toolCallId: "gate-1", type: "tool-approval-request" },
+        delegateToolCall,
+      ],
+      finishReason: "tool-calls",
+      response: {
+        messages: [
+          {
+            content: [
+              gateToolCall,
+              { approvalId: "approval-1", toolCallId: "gate-1", type: "tool-approval-request" },
+              delegateToolCall,
+            ],
+            role: "assistant",
+          },
+        ],
+      },
+      text: "",
+      toolCalls: [gateToolCall, delegateToolCall],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, { tools: createDelegationToolMap() }),
+    );
+
+    const parked = await runStep(createTestSession(), { message: "Gate and delegate." });
+
+    expect(parked.next).toBeNull();
+    expect(getPendingRuntimeActionBatch(parked.session.state)?.actions).toEqual([
+      expect.objectContaining({ callId: "delegate-1", kind: "subagent-call" }),
+    ]);
+    expect(hasPendingInputBatch(parked.session.state)).toBe(true);
+    expect(events.filter((event) => event.type === "input.requested")).toHaveLength(1);
+
+    const parkedWithRunningDelegate = {
+      ...parked.session,
+      state: {
+        ...parked.session.state,
+        [AGENT_HANDLES_STATE_KEY]: {
+          handles: [
+            {
+              address: {
+                continuationToken: "delegate-token",
+                kind: "agent/local",
+                sessionId: "delegate-session",
+              },
+              identity: {
+                id: "ag_worker:delegate",
+                name: "worker",
+                nodeId: "workers",
+              },
+              operation: {
+                callId: "delegate-1",
+                id: "delegate-operation",
+                kind: "start",
+                parentTurnId: "turn_0",
+              },
+              phase: "running",
+            },
+          ],
+        },
+      },
+    } satisfies HarnessSession;
+    const reparked = await runStep(parkedWithRunningDelegate, {
+      runtimeActionResults: [
+        {
+          callId: "delegate-1",
+          kind: "subagent-result",
+          origin: "child",
+          outcome: {
+            kind: "terminal",
+            result: { kind: "succeeded", output: "delegated-done" },
+            usageDelta: {
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+          },
+          output: "delegated-done",
+          subagentName: "worker",
+        },
+      ],
+    });
+
+    expect(reparked.next).toBeNull();
+    expect(getPendingRuntimeActionBatch(reparked.session.state)).toBeUndefined();
+    expect(hasPendingInputBatch(reparked.session.state)).toBe(true);
+    const toolMessages = reparked.session.history.filter((message) => message.role === "tool");
+    expect(JSON.stringify(toolMessages)).toContain("delegated-done");
+    expect(events.filter((event) => event.type === "subagent.completed")).toHaveLength(1);
+    expect(events.at(-1)?.type).toBe("session.waiting");
+  });
+
   it("publishes declared subagent calls from deeply nested sessions", async () => {
     setupMockAgent({
       finishReason: "tool-calls",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -952,6 +952,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       stepInput: coordinated.stepInput,
     });
     if (pending.outcome === "unresolved") {
+      // The runtime-action batch owns the assistant messages. Once that batch
+      // resolves, commit its results before the still-pending HITL batch parks.
+      let parkedSession =
+        resolvedRuntimeActions.outcome === "resolved"
+          ? {
+              ...pending.session,
+              history: [...resolvedRuntimeActions.messages],
+            }
+          : pending.session;
+
       if (
         emit &&
         config.mode === "conversation" &&
@@ -979,8 +989,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         emissionState = await emitTurnEpilogue(emit, emissionState, config.mode);
         return {
           next: null,
-          session: setHarnessEmissionState(pending.session, emissionState),
+          session: setHarnessEmissionState(parkedSession, emissionState),
         };
+      }
+
+      if (resolvedRuntimeActions.outcome === "resolved") {
+        if (emit && config.mode === "conversation") {
+          emissionState = await emitTurnEpilogue(emit, emissionState, config.mode);
+          parkedSession = setHarnessEmissionState(parkedSession, emissionState);
+        }
+        return { next: null, session: parkedSession };
       }
 
       return { next: null, session: pending.session };
@@ -2445,21 +2463,62 @@ async function handleStepResult(input: {
     // parked session carries the default emission state (turnId ""),
     // because the post-preamble `setHarnessEmissionState` is dropped by
     // the later `session = pending.session` / `maybeCompact` rebinds.
+    if (inputRequests.length === 0) {
+      return {
+        next: null,
+        session: setHarnessEmissionState(
+          setPendingRuntimeActionBatch({
+            actions: pendingRuntimeActions,
+            event: {
+              sequence: emissionState.sequence,
+              stepIndex: emissionState.stepIndex,
+              turnId: emissionState.turnId,
+            },
+            responseMessages,
+            session: { ...baseSession, history: [...promptMessages] },
+          }),
+          advanceStep(emissionState),
+        ),
+      };
+    }
+
+    let parkedSession = setPendingRuntimeActionBatch({
+      actions: pendingRuntimeActions,
+      event: {
+        sequence: emissionState.sequence,
+        stepIndex: emissionState.stepIndex,
+        turnId: emissionState.turnId,
+      },
+      responseMessages,
+      session: { ...baseSession, history: [...promptMessages] },
+    });
+
+    // The runtime-action batch already owns the shared assistant response.
+    parkedSession = appendPendingInputBatch({
+      event: {
+        sequence: emissionState.sequence,
+        stepIndex: emissionState.stepIndex,
+        turnId: emissionState.turnId,
+      },
+      requests: inputRequests,
+      responseMessages: [],
+      session: parkedSession,
+    });
+
+    if (emit) {
+      await emit(
+        createInputRequestedEvent({
+          requests: inputRequests,
+          sequence: emissionState.sequence,
+          stepIndex: emissionState.stepIndex,
+          turnId: emissionState.turnId,
+        }),
+      );
+    }
+
     return {
       next: null,
-      session: setHarnessEmissionState(
-        setPendingRuntimeActionBatch({
-          actions: pendingRuntimeActions,
-          event: {
-            sequence: emissionState.sequence,
-            stepIndex: emissionState.stepIndex,
-            turnId: emissionState.turnId,
-          },
-          responseMessages,
-          session: { ...baseSession, history: [...promptMessages] },
-        }),
-        advanceStep(emissionState),
-      ),
+      session: setHarnessEmissionState(parkedSession, advanceStep(emissionState)),
     };
   }
 


### PR DESCRIPTION
### Summary

Fixes #1201. When one model response requested an approval-gated tool and a runtime action together, the runtime-action park discarded the input request; its result then resumed the model with an unanswered tool call and failed with `AI_MissingToolResultsError`. The harness now stores both pending batches, commits resolved runtime-action results before re-parking on the unanswered input, and preserves that updated session through the deferred-message path. A deterministic eval makes an approval-gated tool and a no-tool child agent collide in one assistant response, then proves both complete exactly once after approval. The runtime-action-only path remains unchanged.

### Validation

- Full GitHub CI on `fab891ac`: 90 successful checks and one expected skip, including unit, Linux/Windows integration, scenario, and the regression eval in local, Postgres, and Vercel worlds
- `pnpm test:unit` — 6,439 passed, 1 skipped in `eve`; all workspace unit tasks passed
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/tool-loop.test.ts -t "parks on both batches when one step carries a runtime action and an approval"`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/harness/tool-loop-cancellation.integration.test.ts src/execution/turn-cancellation.integration.test.ts` — 12/12 passed
- `pnpm --filter agent-subagents-hitl typecheck`; `pnpm --filter eve typecheck`; `pnpm typecheck`
- `pnpm lint`; `pnpm guard:invariants`
- Local full integration/scenario runs exposed unrelated shared-state failures around missing Vercel output config; the exact failing files passed 22/22 in isolation, and both corresponding CI suites passed on the final head

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
