### PR TITLE
fix(eve): classify input requests by framework-owned kind

### DIFF
--- a/.changeset/fair-input-request-kinds.md
+++ b/.changeset/fair-input-request-kinds.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Input requests now include a required `kind` discriminator so clients can route tool approvals, questions, and session-limit decisions without inferring behavior from tool names or request IDs. Descendant session-limit Stop responses now let the parent own turn cancellation, avoiding a parent-child wait cycle.

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -102,6 +102,11 @@ Approvals and questions share one protocol:
 3. The turn parks at `session.waiting`, durably, for as long as it takes.
 4. The client answers with `inputResponses` (structured, keyed by `requestId`) or a normal follow-up `message`. A follow-up whose text matches an option ID, option label, or numeric option index resolves automatically, including approval options such as `approve` and `deny`.
 
+Each request includes a `kind` discriminator: `tool-approval`, `question`, or
+`session-limit`. Clients should use `kind` to choose behavior and presentation;
+`toolName` and `requestId` identify the action and request but do not encode its
+semantics.
+
 The run picks back up exactly where it parked. Because the pause is durable, nothing is held in memory while it waits — the process can restart and the parked turn survives.
 
 For approval requests, unrelated follow-up text does not deny the tool call. eve keeps the approval pending and holds that text until the approval is answered, then replays it as the next message in the session.

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v2.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v2.ts
@@ -1,0 +1,10 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineInstructions({
+        markdown: "Answer with evidence from the current session.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v2.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v2.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineSkill({
+        description: "Triage incoming requests.",
+        markdown: "# Triage\n\nInspect the request before acting.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v5.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v5.ts
@@ -1,0 +1,12 @@
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Return the current status.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => ({ status: "ready" }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v3.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v3.ts
@@ -1,0 +1,12 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "input.requested"(event) {
+      console.info(
+        "input requested",
+        event.data.requests.map((request) => request.requestId),
+      );
+    },
+  },
+});

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v3.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v3.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 3,
+  "sha256": "69eb1e3ef30127f0fed202466271dd4d31604eabc1e70cc971db1be12957bb4f",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v3.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v3.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 3,
+  "sha256": "69eb1e3ef30127f0fed202466271dd4d31604eabc1e70cc971db1be12957bb4f",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v6.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v6.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 6,
+  "sha256": "4f92a15e8f67c172876b3026a788d3244455dbb7c697c0cc1082eb59532851a8",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v4.json
+++ b/packages/eve/extension-contracts/reports/hook/v4.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 4,
+  "sha256": "b0d3042903e52d32bef0791348b776cdde87ffb596676f605e4f65995b3f6be2",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/src/channel/resolve-text.test.ts
+++ b/packages/eve/src/channel/resolve-text.test.ts
@@ -6,6 +6,7 @@ const APPROVAL_REQUEST: InputRequest = {
   action: { callId: "call-1", input: { command: "rm -rf" }, kind: "tool-call", toolName: "bash" },
   allowFreeform: false,
   display: "confirmation",
+  kind: "tool-approval",
   options: [
     { id: "approve", label: "Approve", style: "primary" },
     { id: "deny", label: "Deny", style: "danger" },
@@ -17,6 +18,7 @@ const APPROVAL_REQUEST: InputRequest = {
 const SELECT_REQUEST: InputRequest = {
   action: { callId: "call-2", input: {}, kind: "tool-call", toolName: "ask_question" },
   display: "select",
+  kind: "question",
   options: [
     { id: "postgres", label: "Postgres" },
     { id: "mysql", label: "MySQL" },
@@ -30,6 +32,7 @@ const FREEFORM_REQUEST: InputRequest = {
   action: { callId: "call-3", input: {}, kind: "tool-call", toolName: "ask_question" },
   allowFreeform: true,
   display: "text",
+  kind: "question",
   prompt: "What is your name?",
   requestId: "req-3",
 };
@@ -38,6 +41,7 @@ const SELECT_WITH_FREEFORM_REQUEST: InputRequest = {
   action: { callId: "call-4", input: {}, kind: "tool-call", toolName: "ask_question" },
   allowFreeform: true,
   display: "select",
+  kind: "question",
   options: [
     { id: "red", label: "Red" },
     { id: "blue", label: "Blue" },
@@ -120,6 +124,7 @@ describe("resolveTextToResponse", () => {
   it("falls back to freeform for requests with no options", () => {
     const noOptions: InputRequest = {
       action: { callId: "call-5", input: {}, kind: "tool-call", toolName: "ask_question" },
+      kind: "question",
       prompt: "Tell me something.",
       requestId: "req-5",
     };

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -924,6 +924,7 @@ describe("EveTUIRunner native continuation state", () => {
                   toolName: "get_weather",
                 },
                 display: "confirmation",
+                kind: "tool-approval",
                 options: [
                   { id: "approve", label: "Approve" },
                   { id: "deny", label: "Deny" },

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -1879,7 +1879,11 @@ async function* eveEventsToTUIStream(
         for (const request of requests) {
           const toolCallId = request.action.callId;
 
-          if (!knownToolCalls.has(toolCallId)) {
+          // The session-limit continuation is harness-authored — no model
+          // tool call exists behind it, so fabricating a transcript entry
+          // would render a phantom call. Its question rendering already
+          // carries the prompt copy.
+          if (request.kind !== "session-limit" && !knownToolCalls.has(toolCallId)) {
             knownToolCalls.add(toolCallId);
             yield {
               type: "tool-call",
@@ -1893,7 +1897,7 @@ async function* eveEventsToTUIStream(
           seenInputRequestIds.add(request.requestId);
           pendingInputRequests.set(request.requestId, request);
 
-          if (isQuestionRequest(request)) {
+          if (request.kind !== "tool-approval") {
             upsertPendingQuestion(turnState, request);
             continue;
           }
@@ -2210,12 +2214,6 @@ function toFailureEvent(
   const detail = formatFailureDetail(event);
   if (detail !== undefined) failure.detail = detail;
   return failure;
-}
-
-function isQuestionRequest(request: InputRequest): boolean {
-  if (request.display === "select" || request.display === "text") return true;
-  if (request.display === "confirmation") return false;
-  return request.options !== undefined && request.options.length > 0;
 }
 
 function toAgentTUIInputQuestion(request: InputRequest): AgentTUIInputQuestion {

--- a/packages/eve/src/cli/invoke/invoke.test.ts
+++ b/packages/eve/src/cli/invoke/invoke.test.ts
@@ -17,6 +17,7 @@ const localTarget = {
 const resume = { session: cursor, target };
 const request = {
   action: { callId: "call-1", input: {}, kind: "tool-call" as const, toolName: "bash" },
+  kind: "tool-approval" as const,
   display: "confirmation" as const,
   options: [
     { id: "approve", label: "Approve" },
@@ -240,8 +241,18 @@ describe("resolveInvokeOperation", () => {
     const previous = parseInvokeResumeInput({
       status: "input-required",
       requests: [
-        { options: request.options, prompt: request.prompt, requestId: request.requestId },
-        { options: request.options, prompt: request.prompt, requestId: "approval-2" },
+        {
+          kind: request.kind,
+          options: request.options,
+          prompt: request.prompt,
+          requestId: request.requestId,
+        },
+        {
+          kind: request.kind,
+          options: request.options,
+          prompt: request.prompt,
+          requestId: "approval-2",
+        },
       ],
       resume,
     });

--- a/packages/eve/src/cli/invoke/result.ts
+++ b/packages/eve/src/cli/invoke/result.ts
@@ -83,9 +83,10 @@ export type InvokeAuthenticationFailure = Extract<
 
 /** Projects a runtime input request to the stable invocation-facing contract. */
 export function projectInvocationInputRequest(request: InputRequest): InvocationInputRequest {
-  const { allowFreeform, options, prompt, requestId } = request;
+  const { allowFreeform, kind, options, prompt, requestId } = request;
   return {
     allowFreeform,
+    kind,
     options: options?.map(({ description, id, label }) => ({ description, id, label })),
     prompt,
     requestId,

--- a/packages/eve/src/client/index.ts
+++ b/packages/eve/src/client/index.ts
@@ -127,9 +127,15 @@ export type {
 
 export { isCurrentTurnBoundaryEvent, isTurnFailureEvent } from "#protocol/message.js";
 
-export type { InputOption, InputRequest, InputResponse } from "#runtime/input/types.js";
+export type {
+  InputOption,
+  InputRequest,
+  InputRequestKind,
+  InputResponse,
+} from "#runtime/input/types.js";
 export {
   inputOptionSchema,
+  inputRequestKindSchema,
   inputRequestSchema,
   inputResponseSchema,
   isInputRequest,

--- a/packages/eve/src/client/message-action-parts.ts
+++ b/packages/eve/src/client/message-action-parts.ts
@@ -24,6 +24,7 @@ export function toMessageInputRequest(request: InputRequest): EveMessageInputReq
   return {
     allowFreeform: request.allowFreeform,
     display: request.display,
+    kind: request.kind,
     options: request.options,
     prompt: request.prompt,
     requestId: request.requestId,

--- a/packages/eve/src/client/message-reducer-types.ts
+++ b/packages/eve/src/client/message-reducer-types.ts
@@ -1,4 +1,4 @@
-import type { InputResponse } from "#runtime/input/types.js";
+import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { AuthorizationOutcome } from "#protocol/message.js";
 
 /**
@@ -231,12 +231,14 @@ export interface EveMessageToolMetadata {
  * is the question, `display` selects the control (`"confirmation"`, `"select"`,
  * or `"text"`), `options` lists selectable choices (each with a `label` and
  * optional `style`), and `allowFreeform` permits a typed response alongside the
- * options. `requestId` is the stable identifier the client returns in the
- * responding {@link InputResponse}.
+ * options. `kind` identifies the framework-owned request source. `requestId`
+ * is the stable identifier the client returns in the responding
+ * {@link InputResponse}.
  */
 export interface EveMessageInputRequest {
   readonly allowFreeform?: boolean;
   readonly display?: "confirmation" | "select" | "text";
+  readonly kind: InputRequest["kind"];
   readonly options?: readonly {
     readonly description?: string;
     readonly id: string;

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -368,6 +368,7 @@ describe("defaultMessageReducer", () => {
               toolName: "bash",
             },
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
               { id: "deny", label: "No", style: "danger" },
@@ -404,6 +405,7 @@ describe("defaultMessageReducer", () => {
                 inputRequest: {
                   allowFreeform: undefined,
                   display: "confirmation",
+                  kind: "tool-approval",
                   options: [
                     { id: "approve", label: "Yes", style: "primary" },
                     { id: "deny", label: "No", style: "danger" },
@@ -437,6 +439,7 @@ describe("defaultMessageReducer", () => {
               toolName: "bash",
             },
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
               { id: "deny", label: "No", style: "danger" },
@@ -481,6 +484,7 @@ describe("defaultMessageReducer", () => {
                 inputRequest: {
                   allowFreeform: undefined,
                   display: "confirmation",
+                  kind: "tool-approval",
                   options: [
                     { id: "approve", label: "Yes", style: "primary" },
                     { id: "deny", label: "No", style: "danger" },
@@ -515,6 +519,7 @@ describe("defaultMessageReducer", () => {
               toolName: "bash",
             },
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
               { id: "deny", label: "No", style: "danger" },

--- a/packages/eve/src/client/session-utils.test.ts
+++ b/packages/eve/src/client/session-utils.test.ts
@@ -10,6 +10,7 @@ describe("summarizeTurnEvents", () => {
   it("projects the complete waiting-turn lifecycle in one pass", () => {
     const request = {
       action: { callId: "call_1", input: {}, kind: "tool-call" as const, toolName: "bash" },
+      kind: "tool-approval" as const,
       display: "confirmation" as const,
       options: [{ id: "approve", label: "Approve" }],
       prompt: "Approve?",

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,13 +22,13 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: { current: 3, supported: [1, 2, 3], dropped: {} },
-  dynamicTool: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },
+  dynamicTool: { current: 6, supported: [1, 2, 3, 4, 5, 6], dropped: {} },
   connection: { current: 2, supported: [1, 2], dropped: {} },
-  hook: { current: 3, supported: [1, 2, 3], dropped: {} },
+  hook: { current: 4, supported: [1, 2, 3, 4], dropped: {} },
   skill: { current: 1, supported: [1], dropped: {} },
-  dynamicSkill: { current: 2, supported: [1, 2], dropped: {} },
+  dynamicSkill: { current: 3, supported: [1, 2, 3], dropped: {} },
   instructions: { current: 1, supported: [1], dropped: {} },
-  dynamicInstructions: { current: 2, supported: [1, 2], dropped: {} },
+  dynamicInstructions: { current: 3, supported: [1, 2, 3], dropped: {} },
   config: { current: 1, supported: [1], dropped: {} },
   state: { current: 2, supported: [1, 2], dropped: {} },
 } as const satisfies Record<string, ExtensionCapabilityContract>;

--- a/packages/eve/src/evals/runner/derive-run-facts.test.ts
+++ b/packages/eve/src/evals/runner/derive-run-facts.test.ts
@@ -100,6 +100,7 @@ function inputRequested(requestIds: readonly string[]): UnstampedMessageStreamEv
           kind: "tool-call" as const,
           toolName: "bash",
         },
+        kind: "tool-approval" as const,
         prompt: "Approve?",
         requestId,
       })),

--- a/packages/eve/src/evals/runner/execute-task.test.ts
+++ b/packages/eve/src/evals/runner/execute-task.test.ts
@@ -719,6 +719,7 @@ function inputRequested(
           action: { callId: "call_1", input: { command: "pwd" }, kind: "tool-call", toolName },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Approve" },
             { id: "deny", label: "Deny" },

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -53,6 +53,7 @@ function sampleRequest(): InputRequest {
       kind: "tool-call",
       toolName: "create_issue",
     },
+    kind: "tool-approval",
     options: [
       { id: "approve", label: "Approve" },
       { id: "deny", label: "Deny" },

--- a/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
@@ -140,6 +140,7 @@ function buildApprovalRequest(requestId: string): InputRequest {
       toolName: "create_issue",
     },
     display: "confirmation",
+    kind: "tool-approval",
     options: [
       { id: "approve", label: "Approve", style: "primary" },
       { id: "deny", label: "Deny", style: "danger" },

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1482,6 +1482,7 @@ describe("runProxySubagentEventStep", () => {
               kind: "tool-call",
               toolName: "dangerous_tool",
             },
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Approve" },
               { id: "deny", label: "Deny" },

--- a/packages/eve/src/harness/input-extraction.test.ts
+++ b/packages/eve/src/harness/input-extraction.test.ts
@@ -34,6 +34,7 @@ describe("extractQuestionInputRequests", () => {
           toolName: "ask_question",
         },
         display: "select",
+        kind: "question",
         options: [{ id: "yes", label: "Yes" }],
         prompt: "Continue?",
         requestId: "call-1",
@@ -117,6 +118,7 @@ describe("extractToolApprovalInputRequests", () => {
         },
         allowFreeform: false,
         display: "confirmation",
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },
@@ -154,6 +156,7 @@ describe("extractToolApprovalInputRequests", () => {
         },
         allowFreeform: false,
         display: "confirmation",
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },

--- a/packages/eve/src/harness/input-extraction.ts
+++ b/packages/eve/src/harness/input-extraction.ts
@@ -67,12 +67,14 @@ function extractQuestionRequests(input: {
       action: InputRequest["action"];
       allowFreeform?: InputRequest["allowFreeform"];
       display?: InputRequest["display"];
+      kind: InputRequest["kind"];
       options?: InputRequest["options"];
       prompt: InputRequest["prompt"];
       requestId: InputRequest["requestId"];
     } = {
       action,
       display: "text",
+      kind: "question",
       prompt: String(toolInput.prompt),
       requestId: action.callId,
     };
@@ -156,6 +158,7 @@ function extractApprovalRequests(input: {
       action: createRuntimeToolCallActionFromToolCall({ toolCall }),
       allowFreeform: false,
       display: "confirmation",
+      kind: "tool-approval",
       options: [
         { id: "approve", label: "Yes" },
         { id: "deny", label: "No" },

--- a/packages/eve/src/harness/input-request-class.test.ts
+++ b/packages/eve/src/harness/input-request-class.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { classifyInputRequest, isApprovalRequest } from "#harness/input-request-class.js";
 import { createSessionLimitContinuationRequest } from "#harness/session-limit-continuation.js";
+import { ASK_QUESTION_TOOL_NAME } from "#runtime/framework-tools/ask-question.js";
+
 describe("classifyInputRequest", () => {
   const action = {
     callId: "call_1",
@@ -14,6 +16,7 @@ describe("classifyInputRequest", () => {
     expect(
       classifyInputRequest({
         action,
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Approve" },
           { id: "deny", label: "Deny" },
@@ -38,8 +41,9 @@ describe("classifyInputRequest", () => {
   it("classifies model questions as dismissable", () => {
     expect(
       classifyInputRequest({
-        action,
+        action: { ...action, toolName: ASK_QUESTION_TOOL_NAME },
         allowFreeform: true,
+        kind: "question",
         options: [{ id: "blue", label: "Blue" }],
         prompt: "Which color?",
         requestId: "call_1",
@@ -48,17 +52,31 @@ describe("classifyInputRequest", () => {
   });
 
   it("does not mistake non-approval two-option requests for approvals", () => {
-    expect(
-      classifyInputRequest({
-        action,
-        options: [
-          { id: "blue", label: "Blue" },
-          { id: "red", label: "Red" },
-        ],
-        prompt: "Which color?",
-        requestId: "call_1",
-      }),
-    ).toBe("dismissable");
+    const request = {
+      action: { ...action, toolName: ASK_QUESTION_TOOL_NAME },
+      kind: "question" as const,
+      options: [
+        { id: "approve", label: "Approve" },
+        { id: "deny", label: "Deny" },
+      ],
+      prompt: "Should we proceed?",
+      requestId: "call_1",
+    };
+
+    expect(isApprovalRequest(request)).toBe(false);
+    expect(classifyInputRequest(request)).toBe("dismissable");
+  });
+
+  it("uses the request kind rather than the action tool name", () => {
+    const request = {
+      action,
+      kind: "question" as const,
+      prompt: "What should happen next?",
+      requestId: "call_1",
+    };
+
+    expect(isApprovalRequest(request)).toBe(false);
+    expect(classifyInputRequest(request)).toBe("dismissable");
   });
 });
 
@@ -70,28 +88,38 @@ describe("isApprovalRequest", () => {
     toolName: "bash",
   } as const;
 
-  it("matches exactly the approve/deny option pair, in order", () => {
-    const options = (ids: readonly string[]) => ids.map((id) => ({ id, label: id }));
-
+  it("distinguishes approval requests from framework-owned input requests", () => {
     expect(
       isApprovalRequest({
         action,
-        options: options(["approve", "deny"]),
+        kind: "tool-approval",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "deny", label: "Deny" },
+        ],
         prompt: "?",
         requestId: "r",
       }),
     ).toBe(true);
     expect(
       isApprovalRequest({
-        action,
-        options: options(["deny", "approve"]),
+        action: { ...action, toolName: ASK_QUESTION_TOOL_NAME },
+        kind: "question",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "deny", label: "Deny" },
+        ],
         prompt: "?",
         requestId: "r",
       }),
     ).toBe(false);
     expect(
-      isApprovalRequest({ action, options: options(["approve"]), prompt: "?", requestId: "r" }),
+      isApprovalRequest(
+        createSessionLimitContinuationRequest({
+          sessionId: "sess-test",
+          violation: { kind: "input", limit: 12, usedTokens: 12 },
+        }),
+      ),
     ).toBe(false);
-    expect(isApprovalRequest({ action, prompt: "?", requestId: "r" })).toBe(false);
   });
 });

--- a/packages/eve/src/harness/input-request-class.ts
+++ b/packages/eve/src/harness/input-request-class.ts
@@ -4,15 +4,10 @@
  * rendering decisions).
  */
 import type { InputRequest } from "#runtime/input/types.js";
-import { isSessionLimitContinuationRequest } from "#harness/session-limit-continuation.js";
 
-/** Shared approval predicate: a request whose options are exactly `approve` / `deny`. */
+/** Returns true when the request gates an AI SDK tool call. */
 export function isApprovalRequest(request: InputRequest): boolean {
-  return (
-    request.options?.length === 2 &&
-    request.options[0]?.id === "approve" &&
-    request.options[1]?.id === "deny"
-  );
+  return request.kind === "tool-approval";
 }
 
 /**
@@ -31,21 +26,20 @@ export type InputRequestClass = "dismissable" | "required";
 
 /** Classifies one pending request; see {@link InputRequestClass}. */
 export function classifyInputRequest(request: InputRequest): InputRequestClass {
-  // A tool approval gates a model-emitted tool call. AI SDK requires the
-  // approval response to resolve in isolation, and skipping it would leave
-  // the intercepted call permanently un-adjudicated.
-  if (isApprovalRequest(request)) {
-    return "required";
+  switch (request.kind) {
+    // AI SDK requires a tool approval to resolve in isolation. Skipping it
+    // would leave the intercepted call permanently unadjudicated.
+    case "tool-approval":
+      return "required";
+    // Ignoring a session-limit continuation cannot move forward. The next
+    // pre-model gate would park on the same violation again.
+    case "session-limit":
+      return "required";
+    case "question":
+      return "dismissable";
+    default: {
+      const unhandled: never = request.kind;
+      return unhandled;
+    }
   }
-  // A session-limit continuation guards the next model call itself:
-  // "ignore and continue" cannot continue -- the pre-model gate re-parks
-  // while the violation holds -- and, being harness-authored, the request
-  // has no history anchor on which an ignored outcome could be recorded.
-  if (isSessionLimitContinuationRequest(request)) {
-    return "required";
-  }
-  // Everything else wraps a model-emitted tool call whose ignored outcome
-  // is expressible as a tool-result, so dismissal is always representable.
-  // There is no third class.
-  return "dismissable";
 }

--- a/packages/eve/src/harness/input-requests.test.ts
+++ b/packages/eve/src/harness/input-requests.test.ts
@@ -129,6 +129,7 @@ describe("resolvePendingInput", () => {
             toolName: "ask_question",
           },
           display: "select",
+          kind: "question",
           prompt: "Pick one.",
           requestId: "question-call",
         },
@@ -141,6 +142,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -204,6 +206,7 @@ describe("resolvePendingInput", () => {
             toolName: "ask_question",
           },
           display: "text",
+          kind: "question",
           prompt: "Pick one.",
           requestId: "question-call",
         } satisfies InputRequest,
@@ -265,6 +268,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -332,6 +336,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -391,6 +396,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -455,6 +461,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -521,6 +528,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -590,6 +598,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -647,6 +656,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -683,6 +693,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -723,6 +734,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -782,6 +794,7 @@ describe("resolvePendingInput", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -959,6 +972,7 @@ describe("clearPendingSessionLimitPrompt", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },

--- a/packages/eve/src/harness/session-limit-continuation.test.ts
+++ b/packages/eve/src/harness/session-limit-continuation.test.ts
@@ -31,6 +31,7 @@ describe("createSessionLimitContinuationRequest", () => {
       },
       allowFreeform: false,
       display: "confirmation",
+      kind: "session-limit",
       options: [
         {
           description: "Grant a fresh token budget",

--- a/packages/eve/src/harness/session-limit-continuation.ts
+++ b/packages/eve/src/harness/session-limit-continuation.ts
@@ -49,6 +49,7 @@ export function createSessionLimitContinuationRequest(input: {
     },
     allowFreeform: false,
     display: "confirmation",
+    kind: "session-limit",
     options: [
       {
         description: "Grant a fresh token budget",
@@ -96,7 +97,7 @@ function trimTrailingZero(value: number): string {
  * continuation prompt.
  */
 export function isSessionLimitContinuationRequest(request: InputRequest): boolean {
-  return request.action.toolName === SESSION_LIMIT_CONTINUATION_TOOL_NAME;
+  return request.kind === "session-limit";
 }
 
 /**

--- a/packages/eve/src/harness/tool-loop-compaction-accounting.test.ts
+++ b/packages/eve/src/harness/tool-loop-compaction-accounting.test.ts
@@ -259,6 +259,7 @@ describe("tool-loop structured compaction accounting", () => {
             toolName: "ask_question",
           },
           display: "select",
+          kind: "question",
           prompt: "Pick one.",
           requestId: "question-call",
         },

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -63,6 +63,7 @@ function createPendingApprovalSession(): HarnessSession {
         },
         allowFreeform: false,
         display: "confirmation",
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -441,6 +441,7 @@ function createPendingBashApprovalSession(): HarnessSession {
         },
         allowFreeform: false,
         display: "confirmation",
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },
@@ -491,6 +492,7 @@ function createPendingProtectedActionApprovalSession(): HarnessSession {
         },
         allowFreeform: false,
         display: "confirmation",
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },
@@ -1222,6 +1224,7 @@ describe("createToolLoopHarness", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "session-limit",
           options: [
             { id: "continue", label: "Approve", style: "primary" },
             { id: "stop", label: "Stop", style: "danger" },
@@ -2332,6 +2335,7 @@ describe("createToolLoopHarness", () => {
             },
             allowFreeform: false,
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
               { id: "deny", label: "No" },
@@ -6517,6 +6521,7 @@ describe("createToolLoopHarness", () => {
             },
             allowFreeform: false,
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
               { id: "deny", label: "No" },
@@ -6704,6 +6709,7 @@ describe("createToolLoopHarness", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -6868,6 +6874,7 @@ describe("createToolLoopHarness", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -7115,6 +7122,7 @@ describe("createToolLoopHarness", () => {
           },
           allowFreeform: false,
           display: "confirmation",
+          kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
             { id: "deny", label: "No" },
@@ -7269,6 +7277,7 @@ describe("createToolLoopHarness", () => {
               toolName: "ask_question",
             },
             display: "select",
+            kind: "question",
             options: [{ id: "one", label: "One" }],
             prompt: "Choose one.",
             requestId: "question-1",
@@ -7359,6 +7368,7 @@ describe("createToolLoopHarness", () => {
           },
           allowFreeform: true,
           display: "select",
+          kind: "question",
           options: questionInput.options,
           prompt: questionInput.prompt,
           requestId: "question-1",
@@ -7445,6 +7455,7 @@ describe("createToolLoopHarness", () => {
           },
           allowFreeform: true,
           display: "select",
+          kind: "question",
           options: questionInput.options,
           prompt: questionInput.prompt,
           requestId: "question-1",

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -262,6 +262,7 @@ describe("discordChannel() inbound route", () => {
     const { privateKey, publicKeyHex } = testKeys();
     const components = renderInputRequestComponents({
       action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "ask_question" },
+      kind: "question",
       options: [{ id: "approve", label: "Approve" }],
       prompt: "Approve?",
       requestId: "call_1",
@@ -299,6 +300,7 @@ describe("discordChannel() inbound route", () => {
     const components = renderInputRequestComponents({
       action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "ask_question" },
       allowFreeform: true,
+      kind: "question",
       prompt: "Explain",
       requestId: "call_1",
     });

--- a/packages/eve/src/public/channels/discord/hitl.test.ts
+++ b/packages/eve/src/public/channels/discord/hitl.test.ts
@@ -32,6 +32,7 @@ function request(overrides?: Partial<InputRequest>): InputRequest {
     prompt: "Choose one",
     requestId: "call_1",
     ...overrides,
+    kind: overrides?.kind ?? "question",
   };
 }
 

--- a/packages/eve/src/public/channels/linear/hitl.test.ts
+++ b/packages/eve/src/public/channels/linear/hitl.test.ts
@@ -12,6 +12,7 @@ function makeRequest(overrides: Partial<InputRequest> = {}): InputRequest {
     prompt: "Approve deployment?",
     requestId: "call_1",
     ...overrides,
+    kind: overrides.kind ?? "question",
   };
 }
 

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -153,6 +153,7 @@ function makeRequest(overrides: Partial<InputRequest> = {}): InputRequest {
     prompt: "Approve deployment?",
     requestId: "call_1",
     ...overrides,
+    kind: overrides.kind ?? "question",
   };
 }
 

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -27,6 +27,7 @@ function makeRequest(overrides: Partial<InputRequest>): InputRequest {
     prompt: "Pick one",
     requestId: "call_abc123",
     ...overrides,
+    kind: overrides.kind ?? "question",
   };
 }
 
@@ -136,6 +137,7 @@ describe("renderInputRequestBlocks", () => {
         },
       },
       display: "confirmation",
+      kind: "tool-approval",
       prompt: "Approve tool call: mongodb-mutate",
       requestId: "approval_1",
       options: [
@@ -190,6 +192,7 @@ describe("renderInputRequestBlocks", () => {
           input: { value: "x".repeat(SLACK_SECTION_TEXT_MAX_LENGTH + 500) },
         },
         display: "confirmation",
+        kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },
@@ -374,6 +377,7 @@ describe("formatInputRequestFallbackText", () => {
           },
         },
         display: "confirmation",
+        kind: "tool-approval",
         prompt: "Approve tool call: mongodb-mutate",
         options: [
           { id: "approve", label: "Yes" },

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -432,10 +432,5 @@ function truncateWithEllipsis(value: string, maxLength: number): string {
 }
 
 function isApprovalRequest(request: InputRequest): boolean {
-  return (
-    request.display === "confirmation" &&
-    request.options?.length === 2 &&
-    request.options[0]?.id === "approve" &&
-    request.options[1]?.id === "deny"
-  );
+  return request.kind === "tool-approval";
 }

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -445,6 +445,7 @@ describe("slackChannel() default event handlers", () => {
               toolName: "mongodb-mutate",
             },
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
               { id: "deny", label: "No" },
@@ -553,6 +554,7 @@ describe("slackChannel() default event handlers", () => {
               toolName: "ask_question",
             },
             display: "text",
+            kind: "question",
             prompt: longPrompt,
             requestId: "call_long",
           },
@@ -594,6 +596,7 @@ describe("slackChannel() default event handlers", () => {
         toolName: "mongodb-mutate",
       },
       display: "confirmation" as const,
+      kind: "tool-approval" as const,
       options: [
         { id: "approve", label: "Yes" },
         { id: "deny", label: "No" },
@@ -2364,6 +2367,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
               toolName: "escalate_issue",
             },
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
               { id: "deny", label: "No" },
@@ -2379,6 +2383,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
               toolName: "escalate_issue",
             },
             display: "confirmation",
+            kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
               { id: "deny", label: "No" },

--- a/packages/eve/src/public/channels/teams/hitl.test.ts
+++ b/packages/eve/src/public/channels/teams/hitl.test.ts
@@ -85,6 +85,7 @@ function request(): InputRequest {
   return {
     action: { callId: "TC", input: {}, kind: "tool-call", toolName: "deploy" },
     display: "confirmation",
+    kind: "tool-approval",
     options: [
       { id: "approve", label: "Approve", style: "primary" },
       { id: "deny", label: "Deny", style: "danger" },

--- a/packages/eve/src/public/channels/teams/hitl.ts
+++ b/packages/eve/src/public/channels/teams/hitl.ts
@@ -277,12 +277,7 @@ function readHitlPayload(value: Record<string, unknown>): Record<string, unknown
 }
 
 function formatApprovalInput(request: InputRequest): string | null {
-  if (
-    request.display !== "confirmation" ||
-    request.options?.length !== 2 ||
-    request.options[0]?.id !== "approve" ||
-    request.options[1]?.id !== "deny"
-  ) {
+  if (request.kind !== "tool-approval") {
     return null;
   }
   const json = JSON.stringify(request.action.input, null, 2);

--- a/packages/eve/src/public/channels/telegram/hitl.test.ts
+++ b/packages/eve/src/public/channels/telegram/hitl.test.ts
@@ -19,6 +19,7 @@ describe("renderTelegramInputRequest", () => {
     const rendered = renderTelegramInputRequest(
       {
         action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "ask_question" },
+        kind: "question",
         options: [
           { id: "approve", label: "Approve" },
           { id: "deny", label: "Deny" },
@@ -46,6 +47,7 @@ describe("renderTelegramInputRequest", () => {
       {
         action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "ask_question" },
         allowFreeform: true,
+        kind: "question",
         prompt: "Explain",
         requestId: "call_1",
       },

--- a/packages/eve/src/runtime/framework-tools/ask-question.ts
+++ b/packages/eve/src/runtime/framework-tools/ask-question.ts
@@ -11,6 +11,7 @@ export const ASK_QUESTION_TOOL_NAME = "ask_question";
 export const ASK_QUESTION_INPUT_SCHEMA = inputRequestSchema.omit({
   action: true,
   display: true,
+  kind: true,
   requestId: true,
 });
 export const ASK_QUESTION_OUTPUT_SCHEMA = z

--- a/packages/eve/src/runtime/input/types.test.ts
+++ b/packages/eve/src/runtime/input/types.test.ts
@@ -18,6 +18,7 @@ describe("inputRequestSchema", () => {
       },
       allowFreeform: false,
       display: "confirmation",
+      kind: "tool-approval",
       options: [
         { id: "approve", label: "Approve", style: "primary" },
         { id: "deny", label: "Deny", style: "danger" },
@@ -42,6 +43,7 @@ describe("inputRequestSchema", () => {
         toolName: "ask_question",
       },
       display: "select",
+      kind: "question",
       options: [{ id: "yes", label: "Yes" }],
       prompt: "Continue?",
       requestId: "call-2",
@@ -61,6 +63,7 @@ describe("inputRequestSchema", () => {
       },
       allowFreeform: true,
       display: "text",
+      kind: "question",
       prompt: "What is your name?",
       requestId: "call-3",
     };
@@ -77,6 +80,7 @@ describe("inputRequestSchema", () => {
         kind: "tool-call",
         toolName: "ask_question",
       },
+      kind: "question",
       prompt: "Are you sure?",
       requestId: "req-4",
     };
@@ -85,7 +89,7 @@ describe("inputRequestSchema", () => {
     expect(isInputRequest(value)).toBe(true);
   });
 
-  it("rejects unknown fields", () => {
+  it("requires a recognized request kind", () => {
     const value = {
       action: {
         callId: "call-5",
@@ -95,6 +99,23 @@ describe("inputRequestSchema", () => {
       },
       prompt: "Hello?",
       requestId: "req-5",
+    };
+
+    expect(isInputRequest(value)).toBe(false);
+    expect(isInputRequest({ ...value, kind: "unknown" })).toBe(false);
+  });
+
+  it("rejects unknown fields", () => {
+    const value = {
+      action: {
+        callId: "call-6",
+        input: {},
+        kind: "tool-call",
+        toolName: "ask_question",
+      },
+      kind: "question",
+      prompt: "Hello?",
+      requestId: "req-6",
       unknown: true,
     };
 

--- a/packages/eve/src/runtime/input/types.ts
+++ b/packages/eve/src/runtime/input/types.ts
@@ -26,11 +26,19 @@ export const inputOptionSchema = z
   .strict();
 
 /**
- * Unified input request surfaced to the client when the agent needs
- * user input before continuing.
+ * Framework-owned source of an input request.
  *
- * Tool approvals and questions share this shape. Approvals are requests
- * with two options (`"approve"` / `"deny"`) and `display: "confirmation"`.
+ * Consumers use this discriminator for behavior. The action tool name and
+ * request id are presentation and identity fields, not request semantics.
+ */
+export type InputRequestKind = z.infer<typeof inputRequestKindSchema>;
+
+/** Zod schema for the framework-owned source of an input request. */
+export const inputRequestKindSchema = z.enum(["question", "session-limit", "tool-approval"]);
+
+/**
+ * Unified input request surfaced to the client when the agent needs user
+ * input before continuing.
  */
 export type InputRequest = z.infer<typeof inputRequestSchema>;
 
@@ -50,6 +58,9 @@ export const inputRequestSchema = z
       .enum(["confirmation", "select", "text"])
       .describe("Rendering hint: the channel uses this to pick a UX treatment.")
       .optional(),
+    kind: inputRequestKindSchema.describe(
+      "Framework-owned request source used to resolve, route, and render the response.",
+    ),
     options: z
       .array(inputOptionSchema)
       .describe("Selectable answer options to present to the user.")


### PR DESCRIPTION
Input requests come from three producers — `ask_question`, AI SDK tool approvals, and the session-limit continuation gate — but consumers classified them by option shape, display hints, and tool names. Those heuristics drift: shape-sniffing misclassified the session-limit prompt as a tool approval, and the TUI rendered it through the y/n approval flow where its `continue`/`stop` options could not be answered.

## What

- Add a required `InputRequest.kind` discriminator (`question` / `tool-approval` / `session-limit`), stamped by each producer.
- Classify, route, and render by `kind` across the harness, clients, and channels: `classifyInputRequest` becomes an exhaustive switch, the TUI renders non-approvals in the question pane (answering with the request's own option ids), and Slack/Teams HITL use the same predicate.
- Carry `kind` through the invocation-facing contract (`eve invoke` landed on main building requests without it).

## Breaking

`kind` is a required field, so the extension compatibility contracts bump: dynamicTool v5, hook v3, dynamicInstructions v2, dynamicSkill v2.

## Stack

Based on #1262. #1273 (descendant Stop cancellation, which routes by `kind`) and #1312 (TUI regression coverage) layer on this.
