### PR TITLE
fix(eve): avoid ESM path global initialization TDZ

### DIFF
--- a/.changeset/fix-node-esm-compat-banner-tdz.md
+++ b/.changeset/fix-node-esm-compat-banner-tdz.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `eve dev` startup for bundled extensions whose output declares `__filename` without `__dirname`.

--- a/packages/eve/src/internal/node-esm-compat-banner.test.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.test.ts
@@ -52,6 +52,17 @@ describe("buildNodeEsmCompatBanner", () => {
     expect(banner).not.toContain('from "node:path"');
   });
 
+  it("does not read a chunk-provided __filename before it initializes", () => {
+    const chunk = ["const __filename = '/x/file.js';", 'export const value = "noop";'].join("\n");
+
+    const banner = buildNodeEsmCompatBanner(chunk);
+
+    expect(banner).not.toContain("const __filename");
+    expect(banner).toContain(
+      "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));",
+    );
+  });
+
   it("omits the require shim when the chunk binds require", () => {
     const chunk = [
       'import { createRequire } from "node:module";',

--- a/packages/eve/src/internal/node-esm-compat-banner.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.ts
@@ -36,6 +36,9 @@ const BANNER_LINES: readonly BannerLine[] = [
   },
 ];
 
+const FILENAME_BANNER_LINE = BANNER_LINES[0]!;
+const DIRNAME_BANNER_LINE = BANNER_LINES[1]!;
+
 const REQUIRE_LINE: BannerLine = {
   importLine: 'import { createRequire as __eveCreateRequire } from "node:module";',
   declarationLine: "const require = __eveCreateRequire(import.meta.url);",
@@ -62,6 +65,8 @@ export function buildNodeEsmCompatBanner(
 
   const imports: string[] = [];
   const declarations: string[] = [];
+  const chunkProvidesFilename = FILENAME_BANNER_LINE.bindingPattern.test(code);
+  const chunkProvidesDirname = DIRNAME_BANNER_LINE.bindingPattern.test(code);
 
   for (const line of lines) {
     if (line.bindingPattern.test(code)) {
@@ -69,7 +74,16 @@ export function buildNodeEsmCompatBanner(
     }
 
     imports.push(line.importLine);
-    declarations.push(line.declarationLine);
+    declarations.push(
+      line === DIRNAME_BANNER_LINE && chunkProvidesFilename
+        ? "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));"
+        : line.declarationLine,
+    );
+  }
+
+  if (chunkProvidesFilename && !chunkProvidesDirname) {
+    // The chunk's binding is initialized after this prepended banner.
+    imports.unshift(FILENAME_BANNER_LINE.importLine);
   }
 
   if (declarations.length === 0) {


### PR DESCRIPTION
## Summary

Fixes `eve dev` failing to start an app with a mounted workspace extension when bundled extension output binds `__filename` but not `__dirname`.

## Failure reproduced

The failing scenario is:

```ts
it("rebuilds mounted workspace extensions from source and preserves the active dist on failure", async () => {
  const app = await scenarioApp(WORKSPACE_EXTENSION_HMR_DESCRIPTOR);
  const server = await startEveDev(app.appRoot);
  // `eve dev` exited before it printed its server URL.
});
```

At startup, the bundled `marker.mjs` had a top-level `__filename` binding. The ESM compatibility banner correctly avoided redeclaring it, but still prepended `const __dirname = __eveDirname(__filename)`. Because a prepended banner runs before the chunk body initializes its `__filename`, that read hit the temporal dead zone:

```text
Cannot access '__filename' before initialization
```

This fix derives the banner's `__dirname` directly from `import.meta.url` when the chunk already owns `__filename`, so it neither redeclares nor reads that later binding. The added unit regression test covers the banner shape, and the previously failing workspace-extension HMR scenario now passes.

## History

PR #911 (`29ecffcd`) introduced this workspace-extension HMR scenario on July 17. Its merge CI passed the scenario. The banner defect is older, but #1121 (`25c12d3a`) changed the banner matcher on July 23 so real `__filename` bindings are distinguished from bundler-suffixed names. That made this ordering case reachable.

The scenario also passed Linux CI when #1121 and its follow-up #1132 merged, while the same historical source reproduces locally on macOS with the same Node version. Therefore this was a platform-dependent latent failure rather than a test that had continuously failed since #911.

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/node-esm-compat-banner.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/dev-server.scenario.test.ts -t "rebuilds mounted workspace extensions from source"`
- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit`
- `pnpm exec oxlint packages/eve/src/internal/node-esm-compat-banner.ts packages/eve/src/internal/node-esm-compat-banner.test.ts`