### PR TITLE
fix(eve): support just-bash search compatibility

### DIFF
--- a/.changeset/clean-mount-search.md
+++ b/.changeset/clean-mount-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use compatible POSIX search fallbacks in sandboxes whose `rg` implementation lacks the options required by eve, and surface command errors instead of reporting them as empty results.

--- a/.changeset/dynamic-subagent-build.md
+++ b/.changeset/dynamic-subagent-build.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow dynamic subagents to declare compile-time `build.externalDependencies`, so their authored modules can safely use packages that must remain external before runtime resolution.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -74,6 +74,25 @@ supported for subagents. A nil result (`null` or `undefined`) removes the
 subagent's description and tool definition from the model-visible surface.
 The subagent's filesystem manifest is always compiled; a non-nil result injects
 the returned agent configuration when the child runs.
+
+Packaging controls must be available before the resolver runs. Put them on
+`defineDynamic`, rather than the `defineAgent` returned by an event handler:
+
+```ts
+export default defineDynamic({
+  build: { externalDependencies: ["native-package"] },
+  events: {
+    "session.started": () =>
+      defineAgent({
+        description: "Use a native package when handling delegated work.",
+        model: "anthropic/claude-opus-4.8",
+      }),
+  },
+});
+```
+
+The compiler applies `build.externalDependencies` while bundling every authored
+module in that dynamic subagent.
 See [Dynamic capabilities](./guides/dynamic-capabilities#dynamic-subagents) for
 scope precedence, failure behavior, and the dispatch-time guard.
 

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -9,8 +9,8 @@ import {
 import { classifyModelRouting } from "#internal/classify-model-routing.js";
 import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import { compileAgentManifest } from "#compiler/normalize-manifest.js";
-import { defineAgent } from "#public/definitions/agent.js";
-import { defineDynamic, experimental_workflow } from "#public/definitions/tool.js";
+import { defineAgent, defineDynamic } from "#public/definitions/agent.js";
+import { experimental_workflow } from "#public/definitions/tool.js";
 import { webSearch } from "#public/tools/web-search.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 
@@ -154,6 +154,49 @@ describe("compileAgentManifest", () => {
     expect(mocks.compileAgentConfig.mock.calls[1]?.[2]).toMatchObject({
       definition: { model: DEFAULT_AGENT_MODEL_ID },
     });
+  });
+
+  it("applies dynamic subagent build configuration before resolving events", async () => {
+    const dynamic = defineDynamic({
+      build: { externalDependencies: ["just-bash"] },
+      events: {
+        "session.started": () =>
+          defineAgent({
+            description: "Edit the request.",
+            model: "openai/gpt-5.5",
+          }),
+      },
+    });
+    const manifest = createManifestWithSubagent();
+    mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) =>
+      createConfig({ name: input.agentId }),
+    );
+    mocks.loadModuleBackedDefinition.mockResolvedValue(dynamic);
+
+    const compiled = await compileAgentManifest(manifest);
+
+    expect(compiled.subagents[0]?.dynamic).toEqual({
+      eventNames: ["session.started"],
+    });
+    expect(mocks.compileAgentConfig.mock.calls[1]?.[2]).toMatchObject({
+      definition: {
+        build: { externalDependencies: ["just-bash"] },
+        model: DEFAULT_AGENT_MODEL_ID,
+      },
+    });
+  });
+
+  it("rejects invalid dynamic subagent build configuration", async () => {
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+    mocks.loadModuleBackedDefinition.mockResolvedValue({
+      build: { externalDependencies: "just-bash" },
+      events: { "session.started": () => null },
+      kind: "eve:dynamic",
+    });
+
+    await expect(compileAgentManifest(createManifestWithSubagent())).rejects.toThrow(
+      "Expected the dynamic subagent config export",
+    );
   });
 
   it("rejects fallback on a dynamic subagent", async () => {

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -155,17 +155,23 @@ async function compileSubagentDefinition(input: {
     };
   }
 
+  let agentConfigDefinition = definition;
+  if (dynamic !== undefined) {
+    const dynamicAgentConfig: {
+      build?: { readonly externalDependencies?: readonly string[] };
+      readonly model: string;
+    } = { model: DEFAULT_AGENT_MODEL_ID };
+    if (dynamic.build !== undefined) {
+      dynamicAgentConfig.build = dynamic.build;
+    }
+    agentConfigDefinition = dynamicAgentConfig;
+  }
+
   return {
     kind: "local",
     ...(await compileLocalSubagent({
       ...input,
-      agentConfigDefinition:
-        dynamic === undefined
-          ? definition
-          : {
-              ...(dynamic.build === undefined ? {} : { build: dynamic.build }),
-              model: DEFAULT_AGENT_MODEL_ID,
-            },
+      agentConfigDefinition,
       dynamic: dynamic?.definition,
     })),
   };
@@ -323,10 +329,16 @@ function normalizeDynamicSubagentDefinition(
     eventNames.push(eventName as DynamicToolEventName);
   }
 
-  return {
-    ...(build === undefined ? {} : { build }),
+  const normalized: {
+    build?: { readonly externalDependencies?: readonly string[] };
+    readonly definition: { readonly eventNames: readonly DynamicToolEventName[] };
+  } = {
     definition: { eventNames },
   };
+  if (build !== undefined) {
+    normalized.build = build;
+  }
+  return normalized;
 }
 
 function createSubagentConfigModuleSourceRef(

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -26,6 +26,7 @@ import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import { serializeOutputSchema, type ToolSchemaSource } from "#shared/tool-schema.js";
 import type { JsonObject } from "#shared/json.js";
 import { isDynamicSentinel, type DynamicToolEventName } from "#shared/dynamic-tool-definition.js";
+import { normalizeAgentDefinition } from "#internal/authored-definition/core.js";
 
 const ALLOWED_DYNAMIC_SUBAGENT_EVENTS = new Set<DynamicToolEventName>([
   "session.started",
@@ -158,7 +159,13 @@ async function compileSubagentDefinition(input: {
     kind: "local",
     ...(await compileLocalSubagent({
       ...input,
-      agentConfigDefinition: dynamic === undefined ? definition : { model: DEFAULT_AGENT_MODEL_ID },
+      agentConfigDefinition:
+        dynamic === undefined
+          ? definition
+          : {
+              ...(dynamic.build === undefined ? {} : { build: dynamic.build }),
+              model: DEFAULT_AGENT_MODEL_ID,
+            },
       dynamic: dynamic?.definition,
     })),
   };
@@ -280,7 +287,12 @@ function compileRemoteAgent(input: {
 function normalizeDynamicSubagentDefinition(
   value: unknown,
   message: string,
-): { readonly definition: { readonly eventNames: readonly DynamicToolEventName[] } } | undefined {
+):
+  | {
+      readonly build?: { readonly externalDependencies?: readonly string[] };
+      readonly definition: { readonly eventNames: readonly DynamicToolEventName[] };
+    }
+  | undefined {
   if (!isDynamicSentinel(value)) {
     return undefined;
   }
@@ -291,8 +303,13 @@ function normalizeDynamicSubagentDefinition(
       `${message} Dynamic subagent definitions do not support "fallback". Return defineAgent(...) or defineRemoteAgent(...) from an event handler instead.`,
     );
   }
-  expectOnlyKnownKeys(record, ["events", "kind"], message);
+  expectOnlyKnownKeys(record, ["build", "events", "kind"], message);
 
+  const build =
+    record.build === undefined
+      ? undefined
+      : normalizeAgentDefinition({ build: record.build, model: DEFAULT_AGENT_MODEL_ID }, message)
+          .build;
   const rawEvents = expectObjectRecord(record.events, message);
   const eventNames: DynamicToolEventName[] = [];
 
@@ -307,6 +324,7 @@ function normalizeDynamicSubagentDefinition(
   }
 
   return {
+    ...(build === undefined ? {} : { build }),
     definition: { eventNames },
   };
 }

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
@@ -10,6 +10,8 @@ import {
   createJustBashSandboxBackend,
   pruneJustBashSandboxTemplates,
 } from "#execution/sandbox/bindings/just-bash.js";
+import { executeGlobOnSandbox } from "#execution/sandbox/glob-tool.js";
+import { executeGrepOnSandbox } from "#execution/sandbox/grep-tool.js";
 import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
 import { justbash } from "#public/sandbox/backends/just-bash.js";
 
@@ -101,6 +103,20 @@ describe("just-bash sandbox file API", () => {
 
     expect(factoryCalls).toBe(1);
     expect(await handle.session.readTextFile({ path: "/source/instructions.md" })).toBe("before");
+    await expect(
+      executeGlobOnSandbox(handle.session, { path: "/source", pattern: "*" }),
+    ).resolves.toMatchObject({
+      content: "/source/instructions.md",
+      count: 1,
+      path: "/source",
+    });
+    await expect(
+      executeGrepOnSandbox(handle.session, { path: "/source", pattern: "before" }),
+    ).resolves.toMatchObject({
+      content: "/source/instructions.md:1:before",
+      matchCount: 1,
+      path: "/source",
+    });
     await handle.session.writeTextFile({
       content: "after",
       path: "/source/instructions.md",

--- a/packages/eve/src/execution/sandbox/glob-tool.ts
+++ b/packages/eve/src/execution/sandbox/glob-tool.ts
@@ -67,7 +67,10 @@ export async function executeGlobOnSandbox(
   // missing) indicates a real failure. Surface these as structured
   // errors rather than silently pretending the search returned zero
   // files.
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (
+    (result.exitCode !== 0 && result.exitCode !== 1) ||
+    (result.exitCode === 1 && result.stderr.trim().length > 0)
+  ) {
     throw buildGlobExecutionError(command, result.exitCode, result.stderr);
   }
 
@@ -148,7 +151,7 @@ function buildRipgrepCommand(input: BuildCommandInput): string {
     "rg --files --hidden",
     "--glob '!.git/*'",
     `--glob ${shellQuote(input.pattern)}`,
-    `-- ${shellQuote(input.normalizedPath)}`,
+    shellQuote(input.normalizedPath),
   ].join(" ");
 }
 

--- a/packages/eve/src/execution/sandbox/grep-tool.ts
+++ b/packages/eve/src/execution/sandbox/grep-tool.ts
@@ -87,7 +87,10 @@ export async function executeGrepOnSandbox(
   // Any other exit code (e.g. 127 from bash when the tool is missing)
   // indicates a real failure. Surface these as structured errors
   // rather than silently pretending the search returned zero matches.
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (
+    (result.exitCode !== 0 && result.exitCode !== 1) ||
+    (result.exitCode === 1 && result.stderr.trim().length > 0)
+  ) {
     throw buildGrepExecutionError(command, result.exitCode, result.stderr);
   }
 
@@ -162,7 +165,7 @@ function buildRipgrepCommand(input: BuildCommandInput): string {
  * Builds the POSIX fallback form of the grep command using `grep -rn`.
  */
 function buildPosixGrepCommand(input: BuildCommandInput): string {
-  const parts: string[] = ["grep", "-r", "-n", "--color=never", "--exclude-dir=.git"];
+  const parts: string[] = ["grep", "-r", "-n", "--exclude-dir=.git"];
 
   if (input.ignoreCase) {
     parts.push("-i");
@@ -186,8 +189,7 @@ function buildPosixGrepCommand(input: BuildCommandInput): string {
 
   // `-m` limits matches per file, analogous to ripgrep's `--max-count`.
   parts.push(`-m ${input.effectiveLimit}`);
-  parts.push("--");
-  parts.push(shellQuote(input.pattern));
+  parts.push(`-e ${shellQuote(input.pattern)}`);
   parts.push(shellQuote(input.normalizedPath));
 
   return parts.join(" ");

--- a/packages/eve/src/execution/sandbox/ripgrep-probe.ts
+++ b/packages/eve/src/execution/sandbox/ripgrep-probe.ts
@@ -1,14 +1,18 @@
 import type { SandboxSession } from "#public/definitions/sandbox.js";
 
 /**
- * Memoizes the result of probing for `rg` (ripgrep) once per sandbox
- * session. The probe runs exactly one `command -v rg` per distinct
- * session object, regardless of how many grep/glob tool calls happen.
+ * Memoizes the result of probing for a compatible `rg` (ripgrep) once per
+ * sandbox session, regardless of how many grep/glob tool calls happen.
  */
 const probes = new Map<string, Promise<boolean>>();
 
+const RIPGREP_PROBE_COMMAND =
+  "command -v rg >/dev/null 2>&1 || exit 127; " +
+  "rg --line-number --color=never --hidden --glob '!.git/*' --max-count 1 -- " +
+  "'__eve_ripgrep_probe_never_matches__' /workspace";
+
 /**
- * Returns `true` when `rg` is on PATH in the given sandbox session,
+ * Returns `true` when `rg` is on PATH and supports the options used by eve,
  * `false` otherwise. Result is cached per session.
  *
  * Framework `grep` and `glob` tools call this to decide whether to use
@@ -36,6 +40,6 @@ export async function ripgrepIsAvailable(session: SandboxSession): Promise<boole
 }
 
 async function runProbe(session: SandboxSession): Promise<boolean> {
-  const result = await session.run({ command: "command -v rg >/dev/null 2>&1" });
-  return result.exitCode === 0;
+  const result = await session.run({ command: RIPGREP_PROBE_COMMAND });
+  return (result.exitCode === 0 || result.exitCode === 1) && result.stderr.trim().length === 0;
 }

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -1,4 +1,4 @@
-import type { PublicAgentDefinition } from "#shared/agent-definition.js";
+import type { AgentBuildDefinition, PublicAgentDefinition } from "#shared/agent-definition.js";
 import type { ExactDefinition } from "#public/definitions/exact.js";
 import type { RemoteAgentDefinition } from "#public/definitions/remote-agent.js";
 import { defineDynamic as defineDynamicBase } from "#public/definitions/tool.js";
@@ -71,11 +71,7 @@ type DynamicSubagentDescriptionConstraint<TEvents extends DynamicEvents> =
     ? unknown
     : { readonly "Dynamic subagent definitions require a description": never };
 
-/**
- * Defines dynamic agent configuration. A returned subagent requires a
- * description so its parent knows when to delegate.
- */
-export const defineDynamic: {
+interface DefineDynamicAgent {
   <const TEvents extends DynamicEventsWithFallback, TFallback = unknown>(
     definition: {
       readonly fallback: TFallback;
@@ -84,10 +80,27 @@ export const defineDynamic: {
   ): DynamicSentinel<Exclude<DynamicEventResult<TEvents>, undefined>, TFallback>;
   <const TEvents extends DynamicEvents>(
     definition: {
+      readonly build?: AgentBuildDefinition;
       readonly events: TEvents;
     } & DynamicSubagentDescriptionConstraint<TEvents>,
   ): DynamicSentinel<DynamicEventResult<TEvents>>;
-} = defineDynamicBase;
+}
+
+/**
+ * Defines dynamic agent configuration. A returned subagent requires a
+ * description so its parent knows when to delegate. Use `build` for static
+ * packaging controls that must apply before the runtime resolver runs.
+ */
+export const defineDynamic: DefineDynamicAgent = ((definition: {
+  readonly build?: AgentBuildDefinition;
+  readonly events: DynamicEvents;
+  readonly fallback?: unknown;
+}) => {
+  const sentinel = Object.hasOwn(definition, "fallback")
+    ? defineDynamicBase({ events: definition.events, fallback: definition.fallback })
+    : defineDynamicBase({ events: definition.events });
+  return definition.build === undefined ? sentinel : { ...sentinel, build: definition.build };
+}) as DefineDynamicAgent;
 
 /**
  * Defines the agent configuration authored in `agent.ts` and returns it

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -61,6 +61,7 @@ function typeOnlyFixtures(): void {
   });
 
   defineDynamic({
+    build: { externalDependencies: ["just-bash"] },
     events: {
       "session.started": () =>
         Math.random() > 0.5

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.test.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeResolvedDynamicSubagentDefinition } from "#runtime/resolve-dynamic-subagent.js";
+
+describe("normalizeResolvedDynamicSubagentDefinition", () => {
+  it("accepts and omits compile-time build configuration", () => {
+    const handler = () => null;
+    const resolved = normalizeResolvedDynamicSubagentDefinition(
+      {
+        eventNames: ["session.started"],
+        logicalPath: "agent.ts",
+        sourceId: "agent.ts",
+        sourceKind: "module",
+      },
+      {
+        build: { externalDependencies: ["eve-selfmod"] },
+        events: { "session.started": handler },
+        kind: "eve:dynamic",
+      },
+    );
+
+    expect(resolved.events["session.started"]).toBe(handler);
+    expect(resolved).not.toHaveProperty("build");
+  });
+});

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.ts
@@ -46,7 +46,7 @@ export function normalizeResolvedDynamicSubagentDefinition(
 ): ResolvedDynamicSubagentDefinition {
   const message = `Expected the dynamic subagent export "${definition.exportName ?? "default"}" from "${definition.logicalPath}" to provide defineDynamic({ events }).`;
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["events", "kind"], message);
+  expectOnlyKnownKeys(record, ["build", "events", "kind"], message);
 
   if (record.kind !== "eve:dynamic") {
     throw new Error(message);

--- a/packages/eve/test/glob-tool.test.ts
+++ b/packages/eve/test/glob-tool.test.ts
@@ -15,15 +15,18 @@ import type { SandboxSession } from "../src/shared/sandbox-session.js";
 interface FakeAccessOptions {
   readonly pathResolver?: (path: string) => string;
   /**
-   * Exit code returned by the `command -v rg` probe that runs before
+   * Exit code returned by the ripgrep capability probe that runs before
    * each glob call. Defaults to `0` (ripgrep is available) so tests
    * exercise the ripgrep code path by default. Set to a non-zero
-   * code to force the POSIX fallback branch.
+   * code other than `0` or `1` to force the POSIX fallback branch.
    */
   readonly probeExitCode?: number;
 }
 
-const PROBE_COMMAND = "command -v rg >/dev/null 2>&1";
+const PROBE_COMMAND =
+  "command -v rg >/dev/null 2>&1 || exit 127; " +
+  "rg --line-number --color=never --hidden --glob '!.git/*' --max-count 1 -- " +
+  "'__eve_ripgrep_probe_never_matches__' /workspace";
 const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
 
 function createFakeAccess(
@@ -329,7 +332,7 @@ describe("executeGlobOnSandbox", () => {
       (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
     );
 
-    expect(capturedCommand).toMatch(/-- '\/workspace'/);
+    expect(capturedCommand).toMatch(/'\/workspace'$/);
   });
 
   it("preserves /workspace-rooted output paths exactly as emitted", async () => {
@@ -368,7 +371,7 @@ describe("executeGlobOnSandbox", () => {
         };
       },
       (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
-      { probeExitCode: 1 },
+      { probeExitCode: 127 },
     )) as GlobResult;
 
     // POSIX find, not ripgrep.
@@ -388,6 +391,15 @@ describe("executeGlobOnSandbox", () => {
         (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
       ),
     ).rejects.toThrow(/glob failed \(exit 2\).*IO error/s);
+  });
+
+  it("throws when ripgrep exits 1 with an error message", async () => {
+    await expect(
+      runInContext(
+        () => ({ exitCode: 1, stderr: "rg: unrecognized option '--'\n", stdout: "" }),
+        (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
+      ),
+    ).rejects.toThrow(/glob failed \(exit 1\).*unrecognized option/s);
   });
 
   it("treats exit 1 as legitimate 'no files'", async () => {

--- a/packages/eve/test/grep-tool.test.ts
+++ b/packages/eve/test/grep-tool.test.ts
@@ -15,15 +15,18 @@ import type { SandboxSession } from "../src/shared/sandbox-session.js";
 interface FakeAccessOptions {
   readonly pathResolver?: (path: string) => string;
   /**
-   * Exit code returned by the `command -v rg` probe that runs before
+   * Exit code returned by the ripgrep capability probe that runs before
    * each grep call. Defaults to `0` (ripgrep is available) so the
-   * tests exercise the ripgrep code path by default. Set to a
-   * non-zero code to force the POSIX fallback branch.
+   * tests exercise the ripgrep code path by default. Set to a code
+   * other than `0` or `1` to force the POSIX fallback branch.
    */
   readonly probeExitCode?: number;
 }
 
-const PROBE_COMMAND = "command -v rg >/dev/null 2>&1";
+const PROBE_COMMAND =
+  "command -v rg >/dev/null 2>&1 || exit 127; " +
+  "rg --line-number --color=never --hidden --glob '!.git/*' --max-count 1 -- " +
+  "'__eve_ripgrep_probe_never_matches__' /workspace";
 const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
 
 function createFakeAccess(
@@ -490,7 +493,7 @@ describe("executeGrepOnSandbox", () => {
         };
       },
       (sandbox) => executeGrepOnSandbox(sandbox, { pattern: "foo" }),
-      { probeExitCode: 1 },
+      { probeExitCode: 127 },
     )) as GrepResult;
 
     // POSIX grep with -r -n, not ripgrep.
@@ -509,7 +512,7 @@ describe("executeGrepOnSandbox", () => {
           stdout: "",
         }),
         (sandbox) => executeGrepOnSandbox(sandbox, { pattern: "foo" }),
-        { probeExitCode: 1 },
+        { probeExitCode: 127 },
       ),
     ).rejects.toThrow(/grep failed \(exit 2\).*IO error/s);
   });
@@ -538,6 +541,15 @@ describe("executeGrepOnSandbox", () => {
     );
 
     expect(capturedCommand).not.toContain("--no-messages");
+  });
+
+  it("throws when ripgrep exits 1 with an error message", async () => {
+    await expect(
+      runInContext(
+        () => ({ exitCode: 1, stderr: "rg: invalid option\n", stdout: "" }),
+        (sandbox) => executeGrepOnSandbox(sandbox, { pattern: "needle" }),
+      ),
+    ).rejects.toThrow(/grep failed \(exit 1\).*invalid option/s);
   });
 
   it("treats exit 1 as legitimate 'no matches'", async () => {


### PR DESCRIPTION
### Description

Makes eve's framework `grep` and `glob` tools work with the reduced command implementations provided by just-bash and similar sandboxes.

- Probes whether `rg` supports the exact flags eve uses instead of only checking whether an `rg` binary exists.
- Falls back to portable POSIX `grep` syntax when that probe fails, avoiding unsupported `--color` and `--` usage.
- Removes the unnecessary `--` operand separator from the `rg --files` command.
- Treats exit code 1 with stderr as an execution error rather than an empty result.

### Rationale

just-bash exposes commands named `rg` and `grep`, but they do not implement every GNU/ripgrep option. Presence-only detection selected commands that looked available but failed at runtime, and those failures could be silently reported as no matches. Capability probing and portable fallbacks make search reliable without hiding real command errors.

### Testing

Adds unit coverage for incompatible ripgrep probes, portable fallback commands, and exit-code-1 errors, plus a just-bash scenario exercising framework search against a mounted directory. The stack is also covered by the repository lint, typecheck, unit, integration, scenario, and TUI checks.
