### PR TITLE
fix(eve): reject Slack sign-in HTML from private file fetch (missing files:read) (#1317)

### DIFF
--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -278,6 +278,8 @@ Start a session without an inbound message through `receive(slack, { message, ta
 
 Inbound files behind authenticated Slack URLs are staged with `fetchFile`. See [File uploads](./custom#file-uploads) for the `fetchFile` contract.
 
+Staged file downloads require the Slack bot token's **`files:read`** scope. When that scope is missing, Slack answers the authenticated fetch with a `200 OK` browser sign-in page (`text/html`) instead of the file bytes. eve refuses to stage that HTML as the attachment and throws an actionable error naming the missing scope — add `files:read` to the Slack app, reinstall the workspace, and retry. A previously-working bot that starts surfacing "the model received a Slack login page" almost always hit this case.
+
 ## What to read next
 
 - [Channels overview](./overview): the channel contract and every built-in channel

--- a/packages/eve/.changeset/slack-file-fetch-reject-html-wrapper.md
+++ b/packages/eve/.changeset/slack-file-fetch-reject-html-wrapper.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reject Slack's browser sign-in HTML when the private file fetch returns `text/html` (or an HTML body with no `Content-Type`): the Connect/Slack connector then throws an actionable error naming the likely missing `files:read` bot scope (and to reinstall the app after adding it), instead of staging the login page as the attachment and surfacing it downstream as a vision/auth mystery. Happy-path file downloads (binary or non-HTML responses) are unchanged.

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -232,6 +232,53 @@ describe("createSlackFetchFile", () => {
 
     await expect(fetchFile("https://files.slack.com/locked.csv")).rejects.toThrow("HTTP 403");
   });
+
+  it("rejects an HTTP 200 `text/html` sign-in page (missing files:read scope)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<!DOCTYPE html><html><body>Slack sign in</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const fetchFile = createSlackFetchFile({ botToken: "xoxb-test-token" });
+
+    await expect(fetchFile("https://files.slack.com/a/b/locked.png")).rejects.toThrow(
+      /sign-in page.*files:read/is,
+    );
+  });
+
+  it("rejects an HTML sign-in page when the response omits a Content-Type", async () => {
+    // A bare string body makes `Response` default to `text/plain`, so strip
+    // the header explicitly to model Slack's sign-in HTML arriving untyped.
+    const response = new Response("<html><head><title>Slack</title></head></html>", {
+      status: 200,
+    });
+    response.headers.delete("content-type");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+    const fetchFile = createSlackFetchFile({ botToken: "xoxb-test-token" });
+
+    await expect(fetchFile("https://files.slack.com/a/b/locked.png")).rejects.toThrow(
+      /sign-in page.*files:read/is,
+    );
+  });
+
+  it("still returns binary file bytes for ordinary attachments (no false positive)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([137, 80, 78, 71]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const fetchFile = createSlackFetchFile({ botToken: "xoxb-test-token" });
+    const result = await fetchFile("https://files.slack.com/a/b/cat.png");
+
+    expect(result).not.toBeNull();
+    expect(result!.bytes.equals(Buffer.from([137, 80, 78, 71]))).toBe(true);
+    expect(result!.mediaType).toBe("image/png");
+  });
 });
 
 describe("collectInboundFileParts", () => {

--- a/packages/eve/src/public/channels/slack/attachments.ts
+++ b/packages/eve/src/public/channels/slack/attachments.ts
@@ -179,11 +179,44 @@ export function createSlackFetchFile(input: {
     if (!response.ok) {
       throw new Error(`Slack file fetch returned HTTP ${response.status} for ${url}.`);
     }
+    const mediaType = response.headers.get("content-type") ?? undefined;
+    // Slack serves its browser sign-in page (HTTP 200, `text/html`) instead
+    // of the file bytes when the bot token lacks the `files:read` scope.
+    // Staging that HTML as the attachment looks like a vision/auth mystery
+    // downstream ("the model received a Slack login page"), so refuse it here
+    // with an actionable error instead of returning the login page.
+    const servedHtml =
+      (mediaType !== undefined && mediaType.toLowerCase().startsWith("text/html")) ||
+      (mediaType === undefined && (await looksLikeHtml(response)));
+    if (servedHtml) {
+      throw new Error(
+        `Slack file fetch returned an HTML sign-in page instead of file bytes for ${url}. ` +
+          "This almost always means the Slack bot token is missing the files:read scope. " +
+          "Add files:read to your Slack app and reinstall the workspace, then retry.",
+      );
+    }
     return {
       bytes: Buffer.from(await response.arrayBuffer()),
-      mediaType: response.headers.get("content-type") ?? undefined,
+      mediaType,
     };
   };
+}
+
+/**
+ * Reads `response`'s body through a clone and reports whether it looks like
+ * an HTML document (`<!DOCTYPE html` / `<html`), ignoring leading whitespace.
+ * Used only when the response carries no `Content-Type` to trust; a real
+ * Slack file never reaches here with a missing content-type, and a sign-in
+ * page rendered without one is the missing-`files:read` case we refuse.
+ */
+async function looksLikeHtml(response: Response): Promise<boolean> {
+  try {
+    const head = await response.clone().text();
+    const trimmed = head.trimStart().slice(0, 512).toLowerCase();
+    return trimmed.startsWith("<!doctype html") || trimmed.startsWith("<html");
+  } catch {
+    return false;
+  }
 }
 
 function isSlackFileUrl(url: string): boolean {


### PR DESCRIPTION
Fixes #1317.

## Problem
When the Slack bot token lacks `files:read`, the authenticated private-file fetch returns an HTTP 200 browser sign-in page (`text/html`) instead of the file bytes. `createSlackFetchFile` staged that login HTML as the attachment, which surfaced downstream as a confusing "the model received a Slack login page" outcome rather than a clear "missing scope" signal.

## Change
In `packages/eve/src/public/channels/slack/attachments.ts`, `createSlackFetchFile` now refuses to stage an HTML-shaped payload:

- A response whose `Content-Type` is `text/html` after a successful (2xx) fetch throws.
- A response with no `Content-Type` that reads as HTML (`<!DOCTYPE html` / `<html`, leading-whitespace tolerant, checked on a body **clone** so the real bytes are not consumed) also throws.

The error is actionable — it names the likely missing `files:read` bot scope and tells the operator to add it, reinstall the Slack app, and retry.

## Why this is safe / minimal
- Happy-path binary downloads are untouched: a response is refused only when it is *explicitly* `text/html`, or it has **no** content-type and clearly reads as HTML. Real image/binary/other attachments never match `text/html`, so there is no false positive.
- The refusal is a single guard in the fetch seam; no other channel, route, or staging logic changes.
- Error message is the actionable frame (missing scope + reinstall), matching the issue's suggestions #1 + #2.

## Docs
`docs/channels/slack.mdx` → **Attachments** now notes the `files:read` requirement and the intentional sign-in-HTML failure.

## Validation
- Targeted tests in `attachments.test.ts`: reject 200+`text/html`; reject HTML body with no content-type; happy-path binary download still returns bytes + mediaType (no false positive). **32/32 pass.**
- `pnpm typecheck` clean; `oxlint` clean on both edited files.
- Changeset: `packages/eve/.changeset/slack-file-fetch-reject-html-wrapper.md` (patch).
