### PR TITLE
fix(build): co-copy rollup content-hashed sibling .d.ts chunks (#1500)

### DIFF
--- a/packages/eve/scripts/vendor-compiled/_shared.mjs
+++ b/packages/eve/scripts/vendor-compiled/_shared.mjs
@@ -188,7 +188,112 @@ export function createDeclarationCopier({
         }),
       );
     }
+
+    // (eve#1500) Some upstream packages emit rollup content-hashed sibling
+    // chunks that their public `.d.ts` files reference via relative import
+    // (`from './messages-BSoJG691.js'`, `from './types-WYjTBVDi.js'`).
+    // `collectExternalDeclarationImports` intentionally skips relative
+    // specifiers, so without further handling those chunks would be left
+    // behind — the published declarations then resolve to `any` (or fail
+    // `skipLibCheck: false`). Scan each written declaration for relative
+    // import specifiers, resolve them against the upstream `dist/`, and
+    // co-copy any matches, recursively, with cycle protection. This
+    // subsumes `discoverExtraFiles` for the sibling-chunk class of problem.
+    const outputsAlreadyWritten = new Set(declarations.map((d) => d.output));
+    const extrasAlreadyWritten = new Set(
+      typeof discoverExtraFiles === "function" ? discoverExtraFiles(distEntries) : [],
+    );
+    const copiedChunks = new Set([...outputsAlreadyWritten, ...extrasAlreadyWritten]);
+    await coCopyRelativeDeclarationChunks(
+      declarations.map((d) => d.output),
+      destinationRoot,
+      distDir,
+      copiedChunks,
+    );
   };
+}
+
+/**
+ * Regex mirroring the relative side of `collectExternalDeclarationImports`:
+ * finds `from './x'`, `from '.../x'`, and side-effect `import './x'` specifiers.
+ */
+const RELATIVE_DECLARATION_IMPORT_PATTERN =
+  /^(?:import|export)\s+(?:type\s+)?(?:\{[^}]*\}|\*\s+as\s+[A-Za-z_$][\w$]*|\*)?\s*(?:from\s+)?['"](\.[^'"]+)['"]/gm;
+
+/**
+ * Walks a set of already-written declaration outputs, finds relative import
+ * specifiers in their source (looking at the post-rewrite output), and
+ * co-copies any matching upstream `.d.ts` chunk the package embeds. Recurses
+ * into newly-copied chunks so transitively-referenced chunks survive.
+ *
+ * Resolves the specifier against the chunk's own directory (which matches
+ * the upstream layout because we copy files verbatim with their basenames).
+ * Normalizes the `.js` specifier to `.d.ts` — rollup emits `.d.ts` files
+ * whose import clauses reference the `.js` companion.
+ */
+async function coCopyRelativeDeclarationChunks(
+  outputPathsRelativeToDestination,
+  destinationRoot,
+  distDir,
+  copiedChunks,
+) {
+  const queue = [...outputPathsRelativeToDestination];
+  const processed = new Set();
+  while (queue.length > 0) {
+    const relativeOutput = queue.pop();
+    if (processed.has(relativeOutput)) continue;
+    processed.add(relativeOutput);
+
+    const outputPath = join(destinationRoot, relativeOutput);
+    let sourceText;
+    try {
+      sourceText = await readFile(outputPath, "utf8");
+    } catch {
+      // The just-written declaration may not exist yet if a caller raced us;
+      // or the file may be a stub written via a different pathway. Skip.
+      continue;
+    }
+    const fromDir = dirname(relativeOutput);
+
+    for (const match of sourceText.matchAll(RELATIVE_DECLARATION_IMPORT_PATTERN)) {
+      let specifier = match[1];
+      // Skip anchor-only relative specifiers (`./foo.d.ts#Anchor`).
+      const hashIndex = specifier.indexOf("#");
+      if (hashIndex !== -1) specifier = specifier.slice(0, hashIndex);
+      if (specifier.length === 0) continue;
+
+      // Rollup outputs reference the `.js` companion in their `.d.ts`.
+      // Try the `.d.ts` twin first, then the specifier verbatim (in case
+      // the upstream file genuinely ends `.js`, e.g. a paired JS file).
+      const candidateNames = specifier.endsWith(".js")
+        ? [specifier.slice(0, -".js".length) + ".d.ts", specifier]
+        : specifier.endsWith(".d.ts")
+          ? [specifier, specifier.slice(0, -".d.ts".length) + ".d.ts"]
+          : [specifier + ".d.ts"];
+
+      for (const candidateName of candidateNames) {
+        const resolvedOutputRelative = posix.normalize(posix.join(fromDir, candidateName));
+        if (copiedChunks.has(resolvedOutputRelative)) {
+          queue.push(resolvedOutputRelative);
+          break;
+        }
+        const upstreamSource = join(distDir, resolvedOutputRelative);
+        let exists;
+        try {
+          exists = (await stat(upstreamSource)).isFile();
+        } catch {
+          exists = false;
+        }
+        if (!exists) continue;
+        const outputPathForChunk = join(destinationRoot, resolvedOutputRelative);
+        await mkdir(dirname(outputPathForChunk), { recursive: true });
+        await copyFile(upstreamSource, outputPathForChunk);
+        copiedChunks.add(resolvedOutputRelative);
+        queue.push(resolvedOutputRelative);
+        break;
+      }
+    }
+  }
 }
 
 function mergeExternalDeclarationImports(sources) {

--- a/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
@@ -304,4 +304,36 @@ describe("compiled vendor assets", () => {
       expect(vendored).toBe(upstream);
     }
   });
+
+  it("(eve#1500) co-copies content-hashed sibling declaration chunks referenced by vendored entries", async () => {
+    // Some upstream packages emit rollup content-hashed sibling chunks whose
+    // public `.d.ts` files reference them via relative import. If these are
+    // left behind at vendor time, the published package's declarations
+    // resolve them to `any` (or fail `skipLibCheck: false`). Pin the two
+    // chunks the original report surfaced plus the transitive closure.
+    const chatHashedChunk = join(COMPILED_VENDOR_ROOT, "chat/messages-BSoJG691.d.ts");
+    const twilioHashedChunk = join(
+      COMPILED_VENDOR_ROOT,
+      "@chat-adapter/twilio/types-WYjTBVDi.d.ts",
+    );
+
+    for (const chunkPath of [chatHashedChunk, twilioHashedChunk]) {
+      const [chunk, chunkStats] = await Promise.all([readFile(chunkPath, "utf8"), readdir(dirname(chunkPath))]);
+      expect(chunk.length).toBeGreaterThan(0);
+      expect(chunkStats).toContain(chunkPath.split("/").pop());
+    }
+
+    // The chat entry source should still reference its hashed sibling
+    // (i.e. we did NOT strip or break the import — we copied the target
+    // alongside so the specifier resolves).
+    const chatIndex = await readFile(join(COMPILED_VENDOR_ROOT, "chat/index.d.ts"), "utf8");
+    expect(chatIndex).toContain("./messages-BSoJG691");
+
+    // The Twilio webhook entry should reference its hashed sibling too.
+    const twilioWebhook = await readFile(
+      join(COMPILED_VENDOR_ROOT, "@chat-adapter/twilio/webhook.d.ts"),
+      "utf8",
+    );
+    expect(twilioWebhook).toContain("./types-WYjTBVDi");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1500 — published `eve` package was silently missing two rollup content-hashed sibling declaration chunks that its own vendored `.d.ts` files import:

- `chat`'s `messages-BSoJG691.d.ts` (referenced from `chat/index.d.ts`)
- `@chat-adapter/twilio`'s `types-WYjTBVDi.d.ts` (referenced from `@chat-adapter/twilio/webhook.d.ts`)

The type hole degraded ~120 exported names across the Chat SDK surface (`Adapter`, `Chat`, `ChatInstance`, `Message`, `Thread`, `Attachment`, `FileUpload`, `PostableCard`, `PostableMessage`, `StateAdapter`, `UserInfo`, …) plus `TwilioWebhookUrl` / `TwilioVerifiedRequest` to `any` under the default `skipLibCheck: true`, and surfaced as `TS2307: Cannot find module './messages-BSoJG691.js'` under `skipLibCheck: false`.

## Root cause

`createDeclarationCopier` (`packages/eve/scripts/vendor-compiled/_shared.mjs`) had two ways to bring upstream `.d.ts` files into the vendored output:

1. **Explicit `files:`** — hardcoded list (twilio listed only its 5 entry points).
2. **`discoverExtraFiles`** — a per-package filename matcher (chat listed only `jsx-runtime-<hash>.d.ts`).

Meanwhile `collectExternalDeclarationImports` deliberately skips *relative* specifiers (`./…`), so nothing in the pipeline noticed when a vendored declaration referenced a sibling content-hashed chunk. The result: both hashed chunks were left behind.

## Fix

Add a transitive relative-import co-pass to `createDeclarationCopier`: after the existing files/extra-files copies, scan each written declaration for relative import specifiers (`from './x.js'`, `from '../y.d.ts'`, `export * from './z.js'`, side-effect `import './w.js'`), resolve them against the upstream package's `dist/`, and co-copy any matches — recursively, with cycle protection.

This **subsumes** `discoverExtraFiles` for the sibling-chunk class of problem: chat.mjs's `jsx-runtime-` regex remains in place as belt-and-braces but the new helper catches its matches too. The helper is generic across all vendored packages, so future content-hashed chunks in *any* vendored dependency are picked up automatically — no more per-package regexes.

## Verification

Locally (`pnpm build:compiled`):

```text
ls .generated/compiled/chat/
# LICENSE  _mdast.d.ts  _workflow-serde.d.ts  index.d.ts  index.js
# jsx-runtime-_JEEAotp.d.ts  messages-BSoJG691.d.ts       ← NEW

ls .generated/compiled/@chat-adapter/twilio/
# LICENSE  api.d.ts  api.js  format.d.ts  format.js  index.d.ts  index.js
# types-WYjTBVDi.d.ts  voice.d.ts  voice.js  webhook.d.ts  webhook.js  ← NEW
```

Both chunk filenames and contents match the upstream packages the reporter linked:
- `chat@4.34.0` → `dist/messages-BSoJG691.d.ts` ✓
- `@chat-adapter/twilio@4.35.0` → `dist/types-WYjTBVDi.d.ts` ✓

Test suite: `pnpm exec vitest run test/scenarios/compiled-vendor-assets.scenario.test.ts` — **8/8 pass** (7 existing + 1 new regression test).

Type check on the changed script + test: **clean** (pre-existing baseline of 124 errors in 8 unrelated files unchanged).

## Regression test

Added `(eve#1500) co-copies content-hashed sibling declaration chunks referenced by vendored entries` to `compiled-vendor-assets.scenario.test.ts`:

- Asserts both chunk files exist on disk.
- Asserts `chat/index.d.ts` still references `./messages-BSoJG691` and `webhook.d.ts` still references `./types-WYjTBVDi` (i.e. we copied the target alongside, not stripped the import).

## Why this shape and not the cheap fix

Alternative considered: just extend the regexes to include `messages-*.d.ts` and `types-*.d.ts`. Rejected because (a) rollup hashes change per version bump and would silently re-break on the next vendored dependency upgrade, and (b) the reactive-regex pattern would have caught this bug only for the two currently-known chunks. The transitive closure approach is immune to hash churn and automatically picks up new chunks in any vendored package.
