### PR TITLE
WIP: feat(eve): capture gateway correlation details on model-call failures

### DIFF
--- a/.changeset/gateway-stream-termination-diagnostics.md
+++ b/.changeset/gateway-stream-termination-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Model-call failures now surface AI Gateway correlation details — `generationId`, plus the `provider` and `model` actually routed to — in both `step.failed` details and logs, including for failures the semantic-error catalog does not recognize (those previously logged a raw inspector dump with no structured fields). `generationId` is the join key for looking up the upstream cause in gateway telemetry. A gateway stream that ends before its terminal chunk is also now treated as transient, so it retries with backoff instead of parking the session on first contact.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -77,6 +77,25 @@ function gatewayModelCallError(input: {
   return error;
 }
 
+/**
+ * Mirrors the frame AI Gateway synthesizes when a provider stream ends without
+ * a terminal chunk: a plain-object `cause` keyed by `code`/`origin` with
+ * snake_case correlation fields, and no status code.
+ */
+function streamTerminatedModelCallError(): Error {
+  return new Error("Upstream stream ended before terminal chunk", {
+    cause: {
+      code: "gateway_stream_terminated",
+      generation_id: "gen_01KYWVKVSYAH1XKJ08CG9VPB4A",
+      message: "Upstream stream ended before terminal chunk",
+      model: "alibaba:glm-5.2",
+      origin: "gateway",
+      provider: "alibaba",
+      upstream_finish_received: false,
+    },
+  });
+}
+
 function directApiCallError(input: {
   readonly data?: Record<string, unknown>;
   readonly message?: string;
@@ -173,6 +192,13 @@ describe("classifyModelCallError", () => {
   it("returns retry when the AI SDK marks the error as retryable", () => {
     const err = Object.assign(new Error("upstream flaky"), { isRetryable: true });
     expect(classifyModelCallError(err)).toBe("retry");
+  });
+
+  it("returns retry for a gateway stream termination", () => {
+    // The frame carries no status code and is not marked retryable, so before
+    // the `gateway-stream-terminated` catalog rule this fell through to
+    // "recoverable" and parked the turn without a single retry.
+    expect(classifyModelCallError(streamTerminatedModelCallError())).toBe("retry");
   });
 
   it("returns retry for Anthropic overloaded stream payloads", () => {
@@ -605,6 +631,18 @@ describe("extractModelCallErrorDetails", () => {
       upstreamMessage: "AI_APICallError",
       upstreamStatusCode: 400,
       upstreamType: "invalid_request_error",
+    });
+  });
+
+  it("lifts correlation fields off a synthesized gateway stream-termination frame", () => {
+    // The frame carries `code` + `origin` and snake_case fields rather than a
+    // `Gateway*` class name, so it exercises the shape-detection path.
+    const details = extractModelCallErrorDetails(streamTerminatedModelCallError());
+
+    expect(details).toMatchObject({
+      generationId: "gen_01KYWVKVSYAH1XKJ08CG9VPB4A",
+      model: "alibaba:glm-5.2",
+      provider: "alibaba",
     });
   });
 });

--- a/packages/eve/src/harness/model-call-error.ts
+++ b/packages/eve/src/harness/model-call-error.ts
@@ -35,7 +35,9 @@ export interface UpstreamRejectionSummary {
 interface ModelCallErrorSignals {
   readonly apiCallError: boolean;
   readonly apiErrorMessage?: string;
+  readonly gatewayModel?: string;
   readonly gatewayName?: string;
+  readonly gatewayProvider?: string;
   readonly gatewayType?: string;
   readonly generationId?: string;
   readonly responseBodySnippet?: string;
@@ -173,6 +175,11 @@ export function extractModelCallErrorDetails(error: unknown): JsonObject {
   appendJsonField(details, "gatewayType", signals.gatewayType);
   appendJsonField(details, "statusCode", signals.statusCode);
   appendJsonField(details, "generationId", signals.generationId);
+  // Which upstream the gateway actually routed to. A canonical slug like
+  // `zai/glm-5.2` is served by many providers, so the failing one is not
+  // inferable from the model id alone.
+  appendJsonField(details, "provider", signals.gatewayProvider);
+  appendJsonField(details, "model", signals.gatewayModel);
   appendJsonField(details, "upstreamStatusCode", signals.upstreamStatusCode);
   appendJsonField(details, "upstreamType", signals.upstreamType);
   appendJsonField(details, "upstreamMessage", signals.upstreamMessage);
@@ -341,9 +348,16 @@ function readModelCallErrorSignals(error: unknown): ModelCallErrorSignals {
     apiErrorMessage:
       upstreamBody?.apiErrorMessage ??
       firstInformativeApiMessage([readErrorMessage(upstreamError)]),
+    // Synthesized gateway stream frames use snake_case; structured gateway
+    // errors use camelCase. Read both rather than guessing which shape arrived.
+    gatewayModel: readStringField(gatewayError, "model"),
     gatewayName: readErrorName(gatewayError),
+    gatewayProvider: readStringField(gatewayError, "provider"),
     gatewayType: readStringField(gatewayError, "type"),
-    generationId: readStringField(gatewayError, "generationId") ?? upstreamBody?.generationId,
+    generationId:
+      readStringField(gatewayError, "generationId") ??
+      readStringField(gatewayError, "generation_id") ??
+      upstreamBody?.generationId,
     responseBodySnippet:
       responseBody === undefined
         ? undefined
@@ -360,7 +374,17 @@ function findGatewayError(error: unknown): unknown {
   for (const candidate of walkCauseChain(error)) {
     const name = readErrorName(candidate);
     const type = readStringField(candidate, "type");
-    if (name?.startsWith("Gateway") || type?.endsWith("_error") || type === "rate_limit_exceeded") {
+    if (
+      name?.startsWith("Gateway") ||
+      type?.endsWith("_error") ||
+      type === "rate_limit_exceeded" ||
+      // Gateway-synthesized stream frames (e.g. `gateway_stream_terminated`)
+      // carry `code` + `origin` instead of a `Gateway*` class name or a
+      // `*_error` type, so they would otherwise never be found here — and the
+      // correlation fields they carry would be dropped.
+      (readStringField(candidate, "code")?.startsWith("gateway_") === true &&
+        readStringField(candidate, "origin") === "gateway")
+    ) {
       return candidate;
     }
   }

--- a/packages/eve/src/harness/semantic-errors/rules/gateway.ts
+++ b/packages/eve/src/harness/semantic-errors/rules/gateway.ts
@@ -1,4 +1,12 @@
-import { allOf, anyOf, messageMatches, nameIs, typeIs, type SemanticErrorRule } from "../rule.js";
+import {
+  allOf,
+  anyOf,
+  codeIs,
+  messageMatches,
+  nameIs,
+  typeIs,
+  type SemanticErrorRule,
+} from "../rule.js";
 
 /** The summary `name` shared by the gateway-auth rule variants. */
 const GATEWAY_AUTH_FAILURE_SUMMARY_NAME = "AI Gateway authentication failed";
@@ -80,5 +88,20 @@ export const GATEWAY_RULES: readonly SemanticErrorRule[] = [
     when: anyOf(nameIs("GatewayTimeoutError"), typeIs("timeout_error", "overloaded_error")),
     message: "The model provider is overloaded or timing out upstream of AI Gateway.",
     hint: "This is transient — retry shortly, or switch models with `/model` in `eve dev`.",
+  },
+  {
+    // The gateway synthesizes this frame when a provider stream ends without a
+    // terminal chunk — a dropped connection, or a mid-stream throttle the
+    // provider raised after the response was already committed (so the gateway
+    // could no longer fail over). It is a `code`, not a `type`, and carries no
+    // status code, so without this rule it fell through `classifyModelCallError`
+    // to `recoverable` and parked the turn on first contact with zero retries.
+    // `transient` is what earns it the standard 3 attempts with backoff.
+    id: "gateway-stream-terminated",
+    name: "Model stream ended early",
+    tags: ["gateway", "transient"],
+    when: codeIs("gateway_stream_terminated"),
+    message: "The model provider's stream ended before completing.",
+    hint: "Usually a transient upstream throttle or dropped connection — retries are automatic. If it persists, take the `generationId` from the failure details to AI Gateway telemetry for the upstream cause.",
   },
 ];

--- a/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
+++ b/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
@@ -175,6 +175,18 @@ describe("summarizeKnownError (catalog table)", () => {
       error: new TypeError("terminated"),
       id: "network-request-failed",
     },
+    {
+      title: "gateway stream terminated before a terminal chunk",
+      error: new Error("Upstream stream ended before terminal chunk", {
+        cause: {
+          code: "gateway_stream_terminated",
+          message: "Upstream stream ended before terminal chunk",
+          origin: "gateway",
+          upstream_finish_received: false,
+        },
+      }),
+      id: "gateway-stream-terminated",
+    },
   ];
 
   for (const testCase of cases) {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -3560,6 +3560,36 @@ describe("createToolLoopHarness", () => {
     );
   });
 
+  it("logs correlation details even when the failure is unrecognized", async () => {
+    // Regression guard: log fields used to carry `details` only for recognized
+    // failures, so `generationId` and friends were dropped on exactly the
+    // failures that are hardest to diagnose.
+    const unrecognized = Object.assign(new Error("something we have no rule for"), {
+      generationId: "gen_tool_loop",
+      name: "GatewayWeirdNewError",
+      statusCode: 418,
+    });
+    setupMockAgentError(unrecognized);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const { emit } = createEventCollector();
+      const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+      await runStep(createTestSession(), { message: "Hi" });
+
+      const logged = errorSpy.mock.calls.find(
+        ([, fields]) => (fields as { details?: unknown } | undefined)?.details !== undefined,
+      );
+      expect(logged).toBeDefined();
+      expect((logged![1] as { details: Record<string, unknown> }).details).toMatchObject({
+        generationId: "gen_tool_loop",
+        statusCode: 418,
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("emits the full terminal failure cascade on a structural 4xx model-call error", async () => {
     // 400/401/403/404 responses are classified as terminal — the
     // session is torn down because retrying would hit the same wall.

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1470,13 +1470,16 @@ function buildModelCallFailureDetails(input: {
 }
 
 /**
- * Builds the structured log fields for a model-call failure. When the
- * failure was recognized (catalog match or extracted upstream rejection),
- * attach the compact `details` payload and *omit* the raw `error` so the
- * logger's `util.inspect` of the cause chain (which would render
- * `[object Object]` for upstream `APICallError` shapes) is bypassed.
- * Otherwise fall back to the raw error so unrecognized failures keep
- * their full stack in logs.
+ * Builds the structured log fields for a model-call failure.
+ *
+ * `details` rides along whenever it has anything in it, recognized or not:
+ * these are the correlation fields (`generationId`, `provider`,
+ * `upstreamError`, …) an operator needs to take a failure to gateway
+ * telemetry, and they used to be dropped on exactly the unrecognized failures
+ * that are hardest to diagnose. Recognized failures still omit the raw `error`
+ * so the logger's `util.inspect` of the cause chain — which renders
+ * `[object Object]` for upstream `APICallError` shapes — is bypassed;
+ * unrecognized ones keep it for the full stack.
  */
 function buildModelCallFailureLogFields(input: {
   readonly error: unknown;
@@ -1490,9 +1493,12 @@ function buildModelCallFailureLogFields(input: {
     errorId: input.errorId,
     sessionId: input.sessionId,
     turnId: input.turnId,
+    ...(Object.keys(input.modelCallDetails).length > 0 && {
+      details: input.modelCallDetails,
+    }),
   };
   if (input.recognized) {
-    return { ...base, details: input.modelCallDetails };
+    return base;
   }
   return { ...base, error: input.error };
 }


### PR DESCRIPTION
## Summary

Diagnosing a gateway stream failure from an eve log is not currently possible. The error ids in the log are local `crypto.randomUUID()` values, and the structured `details` payload — which already extracts `generationId` — was attached only when the semantic-error catalog *recognized* the failure. On unrecognized failures, the ones hardest to diagnose, eve logged a raw inspector dump with no correlation fields at all.

Surfaced by [AIG-387](https://linear.app/vercel/issue/AIG-387/look-into-eve-glm-52-gateway-web-search-errors): the `agent-tools` / `zai-glm` e2e job failed with `gateway_stream_terminated`, and pinning down the cause took a day of timestamp-correlating gateway logs. The actual cause was an alibaba mid-stream rate limit.

Pairs with vercel/ai-gateway#2934, which puts `generation_id`, `provider`, and `model` on the synthesized frame. **Merge that first** — these extractions are only exercised against the enriched payload.

## Changes

- **`findGatewayError` recognizes gateway-synthesized frames.** They key on `code` + `origin`, not a `Gateway*` class name or a `*_error` type, so they were never matched — meaning the new fields would have been silently dropped even after the gateway started sending them.
- **Extract `provider` and `model`**, and read `generation_id` alongside `generationId` since the frame is snake_case. `provider` matters because a canonical slug like `zai/glm-5.2` is served by many upstreams (alibaba, novita, fireworks, nebius, …), so the failing one is not inferable from the model id.
- **Always log `details` when non-empty.** Recognized failures still omit the raw `error` to bypass the `[object Object]` inspector rendering of `APICallError` cause chains; unrecognized ones keep it for the stack.
- **New `gateway-stream-terminated` catalog rule tagged `transient`.**

## The behavior change worth reviewing

That last item is not just observability. The frame carries no status code and is not marked retryable, so it fell through `classifyModelCallError` to `recoverable` — which means **zero in-process retries** and an immediate session park. A transient upstream throttle killed the turn on first contact.

The `transient` tag reclassifies it to `retry`, earning the standard 3 attempts with 500ms exponential backoff plus jitter. This is very likely what stops `static-tools/web-search-parallel` from flaking on glm-5.2.

I called this out separately rather than folding it in silently, since it changes runtime behavior and not just log content. Happy to split it into its own PR if you would rather land the extraction first.

## What this deliberately does not capture

An earlier revision also consumed an `upstream_error` field carrying the raw provider message. That has been dropped on both sides. eve's logs reach **public** CI output, and provider error bodies echo request content — per the `#help-ai-gateway` investigation, ~5,442 rows in three days had a customer's live Anthropic API key land verbatim in a recorded upstream error. That detail stays gateway-side until the redacting extractor on AIG-394 lands.

`generationId` is the handle instead, and it recovers most of the value: it turns a timestamp-correlation hunt across a high-volume production log into a single query. The rule's hint points operators at it.

## Testing

- `pnpm test:unit` — 5819 passed, 1 skipped
- `pnpm test:integration` — 575 passed
- `pnpm typecheck`, `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants` all clean
- New coverage: correlation-field extraction off a synthesized frame, the `retry` classification, the catalog rule, and a regression guard that `details` survives on unrecognized failures

E2E: the `agent-tools` / `zai-glm` job is the real check. Once the gateway side deploys, a surviving failure should log `generationId` + `provider` directly instead of needing timestamp correlation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)