### PR TITLE
refactor(eve): use public dynamic definitions for connection tools

### DIFF
--- a/.changeset/clean-connection-dynamic-tools.md
+++ b/.changeset/clean-connection-dynamic-tools.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Connection search and discovered connection tools now use the same `defineDynamic` and `defineTool` pipeline as authored tools. Dynamic tool maps now reject entries that omit `defineTool` instead of accepting unsupported raw objects.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -292,7 +292,7 @@
     "clean": "node -e \"fs.rmSync('dist', { recursive: true, force: true })\"",
     "build": "pnpm run check:bin-runtime-dependencies && pnpm run build:js && node ./scripts/copy-docs.mjs && node ./scripts/stamp-version-tokens.mjs",
     "build:compiled": "node ./scripts/vendor-compiled.mjs",
-    "build:js": "pnpm run build:compiled && pnpm run clean && pnpm run build:types && node ./scripts/copy-compiled-assets.mjs && node ./scripts/build-rolldown.mjs && node ./scripts/copy-runtime-assets.mjs",
+    "build:js": "pnpm run build:compiled && pnpm run clean && pnpm run build:types && node ./scripts/copy-compiled-assets.mjs && node --conditions=eve-source ./scripts/build-rolldown.mjs && node ./scripts/copy-runtime-assets.mjs",
     "build:types": "pnpm run build:compiled && tsc -p tsconfig.build.json",
     "check:bin-runtime-dependencies": "node ./scripts/check-bin-runtime-dependencies.mjs",
     "dev": "pnpm run build:compiled && node ./scripts/copy-runtime-assets.mjs && tsc -p tsconfig.dev.json --watch --preserveWatchOutput",

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -5,6 +5,7 @@ import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import type { ApprovalContext } from "#public/definitions/approval.js";
 import { defineTool, type ToolContext } from "#public/definitions/tool.js";
+import type { JsonObject } from "#shared/json.js";
 import { serializeOutputSchema, type ToolSchema } from "#shared/tool-schema.js";
 
 vi.mock("#context/build-callback-context.js", () => ({
@@ -589,7 +590,7 @@ describe("dispatchDynamicToolEvent", () => {
 
   it("leaves unsupported connection input schemas for the MCP server to validate", async () => {
     const ctx = createCtx();
-    const inputSchema = {
+    const inputSchema: JsonObject = {
       properties: {
         filters: {
           anyOf: [
@@ -606,11 +607,11 @@ describe("dispatchDynamicToolEvent", () => {
       type: "object",
     };
     const resolver = createResolver("connection", ["step.started"], () => ({
-      remote: {
+      remote: defineTool({
         description: "remote tool",
         inputSchema,
         execute: async (): Promise<unknown> => ({ ok: true }),
-      },
+      }),
     }));
 
     await dispatchDynamicToolEvent({
@@ -956,6 +957,26 @@ describe("dispatchDynamicToolEvent", () => {
     expect(buildDynamicTools(ctx)).toHaveLength(0);
   });
 
+  it("skips map entries that were not created with defineTool", async () => {
+    const ctx = createCtx();
+    const rawResolver = createResolver("raw", ["step.started"], () => ({
+      unwrapped: {
+        description: "raw tool",
+        inputSchema: { type: "object" },
+        execute: async () => ({ ok: true }),
+      },
+    }));
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [rawResolver],
+      messages: [],
+      event: makeEvent("step.started"),
+    });
+
+    expect(buildDynamicTools(ctx)).toHaveLength(0);
+  });
+
   it("resolver throwing is logged and skipped — other resolvers still work", async () => {
     const ctx = createCtx();
     const badResolver = createResolver("bad", ["session.started"], () => {
@@ -1122,12 +1143,12 @@ describe("framework dynamic tools (no bundler transform)", () => {
   it("propagates approval from a step-scoped entry into the harness tool", async () => {
     const ctx = createCtx();
     const approvalFn = vi.fn(() => "user-approval" as const);
-    const entry: DynamicToolEntry = {
+    const entry: DynamicToolEntry = defineTool({
       description: "destructive op",
       inputSchema: { type: "object" },
       approval: approvalFn,
       execute: async (): Promise<unknown> => ({ ok: true }),
-    };
+    });
     const resolver = createResolver("connection", ["step.started"], () => ({ risky: entry }));
     testRegistry.delete("eve:framework-dynamic:connection:risky");
     testRegistry.delete("eve:dynamic-tool-approval:connection:risky");
@@ -1152,12 +1173,12 @@ describe("framework dynamic tools (no bundler transform)", () => {
   it("replays approval from session-scoped dynamic tools", async () => {
     const ctx = createCtx();
     const approvalFn = vi.fn(async () => "user-approval" as const);
-    const entry: DynamicToolEntry = {
+    const entry: DynamicToolEntry = defineTool({
       description: "destructive op",
       inputSchema: { type: "object" },
       approval: approvalFn,
       execute: async (): Promise<unknown> => ({ ok: true }),
-    };
+    });
     const resolver = createResolver("session_guard", ["session.started"], () => ({
       guarded: entry,
     }));
@@ -1190,12 +1211,12 @@ describe("framework dynamic tools (no bundler transform)", () => {
       required: ["ok"],
       type: "object",
     };
-    const entry: DynamicToolEntry = {
+    const entry: DynamicToolEntry = defineTool({
       description: "typed op",
       inputSchema: { type: "object" },
       outputSchema,
       execute: async (): Promise<unknown> => ({ ok: true }),
-    };
+    });
     const resolver = createResolver("connection", ["session.started"], () => ({ typed: entry }));
 
     await dispatchDynamicToolEvent({

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -202,6 +202,31 @@ interface ResolveResult {
   readonly liveTools: readonly HarnessToolDefinition[];
 }
 
+function readDynamicToolResult(
+  resolver: ResolvedDynamicToolResolver,
+  value: unknown,
+): { readonly entries: Record<string, DynamicToolEntry>; readonly isSingle: boolean } {
+  if (isBrandedToolEntry(value)) {
+    return { entries: { _single: value as DynamicToolEntry }, isSingle: true };
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(
+      `Dynamic tool resolver "${resolver.logicalPath}" must return defineTool(), a map of defineTool() values, or null.`,
+    );
+  }
+
+  const entries: Record<string, DynamicToolEntry> = {};
+  for (const [name, entry] of Object.entries(value)) {
+    if (!isBrandedToolEntry(entry)) {
+      throw new Error(
+        `Dynamic tool resolver "${resolver.logicalPath}" returned "${name}" without defineTool(). Wrap every dynamic tool entry in defineTool().`,
+      );
+    }
+    entries[name] = entry as DynamicToolEntry;
+  }
+  return { entries, isSingle: false };
+}
+
 async function resolveToolsFromEvent(
   ctx: ContextContainer,
   resolvers: readonly ResolvedDynamicToolResolver[],
@@ -216,17 +241,7 @@ async function resolveToolsFromEvent(
       const resolveCtx = buildResolveContext(ctx, messages);
       const rawResult = await handler(event, resolveCtx);
       if (rawResult === null || rawResult === undefined) return null;
-
-      let entries: Record<string, DynamicToolEntry>;
-      let isSingle: boolean;
-      if (isBrandedToolEntry(rawResult)) {
-        entries = { _single: rawResult as DynamicToolEntry };
-        isSingle = true;
-      } else {
-        entries = rawResult as Record<string, DynamicToolEntry>;
-        isSingle = false;
-      }
-
+      const { entries, isSingle } = readDynamicToolResult(resolver, rawResult);
       return { resolver, entries, isSingle };
     }),
   );

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
@@ -204,9 +204,9 @@ export function buildAgentInfoResponseFromManifest(
       authored: authoredTools,
       disabledFramework: [...manifest.disabledFrameworkTools],
       dynamic: [
-        ...getFrameworkDynamicToolResolvers({
-          hasConnections: manifest.connections.length > 0,
-        }).map((resolver) => renderDynamicResolver(resolver, { origin: "framework" })),
+        ...getFrameworkDynamicToolResolvers().map((resolver) =>
+          renderDynamicResolver(resolver, { origin: "framework" }),
+        ),
         ...manifest.dynamicTools.map((resolver) =>
           renderDynamicResolver(resolver, { origin: "authored" }),
         ),

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
@@ -1,9 +1,11 @@
-import { getAllFrameworkToolNames } from "#runtime/framework-tools/index.js";
+import {
+  getAllFrameworkToolNames,
+  getFrameworkDynamicToolResolvers,
+} from "#runtime/framework-tools/index.js";
 import {
   getAllFrameworkChannelNames,
   getFrameworkChannelDefinitions,
 } from "#runtime/framework-channels/index.js";
-import { createConnectionSearchResolver } from "#runtime/framework-tools/connection-search-dynamic.js";
 import type { AgentInfoManifestData } from "#internal/nitro/routes/agent-info/load-agent-info-data.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
 import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
@@ -202,9 +204,9 @@ export function buildAgentInfoResponseFromManifest(
       authored: authoredTools,
       disabledFramework: [...manifest.disabledFrameworkTools],
       dynamic: [
-        ...(manifest.connections.length > 0
-          ? [renderDynamicResolver(createConnectionSearchResolver(), { origin: "framework" })]
-          : []),
+        ...getFrameworkDynamicToolResolvers({
+          hasConnections: manifest.connections.length > 0,
+        }).map((resolver) => renderDynamicResolver(resolver, { origin: "framework" })),
         ...manifest.dynamicTools.map((resolver) =>
           renderDynamicResolver(resolver, { origin: "authored" }),
         ),

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -356,9 +356,7 @@ function buildToolInfo(
   const authoredToolNames = new Set(agent.tools.map((tool) => tool.name));
   const disabledFrameworkTools = new Set(agent.disabledFrameworkTools);
   const allFrameworkToolNames = getAllFrameworkToolNames();
-  const dynamicFrameworkResolvers = getFrameworkDynamicToolResolvers({
-    hasConnections: agent.connections.length > 0,
-  });
+  const dynamicFrameworkResolvers = getFrameworkDynamicToolResolvers();
   const authored = agent.tools.map((tool) =>
     renderTool(tool, {
       origin: "authored",

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -2,12 +2,12 @@ import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
+  getFrameworkDynamicToolResolvers,
 } from "#runtime/framework-tools/index.js";
 import {
   getAllFrameworkChannelNames,
   getFrameworkChannelDefinitions,
 } from "#runtime/framework-channels/index.js";
-import { createConnectionSearchResolver } from "#runtime/framework-tools/connection-search-dynamic.js";
 import type {
   AgentInfoData,
   CompiledAgentManifest,
@@ -356,8 +356,9 @@ function buildToolInfo(
   const authoredToolNames = new Set(agent.tools.map((tool) => tool.name));
   const disabledFrameworkTools = new Set(agent.disabledFrameworkTools);
   const allFrameworkToolNames = getAllFrameworkToolNames();
-  const dynamicFrameworkResolvers =
-    agent.connections.length > 0 ? [createConnectionSearchResolver()] : [];
+  const dynamicFrameworkResolvers = getFrameworkDynamicToolResolvers({
+    hasConnections: agent.connections.length > 0,
+  });
   const authored = agent.tools.map((tool) =>
     renderTool(tool, {
       origin: "authored",

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -53,7 +53,7 @@ async function executeConnectionSearch(
 }
 
 function getConnectionSearchResolver() {
-  return getFrameworkDynamicToolResolvers({ hasConnections: true })[0]!;
+  return getFrameworkDynamicToolResolvers()[0]!;
 }
 
 function registry(input: {
@@ -76,6 +76,31 @@ function registry(input: {
 }
 
 describe("connection dynamic tools", () => {
+  it("contributes no tools when no connections are available", async () => {
+    const ctx = new ContextContainer();
+    ctx.set(
+      ConnectionRegistryKey,
+      registry({
+        connections: [],
+        loadTools: {},
+      }),
+    );
+    const resolve = getConnectionSearchResolver().events["step.started"]!;
+
+    const tools = await contextStorage.run(ctx, () =>
+      resolve(
+        {},
+        {
+          channel: {},
+          messages: [],
+          session: { auth: { current: null, initiator: null }, id: "test-session" },
+        },
+      ),
+    );
+
+    expect(tools).toBeNull();
+  });
+
   it("uses the shared resolver and public tool definitions", async () => {
     const linear = connection("linear");
     const connectionRegistry = registry({

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -8,11 +8,15 @@ import { ConnectionAuthorizationRequiredError } from "#public/connections/errors
 import type { ToolContext } from "#public/definitions/tool.js";
 import type { ConnectionRegistry, ConnectionToolMetadata } from "#runtime/connections/types.js";
 import {
-  createConnectionSearchEvents,
+  createConnectionSearchResolver,
   extractDiscoveredTools,
 } from "#runtime/framework-tools/connection-search-dynamic.js";
 import type { ResolvedConnectionDefinition } from "#runtime/types.js";
-import type { DynamicResolveContext, DynamicToolSet } from "#shared/dynamic-tool-definition.js";
+import {
+  isBrandedToolEntry,
+  type DynamicResolveContext,
+  type DynamicToolSet,
+} from "#shared/dynamic-tool-definition.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Msg = any;
@@ -39,7 +43,7 @@ async function executeConnectionSearch(
   setupContext?.(ctx);
 
   return contextStorage.run(ctx, async () => {
-    const resolve = createConnectionSearchEvents()["step.started"]!;
+    const resolve = createConnectionSearchResolver().events["step.started"]!;
     const resolved = (await resolve({}, {
       channel: {},
       messages: [],
@@ -68,6 +72,56 @@ function registry(input: {
     getConnections: () => input.connections,
   };
 }
+
+describe("connection dynamic tools", () => {
+  it("uses the shared resolver and public tool definitions", async () => {
+    const linear = connection("linear");
+    const connectionRegistry = registry({
+      connections: [linear],
+      loadTools: { linear: async () => [] },
+    });
+    const messages: Msg[] = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "connection_search",
+            output: [
+              {
+                connection: "linear",
+                description: "List issues",
+                inputSchema: { type: "object" },
+                qualifiedName: "linear__list_issues",
+                tool: "list_issues",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const ctx = new ContextContainer();
+    ctx.set(ConnectionRegistryKey, connectionRegistry);
+    const resolver = createConnectionSearchResolver();
+    const resolve = resolver.events["step.started"]!;
+
+    const tools = await contextStorage.run(ctx, async () => {
+      return (await resolve(
+        {},
+        {
+          channel: {},
+          messages,
+          session: { auth: { current: null, initiator: null }, id: "test-session" },
+        },
+      )) as DynamicToolSet;
+    });
+
+    expect(resolver.eventNames).toEqual(["step.started"]);
+    expect(Object.keys(tools)).toEqual(["connection_search", "linear__list_issues"]);
+    expect(Object.values(tools).every(isBrandedToolEntry)).toBe(true);
+  });
+});
 
 describe("connection_search", () => {
   it("fails when every targeted connection fails to load", async () => {

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -7,10 +7,8 @@ import { CallbackBaseUrlKey, isAuthorizationSignal } from "#harness/authorizatio
 import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
 import type { ToolContext } from "#public/definitions/tool.js";
 import type { ConnectionRegistry, ConnectionToolMetadata } from "#runtime/connections/types.js";
-import {
-  createConnectionSearchResolver,
-  extractDiscoveredTools,
-} from "#runtime/framework-tools/connection-search-dynamic.js";
+import { extractDiscoveredTools } from "#runtime/framework-tools/connection-search-dynamic.js";
+import { getFrameworkDynamicToolResolvers } from "#runtime/framework-tools/index.js";
 import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import {
   isBrandedToolEntry,
@@ -43,7 +41,7 @@ async function executeConnectionSearch(
   setupContext?.(ctx);
 
   return contextStorage.run(ctx, async () => {
-    const resolve = createConnectionSearchResolver().events["step.started"]!;
+    const resolve = getConnectionSearchResolver().events["step.started"]!;
     const resolved = (await resolve({}, {
       channel: {},
       messages: [],
@@ -52,6 +50,10 @@ async function executeConnectionSearch(
 
     return resolved["connection_search"]!.execute(input, {} as ToolContext);
   });
+}
+
+function getConnectionSearchResolver() {
+  return getFrameworkDynamicToolResolvers({ hasConnections: true })[0]!;
 }
 
 function registry(input: {
@@ -103,7 +105,7 @@ describe("connection dynamic tools", () => {
     ];
     const ctx = new ContextContainer();
     ctx.set(ConnectionRegistryKey, connectionRegistry);
-    const resolver = createConnectionSearchResolver();
+    const resolver = getConnectionSearchResolver();
     const resolve = resolver.events["step.started"]!;
 
     const tools = await contextStorage.run(ctx, async () => {

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -30,8 +30,6 @@ import {
   type InteractiveAuthorizationDefinition,
   supportsInteractiveAuthorization,
 } from "#runtime/connections/types.js";
-import { resolveDynamicToolValue } from "#runtime/resolve-dynamic-tool.js";
-import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
 import { createLogger } from "#internal/logging.js";
 import { toError } from "#shared/errors.js";
 import type { ModelMessage } from "ai";
@@ -392,7 +390,7 @@ export function extractDiscoveredTools(
 
 // The step-scoped definition re-derives its tools from conversation history.
 // After compaction removes old search results, those tools naturally disappear.
-const CONNECTION_SEARCH_DYNAMIC_DEFINITION = defineDynamic({
+const connectionSearchDynamicDefinition = defineDynamic({
   events: {
     "step.started": async (_event, ctx) => {
       const registry = loadContext().get(ConnectionRegistryKey);
@@ -516,16 +514,4 @@ const CONNECTION_SEARCH_DYNAMIC_DEFINITION = defineDynamic({
   },
 });
 
-/**
- * Creates a `ResolvedDynamicToolResolver` for the framework connection
- * search tool. Used by graph resolution to register alongside authored
- * dynamic tool resolvers.
- */
-export function createConnectionSearchResolver(): ResolvedDynamicToolResolver {
-  return resolveDynamicToolValue(CONNECTION_SEARCH_DYNAMIC_DEFINITION, {
-    sourceId: "eve:connection-search-dynamic",
-    sourceKind: "module",
-    logicalPath: "eve:framework/connection-search-dynamic",
-    slug: "connection",
-  });
-}
+export default connectionSearchDynamicDefinition;

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -14,6 +14,7 @@ import {
   isConnectionAuthorizationFailedError,
   isConnectionAuthorizationRequiredError,
 } from "#public/connections/errors.js";
+import { defineDynamic, defineTool } from "#public/definitions/tool.js";
 import type { JsonValue } from "#public/types/json.js";
 import type { JsonObject } from "#shared/json.js";
 import { writeCachedToken } from "#runtime/connections/authorization-tokens.js";
@@ -29,9 +30,9 @@ import {
   type InteractiveAuthorizationDefinition,
   supportsInteractiveAuthorization,
 } from "#runtime/connections/types.js";
+import { resolveDynamicToolValue } from "#runtime/resolve-dynamic-tool.js";
 import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
 import { createLogger } from "#internal/logging.js";
-import type { DynamicToolEvents, DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import { toError } from "#shared/errors.js";
 import type { ModelMessage } from "ai";
 
@@ -389,16 +390,10 @@ export function extractDiscoveredTools(
   return [...byQualifiedName.values()];
 }
 
-/**
- * Creates the connection search dynamic tool resolver events.
- *
- * The resolver subscribes to `step.started` so it re-derives the tool
- * set from conversation history on every step. After compaction, old
- * `connection_search` results disappear from messages and discovered
- * tools naturally drop from the toolset.
- */
-export function createConnectionSearchEvents(): DynamicToolEvents {
-  return {
+// The step-scoped definition re-derives its tools from conversation history.
+// After compaction removes old search results, those tools naturally disappear.
+const CONNECTION_SEARCH_DYNAMIC_DEFINITION = defineDynamic({
+  events: {
     "step.started": async (_event, ctx) => {
       const registry = loadContext().get(ConnectionRegistryKey);
       if (!registry || registry.getConnections().length === 0) return null;
@@ -416,10 +411,9 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
       }
       const discovered = [...mergedMap.values()];
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tools: Record<string, DynamicToolEntry<any, any>> = {};
+      const tools: Record<string, object> = {};
 
-      tools["connection_search"] = {
+      tools["connection_search"] = defineTool({
         description:
           "Search for tools across your connections. " +
           "Discovered tools become directly callable by their qualified name " +
@@ -430,14 +424,14 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
           return executeConnectionSearch(input);
         },
         outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
-      };
+      });
 
       for (const result of discovered) {
         const connectionName = result.connection;
         const toolName = result.tool!;
         const approval = registry.getConnectionApproval(connectionName);
 
-        tools[qualifiedConnectionToolName(connectionName, toolName)] = {
+        tools[qualifiedConnectionToolName(connectionName, toolName)] = defineTool({
           description: result.description,
           inputSchema: (result.inputSchema ?? {
             type: "object",
@@ -514,13 +508,13 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
               ]);
             }
           },
-        };
+        });
       }
 
       return tools;
     },
-  };
-}
+  },
+});
 
 /**
  * Creates a `ResolvedDynamicToolResolver` for the framework connection
@@ -528,13 +522,10 @@ export function createConnectionSearchEvents(): DynamicToolEvents {
  * dynamic tool resolvers.
  */
 export function createConnectionSearchResolver(): ResolvedDynamicToolResolver {
-  const events = createConnectionSearchEvents();
-  return {
-    slug: "connection",
-    eventNames: Object.keys(events),
-    events: events as ResolvedDynamicToolResolver["events"],
+  return resolveDynamicToolValue(CONNECTION_SEARCH_DYNAMIC_DEFINITION, {
     sourceId: "eve:connection-search-dynamic",
     sourceKind: "module",
     logicalPath: "eve:framework/connection-search-dynamic",
-  };
+    slug: "connection",
+  });
 }

--- a/packages/eve/src/runtime/framework-tools/index.test.ts
+++ b/packages/eve/src/runtime/framework-tools/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
+  getFrameworkDynamicToolResolvers,
   getFrameworkToolDefinitions,
 } from "#runtime/framework-tools/index.js";
 import { isToolSchema } from "#shared/tool-schema.js";
@@ -61,12 +62,15 @@ describe("framework-tools/index", () => {
     }
   });
 
-  it("returns the same registered tools regardless of hasConnections", () => {
-    const withConnections = getFrameworkToolDefinitions({ hasConnections: true });
-    const withoutConnections = getFrameworkToolDefinitions({ hasConnections: false });
-
-    expect(withConnections.map((tool) => tool.name)).toEqual(
-      withoutConnections.map((tool) => tool.name),
-    );
+  it("registers connection search through the framework dynamic tool registry", () => {
+    expect(getFrameworkDynamicToolResolvers({ hasConnections: false })).toEqual([]);
+    expect(getFrameworkDynamicToolResolvers({ hasConnections: true })).toMatchObject([
+      {
+        eventNames: ["step.started"],
+        logicalPath: "eve:framework/connection-search-dynamic",
+        slug: "connection",
+        sourceId: "eve:connection-search-dynamic",
+      },
+    ]);
   });
 });

--- a/packages/eve/src/runtime/framework-tools/index.test.ts
+++ b/packages/eve/src/runtime/framework-tools/index.test.ts
@@ -63,8 +63,7 @@ describe("framework-tools/index", () => {
   });
 
   it("registers connection search through the framework dynamic tool registry", () => {
-    expect(getFrameworkDynamicToolResolvers({ hasConnections: false })).toEqual([]);
-    expect(getFrameworkDynamicToolResolvers({ hasConnections: true })).toMatchObject([
+    expect(getFrameworkDynamicToolResolvers()).toMatchObject([
       {
         eventNames: ["step.started"],
         logicalPath: "eve:framework/connection-search-dynamic",

--- a/packages/eve/src/runtime/framework-tools/index.ts
+++ b/packages/eve/src/runtime/framework-tools/index.ts
@@ -30,20 +30,14 @@ import type { DynamicSentinel } from "#shared/dynamic-tool-definition.js";
 
 interface FrameworkDynamicToolDefinition {
   readonly definition: DynamicSentinel;
-  readonly isEnabled: (config: FrameworkDynamicToolConfig) => boolean;
   readonly logicalPath: string;
   readonly slug: string;
   readonly sourceId: string;
 }
 
-interface FrameworkDynamicToolConfig {
-  readonly hasConnections: boolean;
-}
-
 const REGISTERED_FRAMEWORK_DYNAMIC_TOOLS: readonly FrameworkDynamicToolDefinition[] = [
   {
     definition: connectionSearchDynamicDefinition,
-    isEnabled: (config) => config.hasConnections,
     logicalPath: "eve:framework/connection-search-dynamic",
     slug: "connection",
     sourceId: "eve:connection-search-dynamic",
@@ -89,21 +83,18 @@ export function getFrameworkToolDefinitions(config?: {
 }
 
 /**
- * Returns framework-owned dynamic tool resolvers enabled for an agent.
+ * Returns framework-owned dynamic tool resolvers.
  * Framework definitions use the public `defineDynamic()` contract and enter
  * the same loaded-definition resolver path as authored dynamic tools.
  */
-export function getFrameworkDynamicToolResolvers(
-  config: FrameworkDynamicToolConfig,
-): readonly ResolvedDynamicToolResolver[] {
-  return REGISTERED_FRAMEWORK_DYNAMIC_TOOLS.filter((entry) => entry.isEnabled(config)).map(
-    (entry) =>
-      resolveLoadedDynamicToolDefinition(entry.definition, {
-        logicalPath: entry.logicalPath,
-        slug: entry.slug,
-        sourceId: entry.sourceId,
-        sourceKind: "module",
-      }),
+export function getFrameworkDynamicToolResolvers(): readonly ResolvedDynamicToolResolver[] {
+  return REGISTERED_FRAMEWORK_DYNAMIC_TOOLS.map((entry) =>
+    resolveLoadedDynamicToolDefinition(entry.definition, {
+      logicalPath: entry.logicalPath,
+      slug: entry.slug,
+      sourceId: entry.sourceId,
+      sourceKind: "module",
+    }),
   );
 }
 

--- a/packages/eve/src/runtime/framework-tools/index.ts
+++ b/packages/eve/src/runtime/framework-tools/index.ts
@@ -12,6 +12,8 @@ import { TODO_TOOL_DEFINITION } from "#runtime/framework-tools/todo.js";
 import { WEB_FETCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-fetch.js";
 import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
 import { WRITE_FILE_TOOL_DEFINITION } from "#runtime/framework-tools/write-file.js";
+import connectionSearchDynamicDefinition from "#runtime/framework-tools/connection-search-dynamic.js";
+import { resolveLoadedDynamicToolDefinition } from "#runtime/resolve-dynamic-tool.js";
 
 export { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 export type { ReadFileStamp, ReadFileState } from "#runtime/framework-tools/file-state.js";
@@ -19,7 +21,34 @@ export { ReadFileStateKey } from "#runtime/framework-tools/file-state.js";
 export type { TodoItem, TodoState } from "#runtime/framework-tools/todo.js";
 export { TodoStateKey } from "#runtime/framework-tools/todo.js";
 
-import type { ResolvedSkillDefinition, ResolvedToolDefinition } from "#runtime/types.js";
+import type {
+  ResolvedDynamicToolResolver,
+  ResolvedSkillDefinition,
+  ResolvedToolDefinition,
+} from "#runtime/types.js";
+import type { DynamicSentinel } from "#shared/dynamic-tool-definition.js";
+
+interface FrameworkDynamicToolDefinition {
+  readonly definition: DynamicSentinel;
+  readonly isEnabled: (config: FrameworkDynamicToolConfig) => boolean;
+  readonly logicalPath: string;
+  readonly slug: string;
+  readonly sourceId: string;
+}
+
+interface FrameworkDynamicToolConfig {
+  readonly hasConnections: boolean;
+}
+
+const REGISTERED_FRAMEWORK_DYNAMIC_TOOLS: readonly FrameworkDynamicToolDefinition[] = [
+  {
+    definition: connectionSearchDynamicDefinition,
+    isEnabled: (config) => config.hasConnections,
+    logicalPath: "eve:framework/connection-search-dynamic",
+    slug: "connection",
+    sourceId: "eve:connection-search-dynamic",
+  },
+];
 
 const REGISTERED_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
   ASK_QUESTION_TOOL_DEFINITION,
@@ -48,7 +77,6 @@ const ALL_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
  */
 export function getFrameworkToolDefinitions(config?: {
   readonly authoredSkills?: readonly ResolvedSkillDefinition[];
-  readonly hasConnections?: boolean;
 }): readonly ResolvedToolDefinition[] {
   const authoredSkills = config?.authoredSkills;
   if (authoredSkills === undefined) return REGISTERED_FRAMEWORK_TOOLS;
@@ -57,6 +85,25 @@ export function getFrameworkToolDefinitions(config?: {
     definition.name === SKILL_TOOL_DEFINITION.name
       ? createSkillToolDefinition(authoredSkills)
       : definition,
+  );
+}
+
+/**
+ * Returns framework-owned dynamic tool resolvers enabled for an agent.
+ * Framework definitions use the public `defineDynamic()` contract and enter
+ * the same loaded-definition resolver path as authored dynamic tools.
+ */
+export function getFrameworkDynamicToolResolvers(
+  config: FrameworkDynamicToolConfig,
+): readonly ResolvedDynamicToolResolver[] {
+  return REGISTERED_FRAMEWORK_DYNAMIC_TOOLS.filter((entry) => entry.isEnabled(config)).map(
+    (entry) =>
+      resolveLoadedDynamicToolDefinition(entry.definition, {
+        logicalPath: entry.logicalPath,
+        slug: entry.slug,
+        sourceId: entry.sourceId,
+        sourceKind: "module",
+      }),
   );
 }
 

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -136,7 +136,6 @@ async function resolveRuntimeAgentNode(
     moduleMap: input.moduleMap,
     nodeId: input.nodeId,
   });
-  const hasConnections = agent.connections.length > 0;
   const frameworkTools = getFrameworkToolDefinitions({
     authoredSkills: agent.skills,
   });
@@ -231,10 +230,7 @@ async function resolveRuntimeAgentNode(
   });
   const resolvedAgent = {
     ...agent,
-    dynamicToolResolvers: [
-      ...agent.dynamicToolResolvers,
-      ...getFrameworkDynamicToolResolvers({ hasConnections }),
-    ],
+    dynamicToolResolvers: [...agent.dynamicToolResolvers, ...getFrameworkDynamicToolResolvers()],
   };
 
   const node: ResolvedAgentGraphBundle["root"] = {

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -13,9 +13,9 @@ import {
   getAllFrameworkChannelNames,
   getFrameworkChannelDefinitions,
 } from "#runtime/framework-channels/index.js";
-import { createConnectionSearchResolver } from "#runtime/framework-tools/connection-search-dynamic.js";
 import {
   getAllFrameworkToolNames,
+  getFrameworkDynamicToolResolvers,
   getFrameworkToolDefinitions,
 } from "#runtime/framework-tools/index.js";
 import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
@@ -139,7 +139,6 @@ async function resolveRuntimeAgentNode(
   const hasConnections = agent.connections.length > 0;
   const frameworkTools = getFrameworkToolDefinitions({
     authoredSkills: agent.skills,
-    hasConnections,
   });
   const frameworkToolNames = new Set(frameworkTools.map((t) => t.name));
   const allFrameworkToolNames = getAllFrameworkToolNames();
@@ -230,12 +229,13 @@ async function resolveRuntimeAgentNode(
       subagentNodesById: input.subagentNodesById,
     }),
   });
-  const resolvedAgent = hasConnections
-    ? {
-        ...agent,
-        dynamicToolResolvers: [...agent.dynamicToolResolvers, createConnectionSearchResolver()],
-      }
-    : agent;
+  const resolvedAgent = {
+    ...agent,
+    dynamicToolResolvers: [
+      ...agent.dynamicToolResolvers,
+      ...getFrameworkDynamicToolResolvers({ hasConnections }),
+    ],
+  };
 
   const node: ResolvedAgentGraphBundle["root"] = {
     agent: resolvedAgent,

--- a/packages/eve/src/runtime/resolve-dynamic-tool.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-tool.ts
@@ -35,8 +35,8 @@ export async function resolveDynamicToolDefinition(
       moduleMap,
       nodeId,
     });
-    return createResolvedDynamicToolResolver(
-      expectDynamicToolValue(resolvedExportValue, definition),
+    return resolveLoadedDynamicToolDefinition(
+      resolvedExportValue,
       definition,
       definition.eventNames,
     );
@@ -55,21 +55,23 @@ export async function resolveDynamicToolDefinition(
 }
 
 /**
- * Resolves an in-memory public `defineDynamic()` value into the runtime shape
- * used by the dynamic-tool lifecycle.
+ * Resolves a loaded public `defineDynamic()` value into the runtime shape used
+ * by the dynamic-tool lifecycle.
  *
- * Framework-owned dynamic tools use this path because they have no authored
- * module to load from the compiled module map. Their definitions otherwise
- * follow the same public contract as authored dynamic tools.
+ * Authored definitions reach this boundary after module-map loading.
+ * Framework-owned definitions are already loaded with eve itself. Both use
+ * the same validation, source registration, and resolver construction here.
  */
-export function resolveDynamicToolValue(
-  value: DynamicSentinel,
+export function resolveLoadedDynamicToolDefinition(
+  value: unknown,
   source: DynamicToolResolverSource,
+  eventNames?: readonly string[],
 ): ResolvedDynamicToolResolver {
+  const definition = expectDynamicToolValue(value, source);
   return createResolvedDynamicToolResolver(
-    expectDynamicToolValue(value, source),
+    definition,
     source,
-    Object.keys(value.events),
+    eventNames ?? Object.keys(definition.events),
   );
 }
 

--- a/packages/eve/src/runtime/resolve-dynamic-tool.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-tool.ts
@@ -2,9 +2,18 @@ import type { CompiledDynamicToolDefinition } from "#compiler/manifest.js";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
 import { expectFunction, expectObjectRecord } from "#internal/authored-module.js";
 import { registerDefinitionSource, stampDefinitionKey } from "#public/tool-result-narrowing.js";
+import { isDynamicSentinel, type DynamicSentinel } from "#shared/dynamic-tool-definition.js";
 import { toErrorMessage } from "#shared/errors.js";
+import type { ModuleSourceRef } from "#shared/source-ref.js";
 import { loadResolvedModuleExport, ResolveAgentError } from "#runtime/resolve-helpers.js";
 import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
+
+type DynamicToolResolverSource = Readonly<
+  ModuleSourceRef & {
+    readonly extensionNamespace?: string;
+    readonly slug: string;
+  }
+>;
 
 /**
  * Resolves one compiled dynamic tool entry into a runtime-owned resolver
@@ -26,42 +35,11 @@ export async function resolveDynamicToolDefinition(
       moduleMap,
       nodeId,
     });
-    const resolvedRecord = expectObjectRecord(
-      resolvedExportValue,
-      describe(definition, "to return an object"),
+    return createResolvedDynamicToolResolver(
+      expectDynamicToolValue(resolvedExportValue, definition),
+      definition,
+      definition.eventNames,
     );
-
-    const events = expectObjectRecord(
-      resolvedRecord.events,
-      describe(definition, "to provide an events object"),
-    );
-
-    const handlers: Record<string, Function> = {};
-    for (const eventName of definition.eventNames) {
-      handlers[eventName] = expectFunction(
-        events[eventName],
-        describe(definition, `to provide a handler for event "${eventName}"`),
-      );
-    }
-
-    const sourceKey = `dynamic-tool-source:${definition.sourceId}`;
-    stampDefinitionKey(resolvedRecord, sourceKey);
-    registerDefinitionSource(sourceKey, {
-      kind: "tool",
-      logicalPath: definition.logicalPath,
-      name: definition.slug,
-    });
-
-    return {
-      eventNames: [...definition.eventNames],
-      events: handlers as ResolvedDynamicToolResolver["events"],
-      exportName: definition.exportName,
-      extensionNamespace: definition.extensionNamespace,
-      logicalPath: definition.logicalPath,
-      slug: definition.slug,
-      sourceId: definition.sourceId,
-      sourceKind: "module",
-    };
   } catch (error) {
     if (error instanceof ResolveAgentError) {
       throw error;
@@ -76,6 +54,70 @@ export async function resolveDynamicToolDefinition(
   }
 }
 
-function describe(definition: CompiledDynamicToolDefinition, predicate: string): string {
+/**
+ * Resolves an in-memory public `defineDynamic()` value into the runtime shape
+ * used by the dynamic-tool lifecycle.
+ *
+ * Framework-owned dynamic tools use this path because they have no authored
+ * module to load from the compiled module map. Their definitions otherwise
+ * follow the same public contract as authored dynamic tools.
+ */
+export function resolveDynamicToolValue(
+  value: DynamicSentinel,
+  source: DynamicToolResolverSource,
+): ResolvedDynamicToolResolver {
+  return createResolvedDynamicToolResolver(
+    expectDynamicToolValue(value, source),
+    source,
+    Object.keys(value.events),
+  );
+}
+
+function createResolvedDynamicToolResolver(
+  value: DynamicSentinel,
+  source: DynamicToolResolverSource,
+  eventNames: readonly string[],
+): ResolvedDynamicToolResolver {
+  const handlers: Record<string, Function> = {};
+  for (const eventName of eventNames) {
+    handlers[eventName] = expectFunction(
+      value.events[eventName as keyof typeof value.events],
+      describe(source, `to provide a handler for event "${eventName}"`),
+    );
+  }
+
+  const sourceKey = `dynamic-tool-source:${source.sourceId}`;
+  stampDefinitionKey(value, sourceKey);
+  registerDefinitionSource(sourceKey, {
+    kind: "tool",
+    logicalPath: source.logicalPath,
+    name: source.slug,
+  });
+
+  return {
+    eventNames: [...eventNames],
+    events: handlers as ResolvedDynamicToolResolver["events"],
+    exportName: source.exportName,
+    extensionNamespace: source.extensionNamespace,
+    logicalPath: source.logicalPath,
+    slug: source.slug,
+    sourceId: source.sourceId,
+    sourceKind: "module",
+  };
+}
+
+function expectDynamicToolValue(
+  value: unknown,
+  definition: DynamicToolResolverSource,
+): DynamicSentinel {
+  const record = expectObjectRecord(value, describe(definition, "to return an object"));
+  if (!isDynamicSentinel(record)) {
+    throw new Error(describe(definition, "to be created by defineDynamic()"));
+  }
+  expectObjectRecord(record.events, describe(definition, "to provide an events object"));
+  return record;
+}
+
+function describe(definition: DynamicToolResolverSource, predicate: string): string {
   return `Expected the dynamic tool export "${definition.exportName ?? "default"}" from "${definition.logicalPath}" ${predicate}.`;
 }


### PR DESCRIPTION
## Summary

- make the framework connection module default-export a normal public `defineDynamic` definition whose tools use `defineTool`
- register framework-owned dynamic definitions unconditionally through a generic registry, with each definition deciding whether it contributes tools at resolution time
- remove `hasConnections` plumbing from graph resolution and both agent-info paths; connection search now returns `null` when no connections are available
- converge authored and framework definitions at the same loaded-definition validation and resolver boundary
- reject unbranded raw objects from dynamic tool maps
- build framework dynamic tools with the eve source condition so durable transforms work from a clean checkout

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm typecheck`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build`
- `pnpm test:unit` (560 files; 5,836 passed, 1 skipped)
- focused connection/framework/graph/agent-info tests (35 passed)