### PR TITLE
docs: add Upstash AgentKit integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1240,6 +1240,68 @@ export { default } from "@onkernel/eve-extension";
 
 The default mount can execute JavaScript in the browser VM and reuse authenticated browser sessions. For team or multi-tenant agents, prefer Vercel Connect so each user authenticates separately, and add an approval gate by overriding the extension's \`browser\` connection. See the [Kernel eve extension guide](https://www.kernel.sh/docs/integrations/vercel/eve-extension) for API-key configuration, connection overrides, the complete tool list, and security guidance.`,
   },
+  "upstash-agentkit": {
+    logo: "upstash",
+    docsHref: "https://upstash.com/docs/redis/sdks/agentkit/eve",
+    keywords: [
+      "upstash",
+      "agentkit",
+      "redis",
+      "memory",
+      "long-term memory",
+      "chat history",
+      "search",
+      "rag",
+      "vector search",
+    ],
+    install: `Install the Upstash AgentKit extension for eve:
+
+\`\`\`bash
+pnpm add @upstash/agentkit-eve-extension
+\`\`\`
+
+The extension requires eve 0.25.2 or later. Add an Upstash Redis database's REST credentials to the agent's environment; the default Redis client reads them automatically:
+
+\`\`\`bash title=".env.local"
+UPSTASH_REDIS_REST_URL=https://...
+UPSTASH_REDIS_REST_TOKEN=...
+\`\`\``,
+    quickStart: `Mount the extension under \`agent/extensions/\`:
+
+\`\`\`ts title="agent/extensions/agentkit.ts"
+import agentkit from "@upstash/agentkit-eve-extension";
+
+export default agentkit();
+\`\`\`
+
+The filename supplies the \`agentkit\` namespace. This minimal mount adds \`agentkit__recall_memory\` and \`agentkit__save_memory\`, plus instructions that teach the model when to use them. By default, memory is isolated by the authenticated principal when available and otherwise by the eve session ID.`,
+    configure: `Enable durable transcript capture with \`chatHistory: true\`. To add RAG over a Redis Search index, install \`@upstash/redis\` and provide a schema:
+
+\`\`\`bash
+pnpm add @upstash/redis
+\`\`\`
+
+\`\`\`ts title="agent/extensions/agentkit.ts"
+import { s } from "@upstash/redis";
+import agentkit from "@upstash/agentkit-eve-extension";
+
+export default agentkit({
+  chatHistory: true,
+  search: {
+    schema: s.object({
+      title: s.string(),
+      author: s.string().noTokenize(),
+      year: s.number(),
+    }),
+    indexName: "books",
+  },
+});
+\`\`\`
+
+Search configuration adds the dynamic \`agentkit__search\`, \`agentkit__search_aggregate\`, and \`agentkit__search_count\` tools. Chat history stores each session's user and assistant messages in Redis and makes their text searchable; it does not add a model-facing tool.
+
+For multi-tenant agents, set \`userId\` to a stable tenant-scoped value or derive it from the request context, and never use a shared constant across tenants. You can also tune memory recall, search limits, chat-history keys and TTL, or supply an explicit Redis client. See the [Upstash AgentKit eve extension guide](https://upstash.com/docs/redis/sdks/agentkit/eve) for the complete configuration and override reference.`,
+  },
   jetty: {
     logo: "jetty",
     docsHref: "https://github.com/jettyio/jetty-sdk/tree/main/packages/eve#readme",

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -55,6 +55,19 @@ describe("integration discovery", () => {
     expect(integrationSearchText(jetty!)).toContain("grading");
   });
 
+  it("renders the Upstash AgentKit extension setup", () => {
+    const agentkit = getIntegration("upstash-agentkit");
+    expect(agentkit).toBeDefined();
+
+    const markdown = integrationMarkdown(agentkit!);
+    expect(markdown).toContain("pnpm add @upstash/agentkit-eve-extension");
+    expect(markdown).toContain('import agentkit from "@upstash/agentkit-eve-extension"');
+    expect(markdown).toContain("UPSTASH_REDIS_REST_URL");
+    expect(markdown).toContain("agentkit__recall_memory");
+    expect(markdown).toContain("chatHistory: true");
+    expect(integrationSearchText(agentkit!)).toContain("long-term memory");
+  });
+
   it("renders the GitHub Tools extension setup", () => {
     const githubTools = getIntegration("github-tools");
     expect(githubTools).toBeDefined();

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -27,6 +27,7 @@ import {
   SiSupabase,
   SiTicktick,
   SiTodoist,
+  SiUpstash,
   SiWebflow,
   SiWhatsapp,
   SiWix,
@@ -170,6 +171,8 @@ export const linearLogo = (props: LogoProps) => (
 );
 
 export const notionLogo = (props: LogoProps) => <SiNotion {...props} />;
+
+export const upstashLogo = (props: LogoProps) => <SiUpstash color="default" {...props} />;
 
 export const datadogLogo = (props: LogoProps) => <SiDatadog color="default" {...props} />;
 
@@ -562,6 +565,7 @@ export const logos = {
   datadog: datadogLogo,
   honeycomb: honeycombLogo,
   kernel: kernelLogo,
+  upstash: upstashLogo,
   airtable: airtableLogo,
   bitly: bitlyLogo,
   brex: brexLogo,

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -77,6 +77,11 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("jetty")?.connection).toBeUndefined();
   });
 
+  it("exposes Upstash AgentKit as an extension", () => {
+    expect(getIntegrationEntry("upstash-agentkit")?.kind).toBe("extension");
+    expect(getIntegrationEntry("upstash-agentkit")?.connection).toBeUndefined();
+  });
+
   it("exposes GitHub Tools as an extension distinct from the GitHub channel", () => {
     expect(getIntegrationEntry("github")?.kind).toBe("channel");
     expect(getIntegrationEntry("github-tools")?.kind).toBe("extension");

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -299,6 +299,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "upstash-agentkit",
+    name: "Upstash AgentKit",
+    kind: "extension",
+    tagline: "Add long-term memory, Redis Search, and durable chat history with Upstash Redis.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "browser-use",
     name: "Browser Use",
     kind: "connection",


### PR DESCRIPTION
## Summary

- add Upstash AgentKit to the integrations catalog
- document memory, Redis Search, and durable chat-history setup
- add the official Upstash icon and integration coverage

<img width="960" height="1343" alt="image" src="https://github.com/user-attachments/assets/928b7c30-f79f-42ad-88b4-de66c263dfa6" />

## Validation

- `pnpm --filter @vercel/eve-catalog test`
- `pnpm --filter eve-docs test:unit -- lib/integrations/discovery.test.ts`
- `pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm docs:check`
- `pnpm exec oxlint apps/docs/lib/integrations/data.ts apps/docs/lib/integrations/discovery.test.ts apps/docs/lib/integrations/logos.tsx packages/eve-catalog/src/index.ts packages/eve-catalog/src/index.test.ts`