### PR TITLE
feat(agent-workflow-stress): tracing - export spans to Datadog

### DIFF
--- a/e2e/fixtures/agent-workflow-stress/agent/instrumentation.ts
+++ b/e2e/fixtures/agent-workflow-stress/agent/instrumentation.ts
@@ -1,0 +1,1 @@
+export { default } from "@eve-e2e/config/instrumentation";

--- a/e2e/fixtures/agent-workflow-stress/package.json
+++ b/e2e/fixtures/agent-workflow-stress/package.json
@@ -12,9 +12,6 @@
   },
   "dependencies": {
     "@eve-e2e/config": "workspace:*",
-    "@opentelemetry/core": "catalog:",
-    "@opentelemetry/sdk-trace-base": "catalog:",
-    "@vercel/otel": "catalog:",
     "@workflow/world-postgres": "catalog:",
     "ai": "catalog:",
     "eve": "workspace:*"

--- a/e2e/fixtures/e2e-config/package.json
+++ b/e2e/fixtures/e2e-config/package.json
@@ -4,14 +4,20 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./instrumentation": "./src/instrumentation.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@opentelemetry/core": "catalog:",
+    "@opentelemetry/sdk-trace-base": "catalog:",
+    "@vercel/otel": "catalog:",
+    "eve": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "catalog:",
-    "eve": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/e2e/fixtures/e2e-config/src/instrumentation.ts
+++ b/e2e/fixtures/e2e-config/src/instrumentation.ts
@@ -1,0 +1,34 @@
+import { OTLPHttpJsonTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+/**
+ * Shared instrumentation for e2e fixtures that export traces to Datadog.
+ * Environments without `DD_API_KEY` keep telemetry enabled but do not
+ * register an exporter.
+ */
+export default defineInstrumentation({
+  recordInputs: false,
+  recordOutputs: false,
+  traceChannelRequests: true,
+  events: {
+    "step.started": () => ({
+      runtimeContext: {
+        "vercel.env": process.env.VERCEL_ENV ?? "",
+      },
+    }),
+  },
+  setup({ agentName }) {
+    const datadogApiKey = process.env.DD_API_KEY?.trim();
+    if (!datadogApiKey) {
+      return;
+    }
+
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpJsonTraceExporter({
+        url: "https://vercel.integrations.otlp.datadoghq.com/v1/traces",
+        headers: { "DD-API-KEY": datadogApiKey },
+      }),
+    });
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,15 +1036,6 @@ importers:
       '@eve-e2e/config':
         specifier: workspace:*
         version: link:../e2e-config
-      '@opentelemetry/core':
-        specifier: 'catalog:'
-        version: 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base':
-        specifier: 'catalog:'
-        version: 2.6.1(@opentelemetry/api@1.9.1)
-      '@vercel/otel':
-        specifier: 'catalog:'
-        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
       '@workflow/world-postgres':
         specifier: 'catalog:'
         version: 5.0.0-beta.29(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
@@ -1088,13 +1079,23 @@ importers:
         version: 7.0.2
 
   e2e/fixtures/e2e-config:
+    dependencies:
+      '@opentelemetry/core':
+        specifier: 'catalog:'
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 'catalog:'
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@vercel/otel':
+        specifier: 'catalog:'
+        version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
-      eve:
-        specifier: workspace:*
-        version: link:../../../packages/eve
       typescript:
         specifier: 'catalog:'
         version: 7.0.2


### PR DESCRIPTION
## Summary

- add reusable Datadog OpenTelemetry instrumentation at `@eve-e2e/config/instrumentation`
- have the workflow stress fixture opt in with a one-line default re-export
- centralize the exporter dependencies in the private e2e package
- trace inbound channel requests while excluding model inputs and outputs

## Testing

- `pnpm --filter eve build:compiled`
- `pnpm --filter @eve-e2e/config typecheck`
- `pnpm --filter agent-workflow-stress typecheck`
- `pnpm exec oxlint e2e/fixtures/e2e-config/src/instrumentation.ts e2e/fixtures/agent-workflow-stress/agent/instrumentation.ts`
- `pnpm exec oxfmt --check e2e/fixtures/e2e-config/package.json e2e/fixtures/e2e-config/src/instrumentation.ts e2e/fixtures/agent-workflow-stress/package.json e2e/fixtures/agent-workflow-stress/agent/instrumentation.ts`
- `pnpm guard:invariants`