### PR TITLE
refactor(eve): share local server supervision with eve acp

### DIFF
--- a/.changeset/acp-shared-supervision.md
+++ b/.changeset/acp-shared-supervision.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Share the local development server's close latch and lazy factory between `eve dev` and `eve acp` instead of keeping a copy in each command.

--- a/packages/eve/src/cli/acp/command.ts
+++ b/packages/eve/src/cli/acp/command.ts
@@ -6,7 +6,9 @@ import {
   type DevelopmentRequestHeaders,
 } from "#cli/dev/url-target.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
+import { createServerCloseLatch, loadStartDevelopmentHost } from "#cli/dev/supervised-server.js";
 import { FORCED_EXIT_BACKSTOP_MS, installShutdownSignal } from "#cli/shutdown.js";
+import { hasDevelopmentAuthorizationHeader } from "#services/dev-client/client-options.js";
 import type { ClientOptions } from "#client/types.js";
 import type { DevelopmentServer, DevelopmentServerOptions } from "#internal/nitro/host/types.js";
 
@@ -68,17 +70,11 @@ export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
       }
 
       let server: DevelopmentServer | undefined;
-      let closePromise: Promise<void> | undefined;
-      const closeServer = () => {
-        if (server === undefined) return Promise.resolve();
-        closePromise ??= server.close();
-        void closePromise.catch(() => undefined);
-        return closePromise;
-      };
+      const closeServer = createServerCloseLatch(() => server);
       lifecycle.signal.addEventListener("abort", () => void closeServer(), { once: true });
 
       try {
-        const startHost = options.startHost ?? (await loadStartHost());
+        const startHost = options.startHost ?? (await loadStartDevelopmentHost());
         server = startHost(options.appRoot, {
           existing: "reject",
           host: "127.0.0.1",
@@ -110,17 +106,22 @@ interface AcpCliOptions {
   readonly url?: string;
 }
 
-async function runAcp(
-  options: RegisterAcpCommandOptions,
-  input: Omit<Parameters<RunAcpServer>[0], "eveVersion"> & { readonly vercelScope?: string },
-): Promise<void> {
+/** How the command reaches an agent: a supervised local server, or a URL target. */
+interface AcpTargetInput {
+  readonly headers?: DevelopmentRequestHeaders;
+  readonly serverUrl: string;
+  readonly signal: AbortSignal;
+  readonly vercelScope?: string;
+  readonly workspaceRoot?: string;
+}
+
+async function runAcp(options: RegisterAcpCommandOptions, input: AcpTargetInput): Promise<void> {
   const run = options.runAcpServer ?? (await import("#acp/server.js")).runAcpServer;
   const { vercelScope, ...serverInput } = input;
-  const staticHeaders = typeof serverInput.headers === "function" ? undefined : serverInput.headers;
-  const ownsAuthorization = Object.keys(staticHeaders ?? {}).some(
-    (name) => name.toLowerCase() === "authorization",
-  );
-  if (serverInput.workspaceRoot !== undefined || ownsAuthorization) {
+  if (
+    serverInput.workspaceRoot !== undefined ||
+    hasDevelopmentAuthorizationHeader(serverInput.headers)
+  ) {
     await run({ eveVersion: options.eveVersion, ...serverInput });
     return;
   }
@@ -129,7 +130,7 @@ async function runAcp(
     options.resolveVerifiedRemoteDevelopmentClient ??
     (await import("#setup/verified-remote-client.js")).resolveVerifiedRemoteDevelopmentClient;
   const { options: clientOptions } = await resolveVerifiedRemoteDevelopmentClient({
-    headers: staticHeaders,
+    headers: serverInput.headers,
     serverUrl: serverInput.serverUrl,
     signal: serverInput.signal,
     vercelScope,
@@ -142,8 +143,4 @@ async function runAcp(
     serverUrl: serverInput.serverUrl,
     signal: serverInput.signal,
   });
-}
-
-async function loadStartHost(): Promise<NonNullable<RegisterAcpCommandOptions["startHost"]>> {
-  return (await import("#cli/dev/local-server-process.js")).createDevelopmentServer;
 }

--- a/packages/eve/src/cli/dev/supervised-server.ts
+++ b/packages/eve/src/cli/dev/supervised-server.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared supervision for a local development server that a command owns for
+ * the length of its run (`eve dev`, `eve acp`). Both stop the server from two
+ * directions — a shutdown signal and their own teardown — so both need the
+ * close to be idempotent.
+ */
+
+import type { DevelopmentServer, DevelopmentServerOptions } from "#internal/nitro/host/types.js";
+
+/** Starts a local development server for `appRoot`. */
+export type StartDevelopmentHost = (
+  appRoot: string,
+  options?: DevelopmentServerOptions,
+) => DevelopmentServer;
+
+/**
+ * A one-shot close for the server `getServer` returns. The first call starts
+ * the close and every later call awaits that same promise, so a stop signal
+ * racing the command's own teardown cannot close twice. Resolves immediately
+ * while the server has not been created yet, and swallows the close rejection
+ * so an aborted start cannot surface as an unhandled rejection.
+ */
+export function createServerCloseLatch(
+  getServer: () => DevelopmentServer | undefined,
+): () => Promise<void> {
+  let closePromise: Promise<void> | undefined;
+  return () => {
+    const server = getServer();
+    if (server === undefined) return Promise.resolve();
+    closePromise ??= server.close();
+    void closePromise.catch(() => undefined);
+    return closePromise;
+  };
+}
+
+/** Loads the local server factory lazily, keeping it off the CLI's boot path. */
+export async function loadStartDevelopmentHost(): Promise<StartDevelopmentHost> {
+  return (await import("#cli/dev/local-server-process.js")).createDevelopmentServer;
+}

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -20,6 +20,7 @@ import {
   type CommandLifecycle,
   waitForShutdownSignal,
 } from "#cli/shutdown.js";
+import { createServerCloseLatch, loadStartDevelopmentHost } from "#cli/dev/supervised-server.js";
 import { waitForServerOrStop, waitForUiOrServer } from "#cli/dev/wait-for-ui.js";
 import { parseDevelopmentHeaderOption, resolveDevelopmentUrlTarget } from "#cli/dev/url-target.js";
 import type { DevelopmentCliOptions, ProductionCliOptions } from "#cli/dev/command-options.js";
@@ -126,10 +127,6 @@ async function loadRunDevelopmentTui(): Promise<CliRuntimeDependencies["runDevel
 
 async function loadRunEvalCommand(): Promise<CliRuntimeDependencies["runEvalCommand"]> {
   return (await import("#evals/cli/eval.js")).runEvalCommand;
-}
-
-async function loadStartHost(): Promise<CliRuntimeDependencies["startHost"]> {
-  return (await import("#cli/dev/local-server-process.js")).createDevelopmentServer;
 }
 
 const loadIsActiveDevelopmentServerForApp = async () =>
@@ -442,13 +439,7 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       buildProgress?.update("Building your agent");
 
       let server: DevelopmentServer | undefined;
-      let closePromise: Promise<void> | undefined;
-      const closeServer = () => {
-        if (server === undefined) return Promise.resolve();
-        closePromise ??= server.close();
-        void closePromise.catch(() => undefined);
-        return closePromise;
-      };
+      const closeServer = createServerCloseLatch(() => server);
       const lifecycle = installShutdownSignal({
         exitAfterMs: FORCED_EXIT_BACKSTOP_MS,
         onStop: () => {
@@ -457,7 +448,7 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
       });
 
       try {
-        const startHost = runtime.startHost ?? (await loadStartHost());
+        const startHost = runtime.startHost ?? (await loadStartDevelopmentHost());
         server = startHost(appRoot, {
           existing: mode === "tui" ? "attach-if-unconfigured" : "reject",
           host: options.host,


### PR DESCRIPTION
**Found**
- `cli/acp/command.ts` copies `cli/run.ts`'s idempotent `closeServer` latch byte for byte, and each file has its own `loadStartHost` dynamic import of `createDevelopmentServer` — nothing in `cli/dev/` owned either.
- `runAcp` types its input as the ACP server's own parameters, which admit a headers *thunk*, so it narrows `typeof headers === "function"` — a branch neither call site can reach, since both pass a plain record from `resolveDevelopmentUrlTarget`.
- The authorization-header scan next to it re-implements the exported `hasDevelopmentAuthorizationHeader` already used by `verified-remote-client.ts` and `client-options.ts`.

**Did**
New `cli/dev/supervised-server.ts` owns `createServerCloseLatch` (getter-based, so each command keeps its own lifecycle ordering) and `loadStartDevelopmentHost`; typed `runAcp`'s input as what the command passes and called the shared predicate. −34/+22 across 3 files.

**Validated**
1016 CLI unit tests pass, including `run.test.ts`'s ACP cases (remote target without a local server, `startHost` args, `close` called once) and `local-server-process.test.ts`. No test changed. `tsc --noEmit`, lint, fmt, `guard:invariants` clean.
