### PR TITLE
fix(eve): recover when an OpenAI-compatible endpoint rejects the injected web_search tool

### DIFF
--- a/.changeset/web-search-compat-recovery.md
+++ b/.changeset/web-search-compat-recovery.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Recover automatically when an OpenAI-compatible endpoint (e.g. AWS Bedrock Mantle) rejects the injected provider-managed `web_search` tool. The harness now recognizes the `web_search_call.action.sources` include rejection, drops `web_search`, and retries the step, so agents on such endpoints complete turns instead of failing every model call.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -509,6 +509,81 @@ describe("extractUnsupportedProviderToolTypes", () => {
     expect(extractUnsupportedProviderToolTypes(error)).toEqual(["web_search_20250305"]);
   });
 
+  it("returns the OpenAI web-search include value from an OpenAI-compatible endpoint rejection", () => {
+    // Bedrock Mantle (and other OpenAI-compatible endpoints without native
+    // web search) reject the `web_search_call.action.sources` include the
+    // AI SDK adds for the injected OpenAI web-search tool. The rejection
+    // names the include value, not a tool type.
+    const data = {
+      error: {
+        message:
+          "Invalid value: 'web_search_call.action.sources'. Supported values are: 'reasoning.encrypted_content'.",
+        type: "invalid_request_error",
+        param: "include",
+        code: "invalid_value",
+      },
+    };
+    const error = directApiCallError({
+      data,
+      responseBody: JSON.stringify(data),
+      statusCode: 400,
+    });
+
+    expect(extractUnsupportedProviderToolTypes(error)).toEqual(["web_search_call.action.sources"]);
+  });
+
+  it("returns the include value when only the responseBody carries it", () => {
+    const responseBody = JSON.stringify({
+      error: {
+        message:
+          "Invalid value: 'web_search_call.action.sources'. Supported values are: 'reasoning.encrypted_content'.",
+        type: "invalid_request_error",
+      },
+    });
+    const error = directApiCallError({ responseBody, statusCode: 400 });
+
+    expect(extractUnsupportedProviderToolTypes(error)).toEqual(["web_search_call.action.sources"]);
+  });
+
+  it("recovers the include value from a truncated responseBody via raw string scan", () => {
+    const fullBody = JSON.stringify({
+      error: {
+        message:
+          "Invalid value: 'web_search_call.action.sources'. Supported values are: 'reasoning.encrypted_content'.",
+        type: "invalid_request_error",
+      },
+      request: { input: "large snapshot ".repeat(50) },
+    });
+    const responseBody = `${fullBody.slice(0, fullBody.indexOf("Supported values") + 20)}...<truncated>`;
+    const error = directApiCallError({ responseBody, statusCode: 400 });
+
+    expect(extractUnsupportedProviderToolTypes(error)).toEqual(["web_search_call.action.sources"]);
+  });
+
+  it("ignores the include value when it appears only as a supported value or request echo", () => {
+    // An endpoint that supports web-search sources but rejects a different
+    // include enumerates it after "Supported values are:"; a truncated body
+    // can also echo the request's include array. Neither is a web_search
+    // rejection, so recovery must not drop the tool.
+    const enumeration = directApiCallError({
+      data: {
+        error: {
+          message:
+            "Invalid value: 'code_interpreter_call.outputs'. Supported values are: 'web_search_call.action.sources', 'reasoning.encrypted_content'.",
+          type: "invalid_request_error",
+        },
+      },
+      statusCode: 400,
+    });
+    expect(extractUnsupportedProviderToolTypes(enumeration)).toEqual([]);
+
+    const requestEcho = directApiCallError({
+      responseBody: `{"error":{"message":"Internal error"},"request":{"include":["web_search_call.action.sources"],"input":"...<truncated>`,
+      statusCode: 400,
+    });
+    expect(extractUnsupportedProviderToolTypes(requestEcho)).toEqual([]);
+  });
+
   it("returns empty for the ambiguous internal server error case (no tool rejection)", () => {
     const innerBody = {
       error: { message: "Bad Request", type: "internal_server_error" },

--- a/packages/eve/src/harness/model-call-error.ts
+++ b/packages/eve/src/harness/model-call-error.ts
@@ -22,6 +22,34 @@ const GATEWAY_MODEL_REQUEST_REJECTED_MESSAGE =
 const UNSUPPORTED_TOOL_TYPE_REGEX = /tool type ['"]([\w.-]+)['"] is not supported/i;
 
 /**
+ * Anchored regex for OpenAI-compatible endpoints that reject the
+ * `web_search_call.action.sources` include instead of naming a tool
+ * type (e.g. Bedrock Mantle's "Invalid value:
+ * 'web_search_call.action.sources'. Supported values are:
+ * 'reasoning.encrypted_content'."). The AI SDK adds that include only
+ * when the OpenAI web-search provider tool is in the request, so this
+ * rejection can only be caused by the injected web-search tool. The
+ * `invalid value` prefix keeps the match anchored to the rejected
+ * value — the same token also shows up in supported-value enumerations
+ * for other rejected includes and in request snapshots echoed into
+ * truncated error bodies, and neither of those means web search is
+ * unsupported.
+ */
+const UNSUPPORTED_WEB_SEARCH_INCLUDE_REGEX =
+  /invalid value:\s*['"](web_search_call\.action\.sources)['"]/i;
+
+/**
+ * Every rejection shape the recovery path can map back to a framework
+ * tool: the gateway's "tool type 'X' is not supported" phrasing and the
+ * OpenAI-compatible include rejection. Group 1 of each regex is the
+ * upstream token handed to `resolveFrameworkToolFromUpstreamType`.
+ */
+const UPSTREAM_TOOL_REJECTION_REGEXES: readonly RegExp[] = [
+  UNSUPPORTED_TOOL_TYPE_REGEX,
+  UNSUPPORTED_WEB_SEARCH_INCLUDE_REGEX,
+];
+
+/**
  * The most informative human-readable rejection a model-call error
  * carries, extracted from the upstream response. Not a semantic-error
  * classification: the message is arbitrary provider prose, so it carries
@@ -93,17 +121,19 @@ function isTransientHttpStatus(status: number | undefined): boolean {
 }
 
 /**
- * Returns the distinct upstream tool types referenced by any
- * "tool type 'X' is not supported" rejection in an AI Gateway error's
- * provider attempt list.
+ * Returns the distinct upstream tokens referenced by any provider-tool
+ * rejection the recovery path knows how to act on: the AI Gateway's
+ * "tool type 'X' is not supported" provider-attempt phrasing, and the
+ * OpenAI-compatible "Invalid value: 'web_search_call.action.sources'"
+ * include rejection.
  *
  * Walks the cause chain to find the gateway error and inspects both the
  * structured `data` field and the raw `responseBody` JSON. Returns an
- * empty array for errors that are not of this shape.
+ * empty array for errors that are not of these shapes.
  *
  * Used by the harness recovery path to identify which framework tools
  * to drop before retrying the failing step. Detection is by string
- * match on the upstream tool type — see
+ * match on the upstream token — see
  * {@link resolveFrameworkToolFromUpstreamType} for the mapping back to
  * framework tool names.
  */
@@ -122,10 +152,7 @@ export function extractUnsupportedProviderToolTypes(error: unknown): readonly st
         // includes a large request snapshot. Fall back to a raw string
         // scan so we still surface the tool name when the regex match
         // lies before the truncation boundary.
-        const match = UNSUPPORTED_TOOL_TYPE_REGEX.exec(responseBody);
-        if (match?.[1] !== undefined) {
-          found.add(match[1]);
-        }
+        collectUpstreamToolRejections(responseBody, found);
       }
     }
   }
@@ -133,14 +160,20 @@ export function extractUnsupportedProviderToolTypes(error: unknown): readonly st
   return [...found];
 }
 
+function collectUpstreamToolRejections(value: string, out: Set<string>): void {
+  for (const regex of UPSTREAM_TOOL_REJECTION_REGEXES) {
+    const match = regex.exec(value);
+    if (match?.[1] !== undefined) {
+      out.add(match[1]);
+    }
+  }
+}
+
 function collectUnsupportedToolTypesFromValue(value: unknown, out: Set<string>): void {
   if (value === null || value === undefined) return;
 
   if (typeof value === "string") {
-    const match = UNSUPPORTED_TOOL_TYPE_REGEX.exec(value);
-    if (match?.[1] !== undefined) {
-      out.add(match[1]);
-    }
+    collectUpstreamToolRejections(value, out);
     return;
   }
 

--- a/packages/eve/src/harness/provider-tools.test.ts
+++ b/packages/eve/src/harness/provider-tools.test.ts
@@ -200,6 +200,12 @@ describe("resolveFrameworkToolFromUpstreamType", () => {
     expect(resolveFrameworkToolFromUpstreamType("web_search_20250305")).toBe("web_search");
   });
 
+  it("maps the OpenAI web-search sources include back to web_search", () => {
+    expect(resolveFrameworkToolFromUpstreamType("web_search_call.action.sources")).toBe(
+      "web_search",
+    );
+  });
+
   it("returns null for unknown upstream tool types", () => {
     expect(resolveFrameworkToolFromUpstreamType("computer_20251022")).toBeNull();
     expect(resolveFrameworkToolFromUpstreamType("some.future.tool")).toBeNull();

--- a/packages/eve/src/harness/provider-tools.ts
+++ b/packages/eve/src/harness/provider-tools.ts
@@ -33,6 +33,11 @@ const UPSTREAM_TOOL_TYPE_TO_FRAMEWORK_NAME: Readonly<Record<string, string>> = {
   // Anthropic backends reject this type because they only host the
   // older Claude Messages surface.
   web_search_20250305: WEB_SEARCH_TOOL_DEFINITION.name,
+  // The Responses API include the AI SDK adds whenever the OpenAI
+  // web-search tool is present. OpenAI-compatible endpoints without
+  // native web search (e.g. Bedrock Mantle) reject the request by
+  // quoting this include value instead of naming a tool type.
+  "web_search_call.action.sources": WEB_SEARCH_TOOL_DEFINITION.name,
 };
 
 /**


### PR DESCRIPTION
Fixes #1451

### Problem

eve auto-injects OpenAI's provider-managed `web_search` tool for any BYO model whose id looks OpenAI-shaped (`resolveWebSearchBackend`). When the model is actually served by an OpenAI-compatible endpoint **without** native web search — e.g. GPT 5.6 Sol/Luna through AWS Bedrock Mantle via `createOpenAI({ baseURL })` — the AI SDK adds `include: ["web_search_call.action.sources"]` to every Responses API request and the endpoint rejects it:

```json
{"error":{"message":"Invalid value: 'web_search_call.action.sources'. Supported values are: 'reasoning.encrypted_content'.","type":"invalid_request_error","param":"include","code":"invalid_value"}}
```

The 400 is classified terminal and the existing unsupported-provider-tool recovery never fires (its detection is anchored on the gateway's `tool type 'X' is not supported` phrasing), so **every model call fails** — the agent cannot complete a single turn. The only workaround is a `disableTool()` file at `agent/tools/web_search.ts` in every agent.

### Solution

Extend the existing recovery flow (the one already used when a gateway fallback provider rejects `web_search_20250305`) to recognize this rejection shape:

- `model-call-error.ts`: `extractUnsupportedProviderToolTypes` now also matches an upstream `Invalid value: 'web_search_call.action.sources'` rejection, in both the structured scan and the truncated-`responseBody` raw scan. The regex is anchored on the `invalid value` phrasing so supported-value enumerations (an endpoint rejecting a *different* include) and request-snapshot echoes in truncated error bodies cannot trigger a false drop. That include is added by the AI SDK only when the injected OpenAI web-search tool is present, so mapping the rejection back to `web_search` is safe.
- `provider-tools.ts`: map `web_search_call.action.sources` → `web_search` in `UPSTREAM_TOOL_TYPE_TO_FRAMEWORK_NAME`.

The harness then drops `web_search`, retries the step once with the standard system note, and the retry no longer carries the include — agents on such endpoints self-heal instead of hard-failing.

### Validation

- Reproduced the failure mechanism locally against a mock Mantle-style server using the vendored `@ai-sdk/openai`: with `web_search` in the tool set the SDK sends the include and the call 400s; without it, the call succeeds.
- Confirmed live by a self-hosted fleet on eve 0.24.6 (every agent ships the `disableTool()` workaround); injection/detection paths unchanged on `main`.
- New unit tests: include-rejection via structured `data`, via `responseBody` only, via truncated-body raw scan; negative tests for supported-value enumeration and request-echo shapes; mapping test for `resolveFrameworkToolFromUpstreamType`.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (unit 5600 passed, integration 567 passed) all green; changeset (`patch`) included.

### Notes

- Matching the existing recovery's semantics, the disabled set applies to the recovery retry only, so on affected endpoints each step still pays one failed call before recovering. Persisting the disabled set for the remainder of the turn/session would remove that overhead — happy to file a follow-up issue if there's interest.