### PR TITLE
Add BlitzReels to integration registry

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1158,6 +1158,49 @@ See the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/ven
   },
 };
 const extensionPresentations: Record<string, ExtensionPresentation> = {
+  blitzreels: {
+    logo: "blitzreels",
+    docsHref: "https://www.npmjs.com/package/@blitzreels/eve",
+    keywords: [
+      "video editing",
+      "long form video",
+      "short clips",
+      "shorts",
+      "vertical video",
+      "visual qa",
+      "media generation",
+      "exports",
+    ],
+    install: `Install the BlitzReels extension for eve:
+
+\`\`\`bash
+eve add extension/blitzreels
+\`\`\`
+
+The extension requires Node.js 24 or later. It wraps the BlitzReels API with typed tools for clipping, project inspection, visual-QA repair, AI media generation, and exports.`,
+    quickStart: `Add a BlitzReels API key to the agent's environment:
+
+\`\`\`bash title=".env.local"
+BLITZREELS_API_KEY=br_live_...
+\`\`\`
+
+Then mount the extension under \`agent/extensions/\`:
+
+\`\`\`ts title="agent/extensions/blitzreels.ts"
+import blitzreels from "@blitzreels/eve";
+
+export default blitzreels({
+  apiKey: process.env.BLITZREELS_API_KEY!,
+});
+\`\`\`
+
+The filename supplies the \`blitzreels\` namespace. The extension adds project, media, clipping, repair, generation, snapshot, and export tools such as \`blitzreels__create_clip_batch\`, \`blitzreels__repair_clip\`, and \`blitzreels__start_export\`. It also ships a clipping skill that teaches the agent the long-form-to-shorts workflow and visual-QA repair loop.`,
+    configure: `Keep the API key in the environment rather than prompts or source control. Keys are environment-bounded: use \`br_live_...\` with the production API, and use \`br_test_...\` only with the matching local or development \`baseUrl\`.
+
+Source imports, clipping, generation, and exports call the configured BlitzReels API. Credit-spending, download, and render tools require eve approval by default, and durable retries reuse the original call receipt instead of spending twice. Override an individual tool from a directory mount when it needs stricter \`always()\` approval, or use \`disableTool()\` to remove it.
+
+See the [BlitzReels extension package](https://www.npmjs.com/package/@blitzreels/eve) for the complete tool list, configuration, approval defaults, error contract, and OAuth-backed MCP alternative.`,
+  },
   browserbase: {
     logo: "browserbase",
     docsHref: "https://www.npmjs.com/package/@browserbasehq/eve",

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -73,6 +73,19 @@ describe("integration discovery", () => {
     expect(integrationSearchText(browserbase!)).toContain("Stagehand");
   });
 
+  it("renders the BlitzReels extension setup", () => {
+    const blitzreels = getIntegration("blitzreels");
+    expect(blitzreels).toBeDefined();
+
+    const markdown = integrationMarkdown(blitzreels!);
+    expect(markdown).toContain("eve add extension/blitzreels");
+    expect(markdown).toContain('import blitzreels from "@blitzreels/eve"');
+    expect(markdown).toContain("BLITZREELS_API_KEY");
+    expect(markdown).toContain("blitzreels__create_clip_batch");
+    expect(markdown).toContain("require eve approval");
+    expect(integrationSearchText(blitzreels!)).toContain("video editing");
+  });
+
   it("renders the Jetty extension and eval reporter setup", () => {
     const jetty = getIntegration("jetty");
     expect(jetty).toBeDefined();

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -562,6 +562,14 @@ export const messengerLogo = (props: LogoProps) => <SiMessenger color="default" 
 
 export const xLogo = (props: LogoProps) => <SiX {...props} />;
 
+export const blitzreelsLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 240 174" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M85 0h155v174h-95L0 0h85Z" fill="#0E8062" opacity="0.85" />
+    <path d="M0 0h215v174h-70L0 0Z" fill="#17FFA6" />
+    <path d="M55 0h160v87h-46L98 0H55Z" fill="#15D990" opacity="0.62" />
+  </svg>
+);
+
 export const browserbaseLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" {...props}>
     <rect fill="white" height="124" width="134" x="30" y="36" />
@@ -744,6 +752,7 @@ export const logos = {
   whatsapp: whatsappLogo,
   messenger: messengerLogo,
   x: xLogo,
+  blitzreels: blitzreelsLogo,
   browserbase: browserbaseLogo,
   jetty: jettyLogo,
   "agent-browser": agentBrowserLogo,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -50,6 +50,7 @@
     "@agent-browser/eve": "^0.33.0",
     "@agentphone/chat-sdk-adapter": "0.1.0",
     "@beeper/chat-adapter-matrix": "0.2.0",
+    "@blitzreels/eve": "^0.1.0",
     "@browserbasehq/eve": "^0.1.0",
     "@chat-adapter/gchat": "4.34.0",
     "@chat-adapter/messenger": "4.34.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -50,7 +50,7 @@
     "@agent-browser/eve": "^0.33.0",
     "@agentphone/chat-sdk-adapter": "0.1.0",
     "@beeper/chat-adapter-matrix": "0.2.0",
-    "@blitzreels/eve": "^0.2.0",
+    "@blitzreels/eve": "^0.2.1",
     "@browserbasehq/eve": "^0.1.0",
     "@chat-adapter/gchat": "4.34.0",
     "@chat-adapter/messenger": "4.34.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -50,7 +50,7 @@
     "@agent-browser/eve": "^0.33.0",
     "@agentphone/chat-sdk-adapter": "0.1.0",
     "@beeper/chat-adapter-matrix": "0.2.0",
-    "@blitzreels/eve": "^0.1.0",
+    "@blitzreels/eve": "^0.2.0",
     "@browserbasehq/eve": "^0.1.0",
     "@chat-adapter/gchat": "4.34.0",
     "@chat-adapter/messenger": "4.34.0",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -43,6 +43,23 @@
       ]
     },
     {
+      "name": "extension/blitzreels",
+      "type": "registry:item",
+      "title": "BlitzReels",
+      "description": "Turn long videos into short clips, generate media, repair edits, and export.",
+      "dependencies": ["@blitzreels/eve"],
+      "envVars": {
+        "BLITZREELS_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/extensions/blitzreels.ts",
+          "type": "registry:file",
+          "target": "agent/extensions/blitzreels.ts"
+        }
+      ]
+    },
+    {
       "name": "extension/browserbase",
       "type": "registry:item",
       "title": "Browserbase",

--- a/apps/docs/registry/extensions/blitzreels.ts
+++ b/apps/docs/registry/extensions/blitzreels.ts
@@ -1,0 +1,5 @@
+import blitzreels from "@blitzreels/eve";
+
+export default blitzreels({
+  apiKey: process.env.BLITZREELS_API_KEY!,
+});

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -277,6 +277,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, registry: true, gallery: true },
   },
   {
+    slug: "blitzreels",
+    name: "BlitzReels",
+    kind: "extension",
+    tagline: "Turn long videos into short clips, generate media, repair edits, and export.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "browserbase",
     name: "Browserbase",
     kind: "extension",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@opentelemetry/api@1.9.1)(ai@6.0.191(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
       '@blitzreels/eve':
-        specifier: ^0.1.0
-        version: 0.1.0(eve@packages+eve)
+        specifier: ^0.2.0
+        version: 0.2.0(eve@packages+eve)
       '@browserbasehq/eve':
         specifier: ^0.1.0
         version: 0.1.0(@cfworker/json-schema@4.1.1)(eve@packages+eve)(supports-color@10.2.2)
@@ -1706,18 +1706,18 @@ packages:
     resolution: {integrity: sha512-eqKbU0iosIUkBn2dkRqyg+72a9c+v4vi85U81ZM8ETgjqHuZ34xWWntG2UL4ly6sHE/LiO4WL/k2Q+vlzLh8hw==}
     engines: {node: '>=22'}
 
-  '@blitzreels/contracts@0.1.0':
-    resolution: {integrity: sha512-Q3912jz/a4Eto5bq1b+EJdHDHw2kLff/be9fmMlml7pNbxCXh91qLRy0WJiAQPrSfamgppUshqdwymobBR1lEQ==}
+  '@blitzreels/contracts@0.2.0':
+    resolution: {integrity: sha512-2NOBMoQatxBB164mIkVfx8rsVAuNi2z5PKAqg1696+BstoUZtDodPHQ5SHrhXQKKiyrfCVgCZKO7BdjclhkFAg==}
     engines: {node: '>=20'}
 
-  '@blitzreels/eve@0.1.0':
-    resolution: {integrity: sha512-ZIu8zUFMd/vaCJnMwOn0lBQxb2OKNE50ota2D6J1wjziwg8Z9n7dZo7IRjjj0o35ZaU54X3OeAV6jBzc0mTPoQ==}
+  '@blitzreels/eve@0.2.0':
+    resolution: {integrity: sha512-OiXTnEDpLA1geYQVrHJ1FvPu4ZciJilIAUhwwDoc5uzkbg3Gwlxcs9p38XXBqFapy6iPOnJnbRHx0IjgPntWNA==}
     engines: {node: '>=24'}
     peerDependencies:
       eve: '*'
 
-  '@blitzreels/sdk@0.1.6':
-    resolution: {integrity: sha512-Q3n0Fy74T0KW4jsVewaJjqtZCTKeSGoAzmxQCOoxNd5kEls6fhN9Gv4Fal7sOLEeTXnA4xus/8PVsUl/G7YQbA==}
+  '@blitzreels/sdk@0.2.0':
+    resolution: {integrity: sha512-Jtowqe6Vpwo/+LO/7KzJKrC9KaNrCaGbndQ7ps9M7O8epvXTT/E/y4Ns0At93izMbDRBJa1fFfY0EuqmWN19cw==}
     engines: {node: '>=20'}
 
   '@bomb.sh/tab@0.0.19':
@@ -15750,17 +15750,17 @@ snapshots:
       - workflow
       - zod
 
-  '@blitzreels/contracts@0.1.0': {}
+  '@blitzreels/contracts@0.2.0': {}
 
-  '@blitzreels/eve@0.1.0(eve@packages+eve)':
+  '@blitzreels/eve@0.2.0(eve@packages+eve)':
     dependencies:
-      '@blitzreels/sdk': 0.1.6
+      '@blitzreels/sdk': 0.2.0
       eve: link:packages/eve
       zod: 4.4.3
 
-  '@blitzreels/sdk@0.1.6':
+  '@blitzreels/sdk@0.2.0':
     dependencies:
-      '@blitzreels/contracts': 0.1.0
+      '@blitzreels/contracts': 0.2.0
 
   '@bomb.sh/tab@0.0.19(cac@6.7.14)(citty@0.2.2)(commander@14.0.3)':
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@opentelemetry/api@1.9.1)(ai@6.0.191(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
       '@blitzreels/eve':
-        specifier: ^0.2.0
-        version: 0.2.0(eve@packages+eve)
+        specifier: ^0.2.1
+        version: 0.2.1(eve@packages+eve)
       '@browserbasehq/eve':
         specifier: ^0.1.0
         version: 0.1.0(@cfworker/json-schema@4.1.1)(eve@packages+eve)(supports-color@10.2.2)
@@ -1710,8 +1710,8 @@ packages:
     resolution: {integrity: sha512-2NOBMoQatxBB164mIkVfx8rsVAuNi2z5PKAqg1696+BstoUZtDodPHQ5SHrhXQKKiyrfCVgCZKO7BdjclhkFAg==}
     engines: {node: '>=20'}
 
-  '@blitzreels/eve@0.2.0':
-    resolution: {integrity: sha512-OiXTnEDpLA1geYQVrHJ1FvPu4ZciJilIAUhwwDoc5uzkbg3Gwlxcs9p38XXBqFapy6iPOnJnbRHx0IjgPntWNA==}
+  '@blitzreels/eve@0.2.1':
+    resolution: {integrity: sha512-mgw/0YpDb+Skc0jyH41+EiUxHwKRD/46OkarfQyC85TmeoQm7h+PXQftjVTIo5i5eImVNFAcQBAxuMq3eRjsXQ==}
     engines: {node: '>=24'}
     peerDependencies:
       eve: '*'
@@ -15752,7 +15752,7 @@ snapshots:
 
   '@blitzreels/contracts@0.2.0': {}
 
-  '@blitzreels/eve@0.2.0(eve@packages+eve)':
+  '@blitzreels/eve@0.2.1(eve@packages+eve)':
     dependencies:
       '@blitzreels/sdk': 0.2.0
       eve: link:packages/eve

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       '@beeper/chat-adapter-matrix':
         specifier: 0.2.0
         version: 0.2.0(@opentelemetry/api@1.9.1)(ai@6.0.191(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
+      '@blitzreels/eve':
+        specifier: ^0.1.0
+        version: 0.1.0(eve@packages+eve)
       '@browserbasehq/eve':
         specifier: ^0.1.0
         version: 0.1.0(@cfworker/json-schema@4.1.1)(eve@packages+eve)(supports-color@10.2.2)
@@ -1702,6 +1705,20 @@ packages:
   '@beeper/chat-adapter-matrix@0.2.0':
     resolution: {integrity: sha512-eqKbU0iosIUkBn2dkRqyg+72a9c+v4vi85U81ZM8ETgjqHuZ34xWWntG2UL4ly6sHE/LiO4WL/k2Q+vlzLh8hw==}
     engines: {node: '>=22'}
+
+  '@blitzreels/contracts@0.1.0':
+    resolution: {integrity: sha512-Q3912jz/a4Eto5bq1b+EJdHDHw2kLff/be9fmMlml7pNbxCXh91qLRy0WJiAQPrSfamgppUshqdwymobBR1lEQ==}
+    engines: {node: '>=20'}
+
+  '@blitzreels/eve@0.1.0':
+    resolution: {integrity: sha512-ZIu8zUFMd/vaCJnMwOn0lBQxb2OKNE50ota2D6J1wjziwg8Z9n7dZo7IRjjj0o35ZaU54X3OeAV6jBzc0mTPoQ==}
+    engines: {node: '>=24'}
+    peerDependencies:
+      eve: '*'
+
+  '@blitzreels/sdk@0.1.6':
+    resolution: {integrity: sha512-Q3n0Fy74T0KW4jsVewaJjqtZCTKeSGoAzmxQCOoxNd5kEls6fhN9Gv4Fal7sOLEeTXnA4xus/8PVsUl/G7YQbA==}
+    engines: {node: '>=20'}
 
   '@bomb.sh/tab@0.0.19':
     resolution: {integrity: sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==}
@@ -15732,6 +15749,18 @@ snapshots:
       - supports-color
       - workflow
       - zod
+
+  '@blitzreels/contracts@0.1.0': {}
+
+  '@blitzreels/eve@0.1.0(eve@packages+eve)':
+    dependencies:
+      '@blitzreels/sdk': 0.1.6
+      eve: link:packages/eve
+      zod: 4.4.3
+
+  '@blitzreels/sdk@0.1.6':
+    dependencies:
+      '@blitzreels/contracts': 0.1.0
 
   '@bomb.sh/tab@0.0.19(cac@6.7.14)(citty@0.2.2)(commander@14.0.3)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,40 @@ catalog:
 minimumReleaseAge: 2880 # 2 days
 
 minimumReleaseAgeExclude:
+<<<<<<< HEAD
   - "@blitzreels/eve"
+=======
+  # Registry packages are explicitly reviewed before they are added to the eve registry.
+  - "@agent-browser/eve"
+  - "@agent-browser/sandbox"
+  - "@agentphone/chat-sdk-adapter"
+  - "@beeper/chat-adapter-matrix"
+  - "@blitzreels/contracts"
+  - "@blitzreels/eve"
+  - "@blitzreels/sdk"
+  - "@browserbasehq/eve"
+  - "@chat-adapter/*"
+  - "@getdial/chat-sdk-adapter"
+  - "@github-tools/eve-extension"
+  - "@github-tools/sdk"
+  - "@kapso/chat-adapter"
+  - "@larksuite/vercel-chat-adapter"
+  - "@linqapp/chat-sdk-adapter"
+  - "@liveblocks/chat-sdk-adapter"
+  - "@novu/chat-sdk-adapter"
+  - "@photon-ai/chat-adapter-imessage"
+  - "@resend/chat-sdk-adapter"
+  - "@upstash/agentkit-eve-extension"
+  - "@veltdev/chat-sdk-adapter"
+  - "@zernio/chat-sdk-adapter"
+  - chat
+  - chat-adapter-sendblue
+  - "@ai-sdk/*"
+  - "@rolldown/*"
+  - "@typescript/typescript-*"
+  - "@turbo/*"
+  - "@workflow/*"
+>>>>>>> 468ddb72 (Use the MIT BlitzReels extension release)
   - "@vercel/*"
   - "@workflow/*"
   - nitro

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,6 +57,7 @@ catalog:
 minimumReleaseAge: 2880 # 2 days
 
 minimumReleaseAgeExclude:
+  - "@blitzreels/eve"
   - "@vercel/*"
   - "@workflow/*"
   - nitro


### PR DESCRIPTION
Closes #1334

## What changed

- Registers `@blitzreels/eve` as `extension/blitzreels`.
- Adds catalog and gallery identity, setup and security docs, and the BlitzReels logo.
- Installs the published `@blitzreels/eve@0.2.1` release.
- Adds the reviewed dependency exceptions and focused discovery coverage.

## Public source

- Eve-only MIT repository: https://github.com/blitzreels/eve-extension
- npm package: https://www.npmjs.com/package/@blitzreels/eve

The public repository contains the Eve adapter only. It depends on the npm-distributed `@blitzreels/sdk`; the SDK, contracts, CLI, application, backend, and infrastructure source are not included.

## Why

Makes the published BlitzReels extension discoverable and installable through the Eve registry.

## Verification

- Verified `@blitzreels/eve@0.2.1` metadata, repository link, dependency boundary, and tarball contents.
- `pnpm --filter eve-docs test:unit -- lib/integrations/discovery.test.ts` — 18 tests passed.
- `pnpm --filter eve-docs registry:check`.
- `pnpm typecheck` — 31 packages passed.
- Original submission: `pnpm lint`, full unit/integration tests, build, docs build, and responsive visual checks.