### PR TITLE
Fix root RSS feed route

### DIFF
--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -9,9 +9,10 @@ const proxy = createProxy({
 });
 
 export const config = {
-  // llms.txt needs the locale rewrite even though the general matcher ignores static extensions.
+  // These routes need the locale rewrite even though the general matcher ignores static extensions.
   matcher: [
     "/llms.txt",
+    "/rss.xml",
     "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|eve\\.tgz$|.*\\.(?!mdx?$)[^/]+$).*)",
   ],
 };


### PR DESCRIPTION
### Description

Include `/rss.xml` in the docs locale proxy matcher. The route now receives the default-language rewrite instead of being treated as the `[lang]` segment and failing with a 500.

### How did you test your changes?

- `pnpm exec oxfmt --check apps/docs/proxy.ts`
- `pnpm --filter eve-docs exec next typegen`
- `pnpm --filter eve-docs exec tsc --noEmit`
- Started the docs app and verified `/rss.xml` and `/en/rss.xml` both return `200 application/rss+xml`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)