### PR TITLE
feat(eve): add source editing dev flag

### DIFF
--- a/.changeset/tidy-wolves-selfmod.md
+++ b/.changeset/tidy-wolves-selfmod.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Add an explicit development-only selfmod subagent that can propose and apply changes to an agent's live authored directory while `eve dev` is running. Every proposal has a scrollable, file-by-file diff viewer for required human approval before writing; hosted builds omit the capability entirely.
+Add an approval-gated development source editor for an agent's live authored directory. Declare a selfmod subagent or enable the framework-owned default with `eve dev --allow-source-editing`; hosted builds omit the capability entirely.

--- a/packages/eve/src/cli/dev/local-server-child.ts
+++ b/packages/eve/src/cli/dev/local-server-child.ts
@@ -5,7 +5,7 @@ import { reconcileCleanupIntents, recordCleanupIntent } from "#cli/dev/local-ser
 
 const options = JSON.parse(process.argv[2] ?? "{}") as Pick<
   DevelopmentServerOptions,
-  "existing" | "host" | "port"
+  "allowSourceEditing" | "existing" | "host" | "port"
 >;
 const server = createDevelopmentServer(process.cwd(), {
   ...options,

--- a/packages/eve/src/cli/dev/local-server-process.ts
+++ b/packages/eve/src/cli/dev/local-server-process.ts
@@ -91,6 +91,7 @@ export function createDevelopmentServer(
       childPath,
       [
         JSON.stringify({
+          allowSourceEditing: options.allowSourceEditing,
           existing: options.existing,
           host: options.host,
           port: options.port,

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -465,6 +465,35 @@ describe("eve eval --url protocol", () => {
   });
 });
 
+describe("eve dev --allow-source-editing", () => {
+  it("forwards the capability to a local development server", async () => {
+    const startHost = vi.fn(() => ({
+      start: async () => ({
+        kind: "started" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:4321/",
+      }),
+      close: async () => {},
+    }));
+
+    await runInteractiveDev(["dev", "--allow-source-editing"], { startHost });
+
+    expect(startHost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ allowSourceEditing: true }),
+    );
+  });
+
+  it("rejects the flag for a remote server", async () => {
+    await expect(
+      runCli(["dev", "--url", "https://example.com", "--allow-source-editing"], {
+        error: () => {},
+        log: () => {},
+      }),
+    ).rejects.toThrow("only start a local development server");
+  });
+});
+
 describe("eve dev --logs", () => {
   it("accepts sandbox as the initial TUI log mode", async () => {
     const runDevelopmentTui = await runInteractiveDev([

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -51,6 +51,7 @@ interface CliLogger {
 }
 
 interface DevelopmentCliOptions {
+  allowSourceEditing?: boolean;
   assistantResponseStats?: AssistantResponseStatsMode;
   connectionAuth?: TerminalPartDisplayMode;
   contextSize?: number;
@@ -383,6 +384,10 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       parseDevelopmentHeaderOption,
     )
     .option("--no-ui", "Start the server without an interactive UI")
+    .option(
+      "--allow-source-editing",
+      "Add a development-only source-editing subagent without changing the project",
+    )
     .option("--name <name>", "Title shown in the terminal UI (defaults to the app folder name)")
     .option("--input <text>", "Pre-fill the prompt input, or start onboarding with /model")
     .option(
@@ -427,6 +432,11 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
     .action(async (positionalUrl: string | undefined, options: DevelopmentCliOptions) => {
       const remoteTarget = resolveDevelopmentUrlTarget(options, positionalUrl);
       const remoteServerUrl = remoteTarget?.serverUrl;
+      if (remoteServerUrl !== undefined && options.allowSourceEditing === true) {
+        throw new InvalidArgumentError(
+          "--allow-source-editing can only start a local development server.",
+        );
+      }
       const interactive = hasInteractiveTerminal();
       const mode = resolveDevUiMode({ options, interactive });
       if (options.input !== undefined && mode === "headless") {
@@ -526,12 +536,16 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
 
       try {
         const startHost = runtime.startHost ?? (await loadStartHost());
-        server = startHost(appRoot, {
+        let serverOptions: DevelopmentServerOptions = {
           existing: mode === "tui" ? "attach-if-unconfigured" : "reject",
           host: options.host,
           onBootProgress,
           port: options.port,
-        });
+        };
+        if (options.allowSourceEditing === true) {
+          serverOptions = { ...serverOptions, allowSourceEditing: true };
+        }
+        server = startHost(appRoot, serverOptions);
         const outcome = await Promise.race([
           server.start().then((handle) => ({ handle })),
           lifecycle.stopped.then(() => ({ handle: undefined })),

--- a/packages/eve/src/compiler/artifacts.ts
+++ b/packages/eve/src/compiler/artifacts.ts
@@ -97,6 +97,7 @@ export interface CompilerArtifactLocations {
  * Input for writing compiler-owned discovery artifacts.
  */
 interface WriteCompilerArtifactsInput {
+  allowSourceEditing?: boolean;
   appRoot: string;
   artifactLocations: CompilerArtifactLocations;
   diagnostics: readonly DiscoverDiagnostic[];
@@ -160,6 +161,7 @@ function createDiscoveryDiagnosticsArtifact(
  * payloads.
  */
 export function createCompileMetadata(input: {
+  allowSourceEditing?: boolean;
   appRoot: string;
   diagnosticsArtifactJson: string;
   diagnosticsSummary: DiscoverDiagnosticsSummary;
@@ -190,7 +192,7 @@ export function createCompileMetadata(input: {
         sha256: manifestHash,
       },
       sourceGraphHash: createContentHash(
-        `${manifestHash}:${diagnosticsHash}:${moduleMapHash}:${input.target ?? "hosted"}`,
+        `${manifestHash}:${diagnosticsHash}:${moduleMapHash}:${input.target ?? "hosted"}${input.allowSourceEditing === true ? ":source-editing" : ""}`,
       ),
       summary: input.diagnosticsSummary,
     },
@@ -217,7 +219,10 @@ export async function writeCompilerArtifacts(
   const diagnosticsArtifact = createDiscoveryDiagnosticsArtifact(input.diagnostics);
   const compiledManifest = await materializeWorkspaceResources({
     compileDirectoryPath: paths.compileDirectoryPath,
-    manifest: await compileAgentManifest(input.manifest, { target: input.target ?? "hosted" }),
+    manifest: await compileAgentManifest(input.manifest, {
+      allowSourceEditing: input.allowSourceEditing,
+      target: input.target ?? "hosted",
+    }),
   });
   const compiledManifestJson = serializeArtifactJson(compiledManifest);
   const discoveryManifestJson = serializeArtifactJson(input.manifest);
@@ -227,6 +232,7 @@ export async function writeCompilerArtifacts(
     moduleMapPath: publishedPaths.moduleMapPath,
   });
   const metadata = createCompileMetadata({
+    allowSourceEditing: input.allowSourceEditing,
     appRoot: input.appRoot,
     diagnosticsArtifactJson,
     diagnosticsSummary: diagnosticsArtifact.summary,

--- a/packages/eve/src/compiler/compile-agent.ts
+++ b/packages/eve/src/compiler/compile-agent.ts
@@ -21,6 +21,8 @@ import type { CompileTarget } from "#compiler/target.js";
  * discovery artifacts.
  */
 export interface CompileAgentInput {
+  /** Adds eve's framework-owned source editor to development compilations. */
+  allowSourceEditing?: boolean;
   /**
    * Optional {@link ProjectSource} used for discovery reads. Defaults to a
    * disk-backed source so production callers keep their current behaviour.
@@ -85,7 +87,10 @@ export async function compileAgent(input: CompileAgentInput = {}): Promise<Compi
       publishedRoot: artifactsRoot,
       writeRoot: artifactsRoot,
     },
-    input.target ?? "hosted",
+    {
+      allowSourceEditing: input.allowSourceEditing,
+      target: input.target ?? "hosted",
+    },
   );
 
   return finishAgentCompilation(result, CompileAgentError.fromDurableArtifacts);
@@ -97,16 +102,16 @@ export async function compileAgent(input: CompileAgentInput = {}): Promise<Compi
  * `publishedRoot` where the caller will expose them.
  */
 export async function compileAgentInWorkspace(input: {
+  readonly allowSourceEditing?: boolean;
   readonly artifactLocations: CompilerArtifactLocations;
   readonly startPath: string;
   readonly target?: CompileTarget;
 }): Promise<CompileAgentResult> {
   const discovered = await discoverAgentForCompilation({ startPath: input.startPath });
-  const result = await writeAgentCompilation(
-    discovered,
-    input.artifactLocations,
-    input.target ?? "hosted",
-  );
+  const result = await writeAgentCompilation(discovered, input.artifactLocations, {
+    allowSourceEditing: input.allowSourceEditing,
+    target: input.target ?? "hosted",
+  });
 
   return finishAgentCompilation(result, CompileAgentError.fromTransientArtifacts);
 }
@@ -134,14 +139,18 @@ async function discoverAgentForCompilation(
 async function writeAgentCompilation(
   discovered: DiscoveredAgentCompilation,
   artifactLocations: CompilerArtifactLocations,
-  target: CompileTarget,
+  options: {
+    readonly allowSourceEditing?: boolean;
+    readonly target: CompileTarget;
+  },
 ): Promise<CompileAgentResult> {
   const writtenArtifacts = await writeCompilerArtifacts({
+    allowSourceEditing: options.allowSourceEditing,
     appRoot: discovered.project.appRoot,
     artifactLocations,
     diagnostics: discovered.diagnostics,
     manifest: discovered.manifest,
-    target,
+    target: options.target,
   });
 
   return {

--- a/packages/eve/src/compiler/module-map.ts
+++ b/packages/eve/src/compiler/module-map.ts
@@ -7,6 +7,7 @@ import type {
 } from "#compiler/manifest.js";
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
+import { SELFMOD_SANDBOX_BACKEND_NAME } from "#shared/selfmod-definition.js";
 
 /**
  * Compiled module ownership for one runtime graph node.
@@ -244,7 +245,7 @@ export function collectModuleRefsForManifest(
     });
   }
 
-  if (manifest.sandbox !== null) {
+  if (manifest.sandbox !== null && manifest.sandbox.backendName !== SELFMOD_SANDBOX_BACKEND_NAME) {
     moduleSourceRefs.set(manifest.sandbox.sourceId, {
       exportName: manifest.sandbox.exportName,
       sourceKind: "module",

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -79,6 +79,32 @@ describe("compileAgentManifest", () => {
     );
   });
 
+  it("adds the framework source editor only when a development compile allows it", async () => {
+    const manifest = createAgentSourceManifest({
+      agentId: "root",
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+    });
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+
+    const enabled = await compileAgentManifest(manifest, {
+      allowSourceEditing: true,
+      target: "development",
+    });
+    const hosted = await compileAgentManifest(manifest, {
+      allowSourceEditing: true,
+      target: "hosted",
+    });
+
+    expect(enabled.subagents).toHaveLength(1);
+    expect(enabled.subagents[0]).toMatchObject({
+      name: "selfmod",
+      agent: { sandbox: { backendName: "eve-selfmod" } },
+    });
+    expect(enabled.instructions?.markdown).toContain("selfmod");
+    expect(hosted.subagents).toHaveLength(0);
+  });
+
   it("compiles experimental Workflow tool configuration", async () => {
     const manifest = createAgentSourceManifest({
       agentId: "root",

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -27,6 +27,7 @@ import { compileSandboxDefinition } from "#compiler/normalize-sandbox.js";
 import { compileInstructionsEntry } from "#compiler/normalize-instructions.js";
 import { compileScheduleDefinition } from "#compiler/normalize-schedule.js";
 import { compileSkillSource } from "#compiler/normalize-skill.js";
+import { createFrameworkSelfmodSubagent } from "#compiler/normalize-selfmod-subagent.js";
 import { compileSubagentGraph } from "#compiler/normalize-subagent.js";
 import { compileToolEntry } from "#compiler/normalize-tool.js";
 
@@ -35,7 +36,10 @@ import { compileToolEntry } from "#compiler/normalize-tool.js";
  */
 export async function compileAgentManifest(
   manifest: AgentSourceManifest,
-  options: { readonly target?: CompileTarget } = {},
+  options: {
+    readonly allowSourceEditing?: boolean;
+    readonly target?: CompileTarget;
+  } = {},
 ): Promise<CompiledAgentManifest> {
   const context: ManifestCompileContext = {
     modelCatalog: createCompiledRuntimeModelCatalogLoader(manifest.appRoot),
@@ -52,7 +56,34 @@ export async function compileAgentManifest(
     target: options.target ?? "hosted",
   });
 
-  const selfmodNames = subagentGraph.nodes
+  const authoredSelfmod = subagentGraph.nodes.some(
+    (node) => node.agent.sandbox?.backendName === "eve-selfmod",
+  );
+  const frameworkSelfmod =
+    options.allowSourceEditing === true && options.target === "development" && !authoredSelfmod
+      ? await createFrameworkSelfmodSubagent({
+          appRoot: manifest.appRoot,
+          context,
+          manifest,
+          parentConfig: compiledNode.config,
+          parentNodeId: ROOT_COMPILED_AGENT_NODE_ID,
+        })
+      : undefined;
+  const subagentNodes =
+    frameworkSelfmod === undefined
+      ? subagentGraph.nodes
+      : [...subagentGraph.nodes, frameworkSelfmod];
+  const subagentEdges =
+    frameworkSelfmod === undefined
+      ? subagentGraph.edges
+      : [
+          ...subagentGraph.edges,
+          {
+            childNodeId: frameworkSelfmod.nodeId,
+            parentNodeId: ROOT_COMPILED_AGENT_NODE_ID,
+          },
+        ];
+  const selfmodNames = subagentNodes
     .filter((node) => node.agent.sandbox?.backendName === "eve-selfmod")
     .map((node) => node.name);
   const rootNode =
@@ -78,8 +109,8 @@ export async function compileAgentManifest(
     ...rootNode,
     extensionMounts,
     remoteAgents: subagentGraph.remoteAgents,
-    subagentEdges: subagentGraph.edges,
-    subagents: subagentGraph.nodes,
+    subagentEdges,
+    subagents: subagentNodes,
   });
 }
 

--- a/packages/eve/src/compiler/normalize-selfmod-subagent.ts
+++ b/packages/eve/src/compiler/normalize-selfmod-subagent.ts
@@ -1,4 +1,4 @@
-import type { LocalSubagentSourceRef } from "#discover/manifest.js";
+import type { AgentSourceManifest, LocalSubagentSourceRef } from "#discover/manifest.js";
 import {
   type CompiledAgentDefinition,
   type CompiledSubagentNode,
@@ -28,6 +28,36 @@ You cannot access application files outside the authored agent directory or run 
 interface SelfmodModuleSource {
   readonly logicalPath: string;
   readonly sourceId: string;
+}
+
+/** Creates the framework-owned source editor requested by the development CLI. */
+export async function createFrameworkSelfmodSubagent(input: {
+  readonly appRoot: string;
+  readonly context: ManifestCompileContext;
+  readonly manifest: AgentSourceManifest;
+  readonly parentConfig: CompiledAgentDefinition;
+  readonly parentNodeId: string;
+}): Promise<CompiledSubagentNode> {
+  const sourceId = "eve:framework/selfmod";
+  const result = await normalizeSelfmodSubagent({
+    appRoot: input.appRoot,
+    context: input.context,
+    moduleSource: { logicalPath: sourceId, sourceId },
+    parentConfig: input.parentConfig,
+    parentNodeId: input.parentNodeId,
+    source: {
+      entryPath: input.manifest.agentRoot,
+      logicalPath: sourceId,
+      manifest: input.manifest,
+      rootPath: input.manifest.agentRoot,
+      sourceId,
+      subagentId: "selfmod",
+    },
+    target: "development",
+    value: { development: true, kind: "selfmod" },
+  });
+  if (result === null) throw new Error("The framework source editor was unexpectedly omitted.");
+  return result;
 }
 
 /** Normalizes a development-only selfmod declaration into a compiled agent node. */

--- a/packages/eve/src/internal/nitro/host/dev-authored-rebuild-coordinator.ts
+++ b/packages/eve/src/internal/nitro/host/dev-authored-rebuild-coordinator.ts
@@ -58,10 +58,12 @@ export interface DevelopmentAuthoredRebuildCoordinator {
 }
 
 export async function createDevelopmentAuthoredRebuildCoordinator(input: {
+  readonly allowSourceEditing?: boolean;
   readonly devServer: DrainedNitroDevServer;
   readonly initialHost: PreparedDevelopmentApplicationHost;
 }): Promise<DevelopmentAuthoredRebuildCoordinator> {
   return new TransactionalDevelopmentAuthoredRebuildCoordinator({
+    allowSourceEditing: input.allowSourceEditing === true,
     currentHostFingerprint: await computeDevelopmentHostFingerprint(input.initialHost),
     currentRuntimeFingerprint: input.initialHost.generation.fingerprint,
     devServer: input.devServer,
@@ -80,6 +82,7 @@ export async function createDevelopmentAuthoredRebuildCoordinator(input: {
  * never travel the discard path — see {@link PostCommitDevelopmentRebuildError}.
  */
 class TransactionalDevelopmentAuthoredRebuildCoordinator implements DevelopmentAuthoredRebuildCoordinator {
+  readonly #allowSourceEditing: boolean;
   #currentHost: PreparedDevelopmentApplicationHost;
   #currentHostFingerprint: string;
   #currentRuntimeFingerprint: string;
@@ -87,11 +90,13 @@ class TransactionalDevelopmentAuthoredRebuildCoordinator implements DevelopmentA
   readonly #usesParentWorkflowWorld: boolean;
 
   constructor(input: {
+    readonly allowSourceEditing?: boolean;
     readonly currentHostFingerprint: string;
     readonly currentRuntimeFingerprint: string;
     readonly devServer: DrainedNitroDevServer;
     readonly initialHost: PreparedDevelopmentApplicationHost;
   }) {
+    this.#allowSourceEditing = input.allowSourceEditing === true;
     this.#currentHost = input.initialHost;
     this.#currentHostFingerprint = input.currentHostFingerprint;
     this.#currentRuntimeFingerprint = input.currentRuntimeFingerprint;
@@ -113,10 +118,14 @@ class TransactionalDevelopmentAuthoredRebuildCoordinator implements DevelopmentA
     let nextHost: PreparedDevelopmentApplicationHost | undefined;
 
     try {
-      nextHost = await prepareDevelopmentApplicationHost(previousHost.appRoot, {
+      let preparationOptions: Parameters<typeof prepareDevelopmentApplicationHost>[1] = {
         changedPaths: input.changedPaths,
         previousExtensions: previousHost.workspaceExtensions,
-      });
+      };
+      if (this.#allowSourceEditing) {
+        preparationOptions = { ...preparationOptions, allowSourceEditing: true };
+      }
+      nextHost = await prepareDevelopmentApplicationHost(previousHost.appRoot, preparationOptions);
       if (
         usesParentDevelopmentWorkflowWorld(
           nextHost.compileResult.manifest.config.experimental?.workflow?.world,

--- a/packages/eve/src/internal/nitro/host/prepare-application-host.ts
+++ b/packages/eve/src/internal/nitro/host/prepare-application-host.ts
@@ -33,6 +33,7 @@ import type {
 export async function prepareDevelopmentApplicationHost(
   appRoot: string,
   options: {
+    readonly allowSourceEditing?: boolean;
     readonly changedPaths?: readonly string[];
     readonly previousExtensions?: readonly DevelopmentWorkspaceExtension[];
   } = {},
@@ -54,6 +55,7 @@ export async function prepareDevelopmentApplicationHost(
 
   try {
     const compileResult = await compileAgentInWorkspace({
+      allowSourceEditing: options.allowSourceEditing,
       artifactLocations: {
         publishedRoot: join(appRoot, ".eve"),
         writeRoot: workspace.compilerArtifactsDir,

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -419,6 +419,22 @@ describe("createDevelopmentServer", () => {
     expect(mocks.worldInstance.close).toHaveBeenCalledOnce();
   });
 
+  it("preserves source-editing authority across development rebuilds", async () => {
+    const startDevelopmentServer = await loadStartDevelopmentServer();
+
+    const server = await startDevelopmentServer("/tmp/eve-test", {
+      allowSourceEditing: true,
+    });
+
+    expect(mocks.prepareDevelopmentApplicationHost).toHaveBeenCalledWith("/tmp/eve-test", {
+      allowSourceEditing: true,
+    });
+    expect(mocks.createDevelopmentAuthoredRebuildCoordinator).toHaveBeenCalledWith(
+      expect.objectContaining({ allowSourceEditing: true }),
+    );
+    await server.close();
+  });
+
   it("serves the parent World for an explicitly local Workflow World", async () => {
     const preparedHost = await mocks.prepareDevelopmentApplicationHost();
     mocks.prepareDevelopmentApplicationHost.mockClear();

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -367,7 +367,11 @@ async function startNitroDevelopmentServer(
     isLoopbackServerUrl(existingServerUrl) &&
     (await isEveServerHealthy(existingServerUrl))
   ) {
-    if (options.existing === "attach-if-unconfigured" && !hasExplicitEndpoint) {
+    if (
+      options.existing === "attach-if-unconfigured" &&
+      !hasExplicitEndpoint &&
+      options.allowSourceEditing !== true
+    ) {
       return {
         handle: { kind: "existing", appRoot: project.appRoot, url: existingServerUrl },
         close: undefined,
@@ -392,7 +396,10 @@ async function startNitroDevelopmentServer(
   try {
     const preparedHost = await devBootPhase(
       "compiling agent",
-      () => prepareDevelopmentApplicationHost(project.appRoot),
+      () =>
+        options.allowSourceEditing === true
+          ? prepareDevelopmentApplicationHost(project.appRoot, { allowSourceEditing: true })
+          : prepareDevelopmentApplicationHost(project.appRoot),
       options.onBootProgress,
     );
     preparedDevelopmentHost = preparedHost;
@@ -482,6 +489,7 @@ async function startNitroDevelopmentServer(
     });
 
     const rebuildCoordinator = await createDevelopmentAuthoredRebuildCoordinator({
+      allowSourceEditing: options.allowSourceEditing === true,
       devServer: activeDevServer,
       initialHost: preparedHost,
     });

--- a/packages/eve/src/internal/nitro/host/types.ts
+++ b/packages/eve/src/internal/nitro/host/types.ts
@@ -60,6 +60,7 @@ export interface DevelopmentServer<H extends DevelopmentServerHandle = Developme
 }
 
 export interface DevelopmentServerOptions {
+  readonly allowSourceEditing?: boolean;
   readonly existing?: "attach-if-unconfigured" | "reject";
   readonly host?: string;
   readonly onBootProgress?: DevBootProgressReporter;

--- a/packages/eve/src/runtime/resolve-sandbox.test.ts
+++ b/packages/eve/src/runtime/resolve-sandbox.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompiledSandboxDefinition } from "#compiler/manifest.js";
+import { resolveSandboxDefinition } from "#runtime/resolve-sandbox.js";
+
+const SELFMOD_SANDBOX: CompiledSandboxDefinition = {
+  backendName: "eve-selfmod",
+  description: "Development-only source editor.",
+  logicalPath: "subagents/self-edit.ts",
+  sourceHash: "selfmod-test",
+  sourceId: "subagents/self-edit.ts",
+  sourceKind: "module",
+};
+
+describe("resolveSandboxDefinition", () => {
+  it("resolves selfmod without an authored module namespace", async () => {
+    const resolved = await resolveSandboxDefinition(
+      SELFMOD_SANDBOX,
+      { nodes: {} },
+      "subagents/self-edit.ts",
+    );
+
+    expect(resolved.backend.name).toBe("eve-selfmod");
+  });
+});

--- a/packages/eve/src/runtime/resolve-sandbox.ts
+++ b/packages/eve/src/runtime/resolve-sandbox.ts
@@ -1,10 +1,14 @@
 import type { CompiledSandboxDefinition } from "#compiler/manifest.js";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
+import { createSelfModifyingSandboxBackend } from "#execution/sandbox/bindings/selfmod.js";
 import { lazyBackend } from "#execution/sandbox/lazy-backend.js";
 import { expectObjectRecord } from "#internal/authored-module.js";
 import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
 import { defaultSandbox } from "#public/sandbox/backends/default.js";
-import { readSelfModifyingSandboxDefinition } from "#shared/selfmod-definition.js";
+import {
+  readSelfModifyingSandboxDefinition,
+  SELFMOD_SANDBOX_BACKEND_NAME,
+} from "#shared/selfmod-definition.js";
 import { toErrorMessage } from "#shared/errors.js";
 import { loadResolvedModuleExport, ResolveAgentError } from "#runtime/resolve-helpers.js";
 import type { ResolvedSandboxDefinition } from "#runtime/types.js";
@@ -23,6 +27,19 @@ export async function resolveSandboxDefinition(
   moduleMap: CompiledModuleMap,
   nodeId: string | undefined,
 ): Promise<ResolvedSandboxDefinition> {
+  if (definition.backendName === SELFMOD_SANDBOX_BACKEND_NAME) {
+    return {
+      backend: createSelfModifyingSandboxBackend(),
+      description: definition.description,
+      exportName: definition.exportName,
+      logicalPath: definition.logicalPath,
+      revalidationKey: definition.revalidationKey,
+      sourceHash: definition.sourceHash,
+      sourceId: definition.sourceId,
+      sourceKind: "module",
+    };
+  }
+
   try {
     const resolvedExportValue = await loadResolvedModuleExport({
       definition,


### PR DESCRIPTION
### Description

Adds the local-only `eve dev --allow-source-editing` capability grant. The CLI injects the framework-owned editing subagent without scaffolding authored files, preserves the capability across rebuilds, and avoids duplicate injection when an authored editing subagent already exists.

The sandbox resolver also handles the framework-owned editing backend directly, so authored editing agents do not require a project-authored module namespace.

This PR completes the local development entry point on top of #1398. Hosted builds do not receive the capability.

### How did you test your changes?

- Focused CLI, development-server, compiler, and sandbox-resolution tests.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
