### PR TITLE
feat(eve): agent-handle lifecycle contracts (three-phase handles, turn outcomes)

### DIFF
--- a/packages/eve/src/channel/session-callback.ts
+++ b/packages/eve/src/channel/session-callback.ts
@@ -44,9 +44,9 @@ const sessionCallbackSchema = z
       });
     }
 
-    // SSRF guard: the framework POSTs to this URL on session completion, so a
-    // caller-supplied private/link-local host (e.g. cloud metadata) must be
-    // rejected. The path/token check above does not constrain the host.
+    // SSRF guard: the framework POSTs to this URL when delegated work settles,
+    // so a caller-supplied private/link-local host (e.g. cloud metadata) must
+    // be rejected. The path/token check above does not constrain the host.
     if (isReservedIpAddress(url.hostname)) {
       ctx.addIssue({
         code: "custom",

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -127,6 +127,15 @@ export type EventEmitFn = (event: UnstampedMessageStreamEvent) => Promise<void>;
 // Deliver payload
 // ---------------------------------------------------------------------------
 
+/** Framework-internal caller waiting for one delegated conversation turn. */
+export interface TurnCaller {
+  readonly callId: string;
+  readonly subagentName: string;
+  readonly replyTo:
+    | { readonly kind: "hook"; readonly token: string }
+    | { readonly kind: "callback"; readonly url: string };
+}
+
 /**
  * Base deliver payload crossing the runtime boundary.
  *
@@ -154,12 +163,13 @@ export interface DeliverPayload {
 /**
  * Deliver payload sent through the workflow `resumeHook`.
  *
- * Wraps the raw {@link DeliverPayload} with an optional auth update so
- * deliver-time auth crosses the durable hook boundary without a process-local
- * side-channel.
+ * Wraps the raw {@link DeliverPayload} with optional auth and turn-caller
+ * metadata so both cross the durable hook boundary outside adapter-owned data.
  */
 export interface DeliverHookPayload {
   readonly auth?: SessionAuthContext | null;
+  /** Delegated caller waiting for this turn's settled result. */
+  readonly caller?: TurnCaller;
   /** Inbound channel request id used only for workflow attributes. */
   readonly requestId?: string;
   readonly kind: "deliver";
@@ -240,11 +250,13 @@ export type HookPayload =
   | SubagentInputRequestHookPayload;
 
 /**
- * Terminal callback metadata attached to a session at creation.
+ * Initial caller callback attached to a delegated session at creation.
  *
  * `url` is the absolute callback endpoint. `token` is the capability token
  * embedded in the framework-owned callback route. `callId` and `subagentName`
- * correlate the callee's terminal callback to the pending parent tool call.
+ * correlate the callee's result to the pending tool call. Task sessions send a
+ * terminal session result. Conversation sessions use this as their first turn's
+ * caller; each continuation supplies the caller for that turn.
  */
 export interface SessionCallback {
   readonly callId: string;
@@ -321,8 +333,9 @@ export interface RunInput {
    */
   readonly title?: string;
   /**
-   * Optional terminal callback. When present, the runtime posts a single
-   * callback when the session completes or fails.
+   * Optional caller callback. Task sessions post when the session completes or
+   * fails. Conversation sessions use it for the first turn; continuations carry
+   * the caller for their own turn.
    */
   readonly callback?: SessionCallback;
   /**
@@ -369,12 +382,14 @@ export interface RunInput {
 
 export interface DeliverInput {
   /**
-   * Authenticated caller principal for this follow-up message.
+   * Authenticated principal for this follow-up message.
    * May differ from the session initiator when different users send
    * messages to the same session. The runtime updates `AuthKey` from
    * this field before calling the adapter's hooks.
    */
   readonly auth?: SessionAuthContext | null;
+  /** Delegated caller waiting for this turn's settled result. */
+  readonly caller?: TurnCaller;
   /** Inbound channel request id used to correlate workflow attributes. */
   readonly requestId?: string;
   readonly continuationToken: string;

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -422,6 +422,7 @@ const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
     dynamicModel: compiledDynamicModelDefinitionSchema.optional(),
     experimental: z
       .object({
+        subagentPersistentSessions: z.boolean().optional(),
         workflow: compiledAgentWorkflowDefinitionSchema.optional(),
       })
       .strict()
@@ -810,6 +811,7 @@ export function createCompiledAgentNodeManifest(input: {
         input.config.experimental === undefined
           ? undefined
           : {
+              subagentPersistentSessions: input.config.experimental.subagentPersistentSessions,
               workflow:
                 input.config.experimental.workflow === undefined
                   ? undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -170,6 +170,10 @@ function normalizeExperimentalDefinition(
 
   const compiledExperimental: Mutable<NonNullable<CompiledAgentDefinition["experimental"]>> = {};
 
+  if (experimental.subagentPersistentSessions !== undefined) {
+    compiledExperimental.subagentPersistentSessions = experimental.subagentPersistentSessions;
+  }
+
   if (experimental.workflow !== undefined) {
     compiledExperimental.workflow = {
       world: experimental.workflow.world,

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -80,7 +80,7 @@ export const SubagentDepthKey = new ContextKey<number>("eve.subagentDepth");
 export const CapabilitiesKey = new ContextKey<SessionCapabilities>("eve.capabilities");
 
 /**
- * Optional framework-owned terminal callback metadata for this session.
+ * Optional framework-owned caller callback captured when the session is created.
  */
 export const SessionCallbackKey = new ContextKey<SessionCallback>("eve.sessionCallback");
 

--- a/packages/eve/src/context/run-step.ts
+++ b/packages/eve/src/context/run-step.ts
@@ -77,9 +77,9 @@ export async function runStep(
   callback: (session: HarnessSession) => Promise<StepResult>,
 ): Promise<StepResult> {
   const { result, session } = await withContextScope(ctx, harnessSession, async (enriched) => {
-    const stepResult = await callback(enriched);
-    return { result: stepResult.next, session: stepResult.session };
+    const result = await callback(enriched);
+    return { result, session: result.session };
   });
 
-  return { next: result, session };
+  return { ...result, session };
 }

--- a/packages/eve/src/execution/session-callback-request.ts
+++ b/packages/eve/src/execution/session-callback-request.ts
@@ -1,0 +1,17 @@
+const SESSION_CALLBACK_TIMEOUT_MS = 30_000;
+
+/** Posts one framework callback payload with the shared callback transport policy. */
+export async function postSessionCallbackRequest(input: {
+  readonly body: unknown;
+  readonly url: string;
+}): Promise<Response> {
+  return await fetch(input.url, {
+    body: JSON.stringify(input.body),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+    redirect: "error",
+    signal: AbortSignal.timeout(SESSION_CALLBACK_TIMEOUT_MS),
+  });
+}

--- a/packages/eve/src/harness/agent-handles.test.ts
+++ b/packages/eve/src/harness/agent-handles.test.ts
@@ -7,7 +7,8 @@ import {
   removeAgentHandle,
   renderAgentsSnippet,
   upsertAgentHandle,
-  type AgentHandle,
+  type LocalAgentHandle,
+  type RemoteAgentHandle,
 } from "#harness/agent-handles.js";
 import { AGENTS_SNIPPET_LABEL } from "#harness/compaction-prompt.js";
 import type { HarnessSession } from "#harness/types.js";
@@ -27,7 +28,7 @@ function createSession(state?: HarnessSession["state"]): HarnessSession {
   };
 }
 
-function createHandle(overrides: Partial<AgentHandle> = {}): AgentHandle {
+function createHandle(overrides: Partial<LocalAgentHandle> = {}): LocalAgentHandle {
   return {
     continuationToken: "continuation_handle",
     id: "ag_research:abcdefghijkl",
@@ -37,7 +38,6 @@ function createHandle(overrides: Partial<AgentHandle> = {}): AgentHandle {
     relationship: "child",
     sessionId: "session_abcdefghijkl",
     updatedAt: "2026-07-28T12:00:00.000Z",
-    url: "",
     ...overrides,
   };
 }
@@ -49,15 +49,21 @@ describe("deriveAgentId", () => {
 });
 
 describe("getAgentHandleStore", () => {
-  it("returns undefined for missing or malformed state", () => {
+  it("returns undefined only when no store has been written", () => {
     expect(getAgentHandleStore(undefined)).toBeUndefined();
+    expect(getAgentHandleStore({})).toBeUndefined();
+  });
 
+  it("throws on a present but malformed store instead of treating it as absent", () => {
     for (const malformed of [
       null,
       { handles: "not-an-array" },
       { handles: [{ id: "incomplete" }] },
+      { handles: [{ ...createHandle(), kind: "agent/remote" }] },
     ]) {
-      expect(getAgentHandleStore({ [AGENT_HANDLES_STATE_KEY]: malformed })).toBeUndefined();
+      expect(() => getAgentHandleStore({ [AGENT_HANDLES_STATE_KEY]: malformed })).toThrow(
+        AGENT_HANDLES_STATE_KEY,
+      );
     }
   });
 });
@@ -66,7 +72,7 @@ describe("upsertAgentHandle", () => {
   it("replaces an existing handle by id without mutating the prior session", () => {
     const originalHandle = createHandle({ lastStatus: "working" });
     const inserted = upsertAgentHandle(createSession(), originalHandle);
-    const replacement = createHandle({ lastStatus: "done", url: "https://next.invalid" });
+    const replacement = createHandle({ description: "next task", lastStatus: "done" });
 
     const replaced = upsertAgentHandle(inserted, replacement);
 
@@ -86,25 +92,30 @@ describe("removeAgentHandle", () => {
 describe("renderAgentsSnippet", () => {
   it("starts with the synthetic label and omits private delivery coordinates", () => {
     const url = "https://URL_SENTINEL.invalid";
+    const callbackBaseUrl = "https://CALLBACK_SENTINEL.invalid";
     const continuationToken = "CONTINUATION_TOKEN_SENTINEL";
     const sessionId = "SESSION_ID_SENTINEL_123456789";
-    const snippet = renderAgentsSnippet({
-      handles: [
-        createHandle({
-          continuationToken,
-          id: "ag_research:visible-id",
-          lastStatus: "waiting for input",
-          sessionId,
-          url,
-        }),
-      ],
-    });
+    const remoteHandle: RemoteAgentHandle = {
+      callbackBaseUrl,
+      continuationToken,
+      id: "ag_research:visible-id",
+      kind: "agent/remote",
+      lastStatus: "waiting for input",
+      name: "research",
+      nodeId: "node_research",
+      relationship: "child",
+      sessionId,
+      updatedAt: "2026-07-28T12:00:00.000Z",
+      url,
+    };
+    const snippet = renderAgentsSnippet({ handles: [remoteHandle] });
 
     expect(snippet.startsWith(`${AGENTS_SNIPPET_LABEL}\n<agents>`)).toBe(true);
     expect(snippet).toContain(
       '<agent id="ag_research:visible-id" name="research">waiting for input</agent>',
     );
     expect(snippet).not.toContain(url);
+    expect(snippet).not.toContain(callbackBaseUrl);
     expect(snippet).not.toContain(continuationToken);
     expect(snippet).not.toContain(sessionId);
   });

--- a/packages/eve/src/harness/agent-handles.test.ts
+++ b/packages/eve/src/harness/agent-handles.test.ts
@@ -10,7 +10,6 @@ import {
   type LocalAgentHandle,
   type RemoteAgentHandle,
 } from "#harness/agent-handles.js";
-import { AGENTS_SNIPPET_LABEL } from "#harness/compaction-prompt.js";
 import type { HarnessSession } from "#harness/types.js";
 
 function createSession(state?: HarnessSession["state"]): HarnessSession {
@@ -110,7 +109,7 @@ describe("renderAgentsSnippet", () => {
     };
     const snippet = renderAgentsSnippet({ handles: [remoteHandle] });
 
-    expect(snippet.startsWith(`${AGENTS_SNIPPET_LABEL}\n<agents>`)).toBe(true);
+    expect(snippet.startsWith("[Agents]\n<agents>")).toBe(true);
     expect(snippet).toContain(
       '<agent id="ag_research:visible-id" name="research">waiting for input</agent>',
     );

--- a/packages/eve/src/harness/agent-handles.test.ts
+++ b/packages/eve/src/harness/agent-handles.test.ts
@@ -2,15 +2,32 @@ import { describe, expect, it } from "vitest";
 
 import {
   AGENT_HANDLES_STATE_KEY,
+  confirmAgentStarted,
   deriveAgentId,
+  deriveAgentOperationId,
+  formatAgentStatus,
   getAgentHandleStore,
-  removeAgentHandle,
+  prepareAgentContinuation,
+  prepareAgentStart,
+  projectParkedAgentHandles,
+  rejectAgentEffect,
   renderAgentsSnippet,
-  upsertAgentHandle,
-  type LocalAgentHandle,
-  type RemoteAgentHandle,
+  settleAgentTurn,
+  type AgentAddress,
+  type AgentHandle,
+  type AgentIdentity,
+  type ContinueOperation,
+  type StartOperation,
 } from "#harness/agent-handles.js";
 import type { HarnessSession } from "#harness/types.js";
+import type { TokenUsage } from "#shared/token-usage.js";
+
+const ZERO_USAGE: TokenUsage = {
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+};
 
 function createSession(state?: HarnessSession["state"]): HarnessSession {
   return {
@@ -22,28 +39,88 @@ function createSession(state?: HarnessSession["state"]): HarnessSession {
     compaction: { recentWindowSize: 4, threshold: 1_000_000 },
     continuationToken: "continuation_test",
     history: [],
-    sessionId: "session_test",
+    sessionId: "session_parent",
     state,
   };
 }
 
-function createHandle(overrides: Partial<LocalAgentHandle> = {}): LocalAgentHandle {
-  return {
-    continuationToken: "continuation_handle",
-    id: "ag_research:abcdefghijkl",
-    kind: "agent/local",
-    name: "research",
-    nodeId: "node_research",
-    relationship: "child",
-    sessionId: "session_abcdefghijkl",
-    updatedAt: "2026-07-28T12:00:00.000Z",
-    ...overrides,
-  };
+const startOperation: StartOperation = {
+  callId: "call_1",
+  id: deriveAgentOperationId({
+    callId: "call_1",
+    parentSessionId: "session_parent",
+    parentTurnId: "turn_1",
+  }),
+  kind: "start",
+  parentTurnId: "turn_1",
+};
+
+const identity: AgentIdentity = {
+  id: deriveAgentId("research", startOperation.id),
+  name: "research",
+  nodeId: "node_research",
+};
+
+const address: AgentAddress = {
+  continuationToken: "continuation_child",
+  kind: "agent/local",
+  sessionId: "session_child",
+};
+
+function preparedSession(): HarnessSession {
+  return prepareAgentStart(createSession(), {
+    identity,
+    operation: startOperation,
+    target: { continuationToken: "continuation_child", kind: "agent/local" },
+  });
 }
 
-describe("deriveAgentId", () => {
-  it("uses the agent name and final twelve session-id characters", () => {
-    expect(deriveAgentId("research", "session_123456789012")).toBe("ag_research:123456789012");
+function runningSession(): HarnessSession {
+  return confirmAgentStarted(preparedSession(), {
+    address,
+    operationId: startOperation.id,
+  });
+}
+
+function parkedSession(): HarnessSession {
+  const settled = settleAgentTurn(runningSession(), {
+    operationId: startOperation.id,
+    outcome: {
+      kind: "parked",
+      result: { kind: "succeeded", output: "initial findings" },
+      usageDelta: ZERO_USAGE,
+    },
+    sessionId: address.sessionId,
+  });
+  if (settled.kind !== "settled") {
+    throw new Error("expected settled");
+  }
+  return settled.session;
+}
+
+function handlesOf(session: HarnessSession): readonly AgentHandle[] {
+  return getAgentHandleStore(session.state)?.handles ?? [];
+}
+
+describe("deriveAgentOperationId / deriveAgentId", () => {
+  it("is deterministic on parent-controlled inputs and independent of the child session", () => {
+    const again = deriveAgentOperationId({
+      callId: "call_1",
+      parentSessionId: "session_parent",
+      parentTurnId: "turn_1",
+    });
+    expect(again).toBe(startOperation.id);
+    expect(deriveAgentId("research", again)).toBe(identity.id);
+    expect(identity.id.startsWith("ag_research:")).toBe(true);
+  });
+
+  it("changes when any input changes", () => {
+    const other = deriveAgentOperationId({
+      callId: "call_2",
+      parentSessionId: "session_parent",
+      parentTurnId: "turn_1",
+    });
+    expect(other).not.toBe(startOperation.id);
   });
 });
 
@@ -57,65 +134,316 @@ describe("getAgentHandleStore", () => {
     for (const malformed of [
       null,
       { handles: "not-an-array" },
-      { handles: [{ id: "incomplete" }] },
-      { handles: [{ ...createHandle(), kind: "agent/remote" }] },
+      { handles: [{ phase: "starting" }] },
+      { extra: true, handles: [] },
+      {
+        handles: [
+          {
+            address,
+            identity,
+            lastStatus: "x".repeat(121),
+            phase: "parked",
+          },
+        ],
+      },
     ]) {
       expect(() => getAgentHandleStore({ [AGENT_HANDLES_STATE_KEY]: malformed })).toThrow(
         AGENT_HANDLES_STATE_KEY,
       );
     }
   });
-});
 
-describe("upsertAgentHandle", () => {
-  it("replaces an existing handle by id without mutating the prior session", () => {
-    const originalHandle = createHandle({ lastStatus: "working" });
-    const inserted = upsertAgentHandle(createSession(), originalHandle);
-    const replacement = createHandle({ description: "next task", lastStatus: "done" });
-
-    const replaced = upsertAgentHandle(inserted, replacement);
-
-    expect(getAgentHandleStore(replaced.state)?.handles).toEqual([replacement]);
-    expect(getAgentHandleStore(inserted.state)?.handles).toEqual([originalHandle]);
+  it("rejects duplicate handle ids", () => {
+    const parked = handlesOf(parkedSession());
+    expect(() =>
+      getAgentHandleStore({ [AGENT_HANDLES_STATE_KEY]: { handles: [...parked, ...parked] } }),
+    ).toThrow("unique");
   });
 });
 
-describe("removeAgentHandle", () => {
-  it("returns the same session reference when the id is absent", () => {
-    const session = upsertAgentHandle(createSession(), createHandle());
+describe("prepareAgentStart", () => {
+  it("records starting ownership before any side effect", () => {
+    const session = preparedSession();
+    expect(handlesOf(session)).toEqual([
+      {
+        identity,
+        operation: startOperation,
+        phase: "starting",
+        target: { continuationToken: "continuation_child", kind: "agent/local" },
+      },
+    ]);
+  });
 
-    expect(removeAgentHandle(session, "ag_missing:000000000000")).toBe(session);
+  it("throws when the identity already exists", () => {
+    expect(() =>
+      prepareAgentStart(preparedSession(), {
+        identity,
+        operation: startOperation,
+        target: { continuationToken: "continuation_child", kind: "agent/local" },
+      }),
+    ).toThrow(identity.id);
   });
 });
 
-describe("renderAgentsSnippet", () => {
-  it("starts with the synthetic label and omits private delivery coordinates", () => {
-    const url = "https://URL_SENTINEL.invalid";
-    const callbackBaseUrl = "https://CALLBACK_SENTINEL.invalid";
-    const continuationToken = "CONTINUATION_TOKEN_SENTINEL";
-    const sessionId = "SESSION_ID_SENTINEL_123456789";
-    const remoteHandle: RemoteAgentHandle = {
-      callbackBaseUrl,
-      continuationToken,
-      id: "ag_research:visible-id",
-      kind: "agent/remote",
-      lastStatus: "waiting for input",
-      name: "research",
-      nodeId: "node_research",
-      relationship: "child",
-      sessionId,
-      updatedAt: "2026-07-28T12:00:00.000Z",
-      url,
+describe("confirmAgentStarted", () => {
+  it("moves starting to running with the confirmed address", () => {
+    expect(handlesOf(runningSession())).toEqual([
+      { address, identity, operation: startOperation, phase: "running" },
+    ]);
+  });
+
+  it("is a replay no-op when the handle is already running", () => {
+    const running = runningSession();
+    expect(confirmAgentStarted(running, { address, operationId: startOperation.id })).toBe(running);
+  });
+
+  it("throws for an operation that was never prepared", () => {
+    expect(() =>
+      confirmAgentStarted(createSession(), { address, operationId: "op_unprepared" }),
+    ).toThrow("op_unprepared");
+  });
+});
+
+describe("prepareAgentContinuation", () => {
+  const continueOperation: ContinueOperation = {
+    callId: "call_2",
+    id: deriveAgentOperationId({
+      callId: "call_2",
+      parentSessionId: "session_parent",
+      parentTurnId: "turn_2",
+    }),
+    kind: "continue",
+    parentTurnId: "turn_2",
+    previousStatus: "",
+  };
+
+  it("moves parked to running and captures the previous status", () => {
+    const result = prepareAgentContinuation(parkedSession(), {
+      agentId: identity.id,
+      invokedName: "research",
+      operation: continueOperation,
+    });
+    expect(result.kind).toBe("ready");
+    if (result.kind !== "ready") {
+      return;
+    }
+    expect(result.handle.phase).toBe("running");
+    expect(result.handle.operation).toEqual({
+      ...continueOperation,
+      previousStatus: "initial findings",
+    });
+    expect(handlesOf(result.session)).toEqual([result.handle]);
+  });
+
+  it("reports unknown, mismatch, and busy without changing the session", () => {
+    expect(
+      prepareAgentContinuation(parkedSession(), {
+        agentId: "ag_missing:000000000000",
+        invokedName: "research",
+        operation: continueOperation,
+      }),
+    ).toEqual({ kind: "unknown" });
+
+    expect(
+      prepareAgentContinuation(parkedSession(), {
+        agentId: identity.id,
+        invokedName: "writer",
+        operation: continueOperation,
+      }),
+    ).toEqual({ kind: "mismatch" });
+
+    expect(
+      prepareAgentContinuation(runningSession(), {
+        agentId: identity.id,
+        invokedName: "research",
+        operation: continueOperation,
+      }),
+    ).toEqual({ kind: "busy" });
+  });
+
+  it("treats the operation already recorded on a running handle as a replay", () => {
+    const running = runningSession();
+    const replay = prepareAgentContinuation(running, {
+      agentId: identity.id,
+      invokedName: "research",
+      operation: {
+        callId: startOperation.callId,
+        id: startOperation.id,
+        kind: "continue",
+        parentTurnId: startOperation.parentTurnId,
+        previousStatus: "",
+      },
+    });
+    expect(replay.kind).toBe("ready");
+    if (replay.kind === "ready") {
+      expect(replay.session).toBe(running);
+    }
+  });
+});
+
+describe("rejectAgentEffect", () => {
+  it("deletes a dead start", () => {
+    const session = rejectAgentEffect(preparedSession(), {
+      disposition: "dead",
+      operationId: startOperation.id,
+    });
+    expect(handlesOf(session)).toEqual([]);
+  });
+
+  it("restores parked with the previous status for a retryable continuation", () => {
+    const continueOperation: ContinueOperation = {
+      callId: "call_2",
+      id: "op_continue",
+      kind: "continue",
+      parentTurnId: "turn_2",
+      previousStatus: "",
     };
-    const snippet = renderAgentsSnippet({ handles: [remoteHandle] });
+    const prepared = prepareAgentContinuation(parkedSession(), {
+      agentId: identity.id,
+      invokedName: "research",
+      operation: continueOperation,
+    });
+    if (prepared.kind !== "ready") {
+      throw new Error("expected ready");
+    }
 
+    const restored = rejectAgentEffect(prepared.session, {
+      disposition: "retryable",
+      operationId: "op_continue",
+    });
+    expect(handlesOf(restored)).toEqual([
+      { address, identity, lastStatus: "initial findings", phase: "parked" },
+    ]);
+  });
+
+  it("deletes a running start even when the failure is retryable", () => {
+    // A fresh start has no parked state to restore; the model retries by
+    // starting a new agent instead.
+    const session = rejectAgentEffect(runningSession(), {
+      disposition: "retryable",
+      operationId: startOperation.id,
+    });
+    expect(handlesOf(session)).toEqual([]);
+  });
+
+  it("ignores unknown operations", () => {
+    const parked = parkedSession();
+    expect(rejectAgentEffect(parked, { disposition: "dead", operationId: "op_gone" })).toBe(parked);
+  });
+});
+
+describe("settleAgentTurn", () => {
+  it("parks the handle with a truncated status on a parked outcome", () => {
+    const settled = settleAgentTurn(runningSession(), {
+      operationId: startOperation.id,
+      outcome: {
+        kind: "parked",
+        result: { kind: "succeeded", output: `  padded\n${"x".repeat(200)}  ` },
+        usageDelta: ZERO_USAGE,
+      },
+      sessionId: address.sessionId,
+    });
+    expect(settled.kind).toBe("settled");
+    if (settled.kind !== "settled") {
+      return;
+    }
+    const [handle] = handlesOf(settled.session);
+    expect(handle?.phase).toBe("parked");
+    if (handle?.phase === "parked") {
+      expect(handle.lastStatus.length).toBeLessThanOrEqual(120);
+      expect(handle.lastStatus.startsWith("padded x")).toBe(true);
+    }
+  });
+
+  it("deletes the handle on a terminal outcome, including failures", () => {
+    const settled = settleAgentTurn(runningSession(), {
+      operationId: startOperation.id,
+      outcome: {
+        kind: "terminal",
+        result: { error: { code: "BOOM" }, kind: "failed" },
+        usageDelta: ZERO_USAGE,
+      },
+      sessionId: address.sessionId,
+    });
+    expect(settled.kind).toBe("settled");
+    if (settled.kind === "settled") {
+      expect(handlesOf(settled.session)).toEqual([]);
+    }
+  });
+
+  it("keeps a failed-but-parked child resumable", () => {
+    const settled = settleAgentTurn(runningSession(), {
+      operationId: startOperation.id,
+      outcome: {
+        kind: "parked",
+        result: { error: "model overloaded", kind: "failed" },
+        usageDelta: ZERO_USAGE,
+      },
+      sessionId: address.sessionId,
+    });
+    expect(settled.kind).toBe("settled");
+    if (settled.kind === "settled") {
+      expect(handlesOf(settled.session)[0]?.phase).toBe("parked");
+    }
+  });
+
+  it("ignores stale operations and mismatched child sessions", () => {
+    expect(
+      settleAgentTurn(runningSession(), {
+        operationId: "op_stale",
+        outcome: {
+          kind: "parked",
+          result: { kind: "succeeded", output: "" },
+          usageDelta: ZERO_USAGE,
+        },
+        sessionId: address.sessionId,
+      }),
+    ).toEqual({ kind: "ignored", reason: "unknown-operation" });
+
+    expect(
+      settleAgentTurn(runningSession(), {
+        operationId: startOperation.id,
+        outcome: {
+          kind: "parked",
+          result: { kind: "succeeded", output: "" },
+          usageDelta: ZERO_USAGE,
+        },
+        sessionId: "session_forged",
+      }),
+    ).toEqual({ kind: "ignored", reason: "session-mismatch" });
+  });
+});
+
+describe("projection", () => {
+  it("projects and renders only parked handles", () => {
+    const running = runningSession();
+    const store = getAgentHandleStore(running.state);
+    expect(store).toBeDefined();
+    if (store === undefined) {
+      return;
+    }
+    expect(projectParkedAgentHandles(store)).toEqual([]);
+    expect(renderAgentsSnippet(store)).toBe("[Agents]\n<agents>\n</agents>");
+
+    const parkedStore = getAgentHandleStore(parkedSession().state);
+    expect(parkedStore).toBeDefined();
+    if (parkedStore === undefined) {
+      return;
+    }
+    const snippet = renderAgentsSnippet(parkedStore);
     expect(snippet.startsWith("[Agents]\n<agents>")).toBe(true);
     expect(snippet).toContain(
-      '<agent id="ag_research:visible-id" name="research">waiting for input</agent>',
+      `<agent id="${identity.id}" name="research">initial findings</agent>`,
     );
-    expect(snippet).not.toContain(url);
-    expect(snippet).not.toContain(callbackBaseUrl);
-    expect(snippet).not.toContain(continuationToken);
-    expect(snippet).not.toContain(sessionId);
+    expect(snippet).not.toContain(address.sessionId);
+    expect(snippet).not.toContain(address.continuationToken);
+  });
+});
+
+describe("formatAgentStatus", () => {
+  it("collapses whitespace, truncates to 120, and stringifies objects", () => {
+    expect(formatAgentStatus("  a\n\tb  ")).toBe("a b");
+    expect(formatAgentStatus({ ok: true })).toBe('{"ok":true}');
+    expect(formatAgentStatus("y".repeat(300)).length).toBe(120);
   });
 });

--- a/packages/eve/src/harness/agent-handles.test.ts
+++ b/packages/eve/src/harness/agent-handles.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_HANDLES_STATE_KEY,
+  deriveAgentId,
+  getAgentHandleStore,
+  removeAgentHandle,
+  renderAgentsSnippet,
+  upsertAgentHandle,
+  type AgentHandle,
+} from "#harness/agent-handles.js";
+import { AGENTS_SNIPPET_LABEL } from "#harness/compaction-prompt.js";
+import type { HarnessSession } from "#harness/types.js";
+
+function createSession(state?: HarnessSession["state"]): HarnessSession {
+  return {
+    agent: {
+      modelReference: { id: "model_test" },
+      system: "",
+      tools: [],
+    },
+    compaction: { recentWindowSize: 4, threshold: 1_000_000 },
+    continuationToken: "continuation_test",
+    history: [],
+    sessionId: "session_test",
+    state,
+  };
+}
+
+function createHandle(overrides: Partial<AgentHandle> = {}): AgentHandle {
+  return {
+    continuationToken: "continuation_handle",
+    id: "ag_research:abcdefghijkl",
+    kind: "agent/local",
+    name: "research",
+    nodeId: "node_research",
+    relationship: "child",
+    sessionId: "session_abcdefghijkl",
+    updatedAt: "2026-07-28T12:00:00.000Z",
+    url: "",
+    ...overrides,
+  };
+}
+
+describe("deriveAgentId", () => {
+  it("uses the agent name and final twelve session-id characters", () => {
+    expect(deriveAgentId("research", "session_123456789012")).toBe("ag_research:123456789012");
+  });
+});
+
+describe("getAgentHandleStore", () => {
+  it("returns undefined for missing or malformed state", () => {
+    expect(getAgentHandleStore(undefined)).toBeUndefined();
+
+    for (const malformed of [
+      null,
+      { handles: "not-an-array" },
+      { handles: [{ id: "incomplete" }] },
+    ]) {
+      expect(getAgentHandleStore({ [AGENT_HANDLES_STATE_KEY]: malformed })).toBeUndefined();
+    }
+  });
+});
+
+describe("upsertAgentHandle", () => {
+  it("replaces an existing handle by id without mutating the prior session", () => {
+    const originalHandle = createHandle({ lastStatus: "working" });
+    const inserted = upsertAgentHandle(createSession(), originalHandle);
+    const replacement = createHandle({ lastStatus: "done", url: "https://next.invalid" });
+
+    const replaced = upsertAgentHandle(inserted, replacement);
+
+    expect(getAgentHandleStore(replaced.state)?.handles).toEqual([replacement]);
+    expect(getAgentHandleStore(inserted.state)?.handles).toEqual([originalHandle]);
+  });
+});
+
+describe("removeAgentHandle", () => {
+  it("returns the same session reference when the id is absent", () => {
+    const session = upsertAgentHandle(createSession(), createHandle());
+
+    expect(removeAgentHandle(session, "ag_missing:000000000000")).toBe(session);
+  });
+});
+
+describe("renderAgentsSnippet", () => {
+  it("starts with the synthetic label and omits private delivery coordinates", () => {
+    const url = "https://URL_SENTINEL.invalid";
+    const continuationToken = "CONTINUATION_TOKEN_SENTINEL";
+    const sessionId = "SESSION_ID_SENTINEL_123456789";
+    const snippet = renderAgentsSnippet({
+      handles: [
+        createHandle({
+          continuationToken,
+          id: "ag_research:visible-id",
+          lastStatus: "waiting for input",
+          sessionId,
+          url,
+        }),
+      ],
+    });
+
+    expect(snippet.startsWith(`${AGENTS_SNIPPET_LABEL}\n<agents>`)).toBe(true);
+    expect(snippet).toContain(
+      '<agent id="ag_research:visible-id" name="research">waiting for input</agent>',
+    );
+    expect(snippet).not.toContain(url);
+    expect(snippet).not.toContain(continuationToken);
+    expect(snippet).not.toContain(sessionId);
+  });
+});

--- a/packages/eve/src/harness/agent-handles.ts
+++ b/packages/eve/src/harness/agent-handles.ts
@@ -1,104 +1,258 @@
+import { createHash } from "node:crypto";
+
 import { z } from "#compiled/zod/index.js";
 
 import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+import type { AgentTurnOutcome } from "#shared/agent-turn-outcome.js";
 
 /** Session-state key for delegated agent handles. */
 export const AGENT_HANDLES_STATE_KEY = "eve.agent.handles";
 const AGENTS_SNIPPET_LABEL = "[Agents]";
+const MAX_STATUS_LENGTH = 120;
 
-/** Delivery category for a delegated agent handle. */
-export type AgentHandleKind = AgentHandle["kind"];
+/** Error code for a requested agent id that is not registered. */
+export const AGENT_UNKNOWN = "AGENT_UNKNOWN";
 
-/** Fields shared by every delegated agent handle. */
-interface AgentHandleBase {
-  /** Model-visible identifier derived from the tool name and session id. */
+/** Error code for an agent id invoked through the wrong subagent tool. */
+export const AGENT_MISMATCH = "AGENT_MISMATCH";
+
+/** Error code for a registered agent that cannot be reached. */
+export const AGENT_UNREACHABLE = "AGENT_UNREACHABLE";
+
+/** Error code for an agent that is starting or already running a turn. */
+export const AGENT_BUSY = "AGENT_BUSY";
+
+/**
+ * Stable identity of one delegated child, minted before its start side
+ * effect runs. The model-visible `id` derives from the first start
+ * operation, never from the child session id, so it exists before the
+ * child does and cannot collide on externally supplied session suffixes.
+ */
+export interface AgentIdentity {
+  /** Model-visible identifier: `ag_<name>:<operation-hash>`. */
   readonly id: string;
-  readonly relationship: "child" | "parent";
   /** Subagent tool name. */
   readonly name: string;
-  /** Agent-graph node used to re-resolve remote headers. */
+  /** Agent-graph node used to re-resolve delivery configuration. */
   readonly nodeId: string;
-  readonly sessionId: string;
-  /** Private delivery credential; never model-visible. */
-  readonly continuationToken: string;
-  /** Short task description captured from the latest delegation tool call. */
-  readonly description?: string;
-  /** Latest one-line output snippet, truncated to 120 characters. */
-  readonly lastStatus?: string;
-  /** ISO timestamp for the latest handle update. */
-  readonly updatedAt: string;
 }
 
-/** Handle to a delegated agent running in the same deployment. */
-export interface LocalAgentHandle extends AgentHandleBase {
-  readonly kind: "agent/local";
+/**
+ * One dispatch the parent intends to perform or has performed. Repeating
+ * the same operation is a replay; a different operation against a
+ * starting/running handle is a busy conflict.
+ */
+export interface StartOperation {
+  readonly kind: "start";
+  /** Derived via {@link deriveAgentOperationId}; stable across replays. */
+  readonly id: string;
+  readonly callId: string;
+  readonly parentTurnId: string;
 }
 
-/** Handle to a runtime-defined agent running in the same deployment. */
-export interface RuntimeAgentHandle extends AgentHandleBase {
-  readonly kind: "agent/runtime";
-}
-
-/** Handle to a delegated agent running on another deployment. */
-export interface RemoteAgentHandle extends AgentHandleBase {
-  readonly kind: "agent/remote";
-  /** Deliver target base URL; never model-visible. */
-  readonly url: string;
+/** A continuation delivery against a parked handle. */
+export interface ContinueOperation {
+  readonly kind: "continue";
+  /** Derived via {@link deriveAgentOperationId}; stable across replays. */
+  readonly id: string;
+  readonly callId: string;
+  readonly parentTurnId: string;
   /**
-   * Callback base URL stub captured when the remote child was dispatched.
-   * Continuation binds the current parent token to this stub. Never
-   * model-visible.
+   * Status the handle showed before this delivery, restored when the
+   * delivery is rejected as retryable so the handle returns to `parked`
+   * without optional state.
    */
-  readonly callbackBaseUrl: string;
+  readonly previousStatus: string;
 }
 
-/** Durable delivery coordinates for one delegated agent. */
-export type AgentHandle = LocalAgentHandle | RuntimeAgentHandle | RemoteAgentHandle;
+/** Where a fresh child will be started. No session exists yet. */
+export type AgentStartTarget =
+  | {
+      readonly kind: "agent/local";
+      /** Deterministic child continuation token chosen at dispatch. */
+      readonly continuationToken: string;
+    }
+  | {
+      readonly kind: "agent/self";
+      readonly continuationToken: string;
+    }
+  | {
+      readonly kind: "agent/remote";
+      /** Deliver target base URL; never model-visible. */
+      readonly url: string;
+      /** Callback base URL stub captured at dispatch; never model-visible. */
+      readonly callbackBaseUrl: string;
+    };
+
+/** Confirmed delivery coordinates of a started child. */
+export type AgentAddress =
+  | {
+      readonly kind: "agent/local";
+      readonly sessionId: string;
+      readonly continuationToken: string;
+    }
+  | {
+      readonly kind: "agent/self";
+      readonly sessionId: string;
+      readonly continuationToken: string;
+    }
+  | {
+      readonly kind: "agent/remote";
+      readonly sessionId: string;
+      readonly continuationToken: string;
+      readonly url: string;
+      readonly callbackBaseUrl: string;
+    };
+
+/**
+ * Durable ownership record for one delegated child.
+ *
+ * The store owns the full nonterminal lifecycle:
+ *
+ * - `starting` — the parent committed intent to start; the child may or
+ *   may not exist yet.
+ * - `running` — one identified child turn is outstanding.
+ * - `parked` — the child is idle and resumable; only this phase is
+ *   model-visible.
+ *
+ * A terminal child has no handle: settlement deletes it.
+ */
+export type AgentHandle =
+  | {
+      readonly phase: "starting";
+      readonly identity: AgentIdentity;
+      readonly operation: StartOperation;
+      readonly target: AgentStartTarget;
+    }
+  | {
+      readonly phase: "running";
+      readonly identity: AgentIdentity;
+      readonly operation: StartOperation | ContinueOperation;
+      readonly address: AgentAddress;
+    }
+  | {
+      readonly phase: "parked";
+      readonly identity: AgentIdentity;
+      readonly address: AgentAddress;
+      readonly lastStatus: string;
+    };
+
+/** Lifecycle phase of a delegated agent handle. */
+export type AgentHandlePhase = AgentHandle["phase"];
 
 /** Session-state collection of delegated agent handles. */
 export interface AgentHandleStore {
   readonly handles: readonly AgentHandle[];
 }
 
-const agentHandleBaseShape = {
-  continuationToken: z.string(),
-  description: z.string().optional(),
-  id: z.string(),
-  lastStatus: z.string().optional(),
-  name: z.string(),
-  nodeId: z.string(),
-  relationship: z.enum(["child", "parent"]),
-  sessionId: z.string(),
-  updatedAt: z.string(),
-};
+const nonEmptyString = z.string().min(1);
 
-const agentHandleSchema: z.ZodType<AgentHandle> = z.discriminatedUnion("kind", [
-  z.object({ ...agentHandleBaseShape, kind: z.literal("agent/local") }),
-  z.object({ ...agentHandleBaseShape, kind: z.literal("agent/runtime") }),
-  z.object({
-    ...agentHandleBaseShape,
-    callbackBaseUrl: z.string(),
+const identitySchema = z.strictObject({
+  id: nonEmptyString,
+  name: nonEmptyString,
+  nodeId: nonEmptyString,
+});
+
+const startOperationSchema = z.strictObject({
+  callId: nonEmptyString,
+  id: nonEmptyString,
+  kind: z.literal("start"),
+  parentTurnId: nonEmptyString,
+});
+
+const continueOperationSchema = z.strictObject({
+  callId: nonEmptyString,
+  id: nonEmptyString,
+  kind: z.literal("continue"),
+  parentTurnId: nonEmptyString,
+  previousStatus: z.string().max(MAX_STATUS_LENGTH),
+});
+
+const startTargetSchema: z.ZodType<AgentStartTarget> = z.discriminatedUnion("kind", [
+  z.strictObject({ continuationToken: nonEmptyString, kind: z.literal("agent/local") }),
+  z.strictObject({ continuationToken: nonEmptyString, kind: z.literal("agent/self") }),
+  z.strictObject({
+    callbackBaseUrl: z.url(),
     kind: z.literal("agent/remote"),
-    url: z.string(),
+    url: z.url(),
   }),
 ]);
 
-const agentHandleStoreSchema: z.ZodType<AgentHandleStore> = z.object({
-  handles: z.array(agentHandleSchema),
-});
+const addressSchema: z.ZodType<AgentAddress> = z.discriminatedUnion("kind", [
+  z.strictObject({
+    continuationToken: nonEmptyString,
+    kind: z.literal("agent/local"),
+    sessionId: nonEmptyString,
+  }),
+  z.strictObject({
+    continuationToken: nonEmptyString,
+    kind: z.literal("agent/self"),
+    sessionId: nonEmptyString,
+  }),
+  z.strictObject({
+    callbackBaseUrl: z.url(),
+    continuationToken: nonEmptyString,
+    kind: z.literal("agent/remote"),
+    sessionId: nonEmptyString,
+    url: z.url(),
+  }),
+]);
 
-/** Error code for a requested agent that is not registered. */
-export const AGENT_UNKNOWN = "AGENT_UNKNOWN";
+const agentHandleSchema: z.ZodType<AgentHandle> = z.discriminatedUnion("phase", [
+  z.strictObject({
+    identity: identitySchema,
+    operation: startOperationSchema,
+    phase: z.literal("starting"),
+    target: startTargetSchema,
+  }),
+  z.strictObject({
+    address: addressSchema,
+    identity: identitySchema,
+    operation: z.discriminatedUnion("kind", [startOperationSchema, continueOperationSchema]),
+    phase: z.literal("running"),
+  }),
+  z.strictObject({
+    address: addressSchema,
+    identity: identitySchema,
+    lastStatus: z.string().max(MAX_STATUS_LENGTH),
+    phase: z.literal("parked"),
+  }),
+]);
 
-/** Error code for delivery coordinates that do not match the registered agent. */
-export const AGENT_MISMATCH = "AGENT_MISMATCH";
+const agentHandleStoreSchema: z.ZodType<AgentHandleStore> = z
+  .strictObject({
+    handles: z.array(agentHandleSchema),
+  })
+  .refine(
+    (store) =>
+      new Set(store.handles.map((handle) => handle.identity.id)).size === store.handles.length,
+    { message: "Agent handle ids must be unique." },
+  );
 
-/** Error code for a registered agent that cannot be reached. */
-export const AGENT_UNREACHABLE = "AGENT_UNREACHABLE";
+/**
+ * Derives the stable operation id for one dispatch. All three inputs are
+ * parent-controlled, so the id exists before any child does and replaying
+ * the same call produces the same operation.
+ */
+export function deriveAgentOperationId(input: {
+  readonly callId: string;
+  readonly parentSessionId: string;
+  readonly parentTurnId: string;
+}): string {
+  return createHash("sha256")
+    .update(`${input.parentSessionId}\0${input.parentTurnId}\0${input.callId}`)
+    .digest("hex");
+}
 
-/** Derives the model-visible agent identifier for a delegated agent session. */
-export function deriveAgentId(name: string, sessionId: string): string {
-  return `ag_${name}:${sessionId.slice(-12)}`;
+/** Derives the model-visible agent id from the first start operation. */
+export function deriveAgentId(name: string, startOperationId: string): string {
+  return `ag_${name}:${startOperationId.slice(0, 12)}`;
+}
+
+/** Collapses whitespace and truncates output into a handle status line. */
+export function formatAgentStatus(output: unknown): string {
+  const text = typeof output === "string" ? output : (JSON.stringify(output) ?? "");
+  return text.replaceAll(/\s+/g, " ").trim().slice(0, MAX_STATUS_LENGTH);
 }
 
 /**
@@ -106,7 +260,7 @@ export function deriveAgentId(name: string, sessionId: string): string {
  *
  * Returns `undefined` only when no store has been written. A present but
  * invalid store throws: treating corruption as absence would let the next
- * upsert silently replace every delegated child's delivery coordinates.
+ * transition silently replace every delegated child's delivery coordinates.
  */
 export function getAgentHandleStore(
   state: SessionStateMap | undefined,
@@ -124,49 +278,290 @@ export function getAgentHandleStore(
   return parsed.data;
 }
 
-/** Returns a session with the handle inserted or replaced by identifier. */
-export function upsertAgentHandle(session: HarnessSession, handle: AgentHandle): HarnessSession {
+/**
+ * Records intent to start a fresh child. Must commit before the start
+ * side effect runs so a crashed dispatch never orphans an unowned child.
+ *
+ * Throws when the identity or operation already exists: fresh starts mint
+ * a new identity, so a collision means corrupted derivation, not a replay.
+ */
+export function prepareAgentStart(
+  session: HarnessSession,
+  input: {
+    readonly identity: AgentIdentity;
+    readonly operation: StartOperation;
+    readonly target: AgentStartTarget;
+  },
+): HarnessSession {
   const handles = getAgentHandleStore(session.state)?.handles ?? [];
-  const existingIndex = handles.findIndex((existing) => existing.id === handle.id);
-  const nextHandles =
-    existingIndex === -1
-      ? [...handles, handle]
-      : handles.map((existing, index) => (index === existingIndex ? handle : existing));
-
-  return {
-    ...session,
-    state: {
-      ...session.state,
-      [AGENT_HANDLES_STATE_KEY]: { handles: nextHandles } satisfies AgentHandleStore,
+  if (handles.some((handle) => handle.identity.id === input.identity.id)) {
+    throw new Error(`Agent handle "${input.identity.id}" already exists.`);
+  }
+  return writeHandles(session, [
+    ...handles,
+    {
+      identity: input.identity,
+      operation: input.operation,
+      phase: "starting",
+      target: input.target,
     },
+  ]);
+}
+
+/** Result of preparing a continuation against an existing handle. */
+export type PrepareAgentContinuationResult =
+  | {
+      readonly kind: "ready";
+      readonly session: HarnessSession;
+      readonly handle: Extract<AgentHandle, { phase: "running" }>;
+    }
+  | { readonly kind: "unknown" }
+  | { readonly kind: "mismatch" }
+  | { readonly kind: "busy" };
+
+/**
+ * Records intent to deliver a follow-up turn to a parked child. Must
+ * commit before the delivery side effect runs.
+ *
+ * `unknown`, `mismatch`, and `busy` do not change the session; the caller
+ * maps them onto {@link AGENT_UNKNOWN}, {@link AGENT_MISMATCH}, and
+ * {@link AGENT_BUSY} results. Replaying the operation already recorded on
+ * a running handle returns `ready` with the unchanged session.
+ */
+export function prepareAgentContinuation(
+  session: HarnessSession,
+  input: {
+    readonly agentId: string;
+    readonly invokedName: string;
+    readonly operation: ContinueOperation;
+  },
+): PrepareAgentContinuationResult {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existing = handles.find((handle) => handle.identity.id === input.agentId);
+  if (existing === undefined) {
+    return { kind: "unknown" };
+  }
+  if (existing.identity.name !== input.invokedName) {
+    return { kind: "mismatch" };
+  }
+  if (existing.phase === "running" && existing.operation.id === input.operation.id) {
+    return { handle: existing, kind: "ready", session };
+  }
+  if (existing.phase !== "parked") {
+    return { kind: "busy" };
+  }
+
+  const running: Extract<AgentHandle, { phase: "running" }> = {
+    address: existing.address,
+    identity: existing.identity,
+    operation: { ...input.operation, previousStatus: existing.lastStatus },
+    phase: "running",
+  };
+  return {
+    handle: running,
+    kind: "ready",
+    session: writeHandles(
+      session,
+      handles.map((handle) => (handle.identity.id === input.agentId ? running : handle)),
+    ),
   };
 }
 
-/** Returns a session without the handle, preserving identity when it is absent. */
-export function removeAgentHandle(session: HarnessSession, id: string): HarnessSession {
-  const store = getAgentHandleStore(session.state);
-  if (store === undefined || !store.handles.some((handle) => handle.id === id)) {
+type ActiveAgentHandle = Extract<AgentHandle, { phase: "starting" | "running" }>;
+
+function findActiveHandle(
+  handles: readonly AgentHandle[],
+  operationId: string,
+): ActiveAgentHandle | undefined {
+  return handles.find(
+    (handle): handle is ActiveAgentHandle =>
+      handle.phase !== "parked" && handle.operation.id === operationId,
+  );
+}
+
+/**
+ * Confirms a started child: `starting` becomes `running` with the child's
+ * confirmed address. Throws when no starting handle carries the operation,
+ * because confirming an unprepared start means ownership was never
+ * committed. Re-confirming an already-running handle with the same
+ * operation and address is a replay no-op.
+ */
+export function confirmAgentStarted(
+  session: HarnessSession,
+  input: {
+    readonly operationId: string;
+    readonly address: AgentAddress;
+  },
+): HarnessSession {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existing = findActiveHandle(handles, input.operationId);
+  if (existing === undefined) {
+    throw new Error(`No prepared agent handle for operation "${input.operationId}".`);
+  }
+  if (existing.phase === "running") {
     return session;
   }
 
+  return writeHandles(
+    session,
+    handles.map((handle) =>
+      handle === existing
+        ? {
+            address: input.address,
+            identity: existing.identity,
+            operation: existing.operation,
+            phase: "running",
+          }
+        : handle,
+    ),
+  );
+}
+
+/**
+ * Resolves a dispatch that definitively failed.
+ *
+ * - A dead start or dead continuation deletes the handle: there is no
+ *   child left to own.
+ * - A retryable continuation failure restores `parked` with the status the
+ *   handle showed before the delivery, so the model may retry the same
+ *   `agentId` later.
+ *
+ * Unknown operations are a no-op: the failure raced a settlement that
+ * already resolved the handle.
+ */
+export function rejectAgentEffect(
+  session: HarnessSession,
+  input: {
+    readonly operationId: string;
+    readonly disposition: "dead" | "retryable";
+  },
+): HarnessSession {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existing = findActiveHandle(handles, input.operationId);
+  if (existing === undefined) {
+    return session;
+  }
+
+  if (input.disposition === "retryable" && existing.phase === "running") {
+    const { operation } = existing;
+    if (operation.kind === "continue") {
+      return writeHandles(
+        session,
+        handles.map((handle) =>
+          handle === existing
+            ? {
+                address: existing.address,
+                identity: existing.identity,
+                lastStatus: operation.previousStatus,
+                phase: "parked",
+              }
+            : handle,
+        ),
+      );
+    }
+  }
+
+  return writeHandles(
+    session,
+    handles.filter((handle) => handle !== existing),
+  );
+}
+
+/** Result of applying a settled child turn to the store. */
+export type SettleAgentTurnResult =
+  | { readonly kind: "settled"; readonly session: HarnessSession }
+  | { readonly kind: "ignored"; readonly reason: "unknown-operation" | "session-mismatch" };
+
+/**
+ * Applies one settled child turn: `running` becomes `parked` for a parked
+ * outcome or is deleted for a terminal outcome.
+ *
+ * The settlement must carry the operation currently recorded on the
+ * running handle and the child session the address confirms; anything else
+ * is ignored so a stale or forged delivery can never move a newer turn.
+ */
+export function settleAgentTurn(
+  session: HarnessSession,
+  input: {
+    readonly operationId: string;
+    readonly sessionId: string;
+    readonly outcome: AgentTurnOutcome;
+  },
+): SettleAgentTurnResult {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existing = handles.find(
+    (handle) => handle.phase === "running" && handle.operation.id === input.operationId,
+  );
+  if (existing === undefined || existing.phase !== "running") {
+    return { kind: "ignored", reason: "unknown-operation" };
+  }
+  if (existing.address.sessionId !== input.sessionId) {
+    return { kind: "ignored", reason: "session-mismatch" };
+  }
+
+  if (input.outcome.kind === "terminal") {
+    return {
+      kind: "settled",
+      session: writeHandles(
+        session,
+        handles.filter((handle) => handle !== existing),
+      ),
+    };
+  }
+
+  const { result } = input.outcome;
+  const lastStatus =
+    result.kind === "succeeded"
+      ? formatAgentStatus(result.output)
+      : result.kind === "failed"
+        ? formatAgentStatus(result.error)
+        : "(cancelled)";
+  return {
+    kind: "settled",
+    session: writeHandles(
+      session,
+      handles.map((handle) =>
+        handle === existing
+          ? {
+              address: existing.address,
+              identity: existing.identity,
+              lastStatus,
+              phase: "parked",
+            }
+          : handle,
+      ),
+    ),
+  };
+}
+
+/** Returns the resumable handles: the only phase the model may continue. */
+export function projectParkedAgentHandles(
+  store: AgentHandleStore,
+): readonly Extract<AgentHandle, { phase: "parked" }>[] {
+  return store.handles.filter((handle) => handle.phase === "parked");
+}
+
+/**
+ * Renders the model-visible agent listing. Only parked handles appear:
+ * starting and running children cannot accept a continuation, and private
+ * delivery coordinates never render.
+ */
+export function renderAgentsSnippet(store: AgentHandleStore): string {
+  const agents = projectParkedAgentHandles(store).map(
+    (handle) =>
+      `<agent id="${escapeXml(handle.identity.id)}" name="${escapeXml(handle.identity.name)}">${escapeXml(handle.lastStatus === "" ? "(no status)" : handle.lastStatus)}</agent>`,
+  );
+  return [AGENTS_SNIPPET_LABEL, "<agents>", ...agents, "</agents>"].join("\n");
+}
+
+function writeHandles(session: HarnessSession, handles: readonly AgentHandle[]): HarnessSession {
   return {
     ...session,
     state: {
       ...session.state,
-      [AGENT_HANDLES_STATE_KEY]: {
-        handles: store.handles.filter((handle) => handle.id !== id),
-      } satisfies AgentHandleStore,
+      [AGENT_HANDLES_STATE_KEY]: { handles } satisfies AgentHandleStore,
     },
   };
-}
-
-/** Renders the model-visible agent listing without private delivery coordinates. */
-export function renderAgentsSnippet(store: AgentHandleStore): string {
-  const agents = store.handles.map(
-    (handle) =>
-      `<agent id="${escapeXml(handle.id)}" name="${escapeXml(handle.name)}">${escapeXml(handle.lastStatus ?? "(no status)")}</agent>`,
-  );
-  return [AGENTS_SNIPPET_LABEL, "<agents>", ...agents, "</agents>"].join("\n");
 }
 
 function escapeXml(value: string): string {

--- a/packages/eve/src/harness/agent-handles.ts
+++ b/packages/eve/src/harness/agent-handles.ts
@@ -1,10 +1,10 @@
 import { z } from "#compiled/zod/index.js";
 
-import { AGENTS_SNIPPET_LABEL } from "#harness/compaction-prompt.js";
 import type { HarnessSession, SessionStateMap } from "#harness/types.js";
 
 /** Session-state key for delegated agent handles. */
 export const AGENT_HANDLES_STATE_KEY = "eve.agent.handles";
+const AGENTS_SNIPPET_LABEL = "[Agents]";
 
 /** Delivery category for a delegated agent handle. */
 export type AgentHandleKind = AgentHandle["kind"];

--- a/packages/eve/src/harness/agent-handles.ts
+++ b/packages/eve/src/harness/agent-handles.ts
@@ -1,0 +1,138 @@
+import { z } from "#compiled/zod/index.js";
+
+import { AGENTS_SNIPPET_LABEL } from "#harness/compaction-prompt.js";
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+
+/** Session-state key for delegated agent handles. */
+export const AGENT_HANDLES_STATE_KEY = "eve.agent.handles";
+
+/** Delivery category for a delegated agent handle. */
+export type AgentHandleKind = "agent/local" | "agent/remote" | "agent/runtime";
+
+/** Durable delivery coordinates for one delegated agent. */
+export interface AgentHandle {
+  /** Model-visible identifier derived from the tool name and session id. */
+  readonly id: string;
+  readonly kind: AgentHandleKind;
+  readonly relationship: "child" | "parent";
+  /** Deliver target base URL. Empty for the same deployment; never model-visible. */
+  readonly url: string;
+  /** Subagent tool name. */
+  readonly name: string;
+  /** Agent-graph node used to re-resolve remote headers. */
+  readonly nodeId: string;
+  readonly sessionId: string;
+  /** Private delivery credential; never model-visible. */
+  readonly continuationToken: string;
+  /** Short task description captured from the latest delegation tool call. */
+  readonly description?: string;
+  /**
+   * Callback base URL stub captured when the remote child was dispatched.
+   * Continuation binds the current parent token to this stub; only present
+   * for `agent/remote` handles. Never model-visible.
+   */
+  readonly callbackBaseUrl?: string;
+  /** Latest one-line output snippet, truncated to 120 characters. */
+  readonly lastStatus?: string;
+  /** ISO timestamp for the latest handle update. */
+  readonly updatedAt: string;
+}
+
+/** Session-state collection of delegated agent handles. */
+export interface AgentHandleStore {
+  readonly handles: readonly AgentHandle[];
+}
+
+const agentHandleSchema: z.ZodType<AgentHandle> = z.object({
+  callbackBaseUrl: z.string().optional(),
+  continuationToken: z.string(),
+  description: z.string().optional(),
+  id: z.string(),
+  kind: z.enum(["agent/local", "agent/remote", "agent/runtime"]),
+  lastStatus: z.string().optional(),
+  name: z.string(),
+  nodeId: z.string(),
+  relationship: z.enum(["child", "parent"]),
+  sessionId: z.string(),
+  updatedAt: z.string(),
+  url: z.string(),
+});
+
+const agentHandleStoreSchema: z.ZodType<AgentHandleStore> = z.object({
+  handles: z.array(agentHandleSchema),
+});
+
+/** Error code for a requested agent that is not registered. */
+export const AGENT_UNKNOWN = "AGENT_UNKNOWN";
+
+/** Error code for delivery coordinates that do not match the registered agent. */
+export const AGENT_MISMATCH = "AGENT_MISMATCH";
+
+/** Error code for a registered agent that cannot be reached. */
+export const AGENT_UNREACHABLE = "AGENT_UNREACHABLE";
+
+/** Derives the model-visible agent identifier for a delegated agent session. */
+export function deriveAgentId(name: string, sessionId: string): string {
+  return `ag_${name}:${sessionId.slice(-12)}`;
+}
+
+/** Reads and validates the agent handle store from session state. */
+export function getAgentHandleStore(
+  state: SessionStateMap | undefined,
+): AgentHandleStore | undefined {
+  const parsed = agentHandleStoreSchema.safeParse(state?.[AGENT_HANDLES_STATE_KEY]);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Returns a session with the handle inserted or replaced by identifier. */
+export function upsertAgentHandle(session: HarnessSession, handle: AgentHandle): HarnessSession {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existingIndex = handles.findIndex((existing) => existing.id === handle.id);
+  const nextHandles =
+    existingIndex === -1
+      ? [...handles, handle]
+      : handles.map((existing, index) => (index === existingIndex ? handle : existing));
+
+  return {
+    ...session,
+    state: {
+      ...session.state,
+      [AGENT_HANDLES_STATE_KEY]: { handles: nextHandles } satisfies AgentHandleStore,
+    },
+  };
+}
+
+/** Returns a session without the handle, preserving identity when it is absent. */
+export function removeAgentHandle(session: HarnessSession, id: string): HarnessSession {
+  const store = getAgentHandleStore(session.state);
+  if (store === undefined || !store.handles.some((handle) => handle.id === id)) {
+    return session;
+  }
+
+  return {
+    ...session,
+    state: {
+      ...session.state,
+      [AGENT_HANDLES_STATE_KEY]: {
+        handles: store.handles.filter((handle) => handle.id !== id),
+      } satisfies AgentHandleStore,
+    },
+  };
+}
+
+/** Renders the model-visible agent listing without private delivery coordinates. */
+export function renderAgentsSnippet(store: AgentHandleStore): string {
+  const agents = store.handles.map(
+    (handle) =>
+      `<agent id="${escapeXml(handle.id)}" name="${escapeXml(handle.name)}">${escapeXml(handle.lastStatus ?? "(no status)")}</agent>`,
+  );
+  return [AGENTS_SNIPPET_LABEL, "<agents>", ...agents, "</agents>"].join("\n");
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}

--- a/packages/eve/src/harness/agent-handles.ts
+++ b/packages/eve/src/harness/agent-handles.ts
@@ -7,16 +7,13 @@ import type { HarnessSession, SessionStateMap } from "#harness/types.js";
 export const AGENT_HANDLES_STATE_KEY = "eve.agent.handles";
 
 /** Delivery category for a delegated agent handle. */
-export type AgentHandleKind = "agent/local" | "agent/remote" | "agent/runtime";
+export type AgentHandleKind = AgentHandle["kind"];
 
-/** Durable delivery coordinates for one delegated agent. */
-export interface AgentHandle {
+/** Fields shared by every delegated agent handle. */
+interface AgentHandleBase {
   /** Model-visible identifier derived from the tool name and session id. */
   readonly id: string;
-  readonly kind: AgentHandleKind;
   readonly relationship: "child" | "parent";
-  /** Deliver target base URL. Empty for the same deployment; never model-visible. */
-  readonly url: string;
   /** Subagent tool name. */
   readonly name: string;
   /** Agent-graph node used to re-resolve remote headers. */
@@ -26,37 +23,65 @@ export interface AgentHandle {
   readonly continuationToken: string;
   /** Short task description captured from the latest delegation tool call. */
   readonly description?: string;
-  /**
-   * Callback base URL stub captured when the remote child was dispatched.
-   * Continuation binds the current parent token to this stub; only present
-   * for `agent/remote` handles. Never model-visible.
-   */
-  readonly callbackBaseUrl?: string;
   /** Latest one-line output snippet, truncated to 120 characters. */
   readonly lastStatus?: string;
   /** ISO timestamp for the latest handle update. */
   readonly updatedAt: string;
 }
 
+/** Handle to a delegated agent running in the same deployment. */
+export interface LocalAgentHandle extends AgentHandleBase {
+  readonly kind: "agent/local";
+}
+
+/** Handle to a runtime-defined agent running in the same deployment. */
+export interface RuntimeAgentHandle extends AgentHandleBase {
+  readonly kind: "agent/runtime";
+}
+
+/** Handle to a delegated agent running on another deployment. */
+export interface RemoteAgentHandle extends AgentHandleBase {
+  readonly kind: "agent/remote";
+  /** Deliver target base URL; never model-visible. */
+  readonly url: string;
+  /**
+   * Callback base URL stub captured when the remote child was dispatched.
+   * Continuation binds the current parent token to this stub. Never
+   * model-visible.
+   */
+  readonly callbackBaseUrl: string;
+}
+
+/** Durable delivery coordinates for one delegated agent. */
+export type AgentHandle = LocalAgentHandle | RuntimeAgentHandle | RemoteAgentHandle;
+
 /** Session-state collection of delegated agent handles. */
 export interface AgentHandleStore {
   readonly handles: readonly AgentHandle[];
 }
 
-const agentHandleSchema: z.ZodType<AgentHandle> = z.object({
-  callbackBaseUrl: z.string().optional(),
+const agentHandleBaseShape = {
   continuationToken: z.string(),
   description: z.string().optional(),
   id: z.string(),
-  kind: z.enum(["agent/local", "agent/remote", "agent/runtime"]),
   lastStatus: z.string().optional(),
   name: z.string(),
   nodeId: z.string(),
   relationship: z.enum(["child", "parent"]),
   sessionId: z.string(),
   updatedAt: z.string(),
-  url: z.string(),
-});
+};
+
+const agentHandleSchema: z.ZodType<AgentHandle> = z.discriminatedUnion("kind", [
+  z.object({ ...agentHandleBaseShape, kind: z.literal("agent/local") }),
+  z.object({ ...agentHandleBaseShape, kind: z.literal("agent/runtime") }),
+  z.object({
+    ...agentHandleBaseShape,
+    callbackBaseUrl: z.string(),
+    kind: z.literal("agent/remote"),
+    url: z.string(),
+  }),
+]);
 
 const agentHandleStoreSchema: z.ZodType<AgentHandleStore> = z.object({
   handles: z.array(agentHandleSchema),
@@ -76,12 +101,27 @@ export function deriveAgentId(name: string, sessionId: string): string {
   return `ag_${name}:${sessionId.slice(-12)}`;
 }
 
-/** Reads and validates the agent handle store from session state. */
+/**
+ * Reads and validates the agent handle store from session state.
+ *
+ * Returns `undefined` only when no store has been written. A present but
+ * invalid store throws: treating corruption as absence would let the next
+ * upsert silently replace every delegated child's delivery coordinates.
+ */
 export function getAgentHandleStore(
   state: SessionStateMap | undefined,
 ): AgentHandleStore | undefined {
-  const parsed = agentHandleStoreSchema.safeParse(state?.[AGENT_HANDLES_STATE_KEY]);
-  return parsed.success ? parsed.data : undefined;
+  const raw = state?.[AGENT_HANDLES_STATE_KEY];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = agentHandleStoreSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Corrupt agent handle store under session state key "${AGENT_HANDLES_STATE_KEY}": ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
 }
 
 /** Returns a session with the handle inserted or replaced by identifier. */

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -15,6 +15,12 @@ export const COMPACTION_RESUMPTION_MESSAGE = "Continue.";
 export const TODO_COMPACTION_PRESERVATION_LABEL =
   "[Your task list was preserved across context compaction]";
 
+/**
+ * Label line of the framework-injected agents snippet. Owned here
+ * so compaction can recognize the snippet as synthetic.
+ */
+export const AGENTS_SNIPPET_LABEL = "[Agents]";
+
 const COMPACTION_SYSTEM_PROMPT = `You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.
 
 Include:

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -15,12 +15,6 @@ export const COMPACTION_RESUMPTION_MESSAGE = "Continue.";
 export const TODO_COMPACTION_PRESERVATION_LABEL =
   "[Your task list was preserved across context compaction]";
 
-/**
- * Label line of the framework-injected agents snippet. Owned here
- * so compaction can recognize the snippet as synthetic.
- */
-export const AGENTS_SNIPPET_LABEL = "[Agents]";
-
 const COMPACTION_SYSTEM_PROMPT = `You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.
 
 Include:

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -9,6 +9,7 @@ import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import type { InputResponse } from "#runtime/input/types.js";
 import type { SandboxState } from "#sandbox/state.js";
 import type { JsonObject } from "#shared/json.js";
+import type { TokenUsage } from "#shared/token-usage.js";
 import type { InternalToolDefinition } from "#shared/tool-definition.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
@@ -166,12 +167,24 @@ export interface StepDone {
  */
 export type StepNext = StepDone | StepFn | null;
 
+/** User-facing answer produced when a conversation turn settles. */
+export interface SettledTurn {
+  readonly output: unknown;
+  readonly isError?: boolean;
+  readonly usage?: TokenUsage;
+}
+
 /**
  * Result returned by one harness step invocation.
  */
 export interface StepResult {
   readonly next: StepNext;
   readonly session: HarnessSession;
+  /**
+   * Present when a conversation turn settled with a user-facing answer; carried
+   * across the park boundary so a delegated parent can be notified.
+   */
+  readonly settledTurn?: SettledTurn;
 }
 
 /**

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -238,6 +238,34 @@ describe("normalizeAgentDefinition", () => {
       ),
     ).toThrow('"experimental.workflow.world" must be a non-empty package name');
   });
+
+  it("accepts a boolean subagentPersistentSessions flag", () => {
+    const definition = normalizeAgentDefinition(
+      {
+        model: "openai/gpt-5.5",
+        experimental: {
+          subagentPersistentSessions: true,
+        },
+      },
+      FAILURE_MESSAGE,
+    );
+
+    expect(definition.experimental?.subagentPersistentSessions).toBe(true);
+  });
+
+  it("rejects non-boolean subagentPersistentSessions values", () => {
+    expect(() =>
+      normalizeAgentDefinition(
+        {
+          model: "openai/gpt-5.5",
+          experimental: {
+            subagentPersistentSessions: "yes",
+          },
+        },
+        FAILURE_MESSAGE,
+      ),
+    ).toThrow('"experimental.subagentPersistentSessions" must be a boolean.');
+  });
 });
 
 describe("normalizeScheduleDefinition", () => {

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -257,8 +257,15 @@ function normalizeAgentExperimentalDefinition(
   message: string,
 ): NonNullable<NormalizedAgentDefinition["experimental"]> {
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["workflow"], message);
+  expectOnlyKnownKeys(record, ["subagentPersistentSessions", "workflow"], message);
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["experimental"]>> = {};
+
+  if (record.subagentPersistentSessions !== undefined) {
+    if (typeof record.subagentPersistentSessions !== "boolean") {
+      throw new Error(`${message} "experimental.subagentPersistentSessions" must be a boolean.`);
+    }
+    normalizedDefinition.subagentPersistentSessions = record.subagentPersistentSessions;
+  }
 
   if (record.workflow !== undefined) {
     normalizedDefinition.workflow = normalizeAgentWorkflowDefinition(record.workflow, message);

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -226,6 +226,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
 
   if (manifest.config.experimental !== undefined) {
     config.experimental = {
+      subagentPersistentSessions: manifest.config.experimental.subagentPersistentSessions,
       workflow:
         manifest.config.experimental.workflow === undefined
           ? undefined

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -197,6 +197,13 @@ export interface AgentLimitsDefinition {
  */
 export interface AgentExperimentalDefinition {
   /**
+   * Keeps this agent's delegated subagent sessions alive after they answer.
+   * The model can pass `agentId` to a subagent tool to continue a previous
+   * delegation, and the system prompt documents the `<agents>` listing.
+   * When unset, delegated children run as one-shot tasks.
+   */
+  readonly subagentPersistentSessions?: boolean;
+  /**
    * Durable Workflow runtime configuration. Root agents may use this to select
    * the Workflow world backing sessions and runs.
    */

--- a/packages/eve/src/shared/agent-turn-outcome.ts
+++ b/packages/eve/src/shared/agent-turn-outcome.ts
@@ -1,0 +1,84 @@
+import { z } from "#compiled/zod/index.js";
+
+import type { JsonValue } from "#shared/json.js";
+import { tokenUsageSchema, type TokenUsage } from "#shared/token-usage.js";
+
+/**
+ * What one delegated child turn produced, independent of whether the child
+ * session survived it.
+ */
+export type AgentTurnResult =
+  | {
+      readonly kind: "succeeded";
+      readonly output: JsonValue;
+    }
+  | {
+      readonly kind: "failed";
+      readonly error: JsonValue;
+    }
+  | {
+      readonly kind: "cancelled";
+    };
+
+/**
+ * How one delegated child turn settled.
+ *
+ * `parked` means the child session survived the turn and can accept another
+ * delivery; `terminal` means the child session ended with this turn. The
+ * lifecycle is carried explicitly: a failed turn can leave the child parked,
+ * and a succeeded turn can be terminal (task mode). Consumers must never
+ * infer lifecycle from success or error codes.
+ *
+ * `usageDelta` is the provider-reported usage this turn added to the child's
+ * session subtree: the child captures its session totals at turn entry and
+ * reports final-minus-entry when the turn settles. The parent folds each
+ * delta exactly once, so repeated turns of a persistent child never re-report
+ * earlier turns.
+ */
+export type AgentTurnOutcome =
+  | {
+      readonly kind: "parked";
+      readonly result: AgentTurnResult;
+      readonly usageDelta: TokenUsage;
+    }
+  | {
+      readonly kind: "terminal";
+      readonly result: AgentTurnResult;
+      readonly usageDelta: TokenUsage;
+    };
+
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.null(),
+    z.boolean(),
+    z.number(),
+    z.string(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
+
+const agentTurnResultSchema: z.ZodType<AgentTurnResult> = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("succeeded"), output: jsonValueSchema }),
+  z.strictObject({ error: jsonValueSchema, kind: z.literal("failed") }),
+  z.strictObject({ kind: z.literal("cancelled") }),
+]);
+
+/**
+ * Zod schema for {@link AgentTurnOutcome}.
+ *
+ * Validates outcomes crossing the process boundary (remote session
+ * callbacks). Local notification paths construct the type directly.
+ */
+export const agentTurnOutcomeSchema: z.ZodType<AgentTurnOutcome> = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("parked"),
+    result: agentTurnResultSchema,
+    usageDelta: tokenUsageSchema,
+  }),
+  z.strictObject({
+    kind: z.literal("terminal"),
+    result: agentTurnResultSchema,
+    usageDelta: tokenUsageSchema,
+  }),
+]);


### PR DESCRIPTION
Part 1 of 4 in the agent-messaging stack (contracts → addressing → engine → surface). Types, one session-state module, and the authoring flag. No observable behavior change; wiring lands in the next PRs.

Agent messaging lets a parent keep talking to a delegated conversation-mode child after it answers, instead of the child terminating on its first result. This PR defines the contracts the stack builds on, shaped around one invariant: **the handle store owns a child's whole nonterminal lifecycle, and nothing else does.**

**What**

- `AgentHandle` (`harness/agent-handles.ts`) is a three-phase union discriminated on `phase`: `starting` (intent recorded before the start side effect runs), `running` (one outstanding operation), `parked` (idle and resumable, the only phase the model ever sees). A terminal child has no handle; settlement deletes it. There is no terminal variant and no lifecycle-from-error-code classification anywhere in the contract.
- The store only changes through five transitions: `prepareAgentStart`, `prepareAgentContinuation`, `confirmAgentStarted`, `rejectAgentEffect`, `settleAgentTurn`. No generic upsert or remove; the raw writer is module-private. `prepareAgentContinuation` returns `unknown | mismatch | busy | ready`, so the dispatch layer maps addressing failures onto the closed error-code set (`AGENT_UNKNOWN`, `AGENT_MISMATCH`, `AGENT_BUSY`, `AGENT_UNREACHABLE`) without touching the store.
- Identity is minted before dispatch: `deriveAgentOperationId({ parentSessionId, parentTurnId, callId })` hashes parent-controlled inputs, and the model-visible id derives from that operation, not from the child session id. Ownership exists before the child does, and ids can't collide on externally supplied session suffixes.
- `AgentTurnOutcome` (`shared/agent-turn-outcome.ts`): `{ kind: "parked" | "terminal", result: succeeded | failed | cancelled, usageDelta }`. Lifecycle and success are separate axes. A failed turn can leave the child parked; a succeeded turn can be terminal. `usageDelta` is per-turn, which is what stops a persistent child's earlier turns being re-counted by the parent (the engine PR wires this).
- `SettledTurn` on `StepResult` (`harness/types.ts`) is how a step will report one settled delegated turn upward; `run-step.ts` now spreads the full step result through so the field survives the boundary. Nothing sets it in this PR.
- `TurnCaller` (`channel/types.ts`): the framework-internal caller waiting for one delegated turn, replying via a durable hook token (local) or callback URL (remote). `execution/session-callback-request.ts` adds the fetch wrapper those replies will use (30s timeout, redirects rejected); it has no callers until the engine PR.
- `experimental.subagentPersistentSessions` on `defineAgent`: declared here, consumed from the addressing PR onward.

The store schema is strict: unique ids, non-empty coordinates, validated URLs, 120-char status cap. A present-but-corrupt store throws instead of parsing as absent, because treating corruption as absence would let the next write silently replace every child's delivery coordinates.
