### PR TITLE
feat(eve): bounded catch-up reads at the durable stream tail

### DIFF
--- a/.changeset/stream-tail-index.md
+++ b/.changeset/stream-tail-index.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-The client's `session.stream()` accepts `endAtTail: true` for bounded catch-up reads: it consumes events from the cursor to the durable tail observed when the stream opens — surviving reconnects and still advancing the stored `streamIndex` — then returns instead of following the live stream. The HTTP stream route reports the durable tail as the `x-eve-stream-tail-index` response header when a request opts in with `includeTailIndex=1`, and channel-authoring `Session` objects gain `getStreamTailIndex()` for serving bounded reads from custom routes.
+The client's `session.stream()` accepts `follow: false` for bounded catch-up reads (`follow` defaults to `true`, following the live stream): it consumes events from the cursor to the durable tail observed when the stream opens — surviving reconnects and still advancing the stored `streamIndex` — then returns instead of following the live stream. The HTTP stream route reports the durable tail as the `x-eve-stream-tail-index` response header when a request opts in with `includeTailIndex=1`, and channel-authoring `Session` objects gain `getStreamTailIndex()` for serving bounded reads from custom routes.

--- a/.changeset/stream-tail-index.md
+++ b/.changeset/stream-tail-index.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The client's `session.stream()` accepts `endAtTail: true` for bounded catch-up reads: it consumes events from the cursor to the durable tail observed when the stream opens — surviving reconnects and still advancing the stored `streamIndex` — then returns instead of following the live stream. The HTTP stream route reports the durable tail as the `x-eve-stream-tail-index` response header when a request opts in with `includeTailIndex=1`, and channel-authoring `Session` objects gain `getStreamTailIndex()` for serving bounded reads from custom routes.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -49,7 +49,7 @@ Declare routes with the `POST()` and `GET()` helpers. Each route handler receive
 - `send(message, { auth, continuationToken, state?, title? })` starts or resumes a session. `title` overrides the new workflow session's display title without changing the model message. Returns a `Session`.
 - `cancel({ continuationToken, turnId? })` requests cancellation of the active turn on the session that owns the token. See [Cancel a turn](#cancel-a-turn).
 - `reset({ continuationToken, reason? })` retires the session that owns the token so the next `send()` starts a fresh session. See [Reset a session](#reset-a-session).
-- `getSession(sessionId)` looks up an existing session. The returned `Session` exposes `getEventStream({ startIndex? })` for streaming and `cancel({ turnId? })` for session-id-addressed cancellation.
+- `getSession(sessionId)` looks up an existing session. The returned `Session` exposes `getEventStream({ startIndex? })` for streaming, `getStreamTailIndex()` for resolving the durable tail when a route wants to serve bounded reads, and `cancel({ turnId? })` for session-id-addressed cancellation.
 - `receive(channel, ...)` hands inbound work to a different channel for cross-channel hand-off.
 - `params` holds route parameters extracted from the path pattern.
 - `waitUntil(promise)` extends the request lifetime for background work.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -131,7 +131,7 @@ curl -i "http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream?startIndex=<cou
 # x-eve-stream-tail-index: <tail>
 ```
 
-The lookup is opt-in; requests without the parameter get no header. The TypeScript client wraps this into `stream({ endAtTail: true })`.
+The lookup is opt-in; requests without the parameter get no header. The TypeScript client wraps this into `stream({ follow: false })`.
 
 ## Use the client from TypeScript
 

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -127,11 +127,11 @@ This gives a consumer that only persisted `sessionId` a lightweight way to recov
 For a catch-up read that stops instead of following the live stream, pass `includeTailIndex=1`. The response then carries the `x-eve-stream-tail-index` header: the zero-based index of the last durably recorded event, or `-1` before the first. Read from your cursor until it passes that tail, then disconnect — reconnecting from the updated cursor if the connection drops first:
 
 ```bash
-curl -i "http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream?startIndex=<count>&includeTailIndex=1"
+curl -i "http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream?startIndex=<count>&includeTailIndex=1"
 # x-eve-stream-tail-index: <tail>
 ```
 
-The lookup is opt-in because resolving the tail costs an extra stream-info read; requests without the parameter get no header. The TypeScript client wraps this into `stream({ endAtTail: true })`.
+The lookup is opt-in; requests without the parameter get no header. The TypeScript client wraps this into `stream({ endAtTail: true })`.
 
 ## Use the client from TypeScript
 

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -124,6 +124,15 @@ curl "http://127.0.0.1:2000/eve/v1/session/<sessionId>/stream?startIndex=-1"
 
 This gives a consumer that only persisted `sessionId` a lightweight way to recover the current `continuationToken`. Because a tail-relative position does not resolve to an absolute consumed-event count, client tail reads do not automatically reconnect or advance the stored cursor.
 
+For a catch-up read that stops instead of following the live stream, pass `includeTailIndex=1`. The response then carries the `x-eve-stream-tail-index` header: the zero-based index of the last durably recorded event, or `-1` before the first. Read from your cursor until it passes that tail, then disconnect — reconnecting from the updated cursor if the connection drops first:
+
+```bash
+curl -i "http://127.0.0.1:3000/eve/v1/session/<sessionId>/stream?startIndex=<count>&includeTailIndex=1"
+# x-eve-stream-tail-index: <tail>
+```
+
+The lookup is opt-in because resolving the tail costs an extra stream-info read; requests without the parameter get no header. The TypeScript client wraps this into `stream({ endAtTail: true })`.
+
 ## Use the client from TypeScript
 
 For scripts, server-to-server calls, tests, evals, and custom UIs, `eve/client` wraps these routes in a typed client so you don't hand-roll the POST and NDJSON stream loop.

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -159,10 +159,10 @@ Tail-relative attachments do not automatically reconnect or advance the session'
 
 ## Bounded catch-up reads
 
-Pass `endAtTail: true` to read from the cursor to the durable tail and then stop, instead of following the live stream:
+Pass `follow: false` to read from the cursor to the durable tail and then stop, instead of following the live stream (the default):
 
 ```ts
-for await (const event of session.stream({ endAtTail: true })) {
+for await (const event of session.stream({ follow: false })) {
   console.log(event.type);
 }
 // Returns once every event recorded before the stream opened is consumed.
@@ -170,7 +170,7 @@ for await (const event of session.stream({ endAtTail: true })) {
 
 The first connection pins the bound to the tail the server reports at open time; events recorded afterward are not part of the read. Reconnects during the read keep that original bound, and the session's stored `streamIndex` still advances past the consumed events, so a follow-up `stream()` or `send()` picks up exactly where the bounded read ended. When the cursor is already at or past the tail, the iterator returns immediately without yielding.
 
-Because a tail-relative cursor cannot be bounded, `endAtTail` throws when combined with a negative `startIndex`. It also fails if the server does not report the durable tail (an agent running an older eve version).
+Because a tail-relative cursor cannot be bounded, `follow: false` throws when combined with a negative `startIndex`. It also fails if the server does not report the durable tail (an agent running an older eve version).
 
 `stream()` throws if the session has no `sessionId`, because there's no stream to attach to before the first send.
 

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -157,6 +157,21 @@ for await (const event of session.stream({ startIndex: -1 })) {
 
 Tail-relative attachments do not automatically reconnect or advance the session's stored absolute `streamIndex`. Break after the event you need when using one as a tail lookup.
 
+## Bounded catch-up reads
+
+Pass `endAtTail: true` to read from the cursor to the durable tail and then stop, instead of following the live stream:
+
+```ts
+for await (const event of session.stream({ endAtTail: true })) {
+  console.log(event.type);
+}
+// Returns once every event recorded before the stream opened is consumed.
+```
+
+The first connection pins the bound to the tail the server reports at open time; events recorded afterward are not part of the read. Reconnects during the read keep that original bound, and the session's stored `streamIndex` still advances past the consumed events, so a follow-up `stream()` or `send()` picks up exactly where the bounded read ended. When the cursor is already at or past the tail, the iterator returns immediately without yielding.
+
+Because a tail-relative cursor cannot be bounded, `endAtTail` throws when combined with a negative `startIndex`. It also fails if the server does not report the durable tail (an agent running an older eve version).
+
 `stream()` throws if the session has no `sessionId`, because there's no stream to attach to before the first send.
 
 ## Abort a request

--- a/packages/eve/src/channel/cancel.test.ts
+++ b/packages/eve/src/channel/cancel.test.ts
@@ -8,6 +8,7 @@ function createRuntime(overrides?: Partial<Runtime>): Runtime {
     cancelTurn: vi.fn().mockResolvedValue({ status: "accepted" }),
     deliver: vi.fn(),
     getEventStream: vi.fn(),
+    getStreamTailIndex: vi.fn(),
     resolveSession: vi.fn().mockResolvedValue({ sessionId: "sess_1" }),
     run: vi.fn(),
     terminateSession: vi.fn(),

--- a/packages/eve/src/channel/cross-channel-receive.test.ts
+++ b/packages/eve/src/channel/cross-channel-receive.test.ts
@@ -13,6 +13,7 @@ function makeRuntime(): Runtime {
     cancelTurn: vi.fn(),
     deliver: vi.fn(),
     getEventStream: vi.fn(),
+    getStreamTailIndex: vi.fn(),
     resolveSession: vi.fn(),
     run: vi.fn(),
     terminateSession: vi.fn(),
@@ -28,6 +29,9 @@ function makeSession(): Session {
     },
     async getEventStream() {
       return new ReadableStream();
+    },
+    async getStreamTailIndex() {
+      return -1;
     },
   };
 }

--- a/packages/eve/src/channel/reset-session.test.ts
+++ b/packages/eve/src/channel/reset-session.test.ts
@@ -8,6 +8,7 @@ function createRuntime(overrides?: Partial<Runtime>): Runtime {
     cancelTurn: vi.fn(),
     deliver: vi.fn(),
     getEventStream: vi.fn(),
+    getStreamTailIndex: vi.fn().mockResolvedValue(-1),
     resolveSession: vi.fn().mockResolvedValue({ sessionId: "sess_1" }),
     run: vi.fn(),
     terminateSession: vi.fn().mockResolvedValue({ status: "terminated" }),

--- a/packages/eve/src/channel/resolve-active-session.test.ts
+++ b/packages/eve/src/channel/resolve-active-session.test.ts
@@ -8,6 +8,7 @@ function runtime(): Runtime {
     cancelTurn: vi.fn(),
     deliver: vi.fn(),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
+    getStreamTailIndex: vi.fn().mockResolvedValue(-1),
     resolveSession: vi.fn(),
     run: vi.fn(),
     terminateSession: vi.fn(),

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -29,8 +29,8 @@ function createMockRuntime(): Runtime {
     resolveSession: vi.fn(),
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
-    terminateSession: vi.fn(),
     getStreamTailIndex: vi.fn().mockResolvedValue(-1),
+    terminateSession: vi.fn(),
   };
 }
 

--- a/packages/eve/src/channel/schedule.test.ts
+++ b/packages/eve/src/channel/schedule.test.ts
@@ -30,6 +30,7 @@ function createMockRuntime(): Runtime {
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
     terminateSession: vi.fn(),
+    getStreamTailIndex: vi.fn().mockResolvedValue(-1),
   };
 }
 

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -22,6 +22,7 @@ function createRuntime(deliverError: unknown): Runtime {
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
     terminateSession: vi.fn(),
+    getStreamTailIndex: vi.fn().mockResolvedValue(-1),
   };
 }
 
@@ -85,6 +86,7 @@ describe("createSendFn", () => {
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
       terminateSession: vi.fn(),
+      getStreamTailIndex: vi.fn().mockResolvedValue(-1),
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test");
@@ -119,6 +121,7 @@ describe("createSendFn", () => {
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
       terminateSession: vi.fn(),
+      getStreamTailIndex: vi.fn().mockResolvedValue(-1),
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test", {
@@ -148,6 +151,7 @@ describe("createSendFn", () => {
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
       terminateSession: vi.fn(),
+      getStreamTailIndex: vi.fn().mockResolvedValue(-1),
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test");

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -21,8 +21,8 @@ function createRuntime(deliverError: unknown): Runtime {
     resolveSession: vi.fn(),
     run: vi.fn().mockResolvedValue(createMockRunHandle()),
     getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
-    terminateSession: vi.fn(),
     getStreamTailIndex: vi.fn().mockResolvedValue(-1),
+    terminateSession: vi.fn(),
   };
 }
 
@@ -85,8 +85,8 @@ describe("createSendFn", () => {
       resolveSession: vi.fn(),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
-      terminateSession: vi.fn(),
       getStreamTailIndex: vi.fn().mockResolvedValue(-1),
+      terminateSession: vi.fn(),
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test");
@@ -120,8 +120,8 @@ describe("createSendFn", () => {
       resolveSession: vi.fn(),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
-      terminateSession: vi.fn(),
       getStreamTailIndex: vi.fn().mockResolvedValue(-1),
+      terminateSession: vi.fn(),
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test", {
@@ -150,8 +150,8 @@ describe("createSendFn", () => {
       resolveSession: vi.fn(),
       run: vi.fn().mockResolvedValue(createMockRunHandle()),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream<HandleMessageStreamEvent>()),
-      terminateSession: vi.fn(),
       getStreamTailIndex: vi.fn().mockResolvedValue(-1),
+      terminateSession: vi.fn(),
     };
 
     const deliverSend = createSendFn(deliverRuntime, ADAPTER, "test");

--- a/packages/eve/src/channel/session.test.ts
+++ b/packages/eve/src/channel/session.test.ts
@@ -10,6 +10,7 @@ function createRuntime(): Runtime {
     cancelTurn: vi.fn().mockResolvedValue({ status: "accepted" }),
     deliver: vi.fn(),
     getEventStream: vi.fn(),
+    getStreamTailIndex: vi.fn(),
     resolveSession: vi.fn(),
     run: vi.fn(),
     terminateSession: vi.fn(),

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -30,6 +30,13 @@ export interface Session {
   getEventStream(options?: {
     startIndex?: number;
   }): Promise<ReadableStream<HandleMessageStreamEvent>>;
+  /**
+   * Resolves the durable tail of the event stream: the zero-based index of
+   * the last event recorded so far, or `-1` before the first event. Use it
+   * to bound a read at the tail you observed instead of following the live
+   * stream. Costs one stream-info lookup per call.
+   */
+  getStreamTailIndex(): Promise<number>;
 }
 
 /**
@@ -55,6 +62,9 @@ export function createSession(id: string, continuationToken: string, runtime: Ru
     },
     async getEventStream(options?: { startIndex?: number }) {
       return runtime.getEventStream(id, options);
+    },
+    async getStreamTailIndex() {
+      return runtime.getStreamTailIndex(id);
     },
   };
 }

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -32,9 +32,7 @@ export interface Session {
   }): Promise<ReadableStream<HandleMessageStreamEvent>>;
   /**
    * Resolves the durable tail of the event stream: the zero-based index of
-   * the last event recorded so far, or `-1` before the first event. Use it
-   * to bound a read at the tail you observed instead of following the live
-   * stream. Costs one stream-info lookup per call.
+   * the last recorded event, or `-1` before the first.
    */
   getStreamTailIndex(): Promise<number>;
 }

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -429,13 +429,9 @@ export interface Runtime {
 
   /**
    * Resolves the durable tail of a session's event stream: the zero-based
-   * index of the last event recorded so far, or `-1` before the first event.
-   *
-   * Callers use it to bound a read — consume events until the cursor passes
-   * the observed tail, then stop instead of following the live stream — and
-   * to resolve a tail-relative position into an absolute cursor. It costs one
-   * stream-info lookup, so the framework HTTP session-stream route only
-   * resolves it when a request opts in with `includeTailIndex`.
+   * index of the last recorded event, or `-1` before the first. Callers use
+   * it to bound a read at the tail they observed instead of following the
+   * live stream.
    */
   getStreamTailIndex(sessionId: string): Promise<number>;
 }

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -426,6 +426,18 @@ export interface Runtime {
     sessionId: string,
     options?: GetEventStreamOptions,
   ): Promise<ReadableStream<HandleMessageStreamEvent>>;
+
+  /**
+   * Resolves the durable tail of a session's event stream: the zero-based
+   * index of the last event recorded so far, or `-1` before the first event.
+   *
+   * Callers use it to bound a read — consume events until the cursor passes
+   * the observed tail, then stop instead of following the live stream — and
+   * to resolve a tail-relative position into an absolute cursor. It costs one
+   * stream-info lookup, so the framework HTTP session-stream route only
+   * resolves it when a request opts in with `includeTailIndex`.
+   */
+  getStreamTailIndex(sessionId: string): Promise<number>;
 }
 
 /**

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -1,86 +1,40 @@
 import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import { EVE_STREAM_TAIL_INDEX_HEADER } from "#protocol/message.js";
 import { createEveMessageStreamRoutePath } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { isStreamDisconnectError, readNdjsonStream } from "#client/ndjson.js";
-import type {
-  ClientRedirectPolicy,
-  ResolvedStreamReconnectPolicy as StreamReconnectPolicyOptions,
-  StreamReconnectPolicy,
-  StreamReconnectRetryPolicy,
-} from "#client/types.js";
+import type { ClientRedirectPolicy } from "#client/types.js";
 import { createClientUrl } from "#client/url.js";
 
-interface RetryPolicy {
-  readonly baseDelayMs: number;
-  readonly maxAttempts: number;
-  readonly maxDelayMs: number;
-}
+const STREAM_OPEN_RETRY_ATTEMPTS = 12;
+const STREAM_OPEN_RETRY_BASE_DELAY_MS = 250;
+const STREAM_OPEN_RETRY_MAX_DELAY_MS = 5_000;
+const STREAM_OPEN_RETRYABLE_STATUS = new Set([404, 409, 425, 500, 502, 503, 504]);
 
-interface ResolvedStreamReconnectPolicy {
-  readonly retryableErrorStatuses: ReadonlySet<number>;
-  readonly streamIdleReconnectPolicy: RetryPolicy;
-  readonly streamOpenReconnectPolicy: RetryPolicy;
-}
-
-const DEFAULT_STREAM_RECONNECT_POLICY: ResolvedStreamReconnectPolicy = {
-  retryableErrorStatuses: new Set([404, 409, 425, 500, 502, 503, 504]),
-  streamIdleReconnectPolicy: { baseDelayMs: 250, maxAttempts: 5, maxDelayMs: 4_000 },
-  streamOpenReconnectPolicy: { baseDelayMs: 250, maxAttempts: 12, maxDelayMs: 5_000 },
-};
-
-const NO_STREAM_RECONNECT_POLICY: ResolvedStreamReconnectPolicy = {
-  ...DEFAULT_STREAM_RECONNECT_POLICY,
-  streamIdleReconnectPolicy: {
-    ...DEFAULT_STREAM_RECONNECT_POLICY.streamIdleReconnectPolicy,
-    maxAttempts: 0,
-  },
-  streamOpenReconnectPolicy: {
-    ...DEFAULT_STREAM_RECONNECT_POLICY.streamOpenReconnectPolicy,
-    maxAttempts: 1,
-  },
-};
-
-function resolveRetryPolicy(
-  policy: StreamReconnectRetryPolicy | undefined,
-  defaults: RetryPolicy,
-): RetryPolicy {
-  return { ...defaults, ...policy };
-}
-
-function resolveStreamReconnectPolicy(
-  policy: StreamReconnectPolicy | undefined,
-): ResolvedStreamReconnectPolicy {
-  if (policy && "reconnect" in policy && policy.reconnect === false) {
-    return NO_STREAM_RECONNECT_POLICY;
-  }
-
-  const configured = policy as StreamReconnectPolicyOptions | undefined;
-  return {
-    retryableErrorStatuses: configured?.retryableErrorStatuses
-      ? new Set(configured.retryableErrorStatuses)
-      : DEFAULT_STREAM_RECONNECT_POLICY.retryableErrorStatuses,
-    streamIdleReconnectPolicy: resolveRetryPolicy(
-      configured?.streamIdleReconnectPolicy,
-      DEFAULT_STREAM_RECONNECT_POLICY.streamIdleReconnectPolicy,
-    ),
-    streamOpenReconnectPolicy: resolveRetryPolicy(
-      configured?.streamOpenReconnectPolicy,
-      DEFAULT_STREAM_RECONNECT_POLICY.streamOpenReconnectPolicy,
-    ),
-  };
-}
+const STREAM_RECONNECT_BASE_DELAY_MS = 250;
+const STREAM_RECONNECT_MAX_DELAY_MS = 4_000;
+const STREAM_MAX_IDLE_RECONNECTS = 5;
 
 /**
  * Internal configuration for following a durable event stream.
  */
 interface FollowStreamInput {
   readonly host: string;
-  readonly streamReconnectPolicy?: StreamReconnectPolicy;
   readonly resolveHeaders: () => Promise<Headers>;
   readonly redirect?: ClientRedirectPolicy;
   readonly sessionId: string;
   readonly signal?: AbortSignal;
   readonly startIndex: number;
+  readonly endAtTail?: boolean;
+}
+
+/**
+ * Configuration for one connection open. `requestTailIndex` asks the server
+ * to report the durable tail index on the response; connections that do not
+ * need the bound skip the lookup it costs server-side.
+ */
+interface OpenStreamInput extends FollowStreamInput {
+  readonly requestTailIndex?: boolean;
 }
 
 /**
@@ -91,21 +45,34 @@ interface FollowStreamInput {
  * idle budget; repeated empty streams eventually stop the follow. Callers own
  * boundary handling. Negative tail-relative cursors use one connection because
  * they cannot be advanced safely.
+ *
+ * With `endAtTail`, the first connection's `x-eve-stream-tail-index` header
+ * fixes the bound: the iterator yields events until the cursor passes that
+ * tail, reconnecting as needed, then returns instead of following.
  */
 export async function* followStreamIterable(
   input: FollowStreamInput,
 ): AsyncGenerator<HandleMessageStreamEvent> {
-  const retryPolicy = resolveStreamReconnectPolicy(input.streamReconnectPolicy);
-  const idleRetryPolicy = retryPolicy.streamIdleReconnectPolicy;
+  if (input.endAtTail === true && input.startIndex < 0) {
+    throw new Error(
+      "endAtTail requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
+    );
+  }
+
   let startIndex = input.startIndex;
-  let reconnectDelayMs = idleRetryPolicy.baseDelayMs;
+  let reconnectDelayMs = STREAM_RECONNECT_BASE_DELAY_MS;
   let idleReconnects = 0;
   let initialConnection = true;
+  let tailIndex: number | undefined;
 
   while (true) {
-    let body: ReadableStream<Uint8Array>;
+    let connection: OpenedStream;
     try {
-      body = await openStreamBody({ ...input, retryPolicy, startIndex });
+      connection = await openStreamBody({
+        ...input,
+        startIndex,
+        requestTailIndex: input.endAtTail === true && tailIndex === undefined,
+      });
     } catch (error) {
       if (input.signal?.aborted) {
         return;
@@ -113,14 +80,34 @@ export async function* followStreamIterable(
       throw error;
     }
 
+    if (input.endAtTail === true && tailIndex === undefined) {
+      tailIndex = connection.tailIndex;
+      if (tailIndex === undefined) {
+        await connection.body.cancel().catch(() => {});
+        throw new Error(
+          `endAtTail requires the server to report the ${EVE_STREAM_TAIL_INDEX_HEADER} header. ` +
+            "The agent may be running an older eve version.",
+        );
+      }
+    }
+
+    if (tailIndex !== undefined && startIndex > tailIndex) {
+      await connection.body.cancel().catch(() => {});
+      return;
+    }
+
     let deliveredEvent = false;
     try {
-      for await (const event of readNdjsonStream(body)) {
+      for await (const event of readNdjsonStream(connection.body)) {
         startIndex += 1;
         deliveredEvent = true;
-        reconnectDelayMs = idleRetryPolicy.baseDelayMs;
+        reconnectDelayMs = STREAM_RECONNECT_BASE_DELAY_MS;
         idleReconnects = 0;
         yield event;
+
+        if (tailIndex !== undefined && startIndex > tailIndex) {
+          return;
+        }
       }
     } catch (error) {
       if (!isStreamDisconnectError(error)) {
@@ -128,14 +115,14 @@ export async function* followStreamIterable(
       }
     }
 
-    if (input.signal?.aborted || input.startIndex < 0 || idleRetryPolicy.maxAttempts === 0) {
+    if (input.signal?.aborted || input.startIndex < 0) {
       return;
     }
 
     if (
       !deliveredEvent &&
       !initialConnection &&
-      (idleReconnects += 1) >= idleRetryPolicy.maxAttempts
+      (idleReconnects += 1) >= STREAM_MAX_IDLE_RECONNECTS
     ) {
       return;
     }
@@ -145,8 +132,18 @@ export async function* followStreamIterable(
     if (input.signal?.aborted) {
       return;
     }
-    reconnectDelayMs = Math.min(reconnectDelayMs * 2, idleRetryPolicy.maxDelayMs);
+    reconnectDelayMs = Math.min(reconnectDelayMs * 2, STREAM_RECONNECT_MAX_DELAY_MS);
   }
+}
+
+/**
+ * One opened stream connection: the response body plus the durable tail
+ * index reported by the `x-eve-stream-tail-index` response header, when
+ * present and well-formed.
+ */
+interface OpenedStream {
+  readonly body: ReadableStream<Uint8Array>;
+  readonly tailIndex: number | undefined;
 }
 
 /**
@@ -155,21 +152,22 @@ export async function* followStreamIterable(
  * propagation window where a just-acknowledged session may not yet be
  * readable from the stream route.
  */
-export async function openStreamBody(
-  input: FollowStreamInput & { readonly retryPolicy?: ResolvedStreamReconnectPolicy },
-): Promise<ReadableStream<Uint8Array>> {
-  const retryPolicy = input.retryPolicy ?? DEFAULT_STREAM_RECONNECT_POLICY;
-  const openRetryPolicy = retryPolicy.streamOpenReconnectPolicy;
+export async function openStreamBody(input: OpenStreamInput): Promise<OpenedStream> {
   let lastStatus: number | undefined;
   let lastBody: string | undefined;
   let lastHeaders: Headers | undefined;
-  let retryDelayMs = openRetryPolicy.baseDelayMs;
+  let retryDelayMs = STREAM_OPEN_RETRY_BASE_DELAY_MS;
 
-  for (let attempt = 0; attempt < openRetryPolicy.maxAttempts; attempt += 1) {
+  const searchParams = {
+    ...(input.startIndex !== 0 ? { startIndex: String(input.startIndex) } : {}),
+    ...(input.requestTailIndex === true ? { includeTailIndex: "1" } : {}),
+  };
+
+  for (let attempt = 0; attempt < STREAM_OPEN_RETRY_ATTEMPTS; attempt += 1) {
     const url = createClientUrl(
       input.host,
       createEveMessageStreamRoutePath(input.sessionId),
-      input.startIndex !== 0 ? { startIndex: String(input.startIndex) } : undefined,
+      Object.keys(searchParams).length > 0 ? searchParams : undefined,
     );
 
     const headers = await input.resolveHeaders();
@@ -184,12 +182,12 @@ export async function openStreamBody(
       if (
         input.signal?.aborted ||
         !isStreamDisconnectError(error) ||
-        attempt === openRetryPolicy.maxAttempts - 1
+        attempt === STREAM_OPEN_RETRY_ATTEMPTS - 1
       ) {
         throw error;
       }
       await sleep(retryDelayMs, input.signal);
-      retryDelayMs = Math.min(retryDelayMs * 2, openRetryPolicy.maxDelayMs);
+      retryDelayMs = Math.min(retryDelayMs * 2, STREAM_OPEN_RETRY_MAX_DELAY_MS);
       continue;
     }
 
@@ -197,24 +195,33 @@ export async function openStreamBody(
       if (!response.body) {
         throw new ClientError(response.status, "Response body is null.", response.headers);
       }
-      return response.body;
+      return { body: response.body, tailIndex: parseTailIndexHeader(response.headers) };
     }
 
     lastStatus = response.status;
     lastBody = await response.text();
     lastHeaders = response.headers;
 
-    if (!retryPolicy.retryableErrorStatuses.has(response.status)) {
+    if (!STREAM_OPEN_RETRYABLE_STATUS.has(response.status)) {
       throw new ClientError(response.status, lastBody, response.headers);
     }
 
-    if (attempt < openRetryPolicy.maxAttempts - 1) {
+    if (attempt < STREAM_OPEN_RETRY_ATTEMPTS - 1) {
       await sleep(retryDelayMs, input.signal);
-      retryDelayMs = Math.min(retryDelayMs * 2, openRetryPolicy.maxDelayMs);
+      retryDelayMs = Math.min(retryDelayMs * 2, STREAM_OPEN_RETRY_MAX_DELAY_MS);
     }
   }
 
   throw new ClientError(lastStatus ?? 0, lastBody ?? "Failed to open message stream.", lastHeaders);
+}
+
+function parseTailIndexHeader(headers: Headers): number | undefined {
+  const raw = headers.get(EVE_STREAM_TAIL_INDEX_HEADER);
+  if (raw === null || !/^-?\d+$/.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 async function sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -3,23 +3,80 @@ import { EVE_STREAM_TAIL_INDEX_HEADER } from "#protocol/message.js";
 import { createEveMessageStreamRoutePath } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { isStreamDisconnectError, readNdjsonStream } from "#client/ndjson.js";
-import type { ClientRedirectPolicy } from "#client/types.js";
+import type {
+  ClientRedirectPolicy,
+  ResolvedStreamReconnectPolicy as StreamReconnectPolicyOptions,
+  StreamReconnectPolicy,
+  StreamReconnectRetryPolicy,
+} from "#client/types.js";
 import { createClientUrl } from "#client/url.js";
 
-const STREAM_OPEN_RETRY_ATTEMPTS = 12;
-const STREAM_OPEN_RETRY_BASE_DELAY_MS = 250;
-const STREAM_OPEN_RETRY_MAX_DELAY_MS = 5_000;
-const STREAM_OPEN_RETRYABLE_STATUS = new Set([404, 409, 425, 500, 502, 503, 504]);
+interface RetryPolicy {
+  readonly baseDelayMs: number;
+  readonly maxAttempts: number;
+  readonly maxDelayMs: number;
+}
 
-const STREAM_RECONNECT_BASE_DELAY_MS = 250;
-const STREAM_RECONNECT_MAX_DELAY_MS = 4_000;
-const STREAM_MAX_IDLE_RECONNECTS = 5;
+interface ResolvedStreamReconnectPolicy {
+  readonly retryableErrorStatuses: ReadonlySet<number>;
+  readonly streamIdleReconnectPolicy: RetryPolicy;
+  readonly streamOpenReconnectPolicy: RetryPolicy;
+}
+
+const DEFAULT_STREAM_RECONNECT_POLICY: ResolvedStreamReconnectPolicy = {
+  retryableErrorStatuses: new Set([404, 409, 425, 500, 502, 503, 504]),
+  streamIdleReconnectPolicy: { baseDelayMs: 250, maxAttempts: 5, maxDelayMs: 4_000 },
+  streamOpenReconnectPolicy: { baseDelayMs: 250, maxAttempts: 12, maxDelayMs: 5_000 },
+};
+
+const NO_STREAM_RECONNECT_POLICY: ResolvedStreamReconnectPolicy = {
+  ...DEFAULT_STREAM_RECONNECT_POLICY,
+  streamIdleReconnectPolicy: {
+    ...DEFAULT_STREAM_RECONNECT_POLICY.streamIdleReconnectPolicy,
+    maxAttempts: 0,
+  },
+  streamOpenReconnectPolicy: {
+    ...DEFAULT_STREAM_RECONNECT_POLICY.streamOpenReconnectPolicy,
+    maxAttempts: 1,
+  },
+};
+
+function resolveRetryPolicy(
+  policy: StreamReconnectRetryPolicy | undefined,
+  defaults: RetryPolicy,
+): RetryPolicy {
+  return { ...defaults, ...policy };
+}
+
+function resolveStreamReconnectPolicy(
+  policy: StreamReconnectPolicy | undefined,
+): ResolvedStreamReconnectPolicy {
+  if (policy && "reconnect" in policy && policy.reconnect === false) {
+    return NO_STREAM_RECONNECT_POLICY;
+  }
+
+  const configured = policy as StreamReconnectPolicyOptions | undefined;
+  return {
+    retryableErrorStatuses: configured?.retryableErrorStatuses
+      ? new Set(configured.retryableErrorStatuses)
+      : DEFAULT_STREAM_RECONNECT_POLICY.retryableErrorStatuses,
+    streamIdleReconnectPolicy: resolveRetryPolicy(
+      configured?.streamIdleReconnectPolicy,
+      DEFAULT_STREAM_RECONNECT_POLICY.streamIdleReconnectPolicy,
+    ),
+    streamOpenReconnectPolicy: resolveRetryPolicy(
+      configured?.streamOpenReconnectPolicy,
+      DEFAULT_STREAM_RECONNECT_POLICY.streamOpenReconnectPolicy,
+    ),
+  };
+}
 
 /**
  * Internal configuration for following a durable event stream.
  */
 interface FollowStreamInput {
   readonly host: string;
+  readonly streamReconnectPolicy?: StreamReconnectPolicy;
   readonly resolveHeaders: () => Promise<Headers>;
   readonly redirect?: ClientRedirectPolicy;
   readonly sessionId: string;
@@ -56,8 +113,10 @@ export async function* followStreamIterable(
     );
   }
 
+  const retryPolicy = resolveStreamReconnectPolicy(input.streamReconnectPolicy);
+  const idleRetryPolicy = retryPolicy.streamIdleReconnectPolicy;
   let startIndex = input.startIndex;
-  let reconnectDelayMs = STREAM_RECONNECT_BASE_DELAY_MS;
+  let reconnectDelayMs = idleRetryPolicy.baseDelayMs;
   let idleReconnects = 0;
   let initialConnection = true;
   let tailIndex: number | undefined;
@@ -67,6 +126,7 @@ export async function* followStreamIterable(
     try {
       connection = await openStreamBody({
         ...input,
+        retryPolicy,
         startIndex,
         requestTailIndex: input.follow === false && tailIndex === undefined,
       });
@@ -98,7 +158,7 @@ export async function* followStreamIterable(
       for await (const event of readNdjsonStream(connection.body)) {
         startIndex += 1;
         deliveredEvent = true;
-        reconnectDelayMs = STREAM_RECONNECT_BASE_DELAY_MS;
+        reconnectDelayMs = idleRetryPolicy.baseDelayMs;
         idleReconnects = 0;
         yield event;
 
@@ -112,14 +172,14 @@ export async function* followStreamIterable(
       }
     }
 
-    if (input.signal?.aborted || input.startIndex < 0) {
+    if (input.signal?.aborted || input.startIndex < 0 || idleRetryPolicy.maxAttempts === 0) {
       return;
     }
 
     if (
       !deliveredEvent &&
       !initialConnection &&
-      (idleReconnects += 1) >= STREAM_MAX_IDLE_RECONNECTS
+      (idleReconnects += 1) >= idleRetryPolicy.maxAttempts
     ) {
       return;
     }
@@ -129,7 +189,7 @@ export async function* followStreamIterable(
     if (input.signal?.aborted) {
       return;
     }
-    reconnectDelayMs = Math.min(reconnectDelayMs * 2, STREAM_RECONNECT_MAX_DELAY_MS);
+    reconnectDelayMs = Math.min(reconnectDelayMs * 2, idleRetryPolicy.maxDelayMs);
   }
 }
 
@@ -145,11 +205,15 @@ interface OpenedStream {
  * propagation window where a just-acknowledged session may not yet be
  * readable from the stream route.
  */
-export async function openStreamBody(input: OpenStreamInput): Promise<OpenedStream> {
+export async function openStreamBody(
+  input: OpenStreamInput & { readonly retryPolicy?: ResolvedStreamReconnectPolicy },
+): Promise<OpenedStream> {
+  const retryPolicy = input.retryPolicy ?? DEFAULT_STREAM_RECONNECT_POLICY;
+  const openRetryPolicy = retryPolicy.streamOpenReconnectPolicy;
   let lastStatus: number | undefined;
   let lastBody: string | undefined;
   let lastHeaders: Headers | undefined;
-  let retryDelayMs = STREAM_OPEN_RETRY_BASE_DELAY_MS;
+  let retryDelayMs = openRetryPolicy.baseDelayMs;
 
   const searchParams: Record<string, string> = {};
   if (input.startIndex !== 0) {
@@ -159,7 +223,7 @@ export async function openStreamBody(input: OpenStreamInput): Promise<OpenedStre
     searchParams.includeTailIndex = "1";
   }
 
-  for (let attempt = 0; attempt < STREAM_OPEN_RETRY_ATTEMPTS; attempt += 1) {
+  for (let attempt = 0; attempt < openRetryPolicy.maxAttempts; attempt += 1) {
     const url = createClientUrl(
       input.host,
       createEveMessageStreamRoutePath(input.sessionId),
@@ -178,12 +242,12 @@ export async function openStreamBody(input: OpenStreamInput): Promise<OpenedStre
       if (
         input.signal?.aborted ||
         !isStreamDisconnectError(error) ||
-        attempt === STREAM_OPEN_RETRY_ATTEMPTS - 1
+        attempt === openRetryPolicy.maxAttempts - 1
       ) {
         throw error;
       }
       await sleep(retryDelayMs, input.signal);
-      retryDelayMs = Math.min(retryDelayMs * 2, STREAM_OPEN_RETRY_MAX_DELAY_MS);
+      retryDelayMs = Math.min(retryDelayMs * 2, openRetryPolicy.maxDelayMs);
       continue;
     }
 
@@ -198,13 +262,13 @@ export async function openStreamBody(input: OpenStreamInput): Promise<OpenedStre
     lastBody = await response.text();
     lastHeaders = response.headers;
 
-    if (!STREAM_OPEN_RETRYABLE_STATUS.has(response.status)) {
+    if (!retryPolicy.retryableErrorStatuses.has(response.status)) {
       throw new ClientError(response.status, lastBody, response.headers);
     }
 
-    if (attempt < STREAM_OPEN_RETRY_ATTEMPTS - 1) {
+    if (attempt < openRetryPolicy.maxAttempts - 1) {
       await sleep(retryDelayMs, input.signal);
-      retryDelayMs = Math.min(retryDelayMs * 2, STREAM_OPEN_RETRY_MAX_DELAY_MS);
+      retryDelayMs = Math.min(retryDelayMs * 2, openRetryPolicy.maxDelayMs);
     }
   }
 

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -25,7 +25,8 @@ interface FollowStreamInput {
   readonly sessionId: string;
   readonly signal?: AbortSignal;
   readonly startIndex: number;
-  readonly endAtTail?: boolean;
+  /** Follow the live stream after the durable tail (default). `false` bounds the read at the tail. */
+  readonly follow?: boolean;
 }
 
 /** One connection open; `requestTailIndex` asks the server to report the durable tail index. */
@@ -42,16 +43,16 @@ interface OpenStreamInput extends FollowStreamInput {
  * boundary handling. Negative tail-relative cursors use one connection because
  * they cannot be advanced safely.
  *
- * With `endAtTail`, the first connection fixes the bound: the iterator
+ * With `follow: false`, the first connection fixes the bound: the iterator
  * yields events until the cursor passes that tail, reconnecting as needed,
  * then returns instead of following.
  */
 export async function* followStreamIterable(
   input: FollowStreamInput,
 ): AsyncGenerator<HandleMessageStreamEvent> {
-  if (input.endAtTail === true && input.startIndex < 0) {
+  if (input.follow === false && input.startIndex < 0) {
     throw new Error(
-      "endAtTail requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
+      "stream({ follow: false }) requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
     );
   }
 
@@ -67,7 +68,7 @@ export async function* followStreamIterable(
       connection = await openStreamBody({
         ...input,
         startIndex,
-        requestTailIndex: input.endAtTail === true && tailIndex === undefined,
+        requestTailIndex: input.follow === false && tailIndex === undefined,
       });
     } catch (error) {
       if (input.signal?.aborted) {
@@ -76,12 +77,12 @@ export async function* followStreamIterable(
       throw error;
     }
 
-    if (input.endAtTail === true && tailIndex === undefined) {
+    if (input.follow === false && tailIndex === undefined) {
       tailIndex = connection.tailIndex;
       if (tailIndex === undefined) {
         await connection.body.cancel().catch(() => {});
         throw new Error(
-          `endAtTail requires the server to report the ${EVE_STREAM_TAIL_INDEX_HEADER} header. ` +
+          `stream({ follow: false }) requires the server to report the ${EVE_STREAM_TAIL_INDEX_HEADER} header. ` +
             "The agent may be running an older eve version.",
         );
       }

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -28,11 +28,7 @@ interface FollowStreamInput {
   readonly endAtTail?: boolean;
 }
 
-/**
- * Configuration for one connection open. `requestTailIndex` asks the server
- * to report the durable tail index on the response; connections that do not
- * need the bound skip the lookup it costs server-side.
- */
+/** One connection open; `requestTailIndex` asks the server to report the durable tail index. */
 interface OpenStreamInput extends FollowStreamInput {
   readonly requestTailIndex?: boolean;
 }
@@ -46,9 +42,9 @@ interface OpenStreamInput extends FollowStreamInput {
  * boundary handling. Negative tail-relative cursors use one connection because
  * they cannot be advanced safely.
  *
- * With `endAtTail`, the first connection's `x-eve-stream-tail-index` header
- * fixes the bound: the iterator yields events until the cursor passes that
- * tail, reconnecting as needed, then returns instead of following.
+ * With `endAtTail`, the first connection fixes the bound: the iterator
+ * yields events until the cursor passes that tail, reconnecting as needed,
+ * then returns instead of following.
  */
 export async function* followStreamIterable(
   input: FollowStreamInput,
@@ -136,11 +132,7 @@ export async function* followStreamIterable(
   }
 }
 
-/**
- * One opened stream connection: the response body plus the durable tail
- * index reported by the `x-eve-stream-tail-index` response header, when
- * present and well-formed.
- */
+/** An opened connection: the response body plus the tail index from the response header, if any. */
 interface OpenedStream {
   readonly body: ReadableStream<Uint8Array>;
   readonly tailIndex: number | undefined;

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -150,10 +150,13 @@ export async function openStreamBody(input: OpenStreamInput): Promise<OpenedStre
   let lastHeaders: Headers | undefined;
   let retryDelayMs = STREAM_OPEN_RETRY_BASE_DELAY_MS;
 
-  const searchParams = {
-    ...(input.startIndex !== 0 ? { startIndex: String(input.startIndex) } : {}),
-    ...(input.requestTailIndex === true ? { includeTailIndex: "1" } : {}),
-  };
+  const searchParams: Record<string, string> = {};
+  if (input.startIndex !== 0) {
+    searchParams.startIndex = String(input.startIndex);
+  }
+  if (input.requestTailIndex === true) {
+    searchParams.includeTailIndex = "1";
+  }
 
   for (let attempt = 0; attempt < STREAM_OPEN_RETRY_ATTEMPTS; attempt += 1) {
     const url = createClientUrl(

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -459,6 +459,14 @@ describe("ClientSession", () => {
     expect(session.state).toEqual(initialState);
   });
 
+  it("rejects a bounded stream from a tail-relative cursor", () => {
+    const session = createSession({ sessionId: "session_1", streamIndex: 0 });
+
+    expect(() => session.stream({ endAtTail: true, startIndex: -1 })).toThrow(
+      /nonnegative startIndex/,
+    );
+  });
+
   it("does not reconnect a tail-relative stream after a disconnect", async () => {
     const encoder = new TextEncoder();
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -462,7 +462,7 @@ describe("ClientSession", () => {
   it("rejects a bounded stream from a tail-relative cursor", () => {
     const session = createSession({ sessionId: "session_1", streamIndex: 0 });
 
-    expect(() => session.stream({ endAtTail: true, startIndex: -1 })).toThrow(
+    expect(() => session.stream({ follow: false, startIndex: -1 })).toThrow(
       /nonnegative startIndex/,
     );
   });

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -229,12 +229,12 @@ export class ClientSession {
    * one connection. Negative indices read relative to the current tail on one connection
    * and do not advance the stored absolute cursor.
    *
-   * Pass `endAtTail` for a bounded read: yields events up to the durable
+   * Pass `follow: false` for a bounded read: yields events up to the durable
    * tail observed when the stream opens, then returns instead of following.
    * The stored cursor still advances past the consumed events.
    *
    * @throws {Error} If the session has no session ID (no message has been sent
-   *   yet), or if `endAtTail` is combined with a negative `startIndex`.
+   *   yet), or if `follow: false` is combined with a negative `startIndex`.
    */
   stream(options?: StreamOptions): AsyncIterable<HandleMessageStreamEvent> {
     const sessionId = this.#state.sessionId;
@@ -243,9 +243,9 @@ export class ClientSession {
       throw new Error("Session has no session ID. Send a message first.");
     }
 
-    if (options?.endAtTail === true && (options.startIndex ?? this.#state.streamIndex) < 0) {
+    if (options?.follow === false && (options.startIndex ?? this.#state.streamIndex) < 0) {
       throw new Error(
-        "endAtTail requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
+        "stream({ follow: false }) requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
       );
     }
 
@@ -353,7 +353,7 @@ export class ClientSession {
 
     try {
       for await (const event of followStreamIterable({
-        endAtTail: options?.endAtTail,
+        follow: options?.follow,
         host: this.#context.host,
         resolveHeaders: () => this.#context.resolveHeaders(),
         redirect: this.#context.redirect,

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -229,10 +229,9 @@ export class ClientSession {
    * one connection. Negative indices read relative to the current tail on one connection
    * and do not advance the stored absolute cursor.
    *
-   * Pass `endAtTail` for a bounded read: the iterator yields events up to the
-   * durable tail observed when the stream opens, then returns instead of
-   * following the live stream. The stored cursor still advances past the
-   * consumed events.
+   * Pass `endAtTail` for a bounded read: yields events up to the durable
+   * tail observed when the stream opens, then returns instead of following.
+   * The stored cursor still advances past the consumed events.
    *
    * @throws {Error} If the session has no session ID (no message has been sent
    *   yet), or if `endAtTail` is combined with a negative `startIndex`.

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -229,14 +229,25 @@ export class ClientSession {
    * one connection. Negative indices read relative to the current tail on one connection
    * and do not advance the stored absolute cursor.
    *
+   * Pass `endAtTail` for a bounded read: the iterator yields events up to the
+   * durable tail observed when the stream opens, then returns instead of
+   * following the live stream. The stored cursor still advances past the
+   * consumed events.
+   *
    * @throws {Error} If the session has no session ID (no message has been sent
-   *   yet).
+   *   yet), or if `endAtTail` is combined with a negative `startIndex`.
    */
   stream(options?: StreamOptions): AsyncIterable<HandleMessageStreamEvent> {
     const sessionId = this.#state.sessionId;
 
     if (!sessionId) {
       throw new Error("Session has no session ID. Send a message first.");
+    }
+
+    if (options?.endAtTail === true && (options.startIndex ?? this.#state.streamIndex) < 0) {
+      throw new Error(
+        "endAtTail requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
+      );
     }
 
     return this.#streamAndAdvance(sessionId, options);
@@ -343,6 +354,7 @@ export class ClientSession {
 
     try {
       for await (const event of followStreamIterable({
+        endAtTail: options?.endAtTail,
         host: this.#context.host,
         resolveHeaders: () => this.#context.resolveHeaders(),
         redirect: this.#context.redirect,

--- a/packages/eve/src/client/stream-follow.integration.test.ts
+++ b/packages/eve/src/client/stream-follow.integration.test.ts
@@ -119,24 +119,24 @@ describe("stream following over real sockets", () => {
     const host = await listen(
       createServer((req, res) => {
         connections += 1;
-        const url = new URL(req.url ?? "", "http://127.0.0.1");
-        tailRequests.push(url.searchParams.get("includeTailIndex"));
         const index = startIndexOf(req.url);
+        const tailRequested = new URL(req.url ?? "", "http://127.0.0.1").searchParams.get(
+          "includeTailIndex",
+        );
+        tailRequests.push(tailRequested);
         res.writeHead(200, {
           "content-type": "application/x-ndjson",
-          ...(url.searchParams.get("includeTailIndex") === "1"
-            ? { "x-eve-stream-tail-index": String(log.length - 1) }
-            : {}),
+          ...(tailRequested === "1" ? { "x-eve-stream-tail-index": String(log.length - 1) } : {}),
         });
-        res.write(`${JSON.stringify(log[index])}\n`);
 
+        // The first two connections drop after one event; the third serves the
+        // rest and holds the connection open — a live follow would keep waiting.
+        const events = index < 2 ? [log[index]] : log.slice(index);
+        for (const event of events) {
+          res.write(`${JSON.stringify(event)}\n`);
+        }
         if (index < 2) {
           setTimeout(() => req.socket.destroy(), 40);
-        } else {
-          for (const event of log.slice(index + 1)) {
-            res.write(`${JSON.stringify(event)}\n`);
-          }
-          // Hold the connection open: a live follow would keep waiting here.
         }
       }),
     );
@@ -187,13 +187,9 @@ describe("stream following over real sockets", () => {
       }),
     );
 
-    const consume = async () => {
-      for await (const _event of follow(host, { endAtTail: true })) {
-        // Unreachable: the missing header must fail the read.
-      }
-    };
-
-    await expect(consume()).rejects.toThrow(/x-eve-stream-tail-index/);
+    await expect(follow(host, { endAtTail: true }).next()).rejects.toThrow(
+      /x-eve-stream-tail-index/,
+    );
   });
 
   it("never abandons a progressing turn: any event resets the idle budget", async () => {

--- a/packages/eve/src/client/stream-follow.integration.test.ts
+++ b/packages/eve/src/client/stream-follow.integration.test.ts
@@ -27,9 +27,9 @@ function startIndexOf(url: string | undefined): number {
   return Number(new URL(url ?? "", "http://127.0.0.1").searchParams.get("startIndex") ?? "0");
 }
 
-function follow(host: string, options?: { endAtTail?: boolean }) {
+function follow(host: string, options?: { follow?: boolean }) {
   return followStreamIterable({
-    endAtTail: options?.endAtTail,
+    follow: options?.follow,
     host,
     resolveHeaders: () => Promise.resolve(new Headers()),
     sessionId: "s",
@@ -105,7 +105,7 @@ describe("stream following over real sockets", () => {
     expect(connections).toBe(6);
   }, 20_000);
 
-  it("bounds an endAtTail read at the first connection's tail across reconnects", async () => {
+  it("bounds a follow: false read at the first connection's tail across reconnects", async () => {
     const log = [
       { type: "step.started", data: {} },
       { type: "step.completed", data: {} },
@@ -145,7 +145,7 @@ describe("stream following over real sockets", () => {
     const session = client.session({ sessionId: "s1", streamIndex: 0 });
 
     const received: string[] = [];
-    for await (const event of session.stream({ endAtTail: true })) {
+    for await (const event of session.stream({ follow: false })) {
       received.push(event.type);
     }
 
@@ -155,7 +155,7 @@ describe("stream following over real sockets", () => {
     expect(session.state).toMatchObject({ sessionId: "s1", streamIndex: 6 });
   });
 
-  it("ends an endAtTail read immediately when the cursor is already past the tail", async () => {
+  it("ends a follow: false read immediately when the cursor is already past the tail", async () => {
     let connections = 0;
     const host = await listen(
       createServer((_req, res) => {
@@ -171,7 +171,7 @@ describe("stream following over real sockets", () => {
     );
 
     const received: string[] = [];
-    for await (const event of follow(host, { endAtTail: true })) {
+    for await (const event of follow(host, { follow: false })) {
       received.push(event.type);
     }
 
@@ -179,7 +179,7 @@ describe("stream following over real sockets", () => {
     expect(connections).toBe(1);
   });
 
-  it("fails an endAtTail read when the server does not report a tail index", async () => {
+  it("fails a follow: false read when the server does not report a tail index", async () => {
     const host = await listen(
       createServer((_req, res) => {
         res.writeHead(200, { "content-type": "application/x-ndjson" });
@@ -187,9 +187,7 @@ describe("stream following over real sockets", () => {
       }),
     );
 
-    await expect(follow(host, { endAtTail: true }).next()).rejects.toThrow(
-      /x-eve-stream-tail-index/,
-    );
+    await expect(follow(host, { follow: false }).next()).rejects.toThrow(/x-eve-stream-tail-index/);
   });
 
   it("never abandons a progressing turn: any event resets the idle budget", async () => {

--- a/packages/eve/src/client/stream-follow.integration.test.ts
+++ b/packages/eve/src/client/stream-follow.integration.test.ts
@@ -27,8 +27,9 @@ function startIndexOf(url: string | undefined): number {
   return Number(new URL(url ?? "", "http://127.0.0.1").searchParams.get("startIndex") ?? "0");
 }
 
-function follow(host: string) {
+function follow(host: string, options?: { endAtTail?: boolean }) {
   return followStreamIterable({
+    endAtTail: options?.endAtTail,
     host,
     resolveHeaders: () => Promise.resolve(new Headers()),
     sessionId: "s",
@@ -103,6 +104,97 @@ describe("stream following over real sockets", () => {
     expect(received).toEqual([]);
     expect(connections).toBe(6);
   }, 20_000);
+
+  it("bounds an endAtTail read at the first connection's tail across reconnects", async () => {
+    const log = [
+      { type: "step.started", data: {} },
+      { type: "step.completed", data: {} },
+      { type: "step.started", data: {} },
+      { type: "step.completed", data: {} },
+      { type: "step.started", data: {} },
+      { type: "step.completed", data: {} },
+    ];
+    const tailRequests: Array<string | null> = [];
+    let connections = 0;
+    const host = await listen(
+      createServer((req, res) => {
+        connections += 1;
+        const url = new URL(req.url ?? "", "http://127.0.0.1");
+        tailRequests.push(url.searchParams.get("includeTailIndex"));
+        const index = startIndexOf(req.url);
+        res.writeHead(200, {
+          "content-type": "application/x-ndjson",
+          ...(url.searchParams.get("includeTailIndex") === "1"
+            ? { "x-eve-stream-tail-index": String(log.length - 1) }
+            : {}),
+        });
+        res.write(`${JSON.stringify(log[index])}\n`);
+
+        if (index < 2) {
+          setTimeout(() => req.socket.destroy(), 40);
+        } else {
+          for (const event of log.slice(index + 1)) {
+            res.write(`${JSON.stringify(event)}\n`);
+          }
+          // Hold the connection open: a live follow would keep waiting here.
+        }
+      }),
+    );
+
+    const client = new Client({ host });
+    const session = client.session({ sessionId: "s1", streamIndex: 0 });
+
+    const received: string[] = [];
+    for await (const event of session.stream({ endAtTail: true })) {
+      received.push(event.type);
+    }
+
+    expect(received).toEqual(log.map((event) => event.type));
+    expect(connections).toBe(3);
+    expect(tailRequests).toEqual(["1", null, null]);
+    expect(session.state).toMatchObject({ sessionId: "s1", streamIndex: 6 });
+  });
+
+  it("ends an endAtTail read immediately when the cursor is already past the tail", async () => {
+    let connections = 0;
+    const host = await listen(
+      createServer((_req, res) => {
+        connections += 1;
+        res.writeHead(200, {
+          "content-type": "application/x-ndjson",
+          "x-eve-stream-tail-index": "-1",
+        });
+        // Send headers without any body: a live follow would idle here
+        // waiting for events that never arrive.
+        res.flushHeaders();
+      }),
+    );
+
+    const received: string[] = [];
+    for await (const event of follow(host, { endAtTail: true })) {
+      received.push(event.type);
+    }
+
+    expect(received).toEqual([]);
+    expect(connections).toBe(1);
+  });
+
+  it("fails an endAtTail read when the server does not report a tail index", async () => {
+    const host = await listen(
+      createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/x-ndjson" });
+        res.end();
+      }),
+    );
+
+    const consume = async () => {
+      for await (const _event of follow(host, { endAtTail: true })) {
+        // Unreachable: the missing header must fail the read.
+      }
+    };
+
+    await expect(consume()).rejects.toThrow(/x-eve-stream-tail-index/);
+  });
 
   it("never abandons a progressing turn: any event resets the idle budget", async () => {
     const events = ["step.started", "step.completed", "step.started", "session.completed"];

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -216,6 +216,14 @@ export interface StreamOptions {
   readonly startIndex?: number;
 
   /**
+   * Stop at the durable tail instead of following the live stream. The first
+   * connection reports the index of the last durably recorded event; the
+   * iterator yields events until the cursor passes that tail, reconnecting as
+   * needed, then returns. Requires a nonnegative start cursor.
+   */
+  readonly endAtTail?: boolean;
+
+  /**
    * Abort signal for cancelling the stream.
    */
   readonly signal?: AbortSignal;

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -216,10 +216,9 @@ export interface StreamOptions {
   readonly startIndex?: number;
 
   /**
-   * Stop at the durable tail instead of following the live stream. The first
-   * connection reports the index of the last durably recorded event; the
-   * iterator yields events until the cursor passes that tail, reconnecting as
-   * needed, then returns. Requires a nonnegative start cursor.
+   * Stop at the durable tail instead of following the live stream: yields
+   * events until the cursor passes the tail observed when the stream opened,
+   * then returns. Requires a nonnegative start cursor.
    */
   readonly endAtTail?: boolean;
 

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -216,11 +216,12 @@ export interface StreamOptions {
   readonly startIndex?: number;
 
   /**
-   * Stop at the durable tail instead of following the live stream: yields
-   * events until the cursor passes the tail observed when the stream opened,
-   * then returns. Requires a nonnegative start cursor.
+   * Follow the live stream after the durable tail (default). Pass `false`
+   * for a bounded catch-up read: yields events until the cursor passes the
+   * tail observed when the stream opened, then returns instead of
+   * following. Requires a nonnegative start cursor.
    */
-  readonly endAtTail?: boolean;
+  readonly follow?: boolean;
 
   /**
    * Abort signal for cancelling the stream.

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -224,6 +224,9 @@ function createNoopRuntime(): Runtime {
       .fn()
       .mockRejectedValue(new Error("runtime.getEventStream should not be called in this test")),
     terminateSession: vi.fn(),
+    getStreamTailIndex: vi
+      .fn()
+      .mockRejectedValue(new Error("runtime.getStreamTailIndex should not be called in this test")),
   };
 }
 

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -223,10 +223,10 @@ function createNoopRuntime(): Runtime {
     getEventStream: vi
       .fn()
       .mockRejectedValue(new Error("runtime.getEventStream should not be called in this test")),
-    terminateSession: vi.fn(),
     getStreamTailIndex: vi
       .fn()
       .mockRejectedValue(new Error("runtime.getStreamTailIndex should not be called in this test")),
+    terminateSession: vi.fn(),
   };
 }
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -225,6 +225,17 @@ export function createWorkflowRuntime(config: {
       );
     },
 
+    async getStreamTailIndex(sessionId: string): Promise<number> {
+      // getTailIndex() reads the stream-info record; the readable itself is
+      // never consumed. Cancel it so the unread source does not linger.
+      const readable = getRun(sessionId).getReadable();
+      try {
+        return await readable.getTailIndex();
+      } finally {
+        await readable.cancel().catch(() => {});
+      }
+    },
+
     async resolveSession(continuationToken: string): Promise<{ sessionId: string } | undefined> {
       try {
         const hook = await getHookByToken(continuationToken);

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -226,8 +226,7 @@ export function createWorkflowRuntime(config: {
     },
 
     async getStreamTailIndex(sessionId: string): Promise<number> {
-      // getTailIndex() reads the stream-info record; the readable itself is
-      // never consumed. Cancel it so the unread source does not linger.
+      // The readable is never consumed; cancel it so the unread source does not linger.
       const readable = getRun(sessionId).getReadable();
       try {
         return await readable.getTailIndex();

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -163,6 +163,9 @@ describe("dispatchChannelRequest", () => {
       async getEventStream() {
         return new ReadableStream();
       },
+      async getStreamTailIndex() {
+        return -1;
+      },
     });
     const targetDefinition: CompiledChannel = {
       __kind: CHANNEL_SENTINEL,
@@ -236,6 +239,7 @@ describe("dispatchChannelRequest", () => {
       deliver: vi.fn().mockResolvedValue({ sessionId: "sess_route" }),
       resolveSession: vi.fn(),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
+      getStreamTailIndex: vi.fn().mockResolvedValue(-1),
       run: vi.fn(),
       terminateSession: vi.fn(),
     };
@@ -335,6 +339,7 @@ describe("dispatchChannelRequest", () => {
       deliver: vi.fn().mockResolvedValue({ sessionId: "sess_route" }),
       resolveSession: vi.fn(),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
+      getStreamTailIndex: vi.fn().mockResolvedValue(-1),
       run: vi.fn(),
       terminateSession: vi.fn(),
     };
@@ -378,6 +383,7 @@ describe("dispatchChannelRequest", () => {
       deliver: vi.fn().mockResolvedValue({ sessionId: "sess_deliver" }),
       resolveSession: vi.fn(),
       getEventStream: vi.fn().mockResolvedValue(new ReadableStream()),
+      getStreamTailIndex: vi.fn().mockResolvedValue(-1),
       run: vi.fn().mockResolvedValue({
         continuationToken: "route-token",
         events: new ReadableStream(),

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -287,6 +287,7 @@ describe("dispatchChannelRequest", () => {
       cancelTurn: vi.fn(),
       deliver: vi.fn(),
       getEventStream: vi.fn(),
+      getStreamTailIndex: vi.fn(),
       resolveSession: vi.fn().mockResolvedValue({ sessionId: "sess_previous" }),
       run: vi.fn(),
       terminateSession: vi.fn().mockResolvedValue({ status: "terminated" }),

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -14,6 +14,7 @@ import type { JsonObject, JsonValue } from "#shared/json.js";
 
 export const EVE_SESSION_ID_HEADER = "x-eve-session-id";
 export const EVE_STREAM_FORMAT_HEADER = "x-eve-stream-format";
+export const EVE_STREAM_TAIL_INDEX_HEADER = "x-eve-stream-tail-index";
 export const EVE_STREAM_VERSION_HEADER = "x-eve-stream-version";
 export const EVE_MESSAGE_STREAM_CONTENT_TYPE = "application/x-ndjson; charset=utf-8";
 export const EVE_MESSAGE_STREAM_FORMAT = "ndjson";

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -106,6 +106,9 @@ async function firePost(
     async getEventStream() {
       return new ReadableStream();
     },
+    async getStreamTailIndex() {
+      return -1;
+    },
   });
   const waitUntil = vi.fn();
 
@@ -254,6 +257,9 @@ describe("chatSdkChannel", () => {
       },
       async getEventStream() {
         return new ReadableStream();
+      },
+      async getStreamTailIndex() {
+        return -1;
       },
     });
 

--- a/packages/eve/src/public/channels/eve-forwarded-principal.integration.test.ts
+++ b/packages/eve/src/public/channels/eve-forwarded-principal.integration.test.ts
@@ -63,6 +63,9 @@ function createEveCreateHandler(input: EveChannelInput) {
     async getEventStream() {
       return new ReadableStream();
     },
+    async getStreamTailIndex() {
+      return -1;
+    },
   } satisfies ChannelSession);
 
   return {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -67,6 +67,9 @@ function createEveCreateHandler(input: EveChannelInput) {
     async getEventStream() {
       return new ReadableStream();
     },
+    async getStreamTailIndex() {
+      return -1;
+    },
   } satisfies ChannelSession);
 
   return {
@@ -107,6 +110,9 @@ function createEveContinueHandler(input: EveChannelInput) {
     },
     async getEventStream() {
       return new ReadableStream();
+    },
+    async getStreamTailIndex() {
+      return -1;
     },
   };
 
@@ -229,15 +235,18 @@ function createEveStreamHandler(input: EveChannelInput) {
   if (!streamRoute) throw new Error("No session stream GET route found");
 
   const getEventStream = vi.fn().mockResolvedValue(new ReadableStream());
+  const getStreamTailIndex = vi.fn().mockResolvedValue(-1);
   const mockGetSession = vi.fn().mockReturnValue({
     cancel: vi.fn(),
     continuationToken: "eve:test",
     getEventStream,
+    getStreamTailIndex,
     id: "test-session-id",
   } satisfies ChannelSession);
 
   return {
     getEventStream,
+    getStreamTailIndex,
     async fetch(url: string) {
       const args: RouteHandlerArgs = {
         send: vi.fn(),
@@ -456,6 +465,28 @@ describe("eveChannel — stream cursor", () => {
       expect(handler.getEventStream).not.toHaveBeenCalled();
     },
   );
+
+  it("omits the tail index by default without paying for the lookup", async () => {
+    const handler = createEveStreamHandler({ auth: none() });
+
+    const response = await handler.fetch("https://eve.test/eve/v1/session/test-session-id/stream");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eve-stream-tail-index")).toBeNull();
+    expect(handler.getStreamTailIndex).not.toHaveBeenCalled();
+  });
+
+  it("reports the durable tail index when the request opts in", async () => {
+    const handler = createEveStreamHandler({ auth: none() });
+    handler.getStreamTailIndex.mockResolvedValueOnce(41);
+
+    const response = await handler.fetch(
+      "https://eve.test/eve/v1/session/test-session-id/stream?includeTailIndex=1",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eve-stream-tail-index")).toBe("41");
+  });
 });
 
 describe("eveChannel — onMessage", () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -443,9 +443,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         try {
           const session = getSession(sessionId);
 
-          // Resolving the tail costs one stream-info lookup, so it is
-          // opt-in: only requests that bound a read pay for it. Resolved
-          // before the stream opens; the bound is the tail at open time.
+          // The tail lookup is opt-in: only requests that bound a read pay for it.
           const tailIndex = includeTailIndex ? await session.getStreamTailIndex() : undefined;
           const events = await session.getEventStream({ startIndex });
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -18,6 +18,7 @@ import {
   EVE_MESSAGE_STREAM_VERSION,
   EVE_SESSION_ID_HEADER,
   EVE_STREAM_FORMAT_HEADER,
+  EVE_STREAM_TAIL_INDEX_HEADER,
   EVE_STREAM_VERSION_HEADER,
 } from "#protocol/message.js";
 import {
@@ -437,9 +438,17 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         const startIndex = parseStartIndex(req);
         if (startIndex instanceof Response) return startIndex;
 
+        const includeTailIndex = parseIncludeTailIndex(req);
+
         try {
           const session = getSession(sessionId);
+
+          // Resolving the tail costs one stream-info lookup, so it is
+          // opt-in: only requests that bound a read pay for it. Resolved
+          // before the stream opens; the bound is the tail at open time.
+          const tailIndex = includeTailIndex ? await session.getStreamTailIndex() : undefined;
           const events = await session.getEventStream({ startIndex });
+
           const ndjson = serializeAsNdjson(events);
           return new Response(ndjson, {
             headers: {
@@ -452,6 +461,9 @@ export function eveChannel(input: EveChannelInput): EveChannel {
               "x-accel-buffering": "no",
               [EVE_SESSION_ID_HEADER]: sessionId,
               [EVE_STREAM_FORMAT_HEADER]: EVE_MESSAGE_STREAM_FORMAT,
+              ...(tailIndex === undefined
+                ? {}
+                : { [EVE_STREAM_TAIL_INDEX_HEADER]: String(tailIndex) }),
               [EVE_STREAM_VERSION_HEADER]: EVE_MESSAGE_STREAM_VERSION,
             },
           });
@@ -981,6 +993,11 @@ function parseClientContextField(value: unknown): string[] | Response | undefine
 
 function toClientContextMessage(content: string): string {
   return `${CLIENT_CONTEXT_PREFIX}${content}`;
+}
+
+function parseIncludeTailIndex(request: Request): boolean {
+  const raw = new URL(request.url).searchParams.get("includeTailIndex");
+  return raw === "1" || raw === "true";
 }
 
 function parseStartIndex(request: Request): number | undefined | Response {

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -34,6 +34,7 @@ async function firePost(
     continuationToken: "TOKEN",
     cancel: async () => ({ status: "no_active_turn" as const }),
     getEventStream: async () => new ReadableStream(),
+    getStreamTailIndex: async () => -1,
     id: "SESSION",
   }));
   const waitUntil = vi.fn();
@@ -329,6 +330,7 @@ describe("teamsChannel", () => {
       continuationToken: "TOKEN",
       cancel: async () => ({ status: "no_active_turn" as const }),
       getEventStream: async () => new ReadableStream(),
+      getStreamTailIndex: async () => -1,
       id: "SESSION",
     }));
 

--- a/packages/eve/src/public/definitions/channel.test.ts
+++ b/packages/eve/src/public/definitions/channel.test.ts
@@ -564,6 +564,9 @@ describe("defineChannel", () => {
           async getEventStream() {
             return new ReadableStream();
           },
+          async getStreamTailIndex() {
+            return -1;
+          },
         };
       },
     });

--- a/packages/eve/test/eve-run-stream-channel.test.ts
+++ b/packages/eve/test/eve-run-stream-channel.test.ts
@@ -176,6 +176,9 @@ function createMockGetSession(events: ReadableStream<HandleMessageStreamEvent>) 
     async getEventStream() {
       return events;
     },
+    async getStreamTailIndex() {
+      return -1;
+    },
   } satisfies Session);
 }
 

--- a/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
+++ b/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
@@ -105,11 +105,11 @@ function createCapturingRuntime(captured: CapturedRun[]): Runtime {
     async getEventStream() {
       return new ReadableStream();
     },
-    async terminateSession() {
-      throw new Error("terminateSession should not be called in this scenario");
-    },
     async getStreamTailIndex() {
       return -1;
+    },
+    async terminateSession() {
+      throw new Error("terminateSession should not be called in this scenario");
     },
   };
 }

--- a/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
+++ b/packages/eve/test/scenarios/cross-channel-receive.scenario.test.ts
@@ -108,6 +108,9 @@ function createCapturingRuntime(captured: CapturedRun[]): Runtime {
     async terminateSession() {
       throw new Error("terminateSession should not be called in this scenario");
     },
+    async getStreamTailIndex() {
+      return -1;
+    },
   };
 }
 

--- a/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
+++ b/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
@@ -82,11 +82,11 @@ function createCapturingRuntime(captured: CapturedRun[]): Runtime {
     async getEventStream() {
       return new ReadableStream<HandleMessageStreamEvent>();
     },
-    async terminateSession() {
-      throw new Error("terminateSession should not be called in this scenario");
-    },
     async getStreamTailIndex() {
       return -1;
+    },
+    async terminateSession() {
+      throw new Error("terminateSession should not be called in this scenario");
     },
   };
 }

--- a/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
+++ b/packages/eve/test/scenarios/schedule-trigger.scenario.test.ts
@@ -85,6 +85,9 @@ function createCapturingRuntime(captured: CapturedRun[]): Runtime {
     async terminateSession() {
       throw new Error("terminateSession should not be called in this scenario");
     },
+    async getStreamTailIndex() {
+      return -1;
+    },
   };
 }
 


### PR DESCRIPTION
Clients reconnecting to a session's durable event stream had no way to read "everything recorded so far, then stop" — a follow holds the connection open waiting for live events. This adds a bounded catch-up read across the stack:

- `session.stream({ follow: false })` in the TypeScript client consumes events from the cursor to the durable tail observed when the stream opens, reconnecting through connection cuts with the original bound, then returns instead of following. `follow` defaults to `true`, the existing live-follow behavior. The stored `streamIndex` still advances, so a follow-up `stream()` or `send()` resumes exactly where the bounded read ended.
- The HTTP stream route reports the tail as the `x-eve-stream-tail-index` response header when a request opts in with `includeTailIndex=1`. Default requests skip the lookup entirely.
- Channel authors get `Session.getStreamTailIndex()` for serving bounded reads from custom routes; `getEventStream()` is unchanged.

`follow: false` throws when combined with a negative `startIndex` (a tail-relative cursor cannot be bounded) and fails clearly when the server does not report the tail header (an agent on an older eve version).

**Naming**

Earlier revisions called this `endAtTail: true`. Following is what `stream()` already does, so the bounded read is the inverse toggle on the default mode — `follow: false` — rather than a second mode name. The wire protocol (`includeTailIndex=1`, `x-eve-stream-tail-index`) and `getStreamTailIndex()` keep their names: they describe the tail mechanism, not the toggle.

**Alternative considered**

Having `getEventStream()` resolve to a `{ events, getTailIndex }` handle instead of adding a separate method. One call instead of two, but it breaks every existing `new Response(await session.getEventStream())` route and forces the destructure on callers that never want the tail. A separate `getStreamTailIndex()` keeps `getEventStream()` returning a plain `ReadableStream`, keeps the change non-breaking, and makes the extra stream-info lookup an explicit opt-in.
