### PR TITLE
chore(eve): upgrade undici to v8

### DIFF
--- a/.changeset/modern-undici-dispatcher.md
+++ b/.changeset/modern-undici-dispatcher.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Upgrade the runtime HTTP client to undici 8 while preserving Node fetch compatibility for SSRF-safe web requests.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -300,7 +300,7 @@
   },
   "dependencies": {
     "nitro": "3.0.260610-beta",
-    "undici": "7.28.0"
+    "undici": "8.9.0"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "catalog:",

--- a/packages/eve/src/execution/web-fetch/dispatcher.scenario.test.ts
+++ b/packages/eve/src/execution/web-fetch/dispatcher.scenario.test.ts
@@ -1,0 +1,34 @@
+import { createServer } from "node:http";
+
+import { Agent, Dispatcher1Wrapper } from "undici";
+import { describe, expect, it } from "vitest";
+
+describe("undici dispatcher compatibility", () => {
+  it("bridges an undici 8 agent to Node fetch", async () => {
+    const server = createServer((_request, response) => {
+      response.end("wrapped response");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("Expected an ephemeral TCP listener.");
+    }
+
+    const dispatcher = new Dispatcher1Wrapper(new Agent());
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${address.port}`, {
+        dispatcher,
+      } as RequestInit & { dispatcher: Dispatcher1Wrapper });
+
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toBe("wrapped response");
+    } finally {
+      await dispatcher.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error === undefined ? resolve() : reject(error)));
+      });
+    }
+  });
+});

--- a/packages/eve/src/execution/web-fetch/request.test.ts
+++ b/packages/eve/src/execution/web-fetch/request.test.ts
@@ -7,7 +7,10 @@ import { requestPublicUrl } from "#execution/web-fetch/request.js";
 
 const networkMocks = vi.hoisted(() => ({
   agentClose: vi.fn(),
+  agentInstances: [] as unknown[],
   agentOptions: [] as unknown[],
+  dispatcherInstances: [] as unknown[],
+  dispatcherTargets: [] as unknown[],
   fetch: vi.fn(),
   lookup: vi.fn(),
   socketAddresses: [] as unknown[],
@@ -23,11 +26,25 @@ vi.mock("undici", () => ({
 
     constructor(options: unknown) {
       this.options = options;
+      networkMocks.agentInstances.push(this);
       networkMocks.agentOptions.push(options);
     }
 
     close(): Promise<void> {
       return networkMocks.agentClose();
+    }
+  },
+  Dispatcher1Wrapper: class MockDispatcher1Wrapper {
+    readonly dispatcher: { readonly options: unknown; close(): Promise<void> };
+
+    constructor(dispatcher: { readonly options: unknown; close(): Promise<void> }) {
+      this.dispatcher = dispatcher;
+      networkMocks.dispatcherInstances.push(this);
+      networkMocks.dispatcherTargets.push(dispatcher);
+    }
+
+    close(): Promise<void> {
+      return this.dispatcher.close();
     }
   },
 }));
@@ -47,7 +64,10 @@ interface MockResponse {
 beforeEach(() => {
   networkMocks.agentClose.mockReset();
   networkMocks.agentClose.mockResolvedValue(undefined);
+  networkMocks.agentInstances.length = 0;
   networkMocks.agentOptions.length = 0;
+  networkMocks.dispatcherInstances.length = 0;
+  networkMocks.dispatcherTargets.length = 0;
   networkMocks.fetch.mockReset();
   vi.stubGlobal("fetch", networkMocks.fetch);
   networkMocks.lookup.mockReset();
@@ -168,6 +188,22 @@ describe("requestPublicUrl", () => {
     });
   });
 
+  it("wraps the agent for Node fetch's legacy dispatcher API", async () => {
+    queueResponse({ body: "public content" });
+
+    await requestPublicUrl("https://example.com/page", REQUEST_OPTIONS);
+
+    const [, fetchOptions] = networkMocks.fetch.mock.calls[0]!;
+    const fetchDispatcher = (
+      fetchOptions as RequestInit & {
+        dispatcher: unknown;
+      }
+    ).dispatcher;
+
+    expect(networkMocks.dispatcherTargets).toEqual(networkMocks.agentInstances);
+    expect(fetchDispatcher).toBe(networkMocks.dispatcherInstances[0]);
+  });
+
   it("returns private redirect targets without requesting them", async () => {
     queueResponse({
       headers: { location: "https://169.254.169.254/latest/meta-data" },
@@ -279,8 +315,12 @@ async function connectThroughDispatcher(input: URL, options: RequestInit): Promi
     return;
   }
 
-  const dispatcher = (options as RequestInit & { dispatcher: { options: unknown } }).dispatcher;
-  const agentOptions = dispatcher.options as { connect: { lookup?: LookupFunction } };
+  const dispatcher = (
+    options as RequestInit & {
+      dispatcher: { dispatcher: { options: unknown } };
+    }
+  ).dispatcher;
+  const agentOptions = dispatcher.dispatcher.options as { connect: { lookup?: LookupFunction } };
   const addresses = await runLookup(agentOptions.connect.lookup, hostname);
   networkMocks.socketAddresses.push(addresses);
 }

--- a/packages/eve/src/execution/web-fetch/request.ts
+++ b/packages/eve/src/execution/web-fetch/request.ts
@@ -2,7 +2,7 @@ import { lookup } from "node:dns";
 import { isIP } from "node:net";
 import type { LookupFunction } from "node:net";
 
-import { Agent, Dispatcher1Wrapper } from "undici";
+import type { Dispatcher1Wrapper } from "undici";
 
 import { isLoopbackHostname, isPrivateOrReservedIpAddress } from "#shared/network-address.js";
 
@@ -73,6 +73,7 @@ async function requestOnce(
   options: PublicUrlRequestOptions,
 ): Promise<{ readonly dispatcher: Dispatcher1Wrapper; readonly response: Response }> {
   assertPublicHostname(url.hostname);
+  const { Agent, Dispatcher1Wrapper } = await import("undici");
   const agent = new Agent({
     connect: {
       lookup: createPublicLookup(),

--- a/packages/eve/src/execution/web-fetch/request.ts
+++ b/packages/eve/src/execution/web-fetch/request.ts
@@ -97,7 +97,7 @@ async function requestOnce(
 function fetchWithDispatcher(url: URL, options: DispatcherRequestInit): Promise<Response> {
   // Node's fetch types describe its bundled undici version, while the wrapper
   // adapts the installed undici dispatcher to that runtime protocol.
-  return fetch(url, options as unknown as RequestInit);
+  return fetch(url, options as RequestInit);
 }
 
 function assertPublicHostname(hostname: string): void {

--- a/packages/eve/src/execution/web-fetch/request.ts
+++ b/packages/eve/src/execution/web-fetch/request.ts
@@ -10,6 +10,10 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const UNSAFE_DESTINATION_ERROR =
   "URL must not target localhost, private, link-local, or reserved IP addresses.";
 
+type DispatcherRequestInit = Omit<RequestInit, "dispatcher"> & {
+  readonly dispatcher: Dispatcher1Wrapper;
+};
+
 /** Options for an SSRF-safe HTTPS request. */
 export interface PublicUrlRequestOptions {
   readonly headers: Readonly<Record<string, string>>;
@@ -77,18 +81,23 @@ async function requestOnce(
   const dispatcher = new Dispatcher1Wrapper(agent);
 
   try {
-    const fetchOptions: RequestInit & { dispatcher: Dispatcher1Wrapper } = {
+    const response = await fetchWithDispatcher(url, {
       dispatcher,
       headers: options.headers,
       redirect: "manual",
       signal: options.signal,
-    };
-    const response = await fetch(url, fetchOptions);
+    });
     return { dispatcher, response };
   } catch (error) {
     await dispatcher.close();
     throw error;
   }
+}
+
+function fetchWithDispatcher(url: URL, options: DispatcherRequestInit): Promise<Response> {
+  // Node's fetch types describe its bundled undici version, while the wrapper
+  // adapts the installed undici dispatcher to that runtime protocol.
+  return fetch(url, options as unknown as RequestInit);
 }
 
 function assertPublicHostname(hostname: string): void {

--- a/packages/eve/src/execution/web-fetch/request.ts
+++ b/packages/eve/src/execution/web-fetch/request.ts
@@ -2,7 +2,7 @@ import { lookup } from "node:dns";
 import { isIP } from "node:net";
 import type { LookupFunction } from "node:net";
 
-import { Agent } from "undici";
+import { Agent, Dispatcher1Wrapper } from "undici";
 
 import { isLoopbackHostname, isPrivateOrReservedIpAddress } from "#shared/network-address.js";
 
@@ -67,16 +67,17 @@ function parseHttpsUrl(urlText: string): URL {
 async function requestOnce(
   url: URL,
   options: PublicUrlRequestOptions,
-): Promise<{ readonly dispatcher: Agent; readonly response: Response }> {
+): Promise<{ readonly dispatcher: Dispatcher1Wrapper; readonly response: Response }> {
   assertPublicHostname(url.hostname);
-  const dispatcher = new Agent({
+  const agent = new Agent({
     connect: {
       lookup: createPublicLookup(),
     },
   });
+  const dispatcher = new Dispatcher1Wrapper(agent);
 
   try {
-    const fetchOptions: RequestInit & { dispatcher: Agent } = {
+    const fetchOptions: RequestInit & { dispatcher: Dispatcher1Wrapper } = {
       dispatcher,
       headers: options.headers,
       redirect: "manual",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1134,8 +1134,8 @@ importers:
         specifier: 3.0.260610-beta
         version: 3.0.260610-beta(@upstash/redis@1.38.0)(@vercel/blob@2.4.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1(bufferutil@4.1.0)))(aws4fetch@1.0.20)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.0)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 8.9.0
+        version: 8.9.0
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
@@ -14143,6 +14143,10 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -29963,6 +29967,8 @@ snapshots:
   undici@6.27.0: {}
 
   undici@7.28.0: {}
+
+  undici@8.9.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade the eve runtime dependency to undici 8.9.0
- bridge the per-request undici Agent to Node fetch with Dispatcher1Wrapper
- add unit and real-transport regression coverage for the v1/v2 dispatcher boundary

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/web-fetch/request.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/execution/web-fetch/dispatcher.scenario.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm lint`
- `pnpm guard:invariants`