### PR TITLE
fix(eve): emit turn epilogue when parking for connection authorization in conversation mode (#1525)

### DIFF
--- a/.changeset/fix-auth-park-turn-epilogue.md
+++ b/.changeset/fix-auth-park-turn-epilogue.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Conversation-mode turns that park on connection authorization now emit `turn.completed` and `session.waiting` (with the continuation token) before parking — chat clients render the connect card and settle the turn instead of hanging on "Thinking…". Channel/task sessions are unchanged.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -5151,6 +5151,17 @@ describe("createToolLoopHarness", () => {
         webhookUrl: "https://app.example/callback",
       });
 
+      // Conversation mode must close the turn so the client settles:
+      // `turn.completed` followed by `session.waiting` carrying the
+      // continuation token. Without this epilogue the chat UI hangs on
+      // "Thinking…" after `authorization.required` and never renders the
+      // connect card (issue #1525).
+      const eventTypes = events.map((event) => event.type);
+      const authIndex = eventTypes.indexOf("authorization.required");
+      expect(eventTypes.slice(authIndex + 1)).toEqual(["turn.completed", "session.waiting"]);
+      const waiting = events.find((event) => event.type === "session.waiting");
+      expect(waiting?.data).toMatchObject({ continuationToken: "test-session" });
+
       const actionResults = events.filter((event) => event.type === "action.result");
       expect(actionResults).toHaveLength(0);
     });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -2137,6 +2137,12 @@ async function handleStepResult(input: {
   if (authSignal) {
     const { challenges } = authSignal;
 
+    let parkedSession: HarnessSession = {
+      ...baseSession,
+      history: [...promptMessages],
+      state: setPendingAuthorization(baseSession.state, { challenges }),
+    };
+
     if (emit) {
       for (const ch of challenges) {
         await emit(
@@ -2151,19 +2157,19 @@ async function handleStepResult(input: {
           }),
         );
       }
+
+      if (config.mode === "conversation") {
+        emissionState = await emitTurnEpilogue(
+          emit,
+          emissionState,
+          config.mode,
+          parkedSession.continuationToken,
+        );
+        parkedSession = setHarnessEmissionState(parkedSession, emissionState);
+      }
     }
 
-    return {
-      next: null,
-      session: setHarnessEmissionState(
-        {
-          ...baseSession,
-          history: [...promptMessages],
-          state: setPendingAuthorization(baseSession.state, { challenges }),
-        },
-        emissionState,
-      ),
-    };
+    return { next: null, session: parkedSession };
   }
 
   // --- Continue or terminate ------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1525. A conversation-mode turn that parks on connection authorization never emitted a turn boundary: `authorization.required` went out on the session stream, but no `turn.completed` / `session.waiting` followed. `useEveAgent` clients derive turn status exclusively from a boundary event, so the chat UI spun on "Thinking…" forever, no continuation token reached the client, and cancel could not resolve.

## Root cause

`packages/eve/src/harness/tool-loop.ts` — the two park branches were asymmetric:

- **Input-request park** (pending input batch) emits the input-requested event and then, in conversation mode, calls `emitTurnEpilogue` (which emits `turn.completed` and `session.waiting` with the continuation token) before returning.
- **Authorization park** (`findAuthorizationSignalFromToolResults` hit) emitted `authorization.required` per challenge and returned the parked session **without** calling `emitTurnEpilogue`.

Channel sessions do not need the boundary, and input-request parks (approvals) work everywhere — which is why only conversation-mode surfaces hung.

## Fix

Mirror the input-request branch in the authorization park:

```ts
if (config.mode === "conversation") {
  emissionState = await emitTurnEpilogue(
    emit,
    emissionState,
    config.mode,
    parkedSession.continuationToken,
  );
  parkedSession = setHarnessEmissionState(parkedSession, emissionState);
}
```

Task and channel sessions are unchanged.

## Behavior

Stream events after this change (conversation-mode auth park):

```
session.started
turn.started
message.received
step.started
actions.requested
step.completed
authorization.required
turn.completed        ← new
session.waiting       ← new (carries the continuation token)
```

The connect card renders immediately, the turn settles, cancel resolves, and resumed sessions behave — matching the end-to-end verification recorded on the issue.

## Tests

- Extended the existing conversation-mode auth-park test in `packages/eve/src/harness/tool-loop.test.ts` with a regression assertion proving `turn.completed` and `session.waiting` follow `authorization.required` and carry the session continuation token.
- `packages/eve` typecheck: clean.
- Full `src/harness` unit suite: 45 files / 694 tests passing.

## Verification

`cd packages/eve && pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec vitest run --config vitest.unit.config.ts src/harness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)