### PR TITLE
refactor(eve): share the TUI's terminal control sequences

### DIFF
--- a/.changeset/shared-ansi-sequences.md
+++ b/.changeset/shared-ansi-sequences.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Share the dev TUI's terminal control sequences between the inline scrollback engine and the alternate-screen viewer instead of declaring them twice.

--- a/packages/eve/src/cli/ui/alt-screen.ts
+++ b/packages/eve/src/cli/ui/alt-screen.ts
@@ -11,29 +11,29 @@
  * captured at construction so foreign-output capture never sees the paints.
  */
 
-const ESC = "\x1b";
+import type { TerminalWriteTarget } from "#cli/ui/ansi.js";
+import {
+  CLEAR_TO_END,
+  CURSOR_HOME,
+  ESC,
+  HIDE_CURSOR,
+  SHOW_CURSOR,
+  SYNC_END,
+  SYNC_START,
+} from "#cli/ui/ansi.js";
+
 const ALT_SCREEN_ON = `${ESC}[?1049h`;
 const ALT_SCREEN_OFF = `${ESC}[?1049l`;
 // 1002 (button-event tracking) reports motion while a button is held, which
 // drag-to-select needs; 1006 upgrades coordinates to the SGR encoding.
 const MOUSE_ON = `${ESC}[?1002h${ESC}[?1006h`;
 const MOUSE_OFF = `${ESC}[?1006l${ESC}[?1002l`;
-const HIDE_CURSOR = `${ESC}[?25l`;
-const SHOW_CURSOR = `${ESC}[?25h`;
-const CLEAR_TO_END = `${ESC}[0J`;
-const CURSOR_HOME = `${ESC}[H`;
-const SYNC_START = `${ESC}[?2026h`;
-const SYNC_END = `${ESC}[?2026l`;
-
-export interface AltScreenOutput {
-  write(chunk: string): boolean;
-}
 
 export class AltScreen {
   readonly #write: (chunk: string) => boolean;
   #active = false;
 
-  constructor(output: AltScreenOutput) {
+  constructor(output: TerminalWriteTarget) {
     this.#write = output.write.bind(output);
   }
 

--- a/packages/eve/src/cli/ui/ansi.ts
+++ b/packages/eve/src/cli/ui/ansi.ts
@@ -1,0 +1,25 @@
+/**
+ * Terminal control sequences shared by the two painting engines: the inline
+ * scrollback engine (`live-region.ts`) and the alternate-screen viewer
+ * (`alt-screen.ts`). Sequences used by only one of them stay in that module.
+ */
+
+export const ESC = "\x1b";
+
+export const HIDE_CURSOR = `${ESC}[?25l`;
+export const SHOW_CURSOR = `${ESC}[?25h`;
+/** Erases from the cursor to the end of the screen. */
+export const CLEAR_TO_END = `${ESC}[0J`;
+export const CURSOR_HOME = `${ESC}[H`;
+/** Synchronized-update markers: the terminal presents the frame atomically. */
+export const SYNC_START = `${ESC}[?2026h`;
+export const SYNC_END = `${ESC}[?2026l`;
+
+/**
+ * A terminal's own `write`, captured at construction so the renderer's
+ * foreign-output capture (which monkeypatches `process.stdout.write`) never
+ * mistakes an engine's own paint for agent log output.
+ */
+export interface TerminalWriteTarget {
+  write(chunk: string): boolean;
+}

--- a/packages/eve/src/cli/ui/live-region.ts
+++ b/packages/eve/src/cli/ui/live-region.ts
@@ -20,21 +20,21 @@
  * output.
  */
 
-const ESC = "\x1b";
-const HIDE_CURSOR = `${ESC}[?25l`;
-const SHOW_CURSOR = `${ESC}[?25h`;
-const CLEAR_TO_END = `${ESC}[0J`;
+import type { TerminalWriteTarget } from "#cli/ui/ansi.js";
+import {
+  CLEAR_TO_END,
+  CURSOR_HOME,
+  ESC,
+  HIDE_CURSOR,
+  SHOW_CURSOR,
+  SYNC_END,
+  SYNC_START,
+} from "#cli/ui/ansi.js";
+
 const CLEAR_SCREEN = `${ESC}[2J`;
 const CLEAR_SCROLLBACK = `${ESC}[3J`;
-const CURSOR_HOME = `${ESC}[H`;
-const SYNC_START = `${ESC}[?2026h`;
-const SYNC_END = `${ESC}[?2026l`;
 const BRACKETED_PASTE_ON = `${ESC}[?2004h`;
 const BRACKETED_PASTE_OFF = `${ESC}[?2004l`;
-
-export interface LiveRegionOutput {
-  write(chunk: string): boolean;
-}
 
 export interface LiveRegionOptions {
   /** Wrap each paint in synchronized-update markers to avoid flicker. */
@@ -47,7 +47,7 @@ export class LiveRegion {
   /** Rows the live region currently occupies on screen. */
   #liveRowCount = 0;
 
-  constructor(output: LiveRegionOutput, options?: LiveRegionOptions) {
+  constructor(output: TerminalWriteTarget, options?: LiveRegionOptions) {
     this.#write = output.write.bind(output);
     this.#synchronized = options?.synchronized ?? true;
   }


### PR DESCRIPTION
**Found**
- `cli/ui/alt-screen.ts` and `cli/ui/live-region.ts` each declare their own copy of the same seven control sequences: `ESC`, `HIDE_CURSOR`, `SHOW_CURSOR`, `CLEAR_TO_END`, `CURSOR_HOME`, `SYNC_START`, `SYNC_END`.
- Both also export a structurally identical `write(chunk: string): boolean` interface (`AltScreenOutput`, `LiveRegionOutput`) that nothing imports.

**Did**
New `cli/ui/ansi.ts` owns the shared sequences and one `TerminalWriteTarget`; single-engine sequences (alt-buffer, mouse tracking, scrollback erase, bracketed paste) stay put. +25/−24 across 3 files — flat by line count, but a third painting surface can no longer disagree about what "hide the cursor" is.

**Validated**
1010 CLI unit tests pass unmodified, including `alt-screen.test.ts` and `live-region.test.ts`, which assert the exact emitted byte strings. Every TUI smoke script that runs in this sandbox passes (`tui-traces` all 9 scenarios, plus log-modes, loglevel, rebuild-status, server-logs, transport-error). No test changed. `tsc --noEmit`, lint, fmt, `guard:invariants` clean.
