### PR TITLE
refactor(eve): run the Vercel CLI through one subprocess lifecycle

### DIFF
--- a/.changeset/run-vercel-single-lifecycle.md
+++ b/.changeset/run-vercel-single-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Consolidate the three Vercel CLI subprocess runners onto one shared lifecycle. A `vercel` lookup killed by a signal (for example Ctrl-C during setup) now reports a cancellation failure instead of resolving as a success with truncated output.

--- a/packages/eve/src/setup/primitives/run-vercel.test.ts
+++ b/packages/eve/src/setup/primitives/run-vercel.test.ts
@@ -363,6 +363,26 @@ describe("captureVercel", () => {
     expectSpawnedVercel(["whoami"], { stdio: ["ignore", "pipe", "pipe"] });
   });
 
+  test("treats a signal-killed exit as a failure rather than an empty success", async () => {
+    const child = createChildProcess();
+    mockSpawnReturn(child);
+
+    // Ctrl-C reaches the whole process group: the CLI dies without a status
+    // code, so its stdout is truncated and cannot be parsed as a result.
+    const result = captureVercel(["connect", "list", "-F", "json"], { cwd: "/tmp/eve-agent" });
+    child.emit("close", null);
+
+    await expect(result).resolves.toEqual({
+      ok: false,
+      failure: {
+        code: null,
+        stdout: "",
+        stderr: "",
+        message: "vercel connect list -F json was aborted.",
+      },
+    });
+  });
+
   test("reports a missing CLI as a spawn error", async () => {
     const child = createChildProcess();
     mockSpawnReturn(child);

--- a/packages/eve/src/setup/primitives/run-vercel.ts
+++ b/packages/eve/src/setup/primitives/run-vercel.ts
@@ -184,6 +184,151 @@ function stdioForRun(
   return options.nonInteractive ? ["ignore", "pipe", "pipe"] : "inherit";
 }
 
+type StdioChannel = "inherit" | "ignore" | "pipe";
+
+/** stdio layout for a Vercel CLI child: fully inherited, or per channel. */
+type VercelStdio = "inherit" | [StdioChannel, StdioChannel, StdioChannel];
+
+/** Why a run failed, carried so a caller can act on the cause. */
+interface VercelRunFailure {
+  code?: number | null;
+  errno?: string;
+  message: string;
+}
+
+/** Terminal state of one Vercel CLI run, before it is shaped for the caller. */
+type VercelRunOutcome =
+  | { ok: true; stdout: string; stderr: string }
+  | ({ ok: false; stdout: string; stderr: string } & VercelRunFailure);
+
+/** How a public entry point drives the shared run and shapes its result. */
+interface VercelRunSpec<T> {
+  stdio: VercelStdio;
+  /**
+   * Retain stdout and stderr for the caller. When false, stdout is streamed to
+   * the renderer instead and neither stream is kept in memory.
+   */
+  capture: boolean;
+  /** Write diagnostics to `process.stderr` when no renderer is attached. */
+  reportWithoutRenderer: boolean;
+  result(outcome: VercelRunOutcome): T;
+}
+
+/**
+ * Runs the Vercel CLI with the Connect feature flag enabled and settles exactly
+ * once, whatever ends the run: a clean exit, a non-zero exit, a spawn error, a
+ * failed stdin write, the `timeoutMs` deadline, or cancellation. Every public
+ * entry point shares this lifecycle and differs only in its stdio layout and
+ * result shape.
+ *
+ * A settled run flushes buffered output before its diagnostic so a partial
+ * trailing line cannot appear after the failure it preceded. Cancellation and a
+ * signal-driven exit stay silent: the timeout that killed the child has already
+ * reported, and a user-driven abort is not a fault to narrate.
+ */
+function runVercelProcess<T>(
+  args: string[],
+  options: RunVercelOptions,
+  spec: VercelRunSpec<T>,
+): Promise<T> {
+  if (options.signal?.aborted === true) {
+    return Promise.resolve(
+      spec.result({
+        ok: false,
+        stdout: "",
+        stderr: "",
+        errno: "ABORT_ERR",
+        message: abortMessage(args),
+      }),
+    );
+  }
+  return new Promise<T>((resolvePromise) => {
+    const cwd = existingDir(options.cwd);
+    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
+    const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
+    const child = spawn(invocation.command, invocation.commandArgs, {
+      cwd,
+      stdio: spec.stdio,
+      env: buildSpawnEnv(options.extraEnv ?? {}),
+      shell: invocation.shell,
+      signal: options.signal,
+    });
+    const disarmAbort = armProcessAbort(child, options.signal);
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (spec.capture) stdoutChunks.push(chunk.toString("utf8"));
+      else outputBuffer?.write("stdout", chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (spec.capture) stderrChunks.push(chunk.toString("utf8"));
+      outputBuffer?.write("stderr", chunk);
+    });
+
+    let settled = false;
+    function settle(outcome: VercelRunOutcome, report: boolean): void {
+      if (settled) return;
+      settled = true;
+      outputBuffer?.flush();
+      if (report && !outcome.ok) {
+        if (options.onOutput !== undefined) {
+          options.onOutput({ stream: "stderr", text: outcome.message });
+        } else if (spec.reportWithoutRenderer) {
+          process.stderr.write(`\n${outcome.message}\n`);
+        }
+      }
+      resolvePromise(spec.result(outcome));
+    }
+    function captured(): { stdout: string; stderr: string } {
+      return { stdout: stdoutChunks.join(""), stderr: stderrChunks.join("") };
+    }
+    function fail(failure: VercelRunFailure, report = true): void {
+      settle({ ok: false, ...captured(), ...failure }, report);
+    }
+
+    const disarmDeadline = armDeadline(child, options.timeoutMs, () => {
+      fail({ code: null, message: timeoutMessage(args, options.timeoutMs ?? 0) });
+    });
+    writeStdin(child, options.stdin, (error) => {
+      fail({
+        errno: error.code,
+        message: `vercel ${args.join(" ")} stdin failed: ${error.message}`,
+      });
+    });
+
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      if (isAbortError(error, options.signal)) return;
+      disarmAbort();
+      disarmDeadline();
+      fail({
+        errno: error.code,
+        message:
+          error.code === "ENOENT"
+            ? VERCEL_NOT_FOUND_MESSAGE
+            : `vercel ${args.join(" ")} failed: ${error.message}`,
+      });
+    });
+    child.on("close", (code) => {
+      disarmAbort();
+      disarmDeadline();
+      if (options.signal?.aborted === true) {
+        fail({ code, errno: "ABORT_ERR", message: abortMessage(args) }, false);
+        return;
+      }
+      if (code === 0) {
+        settle({ ok: true, ...captured() }, false);
+        return;
+      }
+      fail(
+        code === null
+          ? { code, message: abortMessage(args) }
+          : { code, message: `vercel ${args.join(" ")} exited with code ${code}.` },
+        code !== null,
+      );
+    });
+  });
+}
+
 /**
  * Runs a Vercel CLI command with the Connect feature flag enabled.
  *
@@ -191,76 +336,11 @@ function stdioForRun(
  * so an interactive parent can keep terminal rendering coherent.
  */
 export async function runVercel(args: string[], options: RunVercelOptions): Promise<boolean> {
-  if (options.signal?.aborted === true) return false;
-  return new Promise<boolean>((resolvePromise) => {
-    const cwd = existingDir(options.cwd);
-    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
-    const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(invocation.command, invocation.commandArgs, {
-      cwd,
-      stdio: stdioForRun(options),
-      env: buildSpawnEnv(options.extraEnv ?? {}),
-      shell: invocation.shell,
-      signal: options.signal,
-    });
-    const disarmAbort = armProcessAbort(child, options.signal);
-    child.stdout?.on("data", (chunk: Buffer) => outputBuffer?.write("stdout", chunk));
-    child.stderr?.on("data", (chunk: Buffer) => outputBuffer?.write("stderr", chunk));
-
-    let settled = false;
-    function settle(success: boolean): void {
-      if (settled) return;
-      settled = true;
-      outputBuffer?.flush();
-      resolvePromise(success);
-    }
-    function reportFailure(message: string): void {
-      if (options.onOutput) {
-        options.onOutput({ stream: "stderr", text: message });
-      } else {
-        process.stderr.write(`\n${message}\n`);
-      }
-    }
-
-    const disarmDeadline = armDeadline(child, options.timeoutMs, () => {
-      reportFailure(timeoutMessage(args, options.timeoutMs ?? 0));
-      settle(false);
-    });
-    writeStdin(child, options.stdin, (error) => {
-      reportFailure(`vercel ${args.join(" ")} stdin failed: ${error.message}`);
-      settle(false);
-    });
-
-    child.on("error", (error: NodeJS.ErrnoException) => {
-      if (isAbortError(error, options.signal)) {
-        return;
-      } else if (error.code === "ENOENT") {
-        disarmAbort();
-        disarmDeadline();
-        reportFailure(VERCEL_NOT_FOUND_MESSAGE);
-        settle(false);
-      } else {
-        disarmAbort();
-        disarmDeadline();
-        reportFailure(`vercel ${args.join(" ")} failed: ${error.message}`);
-        settle(false);
-      }
-    });
-    child.on("close", (code) => {
-      disarmAbort();
-      disarmDeadline();
-      if (options.signal?.aborted === true) {
-        settle(false);
-        return;
-      }
-      // After a timeout has settled the run, the eventual kill-driven exit
-      // must not inject a second, stale diagnostic into the renderer.
-      if (!settled && code !== 0 && code !== null) {
-        outputBuffer?.flush();
-        reportFailure(`vercel ${args.join(" ")} exited with code ${code}.`);
-      }
-      settle(code === 0);
-    });
+  return runVercelProcess(args, options, {
+    stdio: stdioForRun(options),
+    capture: false,
+    reportWithoutRenderer: true,
+    result: (outcome) => outcome.ok,
   });
 }
 
@@ -284,80 +364,12 @@ export async function runVercelCaptureStdout(
   args: string[],
   options: RunVercelOptions,
 ): Promise<RunVercelCaptureResult> {
-  if (options.signal?.aborted === true) return { ok: false, stdout: "", stderr: "" };
-  return new Promise<RunVercelCaptureResult>((resolvePromise) => {
-    const cwd = existingDir(options.cwd);
-    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
-    const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(invocation.command, invocation.commandArgs, {
-      cwd,
-      stdio: [stdinMode(options), "pipe", options.onOutput ? "pipe" : "inherit"],
-      env: buildSpawnEnv(options.extraEnv ?? {}),
-      shell: invocation.shell,
-      signal: options.signal,
-    });
-    const disarmAbort = armProcessAbort(child, options.signal);
-    const chunks: string[] = [];
-    const errorChunks: string[] = [];
-    child.stdout?.on("data", (chunk: Buffer) => chunks.push(chunk.toString("utf8")));
-    child.stderr?.on("data", (chunk: Buffer) => {
-      errorChunks.push(chunk.toString("utf8"));
-      outputBuffer?.write("stderr", chunk);
-    });
-
-    let settled = false;
-    function settle(ok: boolean): void {
-      if (settled) return;
-      settled = true;
-      outputBuffer?.flush();
-      const stdout = chunks.join("");
-      const stderr = errorChunks.join("");
-      resolvePromise(stderr.length === 0 ? { ok, stdout } : { ok, stdout, stderr });
-    }
-    function reportFailure(message: string): void {
-      if (options.onOutput) {
-        options.onOutput({ stream: "stderr", text: message });
-      } else {
-        process.stderr.write(`\n${message}\n`);
-      }
-    }
-
-    const disarmDeadline = armDeadline(child, options.timeoutMs, () => {
-      reportFailure(timeoutMessage(args, options.timeoutMs ?? 0));
-      settle(false);
-    });
-    writeStdin(child, options.stdin, (error) => {
-      reportFailure(`vercel ${args.join(" ")} stdin failed: ${error.message}`);
-      settle(false);
-    });
-
-    child.on("error", (error: NodeJS.ErrnoException) => {
-      if (isAbortError(error, options.signal)) {
-        return;
-      }
-      disarmAbort();
-      disarmDeadline();
-      reportFailure(
-        error.code === "ENOENT"
-          ? VERCEL_NOT_FOUND_MESSAGE
-          : `vercel ${args.join(" ")} failed: ${error.message}`,
-      );
-      settle(false);
-    });
-    child.on("close", (code) => {
-      disarmAbort();
-      disarmDeadline();
-      if (options.signal?.aborted === true) {
-        settle(false);
-        return;
-      }
-      // After a timeout has settled the run, the eventual kill-driven exit
-      // must not inject a second, stale diagnostic into the renderer.
-      if (!settled && code !== 0 && code !== null) {
-        reportFailure(`vercel ${args.join(" ")} exited with code ${code}.`);
-      }
-      settle(code === 0);
-    });
+  return runVercelProcess(args, options, {
+    stdio: [stdinMode(options), "pipe", options.onOutput ? "pipe" : "inherit"],
+    capture: true,
+    reportWithoutRenderer: true,
+    result: ({ ok, stdout, stderr }) =>
+      stderr.length === 0 ? { ok, stdout } : { ok, stdout, stderr },
   });
 }
 
@@ -392,114 +404,29 @@ export type VercelCaptureResult =
  * live `onOutput` renderer attached; when `onOutput` is supplied, stderr is
  * streamed to it and the failure summary is appended after a non-zero exit.
  */
+/** Shapes a failed run as the diagnostic {@link captureVercel} callers act on. */
+function toCaptureFailure(outcome: Extract<VercelRunOutcome, { ok: false }>): VercelCaptureFailure {
+  const failure: VercelCaptureFailure = {
+    stdout: outcome.stdout,
+    stderr: outcome.stderr,
+    message: outcome.message,
+  };
+  if (outcome.code !== undefined) failure.code = outcome.code;
+  if (outcome.errno !== undefined) failure.errno = outcome.errno;
+  return failure;
+}
+
 export async function captureVercel(
   args: string[],
   options: RunVercelOptions,
 ): Promise<VercelCaptureResult> {
-  if (options.signal?.aborted === true) {
-    return {
-      ok: false,
-      failure: {
-        errno: "ABORT_ERR",
-        stdout: "",
-        stderr: "",
-        message: abortMessage(args),
-      },
-    };
-  }
-  return new Promise<VercelCaptureResult>((resolvePromise) => {
-    const cwd = existingDir(options.cwd);
-    const invocation = resolveVercelInvocation(cwd, commandArgs(args, options.nonInteractive));
-    const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(invocation.command, invocation.commandArgs, {
-      cwd,
-      stdio: [options.stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
-      env: buildSpawnEnv(options.extraEnv ?? {}),
-      shell: invocation.shell,
-      signal: options.signal,
-    });
-    const disarmAbort = armProcessAbort(child, options.signal);
-    const stdoutChunks: string[] = [];
-    const stderrChunks: string[] = [];
-    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk.toString("utf8")));
-    child.stderr?.on("data", (chunk: Buffer) => {
-      stderrChunks.push(chunk.toString("utf8"));
-      outputBuffer?.write("stderr", chunk);
-    });
-
-    let settled = false;
-    function fail(failure: VercelCaptureFailure, report = true): void {
-      if (settled) return;
-      settled = true;
-      outputBuffer?.flush();
-      if (report) options.onOutput?.({ stream: "stderr", text: failure.message });
-      resolvePromise({ ok: false, failure });
-    }
-    function succeed(): void {
-      if (settled) return;
-      settled = true;
-      outputBuffer?.flush();
-      resolvePromise({ ok: true, stdout: stdoutChunks.join("") });
-    }
-
-    const disarmDeadline = armDeadline(child, options.timeoutMs, () => {
-      fail({
-        code: null,
-        stdout: stdoutChunks.join(""),
-        stderr: stderrChunks.join(""),
-        message: timeoutMessage(args, options.timeoutMs ?? 0),
-      });
-    });
-    writeStdin(child, options.stdin, (error) => {
-      fail({
-        errno: error.code,
-        stdout: stdoutChunks.join(""),
-        stderr: stderrChunks.join(""),
-        message: `vercel ${args.join(" ")} stdin failed: ${error.message}`,
-      });
-    });
-
-    child.on("error", (error: NodeJS.ErrnoException) => {
-      if (isAbortError(error, options.signal)) {
-        return;
-      }
-      disarmAbort();
-      disarmDeadline();
-      fail({
-        errno: error.code,
-        stdout: stdoutChunks.join(""),
-        stderr: stderrChunks.join(""),
-        message:
-          error.code === "ENOENT"
-            ? VERCEL_NOT_FOUND_MESSAGE
-            : `vercel ${args.join(" ")} failed: ${error.message}`,
-      });
-    });
-    child.on("close", (code) => {
-      disarmAbort();
-      disarmDeadline();
-      if (options.signal?.aborted === true) {
-        fail(
-          {
-            errno: "ABORT_ERR",
-            stdout: stdoutChunks.join(""),
-            stderr: stderrChunks.join(""),
-            message: abortMessage(args),
-          },
-          false,
-        );
-        return;
-      }
-      if (code !== 0 && code !== null) {
-        fail({
-          code,
-          stdout: stdoutChunks.join(""),
-          stderr: stderrChunks.join(""),
-          message: `vercel ${args.join(" ")} exited with code ${code}.`,
-        });
-        return;
-      }
-      succeed();
-    });
+  return runVercelProcess(args, options, {
+    stdio: [options.stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    capture: true,
+    reportWithoutRenderer: false,
+    result: (outcome) =>
+      outcome.ok
+        ? { ok: true, stdout: outcome.stdout }
+        : { ok: false, failure: toCaptureFailure(outcome) },
   });
 }


### PR DESCRIPTION
**Found**
- #1297 added `runVercelCaptureStdout` as a copy of the two runners already in `setup/primitives/run-vercel.ts`, leaving three near-verbatim copies of the same lifecycle: cwd resolution, line-buffered output, abort arming, settle-once, `timeoutMs` + kill escalation, stdin secret writes, error/close handlers.
- They had already drifted: only `runVercel` flushed buffered output before its diagnostic, and `captureVercel` treated a signal-killed exit as a *success* carrying truncated stdout — so Ctrl-C surfaced as an unparseable payload instead of a cancellation.

**Did**
One internal `runVercelProcess`; the three exports are thin specs over it differing only in stdio, whether output is retained, and result shape. Public signatures unchanged. −220/+167.

**Validated**
All 16 existing `run-vercel` tests pass unmodified, plus one added for the harmonized signal-kill case. `test:unit` 538/539 files and `test:integration` 82/83 — both failures reproduce on clean `main`. `tsc --noEmit`, lint, fmt, `guard:invariants` clean.
