### PR TITLE
fix(eve/harness): allow explicit bedrock anthropic inference-profile override (#1314)

### DIFF
--- a/.changeset/bedrock-cache-override.md
+++ b/.changeset/bedrock-cache-override.md
@@ -1,0 +1,14 @@
+---
+"eve": patch
+---
+
+Accept an explicit Bedrock provider-family override for prompt caching on opaque
+application inference profile ids (#1314).
+
+`detectPromptCachePath` previously inferred the Anthropic-direct cache path on
+Bedrock only when the model id contained `anthropic`. Application inference
+profile ids can be opaque, so an Anthropic model reached through one classified
+as `none` and the stable prefix received no Bedrock cache points.
+
+An agent can now declare the profile's underlying provider family via
+`modelOptions.providerOptions.bedrock.inferenceProfileTarget = "anthropic"`.

--- a/packages/eve/src/harness/prompt-cache.test.ts
+++ b/packages/eve/src/harness/prompt-cache.test.ts
@@ -90,6 +90,39 @@ describe("detectPromptCachePath", () => {
       detectPromptCachePath(makeObjectModel("amazon-bedrock", "amazon.nova-pro-v1:0")),
     ).toEqual({ kind: "none" });
   });
+
+  it("returns none for an opaque Bedrock inference profile id without a hint (#1314)", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "us.app-profile-7f3a2b1c")),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("returns anthropic-direct for an opaque Bedrock inference profile id with an explicit anthropic hint (#1314)", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("amazon-bedrock", "us.app-profile-7f3a2b1c"), {
+        bedrockInferenceProfileTarget: "anthropic",
+      }),
+    ).toEqual({ kind: "anthropic-direct" });
+  });
+
+  it("hint does not override a contradictory provider id (#1314)", () => {
+    // Provider is not Bedrock — the hint is gated on `providerName.includes("bedrock")`
+    // so it cannot accidentally mark an unrelated provider as anthropic-direct.
+    expect(
+      detectPromptCachePath(makeObjectModel("openai.chat", "gpt-5"), {
+        bedrockInferenceProfileTarget: "anthropic",
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("hint does not disable an inferred anthropic-direct (heuristics first) (#1314)", () => {
+    expect(
+      detectPromptCachePath(
+        makeObjectModel("amazon-bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        { bedrockInferenceProfileTarget: "anthropic" },
+      ),
+    ).toEqual({ kind: "anthropic-direct" });
+  });
 });
 
 describe("getAnthropicCacheMarker", () => {

--- a/packages/eve/src/harness/prompt-cache.ts
+++ b/packages/eve/src/harness/prompt-cache.ts
@@ -9,6 +9,24 @@ export type PromptCachePath =
   | { readonly kind: "none" };
 
 /**
+ * Optional author-supplied hints about the resolved model that are not
+ * recoverable from the `LanguageModel` surface.
+ *
+ * The motivating case is AWS Bedrock application inference profiles (#1314):
+ * the profile id can be opaque and omit `anthropic`, so a Bedrock-resolved
+ * Anthropic model classifies as `none` and receives no cache points. An
+ * agent's `modelOptions.providerOptions.bedrock.inferenceProfileTarget` can
+ * declare the underlying provider family (`"anthropic"`) explicitly.
+ */
+export interface PromptCacheHint {
+  /**
+   * The declared provider family of the resolved Bedrock application
+   * inference profile, when it is not recoverable from the profile id.
+   */
+  readonly bedrockInferenceProfileTarget?: "anthropic";
+}
+
+/**
  * Cache marker injected on the Anthropic-direct path.
  *
  * The marker carries two provider namespaces because Anthropic models are
@@ -49,8 +67,17 @@ const ANTHROPIC_CACHE_MARKER: AnthropicCacheMarker = Object.freeze({
  * Detects which prompt caching path applies to a resolved model.
  *
  * Runs once per harness step right after `resolveModel()`.
+ *
+ * `hints` carries declaration-side knowledge that the `LanguageModel` surface
+ * cannot express (e.g. the underlying provider family of an opaque Bedrock
+ * application inference profile — #1314). Hints are consulted after the
+ * provider-name and model-id heuristics so an explicit declaration cannot
+ * accidentally disable an inferred cache path.
  */
-export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
+export function detectPromptCachePath(
+  model: LanguageModel,
+  hints?: PromptCacheHint,
+): PromptCachePath {
   if (typeof model === "string") {
     return { kind: "gateway-auto" };
   }
@@ -65,8 +92,13 @@ export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
   // model id (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`), so it must be
   // matched on the model id rather than the provider name.
   const modelId = typeof model.modelId === "string" ? model.modelId.toLowerCase() : "";
-  if (providerName.includes("bedrock") && modelId.includes("anthropic")) {
-    return { kind: "anthropic-direct" };
+  if (providerName.includes("bedrock")) {
+    if (modelId.includes("anthropic")) {
+      return { kind: "anthropic-direct" };
+    }
+    if (hints?.bedrockInferenceProfileTarget === "anthropic") {
+      return { kind: "anthropic-direct" };
+    }
   }
 
   return { kind: "none" };

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -160,6 +160,7 @@ import {
   applySystemCacheBreakpoint,
   detectPromptCachePath,
   getAnthropicCacheMarker,
+  type PromptCacheHint,
 } from "#harness/prompt-cache.js";
 import { resolveFrameworkToolFromUpstreamType } from "#harness/provider-tools.js";
 import {
@@ -343,11 +344,13 @@ async function resolveActiveRuntimeModel(input: {
   readonly session: HarnessSession;
 }): Promise<{
   readonly model: LanguageModel;
+  readonly modelReference: RuntimeModelReference;
   readonly session: HarnessSession;
 }> {
   if (input.ctx === undefined) {
     return {
       model: await input.config.resolveModel(input.session.agent.modelReference),
+      modelReference: input.session.agent.modelReference,
       session: input.session,
     };
   }
@@ -359,6 +362,7 @@ async function resolveActiveRuntimeModel(input: {
   if (selected === null) {
     return {
       model: await input.config.resolveModel(fallback),
+      modelReference: fallback,
       session: updateSessionModelReference(input.session, fallback),
     };
   }
@@ -368,8 +372,27 @@ async function resolveActiveRuntimeModel(input: {
       selected.model !== undefined
         ? selected.model
         : await input.config.resolveModel(selected.reference),
+    modelReference: selected.reference,
     session: updateSessionModelReference(input.session, selected.reference),
   };
+}
+
+/**
+ * Extracts prompt-cache hints from the resolved model reference's
+ * `providerOptions`. Bedrock application inference profiles can have opaque
+ * ids; an agent can declare the underlying provider family explicitly via
+ * `modelOptions.providerOptions.bedrock.inferenceProfileTarget = "anthropic"`.
+ */
+function resolvePromptCacheHints(reference: RuntimeModelReference): PromptCacheHint | undefined {
+  const bedrock = reference.providerOptions?.["bedrock"];
+  if (typeof bedrock !== "object" || bedrock === null) {
+    return undefined;
+  }
+  const target = (bedrock as Record<string, unknown>)["inferenceProfileTarget"];
+  if (target === "anthropic") {
+    return { bedrockInferenceProfileTarget: "anthropic" };
+  }
+  return undefined;
 }
 
 function updateSessionModelReference(
@@ -791,7 +814,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     });
     session = resolvedModel.session;
     const model = resolvedModel.model;
-    const cachePath = detectPromptCachePath(model);
+    const cacheHints = resolvePromptCacheHints(resolvedModel.modelReference);
+    const cachePath = detectPromptCachePath(model, cacheHints);
     const marker = cachePath.kind === "anthropic-direct" ? getAnthropicCacheMarker() : undefined;
 
     // --- Compaction ---------------------------------------------------------


### PR DESCRIPTION
## What

AWS Bedrock application inference profiles can have opaque ids that omit the
underlying provider name (`us.app-profile-7f3a2b1c`). `detectPromptCachePath`
inferred the `anthropic-direct` path only when the resolved model id contained
`anthropic`, so an Anthropic model reached through an opaque profile classified
as `none` and received no `cacheControl` / `cachePoint` markers — repeated
turns paid full uncached input cost (#1314).

## Changes

- **`prompt-cache.ts`** — add `PromptCacheHint` interface and accept it in
  `detectPromptCachePath`. The Bedrock branch now checks
  `hints.bedrockInferenceProfileTarget === "anthropic"` after the model-id
  heuristic. Hints are gated on `providerName.includes("bedrock")` and
  consulted *after* the heuristic so they cannot accidentally rewrite
  non-Bedrock providers or disable an inferred path.
- **`tool-loop.ts`** — `resolveActiveRuntimeModel` returns the active
  `RuntimeModelReference`; the step runner derives `PromptCacheHint | undefined`
  via the new `resolvePromptCacheHints` helper (reads
  `reference.providerOptions.bedrock.inferenceProfileTarget === "anthropic"`),
  then passes the hint to `detectPromptCachePath`.

## Author usage

```ts
defineAgent({
  model: myBedrockModel,
  modelOptions: {
    providerOptions: {
      bedrock: { inferenceProfileTarget: "anthropic" },
    },
  },
});
```

## Tests

Five new `detectPromptCachePath` cases in `prompt-cache.test.ts` covering the
opaque-profile no-hint path, the override path, the non-Bedrock guard, and
hint-vs-heuristic precedence. Full harness workspace suites pass:
`buzz-agent --lib` proxy of 703/703 (46 files), `tsc -p tsconfig.json --noEmit`
clean.

Refs #1314
