### PR TITLE
fix(eve): skip span writes after the span has ended

### DIFF
--- a/.changeset/lucky-pugs-listen.md
+++ b/.changeset/lucky-pugs-listen.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fixed non-fatal "Operation attempted on ended Span" errors on long-running self-hosted deployments. Error logs emitted after a turn's OpenTelemetry span ended are now dropped instead of writing to the ended span.

--- a/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
@@ -8,6 +8,7 @@ export interface SpanContext {
 export interface Span {
   addEvent(name: string, attributes?: Record<string, unknown>): this;
   end(): void;
+  isRecording(): boolean;
   recordException(exception: unknown): void;
   setAttribute(key: string, value: unknown): this;
   setStatus(status: { code: SpanStatusCode; message?: string | undefined }): this;

--- a/packages/eve/src/internal/logging.test.ts
+++ b/packages/eve/src/internal/logging.test.ts
@@ -1,13 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Span } from "#compiled/@opentelemetry/api/index.js";
+import { SpanStatusCode } from "#compiled/@opentelemetry/api/index.js";
 import {
   createErrorId,
   createLogger,
   formatError,
   logError,
+  recordErrorOnSpan,
   setLogRecordSubscriber,
   type LogRecord,
 } from "#internal/logging.js";
+
+/** Active span seen by the logger; `undefined` keeps span recording off. */
+let activeSpan: Span | undefined;
+
+vi.mock("#compiled/@opentelemetry/api/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#compiled/@opentelemetry/api/index.js")>();
+  return {
+    ...actual,
+    trace: { ...actual.trace, getActiveSpan: () => activeSpan },
+  };
+});
 
 // ---------------------------------------------------------------------------
 // createErrorId
@@ -295,5 +309,117 @@ describe("logError", () => {
         detail: expect.stringContaining("upstream"),
       },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// span recording guard
+// ---------------------------------------------------------------------------
+
+interface FakeSpan {
+  addEvent: ReturnType<typeof vi.fn>;
+  recordException: ReturnType<typeof vi.fn>;
+  setStatus: ReturnType<typeof vi.fn>;
+  span: Span;
+}
+
+/**
+ * Mirrors the OTel SDK: a span that has ended is no longer recording, and
+ * mutating it logs "Operation attempted on ended Span" — modeled here as a
+ * throw so any unguarded write fails the test loudly.
+ */
+function makeFakeSpan(isRecording: boolean): FakeSpan {
+  const mutate = (name: string) =>
+    vi.fn((..._args: unknown[]) => {
+      if (!isRecording) {
+        throw new Error(`Operation attempted on ended Span: ${name}`);
+      }
+    });
+  const addEvent = mutate("addEvent");
+  const recordException = mutate("recordException");
+  const setStatus = mutate("setStatus");
+  const setAttribute = mutate("setAttribute");
+
+  const span: Span = {
+    addEvent(name, attributes) {
+      addEvent(name, attributes);
+      return this;
+    },
+    end() {},
+    isRecording: () => isRecording,
+    recordException(exception) {
+      recordException(exception);
+    },
+    setAttribute(key, value) {
+      setAttribute(key, value);
+      return this;
+    },
+    setStatus(status) {
+      setStatus(status);
+      return this;
+    },
+    spanContext: () => ({ spanId: "span-id", traceFlags: 1, traceId: "trace-id" }),
+  };
+
+  return { addEvent, recordException, setStatus, span };
+}
+
+describe("span recording guard", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    activeSpan = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("skips writes to an ended active span", () => {
+    const span = makeFakeSpan(false);
+    activeSpan = span.span;
+
+    expect(() => createLogger("ns").error("boom", { error: new Error("x") })).not.toThrow();
+
+    expect(span.setStatus).not.toHaveBeenCalled();
+    expect(span.recordException).not.toHaveBeenCalled();
+    expect(span.addEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips writes to an ended span passed directly", () => {
+    const span = makeFakeSpan(false);
+
+    expect(() => recordErrorOnSpan(span.span, new Error("x"))).not.toThrow();
+
+    expect(span.setStatus).not.toHaveBeenCalled();
+    expect(span.recordException).not.toHaveBeenCalled();
+  });
+
+  it("still records an error on a recording active span", () => {
+    const span = makeFakeSpan(true);
+    activeSpan = span.span;
+
+    createLogger("ns").error("boom", { error: new Error("x") });
+
+    expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: "x" });
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+  });
+
+  it("still adds an event on a recording active span when no error is present", () => {
+    const span = makeFakeSpan(true);
+    activeSpan = span.span;
+
+    createLogger("ns").error("plain", { foo: "bar" });
+
+    expect(span.addEvent).toHaveBeenCalledWith("plain", { foo: "bar" });
+    expect(span.setStatus).not.toHaveBeenCalled();
+  });
+
+  it("still records on a recording span passed directly", () => {
+    const span = makeFakeSpan(true);
+
+    recordErrorOnSpan(span.span, new Error("x"));
+
+    expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: "x" });
+    expect(span.recordException).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/eve/src/internal/logging.ts
+++ b/packages/eve/src/internal/logging.ts
@@ -228,6 +228,13 @@ function truncateForDisplay(value: string, maxChars = 160): string {
  * non-active span should be annotated.
  */
 export function recordErrorOnSpan(span: Span, error: unknown): void {
+  // The harness turn span is ended in a `finally` while still the active
+  // span, so an error log scheduled on a late continuation can reach here
+  // after the end. Writing then makes the OTel SDK log at error level (#776).
+  if (!span.isRecording()) {
+    return;
+  }
+
   const message = error instanceof Error ? error.message : getErrorMessage(error);
   const name = error instanceof Error ? error.name : "Error";
 
@@ -351,7 +358,7 @@ function renderFields(fields: LogFields): JsonObject {
 
 function recordOnActiveSpan(message: string, fields?: LogFields): void {
   const span = trace.getActiveSpan();
-  if (span === undefined) {
+  if (span === undefined || !span.isRecording()) {
     return;
   }
 


### PR DESCRIPTION
### Description

Fixes #776.

On long-running self-hosted (non-Vercel) deployments, every turn that makes tool calls emits repeated `Operation attempted on ended Span` errors at *error* level. It is non-fatal — the turn finishes and replies send — but it fires several times per turn, buries real errors, and trips log-based alerting.

Root cause: eve writes to an OpenTelemetry span after it has been `.end()`-ed. `harness/tool-loop.ts` creates the `ai.eve.turn` span, installs it as the *active* span via `otelContext.with(...)`, and ends it in a `finally` while it is still active. `internal/logging.ts` writes to the active span on every error log with no guard. Tool-call turns widen the async window (model → tool → model), so an error log emitted on a late microtask continuation can resolve after the `finally` ended the span.

Fix: guard both span-mutating helpers in `internal/logging.ts` with `isRecording()`, which the OTel spec defines as returning `false` once a span has ended.

- `recordErrorOnSpan` — early return when the span is not recording. This is the load-bearing guard; the function is exported and called directly by the harness, so it must be self-protecting.
- `recordOnActiveSpan` — tightened from `span === undefined` to also check `!span.isRecording()`, short-circuiting all three mutation branches (`setStatus` / `recordException` / `addEvent`) before any write.

`isRecording` was also added to the vendored `@opentelemetry/api` `Span` declaration, which did not previously expose it.

No change to `harness/tool-loop.ts`: the `setAttribute` there is synchronous inside the awaited body and provably runs before `end()`, and the direct `recordErrorOnSpan(turnSpan, ...)` call sits inside the model-call `try` where the span is still recording, so the guard is a no-op there.

Behavior while a span is live is unchanged — this only drops writes that would otherwise be errors.

### How did you test your changes?

Added a `span recording guard` block to the existing unit-tier `src/internal/logging.test.ts`. It mocks `#compiled/@opentelemetry/api/index.js` (`importOriginal`, real `SpanStatusCode`, overridden `trace.getActiveSpan`) in the style of `execution/subagent-usage-span.test.ts`, and uses a `makeFakeSpan(isRecording)` factory whose mutators **throw** when not recording — mirroring the SDK — so any unguarded write fails the test loudly. Cases cover: ended active span (no throw, no mutation), ended span passed directly to `recordErrorOnSpan`, and three no-regression cases on a recording span.

```sh
pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/logging.test.ts  # 23 passed
pnpm fmt
pnpm lint
pnpm typecheck
pnpm guard:invariants
```

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RApsUy4qVAeVCWwmCph2R
