### PR TITLE
fix(eve): vercel workflow packaging - preserve traced dependencies

### DIFF
--- a/.changeset/portable-vercel-workflow-externals.md
+++ b/.changeset/portable-vercel-workflow-externals.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep traced external dependencies resolvable from queue-triggered Vercel workflow functions, including dependency graphs that contain multiple versions of the same package.

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -56,6 +56,31 @@ const buildNitroMock = vi.fn(async (nitro: Nitro) => {
     join(outputDir, "functions", "eve", "v1", "health.func"),
     "dir",
   );
+
+  if (process.env.VERCEL) {
+    const flowFunctionDirectory = join(
+      outputDir,
+      "functions",
+      ".well-known",
+      "workflow",
+      "v1",
+      "flow.func",
+    );
+
+    await mkdir(flowFunctionDirectory, { recursive: true });
+    await writeFile(
+      join(flowFunctionDirectory, ".vc-config.json"),
+      `${JSON.stringify(
+        {
+          experimentalTriggers: [{ topic: "eve-test", type: "queue/v2beta" }],
+          maxDuration: "max",
+          runtime: "nodejs24.x",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
 });
 const copyPublicAssetsMock = vi.fn(async () => undefined);
 const createProductionApplicationNitroMock = vi.fn();
@@ -425,6 +450,19 @@ describe("buildApplication", () => {
     const sharedFunctionStats = await lstat(
       join(appRoot, ".vercel", "output", "functions", "eve", "__server.func"),
     );
+    const flowFunctionDirectory = join(
+      appRoot,
+      ".vercel",
+      "output",
+      "functions",
+      ".well-known",
+      "workflow",
+      "v1",
+      "flow.func",
+    );
+    const flowFunctionConfig = JSON.parse(
+      await readFile(join(flowFunctionDirectory, ".vc-config.json"), "utf8"),
+    ) as Record<string, unknown>;
     const vercelConfig = JSON.parse(
       await readFile(join(appRoot, ".vercel", "output", "config.json"), "utf8"),
     ) as {
@@ -451,6 +489,14 @@ describe("buildApplication", () => {
         "utf8",
       ),
     ).resolves.toContain("export default");
+    await expect(readFile(join(flowFunctionDirectory, "_runtime.mjs"), "utf8")).resolves.toContain(
+      "export default",
+    );
+    expect(flowFunctionConfig).toMatchObject({
+      experimentalTriggers: [{ topic: "eve-test", type: "queue/v2beta" }],
+      maxDuration: "max",
+      runtime: "nodejs24.x",
+    });
     expect(vercelConfig.routes).toEqual([
       { handle: "filesystem" },
       { dest: "/eve/__server", src: "/eve/v1/health" },

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -25,7 +25,10 @@ import {
   RecoverablePublicationError,
 } from "#internal/application/output-publication.js";
 import { stageProductionCompilerArtifacts } from "#internal/application/production-compiler-artifacts.js";
-import { normalizeEveVercelFunctionOutput } from "#internal/workflow-bundle/vercel-workflow-output.js";
+import {
+  materializeVercelWorkflowFunctionOutput,
+  normalizeEveVercelFunctionOutput,
+} from "#internal/workflow-bundle/vercel-workflow-output.js";
 import { createProductionApplicationNitro } from "#internal/nitro/host/create-application-nitro.js";
 import { emitVercelAgentSummary } from "#internal/nitro/host/build-vercel-agent-summary.js";
 import { tryReadExtensionBuildConfig } from "#internal/nitro/host/build-extension.js";
@@ -420,6 +423,11 @@ async function buildApplicationInWorkspace(
       );
     }
     await buildNitroOutput(nitro, profiler, "nitro");
+    if (isVercelBuild) {
+      await measureBuildPhase(profiler, "vercel.workflow-function.materialize", () =>
+        materializeVercelWorkflowFunctionOutput(workspace.publication.output.stagedDir),
+      );
+    }
     if (servicePrefix !== undefined) {
       await measureBuildPhase(profiler, "vercel.functions.normalize", () =>
         normalizeEveVercelFunctionOutput(workspace.publication.output.stagedDir, {

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
@@ -1,13 +1,13 @@
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 import { createEveWorkflowQueueTrigger } from "#internal/workflow/queue-namespace.js";
+import { EVE_WORKFLOW_FLOW_ROUTE_PATH } from "#internal/workflow-bundle/eve-service-route-output.js";
 import {
   EVE_PUBLIC_ROUTE_PREFIX_ENV,
   normalizePublicRoutePrefix,
 } from "#shared/public-route-prefix.js";
 
-/** Route Nitro's Vercel preset emits as the queue-triggered workflow function. */
-export const EVE_WORKFLOW_FLOW_ROUTE_PATH = "/.well-known/workflow/v1/flow";
+export { EVE_WORKFLOW_FLOW_ROUTE_PATH };
 
 /**
  * Builds eve's Vercel preset options.

--- a/packages/eve/src/internal/workflow-bundle/eve-service-route-output.ts
+++ b/packages/eve/src/internal/workflow-bundle/eve-service-route-output.ts
@@ -1,5 +1,8 @@
 export const EVE_SHARED_SERVER_FUNCTION_PATH = "eve/__server.func";
 
+/** Route Nitro's Vercel preset emits as the queue-triggered workflow function. */
+export const EVE_WORKFLOW_FLOW_ROUTE_PATH = "/.well-known/workflow/v1/flow";
+
 const EVE_SHARED_SERVER_ROUTE_DESTINATION = "/eve/__server";
 const EVE_VERCEL_FUNCTION_PREFIXES = ["eve/", ".well-known/workflow/"] as const;
 

--- a/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.ts
+++ b/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.ts
@@ -14,6 +14,7 @@ import { dirname, join, relative } from "node:path";
 
 import {
   EVE_SHARED_SERVER_FUNCTION_PATH,
+  EVE_WORKFLOW_FLOW_ROUTE_PATH,
   isEveVercelFunctionPath,
   normalizeEveVercelRoutes,
 } from "#internal/workflow-bundle/eve-service-route-output.js";
@@ -40,6 +41,38 @@ export const WORKFLOW_BUILDER_DEFERRED_PACKAGES = ["@chat-adapter/slack", "chat"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Recreates the queue-triggered flow function from Nitro's completed server
+ * output while retaining its route-specific Vercel configuration.
+ *
+ * Nitro copies function-rule output without preserving relative symlink text,
+ * which can turn traced `.nf3` package links into absolute paths inside eve's
+ * disposable build workspace. Materializing after Nitro finishes keeps those
+ * links relative so the published function remains self-contained.
+ */
+export async function materializeVercelWorkflowFunctionOutput(outputDir: string): Promise<void> {
+  const functionsDir = join(outputDir, "functions");
+  const rootServerFunctionPath = await realpath(join(functionsDir, "__server.func"));
+  const flowFunctionPath = join(functionsDir, `${EVE_WORKFLOW_FLOW_ROUTE_PATH.slice(1)}.func`);
+  const flowFunctionConfig = await readFile(join(flowFunctionPath, ".vc-config.json"));
+  const stagingPath = `${flowFunctionPath}.eve-staging`;
+
+  await rm(stagingPath, {
+    force: true,
+    recursive: true,
+  });
+  await cp(rootServerFunctionPath, stagingPath, {
+    recursive: true,
+    verbatimSymlinks: true,
+  });
+  await writeFile(join(stagingPath, ".vc-config.json"), flowFunctionConfig);
+  await rm(flowFunctionPath, {
+    force: true,
+    recursive: true,
+  });
+  await rename(stagingPath, flowFunctionPath);
 }
 
 /**

--- a/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
+++ b/packages/eve/test/scenarios/app-runtime-dependencies.scenario.test.ts
@@ -572,7 +572,7 @@ describe("app runtime dependency tracing", () => {
       [
         "export default {",
         "  build: {",
-        '    externalDependencies: ["fixture-external-only-dep"],',
+        '    externalDependencies: ["fixture-external-only-dep", "fixture-external-wrapper"],',
         "  },",
 
         '  model: "openai/gpt-5.4-mini",',
@@ -588,11 +588,12 @@ describe("app runtime dependency tracing", () => {
       join(appRoot, "agent", "tools", "use_fixture_dep.ts"),
       [
         'import fixtureExternalOnlyDep from "fixture-external-only-dep";',
+        'import fixtureExternalWrapper from "fixture-external-wrapper";',
         "",
         "export default {",
         '  description: "Use the fixture external dependency.",',
         "  execute() {",
-        "    return fixtureExternalOnlyDep;",
+        "    return { fixtureExternalOnlyDep, fixtureExternalWrapper };",
         "  },",
         "};",
         "",
@@ -600,10 +601,16 @@ describe("app runtime dependency tracing", () => {
     );
 
     const packageRoot = join(appRoot, "node_modules", "fixture-external-only-dep");
+    const wrapperRoot = join(appRoot, "node_modules", "fixture-external-wrapper");
+    const nestedPackageRoot = join(wrapperRoot, "node_modules", "fixture-external-only-dep");
 
-    await mkdir(packageRoot, {
-      recursive: true,
-    });
+    await Promise.all(
+      [packageRoot, wrapperRoot, nestedPackageRoot].map((directoryPath) =>
+        mkdir(directoryPath, {
+          recursive: true,
+        }),
+      ),
+    );
     await writeFile(
       join(packageRoot, "package.json"),
       JSON.stringify(
@@ -623,6 +630,58 @@ describe("app runtime dependency tracing", () => {
       join(packageRoot, "index.js"),
       [
         'export const label = "fixture-external-only-dep";',
+        "export default {",
+        "  label,",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(wrapperRoot, "package.json"),
+      JSON.stringify(
+        {
+          dependencies: {
+            "fixture-external-only-dep": "2.0.0",
+          },
+          exports: {
+            ".": "./index.js",
+          },
+          name: "fixture-external-wrapper",
+          type: "module",
+          version: "1.0.0",
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      join(wrapperRoot, "index.js"),
+      [
+        'import fixtureExternalOnlyDep from "fixture-external-only-dep";',
+        "",
+        "export default fixtureExternalOnlyDep;",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(nestedPackageRoot, "package.json"),
+      JSON.stringify(
+        {
+          exports: {
+            ".": "./index.js",
+          },
+          name: "fixture-external-only-dep",
+          type: "module",
+          version: "2.0.0",
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(
+      join(nestedPackageRoot, "index.js"),
+      [
+        'export const label = "fixture-external-only-dep-v2";',
         "export default {",
         "  label,",
         "};",
@@ -651,6 +710,29 @@ describe("app runtime dependency tracing", () => {
     ).resolves.toContain('"name": "fixture-external-only-dep"');
     expect(serverModuleSource).toContain('"fixture-external-only-dep"');
     expect(serverModuleSource).not.toContain('export const label = "fixture-external-only-dep";');
+
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "");
+
+    const vercelOutputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
+    const rootServerFunctionDirectory = join(vercelOutputDir, "functions", "__server.func");
+    const workflowFlowFunctionDirectory = join(
+      vercelOutputDir,
+      "functions",
+      ".well-known",
+      "workflow",
+      "v1",
+      "flow.func",
+    );
+
+    for (const functionDirectory of [rootServerFunctionDirectory, workflowFlowFunctionDirectory]) {
+      await expect(
+        readFile(
+          join(functionDirectory, "node_modules", "fixture-external-only-dep", "package.json"),
+          "utf8",
+        ),
+      ).resolves.toContain('"name": "fixture-external-only-dep"');
+    }
   }, 30_000);
 
   it("rewrites framework tool executors into hosted Vercel output", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11897,8 +11897,8 @@ packages:
       sass:
         optional: true
 
-  nf3@0.3.17:
-    resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
+  nf3@0.3.23:
+    resolution: {integrity: sha512-RWVLAWozmVD3AaDmaU3qMGB3v+yNlH5d9qqStI4e/WLlNQVnJ4YErGDbYCIrGFyrHdbF6I6Baf0Ae6c7tFYmSg==}
 
   nitro@3.0.260610-beta:
     resolution: {integrity: sha512-KPb4L5yaF/Rx/xoGMpgHRJvZhbhGiqbRKOwwPLCH9jKTKTsEUHLjnJas85AeCzaswqa8Wi52eQBtRsODC4PS0Q==}
@@ -26524,7 +26524,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nf3@0.3.17: {}
+  nf3@0.3.23: {}
 
   nitro@3.0.260610-beta(@upstash/redis@1.38.0)(@vercel/blob@2.4.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1(bufferutil@4.1.0)))(aws4fetch@1.0.20)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.0)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -26534,7 +26534,7 @@ snapshots:
       env-runner: 0.1.16
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.16))
       hookable: 6.1.1
-      nf3: 0.3.17
+      nf3: 0.3.23
       ocache: 0.1.5
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ minimumReleaseAgeExclude:
   - crossws
   - experimental-ai-sdk-code-mode
   - eve
+  - nf3@0.3.23
   - nitro
   - rolldown
   # This release contains the reviewed package-config registry APIs used by the eve CLI.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ minimumReleaseAgeExclude:
   - crossws
   - experimental-ai-sdk-code-mode
   - eve
-  - nf3@0.3.23
+  - nf3
   - nitro
   - rolldown
   # This release contains the reviewed package-config registry APIs used by the eve CLI.


### PR DESCRIPTION
## Summary

- rematerialize the queue-triggered Vercel flow function after Nitro completes dependency tracing
- preserve relative `.nf3` package symlinks while retaining the flow function queue configuration
- cover dependency graphs containing multiple versions of the same external package
- update Nitro’s transitive `nf3` dependency from 0.3.17 to 0.3.23 for the upstream wildcard package-import tracing fix

## Root cause

Nitro copied route-rule functions without preserving relative symlink text. For multi-version traced dependencies such as `@vercel/oidc`, that converted a valid relative `.nf3` link into an absolute path inside eve’s disposable build workspace. Removing the workspace after publication left the deployed workflow function with a dangling dependency link.

This is separate from the wildcard package-import bug fixed by unjs/nf3#66. Resolving `nf3@0.3.23` incorporates that upstream fix while the eve change handles Nitro’s later route-function copy step.

## Testing

- `pnpm install --frozen-lockfile` (including supply-chain policy verification)
- `pnpm why nf3 --recursive` (one resolved version: 0.3.23 through Nitro)
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- related unit tests: 18 passed
- build application scenarios: 12 passed
- multi-version external dependency regression: passed
- formatting and targeted lint checks