### PR TITLE
refactor(eve): one body height for the trace viewer

### DIFF
--- a/.changeset/one-body-viewport.md
+++ b/.changeset/one-body-viewport.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Carry one body-height metric through the `/traces` viewer instead of two fields that always held the same value.

--- a/packages/eve/src/cli/dev/tui/traces/trace-view.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-view.test.ts
@@ -314,8 +314,7 @@ describe("renderTraceViewer", () => {
     // 30 rows minus three header rows (padding, title, padding) and the three-row
     // footer (padding + hints + status).
     const frame = render(viewerState(conversationSpans()), 100, 30);
-    expect(frame.timelineViewportRows).toBe(24);
-    expect(frame.panelViewportRows).toBe(24);
+    expect(frame.bodyViewportRows).toBe(24);
     expect(frame.panelTotalRows).toBe(0);
   });
 

--- a/packages/eve/src/cli/dev/tui/traces/trace-view.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-view.ts
@@ -41,10 +41,8 @@ export interface TraceViewerFrame {
   readonly rows: readonly string[];
   /** Detail rows the panel has for the selected span — fed back into key handling. */
   readonly panelTotalRows: number;
-  /** Body rows available to the conversation. */
-  readonly timelineViewportRows: number;
-  /** Body rows available to the panel. */
-  readonly panelViewportRows: number;
+  /** Body rows the conversation and the detail drawer share. */
+  readonly bodyViewportRows: number;
   /** Column width the body renders at (expandability is width-dependent). */
   readonly contentWidth: number;
 }
@@ -77,7 +75,6 @@ export function renderTraceViewer(
   const timelineWidth = Math.max(20, width - (panelWidth === 0 ? 0 : panelWidth + 1));
 
   const detailLines = panelDetailLines(state, panelWidth, theme, options.surfaces);
-  const panelViewportRows = bodyRows;
 
   const rows: string[] = [];
   rows.push(...renderHeader(state, options));
@@ -116,8 +113,7 @@ export function renderTraceViewer(
   return {
     rows,
     panelTotalRows: detailLines.length,
-    timelineViewportRows: bodyRows,
-    panelViewportRows,
+    bodyViewportRows: bodyRows,
     contentWidth: timelineWidth,
   };
 }

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-session.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-session.ts
@@ -83,8 +83,7 @@ export class TraceViewerSession {
   #refreshAgain = false;
   #surfaces?: TraceViewerSurfaces;
   #metrics: TraceViewerKeyEnvironment = {
-    timelineViewportRows: 0,
-    panelViewportRows: 0,
+    bodyViewportRows: 0,
     panelTotalRows: 0,
     contentWidth: 0,
   };
@@ -158,8 +157,7 @@ export class TraceViewerSession {
       surfaces: this.#surfaces,
     });
     this.#metrics = {
-      timelineViewportRows: frame.timelineViewportRows,
-      panelViewportRows: frame.panelViewportRows,
+      bodyViewportRows: frame.bodyViewportRows,
       panelTotalRows: frame.panelTotalRows,
       contentWidth: frame.contentWidth,
       conversationLineCounts: this.#state.conversationItems.map((item, index) =>

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
@@ -68,8 +68,7 @@ function entry(traceId: string, lastActivityMs = 0): TraceStoreEntry {
 }
 
 const ENV = {
-  timelineViewportRows: 10,
-  panelViewportRows: 10,
+  bodyViewportRows: 10,
   panelTotalRows: 30,
   contentWidth: 80,
 };
@@ -364,7 +363,7 @@ describe("reduceTraceViewerKey", () => {
     state = { ...state, conversationItems: items };
     const env = {
       ...ENV,
-      timelineViewportRows: 12,
+      bodyViewportRows: 12,
       conversationLineCounts: items.map(() => 5),
     };
     expect(state.scrollRow).toBe(0);
@@ -412,7 +411,7 @@ describe("reduceTraceViewerKey", () => {
     // Each card is 5 lines + 1 separator; the viewport holds 12 lines.
     const env = {
       ...ENV,
-      timelineViewportRows: 12,
+      bodyViewportRows: 12,
       conversationLineCounts: items.map(() => 5),
     };
     for (let index = 0; index < 9; index += 1) {

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.ts
@@ -82,10 +82,8 @@ export function orderedTextSelection(selection: TextSelectionRange): {
 
 /** Viewport metrics the controller measures so scrolling math stays pure. */
 export interface TraceViewerKeyEnvironment {
-  /** Body rows available to the conversation. */
-  readonly timelineViewportRows: number;
-  /** Body rows available to the detail panel. */
-  readonly panelViewportRows: number;
+  /** Body rows the conversation and the detail drawer share. */
+  readonly bodyViewportRows: number;
   /** Total detail rows the panel would paint for the selected span. */
   readonly panelTotalRows: number;
   /** Body column width — card expandability is width-dependent. */
@@ -236,7 +234,7 @@ export function reduceTraceViewerKey(
   key: TerminalKey,
   environment: TraceViewerKeyEnvironment,
 ): TraceViewerKeyResult {
-  const panelMaxScroll = Math.max(0, environment.panelTotalRows - environment.panelViewportRows);
+  const panelMaxScroll = Math.max(0, environment.panelTotalRows - environment.bodyViewportRows);
   const base: TraceViewerState =
     state.panelScroll > panelMaxScroll ? { ...state, panelScroll: panelMaxScroll } : state;
 
@@ -442,7 +440,7 @@ function conversationScrollRow(
 ): number {
   const counts = environment.conversationLineCounts;
   if (counts === undefined) return state.scrollRow;
-  const viewportRows = environment.timelineViewportRows;
+  const viewportRows = environment.bodyViewportRows;
   const offsets = cardLineOffsets(state, counts);
   const cardStart = offsets[state.selectedRow] ?? 0;
   const cardHeight = counts[state.selectedRow] ?? 1;
@@ -472,7 +470,7 @@ function conversationCellAt(
   const counts = environment.conversationLineCounts;
   if (counts === undefined || state.conversationItems.length === 0) return undefined;
   const bodyIndex = y - 1 - TRACE_VIEWER_HEADER_ROWS; // 1-based coordinates
-  if (bodyIndex < 0 || bodyIndex >= environment.timelineViewportRows) return undefined;
+  if (bodyIndex < 0 || bodyIndex >= environment.bodyViewportRows) return undefined;
   const column = x - 1;
   if (column < 0 || column >= environment.contentWidth) return undefined;
   const totalLines = conversationLineTotal(state, counts);
@@ -494,7 +492,7 @@ function panelCellAt(
 ): TextSelectionPoint | undefined {
   if (!state.panelOpen || environment.panelTotalRows === 0) return undefined;
   const bodyIndex = y - 1 - TRACE_VIEWER_HEADER_ROWS; // 1-based coordinates
-  if (bodyIndex < 0 || bodyIndex >= environment.panelViewportRows) return undefined;
+  if (bodyIndex < 0 || bodyIndex >= environment.bodyViewportRows) return undefined;
   const column = x - 1 - (environment.contentWidth + 1);
   if (column < 0) return undefined;
   const line = state.panelScroll + bodyIndex;
@@ -542,7 +540,7 @@ function scrollConversation(
 ): TraceViewerState {
   const counts = environment.conversationLineCounts;
   if (counts === undefined || state.conversationItems.length === 0) return state;
-  const viewportRows = environment.timelineViewportRows;
+  const viewportRows = environment.bodyViewportRows;
   const maxScroll = Math.max(0, conversationLineTotal(state, counts) - viewportRows);
   const scrollRow = Math.min(maxScroll, Math.max(0, state.scrollRow + delta));
   if (scrollRow === state.scrollRow) return state;


### PR DESCRIPTION
**Found**
- `cli/dev/tui/traces/trace-view.ts` computes `panelViewportRows = bodyRows` and returns it beside `timelineViewportRows: bodyRows`, so both frame fields — and both matching `TraceViewerKeyEnvironment` fields — have always carried the same number. Nothing has ever set them apart, including in #1403 where they were introduced.
- Two names for one value meant a reader of `panelMaxScroll` couldn't tell it worked in the same units as `conversationCellAt` without checking the renderer.

**Did**
One `bodyViewportRows` replaces both, in the frame and the key environment; the session stops copying the pair out of every frame. −26/+16 across 5 files.

**Validated**
836 TUI unit tests pass, and `tui-traces` passes all 9 smoke scenarios end to end (expand/collapse, click, drag-copy, drawer, trace switching, empty state). One assertion removed: `trace-view.test.ts` asserted both fields were 24 on adjacent lines, and the surviving one covers the value. `tsc --noEmit`, lint, fmt, `guard:invariants` clean.
