### PR TITLE
feat(eve): replace approval denial with cancel

### DIFF
--- a/.changeset/approval-allow-cancel.md
+++ b/.changeset/approval-allow-cancel.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Tool approval responses now use `cancel` instead of `deny`, while retaining `approve` for the positive response, aligning the public protocol with the user-facing flow-control semantics.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -138,7 +138,7 @@ curl -X POST http://127.0.0.1:2000/eve/v1/session/<sessionId> \
 
 The follow-up reuses the same durable session: same history, same state.
 
-If the session is waiting on a human-in-the-loop approval, a matching text reply such as `approve` or `deny` answers the approval. Other follow-up text is held until the approval is answered, so an unrelated message does not implicitly deny the pending tool call.
+If the session is waiting on a human-in-the-loop approval, a matching text reply such as `approve` or `cancel` answers the approval. Other follow-up text is held until the approval is answered, so an unrelated message does not implicitly deny the pending tool call.
 
 If the session is waiting on `ask_question`, a follow-up message clears that pending request before the model continues. An exact option match or permitted freeform response answers the question; any other message marks the question unanswered and starts the follow-up turn.
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -123,7 +123,7 @@ if (request) {
 }
 ```
 
-`request.prompt` and `request.options` give you what you need to render the approve and deny UI. The default reducer marks the part as responded immediately, then updates it again once eve streams the resumed result.
+`request.prompt` and `request.options` give you what you need to render the approve and cancel UI. The default reducer marks the part as responded immediately, then updates it again once eve streams the resumed result.
 
 ## Authorization prompts
 

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -100,7 +100,7 @@ Approvals and questions share one protocol:
 1. The model requests input (an approval, or an `ask_question`).
 2. eve emits an `input.requested` stream event carrying the pending requests.
 3. The turn parks at `session.waiting`, durably, for as long as it takes.
-4. The client answers with `inputResponses` (structured, keyed by `requestId`) or a normal follow-up `message`. A follow-up whose text matches an option ID, option label, or numeric option index resolves automatically, including approval options such as `approve` and `deny`.
+4. The client answers with `inputResponses` (structured, keyed by `requestId`) or a normal follow-up `message`. A follow-up whose text matches an option ID, option label, or numeric option index resolves automatically, including approval options such as `approve` and `cancel`.
 
 The run picks back up exactly where it parked. Because the pause is durable, nothing is held in memory while it waits — the process can restart and the parked turn survives.
 

--- a/docs/tutorial/ship-it.mdx
+++ b/docs/tutorial/ship-it.mdx
@@ -73,7 +73,7 @@ export default function Page() {
 }
 ```
 
-`agent.data.messages` and `agent.status` cover most chat UIs. The hook also surfaces HITL prompts (the spend approval from [Step 8](./guard-the-spend)), so the dashboard can render approve/deny controls. For the full API, see [Frontend](../guides/frontend/overview).
+`agent.data.messages` and `agent.status` cover most chat UIs. The hook also surfaces HITL prompts (the spend approval from [Step 8](./guard-the-spend)), so the dashboard can render approve/cancel controls. For the full API, see [Frontend](../guides/frontend/overview).
 
 ## Replace `placeholderAuth`
 

--- a/e2e/fixtures/agent-openapi-swagger/evals/tfl-swagger-approval.eval.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/tfl-swagger-approval.eval.ts
@@ -20,7 +20,7 @@ export default defineEval({
 
     t.requireInputRequest({
       display: "confirmation",
-      optionIds: ["approve", "deny"],
+      optionIds: ["approve", "cancel"],
       toolName: TFL_APPROVAL_JOURNEY_MODES_TOOL,
     });
     parked.calledTool(TFL_APPROVAL_JOURNEY_MODES_TOOL, { status: "pending", count: 1 });

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/deny-then-regate.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/deny-then-regate.eval.ts
@@ -11,7 +11,7 @@ export default defineEval({
     await t.send('Call the guarded-echo tool with note "denied-call".');
     const request = t.requireInputRequest({ toolName: "guarded-echo" });
 
-    const denied = await t.respondAll("deny");
+    const denied = await t.respondAll("cancel");
     denied.expectOk();
     denied.event("action.result", {
       data: {

--- a/packages/eve/src/channel/resolve-text.test.ts
+++ b/packages/eve/src/channel/resolve-text.test.ts
@@ -8,7 +8,7 @@ const APPROVAL_REQUEST: InputRequest = {
   display: "confirmation",
   options: [
     { id: "approve", label: "Approve", style: "primary" },
-    { id: "deny", label: "Deny", style: "danger" },
+    { id: "cancel", label: "Cancel", style: "danger" },
   ],
   prompt: 'Approve tool "bash"?',
   requestId: "req-1",

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -926,7 +926,7 @@ describe("EveTUIRunner native continuation state", () => {
                 display: "confirmation",
                 options: [
                   { id: "approve", label: "Approve" },
-                  { id: "deny", label: "Deny" },
+                  { id: "cancel", label: "Cancel" },
                 ],
                 prompt: "Approve get_weather?",
                 requestId: "request-1",

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -869,7 +869,7 @@ export class EveTUIRunner {
                 const response = await this.#renderer.readToolApproval(request, { title });
                 responses.push({
                   requestId: request.approvalId,
-                  optionId: response.approved ? "approve" : "deny",
+                  optionId: response.approved ? "approve" : "cancel",
                 });
                 this.#pendingInputRequests.delete(request.approvalId);
               }

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -370,7 +370,7 @@ describe("defaultMessageReducer", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
-              { id: "deny", label: "No", style: "danger" },
+              { id: "cancel", label: "No", style: "danger" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval_1",
@@ -406,7 +406,7 @@ describe("defaultMessageReducer", () => {
                   display: "confirmation",
                   options: [
                     { id: "approve", label: "Yes", style: "primary" },
-                    { id: "deny", label: "No", style: "danger" },
+                    { id: "cancel", label: "No", style: "danger" },
                   ],
                   prompt: "Approve tool call: bash",
                   requestId: "approval_1",
@@ -439,7 +439,7 @@ describe("defaultMessageReducer", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
-              { id: "deny", label: "No", style: "danger" },
+              { id: "cancel", label: "No", style: "danger" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval_1",
@@ -454,7 +454,7 @@ describe("defaultMessageReducer", () => {
     data = reducer.reduce(data, {
       data: {
         createdAt: 1,
-        responses: [{ optionId: "deny", requestId: "approval_1" }],
+        responses: [{ optionId: "cancel", requestId: "approval_1" }],
       },
       type: "client.input.responded",
     });
@@ -483,12 +483,12 @@ describe("defaultMessageReducer", () => {
                   display: "confirmation",
                   options: [
                     { id: "approve", label: "Yes", style: "primary" },
-                    { id: "deny", label: "No", style: "danger" },
+                    { id: "cancel", label: "No", style: "danger" },
                   ],
                   prompt: "Approve tool call: bash",
                   requestId: "approval_1",
                 },
-                inputResponse: { optionId: "deny", requestId: "approval_1" },
+                inputResponse: { optionId: "cancel", requestId: "approval_1" },
                 kind: "tool-call",
                 name: "bash",
               },
@@ -517,7 +517,7 @@ describe("defaultMessageReducer", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
-              { id: "deny", label: "No", style: "danger" },
+              { id: "cancel", label: "No", style: "danger" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval_1",

--- a/packages/eve/src/evals/runner/execute-task.test.ts
+++ b/packages/eve/src/evals/runner/execute-task.test.ts
@@ -82,7 +82,7 @@ describe("executeTask", () => {
         const request = t.requireInputRequest({
           display: "confirmation",
           input: { command: "pwd" },
-          optionIds: ["approve", "deny"],
+          optionIds: ["approve", "cancel"],
           prompt: /Approve/,
           toolName: "bash",
         });
@@ -721,7 +721,7 @@ function inputRequested(
           display: "confirmation",
           options: [
             { id: "approve", label: "Approve" },
-            { id: "deny", label: "Deny" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve?",
           requestId,

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -55,7 +55,7 @@ function sampleRequest(): InputRequest {
     },
     options: [
       { id: "approve", label: "Approve" },
-      { id: "deny", label: "Deny" },
+      { id: "cancel", label: "Cancel" },
     ],
     prompt: "Approve?",
     requestId: "req-1",

--- a/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
@@ -142,7 +142,7 @@ function buildApprovalRequest(requestId: string): InputRequest {
     display: "confirmation",
     options: [
       { id: "approve", label: "Approve", style: "primary" },
-      { id: "deny", label: "Deny", style: "danger" },
+      { id: "cancel", label: "Cancel", style: "danger" },
     ],
     prompt: "Approve?",
     requestId,
@@ -421,7 +421,7 @@ describe("subagent HITL proxy → concurrent-descendant routing", () => {
       payload: {
         inputResponses: [
           { optionId: "approve", requestId: "req-a" },
-          { optionId: "deny", requestId: "req-b" },
+          { optionId: "cancel", requestId: "req-b" },
         ],
       },
       state: parkedSession.state,
@@ -440,7 +440,7 @@ describe("subagent HITL proxy → concurrent-descendant routing", () => {
       inputResponses: [{ optionId: "approve", requestId: "req-a" }],
     });
     expect(byChild.get("subagent:parent:call-b")).toEqual({
-      inputResponses: [{ optionId: "deny", requestId: "req-b" }],
+      inputResponses: [{ optionId: "cancel", requestId: "req-b" }],
     });
 
     // A response whose requestId does not match any proxy entry

--- a/packages/eve/src/execution/subagent-hitl-proxy.test.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.test.ts
@@ -35,7 +35,7 @@ describe("routeDeliverPayload", () => {
       payload: {
         inputResponses: [
           { optionId: "approve", requestId: "req-a" },
-          { optionId: "deny", requestId: "req-b" },
+          { optionId: "cancel", requestId: "req-b" },
           { optionId: "ignore", requestId: "req-parent" },
         ],
       },
@@ -46,7 +46,7 @@ describe("routeDeliverPayload", () => {
     const childA = routed.forChildren.find((c) => c.childContinuationToken === "child-a");
     const childB = routed.forChildren.find((c) => c.childContinuationToken === "child-b");
     expect(childA?.payload.inputResponses).toEqual([{ optionId: "approve", requestId: "req-a" }]);
-    expect(childB?.payload.inputResponses).toEqual([{ optionId: "deny", requestId: "req-b" }]);
+    expect(childB?.payload.inputResponses).toEqual([{ optionId: "cancel", requestId: "req-b" }]);
 
     expect(routed.forSelf?.inputResponses).toEqual([
       { optionId: "ignore", requestId: "req-parent" },

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1484,7 +1484,7 @@ describe("runProxySubagentEventStep", () => {
             },
             options: [
               { id: "approve", label: "Approve" },
-              { id: "deny", label: "Deny" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve?",
             requestId: "req-1",

--- a/packages/eve/src/harness/input-extraction.test.ts
+++ b/packages/eve/src/harness/input-extraction.test.ts
@@ -12,7 +12,7 @@ describe("extractQuestionInputRequests", () => {
       toolCalls: [
         {
           input: {
-            options: [{ id: "yes", label: "Yes" }],
+            options: [{ id: "yes", label: "Approve" }],
             prompt: "Continue?",
           },
           toolCallId: "call-1",
@@ -27,14 +27,14 @@ describe("extractQuestionInputRequests", () => {
         action: {
           callId: "call-1",
           input: {
-            options: [{ id: "yes", label: "Yes" }],
+            options: [{ id: "yes", label: "Approve" }],
             prompt: "Continue?",
           },
           kind: "tool-call",
           toolName: "ask_question",
         },
         display: "select",
-        options: [{ id: "yes", label: "Yes" }],
+        options: [{ id: "yes", label: "Approve" }],
         prompt: "Continue?",
         requestId: "call-1",
       },
@@ -118,8 +118,8 @@ describe("extractToolApprovalInputRequests", () => {
         allowFreeform: false,
         display: "confirmation",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: bash",
         requestId: "approval-1",
@@ -155,8 +155,8 @@ describe("extractToolApprovalInputRequests", () => {
         allowFreeform: false,
         display: "confirmation",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: bash",
         requestId: "approval-1",

--- a/packages/eve/src/harness/input-extraction.ts
+++ b/packages/eve/src/harness/input-extraction.ts
@@ -157,8 +157,8 @@ function extractApprovalRequests(input: {
       allowFreeform: false,
       display: "confirmation",
       options: [
-        { id: "approve", label: "Yes" },
-        { id: "deny", label: "No" },
+        { id: "approve", label: "Approve" },
+        { id: "cancel", label: "Cancel" },
       ],
       prompt: `Approve tool call: ${toolCall.toolName}`,
       requestId: approval.approvalId,

--- a/packages/eve/src/harness/input-requests.test.ts
+++ b/packages/eve/src/harness/input-requests.test.ts
@@ -142,7 +142,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -266,7 +266,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -296,7 +296,7 @@ describe("resolvePendingInput", () => {
     // Deliver an approval response AND a message simultaneously.
     const result = resolvePendingInput({
       stepInput: {
-        inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
         message: "Ignore that and say hi instead.",
       },
       session,
@@ -333,7 +333,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -392,7 +392,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -456,7 +456,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: vercel__list_projects",
           requestId: "approval-1",
@@ -522,7 +522,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -551,7 +551,7 @@ describe("resolvePendingInput", () => {
 
     const result = resolvePendingInput({
       stepInput: {
-        inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
       },
       session,
     });
@@ -591,7 +591,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -603,7 +603,7 @@ describe("resolvePendingInput", () => {
 
     const result = resolvePendingInput({
       stepInput: {
-        inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
       },
       session,
     });
@@ -648,7 +648,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -684,7 +684,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -724,7 +724,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -783,7 +783,7 @@ describe("resolvePendingInput", () => {
           display: "confirmation",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: linear_whoami",
           requestId: "approval-1",

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -505,7 +505,7 @@ function resolveApprovalOutcome(response: InputResponse | undefined): {
     };
   }
 
-  if (response.optionId === "deny") {
+  if (response.optionId === "cancel") {
     return {
       approved: false,
       reason: TOOL_EXECUTION_DENIED_MESSAGE,
@@ -604,7 +604,7 @@ function buildToolResponsePartsForRequest(
       },
     ];
     /*
-     * On denial (explicit "deny" or auto-deny when the user continues
+     * On denial (explicit "cancel" or auto-deny when the user continues
      * without responding), splice in the matching `execution-denied`
      * tool-result. AI SDK's `streamText` synthesizes this for the
      * current turn's `initialResponseMessages`, but that synthesis is
@@ -643,12 +643,12 @@ function buildToolResponsePartsForRequest(
   ];
 }
 
-/** Shared approval predicate: a request whose options are exactly `approve` / `deny`. */
+/** Shared approval predicate: a request whose options are exactly `allow` / `cancel`. */
 export function isApprovalRequest(request: InputRequest): boolean {
   return (
     request.options?.length === 2 &&
     request.options[0]?.id === "approve" &&
-    request.options[1]?.id === "deny"
+    request.options[1]?.id === "cancel"
   );
 }
 

--- a/packages/eve/src/harness/stale-input-responses.test.ts
+++ b/packages/eve/src/harness/stale-input-responses.test.ts
@@ -61,10 +61,10 @@ it("converts a stale approval into a non-authorizing user message", () => {
     throw new Error("Expected the stale response to be converted.");
   }
 
-  expect(result.displayMessage).toBe("Yes");
+  expect(result.displayMessage).toBe("Approve");
   expect(result.stepInput.inputResponses).toBeUndefined();
   expect(result.stepInput.message).toEqual(expect.stringContaining("Approve tool call: bash"));
-  expect(result.stepInput.message).toEqual(expect.stringContaining('"label": "Yes"'));
+  expect(result.stepInput.message).toEqual(expect.stringContaining('"label": "Approve"'));
   expect(result.stepInput.message).toEqual(
     expect.stringContaining("This does not authorize an earlier action"),
   );

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -65,7 +65,7 @@ function createPendingApprovalSession(): HarnessSession {
         display: "confirmation",
         options: [
           { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "cancel", label: "No" },
         ],
         prompt: "Approve tool call: bash",
         requestId: approvalRequest.approvalId,

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -442,8 +442,8 @@ function createPendingBashApprovalSession(): HarnessSession {
         allowFreeform: false,
         display: "confirmation",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: bash",
         requestId: "approval-1",
@@ -492,8 +492,8 @@ function createPendingProtectedActionApprovalSession(): HarnessSession {
         allowFreeform: false,
         display: "confirmation",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: protected_action",
         requestId: "approval-1",
@@ -2297,8 +2297,8 @@ describe("createToolLoopHarness", () => {
             allowFreeform: false,
             display: "confirmation",
             options: [
-              { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "approve", label: "Approve" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval-1",
@@ -6482,8 +6482,8 @@ describe("createToolLoopHarness", () => {
             allowFreeform: false,
             display: "confirmation",
             options: [
-              { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "approve", label: "Approve" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval-1",
@@ -6669,8 +6669,8 @@ describe("createToolLoopHarness", () => {
           allowFreeform: false,
           display: "confirmation",
           options: [
-            { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -6727,7 +6727,7 @@ describe("createToolLoopHarness", () => {
     expect(hasDeferredStepInput(firstResult.session)).toBe(true);
 
     const deniedResult = await createToolLoopHarness(config)(firstResult.session, {
-      inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+      inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
     });
 
     expect(typeof deniedResult.next).toBe("function");
@@ -6833,8 +6833,8 @@ describe("createToolLoopHarness", () => {
           allowFreeform: false,
           display: "confirmation",
           options: [
-            { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve tool call: guarded_echo",
           requestId: "approval-1",
@@ -7080,8 +7080,8 @@ describe("createToolLoopHarness", () => {
           allowFreeform: false,
           display: "confirmation",
           options: [
-            { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -7140,7 +7140,7 @@ describe("createToolLoopHarness", () => {
 
     // Step 2: user denies the approval; the deferred message is NOT in this call.
     const deniedResult = await createToolLoopHarness(config)(firstResult.session, {
-      inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+      inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
     });
     expect(typeof deniedResult.next).toBe("function");
     const step2Last = generateCalls[0]?.at(-1);

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -507,7 +507,7 @@ describe("chatSdkChannel", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Approve", style: "primary" },
-              { id: "deny", label: "Deny", style: "danger" },
+              { id: "cancel", label: "Cancel", style: "danger" },
             ],
             prompt: "Deploy?",
             requestId: "request-1",
@@ -534,11 +534,11 @@ describe("chatSdkChannel", () => {
               value: "approve",
             },
             {
-              id: "eve_input:request-1:deny",
-              label: "Deny",
+              id: "eve_input:request-1:cancel",
+              label: "Cancel",
               style: "danger",
               type: "button",
-              value: "deny",
+              value: "cancel",
             },
           ],
           type: "actions",

--- a/packages/eve/src/public/channels/discord/hitl.test.ts
+++ b/packages/eve/src/public/channels/discord/hitl.test.ts
@@ -42,7 +42,7 @@ describe("renderInputRequestComponents", () => {
         display: "confirmation",
         options: [
           { id: "approve", label: "Approve", style: "primary" },
-          { id: "deny", label: "Deny", style: "danger" },
+          { id: "cancel", label: "Cancel", style: "danger" },
         ],
       }),
     );

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -642,7 +642,7 @@ describe("eveChannel — onMessage", () => {
     const response = await handler.fetch(
       createJsonMessageRequest({
         continuationToken: "http:existing",
-        inputResponses: [{ requestId: "req-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "req-1", optionId: "cancel" }],
       }),
     );
 
@@ -1284,7 +1284,7 @@ describe("eveChannel — continue session HITL (inputResponses)", () => {
     const response = await handler.fetch(
       createJsonMessageRequest({
         continuationToken: "http:existing",
-        inputResponses: [{ requestId: "req-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "req-1", optionId: "cancel" }],
       }),
     );
 
@@ -1292,7 +1292,7 @@ describe("eveChannel — continue session HITL (inputResponses)", () => {
     expect(handler.send).toHaveBeenCalledTimes(1);
     const payload = handler.send.mock.calls[0]?.[0] as SendPayload;
     expect(payload.message).toBeUndefined();
-    expect(payload.inputResponses).toEqual([{ requestId: "req-1", optionId: "deny" }]);
+    expect(payload.inputResponses).toEqual([{ requestId: "req-1", optionId: "cancel" }]);
   });
 });
 

--- a/packages/eve/src/public/channels/linear/hitl.test.ts
+++ b/packages/eve/src/public/channels/linear/hitl.test.ts
@@ -21,14 +21,14 @@ describe("Linear HITL helpers", () => {
       makeRequest({
         options: [
           { id: "approve", label: "Approve" },
-          { id: "deny", label: "Deny", description: "Stop the deployment" },
+          { id: "cancel", label: "Cancel", description: "Stop the deployment" },
         ],
       }),
     ]);
 
     expect(rendered).toContain("Approve deployment?");
     expect(rendered).toContain("1. Approve");
-    expect(rendered).toContain("2. Deny - Stop the deployment");
+    expect(rendered).toContain("2. Cancel - Stop the deployment");
     expect(rendered).not.toContain("eve-input");
     expect(rendered).not.toContain("<!--");
   });
@@ -40,7 +40,7 @@ describe("Linear HITL helpers", () => {
           allowFreeform: true,
           options: [
             { id: "approve", label: "Approve" },
-            { id: "deny", label: "Deny" },
+            { id: "cancel", label: "Cancel" },
           ],
         }),
       ]),
@@ -49,7 +49,7 @@ describe("Linear HITL helpers", () => {
       signalMetadata: {
         options: [
           { label: "Approve", value: "approve" },
-          { label: "Deny", value: "deny" },
+          { label: "Cancel", value: "cancel" },
         ],
       },
     });

--- a/packages/eve/src/public/channels/slack/blocks.test.ts
+++ b/packages/eve/src/public/channels/slack/blocks.test.ts
@@ -51,7 +51,7 @@ describe("cardToBlocks", () => {
         children: [
           Actions([
             Button({ id: "approve", label: "Approve", style: "primary" }),
-            Button({ id: "deny", label: "Deny", style: "danger", value: "force" }),
+            Button({ id: "cancel", label: "Cancel", style: "danger", value: "force" }),
           ]),
         ],
       }),
@@ -68,8 +68,8 @@ describe("cardToBlocks", () => {
           },
           {
             type: "button",
-            action_id: "deny",
-            text: { type: "plain_text", text: "Deny", emoji: true },
+            action_id: "cancel",
+            text: { type: "plain_text", text: "Cancel", emoji: true },
             value: "force",
             style: "danger",
           },

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -89,7 +89,7 @@ describe("renderInputRequestBlocks", () => {
       makeRequest({
         options: [
           { id: "approve", label: "Approve", style: "primary" },
-          { id: "deny", label: "Deny", style: "danger" },
+          { id: "cancel", label: "Cancel", style: "danger" },
         ],
       }),
     );
@@ -117,9 +117,9 @@ describe("renderInputRequestBlocks", () => {
     expect(card.actions[1]).toMatchObject({
       type: "button",
       action_id: `${HITL_ACTION_PREFIX}call_abc123:button:1`,
-      value: "deny",
+      value: "cancel",
       style: "danger",
-      text: { type: "plain_text", text: "Deny", emoji: false },
+      text: { type: "plain_text", text: "Cancel", emoji: false },
     });
   });
 
@@ -139,8 +139,8 @@ describe("renderInputRequestBlocks", () => {
       prompt: "Approve tool call: mongodb-mutate",
       requestId: "approval_1",
       options: [
-        { id: "approve", label: "Yes" },
-        { id: "deny", label: "No" },
+        { id: "approve", label: "Approve" },
+        { id: "cancel", label: "Cancel" },
       ],
     });
 
@@ -157,8 +157,8 @@ describe("renderInputRequestBlocks", () => {
       body: { type: "mrkdwn", text: "*Approve tool call: mongodb-mutate*" },
     });
     expect(card.actions).toMatchObject([
-      { text: { text: "Deny" }, value: "deny" },
-      { style: "primary", text: { text: "Allow" }, value: "approve" },
+      { text: { text: "Cancel" }, value: "cancel" },
+      { style: "primary", text: { text: "Approve" }, value: "approve" },
     ]);
 
     const details = blocks[1] as {
@@ -191,8 +191,8 @@ describe("renderInputRequestBlocks", () => {
         },
         display: "confirmation",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
       }),
     );
@@ -284,7 +284,7 @@ describe("renderInputRequestBlocks", () => {
     const blocks = renderInputRequestBlocks(
       makeRequest({
         allowFreeform: true,
-        options: [{ id: "yes", label: "Yes" }],
+        options: [{ id: "yes", label: "Approve" }],
       }),
     );
     // current behavior: options take precedence; freeform button is the
@@ -376,8 +376,8 @@ describe("formatInputRequestFallbackText", () => {
         display: "confirmation",
         prompt: "Approve tool call: mongodb-mutate",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
       }),
     );
@@ -500,10 +500,10 @@ describe("buildAnsweredBlocks", () => {
   });
 
   it("omits the attribution block when no userId is supplied", () => {
-    const blocks = buildAnsweredBlocks({ promptBlocks: [], answerLabel: "Deny" });
+    const blocks = buildAnsweredBlocks({ promptBlocks: [], answerLabel: "Cancel" });
     expect(blocks).toHaveLength(1);
     expect(blocks[0]).toMatchObject({
-      text: { text: ":white_check_mark: *Deny*" },
+      text: { text: ":white_check_mark: *Cancel*" },
     });
   });
 

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -134,7 +134,7 @@ export function isHitlAction(actionId: string): boolean {
  * - `display === "select"` with more options → `static_select`
  *   dropdown so the picker stays scrollable.
  * - Anything else with options → Slack `card` blocks with action
- *   buttons. Best for visually distinct choices (approve / deny /
+ *   buttons. Best for visually distinct choices (allow / cancel /
  *   cancel).
  * - No options (or `allowFreeform: true`) → a single "Type your answer"
  *   button that opens a Slack modal with a plain_text_input. The modal
@@ -323,13 +323,13 @@ function cardButtonOptions(request: InputRequest): CardButtonOption[] {
   const options = request.options ?? [];
   if (!isApprovalRequest(request)) return options.map(toCardButtonOption);
 
-  const approve = options.find((option) => option.id === "approve");
-  const deny = options.find((option) => option.id === "deny");
-  if (!approve || !deny) return options.map(toCardButtonOption);
+  const allow = options.find((option) => option.id === "approve");
+  const cancel = options.find((option) => option.id === "cancel");
+  if (!allow || !cancel) return options.map(toCardButtonOption);
 
   return [
-    { id: deny.id, label: "Deny" },
-    { id: approve.id, label: "Allow", style: "primary" },
+    { id: cancel.id, label: "Cancel" },
+    { id: allow.id, label: "Approve", style: "primary" },
   ];
 }
 
@@ -436,6 +436,6 @@ function isApprovalRequest(request: InputRequest): boolean {
     request.display === "confirmation" &&
     request.options?.length === 2 &&
     request.options[0]?.id === "approve" &&
-    request.options[1]?.id === "deny"
+    request.options[1]?.id === "cancel"
   );
 }

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -447,7 +447,7 @@ describe("slackChannel() default event handlers", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "cancel", label: "No" },
             ],
             prompt: "Approve tool call: mongodb-mutate",
             requestId: "approval_abc123",
@@ -522,12 +522,12 @@ describe("slackChannel() default event handlers", () => {
     expect(new Set(actionIds).size).toBe(actionIds.length);
     expect(actions).toMatchObject([
       {
-        text: { type: "plain_text", text: "Deny", emoji: false },
-        value: "deny",
+        text: { type: "plain_text", text: "Cancel", emoji: false },
+        value: "cancel",
       },
       {
         style: "primary",
-        text: { type: "plain_text", text: "Allow", emoji: false },
+        text: { type: "plain_text", text: "Approve", emoji: false },
         value: "approve",
       },
     ]);
@@ -596,7 +596,7 @@ describe("slackChannel() default event handlers", () => {
       display: "confirmation" as const,
       options: [
         { id: "approve", label: "Yes" },
-        { id: "deny", label: "No" },
+        { id: "cancel", label: "No" },
       ],
       prompt: `Approve tool call ${index}`,
       requestId: `approval_${index}`,
@@ -2240,13 +2240,13 @@ describe("slackChannel() HITL interaction pipeline", () => {
                 {
                   type: "button",
                   action_id: firstDenyActionId,
-                  text: { type: "plain_text", text: "Deny" },
-                  value: "deny",
+                  text: { type: "plain_text", text: "Cancel" },
+                  value: "cancel",
                 },
                 {
                   type: "button",
                   action_id: firstApproveActionId,
-                  text: { type: "plain_text", text: "Allow" },
+                  text: { type: "plain_text", text: "Approve" },
                   value: "approve",
                 },
               ],
@@ -2271,13 +2271,13 @@ describe("slackChannel() HITL interaction pipeline", () => {
                 {
                   type: "button",
                   action_id: secondDenyActionId,
-                  text: { type: "plain_text", text: "Deny" },
-                  value: "deny",
+                  text: { type: "plain_text", text: "Cancel" },
+                  value: "cancel",
                 },
                 {
                   type: "button",
                   action_id: secondApproveActionId,
-                  text: { type: "plain_text", text: "Allow" },
+                  text: { type: "plain_text", text: "Approve" },
                   value: "approve",
                 },
               ],
@@ -2296,7 +2296,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
         actions: [
           {
             action_id: firstApproveActionId,
-            text: { type: "plain_text", text: "Allow" },
+            text: { type: "plain_text", text: "Approve" },
             value: "approve",
           },
         ],
@@ -2326,14 +2326,14 @@ describe("slackChannel() HITL interaction pipeline", () => {
 
     expect(body).toMatchObject({
       channel: "C01",
-      text: "Answered: Allow",
+      text: "Answered: Approve",
       ts: "1700000000.000010",
     });
     expect(JSON.stringify(body.blocks)).toContain("Approve issue 451?");
-    expect(JSON.stringify(body.blocks)).toContain("Allow");
+    expect(JSON.stringify(body.blocks)).toContain("Approve");
     expect(JSON.stringify(body.blocks)).toContain("Tool input");
     expect(JSON.stringify(body.blocks)).toContain("Approve issue 508?");
-    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Allow* by <@U_APPROVER>");
+    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Approve* by <@U_APPROVER>");
     expect(body.blocks[0]?.subtext?.text?.length).toBeLessThanOrEqual(
       SLACK_CARD_SUBTEXT_MAX_LENGTH,
     );
@@ -2366,7 +2366,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "cancel", label: "No" },
             ],
             prompt: "Approve tool call: escalate_issue",
             requestId: "approval_451",
@@ -2381,7 +2381,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "cancel", label: "No" },
             ],
             prompt: "Approve tool call: escalate_issue",
             requestId: "approval_508",
@@ -2413,11 +2413,11 @@ describe("slackChannel() HITL interaction pipeline", () => {
     );
     expect(posted.blocks[3]?.child_blocks?.[0]?.text?.text).toContain('"issueNumber": 508');
 
-    const firstDenyAction = posted.blocks[0]?.actions?.find((action) => action.value === "deny");
+    const firstDenyAction = posted.blocks[0]?.actions?.find((action) => action.value === "cancel");
     expect(firstDenyAction).toMatchObject({
       action_id: `${HITL_ACTION_PREFIX}approval_451:button:0`,
-      text: { text: "Deny" },
-      value: "deny",
+      text: { text: "Cancel" },
+      value: "cancel",
     });
 
     const { send } = await firePost(
@@ -2440,8 +2440,8 @@ describe("slackChannel() HITL interaction pipeline", () => {
         actions: [
           {
             action_id: firstDenyAction?.action_id,
-            text: { type: "plain_text", text: "Deny" },
-            value: "deny",
+            text: { type: "plain_text", text: "Cancel" },
+            value: "cancel",
           },
         ],
       }),
@@ -2449,7 +2449,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0]?.[0]).toEqual({
-      inputResponses: [{ optionId: "deny", requestId: "approval_451" }],
+      inputResponses: [{ optionId: "cancel", requestId: "approval_451" }],
     });
 
     const updateCall = fetchMock.mock.calls.find(
@@ -2465,7 +2465,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
       }>;
     };
 
-    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Deny* by <@U0AT7H56S90>");
+    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Cancel* by <@U0AT7H56S90>");
     expect(body.blocks[1]?.child_blocks?.[0]?.text?.text).toContain('"issueNumber": 451');
     expect(body.blocks[3]?.child_blocks?.[0]?.text?.text).toContain('"issueNumber": 508');
     const remainingActionIds = body.blocks.flatMap(

--- a/packages/eve/src/public/channels/teams/hitl.test.ts
+++ b/packages/eve/src/public/channels/teams/hitl.test.ts
@@ -52,13 +52,13 @@ describe("Teams HITL helpers", () => {
       activityWithValue({
         [TEAMS_HITL_DATA_KEY]: {
           replyToActivityId: "ROOT",
-          optionId: "deny",
+          optionId: "cancel",
           requestId: "REQ",
         },
       }),
     );
     expect(message ? deriveTeamsInputResponses(message) : []).toEqual([
-      { optionId: "deny", requestId: "REQ" },
+      { optionId: "cancel", requestId: "REQ" },
     ]);
     expect(message ? readTeamsInputReplyToActivityId(message) : null).toBe("ROOT");
 
@@ -87,7 +87,7 @@ function request(): InputRequest {
     display: "confirmation",
     options: [
       { id: "approve", label: "Approve", style: "primary" },
-      { id: "deny", label: "Deny", style: "danger" },
+      { id: "cancel", label: "Cancel", style: "danger" },
     ],
     prompt: "Approve deploy?",
     requestId: "REQ",

--- a/packages/eve/src/public/channels/teams/hitl.ts
+++ b/packages/eve/src/public/channels/teams/hitl.ts
@@ -281,7 +281,7 @@ function formatApprovalInput(request: InputRequest): string | null {
     request.display !== "confirmation" ||
     request.options?.length !== 2 ||
     request.options[0]?.id !== "approve" ||
-    request.options[1]?.id !== "deny"
+    request.options[1]?.id !== "cancel"
   ) {
     return null;
   }

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -227,7 +227,7 @@ describe("teamsChannel", () => {
       eve_input: {
         replyToActivityId: "THREAD_ROOT",
         requestId: "REQ",
-        optionId: "deny",
+        optionId: "cancel",
       },
     };
     const channel = teamsChannel({
@@ -240,7 +240,7 @@ describe("teamsChannel", () => {
 
     expect(onMessage).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledWith(
-      { inputResponses: [{ optionId: "deny", requestId: "REQ" }] },
+      { inputResponses: [{ optionId: "cancel", requestId: "REQ" }] },
       expect.objectContaining({ continuationToken: "TENANT:CONV:THREAD_ROOT" }),
     );
   });

--- a/packages/eve/src/public/channels/telegram/hitl.test.ts
+++ b/packages/eve/src/public/channels/telegram/hitl.test.ts
@@ -21,7 +21,7 @@ describe("renderTelegramInputRequest", () => {
         action: { callId: "call_1", input: {}, kind: "tool-call", toolName: "ask_question" },
         options: [
           { id: "approve", label: "Approve" },
-          { id: "deny", label: "Deny" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve?",
         requestId: "very-long-request-id-that-would-not-fit-comfortably-in-callback-data",
@@ -33,7 +33,7 @@ describe("renderTelegramInputRequest", () => {
       inline_keyboard: [
         [
           { callback_data: "eve:0", text: "Approve" },
-          { callback_data: "eve:1", text: "Deny" },
+          { callback_data: "eve:1", text: "Cancel" },
         ],
       ],
     });

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -588,7 +588,7 @@ describe("useEveAgent", () => {
     let sendPromise: Promise<void> | undefined;
     await act(async () => {
       sendPromise = helpers?.send({
-        inputResponses: [{ optionId: "deny", requestId: "approval_1" }],
+        inputResponses: [{ optionId: "cancel", requestId: "approval_1" }],
       });
       await Promise.resolve();
     });

--- a/packages/eve/src/runtime/input/types.test.ts
+++ b/packages/eve/src/runtime/input/types.test.ts
@@ -20,7 +20,7 @@ describe("inputRequestSchema", () => {
       display: "confirmation",
       options: [
         { id: "approve", label: "Approve", style: "primary" },
-        { id: "deny", label: "Deny", style: "danger" },
+        { id: "cancel", label: "Cancel", style: "danger" },
       ],
       prompt: 'Approve tool "bash"?',
       requestId: "approval-1",

--- a/packages/eve/src/runtime/input/types.ts
+++ b/packages/eve/src/runtime/input/types.ts
@@ -30,7 +30,7 @@ export const inputOptionSchema = z
  * user input before continuing.
  *
  * Tool approvals and questions share this shape. Approvals are requests
- * with two options (`"approve"` / `"deny"`) and `display: "confirmation"`.
+ * with two options (`"approve"` / `"cancel"`) and `display: "confirmation"`.
  */
 export type InputRequest = z.infer<typeof inputRequestSchema>;
 

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -318,7 +318,7 @@ describe("EveAgentStore (Vue composable backing store)", () => {
     });
 
     const sendPromise = store.send({
-      inputResponses: [{ optionId: "deny", requestId: "approval_1" }],
+      inputResponses: [{ optionId: "cancel", requestId: "approval_1" }],
     });
     await Promise.resolve();
 


### PR DESCRIPTION
## Summary

Retains `approve` as the positive HITL response and replaces terminal `deny` with conversation flow-control `cancel` across channels, clients, TUI, proxies, tests, and docs.

Depends on #1368.

## Validation

Covered by the consolidated top-stack checks.