### PR TITLE
fix(eve): slack - convert model markdown in HITL input-request prompts to mrkdwn

### DIFF
--- a/.changeset/slack-hitl-mrkdwn.md
+++ b/.changeset/slack-hitl-mrkdwn.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Convert model-authored markdown to Slack mrkdwn in HITL input-request prompts. The question text on the input-request widget and on the freeform-answer modal was placed into `mrkdwn` sections verbatim, so `**bold**` and `[links](url)` rendered as literal punctuation — even though the same text renders correctly when posted as a normal message. Both surfaces now run the prompt through `gfmToSlackMrkdwn`, matching the rest of the adapter.

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -280,6 +280,23 @@ describe("renderInputRequestBlocks", () => {
     expect(button.style).toBe("primary");
   });
 
+  it("converts model markdown in the prompt to Slack mrkdwn", () => {
+    const blocks = renderInputRequestBlocks(
+      makeRequest({ prompt: "Rename **config.yaml**? See [docs](https://x.dev)" }),
+    );
+
+    const prompt = blocks[0] as { text: { text: string; type: string } };
+    expect(prompt.text.type).toBe("mrkdwn");
+    expect(prompt.text.text).toBe("Rename *config.yaml*? See <https://x.dev|docs>");
+  });
+
+  it("leaves code spans in the prompt untouched", () => {
+    const blocks = renderInputRequestBlocks(makeRequest({ prompt: "Run `**not bold**` first?" }));
+
+    const prompt = blocks[0] as { text: { text: string } };
+    expect(prompt.text.text).toBe("Run `**not bold**` first?");
+  });
+
   it("uses option buttons when allowFreeform is set alongside options", () => {
     const blocks = renderInputRequestBlocks(
       makeRequest({
@@ -417,6 +434,25 @@ describe("buildFreeformModalView", () => {
       | undefined;
     expect(inputBlock?.block_id).toBe(HITL_FREEFORM_MODAL_BLOCK_ID);
     expect(inputBlock?.element?.action_id).toBe(HITL_FREEFORM_MODAL_ACTION_ID);
+  });
+
+  it("converts model markdown in the modal prompt section to Slack mrkdwn", () => {
+    const view = buildFreeformModalView({
+      metadata: {
+        continuationToken: "slack:C01:1.0",
+        channelId: "C01",
+        threadTs: "1.0",
+        messageTs: "1.1",
+        requestId: "call_abc",
+      },
+      prompt: "Rename **config.yaml**?",
+    });
+
+    const blocks = view.blocks as Array<Record<string, unknown>>;
+    const section = blocks.find((b) => b.type === "section") as
+      | { text?: { text?: string } }
+      | undefined;
+    expect(section?.text?.text).toBe("Rename *config.yaml*?");
   });
 
   it("truncates a long modal prompt to fit the section-text limit", () => {

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -19,6 +19,7 @@ import {
   truncatePlainText,
   truncateSectionText,
 } from "#public/channels/slack/limits.js";
+import { gfmToSlackMrkdwn } from "#public/channels/slack/mrkdwn.js";
 import type { InputRequest } from "#runtime/input/types.js";
 
 /**
@@ -145,7 +146,7 @@ export function isHitlAction(actionId: string): boolean {
  */
 export function renderInputRequestBlocks(request: InputRequest): unknown[] {
   const prompt = {
-    text: { text: truncateSectionText(request.prompt), type: "mrkdwn" },
+    text: { text: truncateSectionText(gfmToSlackMrkdwn(request.prompt)), type: "mrkdwn" },
     type: "section",
   };
   const details = renderInputRequestDetailBlocks(request);
@@ -232,7 +233,12 @@ export function buildFreeformModalView(input: {
 }): Record<string, unknown> {
   const title = input.prompt ? truncateModalTitle(input.prompt) : "Your answer";
   const promptBlocks = input.prompt
-    ? [{ type: "section", text: { type: "mrkdwn", text: truncateSectionText(input.prompt) } }]
+    ? [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: truncateSectionText(gfmToSlackMrkdwn(input.prompt)) },
+        },
+      ]
     : [];
   return {
     type: "modal",


### PR DESCRIPTION
Fixes #1293.

## The problem

`renderInputRequestBlocks` puts the model-authored question straight into an `mrkdwn` section with only length truncation applied:

```ts
const prompt = {
  text: { text: truncateSectionText(request.prompt), type: "mrkdwn" },
  type: "section",
};
```

`buildFreeformModalView` does the same for the modal's prompt section. Models write GitHub-flavored markdown, so `**bold**` and `[docs](url)` reach Slack as literal punctuation. The asymmetry the issue calls out is real and a little surprising: the same text renders correctly when posted as a normal message, and only breaks when it is posted as an *ask*.

What made this worth a small patch rather than a big one is that the converter is already here and already correct — `gfmToSlackMrkdwn` in `slack/mrkdwn.ts` handles bold, `__underscores__`, strikethrough and links, and skips code fences and code spans. It has a full test file. It is just never called from any production path: `slackMrkdwnToGfm` is wired up on the inbound side (`inbound.ts`, `api.ts`), and its outbound counterpart is wired to nothing.

So this PR routes the two prompt surfaces through it.

## The change

Two call sites, plus the import:

```ts
text: { text: truncateSectionText(gfmToSlackMrkdwn(request.prompt)), type: "mrkdwn" },
```

Conversion runs **before** truncation on purpose. Converting first means the truncation limit applies to the string Slack actually receives, and it avoids truncation slicing a `**` pair in half and leaving a stray marker behind.

## One thing I deliberately did not change

There is a third surface with the same defect, which the issue does not mention: `renderInputRequestCardBlock` (the options/approval path) builds

```ts
text: truncateCardBodyText(`*${request.prompt}*`)
```

into an `mrkdwn` card body — also unconverted, and additionally wrapping the raw prompt in `*…*`.

I left it alone because fixing it is not purely mechanical. Once the prompt is converted it can contain its own `*emphasis*`, which would nest inside that outer bold wrapper and render badly in Slack. Resolving that means deciding what the wrapper is for — whether the card body should still force the whole question bold, or whether the emphasis should now come from the model's own markup. That is a styling call that belongs to you, not to me, so I would rather ask than guess.

Happy to do it in this PR or a follow-up, whichever you prefer — just say which behaviour you want.

## Testing

Three tests added to `hitl.test.ts`, next to the existing render tests:

- prompt markdown converts (bold + link) in the input-request section
- prompt markdown converts in the modal prompt section
- code spans pass through untouched (guards the fence-splitting path against a future regression)

The two conversion tests fail on `main` and pass with the change:

```
× converts model markdown in the prompt to Slack mrkdwn
  AssertionError: expected 'Rename **config.yaml**? See [docs](ht…'
                        to be 'Rename *config.yaml*? See <https://x.…'
× converts model markdown in the modal prompt section to Slack mrkdwn
  AssertionError: expected 'Rename **config.yaml**?' to be 'Rename *config.yaml*?'
```

Full Slack channel suite is green — 15 files, 292 tests. `tsc -p tsconfig.build.json --noEmit` is clean. Changeset included as a patch.

## Note on commit signatures

The commits carry `Signed-off-by` and the DCO check should pass, but they are **not** GPG/SSH-signed, which CONTRIBUTING requires for merge. I would rather flag that up front than have you find it at merge time — tell me and I will re-sign and force-push the branch before you spend any review effort on it.

---

I use AI assistance in my workflow; the diff and the test expectations above are ones I ran locally against `6dc662c`.
