### PR TITLE
fix(eve): init - allow preconfigured environments

### DIFF
--- a/.changeset/friendly-mise-init.md
+++ b/.changeset/friendly-mise-init.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow `eve init .` to scaffold in a directory that already contains a common source-controlled runtime selector such as `mise.toml`, `.tool-versions`, `.nvmrc`, or `.node-version`, preserving the project's toolchain configuration.
+Allow `eve init .` to scaffold in directories that already contain common, source-controlled toolchain and development-environment manifests. Existing mise configs and lockfiles, Node version selectors, proto, Devbox, Nix flake, and devenv configuration are preserved.

--- a/.changeset/friendly-mise-init.md
+++ b/.changeset/friendly-mise-init.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow `eve init .` to scaffold in a directory that already contains `mise.toml`, preserving the project's runtime configuration.
+Allow `eve init .` to scaffold in a directory that already contains a common source-controlled runtime selector such as `mise.toml`, `.tool-versions`, `.nvmrc`, or `.node-version`, preserving the project's toolchain configuration.

--- a/.changeset/friendly-mise-init.md
+++ b/.changeset/friendly-mise-init.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `eve init .` to scaffold in a directory that already contains `mise.toml`, preserving the project's runtime configuration.

--- a/packages/eve/src/cli/commands/extension-init.ts
+++ b/packages/eve/src/cli/commands/extension-init.ts
@@ -19,6 +19,7 @@ import { pathExists } from "#setup/path-exists.js";
 import { parseProjectName } from "#setup/project-name.js";
 import { runPackageManagerInstall } from "#setup/primitives/index.js";
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
+import { blockingCreateInPlaceEntries } from "#setup/scaffold/create-in-place.js";
 import {
   DEFAULT_EVE_PACKAGE_CONTRACT,
   type EvePackageContract,
@@ -55,7 +56,6 @@ const defaultDependencies: ExtensionInitCommandDependencies = {
 };
 
 const CURRENT_DIRECTORY_PROJECT_NAME = ".";
-const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([".DS_Store", ".git", ".gitkeep", ".hg"]);
 /** Same override env as agent `eve init` so CI can pin the eve package specifier. */
 export const EVE_INIT_PACKAGE_SPEC_ENV = "EVE_INIT_PACKAGE_SPEC";
 
@@ -76,7 +76,7 @@ async function resolveTargetDirectory(
 
 async function assertCanScaffoldInPlace(targetRoot: string): Promise<void> {
   const entries = await readdir(targetRoot);
-  const blocking = entries.filter((entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry));
+  const blocking = blockingCreateInPlaceEntries(entries);
   if (blocking.length === 0) {
     return;
   }

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -299,6 +299,25 @@ describe("runInitCommand", () => {
     },
   );
 
+  it("scaffolds the current directory when mise.toml already exists", async () => {
+    const projectPath = await mkdtemp(join(tmpdir(), "eve-init-mise-"));
+    const miseConfig = '[tools]\nnode = "24"\n';
+    await writeFile(join(projectPath, "mise.toml"), miseConfig, "utf8");
+    const output = logger();
+    const deps = dependencies();
+
+    await runInitCommand(output, projectPath, ".", {}, deps);
+
+    await expect(readFile(join(projectPath, "mise.toml"), "utf8")).resolves.toBe(miseConfig);
+    await expect(pathExists(join(projectPath, "agent/agent.ts"))).resolves.toBe(true);
+    await expect(pathExists(join(projectPath, "package.json"))).resolves.toBe(true);
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      projectPath,
+      expect.objectContaining({ bypassMinimumReleaseAge: true }),
+    );
+  });
+
   it.each([
     ["npm", "overrides", ["exec", "--", "eve", "dev", "--input", "/model"]],
     ["yarn", "resolutions", ["eve", "dev", "--input", "/model"]],

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -25,6 +25,7 @@ import {
 } from "#setup/primitives/index.js";
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
 import { addAgentToProject } from "#setup/scaffold/create/add-to-project.js";
+import { blockingCreateInPlaceEntries } from "#setup/scaffold/create-in-place.js";
 import { ensureChannel, scaffoldBaseProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
 import type { WorkspaceRootMutation } from "#setup/scaffold/workspace-root.js";
@@ -82,7 +83,6 @@ const defaultDependencies: InitCommandDependencies = {
 };
 
 const CURRENT_DIRECTORY_PROJECT_NAME = ".";
-const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([".DS_Store", ".git", ".gitkeep", ".hg"]);
 export const EVE_INIT_PACKAGE_SPEC_ENV = "EVE_INIT_PACKAGE_SPEC";
 
 const initLog = createLogger("init");
@@ -103,7 +103,7 @@ function isCurrentDirectoryTarget(target: string): boolean {
 
 async function assertCanScaffoldInPlace(targetRoot: string): Promise<void> {
   const entries = await readdir(targetRoot);
-  const blocking = entries.filter((entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry));
+  const blocking = blockingCreateInPlaceEntries(entries);
   if (blocking.length === 0) {
     return;
   }

--- a/packages/eve/src/setup/scaffold/create-in-place.test.ts
+++ b/packages/eve/src/setup/scaffold/create-in-place.test.ts
@@ -3,14 +3,27 @@ import { describe, expect, test } from "vitest";
 import { blockingCreateInPlaceEntries } from "./create-in-place.js";
 
 describe("blockingCreateInPlaceEntries", () => {
-  test("allows source-controlled runtime selectors needed before init", () => {
+  test("allows source-controlled development environment manifests needed before init", () => {
     expect(
       blockingCreateInPlaceEntries([
         "mise.toml",
         ".mise.toml",
+        "mise.lock",
+        ".mise.lock",
+        "mise.test.toml",
+        ".mise.ci.lock",
         ".tool-versions",
         ".nvmrc",
         ".node-version",
+        ".prototools",
+        ".protolock",
+        "devbox.json",
+        "devbox.lock",
+        "flake.nix",
+        "flake.lock",
+        "devenv.nix",
+        "devenv.yaml",
+        "devenv.lock",
       ]),
     ).toEqual([]);
   });
@@ -18,10 +31,18 @@ describe("blockingCreateInPlaceEntries", () => {
   test("blocks private configuration and scaffold conflicts", () => {
     const blocking = [
       "mise.local.toml",
+      ".mise.local.lock",
+      "mise.test.local.toml",
+      "devenv.local.nix",
+      "devenv.local.yaml",
+      ".envrc",
       ".npmrc",
       ".gitignore",
       "package.json",
       "pnpm-workspace.yaml",
+      "mise..toml",
+      "mise.test.json",
+      "misery.toml",
     ];
 
     expect(blockingCreateInPlaceEntries(blocking)).toEqual(blocking);

--- a/packages/eve/src/setup/scaffold/create-in-place.test.ts
+++ b/packages/eve/src/setup/scaffold/create-in-place.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { blockingCreateInPlaceEntries } from "./create-in-place.js";
+
+describe("blockingCreateInPlaceEntries", () => {
+  test("allows source-controlled runtime selectors needed before init", () => {
+    expect(
+      blockingCreateInPlaceEntries([
+        "mise.toml",
+        ".mise.toml",
+        ".tool-versions",
+        ".nvmrc",
+        ".node-version",
+      ]),
+    ).toEqual([]);
+  });
+
+  test("blocks private configuration and scaffold conflicts", () => {
+    const blocking = [
+      "mise.local.toml",
+      ".npmrc",
+      ".gitignore",
+      "package.json",
+      "pnpm-workspace.yaml",
+    ];
+
+    expect(blockingCreateInPlaceEntries(blocking)).toEqual(blocking);
+  });
+});

--- a/packages/eve/src/setup/scaffold/create-in-place.ts
+++ b/packages/eve/src/setup/scaffold/create-in-place.ts
@@ -1,0 +1,12 @@
+const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([
+  ".DS_Store",
+  ".git",
+  ".gitkeep",
+  ".hg",
+  // mise.toml may need to exist before init so npx runs with the project's Node version.
+  "mise.toml",
+]);
+
+export function blockingCreateInPlaceEntries(entries: readonly string[]): string[] {
+  return entries.filter((entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry));
+}

--- a/packages/eve/src/setup/scaffold/create-in-place.ts
+++ b/packages/eve/src/setup/scaffold/create-in-place.ts
@@ -3,7 +3,11 @@ const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([
   ".git",
   ".gitkeep",
   ".hg",
-  // mise.toml may need to exist before init so npx runs with the project's Node version.
+  // Toolchain selectors may need to exist before init so npx runs with the project's Node version.
+  ".mise.toml",
+  ".node-version",
+  ".nvmrc",
+  ".tool-versions",
   "mise.toml",
 ]);
 

--- a/packages/eve/src/setup/scaffold/create-in-place.ts
+++ b/packages/eve/src/setup/scaffold/create-in-place.ts
@@ -3,14 +3,35 @@ const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([
   ".git",
   ".gitkeep",
   ".hg",
-  // Toolchain selectors may need to exist before init so npx runs with the project's Node version.
-  ".mise.toml",
+  // These committed manifests may establish the development environment before init can run.
   ".node-version",
   ".nvmrc",
+  ".protolock",
+  ".prototools",
   ".tool-versions",
-  "mise.toml",
+  "devenv.lock",
+  "devenv.nix",
+  "devenv.yaml",
+  "devbox.json",
+  "devbox.lock",
+  "flake.lock",
+  "flake.nix",
 ]);
 
+function isSharedMiseEntry(entry: string): boolean {
+  const filename = entry.startsWith(".") ? entry.slice(1) : entry;
+  const segments = filename.split(".");
+  const extension = segments.at(-1);
+  const variants = segments.slice(1, -1);
+  return (
+    segments[0] === "mise" &&
+    (extension === "toml" || extension === "lock") &&
+    variants.every((variant) => variant !== "" && variant !== "local")
+  );
+}
+
 export function blockingCreateInPlaceEntries(entries: readonly string[]): string[] {
-  return entries.filter((entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry));
+  return entries.filter(
+    (entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry) && !isSharedMiseEntry(entry),
+  );
 }

--- a/packages/eve/src/setup/scaffold/create/extension.ts
+++ b/packages/eve/src/setup/scaffold/create/extension.ts
@@ -4,6 +4,7 @@ import { basename, resolve } from "node:path";
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor } from "../../node-engine.js";
 import { pathExists, writeTextFile } from "../files.js";
+import { blockingCreateInPlaceEntries } from "../create-in-place.js";
 import { resolveVersionToken } from "../version-tokens.js";
 import {
   applyPackageManagerWorkspaceConfiguration,
@@ -20,7 +21,6 @@ import {
   type EvePackageContract,
 } from "./project.js";
 
-const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([".DS_Store", ".git", ".gitkeep", ".hg"]);
 const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "__TYPESCRIPT_VERSION__";
 
 interface ExtensionTemplateContext {
@@ -187,7 +187,7 @@ async function assertCanCreateInPlace(
   }
 
   const entries = await readdir(targetRoot);
-  const blocking = entries.filter((entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry));
+  const blocking = blockingCreateInPlaceEntries(entries);
   if (blocking.length > 0 && !overwriteExisting) {
     const visible = blocking.slice(0, 5).join(", ");
     const suffix = blocking.length > 5 ? `, and ${blocking.length - 5} more` : "";

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -5,6 +5,7 @@ import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor } from "../../node-engine.js";
 import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "../update/module-files.js";
 import { pathExists, writeTextFile } from "../files.js";
+import { blockingCreateInPlaceEntries } from "../create-in-place.js";
 import { resolveVersionToken } from "../version-tokens.js";
 import {
   applyPackageManagerWorkspaceConfiguration,
@@ -15,8 +16,6 @@ import {
 import { WEB_APP_TEMPLATE_FILES } from "./web-template.js";
 
 export const CURRENT_DIRECTORY_PROJECT_NAME = ".";
-
-const ALLOWED_CREATE_IN_PLACE_ENTRIES = new Set([".DS_Store", ".git", ".gitkeep", ".hg"]);
 
 export const DEFAULT_AI_PACKAGE_VERSION = "__AI_SDK_VERSION__";
 export const DEFAULT_CONNECT_PACKAGE_VERSION = "__VERCEL_CONNECT_VERSION__";
@@ -298,7 +297,7 @@ async function assertCanCreateInPlace(
   }
 
   const entries = await readdir(targetRoot);
-  const blocking = entries.filter((entry) => !ALLOWED_CREATE_IN_PLACE_ENTRIES.has(entry));
+  const blocking = blockingCreateInPlaceEntries(entries);
   if (blocking.length > 0 && !overwriteExisting) {
     const visible = blocking.slice(0, 5).join(", ");
     const suffix = blocking.length > 5 ? `, and ${blocking.length - 5} more` : "";


### PR DESCRIPTION
## Summary

- allow `eve init .` to scaffold when common source-controlled toolchain or development-environment manifests already exist
- support Node version selectors, proto, Devbox, Nix flakes, devenv, and shared mise config/lock variants
- keep local mise/devenv overrides, credential-bearing configuration, generated files, and project conflicts blocked
- share the create-in-place policy across agent and extension scaffolds
- add focused allow/deny unit coverage, an end-to-end regression test, and a patch changeset

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/scaffold/create-in-place.test.ts` (2 passed)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/init.integration.test.ts` (49 passed)
- targeted in-place scaffold overwrite-safety integration test
- `pnpm --filter eve typecheck`
- oxlint on changed TypeScript files
- `pnpm guard:invariants`