### PR TITLE
fix(eve): clarify add flow categories

### DIFF
--- a/.changeset/clear-add-tui-copy.md
+++ b/.changeset/clear-add-tui-copy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Clarify the dev TUI’s `/add` flow with consistent integration categories and category-specific browsing labels. MCP connections are now named explicitly, and the flow more clearly explains channels, extensions, and observability integrations.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -35,7 +35,7 @@ Each command echoes as an invocation line, asks through a bordered panel that ta
 | Command       | Does                                                                                                                                                         |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `/model`      | Opens a configure menu that loops until Done (or Esc). See [Configure the model and provider](#configure-the-model-and-provider).                            |
-| `/add`        | Searches registry integrations or adds an item address entered directly.                                                                                     |
+| `/add`        | Adds an integration from the registry or an item address entered directly.                                                                                   |
 | `/deploy`     | Ships the agent to Vercel production, linking the directory first when it is unlinked.                                                                       |
 | `/vc:install` | Installs the Vercel CLI. Available locally and on a remote session.                                                                                          |
 | `/vc:login`   | Logs in to Vercel locally. On a remote session, resolves the deployment's project, refreshes its OIDC token, and confirms any required Trusted Sources rule. |
@@ -55,11 +55,11 @@ The provider row opens one menu: AI Gateway via a project, AI Gateway via `AI_GA
 
 The provider row demands attention (a bold yellow "Configure model access" with a yellow "Not configured" hint that dims when unselected and uses the terminal foreground when selected) until a link or gateway credential is detected, then names the connection afterward (for example "AI Gateway (Linked to my-project in my-team)"). Setup menus mark the cursor row with a padded, filled-arrow inverse label that inherits the row's accent: blue normally and yellow for warning rows. In stacked menus, the selected row's description appears directly beneath that option. The completed command's outcome stays in the transcript after the panel closes. When a turn fails because AI Gateway authentication is missing or stale, the error points you at `/model` directly.
 
-### Browse registry integrations
+### Add registry integrations
 
-`/add` first organizes integrations by what they add: a way to chat, tools and data, capabilities, or observability. Pick a category to open its searchable catalog from the official eve registry and the registry namespaces configured in `package.json`, or browse everything. Each integration shows its source beside its name, such as `Vercel` or a configured registry namespace. Select a result to review its source, packages, environment variables, and target files before adding it, or type an official item path, configured namespace address, or HTTP(S) URL directly into the search bar. After an add attempt finishes, the panel closes instead of returning to the catalog.
+`/add` groups integrations by their role: **Channels** for where people talk to your agent, **MCP connections** for external services and data, **Extensions** for reusable capabilities, and **Observability** for tracing and evaluation. Pick a category to open its searchable catalog from the official eve registry and the registry namespaces configured in `package.json`, or browse every integration. Each result shows its source beside its name, such as `Vercel` or a configured registry namespace. Select a result to review its source, packages, environment variables, and target files before adding it, or enter an official item path, configured namespace address, or HTTP(S) URL directly in the search bar. After an add attempt finishes, the panel closes instead of returning to the catalog.
 
-Connection registry items install their definition and then configure Vercel Connect through the same `/add` flow. If the directory is unlinked, setup first offers to create or link a project. Run `eve add connection/<name>` for the equivalent CLI flow.
+MCP connection registry items install their definition and then configure Vercel Connect through the same `/add` flow. If the directory is unlinked, setup first offers to create or link a project. Run `eve add connection/<name>` for the equivalent CLI flow.
 
 ## Keyboard shortcuts
 

--- a/packages/eve/src/cli/dev/tui/prompt-commands.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-commands.ts
@@ -104,7 +104,7 @@ const PROMPT_COMMAND_DEFINITIONS = [
   {
     name: "add",
     aliases: [],
-    description: "Browse and add registry integrations",
+    description: "Add an integration from the registry",
     takesArgument: false,
     build: () => ({ type: "extension", name: "add", argument: "" }),
     targets: ["local"],

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -55,22 +55,35 @@ describe("runRegistryFlow", () => {
       expect.objectContaining({ silent: true, prompter: fake.prompter }),
     );
     expect(prompts[0]).toMatchObject({
-      message: "",
+      message: "Add an integration",
       hintLayout: "inline",
       options: expect.arrayContaining([
-        expect.objectContaining({ value: "category:channel", label: "Chat channels" }),
-        expect.objectContaining({ value: "category:connection", label: "Tools & data" }),
-        expect.objectContaining({ value: "category:extension", label: "Capabilities" }),
+        expect.objectContaining({
+          value: "category:channel",
+          label: "Channels",
+          hint: "Where people talk to your agent — Web, Slack, Discord, Teams",
+        }),
+        expect.objectContaining({
+          value: "category:connection",
+          label: "MCP connections",
+          hint: "Connect services like Linear, Notion, GitHub, and Vercel",
+        }),
+        expect.objectContaining({
+          value: "category:extension",
+          label: "Extensions",
+          hint: "Add browser automation, memory, and developer tools",
+        }),
         expect.objectContaining({
           value: "category:instrumentation",
           label: "Observability",
+          hint: "Trace, evaluate, and monitor your agent",
         }),
-        expect.objectContaining({ value: "category:all", label: "All integrations" }),
-        expect.objectContaining({ value: "action:done", label: "Back to chat" }),
+        expect.objectContaining({ value: "category:all", label: "Browse all" }),
+        expect.objectContaining({ value: "action:done", label: "Return to chat" }),
       ]),
     });
     expect(prompts[1]).toMatchObject({
-      message: "Browse registry integrations",
+      message: "Browse extensions",
       options: [
         expect.objectContaining({
           label: "Agent Browser",
@@ -247,7 +260,7 @@ describe("runRegistryFlow", () => {
     await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
 
     expect(prompts[1]).toMatchObject({
-      placeholder: "Search or enter an item address",
+      placeholder: "Search integrations or enter an item address",
       searchAction: { label: expect.any(Function), value: expect.any(Function) },
     });
     const searchAction = (prompts[1] as { searchAction: { label(query: string): string } })
@@ -269,6 +282,10 @@ describe("runRegistryFlow", () => {
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() }),
     ).resolves.toEqual({ kind: "done", addedItems: [] });
 
-    expect(fake.selectMessages).toEqual(["", "Browse registry integrations", ""]);
+    expect(fake.selectMessages).toEqual([
+      "Add an integration",
+      "Browse channels",
+      "Add an integration",
+    ]);
   });
 });

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -22,30 +22,35 @@ const REGISTRY_CATEGORIES: ReadonlyArray<{
   prefix: `${RegistryCategory}/`;
   label: string;
   hint: string;
+  browseLabel: string;
 }> = [
   {
     value: "category:channel",
     prefix: "channel/",
-    label: "Chat channels",
-    hint: "Web, Slack, Discord, Teams",
+    label: "Channels",
+    hint: "Where people talk to your agent — Web, Slack, Discord, Teams",
+    browseLabel: "Browse channels",
   },
   {
     value: "category:connection",
     prefix: "connection/",
-    label: "Tools & data",
-    hint: "Linear, Notion, GitHub, Vercel",
+    label: "MCP connections",
+    hint: "Connect services like Linear, Notion, GitHub, and Vercel",
+    browseLabel: "Browse MCP connections",
   },
   {
     value: "category:extension",
     prefix: "extension/",
-    label: "Capabilities",
-    hint: "Browser automation, memory, developer tools",
+    label: "Extensions",
+    hint: "Add browser automation, memory, and developer tools",
+    browseLabel: "Browse extensions",
   },
   {
     value: "category:instrumentation",
     prefix: "instrumentation/",
     label: "Observability",
-    hint: "Sentry, Braintrust, Honeycomb",
+    hint: "Trace, evaluate, and monitor your agent",
+    browseLabel: "Browse observability integrations",
   },
 ];
 
@@ -85,11 +90,15 @@ function categoryRows(): SelectOption<RegistryRow>[] {
     })),
     {
       value: ALL,
-      label: "All integrations",
-      hint: "Search by name or enter an item address",
+      label: "Browse all",
+      hint: "Search every integration or enter an item address",
     },
-    { value: DONE, label: "Back to chat", trailingAction: true },
+    { value: DONE, label: "Return to chat", trailingAction: true },
   ];
+}
+
+function categoryFor(selectedCategory: RegistryRow) {
+  return REGISTRY_CATEGORIES.find((entry) => entry.value === selectedCategory);
 }
 
 function itemsForCategory(
@@ -97,7 +106,7 @@ function itemsForCategory(
   selectedCategory: RegistryRow,
 ): readonly RegistryCatalogItem[] {
   if (selectedCategory === ALL) return items;
-  const category = REGISTRY_CATEGORIES.find((entry) => entry.value === selectedCategory);
+  const category = categoryFor(selectedCategory);
   return category === undefined
     ? items
     : items.filter(
@@ -264,7 +273,7 @@ export async function runRegistryFlow(input: {
         })),
       ];
       const selectedCategory = await input.prompter.select<RegistryRow>({
-        message: "",
+        message: "Add an integration",
         options: categoryRows(),
         hintLayout: "inline",
         notices,
@@ -276,10 +285,10 @@ export async function runRegistryFlow(input: {
       const rows = itemRows(categoryItems);
       rows.push({ value: BACK, label: "Back", trailingAction: true });
       const selected = await input.prompter.select<RegistryRow>({
-        message: "Browse registry integrations",
+        message: categoryFor(selectedCategory)?.browseLabel ?? "Browse integrations",
         options: rows,
         search: true,
-        placeholder: "Search or enter an item address",
+        placeholder: "Search integrations or enter an item address",
         searchAction: {
           label: (query) => `Add “${query}”`,
           value: (query) => `${ADDRESS_PREFIX}${query.trim()}`,

--- a/packages/eve/test/tui-client/tui-packed-install-model.ts
+++ b/packages/eve/test/tui-client/tui-packed-install-model.ts
@@ -150,7 +150,7 @@ void (async () => {
       // The title paints before registry loading necessarily yields to the
       // category picker. Wait for a real option so Escape belongs to the
       // question rather than the setup flow's between-questions interrupt trap.
-      await screen.waitForText("Chat channels", 5_000);
+      await screen.waitForText("Channels", 5_000);
       input.send("\x1b");
       await screen.waitForText("/add dismissed.", 5_000);
       await screen.waitForIdlePrompt(5_000);


### PR DESCRIPTION
## Summary
- name the /add connection category MCP connections and clarify every category
- add category-specific browsing labels and clearer registry search copy
- align the command help and dev TUI documentation with the revised taxonomy

## Testing
- pnpm fmt packages/eve/src/setup/flows/registry.ts packages/eve/src/setup/flows/registry.test.ts packages/eve/src/cli/dev/tui/prompt-commands.ts docs/guides/dev-tui.md
- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/flows/registry.test.ts src/cli/dev/tui/prompt-commands.test.ts