### PR TITLE
tweak(eve): replace "deny" with "cancel" in HITL approval flow

### DIFF
--- a/.changeset/approval-allow-cancel.md
+++ b/.changeset/approval-allow-cancel.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Tool approval responses now use `cancel` instead of `deny`, while retaining `approve` for the positive response, aligning the public protocol with the user-facing flow-control semantics.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -150,7 +150,7 @@ curl -X POST http://127.0.0.1:2000/eve/v1/session/<sessionId> \
 
 The follow-up reuses the same durable session: same history, same state.
 
-If the session is waiting on a human-in-the-loop approval, a matching text reply such as `approve` or `deny` answers the approval. Other follow-up text is held until the approval is answered, so an unrelated message does not implicitly deny the pending tool call.
+If the session is waiting on a human-in-the-loop approval, a matching text reply such as `approve` or `cancel` answers the approval. Other follow-up text is held until the approval is answered, so an unrelated message does not implicitly deny the pending tool call.
 
 If the session is waiting on `ask_question`, a follow-up message clears that pending request before the model continues. An exact option match or permitted freeform response answers the question; any other message marks the question unanswered and starts the follow-up turn.
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -124,7 +124,7 @@ if (request) {
 }
 ```
 
-`request.prompt` and `request.options` give you what you need to render the approve and deny UI. The default reducer marks the part as responded immediately, then updates it again once eve streams the resumed result.
+`request.prompt` and `request.options` give you what you need to render the approve and cancel UI. The default reducer marks the part as responded immediately, then updates it again once eve streams the resumed result.
 
 ## Authorization prompts
 

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -100,7 +100,7 @@ Approvals and questions share one protocol:
 1. The model requests input (an approval, or an `ask_question`).
 2. eve emits an `input.requested` stream event carrying the pending requests.
 3. The turn parks at `session.waiting`, durably, for as long as it takes.
-4. The client answers with `inputResponses` (structured, keyed by `requestId`) or a normal follow-up `message`. A follow-up whose text matches an option ID, option label, or numeric option index resolves automatically, including approval options such as `approve` and `deny`.
+4. The client answers with `inputResponses` (structured, keyed by `requestId`) or a normal follow-up `message`. A follow-up whose text matches an option ID, option label, or numeric option index resolves automatically, including approval options such as `approve` and `cancel`.
 
 Each request includes a `kind` discriminator: `tool-approval`, `question`, or
 `session-limit`. Clients should use `kind` to choose behavior and presentation;

--- a/docs/tutorial/ship-it.mdx
+++ b/docs/tutorial/ship-it.mdx
@@ -73,7 +73,7 @@ export default function Page() {
 }
 ```
 
-`agent.data.messages` and `agent.status` cover most chat UIs. The hook also surfaces HITL prompts (the spend approval from [Step 8](./guard-the-spend)), so the dashboard can render approve/deny controls. For the full API, see [Frontend](../guides/frontend/overview).
+`agent.data.messages` and `agent.status` cover most chat UIs. The hook also surfaces HITL prompts (the spend approval from [Step 8](./guard-the-spend)), so the dashboard can render approve/cancel controls. For the full API, see [Frontend](../guides/frontend/overview).
 
 ## Replace `placeholderAuth`
 

--- a/e2e/fixtures/agent-openapi-swagger/evals/petstore-swagger-approval.eval.ts
+++ b/e2e/fixtures/agent-openapi-swagger/evals/petstore-swagger-approval.eval.ts
@@ -21,7 +21,7 @@ export default defineEval({
 
     t.requireInputRequest({
       display: "confirmation",
-      optionIds: ["approve", "deny"],
+      optionIds: ["approve", "cancel"],
       toolName: PETSTORE_APPROVAL_INVENTORY_TOOL,
     });
     parked.calledTool(PETSTORE_APPROVAL_INVENTORY_TOOL, { status: "pending", count: 1 });

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/deny-then-regate.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/deny-then-regate.eval.ts
@@ -12,7 +12,7 @@ export default defineEval({
     await t.send('Call the guarded-echo tool with note "denied-call".');
     const request = t.requireInputRequest({ toolName: "guarded-echo" });
 
-    const denied = await t.respondAll("deny");
+    const denied = await t.respondAll("cancel");
     denied.expectOk();
     denied.event("action.result", {
       data: {

--- a/packages/eve/src/channel/resolve-text.test.ts
+++ b/packages/eve/src/channel/resolve-text.test.ts
@@ -9,7 +9,7 @@ const APPROVAL_REQUEST: InputRequest = {
   kind: "tool-approval",
   options: [
     { id: "approve", label: "Approve", style: "primary" },
-    { id: "deny", label: "Deny", style: "danger" },
+    { id: "cancel", label: "Cancel", style: "danger" },
   ],
   prompt: 'Approve tool "bash"?',
   requestId: "req-1",

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -1128,7 +1128,7 @@ describe("EveTUIRunner native continuation state", () => {
                 kind: "tool-approval",
                 options: [
                   { id: "approve", label: "Approve" },
-                  { id: "deny", label: "Deny" },
+                  { id: "cancel", label: "Cancel" },
                 ],
                 prompt: "Approve get_weather?",
                 requestId: "request-1",

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -1005,7 +1005,7 @@ export class EveTUIRunner {
                 const response = await this.#renderer.readToolApproval(request, { title });
                 responses.push({
                   requestId: request.approvalId,
-                  optionId: response.approved ? "approve" : "deny",
+                  optionId: response.approved ? "approve" : "cancel",
                 });
                 this.#pendingInputRequests.delete(request.approvalId);
               }

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -462,7 +462,7 @@ describe("defaultMessageReducer", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
-              { id: "deny", label: "No", style: "danger" },
+              { id: "cancel", label: "No", style: "danger" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval_1",
@@ -499,7 +499,7 @@ describe("defaultMessageReducer", () => {
                   kind: "tool-approval",
                   options: [
                     { id: "approve", label: "Yes", style: "primary" },
-                    { id: "deny", label: "No", style: "danger" },
+                    { id: "cancel", label: "No", style: "danger" },
                   ],
                   prompt: "Approve tool call: bash",
                   requestId: "approval_1",
@@ -533,7 +533,7 @@ describe("defaultMessageReducer", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
-              { id: "deny", label: "No", style: "danger" },
+              { id: "cancel", label: "No", style: "danger" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval_1",
@@ -548,7 +548,7 @@ describe("defaultMessageReducer", () => {
     data = reducer.reduce(data, {
       data: {
         createdAt: 1,
-        responses: [{ optionId: "deny", requestId: "approval_1" }],
+        responses: [{ optionId: "cancel", requestId: "approval_1" }],
       },
       type: "client.input.responded",
     });
@@ -578,12 +578,12 @@ describe("defaultMessageReducer", () => {
                   kind: "tool-approval",
                   options: [
                     { id: "approve", label: "Yes", style: "primary" },
-                    { id: "deny", label: "No", style: "danger" },
+                    { id: "cancel", label: "No", style: "danger" },
                   ],
                   prompt: "Approve tool call: bash",
                   requestId: "approval_1",
                 },
-                inputResponse: { optionId: "deny", requestId: "approval_1" },
+                inputResponse: { optionId: "cancel", requestId: "approval_1" },
                 kind: "tool-call",
                 name: "bash",
               },
@@ -613,7 +613,7 @@ describe("defaultMessageReducer", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes", style: "primary" },
-              { id: "deny", label: "No", style: "danger" },
+              { id: "cancel", label: "No", style: "danger" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval_1",

--- a/packages/eve/src/evals/runner/execute-task.test.ts
+++ b/packages/eve/src/evals/runner/execute-task.test.ts
@@ -99,7 +99,7 @@ describe("executeTask", () => {
         const request = t.requireInputRequest({
           display: "confirmation",
           input: { command: "pwd" },
-          optionIds: ["approve", "deny"],
+          optionIds: ["approve", "cancel"],
           prompt: /Approve/,
           toolName: "bash",
         });
@@ -738,7 +738,7 @@ function inputRequested(
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Approve" },
-            { id: "deny", label: "Deny" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve?",
           requestId,

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -56,7 +56,7 @@ function sampleRequest(): InputRequest {
     kind: "tool-approval",
     options: [
       { id: "approve", label: "Approve" },
-      { id: "deny", label: "Deny" },
+      { id: "cancel", label: "Cancel" },
     ],
     prompt: "Approve?",
     requestId: "req-1",

--- a/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.integration.test.ts
@@ -143,7 +143,7 @@ function buildApprovalRequest(requestId: string): InputRequest {
     kind: "tool-approval",
     options: [
       { id: "approve", label: "Approve", style: "primary" },
-      { id: "deny", label: "Deny", style: "danger" },
+      { id: "cancel", label: "Cancel", style: "danger" },
     ],
     prompt: "Approve?",
     requestId,
@@ -430,7 +430,7 @@ describe("subagent HITL proxy → concurrent-descendant routing", () => {
       payload: {
         inputResponses: [
           { optionId: "approve", requestId: "req-a" },
-          { optionId: "deny", requestId: "req-b" },
+          { optionId: "cancel", requestId: "req-b" },
         ],
       },
       state: parkedSession.state,
@@ -449,7 +449,7 @@ describe("subagent HITL proxy → concurrent-descendant routing", () => {
       inputResponses: [{ optionId: "approve", requestId: "req-a" }],
     });
     expect(byChild.get("subagent:parent:call-b")).toEqual({
-      inputResponses: [{ optionId: "deny", requestId: "req-b" }],
+      inputResponses: [{ optionId: "cancel", requestId: "req-b" }],
     });
 
     // A response whose requestId does not match any proxy entry

--- a/packages/eve/src/execution/subagent-hitl-proxy.test.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.test.ts
@@ -35,7 +35,7 @@ describe("routeDeliverPayload", () => {
       payload: {
         inputResponses: [
           { optionId: "approve", requestId: "req-a" },
-          { optionId: "deny", requestId: "req-b" },
+          { optionId: "cancel", requestId: "req-b" },
           { optionId: "ignore", requestId: "req-parent" },
         ],
       },
@@ -46,7 +46,7 @@ describe("routeDeliverPayload", () => {
     const childA = routed.forChildren.find((c) => c.childContinuationToken === "child-a");
     const childB = routed.forChildren.find((c) => c.childContinuationToken === "child-b");
     expect(childA?.payload.inputResponses).toEqual([{ optionId: "approve", requestId: "req-a" }]);
-    expect(childB?.payload.inputResponses).toEqual([{ optionId: "deny", requestId: "req-b" }]);
+    expect(childB?.payload.inputResponses).toEqual([{ optionId: "cancel", requestId: "req-b" }]);
 
     expect(routed.forSelf?.inputResponses).toEqual([
       { optionId: "ignore", requestId: "req-parent" },

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -2048,7 +2048,7 @@ describe("runProxySubagentEventStep", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Approve" },
-              { id: "deny", label: "Deny" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve?",
             requestId: "req-1",

--- a/packages/eve/src/harness/input-extraction.test.ts
+++ b/packages/eve/src/harness/input-extraction.test.ts
@@ -12,7 +12,7 @@ describe("extractQuestionInputRequests", () => {
       toolCalls: [
         {
           input: {
-            options: [{ id: "yes", label: "Yes" }],
+            options: [{ id: "yes", label: "Approve" }],
             prompt: "Continue?",
           },
           toolCallId: "call-1",
@@ -27,7 +27,7 @@ describe("extractQuestionInputRequests", () => {
         action: {
           callId: "call-1",
           input: {
-            options: [{ id: "yes", label: "Yes" }],
+            options: [{ id: "yes", label: "Approve" }],
             prompt: "Continue?",
           },
           kind: "tool-call",
@@ -35,7 +35,7 @@ describe("extractQuestionInputRequests", () => {
         },
         display: "select",
         kind: "question",
-        options: [{ id: "yes", label: "Yes" }],
+        options: [{ id: "yes", label: "Approve" }],
         prompt: "Continue?",
         requestId: "call-1",
       },
@@ -120,8 +120,8 @@ describe("extractToolApprovalInputRequests", () => {
         display: "confirmation",
         kind: "tool-approval",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: bash",
         requestId: "approval-1",
@@ -158,8 +158,8 @@ describe("extractToolApprovalInputRequests", () => {
         display: "confirmation",
         kind: "tool-approval",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: bash",
         requestId: "approval-1",

--- a/packages/eve/src/harness/input-extraction.ts
+++ b/packages/eve/src/harness/input-extraction.ts
@@ -160,8 +160,8 @@ function extractApprovalRequests(input: {
       display: "confirmation",
       kind: "tool-approval",
       options: [
-        { id: "approve", label: "Yes" },
-        { id: "deny", label: "No" },
+        { id: "approve", label: "Approve" },
+        { id: "cancel", label: "Cancel" },
       ],
       prompt: `Approve tool call: ${toolCall.toolName}`,
       requestId: approval.approvalId,

--- a/packages/eve/src/harness/input-requests.test.ts
+++ b/packages/eve/src/harness/input-requests.test.ts
@@ -145,7 +145,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -271,7 +271,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -301,7 +301,7 @@ describe("resolvePendingInput", () => {
     // Deliver an approval response AND a message simultaneously.
     const result = resolvePendingInput({
       stepInput: {
-        inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
         message: "Ignore that and say hi instead.",
       },
       session,
@@ -339,7 +339,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -399,7 +399,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -464,7 +464,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: vercel__list_projects",
           requestId: "approval-1",
@@ -531,7 +531,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -560,7 +560,7 @@ describe("resolvePendingInput", () => {
 
     const result = resolvePendingInput({
       stepInput: {
-        inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
       },
       session,
     });
@@ -601,7 +601,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -613,7 +613,7 @@ describe("resolvePendingInput", () => {
 
     const result = resolvePendingInput({
       stepInput: {
-        inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
       },
       session,
     });
@@ -659,7 +659,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -696,7 +696,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -737,7 +737,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -797,7 +797,7 @@ describe("resolvePendingInput", () => {
           kind: "tool-approval",
           options: [
             { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "cancel", label: "No" },
           ],
           prompt: "Approve tool call: linear_whoami",
           requestId: "approval-1",

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -530,7 +530,7 @@ function resolveApprovalOutcome(response: InputResponse | undefined): {
     };
   }
 
-  if (response.optionId === "deny") {
+  if (response.optionId === "cancel") {
     return {
       approved: false,
       reason: TOOL_EXECUTION_DENIED_MESSAGE,
@@ -629,7 +629,7 @@ function buildToolResponsePartsForRequest(
       },
     ];
     /*
-     * On denial (explicit "deny" or auto-deny when the user continues
+     * On denial (explicit "cancel" or auto-deny when the user continues
      * without responding), splice in the matching `execution-denied`
      * tool-result. AI SDK's `streamText` synthesizes this for the
      * current turn's `initialResponseMessages`, but that synthesis is

--- a/packages/eve/src/harness/stale-input-responses.test.ts
+++ b/packages/eve/src/harness/stale-input-responses.test.ts
@@ -61,10 +61,10 @@ it("converts a stale approval into a non-authorizing user message", () => {
     throw new Error("Expected the stale response to be converted.");
   }
 
-  expect(result.displayMessage).toBe("Yes");
+  expect(result.displayMessage).toBe("Approve");
   expect(result.stepInput.inputResponses).toBeUndefined();
   expect(result.stepInput.message).toEqual(expect.stringContaining("Approve tool call: bash"));
-  expect(result.stepInput.message).toEqual(expect.stringContaining('"label": "Yes"'));
+  expect(result.stepInput.message).toEqual(expect.stringContaining('"label": "Approve"'));
   expect(result.stepInput.message).toEqual(
     expect.stringContaining("This does not authorize an earlier action"),
   );

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -66,7 +66,7 @@ function createPendingApprovalSession(): HarnessSession {
         kind: "tool-approval",
         options: [
           { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "cancel", label: "No" },
         ],
         prompt: "Approve tool call: bash",
         requestId: approvalRequest.approvalId,

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -446,8 +446,8 @@ function createPendingBashApprovalSession(): HarnessSession {
         display: "confirmation",
         kind: "tool-approval",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: bash",
         requestId: "approval-1",
@@ -497,8 +497,8 @@ function createPendingProtectedActionApprovalSession(): HarnessSession {
         display: "confirmation",
         kind: "tool-approval",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve tool call: protected_action",
         requestId: "approval-1",
@@ -2628,8 +2628,8 @@ describe("createToolLoopHarness", () => {
             display: "confirmation",
             kind: "tool-approval",
             options: [
-              { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "approve", label: "Approve" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval-1",
@@ -6968,8 +6968,8 @@ describe("createToolLoopHarness", () => {
             display: "confirmation",
             kind: "tool-approval",
             options: [
-              { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "approve", label: "Approve" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: bash",
             requestId: "approval-1",
@@ -7156,8 +7156,8 @@ describe("createToolLoopHarness", () => {
           display: "confirmation",
           kind: "tool-approval",
           options: [
-            { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -7214,7 +7214,7 @@ describe("createToolLoopHarness", () => {
     expect(hasDeferredStepInput(firstResult.session)).toBe(true);
 
     const deniedResult = await createToolLoopHarness(config)(firstResult.session, {
-      inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+      inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
     });
 
     expect(typeof deniedResult.next).toBe("function");
@@ -7321,8 +7321,8 @@ describe("createToolLoopHarness", () => {
           display: "confirmation",
           kind: "tool-approval",
           options: [
-            { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve tool call: guarded_echo",
           requestId: "approval-1",
@@ -7569,8 +7569,8 @@ describe("createToolLoopHarness", () => {
           display: "confirmation",
           kind: "tool-approval",
           options: [
-            { id: "approve", label: "Yes" },
-            { id: "deny", label: "No" },
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
           ],
           prompt: "Approve tool call: bash",
           requestId: "approval-1",
@@ -7629,7 +7629,7 @@ describe("createToolLoopHarness", () => {
 
     // Step 2: user denies the approval; the deferred message is NOT in this call.
     const deniedResult = await createToolLoopHarness(config)(firstResult.session, {
-      inputResponses: [{ requestId: "approval-1", optionId: "deny" }],
+      inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
     });
     expect(typeof deniedResult.next).toBe("function");
     const step2Last = generateCalls[0]?.at(-1);

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -552,7 +552,7 @@ describe("chatSdkChannel", () => {
             display: "confirmation",
             options: [
               { id: "approve", label: "Approve", style: "primary" },
-              { id: "deny", label: "Deny", style: "danger" },
+              { id: "cancel", label: "Cancel", style: "danger" },
             ],
             prompt: "Deploy?",
             requestId: "request-1",
@@ -579,11 +579,11 @@ describe("chatSdkChannel", () => {
               value: "approve",
             },
             {
-              id: "eve_input:request-1:deny",
-              label: "Deny",
+              id: "eve_input:request-1:cancel",
+              label: "Cancel",
               style: "danger",
               type: "button",
-              value: "deny",
+              value: "cancel",
             },
           ],
           type: "actions",

--- a/packages/eve/src/public/channels/discord/hitl.test.ts
+++ b/packages/eve/src/public/channels/discord/hitl.test.ts
@@ -43,7 +43,7 @@ describe("renderInputRequestComponents", () => {
         display: "confirmation",
         options: [
           { id: "approve", label: "Approve", style: "primary" },
-          { id: "deny", label: "Deny", style: "danger" },
+          { id: "cancel", label: "Cancel", style: "danger" },
         ],
       }),
     );

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -712,14 +712,14 @@ describe("eveChannel — onMessage", () => {
 
     const response = await handler.fetch(
       createJsonMessageRequest({
-        inputResponses: [{ requestId: "req-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "req-1", optionId: "cancel" }],
       }),
     );
 
     expect(response.status).toBe(202);
     expect(onMessage).not.toHaveBeenCalled();
     expect(handler.respond).toHaveBeenCalledWith(
-      [{ requestId: "req-1", optionId: "deny" }],
+      [{ requestId: "req-1", optionId: "cancel" }],
       expect.objectContaining({ auth: ACCEPTED_AUTH }),
     );
     expect(handler.send).not.toHaveBeenCalled();
@@ -1441,13 +1441,13 @@ describe("eveChannel — continue session HITL (inputResponses)", () => {
 
     const response = await handler.fetch(
       createJsonMessageRequest({
-        inputResponses: [{ requestId: "req-1", optionId: "deny" }],
+        inputResponses: [{ requestId: "req-1", optionId: "cancel" }],
       }),
     );
 
     expect(response.status).toBe(202);
     expect(handler.respond).toHaveBeenCalledWith(
-      [{ requestId: "req-1", optionId: "deny" }],
+      [{ requestId: "req-1", optionId: "cancel" }],
       expect.any(Object),
     );
     expect(handler.send).not.toHaveBeenCalled();

--- a/packages/eve/src/public/channels/linear/hitl.test.ts
+++ b/packages/eve/src/public/channels/linear/hitl.test.ts
@@ -22,14 +22,14 @@ describe("Linear HITL helpers", () => {
       makeRequest({
         options: [
           { id: "approve", label: "Approve" },
-          { id: "deny", label: "Deny", description: "Stop the deployment" },
+          { id: "cancel", label: "Cancel", description: "Stop the deployment" },
         ],
       }),
     ]);
 
     expect(rendered).toContain("Approve deployment?");
     expect(rendered).toContain("1. Approve");
-    expect(rendered).toContain("2. Deny - Stop the deployment");
+    expect(rendered).toContain("2. Cancel - Stop the deployment");
     expect(rendered).not.toContain("eve-input");
     expect(rendered).not.toContain("<!--");
   });
@@ -41,7 +41,7 @@ describe("Linear HITL helpers", () => {
           allowFreeform: true,
           options: [
             { id: "approve", label: "Approve" },
-            { id: "deny", label: "Deny" },
+            { id: "cancel", label: "Cancel" },
           ],
         }),
       ]),
@@ -50,7 +50,7 @@ describe("Linear HITL helpers", () => {
       signalMetadata: {
         options: [
           { label: "Approve", value: "approve" },
-          { label: "Deny", value: "deny" },
+          { label: "Cancel", value: "cancel" },
         ],
       },
     });

--- a/packages/eve/src/public/channels/slack/blocks.test.ts
+++ b/packages/eve/src/public/channels/slack/blocks.test.ts
@@ -51,7 +51,7 @@ describe("cardToBlocks", () => {
         children: [
           Actions([
             Button({ id: "approve", label: "Approve", style: "primary" }),
-            Button({ id: "deny", label: "Deny", style: "danger", value: "force" }),
+            Button({ id: "cancel", label: "Cancel", style: "danger", value: "force" }),
           ]),
         ],
       }),
@@ -68,8 +68,8 @@ describe("cardToBlocks", () => {
           },
           {
             type: "button",
-            action_id: "deny",
-            text: { type: "plain_text", text: "Deny", emoji: true },
+            action_id: "cancel",
+            text: { type: "plain_text", text: "Cancel", emoji: true },
             value: "force",
             style: "danger",
           },

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -90,7 +90,7 @@ describe("renderInputRequestBlocks", () => {
       makeRequest({
         options: [
           { id: "approve", label: "Approve", style: "primary" },
-          { id: "deny", label: "Deny", style: "danger" },
+          { id: "cancel", label: "Cancel", style: "danger" },
         ],
       }),
     );
@@ -118,9 +118,9 @@ describe("renderInputRequestBlocks", () => {
     expect(card.actions[1]).toMatchObject({
       type: "button",
       action_id: `${HITL_ACTION_PREFIX}call_abc123:button:1`,
-      value: "deny",
+      value: "cancel",
       style: "danger",
-      text: { type: "plain_text", text: "Deny", emoji: false },
+      text: { type: "plain_text", text: "Cancel", emoji: false },
     });
   });
 
@@ -141,8 +141,8 @@ describe("renderInputRequestBlocks", () => {
       prompt: "Approve tool call: mongodb-mutate",
       requestId: "approval_1",
       options: [
-        { id: "approve", label: "Yes" },
-        { id: "deny", label: "No" },
+        { id: "approve", label: "Approve" },
+        { id: "cancel", label: "Cancel" },
       ],
     });
 
@@ -159,8 +159,8 @@ describe("renderInputRequestBlocks", () => {
       body: { type: "mrkdwn", text: "*Approve tool call: mongodb-mutate*" },
     });
     expect(card.actions).toMatchObject([
-      { text: { text: "Deny" }, value: "deny" },
-      { style: "primary", text: { text: "Allow" }, value: "approve" },
+      { text: { text: "Cancel" }, value: "cancel" },
+      { style: "primary", text: { text: "Approve" }, value: "approve" },
     ]);
 
     const details = blocks[1] as {
@@ -194,8 +194,8 @@ describe("renderInputRequestBlocks", () => {
         display: "confirmation",
         kind: "tool-approval",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
       }),
     );
@@ -287,7 +287,7 @@ describe("renderInputRequestBlocks", () => {
     const blocks = renderInputRequestBlocks(
       makeRequest({
         allowFreeform: true,
-        options: [{ id: "yes", label: "Yes" }],
+        options: [{ id: "yes", label: "Approve" }],
       }),
     );
     // current behavior: options take precedence; freeform button is the
@@ -380,8 +380,8 @@ describe("formatInputRequestFallbackText", () => {
         kind: "tool-approval",
         prompt: "Approve tool call: mongodb-mutate",
         options: [
-          { id: "approve", label: "Yes" },
-          { id: "deny", label: "No" },
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
         ],
       }),
     );
@@ -504,10 +504,10 @@ describe("buildAnsweredBlocks", () => {
   });
 
   it("omits the attribution block when no userId is supplied", () => {
-    const blocks = buildAnsweredBlocks({ promptBlocks: [], answerLabel: "Deny" });
+    const blocks = buildAnsweredBlocks({ promptBlocks: [], answerLabel: "Cancel" });
     expect(blocks).toHaveLength(1);
     expect(blocks[0]).toMatchObject({
-      text: { text: ":white_check_mark: *Deny*" },
+      text: { text: ":white_check_mark: *Cancel*" },
     });
   });
 

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -134,7 +134,7 @@ export function isHitlAction(actionId: string): boolean {
  * - `display === "select"` with more options → `static_select`
  *   dropdown so the picker stays scrollable.
  * - Anything else with options → Slack `card` blocks with action
- *   buttons. Best for visually distinct choices (approve / deny /
+ *   buttons. Best for visually distinct choices (allow / cancel /
  *   cancel).
  * - No options (or `allowFreeform: true`) → a single "Type your answer"
  *   button that opens a Slack modal with a plain_text_input. The modal
@@ -323,13 +323,13 @@ function cardButtonOptions(request: InputRequest): CardButtonOption[] {
   const options = request.options ?? [];
   if (!isApprovalRequest(request)) return options.map(toCardButtonOption);
 
-  const approve = options.find((option) => option.id === "approve");
-  const deny = options.find((option) => option.id === "deny");
-  if (!approve || !deny) return options.map(toCardButtonOption);
+  const allow = options.find((option) => option.id === "approve");
+  const cancel = options.find((option) => option.id === "cancel");
+  if (!allow || !cancel) return options.map(toCardButtonOption);
 
   return [
-    { id: deny.id, label: "Deny" },
-    { id: approve.id, label: "Allow", style: "primary" },
+    { id: cancel.id, label: "Cancel" },
+    { id: allow.id, label: "Approve", style: "primary" },
   ];
 }
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -481,7 +481,7 @@ describe("slackChannel() default event handlers", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: mongodb-mutate",
             requestId: "approval_abc123",
@@ -556,12 +556,12 @@ describe("slackChannel() default event handlers", () => {
     expect(new Set(actionIds).size).toBe(actionIds.length);
     expect(actions).toMatchObject([
       {
-        text: { type: "plain_text", text: "Deny", emoji: false },
-        value: "deny",
+        text: { type: "plain_text", text: "Cancel", emoji: false },
+        value: "cancel",
       },
       {
         style: "primary",
-        text: { type: "plain_text", text: "Allow", emoji: false },
+        text: { type: "plain_text", text: "Approve", emoji: false },
         value: "approve",
       },
     ]);
@@ -632,7 +632,7 @@ describe("slackChannel() default event handlers", () => {
       kind: "tool-approval" as const,
       options: [
         { id: "approve", label: "Yes" },
-        { id: "deny", label: "No" },
+        { id: "cancel", label: "Cancel" },
       ],
       prompt: `Approve tool call ${index}`,
       requestId: `approval_${index}`,
@@ -2324,9 +2324,9 @@ describe("slackChannel() HITL interaction pipeline", () => {
   it("updates one answered HITL card without removing sibling batched buttons", async () => {
     const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
 
-    const firstDenyActionId = `${HITL_ACTION_PREFIX}approval_451:button:0`;
+    const firstCancelActionId = `${HITL_ACTION_PREFIX}approval_451:button:0`;
     const firstApproveActionId = `${HITL_ACTION_PREFIX}approval_451:button:1`;
-    const secondDenyActionId = `${HITL_ACTION_PREFIX}approval_508:button:0`;
+    const secondCancelActionId = `${HITL_ACTION_PREFIX}approval_508:button:0`;
     const secondApproveActionId = `${HITL_ACTION_PREFIX}approval_508:button:1`;
 
     const { send } = await firePost(
@@ -2355,9 +2355,9 @@ describe("slackChannel() HITL interaction pipeline", () => {
               actions: [
                 {
                   type: "button",
-                  action_id: firstDenyActionId,
-                  text: { type: "plain_text", text: "Deny" },
-                  value: "deny",
+                  action_id: firstCancelActionId,
+                  text: { type: "plain_text", text: "Cancel" },
+                  value: "cancel",
                 },
                 {
                   type: "button",
@@ -2386,9 +2386,9 @@ describe("slackChannel() HITL interaction pipeline", () => {
               actions: [
                 {
                   type: "button",
-                  action_id: secondDenyActionId,
-                  text: { type: "plain_text", text: "Deny" },
-                  value: "deny",
+                  action_id: secondCancelActionId,
+                  text: { type: "plain_text", text: "Cancel" },
+                  value: "cancel",
                 },
                 {
                   type: "button",
@@ -2461,7 +2461,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
           ?.map((element) => element.action_id)
           .filter((actionId): actionId is string => typeof actionId === "string") ?? [],
     );
-    expect(remainingActionIds).toEqual([secondDenyActionId, secondApproveActionId]);
+    expect(remainingActionIds).toEqual([secondCancelActionId, secondApproveActionId]);
   });
 
   it("covers the observed e0 batched escalation approval run", async () => {
@@ -2484,7 +2484,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: escalate_issue",
             requestId: "approval_451",
@@ -2500,7 +2500,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
             kind: "tool-approval",
             options: [
               { id: "approve", label: "Yes" },
-              { id: "deny", label: "No" },
+              { id: "cancel", label: "Cancel" },
             ],
             prompt: "Approve tool call: escalate_issue",
             requestId: "approval_508",
@@ -2532,12 +2532,10 @@ describe("slackChannel() HITL interaction pipeline", () => {
     );
     expect(posted.blocks[3]?.child_blocks?.[0]?.text?.text).toContain('"issueNumber": 508');
 
-    const firstDenyAction = posted.blocks[0]?.actions?.find((action) => action.value === "deny");
-    expect(firstDenyAction).toMatchObject({
-      action_id: `${HITL_ACTION_PREFIX}approval_451:button:0`,
-      text: { text: "Deny" },
-      value: "deny",
-    });
+    const firstCancelAction = posted.blocks[0]?.actions?.find(
+      (action) => action.value === "cancel",
+    );
+    expect(firstCancelAction).toMatchObject({ value: "cancel" });
 
     const { send } = await firePost(
       channel,
@@ -2558,9 +2556,9 @@ describe("slackChannel() HITL interaction pipeline", () => {
         },
         actions: [
           {
-            action_id: firstDenyAction?.action_id,
-            text: { type: "plain_text", text: "Deny" },
-            value: "deny",
+            action_id: firstCancelAction?.action_id,
+            text: { type: "plain_text", text: "Cancel" },
+            value: "cancel",
           },
         ],
       }),
@@ -2569,7 +2567,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0]?.[0]).toBe("C01:1700000000.000001");
     expect(send.mock.calls[0]?.[1]).toMatchObject({
-      inputResponses: [{ optionId: "deny", requestId: "approval_451" }],
+      inputResponses: [{ optionId: "cancel", requestId: "approval_451" }],
     });
 
     const updateCall = fetchMock.mock.calls.find(
@@ -2585,7 +2583,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
       }>;
     };
 
-    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Deny* by <@U0AT7H56S90>");
+    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Cancel* by <@U0AT7H56S90>");
     expect(body.blocks[1]?.child_blocks?.[0]?.text?.text).toContain('"issueNumber": 451');
     expect(body.blocks[3]?.child_blocks?.[0]?.text?.text).toContain('"issueNumber": 508');
     const remainingActionIds = body.blocks.flatMap(

--- a/packages/eve/src/public/channels/teams/hitl.test.ts
+++ b/packages/eve/src/public/channels/teams/hitl.test.ts
@@ -52,13 +52,13 @@ describe("Teams HITL helpers", () => {
       activityWithValue({
         [TEAMS_HITL_DATA_KEY]: {
           replyToActivityId: "ROOT",
-          optionId: "deny",
+          optionId: "cancel",
           requestId: "REQ",
         },
       }),
     );
     expect(message ? deriveTeamsInputResponses(message) : []).toEqual([
-      { optionId: "deny", requestId: "REQ" },
+      { optionId: "cancel", requestId: "REQ" },
     ]);
     expect(message ? readTeamsInputReplyToActivityId(message) : null).toBe("ROOT");
 
@@ -88,7 +88,7 @@ function request(): InputRequest {
     kind: "tool-approval",
     options: [
       { id: "approve", label: "Approve", style: "primary" },
-      { id: "deny", label: "Deny", style: "danger" },
+      { id: "cancel", label: "Cancel", style: "danger" },
     ],
     prompt: "Approve deploy?",
     requestId: "REQ",

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -228,7 +228,7 @@ describe("teamsChannel", () => {
       eve_input: {
         replyToActivityId: "THREAD_ROOT",
         requestId: "REQ",
-        optionId: "deny",
+        optionId: "cancel",
       },
     };
     const channel = teamsChannel({
@@ -243,7 +243,7 @@ describe("teamsChannel", () => {
     expect(send).toHaveBeenCalledWith(
       "TENANT:CONV:THREAD_ROOT",
       expect.objectContaining({
-        inputResponses: [{ optionId: "deny", requestId: "REQ" }],
+        inputResponses: [{ optionId: "cancel", requestId: "REQ" }],
       }),
     );
   });

--- a/packages/eve/src/public/channels/telegram/hitl.test.ts
+++ b/packages/eve/src/public/channels/telegram/hitl.test.ts
@@ -22,7 +22,7 @@ describe("renderTelegramInputRequest", () => {
         kind: "question",
         options: [
           { id: "approve", label: "Approve" },
-          { id: "deny", label: "Deny" },
+          { id: "cancel", label: "Cancel" },
         ],
         prompt: "Approve?",
         requestId: "very-long-request-id-that-would-not-fit-comfortably-in-callback-data",
@@ -34,7 +34,7 @@ describe("renderTelegramInputRequest", () => {
       inline_keyboard: [
         [
           { callback_data: "eve:0", text: "Approve" },
-          { callback_data: "eve:1", text: "Deny" },
+          { callback_data: "eve:1", text: "Cancel" },
         ],
       ],
     });

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -586,7 +586,7 @@ describe("useEveAgent", () => {
 
     let sendPromise: Promise<void> | undefined;
     await act(async () => {
-      sendPromise = helpers?.respond([{ optionId: "deny", requestId: "approval_1" }]);
+      sendPromise = helpers?.respond([{ optionId: "cancel", requestId: "approval_1" }]);
       await Promise.resolve();
     });
 

--- a/packages/eve/src/runtime/input/types.test.ts
+++ b/packages/eve/src/runtime/input/types.test.ts
@@ -21,7 +21,7 @@ describe("inputRequestSchema", () => {
       kind: "tool-approval",
       options: [
         { id: "approve", label: "Approve", style: "primary" },
-        { id: "deny", label: "Deny", style: "danger" },
+        { id: "cancel", label: "Cancel", style: "danger" },
       ],
       prompt: 'Approve tool "bash"?',
       requestId: "approval-1",

--- a/packages/eve/src/runtime/input/types.ts
+++ b/packages/eve/src/runtime/input/types.ts
@@ -36,10 +36,7 @@ export type InputRequestKind = z.infer<typeof inputRequestKindSchema>;
 /** Zod schema for the framework-owned source of an input request. */
 export const inputRequestKindSchema = z.enum(["question", "session-limit", "tool-approval"]);
 
-/**
- * Unified input request surfaced to the client when the agent needs user
- * input before continuing.
- */
+/** Unified input request surfaced when the agent needs user input. */
 export type InputRequest = z.infer<typeof inputRequestSchema>;
 
 /**

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -318,7 +318,7 @@ describe("EveAgentStore (Vue composable backing store)", () => {
     });
 
     const sendPromise = store.send({
-      inputResponses: [{ optionId: "deny", requestId: "approval_1" }],
+      inputResponses: [{ optionId: "cancel", requestId: "approval_1" }],
     });
     await Promise.resolve();
 


### PR DESCRIPTION
## Summary

Terminology change, open to pushback.

Replaces `deny` with `cancel` in HITL flows in preparation for authorization requirement, since `allow` implies authz, `deny` may imply that authz is also necessary - but any user should be able to terminate the flow/cancel.

Depends on #1368.

## Validation

Covered by the consolidated top-stack checks.