### PR TITLE
feat(docs): add connection registry items

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,13 +122,44 @@ history, fixtures, report integrity, and assignment of every public authoring
 export to a capability. Reports and fixtures cover structural compatibility;
 behavior changes still need focused compatibility tests.
 
-## Adding an extension to the registry
+## Adding an integration to the registry
+
+The registry source lives under [`apps/docs/registry/`](./apps/docs/registry/). Add the project-owned source file to its collection directory, such as `registry/connections/linear.ts` or `registry/extensions/browserbase.ts`. Registry item names use the singular integration kind. Register the item in [`apps/docs/registry.json`](./apps/docs/registry.json):
+
+```json
+{
+  "name": "connection/linear",
+  "type": "registry:item",
+  "title": "Linear",
+  "description": "Connect an eve agent to Linear.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/linear.ts",
+      "type": "registry:file",
+      "target": "agent/connections/linear.ts"
+    }
+  ]
+}
+```
+
+`path` points to the hand-written source file relative to `apps/docs`; `target` is where `eve add` writes it in the consuming agent. Declare packages with `dependencies` and required environment variables with `envVars`.
+
+Run:
+
+```bash
+pnpm --filter eve-docs registry:check
+```
+
+This runs `shadcn build`, which reads each referenced source file and embeds it as the escaped `content` field in `apps/docs/public/r/<kind>/<slug>.json`. It also rebuilds `apps/docs/public/r/registry.json`, validates connection coverage, and typechecks the registry source files. Never edit `content` or another file under `apps/docs/public/r/` by hand; edit the reference file under `apps/docs/registry/`, rebuild, and commit both the source and generated output.
+
+### Extension requirements
 
 The registry and integrations gallery list reviewed, published extensions. Open an issue and get maintainer agreement before submitting a registry addition. The package must be publicly installable from npm, work with the current released `eve` version, and include documentation for its configuration, authentication, and any security-sensitive behavior.
 
 In the PR, add the package as an `apps/docs` dev dependency, add its package to the reviewed exceptions in `pnpm-workspace.yaml`, and add a mount example under [`apps/docs/registry/extensions/`](./apps/docs/registry/extensions/). Register that example under an `extension/<slug>` name, with its dependencies, title, and description, in [`apps/docs/registry.json`](./apps/docs/registry.json).
 
-Also add the extension identity to [`packages/eve-catalog/src/index.ts`](./packages/eve-catalog/src/index.ts), its gallery presentation and setup instructions to [`apps/docs/lib/integrations/data.ts`](./apps/docs/lib/integrations/data.ts), and a logo in [`apps/docs/lib/integrations/logos.tsx`](./apps/docs/lib/integrations/logos.tsx). Add or update focused tests for the integration page. Run `pnpm --filter eve-docs registry:check`; it generates the files under `apps/docs/public/r/`, so do not edit those generated files by hand.
+Also add the extension identity to [`packages/eve-catalog/src/index.ts`](./packages/eve-catalog/src/index.ts), its gallery presentation and setup instructions to [`apps/docs/lib/integrations/data.ts`](./apps/docs/lib/integrations/data.ts), and a logo in [`apps/docs/lib/integrations/logos.tsx`](./apps/docs/lib/integrations/logos.tsx). Add or update focused tests for the integration page.
 
 ## Documentation
 

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -15,8 +15,7 @@ describe("Browser Use connection setup", () => {
 
     expect(quickStart).toContain('"x-browser-use-api-key": process.env.BROWSER_USE_API_KEY!');
     expect(quickStart).not.toContain("@vercel/connect");
-    expect(buildConnectionInstall(integration)).toContain("npm install eve@latest");
-    expect(buildConnectionInstall(integration)).not.toContain("@vercel/connect");
+    expect(buildConnectionInstall(integration)).toContain("eve add connection/browser-use");
     expect(buildConnectionConfigure(integration)).toContain("BROWSER_USE_API_KEY=your_api_key");
   });
 
@@ -25,7 +24,7 @@ describe("Browser Use connection setup", () => {
     const quickStart = buildConnectionSetup(integration).variants["mcp:user"];
 
     expect(quickStart).toContain("@vercel/connect/eve");
-    expect(buildConnectionInstall(integration)).toContain("@vercel/connect");
+    expect(buildConnectionInstall(integration)).toContain("eve add connection/linear");
   });
 });
 

--- a/apps/docs/lib/integrations/connection-setup.ts
+++ b/apps/docs/lib/integrations/connection-setup.ts
@@ -59,10 +59,13 @@ const buildSnippet = (
     fields.push(
       `  auth: connect({`,
       `    connector: "${connector}",`,
-      `    principalToSubject: (principal) => ({`,
-      `      type: "jwt-bearer",`,
-      `      sub: principal.attributes.email,`,
-      `    }),`,
+      `    principalToSubject: (principal) => {`,
+      `      const email = principal.type === "user" ? principal.attributes?.email : undefined;`,
+      `      if (typeof email !== "string") {`,
+      `        throw new Error("JWT bearer authentication requires a user principal with an email.");`,
+      `      }`,
+      `      return { type: "jwt-bearer", sub: email };`,
+      `    },`,
       `  }),`,
     );
   }
@@ -138,18 +141,14 @@ export const buildConnectionSetup = (integration: Integration): ConnectionSetup 
 
 /** Generated Install markdown for a connection. */
 export const buildConnectionInstall = (integration: Integration): string => {
-  const spec = integration.connection;
-  if (!spec) {
+  if (!integration.connection) {
     return "";
   }
-  const usesConnect = spec.authModes.some((auth) => auth !== "apiKey");
   return [
-    usesConnect
-      ? "Connections live under `agent/connections/`. Auth is brokered by [Vercel Connect](https://vercel.com/docs/connect), so install the framework and the Connect SDK:"
-      : "Connections live under `agent/connections/`. Install the framework:",
+    "Add the connection from eve's registry. This writes the initial definition under `agent/connections/` and installs its authentication dependency when needed:",
     ``,
     "```bash",
-    usesConnect ? "npm install eve@latest @vercel/connect" : "npm install eve@latest",
+    `eve add connection/${integration.slug}`,
     "```",
   ].join("\n");
 };

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,8 @@
     "test:unit": "vitest run --config vitest.config.ts",
     "render:eve-5": "NODE_OPTIONS=--loader=./scripts/wgsl-node-loader.mjs tsx scripts/render-eve-5.ts",
     "registry:build": "shadcn build",
-    "registry:check": "pnpm run registry:build && tsc --project registry/tsconfig.json"
+    "registry:check": "pnpm run registry:build && pnpm run registry:validate && tsc --project registry/tsconfig.json",
+    "registry:validate": "tsx scripts/validate-connection-registry.ts"
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.193",
@@ -73,6 +74,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@upstash/agentkit-eve-extension": "^0.4.0",
+    "@vercel/connect": "catalog:",
     "@vgpu/adapter-node": "0.0.7",
     "@webgpu/types": "^0.1.69",
     "eve": "workspace:*",

--- a/apps/docs/public/r/connection/airtable.json
+++ b/apps/docs/public/r/connection/airtable.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/airtable",
+  "title": "Airtable",
+  "description": "Bases, tables, and records through Airtable's MCP server.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/airtable.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.airtable.com/mcp\",\n  description: \"Airtable: bases, tables, and records.\",\n  auth: connect(\"airtable\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/airtable.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/bitly.json
+++ b/apps/docs/public/r/connection/bitly.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/bitly",
+  "title": "Bitly",
+  "description": "Shorten links, generate QR Codes, and track performance.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/bitly.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://api-ssl.bitly.com/v4/mcp\",\n  description: \"Bitly: shorten links, generate QR Codes, and track link performance.\",\n  auth: connect(\"bitly\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/bitly.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/brex.json
+++ b/apps/docs/public/r/connection/brex.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/brex",
+  "title": "Brex",
+  "description": "Expenses, cards, and cash through Brex's finance automation.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/brex.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://api.brex.com/mcp\",\n  description: \"Brex: expenses, cards, budgets, and cash.\",\n  auth: connect(\"brex\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/brex.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/browser-use.json
+++ b/apps/docs/public/r/connection/browser-use.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/browser-use",
+  "title": "Browser Use",
+  "description": "Run managed browser automation tasks through Browser Use's MCP server.",
+  "files": [
+    {
+      "path": "registry/connections/browser-use.ts",
+      "content": "import { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://api.browser-use.com/v3/mcp\",\n  description:\n    \"Browser Use: run browser automation tasks, inspect sessions, and manage browser profiles.\",\n  headers: () => ({\n    \"x-browser-use-api-key\": process.env.BROWSER_USE_API_KEY!,\n  }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/browser-use.ts"
+    }
+  ],
+  "envVars": {
+    "BROWSER_USE_API_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/candid.json
+++ b/apps/docs/public/r/connection/candid.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/candid",
+  "title": "Candid",
+  "description": "Research nonprofits and funders using Candid's data.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/candid.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.candid.org/mcp\",\n  description: \"Candid: research nonprofits, funders, and grants.\",\n  auth: connect(\"candid\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/candid.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/clickhouse.json
+++ b/apps/docs/public/r/connection/clickhouse.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/clickhouse",
+  "title": "ClickHouse",
+  "description": "Query and explore your ClickHouse Cloud data.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/clickhouse.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.clickhouse.cloud/mcp\",\n  description: \"ClickHouse Cloud: query and explore databases and tables.\",\n  auth: connect(\"clickhouse\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/clickhouse.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/cloudinary.json
+++ b/apps/docs/public/r/connection/cloudinary.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/cloudinary",
+  "title": "Cloudinary",
+  "description": "Manage, transform, and deliver your images and videos.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/cloudinary.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://asset-management.mcp.cloudinary.com/sse\",\n  description: \"Cloudinary: manage, transform, and deliver image and video assets.\",\n  auth: connect(\"cloudinary\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/cloudinary.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/coda.json
+++ b/apps/docs/public/r/connection/coda.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/coda",
+  "title": "Coda",
+  "description": "Create, search, and update docs and tables.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/coda.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://coda.io/apis/mcp\",\n  description: \"Coda: create, search, and update docs and tables.\",\n  auth: connect(\"coda\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/coda.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/datadog.json
+++ b/apps/docs/public/r/connection/datadog.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/datadog",
+  "title": "Datadog",
+  "description": "Query metrics, monitors, and logs through Datadog's MCP server.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/datadog.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.datadoghq.com/api/mcp\",\n  description: \"Datadog: query metrics, monitors, logs, and incidents.\",\n  auth: connect({\n    connector: \"datadog\",\n    principalToSubject: (principal) => {\n      const email = principal.type === \"user\" ? principal.attributes?.email : undefined;\n      if (typeof email !== \"string\") {\n        throw new Error(\"JWT bearer authentication requires a user principal with an email.\");\n      }\n      return { type: \"jwt-bearer\", sub: email };\n    },\n  }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/datadog.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/egnyte.json
+++ b/apps/docs/public/r/connection/egnyte.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/egnyte",
+  "title": "Egnyte",
+  "description": "Securely access and analyze Egnyte content.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/egnyte.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp-server.egnyte.com/mcp\",\n  description: \"Egnyte: search, access, and analyze governed content.\",\n  auth: connect(\"egnyte\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/egnyte.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/embat.json
+++ b/apps/docs/public/r/connection/embat.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/embat",
+  "title": "Embat",
+  "description": "Ask Embat about cash, debt, payments, and accounting.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/embat.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://tellme.embat.io/mcp\",\n  description: \"Embat: cash, debt, payments, and accounting.\",\n  auth: connect(\"embat\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/embat.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/honeycomb.json
+++ b/apps/docs/public/r/connection/honeycomb.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/honeycomb",
+  "title": "Honeycomb",
+  "description": "Explore traces and run queries through Honeycomb's MCP server.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/honeycomb.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.honeycomb.io/mcp\",\n  description: \"Honeycomb: explore traces, run queries, and inspect datasets.\",\n  auth: connect({\n    connector: \"honeycomb\",\n    principalToSubject: (principal) => {\n      const email = principal.type === \"user\" ? principal.attributes?.email : undefined;\n      if (typeof email !== \"string\") {\n        throw new Error(\"JWT bearer authentication requires a user principal with an email.\");\n      }\n      return { type: \"jwt-bearer\", sub: email };\n    },\n  }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/honeycomb.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/hugging-face.json
+++ b/apps/docs/public/r/connection/hugging-face.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/hugging-face",
+  "title": "Hugging Face",
+  "description": "Access the Hugging Face Hub and thousands of Gradio apps.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/hugging-face.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://huggingface.co/mcp?login&gradio=none\",\n  description: \"Hugging Face: models, datasets, Spaces, and Gradio apps on the Hub.\",\n  auth: connect(\"hugging-face\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/hugging-face.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/linear.json
+++ b/apps/docs/public/r/connection/linear.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/linear",
+  "title": "Linear",
+  "description": "Issues, projects, cycles, and comments via Linear's MCP server.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/linear.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.linear.app/mcp\",\n  description: \"Linear workspace: issues, projects, cycles, and comments.\",\n  auth: connect(\"linear\"),\n\n  // For app-scoped authentication, replace the auth block above with:\n  // auth: connect({ connector: \"linear\", principalType: \"app\" }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/linear.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/local-falcon.json
+++ b/apps/docs/public/r/connection/local-falcon.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/local-falcon",
+  "title": "Local Falcon",
+  "description": "AI visibility and local search intelligence.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/local-falcon.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.localfalcon.com\",\n  description: \"Local Falcon: local search rankings and AI visibility reports.\",\n  auth: connect(\"local-falcon\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/local-falcon.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/make.json
+++ b/apps/docs/public/r/connection/make.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/make",
+  "title": "Make",
+  "description": "Run Make scenarios and manage your Make account.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/make.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.make.com\",\n  description: \"Make: run scenarios and manage automations.\",\n  auth: connect(\"make\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/make.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/manufact.json
+++ b/apps/docs/public/r/connection/manufact.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/manufact",
+  "title": "Manufact",
+  "description": "Deploy and monitor MCP servers with Manufact.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/manufact.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.manufact.com/mcp\",\n  description: \"Manufact: deploy and monitor MCP servers.\",\n  auth: connect(\"manufact\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/manufact.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/mem0.json
+++ b/apps/docs/public/r/connection/mem0.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/mem0",
+  "title": "Mem0",
+  "description": "Persistent memory for AI agents and assistants.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/mem0.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.mem0.ai/mcp\",\n  description: \"Mem0: store and retrieve persistent agent memory.\",\n  auth: connect(\"mem0\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/mem0.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/miro.json
+++ b/apps/docs/public/r/connection/miro.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/miro",
+  "title": "Miro",
+  "description": "Access and create content on Miro boards.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/miro.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.miro.com/\",\n  description: \"Miro: read and create content on boards.\",\n  auth: connect(\"miro\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/miro.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/mixpanel.json
+++ b/apps/docs/public/r/connection/mixpanel.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/mixpanel",
+  "title": "Mixpanel",
+  "description": "Analyze, query, and manage your Mixpanel data.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/mixpanel.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.mixpanel.com/mcp\",\n  description: \"Mixpanel: analyze, query, and manage analytics data.\",\n  auth: connect(\"mixpanel\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/mixpanel.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/netlify.json
+++ b/apps/docs/public/r/connection/netlify.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/netlify",
+  "title": "Netlify",
+  "description": "Create, deploy, manage, and secure websites on Netlify.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/netlify.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://netlify-mcp.netlify.app/mcp\",\n  description: \"Netlify: create, deploy, manage, and secure sites.\",\n  auth: connect(\"netlify\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/netlify.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/notion.json
+++ b/apps/docs/public/r/connection/notion.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/notion",
+  "title": "Notion",
+  "description": "Search and edit Notion pages and databases over MCP or OpenAPI.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/notion.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.notion.com/mcp\",\n  description: \"Notion workspace: search and edit pages and databases.\",\n  auth: connect(\"notion\"),\n\n  // For app-scoped authentication, replace the auth block above with:\n  // auth: connect({ connector: \"notion\", principalType: \"app\" }),\n\n  // For JWT bearer authentication, replace the auth block above with:\n  // auth: connect({\n  //   connector: \"notion\",\n  //   principalToSubject: (principal) => {\n  //     const email = principal.type === \"user\" ? principal.attributes?.email : undefined;\n  //     if (typeof email !== \"string\") {\n  //       throw new Error(\"JWT bearer authentication requires a user principal with an email.\");\n  //     }\n  //     return { type: \"jwt-bearer\", sub: email };\n  //   },\n  // }),\n\n  // Notion also supports OpenAPI. See https://eve.dev/integrations/notion for that scaffold.\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/notion.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/oreilly.json
+++ b/apps/docs/public/r/connection/oreilly.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/oreilly",
+  "title": "O'Reilly",
+  "description": "Discover O'Reilly's expert learning content.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/oreilly.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://api.oreilly.com/api/content-discovery/v1/mcp/\",\n  description: \"O'Reilly: search books, courses, and learning content.\",\n  auth: connect(\"oreilly\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/oreilly.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/planetscale.json
+++ b/apps/docs/public/r/connection/planetscale.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/planetscale",
+  "title": "PlanetScale",
+  "description": "Authenticated access to your PlanetScale Postgres and MySQL databases.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/planetscale.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.pscale.dev/mcp/planetscale\",\n  description: \"PlanetScale: query Postgres and MySQL databases.\",\n  auth: connect(\"planetscale\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/planetscale.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/posthog.json
+++ b/apps/docs/public/r/connection/posthog.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/posthog",
+  "title": "PostHog",
+  "description": "Query, analyze, and manage your PostHog insights.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/posthog.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.posthog.com/mcp\",\n  description: \"PostHog: insights, events, and feature flags.\",\n  auth: connect(\"posthog\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/posthog.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/postman.json
+++ b/apps/docs/public/r/connection/postman.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/postman",
+  "title": "Postman",
+  "description": "Give API context to your coding agents with Postman.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/postman.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.postman.com/minimal\",\n  description: \"Postman: APIs, collections, and workspaces.\",\n  auth: connect(\"postman\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/postman.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/razorpay.json
+++ b/apps/docs/public/r/connection/razorpay.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/razorpay",
+  "title": "Razorpay",
+  "description": "Razorpay payments, settlements, and dashboard data.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/razorpay.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.razorpay.com/mcp\",\n  description: \"Razorpay: payments, settlements, and dashboard data.\",\n  auth: connect(\"razorpay\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/razorpay.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/sentry.json
+++ b/apps/docs/public/r/connection/sentry.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/sentry",
+  "title": "Sentry",
+  "description": "Search, query, and debug errors intelligently.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/sentry.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.sentry.dev/mcp\",\n  description: \"Sentry: search, query, and debug errors and issues.\",\n  auth: connect(\"sentry\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/sentry.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/similarweb.json
+++ b/apps/docs/public/r/connection/similarweb.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/similarweb",
+  "title": "Similarweb",
+  "description": "Real-time web, mobile app, and market data.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/similarweb.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.similarweb.com\",\n  description: \"Similarweb: web traffic, app, and market intelligence data.\",\n  auth: connect(\"similarweb\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/similarweb.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/stripe.json
+++ b/apps/docs/public/r/connection/stripe.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/stripe",
+  "title": "Stripe",
+  "description": "Payment processing and financial infrastructure tools.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/stripe.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.stripe.com\",\n  description: \"Stripe: payments, customers, billing, and financial infrastructure.\",\n  auth: connect(\"stripe\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/stripe.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/supabase.json
+++ b/apps/docs/public/r/connection/supabase.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/supabase",
+  "title": "Supabase",
+  "description": "Manage databases, authentication, and storage.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/supabase.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.supabase.com/mcp\",\n  description: \"Supabase: databases, authentication, and storage.\",\n  auth: connect(\"supabase\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/supabase.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/ticket-tailor.json
+++ b/apps/docs/public/r/connection/ticket-tailor.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/ticket-tailor",
+  "title": "Ticket Tailor",
+  "description": "Manage tickets, orders, and events with Ticket Tailor.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/ticket-tailor.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.tickettailor.ai/mcp\",\n  description: \"Ticket Tailor: events, tickets, and orders.\",\n  auth: connect(\"ticket-tailor\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/ticket-tailor.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/ticktick.json
+++ b/apps/docs/public/r/connection/ticktick.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/ticktick",
+  "title": "TickTick",
+  "description": "Search, create, and manage your tasks and habits in TickTick.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/ticktick.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.ticktick.com\",\n  description: \"TickTick: tasks, habits, and lists.\",\n  auth: connect(\"ticktick\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/ticktick.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/todoist.json
+++ b/apps/docs/public/r/connection/todoist.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/todoist",
+  "title": "Todoist",
+  "description": "Search, complete, and manage your tasks in Todoist.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/todoist.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://ai.todoist.net/mcp\",\n  description: \"Todoist: search, complete, and manage tasks.\",\n  auth: connect(\"todoist\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/todoist.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/vercel.json
+++ b/apps/docs/public/r/connection/vercel.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/vercel",
+  "title": "Vercel",
+  "description": "Manage Vercel projects, deployments, and logs through Vercel's MCP server.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/vercel.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.vercel.com\",\n  description: \"Vercel: manage projects and deployments, inspect logs, and search documentation.\",\n  auth: connect(\"vercel\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/vercel.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/webflow.json
+++ b/apps/docs/public/r/connection/webflow.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/webflow",
+  "title": "Webflow",
+  "description": "Manage Webflow CMS, pages, assets, and sites.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/webflow.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.webflow.com/mcp\",\n  description: \"Webflow: CMS items, pages, assets, and sites.\",\n  auth: connect(\"webflow\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/webflow.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/wix.json
+++ b/apps/docs/public/r/connection/wix.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/wix",
+  "title": "Wix",
+  "description": "Manage and build sites and apps on Wix.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/wix.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.wix.com/mcp\",\n  description: \"Wix: manage and build sites and apps.\",\n  auth: connect(\"wix\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/wix.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/zapier.json
+++ b/apps/docs/public/r/connection/zapier.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/zapier",
+  "title": "Zapier",
+  "description": "Automate workflows across thousands of apps.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/zapier.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp.zapier.com/api/v1/connect\",\n  description: \"Zapier: run and manage automations across apps.\",\n  auth: connect(\"zapier\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/zapier.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/connection/zomato.json
+++ b/apps/docs/public/r/connection/zomato.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "connection/zomato",
+  "title": "Zomato",
+  "description": "Online food ordering and delivery through Zomato.",
+  "dependencies": ["@vercel/connect"],
+  "files": [
+    {
+      "path": "registry/connections/zomato.ts",
+      "content": "import { connect } from \"@vercel/connect/eve\";\nimport { defineMcpClientConnection } from \"eve/connections\";\n\nexport default defineMcpClientConnection({\n  url: \"https://mcp-server.zomato.com/mcp\",\n  description: \"Zomato: food ordering and delivery.\",\n  auth: connect(\"zomato\"),\n});\n",
+      "type": "registry:file",
+      "target": "agent/connections/zomato.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/registry.json
+++ b/apps/docs/public/r/registry.json
@@ -103,6 +103,554 @@
           "target": "agent/extensions/agentkit.ts"
         }
       ]
+    },
+    {
+      "name": "connection/browser-use",
+      "type": "registry:item",
+      "title": "Browser Use",
+      "description": "Run managed browser automation tasks through Browser Use's MCP server.",
+      "envVars": {
+        "BROWSER_USE_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/connections/browser-use.ts",
+          "type": "registry:file",
+          "target": "agent/connections/browser-use.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/vercel",
+      "type": "registry:item",
+      "title": "Vercel",
+      "description": "Manage Vercel projects, deployments, and logs through Vercel's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/vercel.ts",
+          "type": "registry:file",
+          "target": "agent/connections/vercel.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/linear",
+      "type": "registry:item",
+      "title": "Linear",
+      "description": "Issues, projects, cycles, and comments via Linear's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/linear.ts",
+          "type": "registry:file",
+          "target": "agent/connections/linear.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/notion",
+      "type": "registry:item",
+      "title": "Notion",
+      "description": "Search and edit Notion pages and databases over MCP or OpenAPI.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/notion.ts",
+          "type": "registry:file",
+          "target": "agent/connections/notion.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/datadog",
+      "type": "registry:item",
+      "title": "Datadog",
+      "description": "Query metrics, monitors, and logs through Datadog's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/datadog.ts",
+          "type": "registry:file",
+          "target": "agent/connections/datadog.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/honeycomb",
+      "type": "registry:item",
+      "title": "Honeycomb",
+      "description": "Explore traces and run queries through Honeycomb's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/honeycomb.ts",
+          "type": "registry:file",
+          "target": "agent/connections/honeycomb.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/airtable",
+      "type": "registry:item",
+      "title": "Airtable",
+      "description": "Bases, tables, and records through Airtable's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/airtable.ts",
+          "type": "registry:file",
+          "target": "agent/connections/airtable.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/bitly",
+      "type": "registry:item",
+      "title": "Bitly",
+      "description": "Shorten links, generate QR Codes, and track performance.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/bitly.ts",
+          "type": "registry:file",
+          "target": "agent/connections/bitly.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/brex",
+      "type": "registry:item",
+      "title": "Brex",
+      "description": "Expenses, cards, and cash through Brex's finance automation.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/brex.ts",
+          "type": "registry:file",
+          "target": "agent/connections/brex.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/candid",
+      "type": "registry:item",
+      "title": "Candid",
+      "description": "Research nonprofits and funders using Candid's data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/candid.ts",
+          "type": "registry:file",
+          "target": "agent/connections/candid.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/clickhouse",
+      "type": "registry:item",
+      "title": "ClickHouse",
+      "description": "Query and explore your ClickHouse Cloud data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/clickhouse.ts",
+          "type": "registry:file",
+          "target": "agent/connections/clickhouse.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/cloudinary",
+      "type": "registry:item",
+      "title": "Cloudinary",
+      "description": "Manage, transform, and deliver your images and videos.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/cloudinary.ts",
+          "type": "registry:file",
+          "target": "agent/connections/cloudinary.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/coda",
+      "type": "registry:item",
+      "title": "Coda",
+      "description": "Create, search, and update docs and tables.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/coda.ts",
+          "type": "registry:file",
+          "target": "agent/connections/coda.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/egnyte",
+      "type": "registry:item",
+      "title": "Egnyte",
+      "description": "Securely access and analyze Egnyte content.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/egnyte.ts",
+          "type": "registry:file",
+          "target": "agent/connections/egnyte.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/embat",
+      "type": "registry:item",
+      "title": "Embat",
+      "description": "Ask Embat about cash, debt, payments, and accounting.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/embat.ts",
+          "type": "registry:file",
+          "target": "agent/connections/embat.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/hugging-face",
+      "type": "registry:item",
+      "title": "Hugging Face",
+      "description": "Access the Hugging Face Hub and thousands of Gradio apps.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/hugging-face.ts",
+          "type": "registry:file",
+          "target": "agent/connections/hugging-face.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/local-falcon",
+      "type": "registry:item",
+      "title": "Local Falcon",
+      "description": "AI visibility and local search intelligence.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/local-falcon.ts",
+          "type": "registry:file",
+          "target": "agent/connections/local-falcon.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/make",
+      "type": "registry:item",
+      "title": "Make",
+      "description": "Run Make scenarios and manage your Make account.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/make.ts",
+          "type": "registry:file",
+          "target": "agent/connections/make.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/manufact",
+      "type": "registry:item",
+      "title": "Manufact",
+      "description": "Deploy and monitor MCP servers with Manufact.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/manufact.ts",
+          "type": "registry:file",
+          "target": "agent/connections/manufact.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/mem0",
+      "type": "registry:item",
+      "title": "Mem0",
+      "description": "Persistent memory for AI agents and assistants.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/mem0.ts",
+          "type": "registry:file",
+          "target": "agent/connections/mem0.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/miro",
+      "type": "registry:item",
+      "title": "Miro",
+      "description": "Access and create content on Miro boards.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/miro.ts",
+          "type": "registry:file",
+          "target": "agent/connections/miro.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/mixpanel",
+      "type": "registry:item",
+      "title": "Mixpanel",
+      "description": "Analyze, query, and manage your Mixpanel data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/mixpanel.ts",
+          "type": "registry:file",
+          "target": "agent/connections/mixpanel.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/netlify",
+      "type": "registry:item",
+      "title": "Netlify",
+      "description": "Create, deploy, manage, and secure websites on Netlify.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/netlify.ts",
+          "type": "registry:file",
+          "target": "agent/connections/netlify.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/oreilly",
+      "type": "registry:item",
+      "title": "O'Reilly",
+      "description": "Discover O'Reilly's expert learning content.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/oreilly.ts",
+          "type": "registry:file",
+          "target": "agent/connections/oreilly.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/planetscale",
+      "type": "registry:item",
+      "title": "PlanetScale",
+      "description": "Authenticated access to your PlanetScale Postgres and MySQL databases.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/planetscale.ts",
+          "type": "registry:file",
+          "target": "agent/connections/planetscale.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/posthog",
+      "type": "registry:item",
+      "title": "PostHog",
+      "description": "Query, analyze, and manage your PostHog insights.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/posthog.ts",
+          "type": "registry:file",
+          "target": "agent/connections/posthog.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/postman",
+      "type": "registry:item",
+      "title": "Postman",
+      "description": "Give API context to your coding agents with Postman.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/postman.ts",
+          "type": "registry:file",
+          "target": "agent/connections/postman.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/razorpay",
+      "type": "registry:item",
+      "title": "Razorpay",
+      "description": "Razorpay payments, settlements, and dashboard data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/razorpay.ts",
+          "type": "registry:file",
+          "target": "agent/connections/razorpay.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/sentry",
+      "type": "registry:item",
+      "title": "Sentry",
+      "description": "Search, query, and debug errors intelligently.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/sentry.ts",
+          "type": "registry:file",
+          "target": "agent/connections/sentry.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/similarweb",
+      "type": "registry:item",
+      "title": "Similarweb",
+      "description": "Real-time web, mobile app, and market data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/similarweb.ts",
+          "type": "registry:file",
+          "target": "agent/connections/similarweb.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/stripe",
+      "type": "registry:item",
+      "title": "Stripe",
+      "description": "Payment processing and financial infrastructure tools.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/stripe.ts",
+          "type": "registry:file",
+          "target": "agent/connections/stripe.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/supabase",
+      "type": "registry:item",
+      "title": "Supabase",
+      "description": "Manage databases, authentication, and storage.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/supabase.ts",
+          "type": "registry:file",
+          "target": "agent/connections/supabase.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/ticket-tailor",
+      "type": "registry:item",
+      "title": "Ticket Tailor",
+      "description": "Manage tickets, orders, and events with Ticket Tailor.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/ticket-tailor.ts",
+          "type": "registry:file",
+          "target": "agent/connections/ticket-tailor.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/ticktick",
+      "type": "registry:item",
+      "title": "TickTick",
+      "description": "Search, create, and manage your tasks and habits in TickTick.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/ticktick.ts",
+          "type": "registry:file",
+          "target": "agent/connections/ticktick.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/todoist",
+      "type": "registry:item",
+      "title": "Todoist",
+      "description": "Search, complete, and manage your tasks in Todoist.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/todoist.ts",
+          "type": "registry:file",
+          "target": "agent/connections/todoist.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/webflow",
+      "type": "registry:item",
+      "title": "Webflow",
+      "description": "Manage Webflow CMS, pages, assets, and sites.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/webflow.ts",
+          "type": "registry:file",
+          "target": "agent/connections/webflow.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/wix",
+      "type": "registry:item",
+      "title": "Wix",
+      "description": "Manage and build sites and apps on Wix.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/wix.ts",
+          "type": "registry:file",
+          "target": "agent/connections/wix.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/zapier",
+      "type": "registry:item",
+      "title": "Zapier",
+      "description": "Automate workflows across thousands of apps.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/zapier.ts",
+          "type": "registry:file",
+          "target": "agent/connections/zapier.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/zomato",
+      "type": "registry:item",
+      "title": "Zomato",
+      "description": "Online food ordering and delivery through Zomato.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/zomato.ts",
+          "type": "registry:file",
+          "target": "agent/connections/zomato.ts"
+        }
+      ]
     }
   ]
 }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -103,6 +103,554 @@
           "target": "agent/extensions/agentkit.ts"
         }
       ]
+    },
+    {
+      "name": "connection/browser-use",
+      "type": "registry:item",
+      "title": "Browser Use",
+      "description": "Run managed browser automation tasks through Browser Use's MCP server.",
+      "envVars": {
+        "BROWSER_USE_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/connections/browser-use.ts",
+          "type": "registry:file",
+          "target": "agent/connections/browser-use.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/vercel",
+      "type": "registry:item",
+      "title": "Vercel",
+      "description": "Manage Vercel projects, deployments, and logs through Vercel's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/vercel.ts",
+          "type": "registry:file",
+          "target": "agent/connections/vercel.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/linear",
+      "type": "registry:item",
+      "title": "Linear",
+      "description": "Issues, projects, cycles, and comments via Linear's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/linear.ts",
+          "type": "registry:file",
+          "target": "agent/connections/linear.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/notion",
+      "type": "registry:item",
+      "title": "Notion",
+      "description": "Search and edit Notion pages and databases over MCP or OpenAPI.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/notion.ts",
+          "type": "registry:file",
+          "target": "agent/connections/notion.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/datadog",
+      "type": "registry:item",
+      "title": "Datadog",
+      "description": "Query metrics, monitors, and logs through Datadog's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/datadog.ts",
+          "type": "registry:file",
+          "target": "agent/connections/datadog.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/honeycomb",
+      "type": "registry:item",
+      "title": "Honeycomb",
+      "description": "Explore traces and run queries through Honeycomb's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/honeycomb.ts",
+          "type": "registry:file",
+          "target": "agent/connections/honeycomb.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/airtable",
+      "type": "registry:item",
+      "title": "Airtable",
+      "description": "Bases, tables, and records through Airtable's MCP server.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/airtable.ts",
+          "type": "registry:file",
+          "target": "agent/connections/airtable.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/bitly",
+      "type": "registry:item",
+      "title": "Bitly",
+      "description": "Shorten links, generate QR Codes, and track performance.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/bitly.ts",
+          "type": "registry:file",
+          "target": "agent/connections/bitly.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/brex",
+      "type": "registry:item",
+      "title": "Brex",
+      "description": "Expenses, cards, and cash through Brex's finance automation.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/brex.ts",
+          "type": "registry:file",
+          "target": "agent/connections/brex.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/candid",
+      "type": "registry:item",
+      "title": "Candid",
+      "description": "Research nonprofits and funders using Candid's data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/candid.ts",
+          "type": "registry:file",
+          "target": "agent/connections/candid.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/clickhouse",
+      "type": "registry:item",
+      "title": "ClickHouse",
+      "description": "Query and explore your ClickHouse Cloud data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/clickhouse.ts",
+          "type": "registry:file",
+          "target": "agent/connections/clickhouse.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/cloudinary",
+      "type": "registry:item",
+      "title": "Cloudinary",
+      "description": "Manage, transform, and deliver your images and videos.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/cloudinary.ts",
+          "type": "registry:file",
+          "target": "agent/connections/cloudinary.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/coda",
+      "type": "registry:item",
+      "title": "Coda",
+      "description": "Create, search, and update docs and tables.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/coda.ts",
+          "type": "registry:file",
+          "target": "agent/connections/coda.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/egnyte",
+      "type": "registry:item",
+      "title": "Egnyte",
+      "description": "Securely access and analyze Egnyte content.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/egnyte.ts",
+          "type": "registry:file",
+          "target": "agent/connections/egnyte.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/embat",
+      "type": "registry:item",
+      "title": "Embat",
+      "description": "Ask Embat about cash, debt, payments, and accounting.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/embat.ts",
+          "type": "registry:file",
+          "target": "agent/connections/embat.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/hugging-face",
+      "type": "registry:item",
+      "title": "Hugging Face",
+      "description": "Access the Hugging Face Hub and thousands of Gradio apps.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/hugging-face.ts",
+          "type": "registry:file",
+          "target": "agent/connections/hugging-face.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/local-falcon",
+      "type": "registry:item",
+      "title": "Local Falcon",
+      "description": "AI visibility and local search intelligence.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/local-falcon.ts",
+          "type": "registry:file",
+          "target": "agent/connections/local-falcon.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/make",
+      "type": "registry:item",
+      "title": "Make",
+      "description": "Run Make scenarios and manage your Make account.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/make.ts",
+          "type": "registry:file",
+          "target": "agent/connections/make.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/manufact",
+      "type": "registry:item",
+      "title": "Manufact",
+      "description": "Deploy and monitor MCP servers with Manufact.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/manufact.ts",
+          "type": "registry:file",
+          "target": "agent/connections/manufact.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/mem0",
+      "type": "registry:item",
+      "title": "Mem0",
+      "description": "Persistent memory for AI agents and assistants.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/mem0.ts",
+          "type": "registry:file",
+          "target": "agent/connections/mem0.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/miro",
+      "type": "registry:item",
+      "title": "Miro",
+      "description": "Access and create content on Miro boards.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/miro.ts",
+          "type": "registry:file",
+          "target": "agent/connections/miro.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/mixpanel",
+      "type": "registry:item",
+      "title": "Mixpanel",
+      "description": "Analyze, query, and manage your Mixpanel data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/mixpanel.ts",
+          "type": "registry:file",
+          "target": "agent/connections/mixpanel.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/netlify",
+      "type": "registry:item",
+      "title": "Netlify",
+      "description": "Create, deploy, manage, and secure websites on Netlify.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/netlify.ts",
+          "type": "registry:file",
+          "target": "agent/connections/netlify.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/oreilly",
+      "type": "registry:item",
+      "title": "O'Reilly",
+      "description": "Discover O'Reilly's expert learning content.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/oreilly.ts",
+          "type": "registry:file",
+          "target": "agent/connections/oreilly.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/planetscale",
+      "type": "registry:item",
+      "title": "PlanetScale",
+      "description": "Authenticated access to your PlanetScale Postgres and MySQL databases.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/planetscale.ts",
+          "type": "registry:file",
+          "target": "agent/connections/planetscale.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/posthog",
+      "type": "registry:item",
+      "title": "PostHog",
+      "description": "Query, analyze, and manage your PostHog insights.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/posthog.ts",
+          "type": "registry:file",
+          "target": "agent/connections/posthog.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/postman",
+      "type": "registry:item",
+      "title": "Postman",
+      "description": "Give API context to your coding agents with Postman.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/postman.ts",
+          "type": "registry:file",
+          "target": "agent/connections/postman.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/razorpay",
+      "type": "registry:item",
+      "title": "Razorpay",
+      "description": "Razorpay payments, settlements, and dashboard data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/razorpay.ts",
+          "type": "registry:file",
+          "target": "agent/connections/razorpay.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/sentry",
+      "type": "registry:item",
+      "title": "Sentry",
+      "description": "Search, query, and debug errors intelligently.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/sentry.ts",
+          "type": "registry:file",
+          "target": "agent/connections/sentry.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/similarweb",
+      "type": "registry:item",
+      "title": "Similarweb",
+      "description": "Real-time web, mobile app, and market data.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/similarweb.ts",
+          "type": "registry:file",
+          "target": "agent/connections/similarweb.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/stripe",
+      "type": "registry:item",
+      "title": "Stripe",
+      "description": "Payment processing and financial infrastructure tools.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/stripe.ts",
+          "type": "registry:file",
+          "target": "agent/connections/stripe.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/supabase",
+      "type": "registry:item",
+      "title": "Supabase",
+      "description": "Manage databases, authentication, and storage.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/supabase.ts",
+          "type": "registry:file",
+          "target": "agent/connections/supabase.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/ticket-tailor",
+      "type": "registry:item",
+      "title": "Ticket Tailor",
+      "description": "Manage tickets, orders, and events with Ticket Tailor.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/ticket-tailor.ts",
+          "type": "registry:file",
+          "target": "agent/connections/ticket-tailor.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/ticktick",
+      "type": "registry:item",
+      "title": "TickTick",
+      "description": "Search, create, and manage your tasks and habits in TickTick.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/ticktick.ts",
+          "type": "registry:file",
+          "target": "agent/connections/ticktick.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/todoist",
+      "type": "registry:item",
+      "title": "Todoist",
+      "description": "Search, complete, and manage your tasks in Todoist.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/todoist.ts",
+          "type": "registry:file",
+          "target": "agent/connections/todoist.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/webflow",
+      "type": "registry:item",
+      "title": "Webflow",
+      "description": "Manage Webflow CMS, pages, assets, and sites.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/webflow.ts",
+          "type": "registry:file",
+          "target": "agent/connections/webflow.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/wix",
+      "type": "registry:item",
+      "title": "Wix",
+      "description": "Manage and build sites and apps on Wix.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/wix.ts",
+          "type": "registry:file",
+          "target": "agent/connections/wix.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/zapier",
+      "type": "registry:item",
+      "title": "Zapier",
+      "description": "Automate workflows across thousands of apps.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/zapier.ts",
+          "type": "registry:file",
+          "target": "agent/connections/zapier.ts"
+        }
+      ]
+    },
+    {
+      "name": "connection/zomato",
+      "type": "registry:item",
+      "title": "Zomato",
+      "description": "Online food ordering and delivery through Zomato.",
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/zomato.ts",
+          "type": "registry:file",
+          "target": "agent/connections/zomato.ts"
+        }
+      ]
     }
   ]
 }

--- a/apps/docs/registry/connections/airtable.ts
+++ b/apps/docs/registry/connections/airtable.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.airtable.com/mcp",
+  description: "Airtable: bases, tables, and records.",
+  auth: connect("airtable"),
+});

--- a/apps/docs/registry/connections/bitly.ts
+++ b/apps/docs/registry/connections/bitly.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://api-ssl.bitly.com/v4/mcp",
+  description: "Bitly: shorten links, generate QR Codes, and track link performance.",
+  auth: connect("bitly"),
+});

--- a/apps/docs/registry/connections/brex.ts
+++ b/apps/docs/registry/connections/brex.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://api.brex.com/mcp",
+  description: "Brex: expenses, cards, budgets, and cash.",
+  auth: connect("brex"),
+});

--- a/apps/docs/registry/connections/browser-use.ts
+++ b/apps/docs/registry/connections/browser-use.ts
@@ -1,0 +1,10 @@
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://api.browser-use.com/v3/mcp",
+  description:
+    "Browser Use: run browser automation tasks, inspect sessions, and manage browser profiles.",
+  headers: () => ({
+    "x-browser-use-api-key": process.env.BROWSER_USE_API_KEY!,
+  }),
+});

--- a/apps/docs/registry/connections/candid.ts
+++ b/apps/docs/registry/connections/candid.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.candid.org/mcp",
+  description: "Candid: research nonprofits, funders, and grants.",
+  auth: connect("candid"),
+});

--- a/apps/docs/registry/connections/clickhouse.ts
+++ b/apps/docs/registry/connections/clickhouse.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.clickhouse.cloud/mcp",
+  description: "ClickHouse Cloud: query and explore databases and tables.",
+  auth: connect("clickhouse"),
+});

--- a/apps/docs/registry/connections/cloudinary.ts
+++ b/apps/docs/registry/connections/cloudinary.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://asset-management.mcp.cloudinary.com/sse",
+  description: "Cloudinary: manage, transform, and deliver image and video assets.",
+  auth: connect("cloudinary"),
+});

--- a/apps/docs/registry/connections/coda.ts
+++ b/apps/docs/registry/connections/coda.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://coda.io/apis/mcp",
+  description: "Coda: create, search, and update docs and tables.",
+  auth: connect("coda"),
+});

--- a/apps/docs/registry/connections/datadog.ts
+++ b/apps/docs/registry/connections/datadog.ts
@@ -1,0 +1,17 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.datadoghq.com/api/mcp",
+  description: "Datadog: query metrics, monitors, logs, and incidents.",
+  auth: connect({
+    connector: "datadog",
+    principalToSubject: (principal) => {
+      const email = principal.type === "user" ? principal.attributes?.email : undefined;
+      if (typeof email !== "string") {
+        throw new Error("JWT bearer authentication requires a user principal with an email.");
+      }
+      return { type: "jwt-bearer", sub: email };
+    },
+  }),
+});

--- a/apps/docs/registry/connections/egnyte.ts
+++ b/apps/docs/registry/connections/egnyte.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp-server.egnyte.com/mcp",
+  description: "Egnyte: search, access, and analyze governed content.",
+  auth: connect("egnyte"),
+});

--- a/apps/docs/registry/connections/embat.ts
+++ b/apps/docs/registry/connections/embat.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://tellme.embat.io/mcp",
+  description: "Embat: cash, debt, payments, and accounting.",
+  auth: connect("embat"),
+});

--- a/apps/docs/registry/connections/honeycomb.ts
+++ b/apps/docs/registry/connections/honeycomb.ts
@@ -1,0 +1,17 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.honeycomb.io/mcp",
+  description: "Honeycomb: explore traces, run queries, and inspect datasets.",
+  auth: connect({
+    connector: "honeycomb",
+    principalToSubject: (principal) => {
+      const email = principal.type === "user" ? principal.attributes?.email : undefined;
+      if (typeof email !== "string") {
+        throw new Error("JWT bearer authentication requires a user principal with an email.");
+      }
+      return { type: "jwt-bearer", sub: email };
+    },
+  }),
+});

--- a/apps/docs/registry/connections/hugging-face.ts
+++ b/apps/docs/registry/connections/hugging-face.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://huggingface.co/mcp?login&gradio=none",
+  description: "Hugging Face: models, datasets, Spaces, and Gradio apps on the Hub.",
+  auth: connect("hugging-face"),
+});

--- a/apps/docs/registry/connections/linear.ts
+++ b/apps/docs/registry/connections/linear.ts
@@ -1,0 +1,11 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.linear.app/mcp",
+  description: "Linear workspace: issues, projects, cycles, and comments.",
+  auth: connect("linear"),
+
+  // For app-scoped authentication, replace the auth block above with:
+  // auth: connect({ connector: "linear", principalType: "app" }),
+});

--- a/apps/docs/registry/connections/local-falcon.ts
+++ b/apps/docs/registry/connections/local-falcon.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.localfalcon.com",
+  description: "Local Falcon: local search rankings and AI visibility reports.",
+  auth: connect("local-falcon"),
+});

--- a/apps/docs/registry/connections/make.ts
+++ b/apps/docs/registry/connections/make.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.make.com",
+  description: "Make: run scenarios and manage automations.",
+  auth: connect("make"),
+});

--- a/apps/docs/registry/connections/manufact.ts
+++ b/apps/docs/registry/connections/manufact.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.manufact.com/mcp",
+  description: "Manufact: deploy and monitor MCP servers.",
+  auth: connect("manufact"),
+});

--- a/apps/docs/registry/connections/mem0.ts
+++ b/apps/docs/registry/connections/mem0.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.mem0.ai/mcp",
+  description: "Mem0: store and retrieve persistent agent memory.",
+  auth: connect("mem0"),
+});

--- a/apps/docs/registry/connections/miro.ts
+++ b/apps/docs/registry/connections/miro.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.miro.com/",
+  description: "Miro: read and create content on boards.",
+  auth: connect("miro"),
+});

--- a/apps/docs/registry/connections/mixpanel.ts
+++ b/apps/docs/registry/connections/mixpanel.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.mixpanel.com/mcp",
+  description: "Mixpanel: analyze, query, and manage analytics data.",
+  auth: connect("mixpanel"),
+});

--- a/apps/docs/registry/connections/netlify.ts
+++ b/apps/docs/registry/connections/netlify.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://netlify-mcp.netlify.app/mcp",
+  description: "Netlify: create, deploy, manage, and secure sites.",
+  auth: connect("netlify"),
+});

--- a/apps/docs/registry/connections/notion.ts
+++ b/apps/docs/registry/connections/notion.ts
@@ -1,0 +1,25 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.notion.com/mcp",
+  description: "Notion workspace: search and edit pages and databases.",
+  auth: connect("notion"),
+
+  // For app-scoped authentication, replace the auth block above with:
+  // auth: connect({ connector: "notion", principalType: "app" }),
+
+  // For JWT bearer authentication, replace the auth block above with:
+  // auth: connect({
+  //   connector: "notion",
+  //   principalToSubject: (principal) => {
+  //     const email = principal.type === "user" ? principal.attributes?.email : undefined;
+  //     if (typeof email !== "string") {
+  //       throw new Error("JWT bearer authentication requires a user principal with an email.");
+  //     }
+  //     return { type: "jwt-bearer", sub: email };
+  //   },
+  // }),
+
+  // Notion also supports OpenAPI. See https://eve.dev/integrations/notion for that scaffold.
+});

--- a/apps/docs/registry/connections/oreilly.ts
+++ b/apps/docs/registry/connections/oreilly.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://api.oreilly.com/api/content-discovery/v1/mcp/",
+  description: "O'Reilly: search books, courses, and learning content.",
+  auth: connect("oreilly"),
+});

--- a/apps/docs/registry/connections/planetscale.ts
+++ b/apps/docs/registry/connections/planetscale.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.pscale.dev/mcp/planetscale",
+  description: "PlanetScale: query Postgres and MySQL databases.",
+  auth: connect("planetscale"),
+});

--- a/apps/docs/registry/connections/posthog.ts
+++ b/apps/docs/registry/connections/posthog.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.posthog.com/mcp",
+  description: "PostHog: insights, events, and feature flags.",
+  auth: connect("posthog"),
+});

--- a/apps/docs/registry/connections/postman.ts
+++ b/apps/docs/registry/connections/postman.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.postman.com/minimal",
+  description: "Postman: APIs, collections, and workspaces.",
+  auth: connect("postman"),
+});

--- a/apps/docs/registry/connections/razorpay.ts
+++ b/apps/docs/registry/connections/razorpay.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.razorpay.com/mcp",
+  description: "Razorpay: payments, settlements, and dashboard data.",
+  auth: connect("razorpay"),
+});

--- a/apps/docs/registry/connections/sentry.ts
+++ b/apps/docs/registry/connections/sentry.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.sentry.dev/mcp",
+  description: "Sentry: search, query, and debug errors and issues.",
+  auth: connect("sentry"),
+});

--- a/apps/docs/registry/connections/similarweb.ts
+++ b/apps/docs/registry/connections/similarweb.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.similarweb.com",
+  description: "Similarweb: web traffic, app, and market intelligence data.",
+  auth: connect("similarweb"),
+});

--- a/apps/docs/registry/connections/stripe.ts
+++ b/apps/docs/registry/connections/stripe.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.stripe.com",
+  description: "Stripe: payments, customers, billing, and financial infrastructure.",
+  auth: connect("stripe"),
+});

--- a/apps/docs/registry/connections/supabase.ts
+++ b/apps/docs/registry/connections/supabase.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.supabase.com/mcp",
+  description: "Supabase: databases, authentication, and storage.",
+  auth: connect("supabase"),
+});

--- a/apps/docs/registry/connections/ticket-tailor.ts
+++ b/apps/docs/registry/connections/ticket-tailor.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.tickettailor.ai/mcp",
+  description: "Ticket Tailor: events, tickets, and orders.",
+  auth: connect("ticket-tailor"),
+});

--- a/apps/docs/registry/connections/ticktick.ts
+++ b/apps/docs/registry/connections/ticktick.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.ticktick.com",
+  description: "TickTick: tasks, habits, and lists.",
+  auth: connect("ticktick"),
+});

--- a/apps/docs/registry/connections/todoist.ts
+++ b/apps/docs/registry/connections/todoist.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://ai.todoist.net/mcp",
+  description: "Todoist: search, complete, and manage tasks.",
+  auth: connect("todoist"),
+});

--- a/apps/docs/registry/connections/vercel.ts
+++ b/apps/docs/registry/connections/vercel.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.vercel.com",
+  description: "Vercel: manage projects and deployments, inspect logs, and search documentation.",
+  auth: connect("vercel"),
+});

--- a/apps/docs/registry/connections/webflow.ts
+++ b/apps/docs/registry/connections/webflow.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.webflow.com/mcp",
+  description: "Webflow: CMS items, pages, assets, and sites.",
+  auth: connect("webflow"),
+});

--- a/apps/docs/registry/connections/wix.ts
+++ b/apps/docs/registry/connections/wix.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.wix.com/mcp",
+  description: "Wix: manage and build sites and apps.",
+  auth: connect("wix"),
+});

--- a/apps/docs/registry/connections/zapier.ts
+++ b/apps/docs/registry/connections/zapier.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.zapier.com/api/v1/connect",
+  description: "Zapier: run and manage automations across apps.",
+  auth: connect("zapier"),
+});

--- a/apps/docs/registry/connections/zomato.ts
+++ b/apps/docs/registry/connections/zomato.ts
@@ -1,0 +1,8 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp-server.zomato.com/mcp",
+  description: "Zomato: food ordering and delivery.",
+  auth: connect("zomato"),
+});

--- a/apps/docs/registry/tsconfig.json
+++ b/apps/docs/registry/tsconfig.json
@@ -4,6 +4,6 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["extensions/**/*.ts"],
+  "include": ["connections/**/*.ts", "extensions/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/apps/docs/scripts/validate-connection-registry.ts
+++ b/apps/docs/scripts/validate-connection-registry.ts
@@ -1,0 +1,57 @@
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { connectionEntries } from "@vercel/eve-catalog";
+
+interface RegistryFile {
+  path: string;
+  target?: string;
+}
+
+interface RegistryItem {
+  name: string;
+  dependencies?: string[];
+  envVars?: Record<string, string>;
+  files?: RegistryFile[];
+}
+
+interface Registry {
+  items: RegistryItem[];
+}
+
+const docsRoot = join(import.meta.dirname, "..");
+const registry = JSON.parse(await readFile(join(docsRoot, "registry.json"), "utf8")) as Registry;
+const items = registry.items.filter((item) => item.name.startsWith("connection/"));
+const expectedSlugs = connectionEntries()
+  .filter((entry) => entry.surfaces.gallery)
+  .map((entry) => entry.slug);
+const actualSlugs = items.map((item) => item.name.slice("connection/".length));
+
+if (JSON.stringify(actualSlugs) !== JSON.stringify(expectedSlugs)) {
+  throw new Error(
+    `Connection registry entries do not match the gallery.\nExpected: ${expectedSlugs.join(", ")}\nActual: ${actualSlugs.join(", ")}`,
+  );
+}
+
+for (const item of items) {
+  const slug = item.name.slice("connection/".length);
+  const expectedPath = `registry/connections/${slug}.ts`;
+  const expectedTarget = `agent/connections/${slug}.ts`;
+  const file = item.files?.[0];
+  if (item.files?.length !== 1 || file?.path !== expectedPath || file.target !== expectedTarget) {
+    throw new Error(
+      `Registry item "${item.name}" must write ${expectedPath} to ${expectedTarget}.`,
+    );
+  }
+  await access(join(docsRoot, expectedPath));
+
+  if (slug === "browser-use") {
+    if (item.dependencies !== undefined || !("BROWSER_USE_API_KEY" in (item.envVars ?? {}))) {
+      throw new Error(
+        'Registry item "connection/browser-use" must declare its API key without Vercel Connect.',
+      );
+    }
+  } else if (!item.dependencies?.includes("@vercel/connect")) {
+    throw new Error(`Registry item "${item.name}" must depend on @vercel/connect.`);
+  }
+}

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -12,9 +12,10 @@ Run `eve add` from an eve agent project. This installs the integration's depende
 
 ```bash
 eve add extension/agent-browser
+eve add connection/linear
 ```
 
-The integration may create an extension mount under `agent/extensions/`. Configure that mount and any required environment variables before running your agent.
+Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Configure the generated file and any required environment variables before running your agent.
 
 ## Find an integration
 

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -48,7 +48,7 @@ export interface ConnectionIdentity {
 
 /** Which eve surfaces an integration is available on today. */
 export interface IntegrationSurfaces {
-  /** The eve CLI can scaffold this integration without further work. */
+  /** eve's interactive setup flow can provision and scaffold this integration. */
   scaffoldable: boolean;
   /** Listed in the docs integrations gallery. */
   gallery: boolean;
@@ -81,10 +81,11 @@ export function connectionProtocols(connection: ConnectionIdentity): ConnectionP
  * carries only shared identity; the scaffolder and docs overlay their own
  * surface-specific data keyed by {@link IntegrationEntry.slug}.
  *
- * `surfaces.scaffoldable` reflects what the CLI can scaffold today: Slack and
- * Web Chat for channels, and every curated connection. The remaining
- * channels are runtime modules that are still configured by hand, so they
- * appear in the gallery but not the CLI picker.
+ * `surfaces.scaffoldable` reflects what eve's interactive setup flow can
+ * provision and scaffold today: Slack and Web Chat for channels, plus its
+ * curated connections. Registry installation is independent of this flag.
+ * The remaining channels are runtime modules configured by hand, so they
+ * appear in the gallery but not the setup picker.
  */
 export const INTEGRATIONS: readonly IntegrationEntry[] = [
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       '@upstash/agentkit-eve-extension':
         specifier: ^0.4.0
         version: 0.4.0(eve@packages+eve)
+      '@vercel/connect':
+        specifier: 'catalog:'
+        version: 0.4.2(@ai-sdk/mcp@2.0.16(zod@4.4.3))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@6.0.191(zod@4.4.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3))(ai@6.0.191(zod@4.4.3))(eve@packages+eve)
       '@vgpu/adapter-node':
         specifier: 0.0.7
         version: 0.0.7(supports-color@10.2.2)


### PR DESCRIPTION
## Summary

- add registry items and generated connection definitions for all 39 connections in the integrations gallery
- install `@vercel/connect` for Connect-backed entries and declare the Browser Use API key through registry metadata
- replace connection install snippets with `eve add connection/<slug>` and document auth alternatives for multi-mode connections
- validate registry coverage against the shared integration catalog and typecheck registry connection sources

## Testing

- `pnpm --filter eve-docs registry:check`
- `pnpm --filter eve-docs test:unit`
- `pnpm docs:check`
- `pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm --filter @vercel/eve-catalog test:unit`
- `pnpm lint`
- `pnpm fmt`
