### PR TITLE
fix(eve): prevent Vercel env pull setup hangs

### DIFF
--- a/.changeset/bright-walls-sip.md
+++ b/.changeset/bright-walls-sip.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent interactive setup from hanging after Vercel successfully pulls project environment variables. Environment pulls now run without terminal input and time out safely if the Vercel CLI does not exit.

--- a/packages/eve/src/setup/boxes/deploy-project.test.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.test.ts
@@ -9,6 +9,7 @@ import type { Prompter } from "../prompter.js";
 import { createDefaultSetupState, type SetupState } from "../state.js";
 import type { OutputSink } from "../step.js";
 import { runHeadless, runInteractive } from "../runner.js";
+import { VERCEL_ENV_PULL_TIMEOUT_MS } from "../run-vercel-link.js";
 import { deployProject, type DeployProjectDeps } from "./deploy-project.js";
 
 const silentSink: OutputSink = { write: () => {} };
@@ -113,6 +114,23 @@ describe("deployProject box", () => {
       1,
       ["deploy", "--prod", "--yes", "--non-interactive"],
       expect.objectContaining({ cwd: "/tmp/project", nonInteractive: true }),
+    );
+  });
+
+  it("closes stdin and bounds the env pull after deployment", async () => {
+    const deps = createDeps();
+    const box = headlessBox({ deps });
+
+    await runHeadless([box], pendingState(), silentSink);
+
+    expect(deps.runVercel).toHaveBeenNthCalledWith(
+      2,
+      ["env", "pull", "--yes"],
+      expect.objectContaining({
+        cwd: "/tmp/project",
+        nonInteractive: true,
+        timeoutMs: VERCEL_ENV_PULL_TIMEOUT_MS,
+      }),
     );
   });
 

--- a/packages/eve/src/setup/boxes/deploy-project.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.ts
@@ -13,6 +13,7 @@ import {
   type ProjectResolution,
 } from "../project-resolution.js";
 import { hasVercelProject, requireProjectPath, type SetupState } from "../state.js";
+import { VERCEL_ENV_PULL_TIMEOUT_MS } from "../run-vercel-link.js";
 import type { SetupBox } from "../step.js";
 import { syncHostFrameworkPreset } from "../vercel-project-framework.js";
 
@@ -200,9 +201,13 @@ export function deployProject(
         () =>
           deps.runVercel(["env", "pull", "--yes"], {
             cwd: projectPath,
-            nonInteractive: input.headless,
+            // `env pull --yes` never needs a prompt. Always detach its stdin:
+            // the CLI has been observed retaining an inherited terminal after
+            // writing .env.local, which otherwise leaves init stuck forever.
+            nonInteractive: true,
             onOutput,
             signal,
+            timeoutMs: VERCEL_ENV_PULL_TIMEOUT_MS,
           }),
       );
       signal?.throwIfAborted();

--- a/packages/eve/src/setup/run-vercel-link.test.ts
+++ b/packages/eve/src/setup/run-vercel-link.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runVercel } from "#setup/primitives/index.js";
+
+import { runVercelEnvPull, VERCEL_ENV_PULL_TIMEOUT_MS } from "./run-vercel-link.js";
+
+vi.mock("#setup/primitives/index.js", () => ({
+  runVercel: vi.fn(),
+}));
+
+const mockedRunVercel = vi.mocked(runVercel);
+
+describe("runVercelEnvPull", () => {
+  it("closes stdin and bounds the non-interactive env pull", async () => {
+    mockedRunVercel.mockResolvedValue(true);
+    const signal = new AbortController().signal;
+    const onOutput = vi.fn();
+
+    await expect(runVercelEnvPull("/tmp/agent", onOutput, signal)).resolves.toBe(true);
+
+    expect(mockedRunVercel).toHaveBeenCalledWith(["env", "pull", "--yes"], {
+      cwd: "/tmp/agent",
+      onOutput,
+      signal,
+      nonInteractive: true,
+      timeoutMs: VERCEL_ENV_PULL_TIMEOUT_MS,
+    });
+  });
+});

--- a/packages/eve/src/setup/run-vercel-link.ts
+++ b/packages/eve/src/setup/run-vercel-link.ts
@@ -2,6 +2,9 @@ import { runVercel, type RunVercelOptions } from "#setup/primitives/index.js";
 
 type VercelOutputHandler = NonNullable<RunVercelOptions["onOutput"]>;
 
+/** Hard deadline for a completed-but-unclosed Vercel CLI env pull. */
+export const VERCEL_ENV_PULL_TIMEOUT_MS = 30_000;
+
 /**
  * Runs `vercel env pull --yes` inside a linked project so `.env.local`
  * picks up the latest values, including `VERCEL_OIDC_TOKEN`, for local
@@ -13,5 +16,14 @@ export async function runVercelEnvPull(
   onOutput?: VercelOutputHandler,
   signal?: AbortSignal,
 ): Promise<boolean> {
-  return runVercel(["env", "pull", "--yes"], { cwd: projectRoot, onOutput, signal });
+  return runVercel(["env", "pull", "--yes"], {
+    cwd: projectRoot,
+    onOutput,
+    signal,
+    // `env pull --yes` has no legitimate prompt. Closing stdin prevents a
+    // Vercel CLI child that ignores its non-interactive flag from retaining
+    // eve's TTY after it has written the environment files.
+    nonInteractive: true,
+    timeoutMs: VERCEL_ENV_PULL_TIMEOUT_MS,
+  });
 }


### PR DESCRIPTION
## Summary
- run `vercel env pull` with stdin detached, including interactive setup flows
- abort a Vercel CLI child that remains alive after the environment files are written
- cover the bounded env-pull invocation in unit tests

## Root cause
Vercel CLI runs an optional Claude Code Vercel-plugin installer after a successful `env` command. Its confirmation helper checked only whether stdin was a TTY, not Vercel CLI's `--non-interactive` state. Therefore `vercel env pull --yes --non-interactive` could successfully write `.env.local` and then wait at the plugin-install confirmation when stdin remained inherited from eve.

The Vercel CLI fix is in vercel/vercel#17345. This eve change is still required to detach stdin for automation and bound a misbehaving child. With stdin ignored, the problematic CLI prompt declines immediately; the 30-second timeout remains a safety net for any future stuck subprocess.

## Validation
- `pnpm --filter eve build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/run-vercel-link.test.ts src/setup/boxes/deploy-project.test.ts src/setup/primitives/run-vercel.test.ts`
- `pnpm typecheck --filter eve`
- `pnpm lint`
- `pnpm fmt`

_Note: the sandbox uses Node 22.22.2 while the repository requires Node >=24; commands completed with engine warnings._