### PR TITLE
fix(eve): target approval candidate feedback

### DIFF
--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -581,9 +581,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           outcome: authorized.kind === "authorization-required" ? "pending" : authorized.kind,
           requestId: authorized.requestId,
           responderPrincipalId:
-            getApprovalAuditState(session.state).activeCandidates.find(
-              (candidate) => candidate.candidateId === authorized.candidateId,
-            )?.responder.principalId ?? "unknown",
+            [
+              ...getApprovalAuditState(session.state).activeCandidates,
+              ...getApprovalAuditState(session.state).candidateHistory,
+            ].find((candidate) => candidate.candidateId === authorized.candidateId)?.responder
+              .principalId ?? "unknown",
           safeReason: "safeReason" in authorized ? authorized.safeReason : undefined,
           sequence: emissionState.sequence,
           stepIndex: emissionState.stepIndex,

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -81,6 +81,33 @@ describe("defaultEvents approval lifecycle", () => {
     );
   });
 
+  it("delivers an immediate rejection to the current responder without prior mapping", async () => {
+    const { channel, postEphemeral } = buildChannelStub();
+    const ctx = sessionContext({
+      attributes: { user_id: "U777" },
+      authenticator: "slack-webhook",
+      principalId: "slack:T1:U777",
+      principalType: "user",
+    });
+
+    await defaultEvents["approval.candidate"]!(
+      {
+        candidateId: "candidate-1",
+        outcome: "rejected",
+        requestId: "approval-1",
+        responderPrincipalId: "slack:T1:U777",
+        safeReason: "GitHub write access is required.",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      channel,
+      ctx,
+    );
+
+    expect(postEphemeral).toHaveBeenCalledWith("U777", "GitHub write access is required.");
+  });
+
   it("updates the shared card only after settlement", async () => {
     const { channel, request } = buildChannelStub({
       pendingApprovalCards: {

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -175,7 +175,12 @@ export const defaultEvents: SlackChannelInternalEvents = {
       );
       return;
     }
-    const userId = channel.state.pendingApprovalCandidateUsers?.[event.candidateId];
+    const mappedUserId = channel.state.pendingApprovalCandidateUsers?.[event.candidateId];
+    const userId =
+      mappedUserId ??
+      (ctx.session.auth.current?.principalId === event.responderPrincipalId
+        ? currentUserId
+        : undefined);
     if (userId === undefined) return;
     if (event.outcome === "rejected" || event.outcome === "failed") {
       await channel.thread.postEphemeral(


### PR DESCRIPTION
## Summary

Fixes private candidate feedback targeting for both immediate and resumed outcomes:

- resolves responder identity from active or completed candidate audit history
- sends immediate rejection to the current verified responder even before a Slack candidate mapping exists
- continues to use durable candidate-to-user mapping after OAuth or intervening clicks
- adds immediate-rejection and runtime event regressions

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/defaults.test.ts src/harness/tool-loop.test.ts`
- `pnpm --filter eve typecheck`

## Stack

Depends on #1358.