### PR TITLE
feat(evals): add eventual assertions

### DIFF
--- a/.changeset/eval-eventually.md
+++ b/.changeset/eval-eventually.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `t.eventually()` for retrying eval assertions against asynchronously settling values.

--- a/docs/evals/assertions.mdx
+++ b/docs/evals/assertions.mdx
@@ -147,6 +147,20 @@ const call = turn.requireToolCall("search");
 const request = session.requireInputRequest({ toolName: "guarded" });
 ```
 
+For asynchronously settling state, `await t.eventually(sample, assertion, options?)` retries a
+fresh sample until the assertion passes, records one gate, and returns the passing value. It
+defaults to a 5-second timeout and 100-millisecond interval:
+
+```ts
+await t.eventually(
+  async () => (await t.target.fetch("/status")).json(),
+  satisfies((status) => status.ready === true, "target becomes ready"),
+);
+```
+
+Callback errors fail immediately. `timeoutMs` controls the retry window, `intervalMs` controls the
+delay between attempts, and the eval timeout signal interrupts pending waits.
+
 ## Severity
 
 Every assertion returns a chainable handle. Severity rides on the assertion, so there is no separate thresholds map to keep in sync.

--- a/e2e/fixtures/agent-session-timeout/evals/session-timeout-channel-rollover.eval.ts
+++ b/e2e/fixtures/agent-session-timeout/evals/session-timeout-channel-rollover.eval.ts
@@ -53,14 +53,11 @@ export default defineEval({
     terminal.notEvent("turn.failed");
     terminal.notEvent("session.failed");
 
-    let owner: OwnerResponse = { sessionId: expiredSessionId };
-    for (let attempt = 0; attempt < 50 && owner.sessionId !== null; attempt += 1) {
-      owner = await postJson<OwnerResponse>(t.target, `/threads/${threadId}/owner`, {});
-      if (owner.sessionId !== null) {
-        await t.sleep(100);
-      }
-    }
-    await t.require(owner.sessionId, equals(null));
+    await t.eventually(
+      async () =>
+        (await postJson<OwnerResponse>(t.target, `/threads/${threadId}/owner`, {})).sessionId,
+      equals(null),
+    );
 
     const replacement = await postJson<MessageResponse>(t.target, `/threads/${threadId}/messages`, {
       message: "REPLACEMENT-TURN",

--- a/packages/eve/src/evals/context.ts
+++ b/packages/eve/src/evals/context.ts
@@ -4,6 +4,7 @@ import { AssertionCollector } from "#evals/assertions/collector.js";
 import { createScopedAssertions } from "#evals/assertions/scoped.js";
 import { buildJudgeContext } from "#evals/judge.js";
 import { EvalRequirementFailed, EvalSkipped } from "#evals/control-flow.js";
+import { requireEventually } from "#evals/eventually.js";
 import type {
   Assertion,
   AssertionHandle,
@@ -84,6 +85,14 @@ export function createEvalContext(deps: {
     // Value-level assertion over an explicit value.
     check: (value, assertion) => recordCheck(collector, value, assertion),
     require: (value, assertion) => requireCheck(collector, value, assertion),
+    eventually: (sample, assertion, options) =>
+      requireEventually({
+        assertion,
+        collector,
+        options,
+        sample,
+        signal: deps.signal,
+      }),
     skip: (reason) => {
       if (reason.trim().length === 0) throw new Error("skip() requires a non-empty reason.");
       if (collector.hasEntries || deps.manager.hasActivity()) {

--- a/packages/eve/src/evals/eventually.test.ts
+++ b/packages/eve/src/evals/eventually.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createEmptyDerivedFacts } from "#evals/runner/derive-run-facts.js";
+import { AssertionCollector } from "#evals/assertions/collector.js";
+import { EvalRequirementFailed } from "#evals/control-flow.js";
+import { requireEventually } from "#evals/eventually.js";
+import { equals } from "#evals/expect/index.js";
+import type { EveEvalTaskResult } from "#evals/types.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("requireEventually", () => {
+  it("retries until the assertion passes and records one gate", async () => {
+    vi.useFakeTimers();
+    const collector = new AssertionCollector();
+    const sample = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("pending")
+      .mockReturnValueOnce("pending")
+      .mockReturnValue("ready");
+
+    const pending = requireEventually({
+      assertion: equals("ready"),
+      collector,
+      options: { intervalMs: 100, timeoutMs: 500 },
+      sample,
+      signal: new AbortController().signal,
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(pending).resolves.toBe("ready");
+    expect(sample).toHaveBeenCalledTimes(3);
+    await expect(collector.finalize(emptyResult())).resolves.toEqual([
+      expect.objectContaining({
+        name: "eventually(equals)",
+        passed: true,
+        score: 1,
+        severity: "gate",
+      }),
+    ]);
+  });
+
+  it("records one failed gate when the retry window ends", async () => {
+    vi.useFakeTimers();
+    const collector = new AssertionCollector();
+    const sample = vi.fn(() => "pending");
+    const pending = requireEventually({
+      assertion: equals("ready"),
+      collector,
+      options: { intervalMs: 100, timeoutMs: 250 },
+      sample,
+      signal: new AbortController().signal,
+    });
+    const rejected = expect(pending).rejects.toBeInstanceOf(EvalRequirementFailed);
+
+    await vi.advanceTimersByTimeAsync(250);
+    await rejected;
+    expect(sample).toHaveBeenCalledTimes(4);
+
+    const assertions = await collector.finalize(emptyResult());
+    expect(assertions).toEqual([
+      expect.objectContaining({
+        message: "condition did not pass within 250ms after 4 attempt(s)",
+        name: "eventually(equals)",
+        passed: false,
+        score: 0,
+        severity: "gate",
+      }),
+    ]);
+  });
+
+  it("propagates callback errors without retrying", async () => {
+    const collector = new AssertionCollector();
+    const error = new Error("read failed");
+    const sample = vi.fn(() => {
+      throw error;
+    });
+
+    await expect(
+      requireEventually({
+        assertion: equals("ready"),
+        collector,
+        sample,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toBe(error);
+    expect(sample).toHaveBeenCalledTimes(1);
+    await expect(collector.finalize(emptyResult())).resolves.toEqual([]);
+  });
+
+  it("stops a pending retry when the eval signal aborts", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const reason = new Error("eval timed out");
+    const pending = requireEventually({
+      assertion: equals("ready"),
+      collector: new AssertionCollector(),
+      options: { intervalMs: 1_000, timeoutMs: 5_000 },
+      sample: () => "pending",
+      signal: controller.signal,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+  });
+
+  it("validates timing options", async () => {
+    const base = {
+      assertion: equals("ready"),
+      collector: new AssertionCollector(),
+      sample: () => "ready",
+      signal: new AbortController().signal,
+    };
+
+    await expect(requireEventually({ ...base, options: { intervalMs: 0 } })).rejects.toThrow(
+      /intervalMs/,
+    );
+    await expect(
+      requireEventually({ ...base, options: { timeoutMs: Number.NaN } }),
+    ).rejects.toThrow(/timeoutMs/);
+  });
+});
+
+function emptyResult(): EveEvalTaskResult {
+  return {
+    derived: createEmptyDerivedFacts(),
+    events: [],
+    finalMessage: null,
+    output: null,
+    status: "completed",
+  };
+}

--- a/packages/eve/src/evals/eventually.ts
+++ b/packages/eve/src/evals/eventually.ts
@@ -1,0 +1,120 @@
+import { toErrorMessage } from "#shared/errors.js";
+import { AssertionCollector } from "#evals/assertions/collector.js";
+import { EvalRequirementFailed } from "#evals/control-flow.js";
+import type { Assertion, EveEvalEventuallyOptions } from "#evals/types.js";
+
+const DEFAULT_INTERVAL_MS = 100;
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/** Implements the required retrying assertion exposed as `t.eventually()`. */
+export async function requireEventually<T>(input: {
+  readonly assertion: Assertion;
+  readonly collector: AssertionCollector;
+  readonly options?: EveEvalEventuallyOptions;
+  readonly sample: () => T | Promise<T>;
+  readonly signal: AbortSignal;
+}): Promise<T> {
+  const intervalMs = input.options?.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const timeoutMs = input.options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  validateOptions({ intervalMs, timeoutMs });
+
+  const assertion = input.assertion.gate(input.assertion.threshold);
+  const threshold = assertion.threshold ?? 1;
+  const deadline = Date.now() + timeoutMs;
+  let attempts = 0;
+  let lastScore = 0;
+  let lastValue: T;
+
+  while (true) {
+    input.signal.throwIfAborted();
+    attempts += 1;
+    lastValue = await input.sample();
+    input.signal.throwIfAborted();
+
+    try {
+      lastScore = await assertion.score(lastValue);
+    } catch (error) {
+      input.signal.throwIfAborted();
+      await recordScoreError({
+        assertion,
+        attempts,
+        collector: input.collector,
+        error,
+      });
+      throw new EvalRequirementFailed();
+    }
+
+    if (lastScore >= threshold) {
+      await input.collector.recordRequirement({
+        name: `eventually(${assertion.name})`,
+        threshold: assertion.threshold,
+        score: async () => ({
+          score: lastScore,
+          metadata: { attempts, timeoutMs },
+        }),
+      });
+      return lastValue;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      await input.collector.recordRequirement({
+        name: `eventually(${assertion.name})`,
+        threshold: assertion.threshold,
+        score: async () => ({
+          score: lastScore,
+          message: `condition did not pass within ${timeoutMs}ms after ${attempts} attempt(s)`,
+          metadata: { attempts, lastScore, timeoutMs },
+        }),
+      });
+      throw new EvalRequirementFailed();
+    }
+
+    await sleep(Math.min(intervalMs, remainingMs), input.signal);
+  }
+}
+
+async function recordScoreError(input: {
+  readonly assertion: Assertion;
+  readonly attempts: number;
+  readonly collector: AssertionCollector;
+  readonly error: unknown;
+}): Promise<void> {
+  await input.collector.recordRequirement({
+    name: `eventually(${input.assertion.name})`,
+    threshold: input.assertion.threshold,
+    score: async () => {
+      throw new Error(
+        `eventual assertion threw on attempt ${input.attempts}: ${toErrorMessage(input.error)}`,
+      );
+    },
+  });
+}
+
+function validateOptions(options: {
+  readonly intervalMs: number;
+  readonly timeoutMs: number;
+}): void {
+  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0) {
+    throw new TypeError("eventually() intervalMs must be a positive finite number.");
+  }
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 0) {
+    throw new TypeError("eventually() timeoutMs must be a non-negative finite number.");
+  }
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal.reason);
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/eve/src/evals/index.ts
+++ b/packages/eve/src/evals/index.ts
@@ -35,6 +35,7 @@ export type {
   EveEvalAssertions,
   EveEvalContext,
   EveEvalDerivedFacts,
+  EveEvalEventuallyOptions,
   EveEvalJudgeConfig,
   EveEvalRunSummary,
   EveEvalSession,

--- a/packages/eve/src/evals/types.ts
+++ b/packages/eve/src/evals/types.ts
@@ -373,6 +373,17 @@ export interface EveEvalContext extends EveEvalSessionDriver, EveEvalAssertions 
   check(value: unknown, assertion: Assertion): AssertionHandle;
   /** Record an immediate gate and abort dependent control flow when it fails. */
   require<T>(value: T, assertion: Assertion): Promise<T>;
+  /**
+   * Retry an async or synchronous sample until its assertion passes.
+   *
+   * Records one gate and returns the passing value. A callback error fails
+   * immediately; the eval timeout signal interrupts waits between attempts.
+   */
+  eventually<T>(
+    sample: () => T | Promise<T>,
+    assertion: Assertion,
+    options?: EveEvalEventuallyOptions,
+  ): Promise<T>;
   /** Mark this eval as intentionally skipped and stop executing its test body. */
   skip(reason: string): never;
 
@@ -397,6 +408,14 @@ export interface EveEvalTarget {
 
 export interface EveEvalTargetCapabilities {
   readonly devRoutes: boolean;
+}
+
+/** Timing controls for {@link EveEvalContext.eventually}. */
+export interface EveEvalEventuallyOptions {
+  /** Delay between attempts. Defaults to 100 milliseconds. */
+  readonly intervalMs?: number;
+  /** Maximum retry window. Defaults to 5 seconds. */
+  readonly timeoutMs?: number;
 }
 
 export interface EveEvalScheduleDispatchResult {


### PR DESCRIPTION
## Summary

- add an abort-aware `t.eventually()` helper that retries a value assertion and records one gate
- document the helper and cover success, timeout, callback-error, abort, and option-validation behavior
- replace the session-timeout e2e retry loop with `t.eventually()`

## Stack

- based on #1308
- merge after the base PR

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/evals`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build`
- `pnpm --filter agent-session-timeout build`
- fixture `tsc --noEmit`
- `pnpm docs:check`
- `pnpm guard:invariants`
- targeted oxfmt and oxlint