### PR TITLE
feat(eve): add web/slack channels to `eve add`

### DIFF
--- a/.changeset/registry-channel-add.md
+++ b/.changeset/registry-channel-add.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `eve add channel/web` and `eve add channel/slack` to use the existing channel setup flows. The official registry now lists Web Chat and Slack channel items.

--- a/apps/docs/public/r/channel/slack.json
+++ b/apps/docs/public/r/channel/slack.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "channel/slack",
+  "title": "Slack",
+  "description": "Connect an eve agent to Slack with Vercel Connect or portable credentials.",
+  "meta": {
+    "eve": {
+      "channel": "slack"
+    }
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/channel/web.json
+++ b/apps/docs/public/r/channel/web.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "channel/web",
+  "title": "Web Chat",
+  "description": "Add the built-in Next.js Web Chat channel to an eve agent.",
+  "meta": {
+    "eve": {
+      "channel": "web"
+    }
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/registry.json
+++ b/apps/docs/public/r/registry.json
@@ -651,6 +651,28 @@
           "target": "agent/connections/zomato.ts"
         }
       ]
+    },
+    {
+      "name": "channel/web",
+      "type": "registry:item",
+      "title": "Web Chat",
+      "description": "Add the built-in Next.js Web Chat channel to an eve agent.",
+      "meta": {
+        "eve": {
+          "channel": "web"
+        }
+      }
+    },
+    {
+      "name": "channel/slack",
+      "type": "registry:item",
+      "title": "Slack",
+      "description": "Connect an eve agent to Slack with Vercel Connect or portable credentials.",
+      "meta": {
+        "eve": {
+          "channel": "slack"
+        }
+      }
     }
   ]
 }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -651,6 +651,28 @@
           "target": "agent/connections/zomato.ts"
         }
       ]
+    },
+    {
+      "name": "channel/web",
+      "type": "registry:item",
+      "title": "Web Chat",
+      "description": "Add the built-in Next.js Web Chat channel to an eve agent.",
+      "meta": {
+        "eve": {
+          "channel": "web"
+        }
+      }
+    },
+    {
+      "name": "channel/slack",
+      "type": "registry:item",
+      "title": "Slack",
+      "description": "Connect an eve agent to Slack with Vercel Connect or portable credentials.",
+      "meta": {
+        "eve": {
+          "channel": "slack"
+        }
+      }
     }
   ]
 }

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -57,11 +57,17 @@ describe("registry commands", () => {
 
   it("installs official items through the registry SDK", async () => {
     const logger = createLogger();
+    getRegistryItems.mockResolvedValue([{ name: "extension/browser", type: "registry:item" }]);
 
     await runAddCommand(logger, "/project", "extension/browser", {
       overwrite: true,
     });
 
+    expect(getRegistryItems).toHaveBeenCalledWith(["https://eve.dev/r/extension/browser.json"], {
+      config: {
+        registries: { "@acme": "https://example.com/r/{name}.json" },
+      },
+    });
     expect(addRegistryItems).toHaveBeenCalledWith(["https://eve.dev/r/extension/browser.json"], {
       config: {
         registries: { "@acme": "https://example.com/r/{name}.json" },
@@ -70,6 +76,72 @@ describe("registry commands", () => {
       overwrite: true,
     });
     expect(logger.errors).toEqual([]);
+  });
+
+  it.each(["web", "slack"] as const)(
+    "routes registry metadata for %s through channel setup",
+    async (kind) => {
+      const logger = createLogger();
+      const runChannelsAddCommand = vi.fn(async () => {});
+      getRegistryItems.mockResolvedValue([
+        {
+          name: `channel/${kind}`,
+          type: "registry:item",
+          meta: { eve: { channel: kind } },
+        },
+      ]);
+
+      await runAddCommand(
+        logger,
+        "/project",
+        `channel/${kind}`,
+        { overwrite: true },
+        { loadChannelsAddCommand: async () => runChannelsAddCommand },
+      );
+
+      expect(runChannelsAddCommand).toHaveBeenCalledWith(logger, "/project", {
+        kind,
+        options: {},
+      });
+      expect(addRegistryItems).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not infer channel setup from the item address", async () => {
+    const logger = createLogger();
+    const runChannelsAddCommand = vi.fn(async () => {});
+    getRegistryItems.mockResolvedValue([{ name: "channel/web", type: "registry:item" }]);
+
+    await runAddCommand(
+      logger,
+      "/project",
+      "channel/web",
+      {},
+      {
+        loadChannelsAddCommand: async () => runChannelsAddCommand,
+      },
+    );
+
+    expect(runChannelsAddCommand).not.toHaveBeenCalled();
+    expect(addRegistryItems).toHaveBeenCalledOnce();
+  });
+
+  it("rejects unknown channel metadata", async () => {
+    const logger = createLogger();
+    getRegistryItems.mockResolvedValue([
+      {
+        name: "channel/unknown",
+        type: "registry:item",
+        meta: { eve: { channel: "unknown" } },
+      },
+    ]);
+
+    await runAddCommand(logger, "/project", "channel/unknown", {});
+
+    expect(logger.errors).toHaveLength(1);
+    expect(logger.errors[0]).toContain("Unknown eve channel kind in registry metadata: unknown");
+    expect(addRegistryItems).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it("adds namespace mappings to package.json", async () => {

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -4,8 +4,10 @@ import {
   searchRegistries,
   type RegistryConfig,
 } from "#compiled/shadcn-registry/index.js";
-import { isEveProject } from "#setup/scaffold/index.js";
+import { z } from "#compiled/zod/index.js";
+import { isEveProject, type ChannelKind } from "#setup/scaffold/index.js";
 
+import type { runChannelsAddCommand } from "./channels.js";
 import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 import { addRegistryMappings, readRegistryConfig } from "./registry-project.js";
 
@@ -18,6 +20,14 @@ export interface AddCommandOptions {
   overwrite?: boolean;
 }
 
+export interface AddCommandDependencies {
+  loadChannelsAddCommand(): Promise<typeof runChannelsAddCommand>;
+}
+
+const defaultAddCommandDependencies: AddCommandDependencies = {
+  loadChannelsAddCommand: async () => (await import("./channels.js")).runChannelsAddCommand,
+};
+
 const OFFICIAL_REGISTRY = "https://eve.dev/r";
 const OFFICIAL_CATALOG = `${OFFICIAL_REGISTRY}/registry.json`;
 
@@ -27,6 +37,27 @@ function isRegistryAddress(value: string): boolean {
 
 function itemAddress(item: string): string {
   return isRegistryAddress(item) ? item : `${OFFICIAL_REGISTRY}/${item}.json`;
+}
+
+const EveRegistryItemMetadataSchema = z.object({
+  meta: z
+    .object({
+      eve: z
+        .object({
+          channel: z
+            .enum(["slack", "web"], {
+              error: (issue) =>
+                `Unknown eve channel kind in registry metadata: ${String(issue.input)}`,
+            })
+            .optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+function channelKindFromRegistryItem(item: unknown): ChannelKind | undefined {
+  return EveRegistryItemMetadataSchema.parse(item).meta?.eve?.channel;
 }
 
 function errorMessage(error: unknown): string {
@@ -105,10 +136,23 @@ export async function runAddCommand(
   appRoot: string,
   item: string,
   options: AddCommandOptions,
+  dependencies: AddCommandDependencies = defaultAddCommandDependencies,
 ): Promise<void> {
   await runRegistryAction(logger, appRoot, async () => {
     const config = await readRegistryConfig(appRoot);
-    await addRegistryItems([itemAddress(item)], { ...options, config, cwd: appRoot });
+    const address = itemAddress(item);
+    const [registryItem] = await getRegistryItems([address], { config });
+    const channelKind = channelKindFromRegistryItem(registryItem);
+    if (channelKind !== undefined) {
+      const runChannelsAddCommand = await dependencies.loadChannelsAddCommand();
+      await runChannelsAddCommand(logger, appRoot, {
+        kind: channelKind,
+        options: {},
+      });
+      return;
+    }
+
+    await addRegistryItems([address], { ...options, config, cwd: appRoot });
   });
 }
 

--- a/packages/eve/src/setup/scaffold/channels-catalog.test.ts
+++ b/packages/eve/src/setup/scaffold/channels-catalog.test.ts
@@ -32,4 +32,13 @@ describe("SCAFFOLDABLE_CHANNELS", () => {
     const slack = SCAFFOLDABLE_CHANNELS.find((channel) => channel.slug === "slack");
     expect(slack?.kind).toBe("slack");
   });
+
+  test("associates scaffoldable channels with canonical registry items", () => {
+    expect(SCAFFOLDABLE_CHANNELS.map(({ kind, registryItem }) => ({ kind, registryItem }))).toEqual(
+      [
+        { kind: "web", registryItem: "channel/web" },
+        { kind: "slack", registryItem: "channel/slack" },
+      ],
+    );
+  });
 });

--- a/packages/eve/src/setup/scaffold/channels-catalog.ts
+++ b/packages/eve/src/setup/scaffold/channels-catalog.ts
@@ -19,6 +19,8 @@ interface ChannelScaffold {
   slug: string;
   /** Internal scaffolder kind; the catalog's `eve` channel is surfaced as `web`. */
   kind: ChannelKind;
+  /** Canonical item in the official eve registry. */
+  registryItem: `channel/${ChannelKind}`;
   /** Picker label. */
   label: string;
   /** Optional picker hint. */
@@ -33,10 +35,17 @@ interface ChannelScaffold {
  * for *which* channels are scaffoldable.
  */
 const CHANNEL_SCAFFOLDS: readonly ChannelScaffold[] = [
-  { slug: "eve", kind: "web", label: "Web Chat", hint: "Next.js app" },
+  {
+    slug: "eve",
+    kind: "web",
+    registryItem: "channel/web",
+    label: "Web Chat",
+    hint: "Next.js app",
+  },
   {
     slug: "slack",
     kind: "slack",
+    registryItem: "channel/slack",
     label: "Slack",
     hint: "Slack app mentions and DMs",
   },
@@ -48,6 +57,8 @@ export interface ScaffoldableChannel {
   slug: string;
   /** Internal scaffolder kind passed to `ensureChannel`. */
   kind: ChannelKind;
+  /** Canonical item in the official eve registry. */
+  registryItem: `channel/${ChannelKind}`;
   /** Picker label. */
   label: string;
   /** Optional picker hint. */
@@ -71,6 +82,7 @@ function buildScaffoldableChannels(): ScaffoldableChannel[] {
     const channel: ScaffoldableChannel = {
       slug: scaffold.slug,
       kind: scaffold.kind,
+      registryItem: scaffold.registryItem,
       label: scaffold.label,
     };
     if (scaffold.hint !== undefined) {


### PR DESCRIPTION
### Description

Adds existing channels to `eve add` registry. For now, post-registry setup is limited to explicit channels, but this will be widened in the future.

<!-- Write a short summary of the problem and solution. -->

### How did you test your changes?

<!-- Include the commands you ran and any manual coverage. -->

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)