### PR TITLE
feat(eve): support dynamic subagents

### DIFF
--- a/.changeset/dynamic-subagents-appear.md
+++ b/.changeset/dynamic-subagents-appear.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow declared subagents to export `defineDynamic` from `agent.ts`. Session and turn resolvers can now return the fallback agent definition to expose the subagent or nil to omit it from direct and Workflow delegation.
+Allow declared subagents to export `defineDynamic` from `agent.ts`. Session and turn resolvers can now return an agent configuration to expose it or nil to omit it from direct and Workflow delegation.

--- a/.changeset/dynamic-subagents-appear.md
+++ b/.changeset/dynamic-subagents-appear.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow declared subagents to export `defineDynamic` from `agent.ts`. Session and turn resolvers can now return the fallback agent definition to expose the subagent or nil to omit it from direct and Workflow delegation.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -51,10 +51,10 @@ compiled manifest. Each resolution can return a different model or other
 runtime agent settings. Runtime-selected models must use string model IDs;
 build and Workflow-world configuration cannot be selected at runtime.
 
-Dynamic subagents support `session.started` and `turn.started`, not
-`step.started`. A turn selection shadows the session selection for that turn,
-including when the turn handler returns nil. If a resolver throws or returns an
-invalid definition, eve logs the failure and omits the subagent.
+Dynamic subagents support `session.started` and `turn.started`. A turn selection
+shadows the session selection for that turn, including when the turn handler
+returns nil. If a resolver throws or returns an invalid definition, eve logs the
+failure and omits the subagent.
 
 The resolved set applies to direct delegation and the `Workflow` tool. eve
 also checks availability again before starting the child, so a stale or

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -1,9 +1,9 @@
 ---
 title: "Dynamic Capabilities"
-description: "Resolve models, tools, skills, and instructions at runtime: dynamic model selection, defineDynamic resolver events, execution order, and durable dynamic tools."
+description: "Resolve models, subagents, tools, skills, and instructions at runtime with defineDynamic resolver events."
 ---
 
-`defineDynamic` resolves the model, tools, skills, and instructions at runtime from a session event instead of declaring them up front. Reach for it when the right capability isn't known until the session starts, because it hinges on who the caller is, what tenant they belong to, feature flags, or external data. The [tools](../tools), [skills](../skills), and [instructions](../instructions) guides each point here for their dynamic form.
+`defineDynamic` resolves the model, subagents, tools, skills, and instructions at runtime from a session event instead of declaring them up front. Reach for it when the right capability isn't known until the session starts, because it hinges on who the caller is, what tenant they belong to, feature flags, or external data. The [subagents](../subagents), [tools](../tools), [skills](../skills), and [instructions](../instructions) guides each point here for their dynamic form.
 
 ## Dynamic models
 
@@ -16,10 +16,49 @@ uncached prices. See
 [agent configuration](../agent-config#choose-the-model-dynamically) for the
 full contract.
 
-`fallback` is model-only: the agent always needs exactly one model, and the
-compiled fallback anchors build-time metadata. Tools, skills, and instructions
+The agent always needs exactly one model, so the compiled fallback anchors
+build-time metadata. A dynamic subagent also uses `fallback` to compile its
+child configuration, as described below. Tools, skills, and instructions
 default by authoring a static entry (or returning `null`), so `fallback` on
 their `defineDynamic` export is a build error.
+
+## Dynamic subagents
+
+Wrap a declared subagent's own `agent.ts` in `defineDynamic` when its
+availability depends on the caller, tenant, environment, or a feature flag.
+Keep the child definition in one constant, pass it as `fallback`, and return
+that same value to expose the subagent. Return `null` or `undefined` to omit it
+from the parent's model-visible tools.
+
+```ts title="agent/subagents/finance/agent.ts"
+import { defineAgent, defineDynamic } from "eve";
+
+const finance = defineAgent({
+  description: "Analyze financial and accounting data.",
+  model: "openai/gpt-5.5",
+});
+
+export default defineDynamic({
+  fallback: finance,
+  events: {
+    "session.started": (_event, ctx) =>
+      ctx.session.auth.current?.attributes.plan === "enterprise" ? finance : null,
+  },
+});
+```
+
+`fallback` is the definition eve compiles and runs when the subagent is
+selected; it does not make the subagent available by itself. A handler must
+return the exact fallback value. Dynamic subagents support `session.started`
+and `turn.started`, not `step.started`. A turn selection shadows the session
+selection for that turn, including when the turn handler returns nil.
+
+The resolved set applies to direct delegation and the `Workflow` tool. eve
+also checks availability again before starting the child, so a stale or
+manually constructed call fails with `SUBAGENT_UNAVAILABLE`. Treat conditional
+availability as capability composition, not as the only authorization
+boundary: sensitive child tools still need their own authorization and
+approval checks.
 
 ## Dynamic tools
 
@@ -162,6 +201,7 @@ Both resolve before the prompt is assembled, so the model sees the right instruc
 
 ## What to read next
 
+- Conditionally expose a specialist → [Subagents](../subagents)
 - The static tool basics this builds on → [Tools](../tools)
 - The built-in tools and how to override them → [Default harness](../concepts/default-harness)
 - Authenticate a tool or connection to an external service → [Auth & route protection](./auth-and-route-protection)

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -17,41 +17,44 @@ uncached prices. See
 full contract.
 
 The agent always needs exactly one model, so the compiled fallback anchors
-build-time metadata. A dynamic subagent also uses `fallback` to compile its
-child configuration, as described below. Tools, skills, and instructions
-default by authoring a static entry (or returning `null`), so `fallback` on
-their `defineDynamic` export is a build error.
+build-time metadata. Tools, skills, instructions, and subagents default by
+authoring a static entry (or returning `null`), so `fallback` on their
+`defineDynamic` export is a build error.
 
 ## Dynamic subagents
 
 Wrap a declared subagent's own `agent.ts` in `defineDynamic` when its
 availability depends on the caller, tenant, environment, or a feature flag.
-Keep the child definition in one constant, pass it as `fallback`, and return
-that same value to expose the subagent. Return `null` or `undefined` to omit it
-from the parent's model-visible tools.
+Return the child definition to configure and expose it. Return `null` or
+`undefined` to omit it from the parent's model-visible tools.
 
 ```ts title="agent/subagents/finance/agent.ts"
 import { defineAgent, defineDynamic } from "eve";
 
-const finance = defineAgent({
-  description: "Analyze financial and accounting data.",
-  model: "openai/gpt-5.5",
-});
-
 export default defineDynamic({
-  fallback: finance,
   events: {
     "session.started": (_event, ctx) =>
-      ctx.session.auth.current?.attributes.plan === "enterprise" ? finance : null,
+      ctx.session.auth.current?.attributes.plan === "enterprise"
+        ? defineAgent({
+            description: "Analyze financial and accounting data.",
+            model: "openai/gpt-5.5",
+          })
+        : null,
   },
 });
 ```
 
-`fallback` is the definition eve compiles and runs when the subagent is
-selected; it does not make the subagent available by itself. A handler must
-return the exact fallback value. Dynamic subagents support `session.started`
-and `turn.started`, not `step.started`. A turn selection shadows the session
-selection for that turn, including when the turn handler returns nil.
+eve always compiles the subagent's filesystem manifest, including its
+instructions, tools, skills, connections, sandbox, and nested subagents. When
+the resolver selects it, eve injects the returned agent configuration into that
+compiled manifest. Each resolution can return a different model or other
+runtime agent settings. Runtime-selected models must use string model IDs;
+build and Workflow-world configuration cannot be selected at runtime.
+
+Dynamic subagents support `session.started` and `turn.started`, not
+`step.started`. A turn selection shadows the session selection for that turn,
+including when the turn handler returns nil. If a resolver throws or returns an
+invalid definition, eve logs the failure and omits the subagent.
 
 The resolved set applies to direct delegation and the `Workflow` tool. eve
 also checks availability again before starting the child, so a stale or

--- a/docs/reference/project-layout.md
+++ b/docs/reference/project-layout.md
@@ -91,7 +91,7 @@ agent/subagents/researcher/
 
 Rules:
 
-- `agent.ts` is required, and must declare a `description`. The parent reads it on the lowered subagent tool to decide when to delegate.
+- `agent.ts` is required, and its agent definition must declare a `description`. For a dynamic subagent, the `fallback` agent definition carries that description. The parent reads it on the lowered subagent tool to decide when to delegate.
 - `instructions.md` / `instructions.ts` is optional (unlike the root agent, where it is required).
 - `connections/`, `hooks/`, `skills/`, `lib/`, `sandbox/`, and `tools/` are all supported, discovered from the subagent's own directory.
 - `channels/` and `schedules/` are not supported inside local subagents.

--- a/docs/reference/project-layout.md
+++ b/docs/reference/project-layout.md
@@ -91,7 +91,7 @@ agent/subagents/researcher/
 
 Rules:
 
-- `agent.ts` is required, and its agent definition must declare a `description`. For a dynamic subagent, the `fallback` agent definition carries that description. The parent reads it on the lowered subagent tool to decide when to delegate.
+- `agent.ts` is required. A static subagent's definition must declare a `description`; a dynamic subagent's resolver must return a definition with one. The parent reads it on the lowered subagent tool to decide when to delegate.
 - `instructions.md` / `instructions.ts` is optional (unlike the root agent, where it is required).
 - `connections/`, `hooks/`, `skills/`, `lib/`, `sandbox/`, and `tools/` are all supported, discovered from the subagent's own directory.
 - `channels/` and `schedules/` are not supported inside local subagents.

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -30,27 +30,27 @@ export default defineTool({
 
 ## The define\* helpers
 
-| Helper                                                | Import from                                   | Authored at                          | Guide                                                  |
-| ----------------------------------------------------- | --------------------------------------------- | ------------------------------------ | ------------------------------------------------------ |
-| `defineAgent`                                         | `eve`                                         | `agent/agent.ts`                     | [agent.ts](../agent-config)                            |
-| `defineTool`                                          | `eve/tools`                                   | `agent/tools/<name>.ts`              | [Tools](../tools)                                      |
-| `defineDynamic`                                       | `eve/tools`, `eve/skills`, `eve/instructions` | `agent/{tools,skills,instructions}/` | [Dynamic capabilities](../guides/dynamic-capabilities) |
-| `defineMcpClientConnection`                           | `eve/connections`                             | `agent/connections/<name>.ts`        | [MCP connections](../connections/mcp)                  |
-| `defineOpenAPIConnection`                             | `eve/connections`                             | `agent/connections/<name>.ts`        | [OpenAPI connections](../connections/openapi)          |
-| `defineChannel`                                       | `eve/channels`                                | `agent/channels/<name>.ts`           | [Custom channels](../channels/custom)                  |
-| `eveChannel`, `slackChannel`, and the other platforms | `eve/channels/<platform>`                     | `agent/channels/<platform>.ts`       | [Channels](../channels/overview)                       |
-| `defineSkill`                                         | `eve/skills`                                  | `agent/skills/<name>.ts`             | [Skills](../skills)                                    |
-| `defineInstructions`                                  | `eve/instructions`                            | `agent/instructions.ts`              | [Instructions](../instructions)                        |
-| `defineHook`                                          | `eve/hooks`                                   | `agent/hooks/<slug>.ts`              | [Hooks](../guides/hooks)                               |
-| `defineSchedule`                                      | `eve/schedules`                               | `agent/schedules/<name>.ts`          | [Schedules](../schedules)                              |
-| `defineState`                                         | `eve/context`                                 | tools, hooks, lifecycle              | [Session context](../guides/session-context)           |
-| `defineSandbox`                                       | `eve/sandbox`                                 | `agent/sandbox.ts`                   | [Sandbox](../sandbox)                                  |
-| `defineInstrumentation`                               | `eve/instrumentation`                         | `agent/instrumentation.ts`           | [instrumentation.ts](../guides/instrumentation)        |
-| `defineRemoteAgent`                                   | `eve`                                         | `agent/subagents/<id>/agent.ts`      | [Remote agents](../guides/remote-agents)               |
-| `defineEval`                                          | `eve/evals`                                   | `evals/*.eval.ts`                    | [Evals](../evals/overview)                             |
-| `defineEvalConfig`                                    | `eve/evals`                                   | `evals/evals.config.ts`              | [Evals](../evals/overview)                             |
-| `mockModel`                                           | `eve/evals`                                   | Deterministic fixture agent models   | [Evals](../evals/overview)                             |
-| `useEveAgent`                                         | `eve/react`, `eve/vue`, `eve/svelte`          | frontend                             | [Frontend](../guides/frontend/overview)                |
+| Helper                                                | Import from                                          | Authored at                                                                | Guide                                                  |
+| ----------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `defineAgent`                                         | `eve`                                                | `agent/agent.ts`                                                           | [agent.ts](../agent-config)                            |
+| `defineTool`                                          | `eve/tools`                                          | `agent/tools/<name>.ts`                                                    | [Tools](../tools)                                      |
+| `defineDynamic`                                       | `eve`, `eve/tools`, `eve/skills`, `eve/instructions` | dynamic model or subagent `agent.ts`; `agent/{tools,skills,instructions}/` | [Dynamic capabilities](../guides/dynamic-capabilities) |
+| `defineMcpClientConnection`                           | `eve/connections`                                    | `agent/connections/<name>.ts`                                              | [MCP connections](../connections/mcp)                  |
+| `defineOpenAPIConnection`                             | `eve/connections`                                    | `agent/connections/<name>.ts`                                              | [OpenAPI connections](../connections/openapi)          |
+| `defineChannel`                                       | `eve/channels`                                       | `agent/channels/<name>.ts`                                                 | [Custom channels](../channels/custom)                  |
+| `eveChannel`, `slackChannel`, and the other platforms | `eve/channels/<platform>`                            | `agent/channels/<platform>.ts`                                             | [Channels](../channels/overview)                       |
+| `defineSkill`                                         | `eve/skills`                                         | `agent/skills/<name>.ts`                                                   | [Skills](../skills)                                    |
+| `defineInstructions`                                  | `eve/instructions`                                   | `agent/instructions.ts`                                                    | [Instructions](../instructions)                        |
+| `defineHook`                                          | `eve/hooks`                                          | `agent/hooks/<slug>.ts`                                                    | [Hooks](../guides/hooks)                               |
+| `defineSchedule`                                      | `eve/schedules`                                      | `agent/schedules/<name>.ts`                                                | [Schedules](../schedules)                              |
+| `defineState`                                         | `eve/context`                                        | tools, hooks, lifecycle                                                    | [Session context](../guides/session-context)           |
+| `defineSandbox`                                       | `eve/sandbox`                                        | `agent/sandbox.ts`                                                         | [Sandbox](../sandbox)                                  |
+| `defineInstrumentation`                               | `eve/instrumentation`                                | `agent/instrumentation.ts`                                                 | [instrumentation.ts](../guides/instrumentation)        |
+| `defineRemoteAgent`                                   | `eve`                                                | `agent/subagents/<id>/agent.ts`                                            | [Remote agents](../guides/remote-agents)               |
+| `defineEval`                                          | `eve/evals`                                          | `evals/*.eval.ts`                                                          | [Evals](../evals/overview)                             |
+| `defineEvalConfig`                                    | `eve/evals`                                          | `evals/evals.config.ts`                                                    | [Evals](../evals/overview)                             |
+| `mockModel`                                           | `eve/evals`                                          | Deterministic fixture agent models                                         | [Evals](../evals/overview)                             |
+| `useEveAgent`                                         | `eve/react`, `eve/vue`, `eve/svelte`                 | frontend                                                                   | [Frontend](../guides/frontend/overview)                |
 
 A few non-`define*` helpers round out the set: `disableTool` and `experimental_workflow` from `eve/tools` (see [Default harness](../concepts/default-harness)), `sleep` from `eve/tools/sleep`, the route verbs `GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`WS` from `eve/channels`, the approval policies `always`/`once`/`never` from `eve/tools/approval`, and the channel auth helpers `localDev`/`vercelOidc`/`placeholderAuth` from `eve/channels/auth`. To wrap a built-in tool, import its default value from `eve/tools/defaults` (`bash`, `readFile`, `writeFile`, `glob`, `grep`, `webFetch`, `webSearch`, `todo`, `loadSkill`). `AgentReasoningDefinition` is exported from `eve` for the top-level `defineAgent({ reasoning })` setting. `AgentLimitsDefinition` is exported for `defineAgent({ limits })`. `AgentWorkflowDefinition` and `AgentWorkflowWorldDefinition` are exported from `eve` for the `defineAgent({ experimental: { workflow } })` config shape. `ExperimentalWorkflowToolInput` is exported from `eve/tools` for the `experimental_workflow(...)` config shape.
 
@@ -68,33 +68,33 @@ A few non-`define*` helpers round out the set: `disableTool` and `experimental_w
 
 ## Imports at a glance
 
-| Import                                                      | Holds                                                                 |
-| ----------------------------------------------------------- | --------------------------------------------------------------------- |
-| `eve`                                                       | `defineAgent`, `defineRemoteAgent`, agent config types                |
-| `eve/tools`                                                 | `defineTool`, `defineDynamic`, `disableTool`, `experimental_workflow` |
-| `eve/tools/defaults`                                        | the built-in tools as plain values                                    |
-| `eve/tools/approval`                                        | `always`, `once`, `never`                                             |
-| `eve/tools/sleep`                                           | opt-in durable `sleep` tool                                           |
-| `eve/connections`                                           | `defineMcpClientConnection`, `defineOpenAPIConnection`                |
-| `eve/channels`                                              | `defineChannel`, route verbs                                          |
-| `eve/channels/eve`                                          | `eveChannel`                                                          |
-| `eve/channels/auth`                                         | `localDev`, `vercelOidc`, `placeholderAuth`                           |
-| `eve/channels/{slack,discord,teams,telegram,twilio,github}` | platform channel factories                                            |
-| `eve/hooks`                                                 | `defineHook`                                                          |
-| `eve/schedules`                                             | `defineSchedule`                                                      |
-| `eve/skills`                                                | `defineSkill`, `defineDynamic`                                        |
-| `eve/instructions`                                          | `defineInstructions`, `defineDynamic`                                 |
-| `eve/context`                                               | `defineState`, session and state types                                |
-| `eve/sandbox`                                               | `defineSandbox`, backends                                             |
-| `eve/instrumentation`                                       | `defineInstrumentation`, `isChannel`                                  |
-| `eve/models/openai`                                         | `experimental_chatgpt`                                                |
-| `eve/evals`                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types             |
-| `eve/evals/expect`                                          | `includes`, `equals`, `matches`, `similarity`                         |
-| `eve/evals/reporters`                                       | `Braintrust`, `JUnit`, `EvalReporter`                                 |
-| `eve/evals/loaders`                                         | `loadJson`, `loadYaml`                                                |
-| `eve/react`, `eve/vue`, `eve/svelte`                        | `useEveAgent`                                                         |
-| `eve/next`, `eve/nuxt`, `eve/sveltekit`                     | framework bundler plugins                                             |
-| [`eve/client`](../guides/client/overview)                   | `Client`, `ClientSession`                                             |
+| Import                                                      | Holds                                                                   |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `eve`                                                       | `defineAgent`, `defineRemoteAgent`, `defineDynamic`, agent config types |
+| `eve/tools`                                                 | `defineTool`, `defineDynamic`, `disableTool`, `experimental_workflow`   |
+| `eve/tools/defaults`                                        | the built-in tools as plain values                                      |
+| `eve/tools/approval`                                        | `always`, `once`, `never`                                               |
+| `eve/tools/sleep`                                           | opt-in durable `sleep` tool                                             |
+| `eve/connections`                                           | `defineMcpClientConnection`, `defineOpenAPIConnection`                  |
+| `eve/channels`                                              | `defineChannel`, route verbs                                            |
+| `eve/channels/eve`                                          | `eveChannel`                                                            |
+| `eve/channels/auth`                                         | `localDev`, `vercelOidc`, `placeholderAuth`                             |
+| `eve/channels/{slack,discord,teams,telegram,twilio,github}` | platform channel factories                                              |
+| `eve/hooks`                                                 | `defineHook`                                                            |
+| `eve/schedules`                                             | `defineSchedule`                                                        |
+| `eve/skills`                                                | `defineSkill`, `defineDynamic`                                          |
+| `eve/instructions`                                          | `defineInstructions`, `defineDynamic`                                   |
+| `eve/context`                                               | `defineState`, session and state types                                  |
+| `eve/sandbox`                                               | `defineSandbox`, backends                                               |
+| `eve/instrumentation`                                       | `defineInstrumentation`, `isChannel`                                    |
+| `eve/models/openai`                                         | `experimental_chatgpt`                                                  |
+| `eve/evals`                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types               |
+| `eve/evals/expect`                                          | `includes`, `equals`, `matches`, `similarity`                           |
+| `eve/evals/reporters`                                       | `Braintrust`, `JUnit`, `EvalReporter`                                   |
+| `eve/evals/loaders`                                         | `loadJson`, `loadYaml`                                                  |
+| `eve/react`, `eve/vue`, `eve/svelte`                        | `useEveAgent`                                                           |
+| `eve/next`, `eve/nuxt`, `eve/sveltekit`                     | framework bundler plugins                                               |
+| [`eve/client`](../guides/client/overview)                   | `Client`, `ClientSession`                                               |
 
 Exported types ship from the same entrypoint as the helper they describe (for example `ToolDefinition` and `ToolContext` from `eve/tools`). For the exhaustive list, read `packages/eve/src/public/index.ts`.
 

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -50,23 +50,21 @@ export default defineAgent({
 ### Conditional availability
 
 To expose a declared subagent only for certain sessions or turns, export
-`defineDynamic` from that subagent's `agent.ts`. The fallback is its compiled
-agent configuration; return that exact value to expose the subagent, or nil to
-omit it from the parent's tools.
+`defineDynamic` from that subagent's `agent.ts`. Return a `defineAgent`
+configuration to expose the subagent, or nil to omit it from the parent's tools.
 
 ```ts title="agent/subagents/researcher/agent.ts"
 import { defineAgent, defineDynamic } from "eve";
 
-const researcher = defineAgent({
-  description: "Investigate ambiguous questions before the parent responds.",
-  model: "anthropic/claude-opus-4.8",
-});
-
 export default defineDynamic({
-  fallback: researcher,
   events: {
     "session.started": (_event, ctx) =>
-      ctx.session.auth.current?.attributes.research === true ? researcher : null,
+      ctx.session.auth.current?.attributes.research === true
+        ? defineAgent({
+            description: "Investigate ambiguous questions before the parent responds.",
+            model: "anthropic/claude-opus-4.8",
+          })
+        : null,
   },
 });
 ```
@@ -74,6 +72,8 @@ export default defineDynamic({
 Resolvers run at `session.started` or `turn.started`; `step.started` is not
 supported for subagents. A nil result (`null` or `undefined`) removes the
 subagent's description and tool definition from the model-visible surface.
+The subagent's filesystem manifest is always compiled; a non-nil result injects
+the returned agent configuration when the child runs.
 See [Dynamic capabilities](./guides/dynamic-capabilities#dynamic-subagents) for
 scope precedence, failure behavior, and the dispatch-time guard.
 
@@ -81,7 +81,7 @@ Minimum files:
 
 ```text
 agent/subagents/researcher/
-├── agent.ts            # required (must export a description)
+├── agent.ts            # required
 ├── instructions.md     # or instructions.ts, optional
 ├── tools/              # optional, its own tools
 ├── skills/             # optional, its own skills

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -47,6 +47,36 @@ export default defineAgent({
 
 `description` is required. The parent reads it to decide whether to delegate, so the compiler rejects any subagent whose `agent.ts` leaves it out.
 
+### Conditional availability
+
+To expose a declared subagent only for certain sessions or turns, export
+`defineDynamic` from that subagent's `agent.ts`. The fallback is its compiled
+agent configuration; return that exact value to expose the subagent, or nil to
+omit it from the parent's tools.
+
+```ts title="agent/subagents/researcher/agent.ts"
+import { defineAgent, defineDynamic } from "eve";
+
+const researcher = defineAgent({
+  description: "Investigate ambiguous questions before the parent responds.",
+  model: "anthropic/claude-opus-4.8",
+});
+
+export default defineDynamic({
+  fallback: researcher,
+  events: {
+    "session.started": (_event, ctx) =>
+      ctx.session.auth.current?.attributes.research === true ? researcher : null,
+  },
+});
+```
+
+Resolvers run at `session.started` or `turn.started`; `step.started` is not
+supported for subagents. A nil result (`null` or `undefined`) removes the
+subagent's description and tool definition from the model-visible surface.
+See [Dynamic capabilities](./guides/dynamic-capabilities#dynamic-subagents) for
+scope precedence, failure behavior, and the dispatch-time guard.
+
 Minimum files:
 
 ```text
@@ -100,7 +130,7 @@ A declared subagent's tool name is the bare path-derived name, with no prefix. `
 }
 ```
 
-Because the name lives in the same runtime tool namespace as authored tools, a subagent named `researcher` collides with a tool named `researcher`. eve rejects the build rather than picking a winner, so keep subagent directory names distinct from tool names.
+Because the name lives in the same runtime tool namespace as authored tools, a subagent named `researcher` collides with a tool named `researcher`. eve rejects static collisions at build time and active dynamic collisions at runtime rather than picking a winner, so keep subagent directory names distinct from tool names.
 
 Do not rely on subagent delegation by itself as an approval boundary. Put sensitive tools behind `approval`, connection approval, route/session authorization, or other controls wherever those tools can be called.
 

--- a/e2e/fixtures/agent-subagents/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/agent.ts
@@ -1,39 +1,11 @@
 import { e2eAgentConfig } from "@eve-e2e/config";
 import { defineAgent } from "eve";
-import type { MockModelRequest, MockModelResponse } from "eve/evals";
 
-const DYNAMIC_SUBAGENT_PROBE = "dynamic subagent availability probe";
-
-function respond(request: MockModelRequest): MockModelResponse | string {
-  const message = request.lastUserMessage ?? "";
-  if (!message.includes(DYNAMIC_SUBAGENT_PROBE)) {
-    return `Mock reply: ${message}`;
-  }
-
-  if (request.tools.some((tool) => tool.name === "omitted-marker")) {
-    return "NIL_SUBAGENT_WAS_VISIBLE";
-  }
-
-  const result = request.toolResults.find((entry) => entry.name === "conditional-marker");
-  if (result !== undefined) {
-    return typeof result.output === "string" ? result.output : JSON.stringify(result.output);
-  }
-
-  if (request.tools.some((tool) => tool.name === "conditional-marker")) {
-    return {
-      toolCalls: [
-        {
-          input: { message: "Return your marker." },
-          name: "conditional-marker",
-        },
-      ],
-    };
-  }
-
-  return "DYNAMIC_SUBAGENT_DISABLED";
+if (process.env.EVE_E2E_MODEL === "mock") {
+  process.env.EVE_MOCK_AUTHORED_MODELS = "1";
 }
 
 export default defineAgent({
-  ...e2eAgentConfig({ mock: respond }),
+  ...e2eAgentConfig(),
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/agent.ts
@@ -16,9 +16,7 @@ function respond(request: MockModelRequest): MockModelResponse | string {
 
   const result = request.toolResults.find((entry) => entry.name === "conditional-marker");
   if (result !== undefined) {
-    const output =
-      typeof result.output === "string" ? result.output : JSON.stringify(result.output);
-    return `${output} NIL_SUBAGENT_OMITTED`;
+    return typeof result.output === "string" ? result.output : JSON.stringify(result.output);
   }
 
   if (request.tools.some((tool) => tool.name === "conditional-marker")) {

--- a/e2e/fixtures/agent-subagents/agent/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/agent.ts
@@ -1,7 +1,41 @@
 import { e2eAgentConfig } from "@eve-e2e/config";
 import { defineAgent } from "eve";
+import type { MockModelRequest, MockModelResponse } from "eve/evals";
+
+const DYNAMIC_SUBAGENT_PROBE = "dynamic subagent availability probe";
+
+function respond(request: MockModelRequest): MockModelResponse | string {
+  const message = request.lastUserMessage ?? "";
+  if (!message.includes(DYNAMIC_SUBAGENT_PROBE)) {
+    return `Mock reply: ${message}`;
+  }
+
+  if (request.tools.some((tool) => tool.name === "omitted-marker")) {
+    return "NIL_SUBAGENT_WAS_VISIBLE";
+  }
+
+  const result = request.toolResults.find((entry) => entry.name === "conditional-marker");
+  if (result !== undefined) {
+    const output =
+      typeof result.output === "string" ? result.output : JSON.stringify(result.output);
+    return `${output} NIL_SUBAGENT_OMITTED`;
+  }
+
+  if (request.tools.some((tool) => tool.name === "conditional-marker")) {
+    return {
+      toolCalls: [
+        {
+          input: { message: "Return your marker." },
+          name: "conditional-marker",
+        },
+      ],
+    };
+  }
+
+  return "DYNAMIC_SUBAGENT_DISABLED";
+}
 
 export default defineAgent({
-  ...e2eAgentConfig(),
+  ...e2eAgentConfig({ mock: respond }),
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/agent.ts
@@ -1,14 +1,16 @@
 import { e2eSubagentConfig } from "@eve-e2e/config";
 import { defineAgent, defineDynamic } from "eve";
 
-const conditionalMarker = defineAgent({
-  ...e2eSubagentConfig({ mock: "DYNAMIC_SUBAGENT_ENABLED" }),
-  description: "Return the dynamic-subagent availability marker.",
-});
+const mockMode = process.env.EVE_E2E_MODEL === "mock";
 
 export default defineDynamic({
-  fallback: conditionalMarker,
   events: {
-    "session.started": () => conditionalMarker,
+    "session.started": () =>
+      defineAgent({
+        description: "Return the dynamic-subagent availability marker.",
+        model: mockMode
+          ? "eve-mock/dynamic-subagent"
+          : e2eSubagentConfig({ mock: "DYNAMIC_SUBAGENT_ENABLED" }).model,
+      }),
   },
 });

--- a/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/agent.ts
@@ -1,0 +1,14 @@
+import { e2eSubagentConfig } from "@eve-e2e/config";
+import { defineAgent, defineDynamic } from "eve";
+
+const conditionalMarker = defineAgent({
+  ...e2eSubagentConfig({ mock: "DYNAMIC_SUBAGENT_ENABLED" }),
+  description: "Return the dynamic-subagent availability marker.",
+});
+
+export default defineDynamic({
+  fallback: conditionalMarker,
+  events: {
+    "session.started": () => conditionalMarker,
+  },
+});

--- a/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/instructions.md
+++ b/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/instructions.md
@@ -1,0 +1,1 @@
+Reply with exactly `DYNAMIC_SUBAGENT_ENABLED` and nothing else.

--- a/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/instructions.md
+++ b/e2e/fixtures/agent-subagents/agent/subagents/conditional-marker/instructions.md
@@ -1,1 +1,1 @@
-Reply with exactly `DYNAMIC_SUBAGENT_ENABLED` and nothing else.
+Reply with the exact string `DYNAMIC_SUBAGENT_ENABLED` and nothing else.

--- a/e2e/fixtures/agent-subagents/agent/subagents/omitted-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/omitted-marker/agent.ts
@@ -1,13 +1,6 @@
-import { e2eSubagentConfig } from "@eve-e2e/config";
-import { defineAgent, defineDynamic } from "eve";
-
-const omittedMarker = defineAgent({
-  ...e2eSubagentConfig({ mock: "NIL_SUBAGENT_WAS_CALLED" }),
-  description: "This subagent must be omitted from the model-visible toolset.",
-});
+import { defineDynamic } from "eve";
 
 export default defineDynamic({
-  fallback: omittedMarker,
   events: {
     "session.started": () => null,
   },

--- a/e2e/fixtures/agent-subagents/agent/subagents/omitted-marker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/omitted-marker/agent.ts
@@ -1,0 +1,14 @@
+import { e2eSubagentConfig } from "@eve-e2e/config";
+import { defineAgent, defineDynamic } from "eve";
+
+const omittedMarker = defineAgent({
+  ...e2eSubagentConfig({ mock: "NIL_SUBAGENT_WAS_CALLED" }),
+  description: "This subagent must be omitted from the model-visible toolset.",
+});
+
+export default defineDynamic({
+  fallback: omittedMarker,
+  events: {
+    "session.started": () => null,
+  },
+});

--- a/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
@@ -1,0 +1,20 @@
+import { defineEval } from "eve/evals";
+
+const PROBE = "dynamic subagent availability probe";
+
+export default defineEval({
+  description:
+    "Dynamic subagents are advertised when their resolver returns the fallback and omitted when it returns nil.",
+  async test(t) {
+    await t.send(
+      `${PROBE}: Call conditional-marker exactly once, then reply with its exact output. Do not call omitted-marker.`,
+    );
+
+    t.succeeded();
+    t.calledSubagent("conditional-marker", { count: 1, output: "DYNAMIC_SUBAGENT_ENABLED" });
+    t.notEvent("subagent.called", { data: { name: "omitted-marker" } });
+    t.messageIncludes("DYNAMIC_SUBAGENT_ENABLED");
+    t.messageIncludes("NIL_SUBAGENT_OMITTED");
+    t.noFailedActions();
+  },
+});

--- a/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
@@ -1,19 +1,21 @@
 import { defineEval } from "eve/evals";
 
-const PROBE = "dynamic subagent availability probe";
-
 export default defineEval({
   description:
     "Dynamic subagents are advertised when their resolver returns an agent config and omitted when it returns nil.",
   async test(t) {
-    await t.send(
-      `${PROBE}: Call conditional-marker exactly once, then reply with its exact output. Do not call omitted-marker.`,
-    );
+    const selected = await t.send("Call conditional-marker exactly once.");
 
-    t.succeeded();
-    t.calledSubagent("conditional-marker", { count: 1, output: "DYNAMIC_SUBAGENT_ENABLED" });
-    t.notEvent("subagent.called", { data: { name: "omitted-marker" } });
-    t.messageIncludes("DYNAMIC_SUBAGENT_ENABLED");
-    t.noFailedActions();
+    selected.calledSubagent("conditional-marker", {
+      count: 1,
+      output: "DYNAMIC_SUBAGENT_ENABLED",
+    });
+    selected.messageIncludes("DYNAMIC_SUBAGENT_ENABLED");
+    selected.noFailedActions();
+
+    const omitted = await t.send("Call omitted-marker exactly once.");
+
+    omitted.notEvent("subagent.called", { data: { name: "omitted-marker" } });
+    omitted.noFailedActions();
   },
 });

--- a/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
@@ -4,7 +4,7 @@ const PROBE = "dynamic subagent availability probe";
 
 export default defineEval({
   description:
-    "Dynamic subagents are advertised when their resolver returns the fallback and omitted when it returns nil.",
+    "Dynamic subagents are advertised when their resolver returns an agent config and omitted when it returns nil.",
   async test(t) {
     await t.send(
       `${PROBE}: Call conditional-marker exactly once, then reply with its exact output. Do not call omitted-marker.`,

--- a/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/dynamic-subagent.eval.ts
@@ -14,7 +14,6 @@ export default defineEval({
     t.calledSubagent("conditional-marker", { count: 1, output: "DYNAMIC_SUBAGENT_ENABLED" });
     t.notEvent("subagent.called", { data: { name: "omitted-marker" } });
     t.messageIncludes("DYNAMIC_SUBAGENT_ENABLED");
-    t.messageIncludes("NIL_SUBAGENT_OMITTED");
     t.noFailedActions();
   },
 });

--- a/packages/eve/src/client/agent-info-schema.ts
+++ b/packages/eve/src/client/agent-info-schema.ts
@@ -65,7 +65,7 @@ const schedule = entry.extend({
 });
 
 const subagent = entry.extend({
-  description: z.string(),
+  description: z.string().optional(),
   entryPath: z.string(),
   nodeId: z.string(),
   rootPath: z.string(),

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -1,9 +1,56 @@
 import { describe, expect, it } from "vitest";
 
-import { compiledAgentManifestSchema, createCompiledAgentManifest } from "#compiler/manifest.js";
+import {
+  compiledAgentManifestSchema,
+  createCompiledAgentManifest,
+  createCompiledAgentNodeManifest,
+} from "#compiler/manifest.js";
 import { classifyModelRouting } from "#internal/classify-model-routing.js";
 
 describe("compiledAgentManifestSchema", () => {
+  it("requires exactly one static description or dynamic resolver for each subagent", () => {
+    const manifest = createCompiledAgentManifest({
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      config: {
+        model: { id: "openai/gpt-5.5", routing: classifyModelRouting("openai/gpt-5.5") },
+        name: "app",
+      },
+    });
+    const subagent = {
+      agent: createCompiledAgentNodeManifest({
+        agentRoot: "/app/agent/subagents/research",
+        appRoot: "/app",
+        config: {
+          model: { id: "openai/gpt-5.5", routing: classifyModelRouting("openai/gpt-5.5") },
+          name: "research",
+        },
+      }),
+      entryPath: "subagents/research/agent.ts",
+      logicalPath: "subagents/research",
+      name: "research",
+      nodeId: "research",
+      rootPath: "/app/agent/subagents/research",
+      sourceId: "subagents/research/agent.ts",
+      sourceKind: "module",
+    } as const;
+    const parses = (variant: Readonly<Record<string, unknown>>): boolean =>
+      compiledAgentManifestSchema.safeParse({
+        ...manifest,
+        subagents: [{ ...subagent, ...variant }],
+      }).success;
+
+    expect(parses({ description: "Research requests." })).toBe(true);
+    expect(parses({ dynamic: { eventNames: ["session.started"] } })).toBe(true);
+    expect(parses({})).toBe(false);
+    expect(
+      parses({
+        description: "Research requests.",
+        dynamic: { eventNames: ["session.started"] },
+      }),
+    ).toBe(false);
+  });
+
   it("preserves reasoning configuration", () => {
     const manifest = createCompiledAgentManifest({
       agentRoot: "/app/agent",

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -252,12 +252,19 @@ export type CompiledSubagentNode = Readonly<
   ModuleSourceRef &
     Node & {
       agent: CompiledAgentNodeManifest;
-      description?: string;
-      dynamic?: CompiledDynamicSubagentDefinition;
       entryPath: string;
       name: string;
       rootPath: string;
-    }
+    } & (
+      | {
+          description: string;
+          dynamic?: never;
+        }
+      | {
+          description?: never;
+          dynamic: CompiledDynamicSubagentDefinition;
+        }
+    )
 >;
 
 export type { CompiledRemoteAgentNode } from "#compiler/remote-agent-node.js";
@@ -660,26 +667,31 @@ const compiledAgentNodeManifestSchema = z
   })
   .strict();
 
-const compiledSubagentNodeSchema: z.ZodType<CompiledSubagentNode> = z
+const compiledSubagentNodeBaseFields = {
+  agent: compiledAgentNodeManifestSchema,
+  entryPath: z.string(),
+  logicalPath: z.string(),
+  name: z.string(),
+  nodeId: z.string(),
+  rootPath: z.string(),
+  sourceId: z.string(),
+  sourceKind: z.literal("module"),
+  exportName: z.string().optional(),
+};
+const compiledDynamicSubagentDefinitionSchema = z
   .object({
-    agent: compiledAgentNodeManifestSchema,
-    description: z.string().optional(),
-    dynamic: z
-      .object({
-        eventNames: z.array(z.string()).readonly(),
-      })
-      .strict()
-      .optional(),
-    entryPath: z.string(),
-    logicalPath: z.string(),
-    name: z.string(),
-    nodeId: z.string(),
-    rootPath: z.string(),
-    sourceId: z.string(),
-    sourceKind: z.literal("module"),
-    exportName: z.string().optional(),
+    eventNames: z.array(z.string()).readonly(),
   })
   .strict();
+const compiledSubagentNodeSchema: z.ZodType<CompiledSubagentNode> = z.union([
+  z.object({ ...compiledSubagentNodeBaseFields, description: z.string() }).strict(),
+  z
+    .object({
+      ...compiledSubagentNodeBaseFields,
+      dynamic: compiledDynamicSubagentDefinitionSchema,
+    })
+    .strict(),
+]);
 
 const compiledSubagentEdgeSchema: z.ZodType<CompiledSubagentEdge> = z
   .object({

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -248,15 +248,11 @@ export interface CompiledHookDefinition extends ModuleSourceRef {
  */
 export type CompiledAgentNodeManifest = z.infer<typeof compiledAgentNodeManifestSchema>;
 
-/**
- * Flattened compiled subagent node emitted by the compiler. `name` and
- * `description` are copied from `agent.config` for fast registry lookup.
- */
 export type CompiledSubagentNode = Readonly<
   ModuleSourceRef &
     Node & {
       agent: CompiledAgentNodeManifest;
-      description: string;
+      description?: string;
       dynamic?: CompiledDynamicSubagentDefinition;
       entryPath: string;
       name: string;
@@ -667,7 +663,7 @@ const compiledAgentNodeManifestSchema = z
 const compiledSubagentNodeSchema: z.ZodType<CompiledSubagentNode> = z
   .object({
     agent: compiledAgentNodeManifestSchema,
-    description: z.string(),
+    description: z.string().optional(),
     dynamic: z
       .object({
         eventNames: z.array(z.string()).readonly(),

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -5,6 +5,7 @@ import {
   discoverDiagnosticsSummarySchema,
 } from "#discover/diagnostics.js";
 import {
+  type CompiledDynamicSubagentDefinition,
   compiledRemoteAgentNodeSchema,
   type CompiledRemoteAgentNode,
 } from "#compiler/remote-agent-node.js";
@@ -41,7 +42,7 @@ export const ROOT_COMPILED_AGENT_NODE_ID = "__root__";
 /**
  * Current compiled manifest schema version.
  */
-export const COMPILED_AGENT_MANIFEST_VERSION = 37;
+export const COMPILED_AGENT_MANIFEST_VERSION = 38;
 
 /**
  * Compiled channel entry preserved in the compiled manifest.
@@ -256,6 +257,7 @@ export type CompiledSubagentNode = Readonly<
     Node & {
       agent: CompiledAgentNodeManifest;
       description: string;
+      dynamic?: CompiledDynamicSubagentDefinition;
       entryPath: string;
       name: string;
       rootPath: string;
@@ -666,6 +668,12 @@ const compiledSubagentNodeSchema: z.ZodType<CompiledSubagentNode> = z
   .object({
     agent: compiledAgentNodeManifestSchema,
     description: z.string(),
+    dynamic: z
+      .object({
+        eventNames: z.array(z.string()).readonly(),
+      })
+      .strict()
+      .optional(),
     entryPath: z.string(),
     logicalPath: z.string(),
     name: z.string(),

--- a/packages/eve/src/compiler/normalize-agent-config.test.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.test.ts
@@ -56,6 +56,33 @@ describe("compileAgentConfig", () => {
       sourceKind: "module",
     });
   });
+
+  it("compiles an injected dynamic-subagent fallback without reloading agent.ts", async () => {
+    const manifest = createAgentSourceManifest({
+      agentId: "researcher",
+      agentRoot: "/app/agent/subagents/researcher",
+      appRoot: "/app",
+      configModule: createModuleSourceRef({
+        logicalPath: "agent.ts",
+        sourceId: "agent-config",
+      }),
+    });
+
+    const compiled = await compileAgentConfig(
+      manifest,
+      { modelCatalog: createModelCatalog() },
+      {
+        definition: {
+          description: "Research the request.",
+          model: "openai/gpt-5.5",
+        },
+      },
+    );
+
+    expect(mocks.loadModuleBackedDefinition).not.toHaveBeenCalled();
+    expect(compiled.description).toBe("Research the request.");
+    expect(compiled.source?.sourceId).toBe("agent-config");
+  });
 });
 
 function createModelCatalog(): ManifestCompileContext["modelCatalog"] {

--- a/packages/eve/src/compiler/normalize-agent-config.test.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.test.ts
@@ -57,7 +57,7 @@ describe("compileAgentConfig", () => {
     });
   });
 
-  it("compiles an injected dynamic-subagent fallback without reloading agent.ts", async () => {
+  it("compiles an injected dynamic-subagent placeholder without reloading agent.ts", async () => {
     const manifest = createAgentSourceManifest({
       agentId: "researcher",
       agentRoot: "/app/agent/subagents/researcher",
@@ -73,14 +73,13 @@ describe("compileAgentConfig", () => {
       { modelCatalog: createModelCatalog() },
       {
         definition: {
-          description: "Research the request.",
           model: "openai/gpt-5.5",
         },
       },
     );
 
     expect(mocks.loadModuleBackedDefinition).not.toHaveBeenCalled();
-    expect(compiled.description).toBe("Research the request.");
+    expect(compiled.description).toBeUndefined();
     expect(compiled.source?.sourceId).toBe("agent-config");
   });
 });

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -31,19 +31,25 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 export async function compileAgentConfig(
   manifest: AgentSourceManifest,
   context: ManifestCompileContext,
+  options: {
+    readonly definition?: unknown;
+  } = {},
 ): Promise<CompiledAgentDefinition> {
   const configModule = manifest.configModule;
   const configModulePath =
     configModule === undefined ? undefined : formatAgentConfigModulePath(manifest, configModule);
+  const hasInjectedDefinition = Object.hasOwn(options, "definition");
   const definition = normalizeAgentDefinition(
-    configModule === undefined
-      ? { model: DEFAULT_AGENT_MODEL_ID }
-      : await loadModuleBackedDefinition({
-          agentRoot: manifest.agentRoot,
-          displayPath: configModulePath!,
-          kind: "agent config",
-          source: configModule,
-        }),
+    hasInjectedDefinition
+      ? options.definition
+      : configModule === undefined
+        ? { model: DEFAULT_AGENT_MODEL_ID }
+        : await loadModuleBackedDefinition({
+            agentRoot: manifest.agentRoot,
+            displayPath: configModulePath!,
+            kind: "agent config",
+            source: configModule,
+          }),
     configModule === undefined
       ? `Expected the default agent config to match the public eve shape.`
       : `Expected the agent config export "${configModule.exportName ?? "default"}" from "${configModulePath}" to match the public eve shape.`,

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -11,6 +11,7 @@ import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import { compileAgentManifest } from "#compiler/normalize-manifest.js";
 import { defineAgent } from "#public/definitions/agent.js";
 import { defineDynamic, experimental_workflow } from "#public/definitions/tool.js";
+import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 
 const mocks = vi.hoisted(() => ({
   compileAgentConfig: vi.fn(),
@@ -95,26 +96,20 @@ describe("compileAgentManifest", () => {
     expect(compiled.workflowTool).toEqual({ maxSubagents: 6 });
   });
 
-  it("compiles a dynamic subagent from its fallback definition", async () => {
-    const fallback = defineAgent({
-      description: "Research the request.",
-      model: "openai/gpt-5.5",
-    });
+  it("compiles a dynamic subagent manifest without resolving an agent config", async () => {
     const dynamic = defineDynamic({
-      fallback,
       events: {
-        "session.started": () => fallback,
+        "session.started": () =>
+          defineAgent({
+            description: "Research the request.",
+            model: "openai/gpt-5.5",
+          }),
         "turn.started": () => null,
       },
     });
     const manifest = createManifestWithSubagent();
     mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) =>
-      input.agentId === "researcher"
-        ? createConfig({
-            description: fallback.description,
-            name: "researcher",
-          })
-        : createConfig({ name: "root" }),
+      createConfig({ name: input.agentId }),
     );
     mocks.loadModuleBackedDefinition.mockResolvedValue(dynamic);
 
@@ -123,15 +118,20 @@ describe("compileAgentManifest", () => {
     expect(compiled.subagents[0]?.dynamic).toEqual({
       eventNames: ["session.started", "turn.started"],
     });
+    expect(compiled.subagents[0]?.description).toBeUndefined();
     expect(mocks.compileAgentConfig.mock.calls[1]?.[2]).toMatchObject({
-      definition: fallback,
+      definition: { model: DEFAULT_AGENT_MODEL_ID },
     });
   });
 
-  it("rejects a dynamic subagent without a fallback definition", async () => {
+  it("rejects fallback on a dynamic subagent", async () => {
     mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
     mocks.loadModuleBackedDefinition.mockResolvedValue(
       defineDynamic({
+        fallback: defineAgent({
+          description: "Research the request.",
+          model: "openai/gpt-5.5",
+        }),
         events: {
           "session.started": () => null,
         },
@@ -139,21 +139,20 @@ describe("compileAgentManifest", () => {
     );
 
     await expect(compileAgentManifest(createManifestWithSubagent())).rejects.toThrow(
-      "Dynamic subagent definitions must include a fallback agent definition",
+      'Dynamic subagent definitions do not support "fallback"',
     );
   });
 
   it("rejects step-scoped dynamic subagents", async () => {
-    const fallback = defineAgent({
-      description: "Research the request.",
-      model: "openai/gpt-5.5",
-    });
     mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
     mocks.loadModuleBackedDefinition.mockResolvedValue(
       defineDynamic({
-        fallback,
         events: {
-          "step.started": () => fallback,
+          "step.started": () =>
+            defineAgent({
+              description: "Research the request.",
+              model: "openai/gpt-5.5",
+            }),
         },
       }),
     );

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -9,7 +9,8 @@ import {
 import { classifyModelRouting } from "#internal/classify-model-routing.js";
 import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import { compileAgentManifest } from "#compiler/normalize-manifest.js";
-import { experimental_workflow } from "#public/definitions/tool.js";
+import { defineAgent } from "#public/definitions/agent.js";
+import { defineDynamic, experimental_workflow } from "#public/definitions/tool.js";
 
 const mocks = vi.hoisted(() => ({
   compileAgentConfig: vi.fn(),
@@ -93,7 +94,98 @@ describe("compileAgentManifest", () => {
 
     expect(compiled.workflowTool).toEqual({ maxSubagents: 6 });
   });
+
+  it("compiles a dynamic subagent from its fallback definition", async () => {
+    const fallback = defineAgent({
+      description: "Research the request.",
+      model: "openai/gpt-5.5",
+    });
+    const dynamic = defineDynamic({
+      fallback,
+      events: {
+        "session.started": () => fallback,
+        "turn.started": () => null,
+      },
+    });
+    const manifest = createManifestWithSubagent();
+    mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) =>
+      input.agentId === "researcher"
+        ? createConfig({
+            description: fallback.description,
+            name: "researcher",
+          })
+        : createConfig({ name: "root" }),
+    );
+    mocks.loadModuleBackedDefinition.mockResolvedValue(dynamic);
+
+    const compiled = await compileAgentManifest(manifest);
+
+    expect(compiled.subagents[0]?.dynamic).toEqual({
+      eventNames: ["session.started", "turn.started"],
+    });
+    expect(mocks.compileAgentConfig.mock.calls[1]?.[2]).toMatchObject({
+      definition: fallback,
+    });
+  });
+
+  it("rejects a dynamic subagent without a fallback definition", async () => {
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+    mocks.loadModuleBackedDefinition.mockResolvedValue(
+      defineDynamic({
+        events: {
+          "session.started": () => null,
+        },
+      }),
+    );
+
+    await expect(compileAgentManifest(createManifestWithSubagent())).rejects.toThrow(
+      "Dynamic subagent definitions must include a fallback agent definition",
+    );
+  });
+
+  it("rejects step-scoped dynamic subagents", async () => {
+    const fallback = defineAgent({
+      description: "Research the request.",
+      model: "openai/gpt-5.5",
+    });
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+    mocks.loadModuleBackedDefinition.mockResolvedValue(
+      defineDynamic({
+        fallback,
+        events: {
+          "step.started": () => fallback,
+        },
+      }),
+    );
+
+    await expect(compileAgentManifest(createManifestWithSubagent())).rejects.toThrow(
+      'Dynamic subagents support only "session.started" and "turn.started" handlers',
+    );
+  });
 });
+
+function createManifestWithSubagent(): AgentSourceManifest {
+  const subagentManifest = createAgentSourceManifest({
+    agentId: "researcher",
+    agentRoot: "/app/agent/subagents/researcher",
+    appRoot: "/app",
+    configModule: createModuleSourceRef({ logicalPath: "agent.ts" }),
+  });
+  return createAgentSourceManifest({
+    agentId: "root",
+    agentRoot: "/app/agent",
+    appRoot: "/app",
+    subagents: [
+      createLocalSubagentSourceRef({
+        entryPath: "subagents/researcher/agent.ts",
+        logicalPath: "subagents/researcher",
+        manifest: subagentManifest,
+        rootPath: "/app/agent/subagents/researcher",
+        subagentId: "researcher",
+      }),
+    ],
+  });
+}
 
 function createConfig(
   input: Pick<CompiledAgentDefinition, "name"> &

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -75,11 +75,16 @@ async function compileAgentNodeManifest(
   manifest: AgentSourceManifest,
   context: ManifestCompileContext,
   options: {
+    readonly agentConfigDefinition?: unknown;
     readonly externalDependencies?: readonly string[];
     readonly allowWorkflowConfig?: boolean;
   } = {},
 ): Promise<CompiledAgentNodeManifest> {
-  const rawConfig = await compileAgentConfig(manifest, context);
+  const rawConfig = Object.hasOwn(options, "agentConfigDefinition")
+    ? await compileAgentConfig(manifest, context, {
+        definition: options.agentConfigDefinition,
+      })
+    : await compileAgentConfig(manifest, context);
   if (options.allowWorkflowConfig === false && rawConfig.experimental?.workflow !== undefined) {
     throw new Error(
       `Workflow runtime configuration is only supported on the root agent config. Remove "experimental.workflow" from "${manifest.agentId}".`,

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -22,13 +22,10 @@ import {
   expectString,
 } from "#internal/authored-module.js";
 import { EVE_CREATE_SESSION_ROUTE_PATH } from "#protocol/routes.js";
+import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import { serializeOutputSchema, type ToolSchemaSource } from "#shared/tool-schema.js";
 import type { JsonObject } from "#shared/json.js";
-import {
-  isDynamicSentinel,
-  type DynamicSentinel,
-  type DynamicToolEventName,
-} from "#shared/dynamic-tool-definition.js";
+import { isDynamicSentinel, type DynamicToolEventName } from "#shared/dynamic-tool-definition.js";
 
 const ALLOWED_DYNAMIC_SUBAGENT_EVENTS = new Set<DynamicToolEventName>([
   "session.started",
@@ -147,15 +144,12 @@ async function compileSubagentDefinition(input: {
     definition,
     `Expected the dynamic subagent config export "${configModule.exportName ?? "default"}" from "${configModuleSource.logicalPath}" to match the public eve shape.`,
   );
-  const staticDefinition = dynamic === undefined ? definition : dynamic.fallback;
-
-  if (readAgentDefinitionKind(staticDefinition) === "remote") {
+  if (dynamic === undefined && readAgentDefinitionKind(definition) === "remote") {
     return {
       kind: "remote",
       node: compileRemoteAgent({
-        dynamic: dynamic?.definition,
         source: input.source,
-        value: staticDefinition,
+        value: definition,
       }),
     };
   }
@@ -164,7 +158,7 @@ async function compileSubagentDefinition(input: {
     kind: "local",
     ...(await compileLocalSubagent({
       ...input,
-      agentConfigDefinition: staticDefinition,
+      agentConfigDefinition: dynamic === undefined ? definition : { model: DEFAULT_AGENT_MODEL_ID },
       dynamic: dynamic?.definition,
     })),
   };
@@ -204,7 +198,7 @@ async function compileSubagent(input: {
 
   const description = agent.config.description;
 
-  if (!description) {
+  if (input.dynamic === undefined && !description) {
     throw new Error(
       `Local subagent "${input.source.logicalPath}" is missing a "description" field on its agent config. Add \`description\` to \`defineAgent({ ... })\` so the parent agent can decide when to delegate to this subagent.`,
     );
@@ -219,9 +213,13 @@ async function compileSubagent(input: {
     subagents: input.source.manifest.subagents,
   });
   const dynamicFields: {
+    description?: string;
     dynamic?: { readonly eventNames: readonly string[] };
   } = {};
 
+  if (description !== undefined) {
+    dynamicFields.description = description;
+  }
   if (input.dynamic !== undefined) {
     dynamicFields.dynamic = input.dynamic;
   }
@@ -233,7 +231,6 @@ async function compileSubagent(input: {
         ...agent,
         remoteAgents: [...descendants.remoteAgents],
       },
-      description,
       ...dynamicFields,
       entryPath: input.source.entryPath,
       logicalPath: input.source.logicalPath,
@@ -249,7 +246,6 @@ async function compileSubagent(input: {
 const compileLocalSubagent = compileSubagent;
 
 function compileRemoteAgent(input: {
-  readonly dynamic?: { readonly eventNames: readonly string[] };
   readonly source: LocalSubagentSourceRef;
   readonly value: unknown;
 }): CompiledRemoteAgentNode {
@@ -266,18 +262,9 @@ function compileRemoteAgent(input: {
     input.value,
     `Expected the remote agent config export "${configModule.exportName ?? "default"}" from "${moduleSource.logicalPath}" to match the public eve shape.`,
   );
-  const dynamicFields: {
-    dynamic?: { readonly eventNames: readonly string[] };
-  } = {};
-
-  if (input.dynamic !== undefined) {
-    dynamicFields.dynamic = input.dynamic;
-  }
-
   const node = {
     ...moduleSource,
     description: definition.description,
-    ...dynamicFields,
     entryPath: input.source.entryPath,
     name: input.source.subagentId,
     nodeId: input.source.sourceId,
@@ -293,24 +280,18 @@ function compileRemoteAgent(input: {
 function normalizeDynamicSubagentDefinition(
   value: unknown,
   message: string,
-):
-  | {
-      readonly definition: { readonly eventNames: readonly DynamicToolEventName[] };
-      readonly fallback: unknown;
-    }
-  | undefined {
+): { readonly definition: { readonly eventNames: readonly DynamicToolEventName[] } } | undefined {
   if (!isDynamicSentinel(value)) {
     return undefined;
   }
 
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["events", "fallback", "kind"], message);
-
-  if (!Object.hasOwn(record, "fallback") || record.fallback === undefined) {
+  if (Object.hasOwn(record, "fallback")) {
     throw new Error(
-      `${message} Dynamic subagent definitions must include a fallback agent definition.`,
+      `${message} Dynamic subagent definitions do not support "fallback". Return defineAgent(...) from an event handler instead.`,
     );
   }
+  expectOnlyKnownKeys(record, ["events", "kind"], message);
 
   const rawEvents = expectObjectRecord(record.events, message);
   const eventNames: DynamicToolEventName[] = [];
@@ -327,7 +308,6 @@ function normalizeDynamicSubagentDefinition(
 
   return {
     definition: { eventNames },
-    fallback: (value as DynamicSentinel<unknown, unknown>).fallback,
   };
 }
 

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -16,6 +16,7 @@ import {
 } from "#compiler/normalize-helpers.js";
 import {
   expectBoolean,
+  expectFunction,
   expectObjectRecord,
   expectOnlyKnownKeys,
   expectString,
@@ -23,6 +24,16 @@ import {
 import { EVE_CREATE_SESSION_ROUTE_PATH } from "#protocol/routes.js";
 import { serializeOutputSchema, type ToolSchemaSource } from "#shared/tool-schema.js";
 import type { JsonObject } from "#shared/json.js";
+import {
+  isDynamicSentinel,
+  type DynamicSentinel,
+  type DynamicToolEventName,
+} from "#shared/dynamic-tool-definition.js";
+
+const ALLOWED_DYNAMIC_SUBAGENT_EVENTS = new Set<DynamicToolEventName>([
+  "session.started",
+  "turn.started",
+]);
 
 /**
  * Callback the subagent compiler uses to recurse into the per-node
@@ -34,6 +45,7 @@ export type CompileAgentNodeManifestFn = (
   manifest: AgentSourceManifest,
   context: ManifestCompileContext,
   options?: {
+    readonly agentConfigDefinition?: unknown;
     readonly externalDependencies?: readonly string[];
     readonly allowWorkflowConfig?: boolean;
   },
@@ -131,20 +143,30 @@ async function compileSubagentDefinition(input: {
     kind: "subagent config",
     source: configModule,
   });
+  const dynamic = normalizeDynamicSubagentDefinition(
+    definition,
+    `Expected the dynamic subagent config export "${configModule.exportName ?? "default"}" from "${configModuleSource.logicalPath}" to match the public eve shape.`,
+  );
+  const staticDefinition = dynamic === undefined ? definition : dynamic.fallback;
 
-  if (readAgentDefinitionKind(definition) === "remote") {
+  if (readAgentDefinitionKind(staticDefinition) === "remote") {
     return {
       kind: "remote",
       node: compileRemoteAgent({
+        dynamic: dynamic?.definition,
         source: input.source,
-        value: definition,
+        value: staticDefinition,
       }),
     };
   }
 
   return {
     kind: "local",
-    ...(await compileLocalSubagent(input)),
+    ...(await compileLocalSubagent({
+      ...input,
+      agentConfigDefinition: staticDefinition,
+      dynamic: dynamic?.definition,
+    })),
   };
 }
 
@@ -152,6 +174,8 @@ async function compileSubagent(input: {
   readonly appRoot: string;
   readonly compileAgentNodeManifest: CompileAgentNodeManifestFn;
   readonly context: ManifestCompileContext;
+  readonly agentConfigDefinition?: unknown;
+  readonly dynamic?: { readonly eventNames: readonly string[] };
   readonly externalDependencies?: readonly string[];
   readonly parentNodeId: string;
   readonly source: LocalSubagentSourceRef;
@@ -171,7 +195,11 @@ async function compileSubagent(input: {
       appRoot: input.appRoot,
     },
     input.context,
-    { allowWorkflowConfig: false, externalDependencies: input.externalDependencies },
+    {
+      agentConfigDefinition: input.agentConfigDefinition,
+      allowWorkflowConfig: false,
+      externalDependencies: input.externalDependencies,
+    },
   );
 
   const description = agent.config.description;
@@ -190,6 +218,13 @@ async function compileSubagent(input: {
     parentNodeId: nodeId,
     subagents: input.source.manifest.subagents,
   });
+  const dynamicFields: {
+    dynamic?: { readonly eventNames: readonly string[] };
+  } = {};
+
+  if (input.dynamic !== undefined) {
+    dynamicFields.dynamic = input.dynamic;
+  }
 
   return {
     descendants,
@@ -199,6 +234,7 @@ async function compileSubagent(input: {
         remoteAgents: [...descendants.remoteAgents],
       },
       description,
+      ...dynamicFields,
       entryPath: input.source.entryPath,
       logicalPath: input.source.logicalPath,
       name: subagentName,
@@ -213,6 +249,7 @@ async function compileSubagent(input: {
 const compileLocalSubagent = compileSubagent;
 
 function compileRemoteAgent(input: {
+  readonly dynamic?: { readonly eventNames: readonly string[] };
   readonly source: LocalSubagentSourceRef;
   readonly value: unknown;
 }): CompiledRemoteAgentNode {
@@ -229,10 +266,18 @@ function compileRemoteAgent(input: {
     input.value,
     `Expected the remote agent config export "${configModule.exportName ?? "default"}" from "${moduleSource.logicalPath}" to match the public eve shape.`,
   );
+  const dynamicFields: {
+    dynamic?: { readonly eventNames: readonly string[] };
+  } = {};
+
+  if (input.dynamic !== undefined) {
+    dynamicFields.dynamic = input.dynamic;
+  }
 
   const node = {
     ...moduleSource,
     description: definition.description,
+    ...dynamicFields,
     entryPath: input.source.entryPath,
     name: input.source.subagentId,
     nodeId: input.source.sourceId,
@@ -243,6 +288,47 @@ function compileRemoteAgent(input: {
 
   // A function `url` is deferred, so the compiled node omits it entirely.
   return definition.url === undefined ? node : { ...node, url: definition.url };
+}
+
+function normalizeDynamicSubagentDefinition(
+  value: unknown,
+  message: string,
+):
+  | {
+      readonly definition: { readonly eventNames: readonly DynamicToolEventName[] };
+      readonly fallback: unknown;
+    }
+  | undefined {
+  if (!isDynamicSentinel(value)) {
+    return undefined;
+  }
+
+  const record = expectObjectRecord(value, message);
+  expectOnlyKnownKeys(record, ["events", "fallback", "kind"], message);
+
+  if (!Object.hasOwn(record, "fallback") || record.fallback === undefined) {
+    throw new Error(
+      `${message} Dynamic subagent definitions must include a fallback agent definition.`,
+    );
+  }
+
+  const rawEvents = expectObjectRecord(record.events, message);
+  const eventNames: DynamicToolEventName[] = [];
+
+  for (const [eventName, handler] of Object.entries(rawEvents)) {
+    if (!ALLOWED_DYNAMIC_SUBAGENT_EVENTS.has(eventName as DynamicToolEventName)) {
+      throw new Error(
+        `${message} Dynamic subagents support only "session.started" and "turn.started" handlers.`,
+      );
+    }
+    expectFunction(handler, message);
+    eventNames.push(eventName as DynamicToolEventName);
+  }
+
+  return {
+    definition: { eventNames },
+    fallback: (value as DynamicSentinel<unknown, unknown>).fallback,
+  };
 }
 
 function createSubagentConfigModuleSourceRef(

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -198,10 +198,22 @@ async function compileSubagent(input: {
 
   const description = agent.config.description;
 
-  if (input.dynamic === undefined && !description) {
-    throw new Error(
-      `Local subagent "${input.source.logicalPath}" is missing a "description" field on its agent config. Add \`description\` to \`defineAgent({ ... })\` so the parent agent can decide when to delegate to this subagent.`,
-    );
+  let variant:
+    | { readonly description: string; readonly dynamic?: never }
+    | {
+        readonly description?: never;
+        readonly dynamic: { readonly eventNames: readonly string[] };
+      };
+
+  if (input.dynamic !== undefined) {
+    variant = { dynamic: input.dynamic };
+  } else {
+    if (!description) {
+      throw new Error(
+        `Local subagent "${input.source.logicalPath}" is missing a "description" field on its agent config. Add \`description\` to \`defineAgent({ ... })\` so the parent agent can decide when to delegate to this subagent.`,
+      );
+    }
+    variant = { description };
   }
 
   const descendants = await compileSubagentGraph({
@@ -212,18 +224,6 @@ async function compileSubagent(input: {
     parentNodeId: nodeId,
     subagents: input.source.manifest.subagents,
   });
-  const dynamicFields: {
-    description?: string;
-    dynamic?: { readonly eventNames: readonly string[] };
-  } = {};
-
-  if (description !== undefined) {
-    dynamicFields.description = description;
-  }
-  if (input.dynamic !== undefined) {
-    dynamicFields.dynamic = input.dynamic;
-  }
-
   return {
     descendants,
     node: {
@@ -231,7 +231,7 @@ async function compileSubagent(input: {
         ...agent,
         remoteAgents: [...descendants.remoteAgents],
       },
-      ...dynamicFields,
+      ...variant,
       entryPath: input.source.entryPath,
       logicalPath: input.source.logicalPath,
       name: subagentName,

--- a/packages/eve/src/compiler/remote-agent-node.ts
+++ b/packages/eve/src/compiler/remote-agent-node.ts
@@ -20,7 +20,6 @@ export type CompiledRemoteAgentNode = Readonly<
       description: string;
       entryPath: string;
       name: string;
-      dynamic?: CompiledDynamicSubagentDefinition;
       outputSchema?: JsonObject;
       path: string;
       rootPath: string;
@@ -40,12 +39,6 @@ export const compiledRemoteAgentNodeSchema: z.ZodType<CompiledRemoteAgentNode> =
     logicalPath: z.string(),
     name: z.string(),
     nodeId: z.string(),
-    dynamic: z
-      .object({
-        eventNames: z.array(z.string()).readonly(),
-      })
-      .strict()
-      .optional(),
     outputSchema: jsonObjectSchema.optional(),
     path: z.string(),
     rootPath: z.string(),

--- a/packages/eve/src/compiler/remote-agent-node.ts
+++ b/packages/eve/src/compiler/remote-agent-node.ts
@@ -6,6 +6,14 @@ import type { Node } from "#shared/node.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 
 /**
+ * Runtime availability resolver metadata for a subagent whose definition is
+ * wrapped in `defineDynamic`.
+ */
+export interface CompiledDynamicSubagentDefinition {
+  readonly eventNames: readonly string[];
+}
+
+/**
  * Remote subagent entry owned by one compiled agent node manifest. Like
  * channels, remote subagents are node-local manifest entries rather than a
  * separate graph-level list.
@@ -16,6 +24,7 @@ export type CompiledRemoteAgentNode = Readonly<
       description: string;
       entryPath: string;
       name: string;
+      dynamic?: CompiledDynamicSubagentDefinition;
       outputSchema?: JsonObject;
       path: string;
       rootPath: string;
@@ -35,6 +44,12 @@ export const compiledRemoteAgentNodeSchema: z.ZodType<CompiledRemoteAgentNode> =
     logicalPath: z.string(),
     name: z.string(),
     nodeId: z.string(),
+    dynamic: z
+      .object({
+        eventNames: z.array(z.string()).readonly(),
+      })
+      .strict()
+      .optional(),
     outputSchema: jsonObjectSchema.optional(),
     path: z.string(),
     rootPath: z.string(),

--- a/packages/eve/src/compiler/remote-agent-node.ts
+++ b/packages/eve/src/compiler/remote-agent-node.ts
@@ -5,10 +5,6 @@ import type { JsonObject } from "#shared/json.js";
 import type { Node } from "#shared/node.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 
-/**
- * Runtime availability resolver metadata for a subagent whose definition is
- * wrapped in `defineDynamic`.
- */
 export interface CompiledDynamicSubagentDefinition {
   readonly eventNames: readonly string[];
 }

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import {
+  buildDynamicSubagentTools,
+  dispatchDynamicSubagentEvent,
+  isDynamicSubagentAvailable,
+  refreshDynamicSessionSubagentsForRuntimeRevision,
+} from "#context/dynamic-subagent-lifecycle.js";
+import { SessionDynamicSubagentRuntimeRevisionKey, SessionIdKey } from "#context/keys.js";
+import { defineAgent } from "#public/definitions/agent.js";
+import { createSessionStartedEvent, createTurnStartedEvent } from "#protocol/message.js";
+import type { ResolvedDynamicSubagentResolver } from "#runtime/subagents/registry.js";
+
+describe("dynamic subagent lifecycle", () => {
+  it("omits a subagent when its resolver returns null", async () => {
+    const ctx = createContext();
+    const { resolver } = createResolver({ handler: () => null });
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(buildDynamicSubagentTools(ctx)).toEqual([]);
+    expect(isDynamicSubagentAvailable(ctx, resolver.nodeId)).toBe(false);
+  });
+
+  it("exposes a subagent when its resolver returns the fallback definition", async () => {
+    const ctx = createContext();
+    const created = createResolver();
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: { "session.started": () => created.fallback },
+    };
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(buildDynamicSubagentTools(ctx)).toMatchObject([
+      {
+        description: "Research the request.",
+        name: "researcher",
+        runtimeAction: {
+          kind: "subagent-call",
+          nodeId: "subagents/researcher",
+          subagentName: "researcher",
+        },
+      },
+    ]);
+    expect(isDynamicSubagentAvailable(ctx, resolver.nodeId)).toBe(true);
+  });
+
+  it("lets a turn-scoped null hide a session-scoped selection", async () => {
+    const ctx = createContext();
+    const created = createResolver({
+      eventNames: ["session.started", "turn.started"],
+    });
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: {
+        "session.started": () => created.fallback,
+        "turn.started": () => null,
+      },
+    };
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+    expect(buildDynamicSubagentTools(ctx)).toHaveLength(1);
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn-1" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    expect(buildDynamicSubagentTools(ctx)).toEqual([]);
+    expect(isDynamicSubagentAvailable(ctx, resolver.nodeId)).toBe(false);
+  });
+
+  it("omits a mismatched non-null agent definition", async () => {
+    const ctx = createContext();
+    const { resolver } = createResolver({
+      handler: () =>
+        defineAgent({
+          description: "A different definition.",
+          model: "openai/gpt-5.5",
+        }),
+    });
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(buildDynamicSubagentTools(ctx)).toEqual([]);
+  });
+
+  it("refreshes session availability once per runtime revision", async () => {
+    const ctx = createContext();
+    const created = createResolver();
+    const handler = vi.fn(() => created.fallback);
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: { "session.started": handler },
+    };
+
+    await refreshDynamicSessionSubagentsForRuntimeRevision({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+      runtimeRevision: "deployment:one",
+    });
+    await refreshDynamicSessionSubagentsForRuntimeRevision({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+      runtimeRevision: "deployment:one",
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(ctx.get(SessionDynamicSubagentRuntimeRevisionKey)).toBe("deployment:one");
+    expect(buildDynamicSubagentTools(ctx)).toHaveLength(1);
+  });
+});
+
+function createContext(): ContextContainer {
+  const ctx = new ContextContainer();
+  ctx.set(SessionIdKey, "session-1");
+  return ctx;
+}
+
+function createResolver(
+  input: {
+    readonly eventNames?: readonly string[];
+    readonly handler?: () => unknown;
+  } = {},
+): {
+  readonly fallback: ReturnType<typeof defineAgent>;
+  readonly resolver: ResolvedDynamicSubagentResolver;
+} {
+  const fallback = defineAgent({
+    description: "Research the request.",
+    model: "openai/gpt-5.5",
+  });
+  const eventNames = input.eventNames ?? ["session.started"];
+  const handler = input.handler ?? (() => null);
+
+  return {
+    fallback,
+    resolver: {
+      eventNames,
+      events: Object.fromEntries(eventNames.map((eventName) => [eventName, handler])),
+      fallback,
+      logicalPath: "agent.ts",
+      nodeId: "subagents/researcher",
+      prepared: {
+        description: fallback.description!,
+        inputSchema: { type: "object" },
+        kind: "subagent",
+        logicalPath: "subagents/researcher",
+        name: "researcher",
+        nodeId: "subagents/researcher",
+        sourceId: "subagents/researcher",
+      },
+      sourceId: "agent.ts",
+      sourceKind: "module",
+    },
+  };
+}

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { ContextContainer } from "#context/container.js";
 import {
   buildDynamicSubagentTools,
   dispatchDynamicSubagentEvent,
-  isDynamicSubagentAvailable,
+  getDynamicSubagentSelection,
   refreshDynamicSessionSubagentsForRuntimeRevision,
 } from "#context/dynamic-subagent-lifecycle.js";
 import { SessionDynamicSubagentRuntimeRevisionKey, SessionIdKey } from "#context/keys.js";
@@ -25,15 +25,15 @@ describe("dynamic subagent lifecycle", () => {
     });
 
     expect(buildDynamicSubagentTools(ctx)).toEqual([]);
-    expect(isDynamicSubagentAvailable(ctx, resolver.nodeId)).toBe(false);
+    expect(getDynamicSubagentSelection(ctx, resolver.nodeId)).toBeUndefined();
   });
 
-  it("exposes a subagent when its resolver returns the fallback definition", async () => {
+  it("exposes a subagent with the returned agent config", async () => {
     const ctx = createContext();
     const created = createResolver();
     const resolver: ResolvedDynamicSubagentResolver = {
       ...created.resolver,
-      events: { "session.started": () => created.fallback },
+      events: { "session.started": () => created.agentConfig },
     };
 
     await dispatchDynamicSubagentEvent({
@@ -54,7 +54,7 @@ describe("dynamic subagent lifecycle", () => {
         },
       },
     ]);
-    expect(isDynamicSubagentAvailable(ctx, resolver.nodeId)).toBe(true);
+    expect(getDynamicSubagentSelection(ctx, resolver.nodeId)).toBeDefined();
   });
 
   it("lets a turn-scoped null hide a session-scoped selection", async () => {
@@ -65,7 +65,7 @@ describe("dynamic subagent lifecycle", () => {
     const resolver: ResolvedDynamicSubagentResolver = {
       ...created.resolver,
       events: {
-        "session.started": () => created.fallback,
+        "session.started": () => created.agentConfig,
         "turn.started": () => null,
       },
     };
@@ -85,17 +85,56 @@ describe("dynamic subagent lifecycle", () => {
       resolvers: [resolver],
     });
     expect(buildDynamicSubagentTools(ctx)).toEqual([]);
-    expect(isDynamicSubagentAvailable(ctx, resolver.nodeId)).toBe(false);
+    expect(getDynamicSubagentSelection(ctx, resolver.nodeId)).toBeUndefined();
   });
 
-  it("omits a mismatched non-null agent definition", async () => {
+  it("lets a turn-scoped agent config switch the subagent model", async () => {
+    const ctx = createContext();
+    const created = createResolver({
+      eventNames: ["session.started", "turn.started"],
+    });
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: {
+        "session.started": () =>
+          defineAgent({
+            description: "Research the request.",
+            model: "anthropic/claude-sonnet-4.5",
+          }),
+        "turn.started": () =>
+          defineAgent({
+            description: "Research the request deeply.",
+            model: "anthropic/claude-opus-4.6",
+          }),
+      },
+    };
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+    expect(getDynamicSubagentSelection(ctx, resolver.nodeId)?.agentConfig.model.id).toBe(
+      "anthropic/claude-sonnet-4.5",
+    );
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn-1" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    expect(getDynamicSubagentSelection(ctx, resolver.nodeId)?.agentConfig).toMatchObject({
+      description: "Research the request deeply.",
+      model: { id: "anthropic/claude-opus-4.6" },
+    });
+  });
+
+  it("omits an invalid non-null result", async () => {
     const ctx = createContext();
     const { resolver } = createResolver({
-      handler: () =>
-        defineAgent({
-          description: "A different definition.",
-          model: "openai/gpt-5.5",
-        }),
+      handler: () => false,
     });
 
     await dispatchDynamicSubagentEvent({
@@ -111,7 +150,7 @@ describe("dynamic subagent lifecycle", () => {
   it("refreshes session availability once per runtime revision", async () => {
     const ctx = createContext();
     const created = createResolver();
-    const handler = vi.fn(() => created.fallback);
+    const handler = vi.fn(() => created.agentConfig);
     const resolver: ResolvedDynamicSubagentResolver = {
       ...created.resolver,
       events: { "session.started": handler },
@@ -150,10 +189,10 @@ function createResolver(
     readonly handler?: () => unknown;
   } = {},
 ): {
-  readonly fallback: ReturnType<typeof defineAgent>;
+  readonly agentConfig: ReturnType<typeof defineAgent>;
   readonly resolver: ResolvedDynamicSubagentResolver;
 } {
-  const fallback = defineAgent({
+  const agentConfig = defineAgent({
     description: "Research the request.",
     model: "openai/gpt-5.5",
   });
@@ -161,22 +200,14 @@ function createResolver(
   const handler = input.handler ?? (() => null);
 
   return {
-    fallback,
+    agentConfig,
     resolver: {
       eventNames,
       events: Object.fromEntries(eventNames.map((eventName) => [eventName, handler])),
-      fallback,
+      kind: "subagent",
       logicalPath: "agent.ts",
+      name: "researcher",
       nodeId: "subagents/researcher",
-      prepared: {
-        description: fallback.description!,
-        inputSchema: { type: "object" },
-        kind: "subagent",
-        logicalPath: "subagents/researcher",
-        name: "researcher",
-        nodeId: "subagents/researcher",
-        sourceId: "subagents/researcher",
-      },
       sourceId: "agent.ts",
       sourceKind: "module",
     },

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -65,7 +65,6 @@ async function resolveSelections(input: {
   return selections;
 }
 
-/** Resolves dynamic subagent availability at session and turn boundaries. */
 export async function dispatchDynamicSubagentEvent(input: {
   readonly ctx: ContextContainer;
   readonly event: UnstampedMessageStreamEvent;
@@ -88,7 +87,6 @@ export async function dispatchDynamicSubagentEvent(input: {
   }
 }
 
-/** Refreshes session-scoped availability after a deployment revision changes. */
 export async function refreshDynamicSessionSubagentsForRuntimeRevision(input: {
   readonly ctx: ContextContainer;
   readonly event: SessionStartedStreamEvent;
@@ -108,7 +106,6 @@ export async function refreshDynamicSessionSubagentsForRuntimeRevision(input: {
   input.ctx.set(SessionDynamicSubagentRuntimeRevisionKey, input.runtimeRevision);
 }
 
-/** Builds the currently active dynamic subagents as harness delegation tools. */
 export function buildDynamicSubagentTools(input: {
   get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;
 }): readonly HarnessToolDefinition[] {
@@ -134,7 +131,6 @@ export function buildDynamicSubagentTools(input: {
   return tools;
 }
 
-/** Returns whether a dynamic subagent is still active at dispatch time. */
 export function isDynamicSubagentAvailable(
   input: {
     get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from "ai";
 
 import type { ContextContainer } from "#context/container.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
+import type { ContextReader } from "#context/key.js";
 import {
   SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicSubagentSelectionsKey,
@@ -116,9 +117,7 @@ export async function refreshDynamicSessionSubagentsForRuntimeRevision(input: {
   input.ctx.set(SessionDynamicSubagentRuntimeRevisionKey, input.runtimeRevision);
 }
 
-export function buildDynamicSubagentTools(input: {
-  get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;
-}): readonly HarnessToolDefinition[] {
+export function buildDynamicSubagentTools(input: ContextReader): readonly HarnessToolDefinition[] {
   const session = input.get(SessionDynamicSubagentSelectionsKey) ?? {};
   const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};
   const effective = { ...session, ...turn };
@@ -142,9 +141,7 @@ export function buildDynamicSubagentTools(input: {
 }
 
 export function getDynamicSubagentSelection(
-  input: {
-    get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;
-  },
+  input: ContextReader,
   nodeId: string,
 ): Exclude<DurableDynamicSubagentSelection, null> | undefined {
   const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -1,0 +1,151 @@
+import type { ModelMessage } from "ai";
+
+import type { ContextContainer } from "#context/container.js";
+import { buildResolveContext } from "#context/dynamic-resolve-context.js";
+import {
+  SessionDynamicSubagentRuntimeRevisionKey,
+  SessionDynamicSubagentSelectionsKey,
+  TurnDynamicSubagentSelectionsKey,
+  type DurableDynamicSubagentSelection,
+} from "#context/keys.js";
+import { createHarnessDelegationToolDefinition } from "#execution/delegation-tool.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import { createLogger } from "#internal/logging.js";
+import type { SessionStartedStreamEvent, UnstampedMessageStreamEvent } from "#protocol/message.js";
+import type { ResolvedDynamicSubagentResolver } from "#runtime/subagents/registry.js";
+import { toErrorMessage } from "#shared/errors.js";
+
+const log = createLogger("dynamic-subagents");
+const ALLOWED_DYNAMIC_SUBAGENT_EVENTS = new Set(["session.started", "turn.started"]);
+
+type DynamicSubagentSelections = Readonly<Record<string, DurableDynamicSubagentSelection>>;
+
+async function resolveSelections(input: {
+  readonly ctx: ContextContainer;
+  readonly event: UnstampedMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  readonly resolvers: readonly ResolvedDynamicSubagentResolver[];
+}): Promise<DynamicSubagentSelections> {
+  const outcomes = await Promise.allSettled(
+    input.resolvers.map(async (resolver) => {
+      const handler = resolver.events[input.event.type];
+      if (handler === undefined) {
+        return [resolver.nodeId, null] as const;
+      }
+
+      const result = await handler(input.event, buildResolveContext(input.ctx, input.messages));
+      if (result === null || result === undefined) {
+        return [resolver.nodeId, null] as const;
+      }
+      if (result !== resolver.fallback) {
+        throw new Error(
+          `Dynamic subagent "${resolver.prepared.name}" must return its fallback agent definition or null.`,
+        );
+      }
+
+      return [resolver.nodeId, resolver.prepared] as const;
+    }),
+  );
+  const selections: Record<string, DurableDynamicSubagentSelection> = {};
+
+  for (let index = 0; index < outcomes.length; index += 1) {
+    const outcome = outcomes[index]!;
+    const resolver = input.resolvers[index]!;
+    if (outcome.status === "rejected") {
+      log.error(`Dynamic subagent resolver (${input.event.type}) threw — omitting subagent.`, {
+        error: toErrorMessage(outcome.reason),
+        subagentName: resolver.prepared.name,
+      });
+      selections[resolver.nodeId] = null;
+      continue;
+    }
+    selections[outcome.value[0]] = outcome.value[1];
+  }
+
+  return selections;
+}
+
+/** Resolves dynamic subagent availability at session and turn boundaries. */
+export async function dispatchDynamicSubagentEvent(input: {
+  readonly ctx: ContextContainer;
+  readonly event: UnstampedMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  readonly resolvers: readonly ResolvedDynamicSubagentResolver[];
+}): Promise<void> {
+  if (!ALLOWED_DYNAMIC_SUBAGENT_EVENTS.has(input.event.type)) {
+    return;
+  }
+
+  const matching = input.resolvers.filter((resolver) =>
+    resolver.eventNames.includes(input.event.type),
+  );
+  const selections = await resolveSelections({ ...input, resolvers: matching });
+
+  if (input.event.type === "session.started") {
+    input.ctx.set(SessionDynamicSubagentSelectionsKey, selections);
+  } else {
+    input.ctx.set(TurnDynamicSubagentSelectionsKey, selections);
+  }
+}
+
+/** Refreshes session-scoped availability after a deployment revision changes. */
+export async function refreshDynamicSessionSubagentsForRuntimeRevision(input: {
+  readonly ctx: ContextContainer;
+  readonly event: SessionStartedStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  readonly resolvers: readonly ResolvedDynamicSubagentResolver[];
+  readonly runtimeRevision: string;
+}): Promise<void> {
+  if (input.ctx.get(SessionDynamicSubagentRuntimeRevisionKey) === input.runtimeRevision) {
+    return;
+  }
+
+  const matching = input.resolvers.filter((resolver) =>
+    resolver.eventNames.includes("session.started"),
+  );
+  const selections = await resolveSelections({ ...input, resolvers: matching });
+  input.ctx.set(SessionDynamicSubagentSelectionsKey, selections);
+  input.ctx.set(SessionDynamicSubagentRuntimeRevisionKey, input.runtimeRevision);
+}
+
+/** Builds the currently active dynamic subagents as harness delegation tools. */
+export function buildDynamicSubagentTools(input: {
+  get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;
+}): readonly HarnessToolDefinition[] {
+  const session = input.get(SessionDynamicSubagentSelectionsKey) ?? {};
+  const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};
+  const effective = { ...session, ...turn };
+  const tools: HarnessToolDefinition[] = [];
+  const names = new Set<string>();
+
+  for (const selection of Object.values(effective)) {
+    if (selection === null) {
+      continue;
+    }
+    if (names.has(selection.name)) {
+      throw new Error(
+        `Found multiple active dynamic subagents named "${selection.name}". Subagent names must be unique at runtime.`,
+      );
+    }
+    names.add(selection.name);
+    tools.push(createHarnessDelegationToolDefinition(selection));
+  }
+
+  return tools;
+}
+
+/** Returns whether a dynamic subagent is still active at dispatch time. */
+export function isDynamicSubagentAvailable(
+  input: {
+    get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;
+  },
+  nodeId: string,
+): boolean {
+  const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};
+  if (Object.hasOwn(turn, nodeId)) {
+    return turn[nodeId] !== null && turn[nodeId] !== undefined;
+  }
+
+  const session = input.get(SessionDynamicSubagentSelectionsKey) ?? {};
+  return session[nodeId] !== null && session[nodeId] !== undefined;
+}

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -13,6 +13,8 @@ import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { createLogger } from "#internal/logging.js";
 import type { SessionStartedStreamEvent, UnstampedMessageStreamEvent } from "#protocol/message.js";
 import type { ResolvedDynamicSubagentResolver } from "#runtime/subagents/registry.js";
+import { createPreparedRuntimeSubagentTool } from "#runtime/subagents/registry.js";
+import { normalizeDynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import { toErrorMessage } from "#shared/errors.js";
 
 const log = createLogger("dynamic-subagents");
@@ -37,13 +39,21 @@ async function resolveSelections(input: {
       if (result === null || result === undefined) {
         return [resolver.nodeId, null] as const;
       }
-      if (result !== resolver.fallback) {
-        throw new Error(
-          `Dynamic subagent "${resolver.prepared.name}" must return its fallback agent definition or null.`,
-        );
-      }
+      const agentConfig = normalizeDynamicSubagentAgentConfig({
+        name: resolver.name,
+        value: result,
+      });
+      const prepared = createPreparedRuntimeSubagentTool({
+        description: agentConfig.description,
+        kind: resolver.kind,
+        logicalPath: resolver.logicalPath,
+        name: resolver.name,
+        nodeId: resolver.nodeId,
+        sourceId: resolver.sourceId,
+        sourceKind: resolver.sourceKind,
+      });
 
-      return [resolver.nodeId, resolver.prepared] as const;
+      return [resolver.nodeId, { agentConfig, prepared }] as const;
     }),
   );
   const selections: Record<string, DurableDynamicSubagentSelection> = {};
@@ -54,7 +64,7 @@ async function resolveSelections(input: {
     if (outcome.status === "rejected") {
       log.error(`Dynamic subagent resolver (${input.event.type}) threw — omitting subagent.`, {
         error: toErrorMessage(outcome.reason),
-        subagentName: resolver.prepared.name,
+        subagentName: resolver.name,
       });
       selections[resolver.nodeId] = null;
       continue;
@@ -119,29 +129,29 @@ export function buildDynamicSubagentTools(input: {
     if (selection === null) {
       continue;
     }
-    if (names.has(selection.name)) {
+    if (names.has(selection.prepared.name)) {
       throw new Error(
-        `Found multiple active dynamic subagents named "${selection.name}". Subagent names must be unique at runtime.`,
+        `Found multiple active dynamic subagents named "${selection.prepared.name}". Subagent names must be unique at runtime.`,
       );
     }
-    names.add(selection.name);
-    tools.push(createHarnessDelegationToolDefinition(selection));
+    names.add(selection.prepared.name);
+    tools.push(createHarnessDelegationToolDefinition(selection.prepared));
   }
 
   return tools;
 }
 
-export function isDynamicSubagentAvailable(
+export function getDynamicSubagentSelection(
   input: {
     get<T>(key: import("#context/key.js").ContextKey<T>): T | undefined;
   },
   nodeId: string,
-): boolean {
+): Exclude<DurableDynamicSubagentSelection, null> | undefined {
   const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};
   if (Object.hasOwn(turn, nodeId)) {
-    return turn[nodeId] !== null && turn[nodeId] !== undefined;
+    return turn[nodeId] ?? undefined;
   }
 
   const session = input.get(SessionDynamicSubagentSelectionsKey) ?? {};
-  return session[nodeId] !== null && session[nodeId] !== undefined;
+  return session[nodeId] ?? undefined;
 }

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -17,6 +17,8 @@ import type {
   SessionTurn,
 } from "#channel/types.js";
 import { ContextKey } from "#context/key.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { SandboxAccess } from "#sandbox/state.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
@@ -163,12 +165,10 @@ export const TurnDynamicToolMetadataKey = new ContextKey<readonly DurableDynamic
  * framework tools (which lack bundler step-function metadata) work.
  * Re-resolved every step — no cross-step persistence needed.
  */
-export const LiveStepToolsKey = new ContextKey<
-  import("#harness/execute-tool.js").HarnessToolDefinition[]
->("eve.liveStepTools");
+export const LiveStepToolsKey = new ContextKey<HarnessToolDefinition[]>("eve.liveStepTools");
 
 export type DurableDynamicSubagentSelection = {
-  readonly agentConfig: import("#runtime/subagents/dynamic-agent-config.js").DynamicSubagentAgentConfig;
+  readonly agentConfig: DynamicSubagentAgentConfig;
   readonly prepared: PreparedRuntimeDelegationTool;
 } | null;
 
@@ -184,9 +184,9 @@ export const SessionDynamicSubagentRuntimeRevisionKey = new ContextKey<string>(
   "eve.sessionDynamicSubagentRuntimeRevision",
 );
 
-export const DynamicSubagentAgentConfigKey = new ContextKey<
-  import("#runtime/subagents/dynamic-agent-config.js").DynamicSubagentAgentConfig
->("eve.dynamicSubagentAgentConfig");
+export const DynamicSubagentAgentConfigKey = new ContextKey<DynamicSubagentAgentConfig>(
+  "eve.dynamicSubagentAgentConfig",
+);
 
 // ---------------------------------------------------------------------------
 // Dynamic skill keys

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -167,23 +167,16 @@ export const LiveStepToolsKey = new ContextKey<
   import("#harness/execute-tool.js").HarnessToolDefinition[]
 >("eve.liveStepTools");
 
-// ---------------------------------------------------------------------------
-// Dynamic subagent keys
-// ---------------------------------------------------------------------------
-
 export type DurableDynamicSubagentSelection = PreparedRuntimeDelegationTool | null;
 
-/** Session-scoped subagent availability keyed by compiled child node id. */
 export const SessionDynamicSubagentSelectionsKey = new ContextKey<
   Readonly<Record<string, DurableDynamicSubagentSelection>>
 >("eve.sessionDynamicSubagentSelections");
 
-/** Turn-scoped subagent availability keyed by compiled child node id. */
 export const TurnDynamicSubagentSelectionsKey = new ContextKey<
   Readonly<Record<string, DurableDynamicSubagentSelection>>
 >("eve.turnDynamicSubagentSelections");
 
-/** Runtime revision that last refreshed session-scoped dynamic subagents. */
 export const SessionDynamicSubagentRuntimeRevisionKey = new ContextKey<string>(
   "eve.sessionDynamicSubagentRuntimeRevision",
 );

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -167,7 +167,10 @@ export const LiveStepToolsKey = new ContextKey<
   import("#harness/execute-tool.js").HarnessToolDefinition[]
 >("eve.liveStepTools");
 
-export type DurableDynamicSubagentSelection = PreparedRuntimeDelegationTool | null;
+export type DurableDynamicSubagentSelection = {
+  readonly agentConfig: import("#runtime/subagents/dynamic-agent-config.js").DynamicSubagentAgentConfig;
+  readonly prepared: PreparedRuntimeDelegationTool;
+} | null;
 
 export const SessionDynamicSubagentSelectionsKey = new ContextKey<
   Readonly<Record<string, DurableDynamicSubagentSelection>>
@@ -180,6 +183,10 @@ export const TurnDynamicSubagentSelectionsKey = new ContextKey<
 export const SessionDynamicSubagentRuntimeRevisionKey = new ContextKey<string>(
   "eve.sessionDynamicSubagentRuntimeRevision",
 );
+
+export const DynamicSubagentAgentConfigKey = new ContextKey<
+  import("#runtime/subagents/dynamic-agent-config.js").DynamicSubagentAgentConfig
+>("eve.dynamicSubagentAgentConfig");
 
 // ---------------------------------------------------------------------------
 // Dynamic skill keys

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -20,6 +20,7 @@ import { ContextKey } from "#context/key.js";
 import type { SandboxAccess } from "#sandbox/state.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
+import type { PreparedRuntimeDelegationTool } from "#runtime/sessions/turn.js";
 
 // Re-export so consumers don't need a direct channel/ import.
 export type { SessionAuthContext, SessionParent, SessionTurn } from "#channel/types.js";
@@ -165,6 +166,27 @@ export const TurnDynamicToolMetadataKey = new ContextKey<readonly DurableDynamic
 export const LiveStepToolsKey = new ContextKey<
   import("#harness/execute-tool.js").HarnessToolDefinition[]
 >("eve.liveStepTools");
+
+// ---------------------------------------------------------------------------
+// Dynamic subagent keys
+// ---------------------------------------------------------------------------
+
+export type DurableDynamicSubagentSelection = PreparedRuntimeDelegationTool | null;
+
+/** Session-scoped subagent availability keyed by compiled child node id. */
+export const SessionDynamicSubagentSelectionsKey = new ContextKey<
+  Readonly<Record<string, DurableDynamicSubagentSelection>>
+>("eve.sessionDynamicSubagentSelections");
+
+/** Turn-scoped subagent availability keyed by compiled child node id. */
+export const TurnDynamicSubagentSelectionsKey = new ContextKey<
+  Readonly<Record<string, DurableDynamicSubagentSelection>>
+>("eve.turnDynamicSubagentSelections");
+
+/** Runtime revision that last refreshed session-scoped dynamic subagents. */
+export const SessionDynamicSubagentRuntimeRevisionKey = new ContextKey<string>(
+  "eve.sessionDynamicSubagentRuntimeRevision",
+);
 
 // ---------------------------------------------------------------------------
 // Dynamic skill keys

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -11,6 +11,8 @@ import { createSession } from "#execution/session.js";
 import { resolveInheritedTokenLimit } from "#execution/run-session-limits.js";
 import type { RunSessionLimits } from "#channel/types.js";
 import type { JsonObject } from "#shared/json.js";
+import { resolveEffectiveAgentRuntimeFromConfig } from "#execution/effective-agent-config.js";
+import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 
 /**
  * Result returned by {@link createSessionStep}.
@@ -31,6 +33,7 @@ export interface CreateSessionStepResult {
 export async function createSessionStep(input: {
   readonly compiledArtifactsSource: DurableCompiledArtifactsSource;
   readonly continuationToken: string;
+  readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
   readonly inheritedLimits?: RunSessionLimits;
   readonly outputSchema?: JsonObject;
   readonly nodeId?: string;
@@ -44,13 +47,17 @@ export async function createSessionStep(input: {
     compiledArtifactsSource: resolveDurableCompiledArtifactsSource(input.compiledArtifactsSource),
     nodeId: input.nodeId,
   });
+  const effectiveAgent = resolveEffectiveAgentRuntimeFromConfig(
+    bundle,
+    input.dynamicSubagentAgentConfig,
+  );
 
   // Both token axes resolve tighter-wins against the cap inherited from the
   // delegating parent: a child may narrow what its parent granted, never widen
   // it. Root runs have no inherited limits, so their configured values apply.
   const session = createSession({
     compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      thresholdPercent: effectiveAgent.thresholdPercent,
     },
     continuationToken: input.continuationToken,
     limits: {
@@ -58,11 +65,11 @@ export async function createSessionStep(input: {
       // dispatch time; an authored `false` uncaps only when there is nothing
       // to inherit.
       maxInputTokensPerSession: resolveInheritedTokenLimit({
-        configured: bundle.resolvedAgent.config.limits?.maxInputTokensPerSession,
+        configured: effectiveAgent.limits?.maxInputTokensPerSession,
         inherited: input.inheritedLimits?.maxInputTokensPerSession,
       }),
       maxOutputTokensPerSession: resolveInheritedTokenLimit({
-        configured: bundle.resolvedAgent.config.limits?.maxOutputTokensPerSession,
+        configured: effectiveAgent.limits?.maxOutputTokensPerSession,
         inherited: input.inheritedLimits?.maxOutputTokensPerSession,
       }),
     },
@@ -70,7 +77,7 @@ export async function createSessionStep(input: {
     rootSessionId: input.rootSessionId,
     sessionId: input.sessionId,
     subagentDepth: input.subagentDepth,
-    turnAgent: bundle.turnAgent,
+    turnAgent: effectiveAgent.turnAgent,
     workflowMaxSubagents: bundle.resolvedAgent.workflowTool?.maxSubagents,
   });
 

--- a/packages/eve/src/execution/delegation-tool.ts
+++ b/packages/eve/src/execution/delegation-tool.ts
@@ -2,7 +2,6 @@ import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { PreparedRuntimeDelegationTool } from "#runtime/sessions/turn.js";
 import { UNSPECIFIED_INPUT_SCHEMA, toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
 
-/** Converts a serializable delegation descriptor into a live harness tool. */
 export function createHarnessDelegationToolDefinition(
   tool: PreparedRuntimeDelegationTool,
 ): HarnessToolDefinition {

--- a/packages/eve/src/execution/delegation-tool.ts
+++ b/packages/eve/src/execution/delegation-tool.ts
@@ -1,0 +1,30 @@
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { PreparedRuntimeDelegationTool } from "#runtime/sessions/turn.js";
+import { UNSPECIFIED_INPUT_SCHEMA, toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
+
+/** Converts a serializable delegation descriptor into a live harness tool. */
+export function createHarnessDelegationToolDefinition(
+  tool: PreparedRuntimeDelegationTool,
+): HarnessToolDefinition {
+  const runtimeAction: HarnessToolDefinition["runtimeAction"] =
+    tool.kind === "remote"
+      ? {
+          kind: "remote-agent-call",
+          nodeId: tool.nodeId,
+          remoteAgentName: tool.name,
+          subagentName: tool.name,
+        }
+      : {
+          kind: "subagent-call",
+          nodeId: tool.nodeId,
+          subagentName: tool.name,
+        };
+
+  return {
+    description: tool.description ?? "",
+    inputSchema: toInputSchema(tool.inputSchema) ?? UNSPECIFIED_INPUT_SCHEMA,
+    name: tool.name,
+    outputSchema: toOutputSchema(tool.outputSchema),
+    runtimeAction,
+  };
+}

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -48,6 +48,7 @@ import { createLogger, logError } from "#internal/logging.js";
 import { toErrorMessage } from "#shared/errors.js";
 import { readSessionTraceContext } from "#tracing/agent-trace-context-store.js";
 import { resolveSubagentDepth } from "#harness/subagent-depth.js";
+import { isDynamicSubagentAvailable } from "#context/dynamic-subagent-lifecycle.js";
 
 const log = createLogger("execution.dispatch-runtime-actions");
 
@@ -114,6 +115,21 @@ export async function dispatchRuntimeActionsStep(input: {
           subagentName: action.subagentName,
         });
         results.push(createRecursiveAgentRootOnlyResult(action));
+        continue;
+      }
+
+      if (
+        (action.kind === "subagent-call" || action.kind === "remote-agent-call") &&
+        bundle.subagentRegistry.dynamicNodeIds?.has(action.nodeId) === true &&
+        !isDynamicSubagentAvailable(ctx, action.nodeId)
+      ) {
+        const subagentName = getSubagentName(action);
+        log.warn("dynamic subagent call blocked after availability changed", {
+          callId: action.callId,
+          nodeId: action.nodeId,
+          subagentName,
+        });
+        results.push(createUnavailableDynamicSubagentResult(action));
         continue;
       }
 
@@ -248,6 +264,28 @@ export async function dispatchRuntimeActionsStep(input: {
       : createDurableSessionState({ session: nextSession });
 
   return { results, sessionState: nextState };
+}
+
+function createUnavailableDynamicSubagentResult(
+  action: RuntimeSubagentCallActionRequest | RuntimeRemoteAgentCallActionRequest,
+): RuntimeSubagentResultActionResult {
+  const subagentName = getSubagentName(action);
+  return {
+    callId: action.callId,
+    isError: true,
+    kind: "subagent-result",
+    output: {
+      code: "SUBAGENT_UNAVAILABLE",
+      message: `Subagent "${subagentName}" is not available in the current session context.`,
+    },
+    subagentName,
+  };
+}
+
+function getSubagentName(
+  action: RuntimeSubagentCallActionRequest | RuntimeRemoteAgentCallActionRequest,
+): string {
+  return action.kind === "remote-agent-call" ? action.remoteAgentName : action.subagentName;
 }
 
 function createRemoteAgentStartFailureResult(input: {

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -48,7 +48,8 @@ import { createLogger, logError } from "#internal/logging.js";
 import { toErrorMessage } from "#shared/errors.js";
 import { readSessionTraceContext } from "#tracing/agent-trace-context-store.js";
 import { resolveSubagentDepth } from "#harness/subagent-depth.js";
-import { isDynamicSubagentAvailable } from "#context/dynamic-subagent-lifecycle.js";
+import { getDynamicSubagentSelection } from "#context/dynamic-subagent-lifecycle.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 
 const log = createLogger("execution.dispatch-runtime-actions");
 
@@ -74,12 +75,13 @@ export async function dispatchRuntimeActionsStep(input: {
 
   const ctx = await deserializeContext(input.serializedContext);
   const bundle = ctx.require(BundleKey);
+  const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
   const session = hydrateDurableSession({
     compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      thresholdPercent: effectiveAgent.thresholdPercent,
     },
     durable: durableSession,
-    turnAgent: bundle.turnAgent,
+    turnAgent: effectiveAgent.turnAgent,
   });
   const adapter = ctx.require(ChannelKey);
   const auth = ctx.get(AuthKey) ?? null;
@@ -104,6 +106,12 @@ export async function dispatchRuntimeActionsStep(input: {
 
   try {
     for (const action of batch.actions) {
+      const isDynamicSubagent =
+        action.kind === "subagent-call" &&
+        bundle.subagentRegistry.dynamicNodeIds?.has(action.nodeId) === true;
+      const dynamicSubagentSelection = isDynamicSubagent
+        ? getDynamicSubagentSelection(ctx, action.nodeId)
+        : undefined;
       if (
         isRecursiveAgentAction(action, bundle.subagentRegistry.subagentsByNodeId) &&
         (session.rootSessionId !== undefined || subagentDepth.currentDepth > 0)
@@ -118,11 +126,7 @@ export async function dispatchRuntimeActionsStep(input: {
         continue;
       }
 
-      if (
-        (action.kind === "subagent-call" || action.kind === "remote-agent-call") &&
-        bundle.subagentRegistry.dynamicNodeIds?.has(action.nodeId) === true &&
-        !isDynamicSubagentAvailable(ctx, action.nodeId)
-      ) {
+      if (isDynamicSubagent && dynamicSubagentSelection === undefined) {
         const subagentName = getSubagentName(action);
         log.warn("dynamic subagent call blocked after availability changed", {
           callId: action.callId,
@@ -141,12 +145,16 @@ export async function dispatchRuntimeActionsStep(input: {
       switch (action.kind) {
         case "subagent-call": {
           const registered = bundle.subagentRegistry.subagentsByNodeId.get(action.nodeId);
+          const description =
+            dynamicSubagentSelection?.agentConfig.description ??
+            (registered?.definition.kind === "subagent"
+              ? registered.definition.description
+              : undefined);
           const source: SubagentInputSource =
-            registered?.definition.kind === "subagent"
-              ? { description: registered.definition.description, type: "local" }
-              : { type: "runtime" };
+            description !== undefined ? { description, type: "local" } : { type: "runtime" };
           const childRuntime = createWorkflowRuntime({
             compiledArtifactsSource: bundle.compiledArtifactsSource,
+            dynamicSubagentAgentConfig: dynamicSubagentSelection?.agentConfig,
             nodeId: action.nodeId,
           });
           const { childContinuationToken, runInput } = buildSubagentRunInput({

--- a/packages/eve/src/execution/dispatch-workflow-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-workflow-runtime-actions-step.ts
@@ -20,6 +20,7 @@ import type {
   RuntimeActionRequest,
   RuntimeSubagentResultActionResult,
 } from "#runtime/actions/types.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 
 const log = createLogger("execution.dispatch-workflow-runtime-actions");
 
@@ -45,6 +46,7 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
 
   const ctx = await deserializeContext(input.serializedContext);
   const bundle = ctx.require(BundleKey);
+  const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
 
   const plan = planWorkflowSubagentDispatch({
     actions,
@@ -70,10 +72,10 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
 
   const session = hydrateDurableSession({
     compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      thresholdPercent: effectiveAgent.thresholdPercent,
     },
     durable: durableSession,
-    turnAgent: bundle.turnAgent,
+    turnAgent: effectiveAgent.turnAgent,
   });
 
   const sessionWithBatch = setPendingRuntimeActionBatch({

--- a/packages/eve/src/execution/effective-agent-config.test.ts
+++ b/packages/eve/src/execution/effective-agent-config.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import { DynamicSubagentAgentConfigKey } from "#context/keys.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
+
+describe("resolveEffectiveAgentRuntime", () => {
+  it("applies the selected subagent model and runtime settings", () => {
+    const ctx = new ContextContainer();
+    ctx.set(DynamicSubagentAgentConfigKey, {
+      compaction: {
+        model: { id: "anthropic/claude-sonnet-4.5" },
+        thresholdPercent: 0.75,
+      },
+      description: "Perform deep research.",
+      limits: { sessionTimeoutMs: 120_000 },
+      model: { id: "anthropic/claude-opus-4.6" },
+      reasoning: "high",
+    });
+    const tools = [{ name: "search" }];
+
+    const effective = resolveEffectiveAgentRuntime(
+      {
+        resolvedAgent: {
+          config: {
+            compaction: { thresholdPercent: 0.9 },
+            limits: { sessionTimeoutMs: 60_000 },
+          },
+        },
+        turnAgent: {
+          id: "researcher",
+          instructions: ["Research carefully."],
+          model: { id: "openai/gpt-5.5" },
+          tools,
+          workspaceSpec: {} as never,
+        },
+      } as never,
+      ctx,
+    );
+
+    expect(effective).toMatchObject({
+      limits: { sessionTimeoutMs: 120_000 },
+      thresholdPercent: 0.75,
+      turnAgent: {
+        compactionModel: { id: "anthropic/claude-sonnet-4.5" },
+        model: { id: "anthropic/claude-opus-4.6" },
+        reasoning: "high",
+      },
+    });
+    expect(effective.turnAgent.instructions).toEqual(["Research carefully."]);
+    expect(effective.turnAgent.tools).toBe(tools);
+  });
+});

--- a/packages/eve/src/execution/effective-agent-config.ts
+++ b/packages/eve/src/execution/effective-agent-config.ts
@@ -1,0 +1,45 @@
+import type { ContextReader } from "#context/key.js";
+import { DynamicSubagentAgentConfigKey } from "#context/keys.js";
+import type { RuntimeTurnAgent } from "#runtime/agent/bootstrap.js";
+import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
+import type { AgentLimitsDefinition } from "#shared/agent-definition.js";
+import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
+
+export interface EffectiveAgentRuntime {
+  readonly limits?: AgentLimitsDefinition;
+  readonly thresholdPercent?: number;
+  readonly turnAgent: RuntimeTurnAgent;
+}
+
+export function resolveEffectiveAgentRuntime(
+  bundle: Pick<CompiledBundle, "resolvedAgent" | "turnAgent">,
+  context: ContextReader,
+): EffectiveAgentRuntime {
+  return resolveEffectiveAgentRuntimeFromConfig(bundle, context.get(DynamicSubagentAgentConfigKey));
+}
+
+export function resolveEffectiveAgentRuntimeFromConfig(
+  bundle: Pick<CompiledBundle, "resolvedAgent" | "turnAgent">,
+  config: DynamicSubagentAgentConfig | undefined,
+): EffectiveAgentRuntime {
+  if (config === undefined) {
+    return {
+      limits: bundle.resolvedAgent.config.limits,
+      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      turnAgent: bundle.turnAgent,
+    };
+  }
+
+  return {
+    limits: config.limits,
+    thresholdPercent: config.compaction?.thresholdPercent,
+    turnAgent: {
+      ...bundle.turnAgent,
+      compactionModel: config.compaction?.model,
+      dynamicModel: undefined,
+      model: config.model,
+      outputSchema: config.outputSchema,
+      reasoning: config.reasoning,
+    },
+  };
+}

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -204,6 +204,8 @@ function createTestNode(
     nodeId: ROOT_RUNTIME_AGENT_NODE_ID,
     sandboxRegistry: createStubSandboxRegistry(),
     subagentRegistry: {
+      dynamicNodeIds: new Set(),
+      dynamicResolvers: [],
       preparedTools: [],
       subagentsByName: new Map(),
       subagentsByNodeId: new Map(),

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -2,6 +2,7 @@ import type { LanguageModel } from "ai";
 
 import type { Runtime, SessionCapabilities } from "#channel/types.js";
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
+import { createHarnessDelegationToolDefinition } from "#execution/delegation-tool.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HandleEventFn, HarnessToolMap, StepFn } from "#harness/types.js";
@@ -9,7 +10,7 @@ import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { getInstrumentationRuntime } from "#harness/instrumentation-runtime.js";
 import { createLogger } from "#internal/logging.js";
 import type { RuntimeIdentity } from "#protocol/message.js";
-import { UNSPECIFIED_INPUT_SCHEMA, toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
+import { UNSPECIFIED_INPUT_SCHEMA } from "#shared/tool-schema.js";
 import type { RunMode } from "#shared/run-mode.js";
 import {
   resolveRuntimeModelReference,
@@ -212,26 +213,7 @@ function resolveHarnessToolDefinition(input: {
   readonly tool: PreparedRuntimeTool;
 }): HarnessToolDefinition | null {
   if (input.tool.kind === "subagent" || input.tool.kind === "remote") {
-    const runtimeAction: HarnessToolDefinition["runtimeAction"] =
-      input.tool.kind === "remote"
-        ? {
-            kind: "remote-agent-call",
-            nodeId: input.tool.nodeId,
-            remoteAgentName: input.tool.name,
-            subagentName: input.tool.name,
-          }
-        : {
-            kind: "subagent-call",
-            nodeId: input.tool.nodeId,
-            subagentName: input.tool.name,
-          };
-    return {
-      description: input.tool.description ?? "",
-      inputSchema: toInputSchema(input.tool.inputSchema) ?? UNSPECIFIED_INPUT_SCHEMA,
-      name: input.tool.name,
-      outputSchema: toOutputSchema(input.tool.outputSchema),
-      runtimeAction,
-    };
+    return createHarnessDelegationToolDefinition(input.tool);
   }
 
   const registeredTool = findRegisteredRuntimeTool(input.node.toolRegistry, input.tool.name);

--- a/packages/eve/src/execution/runtime-context.ts
+++ b/packages/eve/src/execution/runtime-context.ts
@@ -7,6 +7,7 @@ import {
   ChannelInstrumentationKey,
   ChannelRequestIdKey,
   ContinuationTokenKey,
+  DynamicSubagentAgentConfigKey,
   InitiatorAuthKey,
   ModeKey,
   ParentSessionKey,
@@ -15,12 +16,14 @@ import {
   SubagentDepthKey,
 } from "#context/keys.js";
 import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
+import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 
 /**
  * Builds the bootstrap {@link ContextContainer} for one run.
  */
 export function buildRunContext(input: {
   readonly bundle: CompiledBundle;
+  readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
   readonly run: RunInput;
 }): ContextContainer {
   const { bundle, run } = input;
@@ -42,6 +45,10 @@ export function buildRunContext(input: {
   ctx.set(ModeKey, run.mode);
   ctx.set(AuthKey, auth);
   ctx.set(InitiatorAuthKey, run.initiatorAuth ?? auth);
+
+  if (input.dynamicSubagentAgentConfig !== undefined) {
+    ctx.set(DynamicSubagentAgentConfigKey, input.dynamicSubagentAgentConfig);
+  }
 
   if (run.capabilities !== undefined) {
     ctx.set(CapabilitiesKey, run.capabilities);

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -34,6 +34,7 @@ import {
   stampMessageStreamEvent,
 } from "#protocol/message.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 
 export interface CancelledTurnSettleResult {
   readonly serializedContext: Record<string, unknown>;
@@ -58,14 +59,15 @@ export async function settleCancelledTurnStep(input: {
   const adapter = ctx.require(ChannelKey);
   const adapterCtx = buildAdapterContext(adapter, ctx);
   const bundle = ctx.require(BundleKey);
+  const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
   const instrumentation = getInstrumentationRuntime();
 
   let session = hydrateDurableSession({
     compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      thresholdPercent: effectiveAgent.thresholdPercent,
     },
     durable: durableSession,
-    turnAgent: bundle.turnAgent,
+    turnAgent: effectiveAgent.turnAgent,
   });
 
   let emissionState = getHarnessEmissionState(durableSession.state);

--- a/packages/eve/src/execution/subagent-event-proxy-step.ts
+++ b/packages/eve/src/execution/subagent-event-proxy-step.ts
@@ -24,6 +24,7 @@ import type { HarnessSession } from "#harness/types.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import { encodeMessageStreamEvent, stampMessageStreamEvent } from "#protocol/message.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 
 type SubagentEventHookPayload =
   | SubagentAuthorizationEventHookPayload
@@ -66,12 +67,13 @@ export async function emitProxiedSubagentEvent(input: {
   const { ctx } = input;
   const adapter = ctx.require(ChannelKey);
   const bundle = ctx.require(BundleKey);
+  const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
   const session = hydrateDurableSession({
     compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      thresholdPercent: effectiveAgent.thresholdPercent,
     },
     durable: input.durableSession,
-    turnAgent: bundle.turnAgent,
+    turnAgent: effectiveAgent.turnAgent,
   });
   const adapterCtx = buildAdapterContext(adapter, ctx);
   const writer = input.parentWritable.getWriter();

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -35,6 +35,7 @@ import { DEFAULT_SESSION_TIMEOUT_MS } from "#execution/session-timeout.js";
 import { emitTerminalSessionCompletionStep } from "#execution/terminal-session-completion-step.js";
 import { createSessionTimeoutControl } from "#execution/session-timeout-control.js";
 import { readSerializedSubagentDepth } from "#harness/subagent-depth.js";
+import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 
 const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
   "Agent workflow failed. Inspect the private session trace for details.";
@@ -115,10 +116,14 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
     // chain-root id can never drift between persisted session and tags.
     const rootSessionIdFromParent = readRootSessionId(input.serializedContext);
     const subagentDepth = readSerializedSubagentDepth(input.serializedContext);
+    const dynamicSubagentAgentConfig = input.serializedContext["eve.dynamicSubagentAgentConfig"] as
+      | DynamicSubagentAgentConfig
+      | undefined;
 
     const { state: sessionState } = await createSessionStep({
       compiledArtifactsSource: serializedBundle.source,
       continuationToken,
+      dynamicSubagentAgentConfig,
       inheritedLimits: input.limits,
       nodeId: serializedBundle.nodeId,
       outputSchema: input.input.outputSchema,

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -388,6 +388,39 @@ describe("createWorkflowRuntime#run", () => {
     });
   });
 
+  it("serializes the selected dynamic subagent config for the child workflow", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource, 86_400_000);
+    startMock.mockResolvedValue({ runId: "driver-run" });
+
+    await createWorkflowRuntime({
+      compiledArtifactsSource,
+      dynamicSubagentAgentConfig: {
+        description: "Perform deep research.",
+        limits: { sessionTimeoutMs: 120_000 },
+        model: { id: "anthropic/claude-opus-4.6" },
+      },
+      nodeId: "subagents/researcher",
+    }).run({
+      adapter,
+      auth: null,
+      input: { message: "research this" },
+      mode: "task",
+    });
+
+    const [, [workflowInput]] = startMock.mock.calls[0]!;
+    expect(workflowInput).toMatchObject({
+      serializedContext: {
+        "eve.dynamicSubagentAgentConfig": {
+          description: "Perform deep research.",
+          limits: { sessionTimeoutMs: 120_000 },
+          model: { id: "anthropic/claude-opus-4.6" },
+        },
+      },
+      sessionTimeoutMs: 120_000,
+    });
+  });
+
   it("serializes the channel request id into workflow context", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -44,6 +44,7 @@ import { ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import { buildRunContext } from "#execution/runtime-context.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 import { parseNdjsonStream } from "#execution/ndjson-stream.js";
 import { RuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import type { WorkflowEntryInput } from "#execution/workflow-entry.js";
@@ -52,6 +53,7 @@ import {
   sessionCancelHookToken,
   type TurnCancelPayload,
 } from "#execution/turn-cancellation-token.js";
+import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 
 const WORKFLOW_ENTRY_NAME = "workflowEntry";
 const TURN_WORKFLOW_NAME = "turnWorkflow";
@@ -117,6 +119,7 @@ export const sessionTimeoutWorkflowReference = {
  */
 export function createWorkflowRuntime(config: {
   readonly compiledArtifactsSource: RuntimeCompiledArtifactsSource;
+  readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
   readonly nodeId?: string;
 }): Runtime {
   return {
@@ -125,10 +128,15 @@ export function createWorkflowRuntime(config: {
         compiledArtifactsSource: config.compiledArtifactsSource,
         nodeId: config.nodeId,
       });
-      const ctx = buildRunContext({ bundle, run: input });
+      const ctx = buildRunContext({
+        bundle,
+        dynamicSubagentAgentConfig: config.dynamicSubagentAgentConfig,
+        run: input,
+      });
+      const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
       const serializedContext = serializeContext(ctx);
       const parentLineage = readParentLineage(serializedContext);
-      const sessionTimeoutMs = bundle.resolvedAgent.config.limits?.sessionTimeoutMs;
+      const sessionTimeoutMs = effectiveAgent.limits?.sessionTimeoutMs;
       const workflowInput: {
         -readonly [K in keyof WorkflowEntryInput]: WorkflowEntryInput[K];
       } = {

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -7,6 +7,7 @@ import { ContextKey } from "#context/key.js";
 import {
   AuthKey,
   ContinuationTokenKey,
+  DynamicSubagentAgentConfigKey,
   ModeKey,
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
@@ -32,7 +33,7 @@ import {
 } from "#execution/durable-session-store.js";
 import { createTurnWorkflowInput } from "#execution/durable-session-migrations/turn-workflow.js";
 import { projectToDurableSession } from "#execution/session.js";
-import { createExecutionNodeStep } from "#execution/node-step.js";
+import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { defineTool } from "#public/definitions/tool.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
@@ -833,6 +834,69 @@ describe("dispatchRuntimeActionsStep", () => {
 });
 
 describe("turnStep", () => {
+  it("uses the selected dynamic subagent model for execution identity", async () => {
+    const session = createStubSession();
+    installSessionStoreMocks([session]);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (stepSession): Promise<StepResult> => ({
+        next: { done: true, output: "ok" },
+        session: stepSession,
+      });
+    });
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {} as never,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, null);
+    ctx.set(BundleKey, compiledBundle);
+    ctx.set(ChannelKey, threadContextAdapter);
+    ctx.set(ContinuationTokenKey, "dynamic-subagent");
+    ctx.set(DynamicSubagentAgentConfigKey, {
+      description: "Perform deep research.",
+      model: { id: "anthropic/claude-opus-4.6" },
+    });
+    ctx.set(ModeKey, "task");
+    ctx.set(SessionIdKey, "session-1");
+
+    await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "research this" }],
+      },
+      parentWritable: createTestWritable(),
+      serializedContext: serializeContext(ctx),
+      sessionState: createStubSessionState(),
+    });
+
+    const effectiveNode = expect.objectContaining({
+      turnAgent: expect.objectContaining({
+        model: { id: "anthropic/claude-opus-4.6" },
+      }),
+    });
+    expect(buildRuntimeIdentity).toHaveBeenCalledWith(effectiveNode);
+    expect(createExecutionNodeStep).toHaveBeenCalledWith(
+      expect.objectContaining({ node: effectiveNode }),
+    );
+  });
+
   it("reads the durable session from normalized turn-step input", async () => {
     const session = createStubSession({
       continuationToken: "http:turn-step",

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -743,6 +743,93 @@ describe("dispatchRuntimeActionsStep", () => {
     );
     expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE)).toBeUndefined();
   });
+
+  it("blocks a dynamic subagent call when the current selection omits it", async () => {
+    const nodeId = "subagents/researcher";
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {},
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {
+        dynamicNodeIds: new Set([nodeId]),
+        dynamicResolvers: [],
+        subagentsByNodeId: new Map([
+          [
+            nodeId,
+            {
+              definition: {
+                description: "Research the request.",
+                kind: "subagent",
+              },
+            },
+          ],
+        ]),
+      },
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const session = setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "call-dynamic",
+          description: "Research the request.",
+          input: { message: "investigate" },
+          kind: "subagent-call",
+          name: "researcher",
+          nodeId,
+          subagentName: "researcher",
+        },
+      ],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      responseMessages: [],
+      session: createStubSession({
+        continuationToken: "http:parent",
+        sessionId: "parent-session",
+      }),
+    });
+    installSessionStoreMocks([session]);
+    const sessionState = createStubSessionState({
+      continuationToken: "http:parent",
+      sessionId: "parent-session",
+    });
+
+    await expect(
+      dispatchRuntimeActionsStep({
+        parentContinuationToken: "turn-inbox",
+        parentWritable: createTestWritable(),
+        serializedContext: createSerializedContext(),
+        sessionState,
+      }),
+    ).resolves.toEqual({
+      results: [
+        {
+          callId: "call-dynamic",
+          isError: true,
+          kind: "subagent-result",
+          output: {
+            code: "SUBAGENT_UNAVAILABLE",
+            message: 'Subagent "researcher" is not available in the current session context.',
+          },
+          subagentName: "researcher",
+        },
+      ],
+      sessionState,
+    });
+    expect(startMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("turnStep", () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -6,6 +6,10 @@ import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-li
 import { dispatchDynamicModelEvent } from "#context/dynamic-model-lifecycle.js";
 import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
 import {
+  dispatchDynamicSubagentEvent,
+  refreshDynamicSessionSubagentsForRuntimeRevision,
+} from "#context/dynamic-subagent-lifecycle.js";
+import {
   dispatchDynamicToolEvent,
   refreshDynamicSessionToolsForRuntimeRevision,
 } from "#context/dynamic-tool-lifecycle.js";
@@ -13,6 +17,7 @@ import {
   AuthKey,
   CapabilitiesKey,
   ModeKey,
+  SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicToolRuntimeRevisionKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
@@ -273,24 +278,36 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const hookRegistry = bundle.hookRegistry;
   const dynamicInstructionsResolvers = bundle.resolvedAgent.dynamicInstructionsResolvers ?? [];
   const dynamicSkillResolvers = bundle.resolvedAgent.dynamicSkillResolvers ?? [];
+  const dynamicSubagentResolvers = bundle.subagentRegistry.dynamicResolvers ?? [];
   const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
   const runtimeIdentity = buildRuntimeIdentity(bundle.graph.root);
   const deploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
-  const dynamicToolRuntimeRevision = deploymentId
+  const dynamicRuntimeRevision = deploymentId
     ? `deployment:${deploymentId}`
     : await resolveRuntimeCompiledArtifactsVersionedCacheKey(bundle.compiledArtifactsSource);
   const sessionStarted = getHarnessEmissionState(initialSession.state).sessionStarted;
 
   if (!sessionStarted) {
-    ctx.set(SessionDynamicToolRuntimeRevisionKey, dynamicToolRuntimeRevision);
+    ctx.set(SessionDynamicSubagentRuntimeRevisionKey, dynamicRuntimeRevision);
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, dynamicRuntimeRevision);
   } else {
-    await refreshDynamicSessionToolsForRuntimeRevision({
-      ctx,
-      resolvers: dynamicToolResolvers,
-      event: createSessionStartedEvent({ runtime: runtimeIdentity }),
-      messages: initialSession.history,
-      runtimeRevision: dynamicToolRuntimeRevision,
-    });
+    const refreshEvent = createSessionStartedEvent({ runtime: runtimeIdentity });
+    await Promise.all([
+      refreshDynamicSessionSubagentsForRuntimeRevision({
+        ctx,
+        resolvers: dynamicSubagentResolvers,
+        event: refreshEvent,
+        messages: initialSession.history,
+        runtimeRevision: dynamicRuntimeRevision,
+      }),
+      refreshDynamicSessionToolsForRuntimeRevision({
+        ctx,
+        resolvers: dynamicToolResolvers,
+        event: refreshEvent,
+        messages: initialSession.history,
+        runtimeRevision: dynamicRuntimeRevision,
+      }),
+    ]);
   }
 
   const writer = input.parentWritable.getWriter();
@@ -323,6 +340,12 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
         },
       });
     }
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      resolvers: dynamicSubagentResolvers,
+      event: emitted,
+      messages: messages ?? [],
+    });
     await dispatchDynamicToolEvent({
       ctx,
       resolvers: dynamicToolResolvers,

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -72,6 +72,7 @@ import {
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
+import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
@@ -149,6 +150,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const ctx = await deserializeContext(input.serializedContext);
   const adapter = ctx.require(ChannelKey);
   const bundle = ctx.require(BundleKey);
+  const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
 
   // Populate the callback base URL so getHookUrl() works during tool
   // execution, preferring eve's active local origin over metadata fallback.
@@ -221,10 +223,10 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
   const initialSession = hydrateDurableSession({
     compactionOverrides: {
-      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+      thresholdPercent: effectiveAgent.thresholdPercent,
     },
     durable: durableSession,
-    turnAgent: bundle.turnAgent,
+    turnAgent: effectiveAgent.turnAgent,
   });
 
   const adapterCtx = buildAdapterContext(adapter, ctx);
@@ -330,9 +332,9 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     if (emitted.type !== "step.started") {
       await dispatchDynamicModelEvent({
         ctx,
-        dynamicModel: bundle.turnAgent.dynamicModel,
+        dynamicModel: effectiveAgent.turnAgent.dynamicModel,
         event: emitted,
-        fallback: bundle.turnAgent.model,
+        fallback: effectiveAgent.turnAgent.model,
         messages: messages ?? [],
         scope: {
           moduleMap: bundle.moduleMap,
@@ -376,7 +378,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     throwIfTurnAborted(input.abortSignal);
     stepResult = await runStep(ctx, initialSession, async (enrichedSession) => {
       const schemaSession = resolveEffectiveOutputSchema({
-        agentOutputSchema: bundle.turnAgent.outputSchema,
+        agentOutputSchema: effectiveAgent.turnAgent.outputSchema,
         input: resolved,
         mode,
         session: enrichedSession,
@@ -405,10 +407,10 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       ): Promise<StepResult> => {
         const refreshedSession = refreshSessionFromTurnAgent({
           compactionOverrides: {
-            thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+            thresholdPercent: effectiveAgent.thresholdPercent,
           },
           session: lifecycleSession,
-          turnAgent: bundle.turnAgent,
+          turnAgent: effectiveAgent.turnAgent,
         });
 
         const step = createExecutionNodeStep({

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -282,7 +282,11 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const dynamicSkillResolvers = bundle.resolvedAgent.dynamicSkillResolvers ?? [];
   const dynamicSubagentResolvers = bundle.subagentRegistry.dynamicResolvers ?? [];
   const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
-  const runtimeIdentity = buildRuntimeIdentity(bundle.graph.root);
+  const effectiveNode = {
+    ...bundle.graph.root,
+    turnAgent: effectiveAgent.turnAgent,
+  };
+  const runtimeIdentity = buildRuntimeIdentity(effectiveNode);
   const deploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
   const dynamicRuntimeRevision = deploymentId
     ? `deployment:${deploymentId}`
@@ -423,7 +427,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
             moduleMap: bundle.moduleMap,
             nodeId: bundle.nodeId,
           },
-          node: bundle.graph.root,
+          node: effectiveNode,
           workflowMaxSubagents: refreshedSession.workflowMaxSubagents,
         });
         return step(refreshedSession, stepInput);

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -22,6 +22,7 @@ import {
   SessionKey,
   SessionDynamicInstructionsKey,
   SessionDynamicModelReferenceKey,
+  SessionDynamicSubagentSelectionsKey,
 } from "#context/keys.js";
 import { SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
 import { decodeSandboxRef, isSandboxRefUrl } from "#internal/attachments/sandbox-refs.js";
@@ -926,6 +927,71 @@ describe("createToolLoopHarness", () => {
         nodeId: "workers",
         subagentName: "worker",
       },
+    ]);
+  });
+
+  it("parks dynamic subagent calls as pending runtime actions", async () => {
+    setupMockAgent({
+      finishReason: "tool-calls",
+      response: {
+        messages: [
+          {
+            content: [
+              {
+                input: { message: "investigate" },
+                toolCallId: "call-dynamic",
+                toolName: "researcher",
+                type: "tool-call",
+              },
+            ],
+            role: "assistant",
+          },
+        ],
+      },
+      text: "",
+      toolCalls: [
+        {
+          input: { message: "investigate" },
+          toolCallId: "call-dynamic",
+          toolName: "researcher",
+          type: "tool-call",
+        },
+      ],
+      toolResults: [],
+    });
+    const ctx = new ContextContainer();
+    ctx.set(SessionDynamicSubagentSelectionsKey, {
+      "subagents/researcher": {
+        description: "Research the request.",
+        inputSchema: { type: "object" },
+        kind: "subagent",
+        logicalPath: "subagents/researcher",
+        name: "researcher",
+        nodeId: "subagents/researcher",
+        sourceId: "subagents/researcher",
+      },
+    });
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+
+    const result = await contextStorage.run(ctx, () =>
+      runStep(createTestSession(), { message: "Research this." }),
+    );
+
+    expect(events.find((event) => event.type === "actions.requested")?.data.actions).toEqual([
+      expect.objectContaining({
+        callId: "call-dynamic",
+        kind: "subagent-call",
+        nodeId: "subagents/researcher",
+        subagentName: "researcher",
+      }),
+    ]);
+    expect(getPendingRuntimeActionBatch(result.session.state)?.actions).toEqual([
+      expect.objectContaining({
+        callId: "call-dynamic",
+        kind: "subagent-call",
+        nodeId: "subagents/researcher",
+      }),
     ]);
   });
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -962,13 +962,19 @@ describe("createToolLoopHarness", () => {
     const ctx = new ContextContainer();
     ctx.set(SessionDynamicSubagentSelectionsKey, {
       "subagents/researcher": {
-        description: "Research the request.",
-        inputSchema: { type: "object" },
-        kind: "subagent",
-        logicalPath: "subagents/researcher",
-        name: "researcher",
-        nodeId: "subagents/researcher",
-        sourceId: "subagents/researcher",
+        agentConfig: {
+          description: "Research the request.",
+          model: { id: "openai/gpt-5.5" },
+        },
+        prepared: {
+          description: "Research the request.",
+          inputSchema: { type: "object" },
+          kind: "subagent",
+          logicalPath: "subagents/researcher",
+          name: "researcher",
+          nodeId: "subagents/researcher",
+          sourceId: "subagents/researcher",
+        },
       },
     });
     const { emit, events } = createEventCollector();

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -34,6 +34,7 @@ import { AuthKey, ParentSessionKey, ParentTraceContextKey } from "#context/keys.
 import { buildDynamicInstructionMessages } from "#context/dynamic-instruction-lifecycle.js";
 import { getActiveDynamicModelSelection } from "#context/dynamic-model-lifecycle.js";
 import { buildDynamicTools } from "#context/build-dynamic-tools.js";
+import { buildDynamicSubagentTools } from "#context/dynamic-subagent-lifecycle.js";
 import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js";
 import { toErrorMessage } from "#shared/errors.js";
 import {
@@ -478,6 +479,26 @@ function resolveStepOtelContext(
   return undefined;
 }
 
+function buildHarnessToolsWithDynamicSubagents(
+  tools: HarnessToolMap,
+  ctx: Parameters<typeof buildDynamicSubagentTools>[0] | undefined,
+): HarnessToolMap {
+  const effectiveTools = new Map(tools);
+  if (ctx === undefined) {
+    return effectiveTools;
+  }
+
+  for (const dynamicSubagent of buildDynamicSubagentTools(ctx)) {
+    if (effectiveTools.has(dynamicSubagent.name)) {
+      throw new Error(
+        `Dynamic subagent "${dynamicSubagent.name}" collides with another runtime-visible tool name.`,
+      );
+    }
+    effectiveTools.set(dynamicSubagent.name, dynamicSubagent);
+  }
+  return effectiveTools;
+}
+
 export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
   const baseEmit = config.handleEvent;
   const telemetryConfig = getInstrumentationConfig();
@@ -826,6 +847,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       suppressStepStartedEmission?: boolean;
       trailingUserNote?: string;
     };
+    let modelCallRuntimeActionTools = config.tools;
 
     const runSingleModelCall = async (
       opts: ModelCallOptions & { readonly attemptIndex: number },
@@ -844,10 +866,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       const callMessages = opts.trailingUserNote
         ? [...modelMessages, { role: "user" as const, content: opts.trailingUserNote }]
         : modelMessages;
+      const harnessTools = buildHarnessToolsWithDynamicSubagents(config.tools, ctx);
       const advertisedHarnessTools = getAdvertisedTools({
         session,
-        tools: config.tools,
+        tools: harnessTools,
       });
+      modelCallRuntimeActionTools = advertisedHarnessTools;
 
       const flatTools = await buildToolSetWithProviderTools({
         approvedTools,
@@ -870,6 +894,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         });
         // Dynamic tools override a same-named authored tool.
         for (const [name, toolDefinition] of Object.entries(dynamicToolSet)) {
+          if (advertisedHarnessTools.get(name)?.runtimeAction !== undefined) {
+            throw new Error(`Dynamic tool "${name}" collides with a runtime-visible subagent.`);
+          }
           flatTools[name] = toolDefinition;
         }
       }
@@ -992,7 +1019,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             trailingInlineToolResultParts,
           } = await emitStreamContent(emit, emissionState, streamResult.fullStream, {
             excludedActionToolNames,
-            tools: config.tools,
+            tools: advertisedHarnessTools,
           });
           throwIfTurnAborted(config.abortSignal);
           const [stepResult, accumulatedResponseMessages] = await Promise.all([
@@ -1103,6 +1130,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       emissionState,
       runStep,
       session,
+      tools: buildHarnessToolsWithDynamicSubagents(config.tools, ctx),
     });
     if (pendingWorkflowInterrupt !== null) {
       return pendingWorkflowInterrupt;
@@ -1371,6 +1399,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       result,
       runStep,
       session,
+      runtimeActionTools: modelCallRuntimeActionTools,
     });
   }
 
@@ -1863,6 +1892,7 @@ async function handleStepResult(input: {
   readonly promptMessages: readonly ModelMessage[];
   readonly result: HarnessStepResult;
   readonly runStep: StepFn;
+  readonly runtimeActionTools: HarnessToolMap;
   readonly session: HarnessSession;
 }): Promise<StepResult> {
   const { config, emit, promptMessages, result, runStep } = input;
@@ -1948,11 +1978,13 @@ async function handleStepResult(input: {
   const inputRequests: InputRequest[] = [...approvalRequests, ...questionRequests];
   const advertisedRuntimeActionTools = getAdvertisedTools({
     session: baseSession,
-    tools: config.tools,
+    tools: input.runtimeActionTools,
   });
   const pendingRuntimeActions = ((result.toolCalls ?? []) as TypedToolCall<ToolSet>[])
     .filter((toolCall) => !invalidInputToolCallIds.has(toolCall.toolCallId))
-    .filter((toolCall) => config.tools.get(toolCall.toolName)?.runtimeAction !== undefined)
+    .filter(
+      (toolCall) => input.runtimeActionTools.get(toolCall.toolName)?.runtimeAction !== undefined,
+    )
     .filter((toolCall) => {
       if (advertisedRuntimeActionTools.get(toolCall.toolName)?.runtimeAction !== undefined) {
         return true;
@@ -2297,6 +2329,7 @@ async function continuePendingWorkflowInterrupt(input: {
   readonly emissionState: ReturnType<typeof getHarnessEmissionState>;
   readonly runStep: StepFn;
   readonly session: HarnessSession;
+  readonly tools: HarnessToolMap;
 }): Promise<StepResult | null> {
   const pending = getPendingWorkflowInterrupt(input.session.state);
   if (pending === undefined) return null;
@@ -2313,14 +2346,14 @@ async function continuePendingWorkflowInterrupt(input: {
           emit: input.emit,
           emissionState: input.emissionState,
           skipReplayed: true,
-          tools: input.config.tools,
+          tools: input.tools,
         });
   const continuationSecurity = getWorkflowContinuationSecurity(input.session);
 
   let continuationOutput: unknown;
   try {
     const hostTools = buildWorkflowHostTools({
-      tools: input.config.tools,
+      tools: input.tools,
     });
 
     const childResults = input.childResults ?? [];

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -95,7 +95,7 @@ export interface AgentInfoScheduleEntry extends AgentInfoSource {
 }
 
 export interface AgentInfoSubagentEntry extends AgentInfoSource {
-  readonly description: string;
+  readonly description?: string;
   readonly entryPath: string;
   readonly name: string;
   readonly nodeId: string;

--- a/packages/eve/src/internal/vercel-agent-summary.ts
+++ b/packages/eve/src/internal/vercel-agent-summary.ts
@@ -182,7 +182,7 @@ export interface VercelEveSkillEntry {
 
 export interface VercelEveSubagentEntry {
   readonly name: string;
-  readonly description: string;
+  readonly description?: string;
   readonly logicalPath: string;
 }
 

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -1,5 +1,13 @@
 import type { PublicAgentDefinition } from "#shared/agent-definition.js";
 import type { ExactDefinition } from "#public/definitions/exact.js";
+import { defineDynamic as defineDynamicBase } from "#public/definitions/tool.js";
+import type {
+  DynamicEvents,
+  DynamicEventsWithFallback,
+  DynamicSentinel,
+} from "#shared/dynamic-tool-definition.js";
+
+declare const DEFINED_AGENT: unique symbol;
 
 export type {
   AgentModelResolveContext,
@@ -31,6 +39,52 @@ export type {
  */
 export type AgentDefinition = PublicAgentDefinition;
 
+/** Literal-preserving value returned by {@link defineAgent}. */
+export type DefinedAgent<TAgent extends AgentDefinition = AgentDefinition> = TAgent & {
+  readonly [DEFINED_AGENT]: true;
+};
+
+/**
+ * Agent configuration returned by a dynamic subagent resolver. The description
+ * tells the parent agent when to delegate.
+ */
+export type DynamicSubagentDefinition = AgentDefinition & {
+  readonly description: string;
+};
+
+type DynamicEventHandler<TEvents extends DynamicEvents> = Extract<
+  NonNullable<TEvents[keyof TEvents]>,
+  (...args: never[]) => unknown
+>;
+type DynamicEventResult<TEvents extends DynamicEvents> = Awaited<
+  ReturnType<DynamicEventHandler<TEvents>>
+>;
+type DynamicSubagentDescriptionConstraint<TEvents extends DynamicEvents> =
+  Exclude<
+    Extract<DynamicEventResult<TEvents>, DefinedAgent>,
+    DynamicSubagentDefinition
+  > extends never
+    ? unknown
+    : { readonly "Dynamic subagent definitions require a description": never };
+
+/**
+ * Defines dynamic agent configuration. A returned subagent requires a
+ * description so its parent knows when to delegate.
+ */
+export const defineDynamic: {
+  <const TEvents extends DynamicEventsWithFallback, TFallback = unknown>(
+    definition: {
+      readonly fallback: TFallback;
+      readonly events: TEvents;
+    } & DynamicSubagentDescriptionConstraint<TEvents>,
+  ): DynamicSentinel<Exclude<DynamicEventResult<TEvents>, undefined>, TFallback>;
+  <const TEvents extends DynamicEvents>(
+    definition: {
+      readonly events: TEvents;
+    } & DynamicSubagentDescriptionConstraint<TEvents>,
+  ): DynamicSentinel<DynamicEventResult<TEvents>>;
+} = defineDynamicBase;
+
 /**
  * Defines the agent configuration authored in `agent.ts` and returns it
  * unchanged, preserving its literal type.
@@ -42,6 +96,7 @@ export type AgentDefinition = PublicAgentDefinition;
  */
 export function defineAgent<TAgent extends AgentDefinition>(
   definition: ExactDefinition<TAgent, AgentDefinition>,
-): TAgent {
+): DefinedAgent<TAgent>;
+export function defineAgent(definition: AgentDefinition): AgentDefinition {
   return definition;
 }

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
-import { defineAgent } from "#public/definitions/agent.js";
+import { defineAgent, defineDynamic } from "#public/definitions/agent.js";
 import { none } from "#public/channels/auth.js";
 import { eveChannel, defaultEveAuth } from "#public/channels/eve.js";
 import { defineChannel, POST } from "#public/definitions/channel.js";
@@ -49,6 +49,26 @@ describe("definition helper exact inputs", () => {
 });
 
 function typeOnlyFixtures(): void {
+  // @ts-expect-error Dynamic subagents require a parent-facing description.
+  defineDynamic({
+    events: {
+      "session.started": () =>
+        defineAgent({
+          model: "anthropic/claude-sonnet-5",
+        }),
+    },
+  });
+
+  defineDynamic({
+    events: {
+      "session.started": () =>
+        defineAgent({
+          description: "Delegate research tasks.",
+          model: "anthropic/claude-sonnet-5",
+        }),
+    },
+  });
+
   defineAgent({
     limits: {
       // @ts-expect-error Recursive delegation is root-only; this limit was removed.

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -244,9 +244,8 @@ export function defineTool<TInput = unknown, TOutput = unknown>(
  * - `agent/instructions/`: return a single `defineInstructions({ markdown })`,
  *   which lowers to one `{ role: "system", content: markdown }` message,
  *   or `null`. (Maps are not meaningful here.)
- * - `agent/subagents/<name>/agent.ts`: provide the static `defineAgent(...)`
- *   value as `fallback`, then return that same value to expose the subagent or
- *   `null` to omit it.
+ * - `agent/subagents/<name>/agent.ts`: return `defineAgent(...)` to configure
+ *   and expose the subagent, or `null` to omit it.
  *
  * Per-slot events: tools resolvers run at `session.started`,
  * `turn.started`, and `step.started`. Instructions and skills resolvers

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -230,7 +230,7 @@ export function defineTool<TInput = unknown, TOutput = unknown>(
 
 /**
  * Defines a dynamic resolver evaluated at runtime from stream-event
- * handlers. It is shared across three slots, and the directory it is
+ * handlers. It is shared across four slots, and the directory it is
  * authored in (not this function) decides what each handler must return
  * and which events are honored. The file's path-derived slug names the
  * single-entry case; a `Record<string, ...>` return names entries
@@ -244,12 +244,16 @@ export function defineTool<TInput = unknown, TOutput = unknown>(
  * - `agent/instructions/`: return a single `defineInstructions({ markdown })`,
  *   which lowers to one `{ role: "system", content: markdown }` message,
  *   or `null`. (Maps are not meaningful here.)
+ * - `agent/subagents/<name>/agent.ts`: provide the static `defineAgent(...)`
+ *   value as `fallback`, then return that same value to expose the subagent or
+ *   `null` to omit it.
  *
  * Per-slot events: tools resolvers run at `session.started`,
  * `turn.started`, and `step.started`. Instructions and skills resolvers
  * contribute to the system prompt, so for cache stability they run only
  * at `session.started` and `turn.started`; the runtime never invokes a
  * handler keyed on `step.started` in those slots.
+ * Dynamic subagents run at `session.started` and `turn.started` only.
  *
  * ```ts
  * import { defineDynamic, defineTool } from "eve/tools";

--- a/packages/eve/src/public/index.ts
+++ b/packages/eve/src/public/index.ts
@@ -12,9 +12,11 @@ export {
   type AgentReasoningDefinition,
   type AgentWorkflowDefinition,
   type AgentWorkflowWorldDefinition,
+  type DefinedAgent,
+  type DynamicSubagentDefinition,
   defineAgent,
+  defineDynamic,
 } from "#public/definitions/agent.js";
-export { defineDynamic } from "#public/definitions/tool.js";
 export type { DynamicResolveContext, DynamicSentinel } from "#shared/dynamic-tool-definition.js";
 export {
   type RemoteAgentDefinition,

--- a/packages/eve/src/runtime/agent/resolve-model.test.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.test.ts
@@ -21,8 +21,17 @@ describe("dynamic runtime model resolution", () => {
     vi.unstubAllEnvs();
   });
 
-  it("resolves a source-free eve mock model without the test environment", async () => {
+  it("does not resolve a source-free eve mock model without the test seam", async () => {
     vi.stubEnv("NODE_ENV", "production");
+
+    const model = await resolveRuntimeModelReference({ id: "eve-mock/dynamic-subagent" });
+
+    expect(model).toBe("eve-mock/dynamic-subagent");
+  });
+
+  it("resolves a source-free eve mock model through the explicit test seam", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("EVE_MOCK_AUTHORED_MODELS", "1");
 
     const model = await resolveRuntimeModelReference({ id: "eve-mock/dynamic-subagent" });
 

--- a/packages/eve/src/runtime/agent/resolve-model.test.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
@@ -6,6 +6,7 @@ import { defineDynamic } from "#public/definitions/tool.js";
 import {
   loadDynamicRuntimeModelDefinition,
   normalizeDynamicRuntimeModelResult,
+  resolveRuntimeModelReference,
 } from "#runtime/agent/resolve-model.js";
 
 const DYNAMIC_MODEL_SOURCE = {
@@ -16,6 +17,21 @@ const DYNAMIC_MODEL_SOURCE = {
 };
 
 describe("dynamic runtime model resolution", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves a source-free eve mock model without the test environment", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const model = await resolveRuntimeModelReference({ id: "eve-mock/dynamic-subagent" });
+
+    expect(typeof model).toBe("object");
+    if (typeof model === "string") throw new Error("expected a mock model instance");
+    expect(model.provider).toBe("eve-runtime-mock");
+    expect(model.modelId).toBe("eve-mock/dynamic-subagent");
+  });
+
   it("loads dynamic model definitions and normalizes string selections", async () => {
     const moduleMap = createModuleMap({
       default: {

--- a/packages/eve/src/runtime/agent/resolve-model.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.ts
@@ -8,6 +8,7 @@ import type {
 } from "#runtime/agent/bootstrap.js";
 import { resolveBootstrapRuntimeModel } from "#runtime/agent/bootstrap-model.js";
 import {
+  createMockAuthoredRuntimeModel,
   resolveMockAuthoredRuntimeModel,
   shouldMockAuthoredRuntimeModels,
 } from "#runtime/agent/mock-model-adapter.js";
@@ -21,7 +22,6 @@ import {
   type PublicAgentStaticModelDefinition,
 } from "#shared/agent-definition.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
-import { isDynamicSentinel } from "#shared/dynamic-tool-definition.js";
 
 export { shouldMockAuthoredRuntimeModels };
 
@@ -48,6 +48,10 @@ export async function resolveRuntimeModelReference(
 
   if (bootstrapModel !== null) {
     return bootstrapModel;
+  }
+
+  if (reference.source === undefined && reference.id.startsWith("eve-mock/")) {
+    return createMockAuthoredRuntimeModel(reference);
   }
 
   const mockModel = resolveMockAuthoredRuntimeModel(reference);
@@ -82,7 +86,7 @@ async function loadSourceBackedRuntimeModelReference(
     nodeId: scope.nodeId,
   });
   const normalizedDefinition = normalizeAgentDefinition(
-    unwrapDynamicSubagentDefinition(definition),
+    definition,
     `Expected the authored agent config export "${reference.source.exportName ?? "default"}" from "${reference.source.logicalPath}" to match the public eve shape.`,
   );
   const model = normalizedDefinition.model;
@@ -119,7 +123,7 @@ export async function loadDynamicRuntimeModelDefinition(input: {
     nodeId: input.scope.nodeId,
   });
   const normalizedDefinition = normalizeAgentDefinition(
-    unwrapDynamicSubagentDefinition(definition),
+    definition,
     `Expected the authored agent config export "${input.dynamicModel.exportName ?? "default"}" from "${input.dynamicModel.logicalPath}" to match the public eve shape.`,
   );
   const authoredModel = normalizedDefinition.model;
@@ -131,10 +135,6 @@ export async function loadDynamicRuntimeModelDefinition(input: {
   }
 
   return authoredModel;
-}
-
-function unwrapDynamicSubagentDefinition(value: unknown): unknown {
-  return isDynamicSentinel(value) && "fallback" in value ? value.fallback : value;
 }
 
 export function normalizeDynamicRuntimeModelResult(input: {

--- a/packages/eve/src/runtime/agent/resolve-model.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.ts
@@ -21,6 +21,7 @@ import {
   type PublicAgentStaticModelDefinition,
 } from "#shared/agent-definition.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
+import { isDynamicSentinel } from "#shared/dynamic-tool-definition.js";
 
 export { shouldMockAuthoredRuntimeModels };
 
@@ -81,7 +82,7 @@ async function loadSourceBackedRuntimeModelReference(
     nodeId: scope.nodeId,
   });
   const normalizedDefinition = normalizeAgentDefinition(
-    definition,
+    unwrapDynamicSubagentDefinition(definition),
     `Expected the authored agent config export "${reference.source.exportName ?? "default"}" from "${reference.source.logicalPath}" to match the public eve shape.`,
   );
   const model = normalizedDefinition.model;
@@ -118,7 +119,7 @@ export async function loadDynamicRuntimeModelDefinition(input: {
     nodeId: input.scope.nodeId,
   });
   const normalizedDefinition = normalizeAgentDefinition(
-    definition,
+    unwrapDynamicSubagentDefinition(definition),
     `Expected the authored agent config export "${input.dynamicModel.exportName ?? "default"}" from "${input.dynamicModel.logicalPath}" to match the public eve shape.`,
   );
   const authoredModel = normalizedDefinition.model;
@@ -130,6 +131,10 @@ export async function loadDynamicRuntimeModelDefinition(input: {
   }
 
   return authoredModel;
+}
+
+function unwrapDynamicSubagentDefinition(value: unknown): unknown {
+  return isDynamicSentinel(value) && "fallback" in value ? value.fallback : value;
 }
 
 export function normalizeDynamicRuntimeModelResult(input: {

--- a/packages/eve/src/runtime/agent/resolve-model.ts
+++ b/packages/eve/src/runtime/agent/resolve-model.ts
@@ -8,7 +8,6 @@ import type {
 } from "#runtime/agent/bootstrap.js";
 import { resolveBootstrapRuntimeModel } from "#runtime/agent/bootstrap-model.js";
 import {
-  createMockAuthoredRuntimeModel,
   resolveMockAuthoredRuntimeModel,
   shouldMockAuthoredRuntimeModels,
 } from "#runtime/agent/mock-model-adapter.js";
@@ -48,10 +47,6 @@ export async function resolveRuntimeModelReference(
 
   if (bootstrapModel !== null) {
     return bootstrapModel;
-  }
-
-  if (reference.source === undefined && reference.id.startsWith("eve-mock/")) {
-    return createMockAuthoredRuntimeModel(reference);
   }
 
   const mockModel = resolveMockAuthoredRuntimeModel(reference);

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -30,6 +30,7 @@ import { createRuntimeToolRegistry } from "#runtime/tools/registry.js";
 import { WORKFLOW_TOOL_NAME } from "#shared/workflow-sandbox.js";
 import type {
   ResolvedChannelDefinition,
+  ResolvedDynamicSubagentDefinition,
   ResolvedRuntimeDelegationNode,
   ResolvedRuntimeRemoteAgentNode,
   ResolvedRuntimeSubagentNode,
@@ -322,27 +323,23 @@ async function resolveRuntimeSubagent(input: {
       },
     );
   }
-  const dynamicFields: {
-    dynamic?: ResolvedRuntimeSubagentNode["dynamic"];
-  } = {};
-
-  if (input.sourceRef.dynamic !== undefined) {
-    dynamicFields.dynamic = await resolveDynamicSubagentDefinition({
-      definition: {
-        ...dynamicSource!,
-        ...input.sourceRef.dynamic,
-      },
-      moduleMap: input.moduleMap,
-      nodeId: input.sourceRef.nodeId,
-    });
-  }
-  const descriptionFields: { description?: string } = {};
-  if (input.sourceRef.description !== undefined) {
-    descriptionFields.description = input.sourceRef.description;
-  }
+  const variant:
+    | { readonly description: string; readonly dynamic?: never }
+    | { readonly description?: never; readonly dynamic: ResolvedDynamicSubagentDefinition } =
+    input.sourceRef.dynamic === undefined
+      ? { description: input.sourceRef.description }
+      : {
+          dynamic: await resolveDynamicSubagentDefinition({
+            definition: {
+              ...dynamicSource!,
+              ...input.sourceRef.dynamic,
+            },
+            moduleMap: input.moduleMap,
+            nodeId: input.sourceRef.nodeId,
+          }),
+        };
   const resolvedSubagent: ResolvedRuntimeSubagentNode = {
-    ...descriptionFields,
-    ...dynamicFields,
+    ...variant,
     kind: "subagent",
     logicalPath: input.sourceRef.logicalPath,
     name: input.sourceRef.name,

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -21,6 +21,10 @@ import {
 import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
 import { createRuntimeHookRegistry } from "#runtime/hooks/registry.js";
 import { resolveAgent } from "#runtime/resolve-agent.js";
+import {
+  normalizeResolvedDynamicSubagentDefinition,
+  resolveDynamicSubagentDefinition,
+} from "#runtime/resolve-dynamic-subagent.js";
 import { loadResolvedModuleExport } from "#runtime/resolve-helpers.js";
 import { createRuntimeSandboxRegistry } from "#runtime/sandbox/registry.js";
 import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
@@ -311,8 +315,33 @@ async function resolveRuntimeSubagent(input: {
   readonly sourceRef: CompiledSubagentNode;
   readonly subagentNodesById: ReadonlyMap<string, CompiledSubagentNode>;
 }): Promise<ResolvedRuntimeSubagentNode> {
+  const dynamicSource = input.sourceRef.agent.config.source;
+  if (input.sourceRef.dynamic !== undefined && dynamicSource === undefined) {
+    throw new ResolveRuntimeAgentGraphError(
+      `Dynamic subagent "${input.sourceRef.logicalPath}" is missing its agent config source.`,
+      {
+        nodeId: toRuntimeNodeId(input.sourceRef.nodeId),
+        sourceId: input.sourceRef.sourceId,
+      },
+    );
+  }
+  const dynamicFields: {
+    dynamic?: ResolvedRuntimeSubagentNode["dynamic"];
+  } = {};
+
+  if (input.sourceRef.dynamic !== undefined) {
+    dynamicFields.dynamic = await resolveDynamicSubagentDefinition({
+      definition: {
+        ...dynamicSource!,
+        ...input.sourceRef.dynamic,
+      },
+      moduleMap: input.moduleMap,
+      nodeId: input.sourceRef.nodeId,
+    });
+  }
   const resolvedSubagent: ResolvedRuntimeSubagentNode = {
     description: input.sourceRef.description,
+    ...dynamicFields,
     kind: "subagent",
     logicalPath: input.sourceRef.logicalPath,
     name: input.sourceRef.name,
@@ -344,14 +373,25 @@ async function resolveRuntimeRemoteAgent(input: {
     moduleMap: input.moduleMap,
     nodeId: input.nodeScopeId,
   });
+  const dynamic =
+    input.sourceRef.dynamic === undefined
+      ? undefined
+      : normalizeResolvedDynamicSubagentDefinition(
+          {
+            ...input.sourceRef,
+            ...input.sourceRef.dynamic,
+          },
+          resolvedExportValue,
+        );
   const resolvedRecord = expectObjectRecord(
-    resolvedExportValue,
+    dynamic?.fallback ?? resolvedExportValue,
     `Expected remote agent source "${input.sourceRef.logicalPath}" to export an object.`,
   );
 
   const resolvedRemoteAgent: {
     auth?: ResolvedRuntimeRemoteAgentNode["auth"];
     description: string;
+    dynamic?: ResolvedRuntimeRemoteAgentNode["dynamic"];
     forwardPrincipal?: boolean;
     headers?: HeadersValue;
     kind: "remote";
@@ -379,6 +419,10 @@ async function resolveRuntimeRemoteAgent(input: {
       resolvedUrl: resolvedRecord.url,
     }),
   };
+
+  if (dynamic !== undefined) {
+    resolvedRemoteAgent.dynamic = dynamic;
+  }
 
   if (typeof resolvedRecord.auth === "function") {
     resolvedRemoteAgent.auth = resolvedRecord.auth as ResolvedRuntimeRemoteAgentNode["auth"];

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -21,10 +21,7 @@ import {
 import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
 import { createRuntimeHookRegistry } from "#runtime/hooks/registry.js";
 import { resolveAgent } from "#runtime/resolve-agent.js";
-import {
-  normalizeResolvedDynamicSubagentDefinition,
-  resolveDynamicSubagentDefinition,
-} from "#runtime/resolve-dynamic-subagent.js";
+import { resolveDynamicSubagentDefinition } from "#runtime/resolve-dynamic-subagent.js";
 import { loadResolvedModuleExport } from "#runtime/resolve-helpers.js";
 import { createRuntimeSandboxRegistry } from "#runtime/sandbox/registry.js";
 import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
@@ -339,8 +336,12 @@ async function resolveRuntimeSubagent(input: {
       nodeId: input.sourceRef.nodeId,
     });
   }
+  const descriptionFields: { description?: string } = {};
+  if (input.sourceRef.description !== undefined) {
+    descriptionFields.description = input.sourceRef.description;
+  }
   const resolvedSubagent: ResolvedRuntimeSubagentNode = {
-    description: input.sourceRef.description,
+    ...descriptionFields,
     ...dynamicFields,
     kind: "subagent",
     logicalPath: input.sourceRef.logicalPath,
@@ -373,25 +374,14 @@ async function resolveRuntimeRemoteAgent(input: {
     moduleMap: input.moduleMap,
     nodeId: input.nodeScopeId,
   });
-  const dynamic =
-    input.sourceRef.dynamic === undefined
-      ? undefined
-      : normalizeResolvedDynamicSubagentDefinition(
-          {
-            ...input.sourceRef,
-            ...input.sourceRef.dynamic,
-          },
-          resolvedExportValue,
-        );
   const resolvedRecord = expectObjectRecord(
-    dynamic?.fallback ?? resolvedExportValue,
+    resolvedExportValue,
     `Expected remote agent source "${input.sourceRef.logicalPath}" to export an object.`,
   );
 
   const resolvedRemoteAgent: {
     auth?: ResolvedRuntimeRemoteAgentNode["auth"];
     description: string;
-    dynamic?: ResolvedRuntimeRemoteAgentNode["dynamic"];
     forwardPrincipal?: boolean;
     headers?: HeadersValue;
     kind: "remote";
@@ -419,10 +409,6 @@ async function resolveRuntimeRemoteAgent(input: {
       resolvedUrl: resolvedRecord.url,
     }),
   };
-
-  if (dynamic !== undefined) {
-    resolvedRemoteAgent.dynamic = dynamic;
-  }
 
   if (typeof resolvedRecord.auth === "function") {
     resolvedRemoteAgent.auth = resolvedRecord.auth as ResolvedRuntimeRemoteAgentNode["auth"];

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.ts
@@ -44,11 +44,11 @@ export function normalizeResolvedDynamicSubagentDefinition(
   definition: DynamicSubagentSource,
   value: unknown,
 ): ResolvedDynamicSubagentDefinition {
-  const message = `Expected the dynamic subagent export "${definition.exportName ?? "default"}" from "${definition.logicalPath}" to provide defineDynamic({ fallback, events }).`;
+  const message = `Expected the dynamic subagent export "${definition.exportName ?? "default"}" from "${definition.logicalPath}" to provide defineDynamic({ events }).`;
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["events", "fallback", "kind"], message);
+  expectOnlyKnownKeys(record, ["events", "kind"], message);
 
-  if (record.kind !== "eve:dynamic" || !Object.hasOwn(record, "fallback")) {
+  if (record.kind !== "eve:dynamic") {
     throw new Error(message);
   }
 
@@ -62,7 +62,6 @@ export function normalizeResolvedDynamicSubagentDefinition(
     eventNames: [...definition.eventNames],
     events: events as ResolvedDynamicSubagentDefinition["events"],
     exportName: definition.exportName,
-    fallback: record.fallback,
     logicalPath: definition.logicalPath,
     sourceId: definition.sourceId,
     sourceKind: "module",

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.ts
@@ -1,0 +1,72 @@
+import type { CompiledDynamicSubagentDefinition } from "#compiler/remote-agent-node.js";
+import type { CompiledModuleMap } from "#compiler/module-map.js";
+import {
+  expectFunction,
+  expectObjectRecord,
+  expectOnlyKnownKeys,
+} from "#internal/authored-module.js";
+import { loadResolvedModuleExport, ResolveAgentError } from "#runtime/resolve-helpers.js";
+import type { ResolvedDynamicSubagentDefinition } from "#runtime/types.js";
+import { toErrorMessage } from "#shared/errors.js";
+import type { ModuleSourceRef } from "#shared/source-ref.js";
+
+type DynamicSubagentSource = ModuleSourceRef & CompiledDynamicSubagentDefinition;
+
+/** Resolves the live availability handlers from a dynamic subagent config module. */
+export async function resolveDynamicSubagentDefinition(input: {
+  readonly definition: DynamicSubagentSource;
+  readonly moduleMap: CompiledModuleMap;
+  readonly nodeId: string;
+}): Promise<ResolvedDynamicSubagentDefinition> {
+  try {
+    const value = await loadResolvedModuleExport({
+      definition: input.definition,
+      kindLabel: "dynamic subagent",
+      moduleMap: input.moduleMap,
+      nodeId: input.nodeId,
+    });
+
+    return normalizeResolvedDynamicSubagentDefinition(input.definition, value);
+  } catch (error) {
+    if (error instanceof ResolveAgentError) {
+      throw error;
+    }
+    throw new ResolveAgentError(
+      `Failed to resolve dynamic subagent from "${input.definition.logicalPath}": ${toErrorMessage(error)}`,
+      {
+        logicalPath: input.definition.logicalPath,
+        sourceId: input.definition.sourceId,
+      },
+    );
+  }
+}
+
+/** Reattaches validated handlers to compiled dynamic-subagent metadata. */
+export function normalizeResolvedDynamicSubagentDefinition(
+  definition: DynamicSubagentSource,
+  value: unknown,
+): ResolvedDynamicSubagentDefinition {
+  const message = `Expected the dynamic subagent export "${definition.exportName ?? "default"}" from "${definition.logicalPath}" to provide defineDynamic({ fallback, events }).`;
+  const record = expectObjectRecord(value, message);
+  expectOnlyKnownKeys(record, ["events", "fallback", "kind"], message);
+
+  if (record.kind !== "eve:dynamic" || !Object.hasOwn(record, "fallback")) {
+    throw new Error(message);
+  }
+
+  const eventMap = expectObjectRecord(record.events, message);
+  const events: Record<string, Function> = {};
+  for (const eventName of definition.eventNames) {
+    events[eventName] = expectFunction(eventMap[eventName], message);
+  }
+
+  return {
+    eventNames: [...definition.eventNames],
+    events: events as ResolvedDynamicSubagentDefinition["events"],
+    exportName: definition.exportName,
+    fallback: record.fallback,
+    logicalPath: definition.logicalPath,
+    sourceId: definition.sourceId,
+    sourceKind: "module",
+  };
+}

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.ts
@@ -12,7 +12,6 @@ import type { ModuleSourceRef } from "#shared/source-ref.js";
 
 type DynamicSubagentSource = ModuleSourceRef & CompiledDynamicSubagentDefinition;
 
-/** Resolves the live availability handlers from a dynamic subagent config module. */
 export async function resolveDynamicSubagentDefinition(input: {
   readonly definition: DynamicSubagentSource;
   readonly moduleMap: CompiledModuleMap;
@@ -41,7 +40,6 @@ export async function resolveDynamicSubagentDefinition(input: {
   }
 }
 
-/** Reattaches validated handlers to compiled dynamic-subagent metadata. */
 export function normalizeResolvedDynamicSubagentDefinition(
   definition: DynamicSubagentSource,
   value: unknown,

--- a/packages/eve/src/runtime/subagents/dynamic-agent-config.ts
+++ b/packages/eve/src/runtime/subagents/dynamic-agent-config.ts
@@ -1,0 +1,127 @@
+import { normalizeAgentDefinition } from "#internal/authored-definition/core.js";
+import { formatLanguageModelGatewayId } from "#internal/runtime-model.js";
+import {
+  isDynamicModelDefinition,
+  type AgentLimitsDefinition,
+  type AgentReasoningDefinition,
+  type PublicAgentStaticModelDefinition,
+} from "#shared/agent-definition.js";
+import { parseJsonObject, type JsonObject } from "#shared/json.js";
+import { serializeOutputSchema } from "#shared/tool-schema.js";
+
+export interface DynamicSubagentAgentConfig {
+  readonly compaction?: {
+    readonly model?: DynamicSubagentModelReference;
+    readonly thresholdPercent?: number;
+  };
+  readonly description: string;
+  readonly limits?: AgentLimitsDefinition;
+  readonly model: DynamicSubagentModelReference;
+  readonly outputSchema?: JsonObject;
+  readonly reasoning?: AgentReasoningDefinition;
+}
+
+export interface DynamicSubagentModelReference {
+  readonly contextWindowTokens?: number;
+  readonly id: string;
+  readonly providerOptions?: Record<string, JsonObject>;
+}
+
+export function normalizeDynamicSubagentAgentConfig(input: {
+  readonly name: string;
+  readonly value: unknown;
+}): DynamicSubagentAgentConfig {
+  const message = `Dynamic subagent "${input.name}" must return defineAgent({ description, model, ... }) or null.`;
+  const definition = normalizeAgentDefinition(input.value, message);
+
+  if (!definition.description) {
+    throw new Error(`${message} The "description" field is required.`);
+  }
+  if (definition.build !== undefined) {
+    throw new Error(`${message} The "build" field cannot be selected at runtime.`);
+  }
+  if (definition.experimental !== undefined) {
+    throw new Error(`${message} The "experimental" field cannot be selected at runtime.`);
+  }
+  if (isDynamicModelDefinition(definition.model)) {
+    throw new Error(`${message} The returned "model" must be static.`);
+  }
+
+  const config: {
+    compaction?: DynamicSubagentAgentConfig["compaction"];
+    description: string;
+    limits?: AgentLimitsDefinition;
+    model: DynamicSubagentModelReference;
+    outputSchema?: JsonObject;
+    reasoning?: AgentReasoningDefinition;
+  } = {
+    description: definition.description,
+    model: normalizeModelReference({
+      contextWindowTokens: definition.modelContextWindowTokens,
+      model: definition.model,
+      name: input.name,
+      providerOptions: definition.modelOptions?.providerOptions,
+    }),
+  };
+
+  if (definition.compaction !== undefined) {
+    const compaction: {
+      model?: DynamicSubagentModelReference;
+      thresholdPercent?: number;
+    } = {};
+    if (definition.compaction.model !== undefined) {
+      compaction.model = normalizeModelReference({
+        contextWindowTokens: definition.compaction.modelContextWindowTokens,
+        model: definition.compaction.model,
+        name: input.name,
+        providerOptions: definition.modelOptions?.providerOptions,
+      });
+    }
+    if (definition.compaction.thresholdPercent !== undefined) {
+      compaction.thresholdPercent = definition.compaction.thresholdPercent;
+    }
+    config.compaction = compaction;
+  }
+  if (definition.limits !== undefined) {
+    config.limits = definition.limits;
+  }
+  if (definition.outputSchema !== undefined) {
+    config.outputSchema = serializeOutputSchema(definition.outputSchema);
+  }
+  if (definition.reasoning !== undefined) {
+    config.reasoning = definition.reasoning;
+  }
+
+  return config;
+}
+
+function normalizeModelReference(input: {
+  readonly contextWindowTokens?: number;
+  readonly model: PublicAgentStaticModelDefinition;
+  readonly name: string;
+  readonly providerOptions?: Record<string, JsonObject>;
+}): DynamicSubagentModelReference {
+  if (typeof input.model !== "string") {
+    throw new Error(
+      `Dynamic subagent "${input.name}" must return model IDs as strings so its agent config can cross durable workflow boundaries.`,
+    );
+  }
+
+  const reference: {
+    contextWindowTokens?: number;
+    id: string;
+    providerOptions?: Record<string, JsonObject>;
+  } = { id: formatLanguageModelGatewayId(input.model) };
+  if (input.contextWindowTokens !== undefined) {
+    reference.contextWindowTokens = input.contextWindowTokens;
+  }
+  if (input.providerOptions !== undefined) {
+    reference.providerOptions = Object.fromEntries(
+      Object.entries(input.providerOptions).map(([provider, options]) => [
+        provider,
+        parseJsonObject(options),
+      ]),
+    );
+  }
+  return reference;
+}

--- a/packages/eve/src/runtime/subagents/registry.ts
+++ b/packages/eve/src/runtime/subagents/registry.ts
@@ -2,7 +2,10 @@ import { z } from "#compiled/zod/index.js";
 
 import { RuntimeRegistry, RuntimeRegistryError } from "#internal/runtime-registry.js";
 import type { PreparedRuntimeDelegationTool } from "#runtime/sessions/turn.js";
-import type { ResolvedRuntimeDelegationNode } from "#runtime/types.js";
+import type {
+  ResolvedDynamicSubagentDefinition,
+  ResolvedRuntimeDelegationNode,
+} from "#runtime/types.js";
 import { serializeInputSchema } from "#shared/tool-schema.js";
 
 /**
@@ -13,10 +16,18 @@ interface RuntimeRegisteredSubagent {
   readonly prepared: PreparedRuntimeDelegationTool;
 }
 
+/** One dynamic subagent resolver paired with its compiled delegation tool. */
+export interface ResolvedDynamicSubagentResolver extends ResolvedDynamicSubagentDefinition {
+  readonly nodeId: string;
+  readonly prepared: PreparedRuntimeDelegationTool;
+}
+
 /**
  * Runtime-owned registry that exposes resolved subagents as model-visible tools.
  */
 export interface RuntimeSubagentRegistry {
+  readonly dynamicNodeIds: ReadonlySet<string>;
+  readonly dynamicResolvers: readonly ResolvedDynamicSubagentResolver[];
   readonly preparedTools: readonly PreparedRuntimeDelegationTool[];
   readonly subagentsByName: ReadonlyMap<string, RuntimeRegisteredSubagent>;
   readonly subagentsByNodeId: ReadonlyMap<string, RuntimeRegisteredSubagent>;
@@ -51,6 +62,8 @@ export function createRuntimeSubagentRegistry(input: {
   readonly subagents: readonly ResolvedRuntimeDelegationNode[];
 }): RuntimeSubagentRegistry {
   const preparedTools: PreparedRuntimeDelegationTool[] = [];
+  const dynamicNodeIds = new Set<string>();
+  const dynamicResolvers: ResolvedDynamicSubagentResolver[] = [];
   const registry = new RuntimeRegistry<RuntimeRegisteredSubagent>(
     "subagent",
     input.reservedToolNames ?? [],
@@ -77,17 +90,27 @@ export function createRuntimeSubagentRegistry(input: {
       prepared,
     };
 
-    registry.register(subagentDefinition.name, registeredSubagent, {
-      location,
-      duplicateMessage: `Found multiple subagents named "${subagentDefinition.name}". Subagent names must be unique at runtime.`,
-      reservedMessage: `Subagent "${subagentDefinition.name}" collides with another runtime-visible tool name.`,
-    });
-
-    preparedTools.push(prepared);
+    if (subagentDefinition.dynamic === undefined) {
+      registry.register(subagentDefinition.name, registeredSubagent, {
+        location,
+        duplicateMessage: `Found multiple subagents named "${subagentDefinition.name}". Subagent names must be unique at runtime.`,
+        reservedMessage: `Subagent "${subagentDefinition.name}" collides with another runtime-visible tool name.`,
+      });
+      preparedTools.push(prepared);
+    } else {
+      dynamicNodeIds.add(subagentDefinition.nodeId);
+      dynamicResolvers.push({
+        ...subagentDefinition.dynamic,
+        nodeId: subagentDefinition.nodeId,
+        prepared,
+      });
+    }
     subagentsByNodeId.set(subagentDefinition.nodeId, registeredSubagent);
   }
 
   return {
+    dynamicNodeIds,
+    dynamicResolvers,
     preparedTools,
     subagentsByName: registry.asMap(),
     subagentsByNodeId,

--- a/packages/eve/src/runtime/subagents/registry.ts
+++ b/packages/eve/src/runtime/subagents/registry.ts
@@ -16,7 +16,6 @@ interface RuntimeRegisteredSubagent {
   readonly prepared: PreparedRuntimeDelegationTool;
 }
 
-/** One dynamic subagent resolver paired with its compiled delegation tool. */
 export interface ResolvedDynamicSubagentResolver extends ResolvedDynamicSubagentDefinition {
   readonly nodeId: string;
   readonly prepared: PreparedRuntimeDelegationTool;

--- a/packages/eve/src/runtime/subagents/registry.ts
+++ b/packages/eve/src/runtime/subagents/registry.ts
@@ -13,12 +13,13 @@ import { serializeInputSchema } from "#shared/tool-schema.js";
  */
 interface RuntimeRegisteredSubagent {
   readonly definition: ResolvedRuntimeDelegationNode;
-  readonly prepared: PreparedRuntimeDelegationTool;
+  readonly prepared?: PreparedRuntimeDelegationTool;
 }
 
 export interface ResolvedDynamicSubagentResolver extends ResolvedDynamicSubagentDefinition {
+  readonly kind: "subagent";
+  readonly name: string;
   readonly nodeId: string;
-  readonly prepared: PreparedRuntimeDelegationTool;
 }
 
 /**
@@ -83,13 +84,14 @@ export function createRuntimeSubagentRegistry(input: {
       );
     }
 
-    const prepared = createPreparedRuntimeSubagentTool(subagentDefinition);
-    const registeredSubagent: RuntimeRegisteredSubagent = {
-      definition: subagentDefinition,
-      prepared,
-    };
-
-    if (subagentDefinition.dynamic === undefined) {
+    let registeredSubagent: RuntimeRegisteredSubagent;
+    const dynamic = subagentDefinition.kind === "subagent" ? subagentDefinition.dynamic : undefined;
+    if (dynamic === undefined) {
+      const prepared = createPreparedRuntimeSubagentTool(subagentDefinition);
+      registeredSubagent = {
+        definition: subagentDefinition,
+        prepared,
+      };
       registry.register(subagentDefinition.name, registeredSubagent, {
         location,
         duplicateMessage: `Found multiple subagents named "${subagentDefinition.name}". Subagent names must be unique at runtime.`,
@@ -99,10 +101,17 @@ export function createRuntimeSubagentRegistry(input: {
     } else {
       dynamicNodeIds.add(subagentDefinition.nodeId);
       dynamicResolvers.push({
-        ...subagentDefinition.dynamic,
+        ...dynamic,
+        kind: "subagent",
+        logicalPath: subagentDefinition.logicalPath,
+        name: subagentDefinition.name,
         nodeId: subagentDefinition.nodeId,
-        prepared,
+        sourceId: subagentDefinition.sourceId,
+        sourceKind: "module",
       });
+      registeredSubagent = {
+        definition: subagentDefinition,
+      };
     }
     subagentsByNodeId.set(subagentDefinition.nodeId, registeredSubagent);
   }
@@ -116,9 +125,12 @@ export function createRuntimeSubagentRegistry(input: {
   };
 }
 
-function createPreparedRuntimeSubagentTool(
+export function createPreparedRuntimeSubagentTool(
   definition: ResolvedRuntimeDelegationNode,
 ): PreparedRuntimeDelegationTool {
+  if (definition.description === undefined) {
+    throw new Error(`Static subagent "${definition.name}" is missing a description.`);
+  }
   return {
     description: definition.description,
     inputSchema: SUBAGENT_TOOL_INPUT_JSON_SCHEMA,

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -268,7 +268,7 @@ export interface ResolvedChannelDefinition extends ResolvedModuleSourceRef {
 export type ResolvedRuntimeSubagentNode = Readonly<
   ModuleSourceRef &
     Node & {
-      description: string;
+      description?: string;
       dynamic?: ResolvedDynamicSubagentDefinition;
       kind: "subagent";
       name: string;
@@ -284,7 +284,6 @@ export type ResolvedRuntimeRemoteAgentNode = Readonly<
     Node & {
       auth?: OutboundAuthFn;
       description: string;
-      dynamic?: ResolvedDynamicSubagentDefinition;
       forwardPrincipal?: boolean;
       headers?: HeadersValue;
       kind: "remote";
@@ -307,7 +306,6 @@ export interface ResolvedDynamicSubagentDefinition extends Readonly<ModuleSource
   readonly events: Readonly<
     Record<string, (event: unknown, ctx: unknown) => unknown | Promise<unknown>>
   >;
-  readonly fallback: unknown;
 }
 
 /**

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -268,11 +268,18 @@ export interface ResolvedChannelDefinition extends ResolvedModuleSourceRef {
 export type ResolvedRuntimeSubagentNode = Readonly<
   ModuleSourceRef &
     Node & {
-      description?: string;
-      dynamic?: ResolvedDynamicSubagentDefinition;
       kind: "subagent";
       name: string;
-    }
+    } & (
+      | {
+          description: string;
+          dynamic?: never;
+        }
+      | {
+          description?: never;
+          dynamic: ResolvedDynamicSubagentDefinition;
+        }
+    )
 >;
 
 /**

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -269,6 +269,7 @@ export type ResolvedRuntimeSubagentNode = Readonly<
   ModuleSourceRef &
     Node & {
       description: string;
+      dynamic?: ResolvedDynamicSubagentDefinition;
       kind: "subagent";
       name: string;
     }
@@ -283,6 +284,7 @@ export type ResolvedRuntimeRemoteAgentNode = Readonly<
     Node & {
       auth?: OutboundAuthFn;
       description: string;
+      dynamic?: ResolvedDynamicSubagentDefinition;
       forwardPrincipal?: boolean;
       headers?: HeadersValue;
       kind: "remote";
@@ -299,6 +301,16 @@ export type ResolvedRuntimeRemoteAgentNode = Readonly<
 export type ResolvedRuntimeDelegationNode =
   | ResolvedRuntimeRemoteAgentNode
   | ResolvedRuntimeSubagentNode;
+
+/** Live availability resolver loaded from a subagent `agent.ts`. */
+export interface ResolvedDynamicSubagentDefinition extends Readonly<ModuleSourceRef> {
+  readonly eventNames: readonly string[];
+  readonly events: Readonly<
+    Record<string, (event: unknown, ctx: unknown) => unknown | Promise<unknown>>
+  >;
+  /** Static agent definition compiled into the child node. */
+  readonly fallback: unknown;
+}
 
 /**
  * Runtime-owned additive agent configuration resolved from `agent.ts`.

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -302,13 +302,11 @@ export type ResolvedRuntimeDelegationNode =
   | ResolvedRuntimeRemoteAgentNode
   | ResolvedRuntimeSubagentNode;
 
-/** Live availability resolver loaded from a subagent `agent.ts`. */
 export interface ResolvedDynamicSubagentDefinition extends Readonly<ModuleSourceRef> {
   readonly eventNames: readonly string[];
   readonly events: Readonly<
     Record<string, (event: unknown, ctx: unknown) => unknown | Promise<unknown>>
   >;
-  /** Static agent definition compiled into the child node. */
   readonly fallback: unknown;
 }
 

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -157,7 +157,7 @@ export const DYNAMIC_SENTINEL_KIND = "eve:dynamic" as const;
 /**
  * Return value of `defineDynamic`: the runtime shape of a dynamic export,
  * stamped with a sentinel kind the compiler/normalizer detects. `TFallback`
- * is used by dynamic agent models and dynamic subagent `agent.ts` exports.
+ * is used by dynamic agent models.
  */
 export type DynamicSentinel<TResult = unknown, TFallback = never> = {
   readonly kind: typeof DYNAMIC_SENTINEL_KIND;
@@ -169,7 +169,7 @@ export function rejectDynamicSentinelFallback(sentinel: DynamicSentinel, message
     return;
   }
   throw new Error(
-    `${message} "fallback" is only supported on a dynamic agent model or a dynamic subagent agent.ts. For dynamic tools, skills, and instructions, author a static entry as the default or return null.`,
+    `${message} "fallback" is only supported on a dynamic agent model. For dynamic tools, skills, instructions, and subagents, return null when the capability should be omitted.`,
   );
 }
 

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -157,7 +157,7 @@ export const DYNAMIC_SENTINEL_KIND = "eve:dynamic" as const;
 /**
  * Return value of `defineDynamic`: the runtime shape of a dynamic export,
  * stamped with a sentinel kind the compiler/normalizer detects. `TFallback`
- * is `never` except for dynamic agent models, the only slot with a fallback.
+ * is used by dynamic agent models and dynamic subagent `agent.ts` exports.
  */
 export type DynamicSentinel<TResult = unknown, TFallback = never> = {
   readonly kind: typeof DYNAMIC_SENTINEL_KIND;
@@ -165,15 +165,15 @@ export type DynamicSentinel<TResult = unknown, TFallback = never> = {
 } & ([TFallback] extends [never] ? object : { readonly fallback: TFallback });
 
 /**
- * Throws when a dynamic sentinel outside the agent `model` slot carries a
- * `fallback` — anywhere else it would be silently dead configuration.
+ * Throws when a dynamic sentinel in a slot without fallback semantics carries
+ * a `fallback`.
  */
 export function rejectDynamicSentinelFallback(sentinel: DynamicSentinel, message: string): void {
   if (!("fallback" in sentinel)) {
     return;
   }
   throw new Error(
-    `${message} "fallback" is only supported on a dynamic agent model (the "model" field in agent.ts). For dynamic tools, skills, and instructions, author a static entry as the default or return null.`,
+    `${message} "fallback" is only supported on a dynamic agent model or a dynamic subagent agent.ts. For dynamic tools, skills, and instructions, author a static entry as the default or return null.`,
   );
 }
 

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -164,10 +164,6 @@ export type DynamicSentinel<TResult = unknown, TFallback = never> = {
   readonly events: DynamicEvents<TResult>;
 } & ([TFallback] extends [never] ? object : { readonly fallback: TFallback });
 
-/**
- * Throws when a dynamic sentinel in a slot without fallback semantics carries
- * a `fallback`.
- */
 export function rejectDynamicSentinelFallback(sentinel: DynamicSentinel, message: string): void {
   if (!("fallback" in sentinel)) {
     return;

--- a/packages/eve/test/runtime-agent-graph.test.ts
+++ b/packages/eve/test/runtime-agent-graph.test.ts
@@ -118,14 +118,13 @@ describe("resolveRuntimeAgentGraph", () => {
   });
 
   it("keeps dynamic subagents out of the static toolset and resolves their handlers", async () => {
-    const fallback = defineAgent({
-      description: "Research the request.",
-      model: TEST_DEFAULT_MODEL_ID,
-    });
     const dynamic = defineDynamic({
-      fallback,
       events: {
-        "session.started": () => fallback,
+        "session.started": () =>
+          defineAgent({
+            description: "Research the request.",
+            model: TEST_DEFAULT_MODEL_ID,
+          }),
       },
     });
     const manifest = createCompiledAgentManifest({
@@ -150,7 +149,6 @@ describe("resolveRuntimeAgentGraph", () => {
             agentRoot: "/app/agent/subagents/researcher",
             appRoot: "/app",
             config: {
-              description: fallback.description,
               model: {
                 id: TEST_DEFAULT_MODEL_ID,
                 routing: { kind: "gateway", target: "openai" },
@@ -163,7 +161,6 @@ describe("resolveRuntimeAgentGraph", () => {
               },
             },
           }),
-          description: fallback.description,
           dynamic: { eventNames: ["session.started"] },
           entryPath: "/app/agent/subagents/researcher/agent.ts",
           logicalPath: "subagents/researcher",
@@ -195,11 +192,10 @@ describe("resolveRuntimeAgentGraph", () => {
     expect(graph.root.subagentRegistry.dynamicResolvers).toMatchObject([
       {
         eventNames: ["session.started"],
+        name: "researcher",
         nodeId: "subagents/researcher",
-        prepared: { name: "researcher" },
       },
     ]);
-    expect(graph.root.subagentRegistry.dynamicResolvers[0]?.fallback).toBe(fallback);
     expect(graph.nodesByNodeId.has("subagents/researcher")).toBe(true);
   });
 

--- a/packages/eve/test/runtime-agent-graph.test.ts
+++ b/packages/eve/test/runtime-agent-graph.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../src/compiler/manifest.js";
 import type { CompiledModuleMap } from "../src/compiler/module-map.js";
 import { defineAgent } from "../src/public/definitions/agent.js";
+import { defineDynamic } from "../src/public/definitions/tool.js";
 import { createNodeHarnessTools } from "../src/execution/node-step.js";
 import { TEST_DEFAULT_MODEL_ID } from "../src/internal/testing/app-harness.js";
 import { ROOT_RUNTIME_AGENT_NODE_ID } from "../src/runtime/graph.js";
@@ -114,6 +115,92 @@ describe("resolveRuntimeAgentGraph", () => {
       graph.nodesByNodeId.get("subagents/researcher")?.sandboxRegistry.sandbox?.definition.backend
         .name,
     ).toBe("vercel");
+  });
+
+  it("keeps dynamic subagents out of the static toolset and resolves their handlers", async () => {
+    const fallback = defineAgent({
+      description: "Research the request.",
+      model: TEST_DEFAULT_MODEL_ID,
+    });
+    const dynamic = defineDynamic({
+      fallback,
+      events: {
+        "session.started": () => fallback,
+      },
+    });
+    const manifest = createCompiledAgentManifest({
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      config: {
+        model: {
+          id: TEST_DEFAULT_MODEL_ID,
+          routing: { kind: "gateway", target: "openai" },
+        },
+        name: "root",
+      },
+      subagentEdges: [
+        {
+          childNodeId: "subagents/researcher",
+          parentNodeId: ROOT_COMPILED_AGENT_NODE_ID,
+        },
+      ],
+      subagents: [
+        {
+          agent: createCompiledAgentNodeManifest({
+            agentRoot: "/app/agent/subagents/researcher",
+            appRoot: "/app",
+            config: {
+              description: fallback.description,
+              model: {
+                id: TEST_DEFAULT_MODEL_ID,
+                routing: { kind: "gateway", target: "openai" },
+              },
+              name: "researcher",
+              source: {
+                logicalPath: "agent.ts",
+                sourceId: "agent-config",
+                sourceKind: "module",
+              },
+            },
+          }),
+          description: fallback.description,
+          dynamic: { eventNames: ["session.started"] },
+          entryPath: "/app/agent/subagents/researcher/agent.ts",
+          logicalPath: "subagents/researcher",
+          name: "researcher",
+          nodeId: "subagents/researcher",
+          rootPath: "/app/agent/subagents/researcher",
+          sourceId: "subagents/researcher",
+          sourceKind: "module",
+        },
+      ],
+    });
+
+    const graph = await resolveRuntimeAgentGraph({
+      manifest,
+      moduleMap: {
+        nodes: {
+          [ROOT_COMPILED_AGENT_NODE_ID]: { modules: {} },
+          "subagents/researcher": {
+            modules: {
+              "agent-config": { default: dynamic },
+            },
+          },
+        },
+      },
+    });
+
+    expect(graph.root.turnAgent.tools.some((tool) => tool.name === "researcher")).toBe(false);
+    expect(graph.root.subagentRegistry.dynamicNodeIds).toContain("subagents/researcher");
+    expect(graph.root.subagentRegistry.dynamicResolvers).toMatchObject([
+      {
+        eventNames: ["session.started"],
+        nodeId: "subagents/researcher",
+        prepared: { name: "researcher" },
+      },
+    ]);
+    expect(graph.root.subagentRegistry.dynamicResolvers[0]?.fallback).toBe(fallback);
+    expect(graph.nodesByNodeId.has("subagents/researcher")).toBe(true);
   });
 
   it("resolves recursive local subagents into a cached runtime graph bundle", async () => {


### PR DESCRIPTION
### Description

Closes #696.

Allow a declared subagent to export `defineDynamic` from its own `agent.ts`. Session- and turn-scoped resolvers return a `defineAgent(...)` configuration to expose the child, or `null`/`undefined` to omit it from direct and Workflow delegation. Resolver errors and invalid definitions also omit the child.

eve always compiles the subagent filesystem manifest. When selected, it injects the returned runtime agent configuration into that compiled child, so resolvers can choose different descriptions, models, model options, compaction settings, reasoning, output schemas, and limits without changing the child’s instructions, tools, skills, connections, sandbox, or nested subagents. Stale calls are rejected before dispatch.

This also documents the authoring contract, preserves selections across durable workflow steps and deployment revisions, and adds deterministic coverage for runtime model switching and nil omission.

### How did you test your changes?

- `pnpm typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm test:unit`
- `pnpm test:integration`
- focused compiler, lifecycle, model-selection, workflow-runtime, and runtime-graph unit tests after rebasing onto latest `main`
- `EVE_E2E_MODEL=mock pnpm exec eve eval --strict dynamic-subagent` from `e2e/fixtures/agent-subagents`

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
