### PR TITLE
docs(eve): guides - add architecture selection guide

### DIFF
--- a/apps/docs/components/geistdocs/framework-comparison/authoring-shape.tsx
+++ b/apps/docs/components/geistdocs/framework-comparison/authoring-shape.tsx
@@ -1,0 +1,129 @@
+import { Braces, FileCode2, FileText, Folder, FolderOpen, Sparkles } from "lucide-react";
+import type { JSX, ReactNode } from "react";
+
+function TreeRow({
+  depth = 0,
+  icon,
+  children,
+  note,
+}: {
+  depth?: number;
+  icon: ReactNode;
+  children: ReactNode;
+  note?: string;
+}): JSX.Element {
+  return (
+    <div className="flex min-w-0 items-center gap-2 py-1.5" style={{ paddingLeft: depth * 16 }}>
+      <span className="shrink-0 text-gray-900">{icon}</span>
+      <code className="min-w-0 truncate bg-transparent! p-0! text-copy-13! text-gray-1000!">
+        {children}
+      </code>
+      {note ? (
+        <span className="ml-auto hidden text-copy-13 text-gray-700 sm:block">{note}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function Panel({
+  eyebrow,
+  title,
+  children,
+  featured = false,
+}: {
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+  featured?: boolean;
+}): JSX.Element {
+  return (
+    <section
+      className={
+        featured
+          ? "min-w-0 rounded-xl border border-blue-500 bg-blue-100 p-4 shadow-sm sm:p-5"
+          : "min-w-0 rounded-xl border border-gray-alpha-400 bg-background-100 p-4 sm:p-5"
+      }
+    >
+      <div className="font-mono uppercase tracking-[0.1em] text-label-13 text-gray-900">
+        {eyebrow}
+      </div>
+      <h3 className="mt-1 font-medium text-copy-16 text-gray-1000">{title}</h3>
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+/** Contrasts capability-oriented filesystem authoring with centralized composition code. */
+export function AuthoringShape(): JSX.Element {
+  return (
+    <figure className="not-prose my-8 grid min-w-0 gap-4 lg:grid-cols-2">
+      <Panel eyebrow="eve" title="The directory is the agent" featured>
+        <div className="rounded-lg border border-blue-500/30 bg-background-100 px-3 py-2 shadow-xs">
+          <TreeRow icon={<FolderOpen aria-hidden size={15} />}>agent/</TreeRow>
+          <TreeRow depth={1} icon={<FileCode2 aria-hidden size={15} />} note="model + limits">
+            agent.ts
+          </TreeRow>
+          <TreeRow depth={1} icon={<FileText aria-hidden size={15} />} note="identity">
+            instructions.md
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="actions">
+            tools/
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="procedures">
+            skills/
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="services">
+            connections/
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="people + events">
+            channels/
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="specialists">
+            subagents/
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="workspace">
+            sandbox/
+          </TreeRow>
+          <TreeRow depth={1} icon={<Folder aria-hidden size={15} />} note="autonomy">
+            schedules/
+          </TreeRow>
+        </div>
+        <div className="mt-4 flex items-start gap-2 text-copy-14 text-gray-900">
+          <Sparkles aria-hidden className="mt-0.5 shrink-0 text-blue-900" size={15} />
+          Add a capability by adding a file. Its path supplies its role and name.
+        </div>
+      </Panel>
+
+      <Panel eyebrow="Common alternative" title="The composition module is the agent">
+        <div className="rounded-lg border border-gray-alpha-400 bg-background-200 px-4 py-3 font-mono text-copy-13 text-gray-1000 shadow-inner">
+          <div className="flex items-center gap-2 text-gray-900">
+            <Braces aria-hidden size={14} /> agent.ts
+          </div>
+          <pre className="mt-3 overflow-hidden bg-transparent! p-0! text-copy-13! leading-6! text-gray-1000!">
+            <code>{`new Agent({
+  instructions,
+  tools: [search, write, ...],
+  memory: new Memory(...),
+  workspace: new Workspace(...),
+  subagents: [researcher, ...],
+  // every concern converges here
+})`}</code>
+          </pre>
+        </div>
+        <p className="mt-4 text-copy-14 text-gray-900">
+          This is concise at five capabilities. At fifty, the agent becomes an import graph whose
+          architecture is no longer visible from the filesystem.
+        </p>
+        <div className="mt-4 rounded-lg border border-gray-alpha-400 bg-background-200 p-3 text-copy-13 text-gray-900">
+          Some competitors now add file discovery, but usually as a partial layer over this
+          code-first center.
+        </div>
+      </Panel>
+
+      <figcaption className="sr-only">
+        eve represents an agent as a recursive directory of capabilities, while common agent SDKs
+        centralize composition in a TypeScript or Python configuration module.
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/docs/components/geistdocs/framework-comparison/comparison-hero.tsx
+++ b/apps/docs/components/geistdocs/framework-comparison/comparison-hero.tsx
@@ -1,0 +1,50 @@
+import { ArrowDown, FolderTree, ShieldCheck, Users } from "lucide-react";
+import type { JSX, ReactNode } from "react";
+
+function Pill({ icon, children }: { icon: ReactNode; children: ReactNode }): JSX.Element {
+  return (
+    <span className="flex items-center gap-2 rounded-full border border-gray-alpha-400 bg-background-100 px-3 py-1.5 text-copy-13 text-gray-1000 shadow-xs">
+      {icon}
+      {children}
+    </span>
+  );
+}
+
+/** Introduces the comparison's thesis and the three cross-cutting eve advantages. */
+export function ComparisonHero(): JSX.Element {
+  return (
+    <section className="not-prose relative my-8 overflow-hidden rounded-2xl border border-gray-alpha-400 bg-background-100 px-5 py-8 sm:px-8 sm:py-10">
+      <div
+        aria-hidden
+        className="absolute inset-0 opacity-60"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 12% 12%, var(--ds-blue-300) 0, transparent 30%), radial-gradient(circle at 88% 86%, var(--ds-purple-300) 0, transparent 28%)",
+        }}
+      />
+      <div className="relative">
+        <div className="mb-5 flex items-center gap-2 font-mono uppercase tracking-[0.12em] text-blue-900 text-label-13">
+          <span className="size-1.5 rounded-full bg-blue-700" />
+          Framework comparison · July 2026
+        </div>
+        <p className="max-w-3xl font-medium text-heading-24 tracking-tight text-gray-1000 sm:text-heading-32">
+          Give the model a harness,
+          <br className="hidden sm:block" /> not a maze.
+        </p>
+        <p className="mt-4 max-w-2xl text-balance text-copy-16 text-gray-900">
+          Models will keep getting smarter. The winning framework is the one that lets that
+          intelligence compound without turning every new capability into more orchestration code.
+        </p>
+        <div className="mt-7 flex flex-wrap gap-2">
+          <Pill icon={<FolderTree aria-hidden size={15} />}>Filesystem-first</Pill>
+          <Pill icon={<ShieldCheck aria-hidden size={15} />}>Durable by default</Pill>
+          <Pill icon={<Users aria-hidden size={15} />}>Identity-aware multiplayer</Pill>
+        </div>
+        <div className="mt-8 flex items-center gap-2 text-copy-13 text-gray-900">
+          <ArrowDown aria-hidden size={14} />
+          Compare the architecture, not the demo
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/components/geistdocs/framework-comparison/comparison-matrix.tsx
+++ b/apps/docs/components/geistdocs/framework-comparison/comparison-matrix.tsx
@@ -1,0 +1,139 @@
+import { ArrowRight, Check, CircleDot, ExternalLink, Minus, Wrench } from "lucide-react";
+import type { JSX } from "react";
+import {
+  COMPARISON_ROWS,
+  FRAMEWORKS,
+  SUPPORT_LABELS,
+  type ComparisonCell,
+  type SupportLevel,
+} from "./data";
+
+const LEVEL_STYLES: Readonly<Record<SupportLevel, string>> = {
+  native: "border-green-500/30 bg-green-100 text-green-900",
+  integrated: "border-blue-500/30 bg-blue-100 text-blue-900",
+  assemble: "border-amber-500/30 bg-amber-100 text-amber-900",
+  outside: "border-gray-alpha-400 bg-background-200 text-gray-900",
+};
+
+function LevelIcon({ level }: { level: SupportLevel }): JSX.Element {
+  if (level === "native") return <Check aria-hidden size={12} strokeWidth={2.5} />;
+  if (level === "integrated") return <CircleDot aria-hidden size={12} />;
+  if (level === "assemble") return <Wrench aria-hidden size={12} />;
+  return <Minus aria-hidden size={12} />;
+}
+
+function Status({ level }: { level: SupportLevel }): JSX.Element {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-1 font-medium text-label-12 ${LEVEL_STYLES[level]}`}
+    >
+      <LevelIcon level={level} />
+      {SUPPORT_LABELS[level]}
+    </span>
+  );
+}
+
+function MatrixCell({
+  cell,
+  featured = false,
+  isLastColumn,
+  isLastRow,
+}: {
+  cell: ComparisonCell;
+  featured?: boolean;
+  isLastColumn: boolean;
+  isLastRow: boolean;
+}): JSX.Element {
+  return (
+    <td
+      className={`min-w-44 border-gray-alpha-400 align-top ${isLastColumn ? "" : "border-r"} ${isLastRow ? "" : "border-b"} ${featured ? "bg-blue-100/60" : "bg-background-100"}`}
+    >
+      <div className="flex flex-col items-start gap-2 px-4 py-4">
+        <Status level={cell.level} />
+        <a
+          className="group inline-flex items-start gap-1 font-medium text-copy-13 text-gray-1000 no-underline hover:text-blue-900"
+          href={cell.href}
+        >
+          {cell.title}
+          <ExternalLink
+            aria-hidden
+            className="mt-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+            size={11}
+          />
+        </a>
+        <p className="m-0! text-copy-13 leading-5 text-gray-900">{cell.detail}</p>
+      </div>
+    </td>
+  );
+}
+
+/** Evidence-linked feature matrix for the six primary frameworks in the comparison. */
+export function ComparisonMatrix(): JSX.Element {
+  return (
+    <figure className="not-prose my-8 w-full sm:-mx-4 sm:w-[calc(100%+2rem)]">
+      <div className="mb-4 flex flex-wrap items-center gap-2 text-copy-13 text-gray-900">
+        {(Object.keys(SUPPORT_LABELS) as SupportLevel[]).map((level) => (
+          <Status key={level} level={level} />
+        ))}
+        <span className="sm:ml-1">describes integration depth, not theoretical possibility</span>
+        <span className="ml-auto inline-flex items-center gap-1 whitespace-nowrap font-medium text-gray-1000">
+          Scroll to compare <ArrowRight aria-hidden size={13} />
+        </span>
+      </div>
+      <div className="overflow-x-auto rounded-xl border border-gray-alpha-400 bg-background-100 shadow-sm">
+        <table className="w-full min-w-[1160px] border-separate border-spacing-0 text-left">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-20 w-56 border-gray-alpha-400 border-r border-b bg-background-200 px-4 py-4 align-bottom shadow-[1px_0_0_var(--ds-gray-alpha-400)]">
+                <div className="font-mono uppercase tracking-[0.1em] text-label-12 text-gray-700">
+                  Production concern
+                </div>
+              </th>
+              {FRAMEWORKS.map((framework, frameworkIndex) => (
+                <th
+                  key={framework.id}
+                  className={`min-w-44 border-gray-alpha-400 border-b px-4 py-4 align-bottom ${frameworkIndex < FRAMEWORKS.length - 1 ? "border-r" : ""} ${framework.id === "eve" ? "bg-blue-200" : "bg-background-200"}`}
+                  scope="col"
+                >
+                  <div className="font-medium text-copy-14 text-gray-1000">{framework.name}</div>
+                  <div className="mt-1 font-normal text-copy-12 text-gray-700">
+                    {framework.category}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {COMPARISON_ROWS.map((row, rowIndex) => (
+              <tr key={row.feature}>
+                <th
+                  className={`sticky left-0 z-10 w-56 border-gray-alpha-400 border-r bg-background-200 px-4 py-4 align-top shadow-[1px_0_0_var(--ds-gray-alpha-400)] ${rowIndex < COMPARISON_ROWS.length - 1 ? "border-b" : ""}`}
+                  scope="row"
+                >
+                  <div className="font-medium text-copy-13 text-gray-1000">{row.feature}</div>
+                  <div className="mt-1 font-normal text-copy-12 leading-5 text-gray-700">
+                    {row.question}
+                  </div>
+                </th>
+                {FRAMEWORKS.map((framework, frameworkIndex) => (
+                  <MatrixCell
+                    key={framework.id}
+                    cell={row.cells[framework.id]}
+                    featured={framework.id === "eve"}
+                    isLastColumn={frameworkIndex === FRAMEWORKS.length - 1}
+                    isLastRow={rowIndex === COMPARISON_ROWS.length - 1}
+                  />
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <figcaption className="mt-3 text-copy-12 text-gray-700">
+        Assessment of documented, public surfaces as of July 31, 2026. Every cell links to the
+        supporting framework documentation. Products change quickly; verify critical requirements
+        against the linked contract.
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/docs/components/geistdocs/framework-comparison/data.ts
+++ b/apps/docs/components/geistdocs/framework-comparison/data.ts
@@ -1,0 +1,557 @@
+export type FrameworkId = "eve" | "mastra" | "flue" | "cloudflare" | "langgraph" | "hermes";
+
+export type SupportLevel = "native" | "integrated" | "assemble" | "outside";
+
+export interface FrameworkDefinition {
+  readonly id: FrameworkId;
+  readonly name: string;
+  readonly shortName: string;
+  readonly category: string;
+}
+
+export interface ComparisonCell {
+  readonly level: SupportLevel;
+  readonly title: string;
+  readonly detail: string;
+  readonly href: string;
+}
+
+export interface ComparisonRow {
+  readonly feature: string;
+  readonly question: string;
+  readonly cells: Readonly<Record<FrameworkId, ComparisonCell>>;
+}
+
+export const FRAMEWORKS: readonly FrameworkDefinition[] = [
+  {
+    id: "eve",
+    name: "eve",
+    shortName: "eve",
+    category: "Filesystem-first framework",
+  },
+  {
+    id: "mastra",
+    name: "Mastra",
+    shortName: "Mastra",
+    category: "TypeScript agent framework",
+  },
+  {
+    id: "flue",
+    name: "Flue 2.0",
+    shortName: "Flue 2.0",
+    category: "TypeScript harness framework",
+  },
+  {
+    id: "cloudflare",
+    name: "Cloudflare Agents SDK",
+    shortName: "Cloudflare",
+    category: "Edge agent runtime",
+  },
+  {
+    id: "langgraph",
+    name: "LangGraph",
+    shortName: "LangGraph",
+    category: "Graph orchestration runtime",
+  },
+  {
+    id: "hermes",
+    name: "Hermes Agent",
+    shortName: "Hermes",
+    category: "Ready-made personal agent",
+  },
+];
+
+export const SUPPORT_LABELS: Readonly<Record<SupportLevel, string>> = {
+  native: "First-class",
+  integrated: "Supported",
+  assemble: "Assemble",
+  outside: "Outside core",
+};
+
+export const COMPARISON_ROWS: readonly ComparisonRow[] = [
+  {
+    feature: "Agent-shaped authoring",
+    question: "Does the source tree still describe the agent after it becomes large?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "One recursive agent directory",
+        detail:
+          "Instructions, tools, skills, channels, connections, sandbox, and subagents each have a path-derived home.",
+        href: "/docs/project-structure",
+      },
+      mastra: {
+        level: "integrated",
+        title: "Experimental file-based agents",
+        detail:
+          "A partial discovery layer sits beside the established TypeScript object-and-registry surface.",
+        href: "https://mastra.ai/docs/getting-started/file-based-agents",
+      },
+      flue: {
+        level: "integrated",
+        title: "Agent functions + hooks",
+        detail:
+          "Capitalized exports become agents; identity comes from the function while hooks compose its capabilities.",
+        href: "https://flueframework.com/docs/guide/building-agents/",
+      },
+      cloudflare: {
+        level: "assemble",
+        title: "Agent classes + bindings",
+        detail:
+          "You compose a Durable Object class, routes, bindings, model loop, and platform services in code.",
+        href: "https://developers.cloudflare.com/agents/runtime/agents-api/",
+      },
+      langgraph: {
+        level: "assemble",
+        title: "Graph or functional API",
+        detail:
+          "Nodes, edges, state schemas, checkpoints, and deployment configuration define the application.",
+        href: "https://docs.langchain.com/oss/javascript/langgraph/overview",
+      },
+      hermes: {
+        level: "outside",
+        title: "Configure a finished agent",
+        detail:
+          "Hermes is an extensible agent you run, not an application framework for authoring many product agents.",
+        href: "https://hermes-agent.nousresearch.com/docs/",
+      },
+    },
+  },
+  {
+    feature: "Crash-safe agent turns",
+    question:
+      "Can an autonomous turn recover without rebuilding the loop around a workflow engine?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "Every turn is durable",
+        detail:
+          "Model and tool steps checkpoint automatically; interrupted work resumes from the last completed step.",
+        href: "/docs/concepts/execution-model-and-durability",
+      },
+      mastra: {
+        level: "integrated",
+        title: "Durable workflows + Agents beta",
+        detail:
+          "Workflows persist suspend/resume state. Long-running autonomous control uses a separate beta surface.",
+        href: "https://mastra.ai/docs/long-running-agents/durable-agents",
+      },
+      flue: {
+        level: "native",
+        title: "Accepted-work recovery",
+        detail:
+          "A durable log recovers submissions and child tasks; Node needs a durable database and single owner routing.",
+        href: "https://flueframework.com/docs/guide/durability/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "Fibers and Workflows",
+        detail:
+          "Recoverable execution is available, while the application chooses fiber or workflow boundaries.",
+        href: "https://developers.cloudflare.com/agents/runtime/agents-api/",
+      },
+      langgraph: {
+        level: "integrated",
+        title: "Checkpointed graph steps",
+        detail:
+          "A configured checkpointer saves graph supersteps and enables fault-tolerant replay.",
+        href: "https://docs.langchain.com/oss/javascript/langgraph/persistence",
+      },
+      hermes: {
+        level: "assemble",
+        title: "Persistent sessions, not a turn SLA",
+        detail:
+          "History and memory survive restarts, but the product docs do not promise checkpointed mid-turn recovery.",
+        href: "https://hermes-agent.nousresearch.com/docs/",
+      },
+    },
+  },
+  {
+    feature: "Persistent isolated workspace",
+    question:
+      "Does the agent get real files and commands with a lifecycle tied to its durable session?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "Session sandbox by default",
+        detail:
+          "Built-in file and shell tools target an isolated workspace that persists across turns and redeploys.",
+        href: "/docs/sandbox",
+      },
+      mastra: {
+        level: "integrated",
+        title: "Workspace + sandbox adapters",
+        detail:
+          "Files, skills, and compute are supported; multi-user apps resolve a stable workspace per thread.",
+        href: "https://mastra.ai/blog/building-multi-user-multi-channel-agents",
+      },
+      flue: {
+        level: "integrated",
+        title: "Opt-in sandbox adapters",
+        detail:
+          "Virtual workspaces are ephemeral, local mode uses the host, and persistent isolation needs a remote adapter.",
+        href: "https://flueframework.com/docs/guide/sandboxes/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "Cloudflare Sandbox service",
+        detail:
+          "Agents can compose the separate Sandbox product for isolated, persistent container workspaces.",
+        href: "https://developers.cloudflare.com/agents/",
+      },
+      langgraph: {
+        level: "assemble",
+        title: "Bring a sandbox/runtime",
+        detail:
+          "Graph persistence covers state; filesystem compute is supplied by an application or another product.",
+        href: "https://docs.langchain.com/oss/javascript/langgraph/persistence",
+      },
+      hermes: {
+        level: "native",
+        title: "Five execution backends",
+        detail:
+          "A ready-made Hermes install can run tools locally or through Docker, SSH, Singularity, and Modal.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/features/tools/",
+      },
+    },
+  },
+  {
+    feature: "Identity-aware multiplayer",
+    question: "When people share a session, does authorization follow the person speaking now?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "Current + initiating principal",
+        detail:
+          "Every turn records who is speaking now and who opened the session; policy can use either identity.",
+        href: "/docs/guides/session-context",
+      },
+      mastra: {
+        level: "integrated",
+        title: "Shared channels + signals",
+        detail:
+          "Participants share a thread and are attributed, while channel resource scope stays bound to its starter.",
+        href: "https://mastra.ai/blog/building-multi-user-multi-channel-agents",
+      },
+      flue: {
+        level: "assemble",
+        title: "Conversation ID + app auth",
+        detail:
+          "Anyone allowed to reach an instance URL can contribute; identity and access policy live in app middleware.",
+        href: "https://flueframework.com/docs/guide/routing/",
+      },
+      cloudflare: {
+        level: "assemble",
+        title: "Many live connections",
+        detail:
+          "WebSockets broadcast shared state; the application validates tokens and carries user identity.",
+        href: "https://developers.cloudflare.com/agents/runtime/operations/cross-domain-authentication/",
+      },
+      langgraph: {
+        level: "assemble",
+        title: "Thread + runtime context",
+        detail:
+          "User identity can be passed in context, but transport, participant semantics, and policy are app-owned.",
+        href: "https://docs.langchain.com/oss/javascript/langgraph/persistence",
+      },
+      hermes: {
+        level: "integrated",
+        title: "Shared or per-user group sessions",
+        detail:
+          "Messaging groups can share context or isolate it by sender; product authorization remains gateway and plugin policy.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/sessions/",
+      },
+    },
+  },
+  {
+    feature: "Dynamic capabilities and credentials",
+    question:
+      "Can each turn receive the right prompt, tools, skills, workspace, and user-owned access?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "Resolve at session, turn, or step",
+        detail:
+          "Models, instructions, skills, tools, headers, and user OAuth can follow the authenticated caller.",
+        href: "/docs/guides/dynamic-capabilities",
+      },
+      mastra: {
+        level: "integrated",
+        title: "RequestContext resolvers",
+        detail:
+          "Typed request context can select models, instructions, tools, memory, and workspaces at runtime.",
+        href: "https://mastra.ai/docs/server/request-context",
+      },
+      flue: {
+        level: "integrated",
+        title: "Agent hooks re-render",
+        detail:
+          "Functions and hooks rebuild capabilities each turn; trusted caller scope must come from application code.",
+        href: "https://flueframework.com/docs/guide/why-flue/",
+      },
+      cloudflare: {
+        level: "assemble",
+        title: "Application logic",
+        detail:
+          "Agent methods can branch on connection and state; there is no framework capability resolver contract.",
+        href: "https://developers.cloudflare.com/agents/runtime/communication/websockets/",
+      },
+      langgraph: {
+        level: "assemble",
+        title: "Runtime context + graph logic",
+        detail:
+          "Nodes can branch on context and state, with capability selection expressed in application code.",
+        href: "https://docs.langchain.com/oss/javascript/langgraph/persistence",
+      },
+      hermes: {
+        level: "assemble",
+        title: "Profiles and toolsets",
+        detail:
+          "Operators configure an agent's tools, plugins, skills, and model rather than resolve a product surface per caller.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/profiles/",
+      },
+    },
+  },
+  {
+    feature: "Delegation that scales",
+    question:
+      "Can the model fan out to isolated specialists and keep the work durable and observable?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "Parallel, nested, and remote",
+        detail:
+          "Copies, declared specialists, and remote agents all become tools with durable child sessions and streams.",
+        href: "/docs/subagents",
+      },
+      mastra: {
+        level: "integrated",
+        title: "Networks + controller subagents",
+        detail:
+          "Several orchestration surfaces support specialists; file-based nesting is currently capped at three levels.",
+        href: "https://mastra.ai/reference/file-based-agents/subagents",
+      },
+      flue: {
+        level: "integrated",
+        title: "Durable delegated tasks",
+        detail:
+          "Named profiles run as child sessions and recover from their own durable transcripts.",
+        href: "https://flueframework.com/docs/guide/subagents/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "Agent routing + workflows",
+        detail:
+          "Agent instances can call other instances, with coordination expressed through RPC and platform primitives.",
+        href: "https://developers.cloudflare.com/agents/runtime/execution/sub-agents/",
+      },
+      langgraph: {
+        level: "integrated",
+        title: "Subgraphs and supervisors",
+        detail:
+          "Multi-agent patterns compose graphs, subgraphs, handoffs, or supervisor libraries.",
+        href: "https://docs.langchain.com/oss/javascript/langchain/multi-agent",
+      },
+      hermes: {
+        level: "native",
+        title: "Isolated parallel subagents",
+        detail:
+          "The ready-made agent delegates parallel work into separate conversations and terminals; active children do not resume after restart.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/features/delegation/",
+      },
+    },
+  },
+  {
+    feature: "Human-in-the-loop across downtime",
+    question: "Can risky work park for a person without holding compute, then resume safely?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "Approval is a durable park",
+        detail:
+          "Tool, connection, OAuth, and descendant requests surface through the root channel and resume in place.",
+        href: "/docs/tools/human-in-the-loop",
+      },
+      mastra: {
+        level: "integrated",
+        title: "Approval and suspension",
+        detail:
+          "Agents and workflows can pause; current AgentController channel approvals do not survive a restart.",
+        href: "https://mastra.ai/docs/agent-controller/channels",
+      },
+      flue: {
+        level: "outside",
+        title: "Application-owned",
+        detail:
+          "Current agent, tool, channel, and durability docs do not expose a framework approval or input primitive.",
+        href: "https://flueframework.com/docs/guide/tools/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "Workflow approvals",
+        detail:
+          "Cloudflare Workflows supplies durable approval waits; the app connects them to the agent experience.",
+        href: "https://developers.cloudflare.com/agents/concepts/agentic-patterns/human-in-the-loop/",
+      },
+      langgraph: {
+        level: "integrated",
+        title: "Persistent interrupts",
+        detail:
+          "Interrupts checkpoint graph state and wait indefinitely for a Command that resumes the thread.",
+        href: "https://docs.langchain.com/oss/javascript/langgraph/interrupts",
+      },
+      hermes: {
+        level: "integrated",
+        title: "Messaging approvals and steering",
+        detail:
+          "People can clarify, approve, deny, steer, or stop work; the contract belongs to the installed operator runtime.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/messaging",
+      },
+    },
+  },
+  {
+    feature: "Channels and delivery",
+    question: "Can one agent meet users on product, API, chat, and event surfaces?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "A root-level channel contract",
+        detail:
+          "HTTP, web, Slack, Discord, Teams, Telegram, GitHub, Linear, Twilio, and custom routes share one runtime.",
+        href: "/docs/channels/overview",
+      },
+      mastra: {
+        level: "native",
+        title: "Channels via Chat SDK adapters",
+        detail:
+          "Slack, Discord, Telegram, and other adapters map platform threads into agent memory and signals.",
+        href: "https://mastra.ai/docs/capabilities/channels/overview",
+      },
+      flue: {
+        level: "integrated",
+        title: "Discovered provider ingress",
+        detail:
+          "Channel modules verify provider events and dispatch them into agent instances; outbound behavior is authored.",
+        href: "https://flueframework.com/docs/guide/channels/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "Chat, email, voice, Slack, webhooks",
+        detail:
+          "The platform ships primitives and examples for several surfaces around a shared Agent class.",
+        href: "https://developers.cloudflare.com/agents/",
+      },
+      langgraph: {
+        level: "outside",
+        title: "Bring the transport",
+        detail:
+          "Agent Server exposes runs and streams; messaging-platform channel adapters are outside LangGraph core.",
+        href: "https://docs.langchain.com/langsmith/deployment-quickstart",
+      },
+      hermes: {
+        level: "native",
+        title: "Many personal-agent gateways",
+        detail:
+          "One Hermes install connects to Telegram, Discord, Slack, WhatsApp, Signal, email, and CLI.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/messaging",
+      },
+    },
+  },
+  {
+    feature: "Connected services and user OAuth",
+    question:
+      "Can tools reach external systems without exposing credentials to the model or sandbox?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "MCP + OpenAPI connections",
+        detail:
+          "Per-user credentials follow the current principal; interactive OAuth parks and resumes the same turn.",
+        href: "/docs/connections",
+      },
+      mastra: {
+        level: "integrated",
+        title: "MCP and application tools",
+        detail:
+          "MCP clients and servers are native; end-user credential scope and OAuth UX are application concerns.",
+        href: "https://mastra.ai/docs/mcp/overview",
+      },
+      flue: {
+        level: "integrated",
+        title: "MCP tools with trusted headers",
+        detail:
+          "Remote tools are imported into agent code; the application owns credentials and authorization boundaries.",
+        href: "https://flueframework.com/docs/guide/tools/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "MCP client + OAuth flow",
+        detail:
+          "Agents connect remote MCP servers and receive an authorization URL when a server requires OAuth.",
+        href: "https://developers.cloudflare.com/agents/tools/mcp/",
+      },
+      langgraph: {
+        level: "assemble",
+        title: "Use LangChain integrations",
+        detail:
+          "MCP adapters and tools compose into the graph; application code owns auth and credential lifecycle.",
+        href: "https://docs.langchain.com/oss/javascript/langchain/mcp",
+      },
+      hermes: {
+        level: "integrated",
+        title: "Configurable MCP servers",
+        detail:
+          "Operators add MCP servers and plugins to the installed agent's global or profile configuration.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp",
+      },
+    },
+  },
+  {
+    feature: "Schedules, evals, and observability",
+    question: "Are ongoing operation and improvement part of the same framework story?",
+    cells: {
+      eve: {
+        level: "native",
+        title: "All three are authored surfaces",
+        detail:
+          "Path-derived schedules, executable evals, local logs, workflow metadata, and OpenTelemetry ship together.",
+        href: "/docs/evals/overview",
+      },
+      mastra: {
+        level: "native",
+        title: "Broad production toolchain",
+        detail:
+          "Workflows, scorers, datasets, experiments, tracing, and deployment are mature strengths; scheduling depends on runtime.",
+        href: "https://mastra.ai/docs/observability/overview",
+      },
+      flue: {
+        level: "assemble",
+        title: "External scheduler and eval tooling",
+        detail:
+          "Flue 2.0 delegates scheduling to the host and recommends a vitest-evals recipe instead of a built-in runner.",
+        href: "https://flueframework.com/docs/guide/schedules/",
+      },
+      cloudflare: {
+        level: "integrated",
+        title: "Schedules + platform telemetry",
+        detail:
+          "Durable scheduling and platform observability are built in; agent evaluation is assembled separately.",
+        href: "https://developers.cloudflare.com/agents/runtime/execution/schedule-tasks/",
+      },
+      langgraph: {
+        level: "integrated",
+        title: "LangSmith platform",
+        detail:
+          "Tracing, evaluation, deployment, and cron jobs are available through the adjacent LangSmith product.",
+        href: "https://docs.langchain.com/langsmith/observability-concepts",
+      },
+      hermes: {
+        level: "integrated",
+        title: "Cron + trajectory export",
+        detail:
+          "The installed agent schedules unattended work and exports research trajectories; it is not a product eval framework.",
+        href: "https://hermes-agent.nousresearch.com/docs/user-guide/features/cron",
+      },
+    },
+  },
+];

--- a/apps/docs/components/geistdocs/framework-comparison/framework-fit.tsx
+++ b/apps/docs/components/geistdocs/framework-comparison/framework-fit.tsx
@@ -1,0 +1,84 @@
+import { ArrowUpRight } from "lucide-react";
+import type { JSX } from "react";
+
+const FRAMEWORK_FITS: readonly {
+  readonly name: string;
+  readonly eyebrow: string;
+  readonly description: string;
+  readonly href: string;
+  readonly featured?: boolean;
+}[] = [
+  {
+    name: "eve",
+    eyebrow: "Best complete system",
+    description:
+      "Choose eve when the agent is a durable backend product: long-running, sandboxed, multi-channel, multi-user, and expected to keep growing.",
+    href: "/docs/getting-started",
+    featured: true,
+  },
+  {
+    name: "Mastra",
+    eyebrow: "Best application toolkit",
+    description:
+      "A broad TypeScript surface with strong memory, workflows, Studio, observability, and rapidly expanding agent-controller features.",
+    href: "https://mastra.ai/docs/",
+  },
+  {
+    name: "Flue 2.0",
+    eyebrow: "Best portable new harness",
+    description:
+      "A newly released option for teams that like React-style hooks, target Node or Cloudflare, and are comfortable assembling some production edges.",
+    href: "https://flueframework.com/docs/guide/why-flue/",
+  },
+  {
+    name: "Cloudflare Agents SDK",
+    eyebrow: "Best Cloudflare-native substrate",
+    description:
+      "A strong choice when Durable Objects and the Cloudflare platform are already the architecture and you want lower-level control.",
+    href: "https://developers.cloudflare.com/agents/",
+  },
+  {
+    name: "LangGraph",
+    eyebrow: "Best explicit graph runtime",
+    description:
+      "A mature option when a checkpointed graph is the desired abstraction, especially with the Python ecosystem and LangSmith platform.",
+    href: "https://docs.langchain.com/oss/javascript/langgraph/overview",
+  },
+  {
+    name: "Hermes Agent",
+    eyebrow: "Best ready-made personal agent",
+    description:
+      "Install Hermes when you want a capable self-hosted assistant now. Choose a framework when you need to build a distinct product.",
+    href: "https://hermes-agent.nousresearch.com/docs/",
+  },
+];
+
+/** Gives a candid recommendation for the use case each primary comparison target serves best. */
+export function FrameworkFit(): JSX.Element {
+  return (
+    <div className="not-prose my-8 grid gap-3 sm:grid-cols-2">
+      {FRAMEWORK_FITS.map((framework) => (
+        <a
+          key={framework.name}
+          className={`group flex min-w-0 flex-col rounded-xl border p-5 no-underline transition-colors ${framework.featured ? "border-blue-500 bg-blue-100 hover:bg-blue-200" : "border-gray-alpha-400 bg-background-100 hover:bg-background-200"}`}
+          href={framework.href}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="font-mono uppercase tracking-[0.1em] text-label-12 text-gray-700">
+                {framework.eyebrow}
+              </div>
+              <div className="mt-1 font-medium text-copy-16 text-gray-1000">{framework.name}</div>
+            </div>
+            <ArrowUpRight
+              aria-hidden
+              className="shrink-0 text-gray-700 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-gray-1000"
+              size={16}
+            />
+          </div>
+          <p className="mt-3 text-copy-14 leading-6 text-gray-900">{framework.description}</p>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/apps/docs/components/geistdocs/framework-comparison/index.ts
+++ b/apps/docs/components/geistdocs/framework-comparison/index.ts
@@ -1,0 +1,5 @@
+export { AuthoringShape } from "./authoring-shape";
+export { ComparisonHero } from "./comparison-hero";
+export { ComparisonMatrix } from "./comparison-matrix";
+export { FrameworkFit } from "./framework-fit";
+export { MultiplayerTimeline } from "./multiplayer-timeline";

--- a/apps/docs/components/geistdocs/framework-comparison/multiplayer-timeline.tsx
+++ b/apps/docs/components/geistdocs/framework-comparison/multiplayer-timeline.tsx
@@ -1,0 +1,103 @@
+import { ArrowRight, KeyRound, ShieldCheck, UserRound } from "lucide-react";
+import type { JSX } from "react";
+
+const TURNS = [
+  {
+    number: "01",
+    person: "Avery starts the thread",
+    current: "avery",
+    initiator: "avery",
+    capability: "Avery's playbook + credentials",
+  },
+  {
+    number: "02",
+    person: "Jordan joins with a question",
+    current: "jordan",
+    initiator: "avery",
+    capability: "Jordan's tools + data access",
+  },
+  {
+    number: "03",
+    person: "Riley sends the next turn",
+    current: "riley",
+    initiator: "avery",
+    capability: "Riley's policy + OAuth grants",
+  },
+] as const;
+
+/** Shows how eve keeps session identity stable while resolving each active participant per turn. */
+export function MultiplayerTimeline(): JSX.Element {
+  return (
+    <figure className="not-prose my-8 overflow-hidden rounded-2xl border border-gray-alpha-400 bg-background-100">
+      <div className="border-gray-alpha-400 border-b px-5 py-4 sm:px-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="font-mono uppercase tracking-[0.1em] text-label-13 text-blue-900">
+              One durable session
+            </div>
+            <div className="mt-1 font-medium text-copy-16 text-gray-1000">
+              Identity changes by turn. Context does not reset.
+            </div>
+          </div>
+          <span className="rounded-full border border-gray-alpha-400 bg-background-200 px-3 py-1 text-copy-13 text-gray-900">
+            initiator remains Avery
+          </span>
+        </div>
+      </div>
+
+      <ol className="grid list-none gap-0 p-0! lg:grid-cols-3">
+        {TURNS.map((turn, index) => (
+          <li
+            key={turn.number}
+            className="relative min-w-0 border-gray-alpha-400 border-b p-5 last:border-b-0 lg:border-r lg:border-b-0 lg:last:border-r-0"
+          >
+            {index < TURNS.length - 1 ? (
+              <span className="absolute top-7 -right-3 z-10 hidden size-6 items-center justify-center rounded-full border border-gray-alpha-400 bg-background-100 text-gray-900 lg:flex">
+                <ArrowRight aria-hidden size={13} />
+              </span>
+            ) : null}
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-mono text-copy-13 text-gray-700">TURN {turn.number}</span>
+              <UserRound aria-hidden className="text-gray-900" size={15} />
+            </div>
+            <div className="mt-3 font-medium text-copy-14 text-gray-1000">{turn.person}</div>
+            <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-copy-13">
+              <dt className="text-gray-700">current</dt>
+              <dd className="m-0! font-mono text-gray-1000">{turn.current}</dd>
+              <dt className="text-gray-700">initiator</dt>
+              <dd className="m-0! font-mono text-gray-1000">{turn.initiator}</dd>
+            </dl>
+            <div className="mt-4 flex items-start gap-2 rounded-lg bg-blue-100 p-3 text-copy-13 text-blue-900">
+              <KeyRound aria-hidden className="mt-0.5 shrink-0" size={14} />
+              {turn.capability}
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <div className="grid gap-px bg-gray-alpha-400 sm:grid-cols-2">
+        <div className="bg-background-200 p-5 sm:p-6">
+          <div className="text-copy-13 font-medium text-gray-1000">Shared-stream multiplayer</div>
+          <p className="mt-2 text-copy-14 text-gray-900">
+            Several clients can watch, send, queue, and steer. Messages can carry display names.
+          </p>
+        </div>
+        <div className="bg-blue-100 p-5 sm:p-6">
+          <div className="flex items-center gap-2 text-copy-13 font-medium text-blue-900">
+            <ShieldCheck aria-hidden size={15} /> eve's additional contract
+          </div>
+          <p className="mt-2 text-copy-14 text-gray-1000">
+            The runtime knows which authenticated principal owns this turn, then resolves policy,
+            capabilities, and user credentials from that identity.
+          </p>
+        </div>
+      </div>
+
+      <figcaption className="sr-only">
+        Three participants take turns in one eve session. The current principal changes on each
+        turn, the initiating principal remains Avery, and capabilities resolve for the current
+        speaker.
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/docs/components/geistdocs/mdx-components.tsx
+++ b/apps/docs/components/geistdocs/mdx-components.tsx
@@ -4,6 +4,13 @@ import { Step, Steps } from "fumadocs-ui/components/steps";
 import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
 import { AgentRuntimeDiagram } from "./agent-runtime-diagram";
+import {
+  AuthoringShape,
+  ComparisonHero,
+  ComparisonMatrix,
+  FrameworkFit,
+  MultiplayerTimeline,
+} from "./framework-comparison";
 
 const localComponents: MDXComponents = {
   a: ({ href, ...props }) =>
@@ -16,8 +23,13 @@ const localComponents: MDXComponents = {
   Files,
   Folder,
   AgentRuntimeDiagram,
+  AuthoringShape,
+  ComparisonHero,
+  ComparisonMatrix,
   Step,
   Steps,
+  FrameworkFit,
+  MultiplayerTimeline,
 };
 
 export const getMDXComponents = (components?: MDXComponents): MDXComponents =>

--- a/docs/comparison.mdx
+++ b/docs/comparison.mdx
@@ -1,0 +1,90 @@
+---
+title: "Compare Agent Frameworks"
+description: "An evidence-based comparison of eve, Mastra, Flue 2.0, Cloudflare Agents SDK, LangGraph, Hermes Agent, and the wider agent framework landscape."
+---
+
+<ComparisonHero />
+
+The agent ecosystem has no shortage of SDKs that can call a model, execute a tool, or persist a chat. Those are table stakes. The difficult question is what happens when the agent becomes a real product: it works for days, runs code, serves several surfaces, delegates to specialists, asks people for approval, and acts with the credentials of whoever is speaking now.
+
+This comparison evaluates the **documented production contract**, not whether a determined team could build the missing layer. Any general-purpose runtime can be extended indefinitely. “Built in” means the framework owns the lifecycle and gives it one coherent authoring, durability, identity, and observability story.
+
+## The architectural difference
+
+eve treats an agent as a directory. The model gets a durable harness and decides how to use the capabilities inside it. You do not have to turn the model's job into a graph before it can begin.
+
+<AuthoringShape />
+
+That distinction becomes more important as models improve. A graph captures the routing intelligence you had to supply today. A well-designed harness exposes the stable capabilities, policies, and environment that a stronger model can use better tomorrow. With eve, adding a connection, skill, channel, schedule, or specialist makes the agent richer without making its central definition larger.
+
+Mastra now offers [experimental file-based agents](https://mastra.ai/docs/getting-started/file-based-agents), and Flue 2.0 discovers exported agent functions. Those are useful moves in the same direction. The difference is completeness: eve's recursive directory is the framework's primary authoring model, including nested subagents, dynamic capability files, sandbox seed state, connections, channels, schedules, and sibling evals. There is no second registry that becomes the real architecture.
+
+## Capability comparison
+
+The matrix uses four deliberately narrow labels:
+
+- **First-class**: the framework owns the end-to-end lifecycle.
+- **Supported**: there is a documented primitive or close integration, but another surface or adapter completes the story.
+- **Assemble**: application code combines lower-level pieces.
+- **Outside core**: possible in the host ecosystem, but not a documented framework responsibility.
+
+<ComparisonMatrix />
+
+The point is not that eve is the only project with durability, sandboxes, channels, or subagents. It is the only framework in this set where all of those concerns share the same filesystem authoring model and durable session contract—including identity changes between turns.
+
+## Multiplayer is an authorization problem
+
+Several frameworks now use “multiplayer” to mean that multiple clients can subscribe to one stream, send messages into one thread, or steer a running loop. That is valuable, but a shared transcript alone does not answer the production questions: **Who is speaking now? Which tenant are they in? Whose OAuth grant should this tool use? Which instructions and skills may this person load?**
+
+<MultiplayerTimeline />
+
+eve carries both [`auth.current`](./guides/session-context) and `auth.initiator` in the durable session. A follow-up from a different person updates the current principal while preserving who began the session. Dynamic tools, skills, instructions, connection headers, approval policies, and user-scoped credentials can all resolve from that current identity.
+
+Mastra deserves credit for pushing shared-agent interaction forward. Its [Channels architecture](https://mastra.ai/blog/building-multi-user-multi-channel-agents) maps many participants into one platform thread, attributes messages, queues concurrent input, and can isolate a workspace per thread. Its documented resource memory remains bound to whoever started the thread, while other participants arrive as attributed messages. eve goes one layer deeper: the active participant is a runtime security principal, not only conversation metadata.
+
+## Durability without a second programming model
+
+Durability is often available somewhere in a competitor's stack. The catch is where its boundary sits.
+
+- LangGraph checkpoints graph supersteps once a checkpointer is configured.
+- Cloudflare combines Agent instances with Fibers or Workflows.
+- Mastra has durable workflows and a separate beta Durable Agents surface for long-running autonomous loops.
+- Flue 2.0 records accepted submissions and can recover durable tools and delegated tasks, while code around agent sends remains outside that checkpoint boundary.
+
+eve makes the ordinary agent turn the durable unit. Every model step checkpoints automatically. Approval, OAuth, sleep, a long-running child, or a channel reply parks the workflow without holding compute. Tools and subagents keep a synchronous authoring shape even when execution crosses processes or deploys. You can still author deterministic orchestration when the task truly calls for it, but reliability does not require converting the agent into a workflow first.
+
+## A complete harness, not a bag of primitives
+
+The most important eve advantage is cumulative. A production feature is more useful when it composes with every other one:
+
+- The sandbox is isolated from the trusted app runtime, persists per session, supports network policy, and can broker credentials without exposing them to model-controlled code.
+- A nested or remote subagent gets its own durable session; approval and OAuth challenges still surface through the root channel.
+- The same authenticated principal that selects dynamic tools and skills also selects user-scoped MCP or OpenAPI credentials.
+- The same session streams to web clients, messaging channels, the TUI, evals, and OpenTelemetry instrumentation.
+- Schedules, channels, tools, connections, sandboxes, and subagents remain recognizable as files even when the agent grows to hundreds of capabilities.
+
+Other projects can reproduce individual boxes. eve owns the seams between them.
+
+## Where each option is strongest
+
+A useful comparison should make the alternatives legible too. These are different products with different centers of gravity.
+
+<FrameworkFit />
+
+### What about OpenAI Agents SDK, Pydantic AI, and CrewAI?
+
+They are credible choices, but they answer different slices of the problem:
+
+- [OpenAI Agents SDK](https://openai.github.io/openai-agents-js/) is intentionally a small set of TypeScript and Python primitives for agent loops, tools, handoffs, guardrails, sessions, tracing, HITL, MCP, and sandbox agents. It does not try to be the deployment, channel, scheduling, or filesystem application framework around them.
+- [Pydantic AI](https://pydantic.dev/docs/ai/overview/) is an excellent Python-first choice when typed dependencies and outputs, model portability, evals, and opt-in durable execution integrations matter more than a complete product-agent runtime.
+- [CrewAI](https://docs.crewai.com/) centers role-based crews and event-driven flows, with a growing enterprise deployment platform. It is strongest when explicit multi-agent teams and automations are the desired abstraction.
+
+The same principle applies to lower-level model SDKs: being able to assemble a feature is not the same as having a framework own its lifecycle.
+
+## Methodology and sources
+
+This page was last verified on **July 31, 2026** against public, official documentation. The primary comparison covers eve, [Mastra](https://mastra.ai/docs/), [Flue 2.0](https://flueframework.com/docs/), [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/), [LangGraph](https://docs.langchain.com/oss/javascript/langgraph/overview), and [Hermes Agent](https://hermes-agent.nousresearch.com/docs/). Flue refers to the `2.0.0` surface published on that date, not older v1 beta material.
+
+The scope is the open or publicly documented framework surface. Hosted products are credited where they materially complete that framework's production story, and the matrix says so. It does not compare price, benchmarks, GitHub stars, private roadmap claims, or features visible only in a demo. “Not documented” is not a claim of impossibility; it means adopters own that contract until the project publishes one.
+
+Frameworks change quickly. Every matrix assessment links to the relevant source so you can verify a requirement that is critical to your application.

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -18,6 +18,7 @@
     "schedules",
     "evals",
     "---Learn More---",
+    "comparison",
     "tutorial",
     "guides",
     "concepts",


### PR DESCRIPTION
### Description

Adds a new editorial architecture-selection guide and supporting responsive docs components. Kept as a draft while copy and positioning receive internal review.

### How did you test your changes?

- `pnpm docs:check`
- `pnpm --filter eve-docs build`
- Targeted `oxlint` and formatting checks
- Browser QA at desktop and mobile widths, including the production route

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not required; docs-only)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
