### PR TITLE
fix(eve): preserve registry title casing

### DIFF
--- a/.changeset/funny-registries-smile.md
+++ b/.changeset/funny-registries-smile.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Render registry item titles with their exact registry-provided casing by loading manifests for each page of catalog results.

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -412,7 +412,7 @@ describe("registry commands", () => {
     expect(logger.logs).toContain("Added @other to package.json.");
   });
 
-  it("uses the Photon iMessage title for the official provider", async () => {
+  it("loads real item titles in parallel for a page of search results", async () => {
     searchRegistries.mockResolvedValue({
       items: [
         {
@@ -420,15 +420,39 @@ describe("registry commands", () => {
           name: "channel/photon-imessage",
           addCommandArgument: "https://eve.dev/r/channel/photon-imessage.json",
         },
+        {
+          registry: "@acme",
+          name: "extension/ai-sdk-tools",
+          addCommandArgument: "@acme/ai-sdk-tools",
+        },
       ],
-      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+      pagination: { total: 2, offset: 0, limit: 2, hasMore: false },
     });
+    const resolvers = new Map<string, (value: unknown[]) => void>();
+    getRegistryItems.mockImplementation(
+      ([address]: string[]) =>
+        new Promise((resolve) => {
+          resolvers.set(address!, resolve);
+        }),
+    );
 
-    await expect(browseRegistryCatalog("/project")).resolves.toMatchObject({
+    const catalog = browseRegistryCatalog("/project", { query: "sdk" });
+
+    await vi.waitFor(() => expect(getRegistryItems).toHaveBeenCalledTimes(2));
+    resolvers.get("https://eve.dev/r/channel/photon-imessage.json")?.([
+      { title: "Photon iMessage" },
+    ]);
+    resolvers.get("@acme/ai-sdk-tools")?.([{ title: "AI SDK Tools" }]);
+    await expect(catalog).resolves.toMatchObject({
       items: [
-        expect.objectContaining({ name: "channel/photon-imessage", title: "Photon iMessage" }),
+        { name: "channel/photon-imessage", title: "Photon iMessage" },
+        { name: "extension/ai-sdk-tools", title: "AI SDK Tools" },
       ],
     });
+    expect(searchRegistries).toHaveBeenCalledWith(
+      ["https://eve.dev/r/registry.json", "@acme"],
+      expect.objectContaining({ limit: 100, query: "sdk" }),
+    );
   });
 
   it("lists the official registry without configured namespaces", async () => {
@@ -444,6 +468,7 @@ describe("registry commands", () => {
     expect(searchRegistries).toHaveBeenCalledWith(["https://eve.dev/r/registry.json"], {
       config: { registries: {} },
       continueOnError: false,
+      limit: 100,
       query: undefined,
     });
     expect(logger.logs).toEqual(["No registry items found."]);
@@ -499,6 +524,7 @@ describe("registry commands", () => {
         registries: { "@acme": "https://example.com/r/{name}.json" },
       },
       continueOnError: true,
+      limit: 100,
       query: "browser",
     });
     expect(logger.logs).toEqual([

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -70,9 +70,7 @@ const defaultAddCommandDependencies: AddCommandDependencies = {
 
 const OFFICIAL_REGISTRY = process.env.EVE_DEV_OFFICIAL_REGISTRY_URL ?? "https://eve.dev/r";
 const OFFICIAL_CATALOG = `${OFFICIAL_REGISTRY}/registry.json`;
-
-// shadcn's registry search response omits titles. Keep this one exception until it includes them.
-const OFFICIAL_CATALOG_TITLES = new Map([["channel/photon-imessage", "Photon iMessage"]]);
+const CATALOG_PAGE_SIZE = 100;
 
 function isRegistryAddress(value: string): boolean {
   return value.startsWith("@") || /^https?:\/\//.test(value);
@@ -214,9 +212,17 @@ async function searchRegistryCatalog(
   const result = await searchRegistries(sources, {
     config,
     continueOnError: sources.length > 1,
+    limit: CATALOG_PAGE_SIZE,
     query: options.query,
   });
-  return { result, sources };
+  return { config, result, sources };
+}
+
+function registryManifestTitle(manifest: unknown): string | undefined {
+  if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest))
+    return undefined;
+  const title = (manifest as { title?: unknown }).title;
+  return typeof title === "string" ? title : undefined;
 }
 
 /** Browses all configured catalogs, or one namespace or URL source. */
@@ -224,16 +230,22 @@ export async function browseRegistryCatalog(
   appRoot: string,
   options: { query?: string; source?: string } = {},
 ): Promise<RegistryCatalogResult> {
-  const { result } = await searchRegistryCatalog(appRoot, options);
+  const { config, result } = await searchRegistryCatalog(appRoot, options);
+  const manifests = await Promise.all(
+    result.items.map(async (item) => {
+      const [manifest] = await getRegistryItems([item.addCommandArgument], { config });
+      return manifest;
+    }),
+  );
   return {
-    items: result.items.map((item: RegistrySearchItem) => {
+    items: result.items.map((item: RegistrySearchItem, index) => {
       const catalogItem: RegistryCatalogItem = {
         address: item.registry === OFFICIAL_CATALOG ? item.name : item.addCommandArgument,
         name: item.name,
         source: item.registry === OFFICIAL_CATALOG ? "Vercel" : item.registry,
       };
-      const title = OFFICIAL_CATALOG_TITLES.get(item.name);
-      if (title !== undefined && item.registry === OFFICIAL_CATALOG) catalogItem.title = title;
+      const title = registryManifestTitle(manifests[index]);
+      if (title !== undefined) catalogItem.title = title;
       if (item.type !== undefined) catalogItem.type = item.type;
       if (item.description !== undefined) catalogItem.description = item.description;
       return catalogItem;


### PR DESCRIPTION
## Summary

- derive temporary catalog titles while shadcn registry search omits title metadata
- render `photon-imessage` as `Photon iMessage` and `Sdk` segments as `SDK`
- cover title derivation and registry picker rendering

## Tests

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/registry.test.ts src/setup/flows/registry.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm exec oxlint packages/eve/src/cli/commands/registry.ts packages/eve/src/cli/commands/registry.test.ts packages/eve/src/setup/flows/registry.ts packages/eve/src/setup/flows/registry.test.ts`