### PR TITLE
feat: guide agents to use registry commands in generated `AGENTS.md`

### DIFF
--- a/.changeset/init-agents-registry.md
+++ b/.changeset/init-agents-registry.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Update the generated `AGENTS.md` to direct coding agents to the eve registry for discovering and installing integrations.

--- a/packages/eve/src/cli/commands/agent-instructions.test.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.test.ts
@@ -65,6 +65,10 @@ describe("initAgentDevHandoff", () => {
     expect(handoff).toContain("node_modules/eve/docs/");
     expect(handoff).toContain("resolve\nthe installed `eve` package location");
     expect(handoff).toContain("agent/instructions.md");
+    expect(handoff).toContain("`eve registry search <query>`");
+    expect(handoff).toContain("`eve registry list`");
+    expect(handoff).toContain("`eve registry view <item>`");
+    expect(handoff).toContain("`eve add <item>`");
     expect(handoff).not.toContain("/tmp/triage-bot/");
 
     // Shared guidance the leaner handoff used to omit now reaches it.
@@ -89,6 +93,7 @@ describe("initAgentReplPrompt", () => {
 
     expect(prompt).toContain("The project at `.` is already scaffolded.");
     expect(prompt).toContain("What should the agent do?");
+    expect(prompt).toContain("`eve registry search <query>`");
     expect(prompt).toContain("pnpm exec eve dev --no-ui");
     expect(prompt).not.toContain("{{");
   });

--- a/packages/eve/src/cli/commands/agent-prompt/build-and-verify.md
+++ b/packages/eve/src/cli/commands/agent-prompt/build-and-verify.md
@@ -9,6 +9,10 @@ package docs are unavailable, use https://eve.dev/docs as a fallback. Read
 such as `connections`, `channels/slack`, or `guides/auth-and-route-protection`
 for the Vercel Connect flow.
 
+Before implementing an integration yourself, use `eve registry search <query>` or
+`eve registry list` to discover available integrations. Inspect one with
+`eve registry view <item>`, then install it with `eve add <item>`.
+
 - Put the purpose in `agent/instructions.md` (the always-on system prompt),
   replacing the scaffold's placeholder with what the user said the agent should
   do.

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -270,9 +270,9 @@ installed \`eve\` package location first and read its \`docs/\` directory. If
 package docs are unavailable, use https://eve.dev/docs as a fallback.
 
 Before implementing an integration yourself, use
-\`eve registry search <query> --json\` or \`eve registry list --json\` to discover
-available integrations. Inspect one with \`eve registry view <item>\`, then
-install it with \`eve add <item>\`.
+\`eve registry search <query>\` or \`eve registry list\` to discover available
+integrations. Inspect one with \`eve registry view <item>\`, then install it with
+\`eve add <item>\`.
 `,
   "CLAUDE.md": `@AGENTS.md
 `,

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -268,6 +268,11 @@ from the installed eve package docs. In most installs, those docs are at
 \`node_modules/eve/docs/\`. In workspaces or local package installs, resolve the
 installed \`eve\` package location first and read its \`docs/\` directory. If
 package docs are unavailable, use https://eve.dev/docs as a fallback.
+
+Before implementing an integration yourself, use
+\`eve registry search <query> --json\` or \`eve registry list --json\` to discover
+available integrations. Inspect one with \`eve registry view <item>\`, then
+install it with \`eve add <item>\`.
 `,
   "CLAUDE.md": `@AGENTS.md
 `,

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -916,6 +916,10 @@ describe("scaffoldBaseProject", () => {
     expect(agentsMd).toContain("installed eve package docs");
     expect(agentsMd).toContain("node_modules/eve/docs/");
     expect(agentsMd).toContain("resolve the\ninstalled `eve` package location");
+    expect(agentsMd).toContain("`eve registry search <query> --json`");
+    expect(agentsMd).toContain("`eve registry list --json`");
+    expect(agentsMd).toContain("`eve registry view <item>`");
+    expect(agentsMd).toContain("`eve add <item>`");
     // `vercel deploy` uploads everything a .vercelignore doesn't exclude, and
     // the platform default-ignores only the .env.local variants — eve's dev
     // artifacts and a bare .env must be excluded here or a source deploy

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -916,8 +916,8 @@ describe("scaffoldBaseProject", () => {
     expect(agentsMd).toContain("installed eve package docs");
     expect(agentsMd).toContain("node_modules/eve/docs/");
     expect(agentsMd).toContain("resolve the\ninstalled `eve` package location");
-    expect(agentsMd).toContain("`eve registry search <query> --json`");
-    expect(agentsMd).toContain("`eve registry list --json`");
+    expect(agentsMd).toContain("`eve registry search <query>`");
+    expect(agentsMd).toContain("`eve registry list`");
     expect(agentsMd).toContain("`eve registry view <item>`");
     expect(agentsMd).toContain("`eve add <item>`");
     // `vercel deploy` uploads everything a .vercelignore doesn't exclude, and


### PR DESCRIPTION
## Summary

- direct coding agents to discover integrations with `eve registry search` and `eve registry list`
- direct coding agents to inspect and install integrations with `eve registry view` and `eve add`
- cover the generated guidance in the scaffold integration test

## Testing

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/setup/scaffold/index.integration.test.ts`
- `./node_modules/.bin/oxfmt --check packages/eve/src/setup/scaffold/create/project.ts packages/eve/src/setup/scaffold/index.integration.test.ts`
