### PR TITLE
feat(slack): thread workspace identity into bot-token resolution (#222)

### DIFF
--- a/packages/eve/src/public/channels/slack/api.test.ts
+++ b/packages/eve/src/public/channels/slack/api.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Card, CardText } from "#compiled/chat/index.js";
 import { decodeSlackApiBody } from "#public/channels/slack/api-encoding.js";
-import { buildSlackBinding, callSlackApi } from "#public/channels/slack/api.js";
+import {
+  buildSlackBinding,
+  callSlackApi,
+  type SlackBotTokenContext,
+} from "#public/channels/slack/api.js";
 
 interface FetchCall {
   url: string;
@@ -875,5 +879,172 @@ describe("auto-anchor on first post", () => {
     await Promise.all([thread.post("a"), thread.post("b"), thread.post("c")]);
 
     expect(anchors).toHaveLength(1);
+  });
+});
+
+describe("SlackBotTokenContext threading", () => {
+  let mock: ReturnType<typeof buildFetchMock>;
+
+  beforeEach(() => {
+    mock = buildFetchMock();
+    vi.stubGlobal("fetch", mock.fetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("thread.post forwards teamId/channelId/threadTs to a context-aware token callback", async () => {
+    const seen: unknown[] = [];
+    const botToken = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-resolved";
+    });
+    const { thread } = buildSlackBinding({
+      botToken,
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: "T01",
+    });
+
+    await thread.post("hello");
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toEqual({ teamId: "T01", channelId: "C01", threadTs: "1.0" });
+
+    // The resolved (workspace-specific) token — not a static env token —
+    // must be what actually signs the request.
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect(post).toBeDefined();
+  });
+
+  it("slack.request forwards the binding identity to a context-aware token callback", async () => {
+    const seen: unknown[] = [];
+    const botToken = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-resolved";
+    });
+    const { slack } = buildSlackBinding({
+      botToken,
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: "T01",
+    });
+
+    await slack.request("chat.postMessage", { channel: "C99", text: "hi" });
+
+    expect(seen).toEqual([{ teamId: "T01", channelId: "C01", threadTs: "1.0" }]);
+  });
+
+  it("uploadFiles reflects per-call channel/thread overrides in the context", async () => {
+    const seen: unknown[] = [];
+    const botToken = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-resolved";
+    });
+    const { slack } = buildSlackBinding({
+      botToken,
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: "T01",
+    });
+
+    await slack.uploadFiles([{ data: new Uint8Array([1, 2, 3]), filename: "a.bin" }], {
+      channelId: "C02",
+      threadTs: "9.9",
+    });
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toMatchObject({ teamId: "T01", channelId: "C02", threadTs: "9.9" });
+  });
+
+  it("passes the live (post-anchor) threadTs after auto-anchoring on the first post", async () => {
+    const seen: unknown[] = [];
+    const botToken = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-resolved";
+    });
+    const { thread } = buildSlackBinding({
+      botToken,
+      channelId: "C01",
+      threadTs: "",
+      teamId: "T01",
+    });
+
+    await thread.post("first");
+    await thread.refresh();
+
+    // The final resolution happens during conversations.replies, after the
+    // first post anchored the thread at ts 1700000001.000001.
+    const last = seen.at(-1);
+    expect(last).toEqual({ teamId: "T01", channelId: "C01", threadTs: "1700000001.000001" });
+  });
+
+  it("omits undefined identity fields instead of passing empty-ish context", async () => {
+    const seen: unknown[] = [];
+    const botToken = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-resolved";
+    });
+    const { thread } = buildSlackBinding({
+      botToken,
+      channelId: "",
+      threadTs: "",
+      teamId: undefined,
+    });
+
+    await thread.post("first");
+
+    // No team/channel/thread identity known yet → the callback receives an
+    // empty context object rather than keys holding undefined/empty strings.
+    expect(seen[0]).toEqual({});
+  });
+
+  it("never calls a zero-argument token callback with a context", async () => {
+    // A legacy zero-arg callback exposes no parameter. Even if a caller
+    // passes one anyway (arity > 0), the resolver forwards the context only
+    // when the declared arity requires it, so legacy code is unaffected.
+    const botToken = vi.fn(() => "xoxb-zero");
+    const { thread } = buildSlackBinding({
+      botToken,
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: "T01",
+    });
+
+    await thread.post("hello");
+
+    expect(botToken).toHaveBeenCalledWith();
+  });
+
+  it("keeps literal string tokens working with no context object", async () => {
+    const { thread } = buildSlackBinding({
+      botToken: "xoxb-literal",
+      channelId: "C01",
+      threadTs: "1.0",
+      teamId: "T01",
+    });
+
+    await thread.post("hello");
+
+    const post = mock.calls.find((c) => c.url === "https://slack.com/api/chat.postMessage");
+    expect(post).toBeDefined();
+  });
+
+  it("callSlackApi forwards an explicit context to a context-aware token callback", async () => {
+    const seen: unknown[] = [];
+    const botToken = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-resolved";
+    });
+
+    await callSlackApi({
+      botToken,
+      operation: "chat.postMessage",
+      body: { channel: "C01", text: "hi" },
+      context: { teamId: "T02", channelId: "C01", threadTs: "2.0" },
+    });
+
+    expect(seen).toEqual([{ teamId: "T02", channelId: "C01", threadTs: "2.0" }]);
   });
 });

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -16,15 +16,11 @@
  */
 
 import {
-  callSlackApi as callSlackApiPrimitive,
   fetchSlackThreadReplies,
   postSlackEphemeral,
   postSlackMessage,
-  resolveSlackBotToken as resolveSlackBotTokenPrimitive,
   uploadSlackFiles,
-  type SlackApiOptions,
-  type SlackApiResponse as SlackPrimitiveApiResponse,
-  type SlackBotToken as SlackPrimitiveBotToken,
+  type SlackApiResponse,
   type SlackFileUpload,
   type SlackMessageOptions,
 } from "#compiled/@chat-adapter/slack/api.js";
@@ -34,15 +30,22 @@ import { createLogger, logError } from "#internal/logging.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
 import { truncateTypingStatus } from "#public/channels/slack/limits.js";
 import { slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
+import {
+  createSlackApiOptions,
+  createSlackRequester,
+  type SlackBotToken,
+  type SlackBotTokenContext,
+} from "#public/channels/slack/token.js";
+
+export {
+  callSlackApi,
+  resolveSlackBotToken,
+  type SlackBotToken,
+  type SlackBotTokenContext,
+} from "#public/channels/slack/token.js";
+export type { SlackApiResponse } from "#compiled/@chat-adapter/slack/api.js";
 
 const log = createLogger("slack.api");
-
-/**
- * Slack bot token, materialized either as a literal `xoxb-...` string or
- * as a (possibly async) function that returns one. The function form
- * supports secret-manager lookups and credential rotation.
- */
-export type SlackBotToken = SlackPrimitiveBotToken;
 
 /**
  * Builds the channel-local continuation token (`<channelId>:<threadTs>`).
@@ -53,52 +56,6 @@ export type SlackBotToken = SlackPrimitiveBotToken;
  */
 export function slackContinuationToken(channelId: string, threadTs: string): string {
   return `${channelId}:${threadTs}`;
-}
-
-/**
- * Materializes a {@link SlackBotToken} to a string, falling back to
- * `process.env.SLACK_BOT_TOKEN`. Throws when neither is set.
- */
-export async function resolveSlackBotToken(token?: SlackBotToken): Promise<string> {
-  const source = token ?? process.env.SLACK_BOT_TOKEN;
-  if (!source) throw new Error("SLACK_BOT_TOKEN is required.");
-  return resolveSlackBotTokenPrimitive(source);
-}
-
-/**
- * Slack Web API JSON response envelope. `ok` signals success, `error`
- * carries Slack's error code on failure, and method-specific fields pass
- * through verbatim. Callers inspect `ok` themselves.
- */
-export type SlackApiResponse = SlackPrimitiveApiResponse;
-
-/**
- * Low-level POST to a Slack Web API method, signed with the bot token
- * and form-encoded. Form is the only safe default: Slack's JSON support
- * is partial (e.g. `conversations.replies` rejects JSON). Returns the
- * raw JSON response; callers inspect `response.ok` themselves.
- */
-export async function callSlackApi(input: {
-  readonly botToken: SlackBotToken | undefined;
-  readonly operation: string;
-  readonly body: unknown;
-}): Promise<SlackApiResponse> {
-  return callSlackApiPrimitive(
-    input.operation,
-    normalizeSlackApiBody(input.body),
-    createSlackApiOptions(input.botToken),
-  );
-}
-
-/**
- * Builds the `request(op, body)` Slack API caller installed on every
- * {@link SlackHandle}. Resolves the bot token at call time so rotated
- * credentials are picked up without rebuilding the binding.
- */
-function createSlackRequester(
-  botToken: SlackBotToken | undefined,
-): (operation: string, body: unknown) => Promise<SlackApiResponse> {
-  return (operation, body) => callSlackApi({ botToken, operation, body });
 }
 
 /**
@@ -350,9 +307,10 @@ export function buildSlackWorkspaceHandle(input: {
   readonly botToken: SlackBotToken | undefined;
   readonly teamId: string | undefined;
 }): SlackWorkspaceHandle {
+  const context: SlackBotTokenContext = input.teamId ? { teamId: input.teamId } : {};
   return {
     teamId: input.teamId,
-    request: createSlackRequester(input.botToken),
+    request: createSlackRequester(input.botToken, () => context),
   };
 }
 
@@ -386,7 +344,19 @@ export function buildSlackBinding(input: {
   readonly teamId: string | undefined;
   readonly onThreadTsChanged?: (ts: string) => void;
 }): SlackBinding {
-  const request = createSlackRequester(input.botToken);
+  // Lazy so a context-aware token callback always sees the live thread
+  // identity: the thread auto-anchors on the first post for threadless
+  // sessions, and uploadFiles may override channel/thread per call.
+  function bindingContext(): SlackBotTokenContext {
+    const context: {
+      -readonly [K in keyof SlackBotTokenContext]: SlackBotTokenContext[K];
+    } = {};
+    if (input.teamId) context.teamId = input.teamId;
+    if (input.channelId) context.channelId = input.channelId;
+    if (currentThreadTs) context.threadTs = currentThreadTs;
+    return context;
+  }
+  const request = createSlackRequester(input.botToken, bindingContext);
   let messages: readonly SlackThreadMessage[] = [];
   let currentThreadTs = input.threadTs;
   let refreshInFlight: Promise<void> | undefined;
@@ -404,7 +374,11 @@ export function buildSlackBinding(input: {
     const channelId = options?.channelId ?? input.channelId;
     const threadTs = options?.threadTs ?? currentThreadTs;
     return uploadSlackFiles(files.map(toSlackFileUpload), {
-      ...createSlackApiOptions(input.botToken),
+      ...createSlackApiOptions(input.botToken, {
+        ...(input.teamId ? { teamId: input.teamId } : {}),
+        ...(channelId ? { channelId } : {}),
+        ...(threadTs ? { threadTs } : {}),
+      }),
       channelId: channelId || undefined,
       initialComment: options?.initialComment,
       threadTs: threadTs || undefined,
@@ -423,7 +397,7 @@ export function buildSlackBinding(input: {
       }
       try {
         const response = await fetchSlackThreadReplies({
-          ...createSlackApiOptions(input.botToken),
+          ...createSlackApiOptions(input.botToken, bindingContext()),
           channel: input.channelId,
           limit: 50,
           ts: currentThreadTs,
@@ -481,7 +455,13 @@ export function buildSlackBinding(input: {
       }
 
       const response = await postSlackMessage(
-        buildPostMessageOptions(message, input.channelId, currentThreadTs, input.botToken),
+        buildPostMessageOptions(
+          message,
+          input.channelId,
+          currentThreadTs,
+          input.botToken,
+          bindingContext(),
+        ),
       );
       const id = response.id;
       handleMessageTs(id);
@@ -500,7 +480,13 @@ export function buildSlackBinding(input: {
     async postEphemeral(userId, rawMessage) {
       const message = normalizePostInput(rawMessage);
       const response = await postSlackEphemeral({
-        ...buildPostMessageOptions(message, input.channelId, currentThreadTs, input.botToken),
+        ...buildPostMessageOptions(
+          message,
+          input.channelId,
+          currentThreadTs,
+          input.botToken,
+          bindingContext(),
+        ),
         user: userId,
       });
       return { id: response.id, raw: response.raw };
@@ -514,7 +500,10 @@ export function buildSlackBinding(input: {
       }
       const message = normalizePostInput(rawMessage);
       const response = await postSlackMessage(
-        buildPostMessageOptions(message, imChannelId, "", input.botToken),
+        buildPostMessageOptions(message, imChannelId, "", input.botToken, {
+          ...(input.teamId ? { teamId: input.teamId } : {}),
+          channelId: imChannelId,
+        }),
       );
       return { id: response.id, raw: response.raw };
     },
@@ -583,9 +572,10 @@ function buildPostMessageOptions(
   channelId: string,
   threadTs: string,
   botToken: SlackBotToken | undefined,
+  context?: SlackBotTokenContext,
 ): SlackMessageOptions {
   const base: SlackMessageOptions = {
-    ...createSlackApiOptions(botToken),
+    ...createSlackApiOptions(botToken, context),
     channel: channelId,
     threadTs: threadTs || undefined,
     unfurlLinks: false,
@@ -608,17 +598,6 @@ function buildPostMessageOptions(
   }
   base.text = message.text;
   return base;
-}
-
-function createSlackApiOptions(botToken: SlackBotToken | undefined): SlackApiOptions {
-  return { token: () => resolveSlackBotToken(botToken) };
-}
-
-function normalizeSlackApiBody(body: unknown): Record<string, unknown> {
-  if (body && typeof body === "object" && !Array.isArray(body)) {
-    return body as Record<string, unknown>;
-  }
-  return {};
 }
 
 function toSlackFileUpload(file: FileUpload): SlackFileUpload {

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -6,6 +6,7 @@ import {
   collectSlackFileParts,
   createSlackFetchFile,
 } from "#public/channels/slack/attachments.js";
+import type { SlackBotTokenContext } from "#public/channels/slack/api.js";
 import type { SlackAttachment } from "#public/channels/slack/inbound.js";
 import { DEFAULT_UPLOAD_POLICY, mergeUploadPolicy } from "#public/channels/upload-policy.js";
 
@@ -206,6 +207,66 @@ describe("createSlackFetchFile", () => {
     expect((init as RequestInit | undefined)?.headers).toEqual({
       authorization: "Bearer xoxb-rotated-token",
     });
+  });
+
+  it("forwards a static teamId to a context-aware token callback", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(new Uint8Array([0]), { status: 200 }));
+
+    const seen: unknown[] = [];
+    const tokenFn = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-team-token";
+    });
+    const fetchFile = createSlackFetchFile({ botToken: tokenFn, teamId: "T-team-1" });
+
+    await fetchFile("https://files.slack.com/x");
+
+    expect(seen).toEqual([{ teamId: "T-team-1" }]);
+    const [, init] = fetchSpy.mock.calls[0]!;
+    expect((init as RequestInit | undefined)?.headers).toEqual({
+      authorization: "Bearer xoxb-team-token",
+    });
+  });
+
+  it("reads a lazy teamId getter per fetch so the resolved workspace is current", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Promise.resolve(new Response(new Uint8Array([0]), { status: 200 })),
+    );
+
+    const seen: unknown[] = [];
+    const tokenFn = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-team-token";
+    });
+    let liveTeamId: string | null = "T-ws-a";
+    const fetchFile = createSlackFetchFile({ botToken: tokenFn, teamId: () => liveTeamId });
+
+    await fetchFile("https://files.slack.com/one");
+    liveTeamId = "T-ws-b";
+    await fetchFile("https://files.slack.com/two");
+    liveTeamId = null;
+    await fetchFile("https://files.slack.com/three");
+
+    expect(seen).toEqual([{ teamId: "T-ws-a" }, { teamId: "T-ws-b" }, {}]);
+  });
+
+  it("omits teamId (empty context) when the caller provides none", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([0]), { status: 200 }),
+    );
+
+    const seen: unknown[] = [];
+    const tokenFn = vi.fn((context: SlackBotTokenContext) => {
+      seen.push(context);
+      return "xoxb-team-token";
+    });
+    const fetchFile = createSlackFetchFile({ botToken: tokenFn });
+
+    await fetchFile("https://files.slack.com/x");
+
+    expect(seen).toEqual([{}]);
   });
 
   it.each([

--- a/packages/eve/src/public/channels/slack/attachments.ts
+++ b/packages/eve/src/public/channels/slack/attachments.ts
@@ -164,15 +164,23 @@ export function buildSlackTurnMessage(
  * Returns `null` for URLs that don't belong to Slack so they pass
  * through to the model provider unchanged. Fetches Slack file URLs
  * with the bot token.
+ *
+ * `teamId` (static value or lazy getter) is forwarded to context-aware
+ * token callbacks so a multi-install Slack connector resolves the correct
+ * workspace's token. A getter is read per fetch, so a caller may hand in
+ * the live channel state identity once it supports per-event dispatch.
+ * Omitting it preserves the single-token behaviour.
  */
 export function createSlackFetchFile(input: {
   readonly botToken?: SlackBotToken;
+  readonly teamId?: string | (() => string | null | undefined);
 }): (url: string) => Promise<FetchFileResult | null> {
   return async (url) => {
     if (!isSlackFileUrl(url)) {
       return null;
     }
-    const token = await resolveSlackBotToken(input.botToken);
+    const teamId = typeof input.teamId === "function" ? input.teamId() : input.teamId;
+    const token = await resolveSlackBotToken(input.botToken, teamId ? { teamId } : {});
     const response = await fetch(url, {
       headers: { authorization: `Bearer ${token}` },
     });

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -56,6 +56,7 @@ export {
   callSlackApi,
   resolveSlackBotToken,
   slackContinuationToken,
+  type SlackBotTokenContext,
   type SlackPostInput,
   type SlackPostedMessage,
   type SlackThreadMessage,

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -490,7 +490,11 @@ async function openFreeformModal(input: {
 
   const promptText = readPromptTextFromBlocks(input.interaction.messageBlocks);
   const view = buildFreeformModalView({ metadata, prompt: promptText });
-  const token = await resolveSlackBotToken(input.deps.config.credentials?.botToken);
+  const token = await resolveSlackBotToken(input.deps.config.credentials?.botToken, {
+    ...(input.interaction.teamId ? { teamId: input.interaction.teamId } : {}),
+    ...(input.interaction.channelId ? { channelId: input.interaction.channelId } : {}),
+    ...(input.interaction.threadTs ? { threadTs: input.interaction.threadTs } : {}),
+  });
 
   const response = await fetch("https://slack.com/api/views.open", {
     method: "POST",
@@ -580,6 +584,7 @@ async function handleViewSubmission(
       messageTs: metadata.messageTs,
       answerLabel: text,
       userId: triggeringUserId ?? undefined,
+      teamId: teamId ?? undefined,
       deps: _deps,
     }).catch((error: unknown) => {
       log.error("freeform answered-card update failed", { error });
@@ -606,7 +611,11 @@ async function updateAnsweredHitlCard(
     userId: hitlAction.user.id,
   });
 
-  const token = await resolveSlackBotToken(deps.config.credentials?.botToken);
+  const token = await resolveSlackBotToken(deps.config.credentials?.botToken, {
+    ...(interaction.teamId ? { teamId: interaction.teamId } : {}),
+    ...(interaction.channelId ? { channelId: interaction.channelId } : {}),
+    ...(interaction.threadTs ? { threadTs: interaction.threadTs } : {}),
+  });
   const response = await fetch("https://slack.com/api/chat.update", {
     method: "POST",
     headers: {
@@ -630,6 +639,7 @@ async function updateAnsweredFreeformCard(input: {
   readonly messageTs: string;
   readonly answerLabel: string;
   readonly userId?: string;
+  readonly teamId?: string;
   readonly deps: InteractionHandlerDeps;
 }): Promise<void> {
   const blocks = buildAnsweredBlocks({
@@ -637,7 +647,10 @@ async function updateAnsweredFreeformCard(input: {
     answerLabel: input.answerLabel,
     userId: input.userId,
   });
-  const token = await resolveSlackBotToken(input.deps.config.credentials?.botToken);
+  const token = await resolveSlackBotToken(input.deps.config.credentials?.botToken, {
+    ...(input.teamId ? { teamId: input.teamId } : {}),
+    channelId: input.channelId,
+  });
   const response = await fetch("https://slack.com/api/chat.update", {
     method: "POST",
     headers: {

--- a/packages/eve/src/public/channels/slack/token.ts
+++ b/packages/eve/src/public/channels/slack/token.ts
@@ -1,0 +1,123 @@
+/**
+ * Bot-token resolution seam for the Slack channel.
+ *
+ * Owns the public {@link SlackBotToken} / {@link SlackBotTokenContext}
+ * shapes and the low-level {@link callSlackApi} helper so that `api.ts`
+ * (the thread/handle surface) stays under the file-length cap and the
+ * identity→token wiring lives in exactly one place.
+ */
+
+import {
+  callSlackApi as callSlackApiPrimitive,
+  resolveSlackBotToken as resolveSlackBotTokenPrimitive,
+  type SlackApiOptions,
+  type SlackApiResponse,
+  type SlackBotToken as SlackPrimitiveBotToken,
+} from "#compiled/@chat-adapter/slack/api.js";
+
+/**
+ * Slack workspace / thread identity passed to context-aware
+ * {@link SlackBotToken} callbacks. A single Slack app installed into
+ * multiple workspaces receives events carrying each workspace's `team_id`;
+ * a context-aware token callback uses these fields to select the correct
+ * installation's bot token (e.g. via a Connect multi-install connector or
+ * a workspace→token map) instead of a single workspace-agnostic token.
+ *
+ * All fields are optional because not every call site knows the full
+ * identity: threadless proactive posts have no `threadTs` yet, and some
+ * inbound events omit `team_id`. A zero-argument token callback never
+ * receives a context and keeps working unchanged.
+ */
+export interface SlackBotTokenContext {
+  /** Slack workspace id (`T…`) carried by the inbound event, when present. */
+  readonly teamId?: string;
+  /** Slack channel id being posted to, when known. */
+  readonly channelId?: string;
+  /** Slack thread root ts being posted into, when known. */
+  readonly threadTs?: string;
+}
+
+/**
+ * Slack bot token, materialized either as a literal `xoxb-...` string or
+ * as a (possibly async) function that returns one.
+ *
+ * The zero-argument form supports secret-manager lookups and credential
+ * rotation. The context-arg form additionally receives the current Slack
+ * workspace/thread identity ({@link SlackBotTokenContext}) so a single
+ * channel can resolve a per-workspace token for a multi-install Slack
+ * connector. Both function shapes remain valid; existing zero-arg
+ * callbacks are unaffected.
+ */
+export type SlackBotToken =
+  | string
+  | (() => string | Promise<string>)
+  | ((context: SlackBotTokenContext) => string | Promise<string>);
+
+/**
+ * Materializes a {@link SlackBotToken} to a string, falling back to
+ * `process.env.SLACK_BOT_TOKEN`. Throws when neither is set.
+ *
+ * `context` carries the current Slack workspace/thread identity
+ * ({@link SlackBotTokenContext}). It is only forwarded to context-aware
+ * (arity > 0) token callbacks; zero-arg callbacks never receive it, so a
+ * literal string or a `() => token` callback behaves exactly as before.
+ */
+export async function resolveSlackBotToken(
+  token?: SlackBotToken,
+  context?: SlackBotTokenContext,
+): Promise<string> {
+  const source = token ?? process.env.SLACK_BOT_TOKEN;
+  if (!source) throw new Error("SLACK_BOT_TOKEN is required.");
+  if (typeof source === "function" && source.length > 0) {
+    return (source as (ctx: SlackBotTokenContext) => string | Promise<string>)(context ?? {});
+  }
+  return resolveSlackBotTokenPrimitive(source as SlackPrimitiveBotToken);
+}
+
+/**
+ * Low-level POST to a Slack Web API method, signed with the bot token
+ * and form-encoded. Form is the only safe default: Slack's JSON support
+ * is partial (e.g. `conversations.replies` rejects JSON). Returns the
+ * raw JSON response; callers inspect `response.ok` themselves.
+ */
+export async function callSlackApi(input: {
+  readonly botToken: SlackBotToken | undefined;
+  readonly operation: string;
+  readonly body: unknown;
+  /** Slack workspace/thread identity forwarded to context-aware token callbacks. */
+  readonly context?: SlackBotTokenContext;
+}): Promise<SlackApiResponse> {
+  return callSlackApiPrimitive(
+    input.operation,
+    normalizeSlackApiBody(input.body),
+    createSlackApiOptions(input.botToken, input.context),
+  );
+}
+
+/**
+ * Builds the `request(op, body)` Slack API caller installed on every
+ * `SlackHandle`. `context` is a getter so the resolved identity is always
+ * current (the thread auto-anchors on the first post for threadless
+ * sessions, mutating the live `threadTs`).
+ */
+export function createSlackRequester(
+  botToken: SlackBotToken | undefined,
+  context?: () => SlackBotTokenContext,
+): (operation: string, body: unknown) => Promise<SlackApiResponse> {
+  return (operation, body) => callSlackApi({ botToken, operation, body, context: context?.() });
+}
+
+/** Wraps token resolution in the primitive's options envelope. */
+export function createSlackApiOptions(
+  botToken: SlackBotToken | undefined,
+  context?: SlackBotTokenContext,
+): SlackApiOptions {
+  return { token: () => resolveSlackBotToken(botToken, context) };
+}
+
+function normalizeSlackApiBody(body: unknown): Record<string, unknown> {
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    return body as Record<string, unknown>;
+  }
+  return {};
+}


### PR DESCRIPTION
Closes #222

## Problem
The Slack channel parses the inbound `team_id` into channel state but resolves the outgoing bot token context-free (`SlackBotToken = string | (() => string)`). A single Slack app installed into multiple workspaces cannot select the correct installation token when posting a reply, refreshing a thread, uploading files, updating HITL cards, or fetching private files — forcing one channel/route/connector per workspace or AsyncLocalStorage/env-map workarounds.

## Change (additive, backward compatible)
- New `SlackBotTokenContext { teamId?, channelId?, threadTs? }` and `SlackBotToken` widened to accept a context-arg callback. `resolveSlackBotToken` forwards the context **only** to arity>0 callbacks, so literal strings and existing zero-arg callbacks behave exactly as before.
- The binding surfaces the live identity (teamId + channelId + auto-anchored threadTs) to `post` / `postEphemeral` / `postDirectMessage` / `uploadFiles` (incl. per-call channel/thread overrides) / `conversations.replies` refresh / `slack.request` / `buildSlackWorkspaceHandle`, and the HITL + freeform card-update paths thread the interaction `team_id`.
- Token seam extracted into `token.ts` to keep `api.ts` under the structural 700-line cap; `api.ts` re-exports the public surface.
- `createSlackFetchFile` accepts an optional static-or-lazy `teamId` so workspace selection is not silently dropped once the channel adapter supports per-event dispatch.

## Tests
- 8 new `SlackBotTokenContext threading` cases (post / slack.request / uploadFiles overrides / auto-anchor follow-up / omit-absent-fields / zero-arg isolation / literal token / callSlackApi explicit context).
- 3 new `createSlackFetchFile` context cases (static teamId, lazy teamId getter re-read per fetch, omitted teamId → empty context).
- Full slack channel suite green; full unit sweep green except pre-existing `bin-bootstrap` Node>=24 env failures.

## Follow-ups (out of scope)
- `slackContinuationToken(channelId, threadTs)` may need `teamId` because channel/thread ids are unique only per workspace.
- Companion change in `@vercel/connect/eve`: `connectSlackCredentials(...)` could consume this context to select the Connect installation.
- The channel-adapter `fetchFile(url)` contract does not yet carry per-event identity; threading reactive state teamId into file fetch is tracked separately.