### PR TITLE
fix(eve): parse tool-call arguments that arrive as a raw JSON string

### DIFF
--- a/.changeset/tool-call-string-input.md
+++ b/.changeset/tool-call-string-input.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Tool calls whose arguments arrive as a raw JSON string — including the empty string some provider-executed tools send for argument-less calls — are now parsed instead of failing the turn with `Failed to parse tool-call arguments`.
+Tool calls whose arguments arrive as a raw JSON string (e.g. provider-executed server tools) are now parsed, and arguments that cannot be parsed at all — such as malformed JSON emitted by the model — surface as a failed tool result the model can react to instead of failing the whole turn.

--- a/.changeset/tool-call-string-input.md
+++ b/.changeset/tool-call-string-input.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Tool calls whose arguments arrive as a raw JSON string — including the empty string some provider-executed tools send for argument-less calls — are now parsed instead of failing the turn with `Failed to parse tool-call arguments`.

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -597,6 +597,54 @@ describe("emitStreamContent action requests", () => {
       },
     ]);
   });
+
+  it("turns malformed provider-executed tool call input into a failed tool result", async () => {
+    const emit = createEmitStub();
+    const message =
+      'Failed to parse tool-call arguments for "web_search" (call-bad): Expected a JSON-serializable object.';
+
+    const result = await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        {
+          // Opus 5 has emitted syntactically invalid JSON for provider
+          // web_search arguments: an unquoted bare value.
+          input: '{"objective": "Find the champion.", "search_queries": 2025 NBA Finals}',
+          providerExecuted: true,
+          toolCallId: "call-bad",
+          toolName: "web_search",
+          type: "tool-call",
+        },
+        { finishReason: "tool-calls", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+      {
+        excludedActionToolNames: new Set(),
+        tools: new Map<string, HarnessToolDefinition>(),
+      },
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          error: { code: "ACTION_RESULT_FAILED", message },
+          result: {
+            callId: "call-bad",
+            isError: true,
+            kind: "tool-result",
+            output: message,
+            toolName: "web_search",
+          },
+          status: "failed",
+        }),
+        type: "action.result",
+      }),
+    ]);
+    expect([...result.invalidInputToolCallIds]).toEqual(["call-bad"]);
+    // Provider results live in the assistant response; no local tool message.
+    expect(result.trailingInlineToolResultParts).toEqual([]);
+  });
 });
 
 describe("emitStreamContent error-part handling", () => {

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -37,13 +37,11 @@ import {
   createRuntimeToolResultFromToolError,
   createToolResultMessagePartFromToolError,
 } from "#harness/action-result-helpers.js";
-import {
-  createRuntimeActionRequestFromToolCall,
-  resolveToolCallInputObject,
-} from "#harness/runtime-actions.js";
+import { createRuntimeActionRequestFromToolCall } from "#harness/runtime-actions.js";
 import {
   createInvalidToolCallInputError,
   isInvalidToolCall,
+  resolveProviderToolCallRequest,
 } from "#harness/tool-call-input-errors.js";
 import type {
   RuntimeActionRequest,
@@ -455,15 +453,15 @@ async function consumeStreamContent(
       await flushCurrentMessage();
     }
 
-    providerActionBatch.observe({
-      callId: toolCall.toolCallId,
-      input: resolveToolCallInputObject(toolCall.input, {
-        callId: toolCall.toolCallId,
-        toolName: toolCall.toolName,
-      }),
-      kind: "tool-call",
-      toolName: toolCall.toolName,
-    });
+    const resolved = resolveProviderToolCallRequest(toolCall);
+    if (resolved.toolError !== undefined) {
+      invalidInputToolCallIds.add(toolCall.toolCallId);
+      await emitActionResult(createRuntimeToolResultFromToolError(resolved.toolError));
+      handledInlineToolResultCallIds.add(toolCall.toolCallId);
+      return;
+    }
+
+    providerActionBatch.observe(resolved.request);
   };
 
   const emitActionResult = async (result: RuntimeToolResultActionResult): Promise<void> => {

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -6,8 +6,8 @@ import type {
 } from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import { resolveTextToResponses } from "#channel/resolve-text.js";
-import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { coalesceTurnInputs } from "#harness/messages.js";
+import { resolveToolCallInputObject } from "#harness/runtime-actions.js";
 import {
   isSessionLimitContinuationRequest,
   resolveSessionLimitContinuation,
@@ -675,27 +675,4 @@ export function createRuntimeToolCallActionFromToolCall(input: {
     kind: "tool-call",
     toolName: input.toolCall.toolName,
   };
-}
-
-function resolveToolCallInputObject(
-  value: unknown,
-  context: { readonly callId: string; readonly toolName: string },
-): JsonObject {
-  if (value === undefined || value === null) {
-    return {};
-  }
-
-  if (typeof value === "string" && value.trim() === "") {
-    return {};
-  }
-
-  try {
-    return parseJsonObject(typeof value === "string" ? JSON.parse(value) : value);
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new TypeError(
-      `Failed to parse tool-call arguments for "${context.toolName}" (${context.callId}): ${detail}`,
-      { cause: error },
-    );
-  }
 }

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -685,8 +685,12 @@ function resolveToolCallInputObject(
     return {};
   }
 
+  if (typeof value === "string" && value.trim() === "") {
+    return {};
+  }
+
   try {
-    return parseJsonObject(value);
+    return parseJsonObject(typeof value === "string" ? JSON.parse(value) : value);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new TypeError(

--- a/packages/eve/src/harness/runtime-actions.test.ts
+++ b/packages/eve/src/harness/runtime-actions.test.ts
@@ -4,6 +4,7 @@ import {
   getPendingRuntimeActionBatch,
   recordPendingSubagentChild,
   resolvePendingRuntimeActions,
+  resolveToolCallInputObject,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
 import { getSessionTokenUsage, setTurnUsageState } from "#harness/turn-tag-state.js";
@@ -133,5 +134,40 @@ describe("pending subagent child adoption", () => {
         "call-remote": "remote-child",
       },
     });
+  });
+});
+
+describe("resolveToolCallInputObject", () => {
+  const context = { callId: "call-1", toolName: "web_search" };
+
+  it("passes plain objects through", () => {
+    expect(resolveToolCallInputObject({ query: "eve" }, context)).toEqual({ query: "eve" });
+  });
+
+  it("treats undefined, null, and empty-string inputs as empty arguments", () => {
+    expect(resolveToolCallInputObject(undefined, context)).toEqual({});
+    expect(resolveToolCallInputObject(null, context)).toEqual({});
+    expect(resolveToolCallInputObject("", context)).toEqual({});
+    expect(resolveToolCallInputObject("  ", context)).toEqual({});
+  });
+
+  it("parses raw JSON-string inputs from provider-executed tool calls", () => {
+    expect(resolveToolCallInputObject('{"query":"eve"}', context)).toEqual({ query: "eve" });
+  });
+
+  it("rejects strings that are not JSON objects, naming the tool and call", () => {
+    expect(() => resolveToolCallInputObject('"query"', context)).toThrow(
+      /web_search.*call-1.*Expected a JSON-serializable object/su,
+    );
+    expect(() => resolveToolCallInputObject("not json", context)).toThrow(/web_search.*call-1/su);
+  });
+
+  it("rejects non-object JSON values", () => {
+    expect(() => resolveToolCallInputObject(42, context)).toThrow(
+      /Expected a JSON-serializable object/u,
+    );
+    expect(() => resolveToolCallInputObject(["a"], context)).toThrow(
+      /Expected a JSON-serializable object/u,
+    );
   });
 });

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -438,7 +438,7 @@ export function resolveToolCallInputObject(
   }
 
   try {
-    return parseJsonObject(typeof value === "string" ? JSON.parse(value) : value);
+    return parseJsonObject(typeof value === "string" ? parseJsonStringInput(value) : value);
   } catch (error) {
     // This module is bundled into the workflow driver body, which cannot
     // import the logger, so enrich the error (and keep the original as
@@ -448,6 +448,16 @@ export function resolveToolCallInputObject(
       `Failed to parse tool-call arguments for "${context.toolName}" (${context.callId}): ${detail}`,
       { cause: error },
     );
+  }
+}
+
+function parseJsonStringInput(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    // Not JSON at all — return the raw string so parseJsonObject rejects it
+    // with the canonical "Expected a JSON-serializable object." detail.
+    return value;
   }
 }
 

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -420,6 +420,10 @@ export function createRuntimeActionRequestFromToolCall(input: {
  * Coerces an AI SDK tool-call `input` into the runtime-action `JsonObject`
  * contract, throwing a `TypeError` (with the original as `cause`) that names
  * the offending tool when the payload is not a JSON object.
+ *
+ * String inputs are parsed as JSON first: the model protocol carries tool
+ * arguments as text, and provider-executed tool calls can surface that raw
+ * string — or an empty string when the model sends no arguments.
  */
 export function resolveToolCallInputObject(
   value: unknown,
@@ -429,8 +433,12 @@ export function resolveToolCallInputObject(
     return {};
   }
 
+  if (typeof value === "string" && value.trim() === "") {
+    return {};
+  }
+
   try {
-    return parseJsonObject(value);
+    return parseJsonObject(typeof value === "string" ? JSON.parse(value) : value);
   } catch (error) {
     // This module is bundled into the workflow driver body, which cannot
     // import the logger, so enrich the error (and keep the original as

--- a/packages/eve/src/harness/tool-call-input-errors.ts
+++ b/packages/eve/src/harness/tool-call-input-errors.ts
@@ -1,5 +1,6 @@
 import type { ToolSet, TypedToolCall, TypedToolError } from "ai";
 
+import type { RuntimeToolCallActionRequest } from "#runtime/actions/types.js";
 import { resolveToolCallInputObject } from "#harness/runtime-actions.js";
 
 /**
@@ -54,6 +55,52 @@ export function createInvalidToolCallInputError(input: {
   }
 
   return toolError as TypedToolError<ToolSet>;
+}
+
+/**
+ * Resolves a provider-executed tool call into an observable runtime-action
+ * request, or the synthesized tool error when the model emitted arguments
+ * that cannot satisfy the JSON-object contract.
+ *
+ * Provider-executed calls skip the AI SDK's input validation, so malformed
+ * JSON argument text reaches the harness only here.
+ */
+export function resolveProviderToolCallRequest(toolCall: {
+  readonly input?: unknown;
+  readonly toolCallId: string;
+  readonly toolName: string;
+}):
+  | { readonly request: RuntimeToolCallActionRequest; readonly toolError?: undefined }
+  | { readonly request?: undefined; readonly toolError: TypedToolError<ToolSet> } {
+  try {
+    return {
+      request: {
+        callId: toolCall.toolCallId,
+        input: resolveToolCallInputObject(toolCall.input, {
+          callId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+        }),
+        kind: "tool-call",
+        toolName: toolCall.toolName,
+      },
+    };
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+    return {
+      toolError: createInvalidToolCallInputError({
+        error,
+        toolCall: {
+          input: toolCall.input,
+          providerExecuted: true,
+          toolCallId: toolCall.toolCallId,
+          toolName: toolCall.toolName,
+          type: "tool-call",
+        } as TypedToolCall<ToolSet>,
+      }),
+    };
+  }
 }
 
 export function getInvalidToolCallInputError(input: {


### PR DESCRIPTION
Every PR that includes current main fails `e2e-local (agent-tools, anthropic-opus)` on the `static-tools/web-search-narration-ordering` eval:

```
TypeError: Failed to parse tool-call arguments for "web_search" (toolu_01DkyGBuJv6kPcZjePLq4cQH): Expected a JSON-serializable object.
  [cause]: TypeError: Expected a JSON-serializable object.
[eve:harness.tool-loop] model call failed — parking session for retry by the user
```

Reproduced on two consecutive runs on both e2e-local and e2e-vercel (vercel/eve#1219 after merging main). Deterministic since #1187 bumped the e2e fixtures to Opus 5.

**What broke**

`resolveToolCallInputObject` coerces AI SDK tool-call `input` into the runtime-action `JsonObject` contract. It handled `undefined`/`null` but passed everything else to `parseJsonObject`, which rejects strings — a string is a valid JSON value, not an object. The model protocol carries tool arguments as text, and provider-executed tool calls can surface that raw string to the harness; Opus 5 does this for gateway `web_search`, sending an empty string for argument-less calls. The cause chain in the log pins it: `parseJsonValue` accepted the input, `isJsonObjectValue` rejected it, and `null`/`undefined` were already handled — a string is what's left.

**The fix**

Empty and whitespace-only strings coerce to `{}` like `undefined`/`null`. Other strings are `JSON.parse`d and must yield an object. Non-object JSON values (numbers, arrays, bare JSON strings) still throw the tool-naming `TypeError`. Both copies of the coercer get the same change — the exported one in `runtime-actions.ts` and the duplicate in `input-requests.ts` (kept separate because the module is bundled into the workflow driver body).

Unit tests cover the passthrough, the empty/whitespace coercion, JSON-string parsing, and both rejection paths. The e2e proof is the `agent-tools` anthropic-opus cell going green on this PR's own run.
