### PR TITLE
feat(eve): attribute a subagent turn to the call that dispatched it

### DIFF
--- a/.changeset/subagent-trace-lineage.md
+++ b/.changeset/subagent-trace-lineage.md
@@ -1,0 +1,8 @@
+---
+"eve": patch
+---
+
+Subagent turn spans now record the dispatch that created them —
+`agent.parent.session.id`, `agent.parent.turn.id`, `agent.parent.call_id`, and
+`agent.subagent.name` — so a parent turn that fans out to several children can
+be attributed to the exact tool call behind each one.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -258,6 +258,8 @@ A subagent keeps its own session id but records into the trace its parent had op
 
 A session long enough to outgrow one trace — far longer than anything you will drive locally — continues into a new one. Each is a session window, numbered from zero on `agent.session.window`; passing a session id shows every window it produced, oldest first, and a trace id shows just that window.
 
+One parent turn can dispatch several subagents into the same window, so a child's turn spans name the dispatch: `agent.parent.session.id`, `agent.parent.turn.id`, and `agent.parent.call_id` identify the tool call that created the child, and `agent.subagent.name` the subagent it invoked. Top-level sessions carry none of these.
+
 `agent.session` and `agent.turn` outlive the worker that opened them, so they are recorded as zero-duration markers. The span tree shows their descendant extent instead; `agent.step` and the model and tool spans beneath it carry real durations. A third-party OTel backend reports zero for the markers.
 
 ## `eve link`

--- a/packages/eve/src/channel/subagent-emitter.test.ts
+++ b/packages/eve/src/channel/subagent-emitter.test.ts
@@ -4,7 +4,7 @@ import {
   deserializeRuntimeAdapter,
 } from "#runtime/channels/registry.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 
 describe("subagent adapter", () => {
   it("round-trips durable delegation metadata through the ChannelKey codec", async () => {

--- a/packages/eve/src/execution/delegated-parent-notification.test.ts
+++ b/packages/eve/src/execution/delegated-parent-notification.test.ts
@@ -5,7 +5,8 @@ import { serializeContext } from "#context/serialize.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { notifyDelegatedParentStep } from "#execution/delegated-parent-notification.js";
-import { SUBAGENT_ADAPTER, SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
 

--- a/packages/eve/src/execution/delegated-parent-notification.ts
+++ b/packages/eve/src/execution/delegated-parent-notification.ts
@@ -8,7 +8,7 @@
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { deserializeContext } from "#context/serialize.js";
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 import type { TokenUsage } from "#shared/token-usage.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 

--- a/packages/eve/src/execution/delegated-parent-result.ts
+++ b/packages/eve/src/execution/delegated-parent-result.ts
@@ -8,7 +8,7 @@
 import type { RuntimeSubagentResultActionResult } from "#runtime/actions/types.js";
 import type { JsonValue } from "#shared/json.js";
 import { toErrorMessage } from "#shared/errors.js";
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 
 /**
  * Builds the success-shaped {@link RuntimeSubagentResultActionResult}.

--- a/packages/eve/src/execution/subagent-adapter-state.ts
+++ b/packages/eve/src/execution/subagent-adapter-state.ts
@@ -1,0 +1,58 @@
+/**
+ * Durable state for the subagent adapter, split from the adapter itself so
+ * harness code can identify a delegated child run without reaching the
+ * adapter's workflow-coupled behavior (`runtime-boundary.test.ts`).
+ */
+
+/**
+ * Durable adapter kind used for delegated subagent child runs.
+ *
+ * Framework-owned — authored channel code never constructs a subagent
+ * adapter directly. Emitted by `buildSubagentRunInput`
+ * (`execution/subagent-tool.ts`) when a parent dispatches a child
+ * subagent.
+ */
+export const SUBAGENT_ADAPTER_KIND = "subagent";
+
+/**
+ * Durable state carried on a subagent adapter instance.
+ *
+ * Populated by `buildSubagentRunInput` at dispatch time so the child
+ * run retains the parent lineage metadata required to resume its parent
+ * when the child finishes and to forward HITL requests up the chain.
+ *
+ * The parent's turn identifier is not duplicated here — it lives on
+ * `RunInput.parent.turn.id` which is the single source of truth for the
+ * child's parent-turn lineage.
+ */
+export interface SubagentAdapterState extends Record<string, unknown> {
+  readonly callId: string;
+  readonly parentContinuationToken: string;
+  readonly parentSessionId: string;
+  readonly subagentName: string;
+}
+
+/**
+ * Narrow runtime guard for {@link SubagentAdapterState}.
+ *
+ * Framework adapters live through a JSON round-trip at every workflow
+ * step boundary, so consumers that want to treat the adapter state as
+ * a structured record must validate the shape explicitly.
+ */
+export function isSubagentAdapterState(value: unknown): value is SubagentAdapterState {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const state = value as Partial<SubagentAdapterState>;
+
+  return (
+    typeof state.callId === "string" &&
+    state.callId.length > 0 &&
+    typeof state.parentContinuationToken === "string" &&
+    state.parentContinuationToken.length > 0 &&
+    typeof state.parentSessionId === "string" &&
+    typeof state.subagentName === "string" &&
+    state.subagentName.length > 0
+  );
+}

--- a/packages/eve/src/execution/subagent-adapter.test.ts
+++ b/packages/eve/src/execution/subagent-adapter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { callAdapterEventHandler, type ChannelAdapterContext } from "#channel/adapter.js";
 import { buildSessionHandle } from "#channel/session.js";
-import { type SubagentAdapterState } from "#execution/subagent-adapter.js";
+import { type SubagentAdapterState } from "#execution/subagent-adapter-state.js";
 import { ContextContainer } from "#context/container.js";
 import { ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
 import type { InputRequest } from "#runtime/input/types.js";

--- a/packages/eve/src/execution/subagent-adapter.ts
+++ b/packages/eve/src/execution/subagent-adapter.ts
@@ -7,62 +7,13 @@ import type {
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
 import { ContinuationTokenKey, SessionIdKey } from "#context/keys.js";
+import {
+  SUBAGENT_ADAPTER_KIND,
+  isSubagentAdapterState,
+} from "#execution/subagent-adapter-state.js";
 import { createErrorId, createLogger } from "#internal/logging.js";
 
 const log = createLogger("execution.subagent-adapter");
-
-/**
- * Durable adapter kind used for delegated subagent child runs.
- *
- * Framework-owned — authored channel code never constructs a subagent
- * adapter directly. Emitted by `buildSubagentRunInput`
- * (`execution/subagent-tool.ts`) when a parent dispatches a child
- * subagent.
- */
-export const SUBAGENT_ADAPTER_KIND = "subagent";
-
-/**
- * Durable state carried on a subagent adapter instance.
- *
- * Populated by `buildSubagentRunInput` at dispatch time so the child
- * run retains the parent lineage metadata required to resume its parent
- * when the child finishes and to forward HITL requests up the chain.
- *
- * The parent's turn identifier is not duplicated here — it lives on
- * `RunInput.parent.turn.id` which is the single source of truth for the
- * child's parent-turn lineage.
- */
-export interface SubagentAdapterState extends Record<string, unknown> {
-  readonly callId: string;
-  readonly parentContinuationToken: string;
-  readonly parentSessionId: string;
-  readonly subagentName: string;
-}
-
-/**
- * Narrow runtime guard for {@link SubagentAdapterState}.
- *
- * Framework adapters live through a JSON round-trip at every workflow
- * step boundary, so consumers that want to treat the adapter state as
- * a structured record must validate the shape explicitly.
- */
-export function isSubagentAdapterState(value: unknown): value is SubagentAdapterState {
-  if (value === null || typeof value !== "object") {
-    return false;
-  }
-
-  const state = value as Partial<SubagentAdapterState>;
-
-  return (
-    typeof state.callId === "string" &&
-    state.callId.length > 0 &&
-    typeof state.parentContinuationToken === "string" &&
-    state.parentContinuationToken.length > 0 &&
-    typeof state.parentSessionId === "string" &&
-    typeof state.subagentName === "string" &&
-    state.subagentName.length > 0
-  );
-}
 
 /**
  * Framework adapter that bridges a child subagent session to its

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
 import { buildSubagentRunInput } from "#execution/subagent-tool.js";

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -1,4 +1,4 @@
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 import {
   formatSubagentInput,
   normalizeRequestedOutputSchema,

--- a/packages/eve/src/harness/agent-otel-provider.test.ts
+++ b/packages/eve/src/harness/agent-otel-provider.test.ts
@@ -18,6 +18,7 @@ import {
   type InstrumentationAttemptScope,
   type InstrumentationContextRunner,
   type InstrumentationHooks,
+  type InstrumentationParentLineage,
   type InstrumentationTraceContext,
 } from "#harness/instrumentation-lifecycle.js";
 
@@ -142,6 +143,7 @@ async function emitAttempt(input: {
 
 async function publishTurnStarted(input: {
   readonly hooks: InstrumentationHooks;
+  readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId?: string;
   readonly sessionId: string;
@@ -158,6 +160,7 @@ async function publishTurnStarted(input: {
     type: "session.started",
   });
   await input.hooks.publish({
+    parentLineage: input.parentLineage,
     parentTraceContext: input.parentTraceContext,
     rootSessionId,
     sequence: input.turnSequence,
@@ -441,6 +444,69 @@ describe("createAgentOtelInstrumentation", () => {
     // The child adopts a window rather than opening one, so the trace still
     // holds exactly the root's window span.
     expect(byName(spans, "agent.session")).toHaveLength(1);
+  });
+
+  it("attributes a child turn to the exact call that dispatched it", async () => {
+    const runtime = createRuntime();
+    await publishTurnStarted({
+      hooks: runtime.hooks,
+      parentLineage: {
+        callId: "call-7",
+        sessionId: "session-1",
+        subagentName: "researcher",
+        turnId: "turn-1",
+      },
+      rootSessionId: "session-1",
+      sessionId: "child-1",
+      turnId: "child-turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const spans = runtime.exporter.getFinishedSpans();
+    const childTurn = byName(spans, "agent.turn").find(
+      (span) => span.attributes["agent.session.id"] === "child-1",
+    )!;
+    expect(childTurn.attributes["agent.parent.call_id"]).toBe("call-7");
+    expect(childTurn.attributes["agent.parent.session.id"]).toBe("session-1");
+    expect(childTurn.attributes["agent.parent.turn.id"]).toBe("turn-1");
+    expect(childTurn.attributes["agent.subagent.name"]).toBe("researcher");
+  });
+
+  it("omits the subagent name when the dispatch did not carry one", async () => {
+    const runtime = createRuntime();
+    await publishTurnStarted({
+      hooks: runtime.hooks,
+      parentLineage: { callId: "call-7", sessionId: "session-1", turnId: "turn-1" },
+      rootSessionId: "session-1",
+      sessionId: "child-1",
+      turnId: "child-turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const childTurn = byName(runtime.exporter.getFinishedSpans(), "agent.turn").find(
+      (span) => span.attributes["agent.session.id"] === "child-1",
+    )!;
+    expect(childTurn.attributes).not.toHaveProperty("agent.subagent.name");
+    expect(childTurn.attributes["agent.parent.call_id"]).toBe("call-7");
+  });
+
+  it("leaves a top-level turn free of parent lineage attributes", async () => {
+    const runtime = createRuntime();
+    await publishTurnStarted({
+      hooks: runtime.hooks,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const turn = byName(runtime.exporter.getFinishedSpans(), "agent.turn")[0]!;
+    expect(turn.attributes).not.toHaveProperty("agent.parent.call_id");
+    expect(turn.attributes).not.toHaveProperty("agent.parent.session.id");
+    expect(turn.attributes).not.toHaveProperty("agent.parent.turn.id");
+    expect(turn.attributes).not.toHaveProperty("agent.subagent.name");
   });
 
   it("opens its own root when a child session is handed no parent window", async () => {

--- a/packages/eve/src/harness/agent-otel-provider.ts
+++ b/packages/eve/src/harness/agent-otel-provider.ts
@@ -19,6 +19,7 @@ import type {
   InstrumentationModelCallStartedEvent,
   InstrumentationProviderDefinition,
   InstrumentationSessionStartedEvent,
+  InstrumentationParentLineage,
   InstrumentationTraceContext,
   InstrumentationSessionTransitionEvent,
   InstrumentationToolCallStartedEvent,
@@ -156,6 +157,7 @@ export function createAgentOtelInstrumentation(
           "agent.framework.name": "eve",
           "agent.framework.version": input.frameworkVersion,
           "agent.name": session.agentName,
+          ...parentLineageAttributes(event.parentLineage),
           "agent.root.session.id": event.rootSessionId,
           "agent.session.id": event.sessionId,
           "agent.session.window": session.window,
@@ -507,6 +509,21 @@ export function createAgentOtelInstrumentation(
 
 function turnKey(sessionId: string, turnId: string): string {
   return `${sessionId}:${turnId}`;
+}
+
+function parentLineageAttributes(
+  lineage: InstrumentationParentLineage | undefined,
+): Record<string, string> {
+  if (lineage === undefined) return {};
+  const attributes: Record<string, string> = {
+    "agent.parent.call_id": lineage.callId,
+    "agent.parent.session.id": lineage.sessionId,
+    "agent.parent.turn.id": lineage.turnId,
+  };
+  if (lineage.subagentName !== undefined) {
+    attributes["agent.subagent.name"] = lineage.subagentName;
+  }
+  return attributes;
 }
 
 function adoptedSpanContext(handed: InstrumentationTraceContext): SpanContext {

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -37,6 +37,17 @@ export interface InstrumentationTraceContext {
   readonly traceId: string;
 }
 
+/**
+ * Which tool call dispatched a subagent child. The trace structure alone
+ * cannot say: one turn's children all parent to the same window.
+ */
+export interface InstrumentationParentLineage {
+  readonly callId: string;
+  readonly sessionId: string;
+  readonly subagentName?: string;
+  readonly turnId: string;
+}
+
 export interface InstrumentationSessionTransitionEvent {
   readonly type: "session.completed" | "session.failed" | "session.waiting";
   readonly error?: unknown;
@@ -46,6 +57,7 @@ export interface InstrumentationSessionTransitionEvent {
 
 export interface InstrumentationTurnStartedEvent {
   readonly type: "turn.started";
+  readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId: string;
   readonly sequence: number;

--- a/packages/eve/src/harness/instrumentation-native-events.test.ts
+++ b/packages/eve/src/harness/instrumentation-native-events.test.ts
@@ -90,4 +90,51 @@ describe("createInstrumentationHandleEvent", () => {
 
     expect(events).toEqual([{ sessionId: "session-1", turnId: "turn-1", type: "session.waiting" }]);
   });
+
+  it("carries the dispatch lineage onto every turn a child session starts", async () => {
+    const events: { readonly type: string }[] = [];
+    const parentLineage = {
+      callId: "call-7",
+      sessionId: "session-1",
+      subagentName: "researcher",
+      turnId: "turn-1",
+    };
+    const handleEvent = createInstrumentationHandleEvent({
+      handleEvent: async () => {},
+      hooks: {
+        after: async () => {},
+        before: async () => {},
+        publish: async (event) => {
+          events.push(event);
+        },
+      },
+      parentLineage,
+      rootSessionId: "session-1",
+      sessionId: "child-1",
+    })!;
+
+    await handleEvent(createTurnStartedEvent({ sequence: 0, turnId: "child-turn-1" }));
+    await handleEvent(createTurnStartedEvent({ sequence: 1, turnId: "child-turn-2" }));
+
+    expect(events.filter((event) => event.type === "turn.started")).toEqual([
+      {
+        parentLineage,
+        parentTraceContext: undefined,
+        rootSessionId: "session-1",
+        sequence: 0,
+        sessionId: "child-1",
+        turnId: "child-turn-1",
+        type: "turn.started",
+      },
+      {
+        parentLineage,
+        parentTraceContext: undefined,
+        rootSessionId: "session-1",
+        sequence: 1,
+        sessionId: "child-1",
+        turnId: "child-turn-2",
+        type: "turn.started",
+      },
+    ]);
+  });
 });

--- a/packages/eve/src/harness/instrumentation-native-events.ts
+++ b/packages/eve/src/harness/instrumentation-native-events.ts
@@ -1,6 +1,7 @@
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import type {
   InstrumentationHooks,
+  InstrumentationParentLineage,
   InstrumentationPointEvent,
   InstrumentationTraceContext,
 } from "#harness/instrumentation-lifecycle.js";
@@ -10,6 +11,7 @@ export interface CreateInstrumentationHandleEventInput {
   readonly agentName?: string;
   readonly handleEvent?: HandleEventFn;
   readonly hooks?: InstrumentationHooks;
+  readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId?: string;
   readonly sessionId: string;
@@ -60,6 +62,7 @@ function toLifecycleEvent(
       };
     case "turn.started":
       return {
+        parentLineage: input.parentLineage,
         parentTraceContext: input.parentTraceContext,
         rootSessionId: input.rootSessionId ?? input.sessionId,
         sequence: event.data.sequence,

--- a/packages/eve/src/harness/parent-lineage.test.ts
+++ b/packages/eve/src/harness/parent-lineage.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveParentLineage } from "#harness/parent-lineage.js";
+
+const parent = {
+  callId: "call-1",
+  rootSessionId: "root-1",
+  sessionId: "session-1",
+  turn: { id: "turn-1", sequence: 0 },
+};
+
+describe("resolveParentLineage", () => {
+  it("reads the call and turn from the parent and the name from the adapter", () => {
+    expect(
+      resolveParentLineage(parent, {
+        state: {
+          callId: "call-1",
+          parentContinuationToken: "token-1",
+          parentSessionId: "session-1",
+          subagentName: "researcher",
+        },
+      }),
+    ).toEqual({
+      callId: "call-1",
+      sessionId: "session-1",
+      subagentName: "researcher",
+      turnId: "turn-1",
+    });
+  });
+
+  it("returns undefined for a top-level session", () => {
+    expect(resolveParentLineage(undefined, undefined)).toBeUndefined();
+  });
+
+  it("omits the name when the child did not come through the subagent adapter", () => {
+    expect(resolveParentLineage(parent, { state: { kind: "http" } })?.subagentName).toBeUndefined();
+    expect(resolveParentLineage(parent, undefined)?.subagentName).toBeUndefined();
+  });
+});

--- a/packages/eve/src/harness/parent-lineage.ts
+++ b/packages/eve/src/harness/parent-lineage.ts
@@ -1,0 +1,23 @@
+import type { SessionParent } from "#channel/types.js";
+import { isSubagentAdapterState } from "#execution/subagent-adapter-state.js";
+import type { InstrumentationParentLineage } from "#harness/instrumentation-lifecycle.js";
+
+/**
+ * Resolves the dispatch that created the running session, if any. Dispatch
+ * splits the lineage across two owners — the identifiers onto
+ * {@link SessionParent}, the subagent name onto the adapter state — so both
+ * are read here rather than either being duplicated onto the other.
+ */
+export function resolveParentLineage(
+  parent: SessionParent | undefined,
+  adapter: { readonly state?: unknown } | undefined,
+): InstrumentationParentLineage | undefined {
+  if (parent === undefined) return undefined;
+  const state = adapter?.state;
+  return {
+    callId: parent.callId,
+    sessionId: parent.sessionId,
+    subagentName: isSubagentAdapterState(state) ? state.subagentName : undefined,
+    turnId: parent.turn.id,
+  };
+}

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -107,6 +107,8 @@ import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-c
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
 import { createInstrumentationHandleEvent } from "#harness/instrumentation-native-events.js";
 import type { InstrumentationAttemptScope } from "#harness/instrumentation-lifecycle.js";
+import { resolveParentLineage } from "#harness/parent-lineage.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import {
   consumeDeferredStepInput,
   getApprovedTools,
@@ -542,6 +544,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       agentName: config.runtimeIdentity?.agentName,
       handleEvent: baseEmit,
       hooks: config.instrumentation?.hooks,
+      parentLineage: resolveParentLineage(parent, store?.get(ChannelKey)),
       parentTraceContext: store?.get(ParentTraceContextKey),
       rootSessionId: parent?.rootSessionId,
       sessionId: session.sessionId,

--- a/packages/eve/src/runtime/channels/registry.test.ts
+++ b/packages/eve/src/runtime/channels/registry.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { ChannelAdapter } from "#channel/adapter.js";
 import { HTTP_ADAPTER, HTTP_ADAPTER_KIND } from "#channel/http.js";
 import { SCHEDULE_ADAPTER, SCHEDULE_ADAPTER_KIND } from "#channel/schedule.js";
-import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter.js";
+import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 import { SUBAGENT_ADAPTER } from "#execution/subagent-adapter.js";
 import { RuntimeRegistryError } from "#internal/runtime-registry.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";


### PR DESCRIPTION
Stacked on #1410 — **base is `research/windowed-session-traces`, review that first.**

#1410 puts a subagent child into the trace of the session that dispatched it. That answers which trace a child belongs to, but not which dispatch created it. A single parent turn can fan out to several subagents at once, and every one of those children parents to the same span, so the shape of the trace cannot tell them apart. Looking at a child turn, there is no way to say which tool call produced it or which subagent it ran.

## What changed

A child session's `agent.turn` spans now name the dispatch:

| attribute | |
| --- | --- |
| `agent.parent.session.id` | the session that dispatched |
| `agent.parent.turn.id` | the turn it dispatched from |
| `agent.parent.call_id` | the tool call that created this child |
| `agent.subagent.name` | the subagent that call invoked |

Top-level sessions carry none of them. A child that did not arrive through the subagent adapter carries the first three and omits `agent.subagent.name`.

Most of this was already in hand: the session's parent record already carries the three identifiers, and the turn loop already reads it. Only the subagent name needed a second source, since it lives on the durable adapter state rather than on the parent record. The two are read together at the point the turn span is built rather than one being copied onto the other — the parent record is exposed to every extension capability surface, so widening it bumps all of those capability epochs at once. That is the same constraint that kept the parent trace context off it in #1410.

## Naming

`agent.parent.call_id` is what was asked for, so that is what this implements. It is the one attribute here that breaks eve's own dotted convention (`agent.session.id`, `agent.turn.id`, `agent.root.session.id`) and OTel's `gen_ai.tool.call.id`. `agent.parent.call.id` would be consistent; it is a one-line change plus the doc and tests. Say the word.

## Also in this PR

The subagent adapter's durable state shape and its type guard move out of the adapter module into one of their own. Harness code has to stay transitively free of workflow imports, and the adapter module reaches workflow's resume hook, so importing the guard from there would have broken that boundary — the state shape and guard are pure data and carry no such coupling. Consumers import from the new module directly. Re-exporting from the old one type-checks but rolldown resolves it as a missing export when fixture apps build, so there is no shim.

## Not included

The other item raised alongside this one — making sure a finishing subagent child cannot unpin a trace its parent is still writing to — turned out to already be in #1410, with a test for the child-finishes-first case. Nothing was needed here.

## Verification

`pnpm fmt && pnpm lint && pnpm typecheck && pnpm guard:invariants && pnpm docs:check`, then `pnpm test:unit` (5614 passed, 1 skipped) and `pnpm test:integration` (570 passed). Scenario tier not run.
