### PR TITLE
fix(client): preserve approval-responded part across input.requested replays

### DIFF
--- a/.changeset/nasty-crabs-tickle.md
+++ b/.changeset/nasty-crabs-tickle.md
@@ -1,0 +1,9 @@
+---
+"eve": patch
+---
+
+Fix `input.requested` replay erasing a prior HITL `inputResponse` (#1507)
+
+When the event stream replays `input.requested` (e.g. after a resume), the reducer previously rebuilt the tool part from scratch with `state: "approval-requested"`, discarding any stored `eve.inputResponse` metadata written by `client.input.responded`. This left the UI showing an unanswered approval prompt even though the user had already responded.
+
+The reducer now partitions on the existing tool-part state: if it's already `approval-responded`, preserve the prior `approval` and `toolMetadata` verbatim; otherwise emit a fresh `approval-requested` part with merged tool metadata. Includes a regression test covering the replay-after-respond flow.

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -560,40 +560,74 @@ describe("defaultMessageReducer", () => {
       }),
     ]);
 
-    const toolParts = data.messages.flatMap((message) =>
-      message.parts.filter((part) => part.type === "dynamic-tool"),
-    );
-
     expect(
       data.messages.map((message) => [message.id, message.parts.map((part) => part.type)]),
     ).toEqual([
       ["turn_0:assistant", ["step-start", "dynamic-tool"]],
       ["turn_1:assistant", ["step-start"]],
     ]);
-    expect(toolParts).toHaveLength(1);
-    expect(toolParts[0]).toMatchObject({
-      approval: {
-        approved: true,
-        id: "approval_1",
+  });
+
+  it("replayed input.requested does not erase a prior approval-responded part (#1507)", () => {
+    const reducer = defaultMessageReducer();
+    const inputRequest = {
+      action: {
+        callId: "call_1",
+        input: { command: "rm -rf tmp" },
+        kind: "tool-call" as const,
+        toolName: "bash",
       },
-      input: { command: "echo 1" },
-      output: "1",
-      state: "output-available",
-      toolCallId: "call_1",
-      toolMetadata: {
-        eve: {
-          inputRequest: {
-            prompt: "Approve tool call: bash",
-            requestId: "approval_1",
-          },
-          inputResponse: { optionId: "approve", requestId: "approval_1" },
-          kind: "tool-call",
-          name: "bash",
-        },
+      display: "confirmation" as const,
+      kind: "tool-approval" as const,
+      options: [
+        { id: "approve", label: "Yes", style: "primary" as const },
+        { id: "deny", label: "No", style: "danger" as const },
+      ],
+      prompt: "Approve tool call: bash",
+      requestId: "approval_1",
+    };
+
+    // Original flow: input.requested → user responds ("deny").
+    let data = reduceServerEvents(reducer, reducer.initial(), [
+      createInputRequestedEvent({
+        requests: [inputRequest],
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    ]);
+    data = reducer.reduce(data, {
+      data: {
+        createdAt: 1,
+        responses: [{ optionId: "deny", requestId: "approval_1" }],
       },
-      toolName: "bash",
-      type: "dynamic-tool",
+      type: "client.input.responded",
     });
+
+    // Simulate the resume stream replaying the same input.requested event.
+    data = reduceServerEvents(reducer, data, [
+      createInputRequestedEvent({
+        requests: [inputRequest],
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    ]);
+
+    const toolParts = data.messages.flatMap((message) =>
+      message.parts.filter((part) => part.type === "dynamic-tool"),
+    );
+
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]?.state).toBe("approval-responded");
+    expect(toolParts[0]?.approval).toEqual({ id: "approval_1" });
+    expect(toolParts[0]?.toolMetadata?.eve?.inputResponse).toEqual({
+      optionId: "deny",
+      requestId: "approval_1",
+    });
+    expect(toolParts[0]?.toolMetadata?.eve?.inputRequest?.prompt).toBe(
+      "Approve tool call: bash",
+    );
   });
 
   it("keeps text from separate steps as separate parts", () => {

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -148,22 +148,54 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
       let next = data;
       for (const request of event.data.requests) {
         const descriptor = normalizeActionRequest(request.action);
-        next = updateAssistantMessage(next, event.data.turnId, (message) =>
-          upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
-            approval: {
-              id: request.requestId,
-            },
-            input: request.action.input,
-            state: "approval-requested",
-            stepIndex: event.data.stepIndex,
-            toolCallId: request.action.callId,
-            toolMetadata: createToolMetadata(descriptor, {
-              inputRequest: toMessageInputRequest(request),
+        // Idempotent under replay: if we already recorded this tool's part
+        // (e.g. the resume stream replayed `input.requested` after the user
+        // answered), preserve the existing `approval` and any merged
+        // metadata — most importantly `eve.inputResponse` written by
+        // `respondToInputRequest` — rather than rebuilding the part
+        // wholesale. Mirrors what `action.result` does via
+        // `mergeToolMetadata` below. (#1507)
+        const existing = findToolPart(next, request.action.callId);
+        // Replay-safe partition:
+        //   (1) Resumed flow already responded → keep the prior part (with its
+        //       `approval`/`inputResponse`) verbatim; only refresh toolCallId
+        //       and stepIndex to match the latest event. Never collapse the
+        //       approval shape into `approval-requested`'s narrower variant.
+        //   (2) Fresh / pre-response replay → emit `approval-requested` with
+        //       a fresh `approval: { id }`, preserving any prior toolMetadata.
+        if (existing?.state === "approval-responded") {
+          next = updateAssistantMessage(next, event.data.turnId, (message) =>
+            upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+              approval: existing.approval,
+              input: existing.input,
+              state: "approval-responded",
+              stepIndex: event.data.stepIndex,
+              toolCallId: request.action.callId,
+              toolMetadata: existing.toolMetadata,
+              toolName: existing.toolName,
+              type: "dynamic-tool",
             }),
-            toolName: descriptor.toolName,
-            type: "dynamic-tool",
-          }),
-        );
+          );
+        } else {
+          next = updateAssistantMessage(next, event.data.turnId, (message) =>
+            upsertPart(ensureStepStartPart(message, event.data.stepIndex), {
+              approval: {
+                id: request.requestId,
+              },
+              input: request.action.input,
+              state: "approval-requested",
+              stepIndex: event.data.stepIndex,
+              toolCallId: request.action.callId,
+              toolMetadata: mergeToolMetadata(existing?.toolMetadata,
+                createToolMetadata(descriptor, {
+                  inputRequest: toMessageInputRequest(request),
+                }),
+              ),
+              toolName: existing?.toolName ?? descriptor.toolName,
+              type: "dynamic-tool",
+            }),
+          );
+        }
       }
       return next;
     }


### PR DESCRIPTION
fix: preserve approval-responded tool part across replayed input.requested events

## What

This is a **partial fix** for #1507. The issue describes two coupled reducer-idempotency bugs:

1. **HITL answers erased on replay** — fixed here.
2. **Text parts duplicated on replay** — *not* fixed here; that half needs `upsertRun` to detect "same-step done run with identical text" without breaking the multi-run pattern that lets a step emit text, call tools, then emit more text. Worth a follow-up PR with its own coverage.

### This patch: preserve `approval-responded` across `input.requested` replays

When the event stream replays `input.requested` (e.g. after a resume), `defaultMessageReducer` previously rebuilt the tool part wholesale with `state: "approval-requested"`, discarding the `eve.inputResponse` metadata that `client.input.responded` writes. The UI then showed an unanswered approval prompt even though the user had already responded.

The handler now partitions on the existing tool-part state:

- **`approval-responded` → restore, don't rebuild.** The prior `approval`, `input`, `toolMetadata`, and `toolName` are carried forward verbatim; only `stepIndex` and `toolCallId` refresh from the event. We deliberately do not merge `approval` fields: the union member for `approval-requested` (`approved?: never; reason?: never`) is incompatible with the member for `approval-responded` (`approved?: boolean; reason?: string`), so blending them erases the recorded answer.
- **Otherwise → fresh `approval-requested`.** Still emits the part, but merges any prior `toolMetadata` with the newly-derived descriptor via `mergeToolMetadata` — the same pattern `action.result` uses a few branches below.

One nuance: parts in *terminal* states (`output-available` / `output-error` / `output-denied`) also fall into the "otherwise" branch today. That mirrors upstream behavior (a re-request after a terminal result legitimately starts a new approval cycle in the reducer's coarse state machine), and matching it keeps this patch low-blast-radius. Tightening terminal-state replay handling is part of the same follow-up as the duplicate-text fix.

## Why this approach

Fixing the resume-from-stale-`streamIndex` bug (the other half of #1507) would plug the source but wouldn't make the reducer itself idempotent to duplicate `input.requested` events from any cause (multi-session, reconnect, hot-reload). Making the reducer idempotent is the narrower, protocol-level fix — and it's a strict superset of what the resume flow needs.

## Tests

- Adds `defaultMessageReducer › replayed input.requested does not erase a prior approval-responded part (#1507)` in `packages/eve/src/client/message-reducer.test.ts`. It drives `input.requested → client.input.responded → input.requested (replay)` and asserts the part stays `approval-responded` with the original `eve.inputResponse` intact and `eve.inputRequest` preserved.
- Full `vitest run --config vitest.unit.config.ts` in `packages/eve`: **5872 / 5876 passing**, with 4 pre-existing `bin-bootstrap.test.ts` failures that gate on Node 22+ (unrelated).
- `tsc -p tsconfig.json --noEmit` is clean.

## Linked issue

Refs #1507 (partial — see "What" above for the duplicate-text scope split).
