### PR TITLE
feat(tui): rename /new command to /reset

### DIFF
--- a/.changeset/brisk-owls-reset.md
+++ b/.changeset/brisk-owls-reset.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Rename the TUI `/new` command to `/reset` so session reset uses the same name across the client, HTTP, channel, and TUI APIs.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -41,7 +41,7 @@ Each command echoes as an invocation line, asks through a bordered panel that ta
 | `/vc:login`   | Logs in to Vercel locally. On a remote session, resolves the deployment's project, refreshes its OIDC token, and confirms any required Trusted Sources rule. |
 | `/loglevel`   | Switches which logs the transcript shows. See [Control what logs show](#control-what-logs-show).                                                             |
 | `/traces`     | Opens the full-screen local trace viewer. See [Inspect traces](#inspect-traces).                                                                             |
-| `/new`        | Starts a fresh session.                                                                                                                                      |
+| `/reset`      | Starts a fresh session.                                                                                                                                      |
 | `/cancel`     | Cooperatively cancels the running turn while preserving the session and settled context.                                                                     |
 | `/clear`      | Clears model-message history while preserving the current session and its durable resources.                                                                 |
 | `/compact`    | Queues context compaction for the current session without sending a message.                                                                                 |

--- a/packages/eve/src/cli/dev/tui/command-typeahead.test.ts
+++ b/packages/eve/src/cli/dev/tui/command-typeahead.test.ts
@@ -22,7 +22,7 @@ function spec(name: string, options?: Partial<PromptCommandSpec>): PromptCommand
     aliases: [],
     description: `${name} command`,
     takesArgument: false,
-    build: () => ({ type: "new" }),
+    build: () => ({ type: "reset" }),
     ...options,
   };
 }

--- a/packages/eve/src/cli/dev/tui/prompt-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-commands.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./prompt-commands.js";
 
 describe("parsePromptCommand", () => {
-  it("parses /new", () => {
-    expect(parsePromptCommand("/new")).toEqual({ type: "new" });
+  it("parses /reset", () => {
+    expect(parsePromptCommand("/reset")).toEqual({ type: "reset" });
   });
 
   it("parses /cancel", () => {
@@ -76,10 +76,11 @@ describe("parsePromptCommand", () => {
   });
 
   it("trims surrounding whitespace before matching", () => {
-    expect(parsePromptCommand("  /new  ")).toEqual({ type: "new" });
+    expect(parsePromptCommand("  /reset  ")).toEqual({ type: "reset" });
   });
 
   it("rejects near-misses and ordinary prompts", () => {
+    expect(parsePromptCommand("/new")).toBeNull();
     expect(parsePromptCommand("/models")).toBeNull();
     expect(parsePromptCommand("/vercel")).toBeNull();
     expect(parsePromptCommand("/vc")).toBeNull();
@@ -130,7 +131,7 @@ describe("promptCommandsFor", () => {
 
 describe("isPromptControlCommand", () => {
   it("is true exactly for recognized commands", () => {
-    expect(isPromptControlCommand("/new")).toBe(true);
+    expect(isPromptControlCommand("/reset")).toBe(true);
     expect(isPromptControlCommand("/model gpt-5")).toBe(true);
     expect(isPromptControlCommand("/unknown")).toBe(false);
     expect(isPromptControlCommand("hello")).toBe(false);

--- a/packages/eve/src/cli/dev/tui/prompt-commands.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-commands.ts
@@ -4,7 +4,7 @@ type PromptCommandTarget = "local" | "remote";
 
 /** The slash commands the prompt accepts. */
 export type PromptCommand =
-  | { type: "new" }
+  | { type: "reset" }
   | { type: "cancel" }
   | { type: "clear" }
   | { type: "compact" }
@@ -44,7 +44,7 @@ interface PromptCommandDefinition extends PromptCommandSpec {
  */
 const PROMPT_COMMAND_DEFINITIONS = [
   // `help` leads so that the typeahead's default highlight — what a bare `/`
-  // plus Enter submits — is the safest command, not session-resetting `/new`.
+  // plus Enter submits — is the safest command, not session-resetting `/reset`.
   {
     name: "help",
     aliases: [],
@@ -54,11 +54,11 @@ const PROMPT_COMMAND_DEFINITIONS = [
     targets: ["local", "remote"],
   },
   {
-    name: "new",
+    name: "reset",
     aliases: [],
     description: "Start a fresh session",
     takesArgument: false,
-    build: () => ({ type: "new" }),
+    build: () => ({ type: "reset" }),
     targets: ["local", "remote"],
   },
   {
@@ -173,7 +173,7 @@ export function isPromptCommandAvailableFor(
 }
 
 /**
- * Recognizes the slash commands the prompt accepts. `/new` clears the
+ * Recognizes the slash commands the prompt accepts. `/reset` clears the
  * session and transcript; `/cancel` stops the running turn; `/clear` clears
  * context; `/compact` queues context compaction; `/exit` (and `/quit`)
  * terminate the TUI like Ctrl+C; extension commands are dispatched outside

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -197,8 +197,8 @@ describe("parsePromptCommand", () => {
     });
   });
 
-  it("recognizes /new, /cancel, /clear, /compact, /exit, and /quit", () => {
-    expect(parsePromptCommand("/new")).toEqual({ type: "new" });
+  it("recognizes /reset, /cancel, /clear, /compact, /exit, and /quit", () => {
+    expect(parsePromptCommand("/reset")).toEqual({ type: "reset" });
     expect(parsePromptCommand("/cancel")).toEqual({ type: "cancel" });
     expect(parsePromptCommand("/clear")).toEqual({ type: "clear" });
     expect(parsePromptCommand("/compact")).toEqual({ type: "compact" });
@@ -627,7 +627,7 @@ describe("EveTUIRunner development session continuity", () => {
     ).toEqual(["/eve/v1/session", "/eve/v1/session/session-1"]);
   });
 
-  it("starts a fresh session only after an explicit /new command", async () => {
+  it("starts a fresh session only after an explicit /reset command", async () => {
     const initialSession = sessionYielding([{ type: "session.waiting" }]);
     const reset = vi
       .spyOn(initialSession, "reset")
@@ -635,7 +635,7 @@ describe("EveTUIRunner development session continuity", () => {
     const newSession = sessionYielding([{ type: "session.waiting" }]);
     const client = stubClient();
     const createSession = vi.spyOn(client, "session").mockReturnValue(newSession);
-    const prompts: Array<string | undefined> = ["first", "/new", "second", undefined];
+    const prompts: Array<string | undefined> = ["first", "/reset", "second", undefined];
     const runner = new EveTUIRunner({
       client,
       name: "Weather Agent",
@@ -803,12 +803,12 @@ describe("EveTUIRunner development session continuity", () => {
     expect(results).toEqual(["No active turn to cancel."]);
   });
 
-  it("keeps the current transcript and session when /new cannot reset the owner", async () => {
+  it("keeps the current transcript and session when /reset cannot reset the owner", async () => {
     const session = sessionYielding([]);
     const reset = vi.spyOn(session, "reset").mockRejectedValue(new Error("World unavailable"));
     const resetRenderer = vi.fn();
     const notices: string[] = [];
-    const prompts: Array<string | undefined> = ["/new", undefined];
+    const prompts: Array<string | undefined> = ["/reset", undefined];
     const runner = new EveTUIRunner({
       name: "Weather Agent",
       renderer: fakeRenderer({
@@ -826,7 +826,7 @@ describe("EveTUIRunner development session continuity", () => {
     expect(notices).toEqual(["Couldn't reset the session: World unavailable"]);
   });
 
-  it("resets rather than sending a queued /new after a turn boundary", async () => {
+  it("resets rather than sending a queued /reset after a turn boundary", async () => {
     const initialSession = sessionYielding([{ type: "session.waiting" }]);
     const reset = vi
       .spyOn(initialSession, "reset")
@@ -842,7 +842,7 @@ describe("EveTUIRunner development session continuity", () => {
           void event;
         }
       }),
-      takeQueuedPrompt: vi.fn(() => "/new"),
+      takeQueuedPrompt: vi.fn(() => "/reset"),
     });
     const runner = new EveTUIRunner({
       client,
@@ -1875,7 +1875,7 @@ describe("EveTUIRunner replay guards", () => {
 
 describe("parsePromptCommand", () => {
   it.each([
-    ["/new", { type: "new" }],
+    ["/reset", { type: "reset" }],
     ["/exit", { type: "exit" }],
     ["/quit", { type: "exit" }],
     ["/deploy", { type: "extension", name: "deploy", argument: "" }],
@@ -3169,14 +3169,14 @@ describe("EveTUIRunner mid-turn message queue", () => {
 });
 
 describe("EveTUIRunner session id reporting", () => {
-  it("pushes the accepted session id and keeps it sticky across /new", async () => {
+  it("pushes the accepted session id and keeps it sticky across /reset", async () => {
     const session = sessionYielding([{ type: "session.waiting" }]);
     vi.spyOn(session, "state", "get").mockReturnValue({
       sessionId: "session_test",
       streamIndex: 0,
     });
     const reported: string[] = [];
-    const prompts: Array<string | undefined> = ["hello", "/new", undefined];
+    const prompts: Array<string | undefined> = ["hello", "/reset", undefined];
     const renderer = fakeRenderer({
       readPrompt: vi.fn(async () => prompts.shift()),
       renderStream: vi.fn(async (result) => {
@@ -3190,7 +3190,7 @@ describe("EveTUIRunner session id reporting", () => {
     const runner = new EveTUIRunner({ session, renderer, name: "Weather Agent" });
     await runner.run();
 
-    // Named once the turn's send is accepted. `/new` (and interrupt
+    // Named once the turn's send is accepted. `/reset` (and interrupt
     // recovery, which shares #startNewSession) must NOT clear it: the
     // parting line names the last session this TUI talked to, and the
     // replacement session has no id until its first turn is accepted.

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -276,7 +276,7 @@ export type AgentTUIRenderer = {
   /**
    * Reports the server session id backing the conversation — pushed by the
    * runner once a send is accepted, and overwritten when a later session's
-   * turn is accepted. Deliberately sticky across `/new` and interrupt
+   * turn is accepted. Deliberately sticky across `/reset` and interrupt
    * recovery: the terminal renderer echoes the LAST session this TUI talked
    * to in the parting line on exit, so an interrupted conversation (whose
    * replacement session never ran a turn) can still be found again
@@ -345,7 +345,7 @@ export type AgentTUIRenderer = {
   /**
    * Clears the rendered transcript and resets per-conversation display
    * state, leaving the UI interactive on a fresh screen. Used by the
-   * `/new` command to start a new session with a clean slate.
+   * `/reset` command to start a new session with a clean slate.
    */
   reset?(): void;
   /**
@@ -826,7 +826,7 @@ export class EveTUIRunner {
           prompt = undefined;
         }
 
-        if (command?.type === "new") {
+        if (command?.type === "reset") {
           if (!(await this.#resetCurrentSession())) {
             pendingInputResponses = undefined;
             streamWithoutPrompt = false;
@@ -1109,7 +1109,7 @@ export class EveTUIRunner {
   /**
    * Resets all per-conversation runner state and, when a client is
    * available, replaces the active session with a fresh one so the next
-   * turn starts a new server-side conversation. Backs the `/new` command.
+   * turn starts a new server-side conversation. Backs the `/reset` command.
    * In-flight subagent child-session streams are aborted.
    */
   #startNewSession(): void {

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -2525,15 +2525,15 @@ describe("TerminalRenderer (inline scrollback)", () => {
     const { screen, input, renderer } = makeRenderer();
 
     const prompt = renderer.readPrompt();
-    input.type("/new");
+    input.type("/reset");
     input.enter();
-    expect(await prompt).toBe("/new");
+    expect(await prompt).toBe("/reset");
     renderer.shutdown();
 
     // The echo anchors in the user-message grammar (gutter bar), never the
     // prompt glyph: that one is the live-input rendezvous marker.
-    expect(screen.snapshot()).toContain("\u2502 /new");
-    expect(screen.snapshot()).not.toContain("\u276f /new");
+    expect(screen.snapshot()).toContain("\u2502 /reset");
+    expect(screen.snapshot()).not.toContain("\u276f /reset");
   });
 
   it("reassembles an arrow key split across reads", async () => {
@@ -4510,9 +4510,9 @@ describe("TerminalRenderer command typeahead", () => {
     input.type("/");
     input.down();
     input.enter();
-    // Down moved /help → /new; history recall would have submitted the
+    // Down moved /help → /reset; history recall would have submitted the
     // earlier prompt instead.
-    expect(await second).toBe("/new");
+    expect(await second).toBe("/reset");
     renderer.shutdown();
   });
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -1504,7 +1504,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#lastCommitted = undefined;
     this.#committedTranscriptRows.length = 0;
     this.#transcriptBlocks.length = 0;
-    // `/new` resets the conversation, not the workspace: keep #agentHeader
+    // `/reset` resets the conversation, not the workspace: keep #agentHeader
     // (the status line's model segment reads it — the header is not re-sent
     // after a reset) and #vercelStatus (link + pending-deploy outlive the
     // conversation). The header *block* still leaves the transcript because
@@ -1547,7 +1547,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
   /**
    * THE one authority for state scoped to a server-side conversation
-   * context. Called by both context cuts — `/new` (`reset`) and the
+   * context. Called by both context cuts — `/reset` and the
    * mid-conversation session replacement (`renderSessionBoundary`) — so the
    * two can never drift on what dies with the old context: the pinned todo
    * list (its tasks were not finished — dismiss, don't commit), write-diff


### PR DESCRIPTION
## Summary

- rename the local and remote TUI command from `/new` to `/reset`
- keep session replacement on the existing `ClientSession.reset()`, channel `reset(...)`, and `POST /eve/v1/session/reset` APIs
- update command discovery, transcript handling, docs, and focused tests
- add a patch changeset

## Tests

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/dev/tui/prompt-commands.test.ts src/cli/dev/tui/command-typeahead.test.ts src/cli/dev/tui/runner.test.ts src/cli/dev/tui/terminal-renderer.test.ts` (304 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`

Rebased on main after #1514 merged.