### PR TITLE
fix(eve): preserve setup panel rows for multiline output

### DIFF
--- a/.changeset/fix-tui-multiline-flow-output.md
+++ b/.changeset/fix-tui-multiline-flow-output.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent the dev TUI from duplicating setup panels when an integration setup error includes multiline command output.

--- a/packages/eve/src/cli/dev/tui/setup-panel.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.test.ts
@@ -47,6 +47,27 @@ describe("renderFlowPanel", () => {
     expect(text).toContain("   ▷ Create a new project");
   });
 
+  it("renders multiline diagnostics as separate terminal rows", () => {
+    const rows = renderFlowPanel(
+      {
+        title: "Add to your agent",
+        lines: [
+          {
+            text: "Linear connector creation failed:\nError: connector already exists.",
+            tone: "error",
+          },
+        ],
+        content: { kind: "idle", indicator: { glyph: "▪", color: "green" } },
+      },
+      theme,
+      60,
+    );
+
+    expect(rows).toContain("   ⨯ Linear connector creation failed:");
+    expect(rows).toContain("     Error: connector already exists.");
+    expect(rows.every((row) => !row.includes("\n"))).toBe(true);
+  });
+
   it("keeps only the freshest progress lines in view", () => {
     const lines = Array.from({ length: 10 }, (_, index) => ({
       text: `step ${index}`,

--- a/packages/eve/src/cli/dev/tui/setup-panel.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.ts
@@ -307,8 +307,12 @@ export function renderFlowPanel(state: FlowPanelState, theme: Theme, width: numb
 
   const recent = state.lines.slice(-FLOW_PANEL_LINE_CAP);
   for (const line of recent) {
-    const body = line.tone === "info" ? c.dim(line.text) : line.text;
-    rows.push(`  ${toneGlyph(line.tone, theme)} ${body}`);
+    const text = line.text.split("\n");
+    for (const [index, part] of text.entries()) {
+      const body = line.tone === "info" ? c.dim(part) : part;
+      const prefix = index === 0 ? `${toneGlyph(line.tone, theme)} ` : "  ";
+      rows.push(`  ${prefix}${body}`);
+    }
   }
   if (recent.length > 0) {
     rows.push("");
@@ -325,14 +329,17 @@ export function renderFlowPanel(state: FlowPanelState, theme: Theme, width: numb
     case "status":
       rows.push(`  ${renderFlowPanelStatus(state.content.status, theme)}`);
       if (state.content.preview !== undefined) {
-        rows.push(`    ${c.dim(state.content.preview)}`);
+        for (const line of state.content.preview.split("\n")) {
+          rows.push(`    ${c.dim(line)}`);
+        }
       }
       break;
-    case "preview":
-      rows.push(
-        `  ${renderIndicator(state.content.indicator, theme)} ${c.dim(state.content.text)}`,
-      );
+    case "preview": {
+      const [first, ...rest] = state.content.text.split("\n");
+      rows.push(`  ${renderIndicator(state.content.indicator, theme)} ${c.dim(first ?? "")}`);
+      for (const line of rest) rows.push(`    ${c.dim(line)}`);
       break;
+    }
     case "idle":
       // A flow between phases must never look dead: boxes run subprocesses
       // without narrating every gap, so the panel keeps a live pulse.

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -3880,26 +3880,6 @@ describe("TerminalRenderer setup flow session", () => {
     renderer.shutdown();
   });
 
-  it("does not leak panel frames when a setup error includes command output", () => {
-    const { screen, renderer } = makeRenderer();
-
-    renderer.setupFlow.begin("Add to your agent", "pulse");
-    renderer.setupFlow.renderLine(
-      "Linear connector creation failed:\nError: connector already exists.",
-      "error",
-    );
-    renderer.setupFlow.setStatus("Cleaning up…");
-
-    const titles = screen
-      .snapshot()
-      .split("\n")
-      .filter((line) => line.includes("Add to your agent"));
-    expect(titles).toHaveLength(1);
-    expect(screen.snapshot()).toContain("Linear connector creation failed:");
-    renderer.setupFlow.end();
-    renderer.shutdown();
-  });
-
   it("discards input without interrupting a non-interruptible flow", async () => {
     const { input, renderer } = makeRenderer();
     renderer.setupFlow.begin("Add to your agent", "pulse");

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -3880,6 +3880,26 @@ describe("TerminalRenderer setup flow session", () => {
     renderer.shutdown();
   });
 
+  it("does not leak panel frames when a setup error includes command output", () => {
+    const { screen, renderer } = makeRenderer();
+
+    renderer.setupFlow.begin("Add to your agent", "pulse");
+    renderer.setupFlow.renderLine(
+      "Linear connector creation failed:\nError: connector already exists.",
+      "error",
+    );
+    renderer.setupFlow.setStatus("Cleaning up…");
+
+    const titles = screen
+      .snapshot()
+      .split("\n")
+      .filter((line) => line.includes("Add to your agent"));
+    expect(titles).toHaveLength(1);
+    expect(screen.snapshot()).toContain("Linear connector creation failed:");
+    renderer.setupFlow.end();
+    renderer.shutdown();
+  });
+
   it("discards input without interrupting a non-interruptible flow", async () => {
     const { input, renderer } = makeRenderer();
     renderer.setupFlow.begin("Add to your agent", "pulse");


### PR DESCRIPTION
## Summary

- render multiline setup diagnostics and command previews as distinct panel rows
- prevent live-region row accounting from leaving stale setup panel frames in scrollback
- cover a failure with multiline output

## Validation

- Confirmed the new regression test fails against the pre-fix `setup-panel.ts`.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/dev/tui/setup-panel.test.ts src/cli/dev/tui/terminal-renderer.test.ts`
- `pnpm --filter eve typecheck`