### PR TITLE
refactor(eve): state the ACP cancel rule once

### DIFF
--- a/.changeset/acp-cancel-rule.md
+++ b/.changeset/acp-cancel-rule.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+State the ACP adapter's cancellation rule once instead of repeating it at each exit of the prompt loop.

--- a/packages/eve/src/acp/adapter.ts
+++ b/packages/eve/src/acp/adapter.ts
@@ -28,7 +28,6 @@ const ERROR_CODE_UNSUPPORTED = -32_003;
 
 interface ActivePrompt {
   cancelRequested: boolean;
-  protocolCancelled: boolean;
   readonly outboundController: AbortController;
   readonly settled: Promise<void>;
   readonly resolveSettled: () => void;
@@ -154,18 +153,15 @@ export class EveAcpAdapter {
     }
 
     const message = promptContent(params);
-    session.tools.clear();
     const settled = Promise.withResolvers<void>();
     const active: ActivePrompt = {
       cancelRequested: false,
-      protocolCancelled: false,
       outboundController: new AbortController(),
       settled: settled.promise,
       resolveSettled: settled.resolve,
     };
     session.active = active;
     const onProtocolCancel = () => {
-      active.protocolCancelled = true;
       void this.#cancelActive(session).catch(() => undefined);
     };
     if (signal.aborted) {
@@ -174,14 +170,20 @@ export class EveAcpAdapter {
       signal.addEventListener("abort", onProtocolCancel, { once: true });
     }
 
+    // A protocol cancel — this request's own signal — is an error for the
+    // caller, while a client-side cancel (declining an input request) is a
+    // normal stop reason. Both can arrive at any await in the loop below.
+    const clientCancelled = (): boolean => {
+      if (signal.aborted) throw RequestError.requestCancelled({ sessionId: params.sessionId });
+      return active.cancelRequested;
+    };
+
     try {
-      if (active.protocolCancelled) {
-        throw RequestError.requestCancelled({ sessionId: params.sessionId });
-      }
+      if (clientCancelled()) return { stopReason: "cancelled" };
       let input: SendTurnInput = { message };
       for (;;) {
         const response = await session.client.send(input);
-        if (active.cancelRequested || active.protocolCancelled) {
+        if (active.cancelRequested || signal.aborted) {
           await this.#cancelActive(session);
         }
 
@@ -207,10 +209,7 @@ export class EveAcpAdapter {
           await this.#projectEvent(params.sessionId, session, event, client);
         }
 
-        if (active.protocolCancelled) {
-          throw RequestError.requestCancelled({ sessionId: params.sessionId });
-        }
-        if (cancelled || active.cancelRequested) return { stopReason: "cancelled" };
+        if (clientCancelled() || cancelled) return { stopReason: "cancelled" };
         if (failure !== undefined) throw eveFailure(failure);
         if (unsupportedEvent !== undefined) throw unsupportedEvent;
         if (inputRequests.length === 0) return { stopReason: "end_turn" };
@@ -223,16 +222,10 @@ export class EveAcpAdapter {
             ),
           );
         } catch (error) {
-          if (active.protocolCancelled) {
-            throw RequestError.requestCancelled({ sessionId: params.sessionId });
-          }
-          if (active.cancelRequested) return { stopReason: "cancelled" };
+          if (clientCancelled()) return { stopReason: "cancelled" };
           throw error;
         }
-        if (active.protocolCancelled) {
-          throw RequestError.requestCancelled({ sessionId: params.sessionId });
-        }
-        if (active.cancelRequested) return { stopReason: "cancelled" };
+        if (clientCancelled()) return { stopReason: "cancelled" };
         input = { inputResponses };
       }
     } catch (error) {
@@ -380,8 +373,7 @@ export class EveAcpAdapter {
         { cancellationSignal },
       );
       if (response.outcome.outcome === "cancelled") {
-        this.#cancelClientInput(session);
-        return { requestId: request.requestId };
+        return this.#declineInput(session, request);
       }
       if (response.outcome.optionId === approveId) {
         return { requestId: request.requestId, optionId: "approve" };
@@ -417,8 +409,7 @@ export class EveAcpAdapter {
       { cancellationSignal },
     );
     if (response.action !== "accept") {
-      this.#cancelClientInput(session);
-      return { requestId: request.requestId };
+      return this.#declineInput(session, request);
     }
     const content = response.content as Record<string, unknown> | null | undefined;
     const answer = content?.[ANSWER_FIELD];
@@ -435,6 +426,16 @@ export class EveAcpAdapter {
       return { requestId: request.requestId, optionId: answer };
     }
     return { requestId: request.requestId, text: answer };
+  }
+
+  /**
+   * The client dismissed a request instead of answering it. eve receives an
+   * empty response so the turn can wind down, and the prompt settles as
+   * cancelled rather than as a failure.
+   */
+  #declineInput(session: AcpSession, request: InputRequest): InputResponse {
+    this.#cancelClientInput(session);
+    return { requestId: request.requestId };
   }
 
   #cancelClientInput(session: AcpSession): void {


### PR DESCRIPTION
**Found**
- `acp/adapter.ts`'s `ActivePrompt.protocolCancelled` mirrors the prompt request's `signal.aborted` by hand: it is written only by `onProtocolCancel`, which runs only when the signal is already aborted or from its `abort` listener, so the two can never disagree at any of its five reads.
- The rule those reads encode — a protocol cancel is an error, a client-side cancel is a normal `stopReason` — was spelled out at four exits of the prompt loop.
- `session.tools.clear()` before the first send can never see a non-empty map (the `finally` always clears, and a concurrent prompt is rejected up front); the two "client gave no answer" exits of `#requestInput` are the same statement pair.

**Did**
Dropped the mirrored field, added one `clientCancelled()` closure so each exit is a single line, deleted the dead clear, and folded the declined-input pair into `#declineInput`. −24/+25 in one file.

**Validated**
All 20 ACP unit tests pass unmodified, including the four cancellation cases (already-cancelled → `-32800`, cancel during streaming, cancel while awaiting input). Full `pnpm test:unit`: 5737 pass, only the 4 pre-existing `bin-bootstrap` failures that also fail on clean `main` here. No test changed. `tsc --noEmit`, lint, fmt, `guard:invariants` clean.
