### PR TITLE
chore(eve): scenario suite - parallelize and consolidate

### DIFF
--- a/apps/frameworks/nuxt/package.json
+++ b/apps/frameworks/nuxt/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm --filter eve build && nuxt build",
+    "build": "pnpm --filter eve build && pnpm build:nuxt",
+    "build:nuxt": "nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/packages/eve/src/internal/testing/scenario-app.ts
+++ b/packages/eve/src/internal/testing/scenario-app.ts
@@ -370,6 +370,14 @@ async function resolveOrPackScenarioEveTarball(): Promise<string> {
 async function packScenarioEveTarball(): Promise<string> {
   const cacheRoot = await resolveScenarioWorkerCacheDirectory();
   const tarballsRoot = join(cacheRoot, "tarballs");
+  const packageRoot = resolvePackageRoot();
+  const prebuiltEntryPath = join(packageRoot, "dist", "src", "index.js");
+
+  if (!(await isFilePresent(prebuiltEntryPath))) {
+    throw new Error(
+      `Scenario tests require a prebuilt eve package. Run "pnpm build" first. Missing: ${prebuiltEntryPath}`,
+    );
+  }
 
   await rm(tarballsRoot, {
     force: true,
@@ -379,10 +387,8 @@ async function packScenarioEveTarball(): Promise<string> {
     recursive: true,
   });
 
-  const packageRoot = resolvePackageRoot();
-
   await runPnpmCommand({
-    args: ["pack", "--pack-destination", tarballsRoot],
+    args: ["pack", "--config.ignore-scripts=true", "--pack-destination", tarballsRoot],
     cwd: packageRoot,
   });
 

--- a/packages/eve/test/scenarios/dev-server-chaos.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server-chaos.scenario.test.ts
@@ -87,6 +87,7 @@ function toolSource(marker: string): string {
 
 interface HealthProbe {
   readonly failures: readonly string[];
+  count(): number;
   stop(): Promise<number>;
 }
 
@@ -114,6 +115,9 @@ function startHealthProbe(serverUrl: string): HealthProbe {
 
   return {
     failures,
+    count() {
+      return probes;
+    },
     async stop() {
       stopped = true;
       await run;
@@ -155,7 +159,13 @@ describe("eve dev server chaos", () => {
       const probe = startHealthProbe(server.url);
 
       try {
+        await waitForCondition(
+          () => probe.count() > 0,
+          "Timed out waiting for the initial chaos health probe.",
+        );
+
         for (let round = 1; round <= 3; round += 1) {
+          const probesBeforeRound = probe.count();
           await writeFile(toolPath, toolSource(`storm-${String(round)}-a`));
           await writeFile(toolPath, toolSource(`storm-${String(round)}-b`));
           const revisionBeforeBreak = await readDevelopmentRevision(server.url);
@@ -171,19 +181,25 @@ describe("eve dev server chaos", () => {
             forceDevelopmentRebuild(server.url),
             forceDevelopmentRebuild(server.url),
           ]);
+          await waitForCondition(
+            () => probe.count() > probesBeforeRound,
+            `Health probe did not run during chaos round ${String(round)}.`,
+          );
         }
 
+        const probesBeforeStructuralReload = probe.count();
         await writeFile(join(app.appRoot, ".env.local"), "EVE_CHAOS_STRUCTURAL=1\n");
         await writeFile(toolPath, toolSource("storm-final"));
         await forceDevelopmentRebuild(server.url);
         await waitForToolMarker(server.url, "storm-final");
         await completeStreamedTurn(server, "What's the weather in Lisbon?");
+        await waitForCondition(
+          () => probe.count() > probesBeforeStructuralReload,
+          "Health probe did not run during the structural chaos reload.",
+        );
 
-        const probes = await probe.stop();
+        await probe.stop();
         expect(probe.failures, probe.failures.join("\n")).toEqual([]);
-        // The floor proves the probe ran continuously through the storm;
-        // the storm itself is deterministic-length now, not wall-clock.
-        expect(probes).toBeGreaterThan(30);
         expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
       } finally {
         await probe.stop();
@@ -323,7 +339,7 @@ describe("eve dev server chaos", () => {
   );
 
   it(
-    "reports the socket peer as the client address despite forged headers",
+    "protects socket-derived client metadata and internal transport routes",
     async () => {
       const app = await scenarioApp(CHAOS_DESCRIPTOR);
       const server = await startEveDev(app.appRoot);
@@ -341,20 +357,7 @@ describe("eve dev server chaos", () => {
         });
         expect(response.status).toBe(200);
         await expect(response.text()).resolves.toBe("127.0.0.1");
-      } finally {
-        await server.stop();
-      }
-    },
-    CHAOS_SCENARIO_TIMEOUT_MS,
-  );
 
-  it(
-    "rejects untrusted internal transport requests on the public listener",
-    async () => {
-      const app = await scenarioApp(CHAOS_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-
-      try {
         const worldCall = await fetch(new URL("/eve/v1/dev/internal/workflow-world", server.url), {
           body: "{}",
           method: "POST",

--- a/packages/eve/test/scenarios/dev-server-drain.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server-drain.scenario.test.ts
@@ -1,10 +1,8 @@
-import { Agent } from "node:http";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { EVE_HEALTH_ROUTE_PATH } from "../../src/protocol/routes.js";
 import { WEATHER_AGENT_DESCRIPTOR } from "../../src/internal/testing/scenario-apps/weather-agent.js";
 import {
   type ScenarioAppDescriptor,
@@ -15,7 +13,6 @@ import { createDevelopmentSessionState } from "../dev-client-harness/session.js"
 import {
   fetchText,
   hasKnownDevServerFailure,
-  requestWithAgent,
   startEveDev,
   waitForCondition,
   type RunningEveDev,
@@ -34,11 +31,6 @@ const DRAIN_CHANNEL_SOURCE = [
   "export default defineChannel({",
   "  routes: [",
   '    GET("/drain/worker-id", () => new Response(workerId)),',
-  '    GET("/drain/request-ip", (_request, context) => new Response(String(context.requestIp))),',
-  '    GET("/drain/crash", () => {',
-  "      setTimeout(() => process.exit(7), 25);",
-  '      return new Response("crashing");',
-  "    }),",
   '    GET("/drain/slow-stream", () => {',
   "      let timer: ReturnType<typeof setInterval> | undefined;",
   "      const body = new ReadableStream({",
@@ -117,114 +109,6 @@ describe("eve dev drained worker replacement", () => {
         });
         expect(turn.events.some((event) => event.type === "message.completed")).toBe(true);
         expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
-      } finally {
-        await server.stop();
-      }
-    },
-    DRAIN_SCENARIO_TIMEOUT_MS,
-  );
-
-  it(
-    "serves a kept-alive connection across a worker replacement",
-    async () => {
-      const app = await scenarioApp(DRAIN_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
-
-      try {
-        const first = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
-        expect(first.localPort).toBeDefined();
-
-        await triggerWorkerReplacement(server, app.appRoot);
-
-        const second = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
-        expect(second.localPort).toBe(first.localPort);
-        expect(second.body).not.toBe(first.body);
-        expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
-      } finally {
-        agent.destroy();
-        await server.stop();
-      }
-    },
-    DRAIN_SCENARIO_TIMEOUT_MS,
-  );
-
-  it(
-    "restarts the worker after a crash and keeps serving",
-    async () => {
-      const app = await scenarioApp(DRAIN_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-
-      try {
-        const firstWorkerId = await fetchText(server.url, "/drain/worker-id");
-        await fetch(new URL("/drain/crash", server.url));
-
-        await waitForCondition(
-          async () => {
-            try {
-              return (await fetchText(server.url, "/drain/worker-id")) !== firstWorkerId;
-            } catch {
-              return false;
-            }
-          },
-          () =>
-            [
-              "Timed out waiting for the crashed worker to restart.",
-              `stdout:\n${server.stdout()}`,
-              `stderr:\n${server.stderr()}`,
-            ].join("\n\n"),
-        );
-        const health = await fetch(new URL(EVE_HEALTH_ROUTE_PATH, server.url));
-        expect(health.status).toBe(200);
-      } finally {
-        await server.stop();
-      }
-    },
-    DRAIN_SCENARIO_TIMEOUT_MS,
-  );
-
-  it(
-    "shuts down within a bounded deadline while a stream is open",
-    async () => {
-      const app = await scenarioApp(DRAIN_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-      const streamResponse = await fetch(new URL("/drain/slow-stream", server.url));
-      const reader = streamResponse.body?.getReader();
-      await reader?.read();
-
-      const stopStart = Date.now();
-      await server.stop();
-
-      // The harness escalates to SIGKILL at 10s; a graceful exit must beat it.
-      expect(Date.now() - stopStart).toBeLessThan(9_000);
-      await expect(
-        (async () => {
-          for (;;) {
-            const result = await reader?.read();
-            if (result === undefined || result.done) {
-              return "done";
-            }
-          }
-        })().catch(() => "errored"),
-      ).resolves.toBeDefined();
-    },
-    DRAIN_SCENARIO_TIMEOUT_MS,
-  );
-
-  it(
-    "reports a socket-derived client address despite forged forwarding headers",
-    async () => {
-      const app = await scenarioApp(DRAIN_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-
-      try {
-        const response = await fetch(new URL("/drain/request-ip", server.url), {
-          headers: { "x-forwarded-for": "203.0.113.7" },
-        });
-        expect(response.status).toBe(200);
-        const address = await response.text();
-        expect(address).not.toBe("203.0.113.7");
-        expect(address).toContain("127.0.0.1");
       } finally {
         await server.stop();
       }

--- a/packages/eve/test/scenarios/dev-server.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server.scenario.test.ts
@@ -52,31 +52,25 @@ const DEV_SERVER_AGENT_DESCRIPTOR: ScenarioAppDescriptor = {
       'import { defineChannel, GET } from "eve/channels";',
       "",
       "export default defineChannel({",
-      '  routes: [GET("/dev-generation", () => new Response(process.env.EVE_SCENARIO_RELOAD ?? process.env.EVE_WEBSOCKET_RELOAD ?? "initial"))],',
+      '  routes: [GET("/dev-generation", () => new Response(process.env.EVE_SCENARIO_RELOAD ?? "initial"))],',
       "});",
       "",
     ].join("\n"),
   },
 };
-const WEBSOCKET_DEV_SERVER_DESCRIPTOR: ScenarioAppDescriptor = {
-  ...DEV_SERVER_AGENT_DESCRIPTOR,
-  files: {
-    ...DEV_SERVER_AGENT_DESCRIPTOR.files,
-    "agent/channels/socket.ts": [
-      'import { defineChannel, WS } from "eve/channels";',
-      "",
-      "export default defineChannel({",
-      '  routes: [WS("/socket", () => ({',
-      "    message(peer, message) {",
-      '      const transportHeader = peer.request.headers.has("x-eve-dev-workflow-delivery") ? "exposed" : "hidden";',
-      '      peer.send(`${transportHeader}:${peer.remoteAddress ?? "missing"}:${message.text()}`);',
-      "    },",
-      "  }))],",
-      "});",
-      "",
-    ].join("\n"),
-  },
-};
+const WEBSOCKET_CHANNEL_SOURCE = [
+  'import { defineChannel, WS } from "eve/channels";',
+  "",
+  "export default defineChannel({",
+  '  routes: [WS("/socket", () => ({',
+  "    message(peer, message) {",
+  '      const transportHeader = peer.request.headers.has("x-eve-dev-workflow-delivery") ? "exposed" : "hidden";',
+  '      peer.send(`${transportHeader}:${peer.remoteAddress ?? "missing"}:${message.text()}`);',
+  "    },",
+  "  }))],",
+  "});",
+  "",
+].join("\n");
 const TRANSACTIONAL_REBUILD_DESCRIPTOR: ScenarioAppDescriptor = {
   ...DEV_SERVER_AGENT_DESCRIPTOR,
   files: {
@@ -117,6 +111,7 @@ const STREAM_PROMOTION_DESCRIPTOR: ScenarioAppDescriptor = {
       "export default defineChannel({",
       "  routes: [",
       '    GET("/instrumentation-marker", () => new Response(String(globalThis.__EVE_INSTRUMENTATION_MARKER__ ?? "missing"))),',
+      '    GET("/worker-id", () => new Response(String(globalThis.__EVE_WORKER_ID__ ?? "missing"))),',
       '    GET("/held-stream", () => {',
       '      const releasePath = join(process.cwd(), ".stream-release");',
       "      let releaseWatcher: ReturnType<typeof watch> | undefined;",
@@ -147,6 +142,7 @@ const STREAM_PROMOTION_DESCRIPTOR: ScenarioAppDescriptor = {
       "});",
       "",
     ].join("\n"),
+    "agent/channels/socket.ts": WEBSOCKET_CHANNEL_SOURCE,
   },
 };
 const WORKFLOW_GENERATION_DESCRIPTOR: ScenarioAppDescriptor = {
@@ -607,16 +603,33 @@ describe("eve dev server", () => {
   );
 
   it(
-    "keeps streams and parent control routes alive while a structural candidate is prepared",
+    "keeps admitted connections on the retired worker while a structural replacement is promoted",
     async () => {
       const app = await scenarioApp(STREAM_PROMOTION_DESCRIPTOR);
       const server = await startEveDev(app.appRoot);
+      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+      const socketUrl = new URL("/socket", server.url);
+      socketUrl.protocol = "ws:";
+      const socket = new WebSocket(socketUrl);
       const candidateStartedPath = join(app.appRoot, ".candidate-started");
       const candidateReadyPath = join(app.appRoot, ".candidate-ready");
       const streamReleasePath = join(app.appRoot, ".stream-release");
+      let stopRevisionPolling = false;
+      let revisionPoller: Promise<void> | undefined;
 
       try {
         const initialRevision = await readDevelopmentRevision(server.url);
+        const firstConnection = await requestWithAgent(
+          new URL("/worker-id", server.url).href,
+          agent,
+        );
+        expect(firstConnection.localPort).toBeDefined();
+
+        await waitForWebSocketOpen(socket);
+        const firstMessage = waitForWebSocketMessage(socket);
+        socket.send("before");
+        await expect(firstMessage).resolves.toBe("hidden:127.0.0.1:before");
+
         const streamResponse = await fetch(new URL("/held-stream", server.url));
         if (streamResponse.body === null) {
           throw new Error("Held stream response did not include a body.");
@@ -631,8 +644,7 @@ describe("eve dev server", () => {
         // The parent-owned control route must answer continuously through
         // candidate preparation and promotion, not merely at spot checks.
         const revisionFailures: string[] = [];
-        let stopRevisionPolling = false;
-        const revisionPoller = (async () => {
+        revisionPoller = (async () => {
           while (!stopRevisionPolling) {
             try {
               await readDevelopmentRevision(server.url);
@@ -657,8 +669,20 @@ describe("eve dev server", () => {
         await withinDeadline(rebuild, "Timed out waiting for candidate promotion.");
         await expect(fetchText(server.url, "/instrumentation-marker")).resolves.toBe("two");
 
+        const secondConnection = await requestWithAgent(
+          new URL("/worker-id", server.url).href,
+          agent,
+        );
+        expect(secondConnection.localPort).toBe(firstConnection.localPort);
+        expect(secondConnection.body).not.toBe(firstConnection.body);
+
+        const nextMessage = waitForWebSocketMessage(socket);
+        socket.send("after");
+        await expect(nextMessage).resolves.toBe("hidden:127.0.0.1:after");
+
         stopRevisionPolling = true;
         await revisionPoller;
+        revisionPoller = undefined;
         expect(revisionFailures, revisionFailures.join("\n")).toEqual([]);
 
         await writeFile(streamReleasePath, "release");
@@ -670,70 +694,9 @@ describe("eve dev server", () => {
         await expect(reader.read()).resolves.toEqual(expect.objectContaining({ done: true }));
         expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
       } finally {
-        await server.stop();
-      }
-    },
-    DEV_SERVER_SCENARIO_TIMEOUT_MS,
-  );
-
-  it(
-    "serves a kept-alive connection across a structural worker replacement",
-    async () => {
-      const app = await scenarioApp(TRANSACTIONAL_REBUILD_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
-
-      try {
-        const first = await requestWithAgent(new URL("/worker-id", server.url).href, agent);
-        expect(first.localPort).toBeDefined();
-
-        await writeFile(
-          join(app.appRoot, "agent", "instrumentation.ts"),
-          createInstrumentationSource("keep-alive-two"),
-        );
-        await forceDevelopmentRebuild(server.url);
-        await waitForCondition(
-          async () => (await fetchText(server.url, "/instrumentation-marker")) === "keep-alive-two",
-          `Timed out waiting for the structural replacement.\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`,
-        );
-
-        const second = await requestWithAgent(new URL("/worker-id", server.url).href, agent);
-        expect(second.localPort).toBe(first.localPort);
-        expect(second.body).not.toBe(first.body);
-        expect(hasKnownDevServerFailure(`${server.stdout()}\n${server.stderr()}`)).toBe(false);
-      } finally {
+        stopRevisionPolling = true;
+        await revisionPoller;
         agent.destroy();
-        await server.stop();
-      }
-    },
-    DEV_SERVER_SCENARIO_TIMEOUT_MS,
-  );
-
-  it(
-    "keeps an admitted websocket on its worker while a ready replacement is promoted",
-    async () => {
-      const app = await scenarioApp(WEBSOCKET_DEV_SERVER_DESCRIPTOR);
-      const server = await startEveDev(app.appRoot);
-      const socketUrl = new URL("/socket", server.url);
-      socketUrl.protocol = "ws:";
-      const socket = new WebSocket(socketUrl);
-
-      try {
-        await waitForWebSocketOpen(socket);
-        const firstMessage = waitForWebSocketMessage(socket);
-        socket.send("before");
-        await expect(firstMessage).resolves.toBe("hidden:127.0.0.1:before");
-
-        await writeFile(join(app.appRoot, ".env.local"), "EVE_WEBSOCKET_RELOAD=1\n");
-        await waitForCondition(async () => {
-          const generation = await fetch(new URL("/dev-generation", server.url));
-          return (await generation.text()) === "1";
-        }, `Timed out waiting for websocket worker replacement.\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`);
-
-        const nextMessage = waitForWebSocketMessage(socket);
-        socket.send("after");
-        await expect(nextMessage).resolves.toBe("hidden:127.0.0.1:after");
-      } finally {
         if (socket.readyState === WebSocket.OPEN) {
           const closed = waitForWebSocketClose(socket);
           socket.close();

--- a/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
+++ b/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
@@ -128,9 +128,9 @@ async function readVercelOutputRoutes(outputRoot: string): Promise<readonly unkn
 }
 
 describe("framework-next build", () => {
-  it("builds the Next.js framework fixture after regenerating eve dist", async () => {
+  it("builds the Next.js framework fixture against the prebuilt eve dist", async () => {
     await runPnpmCommand({
-      args: ["--filter", "framework-next", "build"],
+      args: ["--filter", "framework-next", "build:next"],
       cwd: REPO_ROOT,
     });
   }, 180_000);

--- a/packages/eve/test/scenarios/framework-nuxt-build.scenario.test.ts
+++ b/packages/eve/test/scenarios/framework-nuxt-build.scenario.test.ts
@@ -58,9 +58,9 @@ function isFilesystemHandle(route: unknown): boolean {
 }
 
 describe("framework-nuxt build", () => {
-  it("builds the Nuxt framework fixture after regenerating eve dist", async () => {
+  it("builds the Nuxt framework fixture against the prebuilt eve dist", async () => {
     await runPnpmCommand({
-      args: ["--filter", "framework-nuxt", "build"],
+      args: ["--filter", "framework-nuxt", "build:nuxt"],
       cwd: REPO_ROOT,
     });
   }, 300_000);

--- a/packages/eve/test/setup/pack-scenario-tarball.ts
+++ b/packages/eve/test/setup/pack-scenario-tarball.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,42 +8,59 @@ import { runPnpmCommand } from "../../src/internal/testing/run-pnpm-command.js";
 const EVE_PACKAGE_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 const EVE_PACKAGE_NAME_TARBALL_PREFIX = "eve";
 const SCENARIO_CACHE_ROOT = join(tmpdir(), "eve-scenario-cache");
-const SHARED_TARBALLS_ROOT = join(SCENARIO_CACHE_ROOT, "shared-tarballs");
+const PREBUILT_EVE_ENTRY = join(EVE_PACKAGE_ROOT, "dist", "src", "index.js");
 
 /**
  * Vitest `globalSetup` that packs the eve package exactly once before any
  * scenario worker boots. The resulting tarball path is exposed to workers
  * through `process.env.EVE_SCENARIO_EVE_TARBALL_PATH` so
- * `materializeScenarioApp()` can reuse it instead of racing to run
- * `pnpm pack` concurrently (which triggers `prepack` → `pnpm run clean &&
- * build`, a shared-state operation that corrupts `dist/` when run in
- * parallel).
+ * `materializeScenarioApp()` can reuse it without rebuilding or packing the
+ * shared workspace package in parallel.
  *
- * Running once upfront avoids that race and also saves N × ~4s of cold-pack
- * time when file parallelism is enabled.
+ * Scenario CI builds the workspace before Vitest starts. Packing with
+ * lifecycle scripts disabled reuses that exact output instead of paying for
+ * `prepack` to clean and rebuild it a second time.
  */
-export default async function packScenarioTarball(): Promise<void> {
-  await rm(SHARED_TARBALLS_ROOT, {
-    force: true,
+export default async function packScenarioTarball(): Promise<() => Promise<void>> {
+  try {
+    await access(PREBUILT_EVE_ENTRY);
+  } catch {
+    throw new Error(
+      `Scenario tests require a prebuilt eve package. Run "pnpm build" before "pnpm test:scenario". Missing: ${PREBUILT_EVE_ENTRY}`,
+    );
+  }
+
+  await mkdir(SCENARIO_CACHE_ROOT, {
     recursive: true,
   });
-  await mkdir(SHARED_TARBALLS_ROOT, {
-    recursive: true,
-  });
+  const tarballsRoot = await mkdtemp(join(SCENARIO_CACHE_ROOT, "shared-tarballs-"));
 
   await runPnpmCommand({
-    args: ["pack", "--pack-destination", SHARED_TARBALLS_ROOT, "--config.minimum-release-age=0"],
+    args: [
+      "pack",
+      "--config.ignore-scripts=true",
+      "--pack-destination",
+      tarballsRoot,
+      "--config.minimum-release-age=0",
+    ],
     cwd: EVE_PACKAGE_ROOT,
   });
 
-  const tarballName = await resolveTarballName();
-  const tarballPath = join(SHARED_TARBALLS_ROOT, tarballName);
+  const tarballName = await resolveTarballName(tarballsRoot);
+  const tarballPath = join(tarballsRoot, tarballName);
 
   process.env.EVE_SCENARIO_EVE_TARBALL_PATH = tarballPath;
+
+  return async () => {
+    await rm(tarballsRoot, {
+      force: true,
+      recursive: true,
+    });
+  };
 }
 
-async function resolveTarballName(): Promise<string> {
-  const entries = await readdir(SHARED_TARBALLS_ROOT);
+async function resolveTarballName(tarballsRoot: string): Promise<string> {
+  const entries = await readdir(tarballsRoot);
   const tarballName = entries
     .filter(
       (entry) => entry.startsWith(`${EVE_PACKAGE_NAME_TARBALL_PREFIX}-`) && entry.endsWith(".tgz"),
@@ -53,7 +70,7 @@ async function resolveTarballName(): Promise<string> {
 
   if (tarballName === undefined) {
     throw new Error(
-      `Expected pnpm pack to emit a ${EVE_PACKAGE_NAME_TARBALL_PREFIX}-*.tgz tarball in "${SHARED_TARBALLS_ROOT}".`,
+      `Expected pnpm pack to emit a ${EVE_PACKAGE_NAME_TARBALL_PREFIX}-*.tgz tarball in "${tarballsRoot}".`,
     );
   }
 

--- a/packages/eve/vitest.scenario.config.ts
+++ b/packages/eve/vitest.scenario.config.ts
@@ -7,9 +7,9 @@ import { defineConfig } from "vitest/config";
  * listeners, real compile/bundle pipelines, or real workflow on-disk state.
  * Scenario tests take seconds to run and frequently mutate
  * `process.cwd`/`process.env`, so each file runs in its own forked worker
- * process. Some scenarios also rebuild the workspace package, which clears
- * its shared `dist/` directory; files therefore run serially. Tests within a
- * single file still run sequentially.
+ * process. Files run concurrently against isolated temporary apps and a
+ * shared, prebuilt eve tarball. Tests within a single file still run
+ * sequentially.
  *
  * Nothing in this tier is expected to be hermetic. Keep the set small —
  * anything that can be expressed through the in-memory `AppHarness` belongs
@@ -31,9 +31,10 @@ export default defineConfig({
   test: {
     environment: "node",
     exclude: ["**/node_modules/**", "test/vercel/**"],
-    fileParallelism: false,
+    fileParallelism: true,
     globalSetup: ["./test/setup/pack-scenario-tarball.ts"],
     include: ["src/**/*.scenario.test.ts", "test/scenarios/**/*.scenario.test.ts"],
+    maxWorkers: 4,
     setupFiles: ["./test/setup/mock-ai-gateway.ts"],
     testTimeout: 120_000,
   },


### PR DESCRIPTION
## Summary

- run scenario files concurrently with a four-worker cap and a run-scoped prebuilt eve tarball
- avoid redundant prepack and framework-triggered rebuilds of the shared eve dist
- consolidate overlapping dev-server drain, transport, and connection lifecycle assertions
- replace the timing-sensitive chaos probe threshold with deterministic progress synchronization

## Performance

- same-host serial baseline: 310.94s
- refactored root `pnpm test:scenario`: 2m48.5s (`166.08s` Vitest duration)
- wall-time reduction: approximately 46%
- result: 64 files passed, 365 tests passed, 15 skipped

## Validation

- `pnpm test:scenario`
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- targeted `oxlint` and `oxfmt`
- `git diff --check`

No changeset: this only changes internal test infrastructure and scenario coverage organization.