### PR TITLE
fix(eve): apply registry package policy before install

### DIFF
--- a/.changeset/registry-package-manager-policy.md
+++ b/.changeset/registry-package-manager-policy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Apply trusted registry package-manager policy before installing item dependencies, so Web Chat installation records pnpm's intentional sharp build denial before pnpm resolves Next.js.

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -778,6 +778,11 @@
       "description": "Add the built-in Next.js Web Chat channel to an eve agent.",
       "meta": {
         "eve": {
+          "packageManager": {
+            "allowBuilds": {
+              "sharp": false
+            }
+          },
           "setup": {
             "command": "eve",
             "args": ["integration", "setup", "web"]

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  installOfficialRegistryItem,
   runAddCommand,
   runRegistryAddCommand,
   runRegistryListCommand,
@@ -11,6 +12,8 @@ import {
 
 const {
   addRegistryItems,
+  applyPackageManagerWorkspaceConfiguration,
+  detectPackageManager,
   getRegistryItems,
   isEveProject,
   readFile,
@@ -19,6 +22,8 @@ const {
   writeFile,
 } = vi.hoisted(() => ({
   addRegistryItems: vi.fn(),
+  applyPackageManagerWorkspaceConfiguration: vi.fn(),
+  detectPackageManager: vi.fn(),
   getRegistryItems: vi.fn(),
   isEveProject: vi.fn(),
   readFile: vi.fn(),
@@ -34,6 +39,8 @@ vi.mock("#compiled/shadcn-registry/index.js", () => ({
 }));
 
 vi.mock("#setup/scaffold/index.js", () => ({ isEveProject }));
+vi.mock("#setup/package-manager.js", () => ({ detectPackageManager }));
+vi.mock("#setup/scaffold/workspace-root.js", () => ({ applyPackageManagerWorkspaceConfiguration }));
 vi.mock("#internal/application/package.js", () => ({ resolveInstalledPackageInfo }));
 vi.mock("node:fs/promises", () => ({ readFile, writeFile }));
 
@@ -52,6 +59,7 @@ describe("registry commands", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     isEveProject.mockResolvedValue(true);
+    detectPackageManager.mockResolvedValue({ kind: "pnpm", source: "lockfile" });
     readFile.mockResolvedValue(
       JSON.stringify({
         name: "project",
@@ -63,6 +71,41 @@ describe("registry commands", () => {
   afterEach(() => {
     process.exitCode = undefined;
   });
+
+  it.each([
+    [
+      "command",
+      (logger: RegistryCommandLogger) => runAddCommand(logger, "/project", "channel/web", {}),
+    ],
+    ["setup", () => installOfficialRegistryItem("/project", "channel/web")],
+  ] as const)(
+    "applies registry package-manager policy before %s installation",
+    async (_case, install) => {
+      const logger = createLogger();
+      getRegistryItems.mockResolvedValue([
+        {
+          name: "channel/web",
+          type: "registry:item",
+          meta: {
+            eve: {
+              packageManager: { allowBuilds: { sharp: false } },
+              requires: ">=0.27.8",
+            },
+          },
+        },
+      ]);
+
+      await install(logger);
+
+      expect(applyPackageManagerWorkspaceConfiguration).toHaveBeenCalledWith({
+        packageManager: "pnpm",
+        projectRoot: "/project",
+      });
+      expect(applyPackageManagerWorkspaceConfiguration.mock.invocationCallOrder[0]).toBeLessThan(
+        addRegistryItems.mock.invocationCallOrder[0]!,
+      );
+    },
+  );
 
   it("installs official items through the registry SDK", async () => {
     const logger = createLogger();

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -7,7 +7,9 @@ import {
 import semver from "#compiled/semver/index.js";
 import { z } from "#compiled/zod/index.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import { detectPackageManager } from "#setup/package-manager.js";
 import { isEveProject } from "#setup/scaffold/index.js";
+import { applyPackageManagerWorkspaceConfiguration } from "#setup/scaffold/workspace-root.js";
 
 import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 import type { runRegistrySetupCommand } from "./registry-setup-command.js";
@@ -51,7 +53,12 @@ export async function installOfficialRegistryItem(
   options: AddCommandOptions = {},
 ): Promise<void> {
   const config = await readRegistryConfig(appRoot);
-  await addRegistryItems([itemAddress(item)], { ...options, config, cwd: appRoot });
+  const address = itemAddress(item);
+  const [registryItem] = await getRegistryItems([address], { config });
+  const eveMetadata = eveMetadataFromRegistryItem(registryItem);
+  assertCompatibleEveVersion(eveMetadata?.requires);
+  await applyRegistryPackageManagerPolicy(appRoot, eveMetadata?.packageManager);
+  await addRegistryItems([address], { ...options, config, cwd: appRoot });
 }
 
 const EveRegistryItemMetadataSchema = z.object({
@@ -59,6 +66,11 @@ const EveRegistryItemMetadataSchema = z.object({
     .object({
       eve: z
         .object({
+          packageManager: z
+            .object({
+              allowBuilds: z.object({ sharp: z.literal(false) }),
+            })
+            .optional(),
           requires: z.string().optional(),
           setup: z
             .object({
@@ -74,6 +86,18 @@ const EveRegistryItemMetadataSchema = z.object({
 
 function eveMetadataFromRegistryItem(item: unknown) {
   return EveRegistryItemMetadataSchema.parse(item).meta?.eve;
+}
+
+async function applyRegistryPackageManagerPolicy(
+  appRoot: string,
+  policy: { allowBuilds: { sharp: false } } | undefined,
+): Promise<void> {
+  if (policy === undefined) return;
+  const packageManager = await detectPackageManager(appRoot);
+  await applyPackageManagerWorkspaceConfiguration({
+    packageManager: packageManager.kind,
+    projectRoot: appRoot,
+  });
 }
 
 function assertCompatibleEveVersion(requiredVersion: string | undefined): void {
@@ -189,6 +213,7 @@ export async function runAddCommand(
       ? eveMetadataFromRegistryItem(registryItem)
       : undefined;
     assertCompatibleEveVersion(eveMetadata?.requires);
+    await applyRegistryPackageManagerPolicy(appRoot, eveMetadata?.packageManager);
 
     const installOptions = { config, cwd: appRoot, overwrite: options.overwrite };
     await addRegistryItems([address], installOptions);


### PR DESCRIPTION
### Description

<!-- Write a short summary of the problem and solution. -->

### How did you test your changes?

<!-- Include the commands you ran and any manual coverage. -->

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
