### PR TITLE
chore(eve): classify authorized approval contracts

### DIFF
--- a/packages/eve/extension-contracts/compatibility/connection/v2.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v2.ts
@@ -1,0 +1,7 @@
+import { defineMcpClientConnection } from "#public/connections/index.js";
+
+export default defineMcpClientConnection({
+  approval: () => "user-approval",
+  description: "Retain request-time connection approval shorthand",
+  url: "https://example.com/mcp",
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v1.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v1.ts
@@ -1,0 +1,10 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineInstructions({
+        markdown: "Retain dynamic instructions authoring.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v1.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v1.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineSkill({
+        description: "Retain dynamic skill authoring",
+        markdown: "# Retained skill",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v3.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v3.ts
@@ -1,0 +1,14 @@
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () => ({
+      inspect: defineTool({
+        approval: () => "user-approval",
+        description: "Retain dynamic request-time approval shorthand",
+        inputSchema: { type: "object", properties: {} },
+        execute: async () => ({ ok: true }),
+      }),
+    }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v2.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v2.ts
@@ -1,0 +1,9 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "input.requested"(event, ctx) {
+      console.info("input requested", event.data.requests.length, ctx.session.id);
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v2.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v2.ts
@@ -1,0 +1,10 @@
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  approval: ({ toolInput }) => (toolInput?.confirmed === true ? "not-applicable" : "user-approval"),
+  description: "Retain request-time approval function shorthand",
+  inputSchema: { type: "object", properties: { confirmed: { type: "boolean" } } },
+  async execute(input, ctx) {
+    return { input, sessionId: ctx.session.id };
+  },
+});

--- a/packages/eve/extension-contracts/reports/connection/v3.json
+++ b/packages/eve/extension-contracts/reports/connection/v3.json
@@ -1,0 +1,15 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 3,
+  "sha256": "d710e0f9607b6f58b4b488547844c452a3278b36cfbedcbb987c93d5b753fcf2",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v2.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v2.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 2,
+  "sha256": "ef164033630f1192feca8a476fee58e505eda94c82d35e130fb4eda5ebc6690c",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v2.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v2.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 2,
+  "sha256": "ef164033630f1192feca8a476fee58e505eda94c82d35e130fb4eda5ebc6690c",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v4.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v4.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 4,
+  "sha256": "0e6adad8133cbf29ddc790e0f40fc9bed8fca9bccc2db1592ca0ed04f8f29e95",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v3.json
+++ b/packages/eve/extension-contracts/reports/hook/v3.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 3,
+  "sha256": "7fcba2edf86a310a94cf4ed9c9a1ac1ad1c10ecee2393be1c2dc282f34301344",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/tool/v3.json
+++ b/packages/eve/extension-contracts/reports/tool/v3.json
@@ -1,0 +1,19 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 3,
+  "sha256": "979ad6f9d2519e66f407331c2891fdba62a4779af50a2110dc552f24d5fdd548",
+  "exports": [
+    "defineBashTool",
+    "defineGlobTool",
+    "defineGrepTool",
+    "defineReadFileTool",
+    "defineTool",
+    "defineWriteFileTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "toolResultFrom"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -21,14 +21,14 @@ interface ExtensionCapabilityContract {
 
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
-  tool: { current: 2, supported: [1, 2], dropped: {} },
-  dynamicTool: { current: 3, supported: [1, 2, 3], dropped: {} },
-  connection: { current: 2, supported: [1, 2], dropped: {} },
-  hook: { current: 2, supported: [1, 2], dropped: {} },
+  tool: { current: 3, supported: [1, 2, 3], dropped: {} },
+  dynamicTool: { current: 4, supported: [1, 2, 3, 4], dropped: {} },
+  connection: { current: 3, supported: [1, 2, 3], dropped: {} },
+  hook: { current: 3, supported: [1, 2, 3], dropped: {} },
   skill: { current: 1, supported: [1], dropped: {} },
-  dynamicSkill: { current: 1, supported: [1], dropped: {} },
+  dynamicSkill: { current: 2, supported: [1, 2], dropped: {} },
   instructions: { current: 1, supported: [1], dropped: {} },
-  dynamicInstructions: { current: 1, supported: [1], dropped: {} },
+  dynamicInstructions: { current: 2, supported: [1, 2], dropped: {} },
   config: { current: 1, supported: [1], dropped: {} },
   state: { current: 2, supported: [1, 2], dropped: {} },
 } as const satisfies Record<string, ExtensionCapabilityContract>;

--- a/research/hitl-approver-authorization.md
+++ b/research/hitl-approver-authorization.md
@@ -1,5 +1,5 @@
 ---
-issue: 1021
+issue: "1021"
 status: proposed
 last_updated: "2026-07-29"
 ---


### PR DESCRIPTION
## Summary

Classifies the additive extension-facing API changes introduced by the authorized-approval stack:

- bumps tool, dynamicTool, connection, hook, dynamicSkill, and dynamicInstructions capability epochs
- retains every prior epoch
- adds representative retained-contract fixtures
- generates the six new immutable API reports
- fixes the research issue frontmatter invariant

## Validation

- `pnpm update:extension-contracts`
- `pnpm guard:invariants`

## Stack

Depends on #1355.