### PR TITLE
fix(eve): make dev shutdown reliable

### DIFF
--- a/.changeset/tidy-tuis-stop.md
+++ b/.changeset/tidy-tuis-stop.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Ensure exiting the dev TUI shuts down its owned server and any surviving workflow processes before the CLI exits. Persisted workflow messages now reach the ready worker during restart instead of being rejected while the file watcher starts.

--- a/packages/eve/src/cli/dev/local-server-process.test.ts
+++ b/packages/eve/src/cli/dev/local-server-process.test.ts
@@ -15,6 +15,7 @@ vi.mock("#cli/dev/environment.js", () => ({ loadDevelopmentEnvironmentFiles: moc
 
 class FakeChild extends EventEmitter {
   connected = true;
+  pid: number | undefined;
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
   readonly send = vi.fn();
@@ -100,6 +101,37 @@ describe("createDevelopmentServer", () => {
       await closing;
       expect(child.unref).toHaveBeenCalledOnce();
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("terminates surviving descendants after the server child exits", async () => {
+    vi.useFakeTimers();
+    child.pid = 4321;
+    let groupAlive = true;
+    const kill = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      expect(pid).toBe(-4321);
+      if (signal === "SIGTERM") groupAlive = false;
+      if (signal === 0 && !groupAlive) throw new Error("process group exited");
+      return true;
+    });
+    try {
+      const server = createDevelopmentServer("/tmp/app");
+      const started = server.start();
+      child.emit("message", {
+        type: "started",
+        handle: { kind: "started", appRoot: "/tmp/app", url: "http://127.0.0.1:2000" },
+      });
+      await started;
+
+      const closing = server.close();
+      child.emit("exit", 0, null);
+      await vi.advanceTimersByTimeAsync(550);
+      await closing;
+
+      expect(kill).toHaveBeenCalledWith(-4321, "SIGTERM");
+    } finally {
+      kill.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/packages/eve/src/cli/dev/local-server-process.ts
+++ b/packages/eve/src/cli/dev/local-server-process.ts
@@ -68,6 +68,7 @@ export function createDevelopmentServer(
   let child: ChildProcess | undefined;
   let handoff: Promise<void> | undefined;
   let expectedExit = false;
+  let childExited = false;
   const exited = Promise.withResolvers<void>();
   const terminated = Promise.withResolvers<void>();
   void exited.promise.catch(() => undefined);
@@ -113,6 +114,7 @@ export function createDevelopmentServer(
       let settled = false;
       spawned.once("error", reject);
       spawned.once("exit", (code, signal) => {
+        childExited = true;
         terminated.resolve();
         release();
         if (!settled) {
@@ -160,11 +162,20 @@ export function createDevelopmentServer(
       expectedExit = true;
       handoff = (async () => {
         if (active.connected) active.send({ type: "shutdown" });
-        if (await settlesWithin(terminated.promise, IPC_SHUTDOWN_GRACE_MS)) return;
+        if (
+          await terminatesWithin(
+            active,
+            terminated.promise,
+            () => childExited,
+            IPC_SHUTDOWN_GRACE_MS,
+          )
+        )
+          return;
         signalProcessGroup(active, "SIGTERM");
-        if (await settlesWithin(terminated.promise, SIGTERM_GRACE_MS)) return;
+        if (await terminatesWithin(active, terminated.promise, () => childExited, SIGTERM_GRACE_MS))
+          return;
         signalProcessGroup(active, "SIGKILL");
-        await settlesWithin(terminated.promise, SIGKILL_REAP_MS);
+        await terminatesWithin(active, terminated.promise, () => childExited, SIGKILL_REAP_MS);
         release();
       })();
       return handoff;
@@ -173,17 +184,49 @@ export function createDevelopmentServer(
   };
 }
 
-async function settlesWithin(operation: Promise<void>, ms: number): Promise<boolean> {
+async function terminatesWithin(
+  child: ChildProcess,
+  exited: Promise<void>,
+  childExited: () => boolean,
+  ms: number,
+): Promise<boolean> {
+  const deadline = Date.now() + ms;
+  await settlesOrTimesOut(exited, ms);
+  while (!hasTerminated(child, childExited()) && Date.now() < deadline) {
+    await sleep(Math.min(25, deadline - Date.now()));
+  }
+  return hasTerminated(child, childExited());
+}
+
+async function settlesOrTimesOut(operation: Promise<void>, ms: number): Promise<void> {
   let timer: NodeJS.Timeout | undefined;
   try {
-    return await Promise.race([
-      operation.then(() => true),
-      new Promise<false>((resolve) => {
-        timer = setTimeout(() => resolve(false), ms);
+    await Promise.race([
+      operation,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, ms);
       }),
     ]);
   } finally {
     if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasTerminated(child: ChildProcess, childExited: boolean): boolean {
+  return childExited && !isProcessGroupAlive(child);
+}
+
+function isProcessGroupAlive(child: ChildProcess): boolean {
+  if (process.platform === "win32" || child.pid === undefined) return false;
+  try {
+    process.kill(-child.pid, 0);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -2066,6 +2066,8 @@ describe("EveTUIRunner renderer teardown", () => {
 
   it("shuts the renderer down once when /exit ends the run loop", async () => {
     const shutdown = vi.fn();
+    const controller = new AbortController();
+    const requestStop = vi.fn(() => controller.abort());
     const renderer = fakeRenderer({
       readPrompt: vi.fn(async () => "/exit"),
       shutdown,
@@ -2074,11 +2076,18 @@ describe("EveTUIRunner renderer teardown", () => {
       session: sessionYielding([]),
       renderer,
       name: "Weather Agent",
+      lifecycle: {
+        signal: controller.signal,
+        stopped: new Promise<NodeJS.Signals | undefined>(() => {}),
+        requestStop,
+        dispose: () => {},
+      },
     });
 
     await runner.run();
 
     expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(requestStop).toHaveBeenCalledOnce();
   });
 
   it("finishes the section on the child's own turn boundary, before subagent.completed", async () => {

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -784,6 +784,7 @@ export class EveTUIRunner {
         const command = parsePromptCommand(prompt);
 
         if (command?.type === "exit") {
+          this.#lifecycle?.requestStop();
           return;
         }
 

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -542,11 +542,14 @@ describe("createDevelopmentServer", () => {
     expect(mocks.files.has(developmentServerStatePath)).toBe(false);
   });
 
-  async function callControlHandler(url: string): Promise<Response | undefined> {
+  async function callControlHandler(
+    url: string,
+    init?: RequestInit,
+  ): Promise<Response | undefined> {
     const call = mocks.devServer.setControlHandler.mock.calls.at(-1);
     const handler = call?.[0] as ((request: Request) => Promise<Response | undefined>) | undefined;
     if (handler === undefined) throw new Error("Missing runtime rebuild handler.");
-    return await handler(new Request(url));
+    return await handler(new Request(url, init));
   }
 
   it("serves runtime artifact state from the parent-owned control handler", async () => {
@@ -567,11 +570,29 @@ describe("createDevelopmentServer", () => {
     const server = await startDevelopmentServer("/tmp/eve-test");
 
     const handlerOrder = mocks.devServer.setControlHandler.mock.invocationCallOrder[0];
+    const workerOrder = mocks.devServer.replaceWorker.mock.invocationCallOrder[0];
     const startOrder = mocks.worldInstance.start.mock.invocationCallOrder[0];
     expect(handlerOrder).toBeDefined();
+    expect(workerOrder).toBeDefined();
     expect(startOrder).toBeDefined();
     expect(handlerOrder ?? Infinity).toBeLessThan(startOrder ?? 0);
+    expect(workerOrder ?? Infinity).toBeLessThan(startOrder ?? 0);
 
+    await server.close();
+  });
+
+  it("forwards persisted workflow deliveries while the file watcher starts", async () => {
+    let deliveryResponse: Response | undefined;
+    mocks.worldInstance.start.mockImplementationOnce(async () => {
+      deliveryResponse = await callControlHandler("http://localhost/.well-known/workflow/v1/flow", {
+        method: "POST",
+      });
+    });
+    const startDevelopmentServer = await loadStartDevelopmentServer();
+
+    const server = await startDevelopmentServer("/tmp/eve-test");
+
+    expect(deliveryResponse).toBeUndefined();
     await server.close();
   });
 

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -208,26 +208,27 @@ function addDevelopmentControlHandler(input: {
     if (url.pathname === EVE_DEV_RUNTIME_ARTIFACTS_ROUTE_PATH && request.method === "GET") {
       return handleDevRuntimeArtifactsRequest({ appRoot: input.appRoot });
     }
+    const isSuspendRequest =
+      url.pathname === EVE_DEV_RUNTIME_ARTIFACTS_SUSPEND_ROUTE_PATH && request.method === "POST";
+    const isResumeRequest =
+      url.pathname === EVE_DEV_RUNTIME_ARTIFACTS_RESUME_ROUTE_PATH && request.method === "POST";
+    const isRebuildRequest =
+      url.pathname === EVE_DEV_RUNTIME_ARTIFACTS_REBUILD_ROUTE_PATH &&
+      (request.method === "GET" || request.method === "POST");
+    if (!isSuspendRequest && !isResumeRequest && !isRebuildRequest) {
+      return undefined;
+    }
     const watcher = input.getWatcher();
     if (watcher === undefined) {
       return Response.json({ error: "The development server is still starting." }, { status: 503 });
     }
-    if (
-      url.pathname === EVE_DEV_RUNTIME_ARTIFACTS_SUSPEND_ROUTE_PATH &&
-      request.method === "POST"
-    ) {
+    if (isSuspendRequest) {
       await watcher.suspend();
       return Response.json({ suspended: true });
     }
-    if (url.pathname === EVE_DEV_RUNTIME_ARTIFACTS_RESUME_ROUTE_PATH && request.method === "POST") {
+    if (isResumeRequest) {
       await watcher.resume({ silent: url.searchParams.get("silent") === "1" });
       return handleDevRuntimeArtifactsRequest({ appRoot: input.appRoot });
-    }
-    if (
-      url.pathname !== EVE_DEV_RUNTIME_ARTIFACTS_REBUILD_ROUTE_PATH ||
-      (request.method !== "GET" && request.method !== "POST")
-    ) {
-      return undefined;
     }
     if (url.searchParams.get("force") === "1") {
       await watcher.rebuild();


### PR DESCRIPTION
## Summary
Fix `eve dev` restarts after exiting the TUI.

- route `/exit` through lifecycle shutdown so server cleanup starts immediately
- wait for the full detached process group, preventing workflow descendants from surviving the server child
- let persisted workflow deliveries reach the ready worker while the file watcher initializes, avoiding transient 503 errors on restart

## Testing
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/nitro/host/start-development-server.test.ts src/cli/dev/local-server-process.test.ts src/cli/dev/tui/runner.test.ts`
- `pnpm typecheck`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm --filter eve build`
- manually started the weather-agent fixture, sent a prompt, exited, and restarted; confirmed clean startup without workflow 503 errors