### PR TITLE
docs: add Pushary integration

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1427,6 +1427,52 @@ export default githubExtension({
 
 For local or non-Vercel deployments, omit \`connector\` and set \`GITHUB_TOKEN\`; the extension also accepts an explicit \`token\`. Prefer fine-grained credentials, expose only the presets the agent needs, and keep approval enabled for writes. See the [GitHub Tools eve documentation](https://github-tools.com/frameworks/eve#eve-extension) for token authentication, per-tool overrides, commit attribution, and the complete tool catalog.`,
   },
+  pushary: {
+    logo: "pushary",
+    docsHref: "https://pushary.com/human-in-the-loop-eve",
+    keywords: [
+      "push",
+      "push notification",
+      "phone",
+      "mobile",
+      "approval",
+      "approvals",
+      "human-in-the-loop",
+      "hitl",
+      "lock screen",
+      "on-call",
+    ],
+    install: `Install the channel package:
+
+\`\`\`bash
+npm install @pushary/eve
+\`\`\`
+
+Set your Pushary credentials. The webhook secret comes from \`decisions.getWebhookSecret()\`, and the callback origin is the public URL this agent is deployed at, so answers can be routed back:
+
+\`\`\`bash title=".env.local"
+PUSHARY_API_KEY=pk_...sk_...
+PUSHARY_WEBHOOK_SECRET=whsec_...
+PUSHARY_CALLBACK_ORIGIN=https://your-agent.vercel.app
+\`\`\``,
+    quickStart: `Create \`agent/channels/pushary.ts\`:
+
+\`\`\`ts
+// agent/channels/pushary.ts
+import { pusharyChannel } from "@pushary/eve";
+
+export default pusharyChannel();
+\`\`\`
+
+That is the whole integration. Every approval and every \`ask_question\` the agent raises is delivered as a push notification, and the answer resolves the parked turn. Because the session parks durably, nothing is held open while it waits — a decision can be answered minutes or hours later.
+
+By default the channel asks the session principal, so user-scoped auth gives each end-user their own approver. Pass \`externalId\` to bind a fixed person for single-user agents and scheduled runs.`,
+    configure: `The channel mounts four routes. \`POST /pushary/answer\` receives the answer and is the URL Pushary calls back; it verifies the Pushary webhook signature and a per-request routing signature before resuming the session. \`POST /pushary/message\`, \`/pushary/stop\`, and \`/pushary/reset\` let the same person send a follow-up, cancel the in-flight turn, or start a fresh session from their phone, mapping onto \`send\`, \`cancel\`, and \`reset\`.
+
+Options are matched back by label and then by id, so an approval resolves to eve's \`approve\` or \`deny\` and a select resolves to the option the human tapped. Each decision carries an idempotency key derived from the session and request id, so a replayed step never asks the same person twice. Set \`requireReachable: true\` to fail loudly when the end-user has no connected device instead of opening a decision that will expire unanswered.
+
+See the [Pushary eve guide](https://pushary.com/human-in-the-loop-eve) for enrollment, multi-tenant keys, and the fail-closed semantics.`,
+  },
   "agent-browser": {
     logo: "agent-browser",
     docsHref:

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1142,6 +1142,52 @@ export default channel;
 See the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/vendor-official/resend) for all supported events and credentials.`,
     configure: `Verify a sending domain in Resend, set \`RESEND_API_KEY\`, \`RESEND_WEBHOOK_SECRET\`, and \`RESEND_FROM_ADDRESS\`, then point the Resend inbound webhook at \`/eve/v1/resend\`. This is a vendor-official Chat SDK adapter. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
+  pushary: {
+    logo: "pushary",
+    docsHref: "https://pushary.com/human-in-the-loop-eve",
+    keywords: [
+      "push",
+      "push notification",
+      "phone",
+      "mobile",
+      "approval",
+      "approvals",
+      "human-in-the-loop",
+      "hitl",
+      "lock screen",
+      "on-call",
+    ],
+    install: `Install the channel package:
+
+\`\`\`bash
+npm install @pushary/eve
+\`\`\`
+
+Set your Pushary credentials. The webhook secret comes from \`decisions.getWebhookSecret()\`, and the callback origin is the public URL this agent is deployed at, so answers can be routed back:
+
+\`\`\`bash title=".env.local"
+PUSHARY_API_KEY=pk_...sk_...
+PUSHARY_WEBHOOK_SECRET=whsec_...
+PUSHARY_CALLBACK_ORIGIN=https://your-agent.vercel.app
+\`\`\``,
+    quickStart: `Create \`agent/channels/pushary.ts\`:
+
+\`\`\`ts
+// agent/channels/pushary.ts
+import { pusharyChannel } from "@pushary/eve";
+
+export default pusharyChannel();
+\`\`\`
+
+That is the whole integration. Every approval and every \`ask_question\` the agent raises is delivered as a push notification, and the answer resolves the parked turn. Because the session parks durably, nothing is held open while it waits — a decision can be answered minutes or hours later.
+
+By default the channel asks the session principal, so user-scoped auth gives each end-user their own approver. Pass \`externalId\` to bind a fixed person for single-user agents and scheduled runs.`,
+    configure: `The channel mounts four routes. \`POST /pushary/answer\` receives the answer and is the URL Pushary calls back; it verifies the Pushary webhook signature and a per-request routing signature before resuming the session. \`POST /pushary/message\`, \`/pushary/stop\`, and \`/pushary/reset\` let the same person send a follow-up, cancel the in-flight turn, or start a fresh session from their phone, mapping onto \`send\`, \`cancel\`, and \`reset\`.
+
+Options are matched back by label and then by id, so an approval resolves to eve's \`approve\` or \`deny\` and a select resolves to the option the human tapped. Each decision carries an idempotency key derived from the session and request id, so a replayed step never asks the same person twice. Set \`requireReachable: true\` to fail loudly when the end-user has no connected device instead of opening a decision that will expire unanswered.
+
+See the [Pushary eve guide](https://pushary.com/human-in-the-loop-eve) for enrollment, multi-tenant keys, and the fail-closed semantics.`,
+  },
 };
 const extensionPresentations: Record<string, ExtensionPresentation> = {
   browserbase: {
@@ -1426,52 +1472,6 @@ export default githubExtension({
 \`\`\`
 
 For local or non-Vercel deployments, omit \`connector\` and set \`GITHUB_TOKEN\`; the extension also accepts an explicit \`token\`. Prefer fine-grained credentials, expose only the presets the agent needs, and keep approval enabled for writes. See the [GitHub Tools eve documentation](https://github-tools.com/frameworks/eve#eve-extension) for token authentication, per-tool overrides, commit attribution, and the complete tool catalog.`,
-  },
-  pushary: {
-    logo: "pushary",
-    docsHref: "https://pushary.com/human-in-the-loop-eve",
-    keywords: [
-      "push",
-      "push notification",
-      "phone",
-      "mobile",
-      "approval",
-      "approvals",
-      "human-in-the-loop",
-      "hitl",
-      "lock screen",
-      "on-call",
-    ],
-    install: `Install the channel package:
-
-\`\`\`bash
-npm install @pushary/eve
-\`\`\`
-
-Set your Pushary credentials. The webhook secret comes from \`decisions.getWebhookSecret()\`, and the callback origin is the public URL this agent is deployed at, so answers can be routed back:
-
-\`\`\`bash title=".env.local"
-PUSHARY_API_KEY=pk_...sk_...
-PUSHARY_WEBHOOK_SECRET=whsec_...
-PUSHARY_CALLBACK_ORIGIN=https://your-agent.vercel.app
-\`\`\``,
-    quickStart: `Create \`agent/channels/pushary.ts\`:
-
-\`\`\`ts
-// agent/channels/pushary.ts
-import { pusharyChannel } from "@pushary/eve";
-
-export default pusharyChannel();
-\`\`\`
-
-That is the whole integration. Every approval and every \`ask_question\` the agent raises is delivered as a push notification, and the answer resolves the parked turn. Because the session parks durably, nothing is held open while it waits — a decision can be answered minutes or hours later.
-
-By default the channel asks the session principal, so user-scoped auth gives each end-user their own approver. Pass \`externalId\` to bind a fixed person for single-user agents and scheduled runs.`,
-    configure: `The channel mounts four routes. \`POST /pushary/answer\` receives the answer and is the URL Pushary calls back; it verifies the Pushary webhook signature and a per-request routing signature before resuming the session. \`POST /pushary/message\`, \`/pushary/stop\`, and \`/pushary/reset\` let the same person send a follow-up, cancel the in-flight turn, or start a fresh session from their phone, mapping onto \`send\`, \`cancel\`, and \`reset\`.
-
-Options are matched back by label and then by id, so an approval resolves to eve's \`approve\` or \`deny\` and a select resolves to the option the human tapped. Each decision carries an idempotency key derived from the session and request id, so a replayed step never asks the same person twice. Set \`requireReachable: true\` to fail loudly when the end-user has no connected device instead of opening a decision that will expire unanswered.
-
-See the [Pushary eve guide](https://pushary.com/human-in-the-loop-eve) for enrollment, multi-tenant keys, and the fail-closed semantics.`,
   },
   "agent-browser": {
     logo: "agent-browser",

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -80,6 +80,18 @@ describe("integration discovery", () => {
     expect(integrationSearchText(githubTools!)).toContain("code review");
   });
 
+  it("renders the Pushary channel setup", () => {
+    const pushary = getIntegration("pushary");
+    expect(pushary).toBeDefined();
+
+    expect(pushary!.type).toBe("channel");
+    const markdown = integrationMarkdown(pushary!);
+    expect(markdown).toContain("npm install @pushary/eve");
+    expect(markdown).toContain('import { pusharyChannel } from "@pushary/eve"');
+    expect(markdown).toContain("PUSHARY_CALLBACK_ORIGIN");
+    expect(integrationSearchText(pushary!)).toContain("human-in-the-loop");
+  });
+
   it("renders every connection setup variant", () => {
     const notion = getIntegration("notion");
     expect(notion).toBeDefined();

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -176,6 +176,21 @@ export const upstashLogo = (props: LogoProps) => <SiUpstash color="default" {...
 
 export const datadogLogo = (props: LogoProps) => <SiDatadog color="default" {...props} />;
 
+export const pusharyLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M12 2a6 6 0 0 0-6 6v3.6l-1.72 2.87A1 1 0 0 0 5.14 16h13.72a1 1 0 0 0 .86-1.53L18 11.6V8a6 6 0 0 0-6-6Z"
+      fill="#D0443F"
+    />
+    <path
+      d="M9.5 18a2.5 2.5 0 0 0 5 0"
+      stroke="#D0443F"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
 export const honeycombLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
@@ -565,6 +580,7 @@ export const logos = {
   datadog: datadogLogo,
   honeycomb: honeycombLogo,
   kernel: kernelLogo,
+  pushary: pusharyLogo,
   upstash: upstashLogo,
   airtable: airtableLogo,
   bitly: bitlyLogo,

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -88,6 +88,11 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("github-tools")?.connection).toBeUndefined();
   });
 
+  it("exposes Pushary as a channel", () => {
+    expect(getIntegrationEntry("pushary")?.kind).toBe("channel");
+    expect(getIntegrationEntry("pushary")?.connection).toBeUndefined();
+  });
+
   it("uses Browser Use's streamable HTTP MCP endpoint", () => {
     expect(getIntegrationEntry("browser-use")!.connection!.mcp!.url).toBe(
       "https://api.browser-use.com/v3/mcp",

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -263,6 +263,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "pushary",
+    name: "Pushary",
+    kind: "channel",
+    tagline: "Answer approvals and questions as a push notification on your phone.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "agent-browser",
     name: "agent-browser",
     kind: "extension",


### PR DESCRIPTION
### Summary

Eve users who are away from their keyboard need a way to answer a parked approval or question. Add Pushary to the channel catalog and integration gallery with installation, customer enrollment, and callback setup. Confirm notifications support lock-screen actions; choices and text open the app. The current adapter is `@pushary/eve@0.3.3` (Node.js >=24, peer `eve >=0.31.0`); a verified, correlated answer resumes the parked turn until the decision expires.

This is a documentation/catalog contribution. The adapter is maintained at [Pushary/pushary-eve](https://github.com/Pushary/pushary-eve) and real delivery requires a Pushary Partner account. I maintain Pushary; this contribution was prepared with AI assistance.

### Validation

Refreshed 2026-09-14:

- Existing catalog and integration-discovery tests: **25 passed**, using a focused Vitest configuration with the workspace catalog aliased to its source. The temporary runner used Vitest 2.1.9 and emitted an ES2024 target warning; this is not a claim that the entire Eve workspace passed.
- Clean public `Pushary/pushary-eve` clone: `npm run build`, `npm test` (**46 passed**, including channel signature/routing tests), and `npm run typecheck` passed with its resolved development peer `eve@0.44.4`. npm reported an optional Nitro/Vite development-peer warning.
- Separate clean published consumer: `@pushary/eve@0.3.3` with current `eve@0.54.4` installed with no dependency-tree problems or duplicate/stale Pushary packages, and the published ask-human tool smoke check passed with simulated HTTP. This checks the tool artifact, not a compiled end-to-end Eve channel on 0.54.4.
- `git diff --check` passed. No physical-device result or fresh full docs build is claimed.

The Vercel preview checks require maintainer deployment authorization, which this contributor cannot grant.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No published `eve` runtime package is changed, so a changeset is not applicable. Maintainer review and the full upstream checks remain pending.
