### PR TITLE
fix(eve): stub content-output file payloads in the compaction transcript

### DIFF
--- a/.changeset/compaction-content-part-stubs.md
+++ b/.changeset/compaction-content-part-stubs.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Compaction no longer reproduces base64 file payloads from `content` tool outputs in the summarizer transcript. File parts are replaced with a text stub naming the file and media type (matching how message attachments are summarized); text parts still reach the checkpoint model raw.
+Compaction no longer reproduces base64 file payloads from `content` tool outputs. In the summarizer transcript and in capped kept-history results alike, file parts are replaced with a text stub naming the file and media type (matching how message attachments are summarized); sibling text parts survive instead of being truncated away behind the serialized payload.

--- a/.changeset/compaction-content-part-stubs.md
+++ b/.changeset/compaction-content-part-stubs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Compaction no longer reproduces base64 file payloads from `content` tool outputs in the summarizer transcript. File parts are replaced with a text stub naming the file and media type (matching how message attachments are summarized); text parts still reach the checkpoint model raw.

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -109,6 +109,8 @@ The `toolOutput.text` and `toolOutput.json` builders construct the other two out
 
 File payloads must be base64 strings — raw bytes (`Uint8Array`, `Buffer`) are rejected because they do not survive eve's durable JSON boundary. Keep payloads small: a content-part image is persisted in session history and re-sent on every subsequent model call, and eve warns above 3 MiB. Sending image parts to a model without vision support fails with that provider's error, the same as image parts in user messages.
 
+When older turns are compacted, file payloads are dropped from the summary and replaced with a text stub naming the file and media type — the model cannot re-see a compacted image. Content parts are for "look at this now"; if the agent may need an artifact again later, write it to the [sandbox](/docs/sandbox) and return its path.
+
 Do not return secrets, credentials, unnecessary personal data, or unbounded sensitive content from tools. Filter, minimize, and redact tool outputs before returning them.
 
 ## What to read next

--- a/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
@@ -3,6 +3,8 @@ import { mockModel, type MockModelRequest } from "eve/evals";
 
 import {
   COMPACTION_CHECKPOINT_TEXT,
+  CONTENT_OUTPUT_COMPACTION_MARKER,
+  CONTENT_OUTPUT_TAIL_MARKER,
   SECOND_CHECKPOINT_MARKER,
   TASK_PRESERVED_MARKER,
   TASK_TAIL_SENTINEL,
@@ -11,7 +13,11 @@ import {
 const TEST_CONTEXT_WINDOW_TOKENS = 32_000;
 const MAX_TOOL_CALLS = 10;
 
-type RegressionCase = "redundant-tool-calls" | "stale-todo-work" | "task-survival";
+type RegressionCase =
+  | "content-output-file-stub"
+  | "redundant-tool-calls"
+  | "stale-todo-work"
+  | "task-survival";
 
 let activeCase: RegressionCase | undefined;
 const checkpointAdvanceCallCounts = new Map<RegressionCase, number>();
@@ -46,6 +52,33 @@ const taskModel = mockModel({
     }
 
     const regressionCase = activeCase;
+
+    if (regressionCase === "content-output-file-stub") {
+      const compacted = request.messages.some(
+        (message) => message.role === "user" && message.text === COMPACTION_CHECKPOINT_TEXT,
+      );
+      if (compacted) {
+        return assistantEvidenceContains(request.messages, CONTENT_OUTPUT_TAIL_MARKER)
+          ? `Checkpoint preserved content-output text: ${CONTENT_OUTPUT_COMPACTION_MARKER}`
+          : "Checkpoint lost content-output text: CONTENT_OUTPUT_TEXT_LOST";
+      }
+
+      const contentOutputCalls = toolCallCounts.get(regressionCase) ?? 0;
+      if (contentOutputCalls >= 1) {
+        return "Hard stop without a compaction: CONTENT_OUTPUT_NO_COMPACTION";
+      }
+
+      toolCallCounts.set(regressionCase, contentOutputCalls + 1);
+      return {
+        toolCalls: [
+          {
+            id: "emit-compaction-content-1",
+            input: {},
+            name: "emit-compaction-content",
+          },
+        ],
+      };
+    }
 
     if (regressionCase === "task-survival") {
       const compacted = request.messages.some(
@@ -161,13 +194,16 @@ function findInitialCase(request: MockModelRequest): RegressionCase | undefined 
 }
 
 function regressionCaseFromText(text: string): RegressionCase | undefined {
+  if (text.includes("[case: content-output-file-stub]")) return "content-output-file-stub";
   if (text.includes("[case: redundant-tool-calls]")) return "redundant-tool-calls";
   if (text.includes("[case: stale-todo-work]")) return "stale-todo-work";
   if (text.includes("[case: task-survival]")) return "task-survival";
   return undefined;
 }
 
-function completionMarker(regressionCase: Exclude<RegressionCase, "task-survival">): string {
+function completionMarker(
+  regressionCase: Exclude<RegressionCase, "content-output-file-stub" | "task-survival">,
+): string {
   return regressionCase === "redundant-tool-calls"
     ? "REPOSITORY_INSPECTION_COMPLETE"
     : "SOURCE_ANALYSIS_COMPLETE";

--- a/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
@@ -4,6 +4,9 @@ import { mockModel, type MockModelRequest } from "eve/evals";
 import {
   COMPACTION_CHECKPOINT_TEXT,
   CONTENT_OUTPUT_COMPACTION_MARKER,
+  CONTENT_OUTPUT_FILENAME,
+  CONTENT_OUTPUT_LEAD_MARKER,
+  CONTENT_OUTPUT_PAYLOAD_CANARY,
   CONTENT_OUTPUT_TAIL_MARKER,
   SECOND_CHECKPOINT_MARKER,
   TASK_PRESERVED_MARKER,
@@ -58,9 +61,33 @@ const taskModel = mockModel({
         (message) => message.role === "user" && message.text === COMPACTION_CHECKPOINT_TEXT,
       );
       if (compacted) {
-        return assistantEvidenceContains(request.messages, CONTENT_OUTPUT_TAIL_MARKER)
-          ? `Checkpoint preserved content-output text: ${CONTENT_OUTPUT_COMPACTION_MARKER}`
-          : "Checkpoint lost content-output text: CONTENT_OUTPUT_TEXT_LOST";
+        // Every check reads assistant evidence (the checkpoint), so each fact
+        // proves what the compaction prompt contained: markers and the stub
+        // filename can only arrive through their own rendering, and the
+        // payload canary can only arrive if the raw payload leaked.
+        const diagnostics = [
+          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_TAIL_MARKER)
+            ? "TAIL_PRESERVED"
+            : "TAIL_LOST",
+          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_LEAD_MARKER)
+            ? "LEAD_PRESERVED"
+            : "LEAD_LOST",
+          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_FILENAME)
+            ? "FILE_STUB_RENDERED"
+            : "FILE_STUB_LOST",
+          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_PAYLOAD_CANARY)
+            ? "PAYLOAD_LEAKED"
+            : "NO_PAYLOAD_LEAK",
+          request.userMessages.some((text) => text.includes("[case: content-output-file-stub]"))
+            ? "NEIGHBOR_PRESERVED"
+            : "NEIGHBOR_LOST",
+        ];
+        const honored =
+          !diagnostics.some((entry) => entry.endsWith("_LOST")) &&
+          !diagnostics.includes("PAYLOAD_LEAKED");
+        return honored
+          ? `Checkpoint honored the content-output contract (${diagnostics.join(", ")}): ${CONTENT_OUTPUT_COMPACTION_MARKER}`
+          : `Checkpoint violated the content-output contract: ${diagnostics.join(", ")}`;
       }
 
       const contentOutputCalls = toolCallCounts.get(regressionCase) ?? 0;

--- a/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
@@ -86,41 +86,31 @@ const taskModel = mockModel({
 
     if (regressionCase === "content-output-file-stub") {
       contentOutputHistoryShapes.push(renderHistoryShape(request));
-      const compacted = request.messages.some(
-        (message) => message.role === "user" && message.text === COMPACTION_CHECKPOINT_TEXT,
-      );
-      if (compacted) {
-        // Every check reads assistant evidence (the checkpoint), so each fact
-        // proves what the compaction prompt contained: markers and the stub
-        // filename can only arrive through their own rendering, and the
-        // payload canary can only arrive if the raw payload leaked.
+      // Compaction's tool-result cap heuristic rewrites the oversized content
+      // output in place: same messages, file part reduced to its text stub.
+      // The canary's absence is the detection signal — the raw payload can
+      // only be missing from the tool message if the cap ran.
+      const toolText = request.messages.find((message) => message.role === "tool")?.text;
+      const capped = toolText !== undefined && !toolText.includes(CONTENT_OUTPUT_PAYLOAD_CANARY);
+      if (toolText !== undefined && capped) {
         const diagnostics = [
-          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_TAIL_MARKER)
-            ? "TAIL_PRESERVED"
-            : "TAIL_LOST",
-          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_LEAD_MARKER)
-            ? "LEAD_PRESERVED"
-            : "LEAD_LOST",
-          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_FILENAME)
+          toolText.includes(CONTENT_OUTPUT_TAIL_MARKER) ? "TAIL_PRESERVED" : "TAIL_LOST",
+          toolText.includes(CONTENT_OUTPUT_LEAD_MARKER) ? "LEAD_PRESERVED" : "LEAD_LOST",
+          toolText.includes(`Attached file ${CONTENT_OUTPUT_FILENAME}`)
             ? "FILE_STUB_RENDERED"
             : "FILE_STUB_LOST",
-          assistantEvidenceContains(request.messages, CONTENT_OUTPUT_PAYLOAD_CANARY)
-            ? "PAYLOAD_LEAKED"
-            : "NO_PAYLOAD_LEAK",
           request.userMessages.some((text) => text.includes("[case: content-output-file-stub]"))
             ? "NEIGHBOR_PRESERVED"
             : "NEIGHBOR_LOST",
         ];
-        const honored =
-          !diagnostics.some((entry) => entry.endsWith("_LOST")) &&
-          !diagnostics.includes("PAYLOAD_LEAKED");
+        const honored = !diagnostics.some((entry) => entry.endsWith("_LOST"));
         const history = contentOutputHistoryShapes
           .map((shape, index) => `${index + 1}: ${shape}`)
           .join(" ;; ");
         return honored
-          ? `Checkpoint honored the content-output contract (${diagnostics.join(", ")}): ` +
+          ? `Capped history honored the content-output contract (${diagnostics.join(", ")}): ` +
               `${CONTENT_OUTPUT_COMPACTION_MARKER} HISTORY<${history}>`
-          : `Checkpoint violated the content-output contract: ${diagnostics.join(", ")} ` +
+          : `Capped history violated the content-output contract: ${diagnostics.join(", ")} ` +
               `HISTORY<${history}>`;
       }
 

--- a/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/agent.ts
@@ -26,6 +26,34 @@ let activeCase: RegressionCase | undefined;
 const checkpointAdvanceCallCounts = new Map<RegressionCase, number>();
 const toolCallCounts = new Map<RegressionCase, number>();
 
+/** One entry per content-output-file-stub model call, rendered by {@link renderHistoryShape}. */
+const contentOutputHistoryShapes: string[] = [];
+
+/**
+ * Renders one request's message list as a stable role:kind sequence so the
+ * eval can assert the exact conversation shape around a compaction. Kinds are
+ * derived from framework-owned sentinels, not content the summarizer writes.
+ */
+function renderHistoryShape(request: MockModelRequest): string {
+  return request.messages
+    .map((message, index) => {
+      if (message.role === "system") return "system";
+      if (message.role === "tool") return "tool:result";
+      if (message.role === "assistant") {
+        const previous = request.messages[index - 1];
+        if (previous?.role === "user" && previous.text === COMPACTION_CHECKPOINT_TEXT) {
+          return "assistant:checkpoint";
+        }
+        return message.text.trim().length === 0 ? "assistant:tool-call" : "assistant:text";
+      }
+      if (message.text === COMPACTION_CHECKPOINT_TEXT) return "user:checkpoint-marker";
+      if (message.text.includes("[case: content-output-file-stub]")) return "user:task";
+      if (message.text === "Continue.") return "user:resume";
+      return `user:other(${message.text.replace(/\s+/g, " ").slice(0, 32)})`;
+    })
+    .join(" > ");
+}
+
 let requestCount = 0;
 
 const taskModel = mockModel({
@@ -57,6 +85,7 @@ const taskModel = mockModel({
     const regressionCase = activeCase;
 
     if (regressionCase === "content-output-file-stub") {
+      contentOutputHistoryShapes.push(renderHistoryShape(request));
       const compacted = request.messages.some(
         (message) => message.role === "user" && message.text === COMPACTION_CHECKPOINT_TEXT,
       );
@@ -85,9 +114,14 @@ const taskModel = mockModel({
         const honored =
           !diagnostics.some((entry) => entry.endsWith("_LOST")) &&
           !diagnostics.includes("PAYLOAD_LEAKED");
+        const history = contentOutputHistoryShapes
+          .map((shape, index) => `${index + 1}: ${shape}`)
+          .join(" ;; ");
         return honored
-          ? `Checkpoint honored the content-output contract (${diagnostics.join(", ")}): ${CONTENT_OUTPUT_COMPACTION_MARKER}`
-          : `Checkpoint violated the content-output contract: ${diagnostics.join(", ")}`;
+          ? `Checkpoint honored the content-output contract (${diagnostics.join(", ")}): ` +
+              `${CONTENT_OUTPUT_COMPACTION_MARKER} HISTORY<${history}>`
+          : `Checkpoint violated the content-output contract: ${diagnostics.join(", ")} ` +
+              `HISTORY<${history}>`;
       }
 
       const contentOutputCalls = toolCallCounts.get(regressionCase) ?? 0;

--- a/e2e/fixtures/agent-compaction-regressions/agent/tools/emit-compaction-content.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/tools/emit-compaction-content.ts
@@ -1,0 +1,28 @@
+import { defineTool, toolOutput, toolOutputPart } from "eve/tools";
+import { z } from "zod";
+
+import { CONTENT_OUTPUT_TAIL_MARKER } from "../../constants";
+
+const INLINE_FILE_BASE64 = "A".repeat(12_000);
+
+export default defineTool({
+  description:
+    "Compaction regression tool. Emits a large inline file followed by text that the checkpoint must preserve.",
+  inputSchema: z.object({}),
+  async execute() {
+    return { completed: true };
+  },
+  toModelOutput() {
+    return toolOutput.content([
+      // The file stays first so prefix-clipping the serialized output loses the
+      // trailing marker. Rendering an attachment stub leaves the marker visible.
+      toolOutputPart.file(INLINE_FILE_BASE64, {
+        filename: "compaction-evidence.bin",
+        mediaType: "application/octet-stream",
+      }),
+      toolOutputPart.text(
+        `Completed content-output work. Preserve this exact marker: ${CONTENT_OUTPUT_TAIL_MARKER}`,
+      ),
+    ]);
+  },
+});

--- a/e2e/fixtures/agent-compaction-regressions/agent/tools/emit-compaction-content.ts
+++ b/e2e/fixtures/agent-compaction-regressions/agent/tools/emit-compaction-content.ts
@@ -1,27 +1,42 @@
 import { defineTool, toolOutput, toolOutputPart } from "eve/tools";
 import { z } from "zod";
 
-import { CONTENT_OUTPUT_TAIL_MARKER } from "../../constants";
+import {
+  CONTENT_OUTPUT_FILENAME,
+  CONTENT_OUTPUT_LEAD_MARKER,
+  CONTENT_OUTPUT_PAYLOAD_CANARY,
+  CONTENT_OUTPUT_TAIL_MARKER,
+} from "../../constants";
 
-const INLINE_FILE_BASE64 = "A".repeat(12_000);
+// The canary sits within the first 2000 serialized characters, where the old
+// prefix-clipping rendering would expose it to the compaction model. The rest
+// of the payload pushes the trailing text far past that clip budget.
+const INLINE_FILE_BASE64 = `${"A".repeat(400)}${CONTENT_OUTPUT_PAYLOAD_CANARY}${"A".repeat(11_600)}`;
 
 export default defineTool({
   description:
-    "Compaction regression tool. Emits a large inline file followed by text that the checkpoint must preserve.",
+    "Compaction regression tool. Emits text, a large inline file, and trailing text the " +
+    "checkpoint must preserve.",
   inputSchema: z.object({}),
   async execute() {
     return { completed: true };
   },
   toModelOutput() {
     return toolOutput.content([
-      // The file stays first so prefix-clipping the serialized output loses the
-      // trailing marker. Rendering an attachment stub leaves the marker visible.
+      // The lead marker is spelled ONLY here — never in the tail's preserve
+      // instructions — so it can reach the checkpoint solely through this
+      // part's own rendering.
+      toolOutputPart.text(`Work log (preserve this marker): ${CONTENT_OUTPUT_LEAD_MARKER}`),
       toolOutputPart.file(INLINE_FILE_BASE64, {
-        filename: "compaction-evidence.bin",
+        filename: CONTENT_OUTPUT_FILENAME,
         mediaType: "application/octet-stream",
       }),
+      // "The attachment's filename" is deliberately not spelled out: the
+      // checkpoint can only carry it by reading the rendered stub.
       toolOutputPart.text(
-        `Completed content-output work. Preserve this exact marker: ${CONTENT_OUTPUT_TAIL_MARKER}`,
+        "Completed content-output work. Preserve every CONTENT_OUTPUT_TEXT_* marker visible " +
+          "in this conversation and the attachment's exact filename. " +
+          `Preserve this exact marker: ${CONTENT_OUTPUT_TAIL_MARKER}`,
       ),
     ]);
   },

--- a/e2e/fixtures/agent-compaction-regressions/constants.ts
+++ b/e2e/fixtures/agent-compaction-regressions/constants.ts
@@ -12,3 +12,9 @@ export const TASK_PRESERVED_MARKER = "TASK_PRESERVED_AFTER_COMPACTION";
 
 /** Checkpoint marker the harness inserts when compaction summarizes. */
 export const COMPACTION_CHECKPOINT_TEXT = "Summary of our conversation so far:";
+
+/** Trailing content-output text that must reach the compaction model. */
+export const CONTENT_OUTPUT_TAIL_MARKER = "CONTENT_OUTPUT_TEXT_AFTER_FILE";
+
+/** Reported by the task model only when the checkpoint preserved the trailing text. */
+export const CONTENT_OUTPUT_COMPACTION_MARKER = "CONTENT_OUTPUT_TEXT_SURVIVED_COMPACTION";

--- a/e2e/fixtures/agent-compaction-regressions/constants.ts
+++ b/e2e/fixtures/agent-compaction-regressions/constants.ts
@@ -13,8 +13,27 @@ export const TASK_PRESERVED_MARKER = "TASK_PRESERVED_AFTER_COMPACTION";
 /** Checkpoint marker the harness inserts when compaction summarizes. */
 export const COMPACTION_CHECKPOINT_TEXT = "Summary of our conversation so far:";
 
+/** Leading content-output text that must reach the compaction model. */
+export const CONTENT_OUTPUT_LEAD_MARKER = "CONTENT_OUTPUT_TEXT_BEFORE_FILE";
+
 /** Trailing content-output text that must reach the compaction model. */
 export const CONTENT_OUTPUT_TAIL_MARKER = "CONTENT_OUTPUT_TEXT_AFTER_FILE";
 
-/** Reported by the task model only when the checkpoint preserved the trailing text. */
+/**
+ * Buried near the start of the inline file payload (base64 alphabet only).
+ * It can appear in the checkpoint only if the raw payload reached the
+ * compaction prompt — a summarizer cannot invent it — so its presence
+ * proves the payload leaked instead of rendering as a stub. Prefix-clipping
+ * the serialized output (the old behavior) exposes it by construction.
+ */
+export const CONTENT_OUTPUT_PAYLOAD_CANARY = "QQPAYLOADCANARYXKJMZZ";
+
+/**
+ * Filename of the emitted file part. It exists nowhere in the transcript
+ * except the rendered attachment stub, so the checkpoint can carry it only
+ * if the stub reached the compaction prompt.
+ */
+export const CONTENT_OUTPUT_FILENAME = "compaction-evidence.bin";
+
+/** Reported by the task model only when the checkpoint honored the full contract. */
 export const CONTENT_OUTPUT_COMPACTION_MARKER = "CONTENT_OUTPUT_TEXT_SURVIVED_COMPACTION";

--- a/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
+++ b/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
@@ -2,24 +2,27 @@ import { defineEval } from "eve/evals";
 
 import { CONTENT_OUTPUT_COMPACTION_MARKER } from "../constants";
 
-// The mock task model reports CONTENT_OUTPUT_COMPACTION_MARKER only when the
-// post-compaction checkpoint honors the full content-output contract:
-// - the text parts around the file survived (lead + tail markers);
-// - the file rendered as a stub (the filename exists nowhere but the stub);
-// - the raw payload did not leak (a canary buried in the base64 can reach
-//   the checkpoint only if the payload reached the compaction prompt);
+// Compaction handles the oversized content output with its tool-result cap
+// heuristic: no summarizer call, no checkpoint — the history keeps its exact
+// shape and only the file part is rewritten to a text stub in place. The
+// mock task model reports CONTENT_OUTPUT_COMPACTION_MARKER only when that
+// capped result honors the full contract:
+// - the raw payload is gone (a canary buried in the base64 detects the cap
+//   and any leak);
+// - the file rendered as its `Attached file <name> (<mediaType>)` stub;
+// - the text parts around the file survived in place (lead + tail markers);
 // - the surrounding conversation was untouched (the case's own user text).
-// On violation the model emits granular *_LOST / PAYLOAD_LEAKED diagnostics
-// instead, so a failing run names the broken clause.
-// The exact conversation shape, rendered by the mock model per request:
-// the pre-compaction call sees only the task; the post-compaction call sees
-// the checkpoint pair and the replayed task — the tool call and its 12KB
-// result must be gone entirely, summarized rather than kept. The shape is
-// deterministic: the payload can never fit the fixture's keep threshold, so
-// the stripped-tail path always runs.
+// On violation the model emits granular *_LOST diagnostics instead, so a
+// failing run names the broken clause.
+// The exact conversation shape, rendered by the mock model per request: the
+// pre-compaction call sees only the task; the post-cap call sees the same
+// conversation, structurally untouched — task, tool call, and tool result
+// all still present, with only the result's file payload stubbed. No
+// checkpoint pair appears because the cap heuristic satisfies the threshold
+// without summarizing.
 const EXPECTED_HISTORY =
   "HISTORY<1: system > user:task ;; " +
-  "2: system > user:checkpoint-marker > assistant:checkpoint > user:task>";
+  "2: system > user:task > assistant:tool-call > tool:result>";
 
 export default defineEval({
   description: "Compaction stubs a large inline file content part without losing its sibling text.",

--- a/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
+++ b/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
@@ -2,8 +2,17 @@ import { defineEval } from "eve/evals";
 
 import { CONTENT_OUTPUT_COMPACTION_MARKER } from "../constants";
 
+// The mock task model reports CONTENT_OUTPUT_COMPACTION_MARKER only when the
+// post-compaction checkpoint honors the full content-output contract:
+// - the text parts around the file survived (lead + tail markers);
+// - the file rendered as a stub (the filename exists nowhere but the stub);
+// - the raw payload did not leak (a canary buried in the base64 can reach
+//   the checkpoint only if the payload reached the compaction prompt);
+// - the surrounding conversation was untouched (the case's own user text).
+// On violation the model emits granular *_LOST / PAYLOAD_LEAKED diagnostics
+// instead, so a failing run names the broken clause.
 export default defineEval({
-  description: "Compaction preserves text after a large inline file content part.",
+  description: "Compaction stubs a large inline file content part without losing its sibling text.",
   async test(t) {
     const turn = await t.send(
       [

--- a/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
+++ b/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
@@ -11,6 +11,16 @@ import { CONTENT_OUTPUT_COMPACTION_MARKER } from "../constants";
 // - the surrounding conversation was untouched (the case's own user text).
 // On violation the model emits granular *_LOST / PAYLOAD_LEAKED diagnostics
 // instead, so a failing run names the broken clause.
+// The exact conversation shape, rendered by the mock model per request:
+// the pre-compaction call sees only the task; the post-compaction call sees
+// the checkpoint pair and the replayed task — the tool call and its 12KB
+// result must be gone entirely, summarized rather than kept. The shape is
+// deterministic: the payload can never fit the fixture's keep threshold, so
+// the stripped-tail path always runs.
+const EXPECTED_HISTORY =
+  "HISTORY<1: system > user:task ;; " +
+  "2: system > user:checkpoint-marker > assistant:checkpoint > user:task>";
+
 export default defineEval({
   description: "Compaction stubs a large inline file content part without losing its sibling text.",
   async test(t) {
@@ -31,5 +41,6 @@ export default defineEval({
     });
     t.event("compaction.completed", { count: 1 });
     t.messageIncludes(CONTENT_OUTPUT_COMPACTION_MARKER);
+    t.messageIncludes(EXPECTED_HISTORY);
   },
 });

--- a/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
+++ b/e2e/fixtures/agent-compaction-regressions/evals/content-output-file-stub.eval.ts
@@ -1,0 +1,26 @@
+import { defineEval } from "eve/evals";
+
+import { CONTENT_OUTPUT_COMPACTION_MARKER } from "../constants";
+
+export default defineEval({
+  description: "Compaction preserves text after a large inline file content part.",
+  async test(t) {
+    const turn = await t.send(
+      [
+        "[case: content-output-file-stub]",
+        "Call emit-compaction-content exactly once.",
+        "After compaction, report whether its completion evidence survived.",
+      ].join("\n"),
+    );
+
+    turn.expectOk();
+    t.succeeded();
+    t.calledTool("emit-compaction-content", {
+      count: 1,
+      input: {},
+      output: { completed: true },
+    });
+    t.event("compaction.completed", { count: 1 });
+    t.messageIncludes(CONTENT_OUTPUT_COMPACTION_MARKER);
+  },
+});

--- a/packages/eve/src/harness/compaction-prompt.test.ts
+++ b/packages/eve/src/harness/compaction-prompt.test.ts
@@ -82,6 +82,70 @@ describe("createCompactionPrompt", () => {
     expect(result.prompt).toContain("…");
   });
 
+  it("stubs content-output file parts instead of reproducing base64", () => {
+    const base64 = "iVBORw0KGgo".repeat(500);
+    const messages: ModelMessage[] = [
+      {
+        content: [
+          {
+            output: {
+              type: "content",
+              value: [
+                { type: "text", text: "Rendered pixel for smoke-test:" },
+                {
+                  type: "file",
+                  data: { type: "data", data: base64 },
+                  filename: "pixel.png",
+                  mediaType: "image/png",
+                },
+              ],
+            },
+            toolCallId: "call-1",
+            toolName: "render_pixel",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+    ];
+
+    const result = createCompactionPrompt({ messages, previousCheckpoint: undefined });
+
+    expect(result.prompt).toContain(
+      "Tool render_pixel returned Rendered pixel for smoke-test: " +
+        "Attached file pixel.png (image/png)",
+    );
+    expect(result.prompt).not.toContain("iVBORw0KGgo");
+  });
+
+  it("stubs content-output file parts without filenames as attachments", () => {
+    const messages: ModelMessage[] = [
+      {
+        content: [
+          {
+            output: {
+              type: "content",
+              value: [
+                { type: "file", data: { type: "data", data: "aGVsbG8=" }, mediaType: "image/jpeg" },
+              ],
+            },
+            toolCallId: "call-1",
+            toolName: "screenshot",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+    ];
+
+    const result = createCompactionPrompt({ messages, previousCheckpoint: undefined });
+
+    expect(result.prompt).toContain(
+      "Tool screenshot returned Attached file attachment (image/jpeg)",
+    );
+    expect(result.prompt).not.toContain("aGVsbG8=");
+  });
+
   it("renders conversational text verbatim regardless of length", () => {
     // A delegated task message destroyed here is unrecoverable after the first
     // compaction, so user/assistant text must reach the summarizer whole.

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -212,8 +212,54 @@ function renderTranscriptToolResult(
   const limit =
     conversationTextLimit === undefined ? TRANSCRIPT_PAYLOAD_LIMIT : COMPACT_PAYLOAD_LIMIT;
   const status = part.isError ? "errored" : "returned";
-  const output = renderPayload(part.output, limit);
+  const output = renderToolResultOutput(part.output, limit);
   return output ? `Tool ${part.toolName} ${status} ${output}` : `Tool ${part.toolName} ${status}`;
+}
+
+// A `content` tool output carries model-facing parts whose file payloads
+// are base64: stringifying them would fill the payload budget with bytes
+// the summarizer cannot read. File parts render as the same stub used for
+// message file parts; text parts stay raw for the checkpoint model to judge.
+function renderToolResultOutput(value: unknown, limit: number): string {
+  const parts = contentToolOutputParts(value);
+  if (parts === undefined) {
+    return renderPayload(value, limit);
+  }
+  const rendered = parts
+    .map((part) => renderContentToolOutputPart(part, limit))
+    .filter((entry) => entry.length > 0)
+    .join(" ");
+  return capText(rendered, limit);
+}
+
+function contentToolOutputParts(value: unknown): readonly unknown[] | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const candidate = value as { readonly type?: unknown; readonly value?: unknown };
+  return candidate.type === "content" && Array.isArray(candidate.value)
+    ? candidate.value
+    : undefined;
+}
+
+function renderContentToolOutputPart(part: unknown, limit: number): string {
+  if (part === null || typeof part !== "object") return renderPayload(part, limit);
+  const candidate = part as {
+    readonly type?: unknown;
+    readonly text?: unknown;
+    readonly filename?: unknown;
+    readonly mediaType?: unknown;
+  };
+  if (candidate.type === "text" && typeof candidate.text === "string") {
+    return candidate.text;
+  }
+  // "media" is the AI SDK's deprecated spelling of a file part; both carry
+  // an inline payload the summarizer cannot read.
+  if (candidate.type === "file" || candidate.type === "media") {
+    const mediaType = typeof candidate.mediaType === "string" ? candidate.mediaType : "unknown";
+    return typeof candidate.filename === "string"
+      ? `Attached file ${candidate.filename} (${mediaType})`
+      : `Attached file attachment (${mediaType})`;
+  }
+  return renderPayload(part, limit);
 }
 
 function renderToolCall(part: { toolName: string; input?: unknown }, limit: number): string {

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -238,6 +238,37 @@ function contentToolOutputParts(value: unknown): readonly unknown[] | undefined 
     : undefined;
 }
 
+/**
+ * Replaces the file parts of a `content` tool output with their text stubs,
+ * leaving every other output shape untouched. History capping uses this so a
+ * capped content output can never carry — or truncate into — a raw payload;
+ * the stub matches the one the summarizer transcript renders.
+ */
+export function stubContentOutputFileParts(output: unknown): unknown {
+  const parts = contentToolOutputParts(output);
+  if (parts === undefined) return output;
+
+  let changed = false;
+  const value = parts.map((part) => {
+    if (part === null || typeof part !== "object") return part;
+    const candidate = part as {
+      readonly type?: unknown;
+      readonly filename?: unknown;
+      readonly mediaType?: unknown;
+    };
+    if (candidate.type !== "file" && candidate.type !== "media") return part;
+    changed = true;
+    return {
+      text: renderAttachedFileStub(
+        typeof candidate.filename === "string" ? candidate.filename : undefined,
+        typeof candidate.mediaType === "string" ? candidate.mediaType : "unknown",
+      ),
+      type: "text",
+    };
+  });
+  return changed ? { type: "content", value } : output;
+}
+
 function renderContentToolOutputPart(part: unknown, limit: number): string {
   if (part === null || typeof part !== "object") return renderPayload(part, limit);
   const candidate = part as {

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -176,9 +176,7 @@ function renderCompactionContentPart(
     case "reasoning":
       return "";
     case "file":
-      return part.filename
-        ? `Attached file ${part.filename} (${part.mediaType})`
-        : `Attached file attachment (${part.mediaType})`;
+      return renderAttachedFileStub(part.filename, part.mediaType);
     case "tool-call":
       return renderTranscriptToolCall(part, conversationTextLimit);
     case "tool-result":
@@ -254,10 +252,10 @@ function renderContentToolOutputPart(part: unknown, limit: number): string {
   // "media" is the AI SDK's deprecated spelling of a file part; both carry
   // an inline payload the summarizer cannot read.
   if (candidate.type === "file" || candidate.type === "media") {
-    const mediaType = typeof candidate.mediaType === "string" ? candidate.mediaType : "unknown";
-    return typeof candidate.filename === "string"
-      ? `Attached file ${candidate.filename} (${mediaType})`
-      : `Attached file attachment (${mediaType})`;
+    return renderAttachedFileStub(
+      typeof candidate.filename === "string" ? candidate.filename : undefined,
+      typeof candidate.mediaType === "string" ? candidate.mediaType : "unknown",
+    );
   }
   return renderPayload(part, limit);
 }
@@ -270,6 +268,14 @@ function renderToolCall(part: { toolName: string; input?: unknown }, limit: numb
 function renderPayload(value: unknown, limit: number): string {
   if (value === undefined) return "";
   return capText(JSON.stringify(value) ?? "", limit);
+}
+
+// One summarized-attachment surface for the checkpoint model, whether the
+// file arrived on a message or inside a content tool output.
+// `renderSandboxRefAsTextPart` in attachment-staging deliberately matches
+// this shape.
+function renderAttachedFileStub(filename: string | undefined, mediaType: string): string {
+  return `Attached file ${filename ?? "attachment"} (${mediaType})`;
 }
 
 function renderConversationText(value: string, limit?: number): string {

--- a/packages/eve/src/harness/compaction.test.ts
+++ b/packages/eve/src/harness/compaction.test.ts
@@ -397,6 +397,105 @@ describe("compactMessages: tool-result cap heuristic", () => {
     expect(shouldCompact(result, { recentWindowSize: 1, threshold: ROOMY })).toBe(false);
   });
 
+  it("stubs content-output file parts instead of truncating into their payloads", async () => {
+    const base64 = "iVBORw0KGgo".repeat(500);
+    const messages: ModelMessage[] = [
+      user("render the chart"),
+      {
+        content: [{ input: {}, toolCallId: "call-0", toolName: "render_chart", type: "tool-call" }],
+        role: "assistant",
+      },
+      {
+        content: [
+          {
+            output: {
+              type: "content",
+              value: [
+                { text: "Chart summary: revenue up.", type: "text" },
+                {
+                  data: { data: base64, type: "data" },
+                  filename: "chart.png",
+                  mediaType: "image/png",
+                  type: "file",
+                },
+              ],
+            },
+            toolCallId: "call-0",
+            toolName: "render_chart",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+      user("what does it show?"),
+    ];
+
+    const { result, summarizer } = await compact(messages, { recentWindowSize: 1 });
+
+    expect(summarizer).not.toHaveBeenCalled();
+    const cappedPart = Array.isArray(result[2]?.content) ? result[2].content[0] : undefined;
+    expect(cappedPart?.type).toBe("tool-result");
+    const output = cappedPart?.type === "tool-result" ? cappedPart.output : undefined;
+    // Stubbing the file part is enough to fit: the output stays a structured
+    // content output, the sibling text survives whole, and no payload bytes
+    // (or truncation annotation) remain.
+    expect(output).toEqual({
+      type: "content",
+      value: [
+        { text: "Chart summary: revenue up.", type: "text" },
+        { text: "Attached file chart.png (image/png)", type: "text" },
+      ],
+    });
+  });
+
+  it("falls back to the annotated text cap when a content output is oversized after stubbing", async () => {
+    const longText = "finding line ".repeat(500);
+    const messages: ModelMessage[] = [
+      user("inspect everything"),
+      {
+        content: [{ input: {}, toolCallId: "call-0", toolName: "render_chart", type: "tool-call" }],
+        role: "assistant",
+      },
+      {
+        content: [
+          {
+            output: {
+              type: "content",
+              value: [
+                { text: longText, type: "text" },
+                {
+                  data: { data: "iVBORw0KGgo".repeat(500), type: "data" },
+                  mediaType: "image/png",
+                  type: "file",
+                },
+              ],
+            },
+            toolCallId: "call-0",
+            toolName: "render_chart",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+      user("what did you find?"),
+    ];
+
+    const { result, summarizer } = await compact(messages, { recentWindowSize: 1 });
+
+    expect(summarizer).not.toHaveBeenCalled();
+    const cappedPart = Array.isArray(result[2]?.content) ? result[2].content[0] : undefined;
+    const output = cappedPart?.type === "tool-result" ? cappedPart.output : undefined;
+    const value =
+      typeof output === "object" && output !== null && "value" in output
+        ? String(output.value)
+        : "";
+    // The prefix cap now truncates stubbed content — readable text — never
+    // raw payload bytes.
+    expect(value).toContain("Truncated by eve");
+    expect(value).toContain("finding line");
+    expect(value).not.toContain("iVBORw0KGgo");
+  });
+
   it("keeps the recent tail verbatim, tool results included", async () => {
     const [olderCall, olderResult] = toolExchange({ callId: "call-0", payloadChars: 4_000 });
     const [recentCall, recentResult] = toolExchange({ callId: "call-1", payloadChars: 50 });

--- a/packages/eve/src/harness/compaction.ts
+++ b/packages/eve/src/harness/compaction.ts
@@ -5,6 +5,7 @@ import {
   COMPACTION_PROMPT_ENVELOPE,
   COMPACTION_RESUMPTION_MESSAGE,
   createCompactionPrompt,
+  stubContentOutputFileParts,
   TODO_COMPACTION_PRESERVATION_LABEL,
   TRANSCRIPT_PAYLOAD_LIMIT,
 } from "#harness/compaction-prompt.js";
@@ -268,9 +269,17 @@ function capToolResults(messages: readonly ModelMessage[]): ModelMessage[] {
       if (part.type !== "tool-result") {
         return part;
       }
-      const serialized = JSON.stringify(part.output) ?? "";
+      // File parts of a content output reduce to their text stubs before the
+      // size check: serializing raw payloads into a prefix cap would keep
+      // bytes the model cannot read while cutting the text it can.
+      const output = stubContentOutputFileParts(part.output) as typeof part.output;
+      const serialized = JSON.stringify(output) ?? "";
       if (serialized.length <= TRANSCRIPT_PAYLOAD_LIMIT) {
-        return part;
+        if (output === part.output) {
+          return part;
+        }
+        changed = true;
+        return { ...part, output };
       }
 
       changed = true;


### PR DESCRIPTION
Stacked on #1250 (base is `rui/tool-model-output-content-parts-impl`, review only the top commit). Follow-up flagged as out of scope in the #456 plan.

There is no such thing as usefully trimming base64: a truncated payload is not a smaller image, it is an invalid one. But that is exactly what the summarizer got — `renderPayload` JSON.stringify's tool-result outputs and clips at the 2,000-char payload limit, so a content-part image reached the checkpoint model as ~2,000 chars of truncated base64. The entire per-payload budget spent on bytes the model cannot read, crowding out the sibling text part that carried the caption.

**The fix is one renderer.** Compaction replaces older turns with a text checkpoint and keeps recent turns verbatim, so persisted history never needs part-level surgery — recent turns keep their images for the live vision window. Only the summarizer transcript changes: `content` outputs now render per part. Text parts stay raw (the checkpoint model judges what matters, same policy as other tool payloads); file parts — including the SDK's deprecated `media` spelling — become `Attached file <name> (<mediaType>)`, the same stub already used for message file parts, so the model sees one summarized-attachment surface.

The same fix now covers the second boundary: `capToolResults` — which caps oversized tool results kept in history — stubbed file parts before its size check instead of prefix-clipping serialized base64; when stubbing alone fits, the result stays a structured content output with its text parts whole.

An e2e regression eval pins the behavior: a mock-model case where a 12KB inline file part precedes a text marker — prefix-clipping loses the marker by construction, stub rendering preserves it through the checkpoint.

The docs section gains the consequence worth designing around: a compacted image cannot be re-seen. Content parts are "look at this now"; artifacts the agent may need again belong in the sandbox, where a path can be re-read.

Other output shapes (`json` embedding base64 in some field) are untouched — there's no structural marker to distinguish media there, and the existing clipping already bounds them.

