### PR TITLE
fix(eve): prefer known Telegram attachment media type over HTTP content-type

### DIFF
--- a/.changeset/telegram-attachment-media-type.md
+++ b/.changeset/telegram-attachment-media-type.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Telegram channel: prefer the known attachment media type over the HTTP `content-type` header when fetching files. Telegram's file endpoint frequently returns `application/octet-stream` (or no content-type) for photos, which broke image recognition in vision models that key off the declared media type.

--- a/packages/eve/src/public/channels/telegram/attachments.test.ts
+++ b/packages/eve/src/public/channels/telegram/attachments.test.ts
@@ -110,4 +110,39 @@ describe("createTelegramFetchFile", () => {
     await expect(result).rejects.not.toThrow("PRIVATE_FILE_ID");
     await expect(result).rejects.not.toThrow("123456:PRIVATE");
   });
+
+  it("prefers the known attachment media type over the HTTP content-type header", async () => {
+    // Telegram's file endpoint frequently returns `application/octet-stream`
+    // (or no content-type) for photos. The channel already knows the photo is
+    // `image/jpeg` from the inbound message; that known type must win so vision
+    // models receive a recognized image media type.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, result: { file_path: "photos/file.jpg" } }), {
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("JFIF", { headers: { "content-type": "application/octet-stream" } }),
+      );
+
+    const fetchFile = createTelegramFetchFile({
+      api: { apiBaseUrl: "https://telegram.example", fetch: fetchMock },
+      credentials: { botToken: "123456:ABCDEF" },
+      policy: { allowedMediaTypes: ["image/*"], maxBytes: 1024 },
+    });
+
+    const result = await fetchFile(
+      String(
+        createTelegramFileUrl({
+          fileId: "photo-id",
+          filename: "photo.jpg",
+          mediaType: "image/jpeg",
+        }),
+      ),
+    );
+
+    expect(result?.mediaType).toBe("image/jpeg");
+  });
 });

--- a/packages/eve/src/public/channels/telegram/attachments.ts
+++ b/packages/eve/src/public/channels/telegram/attachments.ts
@@ -95,8 +95,13 @@ export function createTelegramFetchFile(input: {
     }
 
     const bytes = Buffer.from(await response.arrayBuffer());
+    // Prefer the media type the channel already knows (from the attachment
+    // metadata, e.g. `image/jpeg` for photos) over the HTTP `content-type`
+    // header returned by Telegram's file endpoint, which is frequently
+    // `application/octet-stream` or unset. Using the latter breaks image
+    // recognition in vision models that key off the declared media type.
     const mediaType =
-      response.headers.get("content-type") ?? ref.mediaType ?? "application/octet-stream";
+      ref.mediaType ?? response.headers.get("content-type") ?? "application/octet-stream";
     const result: FetchFileResult = {
       bytes,
       filename: ref.filename,


### PR DESCRIPTION
Closes #1217.

### Description

When a photo is sent to a Telegram-channelled eve agent, `createTelegramFetchFile` resolves the file's media type by prioritizing the HTTP `content-type` header from Telegram's file-download endpoint over the media type the channel already knows from the inbound message. Telegram's file endpoint frequently responds with `application/octet-stream` (or no content-type) for photos, so vision models receive `mediaType: "application/octet-stream"` and cannot recognize the image. With an `uploadPolicy: { allowedMediaTypes: ["image/*"] }`, the photo is rejected before it ever reaches the model:

```
Telegram file rejected — photo.jpg has media type "application/octet-stream"
which is not allowed by this route. Allowed: image/*.
```

The fix inverts the priority so `ref.mediaType` (the known attachment type, e.g. `image/jpeg` for photos) wins, falling back to the HTTP `content-type` and then `application/octet-stream`.

### How did you test your changes?

Ran the Telegram attachments unit tests against the `eve` package:

```bash
cd packages/eve
pnpm run build:compiled
pnpm exec vitest run --config vitest.unit.config.ts \
  src/public/channels/telegram/attachments.test.ts
```

- **With the fix:** all 4 tests pass.
- **Without the fix (reverted to `main`):** the new regression test fails with the exact production error string:

  ```
  FAIL  ... > prefers the known attachment media type over the HTTP content-type header
  Error: Telegram file rejected — photo.jpg has media type "application/octet-stream"
  which is not allowed by this route. Allowed: image/*.
  ```

  This confirms the test guards the regression: it fails on the old behavior and passes on the fixed one.

The regression test mocks Telegram's `getFile` (returning a `file_path`) and the file download (returning a body with `Content-Type: application/octet-stream`), then asserts the resolved `mediaType` is `image/jpeg` — the type the channel already knew from the inbound photo.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted. #1217 is linked, but maintainer confirmation is still pending.
- [x] I ran the relevant checks from `CONTRIBUTING.md`. Formatting, lint, typecheck, invariants, the focused test, and integration tests pass. The full unit suite has two unrelated macOS telemetry path failures in `preference.test.ts`.
- [x] I added tests — regression test in `attachments.test.ts`
- [x] I added a changeset — `.changeset/telegram-attachment-media-type.md` (`eve`: patch)
- [x] DCO sign-off passes for every commit (`git commit --signoff`) — commit is signed and GitHub-verified (SSH signing key)
