### PR TITLE
fix(eve): changesets - exclude private catalog

### DIFF
--- a/.changeset/bright-messages-connect.md
+++ b/.changeset/bright-messages-connect.md
@@ -1,6 +1,5 @@
 ---
 "eve": patch
-"@vercel/eve-catalog": patch
 ---
 
 Add guided Photon setup through `eve add channel/photon-imessage`, including project creation, phone registration, Vercel Connect or portable credentials, and channel scaffolding.


### PR DESCRIPTION
## Summary

- remove the private @vercel/eve-catalog package from the Photon setup changeset
- keep the release entry scoped to the publishable eve package

## Validation

- pnpm changeset status
- git diff --check