### PR TITLE
feat(eve): relay remote subagent progress on the best-effort lane

### DIFF
--- a/.changeset/remote-progress-relay.md
+++ b/.changeset/remote-progress-relay.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+A remote agent's non-terminal progress (message, reasoning, and step events) now surfaces on the caller's stream, wrapped as `subagent.event`. The callee forwards progress to the caller's `:events` ingestion URL, which appends it to the caller's durable stream without waking or replaying the caller's main workflow run — the best-effort progress lane, kept off the main run's journal by design. Delivery is fire-once: a closed stream (finished session) drops silently.

--- a/packages/eve/src/channel/session-callback.ts
+++ b/packages/eve/src/channel/session-callback.ts
@@ -2,6 +2,7 @@ import { z } from "#compiled/zod/index.js";
 
 import type { SessionCallback, SubagentAuthorizationEvent } from "#channel/types.js";
 import { createEveCallbackRoutePath } from "#protocol/routes.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
 import type { JsonValue } from "#shared/json.js";
 import { isReservedIpAddress } from "#shared/network-address.js";
 import type { TokenUsage } from "#shared/token-usage.js";
@@ -52,11 +53,37 @@ export type SessionCallbackNotificationEvent = SubagentAuthorizationEvent & {
 };
 
 /**
+ * Non-terminal, rendering-only child telemetry (issue #1170): message,
+ * reasoning, and step progress. Forwarded best-effort to the caller's
+ * `:events` ingestion URL and appended to the caller's stream wrapped as
+ * `subagent.event`, never touching the caller's main run. Data rides
+ * loosely — progress drives no state, so it is not re-validated per type.
+ */
+export type SessionCallbackProgressEvent = HandleMessageStreamEvent & {
+  readonly status: "working";
+};
+
+/** Non-terminal child stream events forwarded on the progress lane. */
+export const PROGRESS_EVENT_TYPES = [
+  "message.appended",
+  "message.completed",
+  "reasoning.appended",
+  "reasoning.completed",
+  "step.started",
+  "step.completed",
+] as const;
+
+export function isProgressEventType(type: string): boolean {
+  return (PROGRESS_EVENT_TYPES as readonly string[]).includes(type);
+}
+
+/**
  * One event on the session callback wire contract, discriminated by
  * {@link SessionCallbackEventStatus}.
  */
 export type SessionCallbackEvent =
   | SessionCallbackNotificationEvent
+  | SessionCallbackProgressEvent
   | SessionCallbackTerminationEvent;
 
 /**
@@ -132,6 +159,7 @@ export type SessionCallbackParseResult =
 const sessionCallbackSchema = z
   .object({
     callId: z.string().min(1),
+    notifyUrl: z.string().min(1).optional(),
     subagentName: z.string().min(1),
     token: z.string().min(1),
     url: z.string().min(1),
@@ -167,6 +195,30 @@ const sessionCallbackSchema = z
         message: "Callback url host must not be a private or reserved address.",
         path: ["url"],
       });
+    }
+
+    // notifyUrl targets a different hook token (the caller's :events
+    // ingestion), so it gets the absolute-URL and SSRF checks but not the
+    // token match.
+    if (callback.notifyUrl !== undefined) {
+      let notifyUrl: URL;
+      try {
+        notifyUrl = new URL(callback.notifyUrl);
+      } catch {
+        ctx.addIssue({
+          code: "custom",
+          message: "Callback notifyUrl must be absolute.",
+          path: ["notifyUrl"],
+        });
+        return;
+      }
+      if (isReservedIpAddress(notifyUrl.hostname)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Callback notifyUrl host must not be a private or reserved address.",
+          path: ["notifyUrl"],
+        });
+      }
     }
   });
 

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -213,6 +213,13 @@ export type HookPayload =
  */
 export interface SessionCallback {
   readonly callId: string;
+  /**
+   * Best-effort progress lane (issue #1170): the caller's `<sessionId>:events`
+   * ingestion URL. A callee POSTs its non-terminal progress events here; the
+   * caller appends them to its stream without waking its main run. Absent when
+   * the caller predates the progress lane.
+   */
+  readonly notifyUrl?: string;
   readonly subagentName: string;
   readonly token: string;
   readonly url: string;

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -57,6 +57,7 @@ describe("startRemoteAgentSession", () => {
     expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
       callback: {
         callId: "call-remote",
+        notifyUrl: "https://caller.example.com/eve/v1/callback/parent-session%3Aevents",
         subagentName: "research",
         token: "eve:parent-token",
         url: "https://caller.example.com/eve/v1/callback/eve%3Aparent-token",
@@ -198,6 +199,7 @@ describe("startRemoteAgentSession", () => {
 
     expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string).callback).toEqual({
       callId: "call-remote",
+      notifyUrl: "https://caller.example.com/eve/v1/callback/parent-session%3Aevents",
       subagentName: "research",
       token: "turn-inbox",
       url: "https://caller.example.com/eve/v1/callback/turn-inbox",

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -40,6 +40,13 @@ export async function startRemoteAgentSession(input: {
     body: JSON.stringify({
       callback: {
         callId: input.action.callId,
+        // Best-effort progress lane (issue #1170): the callee POSTs its
+        // non-terminal progress here, appended to the caller's stream
+        // without waking the caller's main run.
+        notifyUrl: createWorkflowCallbackUrl(
+          input.callbackBaseUrl,
+          createEveCallbackRoutePath(`${input.session.sessionId}:events`),
+        ),
         subagentName: input.action.remoteAgentName,
         token: callbackToken,
         url: createWorkflowCallbackUrl(

--- a/packages/eve/src/execution/session-callback-progress.ts
+++ b/packages/eve/src/execution/session-callback-progress.ts
@@ -1,0 +1,61 @@
+import { isProgressEventType, parseCallbackMetadata } from "#channel/session-callback.js";
+import type { ContextReader } from "#context/key.js";
+import { SessionCallbackKey, SessionIdKey } from "#context/keys.js";
+import { postSessionCallback } from "#execution/session-callback-post.js";
+import { createLogger } from "#internal/logging.js";
+import type { HandleMessageStreamEvent } from "#protocol/message.js";
+
+const log = createLogger("execution.session-callback-progress");
+
+/**
+ * Forwards one non-terminal progress event to the caller's `:events`
+ * ingestion URL as a `status: "working"` callback event (issue #1170).
+ *
+ * The best-effort progress lane: unlike authorization (a low-frequency
+ * control event that rides the durable `resumeHook` path), progress is
+ * high-frequency rendering-only telemetry, so it must never wake or
+ * inflate the caller's main run. It is POSTed to `callback.notifyUrl`,
+ * where the caller appends it to its stream wrapped as `subagent.event`.
+ *
+ * No-op for sessions without callback metadata, callers that advertised no
+ * `notifyUrl`, and every non-progress event type. Delivery is best-effort:
+ * a failed POST is logged and swallowed.
+ */
+export async function forwardSessionCallbackProgress(input: {
+  readonly ctx: ContextReader;
+  readonly event: HandleMessageStreamEvent;
+}): Promise<void> {
+  const { event } = input;
+  if (!isProgressEventType(event.type)) {
+    return;
+  }
+
+  const value = input.ctx.get(SessionCallbackKey);
+  if (value === undefined) {
+    return;
+  }
+
+  const parsed = parseCallbackMetadata(value);
+  if (!parsed.ok || parsed.callback.notifyUrl === undefined) {
+    return;
+  }
+
+  const sessionId = input.ctx.get(SessionIdKey) ?? "";
+  try {
+    await postSessionCallback({
+      payload: {
+        callId: parsed.callback.callId,
+        event: { ...event, status: "working" },
+        sessionId,
+        subagentName: parsed.callback.subagentName,
+      },
+      url: parsed.callback.notifyUrl,
+    });
+  } catch (error) {
+    log.warn("failed to post session callback progress", {
+      error,
+      eventType: event.type,
+      sessionId,
+    });
+  }
+}

--- a/packages/eve/src/execution/session-stream-append.ts
+++ b/packages/eve/src/execution/session-stream-append.ts
@@ -1,0 +1,35 @@
+import { getWorld } from "#internal/workflow/runtime.js";
+import {
+  encodeMessageStreamEvent,
+  type HandleMessageStreamEvent,
+  timestampHandleMessageStreamEvent,
+} from "#protocol/message.js";
+
+/**
+ * PROTOTYPE (issue #1170): the engine's default run-stream name, derived
+ * from the run id. Naming contract of the vendored `@workflow/core`
+ * (`strm_<id>_user` for the default namespace); if the engine ever exposes
+ * a public name resolver or accepts name-less default writes, use that
+ * instead.
+ */
+export function sessionStreamName(sessionId: string): string {
+  return `${sessionId.replace("wrun_", "strm_")}_user`;
+}
+
+/**
+ * PROTOTYPE (issue #1170): appends one event to a session's durable stream
+ * from plain runtime code — the producer side of the event-consumer lane.
+ * Throws on a closed or missing stream; callers decide whether that is
+ * best-effort (notifications: log and drop) or an error.
+ */
+export async function appendSessionStreamEvent(
+  sessionId: string,
+  event: HandleMessageStreamEvent,
+): Promise<void> {
+  const world = await getWorld();
+  await world.streams.write(
+    sessionId,
+    sessionStreamName(sessionId),
+    encodeMessageStreamEvent(timestampHandleMessageStreamEvent(event)),
+  );
+}

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -26,6 +26,7 @@ import {
 } from "#harness/turn-cancellation.js";
 import { setChannelContext } from "#execution/channel-context.js";
 import { forwardSessionCallbackNotification } from "#execution/session-callback-notification.js";
+import { forwardSessionCallbackProgress } from "#execution/session-callback-progress.js";
 import { hasPendingInputBatch } from "#harness/input-requests.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
 import {
@@ -296,6 +297,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
     await writer.write(encodeMessageStreamEvent(timestampHandleMessageStreamEvent(toEmit)));
     await forwardSessionCallbackNotification({ ctx, event: toEmit });
+    await forwardSessionCallbackProgress({ ctx, event: toEmit });
     return toEmit;
   };
 

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -281,6 +281,8 @@ export interface SubagentStartedStreamEvent {
 export interface SubagentChildEventStreamEvent {
   data: {
     callId: string;
+    /** Durable session id of the child that produced `event`. */
+    childSessionId?: string;
     event: HandleMessageStreamEvent;
     subagentName: string;
   };

--- a/packages/eve/src/runtime/session-callback-route.test.ts
+++ b/packages/eve/src/runtime/session-callback-route.test.ts
@@ -10,14 +10,92 @@ import {
 } from "#runtime/session-callback-route.js";
 
 const resumeHookMock = vi.fn();
+const appendSessionStreamEventMock = vi.fn();
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   resumeHook: (token: string, payload: unknown) => resumeHookMock(token, payload),
 }));
 
+vi.mock("#execution/session-stream-append.js", () => ({
+  appendSessionStreamEvent: (sessionId: string, event: unknown) =>
+    appendSessionStreamEventMock(sessionId, event),
+}));
+
 describe("session callback route", () => {
   beforeEach(() => {
     resumeHookMock.mockReset();
+    appendSessionStreamEventMock.mockReset();
+  });
+
+  it("appends a progress event to the caller stream as subagent.event, best-effort", async () => {
+    appendSessionStreamEventMock.mockResolvedValue(undefined);
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/wrun_parent%3Aevents", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: {
+            data: { message: "half a thought", sequence: 2, stepIndex: 0, turnId: "turn-0" },
+            status: "working",
+            type: "message.completed",
+          },
+          sessionId: "wrun_child",
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "wrun_parent:events" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+    expect(appendSessionStreamEventMock).toHaveBeenCalledWith("wrun_parent", {
+      data: {
+        callId: "call-1",
+        childSessionId: "wrun_child",
+        event: {
+          data: { message: "half a thought", sequence: 2, stepIndex: 0, turnId: "turn-0" },
+          type: "message.completed",
+        },
+        subagentName: "research",
+      },
+      type: "subagent.event",
+    });
+  });
+
+  it("still returns 202 when the progress stream append fails (session over)", async () => {
+    appendSessionStreamEventMock.mockRejectedValue(new Error("stream closed"));
+
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/wrun_parent%3Aevents", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: { data: {}, status: "working", type: "step.started" },
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "wrun_parent:events" }),
+    );
+
+    expect(response.status).toBe(202);
+  });
+
+  it("rejects a non-progress event type on the progress lane", async () => {
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/wrun_parent%3Aevents", {
+        body: JSON.stringify({
+          callId: "call-1",
+          event: { data: {}, status: "working", type: "session.completed" },
+          subagentName: "research",
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "wrun_parent:events" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(appendSessionStreamEventMock).not.toHaveBeenCalled();
   });
 
   it("registers the POST framework callback route", () => {

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -1,17 +1,29 @@
+import { z } from "#compiled/zod/index.js";
+
+import { createLogger, logError } from "#internal/logging.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 import { EVE_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
-import { sessionCallbackNotificationEventSchema } from "#channel/session-callback.js";
+import {
+  PROGRESS_EVENT_TYPES,
+  sessionCallbackNotificationEventSchema,
+} from "#channel/session-callback.js";
+import { appendSessionStreamEvent } from "#execution/session-stream-append.js";
 import type {
   SessionCallbackPayload,
   SessionCallbackTerminationEvent,
 } from "#channel/session-callback.js";
 import type { HookPayload, SubagentAuthorizationEvent } from "#channel/types.js";
+import type { HandleMessageStreamEvent, SubagentChildEventStreamEvent } from "#protocol/message.js";
 import type { ChannelMethod, RouteContext } from "#public/definitions/channel.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
 import { tokenUsageSchema, type TokenUsage } from "#shared/token-usage.js";
 
 export const HTTP_SESSION_CALLBACK_CHANNEL_NAME_PREFIX = "eve/v1/callback";
+
+const log = createLogger("runtime.session-callback-route");
+
+const PROGRESS_TOKEN_SUFFIX = ":events";
 
 const HANDLED_METHODS: readonly ChannelMethod[] = ["POST"];
 
@@ -56,6 +68,25 @@ export async function handleSessionCallbackRequest(
     return Response.json({ error: "Invalid JSON body.", ok: false }, { status: 400 });
   }
 
+  // Best-effort progress lane (issue #1170): a callee's non-terminal
+  // progress, appended to this session's stream wrapped as `subagent.event`
+  // — no run, no hook, no resume, so it never inflates the main run's
+  // replay journal. Always 202 once well-formed; a closed stream (session
+  // over) logs and drops. Nothing retries.
+  if (token.endsWith(PROGRESS_TOKEN_SUFFIX)) {
+    const wrapped = projectWrappedProgressEvent(body);
+    if (wrapped instanceof Response) {
+      return wrapped;
+    }
+    const sessionId = token.slice(0, -PROGRESS_TOKEN_SUFFIX.length);
+    try {
+      await appendSessionStreamEvent(sessionId, wrapped);
+    } catch (error) {
+      logError(log, "progress append failed; event dropped", error, { sessionId });
+    }
+    return Response.json({ ok: true }, { status: 202 });
+  }
+
   const hookPayload = projectSessionCallbackHookPayload(body);
   if (hookPayload instanceof Response) {
     return hookPayload;
@@ -68,6 +99,43 @@ export async function handleSessionCallbackRequest(
   }
 
   return Response.json({ ok: true }, { status: 202 });
+}
+
+const progressCallbackPayloadSchema = z.object({
+  callId: z.string().min(1),
+  event: z.object({
+    // Progress is rendering-only, so the child event's data rides loosely —
+    // it is not re-validated per type, only allow-listed by `type`.
+    data: z.looseObject({}).optional(),
+    type: z.enum(PROGRESS_EVENT_TYPES),
+  }),
+  sessionId: z.string().optional(),
+  subagentName: z.string().min(1),
+});
+
+/**
+ * Projects one progress POST into the wrapped `subagent.event` appended to
+ * the caller's durable stream — the form followers read.
+ */
+function projectWrappedProgressEvent(value: unknown): SubagentChildEventStreamEvent | Response {
+  const parsed = progressCallbackPayloadSchema.safeParse(value);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "Invalid progress callback payload.", ok: false },
+      { status: 400 },
+    );
+  }
+
+  const { callId, event, sessionId, subagentName } = parsed.data;
+  return {
+    data: {
+      callId,
+      childSessionId: sessionId ?? "",
+      event: { data: event.data ?? {}, type: event.type } as HandleMessageStreamEvent,
+      subagentName,
+    },
+    type: "subagent.event",
+  };
 }
 
 function projectSessionCallbackHookPayload(value: unknown): HookPayload | Response {


### PR DESCRIPTION
Implements the **progress lane** for #1170 — the one lane that genuinely needs to stay off the main run's replay journal. Stacked on #1207 (remote authorization, durable path).

## What

A remote callee's non-terminal progress — `message.*`, `reasoning.*`, `step.*` — now surfaces on the caller's stream wrapped as `subagent.event`:

- **Callee** forwards each progress event to the caller's `:events` ingestion URL (`notifyUrl`, baked into the dispatch callback metadata) — `session-callback-progress.ts`, best-effort, swallows POST failures.
- **Caller route** (`:events` branch) validates the progress event, wraps it as `subagent.event` (with `childSessionId`), and appends it to the caller's durable stream via `world.streams.write` — **no run, no hook, no resume**. Followers (TUI, clients) read it off the stream.

## Why this lane exists (the plain reason)

High-frequency progress must **never** ride `resumeHook`, because every resume replays the main run's journal — and inflating that with progress deltas is exactly what the two-lane split prevents (#1205). So progress takes the best-effort append path, off the main run entirely. Contrast **authorization** (#1207): low-frequency control, so it *does* ride the durable `resumeHook` path like a local subagent. Same wire envelope, opposite lanes, by frequency.

This is #1204's route-direct mechanism — restored for its correct purpose. #1204 aimed it at authorization (wrong: authorization is control); here it carries progress (right).

## Scope / deferred

- **Delivery is fire-once**, drop-ok: a closed stream (finished session) logs and drops. Correct for rendering-only telemetry.
- Progress **data rides loosely** (allow-listed by `type`, not re-validated per shape) — it drives no state.
- **`childSessionId`** added to `SubagentChildEventStreamEvent`; this trips the rule-36 capability-epoch ceremony (deferred, known-red on the stack).
- **e2e evals** for progress + authorization are the next step (the fixture exercises both lanes); unit coverage — route append/reject + dispatch metadata, 45 tests across the touched files — is green.
- Local-subagent progress relay (child → parent stream directly) is a natural follow-up on the same mechanism; this PR does the remote lane.

Full unit suite green (5370); lint clean; `guard:invariants` red only on the deferred epoch ceremony.