### PR TITLE
feat(eve): add the experimental.tasks flag, plumbing only

### DIFF
--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -429,6 +429,7 @@ const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
     experimental: z
       .object({
         subagentPersistentSessions: z.boolean().optional(),
+        tasks: z.boolean().optional(),
         workflow: compiledAgentWorkflowDefinitionSchema.optional(),
       })
       .strict()
@@ -834,6 +835,7 @@ export function createCompiledAgentNodeManifest(input: {
           ? undefined
           : {
               subagentPersistentSessions: input.config.experimental.subagentPersistentSessions,
+              tasks: input.config.experimental.tasks,
               workflow:
                 input.config.experimental.workflow === undefined
                   ? undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -180,6 +180,10 @@ function normalizeExperimentalDefinition(
     compiledExperimental.subagentPersistentSessions = experimental.subagentPersistentSessions;
   }
 
+  if (experimental.tasks !== undefined) {
+    compiledExperimental.tasks = experimental.tasks;
+  }
+
   if (experimental.workflow !== undefined) {
     compiledExperimental.workflow = {
       world: experimental.workflow.world,

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -148,6 +148,53 @@ describe("compileAgentManifest", () => {
     });
   });
 
+  it("rejects background-task configuration on subagents", async () => {
+    const subagentManifest = createAgentSourceManifest({
+      agentId: "research",
+      agentRoot: "/app/agent/subagents/research",
+      appRoot: "/app",
+      configModule: createModuleSourceRef({
+        logicalPath: "agent.ts",
+      }),
+    });
+    const manifest = createAgentSourceManifest({
+      agentId: "root",
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      subagents: [
+        createLocalSubagentSourceRef({
+          entryPath: "subagents/research/agent.ts",
+          logicalPath: "subagents/research",
+          manifest: subagentManifest,
+          rootPath: "/app/agent/subagents/research",
+          subagentId: "research",
+        }),
+      ],
+    });
+
+    mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) => {
+      if (input.agentId === "research") {
+        return createConfig({
+          description: "Research subagent",
+          name: "research",
+          experimental: {
+            tasks: true,
+          },
+        });
+      }
+
+      return createConfig({ name: "root" });
+    });
+    mocks.loadModuleBackedDefinition.mockResolvedValue({
+      description: "Research subagent",
+      model: "openai/gpt-5.5",
+    });
+
+    await expect(compileAgentManifest(manifest)).rejects.toThrow(
+      'Remove "experimental.tasks" from "research"',
+    );
+  });
+
   it("compiles experimental Workflow tool configuration", async () => {
     const manifest = createAgentSourceManifest({
       agentId: "root",

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -64,7 +64,7 @@ async function compileAgentNodeManifest(
   options: {
     readonly agentConfigDefinition?: unknown;
     readonly externalDependencies?: readonly string[];
-    readonly allowWorkflowConfig?: boolean;
+    readonly allowRootOnlyConfig?: boolean;
   } = {},
 ): Promise<CompiledAgentNodeManifest> {
   const rawConfig = Object.hasOwn(options, "agentConfigDefinition")
@@ -72,9 +72,14 @@ async function compileAgentNodeManifest(
         definition: options.agentConfigDefinition,
       })
     : await compileAgentConfig(manifest, context);
-  if (options.allowWorkflowConfig === false && rawConfig.experimental?.workflow !== undefined) {
+  if (options.allowRootOnlyConfig === false && rawConfig.experimental?.workflow !== undefined) {
     throw new Error(
       `Workflow runtime configuration is only supported on the root agent config. Remove "experimental.workflow" from "${manifest.agentId}".`,
+    );
+  }
+  if (options.allowRootOnlyConfig === false && rawConfig.experimental?.tasks !== undefined) {
+    throw new Error(
+      `Background tasks are only supported on the root agent config. Remove "experimental.tasks" from "${manifest.agentId}".`,
     );
   }
   const externalDependencies = mergeExternalDependencies(

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -45,7 +45,7 @@ export type CompileAgentNodeManifestFn = (
   options?: {
     readonly agentConfigDefinition?: unknown;
     readonly externalDependencies?: readonly string[];
-    readonly allowWorkflowConfig?: boolean;
+    readonly allowRootOnlyConfig?: boolean;
   },
 ) => Promise<CompiledAgentNodeManifest>;
 
@@ -204,7 +204,7 @@ async function compileSubagent(input: {
     input.context,
     {
       agentConfigDefinition: input.agentConfigDefinition,
-      allowWorkflowConfig: false,
+      allowRootOnlyConfig: false,
       externalDependencies: input.externalDependencies,
     },
   );

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -266,6 +266,34 @@ describe("normalizeAgentDefinition", () => {
       ),
     ).toThrow('"experimental.subagentPersistentSessions" must be a boolean.');
   });
+
+  it("accepts a boolean tasks flag", () => {
+    const definition = normalizeAgentDefinition(
+      {
+        model: "openai/gpt-5.5",
+        experimental: {
+          tasks: true,
+        },
+      },
+      FAILURE_MESSAGE,
+    );
+
+    expect(definition.experimental?.tasks).toBe(true);
+  });
+
+  it("rejects non-boolean tasks values", () => {
+    expect(() =>
+      normalizeAgentDefinition(
+        {
+          model: "openai/gpt-5.5",
+          experimental: {
+            tasks: "yes",
+          },
+        },
+        FAILURE_MESSAGE,
+      ),
+    ).toThrow('"experimental.tasks" must be a boolean.');
+  });
 });
 
 describe("normalizeScheduleDefinition", () => {

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -257,7 +257,7 @@ function normalizeAgentExperimentalDefinition(
   message: string,
 ): NonNullable<NormalizedAgentDefinition["experimental"]> {
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["subagentPersistentSessions", "workflow"], message);
+  expectOnlyKnownKeys(record, ["subagentPersistentSessions", "tasks", "workflow"], message);
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["experimental"]>> = {};
 
   if (record.subagentPersistentSessions !== undefined) {
@@ -265,6 +265,13 @@ function normalizeAgentExperimentalDefinition(
       throw new Error(`${message} "experimental.subagentPersistentSessions" must be a boolean.`);
     }
     normalizedDefinition.subagentPersistentSessions = record.subagentPersistentSessions;
+  }
+
+  if (record.tasks !== undefined) {
+    if (typeof record.tasks !== "boolean") {
+      throw new Error(`${message} "experimental.tasks" must be a boolean.`);
+    }
+    normalizedDefinition.tasks = record.tasks;
   }
 
   if (record.workflow !== undefined) {

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -228,6 +228,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
   if (manifest.config.experimental !== undefined) {
     config.experimental = {
       subagentPersistentSessions: manifest.config.experimental.subagentPersistentSessions,
+      tasks: manifest.config.experimental.tasks,
       workflow:
         manifest.config.experimental.workflow === undefined
           ? undefined

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -204,6 +204,13 @@ export interface AgentExperimentalDefinition {
    */
   readonly subagentPersistentSessions?: boolean;
   /**
+   * Runs this agent's delegated subagent calls as durable background tasks.
+   * The originating tool call returns a task receipt immediately and the
+   * model manages the work through the `task_*` framework tools. Implies
+   * persistent-session children for subagent dispatch. Root agents only.
+   */
+  readonly tasks?: boolean;
+  /**
    * Durable Workflow runtime configuration. Root agents may use this to select
    * the Workflow world backing sessions and runs.
    */


### PR DESCRIPTION
First of five implementation PRs for the [subagents-as-tasks plan](https://github.com/vercel/eve/pull/1482), which this stacks on:

1. this — flag plumbing
2. #1518 — task foundation (durable task run, session index)
3. #1519 — flag-gated task tools
4. #1521 — delegated execution and the task wire
5. #1522 — `task_send`

## What

Adds `experimental.tasks` to the authored agent config. Nothing reads it: a flag-on agent compiles and runs identically to a flag-off one.

The field travels the same path as `subagentPersistentSessions`, field for field: authored `agent.ts` → authored-definition normalization → compiler copy → strict compiled-manifest schema → manifest clone → `ResolvedAgent.config.experimental`.

## Root-only enforcement

Subagent configs reject the flag at compile, same as `experimental.workflow`. That check's option was named `allowWorkflowConfig`; it now gates two root-only flags, so it's renamed `allowRootOnlyConfig`. Only rename outside the new field.

Part of #1084.