### PR TITLE
fix(eve): emit candidate outcomes after persistence

### DIFF
--- a/packages/eve/src/harness/approval-candidates.ts
+++ b/packages/eve/src/harness/approval-candidates.ts
@@ -19,6 +19,7 @@ export interface ApprovalCandidateAuditRecord {
   readonly status: ApprovalCandidateStatus;
   readonly createdAt: number;
   readonly completedAt?: number;
+  readonly eventEmitted?: boolean;
   readonly expiresAt?: number;
   readonly provider?: string;
   readonly runtimeRevision?: string;
@@ -133,6 +134,25 @@ export function markApprovalCandidatePendingEventEmitted(input: {
       [input.candidateId]: { ...candidate, pendingEventEmitted: true },
     },
   });
+}
+
+/** Marks a terminal candidate history event as emitted. */
+export function markApprovalCandidateHistoryEventEmitted(input: {
+  readonly candidateId: string;
+  readonly state: SessionStateMap | undefined;
+}): SessionStateMap | undefined {
+  const approvalState = readApprovalState(input.state);
+  let changed = false;
+  const candidateHistory = approvalState.candidateHistory.map((candidate) => {
+    if (candidate.candidateId !== input.candidateId || candidate.eventEmitted === true) {
+      return candidate;
+    }
+    changed = true;
+    return { ...candidate, eventEmitted: true };
+  });
+  return changed
+    ? writeApprovalState(input.state, { ...approvalState, candidateHistory })
+    : input.state;
 }
 
 /** Marks a terminal settlement event as emitted. */

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -106,6 +106,7 @@ import { createToolResultMessagePartFromToolError } from "#harness/action-result
 import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-context.js";
 import {
   getApprovalAuditState,
+  markApprovalCandidateHistoryEventEmitted,
   markApprovalCandidatePendingEventEmitted,
   markApprovalSettlementEventEmitted,
 } from "#harness/approval-candidates.js";
@@ -606,29 +607,36 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       };
     }
 
-    if (
-      emit &&
-      authorized.kind !== "continue" &&
-      authorized.kind !== "duplicate" &&
-      authorized.kind !== "authorization-required"
-    ) {
+    const pendingCandidateHistoryEvent = getApprovalAuditState(session.state).candidateHistory.find(
+      (candidate) =>
+        candidate.eventEmitted !== true &&
+        candidate.status !== "allowed" &&
+        candidate.status !== "authorization-required",
+    );
+    if (emit && pendingCandidateHistoryEvent !== undefined) {
       await emit(
         createApprovalCandidateEvent({
-          candidateId: authorized.candidateId ?? `stale:${authorized.requestId}`,
-          outcome: authorized.kind,
-          requestId: authorized.requestId,
-          responderPrincipalId:
-            [
-              ...getApprovalAuditState(session.state).activeCandidates,
-              ...getApprovalAuditState(session.state).candidateHistory,
-            ].find((candidate) => candidate.candidateId === authorized.candidateId)?.responder
-              .principalId ?? "unknown",
-          safeReason: "safeReason" in authorized ? authorized.safeReason : undefined,
+          candidateId: pendingCandidateHistoryEvent.candidateId,
+          outcome: pendingCandidateHistoryEvent.status as Exclude<
+            typeof pendingCandidateHistoryEvent.status,
+            "allowed" | "authorization-required"
+          >,
+          requestId: pendingCandidateHistoryEvent.requestId,
+          responderPrincipalId: pendingCandidateHistoryEvent.responder.principalId,
+          safeReason: pendingCandidateHistoryEvent.safeReason,
           sequence: emissionState.sequence,
           stepIndex: emissionState.stepIndex,
           turnId: emissionState.turnId,
         }),
       );
+      session = {
+        ...session,
+        state: markApprovalCandidateHistoryEventEmitted({
+          candidateId: pendingCandidateHistoryEvent.candidateId,
+          state: session.state,
+        }),
+      };
+      return { next: runStep, session };
     }
     if (authorized.kind === "authorization-required") {
       const { challenges } = authorized.authorization;

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -586,18 +586,20 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const pendingCandidateEvent = getApprovalAuditState(session.state).activeCandidates.find(
       (candidate) => candidate.pendingEventEmitted !== true,
     );
-    if (emit && pendingCandidateEvent !== undefined) {
-      await emit(
-        createApprovalCandidateEvent({
-          candidateId: pendingCandidateEvent.candidateId,
-          outcome: "pending",
-          requestId: pendingCandidateEvent.requestId,
-          responderPrincipalId: pendingCandidateEvent.responder.principalId,
-          sequence: emissionState.sequence,
-          stepIndex: emissionState.stepIndex,
-          turnId: emissionState.turnId,
-        }),
-      );
+    if (pendingCandidateEvent !== undefined) {
+      if (emit) {
+        await emit(
+          createApprovalCandidateEvent({
+            candidateId: pendingCandidateEvent.candidateId,
+            outcome: "pending",
+            requestId: pendingCandidateEvent.requestId,
+            responderPrincipalId: pendingCandidateEvent.responder.principalId,
+            sequence: emissionState.sequence,
+            stepIndex: emissionState.stepIndex,
+            turnId: emissionState.turnId,
+          }),
+        );
+      }
       session = {
         ...session,
         state: markApprovalCandidatePendingEventEmitted({
@@ -605,6 +607,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           state: session.state,
         }),
       };
+      return { next: runStep, session };
     }
 
     const pendingCandidateHistoryEvent = getApprovalAuditState(session.state).candidateHistory.find(


### PR DESCRIPTION
## Summary

Applies durable-first ordering to rejected, failed, timed-out, and stale candidate outcomes:

- persists terminal candidate audit records before lifecycle emission
- emits pending terminal candidate history on the next workflow step
- marks emitted history to prevent replay duplicates
- keeps shared approval UI as a projection of committed candidate state

## Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/approval-candidates.test.ts src/harness/input-requests.test.ts src/harness/tool-loop.test.ts src/public/channels/slack/defaults.test.ts`
- `pnpm --filter eve typecheck`

## Stack

Depends on #1361.