### PR TITLE
feat(eve): support extensions in local subagents

### DIFF
--- a/.changeset/calm-subagents-mount.md
+++ b/.changeset/calm-subagents-mount.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow declared local subagents to mount extensions under their own `extensions/` directory. Contributions, configuration, and overrides are scoped to that subagent and do not extend the root agent.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -103,10 +103,19 @@ agent/subagents/researcher/
 ├── agent.ts            # required
 ├── instructions.md     # or instructions.ts, optional
 ├── tools/              # optional, its own tools
+├── extensions/         # optional, mounted only into this subagent
 ├── skills/             # optional, its own skills
 ├── sandbox/            # optional, its own sandbox + workspace seed
 └── subagents/          # optional, nested subagents
 ```
+
+Extensions mounted under `subagents/<id>/extensions/` contribute only to that subagent. They use the same file and directory mount forms, namespacing, configuration, and overrides as root-agent extensions:
+
+```ts title="agent/subagents/researcher/extensions/search.ts"
+export { default } from "@acme/research-search";
+```
+
+The root agent does not receive the extension's tools, skills, instructions, connections, or hooks.
 
 `schedules/` is not supported inside a declared subagent. Schedules are root-only.
 
@@ -122,6 +131,7 @@ A declared subagent inherits nothing from the root's authored slots. Discovery t
 | Skills       | Inherited                     | Own `skills/`                          |
 | Sandbox      | Shared with parent            | Own `sandbox/`, else framework default |
 | Hooks        | Inherited                     | Own `hooks/`                           |
+| Extensions   | Inherited contributions       | Own `extensions/`                      |
 | State        | Fresh                         | Fresh                                  |
 | Channels     | Root-only                     | Root-only                              |
 | Schedules    | Root-only                     | Root-only                              |

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -640,6 +640,17 @@ const compiledHookDefinitionSchema: z.ZodType<CompiledHookDefinition> = z
   })
   .strict();
 
+const compiledExtensionMountSchema: z.ZodType<CompiledExtensionMount> = z
+  .object({
+    namespace: z.string(),
+    packageName: z.string(),
+    packageNamespace: z.string(),
+    sourceRoot: z.string(),
+    mountSourceId: z.string(),
+    mountLogicalPath: z.string(),
+  })
+  .strict();
+
 /**
  * Zod schema for one non-recursive compiled authored agent payload.
  */
@@ -657,6 +668,7 @@ const compiledAgentNodeManifestSchema = z
     dynamicInstructions: z.array(compiledDynamicInstructionsDefinitionSchema).default([]),
     dynamicSkills: z.array(compiledDynamicSkillDefinitionSchema).default([]),
     dynamicTools: z.array(compiledDynamicToolDefinitionSchema).default([]),
+    extensionMounts: z.array(compiledExtensionMountSchema).default([]),
     hooks: z.array(compiledHookDefinitionSchema),
     sandbox: compiledSandboxDefinitionSchema.nullable(),
     sandboxWorkspaces: z.array(compiledSandboxWorkspaceSchema),
@@ -703,7 +715,7 @@ const compiledSubagentEdgeSchema: z.ZodType<CompiledSubagentEdge> = z
   .strict();
 
 /**
- * One mounted extension recorded on the root compiled manifest. The runtime
+ * One mounted extension recorded on a compiled agent manifest. The runtime
  * evaluates {@link mountLogicalPath} at module-map load so the mount's factory
  * call binds the extension's config before any tool runs.
  */
@@ -726,17 +738,6 @@ export interface CompiledExtensionMount {
   readonly mountSourceId: string;
   readonly mountLogicalPath: string;
 }
-
-const compiledExtensionMountSchema: z.ZodType<CompiledExtensionMount> = z
-  .object({
-    namespace: z.string(),
-    packageName: z.string(),
-    packageNamespace: z.string(),
-    sourceRoot: z.string(),
-    mountSourceId: z.string(),
-    mountLogicalPath: z.string(),
-  })
-  .strict();
 
 /**
  * Zod schema for the versioned compiled manifest emitted by the compiler.
@@ -788,6 +789,7 @@ export function createCompiledAgentNodeManifest(input: {
   readonly dynamicInstructions?: readonly CompiledDynamicInstructionsDefinition[];
   readonly dynamicSkills?: readonly CompiledDynamicSkillDefinition[];
   readonly dynamicTools?: readonly CompiledDynamicToolDefinition[];
+  readonly extensionMounts?: readonly CompiledExtensionMount[];
   readonly hooks?: readonly CompiledHookDefinition[];
   readonly remoteAgents?: readonly CompiledRemoteAgentNode[];
   readonly sandbox?: CompiledSandboxDefinition | null;
@@ -871,6 +873,7 @@ export function createCompiledAgentNodeManifest(input: {
     dynamicInstructions: [...(input.dynamicInstructions ?? [])],
     dynamicSkills: [...(input.dynamicSkills ?? [])],
     dynamicTools: [...(input.dynamicTools ?? [])],
+    extensionMounts: [...(input.extensionMounts ?? [])],
     hooks: [...(input.hooks ?? [])],
     remoteAgents: [...(input.remoteAgents ?? [])],
     sandbox: input.sandbox ?? null,

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -9,6 +9,7 @@ import {
 import { classifyModelRouting } from "#internal/classify-model-routing.js";
 import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import { compileAgentManifest } from "#compiler/normalize-manifest.js";
+import { collectModuleRefsForManifest } from "#compiler/module-map.js";
 import { defineAgent, defineDynamic } from "#public/definitions/agent.js";
 import { experimental_workflow } from "#public/definitions/tool.js";
 import { webSearch } from "#public/tools/web-search.js";
@@ -80,6 +81,71 @@ describe("compileAgentManifest", () => {
     await expect(compileAgentManifest(manifest)).rejects.toThrow(
       'Remove "experimental.workflow" from "research"',
     );
+  });
+
+  it("retains extension mounts on the subagent that owns them", async () => {
+    const extensionManifest = createAgentSourceManifest({
+      agentId: "research-extension",
+      agentRoot: "/packages/research/dist/extension",
+      appRoot: "/packages/research",
+    });
+    const mountRef = createModuleSourceRef({ logicalPath: "extensions/research.ts" });
+    const subagentManifest = createAgentSourceManifest({
+      agentId: "researcher",
+      agentRoot: "/app/agent/subagents/researcher",
+      appRoot: "/app",
+      configModule: createModuleSourceRef({ logicalPath: "agent.ts" }),
+      extensions: [mountRef],
+      resolvedExtensions: [
+        {
+          namespace: "research",
+          specifier: "@acme/research",
+          packageName: "@acme/research",
+          packageRoot: "/packages/research",
+          sourceRoot: "/packages/research/dist/extension",
+          manifest: extensionManifest,
+        },
+      ],
+    });
+    const manifest = createAgentSourceManifest({
+      agentId: "root",
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      subagents: [
+        createLocalSubagentSourceRef({
+          entryPath: "subagents/researcher/agent.ts",
+          logicalPath: "subagents/researcher",
+          manifest: subagentManifest,
+          rootPath: "/app/agent/subagents/researcher",
+          subagentId: "researcher",
+        }),
+      ],
+    });
+    mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) =>
+      input.agentId === "researcher"
+        ? createConfig({ name: input.agentId, description: "Research the request." })
+        : createConfig({ name: input.agentId }),
+    );
+    mocks.loadModuleBackedDefinition.mockResolvedValue({
+      description: "Research the request.",
+      model: "openai/gpt-5.5",
+    });
+
+    const compiled = await compileAgentManifest(manifest);
+
+    expect(compiled.extensionMounts).toEqual([]);
+    expect(compiled.subagents[0]?.agent.extensionMounts).toEqual([
+      expect.objectContaining({
+        namespace: "research",
+        mountLogicalPath: "extensions/research.ts",
+        packageName: "@acme/research",
+      }),
+    ]);
+    expect(collectModuleRefsForManifest(compiled.subagents[0]!.agent)).toContainEqual({
+      sourceKind: "module",
+      logicalPath: "extensions/research.ts",
+      sourceId: "extensions/research.ts",
+    });
   });
 
   it("compiles experimental Workflow tool configuration", async () => {

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -49,23 +49,9 @@ export async function compileAgentManifest(
     subagents: manifest.subagents,
   });
 
-  const extensionMounts: CompiledExtensionMount[] = manifest.resolvedExtensions.map((mount) => {
-    const mountRef = manifest.extensions.find(
-      (entry) => mountRefNamespace(entry.logicalPath) === mount.namespace,
-    );
-    return {
-      namespace: mount.namespace,
-      packageName: mount.packageName,
-      packageNamespace: packageStateNamespace(mount.packageName),
-      sourceRoot: mount.sourceRoot,
-      mountSourceId: mountRef?.sourceId ?? `extensions/${mount.namespace}`,
-      mountLogicalPath: mountRef?.logicalPath ?? `extensions/${mount.namespace}`,
-    };
-  });
-
   return createCompiledAgentManifest({
     ...compiledNode,
-    extensionMounts,
+    extensionMounts: compiledNode.extensionMounts,
     remoteAgents: subagentGraph.remoteAgents,
     subagentEdges: subagentGraph.edges,
     subagents: subagentGraph.nodes,
@@ -252,6 +238,7 @@ async function compileAgentNodeManifest(
     agentRoot: manifest.agentRoot,
     appRoot: manifest.appRoot,
     channels: compiledChannels,
+    extensionMounts: compileExtensionMounts(manifest),
     config,
     connections,
     diagnosticsSummary: manifest.diagnosticsSummary,
@@ -278,6 +265,22 @@ async function compileAgentNodeManifest(
     skills,
     instructions: composedInstructions,
     tools,
+  });
+}
+
+function compileExtensionMounts(manifest: AgentSourceManifest): CompiledExtensionMount[] {
+  return manifest.resolvedExtensions.map((mount) => {
+    const mountRef = manifest.extensions.find(
+      (entry) => mountRefNamespace(entry.logicalPath) === mount.namespace,
+    );
+    return {
+      namespace: mount.namespace,
+      packageName: mount.packageName,
+      packageNamespace: packageStateNamespace(mount.packageName),
+      sourceRoot: mount.sourceRoot,
+      mountSourceId: mountRef?.sourceId ?? `extensions/${mount.namespace}`,
+      mountLogicalPath: mountRef?.logicalPath ?? `extensions/${mount.namespace}`,
+    };
   });
 }
 

--- a/packages/eve/src/discover/discover-agent.ts
+++ b/packages/eve/src/discover/discover-agent.ts
@@ -268,7 +268,7 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
     }),
   );
 
-  const resolvedExtensions: ResolvedExtensionMount[] = [];
+  let resolvedExtensions: readonly ResolvedExtensionMount[] = [];
   if (role !== "agent") {
     // Extensions cannot mount other extensions yet. Fail loudly instead of
     // silently dropping the nested mount, and reserve the behavior so enabling
@@ -283,56 +283,14 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
       );
     }
   } else {
-    for (const descriptor of mountCollection.mounts) {
-      const located = await locateExtensionMount({
-        source,
-        agentRoot,
-        appRoot,
-        mount: descriptor.mountRef,
-        namespace: descriptor.namespace,
-      });
-      diagnostics.push(...located.diagnostics);
-      if (located.location === undefined) {
-        continue;
-      }
-
-      const extensionResult = await discoverAgent({
-        agentRoot: located.location.sourceRoot,
-        appRoot: located.location.packageRoot,
-        source,
-        role: "extension",
-      });
-      diagnostics.push(...extensionResult.diagnostics);
-
-      // The mount directory's override slots discover as an agent-shaped source;
-      // its `extension.<ext>` declaration matches no slot, so it is ignored here.
-      let overrides: AgentSourceManifest | undefined;
-      if (descriptor.overridesRoot !== undefined) {
-        const overridesResult = await discoverAgent({
-          agentRoot: descriptor.overridesRoot,
-          appRoot,
-          source,
-          role: "extension",
-        });
-        diagnostics.push(...overridesResult.diagnostics);
-        overrides = overridesResult.manifest;
-      }
-
-      const resolved: { -readonly [K in keyof ResolvedExtensionMount]: ResolvedExtensionMount[K] } =
-        {
-          namespace: located.location.namespace,
-          specifier: located.location.specifier,
-          packageName: located.location.packageName,
-          packageRoot: located.location.packageRoot,
-          sourceRoot: located.location.sourceRoot,
-          manifest: extensionResult.manifest,
-        };
-      if (overrides !== undefined) {
-        resolved.overrides = overrides;
-      }
-
-      resolvedExtensions.push(resolved);
-    }
+    const result = await resolveExtensionMounts({
+      agentRoot,
+      appRoot,
+      mounts: mountCollection.mounts,
+      source,
+    });
+    diagnostics.push(...result.diagnostics);
+    resolvedExtensions = result.mounts;
   }
 
   const manifestInput: CreateAgentSourceManifestInput = {
@@ -373,6 +331,64 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
  * file form (`extensions/crm.ts`) or the directory form
  * (`extensions/crm/extension.ts` with optional override slots).
  */
+/** Resolves extension declarations into their discovered source manifests. */
+export async function resolveExtensionMounts(input: {
+  readonly agentRoot: string;
+  readonly appRoot: string;
+  readonly mounts: readonly ExtensionMountDescriptor[];
+  readonly source: ProjectSource;
+}): Promise<{
+  readonly diagnostics: readonly DiscoverDiagnostic[];
+  readonly mounts: readonly ResolvedExtensionMount[];
+}> {
+  const diagnostics: DiscoverDiagnostic[] = [];
+  const mounts: ResolvedExtensionMount[] = [];
+
+  for (const descriptor of input.mounts) {
+    const located = await locateExtensionMount({
+      source: input.source,
+      agentRoot: input.agentRoot,
+      appRoot: input.appRoot,
+      mount: descriptor.mountRef,
+      namespace: descriptor.namespace,
+    });
+    diagnostics.push(...located.diagnostics);
+    if (located.location === undefined) continue;
+
+    const extensionResult = await discoverAgent({
+      agentRoot: located.location.sourceRoot,
+      appRoot: located.location.packageRoot,
+      source: input.source,
+      role: "extension",
+    });
+    diagnostics.push(...extensionResult.diagnostics);
+
+    let overrides: AgentSourceManifest | undefined;
+    if (descriptor.overridesRoot !== undefined) {
+      const overridesResult = await discoverAgent({
+        agentRoot: descriptor.overridesRoot,
+        appRoot: input.appRoot,
+        source: input.source,
+        role: "extension",
+      });
+      diagnostics.push(...overridesResult.diagnostics);
+      overrides = overridesResult.manifest;
+    }
+
+    mounts.push({
+      namespace: located.location.namespace,
+      specifier: located.location.specifier,
+      packageName: located.location.packageName,
+      packageRoot: located.location.packageRoot,
+      sourceRoot: located.location.sourceRoot,
+      manifest: extensionResult.manifest,
+      overrides,
+    });
+  }
+
+  return { diagnostics, mounts };
+}
+
 export interface ExtensionMountDescriptor {
   /** Mount namespace prefixed onto every composed contribution. */
   readonly namespace: string;
@@ -526,7 +542,7 @@ async function collectExtensionMounts(input: {
  * overrides, so a root-level `<ns>__…` file would override the extension from
  * outside its mount directory — rejected here.
  */
-function detectRootNamespaceCollisions(input: {
+export function detectRootNamespaceCollisions(input: {
   readonly agentRoot: string;
   readonly namespaces: readonly string[];
   readonly sources: ReadonlyArray<{ readonly logicalPath: string }>;

--- a/packages/eve/src/discover/discover-subagent.ts
+++ b/packages/eve/src/discover/discover-subagent.ts
@@ -2,6 +2,11 @@ import { join, relative, resolve } from "node:path";
 import { discoverConnectionSources } from "#discover/connections.js";
 import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discover/diagnostics.js";
 import {
+  detectRootNamespaceCollisions,
+  discoverExtensionMountDeclarations,
+  resolveExtensionMounts,
+} from "#discover/discover-agent.js";
+import {
   classifyLocalSubagentEntry,
   getDirectoryEntryType,
   getSupportedModuleBaseName,
@@ -280,11 +285,34 @@ async function discoverLocalSubagentPackage(input: {
   });
   diagnostics.push(...subagentsResult.diagnostics);
 
+  const extensionsResult = await discoverExtensionMountDeclarations({
+    agentRoot: input.subagentRoot,
+    source: input.source,
+  });
+  diagnostics.push(...extensionsResult.diagnostics);
+  diagnostics.push(
+    ...detectRootNamespaceCollisions({
+      agentRoot: input.subagentRoot,
+      namespaces: extensionsResult.mounts.map((mount) => mount.namespace),
+      sources: [...toolsResult.sources, ...connectionsResult.connections, ...skillsResult.skills],
+    }),
+  );
+
+  const resolvedExtensions = await resolveExtensionMounts({
+    agentRoot: input.subagentRoot,
+    appRoot: input.appRoot,
+    mounts: extensionsResult.mounts,
+    source: input.source,
+  });
+  diagnostics.push(...resolvedExtensions.diagnostics);
+
   const manifestInput: CreateAgentSourceManifestInput = {
     agentRoot: input.subagentRoot,
     appRoot: input.appRoot,
     connections: connectionsResult.connections,
     diagnostics,
+    extensions: extensionsResult.mounts.map((mount) => mount.mountRef),
+    resolvedExtensions: resolvedExtensions.mounts,
     hooks: hooksResult.sources,
     lib: libResult.lib,
     instructions: instructionsResult.instructions,

--- a/packages/eve/src/discover/filesystem.ts
+++ b/packages/eve/src/discover/filesystem.ts
@@ -62,6 +62,7 @@ export type AgentRootEntryKind =
 export type LocalSubagentEntryKind =
   | "agent-config-module"
   | "connections-directory"
+  | "extensions-directory"
   | "hooks-directory"
   | "ignored-directory"
   | "instructions-directory"
@@ -243,6 +244,10 @@ export function classifyLocalSubagentEntry(
 
     if (name === "connections") {
       return "connections-directory";
+    }
+
+    if (name === "extensions") {
+      return "extensions-directory";
     }
 
     if (name === "hooks") {

--- a/packages/eve/src/discover/subagent.integration.test.ts
+++ b/packages/eve/src/discover/subagent.integration.test.ts
@@ -144,6 +144,58 @@ describe("discoverSubagents (memory)", () => {
     });
   });
 
+  it("discovers extension mounts inside local subagent packages", async () => {
+    const project = buildMemoryAgentProject({
+      appFiles: {
+        "node_modules/@acme/research/package.json": JSON.stringify({
+          name: "@acme/research",
+          eve: { extension: { dist: "extension" } },
+        }),
+        "node_modules/@acme/research/extension/_manifest.json": JSON.stringify({
+          kind: "eve-extension",
+          formatVersion: 1,
+          builtWithEve: "test",
+          requires: { extension: 1, tool: 1 },
+        }),
+        "node_modules/@acme/research/extension/tools/search.ts": "export default {};",
+      },
+      agentFiles: {
+        "instructions.md": "Route research tasks.",
+        "subagents/researcher/agent.ts": "export default {};",
+        "subagents/researcher/extensions/research.ts": 'export { default } from "@acme/research";',
+      },
+    });
+
+    const result = await discoverAgent({
+      agentRoot: project.agentRoot,
+      appRoot: project.appRoot,
+      source: project.source,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.manifest.resolvedExtensions).toEqual([]);
+    expect(result.manifest.subagents[0]?.manifest.extensions).toEqual([
+      {
+        sourceKind: "module",
+        logicalPath: "extensions/research.ts",
+        sourceId: "extensions/research.ts",
+      },
+    ]);
+    expect(result.manifest.subagents[0]?.manifest.resolvedExtensions[0]).toMatchObject({
+      namespace: "research",
+      packageName: "@acme/research",
+      specifier: "@acme/research",
+      manifest: {
+        tools: [
+          {
+            logicalPath: "tools/search.ts",
+            sourceId: "tools/search.ts",
+          },
+        ],
+      },
+    });
+  });
+
   it("discovers uppercase instructions in local subagent packages", async () => {
     const project = buildMemoryAgentProject({
       agentFiles: {

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -269,10 +269,13 @@ export async function bundleAuthoredModuleMapForGeneration(input: {
     moduleMapPath: input.moduleMapPath,
   });
   const extensionScopePlugin = createExtensionScopePlugin(
-    input.manifest.extensionMounts.map((mount) => ({
-      packageNamespace: mount.packageNamespace,
-      sourceRoot: mount.sourceRoot,
-    })),
+    [input.manifest, ...input.manifest.subagents.map((subagent) => subagent.agent)].flatMap(
+      (node) =>
+        node.extensionMounts.map((mount) => ({
+          packageNamespace: mount.packageNamespace,
+          sourceRoot: mount.sourceRoot,
+        })),
+    ),
   );
   const plugins = [
     createVirtualGenerationModuleMapPlugin({

--- a/packages/eve/src/internal/authored-module-map-loader.ts
+++ b/packages/eve/src/internal/authored-module-map-loader.ts
@@ -80,15 +80,21 @@ async function hydrateCompiledModuleMapFromManifest(
       })),
   ];
 
-  const scopeIndex: ExtensionScopeIndex = {
-    byMountNamespace: new Map(
-      manifest.extensionMounts.map((mount) => [mount.namespace, mount.packageNamespace]),
-    ),
-    byMountSourceId: new Map(
-      manifest.extensionMounts.map((mount) => [mount.mountSourceId, mount.packageNamespace]),
-    ),
-  };
   for (const nodeManifest of nodeManifests) {
+    const scopeIndex: ExtensionScopeIndex = {
+      byMountNamespace: new Map(
+        nodeManifest.manifest.extensionMounts.map((mount) => [
+          mount.namespace,
+          mount.packageNamespace,
+        ]),
+      ),
+      byMountSourceId: new Map(
+        nodeManifest.manifest.extensionMounts.map((mount) => [
+          mount.mountSourceId,
+          mount.packageNamespace,
+        ]),
+      ),
+    };
     nodes[nodeManifest.nodeId] = {
       modules: await hydrateCompiledNodeScope({
         agentRoot: nodeManifest.agentRoot,

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -132,6 +132,7 @@ function createPreparedHost(): PreparedDevelopmentApplicationHost {
       manifest: {
         channels: [],
         config: { name: "weather-agent" },
+        extensionMounts: [],
         sandbox: null,
         subagents: [],
       },

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -621,10 +621,15 @@ function createApplicationNitroBundlerConfiguration(
     ).push(packageName);
   }
   const extensionScopePlugin = createExtensionScopePlugin(
-    (preparedHost.compileResult.manifest.extensionMounts ?? []).map((mount) => ({
-      sourceRoot: mount.sourceRoot,
-      packageNamespace: mount.packageNamespace,
-    })),
+    [
+      preparedHost.compileResult.manifest,
+      ...preparedHost.compileResult.manifest.subagents.map((subagent) => subagent.agent),
+    ].flatMap((node) =>
+      node.extensionMounts.map((mount) => ({
+        sourceRoot: mount.sourceRoot,
+        packageNamespace: mount.packageNamespace,
+      })),
+    ),
   );
   const nitroBundlerPlugins = [
     compiledSandboxBackendPrunePlugin,

--- a/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
+++ b/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
@@ -16,7 +16,8 @@ export async function computeDevelopmentHostFingerprint(
       externalDependencies: [
         ...new Set(agentNodes.flatMap((node) => node.config.build?.externalDependencies ?? [])),
       ].sort((left, right) => left.localeCompare(right)),
-      extensionScopes: (manifest.extensionMounts ?? [])
+      extensionScopes: agentNodes
+        .flatMap((node) => node.extensionMounts)
         .map((mount) => ({
           packageNamespace: mount.packageNamespace,
           sourceRoot: mount.sourceRoot,

--- a/packages/eve/src/internal/nitro/host/dev-workspace-extensions.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-workspace-extensions.integration.test.ts
@@ -92,6 +92,24 @@ describe("prepareDevelopmentWorkspaceExtensions", () => {
     );
   });
 
+  it("builds workspace extensions mounted by local subagents", async () => {
+    const appRoot = await createWorkspaceAgent(["alpha"]);
+    await rm(join(appRoot, "agent", "extensions", "alpha.ts"));
+    await writeText(
+      join(appRoot, "agent", "subagents", "researcher", "extensions", "alpha.ts"),
+      'export { default } from "../../../../packages/alpha";\n',
+    );
+
+    const extensions = await prepareDevelopmentWorkspaceExtensions({ appRoot });
+
+    expect(extensions).toHaveLength(1);
+    expect(mocks.buildExtensionPackage).toHaveBeenCalledOnce();
+    expect(mocks.buildExtensionPackage).toHaveBeenCalledWith(
+      join(appRoot, "packages", "alpha"),
+      expect.objectContaining({ packageName: "@acme/alpha" }),
+    );
+  });
+
   it("does not rebuild an extension for an unrelated workspace dependency edit", async () => {
     const appRoot = await createWorkspaceAgent(["alpha"]);
     const initial = await prepareDevelopmentWorkspaceExtensions({ appRoot });

--- a/packages/eve/src/internal/nitro/host/dev-workspace-extensions.ts
+++ b/packages/eve/src/internal/nitro/host/dev-workspace-extensions.ts
@@ -40,18 +40,18 @@ export async function prepareDevelopmentWorkspaceExtensions(input: {
   const appRoot = resolve(input.appRoot);
   const project = await resolveDiscoveryProject(appRoot);
   const source = createDiskProjectSource();
-  const discovered = await discoverExtensionMountDeclarations({
+  const discoveredMounts = await discoverExtensionMountGraph({
     agentRoot: project.agentRoot,
     source,
   });
   const workspaceSourceRoot = await toCanonicalPath(resolveDevelopmentSourceRoot(appRoot));
   const extensionsByPackageRoot = new Map<string, DevelopmentWorkspaceExtension>();
 
-  for (const mount of discovered.mounts) {
+  for (const discovered of discoveredMounts) {
     const extension = await resolveWorkspaceExtension({
       appRoot,
-      agentRoot: project.agentRoot,
-      mount,
+      agentRoot: discovered.agentRoot,
+      mount: discovered.mount,
       source,
       workspaceSourceRoot,
     });
@@ -87,6 +87,30 @@ export async function prepareDevelopmentWorkspaceExtensions(input: {
   );
 
   return extensions;
+}
+
+async function discoverExtensionMountGraph(input: {
+  readonly agentRoot: string;
+  readonly source: ReturnType<typeof createDiskProjectSource>;
+}): Promise<readonly { agentRoot: string; mount: ExtensionMountDescriptor }[]> {
+  const discovered = await discoverExtensionMountDeclarations(input);
+  const mounts = discovered.mounts.map((mount) => ({ agentRoot: input.agentRoot, mount }));
+  const subagentsRoot = join(input.agentRoot, "subagents");
+  if ((await input.source.stat(subagentsRoot)) !== "directory") return mounts;
+
+  const entries = await input.source.readDirectory(subagentsRoot);
+  const nestedMounts = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(
+        async (entry) =>
+          await discoverExtensionMountGraph({
+            agentRoot: join(subagentsRoot, entry.name),
+            source: input.source,
+          }),
+      ),
+  );
+  return [...mounts, ...nestedMounts.flat()];
 }
 
 async function resolveWorkspaceExtension(input: {


### PR DESCRIPTION
### Description

Allows declared local subagents to mount extensions from their own `extensions/` directories. eve now discovers, resolves, compiles, and loads those mounts on each subagent node, including nested subagents and linked workspace extensions in development.

Extension contributions, configuration, namespace collision checks, and overrides are evaluated relative to the declaring subagent. Their tools, skills, instructions, connections, and hooks do not leak into the root agent.

### Rationale

Some capabilities should be packaged as reusable extensions but granted only to a dedicated subagent. Requiring a root-level mount would broaden the capability to the whole agent and break the subagent isolation boundary. Node-local mounts preserve least privilege while reusing the existing extension authoring model.

### Testing

Adds normalization, discovery, integration, and development-workspace coverage for subagent-local extension mounts and updates the subagent documentation. The stack is also covered by the repository lint, typecheck, unit, integration, scenario, and TUI checks.
