### PR TITLE
fix(eve): simplify registry discovery output to match shadcn stdout

### DIFF
--- a/.changeset/concise-registry-items.md
+++ b/.changeset/concise-registry-items.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show result counts and concise kind-and-slug addresses for official items in `eve registry list` and `eve registry search` instead of their full registry URLs.

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -185,10 +185,39 @@ describe("registry commands", () => {
     expect(logger.logs).toEqual(["No registry items found."]);
   });
 
+  it("preserves explicit registry URLs in list output", async () => {
+    const logger = createLogger();
+    searchRegistries.mockResolvedValue({
+      items: [
+        {
+          registry: "https://example.com/r/registry.json",
+          name: "search",
+          addCommandArgument: "https://example.com/r/search.json",
+          description: "External search tools",
+        },
+      ],
+      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+    });
+
+    await runRegistryListCommand(logger, "/project", "https://example.com/r/registry.json");
+
+    expect(logger.logs).toEqual([
+      "Found 1 item in 1 registry",
+      "",
+      "https://example.com/r/search.json — External search tools",
+    ]);
+  });
+
   it("searches the official catalog and configured registries", async () => {
     const logger = createLogger();
     searchRegistries.mockResolvedValue({
       items: [
+        {
+          registry: "https://eve.dev/r/registry.json",
+          name: "extension/agent-browser",
+          addCommandArgument: "https://eve.dev/r/extension/agent-browser.json",
+          description: "Browser automation",
+        },
         {
           registry: "@acme",
           name: "browser",
@@ -196,7 +225,7 @@ describe("registry commands", () => {
           description: "Browser tools",
         },
       ],
-      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+      pagination: { total: 2, offset: 0, limit: 2, hasMore: false },
     });
 
     await runRegistrySearchCommand(logger, "/project", "browser");
@@ -208,7 +237,12 @@ describe("registry commands", () => {
       continueOnError: true,
       query: "browser",
     });
-    expect(logger.logs).toEqual(["@acme/browser — Browser tools"]);
+    expect(logger.logs).toEqual([
+      'Found 2 items matching "browser" in 2 registries',
+      "",
+      "extension/agent-browser",
+      "@acme/browser",
+    ]);
   });
 
   it("reports total registry failure without describing it as an empty result", async () => {

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -95,14 +95,25 @@ function validateRegistrySource(source: string | undefined): void {
 
 function printSearchResults(
   logger: RegistryCommandLogger,
-  items: Array<{ addCommandArgument: string; description?: string }>,
+  result: Awaited<ReturnType<typeof searchRegistries>>,
+  options: { query: string | undefined; sources: string[] },
 ): void {
-  if (items.length === 0) {
+  if (result.items.length === 0) {
     logger.log("No registry items found.");
     return;
   }
-  for (const item of items) {
-    logger.log(`${item.addCommandArgument}${item.description ? ` — ${item.description}` : ""}`);
+
+  const count = `${result.pagination.total} item${result.pagination.total === 1 ? "" : "s"}`;
+  const query = options.query === undefined ? "" : ` matching "${options.query}"`;
+  const registries = `${options.sources.length} registr${options.sources.length === 1 ? "y" : "ies"}`;
+  logger.log(`Found ${count}${query} in ${registries}`);
+  logger.log("");
+
+  for (const item of result.items) {
+    const address = item.registry === OFFICIAL_CATALOG ? item.name : item.addCommandArgument;
+    const description =
+      options.query === undefined && item.description ? ` — ${item.description}` : "";
+    logger.log(`${address}${description}`);
   }
 }
 
@@ -122,7 +133,7 @@ async function browseRegistryItems(
   });
   const errors = result.errors ?? [];
   if (errors.length < sources.length) {
-    printSearchResults(logger, result.items);
+    printSearchResults(logger, result, { query, sources });
   }
   for (const error of errors) {
     logger.error(`${error.registry}: ${error.message}`);


### PR DESCRIPTION
### Description

Make `eve registry list` and `eve registry search` easier to scan by adding a result-count header and displaying official eve items with the same kind-and-slug. This is modeled after `shadcn` command output.

#### Before

```text
 λ eve registry list
 
https://eve.dev/r/extension/agent-browser.json — Browser automation
...
```

Search output also repeated descriptions:

```text
 λ eve registry search browser
 
@acme/browser — Acme browser tools
...
```

#### After

```text
 λ eve registry list
 
Found 2 items in 2 registries

extension/agent-browser — Browser automation
@acme/browser — Acme browser tools
```

Search output includes its query and stays compact:

```text
 λ eve registry search browser
 
Found 1 item matching "browser" in 2 registries

@acme/browser
```

The output intentionally omits a `Showing 1-2 of 2` line because eve does not currently expose pagination options.

### How did you test your changes?

- `cd packages/eve && node_modules/.bin/vitest run --config vitest.unit.config.ts src/cli/commands/registry.test.ts`
- `cd packages/eve && node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node_modules/.bin/oxfmt --check packages/eve/src/cli/commands/registry.ts packages/eve/src/cli/commands/registry.test.ts .changeset/concise-registry-items.md`
- `git diff --check`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
