### PR TITLE
[docs] Improve code color highlighting

### DIFF
--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -15,6 +15,10 @@ body {
   background-color: var(--ds-background-200);
 }
 
+:root {
+  --shiki-token-parameter: var(--shiki-color-text);
+}
+
 /* Tint the global footer to match the landing background, but only on the
    home route (`/`), which renders the [data-home-route] marker. */
 body:has([data-home-route]) footer {


### PR DESCRIPTION
## Summary

* Get rid of the orange code highlighting which looked like a halloween theme


## Before and after

| Before | After |
| --- | --- |
| ![Before: parameter-like syntax tokens in amber](https://github.com/user-attachments/assets/0670b2a6-6e3d-4a16-a798-857ff425dc13) | ![After: parameter-like syntax tokens using the foreground color](https://github.com/user-attachments/assets/a57a5cf1-2024-4b97-b3bc-736fbf193288) |

## Validation

- pnpm docs:check
- pnpm exec oxfmt --check apps/docs/app/styles/geistdocs.css
- visually verified the Hooks guide in light and dark themes at desktop and mobile widths