### PR TITLE
feat(docs): add instrumentation registry items

### DIFF
--- a/apps/docs/app/[lang]/integrations/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/integrations/[slug]/page.tsx
@@ -23,6 +23,7 @@ const typeLabel = {
   channel: "Channel",
   connection: "Connection",
   extension: "Extension",
+  instrumentation: "Instrumentation",
 } as const;
 
 const languages = Object.keys(translations);

--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -15,9 +15,9 @@ const FILTERS: { value: GalleryFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "channel", label: "Channels" },
   { value: "connection", label: "Connections" },
-  { value: "memory", label: "Memory" },
   { value: "extension", label: "Extensions" },
-  { value: "instrumentation", label: "Instrumentation" },
+  { value: "memory", label: "Memory" },
+  { value: "instrumentation", label: "Observability" },
 ];
 
 const FILTER_DESCRIPTIONS: Record<Exclude<GalleryFilter, "all">, string> = {
@@ -27,7 +27,7 @@ const FILTER_DESCRIPTIONS: Record<Exclude<GalleryFilter, "all">, string> = {
     "Connections are the tools your agent calls during a run: services reached over MCP or OpenAPI.",
   extension: "Extensions are packages that add reusable tools, skills, connections, and hooks.",
   instrumentation:
-    "Instrumentation providers are OpenTelemetry backends that receive your agent's traces: every model call, tool execution, and turn.",
+    "Observability providers are OpenTelemetry backends that receive your agent's traces: every model call, tool execution, and turn.",
   memory: "Memory integrations let your agent store and recall information across sessions.",
 };
 

--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -17,6 +17,7 @@ const FILTERS: { value: GalleryFilter; label: string }[] = [
   { value: "connection", label: "Connections" },
   { value: "memory", label: "Memory" },
   { value: "extension", label: "Extensions" },
+  { value: "instrumentation", label: "Instrumentation" },
 ];
 
 const FILTER_DESCRIPTIONS: Record<Exclude<GalleryFilter, "all">, string> = {
@@ -25,6 +26,8 @@ const FILTER_DESCRIPTIONS: Record<Exclude<GalleryFilter, "all">, string> = {
   connection:
     "Connections are the tools your agent calls during a run: services reached over MCP or OpenAPI.",
   extension: "Extensions are packages that add reusable tools, skills, connections, and hooks.",
+  instrumentation:
+    "Instrumentation providers are OpenTelemetry backends that receive your agent's traces: every model call, tool execution, and turn.",
   memory: "Memory integrations let your agent store and recall information across sessions.",
 };
 

--- a/apps/docs/app/[lang]/integrations/components/integration-card.tsx
+++ b/apps/docs/app/[lang]/integrations/components/integration-card.tsx
@@ -6,6 +6,7 @@ const typeLabel: Record<Integration["type"], string> = {
   channel: "Channel",
   connection: "Connection",
   extension: "Extension",
+  instrumentation: "Instrumentation",
 };
 
 interface IntegrationCardProps {

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -5,7 +5,7 @@ import { Gallery, type GalleryFilter } from "./components/gallery";
 
 const title = "Integrations";
 const description =
-  "Browse the channels, connections, and extensions available to an eve agent, each with install, quick start, and configuration steps.";
+  "Browse the channels, connections, extensions, and instrumentation providers available to an eve agent, each with install, quick start, and configuration steps.";
 
 export const metadata: Metadata = {
   title,
@@ -14,7 +14,14 @@ export const metadata: Metadata = {
 
 export const generateStaticParams = () => Object.keys(translations).map((lang) => ({ lang }));
 
-const galleryFilters: GalleryFilter[] = ["all", "channel", "connection", "extension", "memory"];
+const galleryFilters: GalleryFilter[] = [
+  "all",
+  "channel",
+  "connection",
+  "extension",
+  "instrumentation",
+  "memory",
+];
 
 const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integrations">) => {
   const filterParam = (await searchParams).filter;
@@ -30,8 +37,9 @@ const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integration
           Integrations
         </h1>
         <p className="mt-5 max-w-2xl text-gray-900 text-lg">
-          Add the channels where people reach your agent, connections to external services, and
-          extensions that package reusable capabilities.
+          Add the channels where people reach your agent, connections to external services,
+          extensions that package reusable capabilities, and instrumentation providers that receive
+          traces.
         </p>
       </section>
       <Gallery filter={filter} integrations={integrations} />

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -5,6 +5,7 @@ import {
   connectionEntries,
   connectionProtocols as protocolsForIdentity,
   extensionEntries,
+  instrumentationEntries,
 } from "@vercel/eve-catalog";
 import type { LogoKey } from "./logos";
 
@@ -17,7 +18,7 @@ import type { LogoKey } from "./logos";
  * keyed by slug.
  */
 
-export type IntegrationType = "channel" | "connection" | "extension";
+export type IntegrationType = "channel" | "connection" | "extension" | "instrumentation";
 
 /** Wire protocol and transport identity types are owned by the shared catalog. */
 export type { ConnectionProtocol, McpTransport, OpenApiTransport } from "@vercel/eve-catalog";
@@ -1734,6 +1735,234 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
   },
 };
 
+/**
+ * Instrumentation overlay: presentation plus hand-authored setup markdown.
+ * Instrumentation providers are OpenTelemetry backends configured in
+ * `agent/instrumentation.ts`, so they follow the channel shape (markdown)
+ * rather than the generated connection shape.
+ */
+type InstrumentationPresentation = ChannelPresentation;
+
+const instrumentationPresentations: Record<string, InstrumentationPresentation> = {
+  braintrust: {
+    logo: "braintrust",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "evals", "monitoring"],
+    install: `Install the framework, the Vercel OpenTelemetry wrapper, and Braintrust's exporter:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel @braintrust/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\`. eve auto-discovers it and runs it at server startup, and its presence enables telemetry:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { BraintrustExporter } from "@braintrust/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new BraintrustExporter({
+        parent: \`project_name:\${agentName}\`,
+        filterAISpans: true,
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Create an API key in the Braintrust dashboard and expose it as \`BRAINTRUST_API_KEY\`. Spans land in the Braintrust project named after your agent. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  "sentry-instrumentation": {
+    logo: "sentry",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "otlp", "errors"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Sentry ingests OTLP directly, so no Sentry SDK is required:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your project's Sentry traces endpoint:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+        headers: {
+          "x-sentry-auth": \`sentry sentry_key=\${process.env.SENTRY_PUBLIC_KEY}\`,
+        },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Copy the OTLP traces endpoint and public key from your Sentry project under **Settings → Client Keys (DSN)** and expose them as environment variables. Sentry's OTLP intake accepts traces only, and span events are dropped at ingestion. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  "datadog-instrumentation": {
+    logo: "datadog",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "apm", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at Datadog's intake for your site, authenticated with your API key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+        headers: { "dd-api-key": process.env.DD_API_KEY! },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Datadog's direct OTLP trace intake is site-specific (for example \`datadoghq.com\` vs \`datadoghq.eu\`) and currently in Preview; look up the endpoint for your site in Datadog's OTLP intake docs. For production, Datadog recommends routing through an OpenTelemetry Collector with the Datadog exporter instead. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  "honeycomb-instrumentation": {
+    logo: "honeycomb",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "queries", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Honeycomb ingests OTLP directly:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Honeycomb's OTLP endpoint with your ingest key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://api.honeycomb.io/v1/traces",
+        headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Create an ingest key under your Honeycomb environment settings and expose it as \`HONEYCOMB_API_KEY\`. Spans arrive in a dataset named after your agent (the OTel service name). EU teams use \`https://api.eu1.honeycomb.io/v1/traces\`. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  arize: {
+    logo: "arize",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "llm observability", "evaluation", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Arize AX ingests OTLP directly:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Arize's OTLP endpoint with your space ID and API key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      attributes: { "openinference.project.name": agentName },
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://otlp.arize.com/v1/traces",
+        headers: {
+          space_id: process.env.ARIZE_SPACE_ID!,
+          api_key: process.env.ARIZE_API_KEY!,
+        },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Copy the space ID and API key from your Arize AX space settings and expose them as \`ARIZE_SPACE_ID\` and \`ARIZE_API_KEY\`. The \`openinference.project.name\` resource attribute routes spans to a project named after your agent. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  raindrop: {
+    logo: "raindrop",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "ai issues", "otlp"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper. Raindrop ingests OTLP directly:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Raindrop's OTLP endpoint with your write key:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://api.raindrop.ai/v1/traces",
+        headers: {
+          Authorization: \`Bearer \${process.env.RAINDROP_WRITE_KEY}\`,
+        },
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Create a write key in the Raindrop dashboard and expose it as \`RAINDROP_WRITE_KEY\`. Raindrop's Vercel AI SDK integration picks up the AI SDK spans eve emits on every turn. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+  jaeger: {
+    logo: "jaeger",
+    docsHref: "/docs/guides/instrumentation",
+    keywords: ["otel", "opentelemetry", "tracing", "observability", "local", "self-hosted"],
+    install: `Install the framework and the Vercel OpenTelemetry wrapper:
+
+\`\`\`bash
+npm install eve@latest @vercel/otel
+\`\`\``,
+    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your Jaeger collector:
+
+\`\`\`ts
+// agent/instrumentation.ts
+import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "http://localhost:4318/v1/traces",
+      }),
+    }),
+});
+\`\`\``,
+    configure: `Run Jaeger locally with Docker and open the UI at \`http://localhost:16686\`:
+
+\`\`\`bash
+docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:latest
+\`\`\`
+
+Point the exporter at your collector's OTLP HTTP endpoint when self-hosting. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+  },
+};
+
 function buildChannel(entry: IntegrationEntry): Integration {
   const presentation = channelPresentations[entry.slug];
   if (presentation === undefined) {
@@ -1813,6 +2042,27 @@ function buildExtension(entry: IntegrationEntry): Integration {
   };
 }
 
+function buildInstrumentation(entry: IntegrationEntry): Integration {
+  const presentation = instrumentationPresentations[entry.slug];
+  if (presentation === undefined) {
+    throw new Error(
+      `Instrumentation provider "${entry.slug}" is in the catalog gallery but has no docs presentation.`,
+    );
+  }
+  return {
+    slug: entry.slug,
+    name: entry.name,
+    type: "instrumentation",
+    tagline: entry.tagline,
+    logo: presentation.logo,
+    docsHref: presentation.docsHref,
+    keywords: presentation.keywords,
+    install: presentation.install,
+    quickStart: presentation.quickStart,
+    configure: presentation.configure,
+  };
+}
+
 const channels: Integration[] = channelEntries()
   .filter((entry) => entry.surfaces.gallery)
   .map(buildChannel);
@@ -1824,6 +2074,10 @@ const connections: Integration[] = connectionEntries()
 const extensions: Integration[] = extensionEntries()
   .filter((entry) => entry.surfaces.gallery)
   .map(buildExtension);
+
+const instrumentation: Integration[] = instrumentationEntries()
+  .filter((entry) => entry.surfaces.gallery)
+  .map(buildInstrumentation);
 
 /** Display label for each connection protocol. */
 export const protocolLabel: Record<ConnectionProtocol, string> = {
@@ -1845,7 +2099,12 @@ export const authModeLabel: Record<AuthMode, string> = {
   apiKey: "API key",
 };
 
-export const integrations: Integration[] = [...channels, ...extensions, ...connections];
+export const integrations: Integration[] = [
+  ...channels,
+  ...extensions,
+  ...connections,
+  ...instrumentation,
+];
 
 export const getIntegration = (slug: string): Integration | undefined =>
   integrations.find((integration) => integration.slug === slug);

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1748,11 +1748,12 @@ const instrumentationPresentations: Record<string, InstrumentationPresentation> 
     logo: "braintrust",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "observability", "evals", "monitoring"],
-    install: `Install the framework, the Vercel OpenTelemetry wrapper, and Braintrust's exporter:
+    install: `Add Braintrust instrumentation from eve's registry:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel @braintrust/otel
+eve add instrumentation/braintrust
 \`\`\``,
+
     quickStart: `Create \`agent/instrumentation.ts\`. eve auto-discovers it and runs it at server startup, and its presence enables telemetry:
 
 \`\`\`ts
@@ -1778,11 +1779,12 @@ export default defineInstrumentation({
     logo: "sentry",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "observability", "otlp", "errors"],
-    install: `Install the framework and the Vercel OpenTelemetry wrapper. Sentry ingests OTLP directly, so no Sentry SDK is required:
+    install: `Add Sentry instrumentation from eve's registry. Sentry ingests OTLP directly, so no Sentry SDK is required:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel
+eve add instrumentation/sentry
 \`\`\``,
+
     quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your project's Sentry traces endpoint:
 
 \`\`\`ts
@@ -1809,10 +1811,10 @@ export default defineInstrumentation({
     logo: "datadog",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "observability", "apm", "otlp"],
-    install: `Install the framework and the Vercel OpenTelemetry wrapper:
+    install: `Add Datadog instrumentation from eve's registry:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel
+eve add instrumentation/datadog
 \`\`\``,
     quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at Datadog's intake for your site, authenticated with your API key:
 
@@ -1838,11 +1840,12 @@ export default defineInstrumentation({
     logo: "honeycomb",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "observability", "queries", "otlp"],
-    install: `Install the framework and the Vercel OpenTelemetry wrapper. Honeycomb ingests OTLP directly:
+    install: `Add Honeycomb instrumentation from eve's registry. Honeycomb ingests OTLP directly:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel
+eve add instrumentation/honeycomb
 \`\`\``,
+
     quickStart: `Create \`agent/instrumentation.ts\` and send traces to Honeycomb's OTLP endpoint with your ingest key:
 
 \`\`\`ts
@@ -1867,11 +1870,12 @@ export default defineInstrumentation({
     logo: "arize",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "llm observability", "evaluation", "otlp"],
-    install: `Install the framework and the Vercel OpenTelemetry wrapper. Arize AX ingests OTLP directly:
+    install: `Add Arize instrumentation from eve's registry. Arize AX ingests OTLP directly:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel
+eve add instrumentation/arize
 \`\`\``,
+
     quickStart: `Create \`agent/instrumentation.ts\` and send traces to Arize's OTLP endpoint with your space ID and API key:
 
 \`\`\`ts
@@ -1900,11 +1904,12 @@ export default defineInstrumentation({
     logo: "raindrop",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "observability", "ai issues", "otlp"],
-    install: `Install the framework and the Vercel OpenTelemetry wrapper. Raindrop ingests OTLP directly:
+    install: `Add Raindrop instrumentation from eve's registry. Raindrop ingests OTLP directly:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel
+eve add instrumentation/raindrop
 \`\`\``,
+
     quickStart: `Create \`agent/instrumentation.ts\` and send traces to Raindrop's OTLP endpoint with your write key:
 
 \`\`\`ts
@@ -1931,10 +1936,10 @@ export default defineInstrumentation({
     logo: "jaeger",
     docsHref: "/docs/guides/instrumentation",
     keywords: ["otel", "opentelemetry", "tracing", "observability", "local", "self-hosted"],
-    install: `Install the framework and the Vercel OpenTelemetry wrapper:
+    install: `Add Jaeger instrumentation from eve's registry:
 
 \`\`\`bash
-npm install eve@latest @vercel/otel
+eve add instrumentation/jaeger
 \`\`\``,
     quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your Jaeger collector:
 

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -89,4 +89,14 @@ describe("integration discovery", () => {
     expect(markdown).toContain("### OpenAPI · User");
     expect(markdown).toContain("agent/connections/notion.ts");
   });
+
+  it("renders instrumentation providers with registry installation", () => {
+    const braintrust = getIntegration("braintrust");
+    expect(braintrust).toBeDefined();
+
+    const markdown = integrationMarkdown(braintrust!);
+    expect(markdown).toContain("eve add instrumentation/braintrust");
+    expect(markdown).toContain("agent/instrumentation.ts");
+    expect(markdown).toContain("BRAINTRUST_API_KEY");
+  });
 });

--- a/apps/docs/lib/integrations/discovery.ts
+++ b/apps/docs/lib/integrations/discovery.ts
@@ -9,6 +9,7 @@ const typeLabel: Record<Integration["type"], string> = {
   channel: "Channel",
   connection: "Connection",
   extension: "Extension",
+  instrumentation: "Instrumentation",
 };
 
 const section = (title: string, content: string): string => `## ${title}\n\n${content}`;

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -1,6 +1,7 @@
 import {
   SiAirtable,
   SiBitly,
+  SiBraintrust,
   SiBrex,
   SiClickhouse,
   SiCloudinary,
@@ -10,6 +11,7 @@ import {
   SiGooglechat,
   SiResend,
   SiHuggingface,
+  SiJaeger,
   SiMake,
   SiMessenger,
   SiMiro,
@@ -549,6 +551,32 @@ export const agentBrowserLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const braintrustLogo = (props: LogoProps) => <SiBraintrust {...props} />;
+
+export const jaegerLogo = (props: LogoProps) => <SiJaeger color="default" {...props} />;
+
+export const arizeLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 50 54.1" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M25.01 5.71c1.37-.05 2.65.64 3.37 1.81 6.87 9.89 13.73 19.79 20.56 29.69 1.35 1.79 1 4.33-.78 5.69l-.22.15c-1.92 1.29-4.53.77-5.81-1.15l-.09-.14c-4.73-6.8-9.43-13.61-14.1-20.42l-.28-.34c-1.88-2.67-3.74-2.67-5.57 0-4.77 6.84-9.53 13.7-14.29 20.57-.67 1.16-1.84 1.94-3.16 2.13-1.61.25-3.2-.52-4-1.94-.91-1.41-.84-3.24.17-4.58 2.28-3.31 4.59-6.61 6.89-9.92 4.54-6.51 9.07-13.03 13.6-19.55.78-1.29 2.2-2.05 3.71-2Z"
+      fill="#FF008C"
+    />
+    <path
+      d="M24.84 44.06c2.76-.06 5.04 2.14 5.1 4.9v.04c.02 2.78-2.22 5.05-5 5.06-2.78.02-5.05-2.22-5.07-4.99-.04-2.72 2.13-4.97 4.85-5.01h.12Z"
+      fill="#FF008C"
+    />
+  </svg>
+);
+
+export const raindropLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M12 2.25c3.93 4.92 6.55 8.58 6.55 11.7a6.55 6.55 0 1 1-13.1 0c0-3.12 2.62-6.78 6.55-11.7Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const logos = {
   eve: eveLogo,
   web: webLogo,
@@ -564,6 +592,10 @@ export const logos = {
   notion: notionLogo,
   datadog: datadogLogo,
   honeycomb: honeycombLogo,
+  arize: arizeLogo,
+  braintrust: braintrustLogo,
+  jaeger: jaegerLogo,
+  raindrop: raindropLogo,
   kernel: kernelLogo,
   upstash: upstashLogo,
   airtable: airtableLogo,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,8 +13,9 @@
     "test:unit": "vitest run --config vitest.config.ts",
     "render:eve-5": "NODE_OPTIONS=--loader=./scripts/wgsl-node-loader.mjs tsx scripts/render-eve-5.ts",
     "registry:build": "shadcn build",
-    "registry:check": "pnpm run registry:build && pnpm run registry:validate && tsc --project registry/tsconfig.json",
-    "registry:validate": "tsx scripts/validate-connection-registry.ts"
+    "registry:check": "pnpm run registry:build && pnpm run registry:validate && pnpm run registry:validate:instrumentation && tsc --project registry/tsconfig.json",
+    "registry:validate": "tsx scripts/validate-connection-registry.ts",
+    "registry:validate:instrumentation": "tsx scripts/validate-instrumentation-registry.ts"
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.193",
@@ -63,6 +64,7 @@
   },
   "devDependencies": {
     "@agent-browser/eve": "^0.33.0",
+    "@braintrust/otel": "^0.3.0",
     "@browserbasehq/eve": "^0.1.0",
     "@github-tools/eve-extension": "^0.1.0",
     "@jetty/eve": "^0.3.0",
@@ -75,6 +77,7 @@
     "@types/react-dom": "catalog:",
     "@upstash/agentkit-eve-extension": "^0.4.0",
     "@vercel/connect": "catalog:",
+    "@vercel/otel": "2.1.3",
     "@vgpu/adapter-node": "0.0.7",
     "@webgpu/types": "^0.1.69",
     "eve": "workspace:*",

--- a/apps/docs/public/r/instrumentation/arize.json
+++ b/apps/docs/public/r/instrumentation/arize.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/arize",
+  "title": "Arize",
+  "description": "Export traces to Arize AX for LLM observability and evaluation.",
+  "dependencies": ["@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/arize.ts",
+      "content": "import { OTLPHttpProtoTraceExporter, registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      attributes: { \"openinference.project.name\": agentName },\n      traceExporter: new OTLPHttpProtoTraceExporter({\n        url: \"https://otlp.arize.com/v1/traces\",\n        headers: {\n          space_id: process.env.ARIZE_SPACE_ID!,\n          api_key: process.env.ARIZE_API_KEY!,\n        },\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "envVars": {
+    "ARIZE_SPACE_ID": "",
+    "ARIZE_API_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/instrumentation/braintrust.json
+++ b/apps/docs/public/r/instrumentation/braintrust.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/braintrust",
+  "title": "Braintrust",
+  "description": "Export AI SDK spans to Braintrust for tracing, evals, and monitoring.",
+  "dependencies": ["@braintrust/otel", "@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/braintrust.ts",
+      "content": "import { BraintrustExporter } from \"@braintrust/otel\";\nimport { registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      traceExporter: new BraintrustExporter({\n        parent: `project_name:${agentName}`,\n        filterAISpans: true,\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "envVars": {
+    "BRAINTRUST_API_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/instrumentation/datadog.json
+++ b/apps/docs/public/r/instrumentation/datadog.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/datadog",
+  "title": "Datadog",
+  "description": "Export agent traces to Datadog APM alongside the rest of your stack.",
+  "dependencies": ["@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/datadog.ts",
+      "content": "import { OTLPHttpProtoTraceExporter, registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      traceExporter: new OTLPHttpProtoTraceExporter({\n        url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,\n        headers: { \"dd-api-key\": process.env.DD_API_KEY! },\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "envVars": {
+    "DATADOG_OTLP_TRACES_ENDPOINT": "",
+    "DD_API_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/instrumentation/honeycomb.json
+++ b/apps/docs/public/r/instrumentation/honeycomb.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/honeycomb",
+  "title": "Honeycomb",
+  "description": "Send OpenTelemetry traces to Honeycomb and query every agent turn.",
+  "dependencies": ["@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/honeycomb.ts",
+      "content": "import { OTLPHttpProtoTraceExporter, registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      traceExporter: new OTLPHttpProtoTraceExporter({\n        url: \"https://api.honeycomb.io/v1/traces\",\n        headers: { \"x-honeycomb-team\": process.env.HONEYCOMB_API_KEY! },\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "envVars": {
+    "HONEYCOMB_API_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/instrumentation/jaeger.json
+++ b/apps/docs/public/r/instrumentation/jaeger.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/jaeger",
+  "title": "Jaeger",
+  "description": "Trace your agent with a local or self-hosted Jaeger OTLP backend.",
+  "dependencies": ["@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/jaeger.ts",
+      "content": "import { OTLPHttpProtoTraceExporter, registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      traceExporter: new OTLPHttpProtoTraceExporter({\n        url: \"http://localhost:4318/v1/traces\",\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/instrumentation/raindrop.json
+++ b/apps/docs/public/r/instrumentation/raindrop.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/raindrop",
+  "title": "Raindrop",
+  "description": "Send agent traces to Raindrop to detect and debug AI product issues.",
+  "dependencies": ["@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/raindrop.ts",
+      "content": "import { OTLPHttpProtoTraceExporter, registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      traceExporter: new OTLPHttpProtoTraceExporter({\n        url: \"https://api.raindrop.ai/v1/traces\",\n        headers: {\n          Authorization: `Bearer ${process.env.RAINDROP_WRITE_KEY}`,\n        },\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "envVars": {
+    "RAINDROP_WRITE_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/instrumentation/sentry.json
+++ b/apps/docs/public/r/instrumentation/sentry.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "instrumentation/sentry",
+  "title": "Sentry",
+  "description": "Send agent traces to Sentry's OTLP endpoint for tracing and debugging.",
+  "dependencies": ["@vercel/otel"],
+  "files": [
+    {
+      "path": "registry/instrumentation/sentry.ts",
+      "content": "import { OTLPHttpProtoTraceExporter, registerOTel } from \"@vercel/otel\";\nimport { defineInstrumentation } from \"eve/instrumentation\";\n\nexport default defineInstrumentation({\n  setup: ({ agentName }) =>\n    registerOTel({\n      serviceName: agentName,\n      traceExporter: new OTLPHttpProtoTraceExporter({\n        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,\n        headers: {\n          \"x-sentry-auth\": `sentry sentry_key=${process.env.SENTRY_PUBLIC_KEY}`,\n        },\n      }),\n    }),\n});\n",
+      "type": "registry:file",
+      "target": "agent/instrumentation.ts"
+    }
+  ],
+  "envVars": {
+    "SENTRY_OTLP_TRACES_ENDPOINT": "",
+    "SENTRY_PUBLIC_KEY": ""
+  },
+  "type": "registry:item"
+}

--- a/apps/docs/public/r/registry.json
+++ b/apps/docs/public/r/registry.json
@@ -673,6 +673,125 @@
           "channel": "slack"
         }
       }
+    },
+    {
+      "name": "instrumentation/braintrust",
+      "type": "registry:item",
+      "title": "Braintrust",
+      "description": "Export AI SDK spans to Braintrust for tracing, evals, and monitoring.",
+      "dependencies": ["@braintrust/otel", "@vercel/otel"],
+      "envVars": {
+        "BRAINTRUST_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/braintrust.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/sentry",
+      "type": "registry:item",
+      "title": "Sentry",
+      "description": "Send agent traces to Sentry's OTLP endpoint for tracing and debugging.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "SENTRY_OTLP_TRACES_ENDPOINT": "",
+        "SENTRY_PUBLIC_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/sentry.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/datadog",
+      "type": "registry:item",
+      "title": "Datadog",
+      "description": "Export agent traces to Datadog APM alongside the rest of your stack.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "DATADOG_OTLP_TRACES_ENDPOINT": "",
+        "DD_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/datadog.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/honeycomb",
+      "type": "registry:item",
+      "title": "Honeycomb",
+      "description": "Send OpenTelemetry traces to Honeycomb and query every agent turn.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "HONEYCOMB_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/honeycomb.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/arize",
+      "type": "registry:item",
+      "title": "Arize",
+      "description": "Export traces to Arize AX for LLM observability and evaluation.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "ARIZE_SPACE_ID": "",
+        "ARIZE_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/arize.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/raindrop",
+      "type": "registry:item",
+      "title": "Raindrop",
+      "description": "Send agent traces to Raindrop to detect and debug AI product issues.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "RAINDROP_WRITE_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/raindrop.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/jaeger",
+      "type": "registry:item",
+      "title": "Jaeger",
+      "description": "Trace your agent with a local or self-hosted Jaeger OTLP backend.",
+      "dependencies": ["@vercel/otel"],
+      "files": [
+        {
+          "path": "registry/instrumentation/jaeger.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
     }
   ]
 }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -673,6 +673,125 @@
           "channel": "slack"
         }
       }
+    },
+    {
+      "name": "instrumentation/braintrust",
+      "type": "registry:item",
+      "title": "Braintrust",
+      "description": "Export AI SDK spans to Braintrust for tracing, evals, and monitoring.",
+      "dependencies": ["@braintrust/otel", "@vercel/otel"],
+      "envVars": {
+        "BRAINTRUST_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/braintrust.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/sentry",
+      "type": "registry:item",
+      "title": "Sentry",
+      "description": "Send agent traces to Sentry's OTLP endpoint for tracing and debugging.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "SENTRY_OTLP_TRACES_ENDPOINT": "",
+        "SENTRY_PUBLIC_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/sentry.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/datadog",
+      "type": "registry:item",
+      "title": "Datadog",
+      "description": "Export agent traces to Datadog APM alongside the rest of your stack.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "DATADOG_OTLP_TRACES_ENDPOINT": "",
+        "DD_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/datadog.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/honeycomb",
+      "type": "registry:item",
+      "title": "Honeycomb",
+      "description": "Send OpenTelemetry traces to Honeycomb and query every agent turn.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "HONEYCOMB_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/honeycomb.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/arize",
+      "type": "registry:item",
+      "title": "Arize",
+      "description": "Export traces to Arize AX for LLM observability and evaluation.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "ARIZE_SPACE_ID": "",
+        "ARIZE_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/arize.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/raindrop",
+      "type": "registry:item",
+      "title": "Raindrop",
+      "description": "Send agent traces to Raindrop to detect and debug AI product issues.",
+      "dependencies": ["@vercel/otel"],
+      "envVars": {
+        "RAINDROP_WRITE_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/instrumentation/raindrop.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
+    },
+    {
+      "name": "instrumentation/jaeger",
+      "type": "registry:item",
+      "title": "Jaeger",
+      "description": "Trace your agent with a local or self-hosted Jaeger OTLP backend.",
+      "dependencies": ["@vercel/otel"],
+      "files": [
+        {
+          "path": "registry/instrumentation/jaeger.ts",
+          "type": "registry:file",
+          "target": "agent/instrumentation.ts"
+        }
+      ]
     }
   ]
 }

--- a/apps/docs/registry/instrumentation/arize.ts
+++ b/apps/docs/registry/instrumentation/arize.ts
@@ -1,0 +1,17 @@
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      attributes: { "openinference.project.name": agentName },
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://otlp.arize.com/v1/traces",
+        headers: {
+          space_id: process.env.ARIZE_SPACE_ID!,
+          api_key: process.env.ARIZE_API_KEY!,
+        },
+      }),
+    }),
+});

--- a/apps/docs/registry/instrumentation/braintrust.ts
+++ b/apps/docs/registry/instrumentation/braintrust.ts
@@ -1,0 +1,14 @@
+import { BraintrustExporter } from "@braintrust/otel";
+import { registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new BraintrustExporter({
+        parent: `project_name:${agentName}`,
+        filterAISpans: true,
+      }),
+    }),
+});

--- a/apps/docs/registry/instrumentation/datadog.ts
+++ b/apps/docs/registry/instrumentation/datadog.ts
@@ -1,0 +1,13 @@
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+        headers: { "dd-api-key": process.env.DD_API_KEY! },
+      }),
+    }),
+});

--- a/apps/docs/registry/instrumentation/honeycomb.ts
+++ b/apps/docs/registry/instrumentation/honeycomb.ts
@@ -1,0 +1,13 @@
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://api.honeycomb.io/v1/traces",
+        headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
+      }),
+    }),
+});

--- a/apps/docs/registry/instrumentation/jaeger.ts
+++ b/apps/docs/registry/instrumentation/jaeger.ts
@@ -1,0 +1,12 @@
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "http://localhost:4318/v1/traces",
+      }),
+    }),
+});

--- a/apps/docs/registry/instrumentation/raindrop.ts
+++ b/apps/docs/registry/instrumentation/raindrop.ts
@@ -1,0 +1,15 @@
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: "https://api.raindrop.ai/v1/traces",
+        headers: {
+          Authorization: `Bearer ${process.env.RAINDROP_WRITE_KEY}`,
+        },
+      }),
+    }),
+});

--- a/apps/docs/registry/instrumentation/sentry.ts
+++ b/apps/docs/registry/instrumentation/sentry.ts
@@ -1,0 +1,15 @@
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+        headers: {
+          "x-sentry-auth": `sentry sentry_key=${process.env.SENTRY_PUBLIC_KEY}`,
+        },
+      }),
+    }),
+});

--- a/apps/docs/registry/tsconfig.json
+++ b/apps/docs/registry/tsconfig.json
@@ -4,6 +4,6 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["connections/**/*.ts", "extensions/**/*.ts"],
+  "include": ["connections/**/*.ts", "extensions/**/*.ts", "instrumentation/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/apps/docs/scripts/validate-instrumentation-registry.ts
+++ b/apps/docs/scripts/validate-instrumentation-registry.ts
@@ -1,0 +1,61 @@
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { instrumentationEntries } from "@vercel/eve-catalog";
+
+interface RegistryFile {
+  path: string;
+  target?: string;
+}
+
+interface RegistryItem {
+  name: string;
+  files?: RegistryFile[];
+}
+
+interface Registry {
+  items: RegistryItem[];
+}
+
+const registrySlugsByCatalogSlug: Readonly<Record<string, string>> = {
+  braintrust: "braintrust",
+  "sentry-instrumentation": "sentry",
+  "datadog-instrumentation": "datadog",
+  "honeycomb-instrumentation": "honeycomb",
+  arize: "arize",
+  raindrop: "raindrop",
+  jaeger: "jaeger",
+};
+
+const docsRoot = join(import.meta.dirname, "..");
+const registry = JSON.parse(await readFile(join(docsRoot, "registry.json"), "utf8")) as Registry;
+const items = registry.items.filter((item) => item.name.startsWith("instrumentation/"));
+const expectedSlugs = instrumentationEntries()
+  .filter((entry) => entry.surfaces.gallery)
+  .map((entry) => registrySlugsByCatalogSlug[entry.slug]);
+const actualSlugs = items.map((item) => item.name.slice("instrumentation/".length));
+
+if (expectedSlugs.some((slug) => slug === undefined)) {
+  throw new Error("Every gallery instrumentation provider needs a registry slug mapping.");
+}
+if (JSON.stringify(actualSlugs) !== JSON.stringify(expectedSlugs)) {
+  throw new Error(
+    `Instrumentation registry entries do not match the gallery.\nExpected: ${expectedSlugs.join(", ")}\nActual: ${actualSlugs.join(", ")}`,
+  );
+}
+
+for (const item of items) {
+  const slug = item.name.slice("instrumentation/".length);
+  const expectedPath = `registry/instrumentation/${slug}.ts`;
+  const file = item.files?.[0];
+  if (
+    item.files?.length !== 1 ||
+    file?.path !== expectedPath ||
+    file.target !== "agent/instrumentation.ts"
+  ) {
+    throw new Error(
+      `Registry item "${item.name}" must write ${expectedPath} to agent/instrumentation.ts.`,
+    );
+  }
+  await access(join(docsRoot, expectedPath));
+}

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -13,9 +13,10 @@ Run `eve add` from an eve agent project. This installs the integration's depende
 ```bash
 eve add extension/agent-browser
 eve add connection/linear
+eve add instrumentation/braintrust
 ```
 
-Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Configure the generated file and any required environment variables before running your agent.
+Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Instrumentation providers write `agent/instrumentation.ts`; because an agent has one instrumentation file, compose multiple exporters there by hand. Configure generated files and required environment variables before running your agent.
 
 ## Find an integration
 

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   connectionProtocols,
   extensionEntries,
   getIntegrationEntry,
+  instrumentationEntries,
 } from "./index.js";
 
 describe("integration catalog", () => {
@@ -15,10 +16,13 @@ describe("integration catalog", () => {
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 
-  it("partitions cleanly into channels, connections, and extensions", () => {
-    expect(channelEntries().length + connectionEntries().length + extensionEntries().length).toBe(
-      INTEGRATIONS.length,
-    );
+  it("partitions cleanly into every integration kind", () => {
+    expect(
+      channelEntries().length +
+        connectionEntries().length +
+        extensionEntries().length +
+        instrumentationEntries().length,
+    ).toBe(INTEGRATIONS.length);
   });
 
   it("gives every connection a transport and description", () => {
@@ -37,6 +41,13 @@ describe("integration catalog", () => {
 
   it("keeps extensions free of connection identity", () => {
     for (const entry of extensionEntries()) {
+      expect(entry.connection).toBeUndefined();
+    }
+  });
+
+  it("keeps instrumentation providers free of connection identity", () => {
+    expect(instrumentationEntries().length).toBeGreaterThan(0);
+    for (const entry of instrumentationEntries()) {
       expect(entry.connection).toBeUndefined();
     }
   });

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Shared identity for eve integrations. This package is the single source of
- * truth for *which* integrations exist (channels, connections, and extensions)
- * and how a connection is wired (transport + model-facing description).
+ * truth for *which* integrations exist (channels, connections, extensions, and
+ * instrumentation providers) and how a connection is wired (transport +
+ * model-facing description).
  *
  * Surface-specific concerns live with their consumer, keyed by {@link
  * IntegrationEntry.slug}: the scaffolder (eve) overlays the
@@ -18,7 +19,7 @@
  */
 
 /** Surface an integration targets. Extend as new kinds are catalogued. */
-export type IntegrationKind = "channel" | "connection" | "extension";
+export type IntegrationKind = "channel" | "connection" | "extension" | "instrumentation";
 
 /** Wire protocol a connection speaks at runtime. */
 export type ConnectionProtocol = "mcp" | "openapi";
@@ -742,6 +743,58 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
       mcp: { url: "https://mcp-server.zomato.com/mcp" },
     },
   },
+  // Instrumentation providers are OpenTelemetry backends configured in
+  // `agent/instrumentation.ts`. Slugs stay unique across the whole catalog, so
+  // providers that also ship a connection carry an `-instrumentation` suffix.
+  {
+    slug: "braintrust",
+    name: "Braintrust",
+    kind: "instrumentation",
+    tagline: "Export AI SDK spans to Braintrust for tracing, evals, and monitoring.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "sentry-instrumentation",
+    name: "Sentry",
+    kind: "instrumentation",
+    tagline: "Send agent traces to Sentry's OTLP endpoint for tracing and debugging.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "datadog-instrumentation",
+    name: "Datadog",
+    kind: "instrumentation",
+    tagline: "Export agent traces to Datadog APM alongside the rest of your stack.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "honeycomb-instrumentation",
+    name: "Honeycomb",
+    kind: "instrumentation",
+    tagline: "Send OpenTelemetry traces to Honeycomb and query every agent turn.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "arize",
+    name: "Arize",
+    kind: "instrumentation",
+    tagline: "Export traces to Arize AX for LLM observability and evaluation.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "raindrop",
+    name: "Raindrop",
+    kind: "instrumentation",
+    tagline: "Send agent traces to Raindrop to detect and debug AI product issues.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "jaeger",
+    name: "Jaeger",
+    kind: "instrumentation",
+    tagline: "Trace your agent with a local or self-hosted Jaeger OTLP backend.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
 ];
 
 const BY_SLUG = new Map(INTEGRATIONS.map((entry) => [entry.slug, entry]));
@@ -769,4 +822,9 @@ export function channelEntries(): IntegrationEntry[] {
 /** All extension entries, in catalog order. */
 export function extensionEntries(): IntegrationEntry[] {
   return integrationsByKind("extension");
+}
+
+/** All instrumentation entries, in catalog order. */
+export function instrumentationEntries(): IntegrationEntry[] {
+  return integrationsByKind("instrumentation");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@agent-browser/eve':
         specifier: ^0.33.0
         version: 0.33.0(@vercel/sandbox@2.8.0)(eve@packages+eve)
+      '@braintrust/otel':
+        specifier: ^0.3.0
+        version: 0.3.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(braintrust@3.14.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.4.3))
       '@browserbasehq/eve':
         specifier: ^0.1.0
         version: 0.1.0(eve@packages+eve)(supports-color@10.2.2)
@@ -294,6 +297,9 @@ importers:
       '@vercel/connect':
         specifier: 'catalog:'
         version: 0.4.2(@ai-sdk/mcp@2.0.16(zod@4.4.3))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@6.0.191(zod@4.4.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3))(ai@6.0.191(zod@4.4.3))(eve@packages+eve)
+      '@vercel/otel':
+        specifier: 2.1.3
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       '@vgpu/adapter-node':
         specifier: 0.0.7
         version: 0.0.7(supports-color@10.2.2)
@@ -338,7 +344,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -614,7 +620,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -639,7 +645,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -664,7 +670,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       ai:
         specifier: 'catalog:'
         version: 7.0.38(zod@4.4.3)
@@ -692,7 +698,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -730,7 +736,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -774,7 +780,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -799,7 +805,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -821,7 +827,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -846,7 +852,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -890,7 +896,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -915,7 +921,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -940,7 +946,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -965,7 +971,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       eve:
         specifier: workspace:*
         version: link:../../../packages/eve
@@ -990,7 +996,7 @@ importers:
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@vercel/otel':
         specifier: 2.1.3
-        version: 2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       ai:
         specifier: 'catalog:'
         version: 7.0.38(zod@4.4.3)
@@ -1736,6 +1742,15 @@ packages:
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@braintrust/otel@0.3.0':
+    resolution: {integrity: sha512-QTlvCleJ41MCleOt7BhwfYaIEVLrRZIp9xoSQcTjhdl91yLURyqieFNBA3FP3m1GxAxZmK6cSKgxW9q52iGTHA==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+      '@opentelemetry/core': '>=1.9.0'
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.35.0'
+      '@opentelemetry/sdk-trace-base': '>=1.9.0'
+      braintrust: '>=1.0.0-0'
 
   '@browserbasehq/eve@0.1.0':
     resolution: {integrity: sha512-zKv0sbKjP5edfphVXARwHUyxuUty8O2wn7Fptz5CaoJOUiV075CVHDrjEnwubioUR3iZL3+aiV3VLJBnZubXSw==}
@@ -3581,6 +3596,10 @@ packages:
     resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -3589,11 +3608,23 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@2.6.1':
     resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/instrumentation@0.214.0':
     resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
@@ -3601,20 +3632,38 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/resources@2.6.1':
     resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.214.0':
-    resolution: {integrity: sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==}
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-metrics@2.6.1':
-    resolution: {integrity: sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==}
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
@@ -3625,9 +3674,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/semantic-conventions@1.41.1':
-    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
-    engines: {node: '>=14'}
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -8266,6 +8317,12 @@ packages:
   ai@6.0.191:
     resolution: {integrity: sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.34:
+    resolution: {integrity: sha512-jDqclWYqPGFKcUG4CQiKcBiwi5XqVMqvYy6eJdujVpvE1SDoB6j7RtjrGYz3Bn5B1dzTj1StAlrOebY//WK9/Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -15044,7 +15101,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 4.0.3
       '@opentelemetry/api': 1.9.1
-      ai: 7.0.38(zod@4.4.3)
+      ai: 7.0.34(zod@4.4.3)
     transitivePeerDependencies:
       - zod
 
@@ -15432,6 +15489,14 @@ snapshots:
   '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
+
+  '@braintrust/otel@0.3.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(braintrust@3.14.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.4.3))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      braintrust: 3.14.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.4.3)
 
   '@browserbasehq/eve@0.1.0(eve@packages+eve)(supports-color@10.2.2)':
     dependencies:
@@ -17529,14 +17594,30 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
   '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
@@ -17547,34 +17628,61 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.214.0
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/semantic-conventions@1.41.1': {}
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
@@ -21565,14 +21673,14 @@ snapshots:
       '@vercel/cli-exec': 1.0.0
       jose: 5.10.0
 
-  '@vercel/otel@2.1.3(@opentelemetry/api-logs@0.214.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
+  '@vercel/otel@2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/api-logs': 0.221.0
       '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
-      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
 
   '@vercel/prepare-flags-definitions@0.3.0': {}
@@ -22075,6 +22183,13 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
+
+  ai@7.0.34(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.26(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
   ai@7.0.38(zod@4.4.3):


### PR DESCRIPTION
## Summary

- add Braintrust, Sentry, Datadog, Honeycomb, Arize, Raindrop, and Jaeger to the integrations gallery
- add `instrumentation/<provider>` registry items that install exporter dependencies and write `agent/instrumentation.ts`
- replace manual npm install steps with `eve add instrumentation/<provider>`
- validate instrumentation registry coverage against the shared catalog and typecheck every registry source

This incorporates and supersedes the instrumentation gallery work from #673, retaining Allen's authored commit.

## Testing

- `pnpm --filter eve-docs registry:check`
- `pnpm --filter eve-docs test:unit`
- `pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm --filter @vercel/eve-catalog test:unit`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm fmt`
