### PR TITLE
feat(eve): plan subagents as background tasks

### DIFF
--- a/research/subagents-as-tasks-implementation.md
+++ b/research/subagents-as-tasks-implementation.md
@@ -1,0 +1,197 @@
+---
+issue: https://github.com/vercel/eve/issues/1084
+status: draft
+last_updated: "2026-07-31"
+---
+
+# Subagents as tasks: additive delivery plan
+
+## Summary
+
+This plan sequences the implementation of the [subagents-as-tasks design] into strictly additive
+stages behind `experimental.tasks`. Every stage must land with this invariant: **with the flag
+absent, no existing codepath's behavior, wire shapes, or event stream changes.** The design doc
+owns the contract; this doc owns the order of construction, what each stage reuses from the
+agent-messaging stack, and how each stage is verified before the next begins.
+
+## Baseline
+
+The baseline is `main` plus the agent-messaging stack (`am/01-contracts` through
+`am/04-surface`, the phase-one agent2agent work). That stack supplies the session-addressing
+dependency the design doc declares:
+
+- **Durable child address**: the agent handle store (`eve.agent.handles` on session state) with
+  replay-safe operation ids, commit-before-side-effect dispatch, and `starting/running/parked`
+  phases. Handles hold the child `continuationToken` (local) or `url` + `continuationToken`
+  (remote); credentials never render to the model.
+- **Follow-up delivery**: `dispatchToAgentHandle` / `continueRemoteAgentSession`, with
+  `AGENT_BUSY` / `AGENT_MISMATCH` / `AGENT_UNREACHABLE` classification and `intent: "resume"`
+  sends that 404 instead of silently starting a new session.
+- **Reply envelope**: `TurnCaller` (`replyTo: hook token | callback URL`) and the
+  `turn.completed` / `turn.failed` callback kinds carrying an explicit `AgentTurnOutcome`.
+- **Result binding**: inbox results are bound to a running handle, so a callee cannot settle a
+  sibling's call and replays cannot double-settle.
+
+Tasks must not build a second addressing mechanism. The task record composes with handles:
+
+- the **handle** identifies the reusable child session (agent-messaging owns it);
+- the **task** identifies one unit of work against that handle and adds what handles lack:
+  a durable record that survives terminal settlement, `working` / `input_required` status,
+  progress messages, receipts instead of turn-blocking, and `task_await`.
+
+Task identity reuses the operation-id derivation, `hash(parentSessionId, parentTurnId, callId)`,
+so replayed creation for the same originating call yields the same task without new machinery.
+
+### Flag composition
+
+`task_send` follow-ups to a finished child require conversation-mode children and parked
+handles, which `experimental.subagentPersistentSessions` gates today. `experimental.tasks`
+therefore implies persistent-session children for subagent dispatch. Whether it sets the other
+flag or simply selects the same behavior internally is a stage-4 decision; the two flags must
+not produce a third hybrid mode.
+
+## Additivity rules
+
+Each PR in this plan must satisfy:
+
+1. New optional fields only on closed contracts (`NextDriverAction`, `DurableStepResult`,
+   `TurnWorkflowInput.driverCapabilities`); never a changed meaning for an existing `kind`.
+   The driver run is pinned to its starting deployment while turn workflows route to latest,
+   so new turn behavior is negotiated the way `turnInbox` was.
+2. New payload kinds (turn inbox, hooks, callback route) may be defined early but nothing emits
+   them until the stage that selects the mode. Receivers land before senders.
+3. New modules over edits to shared modules wherever possible. Where a shared codepath must
+   branch, the branch condition is the flag or a mode value that nothing sets yet.
+4. Existing tests pass unmodified. Stages add tests; they do not rewrite flag-off expectations.
+
+## Stages
+
+Stages 1–3 are inert: they compile, are fully tested in isolation, and are unreachable in a
+production agent. Stage 4 makes the flag mean something. This mirrors the design doc's Delivery
+section, folding its A2A step into the baseline.
+
+### Stage 0 — flag plumbing
+
+Add `tasks?: boolean` to `AgentExperimentalDefinition`, mirroring the
+`subagentPersistentSessions` plumbing exactly: authored normalization, compiler copy, the strict
+compiled-manifest schema, manifest serialization, root-only enforcement, and a
+`ResolvedAgent` / harness-session projection. The flag does nothing.
+
+Verification: compile/manifest unit tests; a fixture with the flag on behaves identically to one
+without it.
+
+### Stage 1 — task foundation
+
+New `packages/eve/src/tasks/` module cluster:
+
+- `TaskStatus`, `TaskView`, `TaskMetadata`, `TaskOutput`, and a pure transition function
+  enforcing the lifecycle rules (terminal is final; `working <-> input_required`). This stage
+  also settles the design doc's open API questions that block types: the discriminated
+  `task_send` input and how `input_required` exposes its outstanding `InputRequest[]`.
+- The **durable task run**: a dedicated small workflow per task (precedent: the session-timeout
+  run). It is the single writer for transitions, consumes commands over its own hook, and
+  appends a full `TaskView` snapshot per accepted command. Competing completion, cancellation,
+  and input-response commands serialize here.
+- The **session task index**: one new namespaced session-state key holding
+  `{ taskId, taskRunId }` entries. Adding a key to `SessionStateMap` needs no session-version
+  migration.
+
+Verification: exhaustive unit tests on transitions (late completion after `cancelled`,
+idempotent cancel, replayed commands); integration tests driving a task run through every
+lifecycle path.
+
+### Stage 2 — task tools, undiscoverable
+
+Register the parent tools (`task_peek`, `task_await`, `task_send`, `task_cancel`, `task_sleep`)
+as framework tools, filtered out of the tool set unless the flag is on, plus the child
+`task_message` tool advertised only when a task binding is present (the same capability-gating
+pattern as `ask_question`).
+
+- `task_sleep` reuses the existing durable turn-sleep request.
+- `task_peek`, `task_cancel`, and `task_send` read the session task index and command the task
+  run; `task_send` resolves the child address through the agent handle store and the existing
+  continuation dispatch.
+- `task_await` introduces the one new turn-workflow wait: a new optional wait arm on the durable
+  step result that subscribes to selected task runs and returns when every selected task is
+  terminal or `input_required` (already-ready tasks return immediately). This is the only piece
+  of stage 2 that touches the turn workflow, and it rides an optional field nothing produces
+  when the flag is off.
+
+Verification: unit tests per tool; a scenario test that the tools are absent from advertised
+tool sets and `/agent-info` when the flag is off.
+
+### Stage 3 — delegated execution mode, inert
+
+In the runtime-action dispatch step, add a delegated mode alongside the existing dispatch plan:
+
+1. create the durable `working` task run and record it in the session task index;
+2. dispatch the child with a task binding in its adapter state, reusing the handle-store
+   start/continue planning for identity and addressing;
+3. persist the child acknowledgement (`childSessionId`) on the handle, as agent-messaging
+   already does at dispatch;
+4. resolve the originating tool call **immediately** with the task receipt
+   `{ taskId, status: "working" }`.
+
+Step 4 is what keeps the parent turn moving and history provider-valid: the receipt is the one
+result the existing key-based batch matching consumes, so the turn continues without a second
+result path. The eventual outcome reaches the model only through `task_await`, `task_peek`, or a
+task notification. Nothing selects this mode yet.
+
+Verification: integration tests invoking the mode directly; replay tests proving the same
+originating call returns the same task and never dispatches twice.
+
+### Stage 4 — the task wire, and the flag selects the mode
+
+Carry the six flows over the task contract for local and remote children alike, then let
+`experimental.tasks` route the two subagent runtime-action kinds into delegated execution:
+
+| Flow                       | Carrier                                                           |
+| -------------------------- | ----------------------------------------------------------------- |
+| Terminal result or failure | `task.update` command to the task run, terminal snapshot          |
+| Input request / approval   | `task.update` with `input_required` plus the outstanding batch    |
+| Authorization event        | `task.authorization` through the task binding                     |
+| Input response             | `task_send`, routed via the handle address                        |
+| Cancellation               | `task_cancel`: commit `cancelled`, then propagate executor abort  |
+| Progress                   | `task_message` from the child, recorded as latest `statusMessage` |
+
+Concretely:
+
+- a task-aware sibling of the local subagent channel adapter posts to the task run instead of
+  the parent turn hook; the existing adapter is untouched;
+- the remote callback route gains task payload kinds alongside the existing session and turn
+  kinds; old payloads are unchanged and old deployments never receive the new kinds;
+- routing policy: terminal and `input_required` snapshots wake a parked parent through the
+  session delivery path; progress updates task state and client-visible events only. During an
+  active turn, inbound task events wait for the next safe step boundary;
+- parent-session finalization extends the existing end-of-session child termination to
+  cooperatively cancel live tasks first.
+
+Verification: the design doc's acceptance criteria become a scenario suite plus a new e2e
+fixture with the flag on; existing subagent fixtures prove the flag-off path is unchanged.
+
+### Stage 5 — normalize and retire
+
+Converge local and remote subagents onto the same delegated path while preserving authored
+definitions, then make tasks the default subagent execution and retire the flag once the
+acceptance criteria hold. Both are behavior changes, not additive, and are sequenced last
+deliberately; they get their own plans if anything nontrivial surfaces.
+
+## Known gaps to resolve in flight
+
+1. **`task_send` to a busy child.** Handle continuation classifies a running child as
+   `AGENT_BUSY`, a hard error. The design doc expects `task_send` to answer `input_required`
+   and to message the child session; decide in stage 2 whether a send to a `working` task
+   queues on the task run or surfaces the busy error to the model.
+2. **Remote children outlive the parent.** Agent-messaging documents that remote children are
+   not terminated with the parent. The tasks acceptance criterion "completing the parent
+   session cancels its live tasks" needs the remote cancel path wired into parent finalization
+   in stage 4, or an explicit scope cut.
+3. **Blocked vs computing children.** Today a child parked on input or authorization looks like
+   any running child. The `input_required` transition in stage 4 is what makes the difference
+   observable; until then `task_peek` reports `working` for both, which is acceptable for the
+   inert stages but must be closed before the flag ships.
+4. **MCP failure taxonomy.** Whether tool-level errors map to `failed` or to a completed result
+   carrying an error must be decided when `TaskOutput` lands in stage 1, since the transition
+   function encodes it.
+
+[subagents-as-tasks design]: https://github.com/vercel/eve/pull/1482

--- a/research/subagents-as-tasks-implementation.md
+++ b/research/subagents-as-tasks-implementation.md
@@ -37,7 +37,7 @@ Tasks must not build a second addressing mechanism. The task record composes wit
 - the **handle** identifies the reusable child session (agent-messaging owns it);
 - the **task** identifies one unit of work against that handle and adds what handles lack:
   a durable record that survives terminal settlement, `working` / `input_required` status,
-  progress messages, receipts instead of turn-blocking, and `task_await`.
+  progress messages, and receipts instead of turn-blocking.
 
 Task identity reuses the operation-id derivation, `hash(parentSessionId, parentTurnId, callId)`,
 so replayed creation for the same originating call yields the same task without new machinery.
@@ -86,14 +86,14 @@ New `packages/eve/src/tasks/` module cluster:
 
 - `TaskStatus`, `TaskView`, `TaskMetadata`, `TaskOutput`, and a pure transition function
   enforcing the lifecycle rules (terminal is final; `working <-> input_required`). This stage
-  also settles the design doc's open API questions that block types: the discriminated
-  `task_send` input and how `input_required` exposes its outstanding `InputRequest[]`.
+  also settles how `input_required` exposes its outstanding `InputRequest[]`; `task_send`
+  accepts only a message follow-up for a terminal task.
 - The **durable task run**: a dedicated small workflow per task (precedent: the session-timeout
   run). It is the single writer for transitions, consumes commands over its own hook, and
   appends a full `TaskView` snapshot per accepted command. Competing completion, cancellation,
   and input-response commands serialize here.
 - The **session task index**: one new namespaced session-state key holding
-  `{ taskId, taskRunId }` entries. Adding a key to `SessionStateMap` needs no session-version
+  `{ taskId, taskRunId, metadata }` entries. Adding a key to `SessionStateMap` needs no session-version
   migration.
 
 Verification: exhaustive unit tests on transitions (late completion after `cancelled`,
@@ -102,20 +102,13 @@ lifecycle path.
 
 ### Stage 2 — task tools, undiscoverable
 
-Register the parent tools (`task_peek`, `task_await`, `task_send`, `task_cancel`, `task_sleep`)
-as framework tools, filtered out of the tool set unless the flag is on, plus the child
-`task_message` tool advertised only when a task binding is present (the same capability-gating
-pattern as `ask_question`).
+Register the parent tools (`task_peek`, `task_send`, `task_cancel`, `task_sleep`)
+as framework tools, filtered out of the tool set unless the flag is on. The first implementation
+has no child-facing task tool.
 
 - `task_sleep` reuses the existing durable turn-sleep request.
-- `task_peek`, `task_cancel`, and `task_send` read the session task index and command the task
-  run; `task_send` resolves the child address through the agent handle store and the existing
-  continuation dispatch.
-- `task_await` introduces the one new turn-workflow wait: a new optional wait arm on the durable
-  step result that subscribes to selected task runs and returns when every selected task is
-  terminal or `input_required` (already-ready tasks return immediately). This is the only piece
-  of stage 2 that touches the turn workflow, and it rides an optional field nothing produces
-  when the flag is off.
+- `task_peek`, `task_cancel`, and `task_send` read the session task index; `task_send` resolves a
+  terminal task's child address through the agent handle store and starts a new task.
 
 Verification: unit tests per tool; a scenario test that the tools are absent from advertised
 tool sets and `/agent-info` when the flag is off.
@@ -134,8 +127,8 @@ In the runtime-action dispatch step, add a delegated mode alongside the existing
 
 Step 4 is what keeps the parent turn moving and history provider-valid: the receipt is the one
 result the existing key-based batch matching consumes, so the turn continues without a second
-result path. The eventual outcome reaches the model only through `task_await`, `task_peek`, or a
-task notification. Nothing selects this mode yet.
+result path. A task notification starts or nudges a parent turn, and the model can read additional
+current state through `task_peek`. Nothing selects this mode yet.
 
 Verification: integration tests invoking the mode directly; replay tests proving the same
 originating call returns the same task and never dispatches twice.
@@ -150,9 +143,8 @@ Carry the six flows over the task contract for local and remote children alike, 
 | Terminal result or failure | `task.update` command to the task run, terminal snapshot          |
 | Input request / approval   | `task.update` with `input_required` plus the outstanding batch    |
 | Authorization event        | `task.authorization` through the task binding                     |
-| Input response             | `task_send`, routed via the handle address                        |
+| Input response             | Parent-session HITL proxy, routed directly to the blocked child   |
 | Cancellation               | `task_cancel`: commit `cancelled`, then propagate executor abort  |
-| Progress                   | `task_message` from the child, recorded as latest `statusMessage` |
 
 Concretely:
 
@@ -160,9 +152,9 @@ Concretely:
   the parent turn hook; the existing adapter is untouched;
 - the remote callback route gains task payload kinds alongside the existing session and turn
   kinds; old payloads are unchanged and old deployments never receive the new kinds;
-- routing policy: terminal and `input_required` snapshots wake a parked parent through the
-  session delivery path; progress updates task state and client-visible events only. During an
-  active turn, inbound task events wait for the next safe step boundary;
+- routing policy: a local `input_required` snapshot commits task-owned proxy routes and emits the
+  exact request on the parent session; a fully routed response starts no parent model turn.
+  Terminal snapshots still wake the parent through the session delivery path;
 - parent-session finalization extends the existing end-of-session child termination to
   cooperatively cancel live tasks first.
 
@@ -178,25 +170,26 @@ deliberately; they get their own plans if anything nontrivial surfaces.
 
 ## Settled decisions
 
-1. **Wake policy.** Terminal and `input_required` transitions wake a parked parent through the
-   session delivery path; they are the only wake triggers. Progress never wakes on its own.
-2. **`task_send` to a busy child.** A send to a `working` task surfaces `AGENT_BUSY` as a tool
+1. **Lifecycle ownership.** In tasks mode, the task run is the sole execution-lifecycle writer.
+   Agent records retain stable identity and private address only. Availability is derived from
+   nonterminal tasks, with at most one such task per child session; busy agents remain visible in
+   `<agents>` with their active task id and status.
+2. **Wake policy.** Terminal and `input_required` transitions wake a parked parent through the
+   session delivery path; they are the only wake triggers.
+3. **`task_send` to a busy child.** A send to a `working` task surfaces `AGENT_BUSY` as a tool
    error, matching handle-continuation semantics. Queuing on the task run is deferred; it is
    the reversible follow-up if busy errors prove noisy in practice.
-3. **Failure taxonomy.** Child failure maps to the `failed` status, and as a consequence of
+   The same agent is reserved for the whole dispatch batch even if its first task settles quickly.
+4. **Failure taxonomy.** Child failure maps to the `failed` status, and as a consequence of
    that transition the task's output carries the error (`TaskOutput.error`). Failure is the
    state; the error output is its consequence. This intentionally diverges from MCP, which
    reserves `failed` for protocol-level errors.
-4. **Progress is deferred.** The child-facing `task_message` tool and the progress flow are cut
-   from the first implementation; the stage 4 table's progress row lands in a follow-up. The
-   five remaining flows ship first.
+5. **Progress is deferred.** The first implementation has no child-facing progress contract.
 
 ## Known gaps to resolve in flight
 
-1. **Remote children outlive the parent.** Agent-messaging documents that remote children are
-   not terminated with the parent. The tasks acceptance criterion "completing the parent
-   session cancels its live tasks" needs the remote cancel path wired into parent finalization
-   in stage 4, or an explicit scope cut.
+1. **Remote parity is release-blocking.** Remote task children must support the same HITL,
+   authorization, cancellation, and terminal lifecycle as local children before the flag ships.
 2. **Blocked vs computing children.** Today a child parked on input or authorization looks like
    any running child. The `input_required` transition in stage 4 is what makes the difference
    observable; until then `task_peek` reports `working` for both, which is acceptable for the

--- a/research/subagents-as-tasks-implementation.md
+++ b/research/subagents-as-tasks-implementation.md
@@ -194,4 +194,4 @@ deliberately; they get their own plans if anything nontrivial surfaces.
    carrying an error must be decided when `TaskOutput` lands in stage 1, since the transition
    function encodes it.
 
-[subagents-as-tasks design]: https://github.com/vercel/eve/pull/1482
+[subagents-as-tasks design]: ./tools-as-tasks.md

--- a/research/subagents-as-tasks-implementation.md
+++ b/research/subagents-as-tasks-implementation.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1084
 status: draft
-last_updated: "2026-07-31"
+last_updated: "2026-08-01"
 ---
 
 # Subagents as tasks: additive delivery plan
@@ -16,9 +16,9 @@ agent-messaging stack, and how each stage is verified before the next begins.
 
 ## Baseline
 
-The baseline is `main` plus the agent-messaging stack (`am/01-contracts` through
-`am/04-surface`, the phase-one agent2agent work). That stack supplies the session-addressing
-dependency the design doc declares:
+The baseline is `am/04-surface`, the tip of the agent-messaging stack (the phase-one
+agent2agent work), which this plan's branch now stacks on directly. That stack supplies the
+session-addressing dependency the design doc declares:
 
 - **Durable child address**: the agent handle store (`eve.agent.handles` on session state) with
   replay-safe operation ids, commit-before-side-effect dispatch, and `starting/running/parked`
@@ -176,22 +176,30 @@ definitions, then make tasks the default subagent execution and retire the flag 
 acceptance criteria hold. Both are behavior changes, not additive, and are sequenced last
 deliberately; they get their own plans if anything nontrivial surfaces.
 
+## Settled decisions
+
+1. **Wake policy.** Terminal and `input_required` transitions wake a parked parent through the
+   session delivery path; they are the only wake triggers. Progress never wakes on its own.
+2. **`task_send` to a busy child.** A send to a `working` task surfaces `AGENT_BUSY` as a tool
+   error, matching handle-continuation semantics. Queuing on the task run is deferred; it is
+   the reversible follow-up if busy errors prove noisy in practice.
+3. **Failure taxonomy.** Child failure maps to the `failed` status, and as a consequence of
+   that transition the task's output carries the error (`TaskOutput.error`). Failure is the
+   state; the error output is its consequence. This intentionally diverges from MCP, which
+   reserves `failed` for protocol-level errors.
+4. **Progress is deferred.** The child-facing `task_message` tool and the progress flow are cut
+   from the first implementation; the stage 4 table's progress row lands in a follow-up. The
+   five remaining flows ship first.
+
 ## Known gaps to resolve in flight
 
-1. **`task_send` to a busy child.** Handle continuation classifies a running child as
-   `AGENT_BUSY`, a hard error. The design doc expects `task_send` to answer `input_required`
-   and to message the child session; decide in stage 2 whether a send to a `working` task
-   queues on the task run or surfaces the busy error to the model.
-2. **Remote children outlive the parent.** Agent-messaging documents that remote children are
+1. **Remote children outlive the parent.** Agent-messaging documents that remote children are
    not terminated with the parent. The tasks acceptance criterion "completing the parent
    session cancels its live tasks" needs the remote cancel path wired into parent finalization
    in stage 4, or an explicit scope cut.
-3. **Blocked vs computing children.** Today a child parked on input or authorization looks like
+2. **Blocked vs computing children.** Today a child parked on input or authorization looks like
    any running child. The `input_required` transition in stage 4 is what makes the difference
    observable; until then `task_peek` reports `working` for both, which is acceptable for the
    inert stages but must be closed before the flag ships.
-4. **MCP failure taxonomy.** Whether tool-level errors map to `failed` or to a completed result
-   carrying an error must be decided when `TaskOutput` lands in stage 1, since the transition
-   function encodes it.
 
 [subagents-as-tasks design]: ./tools-as-tasks.md

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -11,7 +11,7 @@ last_updated: "2026-08-01"
 Under an opt-in `experimental.tasks` mode, eve should represent long-running work as durable,
 addressable tasks. This plan applies that model only to local and remote subagents. A subagent call
 returns a task receipt after dispatch instead of keeping the parent turn blocked until the child
-finishes. The parent can inspect, await, message, or cancel the task with framework-owned tools,
+finishes. The parent can inspect, message, or cancel the task with framework-owned tools,
 and the child can intentionally report progress to its parent with one framework-owned tool.
 
 Without the flag, current tool and subagent behavior must remain unchanged.
@@ -79,7 +79,7 @@ A **task** is one unit of work with a durable identity and lifecycle. A task is 
 session. Terminal tasks never restart.
 
 A **child session** is the resumable conversation owned by a delegated agent. A follow-up sent to
-the same child session creates a new task bound to the same `childSessionId`. This matches A2A's
+the same agent creates a new task bound to the same `agentId`. This matches A2A's
 separation between immutable tasks and a longer-lived [`contextId`].
 
 A **runtime action** is today's framework-internal dispatch mechanism behind execute-less tools
@@ -92,12 +92,17 @@ model step in the same turn.
 A **background task** is owned by the parent session, not the originating turn. It may complete,
 request input, or emit progress after that turn ends.
 
+An **agent address** is the persistent identity and private routing record for one child session.
+Tasks own execution lifecycle and availability; agent addresses do not duplicate `working` or
+`input_required`. At most one nonterminal task may target one child session. The model-visible
+`<agents>` projection keeps an occupied agent visible as busy and names its active task.
+
 **Delegated execution** is a runtime execution mode, not a tool-authoring surface. A delegated
 dispatch returns once the executor acknowledges the work; the task stays `working`, and every
 later transition arrives over the task wire.
 
 `completed`, `failed`, and `cancelled` are terminal statuses. `input_required` is not terminal,
-but it is ready for parent action. `task_await` must return for either condition so a parent never
+but it is ready for parent action. Entering either condition wakes the parent so it never
 deadlocks while its child waits for input.
 
 ## Authoring contract
@@ -121,48 +126,26 @@ The parent receives these framework-owned tools:
 interface TaskParentTools {
   task_cancel(input: { taskIds: string[] }): Promise<TaskToolResult<boolean>>;
   task_peek(input: { taskIds: string[] }): Promise<TaskToolResult<TaskView[]>>;
-  task_send(input: { taskId: string; input: unknown }): Promise<TaskToolResult<TaskView>>;
-  task_await(input: { taskIds: string[] }): Promise<TaskToolResult<TaskView[]>>;
-  task_sleep(input: { durationMs: number }): Promise<TaskToolResult<boolean>>;
+  task_send(input: { taskId: string; message: string }): Promise<TaskToolResult<TaskView>>;
+  task_sleep(input: { seconds: number }): Promise<TaskToolResult<boolean>>;
 }
 ```
 
-The exact `TaskToolResult` error shape and `task_send.input` union remain open. Before
-implementation, `task_send.input` should become a discriminated eve-owned type that separates an
-`InputResponse[]` batch from an arbitrary child message.
+Human responses are not a model capability. Clients answer the ordinary `input.requested` event
+on the parent session, and eve routes matching responses directly to the blocked child.
 
 The controls have distinct behavior:
 
 - `task_peek` reads current state without blocking and does not return credentials or routing
   handles.
-- `task_await` durably pauses the current turn until every selected task is terminal or
-  `input_required`. An already-ready task returns immediately.
-- `task_send` answers an `input_required` task or sends a follow-up message to the addressed child
-  session. A message sent after the prior task became terminal creates a new task bound to the
-  same child session; it never reopens the terminal task.
+- `task_send` sends a follow-up message after the prior task became terminal, creating a new task
+  bound to the same child session. It never reopens a terminal task or answers HITL.
 - `task_cancel` requests cooperative cancellation. A committed terminal state is final, so a late
   child result cannot revive a cancelled task.
 - `task_sleep` durably pauses the current turn for paced checks. It does not poll or mutate a task.
 
-### Child task tools
-
-A child session dispatched as a task receives one framework-owned tool:
-
-```ts
-interface TaskChildTools {
-  task_message(input: { message: string }): Promise<TaskToolResult<boolean>>;
-}
-```
-
-`task_message` emits a `task.message` event through the task binding and updates the task's
-durable `statusMessage`. It returns after the update is durably recorded. It does not change the
-child's lifecycle and is not a substitute for the terminal result.
-
-No child-facing surface exists today: child-to-parent communication is entirely harness-level.
-The [local subagent adapter] forwards events as side effects the child model never sees, and the
-[remote callback route] accepts only terminal payloads. This tool is the model-facing half of the
-proposal's original motivation — letting a child report progress on purpose rather than having
-channels infer it.
+There is no child-facing task tool in the first implementation. Child-to-parent lifecycle and
+HITL communication is framework-owned; progress reporting remains a separate follow-up.
 
 ### Task view
 
@@ -178,11 +161,10 @@ interface TaskView {
 }
 
 interface TaskMetadata {
+  readonly agentId: string;
   readonly kind: "subagent";
   readonly mode: "local" | "remote";
   readonly name: string;
-  readonly childSessionId: string;
-  readonly url: string;
 }
 
 type TaskOutput =
@@ -205,14 +187,15 @@ gets one receipt:
 
 ```json
 {
+  "agentId": "ag_research:...",
   "taskId": "task_01K...",
   "status": "working"
 }
 ```
 
-The eventual child result must not become a second result for that call. It reaches the model
-through `task_await`, `task_peek`, or a later framework-authored task notification. This keeps
-history append-only and leaves no dangling provider tool call.
+The eventual child result must not become a second result for that call. A framework-authored
+task notification starts or nudges a parent turn, and the model reads any additional current state
+with `task_peek`. This keeps history append-only and leaves no dangling provider tool call.
 
 ## Task state and ownership
 
@@ -224,6 +207,7 @@ The parent session stores only a live-task index:
 
 ```ts
 interface SessionTaskIndexEntry {
+  readonly metadata: TaskMetadata;
   readonly taskId: string;
   readonly taskRunId: string;
 }
@@ -263,7 +247,7 @@ replaces the park-and-wait mechanism in the same dispatch codepath:
 
 1. The harness creates a durable `working` task for the subagent call.
 2. It dispatches the child with the task binding.
-3. The child acknowledges its `childSessionId`, which is persisted immediately.
+3. The child acknowledges its private address, which is persisted on the agent record immediately.
 4. The originating call receives its receipt and the turn continues.
 
 Everything after acknowledgement — progress, input requests, authorization, terminal outcome —
@@ -285,20 +269,18 @@ interface TaskBinding {
 }
 
 interface TaskExecutorBinding {
-  readonly childSessionId: string;
   readonly inbound: { readonly url: string; readonly token: string };
 }
 
 type ParentInbound =
   | { readonly type: "task.update"; readonly task: TaskView }
-  | { readonly type: "task.message"; readonly taskId: string; readonly message: JsonValue }
   | { readonly type: "task.authorization"; readonly taskId: string; readonly data: JsonValue };
 ```
 
 An `input_required` transition carries the full outstanding request batch in its task snapshot.
 The parent emits those requests through the normal `input.requested` stream contract. Matching
-responses route back through `task_send`. Authorization uses the same task binding but remains a
-distinct event because it has different disclosure rules.
+responses sent to the parent session route directly through its private child proxy. Authorization
+uses the same task binding but remains a distinct event because it has different disclosure rules.
 
 The five flows that split across two transports today all converge on this one contract, for
 local and remote children alike:
@@ -308,16 +290,12 @@ local and remote children alike:
 | Terminal result or failure        | `task.update` with a terminal snapshot                        |
 | Input request, including approval | `task.update` with `input_required` and the outstanding batch |
 | Authorization event               | `task.authorization`                                          |
-| Input response                    | `task_send` addressed to the owning task                      |
+| Input response                    | Parent-session proxy addressed by the recorded request id     |
 | Cancellation                      | `task_cancel`, committed then propagated to the executor      |
 
-Progress is the sixth flow, new in this plan: `task.message` from the child's `task_message`
-tool, durably recorded as the task's latest `statusMessage`.
-
 The proposed routing policy makes terminal updates and `input_required` wake a parked parent
-session. Progress updates change task state and emit client-visible lifecycle events, but do not
-start a model turn on their own. During an active turn, inbound task events wait for the next safe
-step boundary. They never interrupt an active model call.
+session. During an active turn, inbound task events wait for the next safe step boundary. They
+never interrupt an active model call.
 
 ```mermaid
 sequenceDiagram
@@ -329,14 +307,14 @@ sequenceDiagram
     M->>H: subagent tool call
     H->>T: create working task
     H->>C: dispatch with TaskBinding
-    C-->>H: acknowledge childSessionId
+    C-->>H: acknowledge private child address
     H-->>M: task receipt
-    M->>H: continue turn or task_await
+    M->>H: continue turn
 
-    C->>T: task.update, task.message, or authorization
+    C->>T: task.update or authorization
     T->>H: full task snapshot
     H->>H: queue until safe boundary
-    H-->>M: await result or later task notification
+    H-->>M: task notification; task_peek if needed
 ```
 
 ### Agent-to-agent dependency
@@ -347,11 +325,11 @@ one record:
 
 - the task identifies the current unit of work;
 - the handle identifies the reusable child session;
-- the task's private `TaskExecutorBinding` lets `task_send` address in-flight work;
+- the task's private binding lets the parent session route HITL and guarded cancellation;
 - resuming that child creates a new task bound to the same handle.
 
 The A2A draft currently records a handle after the child's first result. That is too late for
-`task_send` during `working` or `input_required`. Task dispatch must persist the private executor
+direct HITL and cancellation during `working` or `input_required`. Task dispatch must persist the private executor
 binding as soon as the child acknowledges its session. The same acknowledgement may create or
 update the reusable agent handle. Both records may reuse the A2A inbox route, but routing tokens
 belong in one shared credential store rather than two independent session-addressing mechanisms.
@@ -366,9 +344,8 @@ The current [MCP Tasks extension] provides the closest standard vocabulary:
 - full task snapshots in `notifications/tasks`;
 - terminal states that do not change.
 
-eve's `task_peek`, `task_send`, and `task_cancel` map to those operations. `task_await` and
-`task_sleep` are eve controls, not MCP methods. eve is not implementing the MCP wire protocol in
-this work.
+eve's `task_peek`, `task_send`, and `task_cancel` map to those operations. `task_sleep` is an eve
+control, not an MCP method. eve is not implementing the MCP wire protocol in this work.
 
 One semantic difference is decided. MCP treats a tool-level `isError: true` result as
 `completed`; `failed` is reserved for JSON-RPC execution failure. eve diverges: child failure
@@ -384,20 +361,15 @@ than MCP compatibility.
 
 ## Delivery
 
-1. Land the task foundation inert: types, transition rules, durable task run, session index, and
-   the parent and child task tools, all undiscoverable without the experiment.
-2. Land delegated execution in the runtime, inert: dispatch acknowledges, the task stays
-   `working`, and nothing selects the mode yet.
-3. Land the A2A handle and inbox dependency needed to address an existing child session.
-4. Behind `experimental.tasks`, run subagent runtime actions as tasks: create the task in the
-   runtime-action dispatch codepath, return its receipt, and dispatch the child with a task
-   binding.
-5. Carry all six child flows over the task wire: terminal outcome, input request, authorization,
-   input response, cancellation, and progress.
-6. Normalize local and remote subagents onto the same delegated execution path while preserving
-   their authored definitions.
-7. Make tasks the default subagent execution path and retire the flag once the acceptance
-   criteria hold.
+1. Land the final-shape task kernel inert: types, transition rules, durable task run, and session
+   index. No public flag, tool, writer, or existing production caller reaches it.
+2. Land authenticated create-once session creation as an independently complete channel feature.
+3. Behind `experimental.tasks`, land the complete background-task runtime contract at once:
+   final tools, persistence writer, stable agent identity, local/remote HITL and cancellation,
+   receipts, and usage retention.
+4. Gate that runtime with deterministic end-to-end acceptance in every supported world.
+5. Land the final TUI consumer as one state machine, including background sections, idle wakes,
+   remote child streaming through the parent, and authoritative finalization.
 
 ## Acceptance criteria
 
@@ -407,33 +379,33 @@ than MCP compatibility.
   step before the child completes.
 - The original tool call has exactly one result in durable history. Later task output cannot be
   attached to that call a second time.
-- Local and remote subagents support the same six parent-child flows.
-- A child dispatched as a task can call `task_message`; the parent observes the durable latest
-  message through `task_peek` without a model turn starting on its own.
-- `task_await` returns on terminal status and `input_required`, including when the task was already
-  ready before the call.
+- Local and remote subagents support the same five parent-child flows.
+- Terminal and `input_required` transitions wake the parent; the model can inspect all relevant
+  task views with `task_peek` and decide whether the available state is sufficient.
 - `task_peek` observes current state without waking or mutating the executor.
-- `task_send` routes each response or message to the intended child session and cannot cross
-  parent-session ownership.
+- Parent-session responses route directly to the intended local task child without a parent model
+  turn and cannot cross task or session ownership. `task_send` accepts terminal follow-up messages only.
+- One child session owns at most one nonterminal task; repeated sends return `AGENT_BUSY` and do
+  not queue.
 - Cancellation is cooperative and idempotent. A late completion cannot overwrite `cancelled`.
-- Progress is durable latest state and a client-visible event, but does not create unbounded model
-  history or unsolicited model turns.
 - Replay returns the same task ID for the same originating call and never dispatches the child
   twice.
 - Completing the parent session cancels its live tasks.
-- Resuming an existing child session creates a new task with a new task ID and the same
-  `childSessionId`.
+- Resuming an existing child session creates a new task with a new task ID and the same `agentId`.
+- Background budgets are best-effort: each local child is capped from the parent's remainder at
+  its dispatch time, but no reservation couples sequential dispatches, so aggregate grants can
+  exceed the parent's remaining session limits. The child's reported usage is retained on the
+  terminal task snapshot (internal, not model-visible) so strict accounting can land later
+  without data loss.
 
 ## Open questions
 
-1. What is the exact discriminated input for `task_send`, including arbitrary messages and
-   `InputResponse[]` batches?
-2. Should `TaskView` include a monotonic revision for notification deduplication, or can the task
+1. Should `TaskView` include a monotonic revision for notification deduplication, or can the task
    run's stream index remain internal?
-3. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
-4. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
-5. Which task events enter model context, and how are repeated progress messages coalesced?
-6. How are child token usage and remaining parent budgets accounted after a background child
+2. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
+3. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
+4. Which task events enter model context, and how are repeated progress messages coalesced?
+5. How are child token usage and remaining parent budgets accounted after a background child
    completes on a later turn?
 
 Two former open questions are settled and recorded in the [delivery plan]: failure taxonomy

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -1,0 +1,384 @@
+---
+issue: https://github.com/vercel/eve/issues/1084
+status: draft
+last_updated: "2026-07-31"
+---
+
+# Subagents as tasks
+
+## Summary
+
+Under an opt-in `experimental.tasks` mode, eve should represent long-running work as durable,
+addressable tasks. This plan applies that model only to local and remote subagents. A subagent call
+returns a task receipt after dispatch instead of keeping the parent turn blocked until the child
+finishes. The parent can inspect, await, message, or cancel the task with framework-owned tools.
+
+Without the flag, current tool and subagent behavior must remain unchanged.
+
+This draft is based on the [Tools as Tasks proposal], the earlier background-task plan in
+[PR #1085], and the storage-boundary findings from the closed [PR #1190] implementation spike.
+
+## Current behavior
+
+Authored tools expose `execute(input, ctx)`. Subagents are different: eve lowers them to
+execute-less tools carrying `runtimeAction` metadata, then handles them after the model step
+outside the authored tool API. The split is visible in the current
+[`ToolDefinition` contract] and [`createNodeHarnessTools` lowering].
+
+The harness first lets the AI SDK run ordinary tool calls. It then collects subagent tool calls
+into a pending runtime-action batch. The turn workflow dispatches that batch and waits for all
+results before starting the next model step. See the [runtime-action park path], the
+[serial dispatch loop], and the [turn-level wait]. The dispatch loop starts children one by one;
+once started, their runs proceed independently. The parent still waits for the whole batch.
+
+Local and remote children also have different communication paths:
+
+| Flow                              | Local child today                      | Remote child today                                                  |
+| --------------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
+| Terminal result or failure        | Resumes the parent turn hook           | Posts `session.completed` or `session.failed` to the callback route |
+| Input request, including approval | Forwarded by the subagent adapter      | No callback shape                                                   |
+| Authorization event               | Forwarded by the subagent adapter      | No callback shape                                                   |
+| Input response                    | Routed to the child continuation token | No callback shape                                                   |
+| Cancellation                      | Descendant cancellation                | Remote `cancel-turn` request                                        |
+
+The [local subagent adapter] forwards input and authorization events to an active parent turn.
+The [remote callback route] accepts only terminal completion and failure. This is why progress
+and human input cannot be added cleanly as channel-only behavior: the parent harness and remote
+transport do not share a non-terminal child protocol. Current input responses use
+[child response routing], while [descendant cancellation] selects separate local and remote
+cancel paths.
+
+## Goals
+
+- Let a parent continue its turn while delegated work runs.
+- Give the model explicit task controls instead of making every wait implicit.
+- Carry progress, input requests, authorization events, results, failures, and cancellation over
+  one local and remote task contract.
+- Keep task state durable across turns and replay.
+- Preserve provider-valid history. The originating tool call receives exactly one result.
+- Keep authored subagent files unchanged.
+- Give local and remote subagents the same externally visible lifecycle.
+- Align task status and control semantics with the MCP Tasks extension where the contracts match.
+
+## Non-goals
+
+- Exposing an MCP Tasks server or client endpoint in this work.
+- Changing authored tools, built-in tools, connections, skills, or dynamic workflows.
+- Replacing `runtimeAction` lowering with a new public `defineTool` API.
+- Rolling back external side effects after cancellation.
+- Retrying failed subagent work automatically.
+- Streaming every progress event into model context.
+- Sharing task handles across parent sessions.
+
+## Terminology
+
+A **task** is one unit of work with a durable identity and lifecycle. A task is not an agent
+session. Terminal tasks never restart.
+
+A **child session** is the resumable conversation owned by a delegated agent. A follow-up sent to
+the same child session creates a new task bound to the same `childSessionId`. This matches A2A's
+separation between immutable tasks and a longer-lived [`contextId`].
+
+A **synchronous invocation** runs inside the current harness step. Its result may trigger another
+model step in the same turn.
+
+A **background task** is owned by the parent session, not the originating turn. It may complete,
+request input, or emit progress after that turn ends.
+
+`completed`, `failed`, and `cancelled` are terminal statuses. `input_required` is not terminal,
+but it is ready for parent action. `task_await` must return for either condition so a parent never
+deadlocks while its child waits for input.
+
+## Authoring contract
+
+The root agent opts in:
+
+```ts
+export default defineAgent({
+  experimental: {
+    tasks: true,
+  },
+});
+```
+
+The flag changes only local and remote subagent calls. Every such call runs in background mode.
+All other tools keep their current behavior.
+
+The parent receives these framework-owned tools:
+
+```ts
+interface TaskParentTools {
+  task_cancel(input: { taskIds: string[] }): Promise<TaskToolResult<boolean>>;
+  task_peek(input: { taskIds: string[] }): Promise<TaskToolResult<TaskView[]>>;
+  task_send(input: { taskId: string; input: unknown }): Promise<TaskToolResult<TaskView>>;
+  task_await(input: { taskIds: string[] }): Promise<TaskToolResult<TaskView[]>>;
+  task_sleep(input: { durationMs: number }): Promise<TaskToolResult<boolean>>;
+}
+```
+
+The exact `TaskToolResult` error shape and `task_send.input` union remain open. Before
+implementation, `task_send.input` should become a discriminated eve-owned type that separates an
+`InputResponse[]` batch from an arbitrary child message.
+
+The controls have distinct behavior:
+
+- `task_peek` reads current state without blocking and does not return credentials or routing
+  handles.
+- `task_await` durably pauses the current turn until every selected task is terminal or
+  `input_required`. An already-ready task returns immediately.
+- `task_send` answers an `input_required` task or sends a follow-up message to the addressed child
+  session. A message sent after the prior task became terminal creates a new task bound to the
+  same child session; it never reopens the terminal task.
+- `task_cancel` requests cooperative cancellation. A committed terminal state is final, so a late
+  child result cannot revive a cancelled task.
+- `task_sleep` durably pauses the current turn for paced checks. It does not poll or mutate a task.
+
+### Task view
+
+```ts
+type TaskStatus = "working" | "input_required" | "completed" | "failed" | "cancelled";
+
+interface TaskView {
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly statusMessage?: string;
+  readonly metadata: TaskMetadata;
+  readonly lastOutput?: TaskOutput;
+}
+
+interface TaskMetadata {
+  readonly kind: "subagent";
+  readonly mode: "local" | "remote";
+  readonly name: string;
+  readonly childSessionId: string;
+  readonly url: string;
+}
+
+type TaskOutput =
+  | { readonly type: "result"; readonly data: JsonValue }
+  | { readonly type: "error"; readonly data: JsonValue };
+```
+
+When `status` is `input_required`, the view must also expose the outstanding `InputRequest[]`.
+Whether that becomes a discriminated `TaskView` variant or a status-specific field is an API
+decision, not an implementation detail.
+
+Task IDs are minted identifiers. They are never child session IDs, continuation tokens, callback
+tokens, or authorization capabilities. A parent session owns many tasks, and lookup verifies both
+the parent `sessionId` and `taskId`.
+
+### Original call result
+
+After durable task creation and child-dispatch acknowledgement, the originating subagent call
+gets one receipt:
+
+```json
+{
+  "taskId": "task_01K...",
+  "status": "working"
+}
+```
+
+The eventual child result must not become a second result for that call. It reaches the model
+through `task_await`, `task_peek`, or a later framework-authored task notification. This keeps
+history append-only and leaves no dangling provider tool call.
+
+## Task state and ownership
+
+The mutable task record should live in a dedicated durable task run. That run is the single writer
+for lifecycle transitions and appends a full `TaskView` snapshot after each accepted command.
+Other paths address it through a command hook and read its stream.
+
+The parent session stores only a live-task index:
+
+```ts
+interface SessionTaskIndexEntry {
+  readonly taskId: string;
+  readonly taskRunId: string;
+}
+```
+
+This changes one sentence in the Notion proposal, which places the record directly in durable
+session state. The [PR #1190] spike found that boundary unworkable: session state is threaded
+through step results, while callback routes and child executors need to update task state without
+holding the current session snapshot. A task-owned run also serializes competing completion,
+cancellation, and input-response transitions.
+
+The lifecycle rules are:
+
+```text
+working <-> input_required
+   |             |
+   +-----> completed
+   +-----> failed
+   +-----> cancelled
+
+completed, failed, and cancelled are final
+```
+
+- A background task survives turn completion and turn cancellation.
+- It ends when it completes, fails, is cancelled, or its parent session ends.
+- Parent-session finalization cooperatively cancels every live task before completing.
+- Task cancellation commits the `cancelled` state before propagating the executor abort.
+- Replayed creation for the same parent session and tool-call ID returns the same task and must not
+  dispatch duplicate work.
+
+## Parent and executor wire contract
+
+The parent-facing half of a task binding is passed to a local or remote child executor. Routing
+credentials never enter model-visible context, history, task events, or compaction summaries.
+
+```ts
+interface TaskBinding {
+  readonly taskId: string;
+  readonly token: string;
+  readonly url: string;
+}
+
+interface TaskExecutorBinding {
+  readonly childSessionId: string;
+  readonly inbound: { readonly url: string; readonly token: string };
+}
+
+type ParentInbound =
+  | { readonly type: "task.update"; readonly task: TaskView }
+  | { readonly type: "task.message"; readonly taskId: string; readonly message: JsonValue }
+  | { readonly type: "task.authorization"; readonly taskId: string; readonly data: JsonValue };
+```
+
+An `input_required` transition carries the full outstanding request batch in its task snapshot.
+The parent emits those requests through the normal `input.requested` stream contract. Matching
+responses route back through `task_send`. Authorization uses the same task binding but remains a
+distinct event because it has different disclosure rules.
+
+The proposed routing policy makes terminal updates and `input_required` wake a parked parent
+session. Progress updates change task state and emit client-visible lifecycle events, but do not
+start a model turn on their own. During an active turn, inbound task events wait for the next safe
+step boundary. They never interrupt an active model call.
+
+```mermaid
+sequenceDiagram
+    participant M as Parent model
+    participant H as Parent harness
+    participant T as Durable task run
+    participant C as Child executor
+
+    M->>H: subagent tool call
+    H->>T: create working task
+    H->>C: dispatch with TaskBinding
+    C-->>H: acknowledge childSessionId
+    H-->>M: task receipt
+    M->>H: continue turn or task_await
+
+    C->>T: task.update, task.message, or authorization
+    T->>H: full task snapshot
+    H->>H: queue until safe boundary
+    H-->>M: await result or later task notification
+```
+
+### Agent-to-agent dependency
+
+This plan depends on the session-addressing route and authentication envelope from the first
+phase of the [agent2agent communication proposal]. Tasks and agent handles must not collapse into
+one record:
+
+- the task identifies the current unit of work;
+- the handle identifies the reusable child session;
+- the task's private `TaskExecutorBinding` lets `task_send` address in-flight work;
+- resuming that child creates a new task bound to the same handle.
+
+The A2A draft currently records a handle after the child's first result. That is too late for
+`task_send` during `working` or `input_required`. Task dispatch must persist the private executor
+binding as soon as the child acknowledges its session. The same acknowledgement may create or
+update the reusable agent handle. Both records may reuse the A2A inbox route, but routing tokens
+belong in one shared credential store rather than two independent session-addressing mechanisms.
+
+## MCP alignment
+
+The current [MCP Tasks extension] provides the closest standard vocabulary:
+
+- `working`, `input_required`, `completed`, `failed`, and `cancelled` statuses;
+- a durable task handle returned instead of a final tool result;
+- `tasks/get`, `tasks/update`, and `tasks/cancel` operations;
+- full task snapshots in `notifications/tasks`;
+- terminal states that do not change.
+
+eve's `task_peek`, `task_send`, and `task_cancel` map to those operations. `task_await` and
+`task_sleep` are eve controls, not MCP methods. eve is not implementing the MCP wire protocol in
+this work.
+
+One semantic difference needs an explicit decision. MCP treats a tool-level `isError: true`
+result as `completed`; `failed` is reserved for JSON-RPC execution failure. This draft's
+`TaskOutput` has separate `result` and `error` variants. The implementation must either adopt the
+MCP distinction or state why eve uses a different failure taxonomy.
+
+Cancellation also differs. MCP `tasks/cancel` acknowledges intent and allows the task to finish in
+a non-cancelled state. This draft commits `cancelled` before propagating abort and discards late
+results. That stronger guarantee is useful for model reasoning, but it is an eve semantic rather
+than MCP compatibility.
+
+## Delivery
+
+1. Add the task types, transition rules, durable task run, session index, and inert task service.
+2. Add the parent task tools but keep them undiscoverable until the experiment is enabled.
+3. Land the A2A handle and inbox dependency needed to address an existing child session.
+4. Behind `experimental.tasks`, create a task for every local and remote subagent call, return its
+   receipt, and dispatch the child with a task binding.
+5. Carry all five child flows over the task wire: terminal outcome, input request, authorization,
+   input response, and cancellation.
+6. Normalize local and remote subagents onto the same lifecycle while preserving their authored
+   definitions.
+
+## Acceptance criteria
+
+- With `experimental.tasks` absent or false, existing tool results, events, cancellation, and
+  subagent blocking behavior do not change.
+- With it enabled, a slow subagent returns a task receipt and the parent can take another model
+  step before the child completes.
+- The original tool call has exactly one result in durable history. Later task output cannot be
+  attached to that call a second time.
+- Local and remote subagents support the same five parent-child flows.
+- `task_await` returns on terminal status and `input_required`, including when the task was already
+  ready before the call.
+- `task_peek` observes current state without waking or mutating the executor.
+- `task_send` routes each response or message to the intended child session and cannot cross
+  parent-session ownership.
+- Cancellation is cooperative and idempotent. A late completion cannot overwrite `cancelled`.
+- Progress is durable latest state and a client-visible event, but does not create unbounded model
+  history or unsolicited model turns.
+- Replay returns the same task ID for the same originating call and never dispatches the child
+  twice.
+- Completing the parent session cancels its live tasks.
+- Resuming an existing child session creates a new task with a new task ID and the same
+  `childSessionId`.
+
+## Open questions
+
+1. What is the exact discriminated input for `task_send`, including arbitrary messages and
+   `InputResponse[]` batches?
+2. Should `TaskView` include a monotonic revision for notification deduplication, or can the task
+   run's stream index remain internal?
+3. Which output failures map to `failed` versus a completed tool result containing an error?
+4. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
+5. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
+6. Should a terminal background task always wake a parked conversation, or only become visible
+   through `task_peek` and explicit notification policy?
+7. Which task events enter model context, and how are repeated progress messages coalesced?
+8. How are child token usage and remaining parent budgets accounted after a background child
+   completes on a later turn?
+
+[Tools as Tasks proposal]: https://app.notion.com/p/3a5e06b059c48004ad1df5c7cfa58eea
+[agent2agent communication proposal]: https://app.notion.com/p/3abe06b059c4800da816f20918c5e628
+[PR #1085]: https://github.com/vercel/eve/pull/1085
+[PR #1190]: https://github.com/vercel/eve/pull/1190
+[MCP Tasks extension]: https://modelcontextprotocol.io/extensions/tasks/overview
+[`contextId`]: https://a2a-protocol.org/latest/topics/life-of-a-task/#group-related-interactions
+[`ToolDefinition` contract]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/public/definitions/tool.ts#L117-L142
+[`createNodeHarnessTools` lowering]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/execution/node-step.ts#L166-L234
+[runtime-action park path]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/harness/tool-loop.ts#L1949-L1996
+[serial dispatch loop]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/execution/dispatch-runtime-actions-step.ts#L104-L240
+[turn-level wait]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/execution/turn-workflow.ts#L159-L198
+[local subagent adapter]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/execution/subagent-adapter.ts#L18-L59
+[remote callback route]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/runtime/session-callback-route.ts#L13-L130
+[child response routing]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/execution/route-child-delivery.ts#L6-L32
+[descendant cancellation]: https://github.com/vercel/eve/blob/a5acde8255f5e8fe38d13755a93111bce841bf2a/packages/eve/src/execution/cancel-descendant-turns-step.ts#L66-L147

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1084
 status: draft
-last_updated: "2026-07-31"
+last_updated: "2026-08-01"
 ---
 
 # Subagents as tasks
@@ -370,10 +370,12 @@ eve's `task_peek`, `task_send`, and `task_cancel` map to those operations. `task
 `task_sleep` are eve controls, not MCP methods. eve is not implementing the MCP wire protocol in
 this work.
 
-One semantic difference needs an explicit decision. MCP treats a tool-level `isError: true`
-result as `completed`; `failed` is reserved for JSON-RPC execution failure. This draft's
-`TaskOutput` has separate `result` and `error` variants. The implementation must either adopt the
-MCP distinction or state why eve uses a different failure taxonomy.
+One semantic difference is decided. MCP treats a tool-level `isError: true` result as
+`completed`; `failed` is reserved for JSON-RPC execution failure. eve diverges: child failure
+maps to the `failed` status, and as a consequence of that transition the task's output carries
+the error (`TaskOutput.error`). Failure is the state; the error output is its consequence. The
+model reasons about one lifecycle field instead of cross-referencing a completed status against
+an error payload.
 
 Cancellation also differs. MCP `tasks/cancel` acknowledges intent and allows the task to finish in
 a non-cancelled state. This draft commits `cancelled` before propagating abort and discards late
@@ -428,15 +430,17 @@ than MCP compatibility.
    `InputResponse[]` batches?
 2. Should `TaskView` include a monotonic revision for notification deduplication, or can the task
    run's stream index remain internal?
-3. Which output failures map to `failed` versus a completed tool result containing an error?
-4. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
-5. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
-6. Should a terminal background task always wake a parked conversation, or only become visible
-   through `task_peek` and explicit notification policy?
-7. Which task events enter model context, and how are repeated progress messages coalesced?
-8. How are child token usage and remaining parent budgets accounted after a background child
+3. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
+4. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
+5. Which task events enter model context, and how are repeated progress messages coalesced?
+6. How are child token usage and remaining parent budgets accounted after a background child
    completes on a later turn?
 
+Two former open questions are settled and recorded in the [delivery plan]: failure taxonomy
+(`failed` carries the error output) and wake policy (terminal and `input_required` wake a
+parked parent; nothing else does).
+
+[delivery plan]: ./subagents-as-tasks-implementation.md
 [Tools as Tasks proposal]: https://app.notion.com/p/3a5e06b059c48004ad1df5c7cfa58eea
 [agent2agent communication proposal]: https://app.notion.com/p/3abe06b059c4800da816f20918c5e628
 [PR #1085]: https://github.com/vercel/eve/pull/1085

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -11,7 +11,8 @@ last_updated: "2026-07-31"
 Under an opt-in `experimental.tasks` mode, eve should represent long-running work as durable,
 addressable tasks. This plan applies that model only to local and remote subagents. A subagent call
 returns a task receipt after dispatch instead of keeping the parent turn blocked until the child
-finishes. The parent can inspect, await, message, or cancel the task with framework-owned tools.
+finishes. The parent can inspect, await, message, or cancel the task with framework-owned tools,
+and the child can intentionally report progress to its parent with one framework-owned tool.
 
 Without the flag, current tool and subagent behavior must remain unchanged.
 
@@ -52,6 +53,8 @@ cancel paths.
 
 - Let a parent continue its turn while delegated work runs.
 - Give the model explicit task controls instead of making every wait implicit.
+- Let a child intentionally report progress to its parent instead of leaving progress to
+  channel-layer guesswork.
 - Carry progress, input requests, authorization events, results, failures, and cancellation over
   one local and remote task contract.
 - Keep task state durable across turns and replay.
@@ -79,11 +82,19 @@ A **child session** is the resumable conversation owned by a delegated agent. A 
 the same child session creates a new task bound to the same `childSessionId`. This matches A2A's
 separation between immutable tasks and a longer-lived [`contextId`].
 
+A **runtime action** is today's framework-internal dispatch mechanism behind execute-less tools
+such as subagent calls. This plan changes how the runtime executes the two subagent kinds, not
+how authored files lower to them.
+
 A **synchronous invocation** runs inside the current harness step. Its result may trigger another
 model step in the same turn.
 
 A **background task** is owned by the parent session, not the originating turn. It may complete,
 request input, or emit progress after that turn ends.
+
+**Delegated execution** is a runtime execution mode, not a tool-authoring surface. A delegated
+dispatch returns once the executor acknowledges the work; the task stays `working`, and every
+later transition arrives over the task wire.
 
 `completed`, `failed`, and `cancelled` are terminal statuses. `input_required` is not terminal,
 but it is ready for parent action. `task_await` must return for either condition so a parent never
@@ -132,6 +143,26 @@ The controls have distinct behavior:
 - `task_cancel` requests cooperative cancellation. A committed terminal state is final, so a late
   child result cannot revive a cancelled task.
 - `task_sleep` durably pauses the current turn for paced checks. It does not poll or mutate a task.
+
+### Child task tools
+
+A child session dispatched as a task receives one framework-owned tool:
+
+```ts
+interface TaskChildTools {
+  task_message(input: { message: string }): Promise<TaskToolResult<boolean>>;
+}
+```
+
+`task_message` emits a `task.message` event through the task binding and updates the task's
+durable `statusMessage`. It returns after the update is durably recorded. It does not change the
+child's lifecycle and is not a substitute for the terminal result.
+
+No child-facing surface exists today: child-to-parent communication is entirely harness-level.
+The [local subagent adapter] forwards events as side effects the child model never sees, and the
+[remote callback route] accepts only terminal payloads. This tool is the model-facing half of the
+proposal's original motivation — letting a child report progress on purpose rather than having
+channels infer it.
 
 ### Task view
 
@@ -187,7 +218,7 @@ history append-only and leaves no dangling provider tool call.
 
 The mutable task record should live in a dedicated durable task run. That run is the single writer
 for lifecycle transitions and appends a full `TaskView` snapshot after each accepted command.
-Other paths address it through a command hook and read its stream.
+Other paths submit commands to that run and read its snapshots.
 
 The parent session stores only a live-task index:
 
@@ -223,6 +254,24 @@ completed, failed, and cancelled are final
 - Replayed creation for the same parent session and tool-call ID returns the same task and must not
   dispatch duplicate work.
 
+## Delegated execution
+
+Today the runtime parks subagent tool calls, dispatches them serially as a batch after the
+synchronous calls, and holds the turn until every action in the batch resolves (the
+[runtime-action park path], [serial dispatch loop], and [turn-level wait]). Delegated execution
+replaces the park-and-wait mechanism in the same dispatch codepath:
+
+1. The harness creates a durable `working` task for the subagent call.
+2. It dispatches the child with the task binding.
+3. The child acknowledges its `childSessionId`, which is persisted immediately.
+4. The originating call receives its receipt and the turn continues.
+
+Everything after acknowledgement — progress, input requests, authorization, terminal outcome —
+arrives over the task wire instead of resolving the dispatch. Delegated execution is an agent
+runtime change, not a `defineTool` change: authored tool contracts and the `runtimeAction`
+lowering stay as they are, and the mode lands inert until the experiment selects the two subagent
+kinds into it. A later phase can expose delegation to authored tools on top of the same mode.
+
 ## Parent and executor wire contract
 
 The parent-facing half of a task binding is passed to a local or remote child executor. Routing
@@ -250,6 +299,20 @@ An `input_required` transition carries the full outstanding request batch in its
 The parent emits those requests through the normal `input.requested` stream contract. Matching
 responses route back through `task_send`. Authorization uses the same task binding but remains a
 distinct event because it has different disclosure rules.
+
+The five flows that split across two transports today all converge on this one contract, for
+local and remote children alike:
+
+| Flow                              | Over the task wire                                            |
+| --------------------------------- | ------------------------------------------------------------- |
+| Terminal result or failure        | `task.update` with a terminal snapshot                        |
+| Input request, including approval | `task.update` with `input_required` and the outstanding batch |
+| Authorization event               | `task.authorization`                                          |
+| Input response                    | `task_send` addressed to the owning task                      |
+| Cancellation                      | `task_cancel`, committed then propagated to the executor      |
+
+Progress is the sixth flow, new in this plan: `task.message` from the child's `task_message`
+tool, durably recorded as the task's latest `statusMessage`.
 
 The proposed routing policy makes terminal updates and `input_required` wake a parked parent
 session. Progress updates change task state and emit client-visible lifecycle events, but do not
@@ -319,15 +382,20 @@ than MCP compatibility.
 
 ## Delivery
 
-1. Add the task types, transition rules, durable task run, session index, and inert task service.
-2. Add the parent task tools but keep them undiscoverable until the experiment is enabled.
+1. Land the task foundation inert: types, transition rules, durable task run, session index, and
+   the parent and child task tools, all undiscoverable without the experiment.
+2. Land delegated execution in the runtime, inert: dispatch acknowledges, the task stays
+   `working`, and nothing selects the mode yet.
 3. Land the A2A handle and inbox dependency needed to address an existing child session.
-4. Behind `experimental.tasks`, create a task for every local and remote subagent call, return its
-   receipt, and dispatch the child with a task binding.
-5. Carry all five child flows over the task wire: terminal outcome, input request, authorization,
-   input response, and cancellation.
-6. Normalize local and remote subagents onto the same lifecycle while preserving their authored
-   definitions.
+4. Behind `experimental.tasks`, run subagent runtime actions as tasks: create the task in the
+   runtime-action dispatch codepath, return its receipt, and dispatch the child with a task
+   binding.
+5. Carry all six child flows over the task wire: terminal outcome, input request, authorization,
+   input response, cancellation, and progress.
+6. Normalize local and remote subagents onto the same delegated execution path while preserving
+   their authored definitions.
+7. Make tasks the default subagent execution path and retire the flag once the acceptance
+   criteria hold.
 
 ## Acceptance criteria
 
@@ -337,7 +405,9 @@ than MCP compatibility.
   step before the child completes.
 - The original tool call has exactly one result in durable history. Later task output cannot be
   attached to that call a second time.
-- Local and remote subagents support the same five parent-child flows.
+- Local and remote subagents support the same six parent-child flows.
+- A child dispatched as a task can call `task_message`; the parent observes the durable latest
+  message through `task_peek` without a model turn starting on its own.
 - `task_await` returns on terminal status and `input_required`, including when the task was already
   ready before the call.
 - `task_peek` observes current state without waking or mutating the executor.


### PR DESCRIPTION
This is the contract for running subagents as durable background tasks after the agent-messaging stack lands. It changes no runtime behavior.

Today a subagent call leaves the model step as a private `runtimeAction`. eve starts the child, then keeps the parent turn open until every child in the batch finishes. Local children can forward input and authorization through that active turn; remote children can only report completion or failure.

That boundary works for synchronous delegation. It does not work for background work: the parent cannot move on while the child runs, progress has no shared local/remote path, and non-terminal communication depends on the original turn still being alive.

## Proposed flow

With `experimental.tasks`, each subagent call creates a durable task. The original tool call receives one task receipt, closing that call. Progress, input requests, authorization, completion, failure, and cancellation then move over the task boundary without keeping the parent turn open.

```text
parent model
    |
    v
parent harness ---- creates/indexes ----> task run
    |                                      | owns lifecycle state
    +---- resolves ---------------------> agent handle
    |                                      | owns child address
    +---- dispatches --------------------> child executor
                                           |
                                           +---- updates task run

parent returns to task through task_peek / task_await / notifications
```

The ownership split is the main design decision. The task run is the single writer for lifecycle transitions. The parent session stores only the `taskId -> taskRunId` index. Agent handles remain the source of child identity and routing. Credentials stay in private bindings and never enter model context or history.

The dedicated task run comes from the failure exposed by [#1190](https://github.com/vercel/eve/pull/1190): callback routes and child executors need to update task state, but neither owns the current threaded session snapshot. A separate durable run gives those writers a stable boundary and serializes competing updates.

## Delivery shape

The rollout is additive. Flag plumbing, task storage, gated controls, and delegated execution land inert first. A later stage moves the six child flows onto the task wire and lets the flag select the new mode. Local/remote normalization and flag removal come last.

This plan assumes the agent-messaging stack [#1328](https://github.com/vercel/eve/pull/1328)-[#1331](https://github.com/vercel/eve/pull/1331) as its addressing layer. Tasks compose with agent handles; they do not introduce another child-session identity or credential store.

The first implementation is subagents only. Authored tools, built-ins, connections, skills, dynamic workflows, and the public `defineTool` API stay unchanged. MCP Tasks provides lifecycle vocabulary and control semantics, not an MCP endpoint.

## Review focus

- **Sequencing:** the design and delivery plan currently disagree on whether agent messaging is already the baseline. They should both describe tasks as phase 2.
- **Creation:** define the task shape before child acknowledgement, including local metadata and dispatch-start failure.
- **Wake policy:** decide when terminal and `input_required` updates wake a parked parent instead of waiting for an explicit task control.
- **Busy semantics:** decide whether `task_send` queues behind a running child or returns `AGENT_BUSY`.
- **Trust and retention:** narrow which fields an executor may update, then define how long terminal tasks remain addressable.

Part of [#1084](https://github.com/vercel/eve/issues/1084).
