### PR TITLE
feat(eve): add JSON registry discovery output

### DIFF
--- a/.changeset/registry-json-output.md
+++ b/.changeset/registry-json-output.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add JSON output to `eve registry list` and `eve registry search` for scripts that inspect registry catalogs.

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -46,18 +46,20 @@ export function registerRegistryCommands(input: {
     .command("list")
     .description("List items from all registries or one source.")
     .option("-r, --registry <source>", "List items from one registry.")
-    .action(async (options: { registry?: string }) => {
+    .option("--json", "Output as JSON")
+    .action(async (options: { json?: boolean; registry?: string }) => {
       const { runRegistryListCommand } = await import("./registry.js");
-      await runRegistryListCommand(logger, appRoot, options.registry);
+      await runRegistryListCommand(logger, appRoot, options.registry, options);
     });
 
   registry
     .command("search <query>")
     .description("Search all registries or one source.")
     .option("-r, --registry <source>", "Search one registry.")
-    .action(async (query: string, options: { registry?: string }) => {
+    .option("--json", "Output as JSON")
+    .action(async (query: string, options: { json?: boolean; registry?: string }) => {
       const { runRegistrySearchCommand } = await import("./registry.js");
-      await runRegistrySearchCommand(logger, appRoot, query, options.registry);
+      await runRegistrySearchCommand(logger, appRoot, query, options.registry, options);
     });
 
   registry

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -491,6 +491,19 @@ describe("registry commands", () => {
     expect(logger.logs).toEqual(["No registry items found."]);
   });
 
+  it("emits list results as JSON", async () => {
+    const logger = createLogger();
+    const result = {
+      items: [{ registry: "https://eve.dev/r/registry.json", name: "extension/browser" }],
+      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+    };
+    searchRegistries.mockResolvedValue(result);
+
+    await runRegistryListCommand(logger, "/project", undefined, { json: true });
+
+    expect(logger.logs).toEqual([JSON.stringify(result, null, 2)]);
+  });
+
   it("preserves explicit registry URLs in list output", async () => {
     const logger = createLogger();
     searchRegistries.mockResolvedValue({
@@ -550,6 +563,35 @@ describe("registry commands", () => {
       "extension/agent-browser",
       "@acme/browser",
     ]);
+  });
+
+  it("emits search results as JSON", async () => {
+    const logger = createLogger();
+    const result = {
+      items: [{ registry: "@acme", name: "browser", addCommandArgument: "@acme/browser" }],
+      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+    };
+    searchRegistries.mockResolvedValue(result);
+
+    await runRegistrySearchCommand(logger, "/project", "browser", undefined, { json: true });
+
+    expect(logger.logs).toEqual([JSON.stringify(result, null, 2)]);
+  });
+
+  it("emits JSON when every registry search fails", async () => {
+    const logger = createLogger();
+    const result = {
+      items: [],
+      errors: [{ registry: "https://eve.dev/r/registry.json", message: "eve unavailable" }],
+      pagination: { total: 0, offset: 0, limit: 0, hasMore: false },
+    };
+    searchRegistries.mockResolvedValue(result);
+
+    await runRegistryListCommand(logger, "/project", undefined, { json: true });
+
+    expect(logger.logs).toEqual([JSON.stringify(result, null, 2)]);
+    expect(logger.errors).toEqual(["https://eve.dev/r/registry.json: eve unavailable"]);
+    expect(process.exitCode).toBe(1);
   });
 
   it("reports total registry failure without describing it as an empty result", async () => {

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -30,6 +30,12 @@ export interface AddCommandOptions {
   silent?: boolean;
 }
 
+/** Options shared by registry catalog commands. */
+export interface RegistryCommandOptions {
+  /** Emit the underlying registry result as JSON. */
+  json?: boolean;
+}
+
 type SetupCommandOptions = Pick<AddCommandOptions, "yes"> & {
   prompter?: Prompter;
   signal?: AbortSignal;
@@ -212,8 +218,13 @@ function validateRegistrySource(source: string | undefined): void {
 function printSearchResults(
   logger: RegistryCommandLogger,
   result: Awaited<ReturnType<typeof searchRegistries>>,
-  options: { query: string | undefined; sources: string[] },
+  options: { query: string | undefined; sources: string[]; json?: boolean },
 ): void {
+  if (options.json) {
+    logger.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   if (result.items.length === 0) {
     logger.log("No registry items found.");
     return;
@@ -293,11 +304,12 @@ async function browseRegistryItems(
   appRoot: string,
   query: string | undefined,
   source: string | undefined,
+  options: RegistryCommandOptions = {},
 ): Promise<void> {
   const { result, sources } = await searchRegistryCatalog(appRoot, { query, source });
   const errors = result.errors ?? [];
-  if (errors.length < sources.length) {
-    printSearchResults(logger, result, { query, sources });
+  if (options.json || errors.length < sources.length) {
+    printSearchResults(logger, result, { ...options, query, sources });
   }
   for (const error of errors) {
     logger.error(`${error.registry}: ${error.message}`);
@@ -467,9 +479,10 @@ export async function runRegistryListCommand(
   logger: RegistryCommandLogger,
   appRoot: string,
   source?: string,
+  options: RegistryCommandOptions = {},
 ): Promise<void> {
   await runRegistryAction(logger, appRoot, () =>
-    browseRegistryItems(logger, appRoot, undefined, source),
+    browseRegistryItems(logger, appRoot, undefined, source, options),
   );
 }
 
@@ -479,9 +492,10 @@ export async function runRegistrySearchCommand(
   appRoot: string,
   query: string,
   source?: string,
+  options: RegistryCommandOptions = {},
 ): Promise<void> {
   await runRegistryAction(logger, appRoot, () =>
-    browseRegistryItems(logger, appRoot, query, source),
+    browseRegistryItems(logger, appRoot, query, source, options),
   );
 }
 

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -75,6 +75,19 @@ describe("CLI command registration", () => {
     expect(help).not.toContain("--path");
   });
 
+  it("registers JSON output for registry discovery commands", async () => {
+    const output: string[] = [];
+    const logger = {
+      error: (message: string) => output.push(message),
+      log: (message: string) => output.push(message),
+    };
+
+    await runCli(["registry", "list", "--help"], logger).catch(() => {});
+    await runCli(["registry", "search", "--help"], logger).catch(() => {});
+
+    expect(output.join("\n")).toContain("--json");
+  });
+
   it("registers only supported shadcn registry commands", async () => {
     const output: string[] = [];
     const logger = {


### PR DESCRIPTION
### Description

Add `--json` to `eve registry list` and `eve registry search`.
### How did you test your changes?

- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/run.test.ts src/cli/commands/registry.test.ts`
- `pnpm docs:check`
- `pnpm typecheck`

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)