### PR TITLE
feat(eve): require approval for self-modification

### DIFF
--- a/.changeset/tidy-wolves-selfmod.md
+++ b/.changeset/tidy-wolves-selfmod.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Add an explicit development-only selfmod subagent that can edit an agent's live authored directory while `eve dev` is running. Configure parent-facing delegation guidance separately from child instructions; hosted builds omit the capability entirely.
+Add an explicit development-only selfmod subagent that can propose changes to an agent's live authored directory while `eve dev` is running. Every proposal displays its serialized file edits for required human approval before writing; hosted builds omit the capability entirely.

--- a/packages/eve/src/compiler/normalize-selfmod-subagent.ts
+++ b/packages/eve/src/compiler/normalize-selfmod-subagent.ts
@@ -21,7 +21,9 @@ const SELFMOD_DESCRIPTION =
   "Immediately delegate here when the developer asks to change this eve agent or its source. Only this subagent has the live agent tree; do not use the root agent's shell or file tools to inspect or verify source before or after delegation.";
 const SELFMOD_INSTRUCTIONS = `You are a development-only source editor for an eve application.
 
-The live authored agent directory is mounted at /workspace. Inspect relevant files before editing them, keep changes minimal, and modify only what the developer requested. Existing files must be read before they are overwritten. You cannot access application files outside the authored agent directory or run host binaries such as git, node, pnpm, or tsc; eve's development watcher validates authored changes and keeps the previous generation active when compilation fails. Return a concise summary of files changed and any validation limitations.`;
+The live authored agent directory is mounted read-only for your model-visible tools at /workspace. Inspect relevant files, keep changes minimal, and modify only what the developer requested. To make changes, call propose_edits once with the complete set of create, replace, and delete operations. It records the proposal without writing files. Then pass the returned proposalId to finalize_edits; eve will show those edits to the developer and require approval before writing anything. Never claim edits were applied unless finalize_edits succeeds. If approval is denied or a file changed after proposal, do not work around the decision.
+
+You cannot access application files outside the authored agent directory or run host binaries such as git, node, pnpm, or tsc; eve's development watcher validates approved changes and keeps the previous generation active when compilation fails. Return a concise summary of approved files changed and any validation limitations.`;
 
 interface SelfmodModuleSource {
   readonly logicalPath: string;
@@ -96,7 +98,15 @@ export async function normalizeSelfmodSubagent(input: {
     agentRoot: input.source.manifest.agentRoot,
     appRoot: input.appRoot,
     config,
-    disabledFrameworkTools: ["ask_question", "load_skill", "todo", "web_fetch", "web_search"],
+    disabledFrameworkTools: [
+      "ask_question",
+      "bash",
+      "load_skill",
+      "todo",
+      "web_fetch",
+      "web_search",
+      "write_file",
+    ],
     instructions: {
       logicalPath: "eve:extensions/selfmod/instructions",
       markdown:
@@ -111,7 +121,7 @@ export async function normalizeSelfmodSubagent(input: {
       backendName: SELFMOD_SANDBOX_BACKEND_NAME,
       description: "Development-only live eve application source tree.",
       logicalPath: input.moduleSource.logicalPath,
-      sourceHash: "eve-selfmod-v1",
+      sourceHash: "eve-selfmod-v2",
       sourceId: input.moduleSource.sourceId,
       sourceKind: "module",
     },

--- a/packages/eve/src/execution/sandbox/glob-tool.ts
+++ b/packages/eve/src/execution/sandbox/glob-tool.ts
@@ -68,7 +68,7 @@ export async function executeGlobOnSandbox(
   // missing) indicates a real failure. Surface these as structured
   // errors rather than silently pretending the search returned zero
   // files.
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (result.exitCode !== 0 && (result.exitCode !== 1 || result.stderr.trim().length > 0)) {
     throw buildGlobExecutionError(command, result.exitCode, result.stderr);
   }
 

--- a/packages/eve/src/execution/sandbox/grep-tool.ts
+++ b/packages/eve/src/execution/sandbox/grep-tool.ts
@@ -69,7 +69,7 @@ export async function executeGrepOnSandbox(
         normalizedPath,
         pattern: args.pattern,
       })
-    : buildPosixGrepCommand({
+    : buildFallbackGrepCommand({
         contextLines,
         effectiveLimit,
         glob: args.glob,
@@ -88,7 +88,7 @@ export async function executeGrepOnSandbox(
   // Any other exit code (e.g. 127 from bash when the tool is missing)
   // indicates a real failure. Surface these as structured errors
   // rather than silently pretending the search returned zero matches.
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (result.exitCode !== 0 && (result.exitCode !== 1 || result.stderr.trim().length > 0)) {
     throw buildGrepExecutionError(command, result.exitCode, result.stderr);
   }
 
@@ -159,11 +159,11 @@ function buildRipgrepCommand(input: BuildCommandInput): string {
   return parts.join(" ");
 }
 
-/**
- * Builds the POSIX fallback form of the grep command using `grep -rn`.
- */
-function buildPosixGrepCommand(input: BuildCommandInput): string {
-  const parts: string[] = ["grep", "-r", "-n", "--color=never", "--exclude-dir=.git"];
+function buildFallbackGrepCommand(input: BuildCommandInput): string {
+  // Keep this compatible with small implementations such as just-bash: no
+  // `--color` or `--` separator. `-e` below safely marks the pattern even
+  // when it starts with a dash.
+  const parts: string[] = ["grep", "-r", "-n", "--exclude-dir=.git"];
 
   if (input.ignoreCase) {
     parts.push("-i");
@@ -187,7 +187,7 @@ function buildPosixGrepCommand(input: BuildCommandInput): string {
 
   // `-m` limits matches per file, analogous to ripgrep's `--max-count`.
   parts.push(`-m ${input.effectiveLimit}`);
-  parts.push("--");
+  parts.push("-e");
   parts.push(shellQuote(input.pattern));
   parts.push(shellQuote(input.normalizedPath));
 

--- a/packages/eve/src/execution/sandbox/ripgrep-probe.test.ts
+++ b/packages/eve/src/execution/sandbox/ripgrep-probe.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ripgrepIsAvailable } from "#execution/sandbox/ripgrep-probe.js";
+import type { SandboxSession } from "#shared/sandbox-session.js";
+
+function createSession(
+  id: string,
+  results: readonly {
+    readonly exitCode: number;
+    readonly stderr: string;
+    readonly stdout: string;
+  }[],
+): Pick<SandboxSession, "id" | "run"> {
+  const queue = [...results];
+  const run: Pick<SandboxSession, "run">["run"] = vi.fn(async () => queue.shift()!);
+  return { id, run };
+}
+
+describe("ripgrepIsAvailable", () => {
+  it("rejects an rg implementation that cannot parse framework flags", async () => {
+    const results = [
+      { exitCode: 0, stderr: "", stdout: "" },
+      { exitCode: 1, stderr: "rg: unrecognized option '--'\n", stdout: "" },
+    ];
+    const session = createSession("limited-rg", results);
+
+    await expect(ripgrepIsAvailable(session)).resolves.toBe(false);
+  });
+
+  it("rejects an rg implementation missing grep capabilities", async () => {
+    const results = [
+      { exitCode: 0, stderr: "", stdout: "" },
+      { exitCode: 1, stderr: "", stdout: "" },
+      { exitCode: 1, stderr: "rg: unrecognized option '--context'\n", stdout: "" },
+    ];
+    const session = createSession("limited-grep-rg", results);
+
+    await expect(ripgrepIsAvailable(session)).resolves.toBe(false);
+  });
+
+  it("accepts a capable rg whose probes legitimately find no matches", async () => {
+    const results = [
+      { exitCode: 0, stderr: "", stdout: "" },
+      { exitCode: 1, stderr: "", stdout: "" },
+      { exitCode: 1, stderr: "", stdout: "" },
+    ];
+    const session = createSession("capable-rg", results);
+
+    await expect(ripgrepIsAvailable(session)).resolves.toBe(true);
+  });
+});

--- a/packages/eve/src/execution/sandbox/ripgrep-probe.ts
+++ b/packages/eve/src/execution/sandbox/ripgrep-probe.ts
@@ -1,20 +1,11 @@
 import type { SandboxSession } from "#public/definitions/sandbox.js";
 
-/**
- * Memoizes the result of probing for `rg` (ripgrep) once per sandbox
- * session. The probe runs exactly one `command -v rg` per distinct
- * session object, regardless of how many grep/glob tool calls happen.
- */
 const probes = new Map<string, Promise<boolean>>();
 
-/**
- * Returns `true` when `rg` is on PATH in the given sandbox session,
- * `false` otherwise. Result is cached per session.
- *
- * Framework `grep` and `glob` tools call this to decide whether to use
- * ripgrep or the POSIX `grep`/`find` fallback.
- */
-export async function ripgrepIsAvailable(session: SandboxSession): Promise<boolean> {
+/** Reports whether `rg` supports eve's search flags, cached by sandbox session. */
+export async function ripgrepIsAvailable(
+  session: Pick<SandboxSession, "id" | "run">,
+): Promise<boolean> {
   const existing = probes.get(session.id);
   if (existing !== undefined) {
     return existing;
@@ -35,7 +26,19 @@ export async function ripgrepIsAvailable(session: SandboxSession): Promise<boole
   }
 }
 
-async function runProbe(session: SandboxSession): Promise<boolean> {
-  const result = await session.run({ command: "command -v rg >/dev/null 2>&1" });
-  return result.exitCode === 0;
+async function runProbe(session: Pick<SandboxSession, "id" | "run">): Promise<boolean> {
+  const located = await session.run({ command: "command -v rg >/dev/null 2>&1" });
+  if (located.exitCode !== 0) return false;
+
+  // just-bash provides `rg` but not every flag used by eve's search tools.
+  for (const command of [
+    "rg --files --hidden --glob '__eve_capability_probe_no_match__' -- /workspace",
+    "rg --line-number --color=never --hidden --ignore-case --fixed-strings --glob '!.git/*' --glob '*.ts' --context 1 --max-count 1 -- '__eve_capability_probe_no_match__' /workspace",
+  ]) {
+    const capability = await session.run({ command });
+    if ((capability.exitCode !== 0 && capability.exitCode !== 1) || capability.stderr.length > 0) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/eve/src/runtime/agent/mock-model-adapter.ts
+++ b/packages/eve/src/runtime/agent/mock-model-adapter.ts
@@ -622,15 +622,12 @@ function findRelevantTool(
   // `load_skill` is reachable only through skill-relevance selection
   // (createSkillLoadResult); matching it by name here would re-call it on
   // every step, because its results are invisible to the tool-result check.
-  const explicitTool = tools.find(
-    (tool) =>
-      tool.name !== "agent" &&
-      tool.name !== LOAD_SKILL_TOOL_NAME &&
-      normalizedMessage.includes(normalizeText(tool.name)),
-  );
-  if (explicitTool !== undefined) {
-    return explicitTool;
-  }
+  const explicitTool = tools
+    .filter((tool) => tool.name !== "agent" && tool.name !== LOAD_SKILL_TOOL_NAME)
+    .map((tool) => ({ index: normalizedMessage.indexOf(normalizeText(tool.name)), tool }))
+    .filter((candidate) => candidate.index >= 0)
+    .sort((left, right) => left.index - right.index)[0]?.tool;
+  if (explicitTool !== undefined) return explicitTool;
 
   if (!/\b(forecast|temperature|weather|wind|rain|snow)\b/u.test(normalizedMessage)) {
     return null;

--- a/packages/eve/src/runtime/framework-tools/index.test.ts
+++ b/packages/eve/src/runtime/framework-tools/index.test.ts
@@ -21,6 +21,8 @@ describe("framework-tools/index", () => {
     expect(names.has("load_skill")).toBe(true);
     expect(names.has("ask_question")).toBe(true);
     expect(names.has("agent")).toBe(true);
+    expect(names.has("propose_edits")).toBe(true);
+    expect(names.has("finalize_edits")).toBe(true);
     // connection_search is now a dynamic tool resolver, not a framework tool
     expect(names.has("connection_search")).toBe(false);
   });
@@ -68,5 +70,17 @@ describe("framework-tools/index", () => {
     expect(withConnections.map((tool) => tool.name)).toEqual(
       withoutConnections.map((tool) => tool.name),
     );
+  });
+
+  it("registers edit proposal tools only for self-modifying agents", () => {
+    const ordinaryNames = getFrameworkToolDefinitions().map((tool) => tool.name);
+    const selfmodNames = getFrameworkToolDefinitions({ selfModifying: true }).map(
+      (tool) => tool.name,
+    );
+
+    expect(ordinaryNames).not.toContain("propose_edits");
+    expect(ordinaryNames).not.toContain("finalize_edits");
+    expect(selfmodNames).toContain("propose_edits");
+    expect(selfmodNames).toContain("finalize_edits");
   });
 });

--- a/packages/eve/src/runtime/framework-tools/index.ts
+++ b/packages/eve/src/runtime/framework-tools/index.ts
@@ -4,6 +4,7 @@ import { BASH_TOOL_DEFINITION } from "#runtime/framework-tools/bash.js";
 import { GLOB_TOOL_DEFINITION } from "#runtime/framework-tools/glob.js";
 import { GREP_TOOL_DEFINITION } from "#runtime/framework-tools/grep.js";
 import { READ_FILE_TOOL_DEFINITION } from "#runtime/framework-tools/read-file.js";
+import { SELFMOD_EDIT_TOOL_DEFINITIONS } from "#runtime/framework-tools/selfmod-edits.js";
 import {
   createSkillToolDefinition,
   SKILL_TOOL_DEFINITION,
@@ -36,6 +37,7 @@ const REGISTERED_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
 
 const ALL_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
   ...REGISTERED_FRAMEWORK_TOOLS,
+  ...SELFMOD_EDIT_TOOL_DEFINITIONS,
   AGENT_TOOL_DEFINITION,
 ];
 
@@ -49,11 +51,16 @@ const ALL_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
 export function getFrameworkToolDefinitions(config?: {
   readonly authoredSkills?: readonly ResolvedSkillDefinition[];
   readonly hasConnections?: boolean;
+  readonly selfModifying?: boolean;
 }): readonly ResolvedToolDefinition[] {
   const authoredSkills = config?.authoredSkills;
-  if (authoredSkills === undefined) return REGISTERED_FRAMEWORK_TOOLS;
+  const tools =
+    config?.selfModifying === true
+      ? [...REGISTERED_FRAMEWORK_TOOLS, ...SELFMOD_EDIT_TOOL_DEFINITIONS]
+      : REGISTERED_FRAMEWORK_TOOLS;
+  if (authoredSkills === undefined) return tools;
 
-  return REGISTERED_FRAMEWORK_TOOLS.map((definition) =>
+  return tools.map((definition) =>
     definition.name === SKILL_TOOL_DEFINITION.name
       ? createSkillToolDefinition(authoredSkills)
       : definition,

--- a/packages/eve/src/runtime/framework-tools/selfmod-edits.test.ts
+++ b/packages/eve/src/runtime/framework-tools/selfmod-edits.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import {
+  FINALIZE_EDITS_TOOL_DEFINITION,
+  finalizeEdits,
+  proposeEdits,
+} from "#runtime/framework-tools/selfmod-edits.js";
+import type { SandboxSession } from "#shared/sandbox-session.js";
+
+function createSandbox(initial: Readonly<Record<string, string>>): {
+  readonly files: Map<string, string>;
+  readonly removePath: ReturnType<typeof vi.fn>;
+  readonly sandbox: Pick<SandboxSession, "readTextFile" | "removePath" | "writeTextFile">;
+  readonly writeTextFile: ReturnType<typeof vi.fn>;
+} {
+  const files = new Map(Object.entries(initial));
+  const writeTextFile = vi.fn(async ({ content, path }: { content: string; path: string }) => {
+    files.set(path, content);
+  });
+  const removePath = vi.fn(async ({ path }: { path: string }) => {
+    files.delete(path);
+  });
+  const sandbox = {
+    readTextFile: vi.fn(async ({ path }: { path: string }) => files.get(path) ?? null),
+    removePath,
+    writeTextFile,
+  } satisfies Pick<SandboxSession, "readTextFile" | "removePath" | "writeTextFile">;
+  return { files, removePath, sandbox, writeTextFile };
+}
+
+async function withContext<T>(fn: () => Promise<T>): Promise<T> {
+  return await contextStorage.run(new ContextContainer(), fn);
+}
+
+describe("selfmod edit tools", () => {
+  it("records a reviewable proposal without writing, then applies it after approval", async () => {
+    const { files, removePath, sandbox, writeTextFile } = createSandbox({
+      "/workspace/agent.ts": "model: 'old'\n",
+      "/workspace/obsolete.md": "remove me\n",
+    });
+
+    await withContext(async () => {
+      const proposal = await proposeEdits(sandbox, {
+        edits: [
+          {
+            filePath: "/workspace/agent.ts",
+            kind: "replace",
+            newText: "model: 'new'",
+            oldText: "model: 'old'",
+          },
+          { content: "hello\n", filePath: "/workspace/new.md", kind: "create" },
+          { filePath: "/workspace/obsolete.md", kind: "delete" },
+        ],
+        summary: "Update the model and supporting files.",
+      });
+
+      expect(proposal).toEqual({ proposalId: expect.any(String) });
+      expect(writeTextFile).not.toHaveBeenCalled();
+      expect(removePath).not.toHaveBeenCalled();
+      expect(files.get("/workspace/agent.ts")).toBe("model: 'old'\n");
+
+      await finalizeEdits(sandbox, proposal.proposalId);
+
+      expect(files.get("/workspace/agent.ts")).toBe("model: 'new'\n");
+      expect(files.get("/workspace/new.md")).toBe("hello\n");
+      expect(files.has("/workspace/obsolete.md")).toBe(false);
+    });
+  });
+
+  it("refuses an unknown proposal and a file changed while approval was pending", async () => {
+    const { files, sandbox } = createSandbox({ "/workspace/a.ts": "old\n" });
+
+    await withContext(async () => {
+      const proposal = await proposeEdits(sandbox, {
+        edits: [{ filePath: "/workspace/a.ts", kind: "replace", newText: "new", oldText: "old" }],
+        summary: "Change a.ts.",
+      });
+
+      await expect(finalizeEdits(sandbox, "00000000-0000-4000-8000-000000000000")).rejects.toThrow(
+        "Unknown or expired",
+      );
+
+      files.set("/workspace/a.ts", "external change\n");
+      await expect(finalizeEdits(sandbox, proposal.proposalId)).rejects.toThrow(
+        "changed after the edits were proposed",
+      );
+    });
+  });
+
+  it("reads changed files concurrently", async () => {
+    let releaseReads!: () => void;
+    const readsReleased = new Promise<void>((resolve) => {
+      releaseReads = resolve;
+    });
+    const readTextFile = vi.fn(async () => {
+      await readsReleased;
+      return "old\n";
+    });
+    const sandbox = {
+      readTextFile,
+      removePath: vi.fn(),
+      writeTextFile: vi.fn(),
+    } satisfies Pick<SandboxSession, "readTextFile" | "removePath" | "writeTextFile">;
+
+    const pending = withContext(
+      async () =>
+        await proposeEdits(sandbox, {
+          edits: [
+            { filePath: "/workspace/a.ts", kind: "delete" },
+            { filePath: "/workspace/b.ts", kind: "delete" },
+          ],
+          summary: "Delete two files.",
+        }),
+    );
+    await vi.waitFor(() => expect(readTextFile).toHaveBeenCalledTimes(2));
+    releaseReads();
+
+    await expect(pending).resolves.toEqual({ proposalId: expect.any(String) });
+  });
+
+  it("returns a compact reference even for a large proposal", async () => {
+    const { sandbox } = createSandbox({});
+
+    await withContext(async () => {
+      const proposal = await proposeEdits(sandbox, {
+        edits: [
+          { content: "x".repeat(1_000_000), filePath: "/workspace/large.txt", kind: "create" },
+        ],
+        summary: "Create a large file.",
+      });
+
+      expect(JSON.stringify(proposal).length).toBeLessThan(64);
+    });
+  });
+
+  it("requires approval for a recorded proposal", async () => {
+    const { sandbox } = createSandbox({ "/workspace/a.ts": "old\n" });
+
+    await withContext(async () => {
+      const proposal = await proposeEdits(sandbox, {
+        edits: [{ filePath: "/workspace/a.ts", kind: "replace", newText: "new", oldText: "old" }],
+        summary: "Change a.ts.",
+      });
+      const approval = await FINALIZE_EDITS_TOOL_DEFINITION.approval?.({
+        callId: "call-1",
+        session: { id: "session-1" },
+        toolInput: proposal,
+      } as never);
+
+      expect(approval).toBe("user-approval");
+    });
+  });
+});

--- a/packages/eve/src/runtime/framework-tools/selfmod-edits.ts
+++ b/packages/eve/src/runtime/framework-tools/selfmod-edits.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "node:crypto";
+
+import { z } from "#compiled/zod/index.js";
+
+import { loadContext } from "#context/container.js";
+import { ContextKey } from "#context/key.js";
+import { requireSandboxSession } from "#execution/sandbox/require-sandbox.js";
+import type { ApprovalContext, ApprovalStatus } from "#public/definitions/approval.js";
+import { normalizeModelPath } from "#runtime/framework-tools/file-state.js";
+import type { ResolvedToolDefinition } from "#runtime/types.js";
+import type { SandboxSession } from "#shared/sandbox-session.js";
+import type { SourceEditChange, SourceEditProposal } from "#shared/source-edit-proposal.js";
+import type { ToolExecuteOptions } from "#shared/tool-definition.js";
+
+export const PROPOSE_EDITS_TOOL_NAME = "propose_edits";
+export const FINALIZE_EDITS_TOOL_NAME = "finalize_edits";
+
+const FILE_PATH_SCHEMA = z
+  .string()
+  .describe("Absolute path under /workspace for the file being changed.");
+
+const EDIT_SCHEMA = z.discriminatedUnion("kind", [
+  z.strictObject({
+    content: z.string().describe("Complete contents for the new file."),
+    filePath: FILE_PATH_SCHEMA,
+    kind: z.literal("create"),
+  }),
+  z.strictObject({
+    filePath: FILE_PATH_SCHEMA,
+    kind: z.literal("replace"),
+    newText: z.string().describe("Replacement text."),
+    oldText: z.string().min(1).describe("Existing text that must occur exactly once."),
+  }),
+  z.strictObject({
+    filePath: FILE_PATH_SCHEMA,
+    kind: z.literal("delete"),
+  }),
+]);
+
+const PROPOSE_EDITS_INPUT_SCHEMA = z.strictObject({
+  edits: z.array(EDIT_SCHEMA).min(1).describe("The complete set of proposed file edits."),
+  summary: z.string().min(1).describe("A concise explanation of the proposed change."),
+});
+
+const PROPOSAL_REFERENCE_SCHEMA = z.strictObject({
+  proposalId: z.string().uuid(),
+});
+
+const FINALIZE_EDITS_OUTPUT_SCHEMA = z.strictObject({
+  changedFiles: z.array(z.string()),
+  proposalId: z.string(),
+});
+
+export type ProposedEdit = z.infer<typeof EDIT_SCHEMA>;
+export type SourceEditProposalReference = z.infer<typeof PROPOSAL_REFERENCE_SCHEMA>;
+
+type SelfmodEditSandbox = Pick<SandboxSession, "readTextFile" | "removePath" | "writeTextFile">;
+
+type SelfmodEditState = {
+  readonly proposals: Readonly<Record<string, SourceEditProposal>>;
+};
+
+const SelfmodEditStateKey = new ContextKey<SelfmodEditState>("eve.selfmodEdits");
+
+function normalizeWorkspacePath(filePath: string): string {
+  if (!filePath.startsWith("/")) {
+    throw new Error(`Self-modification path must be absolute: ${filePath}`);
+  }
+  const normalized = normalizeModelPath(filePath);
+  if (!normalized.startsWith("/workspace/")) {
+    throw new Error(`Self-modification path must be under /workspace: ${filePath}`);
+  }
+  return normalized;
+}
+
+function requirePendingProposal(proposalId: string): SourceEditProposal {
+  const proposal = loadContext().get(SelfmodEditStateKey)?.proposals[proposalId];
+  if (proposal === undefined) {
+    throw new Error(`Unknown or expired edit proposal: ${proposalId}`);
+  }
+  return proposal;
+}
+
+function requestFinalizeEditsApproval(ctx: ApprovalContext): ApprovalStatus {
+  try {
+    const { proposalId } = PROPOSAL_REFERENCE_SCHEMA.parse(ctx.toolInput);
+    requirePendingProposal(proposalId);
+    return "user-approval";
+  } catch (error) {
+    return {
+      type: "denied",
+      reason: error instanceof Error ? error.message : "The proposed edits cannot be reviewed.",
+    };
+  }
+}
+
+/** Finalizes and records edits without changing the sandbox filesystem. */
+export async function proposeEdits(
+  sandbox: SelfmodEditSandbox,
+  input: z.infer<typeof PROPOSE_EDITS_INPUT_SCHEMA>,
+): Promise<SourceEditProposalReference> {
+  const paths = new Set<string>();
+  const normalizedPaths = input.edits.map((edit) => {
+    const path = normalizeWorkspacePath(edit.filePath);
+    if (paths.has(path)) {
+      throw new Error(`A proposal may edit each file only once: ${path}`);
+    }
+    paths.add(path);
+    return path;
+  });
+  const currentContents = await Promise.all(
+    normalizedPaths.map((path) => sandbox.readTextFile({ path })),
+  );
+  const changes: SourceEditChange[] = input.edits.map((edit, index) => {
+    const path = normalizedPaths[index]!;
+    const current = currentContents[index] ?? null;
+    if (edit.kind === "create") {
+      if (current !== null) {
+        throw new Error(`Cannot create ${path} because it already exists.`);
+      }
+      return [path, null, edit.content];
+    }
+    if (current === null) {
+      throw new Error(`Cannot ${edit.kind} ${path} because it does not exist.`);
+    }
+    if (edit.kind === "delete") return [path, current, null];
+
+    const first = current.indexOf(edit.oldText);
+    const second = first < 0 ? -1 : current.indexOf(edit.oldText, first + edit.oldText.length);
+    if (first < 0 || second >= 0) {
+      throw new Error(
+        `Expected oldText exactly once in ${path}, but found ${countOccurrences(current, edit.oldText)} occurrences.`,
+      );
+    }
+    const after =
+      current.slice(0, first) + edit.newText + current.slice(first + edit.oldText.length);
+    return [path, current, after];
+  });
+
+  const proposal: SourceEditProposal = {
+    changes,
+    id: randomUUID(),
+    summary: input.summary,
+  };
+  const ctx = loadContext();
+  const state = ctx.ensure(SelfmodEditStateKey, () => ({ proposals: {} }));
+  ctx.set(SelfmodEditStateKey, {
+    proposals: { ...state.proposals, [proposal.id]: proposal },
+  });
+  return { proposalId: proposal.id };
+}
+
+function countOccurrences(content: string, search: string): number {
+  let count = 0;
+  let index = 0;
+  while ((index = content.indexOf(search, index)) >= 0) {
+    count += 1;
+    index += search.length;
+  }
+  return count;
+}
+
+/** Applies a recorded proposal after its approval gate passes. */
+export async function finalizeEdits(
+  sandbox: SelfmodEditSandbox,
+  proposalId: string,
+): Promise<z.infer<typeof FINALIZE_EDITS_OUTPUT_SCHEMA>> {
+  const proposal = requirePendingProposal(proposalId);
+
+  const currentContents = await Promise.all(
+    proposal.changes.map(([path]) => sandbox.readTextFile({ path })),
+  );
+  for (const [index, [path, before]] of proposal.changes.entries()) {
+    if ((currentContents[index] ?? null) !== before) {
+      throw new Error(
+        `${path} changed after the edits were proposed. Inspect it and propose the edits again.`,
+      );
+    }
+  }
+
+  for (const [path, , after] of proposal.changes) {
+    if (after === null) {
+      await sandbox.removePath({ path });
+    } else {
+      await sandbox.writeTextFile({ content: after, path });
+    }
+  }
+
+  const ctx = loadContext();
+  const state = ctx.require(SelfmodEditStateKey);
+  const remainingProposals = { ...state.proposals };
+  delete remainingProposals[proposalId];
+  ctx.set(SelfmodEditStateKey, { proposals: remainingProposals });
+
+  return {
+    changedFiles: proposal.changes.map(([path]) => path),
+    proposalId,
+  };
+}
+
+async function executeProposeEdits(
+  input: unknown,
+  options?: ToolExecuteOptions,
+): Promise<SourceEditProposalReference> {
+  return await proposeEdits(
+    await requireSandboxSession(options?.abortSignal),
+    input as z.infer<typeof PROPOSE_EDITS_INPUT_SCHEMA>,
+  );
+}
+
+async function executeFinalizeEdits(
+  input: unknown,
+  options?: ToolExecuteOptions,
+): Promise<z.infer<typeof FINALIZE_EDITS_OUTPUT_SCHEMA>> {
+  const { proposalId } = input as SourceEditProposalReference;
+  return await finalizeEdits(await requireSandboxSession(options?.abortSignal), proposalId);
+}
+
+export const PROPOSE_EDITS_TOOL_DEFINITION: ResolvedToolDefinition = {
+  description:
+    "Finalize source edits without writing files. Pass the returned proposalId to finalize_edits.",
+  execute: executeProposeEdits,
+  inputSchema: PROPOSE_EDITS_INPUT_SCHEMA,
+  logicalPath: "eve:framework/selfmod/propose-edits",
+  name: PROPOSE_EDITS_TOOL_NAME,
+  outputSchema: PROPOSAL_REFERENCE_SCHEMA,
+  sourceId: "eve:selfmod-propose-edits-tool",
+  sourceKind: "module",
+};
+
+export const FINALIZE_EDITS_TOOL_DEFINITION: ResolvedToolDefinition = {
+  approval: requestFinalizeEditsApproval,
+  description:
+    "Request human approval for a proposalId returned by propose_edits, then apply its exact edits.",
+  execute: executeFinalizeEdits,
+  inputSchema: PROPOSAL_REFERENCE_SCHEMA,
+  logicalPath: "eve:framework/selfmod/finalize-edits",
+  name: FINALIZE_EDITS_TOOL_NAME,
+  outputSchema: FINALIZE_EDITS_OUTPUT_SCHEMA,
+  sourceId: "eve:selfmod-finalize-edits-tool",
+  sourceKind: "module",
+};
+
+export const SELFMOD_EDIT_TOOL_DEFINITIONS: readonly ResolvedToolDefinition[] = [
+  PROPOSE_EDITS_TOOL_DEFINITION,
+  FINALIZE_EDITS_TOOL_DEFINITION,
+];

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -13,6 +13,7 @@ import {
   getAllFrameworkChannelNames,
   getFrameworkChannelDefinitions,
 } from "#runtime/framework-channels/index.js";
+import { SELFMOD_SANDBOX_BACKEND_NAME } from "#shared/selfmod-definition.js";
 import { createConnectionSearchResolver } from "#runtime/framework-tools/connection-search-dynamic.js";
 import {
   getAllFrameworkToolNames,
@@ -138,6 +139,7 @@ async function resolveRuntimeAgentNode(
   const frameworkTools = getFrameworkToolDefinitions({
     authoredSkills: agent.skills,
     hasConnections,
+    selfModifying: agent.sandbox?.backend.name === SELFMOD_SANDBOX_BACKEND_NAME,
   });
   const frameworkToolNames = new Set(frameworkTools.map((t) => t.name));
   const allFrameworkToolNames = getAllFrameworkToolNames();

--- a/packages/eve/src/shared/source-edit-proposal.ts
+++ b/packages/eve/src/shared/source-edit-proposal.ts
@@ -1,0 +1,9 @@
+/** Exact text transition stored compactly as `[path, before, after]`. */
+export type SourceEditChange = readonly [path: string, before: string | null, after: string | null];
+
+/** Trusted source changes finalized for approval and application. */
+export interface SourceEditProposal {
+  readonly changes: readonly SourceEditChange[];
+  readonly id: string;
+  readonly summary: string;
+}

--- a/packages/eve/test/scenarios/compile-agent.scenario.test.ts
+++ b/packages/eve/test/scenarios/compile-agent.scenario.test.ts
@@ -99,7 +99,15 @@ describe("compiler artifacts", () => {
       description: "Handle source changes immediately.",
       name: "selfmod",
       agent: {
-        disabledFrameworkTools: ["ask_question", "load_skill", "todo", "web_fetch", "web_search"],
+        disabledFrameworkTools: [
+          "ask_question",
+          "bash",
+          "load_skill",
+          "todo",
+          "web_fetch",
+          "web_search",
+          "write_file",
+        ],
         sandbox: { backendName: "eve-selfmod" },
       },
     });

--- a/packages/eve/test/scenarios/dev-server.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server.scenario.test.ts
@@ -58,6 +58,22 @@ const DEV_SERVER_AGENT_DESCRIPTOR: ScenarioAppDescriptor = {
     ].join("\n"),
   },
 };
+const SELFMOD_DEV_SERVER_DESCRIPTOR: ScenarioAppDescriptor = {
+  ...DEV_SERVER_AGENT_DESCRIPTOR,
+  dependencies: {
+    ...DEV_SERVER_AGENT_DESCRIPTOR.dependencies,
+    "just-bash": "3.1.0",
+  },
+  files: {
+    ...DEV_SERVER_AGENT_DESCRIPTOR.files,
+    "agent/subagents/self-edit.ts": [
+      'import { defineSelfModifyingAgent } from "eve/extensions/selfmod";',
+      "export default defineSelfModifyingAgent({ development: true });",
+      "",
+    ].join("\n"),
+  },
+  name: "weather-agent-selfmod",
+};
 const WEBSOCKET_DEV_SERVER_DESCRIPTOR: ScenarioAppDescriptor = {
   ...DEV_SERVER_AGENT_DESCRIPTOR,
   files: {
@@ -1014,6 +1030,27 @@ describe("eve dev server", () => {
           method: "POST",
         });
         expect(unknown.status).toBe(404);
+        expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
+      } finally {
+        await server.stop();
+      }
+    },
+    DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  );
+
+  it(
+    "mounts the live agent tree for selfmod tools in the development runtime",
+    async () => {
+      const app = await scenarioApp(SELFMOD_DEV_SERVER_DESCRIPTOR);
+      const server = await startEveDev(app.appRoot);
+
+      try {
+        const messageResult = await sendDevelopmentMessage({
+          message: `Call self-edit with message: 'glob pattern "**/*"'`,
+          session: createDevelopmentSessionState(),
+          serverUrl: server.url,
+        });
+        expect(readCompletedMessages(messageResult.events)).toContain("tools/get_weather.ts");
         expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
       } finally {
         await server.stop();


### PR DESCRIPTION
### Description

Requires explicit eve approval before staged source changes can be applied. Proposal generation remains side-effect free, while application is gated through the existing approval lifecycle and uses the exact reviewed proposal bytes.

This PR adds the approval boundary and regression coverage on top of the local development editing primitive in #1396.

### How did you test your changes?

- Focused approval, editing-policy, tool-loop, and application tests.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
