### PR TITLE
feat(eve): ingest session notifications inline in the callback route

### DIFF
--- a/packages/eve/src/execution/notification-ingestion.ts
+++ b/packages/eve/src/execution/notification-ingestion.ts
@@ -1,0 +1,69 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import { deserializeContext } from "#context/serialize.js";
+import { appendSessionStreamEvent } from "#execution/session-stream-append.js";
+import { getWorld } from "#internal/workflow/runtime.js";
+import { createLogger, logError } from "#internal/logging.js";
+import type { SubagentChildEventStreamEvent } from "#protocol/message.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+
+const log = createLogger("execution.notification-ingestion");
+
+/**
+ * PROTOTYPE (issue #1170): ingests one notification-class event for a
+ * session, inline in the caller's already-running compute — no run, no
+ * hook, no queue wake.
+ *
+ * Two effects, both best-effort:
+ *
+ * 1. Run the channel's existing adapter event handler against the curated
+ *    child event — the same handler the local proxy step invokes today, so
+ *    channels render with zero changes. The channel context is loaded from
+ *    the session entry run's input (`world.runs.get`), read-only.
+ * 2. Append the wrapped `subagent.event` to the session's durable stream,
+ *    where every follower (TUI, web clients, evals) reads it.
+ *
+ * Failures log and drop: the lane's contract is fire-once, and a closed
+ * stream or finished session means nobody is rendering.
+ */
+export async function ingestSessionNotification(
+  sessionId: string,
+  wrapped: SubagentChildEventStreamEvent,
+): Promise<void> {
+  try {
+    const serializedContext = await loadEntrySerializedContext(sessionId);
+    if (serializedContext !== undefined) {
+      const ctx = await deserializeContext(serializedContext);
+      const adapter = ctx.get(ChannelKey);
+      if (adapter !== undefined) {
+        const adapterCtx = buildAdapterContext(adapter, ctx);
+        await callAdapterEventHandler(adapter, wrapped.data.event, adapterCtx);
+      }
+    }
+  } catch (error) {
+    logError(log, "notification channel render failed; continuing to stream append", error, {
+      sessionId,
+    });
+  }
+
+  await appendSessionStreamEvent(sessionId, wrapped);
+}
+
+/**
+ * Loads the session entry run's `serializedContext` from its recorded
+ * input. The entry is started with `[{ input, limits, serializedContext }]`,
+ * so the channel context is addressable by session id without any
+ * dedicated persistence.
+ */
+async function loadEntrySerializedContext(
+  sessionId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const world = await getWorld();
+  const run = await world.runs.get(sessionId, { resolveData: "all" });
+  const args = (run as { input?: unknown }).input;
+  const first = Array.isArray(args) ? args[0] : args;
+  if (first === null || typeof first !== "object") return undefined;
+  const serialized = (first as { serializedContext?: unknown }).serializedContext;
+  if (serialized === null || typeof serialized !== "object") return undefined;
+  return serialized as Record<string, unknown>;
+}

--- a/packages/eve/src/execution/session-stream-append.ts
+++ b/packages/eve/src/execution/session-stream-append.ts
@@ -1,0 +1,35 @@
+import { getWorld } from "#internal/workflow/runtime.js";
+import {
+  encodeMessageStreamEvent,
+  type HandleMessageStreamEvent,
+  timestampHandleMessageStreamEvent,
+} from "#protocol/message.js";
+
+/**
+ * PROTOTYPE (issue #1170): the engine's default run-stream name, derived
+ * from the run id. Naming contract of the vendored `@workflow/core`
+ * (`strm_<id>_user` for the default namespace); if the engine ever exposes
+ * a public name resolver or accepts name-less default writes, use that
+ * instead.
+ */
+export function sessionStreamName(sessionId: string): string {
+  return `${sessionId.replace("wrun_", "strm_")}_user`;
+}
+
+/**
+ * PROTOTYPE (issue #1170): appends one event to a session's durable stream
+ * from plain runtime code — the producer side of the event-consumer lane.
+ * Throws on a closed or missing stream; callers decide whether that is
+ * best-effort (notifications: log and drop) or an error.
+ */
+export async function appendSessionStreamEvent(
+  sessionId: string,
+  event: HandleMessageStreamEvent,
+): Promise<void> {
+  const world = await getWorld();
+  await world.streams.write(
+    sessionId,
+    sessionStreamName(sessionId),
+    encodeMessageStreamEvent(timestampHandleMessageStreamEvent(event)),
+  );
+}

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -167,6 +167,7 @@ async function runDriverLoop(input: {
     token: `${input.sessionState.sessionId}:auth`,
   });
   const authIterator: AsyncIterator<HookPayload> = authHook[Symbol.asyncIterator]();
+
   // Fast descendant resumes can start the next turn before the prior
   // control hook disposal is persisted by the Workflow SDK, so each
   // turn needs its own session-scoped token.

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -281,6 +281,8 @@ export interface SubagentStartedStreamEvent {
 export interface SubagentChildEventStreamEvent {
   data: {
     callId: string;
+    /** Durable session id of the child that produced `event`. */
+    childSessionId?: string;
     event: HandleMessageStreamEvent;
     subagentName: string;
   };

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -141,47 +141,43 @@ const notificationEventSchema = z.union([
 ]);
 
 /**
+ * Full notification POST body: correlation fields plus the enveloped event.
+ * The whole payload is validated as one schema — `sessionId` is optional
+ * (older callees omit it) and unknown top-level keys are stripped.
+ */
+const notificationCallbackPayloadSchema = z.object({
+  callId: z.string().min(1),
+  event: notificationEventSchema,
+  sessionId: z.string().optional(),
+  subagentName: z.string().min(1),
+});
+
+/**
  * Projects one notification POST into the wrapped `subagent.event` appended
  * to the session's durable stream — the canonical form both followers and
  * channel rendering read.
  */
 function projectWrappedNotificationEvent(value: unknown): SubagentChildEventStreamEvent | Response {
-  if (value === null || typeof value !== "object") {
-    return Response.json({ error: "Expected a JSON object.", ok: false }, { status: 400 });
-  }
-
-  const payload = value as {
-    readonly callId?: unknown;
-    readonly event?: unknown;
-    readonly sessionId?: unknown;
-    readonly subagentName?: unknown;
-  };
-  if (typeof payload.callId !== "string" || payload.callId.length === 0) {
-    return Response.json({ error: "Missing callback callId.", ok: false }, { status: 400 });
-  }
-  if (typeof payload.subagentName !== "string" || payload.subagentName.length === 0) {
-    return Response.json({ error: "Missing callback subagentName.", ok: false }, { status: 400 });
-  }
-
-  const parsed = notificationEventSchema.safeParse(payload.event);
+  const parsed = notificationCallbackPayloadSchema.safeParse(value);
   if (!parsed.success) {
     return Response.json(
-      { error: "Invalid notification callback event.", ok: false },
+      { error: "Invalid notification callback payload.", ok: false },
       { status: 400 },
     );
   }
 
+  const { callId, event: parsedEvent, sessionId, subagentName } = parsed.data;
   const event: SubagentAuthorizationEvent =
-    parsed.data.type === "authorization.required"
-      ? { data: parsed.data.data, type: "authorization.required" }
-      : { data: parsed.data.data, type: "authorization.completed" };
+    parsedEvent.type === "authorization.required"
+      ? { data: parsedEvent.data, type: "authorization.required" }
+      : { data: parsedEvent.data, type: "authorization.completed" };
 
   return {
     data: {
-      callId: payload.callId,
-      childSessionId: typeof payload.sessionId === "string" ? payload.sessionId : "",
+      callId,
+      childSessionId: sessionId ?? "",
       event,
-      subagentName: payload.subagentName,
+      subagentName,
     },
     type: "subagent.event",
   };

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -1,16 +1,23 @@
+import { z } from "#compiled/zod/index.js";
+
+import { createLogger, logError } from "#internal/logging.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 import { EVE_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { ingestSessionNotification } from "#execution/notification-ingestion.js";
 import type {
   SessionCallbackPayload,
   SessionCallbackTerminationEvent,
 } from "#channel/session-callback.js";
-import type { HookPayload } from "#channel/types.js";
+import type { HookPayload, SubagentAuthorizationEvent } from "#channel/types.js";
+import type { SubagentChildEventStreamEvent } from "#protocol/message.js";
 import type { ChannelMethod, RouteContext } from "#public/definitions/channel.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
 import { tokenUsageSchema, type TokenUsage } from "#shared/token-usage.js";
 
 export const HTTP_SESSION_CALLBACK_CHANNEL_NAME_PREFIX = "eve/v1/callback";
+
+const log = createLogger("runtime.session-callback-route");
 
 const HANDLED_METHODS: readonly ChannelMethod[] = ["POST"];
 
@@ -55,6 +62,27 @@ export async function handleSessionCallbackRequest(
     return Response.json({ error: "Invalid JSON body.", ok: false }, { status: 400 });
   }
 
+  // The relay lane (issue #1170): notification-class events, handled inline
+  // in this request's compute — no run, no hook, no queue wake. The
+  // validated notification runs the channel's existing adapter event
+  // handler and is appended to the session's durable stream for followers.
+  // Once the payload is well-formed the response is always 202: a finished
+  // session means nobody is rendering (log, drop). Nothing retries.
+  if (token.endsWith(EVENT_INGESTION_TOKEN_SUFFIX)) {
+    const wrapped = projectWrappedNotificationEvent(body);
+    if (wrapped instanceof Response) {
+      return wrapped;
+    }
+    const sessionId = token.slice(0, -EVENT_INGESTION_TOKEN_SUFFIX.length);
+    try {
+      await ingestSessionNotification(sessionId, wrapped);
+    } catch (error) {
+      logError(log, "notification ingestion failed; event dropped", error, { sessionId });
+    }
+    return Response.json({ ok: true }, { status: 202 });
+  }
+
+  // The control lane: terminal callbacks resume the parked parent turn.
   const hookPayload = projectSessionCallbackHookPayload(body);
   if (hookPayload instanceof Response) {
     return hookPayload;
@@ -67,6 +95,96 @@ export async function handleSessionCallbackRequest(
   }
 
   return Response.json({ ok: true }, { status: 202 });
+}
+
+const EVENT_INGESTION_TOKEN_SUFFIX = ":events";
+
+const notificationAuthorizationChallengeSchema = z.object({
+  displayName: z.string().optional(),
+  expiresAt: z.string().optional(),
+  instructions: z.string().optional(),
+  url: z.string().optional(),
+  userCode: z.string().optional(),
+});
+
+/**
+ * The relay lane's event vocabulary (issue #1170). Payloads arrive from
+ * outside this deployment and are re-emitted on the session stream, so they
+ * validate to the exact shapes a follower knows how to render; unknown keys
+ * are stripped.
+ */
+const notificationEventSchema = z.union([
+  z.object({
+    data: z.object({
+      authorization: notificationAuthorizationChallengeSchema.optional(),
+      description: z.string(),
+      name: z.string(),
+      sequence: z.number(),
+      stepIndex: z.number(),
+      turnId: z.string(),
+      webhookUrl: z.string().optional(),
+    }),
+    type: z.literal("authorization.required"),
+  }),
+  z.object({
+    data: z.object({
+      authorization: notificationAuthorizationChallengeSchema.optional(),
+      name: z.string(),
+      outcome: z.enum(["authorized", "declined", "failed", "timed-out"]),
+      reason: z.string().optional(),
+      sequence: z.number(),
+      stepIndex: z.number(),
+      turnId: z.string(),
+    }),
+    type: z.literal("authorization.completed"),
+  }),
+]);
+
+/**
+ * Projects one notification POST into the wrapped `subagent.event` appended
+ * to the session's durable stream — the canonical form both followers and
+ * channel rendering read.
+ */
+function projectWrappedNotificationEvent(value: unknown): SubagentChildEventStreamEvent | Response {
+  if (value === null || typeof value !== "object") {
+    return Response.json({ error: "Expected a JSON object.", ok: false }, { status: 400 });
+  }
+
+  const payload = value as {
+    readonly callId?: unknown;
+    readonly event?: unknown;
+    readonly sessionId?: unknown;
+    readonly subagentName?: unknown;
+  };
+  if (typeof payload.callId !== "string" || payload.callId.length === 0) {
+    return Response.json({ error: "Missing callback callId.", ok: false }, { status: 400 });
+  }
+  if (typeof payload.subagentName !== "string" || payload.subagentName.length === 0) {
+    return Response.json({ error: "Missing callback subagentName.", ok: false }, { status: 400 });
+  }
+
+  const parsed = notificationEventSchema.safeParse(payload.event);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Invalid notification callback event.", ok: false },
+      { status: 400 },
+    );
+  }
+
+  const event: SubagentAuthorizationEvent =
+    parsed.data.type === "authorization.required"
+      ? { data: parsed.data.data, type: "authorization.required" }
+      : { data: parsed.data.data, type: "authorization.completed" };
+
+  return {
+    data: {
+      callId: payload.callId,
+      childSessionId: typeof payload.sessionId === "string" ? payload.sessionId : "",
+      event,
+      subagentName: payload.subagentName,
+    },
+    type: "subagent.event",
+  };
 }
 
 function projectSessionCallbackHookPayload(value: unknown): HookPayload | Response {
@@ -95,7 +213,7 @@ function projectSessionCallbackHookPayload(value: unknown): HookPayload | Respon
   }
 
   // "notification" (and the reserved "working"/"input_required") are the
-  // relay lane, delivered separately from this durable terminal path.
+  // relay lane, delivered via the :events ingestion branch above.
   return Response.json({ error: "Unsupported callback event status.", ok: false }, { status: 400 });
 }
 


### PR DESCRIPTION
**Relay lane** for #1170. Stacked on #1202 (terminal/control lane); the research doc PR stacks on top of this one. Recreated after a stack reparent flipped the prior PR to a false MERGED state and auto-deleted its branch — nothing reached `main`.

## What

Notification-class child events (`authorization.*`) reach the channel and the stream with **no run, no hook, no queue wake** — the event arrives as an HTTP callback, so the compute is already paid. `POST /eve/v1/callback/<sessionId>:events`:

1. validates the reserved notification vocabulary and wraps the event as `subagent.event` (carrying `childSessionId`);
2. loads the session entry run's channel context (`world.runs.get`, read-only) and runs the channel's existing adapter event handler against it — push channels render with zero authoring changes;
3. appends the wrapped event to the session's durable stream (`world.streams.write`) for followers.

Best-effort per the lane's fire-once contract: a finished session logs and drops; nothing retries. Activates the `"notification"` status that #1202 reserved on the wire.

## Two-lane split

Relay lane (fire-once, drop-ok, rendering-only) — counterpart to #1202's control lane (exactly-once, never-drop, durable resume).

## Known-incomplete (prototype)

- **Caller-side ingestion only.** The callee-side forwarder that *sends* `authorization.*` to `:events` isn't in this PR yet (lives in #1167's commit, needs adapting), so nothing produces on the lane end-to-end until it lands; the fixture + evals come with it.
- `childSessionId` on `SubagentChildEventStreamEvent` trips the rule-36 capability-epoch ceremony (additive; not run), so `guard:invariants` fails on this branch.
- Default stream name (`strm_<id>_user`) is a vendored-engine naming contract.

Typecheck clean; route + unit tests green.