### PR TITLE
docs: explain agent loop and sandbox boundary

### DIFF
--- a/apps/docs/components/geistdocs/agent-runtime-diagram.tsx
+++ b/apps/docs/components/geistdocs/agent-runtime-diagram.tsx
@@ -1,0 +1,148 @@
+import {
+  IconFileText,
+  IconFolderOpen,
+  IconLinked,
+  IconSandbox,
+  IconWorkflow,
+  IconWrench,
+} from "@vercel/geistdocs/assets/icons";
+import type { JSX, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+function Environment({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <section className="flex min-w-0 flex-col gap-4 rounded-xl border border-gray-alpha-400 bg-background-100 p-4 sm:p-5">
+      <div className="flex flex-col gap-1">
+        <span className="font-mono font-medium uppercase tracking-[0.1em] text-gray-1000 text-label-14">
+          {title}
+        </span>
+        <span className="break-words text-copy-14 text-gray-900">{description}</span>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function RuntimeCard({
+  icon,
+  title,
+  description,
+  paths,
+  className,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  paths?: string[];
+  className?: string;
+}): JSX.Element {
+  return (
+    <div className={cn("flex min-w-0 items-start gap-3 rounded-lg p-4 material-small", className)}>
+      <span className="mt-0.5 shrink-0 text-gray-1000">{icon}</span>
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="font-medium text-copy-14 text-gray-1000">{title}</span>
+        <span className="text-copy-14 text-gray-900">{description}</span>
+        {paths ? (
+          <span className="mt-1 flex flex-col font-mono text-copy-13 text-gray-900">
+            {paths.map((path) => (
+              <span key={path} className="break-words">
+                {path}
+              </span>
+            ))}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SandboxBridge(): JSX.Element {
+  return (
+    <div className="relative flex min-h-28 items-center justify-center lg:min-h-0">
+      <div
+        aria-hidden
+        className="absolute top-0 bottom-0 left-1/2 border-gray-alpha-700 border-l border-dashed lg:top-1/2 lg:bottom-auto lg:-right-3 lg:-left-3 lg:border-t lg:border-l-0"
+      />
+      <div className="relative flex max-w-44 flex-col items-center rounded-xl border border-gray-alpha-700 bg-background-100 px-4 py-3 text-center shadow-sm">
+        <span className="font-medium text-copy-13 text-gray-1000">Logical sandbox bridge</span>
+        <code className="bg-transparent! p-0! text-copy-13! text-gray-900!">ctx.getSandbox()</code>
+        <span className="text-copy-12 text-gray-900">sandbox-backed tools</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shows the execution boundary between eve's trusted app runtime and isolated sandbox.
+ */
+export function AgentRuntimeDiagram(): JSX.Element {
+  return (
+    <figure
+      aria-label="Agent loop and sandbox execution boundary"
+      className="my-8 grid w-full min-w-0 items-stretch gap-3 lg:grid-cols-[minmax(0,1fr)_192px_minmax(0,1fr)]"
+    >
+      <Environment title="Trusted app runtime" description="Full Node.js access and credentials">
+        <RuntimeCard
+          icon={<IconWorkflow size={18} />}
+          title="Agent loop"
+          description="Durable workflow, model calls, and orchestration"
+          paths={["agent/agent.ts", "agent/instructions.md"]}
+        />
+        <RuntimeCard
+          icon={<IconWrench size={18} />}
+          title="Runtime code"
+          description="Tools, hooks, instrumentation, and connections"
+          paths={[
+            "agent/tools/**",
+            "agent/hooks/**",
+            "agent/instrumentation.ts",
+            "agent/connections/**",
+          ]}
+        />
+        <RuntimeCard
+          icon={<IconLinked size={18} />}
+          title="Secrets and credentials"
+          description="Provider keys, tool secrets, and MCP/OpenAPI auth stay here"
+        />
+      </Environment>
+
+      <SandboxBridge />
+
+      <Environment
+        title="Isolated sandbox"
+        description="Filesystem and processes without app secrets"
+      >
+        <div className="grid gap-3">
+          <RuntimeCard
+            icon={<IconFileText size={18} />}
+            title="Skills"
+            description="Materialized for the agent"
+            paths={["$HOME/.agents/skills", "from agent/skills/**"]}
+            className="order-2 lg:order-1"
+          />
+          <RuntimeCard
+            icon={<IconSandbox size={18} />}
+            title="Sandbox operations"
+            description="Shell commands, file access, scripts, and servers"
+            className="order-1 lg:order-2"
+          />
+          <RuntimeCard
+            icon={<IconFolderOpen size={18} />}
+            title="Workspace"
+            description="Persistent per-session files"
+            paths={["/workspace", "from agent/sandbox/workspace/**"]}
+            className="order-3"
+          />
+        </div>
+      </Environment>
+    </figure>
+  );
+}

--- a/apps/docs/components/geistdocs/agent-runtime-diagram.tsx
+++ b/apps/docs/components/geistdocs/agent-runtime-diagram.tsx
@@ -19,8 +19,8 @@ function Environment({
   children: ReactNode;
 }): JSX.Element {
   return (
-    <section className="flex min-w-0 flex-col gap-4 rounded-xl border border-gray-alpha-400 bg-background-100 p-4 sm:p-5">
-      <div className="flex flex-col gap-1">
+    <section className="flex min-w-0 flex-col gap-3 rounded-xl border border-gray-alpha-400 bg-background-100 p-4 sm:p-5">
+      <div className="flex flex-col gap-1 lg:min-h-16">
         <span className="font-mono font-medium uppercase tracking-[0.1em] text-gray-1000 text-label-14">
           {title}
         </span>
@@ -66,15 +66,15 @@ function RuntimeCard({
 
 function SandboxBridge(): JSX.Element {
   return (
-    <div className="relative flex min-h-28 items-center justify-center lg:min-h-0">
+    <div className="relative flex min-h-20 items-center justify-center lg:min-h-0">
       <div
         aria-hidden
-        className="absolute top-0 bottom-0 left-1/2 border-gray-alpha-700 border-l border-dashed lg:top-1/2 lg:bottom-auto lg:-right-3 lg:-left-3 lg:border-t lg:border-l-0"
+        className="absolute top-0 bottom-0 left-1/2 border-gray-alpha-700 border-l border-dashed lg:top-1/2 lg:bottom-auto lg:-right-4 lg:-left-4 lg:border-t lg:border-l-0"
       />
-      <div className="relative flex max-w-44 flex-col items-center rounded-xl border border-gray-alpha-700 bg-background-100 px-4 py-3 text-center shadow-sm">
-        <span className="font-medium text-copy-13 text-gray-1000">Logical sandbox bridge</span>
-        <code className="bg-transparent! p-0! text-copy-13! text-gray-900!">ctx.getSandbox()</code>
-        <span className="text-copy-12 text-gray-900">sandbox-backed tools</span>
+      <div className="relative rounded-lg border border-gray-alpha-700 bg-background-100 px-3 py-2 text-center shadow-sm">
+        <code className="bg-transparent! p-0! font-medium text-copy-13! text-gray-1000!">
+          ctx.getSandbox()
+        </code>
       </div>
     </div>
   );
@@ -87,7 +87,7 @@ export function AgentRuntimeDiagram(): JSX.Element {
   return (
     <figure
       aria-label="Agent loop and sandbox execution boundary"
-      className="my-8 grid w-full min-w-0 items-stretch gap-3 lg:grid-cols-[minmax(0,1fr)_192px_minmax(0,1fr)]"
+      className="my-8 grid w-full min-w-0 items-stretch gap-4 lg:grid-cols-[minmax(0,1fr)_160px_minmax(0,1fr)]"
     >
       <Environment title="Trusted app runtime" description="Full Node.js access and credentials">
         <RuntimeCard

--- a/apps/docs/components/geistdocs/mdx-components.tsx
+++ b/apps/docs/components/geistdocs/mdx-components.tsx
@@ -3,6 +3,7 @@ import { File, Files, Folder } from "fumadocs-ui/components/files";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
+import { AgentRuntimeDiagram } from "./agent-runtime-diagram";
 
 const localComponents: MDXComponents = {
   a: ({ href, ...props }) =>
@@ -14,6 +15,7 @@ const localComponents: MDXComponents = {
   File,
   Files,
   Folder,
+  AgentRuntimeDiagram,
   Step,
   Steps,
 };

--- a/docs/concepts/execution-model-and-durability.md
+++ b/docs/concepts/execution-model-and-durability.md
@@ -40,47 +40,40 @@ The world package backs workflow state, queues, hooks, and streams. Keep secrets
 
 ## Agent loop and sandbox
 
-The agent loop and its sandbox are separate runtime components joined by a narrow bridge:
+An eve agent spans two execution environments with different responsibilities:
 
 ```mermaid
 flowchart LR
   subgraph App["Trusted app runtime"]
     direction TB
-    Loop["Agent loop<br/>durable workflow<br/>model calls · orchestration<br/>agent/agent.ts · agent/instructions.md"]
-    AppTools["Tool execution<br/>authored tools · MCP/OpenAPI · built-in executors<br/>agent/tools/*.ts · agent/connections/*.ts"]
-    Credentials["Credentials stay here<br/>model keys · tool secrets · connection tokens"]
-    Loop --> AppTools
-    Credentials -.-> Loop
-    Credentials -.-> AppTools
+    Loop["Agent loop<br/>durable workflow<br/>agent/agent.ts · agent/instructions.md"]
+    Runtime["Runtime code<br/>model calls · tools · hooks · instrumentation · connections<br/>agent/tools/** · agent/hooks/** · agent/instrumentation.ts · agent/connections/**"]
+    Credentials["Secrets and credentials<br/>provider keys · tool secrets · MCP/OpenAPI auth"]
+    Loop --> Runtime
+    Credentials --> Runtime
   end
 
-  Bridge{{"Sandbox bridge<br/>bash · read_file · write_file · glob · grep<br/>ctx.getSandbox()<br/>operations ↔ results"}}
-
-  subgraph Isolated["Isolated sandbox"]
+  subgraph Sandbox["Isolated sandbox"]
     direction TB
-    Session["Sandbox session"]
+    Operations["Sandbox operations<br/>shell · files · processes"]
     Skills["Skills<br/>$HOME/.agents/skills<br/>from agent/skills/**"]
     Workspace["Workspace<br/>/workspace<br/>from agent/sandbox/workspace/**"]
-    Processes["Shell and processes<br/>commands · scripts · servers"]
-    Session --- Skills
-    Session --- Workspace
-    Session --- Processes
+    Processes["Running work<br/>commands · scripts · servers"]
+    Operations --- Skills
+    Operations --- Workspace
+    Operations --- Processes
   end
 
-  Loop -->|"sandbox-backed built-ins"| Bridge
-  AppTools -->|"sandbox operations"| Bridge
-  Bridge <--> Session
-
-  style Bridge stroke-width:4px
+  Runtime -.->|"optional sandbox access: ctx.getSandbox()"| Operations
 ```
 
-The loop runs as a durable workflow in the app runtime. Except for provider-managed tools, tool executors also run there. The bridge is the runtime API boundary: it turns built-in shell and file tool calls—or calls through `ctx.getSandbox()`—into sandbox backend operations, then returns their results. The executor stays in the app; only the requested command or filesystem effect lands in the sandbox. The model never receives a live sandbox handle, app environment, or credential.
+The agent loop runs as a durable workflow in the app runtime. Model calls, tool executors, hooks, instrumentation, and connection clients also run there with full Node.js access. Provider-managed tools execute at the model provider, but the loop still orchestrates them from the app runtime.
 
-The [sandbox](../sandbox) owns the per-session filesystem, materialized skills, and any processes the agent starts. It opens lazily on first access. At step boundaries, eve records the identifiers needed to reattach it; live process handles never become workflow state.
+The dashed edge is a logical bridge, not another service or process. `ctx.getSandbox()` gives app-side runtime code a handle for sandbox operations. The built-in `bash`, `read_file`, `write_file`, `glob`, and `grep` tools use it, and authored tools can use it when they need isolated filesystem or process access.
 
-Credentials stay on the trusted side. eve resolves model-provider keys, authored-tool secrets, and MCP, OpenAPI, and connection credentials in the app runtime and does not copy them into model context, sandbox environment variables, or files. Each credential is sent only to the service it authenticates. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) injects credentials at the network boundary without exposing them to the process.
+The [sandbox](../sandbox) owns the per-session filesystem and processes. Authored skills are materialized under `$HOME/.agents/skills`, and `agent/sandbox/workspace/**` seeds `/workspace`. The loop and sandbox have decoupled lifetimes: the durable workflow can park or restart independently, while the app runtime opens or reuses sandbox compute only when code needs it.
 
-The lifetimes are deliberately decoupled. A workflow can park for days while sandbox compute idles, then resume and reattach the same per-session filesystem. An app redeploy does not discard that workspace, and the workflow world and sandbox backend can scale or change independently. Changing the sandbox definition replaces the sandbox without resetting conversation history, so keep application state that must survive sandbox replacement in [`defineState`](../guides/state), not only in `/workspace`.
+Credentials remain on the trusted side. eve resolves model-provider keys, tool secrets, and MCP, OpenAPI, and connection credentials in the app runtime rather than copying them into model context or the sandbox. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) supplies it without exposing the credential to the process.
 
 ## Resuming after a crash
 

--- a/docs/concepts/execution-model-and-durability.md
+++ b/docs/concepts/execution-model-and-durability.md
@@ -38,6 +38,23 @@ export default defineAgent({
 
 The world package backs workflow state, queues, hooks, and streams. Keep secrets and deployment-specific options in runtime environment variables read by that package, not in `agent.ts`. Custom worlds must implement the runtime protocol expected by eve's vendored `@workflow/*` packages (currently the `5.0.0-beta` line); the Workflow SDK rejects incompatible protocol versions during initialization. See [Self-host eve](../guides/deployment/self-hosting#persist-workflow-state), [agent.ts](../agent-config#workflow-world), and [Workflow Worlds](https://workflow-sdk.dev/worlds).
 
+## Agent loop and sandbox
+
+The agent loop and its sandbox are separate runtime components:
+
+|                    | Agent loop                                                              | Sandbox                                                                  |
+| ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Runs as            | A durable workflow in the trusted app runtime                           | An isolated backend session, separate from the loop                      |
+| Owns               | Conversation, model calls, tool orchestration, and durable state        | `/workspace`, materialized skills, and processes started by the agent    |
+| Accesses the other | Opens or reattaches the sandbox through eve's managed runtime context   | Exposes sandbox operations; it does not run the agent loop               |
+| Lifetime           | Checkpoints, parks without compute, and resumes across process restarts | Can idle or stop while its filesystem remains available for reattachment |
+
+The loop reaches the [sandbox](../sandbox) through operations such as the built-in shell and file tools or `ctx.getSandbox()`. The sandbox is opened lazily on first access. At step boundaries, eve records the identifiers needed to reattach it; live process handles never become workflow state.
+
+Credentials stay on the trusted side. eve resolves model-provider keys, authored-tool secrets, and MCP, OpenAPI, and connection credentials in the app runtime and does not copy them into model context, sandbox environment variables, or files. Each credential is sent only to the service it authenticates. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) injects credentials at the network boundary without exposing them to the process.
+
+The lifetimes are deliberately decoupled. A workflow can park for days while sandbox compute idles, then resume and reattach the same per-session filesystem. An app redeploy does not discard that workspace, and the workflow world and sandbox backend can scale or change independently. Changing the sandbox definition replaces the sandbox without resetting conversation history, so keep application state that must survive sandbox replacement in [`defineState`](../guides/state), not only in `/workspace`.
+
 ## Resuming after a crash
 
 Crash the process, hit a timeout, or redeploy mid-turn, and the run picks up from the last completed step rather than replaying the whole turn. Completed steps never re-run; eve replays the recorded result. A step interrupted mid-execution re-runs, so make non-idempotent side effects like charges or emails idempotent, or gate them with approval.

--- a/docs/concepts/execution-model-and-durability.md
+++ b/docs/concepts/execution-model-and-durability.md
@@ -40,16 +40,43 @@ The world package backs workflow state, queues, hooks, and streams. Keep secrets
 
 ## Agent loop and sandbox
 
-The agent loop and its sandbox are separate runtime components:
+The agent loop and its sandbox are separate runtime components joined by a narrow bridge:
 
-|                    | Agent loop                                                              | Sandbox                                                                  |
-| ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Runs as            | A durable workflow in the trusted app runtime                           | An isolated backend session, separate from the loop                      |
-| Owns               | Conversation, model calls, tool orchestration, and durable state        | `/workspace`, materialized skills, and processes started by the agent    |
-| Accesses the other | Opens or reattaches the sandbox through eve's managed runtime context   | Exposes sandbox operations; it does not run the agent loop               |
-| Lifetime           | Checkpoints, parks without compute, and resumes across process restarts | Can idle or stop while its filesystem remains available for reattachment |
+```mermaid
+flowchart LR
+  subgraph App["Trusted app runtime"]
+    direction TB
+    Loop["Agent loop<br/>durable workflow<br/>model calls · orchestration<br/>agent/agent.ts · agent/instructions.md"]
+    AppTools["Tool execution<br/>authored tools · MCP/OpenAPI · built-in executors<br/>agent/tools/*.ts · agent/connections/*.ts"]
+    Credentials["Credentials stay here<br/>model keys · tool secrets · connection tokens"]
+    Loop --> AppTools
+    Credentials -.-> Loop
+    Credentials -.-> AppTools
+  end
 
-The loop reaches the [sandbox](../sandbox) through operations such as the built-in shell and file tools or `ctx.getSandbox()`. The sandbox is opened lazily on first access. At step boundaries, eve records the identifiers needed to reattach it; live process handles never become workflow state.
+  Bridge{{"Sandbox bridge<br/>bash · read_file · write_file · glob · grep<br/>ctx.getSandbox()<br/>operations ↔ results"}}
+
+  subgraph Isolated["Isolated sandbox"]
+    direction TB
+    Session["Sandbox session"]
+    Skills["Skills<br/>$HOME/.agents/skills<br/>from agent/skills/**"]
+    Workspace["Workspace<br/>/workspace<br/>from agent/sandbox/workspace/**"]
+    Processes["Shell and processes<br/>commands · scripts · servers"]
+    Session --- Skills
+    Session --- Workspace
+    Session --- Processes
+  end
+
+  Loop -->|"sandbox-backed built-ins"| Bridge
+  AppTools -->|"sandbox operations"| Bridge
+  Bridge <--> Session
+
+  style Bridge stroke-width:4px
+```
+
+The loop runs as a durable workflow in the app runtime. Except for provider-managed tools, tool executors also run there. The bridge is the runtime API boundary: it turns built-in shell and file tool calls—or calls through `ctx.getSandbox()`—into sandbox backend operations, then returns their results. The executor stays in the app; only the requested command or filesystem effect lands in the sandbox. The model never receives a live sandbox handle, app environment, or credential.
+
+The [sandbox](../sandbox) owns the per-session filesystem, materialized skills, and any processes the agent starts. It opens lazily on first access. At step boundaries, eve records the identifiers needed to reattach it; live process handles never become workflow state.
 
 Credentials stay on the trusted side. eve resolves model-provider keys, authored-tool secrets, and MCP, OpenAPI, and connection credentials in the app runtime and does not copy them into model context, sandbox environment variables, or files. Each credential is sent only to the service it authenticates. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) injects credentials at the network boundary without exposing them to the process.
 

--- a/docs/concepts/execution-model-and-durability.mdx
+++ b/docs/concepts/execution-model-and-durability.mdx
@@ -44,13 +44,15 @@ An eve agent spans two execution environments with different responsibilities:
 
 <AgentRuntimeDiagram />
 
-The agent loop runs as a durable workflow in the app runtime. Model calls, tool executors, hooks, instrumentation, and connection clients also run there with full Node.js access. Provider-managed tools execute at the model provider, but the loop still orchestrates them from the app runtime.
+The agent loop runs as a durable workflow in the app runtime. Model calls, tool executors, hooks, instrumentation, and connection clients also run there with full Node.js access.
 
-The dashed edge is a logical bridge, not another service or process. `ctx.getSandbox()` gives app-side runtime code a handle for sandbox operations. The built-in `bash`, `read_file`, `write_file`, `glob`, and `grep` tools use it, and authored tools can use it when they need isolated filesystem or process access.
+App-side code reaches the sandbox through `ctx.getSandbox()`. The built-in `bash`, `read_file`, `write_file`, `glob`, and `grep` tools use it, and authored tools can use it when they need isolated filesystem or process access.
 
 The [sandbox](../sandbox) owns the per-session filesystem and processes. Authored skills are materialized under `$HOME/.agents/skills`, and `agent/sandbox/workspace/**` seeds `/workspace`. The loop and sandbox have decoupled lifetimes: the durable workflow can park or restart independently, while the app runtime opens or reuses sandbox compute only when code needs it.
 
-Credentials remain on the trusted side. eve resolves model-provider keys, tool secrets, and MCP, OpenAPI, and connection credentials in the app runtime rather than copying them into model context or the sandbox. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) supplies it without exposing the credential to the process.
+This split keeps credentials and trusted integration code out of model-controlled compute while giving the agent a real filesystem and process environment. Parked workflows also avoid holding sandbox compute.
+
+Provider keys, tool secrets, and MCP, OpenAPI, and connection credentials stay in the app runtime. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) handles the request without exposing the credential to the process.
 
 ## Resuming after a crash
 

--- a/docs/concepts/execution-model-and-durability.mdx
+++ b/docs/concepts/execution-model-and-durability.mdx
@@ -50,7 +50,7 @@ App-side code reaches the sandbox through `ctx.getSandbox()`. The built-in `bash
 
 The [sandbox](../sandbox) owns the per-session filesystem and processes. Authored skills are materialized under `$HOME/.agents/skills`, and `agent/sandbox/workspace/**` seeds `/workspace`. The loop and sandbox have decoupled lifetimes: the durable workflow can park or restart independently, while the app runtime opens or reuses sandbox compute only when code needs it.
 
-This split keeps credentials and trusted integration code out of model-controlled compute while giving the agent a real filesystem and process environment. Parked workflows also avoid holding sandbox compute.
+This split keeps credentials and trusted integration code out of model-controlled compute while giving the agent a real filesystem and process environment. Parked workflows do not hold sandbox compute, sandboxes can scale independently, and a sandbox failure does not erase durable session state. Because access flows through app-side tools, sandbox work gets the same approval and instrumentation path as any other tool call.
 
 Provider keys, tool secrets, and MCP, OpenAPI, and connection credentials stay in the app runtime. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) handles the request without exposing the credential to the process.
 

--- a/docs/concepts/execution-model-and-durability.mdx
+++ b/docs/concepts/execution-model-and-durability.mdx
@@ -42,30 +42,7 @@ The world package backs workflow state, queues, hooks, and streams. Keep secrets
 
 An eve agent spans two execution environments with different responsibilities:
 
-```mermaid
-flowchart LR
-  subgraph App["Trusted app runtime"]
-    direction TB
-    Loop["Agent loop<br/>durable workflow<br/>agent/agent.ts · agent/instructions.md"]
-    Runtime["Runtime code<br/>model calls · tools · hooks · instrumentation · connections<br/>agent/tools/** · agent/hooks/** · agent/instrumentation.ts · agent/connections/**"]
-    Credentials["Secrets and credentials<br/>provider keys · tool secrets · MCP/OpenAPI auth"]
-    Loop --> Runtime
-    Credentials --> Runtime
-  end
-
-  subgraph Sandbox["Isolated sandbox"]
-    direction TB
-    Operations["Sandbox operations<br/>shell · files · processes"]
-    Skills["Skills<br/>$HOME/.agents/skills<br/>from agent/skills/**"]
-    Workspace["Workspace<br/>/workspace<br/>from agent/sandbox/workspace/**"]
-    Processes["Running work<br/>commands · scripts · servers"]
-    Operations --- Skills
-    Operations --- Workspace
-    Operations --- Processes
-  end
-
-  Runtime -.->|"optional sandbox access: ctx.getSandbox()"| Operations
-```
+<AgentRuntimeDiagram />
 
 The agent loop runs as a durable workflow in the app runtime. Model calls, tool executors, hooks, instrumentation, and connection clients also run there with full Node.js access. Provider-managed tools execute at the model provider, but the loop still orchestrates them from the app runtime.
 

--- a/docs/concepts/execution-model-and-durability.mdx
+++ b/docs/concepts/execution-model-and-durability.mdx
@@ -50,7 +50,7 @@ App-side code reaches the sandbox through `ctx.getSandbox()`. The built-in `bash
 
 The [sandbox](../sandbox) owns the per-session filesystem and processes. Authored skills are materialized under `$HOME/.agents/skills`, and `agent/sandbox/workspace/**` seeds `/workspace`. The loop and sandbox have decoupled lifetimes: the durable workflow can park or restart independently, while the app runtime opens or reuses sandbox compute only when code needs it.
 
-This split keeps credentials and trusted integration code out of model-controlled compute while giving the agent a real filesystem and process environment. Parked workflows do not hold sandbox compute, sandboxes can scale independently, and a sandbox failure does not erase durable session state. Because access flows through app-side tools, sandbox work gets the same approval and instrumentation path as any other tool call.
+This split gives the agent a real filesystem and process environment without putting credentials or trusted integration code in model-controlled compute. The workflow can park without holding sandbox compute, while sandbox capacity and backends can change independently of durable orchestration. Because access flows through app-side tools, sandbox work gets the same approval and instrumentation path as any other tool call.
 
 Provider keys, tool secrets, and MCP, OpenAPI, and connection credentials stay in the app runtime. When a sandbox process needs authenticated network access, [credential brokering](./security-model#credential-brokering) handles the request without exposing the credential to the process.
 

--- a/docs/concepts/security-model.md
+++ b/docs/concepts/security-model.md
@@ -20,6 +20,8 @@ The sandbox is the isolated side. The model runs shell commands there through th
 
 A concrete trace makes the boundary clear. When the model calls a custom `charge_card` tool, its `execute` runs in the app runtime, reads `process.env.STRIPE_KEY`, calls Stripe, and returns `{ ok: true }`. The model sees only `{ ok: true }`: the key never leaves the app runtime, and nothing about the call touches the sandbox. The built-in `write_file` is the mirror image, running in the app runtime and proxying the write into the sandbox `/workspace`. Either way the model drives the work through tool calls and their results, never by holding a credential or reaching the runtime directly.
 
+See [Agent loop and sandbox](./execution-model-and-durability#agent-loop-and-sandbox) for how eve connects these contexts while keeping their state and lifetimes separate.
+
 ## Data flow at a glance
 
 ```mermaid


### PR DESCRIPTION
### Description

Document how the durable agent loop and isolated sandbox divide execution, state, credentials, and lifecycle management. Link the security model to the new execution-model section for the full runtime explanation.

### How did you test your changes?

- `pnpm docs:check`
- `pnpm exec oxfmt docs/concepts/execution-model-and-durability.md docs/concepts/security-model.md`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not applicable: docs-only)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)