### PR TITLE
fix(eve): keep the card band behind metrics when a clipped title resets styles

### DIFF
--- a/packages/eve/src/cli/dev/tui/traces/trace-conversation.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-conversation.test.ts
@@ -493,6 +493,25 @@ describe("renderConversationItem", () => {
     expect(errorLines[3]).toContain("\x1b[48;2;58;26;31m");
   });
 
+  it("keeps the band behind the metrics when a styled title clips mid-row", () => {
+    const assistant = buildConversationItems(trace(weatherTurn())).find(
+      (item) => item.kind === "assistant",
+    )!;
+    const themed = createTheme({ color: true, unicode: true });
+    const surfaces = deriveTraceViewerSurfaces({ r: 0, g: 0, b: 0 });
+    // Narrow enough (like a card beside the open drawer) that the styled
+    // title clips, which embeds a full SGR reset mid-row. The band must
+    // re-open after it, or the gap and right-aligned metrics render on the
+    // terminal's default background.
+    const title = renderConversationItem(assistant, 46, themed, false, false, surfaces)[1]!;
+    expect(stripAnsi(title)).toContain("↓50");
+    const afterResets = title.split("\x1b[0m").slice(1);
+    expect(afterResets.length).toBeGreaterThan(1);
+    for (const segment of afterResets) {
+      expect(segment.startsWith("\x1b[48;2;22;22;22m")).toBe(true);
+    }
+  });
+
   it("inverts primary text on light backgrounds so titles stay legible", () => {
     const assistant = buildConversationItems(trace(weatherTurn())).find(
       (item) => item.kind === "assistant",

--- a/packages/eve/src/cli/dev/tui/traces/trace-conversation.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-conversation.ts
@@ -367,9 +367,14 @@ function cardRow(
   const clipped = clipVisible(line, Math.max(1, width - 8));
   const pad = " ".repeat(Math.max(0, width - 8 - visibleLength(clipped)));
   if (surface === undefined || !theme.color) return ` ${rail}  ${clipped}${pad}    `;
-  // The second surface open re-establishes the band past any embedded style
-  // reset in the clipped content, so the padding is covered too.
-  return ` ${rail}${surface}  ${clipped}\x1b[0m${surface}${pad}  ${SURFACE_CLOSE}  `;
+  // A style reset embedded in the content — `clipVisible` appends one when
+  // it truncates styled text, e.g. a title clipped by the details drawer —
+  // would drop the band's background for the rest of the row (the metrics
+  // after a clipped title would sit on the terminal's default background).
+  // Re-open the surface after every embedded reset, and once more before
+  // the padding to close any style the content left open.
+  const covered = clipped.replaceAll("\x1b[0m", `\x1b[0m${surface}`);
+  return ` ${rail}${surface}  ${covered}\x1b[0m${surface}${pad}  ${SURFACE_CLOSE}  `;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the mid-row background artifact behind the assistant card's metrics (duration · tokens · cost) that appeared once the details drawer opened.

**Cause:** with the drawer open, card titles clip to the narrower timeline, and `clipVisible` appends a full SGR reset (`ESC[0m`) to the truncated styled title. That reset dropped the card band's background mid-row, so the gap and the right-aligned metrics rendered on the terminal's default (black) background.

**Fix:** `cardRow` re-opens the surface after every reset embedded in the clipped content — the same trick the old full-screen canvas post-processing used — so the band stays continuous across the row.

Includes a regression test that renders a card at drawer width and asserts every embedded reset is immediately followed by the surface re-open (fails without the fix).