### PR TITLE
feat(eve): add guided Linear Agent setup

### DIFF
--- a/.changeset/linear-agent-session-trigger.md
+++ b/.changeset/linear-agent-session-trigger.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Configure new Linear connectors to receive only Agent Session webhook events, avoiding unrelated default Linear webhook deliveries.

--- a/.changeset/lucky-linear-agent-setup.md
+++ b/.changeset/lucky-linear-agent-setup.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add guided Linear Agent channel setup through `eve add channel/linear-agent`. The flow provisions a Vercel Connect Linear app, routes verified Agent Session events, scaffolds the channel, and explains how to install and use the agent in Linear.

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -287,25 +287,23 @@ export default githubChannel({
     logo: "linear",
     docsHref: "/docs/channels/linear",
     keywords: ["issues", "comments", "agent sessions", "developer preview", "webhook"],
-    install: `Add this channel from eve's registry. This writes \`agent/channels/linear.ts\`:
+    install: `Add this channel from eve's registry to create a Vercel Connect client, route verified Agent Session events, and write \`agent/channels/linear.ts\`:
 
 \`\`\`bash
 eve add channel/linear-agent
 \`\`\``,
-    quickStart: `Create \`agent/channels/linear.ts\`:
+    quickStart: `The guided setup writes \`agent/channels/linear.ts\`:
 
 \`\`\`ts
 // agent/channels/linear.ts
+import { connectLinearCredentials } from "@vercel/connect/eve";
 import { linearChannel } from "eve/channels/linear";
 
 export default linearChannel({
-  credentials: {
-    accessToken: () => process.env.LINEAR_AGENT_ACCESS_TOKEN!,
-    webhookSecret: () => process.env.LINEAR_WEBHOOK_SECRET!,
-  },
+  credentials: connectLinearCredentials("linear/my-agent"),
 });
 \`\`\``,
-    configure: `Create a Linear OAuth app with Agent Session events enabled, make the app assignable and mentionable, and point the webhook at eve's route (\`/eve/v1/linear\`). Provide the app access token and webhook secret through environment variables. See the [Linear channel docs](/docs/channels/linear) for scopes and Agent Activity behavior.`,
+    configure: `Sign in to Vercel, then let the guided flow create or link a project, provision the Linear app, and attach its verified AgentSessionEvent trigger to \`/eve/v1/linear\`. Deploy, install the app in your Linear workspace from Vercel Connect, then delegate an issue or mention the agent. See the [Linear channel docs](/docs/channels/linear) for Agent Activity behavior.`,
   },
   eve: {
     logo: "eve",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1178,18 +1178,19 @@
       "name": "channel/linear-agent",
       "type": "registry:item",
       "title": "Linear Agent",
-      "description": "Delegate Linear issues and comments to your agent through Linear's Agent Sessions.",
-      "envVars": {
-        "LINEAR_AGENT_ACCESS_TOKEN": "",
-        "LINEAR_WEBHOOK_SECRET": ""
-      },
-      "files": [
-        {
-          "path": "registry/channels/linear-agent.ts",
-          "type": "registry:file",
-          "target": "agent/channels/linear.ts"
+      "description": "Delegate Linear issues and comments through Agent Sessions, with guided Vercel Connect setup.",
+      "meta": {
+        "eve": {
+          "setup": {
+            "command": "eve",
+            "package": "eve",
+            "bin": "eve",
+            "args": ["integration", "setup", "linear"]
+          },
+          "requires": ">=0.31.0"
         }
-      ]
+      },
+      "dependencies": ["@vercel/connect"]
     },
     {
       "name": "channel/web",

--- a/apps/docs/scripts/validate-channel-registry.ts
+++ b/apps/docs/scripts/validate-channel-registry.ts
@@ -35,6 +35,7 @@ const registrySlugsByCatalogSlug: Readonly<Record<string, string>> = {
 
 const setupKindsByCatalogSlug: Readonly<Record<string, string>> = {
   discord: "discord",
+  "linear-agent": "linear",
   eve: "web",
   photon: "photon",
 };
@@ -114,6 +115,7 @@ for (const [index, item] of items.entries()) {
   if (
     entry.slug === "slack" ||
     entry.slug === "discord" ||
+    entry.slug === "linear-agent" ||
     entry.slug === "eve" ||
     entry.slug === "photon"
   ) {

--- a/docs/channels/linear.mdx
+++ b/docs/channels/linear.mdx
@@ -6,24 +6,19 @@ type: integration
 
 The Linear channel uses Linear's Agent Session surface rather than ordinary comments. Users delegate work to the agent from Linear, eve receives `AgentSessionEvent` webhooks at `/eve/v1/linear`, and the channel replies with native Agent Activities, including `thought`, `action`, `elicitation`, `response`, and `error`. Credentials can run through [Vercel Connect](../guides/auth-and-route-protection), which manages the Linear app, its access token, and inbound webhook verification, so there's no API key or webhook secret for you to hold. See [Channels](./overview) for the contract this builds on.
 
-## Set up Connect
+## Guided Connect setup
 
-Create a Linear Connect client and copy its UID (e.g. `linear/my-agent`), then attach this project as the trigger destination at eve's Linear route:
-
-```bash
-npm install -g vercel@latest
-vercel connect create linear --triggers
-vercel connect detach <uid> --yes
-vercel connect attach <uid> --triggers --trigger-path /eve/v1/linear --yes
-```
-
-The `create` step provisions the Linear app — with the `app:assignable` and `app:mentionable` scopes the agent surface needs — and a trigger destination at the default Connect path. `detach` then `attach --trigger-path /eve/v1/linear` re-points the trigger at the eve Linear route, since eve does not serve the default Connect path. `--triggers` makes Connect receive Linear's webhooks, verify them, and forward them to your deployment. During registration, subscribe to the `AgentSessionEvent` webhook category — the managed app defaults to `Comment` and `Issue` — so Linear sends `created` events when the agent is delegated or mentioned and `prompted` events when the user continues the session. You can also create the client from the [Connect dashboard](https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Go+to+Connect).
-
-## Add the channel
+Run the registry setup from the agent directory:
 
 ```bash
-npm install @vercel/connect
+eve add channel/linear-agent
 ```
+
+The flow checks that the Vercel CLI is authenticated, creates or links a Vercel project when needed, provisions an app-scoped Linear Connect client, and replaces its default trigger with `/eve/v1/linear`. It then installs `@vercel/connect` and writes `agent/channels/linear.ts` with the connector UID.
+
+Vercel Connect creates the Linear app with the `app:assignable` and `app:mentionable` scopes required for Agent Sessions, receives and verifies `AgentSessionEvent` webhooks, and forwards them to the deployed agent. After deploying, open the Linear app in the Connect dashboard and install it in the workspace where you want to delegate work. Then delegate an issue or mention the agent in a Linear Agent Session.
+
+The generated channel uses Connect-managed credentials:
 
 ```ts title="agent/channels/linear.ts"
 import { connectLinearCredentials } from "@vercel/connect/eve";

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "syncpack": "15.3.2",
     "turbo": "2.9.18",
     "typescript": "catalog:",
-    "vercel": "58.4.0",
+    "vercel": "58.5.1",
     "vitest": "catalog:"
   },
   "simple-git-hooks": {

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -129,7 +129,8 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     slug: "linear-agent",
     name: "Linear Agent",
     kind: "channel",
-    tagline: "Delegate Linear issues and comments to your agent through Linear's Agent Sessions.",
+    tagline:
+      "Delegate Linear issues and comments through Agent Sessions, with guided Connect setup.",
     surfaces: { scaffoldable: false, gallery: true },
   },
   {

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -2286,6 +2286,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
         mask: opts.mask === true,
       };
       if (opts.placeholder !== undefined) state.placeholder = opts.placeholder;
+      else if (opts.defaultValue !== undefined) state.placeholder = opts.defaultValue;
       if (opts.notices !== undefined) state.notices = opts.notices;
       if (error !== undefined) state.error = error;
       return renderTextQuestion(state, this.#theme, width, this.#caretVisible);

--- a/packages/eve/src/setup/integrations/linear/connect.test.ts
+++ b/packages/eve/src/setup/integrations/linear/connect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChannelSetupLog } from "#setup/cli/index.js";
+import {
+  findLinearConnector,
+  parseCreatedLinearConnector,
+  provisionLinearConnector,
+} from "./connect.js";
+
+function log(): ChannelSetupLog {
+  return {
+    message: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    commandOutput: vi.fn(),
+  };
+}
+
+describe("Linear Connect provisioning", () => {
+  it("parses an app-scoped Linear connector", () => {
+    expect(
+      parseCreatedLinearConnector(
+        JSON.stringify({
+          id: "scl_linear",
+          uid: "linear/agent",
+          supportedSubjectTypes: ["app"],
+        }),
+      ),
+    ).toEqual({ id: "scl_linear", uid: "linear/agent" });
+  });
+
+  it("finds an existing Linear connector", async () => {
+    const runVercelCaptureStdout = vi.fn(async () => ({
+      ok: true as const,
+      stdout: JSON.stringify({
+        connectors: [
+          { id: "scl_other", uid: "linear/other" },
+          { id: "scl_agent", uid: "linear/agent" },
+        ],
+      }),
+      stderr: "",
+    }));
+
+    await expect(
+      findLinearConnector({
+        project: { orgId: "team_123", projectId: "prj_123" },
+        projectRoot: "/project",
+        slug: "agent",
+        deps: { runVercel: vi.fn(), runVercelCaptureStdout },
+      }),
+    ).resolves.toEqual({ id: "scl_agent", uid: "linear/agent" });
+  });
+
+  it("creates the connector and replaces its trigger", async () => {
+    const runVercelCaptureStdout = vi.fn(async () => ({
+      ok: true as const,
+      stdout: JSON.stringify({
+        id: "scl_linear",
+        uid: "linear/agent",
+        supportedSubjectTypes: ["app"],
+      }),
+      stderr: "",
+    }));
+    const runVercel = vi.fn(async () => true);
+
+    await expect(
+      provisionLinearConnector({
+        log: log(),
+        project: { orgId: "team_123", projectId: "prj_123" },
+        projectRoot: "/project",
+        slug: "agent",
+        deps: { runVercel, runVercelCaptureStdout },
+      }),
+    ).resolves.toEqual({ id: "scl_linear", uid: "linear/agent" });
+
+    expect(runVercelCaptureStdout).toHaveBeenCalledWith(
+      [
+        "connect",
+        "create",
+        "linear",
+        "--name",
+        "agent",
+        "--triggers",
+        "--trigger-event",
+        "AgentSessionEvent",
+        "-F",
+        "json",
+        "--scope",
+        "team_123",
+      ],
+      expect.objectContaining({ cwd: "/project", nonInteractive: true }),
+    );
+    expect(runVercel).toHaveBeenNthCalledWith(
+      2,
+      [
+        "connect",
+        "attach",
+        "linear/agent",
+        "--project",
+        "prj_123",
+        "--environment",
+        "production",
+        "--triggers",
+        "--trigger-path",
+        "/eve/v1/linear",
+        "--yes",
+        "--scope",
+        "team_123",
+      ],
+      expect.objectContaining({ cwd: "/project", nonInteractive: true }),
+    );
+  });
+});

--- a/packages/eve/src/setup/integrations/linear/connect.ts
+++ b/packages/eve/src/setup/integrations/linear/connect.ts
@@ -1,0 +1,159 @@
+import { createPromptCommandOutput, withPhase, type ChannelSetupLog } from "#setup/cli/index.js";
+import { replaceConnectTrigger } from "#setup/connect-provisioning.js";
+import type { VercelProjectReference } from "#setup/project-resolution.js";
+import { runVercel, runVercelCaptureStdout } from "#setup/primitives/run-vercel.js";
+import { z } from "zod";
+
+export const LINEAR_TRIGGER_PATH = "/eve/v1/linear";
+const LINEAR_AGENT_SESSION_TRIGGER_EVENT = "AgentSessionEvent";
+
+/** Identity of the Linear connector provisioned for an agent channel. */
+export interface LinearConnectorRef {
+  id: string;
+  uid: string;
+}
+
+/** Effects used to provision a Linear Connect connector. */
+export interface ProvisionLinearConnectorDeps {
+  runVercel: typeof runVercel;
+  runVercelCaptureStdout: typeof runVercelCaptureStdout;
+}
+
+const LinearConnectorRefSchema = z.object({
+  id: z.string().min(1),
+  uid: z.string().min(1),
+  supportedSubjectTypes: z.array(z.string()).refine((types) => types.includes("app")),
+});
+
+/** Parses `vercel connect create -F json` output for an app-scoped Linear connector. */
+export function parseCreatedLinearConnector(stdout: string): LinearConnectorRef | undefined {
+  try {
+    const parsed = LinearConnectorRefSchema.safeParse(JSON.parse(stdout));
+    return parsed.success ? { id: parsed.data.id, uid: parsed.data.uid } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Finds the canonical Linear connector if it already exists in this Vercel team. */
+export async function findLinearConnector(input: {
+  project: VercelProjectReference;
+  projectRoot: string;
+  slug: string;
+  signal?: AbortSignal;
+  deps?: ProvisionLinearConnectorDeps;
+}): Promise<LinearConnectorRef | undefined> {
+  const deps = input.deps ?? { runVercel, runVercelCaptureStdout };
+  const result = await deps.runVercelCaptureStdout(
+    [
+      "connect",
+      "list",
+      "--all-projects",
+      "--service",
+      "linear",
+      "-F",
+      "json",
+      "--scope",
+      input.project.orgId,
+    ],
+    { cwd: input.projectRoot, nonInteractive: true, signal: input.signal },
+  );
+  if (!result.ok) return undefined;
+  try {
+    const parsed = JSON.parse(result.stdout) as { connectors?: unknown };
+    if (!Array.isArray(parsed.connectors)) return undefined;
+    const expectedUid = `linear/${input.slug}`;
+    const connector = parsed.connectors.find(
+      (value): value is Record<string, unknown> =>
+        typeof value === "object" &&
+        value !== null &&
+        (value as { uid?: unknown }).uid === expectedUid,
+    );
+    return typeof connector?.id === "string" ? { id: connector.id, uid: expectedUid } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Attaches a Linear connector's verified events to this agent's production route. */
+export async function attachLinearConnector(input: {
+  connector: LinearConnectorRef;
+  log: ChannelSetupLog;
+  project: VercelProjectReference;
+  projectRoot: string;
+  signal?: AbortSignal;
+  deps?: ProvisionLinearConnectorDeps;
+}): Promise<void> {
+  const deps = input.deps ?? { runVercel, runVercelCaptureStdout };
+  const onOutput = createPromptCommandOutput(input.log);
+  const attachment = await withPhase(input.log, "Connecting Linear Agent Sessions...", () =>
+    replaceConnectTrigger({
+      connectorUid: input.connector.uid,
+      projectRoot: input.projectRoot,
+      projectId: input.project.projectId,
+      orgId: input.project.orgId,
+      environment: "production",
+      triggerPath: LINEAR_TRIGGER_PATH,
+      onOutput,
+      signal: input.signal,
+      deps,
+    }),
+  );
+  input.signal?.throwIfAborted();
+  if (attachment.state !== "attached") {
+    throw new Error(
+      `Linear connector was found, but its trigger could not be attached. Run \`vercel connect attach ${input.connector.uid} --project ${input.project.projectId} --environment production --triggers --trigger-path ${LINEAR_TRIGGER_PATH} --yes --scope ${input.project.orgId}\`.`,
+    );
+  }
+}
+
+/** Creates a Linear connector and routes its verified Agent Session events to eve. */
+export async function provisionLinearConnector(input: {
+  log: ChannelSetupLog;
+  project: VercelProjectReference;
+  projectRoot: string;
+  slug: string;
+  signal?: AbortSignal;
+  deps?: ProvisionLinearConnectorDeps;
+}): Promise<LinearConnectorRef> {
+  const deps = input.deps ?? { runVercel, runVercelCaptureStdout };
+  const onOutput = createPromptCommandOutput(input.log);
+  const result = await withPhase(input.log, "Creating Linear connector...", () =>
+    deps.runVercelCaptureStdout(
+      [
+        "connect",
+        "create",
+        "linear",
+        "--name",
+        input.slug,
+        "--triggers",
+        "--trigger-event",
+        LINEAR_AGENT_SESSION_TRIGGER_EVENT,
+        "-F",
+        "json",
+        "--scope",
+        input.project.orgId,
+      ],
+      {
+        cwd: input.projectRoot,
+        nonInteractive: true,
+        onOutput,
+        signal: input.signal,
+      },
+    ),
+  );
+  input.signal?.throwIfAborted();
+  if (!result.ok) {
+    const detail = [result.stderr, result.stdout].find(
+      (value): value is string => value !== undefined && value.trim().length > 0,
+    );
+    throw new Error(
+      detail ? `Linear connector creation failed:\n${detail}` : "Linear connector creation failed.",
+    );
+  }
+  const connector = parseCreatedLinearConnector(result.stdout);
+  if (connector === undefined) throw new Error("Vercel returned an invalid Linear connector.");
+
+  await attachLinearConnector({ ...input, connector, deps });
+  return connector;
+}

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import type { Asker, Question } from "#setup/ask.js";
+
+import { integrationSetupEnvironment } from "../shared/environment.js";
+import { createIntegrationSetupUi } from "../shared/ui.js";
+import { linearSafeConnectorSlug, setupLinear, type LinearSetupDeps } from "./setup.js";
+
+function deps(): LinearSetupDeps {
+  return {
+    attachConnector: vi.fn(async () => {}),
+    deriveConnectorSlug: vi.fn(async () => "agent" as never),
+    ensureVercelProject: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
+    findConnector: vi.fn(async () => undefined),
+    provisionConnector: vi.fn(async () => ({ id: "scl_linear", uid: "linear/agent" })),
+    writeTextFile: vi.fn(async () => {}),
+  };
+}
+
+function recommendedAsker(): Asker {
+  const ask = async <T>(question: Question<T>): Promise<T> => question.recommended as T;
+  const askMany: Asker["askMany"] = async () => [];
+  return { ask, askMany };
+}
+
+describe("Linear setup", () => {
+  it("removes Linear from managed app names", () => {
+    expect(linearSafeConnectorSlug("eve-linear-agent")).toBe("eve-agent");
+    expect(linearSafeConnectorSlug("linear")).toBe("agent");
+  });
+
+  it("provisions Connect, routes Agent Session events, and scaffolds the channel", async () => {
+    const fake = createFakePrompter();
+    const effects = deps();
+
+    const result = await setupLinear(
+      {
+        appRoot: "/project",
+        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({ asker: recommendedAsker(), prompter: fake.prompter }),
+      },
+      effects,
+    );
+
+    expect(result).toMatchObject({
+      kind: "done",
+      facts: [
+        {
+          label: "Vercel Connect",
+          value: "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect",
+          kind: "url",
+        },
+      ],
+    });
+
+    expect(effects.provisionConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: "agent" }),
+    );
+    expect(effects.writeTextFile).toHaveBeenCalledWith(
+      "/project/agent/channels/linear.ts",
+      expect.stringContaining('connectLinearCredentials("linear/agent")'),
+      { force: undefined },
+    );
+  });
+
+  it("reuses an existing connector when selected", async () => {
+    const fake = createFakePrompter();
+    const effects = deps();
+    vi.mocked(effects.findConnector).mockResolvedValue({ id: "scl_existing", uid: "linear/agent" });
+    const asker = recommendedAsker();
+
+    await expect(
+      setupLinear(
+        {
+          appRoot: "/project",
+          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+          ui: createIntegrationSetupUi({ asker, prompter: fake.prompter }),
+        },
+        effects,
+      ),
+    ).resolves.toMatchObject({ kind: "done" });
+
+    expect(effects.attachConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ connector: { id: "scl_existing", uid: "linear/agent" } }),
+    );
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+  });
+
+  it("requires an authenticated Vercel CLI", async () => {
+    const fake = createFakePrompter();
+    await expect(
+      setupLinear({
+        appRoot: "/project",
+        environment: integrationSetupEnvironment("logged-out", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({ asker: recommendedAsker(), prompter: fake.prompter }),
+      }),
+    ).rejects.toThrow("vercel login");
+  });
+});

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -1,0 +1,171 @@
+import { join } from "node:path";
+
+import { select, text } from "#setup/ask.js";
+import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
+import { deriveSlackConnectorSlug, normalizeSlackConnectorSlug } from "#setup/scaffold/index.js";
+import { writeTextFile } from "#setup/scaffold/files.js";
+import { WizardCancelledError } from "#setup/step.js";
+
+import type {
+  IntegrationSetupContext,
+  IntegrationSetupResult,
+  SetupIntegration,
+} from "../types.js";
+import {
+  attachLinearConnector,
+  findLinearConnector,
+  provisionLinearConnector,
+  type LinearConnectorRef,
+} from "./connect.js";
+
+export interface LinearSetupDeps {
+  attachConnector: typeof attachLinearConnector;
+  deriveConnectorSlug: typeof deriveSlackConnectorSlug;
+  ensureVercelProject: typeof ensureVercelProject;
+  findConnector: typeof findLinearConnector;
+  provisionConnector: typeof provisionLinearConnector;
+  writeTextFile: typeof writeTextFile;
+}
+
+const defaultDeps: LinearSetupDeps = {
+  attachConnector: attachLinearConnector,
+  deriveConnectorSlug: deriveSlackConnectorSlug,
+  ensureVercelProject,
+  findConnector: findLinearConnector,
+  provisionConnector: provisionLinearConnector,
+  writeTextFile,
+};
+
+/** Linear does not allow its brand name in a managed app's name. */
+export function linearSafeConnectorSlug(slug: string): string {
+  const withoutLinear = slug.replaceAll(/linear/gi, "").replace(/[-_]{2,}/g, "-");
+  return normalizeSlackConnectorSlug(withoutLinear || "agent");
+}
+
+function connectTemplate(uid: string): string {
+  return `import { connectLinearCredentials } from "@vercel/connect/eve";
+import { linearChannel } from "eve/channels/linear";
+
+export default linearChannel({
+  credentials: connectLinearCredentials(${JSON.stringify(uid)}),
+});
+`;
+}
+
+async function chooseConnector(
+  context: IntegrationSetupContext,
+  deps: LinearSetupDeps,
+  project: Awaited<ReturnType<typeof ensureVercelProject>>,
+): Promise<LinearConnectorRef | undefined> {
+  const defaultSlug = linearSafeConnectorSlug(await deps.deriveConnectorSlug(context.appRoot));
+  const slug = linearSafeConnectorSlug(
+    await context.ui.asker.ask(
+      text({
+        key: "linear.connector-name",
+        message: "Name your Linear agent",
+        recommended: defaultSlug,
+        validate: (value) =>
+          value.trim().length === 0 ? "A Linear agent name is required." : null,
+      }),
+    ),
+  );
+  const existing = await deps.findConnector({
+    project,
+    projectRoot: context.appRoot,
+    slug,
+    signal: context.signal,
+  });
+  if (existing !== undefined) {
+    const choice = await context.ui.asker.ask(
+      select({
+        key: "linear.existing-connector",
+        message: `A Linear connector named "${slug}" already exists. What would you like to do?`,
+        options: [
+          { id: "reuse", label: "Reuse existing connector", value: "reuse" as const },
+          { id: "new", label: "Create a new connector", value: "new" as const },
+          { id: "exit", label: "Exit setup", value: "exit" as const },
+        ],
+        recommended: "reuse" as const,
+      }),
+    );
+    if (choice === "exit") return undefined;
+    if (choice === "reuse") {
+      await deps.attachConnector({
+        connector: existing,
+        log: context.ui.prompter.log,
+        project,
+        projectRoot: context.appRoot,
+        signal: context.signal,
+      });
+      return existing;
+    }
+  }
+
+  const connectorSlug =
+    existing === undefined
+      ? slug
+      : linearSafeConnectorSlug(
+          await context.ui.asker.ask(
+            text({
+              key: "linear.new-connector-name",
+              message: "Name the new Linear agent",
+              recommended: `${slug}-2`,
+              validate: (value) =>
+                value.trim().length === 0 ? "A Linear agent name is required." : null,
+            }),
+          ),
+        );
+  return deps.provisionConnector({
+    log: context.ui.prompter.log,
+    project,
+    projectRoot: context.appRoot,
+    slug: connectorSlug,
+    signal: context.signal,
+  });
+}
+
+/** Runs guided Linear Agent Session connector and channel setup. */
+export async function setupLinear(
+  context: IntegrationSetupContext,
+  deps: LinearSetupDeps = defaultDeps,
+): Promise<IntegrationSetupResult> {
+  if (context.environment.vercel.kind === "unavailable") {
+    throw new Error(
+      "Linear setup requires an authenticated Vercel CLI. Run `vercel login`, then retry.",
+    );
+  }
+  try {
+    const project = await deps.ensureVercelProject({
+      appRoot: context.appRoot,
+      prompter: context.ui.prompter,
+      signal: context.signal,
+    });
+    const connector = await chooseConnector(context, deps, project);
+    if (connector === undefined) return { kind: "cancelled" };
+    await deps.writeTextFile(
+      join(context.appRoot, "agent/channels/linear.ts"),
+      connectTemplate(connector.uid),
+      { force: context.force },
+    );
+    const dashboardUrl = "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect";
+    context.ui.nextSteps([
+      "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
+      "In Linear, delegate an issue or mention the agent in an Agent Session to start a conversation.",
+    ]);
+    return {
+      kind: "done",
+      facts: [{ label: "Vercel Connect", value: dashboardUrl, kind: "url" }],
+    };
+  } catch (error) {
+    if (error instanceof WizardCancelledError) return { kind: "cancelled" };
+    throw error;
+  }
+}
+
+/** Linear Agent Session setup registration. */
+export const LINEAR_SETUP: SetupIntegration = {
+  kind: "linear",
+  label: "Linear Agent",
+  hint: "Delegate Linear issues and comments",
+  setup: setupLinear,
+};

--- a/packages/eve/src/setup/integrations/registry.ts
+++ b/packages/eve/src/setup/integrations/registry.ts
@@ -1,4 +1,5 @@
 import { DISCORD_SETUP } from "./discord/setup.js";
+import { LINEAR_SETUP } from "./linear/setup.js";
 import { PHOTON_SETUP } from "./photon/setup.js";
 import { SLACK_SETUP } from "./slack/setup.js";
 import type { SetupIntegration } from "./types.js";
@@ -9,6 +10,7 @@ export const SETUP_INTEGRATIONS: readonly SetupIntegration[] = [
   WEB_SETUP,
   SLACK_SETUP,
   DISCORD_SETUP,
+  LINEAR_SETUP,
   PHOTON_SETUP,
 ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
       vercel:
-        specifier: 58.4.0
-        version: 58.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(bufferutil@4.1.0)(rollup@4.62.2)(supports-color@10.2.2)
+        specifier: 58.5.1
+        version: 58.5.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(bufferutil@4.1.0)(rollup@4.62.2)(supports-color@10.2.2)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -7433,28 +7433,31 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/backends@0.8.29':
-    resolution: {integrity: sha512-JlVAVV0IUCxgjaVRbxxVtkqJ9Q6RDncPJhJ20u+OZMTehq3Ezpqw0X+8ehymbBQhaIowIoELa0RBdu23DOisjw==}
+  '@vercel/backends@0.8.32':
+    resolution: {integrity: sha512-mYnxcC4PZqpJdJl4VDz6pHRKv1BUOiFUBJ6wYeBX+iywxTuh0ISnXtMa0OQDicSQzujvj3CKvm4DlFniqx1CwA==}
 
   '@vercel/blob@2.4.0':
     resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/build-utils@13.36.2':
-    resolution: {integrity: sha512-TC+LhfYxW0N17cqJoYHtow6ybMRF1v6NnlRWjeeyuWAdGwdzXcKYNuD1MqheshyNOrz2Hu9LpifxmpXvLqRHiA==}
+  '@vercel/build-utils@14.0.1':
+    resolution: {integrity: sha512-EGOVxPX5T6yYfITMZACezM0rDHByCXEJ7X42jGytl5bAYi/DSJR0S3PpRPOiqYOh46ml9LmRJyZeq5V13HeGDg==}
 
-  '@vercel/cervel@0.1.37':
-    resolution: {integrity: sha512-7RmHKPiA6xTiTlSkmxM0rMhGouJIdJve7wn2WVnFAJP2KWGaAY13IK/Md1EPUYyy70TXxeuhdQC+oY063kL3eQ==}
+  '@vercel/cervel@0.1.40':
+    resolution: {integrity: sha512-RaQfwOT4urYqwz+WSFT8PR1NQNpm/vI3uoK/5I0bs8zSWiS6KAHCVPIP6Lww5QZw8ctqMxu4xcyPmOnWGZvU7w==}
     hasBin: true
 
-  '@vercel/cli-auth@0.3.1':
-    resolution: {integrity: sha512-TaMXMiPrwcLoLxu6ExcJ8yEw8b8Qss6UZkNYF4xIq+/VdvAk0l8JCpeAwzuHgKuJqmIDrOvtfjHO2+T/MBR3dg==}
+  '@vercel/cli-auth@0.3.2':
+    resolution: {integrity: sha512-10LPmnA6Zg1BgFNzKzjUVcQrTbKl8rIUhXmvMWgo659qC2G0L7vFPf+EL4RZ2CG8onLo3Z5oS5y87zZlK9pWWA==}
 
   '@vercel/cli-config@0.2.0':
     resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
 
   '@vercel/cli-config@0.2.1':
     resolution: {integrity: sha512-RhfyXmRLHdbnry8RJqHDc+5rGxMZ0bu+fpysZjtv3bE+BubpuwxTancHOKiH5zKQREsdwFVr3mOI2kOvxlOyxA==}
+
+  '@vercel/cli-config@0.2.2':
+    resolution: {integrity: sha512-kAy35eymNzRBfmcqEViVQge0KJ59FYEKsPqGNCSJQ7M9HTuFGWd3qPcZos1A5cZpAWRBdiYe82Bcz9P7pIZvUQ==}
 
   '@vercel/cli-exec@1.0.0':
     resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
@@ -7483,24 +7486,28 @@ packages:
       eve:
         optional: true
 
-  '@vercel/container@0.1.0':
-    resolution: {integrity: sha512-m1Y3qT1JOUFKLXUI54hVHSkRTGrvI8LC7EPNsEE1MBME8gk8aoIB+lJWl59jd56MjTDcTc3NCzPdHIZ65grZkA==}
+  '@vercel/container@0.1.1':
+    resolution: {integrity: sha512-BYT1ViD7Xm0RLrCDrts4zu686pTlB27AcINDhXBrvshGe1Qm1IwjYYLLMltHQ+HiK8AX43j8GWTcyCQijzHIyQ==}
 
   '@vercel/detect-agent@1.2.3':
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.106':
-    resolution: {integrity: sha512-ho0ci5sAp0GsV+B+ACQxzOkL+NpOdAo/yCFE7AuL1En9aWYBUgRUGWFQTNarmK1fReOPRjwWn85FTIu2c2GOAQ==}
+  '@vercel/detect-agent@1.2.4':
+    resolution: {integrity: sha512-euARTdvCVoi2k7/mqRUGyareO98jiVjwUyfJ8VFpN53aUv3R6ZgwSpU3ErOwFQKT6Fq8dOplEsy+DSmEoJPQdQ==}
+    engines: {node: '>=14'}
 
-  '@vercel/error-utils@2.2.0':
-    resolution: {integrity: sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==}
+  '@vercel/elysia@0.1.109':
+    resolution: {integrity: sha512-z4PLJ5rCmwLDeqoRstH97OSChqvC4tFnLpiefMJ5rDJcLvR4tqhnKLKcEcMnZgp1Ocr+JHuJ6u0Yaj3WO8Y5Zg==}
 
-  '@vercel/express@0.1.120':
-    resolution: {integrity: sha512-roE4e063Ycl0wi8eZMpeRsLGGPAkjGaykABR+ZH+Z+0MPorH6+WB626yvZOVsRHbVVRPYa6IKDDRsehK1DN4NQ==}
+  '@vercel/error-utils@2.2.1':
+    resolution: {integrity: sha512-9DhP8jP7raLML4hGsBemxX5fXuQnu5xxMV+HjGygGbzEmVK/+KyJ3QP2Cw7PdF0uXdb9N0Qa4c3tRGH34ZX6vw==}
 
-  '@vercel/fastify@0.1.109':
-    resolution: {integrity: sha512-MtJLWsOdpAIKpvVtZHh7r7R/3b+rnuo02KIkwWWsxxmO/C+ucEc5Mf1n9ecf96XfMIG9mAZnvEHjN7fAbeMRsw==}
+  '@vercel/express@0.1.123':
+    resolution: {integrity: sha512-Z/jHexu1xlRMbJkSXFxwq5Nf/mmqrYBWeNxL66dEHxh2kkHqhXHpcojsHNic3gY+CBow0jMno74fBrOuk8L4Ng==}
+
+  '@vercel/fastify@0.1.112':
+    resolution: {integrity: sha512-sOzNXLJ0KB+2NvuzOoJVwS9tSa/E6rT/dBK3BJ9ksHys1EM8qUK2X3YL4amL3PJNeSdDLklnwcO3XIY0CtaICA==}
 
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
@@ -7527,11 +7534,11 @@ packages:
       ws:
         optional: true
 
-  '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
-    resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.12':
+    resolution: {integrity: sha512-Ejlhwxr7EBYJxtwYnlh6Vm6A2dPsUSPxMdYrfv0koZkgAzVwo7cG4aDQiy7iASMaGzwuI/PAnwlY2sJBF5b4OA==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.2.32':
-    resolution: {integrity: sha512-Ku2s4zykwPl3vlU835yv/VA6aoG59LlTrPrt40SrEshlPg7p5Ot62T3M+6PbWkgCRvul7zDLIgamjZemN9ypFQ==}
+  '@vercel/gatsby-plugin-vercel-builder@2.2.35':
+    resolution: {integrity: sha512-H1qNhnvyRIhek/esVnVK+RoFsxrSOLl4qiM4iyV2IcjDoqY4H0Ped65tc5ZgZEP/P2KGNYfEDSBEukdBZa+kCg==}
 
   '@vercel/geistdocs@1.19.2':
     resolution: {integrity: sha512-LOxbVHAVsfWIkBIo98TUNL2pRKBL/XrthAxgGm3eYP57G9xlKSTRsA43mpnZ1k80rUz1IzhLrGFffOIV6UR7oQ==}
@@ -7542,26 +7549,26 @@ packages:
       react-dom: ^19.2.3
       tailwindcss: ^4.1.17
 
-  '@vercel/go@3.10.2':
-    resolution: {integrity: sha512-ZJqx1GzD1qqMkI92jEHp04zCwbZ7tNwcgI58e7t8HiYvILwCZ4Rvq0hfjTjsk+0Zn8A369qs4eAHvCYu38uB5A==}
+  '@vercel/go@3.10.4':
+    resolution: {integrity: sha512-iFVcaTHUWUiG5x5mYmrzg1WLOkyQhsxrZYGWN0/TNE66qyaTxz3NBMJ7CbH712XPuBszOY6HFKyRcSHmUFWIXQ==}
 
-  '@vercel/h3@0.1.115':
-    resolution: {integrity: sha512-YFEdyL3w7Mm356IobHk6chqnAUo2lDuLj1zv7PhoofCbRetHPw+nrIFQqaIVrLPVIq4qmX7jxe4bmieHKPonWQ==}
+  '@vercel/h3@0.1.118':
+    resolution: {integrity: sha512-6nKeOdQTw9hoV2k8nHtgvU5USTSujdW2uw0otMZzOqucwRrFxwxJwIvPUe32ajHEopcKjaat/FzJy+4MA2SPJg==}
 
-  '@vercel/hono@0.2.109':
-    resolution: {integrity: sha512-Ves8S9ix8g7NGJEStTrcBAdDBF1xzQ8KkVPzvyQ7l9nPlpYhYR7WCnTdJwi9ZpaHniCGVDZ+Q/kNk4PChOVt6Q==}
+  '@vercel/hono@0.2.112':
+    resolution: {integrity: sha512-CFjJiuuXrAe6ejTzzgM9CPp725hnpf/1Oj8NY11dKE1qBxCsXC6gWspXmBsv0aAMiJLEcazxfiT7WLi1jwxbFQ==}
 
-  '@vercel/hydrogen@1.4.0':
-    resolution: {integrity: sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==}
+  '@vercel/hydrogen@1.4.1':
+    resolution: {integrity: sha512-fD3DAjMcWkGPZwcWCbF4ekZpDY4cMz+QZWR5F3Qss3hkQx6Vuu0kTpKX0xGgQ/CYTtKknZJTwIfM/ZvByAsrKA==}
 
-  '@vercel/koa@0.1.89':
-    resolution: {integrity: sha512-nMsKdtBliVDxEEXNl2lwZBNT7DABqTn1LBSAGx6QLrk469x9hdphFijaOO3UdVXWWZQbbojw4IOcrhVtIkNNmg==}
+  '@vercel/koa@0.1.92':
+    resolution: {integrity: sha512-NRl+ZQcpL/KJIa/KqNJ/GfyLSvBVqtxyKbO8QeyQgForqgl97QsCxBqRu7NbfrQUaiszi1dbfRcK++3siUNkcQ==}
 
-  '@vercel/nestjs@0.2.110':
-    resolution: {integrity: sha512-gUXKyrwsmBJzpE5M9aNwiN8KzxgU2Y6P8VaKh2/r9vJO8558Yi2mhottr/w/1G1DoojaUKLZcQcdbipvuXIcRQ==}
+  '@vercel/nestjs@0.2.113':
+    resolution: {integrity: sha512-t/QdaQeo2icTAfOLd74wpunDc3ZDl+w18qJywpeqPaRjugbNkKEZiuLRbQOEknY4HJe6oSBMU4DM+iMPp8x5EA==}
 
-  '@vercel/next@4.20.4':
-    resolution: {integrity: sha512-8m39IHTAgO5yE9xAW8lnjv01z8qQ/qm1FWqyg46qBH2GPtn0MHEME2tAbRy+XzV0Q2J/KGSwmH4xFq8FgECAfg==}
+  '@vercel/next@4.21.1':
+    resolution: {integrity: sha512-BH/L+ygzRGuJUgSvicp2j9AeyC04g+WFsdMmPH3iken62ZplhkPRjzHMNEHGcR1C256IDP0Bhv3n9dqDOajdeg==}
 
   '@vercel/nft@1.10.0':
     resolution: {integrity: sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==}
@@ -7573,8 +7580,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/node@5.9.2':
-    resolution: {integrity: sha512-QM9btX0pYWl+abtHOhJMiBUNy0xnmCszrDbcM0nHln9FKD/4DzOxQgGEUWN78YWzfO+7qVoY3bCZg+4fElbdVw==}
+  '@vercel/node@5.9.5':
+    resolution: {integrity: sha512-QhMkTJzSuxTqdxpM6UwO/HRwk7euT09dvjohekALsBLAXZ3qXsFcLfKH8IoQ1xoyUbCxDJBe16MQesq26IqePw==}
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -7607,11 +7614,11 @@ packages:
   '@vercel/prepare-flags-definitions@0.3.0':
     resolution: {integrity: sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==}
 
-  '@vercel/python-analysis@0.12.0':
-    resolution: {integrity: sha512-T9YgtINVJfZmDhXe6ULKoLC1Zr3LU3Cl4CgC+m+S1KsNDPlfGfXdr93K7aOqkMaJEDLpUH8dqrPP3/TuZXTjRw==}
+  '@vercel/python-analysis@0.13.1':
+    resolution: {integrity: sha512-ec4tii9I7i6eHfvsvG/eaNaKh0TxmxBsc904V7yjwZImeyFTEVvDSLQ/+510FB+wBG6gCvpyqBH5aAKP9llqsw==}
 
-  '@vercel/python@6.54.0':
-    resolution: {integrity: sha512-shBuOJNbNJ6RLclIln35xtoVZO0O2jq5hurbyaJouoAM4HkzOof7KbQ2POqaDcj9YFQpJ+nHnCxTZ2q6BMJGTw==}
+  '@vercel/python@6.55.1':
+    resolution: {integrity: sha512-5IaUnwvmfeziC+jdT7z8JFSZBU+ItffZG+EPVpF+zkl/H7FdiFwiCqZoIacIWI7GYX415uQTV8HBi6c06SX2Lw==}
 
   '@vercel/queue@0.4.0':
     resolution: {integrity: sha512-2HctPb2+6Pj1DMxbPohMq574rE9OP3fUAGhwV0R4Qv1FHQIR+qti92G8FGjFMJGUSFxVlWdNwVfgHU2hZlM6Dw==}
@@ -7622,17 +7629,17 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@vercel/redwood@2.5.0':
-    resolution: {integrity: sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==}
+  '@vercel/redwood@2.5.1':
+    resolution: {integrity: sha512-oldy4mZmhFzHKkXluyPNHiIyZHxVW1Zpznn0qBag2hzmn2HpqkL9fZfZvlWGIvuAdQz/Sa4AErbreMEPOzCv0w==}
 
-  '@vercel/remix-builder@5.9.1':
-    resolution: {integrity: sha512-s0SpfV640nmQ1BsKCPMYugGrH/V+319onTo2ZILSmsy6NTBlmeN0zJU9nPcP8dBEotGqtp68NfOlOUUdrVBzkw==}
+  '@vercel/remix-builder@5.9.2':
+    resolution: {integrity: sha512-QXe2mi6n8/ZnKgGbLV+yl8gMdqeEVSQ9ms9Rwp3mUpVuVIHyJz1JvfJfpNU8cRccvUkBrsEt/7umUgV7X2b8zA==}
 
   '@vercel/ruby@2.5.1':
     resolution: {integrity: sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==}
 
-  '@vercel/rust@1.4.0':
-    resolution: {integrity: sha512-/zRJtaf3pvdxZ7+tShmIo8StdbkCSBDcY7Gy7LOwNTIxm6GU9vkS+BlCwJHkOu6qNkbcSRH6ZQIeo4vNmqzKdQ==}
+  '@vercel/rust@1.4.1':
+    resolution: {integrity: sha512-5KNA/WixZ3Ktitg8kBLLb9UTvfZmBxYbJtVOHEBX5JZApIvCeezWHhtnpYbXMpW0wPEOFNBvEMVTRqjZAiAKOQ==}
 
   '@vercel/sandbox@2.4.0':
     resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
@@ -7669,36 +7676,11 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/static-build@2.11.12':
-    resolution: {integrity: sha512-BwIEj/0PBys4R9eGcPcnkIararnQYwcm07iU58xk+YceOQAROJZK9ZnD4LO/LpGakt07SA4mjaQVSGYtueqzww==}
+  '@vercel/static-build@2.12.1':
+    resolution: {integrity: sha512-L7DatMqF3p76MBC1K70mLVk5p/cPc95PX2jVkZbMz2y95hdkWNH0VSC9K4O1gqIT2zjGYkRjK/yaY7pemEBZzw==}
 
-  '@vercel/static-config@3.4.0':
-    resolution: {integrity: sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==}
-
-  '@vercel/vc-native-darwin-arm64@58.4.0':
-    resolution: {integrity: sha512-2JyiuiCji3h4zBAt8p1UZ316G3SRPU9/LOcHQzeEkwLqN/tXen9kDnVSYVsZ0xyx4t8FS/P+dtr+afjKr5pyXQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@vercel/vc-native-darwin-x64@58.4.0':
-    resolution: {integrity: sha512-SzxdkV2uLOqCLXSppdASzwIV7rd1D4Spw8K6y8wio2d+w7n8KWFreWhYira2hSfJrA38ltRpw9Ztt2MlWl2GcA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@vercel/vc-native-linux-arm64@58.4.0':
-    resolution: {integrity: sha512-aI+8zMFYGE8TyjJE44SqNcLOVpZAcuek2hu+VthZ8G/RMZskFDd0aMRAh+jWaHhBQ1yYb7QTWl3EMI7no36MPQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@vercel/vc-native-linux-x64@58.4.0':
-    resolution: {integrity: sha512-UCZIF5rA9hjHCQ8oZ4oSPhoLrH412oq3b/owB1GhN6qjbJDFp/eQhg0Ocn+UUULk/Zs5MmOUCvE7o1rYelA9uw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@vercel/vc-native-win32-x64@58.4.0':
-    resolution: {integrity: sha512-ykAWnf1mCcRIbcbPDQGUAug81M2ODQoPBTv3wGf5qP+BqFqkSHWCWTUSZ7lHsBDeX3fpo2kwNh0NKVNAIP+LEA==}
-    cpu: [x64]
-    os: [win32]
+  '@vercel/static-config@3.4.1':
+    resolution: {integrity: sha512-kJKTyOg25JDRgDkHEkc+vWlvURxmSQkVKyRPO4EEGD/8HpJT+4u9Z/VGxwnCZ6zZBxYPpma283qBsHwY0gXjfw==}
 
   '@vgpu/adapter-node@0.0.7':
     resolution: {integrity: sha512-IgSq52apOkMN1LvqF96b7Umzw/qTysuIDKF4I7SgUZUZSKbtH+j3eqdk33zEec5iuP5mHZ42/zKg4575zNm1Bg==}
@@ -9277,9 +9259,6 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-
-  devalue@5.8.1:
-    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devalue@5.9.0:
     resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
@@ -14863,8 +14842,8 @@ packages:
   vcf@2.1.2:
     resolution: {integrity: sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg==}
 
-  vercel@58.4.0:
-    resolution: {integrity: sha512-bc/34wx40JAakmR5Dwqe9LUgiRGPB+a04gA3c8/q4F1peg8IAslHnqN9TfcDeXOa20PSJX372vvRmdIsfvd+zA==}
+  vercel@58.5.1:
+    resolution: {integrity: sha512-1BWBLm62nohVZ8D8c5qbp3qY/tAQQwE3HAvSM/B1Ez+OHLKdgS2G/nsPZEFLTc7x92ma2v4uAEe4L0OqMy/LFw==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -17719,7 +17698,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.8.1
+      devalue: 5.9.0
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
@@ -17798,7 +17777,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.8.1
+      devalue: 5.9.0
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
@@ -20733,7 +20712,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.17.0
       cookie: 0.6.0
-      devalue: 5.8.1
+      devalue: 5.9.0
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -20755,7 +20734,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.17.0
       cookie: 0.6.0
-      devalue: 5.8.1
+      devalue: 5.9.0
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -21505,11 +21484,11 @@ snapshots:
       svelte: 5.56.1(@typescript-eslint/types@8.59.4)
       vue: 3.5.35(typescript@6.0.3)
 
-  '@vercel/backends@0.8.29(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/backends@0.8.32(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/build-utils': 13.36.2
+      '@vercel/build-utils': 14.0.1
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/static-config': 3.4.1
       execa: 3.2.0
       fs-extra: 11.1.0
       get-port: 5.1.1
@@ -21536,15 +21515,15 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.27.0
 
-  '@vercel/build-utils@13.36.2':
+  '@vercel/build-utils@14.0.1':
     dependencies:
-      '@vercel/python-analysis': 0.12.0
+      '@vercel/python-analysis': 0.13.1
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.1.37(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/cervel@0.1.40(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/backends': 0.8.29(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/backends': 0.8.32(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -21552,10 +21531,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/cli-auth@0.3.1':
+  '@vercel/cli-auth@0.3.2':
     dependencies:
       '@napi-rs/keyring': 1.2.0
-      '@vercel/cli-config': 0.2.1
+      '@vercel/cli-config': 0.2.2
       async-listen: 3.0.0
       open: 8.4.0
       zod: 4.1.11
@@ -21566,6 +21545,11 @@ snapshots:
       zod: 4.1.11
 
   '@vercel/cli-config@0.2.1':
+    dependencies:
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+
+  '@vercel/cli-config@0.2.2':
     dependencies:
       xdg-app-paths: 5.1.0
       zod: 4.1.11
@@ -21584,27 +21568,29 @@ snapshots:
       ai: 7.0.38(zod@4.4.3)
       eve: link:packages/eve
 
-  '@vercel/container@0.1.0': {}
+  '@vercel/container@0.1.1': {}
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.106(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/detect-agent@1.2.4': {}
+
+  '@vercel/elysia@0.1.109(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/error-utils@2.2.0': {}
+  '@vercel/error-utils@2.2.1': {}
 
-  '@vercel/express@0.1.120(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/express@0.1.123(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/cervel': 0.1.37(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/cervel': 0.1.40(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
       ts-morph: 12.0.0
@@ -21616,10 +21602,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/fastify@0.1.109(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/fastify@0.1.112(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -21660,14 +21646,14 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       ws: 8.21.1(bufferutil@4.1.0)
 
-  '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.12':
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.2.32':
+  '@vercel/gatsby-plugin-vercel-builder@2.2.35':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.36.2
+      '@vercel/build-utils': 14.0.1
       esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
@@ -21739,22 +21725,22 @@ snapshots:
       - vite
       - waku
 
-  '@vercel/go@3.10.2': {}
+  '@vercel/go@3.10.4': {}
 
-  '@vercel/h3@0.1.115(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/h3@0.1.118(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.109(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/hono@0.2.112(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
       ts-morph: 12.0.0
@@ -21764,30 +21750,30 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/hydrogen@1.4.0':
+  '@vercel/hydrogen@1.4.1':
     dependencies:
-      '@vercel/static-config': 3.4.0
+      '@vercel/static-config': 3.4.1
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.89(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/koa@0.1.92(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nestjs@0.2.110(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/nestjs@0.2.113(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/static-config': 3.4.1
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/next@4.20.4(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/next@4.21.1(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -21833,16 +21819,16 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.9.2(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/node@5.9.5(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.11.0
-      '@vercel/build-utils': 13.36.2
-      '@vercel/error-utils': 2.2.0
+      '@vercel/build-utils': 14.0.1
+      '@vercel/error-utils': 2.2.1
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/static-config': 3.4.1
       async-listen: 3.0.0
       cjs-module-lexer: 1.2.3
       edge-runtime: 2.5.9
@@ -21900,7 +21886,7 @@ snapshots:
 
   '@vercel/prepare-flags-definitions@0.3.0': {}
 
-  '@vercel/python-analysis@0.12.0':
+  '@vercel/python-analysis@0.13.1':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
@@ -21910,9 +21896,9 @@ snapshots:
       smol-toml: 1.5.2
       zod: 3.22.4
 
-  '@vercel/python@6.54.0':
+  '@vercel/python@6.55.1':
     dependencies:
-      '@vercel/python-analysis': 0.12.0
+      '@vercel/python-analysis': 0.13.1
 
   '@vercel/queue@0.4.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -21923,10 +21909,10 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@vercel/redwood@2.5.0(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/redwood@2.5.1(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/static-config': 3.4.1
       semver: 6.3.1
       ts-morph: 12.0.0
     transitivePeerDependencies:
@@ -21934,11 +21920,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/remix-builder@5.9.1(rollup@4.62.2)(supports-color@10.2.2)':
+  '@vercel/remix-builder@5.9.2(rollup@4.62.2)(supports-color@10.2.2)':
     dependencies:
-      '@vercel/error-utils': 2.2.0
+      '@vercel/error-utils': 2.2.1
       '@vercel/nft': 1.10.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/static-config': 3.4.0
+      '@vercel/static-config': 3.4.1
       path-to-regexp: 6.1.0
       path-to-regexp-updated: path-to-regexp@6.3.0
       ts-morph: 12.0.0
@@ -21949,7 +21935,7 @@ snapshots:
 
   '@vercel/ruby@2.5.1': {}
 
-  '@vercel/rust@1.4.0':
+  '@vercel/rust@1.4.1':
     dependencies:
       execa: 5.1.1
       get-port: 5.1.1
@@ -22002,33 +21988,18 @@ snapshots:
       svelte: 5.56.1(@typescript-eslint/types@8.59.4)
       vue: 3.5.35(typescript@6.0.3)
 
-  '@vercel/static-build@2.11.12':
+  '@vercel/static-build@2.12.1':
     dependencies:
-      '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.2.32
-      '@vercel/static-config': 3.4.0
+      '@vercel/gatsby-plugin-vercel-analytics': 1.0.12
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.35
+      '@vercel/static-config': 3.4.1
       ts-morph: 12.0.0
 
-  '@vercel/static-config@3.4.0':
+  '@vercel/static-config@3.4.1':
     dependencies:
       ajv: 8.6.3
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
-
-  '@vercel/vc-native-darwin-arm64@58.4.0':
-    optional: true
-
-  '@vercel/vc-native-darwin-x64@58.4.0':
-    optional: true
-
-  '@vercel/vc-native-linux-arm64@58.4.0':
-    optional: true
-
-  '@vercel/vc-native-linux-x64@58.4.0':
-    optional: true
-
-  '@vercel/vc-native-win32-x64@58.4.0':
-    optional: true
 
   '@vgpu/adapter-node@0.0.7(supports-color@10.2.2)':
     dependencies:
@@ -23898,8 +23869,6 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
-
-  devalue@5.8.1: {}
 
   devalue@5.9.0: {}
 
@@ -27970,7 +27939,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 3.1.1
       defu: 6.1.7
-      devalue: 5.8.1
+      devalue: 5.9.0
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
@@ -28107,7 +28076,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 3.1.1
       defu: 6.1.7
-      devalue: 5.8.1
+      devalue: 5.9.0
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
@@ -30693,7 +30662,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.8.1
+      devalue: 5.9.0
       esm-env: 1.2.2
       esrap: 2.2.13(@typescript-eslint/types@8.59.4)
       is-reference: 3.0.3
@@ -31444,34 +31413,34 @@ snapshots:
       camelcase: 5.3.1
       foldline: 1.1.0
 
-  vercel@58.4.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(bufferutil@4.1.0)(rollup@4.62.2)(supports-color@10.2.2):
+  vercel@58.5.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(bufferutil@4.1.0)(rollup@4.62.2)(supports-color@10.2.2):
     dependencies:
-      '@vercel/backends': 0.8.29(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/backends': 0.8.32(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
       '@vercel/blob': 2.4.0
-      '@vercel/build-utils': 13.36.2
-      '@vercel/cli-auth': 0.3.1
-      '@vercel/cli-config': 0.2.1
-      '@vercel/container': 0.1.0
-      '@vercel/detect-agent': 1.2.3
-      '@vercel/elysia': 0.1.106(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/express': 0.1.120(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/fastify': 0.1.109(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/build-utils': 14.0.1
+      '@vercel/cli-auth': 0.3.2
+      '@vercel/cli-config': 0.2.2
+      '@vercel/container': 0.1.1
+      '@vercel/detect-agent': 1.2.4
+      '@vercel/elysia': 0.1.109(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/express': 0.1.123(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/fastify': 0.1.112(rollup@4.62.2)(supports-color@10.2.2)
       '@vercel/fun': 1.3.0(supports-color@10.2.2)
-      '@vercel/go': 3.10.2
-      '@vercel/h3': 0.1.115(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/hono': 0.2.109(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/hydrogen': 1.4.0
-      '@vercel/koa': 0.1.89(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/nestjs': 0.2.110(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/next': 4.20.4(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/node': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/go': 3.10.4
+      '@vercel/h3': 0.1.118(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/hono': 0.2.112(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/hydrogen': 1.4.1
+      '@vercel/koa': 0.1.92(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/nestjs': 0.2.113(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/next': 4.21.1(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/node': 5.9.5(rollup@4.62.2)(supports-color@10.2.2)
       '@vercel/prepare-flags-definitions': 0.3.0
-      '@vercel/python': 6.54.0
-      '@vercel/redwood': 2.5.0(rollup@4.62.2)(supports-color@10.2.2)
-      '@vercel/remix-builder': 5.9.1(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/python': 6.55.1
+      '@vercel/redwood': 2.5.1(rollup@4.62.2)(supports-color@10.2.2)
+      '@vercel/remix-builder': 5.9.2(rollup@4.62.2)(supports-color@10.2.2)
       '@vercel/ruby': 2.5.1
-      '@vercel/rust': 1.4.0
-      '@vercel/static-build': 2.11.12
+      '@vercel/rust': 1.4.1
+      '@vercel/static-build': 2.12.1
       chokidar: 4.0.0
       esbuild: 0.27.0
       jose: 5.9.6
@@ -31481,12 +31450,6 @@ snapshots:
       smol-toml: 1.5.2
       undici: 5.29.0
       zod: 4.1.11
-    optionalDependencies:
-      '@vercel/vc-native-darwin-arm64': 58.4.0
-      '@vercel/vc-native-darwin-x64': 58.4.0
-      '@vercel/vc-native-linux-arm64': 58.4.0
-      '@vercel/vc-native-linux-x64': 58.4.0
-      '@vercel/vc-native-win32-x64': 58.4.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'


### PR DESCRIPTION
## Summary
- add a guided `eve add channel/linear-agent` flow that provisions a Linear Vercel Connect app and routes Agent Session events to eve
- scaffold the Connect-backed Linear channel and guide deployment, workspace installation, and delegation
- update the registry, docs, gallery copy, tests, and changeset

## Validation
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/linear/connect.test.ts src/setup/integrations/linear/setup.test.ts src/setup/integrations/registry.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm --dir apps/docs run registry:validate:channels`
- `git diff --check`