### PR TITLE
Fix duplicate GitHub link in eve.dev nav

### DIFF
--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -21,10 +21,8 @@ export const nav = [
     label: "Templates",
     href: "/templates",
   },
-  {
-    label: "GitHub",
-    href: `https://github.com/${github.owner}/${github.repo}/`,
-  },
+  // No GitHub entry here: geistdocs renders it from `github` above (icon button
+  // on desktop, "GitHub" link in the mobile menu). Adding it duplicates the link.
 ];
 
 export const suggestions = [


### PR DESCRIPTION
The eve.dev mobile menu showed "GitHub ↗" twice. `@vercel/geistdocs` already renders a GitHub link on its own from `config.github` (an icon button on desktop, a "GitHub" row in the mobile sheet), so the extra `GitHub` entry in the site's `nav` array produced a second, identical link. Reported by [@Guillermo Rauch](https://slack.com/team/U0CAL2338) via a mobile web report.

### What changed
- Dropped the redundant `GitHub` item from the `nav` array in `apps/docs/geistdocs.tsx`, leaving the package-rendered link as the single source.
- Added a short comment so the entry doesn't get re-added.

### How to test
Open eve.dev on a narrow viewport, tap the hamburger menu, and confirm only one "GitHub ↗" row appears above "Vercel OSS". On desktop, the GitHub icon button in the header is unchanged.