### PR TITLE
fix(harness): defer step input when a runtime-action batch parks the step

### DIFF
--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -426,7 +426,12 @@ function getDeferredStepInput(session: HarnessSession): StepInput | undefined {
   return session.state?.[DEFERRED_STEP_INPUT_KEY] as StepInput | undefined;
 }
 
-function queueDeferredStepInput(session: HarnessSession, input: StepInput): HarnessSession {
+/**
+ * Queues step input to replay on the next internal harness step. Also used by
+ * the tool loop when a pending runtime-action batch parks the step: the
+ * user's follow-up input must survive the park rather than being dropped.
+ */
+export function queueDeferredStepInput(session: HarnessSession, input: StepInput): HarnessSession {
   const existing = getDeferredStepInput(session);
   const deferredInput = existing === undefined ? input : coalesceTurnInputs(existing, input);
   const state = { ...session.state };

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -42,7 +42,10 @@ import {
   hasPendingInputBatch,
   setPendingInputBatch,
 } from "#harness/input-requests.js";
-import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
+import {
+  getPendingRuntimeActionBatch,
+  setPendingRuntimeActionBatch,
+} from "#harness/runtime-actions.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import { isSessionLimitDecline, TurnCancelledError } from "#harness/turn-cancellation.js";
@@ -5381,6 +5384,41 @@ describe("createToolLoopHarness", () => {
       result.session.history.at(-1)?.role,
     ]).toEqual(["assistant", "tool-call", "tool-result", "assistant"]);
     expect(toolResult).toEqual(resumedToolResultMessage.content[0]);
+  });
+
+  it("defers a follow-up message that arrives while a runtime-action batch is parked", async () => {
+    const { emit } = createEventCollector();
+    const session = setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "call-1",
+          description: "Delegate the work.",
+          input: { message: "investigate latest routing" },
+          kind: "subagent-call",
+          name: "delegate",
+          nodeId: "subagents/delegate",
+          subagentName: "delegate",
+        },
+      ],
+      event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
+      responseMessages: [],
+      session: createTestSession(),
+    });
+
+    const harness = createToolLoopHarness(
+      createTestConfig("conversation", emit, { tools: new Map() }),
+    );
+    const result = await harness(session, {
+      message: "Can you do this in three separate tool calls?",
+    });
+
+    // The step parks until the runtime-action results arrive...
+    expect(result.next).toBeNull();
+    // ...and the user's message survives the park as deferred step input
+    // instead of being dropped on the floor.
+    expect(result.session.state?.["eve.runtime.deferredStepInput"]).toMatchObject({
+      message: "Can you do this in three separate tool calls?",
+    });
   });
 
   it("does not persist provider-executed deferred tool-results as generic tool messages", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -118,6 +118,7 @@ import {
   getPendingInputRequestIds,
   hasDeferredStepInput,
   hasStepInput,
+  queueDeferredStepInput,
   resolvePendingInput,
   setPendingInputBatch,
 } from "#harness/input-requests.js";
@@ -649,7 +650,14 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       stepInput: stepInput.input,
     });
     if (resolvedRuntimeActions.outcome === "unresolved") {
-      return { next: null, session: resolvedRuntimeActions.session };
+      // The step parks until the runtime-action results arrive. Any user
+      // input that rode in on this step must survive the park — queue it for
+      // replay on the resuming step instead of dropping it on the floor.
+      let parkedSession = resolvedRuntimeActions.session;
+      if (hasStepInput(stepInput.input)) {
+        parkedSession = queueDeferredStepInput(parkedSession, stepInput.input!);
+      }
+      return { next: null, session: parkedSession };
     }
     session = resolvedRuntimeActions.session;
 


### PR DESCRIPTION
### Description

Fixes #1538.

A step arriving while a pending runtime-action batch is unresolved parks with `return { next: null, session: resolvedRuntimeActions.session }` and silently discards the user's step input — dead air with data loss. The HITL sibling path (`resolvePendingInput`) already defers the incoming input via `queueDeferredStepInput` so it replays once the batch resolves; the runtime-action park path was missing the equivalent call.

Real-world context: in a product using client-executed runtime actions with approval, a user sent a follow-up message while an action batch was parked awaiting results. The message rendered client-side but was silently dropped server-side — no error anywhere, the pending approval stayed outstanding, and the message never reached the model.

### Changes

- `packages/eve/src/harness/tool-loop.ts`: when `resolvePendingRuntimeActions` returns `outcome: "unresolved"`, queue the incoming step input via `queueDeferredStepInput` before parking, mirroring the existing HITL path.
- `packages/eve/src/harness/input-requests.ts`: export `queueDeferredStepInput` (was module-private) with a doc comment covering both call sites.
- `packages/eve/src/harness/tool-loop.test.ts`: regression test "defers a follow-up message that arrives while a runtime-action batch is parked" — proven discriminating (fails without the fix; `result.session.state?.["eve.runtime.deferredStepInput"]` is `undefined`).

### How did you test your changes?

From `packages/eve`:

```
pnpm exec vitest run src/harness/tool-loop.test.ts src/harness/input-requests.test.ts --config vitest.unit.config.ts
```

- Green with the fix: 194 passed, exit 0.
- Red-check: reverted only the `tool-loop.ts` hunk and reran — 1 failed / 193 passed, exit 1. The new regression test is the sole failure:
  ```
  AssertionError: expected undefined to match object { Object (message) }
  - Expected: { "message": "Can you do this in three separate tool calls?" }
  + Received: undefined
  ```
  Restored the fix afterward; working tree clean.

Also ran `pnpm install` and `pnpm run build:compiled` in a clean worktree off `main` before testing.

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted (#1538 — opened alongside this PR per CONTRIBUTING.md; the fix is small and self-contained, offered for maintainer review rather than gated on a separate discussion round)
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant (regression test added; no public-facing docs affected — internal harness behavior only)
- [ ] I added a changeset if this touches the published `eve` package (not added — happy to add one if maintainers want this released as a fix rather than folded into another patch)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZ7Q1CMcajXuUPNjzsNZz9
