### PR TITLE
refactor(eve): batch the registry catalog's title lookups

### DIFF
--- a/.changeset/registry-batched-titles.md
+++ b/.changeset/registry-batched-titles.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fetch registry catalog titles in one batched request instead of one request per item, so browsing a page of 100 items no longer makes 100 round trips.

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -429,7 +429,7 @@ describe("registry commands", () => {
     expect(logger.logs).toContain("Added @other to package.json.");
   });
 
-  it("loads real item titles in parallel for a page of search results", async () => {
+  it("loads real item titles for a page of search results in one batch", async () => {
     searchRegistries.mockResolvedValue({
       items: [
         {
@@ -445,27 +445,22 @@ describe("registry commands", () => {
       ],
       pagination: { total: 2, offset: 0, limit: 2, hasMore: false },
     });
-    const resolvers = new Map<string, (value: unknown[]) => void>();
-    getRegistryItems.mockImplementation(
-      ([address]: string[]) =>
-        new Promise((resolve) => {
-          resolvers.set(address!, resolve);
-        }),
-    );
+    getRegistryItems.mockResolvedValue([{ title: "Photon iMessage" }, { title: "AI SDK Tools" }]);
 
     const catalog = browseRegistryCatalog("/project", { query: "sdk" });
 
-    await vi.waitFor(() => expect(getRegistryItems).toHaveBeenCalledTimes(2));
-    resolvers.get("https://eve.dev/r/channel/photon-imessage.json")?.([
-      { title: "Photon iMessage" },
-    ]);
-    resolvers.get("@acme/ai-sdk-tools")?.([{ title: "AI SDK Tools" }]);
     await expect(catalog).resolves.toMatchObject({
       items: [
         { name: "channel/photon-imessage", title: "Photon iMessage" },
         { name: "extension/ai-sdk-tools", title: "AI SDK Tools" },
       ],
     });
+    // One batched fetch for the whole page, with manifests mapped back by order.
+    expect(getRegistryItems).toHaveBeenCalledTimes(1);
+    expect(getRegistryItems).toHaveBeenCalledWith(
+      ["https://eve.dev/r/channel/photon-imessage.json", "@acme/ai-sdk-tools"],
+      { config: { registries: { "@acme": "https://example.com/r/{name}.json" } } },
+    );
     expect(searchRegistries).toHaveBeenCalledWith(
       ["https://eve.dev/r/registry.json", "@acme"],
       expect.objectContaining({ limit: 100, query: "sdk" }),

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -81,13 +81,8 @@ export function resolveOfficialRegistryUrl(
 ): string {
   if (configured === undefined) return DEFAULT_OFFICIAL_REGISTRY_URL;
 
-  let url: URL;
-  try {
-    url = new URL(configured);
-  } catch {
-    throw new Error("EVE_DEV_OFFICIAL_REGISTRY_URL must be an HTTP(S) URL.");
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
+  const url = URL.parse(configured);
+  if (url === null || (url.protocol !== "http:" && url.protocol !== "https:")) {
     throw new Error("EVE_DEV_OFFICIAL_REGISTRY_URL must be an HTTP(S) URL.");
   }
   if (url.username !== "" || url.password !== "") {
@@ -264,11 +259,12 @@ export async function browseRegistryCatalog(
   options: { query?: string; source?: string } = {},
 ): Promise<RegistryCatalogResult> {
   const { config, result } = await searchRegistryCatalog(appRoot, options);
-  const manifests = await Promise.all(
-    result.items.map(async (item) => {
-      const [manifest] = await getRegistryItems([item.addCommandArgument], { config });
-      return manifest;
-    }),
+  // One batched call: it resolves its addresses in parallel behind a shared
+  // source cache and returns them in order, so a page of 100 catalog items
+  // costs one fetch pass instead of 100 independent ones.
+  const manifests = await getRegistryItems(
+    result.items.map((item) => item.addCommandArgument),
+    { config },
   );
   return {
     items: result.items.map((item: RegistrySearchItem, index) => {


### PR DESCRIPTION
**Found**
- `cli/commands/registry.ts`: #1436 fetches one manifest per search result inside a `Promise.all`, but `getRegistryItems` already takes an array — the vendored implementation is `Promise.all(items.map(...))` behind a shared source cache, returning results in input order. With #1436's `CATALOG_PAGE_SIZE = 100`, one browse made up to 100 separate calls.
- `resolveOfficialRegistryUrl` (from #1427) validates with a try/catch around `new URL` plus a protocol check, repeating the same error message in both arms.

**Did**
Batched the page into one `getRegistryItems` call (the index mapping the surrounding `map` already relies on is unchanged), and collapsed the URL validation with `URL.parse`, already used in `cli/dev/url-target.ts`. −25/+16 across 2 files.

**Validated**
1615 tests pass across `src/cli/` and `src/setup/`. One test changed: the case pinning the per-item fan-out now pins the batch — same expected titles in the same order, plus an assertion that a page costs one call. `tsc --noEmit`, lint, fmt, `guard:invariants` clean.
