### PR TITLE
fix(eve): avoid ESM banner initialization failure

### DIFF
--- a/.changeset/fix-esm-banner-tdz.md
+++ b/.changeset/fix-esm-banner-tdz.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent authored module evaluation from intermittently failing when bundled extension code declares its own `__filename` binding.

--- a/packages/eve/src/internal/node-esm-compat-banner.test.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.test.ts
@@ -10,7 +10,9 @@ describe("buildNodeEsmCompatBanner", () => {
     const banner = buildNodeEsmCompatBanner('console.log("noop");');
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
-    expect(banner).toContain("const __dirname = __eveDirname(__filename);");
+    expect(banner).toContain(
+      "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));",
+    );
     expect(banner).not.toContain("__eveCreateRequire");
   });
 
@@ -52,6 +54,21 @@ describe("buildNodeEsmCompatBanner", () => {
     expect(banner).not.toContain('from "node:path"');
   });
 
+  it("does not initialize __dirname through a chunk-owned __filename", () => {
+    const chunk = [
+      "console.log(__dirname);",
+      "const __filename = '/x/file.js';",
+      'export const value = "noop";',
+    ].join("\n");
+
+    const banner = buildNodeEsmCompatBanner(chunk);
+
+    expect(banner).not.toContain("const __filename =");
+    expect(banner).toContain(
+      "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));",
+    );
+  });
+
   it("omits the require shim when the chunk binds require", () => {
     const chunk = [
       'import { createRequire } from "node:module";',
@@ -76,7 +93,9 @@ describe("buildNodeEsmCompatBanner", () => {
     const banner = buildNodeEsmCompatBanner(chunk, { includeRequire: true });
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
-    expect(banner).toContain("const __dirname = __eveDirname(__filename);");
+    expect(banner).toContain(
+      "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));",
+    );
     expect(banner).toContain("const require = __eveCreateRequire(import.meta.url);");
   });
 
@@ -93,7 +112,9 @@ describe("buildNodeEsmCompatBanner", () => {
 
     // The chunk has not bound `__dirname` at the top level, so the
     // banner must still provide it.
-    expect(banner).toContain("const __dirname = __eveDirname(__filename);");
+    expect(banner).toContain(
+      "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));",
+    );
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
   });
 });

--- a/packages/eve/src/internal/node-esm-compat-banner.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.ts
@@ -14,7 +14,7 @@ interface NodeEsmCompatBannerOptions {
 }
 
 interface BannerLine {
-  readonly importLine: string;
+  readonly importLines: readonly string[];
   readonly declarationLine: string;
   readonly bindingPattern: RegExp;
 }
@@ -25,19 +25,22 @@ interface BannerLine {
 // not collide with the banner.
 const BANNER_LINES: readonly BannerLine[] = [
   {
-    importLine: 'import { fileURLToPath as __eveFileURLToPath } from "node:url";',
+    importLines: ['import { fileURLToPath as __eveFileURLToPath } from "node:url";'],
     declarationLine: "const __filename = __eveFileURLToPath(import.meta.url);",
     bindingPattern: /^(?:const|let|var)\s+__filename(?![\w$])/m,
   },
   {
-    importLine: 'import { dirname as __eveDirname } from "node:path";',
-    declarationLine: "const __dirname = __eveDirname(__filename);",
+    importLines: [
+      'import { fileURLToPath as __eveFileURLToPath } from "node:url";',
+      'import { dirname as __eveDirname } from "node:path";',
+    ],
+    declarationLine: "const __dirname = __eveDirname(__eveFileURLToPath(import.meta.url));",
     bindingPattern: /^(?:const|let|var)\s+__dirname(?![\w$])/m,
   },
 ];
 
 const REQUIRE_LINE: BannerLine = {
-  importLine: 'import { createRequire as __eveCreateRequire } from "node:module";',
+  importLines: ['import { createRequire as __eveCreateRequire } from "node:module";'],
   declarationLine: "const require = __eveCreateRequire(import.meta.url);",
   bindingPattern: /^(?:const|let|var)\s+require(?![\w$])/m,
 };
@@ -60,7 +63,7 @@ export function buildNodeEsmCompatBanner(
     lines.push(REQUIRE_LINE);
   }
 
-  const imports: string[] = [];
+  const imports = new Set<string>();
   const declarations: string[] = [];
 
   for (const line of lines) {
@@ -68,7 +71,9 @@ export function buildNodeEsmCompatBanner(
       continue;
     }
 
-    imports.push(line.importLine);
+    for (const importLine of line.importLines) {
+      imports.add(importLine);
+    }
     declarations.push(line.declarationLine);
   }
 


### PR DESCRIPTION
### Description

Fix intermittent authored-module startup failures caused by eve's ESM compatibility banner reading a bundle-generated `__filename` before it was initialized.

Compute `__dirname` directly from `import.meta.url` so it does not depend on another generated binding. Also deduplicate banner imports and add regression coverage for bundles that declare `__filename` themselves.

### How did you test your changes?

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/node-esm-compat-banner.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/dev-server.scenario.test.ts -t "rebuilds mounted workspace extensions"`
- `pnpm --filter eve typecheck`
- Targeted oxlint and oxfmt checks

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant (regression test added; no docs change needed)
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
