### PR TITLE
fix(eve): support explicit prompt-cache-path override for opaque Bedrock inference profiles (#1314)

### DIFF
--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -104,6 +104,43 @@ Supported values are `"provider-default"`, `"none"`, `"minimal"`, `"low"`,
 which levels are available and how they map to provider-native settings. Use
 `modelOptions.providerOptions` when you need provider-specific reasoning controls.
 
+## Prompt caching override
+
+Eve automatically selects a prompt-caching path for each turn. For Anthropic
+models it places cache breakpoints on the stable system, tool, and
+conversation prefix; for models routed through the AI Gateway it forwards
+gateway auto-caching. Detection normally infers the path from the resolved
+model's provider name and model id — direct Anthropic providers, and
+`@ai-sdk/amazon-bedrock` Converse models whose id carries the `anthropic`
+family (for example `anthropic.claude-...`), are recognized automatically.
+
+Some backends hide the underlying family behind an opaque identifier. An AWS
+Bedrock **application inference profile** id can omit the `anthropic` family
+even though it targets an Anthropic model, so automatic detection returns no
+cache path and repeated turns are billed as fully uncached input. Declare the
+path explicitly through the eve-owned `providerOptions.eve` namespace on
+`modelOptions`:
+
+```ts title="agent/agent.ts"
+import { bedrock } from "@ai-sdk/amazon-bedrock";
+
+export default defineAgent({
+  model: bedrock(
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+  ),
+  modelOptions: {
+    providerOptions: {
+      eve: { cachePath: "anthropic-direct" },
+    },
+  },
+});
+```
+
+`eve.cachePath` accepts `"anthropic-direct"` (force the Anthropic breakpoint
+path) or `"none"` (opt the model out of caching). An explicit value takes
+precedence over inference; models without an override keep their existing
+automatic behavior, and an unrecognized value fails fast at turn start.
+
 ## Compaction
 
 Compaction summarizes older turns as you approach the context window. It's on by default, so you only tune when it kicks in. eve adds the estimated fixed checkpoint-prompt envelope to the trigger count, so compaction starts sooner than the conversation-only estimate. Lower `thresholdPercent` to compact sooner:

--- a/packages/eve/.changeset/bedrock-inference-profile-cache-path.md
+++ b/packages/eve/.changeset/bedrock-inference-profile-cache-path.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix prompt-cache detection for AWS Bedrock application inference profiles. Previously the Anthropic-direct cache path was inferred solely from the resolved model's `provider` name and `modelId`; an application inference profile id can be opaque and omit the underlying `anthropic` family, so the stable system/tool prefix received no Bedrock cache points and repeated turns were billed as fully uncached input. Detection now supports an explicit, strictly-validated override via `modelOptions.providerOptions.eve = { cachePath: "anthropic-direct" | "none" }`, which takes precedence over inference while leaving existing automatic detection (direct Anthropic, `@ai-sdk/amazon-bedrock` Anthropic model ids, Vertex Anthropic) unchanged.

--- a/packages/eve/src/harness/prompt-cache.test.ts
+++ b/packages/eve/src/harness/prompt-cache.test.ts
@@ -90,6 +90,78 @@ describe("detectPromptCachePath", () => {
       detectPromptCachePath(makeObjectModel("amazon-bedrock", "amazon.nova-pro-v1:0")),
     ).toEqual({ kind: "none" });
   });
+
+  it("returns none for a Bedrock application inference profile with an opaque model id", () => {
+    // An application inference profile id can be opaque and omit the `anthropic`
+    // family even though it targets an Anthropic model.
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "my-team-prod-claude-profile")),
+    ).toEqual({ kind: "none" });
+    expect(
+      detectPromptCachePath(
+        makeObjectModel("amazon-bedrock", "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef0123456789"),
+      ),
+    ).toEqual({ kind: "none" });
+  });
+});
+
+describe("detectPromptCachePath eve.cachePath override", () => {
+  it("honors an explicit anthropic-direct override on an opaque Bedrock inference profile", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "my-team-prod-claude-profile"), {
+        eve: { cachePath: "anthropic-direct" },
+      }),
+    ).toEqual({ kind: "anthropic-direct" });
+  });
+
+  it("lets an explicit override take precedence over inference", () => {
+    // Inference would say `none`; the explicit override wins.
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "amazon.nova-pro-v1:0"), {
+        eve: { cachePath: "anthropic-direct" },
+      }),
+    ).toEqual({ kind: "anthropic-direct" });
+  });
+
+  it("supports none as an explicit opt-out", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("anthropic.messages"), { eve: { cachePath: "none" } }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("falls back to inference when no override is declared", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"), {}),
+    ).toEqual({ kind: "anthropic-direct" });
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"), {
+        eve: {},
+      }),
+    ).toEqual({ kind: "anthropic-direct" });
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0")),
+    ).toEqual({ kind: "anthropic-direct" });
+  });
+
+  it("leaves ordinary non-Anthropic providers unchanged", () => {
+    expect(detectPromptCachePath(makeObjectModel("openai.chat"))).toEqual({ kind: "none" });
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "amazon.nova-pro-v1:0")),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("throws on an unrecognized override value", () => {
+    expect(() =>
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "opaque-profile"), {
+        eve: { cachePath: "bedrock" },
+      }),
+    ).toThrow(/providerOptions\.eve\.cachePath/);
+    expect(() =>
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "opaque-profile"), {
+        eve: { cachePath: "anthropic" },
+      }),
+    ).toThrow(/Expected one of/);
+  });
 });
 
 describe("getAnthropicCacheMarker", () => {

--- a/packages/eve/src/harness/prompt-cache.ts
+++ b/packages/eve/src/harness/prompt-cache.ts
@@ -9,6 +9,56 @@ export type PromptCachePath =
   | { readonly kind: "none" };
 
 /**
+ * An explicit author-declared prompt-cache-path override, declared under the
+ * eve-owned `providerOptions.eve` namespace on `modelOptions`.
+ *
+ * Used to force a caching path that cannot be inferred from the resolved
+ * model's `provider`/`modelId` alone — for example an AWS Bedrock application
+ * inference profile whose opaque id omits the underlying `anthropic` provider
+ * family (`modelOptions.providerOptions.eve = { cachePath: "anthropic-direct" }`).
+ */
+export type PromptCachePathOverride = "anthropic-direct" | "none";
+
+/**
+ * The eve-owned namespace inside `modelOptions.providerOptions`. Provider SDKs
+ * do not read this key, so eve may use it to carry framework hints (the same
+ * role as `providerOptions.gateway.byok`) without leaking into the provider's
+ * request payload semantics.
+ */
+const EVE_PROVIDER_OPTIONS_NAMESPACE = "eve";
+
+/**
+ * Reads a strictly-validated prompt-cache-path override out of the model's
+ * authored `modelOptions.providerOptions.eve` block. Returns `undefined` when
+ * no override is declared. Throws on an unrecognized value so a typo cannot
+ * silently fall back to inference.
+ */
+function readCachePathOverride(
+  modelProviderOptions: Readonly<Record<string, unknown>> | undefined,
+): PromptCachePathOverride | undefined {
+  const eve = modelProviderOptions?.[EVE_PROVIDER_OPTIONS_NAMESPACE];
+  if (eve === undefined || eve === null) {
+    return undefined;
+  }
+  if (typeof eve !== "object" || Array.isArray(eve)) {
+    return undefined;
+  }
+
+  const override = (eve as Record<string, unknown>).cachePath;
+  if (override === undefined || override === null) {
+    return undefined;
+  }
+  if (override === "anthropic-direct" || override === "none") {
+    return override;
+  }
+
+  throw new Error(
+    `Unsupported modelOptions.providerOptions.eve.cachePath ${JSON.stringify(override)}. ` +
+      `Expected one of "anthropic-direct" or "none".`,
+  );
+}
+
+/**
  * Cache marker injected on the Anthropic-direct path.
  *
  * The marker carries two provider namespaces because Anthropic models are
@@ -48,9 +98,21 @@ const ANTHROPIC_CACHE_MARKER: AnthropicCacheMarker = Object.freeze({
 /**
  * Detects which prompt caching path applies to a resolved model.
  *
- * Runs once per harness step right after `resolveModel()`.
+ * Runs once per harness step right after `resolveModel()`. An explicit
+ * `modelOptions.providerOptions.eve.cachePath` override (read from
+ * `modelProviderOptions`, the active model reference's `providerOptions`)
+ * takes precedence over inference; when no override is declared the path is
+ * inferred from the resolved model's provider name and model id.
  */
-export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
+export function detectPromptCachePath(
+  model: LanguageModel,
+  modelProviderOptions?: Readonly<Record<string, unknown>>,
+): PromptCachePath {
+  const override = readCachePathOverride(modelProviderOptions);
+  if (override !== undefined) {
+    return { kind: override };
+  }
+
   if (typeof model === "string") {
     return { kind: "gateway-auto" };
   }
@@ -62,8 +124,10 @@ export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
 
   // The standard `@ai-sdk/amazon-bedrock` Converse provider reports its
   // provider as `amazon-bedrock` and carries the Anthropic identity in the
-  // model id (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`), so it must be
-  // matched on the model id rather than the provider name.
+  // model id (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`). Application
+  // inference profile ids can be opaque and omit that family name; those need
+  // the explicit `eve.cachePath` override above rather than id substring
+  // inference.
   const modelId = typeof model.modelId === "string" ? model.modelId.toLowerCase() : "";
   if (providerName.includes("bedrock") && modelId.includes("anthropic")) {
     return { kind: "anthropic-direct" };

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -700,7 +700,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     });
     session = resolvedModel.session;
     const model = resolvedModel.model;
-    const cachePath = detectPromptCachePath(model);
+    const cachePath = detectPromptCachePath(model, session.agent.modelReference.providerOptions);
     const marker = cachePath.kind === "anthropic-direct" ? getAnthropicCacheMarker() : undefined;
 
     // --- Compaction ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1314.

Eve inferred the Anthropic-direct prompt-cache path for AWS Bedrock **only** when the resolved model id contained the substring `anthropic`. Bedrock **application inference profile** ids can be opaque and omit the underlying provider family, so an Anthropic model reached through such a profile was misclassified as `none` — the stable system/tool prefix received no Bedrock cache points, and repeated turns were billed as **fully uncached input.**

Plain Anthropic foundation-model ids kept working only because they happen to include `anthropic`. Inferring provider family from an opaque deployment identifier is not reliable.

## What changed

`detectPromptCachePath` now honors an **explicit, supported, per-model override** declared under the eve-owned namespace in the model's options:

```ts
export default defineAgent({
  model: bedrock("arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"),
  modelOptions: {
    providerOptions: {
      eve: { cachePath: "anthropic-direct" },
    },
  },
});
```

- `eve.cachePath` accepts `"anthropic-direct"` (force the Anthropic breakpoint path) or `"none"` (opt the model out of caching).
- An explicit value **takes precedence over inference**; models without an override keep their **existing automatic detection** unchanged (direct Anthropic providers, `@ai-sdk/amazon-bedrock` Anthropic model ids, Vertex Anthropic).
- An unrecognized value **fails fast at turn start**, so a mis-declared cache path is loud instead of silently uncached.
- The override is read from the **active model reference's `providerOptions`**, so it stays per-model correct for dynamic-model agents with a scoped selection.

This mirrors the existing eve-namespaced `providerOptions.gateway.byok` hint pattern and **preserves the public `defineAgent` / compiled-manifest schema** — it rides the already-validated open `providerOptions` bag rather than adding a new top-level key.

## Why this design (smallest supported override)

I considered two narrower alternatives and rejected them: a `providerFamily` boolean forces a fake family onto models it can't know and silently no-ops elsewhere; an opaque-id heuristic keeps doing substring inference, which this issue shows is unreliable. An explicit cache-path override is the smallest *supported* surface that solves the opaque-profile case while leaving the inference path untouched.

## Validation

| Command | Result |
| --- | --- |
| `pnpm --filter eve typecheck` | ✅ |
| `pnpm lint` (oxlint) | ✅ |
| Scoped unit — `prompt-cache` + `tool-loop` + `step-hooks` + `prompt-cache-accounting` | ✅ 212 passed |
| Targeted new tests for this change | ✅ 6 — opaque profile (no override) → `none`; opaque profile + `anthropic-direct` override; explicit-override precedence; `none` opt-out; fallback-to-inference; invalid override throws; non-Anthropic unchanged |
| Full `packages/eve` unit tier | ✅ 5660/5665 — the only 4 failures are `test/bin-bootstrap.test.ts` asserting the **Node `>=24` engine contract** while this shell runs Node `v22.22.3` (pre-existing ambient mismatch; `bin/eve.js` declares the same `requiredRange` guard on pristine main, and that file is not touched by this change) |

## Notes for reviewers

- The override is namespaced to `eve` (provider SDKs don't consume it), so it carries a framework hint without changing the provider's request semantics.
- I did **not** change automatic detection for any currently-working configuration; this only adds an opt-in override for identifiers inference cannot classify.

---

*Authoring: drafted under the Codex6 planning chain with an independent-reviewer gate; full review ledger (GLM-5.2/GRID + Codex6 admission attempts, findings, machine gate) is recorded and available. Happy to route a fresh GLM-5.2 independent re-review on request.*

---

### Maintainer note — DCO, base freshness, and the two "fail" checks

- **DCO** ✅ — commit is signed off (`git commit -s`), matching the PR author identity.
- **Rebased onto current `main`** (`5ff5534`) so the diff is clean and current.
- **`Vercel – eve-docs` / `eve-docs-4759` "Authorization required to deploy"** and the four **`agent-prompt-cache` e2e** runners: these are the standard **external-fork secret/deploy gate**, not a code regression. On a maintainer-authorized run they should behave exactly as on a same-repo branch. Evidence this change does not regress the prompt-cache path:
  - The `agent-prompt-cache` e2e fixture authors a **direct `anthropic(...)` instance with no override**, so this change is a **strict no-op** on that code path (`readCachePathOverride(undefined)` → `undefined` → unchanged inference → `anthropic-direct`).
  - The failure itself is environmental: the job ran with an **empty `AI_GATEWAY_API_KEY`**, fell back to Vercel OIDC, and failed with `VercelOidcTokenError: x-vercel-oidc-token header is missing / Unable to find project root (... vc link)`, producing `0` tool calls and a `NaN%` cache rate. For comparison, same-repo PR #1389 ran these exact `agent-prompt-cache` runners to **pass** with the gateway secret present.
  - Everything controllable from a fork is green: `lint`, `typecheck`, `test-unit`, `test-integration (ubuntu)`, `changes`, `Socket`, `Vercel Agent Review`.

Happy to push any adjustment a maintainer-authorized CI run surfaces.
