### PR TITLE
Add memory filter to integrations gallery

### DIFF
--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -3,40 +3,46 @@
 import { Input } from "@vercel/geistdocs/components/input";
 import { InputGroup, InputGroupAddon } from "@vercel/geistdocs/components/input-group";
 import { SearchIcon } from "lucide-react";
+import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { Integration, IntegrationType } from "@/lib/integrations/data";
 import { cn } from "@/lib/utils";
 import { IntegrationCard } from "./integration-card";
 
-type Filter = "all" | IntegrationType;
+export type GalleryFilter = "all" | IntegrationType | "memory";
 
-const FILTERS: { value: Filter; label: string }[] = [
+const FILTERS: { value: GalleryFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "channel", label: "Channels" },
   { value: "connection", label: "Connections" },
+  { value: "memory", label: "Memory" },
   { value: "extension", label: "Extensions" },
 ];
 
-const TYPE_DESCRIPTIONS: Record<IntegrationType, string> = {
+const FILTER_DESCRIPTIONS: Record<Exclude<GalleryFilter, "all">, string> = {
   channel:
     "Channels are the surfaces where users talk to your agent: Slack, Discord, web chat, and more.",
   connection:
     "Connections are the tools your agent calls during a run: services reached over MCP or OpenAPI.",
   extension: "Extensions are packages that add reusable tools, skills, connections, and hooks.",
+  memory: "Memory integrations let your agent store and recall information across sessions.",
 };
 
 interface GalleryProps {
+  filter: GalleryFilter;
   integrations: Integration[];
 }
 
-export const Gallery = ({ integrations }: GalleryProps) => {
-  const [filter, setFilter] = useState<Filter>("all");
+export const Gallery = ({ filter, integrations }: GalleryProps) => {
   const [query, setQuery] = useState("");
 
   const results = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     return integrations.filter((integration) => {
-      if (filter !== "all" && integration.type !== filter) {
+      if (filter === "memory" && !integration.keywords?.includes("memory")) {
+        return false;
+      }
+      if (filter !== "all" && filter !== "memory" && integration.type !== filter) {
         return false;
       }
       if (!normalized) {
@@ -53,24 +59,25 @@ export const Gallery = ({ integrations }: GalleryProps) => {
     <div className="flex min-w-0 flex-col gap-6">
       <div className="flex min-w-0 flex-col gap-3 min-[1024px]:flex-row min-[1024px]:items-center min-[1024px]:justify-between">
         <div
-          aria-label="Integration type"
+          aria-label="Integration filter"
           className="flex w-full gap-0.5 overflow-x-auto rounded-md border bg-background-100 p-1 [scrollbar-width:none] min-[1024px]:w-fit [&::-webkit-scrollbar]:hidden"
           role="group"
         >
           {FILTERS.map(({ value, label }) => (
-            <button
+            <Link
+              aria-current={filter === value ? "page" : undefined}
               className={cn(
-                "shrink-0 whitespace-nowrap rounded px-3 py-1 font-medium text-sm transition-colors",
+                "shrink-0 whitespace-nowrap rounded px-3 py-1 font-medium text-sm no-underline transition-colors",
                 filter === value
                   ? "bg-gray-100 text-gray-1000"
                   : "text-gray-900 hover:bg-gray-100/40 hover:text-gray-1000",
               )}
+              href={value === "all" ? "/integrations" : `/integrations?filter=${value}`}
               key={value}
-              onClick={() => setFilter(value)}
-              type="button"
+              scroll={false}
             >
               {label}
-            </button>
+            </Link>
           ))}
         </div>
         <InputGroup className="h-9 w-full bg-background min-[1024px]:w-64">
@@ -87,9 +94,7 @@ export const Gallery = ({ integrations }: GalleryProps) => {
         </InputGroup>
       </div>
 
-      {filter !== "all" && (
-        <p className="text-gray-800 text-sm">{TYPE_DESCRIPTIONS[filter as IntegrationType]}</p>
-      )}
+      {filter !== "all" && <p className="text-gray-800 text-sm">{FILTER_DESCRIPTIONS[filter]}</p>}
 
       {results.length > 0 ? (
         <div className="grid min-w-0 grid-cols-1 gap-4 min-[1024px]:grid-cols-2 min-[1200px]:grid-cols-3">

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { integrations } from "@/lib/integrations/data";
 import { translations } from "@/geistdocs";
-import { Gallery } from "./components/gallery";
+import { Gallery, type GalleryFilter } from "./components/gallery";
 
 const title = "Integrations";
 const description =
@@ -14,19 +14,29 @@ export const metadata: Metadata = {
 
 export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
 
-const IntegrationsPage = () => (
-  <main className="mx-auto w-full min-w-0 max-w-[1080px] px-4 pb-32 sm:px-6">
-    <section className="flex min-w-0 flex-col items-center px-0 pt-24 pb-12 text-center sm:px-4">
-      <h1 className="font-bold text-5xl text-gray-1000 tracking-tighter sm:text-6xl">
-        Integrations
-      </h1>
-      <p className="mt-5 max-w-2xl text-gray-900 text-lg">
-        Add the channels where people reach your agent, connections to external services, and
-        extensions that package reusable capabilities.
-      </p>
-    </section>
-    <Gallery integrations={integrations} />
-  </main>
-);
+const galleryFilters: GalleryFilter[] = ["all", "channel", "connection", "extension", "memory"];
+
+const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integrations">) => {
+  const filterParam = (await searchParams).filter;
+  const filter =
+    typeof filterParam === "string" && galleryFilters.includes(filterParam as GalleryFilter)
+      ? (filterParam as GalleryFilter)
+      : "all";
+
+  return (
+    <main className="mx-auto w-full min-w-0 max-w-[1080px] px-4 pb-32 sm:px-6">
+      <section className="flex min-w-0 flex-col items-center px-0 pt-24 pb-12 text-center sm:px-4">
+        <h1 className="font-bold text-5xl text-gray-1000 tracking-tighter sm:text-6xl">
+          Integrations
+        </h1>
+        <p className="mt-5 max-w-2xl text-gray-900 text-lg">
+          Add the channels where people reach your agent, connections to external services, and
+          extensions that package reusable capabilities.
+        </p>
+      </section>
+      <Gallery filter={filter} integrations={integrations} />
+    </main>
+  );
+};
 
 export default IntegrationsPage;

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -9,7 +9,7 @@ A channel is the edge adapter between a platform and your agent. It does three t
 - Owns the `continuationToken`, the resume handle for a conversation on that surface.
 - Decides delivery, meaning how, where, and whether a response goes back.
 
-eve ships a base HTTP channel plus first-class platform channels, and you can author your own. Browse the full set in the [Integrations](/integrations) gallery.
+eve ships a base HTTP channel plus first-class platform channels, and you can author your own. Browse the full set in the [Integrations](/integrations?filter=channel) gallery.
 
 After a channel normalizes input, eve runs the same agent runtime regardless of where the message came from. Tools and instructions do not need channel-specific logic.
 
@@ -70,4 +70,4 @@ Where an eve agent communicates with people, you may be required to disclose tha
 - [Slack](./slack): the most common platform channel, end to end
 - [Custom channels](./custom): build a channel for any surface with `defineChannel`
 - [Frontend](../guides/frontend/overview): browser chat on the eve channel with `useEveAgent`
-- [Integrations](/integrations): browse every built-in channel and connection in one gallery
+- [Integrations](/integrations?filter=channel): browse every built-in channel in one gallery

--- a/docs/connections/overview.mdx
+++ b/docs/connections/overview.mdx
@@ -274,6 +274,6 @@ A tool can require both sign-in (`auth`) and a human approval. The model's appro
 
 - [MCP connections](/docs/connections/mcp): connect to remote MCP servers.
 - [OpenAPI connections](/docs/connections/openapi): generate tools from OpenAPI operations.
-- [Integrations](/integrations): browse every channel and connection eve ships, in one gallery.
+- [Integrations](/integrations?filter=connection): browse every connection eve ships, in one gallery.
 - [Tools](/docs/tools): authored tools live alongside connection-provided tools; the same approval helpers apply.
 - [Security model](/docs/concepts/security-model): how connection credentials stay out of the model's reach.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -321,6 +321,7 @@ At build time, eve checks the extension's generated capability metadata. If the 
 
 ## What to read next
 
+- [Extension integrations](/integrations?filter=extension): browse ready-to-install extensions
 - [Tools](/docs/tools): static tools, approval, and tool output
 - [Dynamic capabilities](/docs/guides/dynamic-capabilities): dynamic tools, skills, and instructions
 - [Instructions](/docs/instructions): static and TypeScript instructions

--- a/docs/guides/state.md
+++ b/docs/guides/state.md
@@ -69,7 +69,7 @@ Every [subagent](../subagents) starts with its own fresh state, whether it's a b
 
 ## State vs. connection-side storage
 
-`defineState` holds conversation-scoped working memory that lives and dies with the session, including counters, the current plan, and what the user has told you this conversation. It is the agent's short-term memory, persisted durably for the life of the session. Anything that has to outlive the session, be shared across sessions or users, or be queried independently of a turn belongs in an external store, either a [connection](../connections) or your own database.
+`defineState` holds conversation-scoped working memory that lives and dies with the session, including counters, the current plan, and what the user has told you this conversation. It is the agent's short-term memory, persisted durably for the life of the session. Anything that has to outlive the session, be shared across sessions or users, or be queried independently of a turn belongs in an external store. Start with a packaged [memory integration](/integrations?filter=memory), a general [connection](../connections), or your own database.
 
 ## What to read next
 

--- a/docs/patterns/multi-tenant-memory.md
+++ b/docs/patterns/multi-tenant-memory.md
@@ -3,7 +3,7 @@ title: "Multi-tenant memory"
 description: "Compose dynamic instructions, authenticated session context, and ordinary tools into tenant-scoped long-term memory."
 ---
 
-eve does not have a tenant-aware memory subsystem. You can build one today by composing three existing primitives:
+You can add long-term memory with a packaged [memory integration](/integrations?filter=memory), or build tenant-aware memory from your own application store by composing three existing eve primitives:
 
 1. route auth puts the tenant and user on `ctx.session.auth`;
 2. dynamic instructions load that caller's memories before each turn;


### PR DESCRIPTION
## Summary

- add a top-level Memory filter to the integrations gallery
- make gallery filters deep-linkable through the `filter` query parameter
- link relevant channel, connection, extension, state, and memory pattern docs to filtered gallery views

<img width="1681" height="815" alt="image" src="https://github.com/user-attachments/assets/c787c074-faa8-48a9-828a-acaf77804468" />


## Validation

- `pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm docs:check`
- `pnpm exec oxlint apps/docs/app/[lang]/integrations/components/gallery.tsx apps/docs/app/[lang]/integrations/page.tsx`
- `pnpm exec oxfmt --check ...`