### PR TITLE
fix(eve): vendor content-hashed declaration chunks (chat, @chat-adapter/twilio)

### DIFF
--- a/.changeset/fix-1500-missing-declaration-chunks.md
+++ b/.changeset/fix-1500-missing-declaration-chunks.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix missing content-hashed declaration chunks in the published `eve` tarball. The chat and twilio vendor configs previously only co-copied `jsx-runtime-<hash>.d.ts` (chat) or no hashed chunks at all (twilio), so the upstream `messages-<hash>.d.ts` and `types-<hash>.d.ts` files were dropped from the published package — degrading ~120 chat exports to `any` and producing TS2307 errors with `skipLibCheck: false`. Extend `discoverExtraFiles` in `_shared.mjs` to fold the hashed siblings into the same declaration-rewrite pass as the named entry files, and add the chunk patterns (`messages-`, `types-`) to the chat and twilio configs. Also fixes a small set of `chat` and `@chat-adapter/twilio` type-surface leaks in eve sources and tests that were silently relying on the previous `any` fallback. Resolves #1500.

--- a/packages/eve/scripts/vendor-compiled/@chat-adapter/twilio.mjs
+++ b/packages/eve/scripts/vendor-compiled/@chat-adapter/twilio.mjs
@@ -35,5 +35,14 @@ export default {
     rewrites: {
       chat: { kind: "vendored", compiledPath: "chat" },
     },
+    discoverExtraFiles: (distEntries) =>
+      // The upstream bundler emits content-hashed sibling declaration
+      // chunks (`types-<hash>.d.ts`) that the entry .d.ts files import by
+      // relative path. Co-copy them verbatim so the specifier resolves
+      // inside the published tarball — the miss here produced TS2307 for
+      // `TwilioWebhookUrl` and `TwilioVerifiedRequest` under
+      // skipLibCheck:false (see #1500). Mirrors the @chat-adapter/slack
+      // pattern a few directories over.
+      distEntries.filter((name) => /^types-[^./]+\.d\.ts$/.test(name)),
   }),
 };

--- a/packages/eve/scripts/vendor-compiled/_shared.mjs
+++ b/packages/eve/scripts/vendor-compiled/_shared.mjs
@@ -120,8 +120,21 @@ export function createDeclarationCopier({
           ? files
           : [{ source: "index.d.ts", output: "index.d.ts" }];
 
+    // discoverExtraFiles names content-hashed sibling chunks (e.g.
+    // `messages-<hash>.d.ts`, `types-<hash>.d.ts`) that the upstream
+    // bundler emits next to the entry .d.ts. They must flow through the
+    // same rewrite pass as the named `files` — chat's `messages-<hash>`
+    // chunk imports `mdast`, and the published package cannot ship that
+    // bare specifier (no @types/mdast in scope; see #1500).
+    const extraFileNames =
+      typeof discoverExtraFiles === "function" ? discoverExtraFiles(distEntries) : [];
+    const allFiles = [
+      ...declarationFiles,
+      ...extraFileNames.map((name) => ({ source: name, output: name })),
+    ];
+
     const declarations = await Promise.all(
-      declarationFiles.map(async (file) => ({
+      allFiles.map(async (file) => ({
         ...file,
         sourceText: await readFile(join(distDir, file.source), "utf8"),
       })),
@@ -178,16 +191,10 @@ export function createDeclarationCopier({
       }),
     );
 
-    if (typeof discoverExtraFiles === "function") {
-      const extras = discoverExtraFiles(distEntries);
-      await Promise.all(
-        extras.map(async (file) => {
-          const outputPath = join(destinationRoot, file);
-          await mkdir(dirname(outputPath), { recursive: true });
-          await copyFile(join(distDir, file), outputPath);
-        }),
-      );
-    }
+    // NOTE: the previous tail block that re-copied each extra file verbatim
+    // (via copyFile) is removed — extras are folded into `declarations`
+    // above so they receive the same rewrite pass. Re-adding it would
+    // overwrite the rewritten output with the un-rewritten source.
   };
 }
 

--- a/packages/eve/scripts/vendor-compiled/chat.mjs
+++ b/packages/eve/scripts/vendor-compiled/chat.mjs
@@ -38,6 +38,14 @@ export default {
       },
     },
     discoverExtraFiles: (distEntries) =>
-      distEntries.filter((name) => /^jsx-runtime-[^./]+\.d\.ts$/.test(name)),
+      // Co-copy the sibling content-hashed declaration chunks the upstream
+      // build emits that the entry .d.ts imports by relative path:
+      // `jsx-runtime-<hash>.d.ts` (pre-existing) and `messages-<hash>.d.ts`
+      // (previously missed — its absence with skipLibCheck:false produced
+      // TS2307 across ~120 chat exports, see #1500). The hash suffix is
+      // content-derived and drifts on every upstream build.
+      distEntries.filter((name) =>
+        /^(jsx-runtime|messages)-[^./]+\.d\.ts$/.test(name),
+      ),
   }),
 };

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -270,7 +270,7 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
       { inputResponses: [response] },
       {
         auth: config.resolveInputAuth ? await config.resolveInputAuth(event) : null,
-        thread: event.thread,
+        thread: event.thread as Thread,
       },
     );
   });

--- a/packages/eve/src/public/channels/photon/inboundContent.test.ts
+++ b/packages/eve/src/public/channels/photon/inboundContent.test.ts
@@ -6,8 +6,10 @@ import { photonInboundContent } from "#public/channels/photon/inboundContent.js"
 function message(text: string, attachments: Message["attachments"] = []): Message {
   return new Message({
     attachments,
-    author: { isBot: false, isMe: false, userId: "user", userName: "user" },
+    author: { fullName: "user", isBot: false, isMe: false, userId: "user", userName: "user" },
+    formatted: { type: "root", children: [] },
     id: "message-id",
+    metadata: { dateSent: new Date(), edited: false },
     raw: {},
     text,
     threadId: "thread-id",

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
@@ -42,8 +42,11 @@ describe("photonIMessageChannel", () => {
     if (handler === undefined) throw new Error("Expected an inbound direct-message handler.");
     const thread = { id: "thread-id" };
     const message = new Message({
-      author: { isBot: false, isMe: false, userId: "user", userName: "user" },
+      attachments: [],
+      author: { fullName: "user", isBot: false, isMe: false, userId: "user", userName: "user" },
+      formatted: { type: "root", children: [] },
       id: "message-id",
+      metadata: { dateSent: new Date(), edited: false },
       raw: {},
       text: "Steer this response",
       threadId: thread.id,
@@ -65,8 +68,11 @@ describe("photonIMessageChannel", () => {
     if (handler === undefined) throw new Error("Expected an inbound direct-message handler.");
     const thread = { id: "thread-id" };
     const message = new Message({
-      author: { isBot: false, isMe: false, userId: "user", userName: "user" },
+      attachments: [],
+      author: { fullName: "user", isBot: false, isMe: false, userId: "user", userName: "user" },
+      formatted: { type: "root", children: [] },
       id: "message-id",
+      metadata: { dateSent: new Date(), edited: false },
       raw: {},
       text: "  \n",
       threadId: thread.id,
@@ -87,8 +93,11 @@ describe("photonIMessageChannel", () => {
     }
     const thread = { id: "group-thread-id" };
     const message = new Message({
-      author: { isBot: false, isMe: false, userId: "user", userName: "user" },
+      attachments: [],
+      author: { fullName: "user", isBot: false, isMe: false, userId: "user", userName: "user" },
+      formatted: { type: "root", children: [] },
       id: "message-id",
+      metadata: { dateSent: new Date(), edited: false },
       raw: {},
       text: "Hello group",
       threadId: thread.id,


### PR DESCRIPTION
## Problem

`chat` and `@chat-adapter/twilio` both ship content-hashed sibling declaration chunks that their `index.d.ts` (or sibling entry `.d.ts`) imports by relative path:

- `chat/dist/messages-BSoJG691.d.ts` (145 type/interface/class declarations — `Message`, `Thread`, `Channel`, `ActionEvent`, `Author`, `MessageData`, `Attachment`, …)
- `@chat-adapter/twilio/dist/types-WYjTBVDi.d.ts` (15 declarations — `TwilioWebhookUrl`, `TwilioVerifiedRequest`, `TwilioVerifyOptions`, `TwilioWebhookPayload`, …)

`packages/eve/scripts/vendor-compiled/chat.mjs` only matched `jsx-runtime-<hash>.d.ts` via `discoverExtraFiles`, and `vendor-compiled/@chat-adapter/twilio.mjs` had no discovery block at all. Those chunks were dropped from the published `eve` tarball while `index.d.ts` still references them by relative path, so consumers of `eve`'s `#compiled/chat` and `#compiled/@chat-adapter/twilio` namespaces see:

- ~120+ type exports degrade to `any` (`skipLibCheck: true`, the default),
- `TS2307: Cannot find module './messages-….js'` / `'./types-….js'` with `skipLibCheck: false`,
- downstream noise like `TS2741: Property 'fullName' is missing in type …` once the leaked symbols re-route through `Author`/`MessageData`/`Thread`.

Resolves #1500.

## Fix

**`packages/eve/scripts/vendor-compiled/_shared.mjs` (`createDeclarationCopier`)** — previously `discoverExtraFiles`-selected files were copied **verbatim** via `copyFile` *after* the named `files` went through the rewrite pass. Chat's `messages-<hash>.d.ts` contains `import { Root } from 'mdast'` and `import { WORKFLOW_SERIALIZE, WORKFLOW_DESERIALIZE } from '@workflow/serde'` — bare specifiers that cannot reach the published package (no `@types/mdast`, no `@workflow/serde` declaration in closure). Extras must flow through the same rewrite pipeline.

Fold extras into the `declarations` array before `mergeExternalDeclarationImports` runs, so the existing vendored/stub/external rule matrix applies uniformly. Drop the tailing verbatim `copyFile` block (it would otherwise overwrite the rewritten outputs with the un-rewritten sources).

**`packages/eve/scripts/vendor-compiled/chat.mjs`** — broaden the matcher from `^jsx-runtime-[^./]+\.d\.ts$` to `^(jsx-runtime|messages)-[^./]+\.d\.ts$`. The hash suffix is content-derived and drifts every upstream build, so keep matching on basename + any tail.

**`packages/eve/scripts/vendor-compiled/@chat-adapter/twilio.mjs`** — add a `discoverExtraFiles` block matching `^types-[^./]+\.d\.ts$`, mirroring `@chat-adapter/slack.mjs`'s pre-existing shape.

**Type-graph side-effects.** Precise types from the copied chunk expose a small set of sites in eve that were silently relying on the previous `any` fallback:

- `src/public/channels/chat-sdk/chatSdkChannel.ts`: `ActionEvent.thread` is `Thread<TRawMessage, unknown>`; cast through the declared `Thread` alias on the `ChatSdkSendOptions.thread` field so the existing `TState = Record<string, unknown>` default applies.
- `src/public/channels/photon/inboundContent.test.ts`: add the now-required `formatted` (mdast `Root`), `metadata` (`{dateSent, edited}`), and `fullName` (Author) fields to the `new Message({...})` mock.
- `src/public/channels/photon/photonIMessageChannel.test.ts`: same three mocks, plus `attachments: []` each.

**`.changeset/fix-1500-missing-declaration-chunks.md`** — `"eve": patch`.

## Verification

| Gate | Result |
|---|---|
| Fresh worktree + `pnpm install --frozen-lockfile` | ✓ |
| `node scripts/vendor-compiled.mjs` (all 41 modules) | ✓ `messages-BSoJG691.d.ts` alongside `jsx-runtime-_JEEAotp.d.ts` in `.generated/compiled/chat/`; `types-WYjTBVDi.d.ts` in `.generated/compiled/@chat-adapter/twilio/` |
| Rewrites applied to chunk | ✓ `from './_mdast.js'` on line 2, `from './_workflow-serde.js'` on line 1 of the copied `messages-BSoJG691.d.ts` |
| `npx tsc --noEmit -p tsconfig.json` (full package) | ✓ **0 errors** (baseline main: 5 — all the photon `fullName`/MessageData mocks tightened here) |
| `npx tsc -p tsconfig.build.json` (production build types) | ✓ exit 0 |
| `pnpm run test:unit` | ✓ **5870 pass / 4 fail** — identical to baseline main; all 4 failures are `test/bin-bootstrap.test.ts` gating on Node.js ≥24 (running on v22.22.3 locally), unrelated |
| Targeted `tsc` probe with `skipLibCheck: false` against `.generated/compiled/` | ✓ zero `TS2307` on `./messages-…` or `./types-…` — the #1500 repro closes |
| `npx oxlint --fix` on touched paths | ✓ exit 0 |

## Out of scope maintained

- Identical 4 `bin-bootstrap` failures match baseline (Node env).
- The 5 baseline `tsc --noEmit` errors were in the same photon test mocks tightened here — those leaks were only visible without the precise type graph.
- No upstream package edits; no unrelated refactors.

DCO-signed.

/test
