### PR TITLE
feat(eve): remote authorization events via the durable resumeHook path

### DIFF
--- a/.changeset/remote-authorization-durable.md
+++ b/.changeset/remote-authorization-durable.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+A remote agent's `authorization.required`/`authorization.completed` events now surface on the caller's stream. The callee forwards them to the caller's session-callback URL as `status: "notification"` events; the caller resumes its parked turn and proxies them onto its stream exactly as a local subagent's authorization events — the durable `resumeHook` path, handled in the session workflow, not a best-effort side channel. So a remote subagent that needs a connection authorized mid-run surfaces the sign-in prompt in the caller's channel just like a local one.

--- a/packages/eve/src/execution/session-callback-notification.test.ts
+++ b/packages/eve/src/execution/session-callback-notification.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import { SessionCallbackKey, SessionIdKey } from "#context/keys.js";
+import { forwardSessionCallbackNotification } from "#execution/session-callback-notification.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+
+const CALLBACK = {
+  callId: "call-1",
+  subagentName: "research",
+  token: "tok123",
+  url: "https://caller.example.com/eve/v1/callback/tok123",
+};
+
+const AUTHORIZATION_REQUIRED_EVENT = {
+  data: {
+    authorization: { url: "https://idp.example.com/authorize" },
+    description: "Linear workspace access",
+    name: "linear",
+    sequence: 3,
+    stepIndex: 1,
+    turnId: "turn-1",
+  },
+  type: "authorization.required",
+} satisfies HandleMessageStreamEvent;
+
+describe("forwardSessionCallbackNotification", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    warnSpy.mockRestore();
+  });
+
+  it("posts an authorization event as a notification callback", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await forwardSessionCallbackNotification({
+      ctx: createContext(),
+      event: AUTHORIZATION_REQUIRED_EVENT,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://caller.example.com/eve/v1/callback/tok123", {
+      body: JSON.stringify({
+        callId: "call-1",
+        event: { ...AUTHORIZATION_REQUIRED_EVENT, status: "notification" },
+        sessionId: "remote-session",
+        subagentName: "research",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+      redirect: "error",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("forwards authorization.completed events", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await forwardSessionCallbackNotification({
+      ctx: createContext(),
+      event: {
+        data: {
+          name: "linear",
+          outcome: "authorized",
+          sequence: 4,
+          stepIndex: 1,
+          turnId: "turn-1",
+        },
+        type: "authorization.completed",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const init = fetchMock.mock.calls[0]?.[1] as { body: string } | undefined;
+    const body = JSON.parse(init?.body ?? "{}") as {
+      event: { status: string; type: string };
+    };
+    expect(body.event).toMatchObject({ status: "notification", type: "authorization.completed" });
+  });
+
+  it("does nothing for sessions without callback metadata", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = new ContextContainer();
+    ctx.set(SessionIdKey, "remote-session");
+
+    await forwardSessionCallbackNotification({ ctx, event: AUTHORIZATION_REQUIRED_EVENT });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["message.appended", "session.completed", "input.requested"] as const)(
+    "does nothing for %s events",
+    async (type) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await forwardSessionCallbackNotification({
+        ctx: createContext(),
+        event: { type } as HandleMessageStreamEvent,
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("skips and warns on invalid callback metadata without throwing", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = new ContextContainer();
+    ctx.set(SessionIdKey, "remote-session");
+    ctx.set(SessionCallbackKey, {
+      ...CALLBACK,
+      url: "http://169.254.169.254/eve/v1/callback/tok123",
+    });
+
+    await forwardSessionCallbackNotification({ ctx, event: AUTHORIZATION_REQUIRED_EVENT });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("swallows and logs delivery failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+
+    await expect(
+      forwardSessionCallbackNotification({
+        ctx: createContext(),
+        event: AUTHORIZATION_REQUIRED_EVENT,
+      }),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("swallows and logs network failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(
+      forwardSessionCallbackNotification({
+        ctx: createContext(),
+        event: AUTHORIZATION_REQUIRED_EVENT,
+      }),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+function createContext(): ContextContainer {
+  const ctx = new ContextContainer();
+  ctx.set(SessionIdKey, "remote-session");
+  ctx.set(SessionCallbackKey, CALLBACK);
+  return ctx;
+}

--- a/packages/eve/src/execution/session-callback-notification.ts
+++ b/packages/eve/src/execution/session-callback-notification.ts
@@ -1,0 +1,67 @@
+import { parseCallbackMetadata } from "#channel/session-callback.js";
+import type { ContextReader } from "#context/key.js";
+import { SessionCallbackKey, SessionIdKey } from "#context/keys.js";
+import { postSessionCallback } from "#execution/session-callback-post.js";
+import { createLogger } from "#internal/logging.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+
+const log = createLogger("execution.session-callback-notification");
+
+/**
+ * Forwards one notification-worthy stream event to the session's
+ * registered callback URL as a `status: "notification"` callback event.
+ *
+ * The callback-URL analog of the local subagent adapter's
+ * `subagent-authorization-event` forwarding: a callee dispatched with a
+ * {@link SessionCallback} has no hook into its caller, so authorization
+ * lifecycle events are POSTed to the callback URL, where the caller
+ * re-emits them on its own stream without resolving the pending call.
+ *
+ * No-op for sessions without callback metadata and for every other event
+ * type. Delivery is best-effort: unlike the terminal callback, a failed
+ * POST is logged and swallowed so an unreachable caller never fails the
+ * callee's turn.
+ */
+export async function forwardSessionCallbackNotification(input: {
+  readonly ctx: ContextReader;
+  readonly event: HandleMessageStreamEvent;
+}): Promise<void> {
+  const { event } = input;
+  if (event.type !== "authorization.required" && event.type !== "authorization.completed") {
+    return;
+  }
+
+  const value = input.ctx.get(SessionCallbackKey);
+  if (value === undefined) {
+    return;
+  }
+
+  const sessionId = input.ctx.get(SessionIdKey) ?? "";
+  const parsed = parseCallbackMetadata(value);
+  if (!parsed.ok) {
+    log.warn("skipping session callback notification: invalid callback metadata", {
+      eventType: event.type,
+      message: parsed.message,
+      sessionId,
+    });
+    return;
+  }
+
+  try {
+    await postSessionCallback({
+      payload: {
+        callId: parsed.callback.callId,
+        event: { ...event, status: "notification" },
+        sessionId,
+        subagentName: parsed.callback.subagentName,
+      },
+      url: parsed.callback.url,
+    });
+  } catch (error) {
+    log.warn("failed to post session callback notification", {
+      error,
+      eventType: event.type,
+      sessionId,
+    });
+  }
+}

--- a/packages/eve/src/execution/subagent-event-proxy-step.ts
+++ b/packages/eve/src/execution/subagent-event-proxy-step.ts
@@ -9,6 +9,7 @@ import { ModeKey } from "#context/keys.js";
 import { withContextScope } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import { setChannelContext } from "#execution/channel-context.js";
+import { forwardSessionCallbackNotification } from "#execution/session-callback-notification.js";
 import {
   createDurableSessionState,
   type DurableSession,
@@ -84,6 +85,9 @@ export async function emitProxiedSubagentEvent(input: {
     const emit = async (event: HandleMessageStreamEvent): Promise<void> => {
       const transformed = await callAdapterEventHandler(adapter, event, adapterCtx);
       await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(transformed)));
+      // A parent that is itself a remote callee relays proxied child
+      // events one more hop up its own callback URL.
+      await forwardSessionCallbackNotification({ ctx, event: transformed });
     };
 
     const scopeResult = await withContextScope(ctx, session, async (enrichedSession) => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -25,6 +25,7 @@ import {
   throwIfTurnAborted,
 } from "#harness/turn-cancellation.js";
 import { setChannelContext } from "#execution/channel-context.js";
+import { forwardSessionCallbackNotification } from "#execution/session-callback-notification.js";
 import { hasPendingInputBatch } from "#harness/input-requests.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
 import {
@@ -294,6 +295,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     const toEmit = await callAdapterEventHandler(adapter, event, adapterCtx);
     setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
     await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(toEmit)));
+    await forwardSessionCallbackNotification({ ctx, event: toEmit });
     return toEmit;
   };
 

--- a/packages/eve/src/runtime/session-callback-route.test.ts
+++ b/packages/eve/src/runtime/session-callback-route.test.ts
@@ -105,8 +105,157 @@ describe("session callback route", () => {
     });
   });
 
-  it.each(["notification", "working", "input_required", "unknown-status"])(
-    "rejects the non-terminal callback event status %s on the durable lane",
+  it("resumes a notification callback as a subagent authorization event", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: {
+            data: {
+              authorization: { url: "https://idp.example.com/authorize" },
+              description: "Linear workspace access",
+              name: "linear",
+              sequence: 3,
+              stepIndex: 1,
+              turnId: "turn-1",
+            },
+            status: "notification",
+            type: "authorization.required",
+          },
+          sessionId: "remote-session",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).toHaveBeenCalledWith("tok123", {
+      callId: "call-1",
+      childSessionId: "remote-session",
+      event: {
+        data: {
+          authorization: { url: "https://idp.example.com/authorize" },
+          description: "Linear workspace access",
+          name: "linear",
+          sequence: 3,
+          stepIndex: 1,
+          turnId: "turn-1",
+        },
+        type: "authorization.required",
+      },
+      kind: "subagent-authorization-event",
+      subagentName: "research",
+    });
+  });
+
+  it("resumes an authorization.completed notification callback", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: {
+            data: {
+              name: "linear",
+              outcome: "authorized",
+              sequence: 4,
+              stepIndex: 1,
+              turnId: "turn-1",
+            },
+            status: "notification",
+            type: "authorization.completed",
+          },
+          sessionId: "remote-session",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).toHaveBeenCalledWith("tok123", {
+      callId: "call-1",
+      childSessionId: "remote-session",
+      event: {
+        data: {
+          name: "linear",
+          outcome: "authorized",
+          sequence: 4,
+          stepIndex: 1,
+          turnId: "turn-1",
+        },
+        type: "authorization.completed",
+      },
+      kind: "subagent-authorization-event",
+      subagentName: "research",
+    });
+  });
+
+  it("strips unknown keys from a notification event before resuming", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: {
+            data: {
+              description: "Linear workspace access",
+              futureField: true,
+              name: "linear",
+              sequence: 3,
+              stepIndex: 1,
+              turnId: "turn-1",
+            },
+            status: "notification",
+            type: "authorization.required",
+          },
+          sessionId: "remote-session",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(202);
+    const payload = resumeHookMock.mock.calls[0]?.[1] as {
+      event: { data: Record<string, unknown> };
+    };
+    expect(payload.event.data.futureField).toBeUndefined();
+    expect(payload.event.data.name).toBe("linear");
+  });
+
+  it("rejects a malformed notification event", async () => {
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: {
+            data: { name: "linear" },
+            status: "notification",
+            type: "authorization.required",
+          },
+          sessionId: "remote-session",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["working", "input_required", "unknown-status"])(
+    "rejects the not-yet-supported callback event status %s",
     async (status) => {
       const response = await handleSessionCallbackRequest(
         new Request("https://app.example.com/eve/v1/callback/tok123", {
@@ -125,6 +274,35 @@ describe("session callback route", () => {
       expect(resumeHookMock).not.toHaveBeenCalled();
     },
   );
+
+  it("returns 404 when a notification arrives for a hook that is not pending", async () => {
+    resumeHookMock.mockRejectedValue(new Error("no pending hook"));
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/tok123", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: {
+            data: {
+              description: "Linear workspace access",
+              name: "linear",
+              sequence: 3,
+              stepIndex: 1,
+              turnId: "turn-1",
+            },
+            status: "notification",
+            type: "authorization.required",
+          },
+          sessionId: "remote-session",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "tok123" }),
+    );
+
+    expect(response.status).toBe(404);
+  });
 
   it("projects reported usage onto the resumed result", async () => {
     resumeHookMock.mockResolvedValue(undefined);

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -1,10 +1,11 @@
 import { resumeHook } from "#internal/workflow/runtime.js";
 import { EVE_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { sessionCallbackNotificationEventSchema } from "#channel/session-callback.js";
 import type {
   SessionCallbackPayload,
   SessionCallbackTerminationEvent,
 } from "#channel/session-callback.js";
-import type { HookPayload } from "#channel/types.js";
+import type { HookPayload, SubagentAuthorizationEvent } from "#channel/types.js";
 import type { ChannelMethod, RouteContext } from "#public/definitions/channel.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
@@ -94,8 +95,34 @@ function projectSessionCallbackHookPayload(value: unknown): HookPayload | Respon
     });
   }
 
-  // "notification" (and the reserved "working"/"input_required") are the
-  // relay lane, delivered separately from this durable terminal path.
+  // A remote callee's authorization events are low-frequency control
+  // events, so they ride the same durable resumeHook path as a local
+  // subagent's: projected into a `subagent-authorization-event` and
+  // resumed onto the parent turn inbox, where the turn workflow proxies
+  // them onto the parent stream (workflow-entry, exactly as local). The
+  // separate high-frequency progress lane is future work.
+  if (event.status === "notification") {
+    const parsed = sessionCallbackNotificationEventSchema.safeParse(event);
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Invalid notification callback event.", ok: false },
+        { status: 400 },
+      );
+    }
+    const authorizationEvent: SubagentAuthorizationEvent =
+      parsed.data.type === "authorization.required"
+        ? { data: parsed.data.data, type: "authorization.required" }
+        : { data: parsed.data.data, type: "authorization.completed" };
+    return {
+      callId: payload.callId,
+      childSessionId: typeof payload.sessionId === "string" ? payload.sessionId : "",
+      event: authorizationEvent,
+      kind: "subagent-authorization-event",
+      subagentName: payload.subagentName,
+    };
+  }
+
+  // "working"/"input_required" remain reserved on the wire.
   return Response.json({ error: "Unsupported callback event status.", ok: false }, { status: 400 });
 }
 


### PR DESCRIPTION
Replaces the closed #1204. For #1170. Stacked on #1202 (terminal envelope).

## What changed and why

#1204 relayed a remote callee's `authorization.*` through a best-effort route-direct side channel (`world.streams.write`, drop-ok). That was the wrong lane. Authorization events are **low-frequency control** — a handful per session, gated by human sign-ins — so they belong on the **main run's durable path**, exactly where a *local* subagent's authorization events already go.

This PR does that:

- The callee forwards each `authorization.required`/`authorization.completed` to the caller's session-callback URL as a `status: "notification"` event (`session-callback-notification.ts`).
- The caller's callback route projects it into a `subagent-authorization-event` hook payload and `resumeHook(continuationToken)`s the parked parent turn — the same durable resume the terminal callback uses.
- The turn workflow handles it identically to a local subagent's authorization event (`turn-workflow.ts` → `runProxySubagentEventStep` → re-emit on the parent stream). Zero new handling in `workflowEntry`; it reuses the local path.

So local and remote authorization now converge on one mechanism, and nothing rides a lossy side channel.

## The lane split (see #1205)

The separate high-frequency **progress** lane — the one that must stay off the main run's replay journal — remains reserved. It has no concrete event type yet, so it's future work; `"working"`/`"input_required"` stay reserved on the wire.

## Not yet here

- **e2e verification.** The fixture + evals aren't ported onto this branch yet. This branch re-emits authorization events **raw** on the parent stream (the durable proxy path), so the evals need #1167's top-level `authorization.*` assertions with the interactive-connection fixture (since the `eve/tools` export is dropped) — an adaptation, not a copy. Tracked as the next step; unit coverage (route projection + callee forwarder, 24 tests) is green in the meantime.
- Remote `input.required` (proxied HITL) — shelved follow-up.

Unit suite 5367 green, lint + guard clean.