### PR TITLE
fix(eve/slack): fail loudly when private file fetch returns login HTML (#1317)

### DIFF
--- a/.changeset/slack-html-login-fail-loudly.md
+++ b/.changeset/slack-html-login-fail-loudly.md
@@ -1,0 +1,10 @@
+---
+"eve": patch
+---
+
+Fail loudly when a Slack private file fetch returns a login HTML page (HTTP 200)
+instead of the file bytes. This happens when the bot token is missing the
+`files:read` scope or the app has not been reinstalled since the scope was
+added; staging the HTML as the attachment previously made the model report a
+Slack sign-in page without any indication of the underlying misconfiguration.
+The fetch now throws an error naming `files:read` and the reinstall step.

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -464,3 +464,71 @@ describe("buildSlackTurnMessage", () => {
     expect(content[0]).toBe(fileParts[0]);
   });
 });
+
+describe("createSlackFetchFile", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const fileUrl = "https://files.slack.com/files-pri/T000/F000/cat.png";
+
+  function stubFetch(body: string | Buffer, init: { status?: number; contentType?: string } = {}) {
+    const headers = new Headers();
+    if (init.contentType !== undefined) {
+      headers.set("content-type", init.contentType);
+    }
+    const fetchMock = vi.fn(
+      async (_url: URL | string, _init: RequestInit) =>
+        new Response(body, { status: init.status ?? 200, headers }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("returns null for non-Slack URLs", async () => {
+    const fetch = createSlackFetchFile({ botToken: "xoxb-test" });
+    const result = await fetch("https://example.com/not-slack.png");
+    expect(result).toBeNull();
+  });
+
+  it("returns bytes and content-type for a real file response", async () => {
+    stubFetch(Buffer.from([0x89, 0x50, 0x4e, 0x47]), { contentType: "image/png" });
+    const fetch = createSlackFetchFile({ botToken: "xoxb-test" });
+    const result = await fetch(fileUrl);
+    expect(result?.mediaType).toBe("image/png");
+    expect(result?.bytes.subarray(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  });
+
+  it("throws on HTML content-type — Slack login page under missing files:read scope (#1317)", async () => {
+    stubFetch("<html><body>Sign in to Slack</body></html>", { contentType: "text/html" });
+    const fetch = createSlackFetchFile({ botToken: "xoxb-test" });
+    await expect(fetch(fileUrl)).rejects.toThrow(
+      /files:read|Slack file fetch .* HTML login page/s,
+    );
+  });
+
+  it("throws when the body is HTML even if content-type is missing (#1317)", async () => {
+    stubFetch("<!DOCTYPE html>\n<html><body>slack workspace signin</body></html>");
+    const fetch = createSlackFetchFile({ botToken: "xoxb-test" });
+    await expect(fetch(fileUrl)).rejects.toThrow(/HTML login page/);
+  });
+
+  it("error message names the fix (files:read scope + reinstall)", async () => {
+    stubFetch("<html><body>Sign in</body></html>", { contentType: "text/html" });
+    const fetch = createSlackFetchFile({ botToken: "xoxb-test" });
+    try {
+      await fetch(fileUrl);
+      expect.unreachable("expected fetch to throw");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain("files:read");
+      expect(message.toLowerCase()).toContain("reinstalled");
+    }
+  });
+
+  it("throws on non-2xx HTTP", async () => {
+    stubFetch("forbidden", { status: 403, contentType: "text/plain" });
+    const fetch = createSlackFetchFile({ botToken: "xoxb-test" });
+    await expect(fetch(fileUrl)).rejects.toThrow(/HTTP 403/);
+  });
+});

--- a/packages/eve/src/public/channels/slack/attachments.ts
+++ b/packages/eve/src/public/channels/slack/attachments.ts
@@ -179,11 +179,37 @@ export function createSlackFetchFile(input: {
     if (!response.ok) {
       throw new Error(`Slack file fetch returned HTTP ${response.status} for ${url}.`);
     }
+    const contentType = response.headers.get("content-type") ?? undefined;
+    const bytes = Buffer.from(await response.arrayBuffer());
+    // Slack can return HTTP 200 with a browser login page (not a 401/403) when the
+    // bot token is missing `files:read` or the workspace app has not been
+    // reinstalled after the scope was added. Staging that HTML as the
+    // attachment reads back as "Slack sign-in page" to the model; fail loudly
+    // here so the misconfiguration is obvious (#1317).
+    if (looksLikeSlackLoginHtml(contentType, bytes)) {
+      throw new Error(
+        `Slack file fetch for ${url} returned an HTML login page (HTTP 200). ` +
+          `The bot token likely lacks the \`files:read\` scope, or the Slack/Bolt app ` +
+          `has not been reinstalled since the scope was added. Add \`files:read\` via ` +
+          `your Slack app manifest (or Connect "Advanced scopes"), reinstall the app ` +
+          `into the workspace, then retry.`,
+      );
+    }
     return {
-      bytes: Buffer.from(await response.arrayBuffer()),
-      mediaType: response.headers.get("content-type") ?? undefined,
+      bytes,
+      mediaType: contentType,
     };
   };
+}
+
+function looksLikeSlackLoginHtml(contentType: string | undefined, bytes: Buffer): boolean {
+  if (typeof contentType === "string" && contentType.toLowerCase().includes("text/html")) {
+    return true;
+  }
+  // Some Slack login responses omit the content-type on proxies; sniff a small
+  // prefix instead of parsing the whole body.
+  const head = bytes.subarray(0, 256).toString("utf-8").trimStart().toLowerCase();
+  return head.startsWith("<!doctype html") || head.startsWith("<html");
 }
 
 function isSlackFileUrl(url: string): boolean {


### PR DESCRIPTION
## What

When a Slack bot token lacks `files:read` (or the app has not been reinstalled
since the scope was added), Slack's private-file endpoint returns **HTTP 200
with a browser login page** rather than a 401/403. Eve staged that HTML as the
attachment, so the model honestly reported receiving a "Slack sign-in page" —
masking the underlying scope misconfiguration as a vision/auth mystery.

## Changes

`createSlackFetchFile` (`packages/eve/src/public/channels/slack/attachments.ts`)
now detects the login page after a successful status check:

- If `Content-Type` is `text/html`, or
- If the body begins with `<!doctype html` or `<html` (some proxies drop the
  content-type)

…it throws with a message naming the fix:

```
Slack file fetch for <url> returned an HTML login page (HTTP 200). The bot
token likely lacks the `files:read` scope, or the Slack/Bolt app has not been
reinstalled since the scope was added. Add `files:read` via your Slack app
manifest (or Connect "Advanced scopes"), reinstall the app into the workspace,
then retry.
```

Matches the failure-loudly pattern other Slack clients (e.g. OpenClaw) already
use.

## Tests

Six new `createSlackFetchFile` cases in `attachments.test.ts` (pass-through for
non-Slack URLs, bytes + content-type for a real file, throw on HTML
content-type, throw on body-sniff even without content-type, message names
`files:read` + reinstall, and the existing non-2xx HTTP path). All 35
attachments tests pass; `tsc -p tsconfig.json --noEmit` clean.

Refs #1317
