### PR TITLE
docs: invite registry integration contributions

### DIFF
--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -43,6 +43,21 @@ const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integration
         </p>
       </section>
       <Gallery filter={filter} integrations={integrations} />
+      <section className="mt-12 rounded-lg border border-dashed px-6 py-10 text-center">
+        <h2 className="font-medium text-gray-1000 text-xl tracking-tight">
+          Don&apos;t see your integration?
+        </h2>
+        <p className="mt-2 text-gray-800 text-sm">
+          Help grow the official registry. Read the{" "}
+          <a
+            className="font-medium text-gray-1000 underline underline-offset-4"
+            href="https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry"
+          >
+            integration contribution guide
+          </a>
+          .
+        </p>
+      </section>
     </main>
   );
 };

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -50,14 +50,14 @@ const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integration
         <p className="mt-2 text-gray-800 text-sm">
           <a
             className="font-medium text-gray-1000 underline underline-offset-4"
-            href="/install-integrations#contribute-an-official-integration"
+            href="/docs/install-integrations#contribute-an-official-integration"
           >
             Contribute to the official registry
           </a>{" "}
           or{" "}
           <a
             className="font-medium text-gray-1000 underline underline-offset-4"
-            href="/install-integrations#host-your-own-registry"
+            href="/docs/install-integrations#host-your-own-registry"
           >
             host a third-party registry
           </a>

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -48,12 +48,18 @@ const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integration
           Don&apos;t see your integration?
         </h2>
         <p className="mt-2 text-gray-800 text-sm">
-          Help grow the official registry. Read the{" "}
           <a
             className="font-medium text-gray-1000 underline underline-offset-4"
             href="/install-integrations#contribute-an-official-integration"
           >
-            integration contribution guide
+            Contribute to the official registry
+          </a>{" "}
+          or{" "}
+          <a
+            className="font-medium text-gray-1000 underline underline-offset-4"
+            href="/install-integrations#host-your-own-registry"
+          >
+            host a third-party registry
           </a>
           .
         </p>

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -51,7 +51,7 @@ const IntegrationsPage = async ({ searchParams }: PageProps<"/[lang]/integration
           Help grow the official registry. Read the{" "}
           <a
             className="font-medium text-gray-1000 underline underline-offset-4"
-            href="https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry"
+            href="/install-integrations#contribute-an-official-integration"
           >
             integration contribution guide
           </a>

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -71,6 +71,10 @@ Install a known integration URL directly when you do not need a namespace:
 eve add https://registry.acme.com/r/analytics.json
 ```
 
+## Contribute an official integration
+
+Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
+
 ## Host your own registry
 
 Hosting your own registry is the publishing side of the [third-party source workflow](#add-a-third-party-source). Once it is deployed, other eve projects can give it a namespace and pull integrations from it.
@@ -165,10 +169,6 @@ eve add extension/agent-browser --overwrite
 ```
 
 Update the installed package with your package manager. Check the publisher's release notes before changing the generated mount or package version.
-
-## Contribute an official integration
-
-Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
 
 ## Choose trusted sources
 

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -140,10 +140,6 @@ eve registry add @acme=https://registry.acme.com/r/{name}.json
 eve add @acme/analytics
 ```
 
-## Contribute an official integration
-
-Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
-
 ## Configure generated files
 
 Integrations add project files. Read the generated mount before you run the agent, then add the configuration the extension requires.
@@ -169,6 +165,10 @@ eve add extension/agent-browser --overwrite
 ```
 
 Update the installed package with your package manager. Check the publisher's release notes before changing the generated mount or package version.
+
+## Contribute an official integration
+
+Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
 
 ## Choose trusted sources
 

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -166,6 +166,10 @@ eve add extension/agent-browser --overwrite
 
 Update the installed package with your package manager. Check the publisher's release notes before changing the generated mount or package version.
 
+## Contribute an official integration
+
+Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
+
 ## Choose trusted sources
 
 Integrations can add dependencies and write files. Add sources you trust, inspect an integration with `eve registry view`, and review the resulting project diff before you run the agent.

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -140,6 +140,10 @@ eve registry add @acme=https://registry.acme.com/r/{name}.json
 eve add @acme/analytics
 ```
 
+## Contribute an official integration
+
+Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
+
 ## Configure generated files
 
 Integrations add project files. Read the generated mount before you run the agent, then add the configuration the extension requires.
@@ -165,10 +169,6 @@ eve add extension/agent-browser --overwrite
 ```
 
 Update the installed package with your package manager. Check the publisher's release notes before changing the generated mount or package version.
-
-## Contribute an official integration
-
-Community contributions to the official registry are welcome. Open an issue and get maintainer agreement before submitting a pull request, then follow the [registry contribution guide](https://github.com/vercel/eve/blob/main/CONTRIBUTING.md#adding-an-integration-to-the-registry) for the required source files, metadata, validation, and extension requirements.
 
 ## Choose trusted sources
 


### PR DESCRIPTION
## Summary
- document how community members can contribute official registry integrations
- add a contribution callout to the Integrations gallery

CTA in `/integrations` footer:

<img width="1138" height="566" alt="image" src="https://github.com/user-attachments/assets/9aa46d27-2cca-4e0c-831f-1735fe0847b2" />

Contribution section in registry documentation:

<img width="1040" height="402" alt="image" src="https://github.com/user-attachments/assets/f099996d-b117-4254-8040-9e3e557a0713" />

## Validation
- `pnpm docs:check`