### PR TITLE
feat(eve): add review content to tool approvals

### DIFF
--- a/.changeset/approval-review-content.md
+++ b/.changeset/approval-review-content.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Tools can now attach pageable text content to a user-approval decision for review in the dev TUI. Existing approval policies and non-TUI channel behavior are unchanged.

--- a/.changeset/calm-subagents-mount.md
+++ b/.changeset/calm-subagents-mount.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow declared local subagents to mount extensions under their own `extensions/` directory. Contributions, configuration, and overrides are scoped to that subagent and do not extend the root agent.

--- a/.changeset/clean-mount-search.md
+++ b/.changeset/clean-mount-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use compatible POSIX search fallbacks in sandboxes whose `rg` implementation lacks the options required by eve, and surface command errors instead of reporting them as empty results.

--- a/.changeset/dynamic-subagent-build.md
+++ b/.changeset/dynamic-subagent-build.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow dynamic subagents to declare compile-time `build.externalDependencies`, so their authored modules can safely use packages that must remain external before runtime resolution.

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -74,6 +74,25 @@ supported for subagents. A nil result (`null` or `undefined`) removes the
 subagent's description and tool definition from the model-visible surface.
 The subagent's filesystem manifest is always compiled; a non-nil result injects
 the returned agent configuration when the child runs.
+
+Packaging controls must be available before the resolver runs. Put them on
+`defineDynamic`, rather than the `defineAgent` returned by an event handler:
+
+```ts
+export default defineDynamic({
+  build: { externalDependencies: ["native-package"] },
+  events: {
+    "session.started": () =>
+      defineAgent({
+        description: "Use a native package when handling delegated work.",
+        model: "anthropic/claude-opus-4.8",
+      }),
+  },
+});
+```
+
+The compiler applies `build.externalDependencies` while bundling every authored
+module in that dynamic subagent.
 See [Dynamic capabilities](./guides/dynamic-capabilities#dynamic-subagents) for
 scope precedence, failure behavior, and the dispatch-time guard.
 

--- a/docs/subagents.mdx
+++ b/docs/subagents.mdx
@@ -103,10 +103,19 @@ agent/subagents/researcher/
 ├── agent.ts            # required
 ├── instructions.md     # or instructions.ts, optional
 ├── tools/              # optional, its own tools
+├── extensions/         # optional, mounted only into this subagent
 ├── skills/             # optional, its own skills
 ├── sandbox/            # optional, its own sandbox + workspace seed
 └── subagents/          # optional, nested subagents
 ```
+
+Extensions mounted under `subagents/<id>/extensions/` contribute only to that subagent. They use the same file and directory mount forms, namespacing, configuration, and overrides as root-agent extensions:
+
+```ts title="agent/subagents/researcher/extensions/search.ts"
+export { default } from "@acme/research-search";
+```
+
+The root agent does not receive the extension's tools, skills, instructions, connections, or hooks.
 
 `schedules/` is not supported inside a declared subagent. Schedules are root-only.
 
@@ -122,6 +131,7 @@ A declared subagent inherits nothing from the root's authored slots. Discovery t
 | Skills       | Inherited                     | Own `skills/`                          |
 | Sandbox      | Shared with parent            | Own `sandbox/`, else framework default |
 | Hooks        | Inherited                     | Own `hooks/`                           |
+| Extensions   | Inherited contributions       | Own `extensions/`                      |
 | State        | Fresh                         | Fresh                                  |
 | Channels     | Root-only                     | Root-only                              |
 | Schedules    | Root-only                     | Root-only                              |

--- a/packages/eve/src/cli/dev/tui/approval-content-panel.test.ts
+++ b/packages/eve/src/cli/dev/tui/approval-content-panel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { ApprovalContentPanel } from "./approval-content-panel.js";
+import { createTheme } from "./theme.js";
+
+const content = {
+  type: "text" as const,
+  text: "--- agent.ts\n+++ agent.ts\n- old\n+ new\n\n--- new.ts\n+++ new.ts\n+ created",
+};
+const theme = createTheme({ color: false, unicode: true });
+
+describe("ApprovalContentPanel", () => {
+  it("renders tool-provided text without interpreting it", () => {
+    const rows = new ApprovalContentPanel(content).render(theme, 80, 30);
+
+    expect(rows.join("\n")).toContain("--- agent.ts");
+    expect(rows.join("\n")).toContain("- old");
+    expect(rows.join("\n")).toContain("+ new");
+    expect(rows.join("\n")).toContain("--- new.ts");
+  });
+
+  it("makes undisplayed content explicit", () => {
+    const panel = new ApprovalContentPanel({
+      type: "text",
+      text: Array.from({ length: 20 }, (_, index) => `line-${index}`).join("\n"),
+    });
+    expect(panel.render(theme, 80, 8).join("\n")).toContain("↓ more content");
+
+    panel.move("end", 1, 80, 8);
+    const renderedEnd = panel.render(theme, 80, 8).join("\n");
+    expect(renderedEnd).toContain("↑ earlier content");
+    expect(renderedEnd).not.toContain("↓ more content");
+
+    panel.move("up", 1, 80, 8);
+    expect(panel.render(theme, 80, 8).join("\n")).toContain("↓ more content");
+  });
+
+  it("pages and toggles visibility", () => {
+    const panel = new ApprovalContentPanel(content);
+    panel.move("page-down", 4, 20, 8);
+    panel.move("page-up", 4, 20, 8);
+    expect(panel.render(theme, 20, 8).join("\n")).toContain("--- agent.ts");
+
+    panel.close();
+    expect(panel.visible).toBe(false);
+    panel.open();
+    expect(panel.visible).toBe(true);
+  });
+});

--- a/packages/eve/src/cli/dev/tui/approval-content-panel.ts
+++ b/packages/eve/src/cli/dev/tui/approval-content-panel.ts
@@ -1,0 +1,86 @@
+import type { ToolApprovalContent } from "#public/tools/approval/content.js";
+import { clipVisible, stripTerminalControls, wrapVisibleLine } from "#cli/ui/terminal-text.js";
+import type { Theme } from "./theme.js";
+
+type ApprovalContentMove = "down" | "end" | "home" | "page-down" | "page-up" | "up";
+
+/** Stateful viewport for tool-provided approval review content. */
+export class ApprovalContentPanel {
+  readonly #content: ToolApprovalContent;
+  #scroll = 0;
+  #visible = true;
+
+  constructor(content: ToolApprovalContent) {
+    this.#content = content;
+  }
+
+  get visible(): boolean {
+    return this.#visible;
+  }
+
+  close(): void {
+    this.#visible = false;
+  }
+
+  open(): void {
+    this.#visible = true;
+  }
+
+  move(action: ApprovalContentMove, pageSize: number, width: number, height: number): void {
+    const maxScroll = this.#maxScroll(width, height);
+    const scroll = Math.min(this.#scroll, maxScroll);
+    switch (action) {
+      case "down":
+        this.#scroll = Math.min(maxScroll, scroll + 1);
+        break;
+      case "up":
+        this.#scroll = Math.max(0, scroll - 1);
+        break;
+      case "page-down":
+        this.#scroll = Math.min(maxScroll, scroll + Math.max(1, pageSize));
+        break;
+      case "page-up":
+        this.#scroll = Math.max(0, scroll - Math.max(1, pageSize));
+        break;
+      case "home":
+        this.#scroll = 0;
+        break;
+      case "end":
+        this.#scroll = maxScroll;
+        break;
+    }
+  }
+
+  render(theme: Theme, width: number, height: number): string[] {
+    const body = approvalContentRows(this.#content, width);
+    const bodyHeight = Math.max(1, height - 3);
+    const maxScroll = this.#maxScroll(width, height);
+    const scroll = Math.min(Math.max(0, this.#scroll), maxScroll);
+    const visibleBody = body.slice(scroll, scroll + bodyHeight);
+    const firstVisible = body.length === 0 ? 0 : scroll + 1;
+    const lastVisible = Math.min(body.length, scroll + visibleBody.length);
+    const earlier = scroll > 0 ? "↑ earlier content" : undefined;
+    const later = scroll < maxScroll ? "↓ more content" : undefined;
+    const position = [earlier, later, `Viewing ${firstVisible}–${lastVisible} of ${body.length}`]
+      .filter((part) => part !== undefined)
+      .join(" · ");
+    const c = theme.colors;
+    return [
+      c.dim(theme.glyph.hrule.repeat(Math.max(1, width))),
+      ...visibleBody.map((line) => `  ${line}`),
+      "",
+      `  ${c.dim(position)}`,
+    ].map((row) => clipVisible(row, width));
+  }
+
+  #maxScroll(width: number, height: number): number {
+    return Math.max(0, approvalContentRows(this.#content, width).length - Math.max(1, height - 3));
+  }
+}
+
+function approvalContentRows(content: ToolApprovalContent, width: number): string[] {
+  return content.text.split(/\r?\n/u).flatMap((line) => {
+    const safe = stripTerminalControls(line);
+    return safe === "" ? [""] : wrapVisibleLine(safe, Math.max(1, width - 2));
+  });
+}

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -22,11 +22,13 @@ import {
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import { subscribeDevelopmentSandboxPrewarmLogs } from "#execution/sandbox/development-prewarm.js";
 import { createEventDeduper } from "#protocol/event-dedupe.js";
+import type { ToolApprovalContent } from "#public/tools/approval/content.js";
 import {
   createDevelopmentRuntimeArtifactRefresher,
   type DevelopmentRuntimeArtifactRefresher,
 } from "#services/dev-client.js";
 import { toErrorMessage } from "#shared/errors.js";
+import { getToolApprovalContent } from "#runtime/input/tool-approval-content.js";
 import { SubagentPump, type SubagentPumpOptions, type SubagentView } from "./subagent-pump.js";
 export type {
   SubagentRun,
@@ -192,6 +194,7 @@ export type AgentTUIToolApprovalRequest = {
   toolCallId: string;
   toolName: string;
   title?: string;
+  content?: ToolApprovalContent;
   input: unknown;
 };
 
@@ -2211,6 +2214,7 @@ function toAgentTUIToolApprovalRequest(request: InputRequest): AgentTUIToolAppro
     approvalId: request.requestId,
     toolCallId: request.action.callId,
     toolName: request.action.toolName,
+    content: getToolApprovalContent(request),
     input: request.action.input,
   };
 }

--- a/packages/eve/src/cli/dev/tui/stream-format.test.ts
+++ b/packages/eve/src/cli/dev/tui/stream-format.test.ts
@@ -157,6 +157,11 @@ describe("nextKey", () => {
     expect(nextKey("\r")).toEqual({ key: { type: "enter" }, consumed: 1 });
   });
 
+  it("decodes Page Up and Page Down", () => {
+    expect(nextKey("\x1b[5~")).toEqual({ key: { type: "page-up" }, consumed: 4 });
+    expect(nextKey("\x1b[6~")).toEqual({ key: { type: "page-down" }, consumed: 4 });
+  });
+
   it("stops a printable run at a control byte", () => {
     expect(nextKey("ab\rcd")).toEqual({
       key: { type: "text", value: "ab", framing: "unframed" },

--- a/packages/eve/src/cli/dev/tui/stream-format.ts
+++ b/packages/eve/src/cli/dev/tui/stream-format.ts
@@ -23,6 +23,8 @@ export type TerminalKey =
   | { type: "right" }
   | { type: "home" }
   | { type: "end" }
+  | { type: "page-up" }
+  | { type: "page-down" }
   | { type: "tab" }
   | { type: "escape" }
   | {
@@ -35,8 +37,10 @@ export type TerminalKey =
       y: number;
     }
   | { type: "ctrl-a" }
+  | { type: "ctrl-b" }
   | { type: "ctrl-e" }
   | { type: "ctrl-d" }
+  | { type: "ctrl-f" }
   | { type: "ctrl-k" }
   | { type: "ctrl-n" }
   | { type: "ctrl-p" }
@@ -224,10 +228,14 @@ export function parseKey(chunk: Buffer): TerminalKey {
   switch (value) {
     case "\u0001":
       return { type: "ctrl-a" };
+    case "\u0002":
+      return { type: "ctrl-b" };
     case "\u0005":
       return { type: "ctrl-e" };
     case "\u0004":
       return { type: "ctrl-d" };
+    case "\u0006":
+      return { type: "ctrl-f" };
     case "\u000b":
       return { type: "ctrl-k" };
     case "\u000e":
@@ -277,6 +285,10 @@ export function parseKey(chunk: Buffer): TerminalKey {
       return { type: "end" };
     case "\x1B[3~":
       return { type: "delete" };
+    case "\x1B[5~":
+      return { type: "page-up" };
+    case "\x1B[6~":
+      return { type: "page-down" };
     case "\t":
       return { type: "tab" };
     case "\x1B":

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -3311,6 +3311,91 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("shows tool-provided content without changing decision keys", async () => {
+    const { screen, input, renderer } = makeRenderer();
+    const approval = renderer.readToolApproval({
+      approvalId: "a-review",
+      toolCallId: "c-review",
+      toolName: "extension__finalize",
+      input: {},
+      content: {
+        type: "text",
+        text: "--- agent.ts\n- old\n+ new",
+      },
+    });
+
+    expect(screen.snapshot()).toContain("Approve extension__finalize?");
+    expect(screen.snapshot()).toContain("(y/n)");
+    expect(screen.snapshot()).toContain("--- agent.ts");
+    expect(screen.snapshot()).toContain("- old");
+    expect(screen.snapshot()).toContain("+ new");
+    input.type("y");
+
+    await expect(approval).resolves.toEqual({ approved: true });
+    renderer.shutdown();
+  });
+
+  it("scrolls up immediately after paging and pages up with b", async () => {
+    const { screen, input, renderer } = makeRenderer();
+    const approval = renderer.readToolApproval({
+      approvalId: "a-scroll",
+      toolCallId: "c-scroll",
+      toolName: "review",
+      input: {},
+      content: {
+        type: "text",
+        text: Array.from(
+          { length: 30 },
+          (_, index) => `line-${String(index).padStart(2, "0")}`,
+        ).join("\n"),
+      },
+    });
+
+    input.type(" ");
+    expect(screen.snapshot()).toContain("line-07");
+    expect(screen.snapshot()).not.toContain("line-06");
+    input.up();
+    expect(screen.snapshot()).toContain("line-06");
+    input.type("b");
+    expect(screen.snapshot()).toContain("line-00");
+
+    input.type("n");
+    await expect(approval).resolves.toEqual({ approved: false, reason: "Denied by user." });
+    renderer.shutdown();
+  });
+
+  it("supports pager bindings and closes review content without deciding", async () => {
+    const { screen, input, renderer } = makeRenderer();
+    const approval = renderer.readToolApproval({
+      approvalId: "a-pager",
+      toolCallId: "c-pager",
+      toolName: "review",
+      input: {},
+      content: {
+        type: "text",
+        text: Array.from({ length: 40 }, (_, index) => `pager-line-${index}`).join("\n"),
+      },
+    });
+
+    input.type("G");
+    expect(screen.snapshot()).toContain("pager-line-39");
+    input.type("g");
+    expect(screen.snapshot()).toContain("pager-line-0");
+    input.send("\x1b[6~");
+    expect(screen.snapshot()).not.toContain("pager-line-0");
+    input.type("b");
+    expect(screen.snapshot()).toContain("pager-line-0");
+    input.type("q");
+    expect(screen.snapshot()).not.toContain("pager-line-0");
+    expect(screen.snapshot()).toContain("Review content available");
+    input.type("v");
+    expect(screen.snapshot()).toContain("pager-line-0");
+
+    input.type("n");
+    await expect(approval).resolves.toEqual({ approved: false, reason: "Denied by user." });
+    renderer.shutdown();
+  });
+
   it("marks a tool block denied when the user rejects the approval", async () => {
     const { screen, input, renderer } = makeRenderer();
     await renderer.renderStream(

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -139,6 +139,7 @@ import {
 import { FileContentCache } from "./file-content-cache.js";
 import { groupToolBlocksForDisplay } from "./tool-block-groups.js";
 import { renderQuestionPanel } from "./question-panel.js";
+import { ApprovalContentPanel } from "./approval-content-panel.js";
 import { promptPlaceholder } from "./prompt-placeholder.js";
 import { TurnClock } from "./turn-clock.js";
 import {
@@ -517,6 +518,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #pendingEchoedPrompt?: string;
   /** The open HITL question overlay, painted above the input area. */
   #questionPanel?: (width: number) => string[];
+  /** Tool-provided content shown above the open approval prompt. */
+  #approvalContentPanel?: ApprovalContentPanel;
   /** The active setup flow's bordered panel: progress, question, status. */
   #setupFlow?: SetupFlowState;
   /** The clearable setup attention line (`⚠ … · /vc:login`), rendered in the live footer. */
@@ -965,7 +968,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#stopTicker();
     this.#inputActive = false;
     this.#turnIndicator = { kind: "idle" };
-    this.#status = `Approve ${formatToolApprovalTitle(request)}?  (y/n)`;
+    this.#approvalContentPanel =
+      request.content === undefined ? undefined : new ApprovalContentPanel(request.content);
+    const approvalTitle = formatToolApprovalTitle(request);
+    const openStatus = `Approve ${approvalTitle}?  (y/n)`;
+    const closedStatus = `Review content available · Approve ${approvalTitle}?  (y/n)`;
+    this.#status = openStatus;
     this.#interrupted = false;
     this.#paint();
 
@@ -975,16 +983,45 @@ export class TerminalRenderer implements AgentTUIRenderer {
         switch (key.type) {
           case "text": {
             // This prevents ordinary bracketed paste from confirming by
-            // accident; terminal framing is not an authentication signal.
+            // accident; terminal framing is not proof of a physical keypress.
             if (key.framing !== "unframed") break;
-            const value = key.value.toLowerCase();
-            if (value === "y") {
+            const value = key.value;
+            if (value === " " && this.#approvalContentPanel?.visible === true) {
+              this.#moveApprovalContent("page-down", Math.max(1, this.#height() - 10));
+            } else if (value === "b" && this.#approvalContentPanel?.visible === true) {
+              this.#moveApprovalContent("page-up", Math.max(1, this.#height() - 10));
+            } else if (value === "j" && this.#approvalContentPanel?.visible === true) {
+              this.#moveApprovalContent("down");
+            } else if (value === "k" && this.#approvalContentPanel?.visible === true) {
+              this.#moveApprovalContent("up");
+            } else if (value === "g" && this.#approvalContentPanel?.visible === true) {
+              this.#moveApprovalContent("home");
+            } else if (value === "G" && this.#approvalContentPanel?.visible === true) {
+              this.#moveApprovalContent("end");
+            } else if (
+              value.toLowerCase() === "q" &&
+              this.#approvalContentPanel?.visible === true
+            ) {
+              this.#approvalContentPanel.close();
+              this.#status = closedStatus;
+              this.#paint();
+            } else if (
+              value.toLowerCase() === "v" &&
+              this.#approvalContentPanel !== undefined &&
+              !this.#approvalContentPanel.visible
+            ) {
+              this.#approvalContentPanel.open();
+              this.#status = openStatus;
+              this.#paint();
+            } else if (value.toLowerCase() === "y") {
+              this.#approvalContentPanel = undefined;
               this.#startWorking();
               this.#status = STATUS.processing;
               this.#detachInput();
               this.#paint();
               resolve({ approved: true });
-            } else if (value === "n") {
+            } else if (value.toLowerCase() === "n") {
+              this.#approvalContentPanel = undefined;
               this.#startWorking();
               this.#status = STATUS.processing;
               this.#markToolDenied(request.toolCallId);
@@ -994,10 +1031,46 @@ export class TerminalRenderer implements AgentTUIRenderer {
             }
             break;
           }
+          case "page-up":
+          case "ctrl-b":
+          case "ctrl-f": {
+            const action = key.type === "ctrl-f" ? "page-down" : "page-up";
+            this.#moveApprovalContent(action, Math.max(1, this.#height() - 10));
+            break;
+          }
+          case "page-down":
+            this.#moveApprovalContent("page-down", Math.max(1, this.#height() - 10));
+            break;
+          case "ctrl-d":
+            this.#moveApprovalContent(
+              "page-down",
+              Math.max(1, Math.floor((this.#height() - 10) / 2)),
+            );
+            break;
+          case "ctrl-u":
+            this.#moveApprovalContent(
+              "page-up",
+              Math.max(1, Math.floor((this.#height() - 10) / 2)),
+            );
+            break;
+          case "up":
+          case "down":
+          case "home":
+          case "end":
+            this.#moveApprovalContent(key.type);
+            break;
+          case "escape":
+            if (this.#approvalContentPanel?.visible === true) {
+              this.#approvalContentPanel.close();
+              this.#status = closedStatus;
+              this.#paint();
+            }
+            break;
           case "ctrl-r":
             this.#paint();
             break;
           case "ctrl-c":
+            this.#approvalContentPanel = undefined;
             this.#interrupted = true;
             this.#stop();
             reject(interruptedError());
@@ -2736,6 +2809,20 @@ export class TerminalRenderer implements AgentTUIRenderer {
   // Lifecycle
   // ---------------------------------------------------------------------------
 
+  #moveApprovalContent(
+    action: "down" | "end" | "home" | "page-down" | "page-up" | "up",
+    pageSize = 1,
+  ): void {
+    if (this.#approvalContentPanel?.visible !== true) return;
+    this.#approvalContentPanel.move(
+      action,
+      pageSize,
+      this.#width(),
+      Math.max(8, this.#height() - 4),
+    );
+    this.#paint();
+  }
+
   #start(options?: AgentTUISessionOptions) {
     this.#title = options?.title ?? this.#title;
     if (options?.contextSize !== undefined) this.#contextSize = options.contextSize;
@@ -3847,6 +3934,16 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #footerRows(width: number): string[] {
     const c = this.#theme.colors;
     const rows: string[] = [""];
+
+    if (this.#approvalContentPanel?.visible === true) {
+      rows.push(
+        ...this.#approvalContentPanel.render(this.#theme, width, Math.max(8, this.#height() - 4)),
+        "",
+      );
+      rows.push(clip(`${c.dim(this.#theme.glyph.dot)} ${this.#status}`, width));
+      this.#pushStatusLine(rows, width);
+      return rows;
+    }
 
     // The HITL question overlay owns the footer down to the status bar —
     // no indicator or hint row beneath it (the panel carries its own).

--- a/packages/eve/src/client/message-action-parts.ts
+++ b/packages/eve/src/client/message-action-parts.ts
@@ -1,5 +1,6 @@
 import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
 import type { InputRequest } from "#runtime/input/types.js";
+import { getToolApprovalContent } from "#runtime/input/tool-approval-content.js";
 import type {
   EveDynamicToolPart,
   EveMessageInputRequest,
@@ -26,6 +27,7 @@ export function toMessageInputRequest(request: InputRequest): EveMessageInputReq
     display: request.display,
     kind: request.kind,
     options: request.options,
+    content: getToolApprovalContent(request),
     prompt: request.prompt,
     requestId: request.requestId,
   };

--- a/packages/eve/src/client/message-reducer-types.ts
+++ b/packages/eve/src/client/message-reducer-types.ts
@@ -1,5 +1,6 @@
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { AuthorizationOutcome } from "#protocol/message.js";
+import type { ToolApprovalContent } from "#public/tools/approval/content.js";
 
 /**
  * UIMessage-compatible eve message projection for chat and agent UIs.
@@ -245,6 +246,7 @@ export interface EveMessageInputRequest {
     readonly label: string;
     readonly style?: "danger" | "default" | "primary";
   }[];
+  readonly content?: ToolApprovalContent;
   readonly prompt: string;
   readonly requestId: string;
 }

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -640,6 +640,17 @@ const compiledHookDefinitionSchema: z.ZodType<CompiledHookDefinition> = z
   })
   .strict();
 
+const compiledExtensionMountSchema: z.ZodType<CompiledExtensionMount> = z
+  .object({
+    namespace: z.string(),
+    packageName: z.string(),
+    packageNamespace: z.string(),
+    sourceRoot: z.string(),
+    mountSourceId: z.string(),
+    mountLogicalPath: z.string(),
+  })
+  .strict();
+
 /**
  * Zod schema for one non-recursive compiled authored agent payload.
  */
@@ -657,6 +668,7 @@ const compiledAgentNodeManifestSchema = z
     dynamicInstructions: z.array(compiledDynamicInstructionsDefinitionSchema).default([]),
     dynamicSkills: z.array(compiledDynamicSkillDefinitionSchema).default([]),
     dynamicTools: z.array(compiledDynamicToolDefinitionSchema).default([]),
+    extensionMounts: z.array(compiledExtensionMountSchema).default([]),
     hooks: z.array(compiledHookDefinitionSchema),
     sandbox: compiledSandboxDefinitionSchema.nullable(),
     sandboxWorkspaces: z.array(compiledSandboxWorkspaceSchema),
@@ -703,7 +715,7 @@ const compiledSubagentEdgeSchema: z.ZodType<CompiledSubagentEdge> = z
   .strict();
 
 /**
- * One mounted extension recorded on the root compiled manifest. The runtime
+ * One mounted extension recorded on a compiled agent manifest. The runtime
  * evaluates {@link mountLogicalPath} at module-map load so the mount's factory
  * call binds the extension's config before any tool runs.
  */
@@ -726,17 +738,6 @@ export interface CompiledExtensionMount {
   readonly mountSourceId: string;
   readonly mountLogicalPath: string;
 }
-
-const compiledExtensionMountSchema: z.ZodType<CompiledExtensionMount> = z
-  .object({
-    namespace: z.string(),
-    packageName: z.string(),
-    packageNamespace: z.string(),
-    sourceRoot: z.string(),
-    mountSourceId: z.string(),
-    mountLogicalPath: z.string(),
-  })
-  .strict();
 
 /**
  * Zod schema for the versioned compiled manifest emitted by the compiler.
@@ -788,6 +789,7 @@ export function createCompiledAgentNodeManifest(input: {
   readonly dynamicInstructions?: readonly CompiledDynamicInstructionsDefinition[];
   readonly dynamicSkills?: readonly CompiledDynamicSkillDefinition[];
   readonly dynamicTools?: readonly CompiledDynamicToolDefinition[];
+  readonly extensionMounts?: readonly CompiledExtensionMount[];
   readonly hooks?: readonly CompiledHookDefinition[];
   readonly remoteAgents?: readonly CompiledRemoteAgentNode[];
   readonly sandbox?: CompiledSandboxDefinition | null;
@@ -871,6 +873,7 @@ export function createCompiledAgentNodeManifest(input: {
     dynamicInstructions: [...(input.dynamicInstructions ?? [])],
     dynamicSkills: [...(input.dynamicSkills ?? [])],
     dynamicTools: [...(input.dynamicTools ?? [])],
+    extensionMounts: [...(input.extensionMounts ?? [])],
     hooks: [...(input.hooks ?? [])],
     remoteAgents: [...(input.remoteAgents ?? [])],
     sandbox: input.sandbox ?? null,

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -9,8 +9,8 @@ import {
 import { classifyModelRouting } from "#internal/classify-model-routing.js";
 import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import { compileAgentManifest } from "#compiler/normalize-manifest.js";
-import { defineAgent } from "#public/definitions/agent.js";
-import { defineDynamic, experimental_workflow } from "#public/definitions/tool.js";
+import { defineAgent, defineDynamic } from "#public/definitions/agent.js";
+import { experimental_workflow } from "#public/definitions/tool.js";
 import { webSearch } from "#public/tools/web-search.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 
@@ -154,6 +154,49 @@ describe("compileAgentManifest", () => {
     expect(mocks.compileAgentConfig.mock.calls[1]?.[2]).toMatchObject({
       definition: { model: DEFAULT_AGENT_MODEL_ID },
     });
+  });
+
+  it("applies dynamic subagent build configuration before resolving events", async () => {
+    const dynamic = defineDynamic({
+      build: { externalDependencies: ["just-bash"] },
+      events: {
+        "session.started": () =>
+          defineAgent({
+            description: "Edit the request.",
+            model: "openai/gpt-5.5",
+          }),
+      },
+    });
+    const manifest = createManifestWithSubagent();
+    mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) =>
+      createConfig({ name: input.agentId }),
+    );
+    mocks.loadModuleBackedDefinition.mockResolvedValue(dynamic);
+
+    const compiled = await compileAgentManifest(manifest);
+
+    expect(compiled.subagents[0]?.dynamic).toEqual({
+      eventNames: ["session.started"],
+    });
+    expect(mocks.compileAgentConfig.mock.calls[1]?.[2]).toMatchObject({
+      definition: {
+        build: { externalDependencies: ["just-bash"] },
+        model: DEFAULT_AGENT_MODEL_ID,
+      },
+    });
+  });
+
+  it("rejects invalid dynamic subagent build configuration", async () => {
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+    mocks.loadModuleBackedDefinition.mockResolvedValue({
+      build: { externalDependencies: "just-bash" },
+      events: { "session.started": () => null },
+      kind: "eve:dynamic",
+    });
+
+    await expect(compileAgentManifest(createManifestWithSubagent())).rejects.toThrow(
+      "Expected the dynamic subagent config export",
+    );
   });
 
   it("rejects fallback on a dynamic subagent", async () => {

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -9,6 +9,7 @@ import {
 import { classifyModelRouting } from "#internal/classify-model-routing.js";
 import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import { compileAgentManifest } from "#compiler/normalize-manifest.js";
+import { collectModuleRefsForManifest } from "#compiler/module-map.js";
 import { defineAgent, defineDynamic } from "#public/definitions/agent.js";
 import { experimental_workflow } from "#public/definitions/tool.js";
 import { webSearch } from "#public/tools/web-search.js";
@@ -80,6 +81,71 @@ describe("compileAgentManifest", () => {
     await expect(compileAgentManifest(manifest)).rejects.toThrow(
       'Remove "experimental.workflow" from "research"',
     );
+  });
+
+  it("retains extension mounts on the subagent that owns them", async () => {
+    const extensionManifest = createAgentSourceManifest({
+      agentId: "research-extension",
+      agentRoot: "/packages/research/dist/extension",
+      appRoot: "/packages/research",
+    });
+    const mountRef = createModuleSourceRef({ logicalPath: "extensions/research.ts" });
+    const subagentManifest = createAgentSourceManifest({
+      agentId: "researcher",
+      agentRoot: "/app/agent/subagents/researcher",
+      appRoot: "/app",
+      configModule: createModuleSourceRef({ logicalPath: "agent.ts" }),
+      extensions: [mountRef],
+      resolvedExtensions: [
+        {
+          namespace: "research",
+          specifier: "@acme/research",
+          packageName: "@acme/research",
+          packageRoot: "/packages/research",
+          sourceRoot: "/packages/research/dist/extension",
+          manifest: extensionManifest,
+        },
+      ],
+    });
+    const manifest = createAgentSourceManifest({
+      agentId: "root",
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      subagents: [
+        createLocalSubagentSourceRef({
+          entryPath: "subagents/researcher/agent.ts",
+          logicalPath: "subagents/researcher",
+          manifest: subagentManifest,
+          rootPath: "/app/agent/subagents/researcher",
+          subagentId: "researcher",
+        }),
+      ],
+    });
+    mocks.compileAgentConfig.mockImplementation(async (input: AgentSourceManifest) =>
+      input.agentId === "researcher"
+        ? createConfig({ name: input.agentId, description: "Research the request." })
+        : createConfig({ name: input.agentId }),
+    );
+    mocks.loadModuleBackedDefinition.mockResolvedValue({
+      description: "Research the request.",
+      model: "openai/gpt-5.5",
+    });
+
+    const compiled = await compileAgentManifest(manifest);
+
+    expect(compiled.extensionMounts).toEqual([]);
+    expect(compiled.subagents[0]?.agent.extensionMounts).toEqual([
+      expect.objectContaining({
+        namespace: "research",
+        mountLogicalPath: "extensions/research.ts",
+        packageName: "@acme/research",
+      }),
+    ]);
+    expect(collectModuleRefsForManifest(compiled.subagents[0]!.agent)).toContainEqual({
+      sourceKind: "module",
+      logicalPath: "extensions/research.ts",
+      sourceId: "extensions/research.ts",
+    });
   });
 
   it("compiles experimental Workflow tool configuration", async () => {

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -49,23 +49,9 @@ export async function compileAgentManifest(
     subagents: manifest.subagents,
   });
 
-  const extensionMounts: CompiledExtensionMount[] = manifest.resolvedExtensions.map((mount) => {
-    const mountRef = manifest.extensions.find(
-      (entry) => mountRefNamespace(entry.logicalPath) === mount.namespace,
-    );
-    return {
-      namespace: mount.namespace,
-      packageName: mount.packageName,
-      packageNamespace: packageStateNamespace(mount.packageName),
-      sourceRoot: mount.sourceRoot,
-      mountSourceId: mountRef?.sourceId ?? `extensions/${mount.namespace}`,
-      mountLogicalPath: mountRef?.logicalPath ?? `extensions/${mount.namespace}`,
-    };
-  });
-
   return createCompiledAgentManifest({
     ...compiledNode,
-    extensionMounts,
+    extensionMounts: compiledNode.extensionMounts,
     remoteAgents: subagentGraph.remoteAgents,
     subagentEdges: subagentGraph.edges,
     subagents: subagentGraph.nodes,
@@ -252,6 +238,7 @@ async function compileAgentNodeManifest(
     agentRoot: manifest.agentRoot,
     appRoot: manifest.appRoot,
     channels: compiledChannels,
+    extensionMounts: compileExtensionMounts(manifest),
     config,
     connections,
     diagnosticsSummary: manifest.diagnosticsSummary,
@@ -278,6 +265,22 @@ async function compileAgentNodeManifest(
     skills,
     instructions: composedInstructions,
     tools,
+  });
+}
+
+function compileExtensionMounts(manifest: AgentSourceManifest): CompiledExtensionMount[] {
+  return manifest.resolvedExtensions.map((mount) => {
+    const mountRef = manifest.extensions.find(
+      (entry) => mountRefNamespace(entry.logicalPath) === mount.namespace,
+    );
+    return {
+      namespace: mount.namespace,
+      packageName: mount.packageName,
+      packageNamespace: packageStateNamespace(mount.packageName),
+      sourceRoot: mount.sourceRoot,
+      mountSourceId: mountRef?.sourceId ?? `extensions/${mount.namespace}`,
+      mountLogicalPath: mountRef?.logicalPath ?? `extensions/${mount.namespace}`,
+    };
   });
 }
 

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -155,17 +155,23 @@ async function compileSubagentDefinition(input: {
     };
   }
 
+  let agentConfigDefinition = definition;
+  if (dynamic !== undefined) {
+    const dynamicAgentConfig: {
+      build?: { readonly externalDependencies?: readonly string[] };
+      readonly model: string;
+    } = { model: DEFAULT_AGENT_MODEL_ID };
+    if (dynamic.build !== undefined) {
+      dynamicAgentConfig.build = dynamic.build;
+    }
+    agentConfigDefinition = dynamicAgentConfig;
+  }
+
   return {
     kind: "local",
     ...(await compileLocalSubagent({
       ...input,
-      agentConfigDefinition:
-        dynamic === undefined
-          ? definition
-          : {
-              ...(dynamic.build === undefined ? {} : { build: dynamic.build }),
-              model: DEFAULT_AGENT_MODEL_ID,
-            },
+      agentConfigDefinition,
       dynamic: dynamic?.definition,
     })),
   };
@@ -323,10 +329,16 @@ function normalizeDynamicSubagentDefinition(
     eventNames.push(eventName as DynamicToolEventName);
   }
 
-  return {
-    ...(build === undefined ? {} : { build }),
+  const normalized: {
+    build?: { readonly externalDependencies?: readonly string[] };
+    readonly definition: { readonly eventNames: readonly DynamicToolEventName[] };
+  } = {
     definition: { eventNames },
   };
+  if (build !== undefined) {
+    normalized.build = build;
+  }
+  return normalized;
 }
 
 function createSubagentConfigModuleSourceRef(

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -26,6 +26,7 @@ import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import { serializeOutputSchema, type ToolSchemaSource } from "#shared/tool-schema.js";
 import type { JsonObject } from "#shared/json.js";
 import { isDynamicSentinel, type DynamicToolEventName } from "#shared/dynamic-tool-definition.js";
+import { normalizeAgentDefinition } from "#internal/authored-definition/core.js";
 
 const ALLOWED_DYNAMIC_SUBAGENT_EVENTS = new Set<DynamicToolEventName>([
   "session.started",
@@ -158,7 +159,13 @@ async function compileSubagentDefinition(input: {
     kind: "local",
     ...(await compileLocalSubagent({
       ...input,
-      agentConfigDefinition: dynamic === undefined ? definition : { model: DEFAULT_AGENT_MODEL_ID },
+      agentConfigDefinition:
+        dynamic === undefined
+          ? definition
+          : {
+              ...(dynamic.build === undefined ? {} : { build: dynamic.build }),
+              model: DEFAULT_AGENT_MODEL_ID,
+            },
       dynamic: dynamic?.definition,
     })),
   };
@@ -280,7 +287,12 @@ function compileRemoteAgent(input: {
 function normalizeDynamicSubagentDefinition(
   value: unknown,
   message: string,
-): { readonly definition: { readonly eventNames: readonly DynamicToolEventName[] } } | undefined {
+):
+  | {
+      readonly build?: { readonly externalDependencies?: readonly string[] };
+      readonly definition: { readonly eventNames: readonly DynamicToolEventName[] };
+    }
+  | undefined {
   if (!isDynamicSentinel(value)) {
     return undefined;
   }
@@ -291,8 +303,13 @@ function normalizeDynamicSubagentDefinition(
       `${message} Dynamic subagent definitions do not support "fallback". Return defineAgent(...) or defineRemoteAgent(...) from an event handler instead.`,
     );
   }
-  expectOnlyKnownKeys(record, ["events", "kind"], message);
+  expectOnlyKnownKeys(record, ["build", "events", "kind"], message);
 
+  const build =
+    record.build === undefined
+      ? undefined
+      : normalizeAgentDefinition({ build: record.build, model: DEFAULT_AGENT_MODEL_ID }, message)
+          .build;
   const rawEvents = expectObjectRecord(record.events, message);
   const eventNames: DynamicToolEventName[] = [];
 
@@ -307,6 +324,7 @@ function normalizeDynamicSubagentDefinition(
   }
 
   return {
+    ...(build === undefined ? {} : { build }),
     definition: { eventNames },
   };
 }

--- a/packages/eve/src/discover/discover-agent.ts
+++ b/packages/eve/src/discover/discover-agent.ts
@@ -268,7 +268,7 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
     }),
   );
 
-  const resolvedExtensions: ResolvedExtensionMount[] = [];
+  let resolvedExtensions: readonly ResolvedExtensionMount[] = [];
   if (role !== "agent") {
     // Extensions cannot mount other extensions yet. Fail loudly instead of
     // silently dropping the nested mount, and reserve the behavior so enabling
@@ -283,56 +283,14 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
       );
     }
   } else {
-    for (const descriptor of mountCollection.mounts) {
-      const located = await locateExtensionMount({
-        source,
-        agentRoot,
-        appRoot,
-        mount: descriptor.mountRef,
-        namespace: descriptor.namespace,
-      });
-      diagnostics.push(...located.diagnostics);
-      if (located.location === undefined) {
-        continue;
-      }
-
-      const extensionResult = await discoverAgent({
-        agentRoot: located.location.sourceRoot,
-        appRoot: located.location.packageRoot,
-        source,
-        role: "extension",
-      });
-      diagnostics.push(...extensionResult.diagnostics);
-
-      // The mount directory's override slots discover as an agent-shaped source;
-      // its `extension.<ext>` declaration matches no slot, so it is ignored here.
-      let overrides: AgentSourceManifest | undefined;
-      if (descriptor.overridesRoot !== undefined) {
-        const overridesResult = await discoverAgent({
-          agentRoot: descriptor.overridesRoot,
-          appRoot,
-          source,
-          role: "extension",
-        });
-        diagnostics.push(...overridesResult.diagnostics);
-        overrides = overridesResult.manifest;
-      }
-
-      const resolved: { -readonly [K in keyof ResolvedExtensionMount]: ResolvedExtensionMount[K] } =
-        {
-          namespace: located.location.namespace,
-          specifier: located.location.specifier,
-          packageName: located.location.packageName,
-          packageRoot: located.location.packageRoot,
-          sourceRoot: located.location.sourceRoot,
-          manifest: extensionResult.manifest,
-        };
-      if (overrides !== undefined) {
-        resolved.overrides = overrides;
-      }
-
-      resolvedExtensions.push(resolved);
-    }
+    const result = await resolveExtensionMounts({
+      agentRoot,
+      appRoot,
+      mounts: mountCollection.mounts,
+      source,
+    });
+    diagnostics.push(...result.diagnostics);
+    resolvedExtensions = result.mounts;
   }
 
   const manifestInput: CreateAgentSourceManifestInput = {
@@ -373,6 +331,64 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
  * file form (`extensions/crm.ts`) or the directory form
  * (`extensions/crm/extension.ts` with optional override slots).
  */
+/** Resolves extension declarations into their discovered source manifests. */
+export async function resolveExtensionMounts(input: {
+  readonly agentRoot: string;
+  readonly appRoot: string;
+  readonly mounts: readonly ExtensionMountDescriptor[];
+  readonly source: ProjectSource;
+}): Promise<{
+  readonly diagnostics: readonly DiscoverDiagnostic[];
+  readonly mounts: readonly ResolvedExtensionMount[];
+}> {
+  const diagnostics: DiscoverDiagnostic[] = [];
+  const mounts: ResolvedExtensionMount[] = [];
+
+  for (const descriptor of input.mounts) {
+    const located = await locateExtensionMount({
+      source: input.source,
+      agentRoot: input.agentRoot,
+      appRoot: input.appRoot,
+      mount: descriptor.mountRef,
+      namespace: descriptor.namespace,
+    });
+    diagnostics.push(...located.diagnostics);
+    if (located.location === undefined) continue;
+
+    const extensionResult = await discoverAgent({
+      agentRoot: located.location.sourceRoot,
+      appRoot: located.location.packageRoot,
+      source: input.source,
+      role: "extension",
+    });
+    diagnostics.push(...extensionResult.diagnostics);
+
+    let overrides: AgentSourceManifest | undefined;
+    if (descriptor.overridesRoot !== undefined) {
+      const overridesResult = await discoverAgent({
+        agentRoot: descriptor.overridesRoot,
+        appRoot: input.appRoot,
+        source: input.source,
+        role: "extension",
+      });
+      diagnostics.push(...overridesResult.diagnostics);
+      overrides = overridesResult.manifest;
+    }
+
+    mounts.push({
+      namespace: located.location.namespace,
+      specifier: located.location.specifier,
+      packageName: located.location.packageName,
+      packageRoot: located.location.packageRoot,
+      sourceRoot: located.location.sourceRoot,
+      manifest: extensionResult.manifest,
+      overrides,
+    });
+  }
+
+  return { diagnostics, mounts };
+}
+
 export interface ExtensionMountDescriptor {
   /** Mount namespace prefixed onto every composed contribution. */
   readonly namespace: string;
@@ -526,7 +542,7 @@ async function collectExtensionMounts(input: {
  * overrides, so a root-level `<ns>__…` file would override the extension from
  * outside its mount directory — rejected here.
  */
-function detectRootNamespaceCollisions(input: {
+export function detectRootNamespaceCollisions(input: {
   readonly agentRoot: string;
   readonly namespaces: readonly string[];
   readonly sources: ReadonlyArray<{ readonly logicalPath: string }>;

--- a/packages/eve/src/discover/discover-subagent.ts
+++ b/packages/eve/src/discover/discover-subagent.ts
@@ -2,6 +2,11 @@ import { join, relative, resolve } from "node:path";
 import { discoverConnectionSources } from "#discover/connections.js";
 import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discover/diagnostics.js";
 import {
+  detectRootNamespaceCollisions,
+  discoverExtensionMountDeclarations,
+  resolveExtensionMounts,
+} from "#discover/discover-agent.js";
+import {
   classifyLocalSubagentEntry,
   getDirectoryEntryType,
   getSupportedModuleBaseName,
@@ -280,11 +285,34 @@ async function discoverLocalSubagentPackage(input: {
   });
   diagnostics.push(...subagentsResult.diagnostics);
 
+  const extensionsResult = await discoverExtensionMountDeclarations({
+    agentRoot: input.subagentRoot,
+    source: input.source,
+  });
+  diagnostics.push(...extensionsResult.diagnostics);
+  diagnostics.push(
+    ...detectRootNamespaceCollisions({
+      agentRoot: input.subagentRoot,
+      namespaces: extensionsResult.mounts.map((mount) => mount.namespace),
+      sources: [...toolsResult.sources, ...connectionsResult.connections, ...skillsResult.skills],
+    }),
+  );
+
+  const resolvedExtensions = await resolveExtensionMounts({
+    agentRoot: input.subagentRoot,
+    appRoot: input.appRoot,
+    mounts: extensionsResult.mounts,
+    source: input.source,
+  });
+  diagnostics.push(...resolvedExtensions.diagnostics);
+
   const manifestInput: CreateAgentSourceManifestInput = {
     agentRoot: input.subagentRoot,
     appRoot: input.appRoot,
     connections: connectionsResult.connections,
     diagnostics,
+    extensions: extensionsResult.mounts.map((mount) => mount.mountRef),
+    resolvedExtensions: resolvedExtensions.mounts,
     hooks: hooksResult.sources,
     lib: libResult.lib,
     instructions: instructionsResult.instructions,

--- a/packages/eve/src/discover/filesystem.ts
+++ b/packages/eve/src/discover/filesystem.ts
@@ -62,6 +62,7 @@ export type AgentRootEntryKind =
 export type LocalSubagentEntryKind =
   | "agent-config-module"
   | "connections-directory"
+  | "extensions-directory"
   | "hooks-directory"
   | "ignored-directory"
   | "instructions-directory"
@@ -243,6 +244,10 @@ export function classifyLocalSubagentEntry(
 
     if (name === "connections") {
       return "connections-directory";
+    }
+
+    if (name === "extensions") {
+      return "extensions-directory";
     }
 
     if (name === "hooks") {

--- a/packages/eve/src/discover/subagent.integration.test.ts
+++ b/packages/eve/src/discover/subagent.integration.test.ts
@@ -144,6 +144,58 @@ describe("discoverSubagents (memory)", () => {
     });
   });
 
+  it("discovers extension mounts inside local subagent packages", async () => {
+    const project = buildMemoryAgentProject({
+      appFiles: {
+        "node_modules/@acme/research/package.json": JSON.stringify({
+          name: "@acme/research",
+          eve: { extension: { dist: "extension" } },
+        }),
+        "node_modules/@acme/research/extension/_manifest.json": JSON.stringify({
+          kind: "eve-extension",
+          formatVersion: 1,
+          builtWithEve: "test",
+          requires: { extension: 1, tool: 1 },
+        }),
+        "node_modules/@acme/research/extension/tools/search.ts": "export default {};",
+      },
+      agentFiles: {
+        "instructions.md": "Route research tasks.",
+        "subagents/researcher/agent.ts": "export default {};",
+        "subagents/researcher/extensions/research.ts": 'export { default } from "@acme/research";',
+      },
+    });
+
+    const result = await discoverAgent({
+      agentRoot: project.agentRoot,
+      appRoot: project.appRoot,
+      source: project.source,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.manifest.resolvedExtensions).toEqual([]);
+    expect(result.manifest.subagents[0]?.manifest.extensions).toEqual([
+      {
+        sourceKind: "module",
+        logicalPath: "extensions/research.ts",
+        sourceId: "extensions/research.ts",
+      },
+    ]);
+    expect(result.manifest.subagents[0]?.manifest.resolvedExtensions[0]).toMatchObject({
+      namespace: "research",
+      packageName: "@acme/research",
+      specifier: "@acme/research",
+      manifest: {
+        tools: [
+          {
+            logicalPath: "tools/search.ts",
+            sourceId: "tools/search.ts",
+          },
+        ],
+      },
+    });
+  });
+
   it("discovers uppercase instructions in local subagent packages", async () => {
     const project = buildMemoryAgentProject({
       agentFiles: {

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
@@ -10,6 +10,8 @@ import {
   createJustBashSandboxBackend,
   pruneJustBashSandboxTemplates,
 } from "#execution/sandbox/bindings/just-bash.js";
+import { executeGlobOnSandbox } from "#execution/sandbox/glob-tool.js";
+import { executeGrepOnSandbox } from "#execution/sandbox/grep-tool.js";
 import type { SandboxBackend } from "#public/definitions/sandbox-backend.js";
 import { justbash } from "#public/sandbox/backends/just-bash.js";
 
@@ -101,6 +103,20 @@ describe("just-bash sandbox file API", () => {
 
     expect(factoryCalls).toBe(1);
     expect(await handle.session.readTextFile({ path: "/source/instructions.md" })).toBe("before");
+    await expect(
+      executeGlobOnSandbox(handle.session, { path: "/source", pattern: "*" }),
+    ).resolves.toMatchObject({
+      content: "/source/instructions.md",
+      count: 1,
+      path: "/source",
+    });
+    await expect(
+      executeGrepOnSandbox(handle.session, { path: "/source", pattern: "before" }),
+    ).resolves.toMatchObject({
+      content: "/source/instructions.md:1:before",
+      matchCount: 1,
+      path: "/source",
+    });
     await handle.session.writeTextFile({
       content: "after",
       path: "/source/instructions.md",

--- a/packages/eve/src/execution/sandbox/glob-tool.ts
+++ b/packages/eve/src/execution/sandbox/glob-tool.ts
@@ -67,7 +67,10 @@ export async function executeGlobOnSandbox(
   // missing) indicates a real failure. Surface these as structured
   // errors rather than silently pretending the search returned zero
   // files.
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (
+    (result.exitCode !== 0 && result.exitCode !== 1) ||
+    (result.exitCode === 1 && result.stderr.trim().length > 0)
+  ) {
     throw buildGlobExecutionError(command, result.exitCode, result.stderr);
   }
 
@@ -148,7 +151,7 @@ function buildRipgrepCommand(input: BuildCommandInput): string {
     "rg --files --hidden",
     "--glob '!.git/*'",
     `--glob ${shellQuote(input.pattern)}`,
-    `-- ${shellQuote(input.normalizedPath)}`,
+    shellQuote(input.normalizedPath),
   ].join(" ");
 }
 

--- a/packages/eve/src/execution/sandbox/grep-tool.ts
+++ b/packages/eve/src/execution/sandbox/grep-tool.ts
@@ -87,7 +87,10 @@ export async function executeGrepOnSandbox(
   // Any other exit code (e.g. 127 from bash when the tool is missing)
   // indicates a real failure. Surface these as structured errors
   // rather than silently pretending the search returned zero matches.
-  if (result.exitCode !== 0 && result.exitCode !== 1) {
+  if (
+    (result.exitCode !== 0 && result.exitCode !== 1) ||
+    (result.exitCode === 1 && result.stderr.trim().length > 0)
+  ) {
     throw buildGrepExecutionError(command, result.exitCode, result.stderr);
   }
 
@@ -162,7 +165,7 @@ function buildRipgrepCommand(input: BuildCommandInput): string {
  * Builds the POSIX fallback form of the grep command using `grep -rn`.
  */
 function buildPosixGrepCommand(input: BuildCommandInput): string {
-  const parts: string[] = ["grep", "-r", "-n", "--color=never", "--exclude-dir=.git"];
+  const parts: string[] = ["grep", "-r", "-n", "--exclude-dir=.git"];
 
   if (input.ignoreCase) {
     parts.push("-i");
@@ -186,8 +189,7 @@ function buildPosixGrepCommand(input: BuildCommandInput): string {
 
   // `-m` limits matches per file, analogous to ripgrep's `--max-count`.
   parts.push(`-m ${input.effectiveLimit}`);
-  parts.push("--");
-  parts.push(shellQuote(input.pattern));
+  parts.push(`-e ${shellQuote(input.pattern)}`);
   parts.push(shellQuote(input.normalizedPath));
 
   return parts.join(" ");

--- a/packages/eve/src/execution/sandbox/ripgrep-probe.ts
+++ b/packages/eve/src/execution/sandbox/ripgrep-probe.ts
@@ -1,14 +1,18 @@
 import type { SandboxSession } from "#public/definitions/sandbox.js";
 
 /**
- * Memoizes the result of probing for `rg` (ripgrep) once per sandbox
- * session. The probe runs exactly one `command -v rg` per distinct
- * session object, regardless of how many grep/glob tool calls happen.
+ * Memoizes the result of probing for a compatible `rg` (ripgrep) once per
+ * sandbox session, regardless of how many grep/glob tool calls happen.
  */
 const probes = new Map<string, Promise<boolean>>();
 
+const RIPGREP_PROBE_COMMAND =
+  "command -v rg >/dev/null 2>&1 || exit 127; " +
+  "rg --line-number --color=never --hidden --glob '!.git/*' --max-count 1 -- " +
+  "'__eve_ripgrep_probe_never_matches__' /workspace";
+
 /**
- * Returns `true` when `rg` is on PATH in the given sandbox session,
+ * Returns `true` when `rg` is on PATH and supports the options used by eve,
  * `false` otherwise. Result is cached per session.
  *
  * Framework `grep` and `glob` tools call this to decide whether to use
@@ -36,6 +40,6 @@ export async function ripgrepIsAvailable(session: SandboxSession): Promise<boole
 }
 
 async function runProbe(session: SandboxSession): Promise<boolean> {
-  const result = await session.run({ command: "command -v rg >/dev/null 2>&1" });
-  return result.exitCode === 0;
+  const result = await session.run({ command: RIPGREP_PROBE_COMMAND });
+  return (result.exitCode === 0 || result.exitCode === 1) && result.stderr.trim().length === 0;
 }

--- a/packages/eve/src/harness/input-extraction.test.ts
+++ b/packages/eve/src/harness/input-extraction.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { getToolApprovalContent } from "#runtime/input/tool-approval-content.js";
+
+import { ToolApprovalContentCollector } from "#harness/tool-approval-content.js";
 import {
   extractQuestionInputRequests,
   extractToolApprovalInputRequests,
@@ -127,6 +130,35 @@ describe("extractToolApprovalInputRequests", () => {
         requestId: "approval-1",
       },
     ]);
+  });
+
+  it("attaches collected review content by tool call id", () => {
+    const approvalContents = new ToolApprovalContentCollector();
+    approvalContents.set("call-1", {
+      type: "text",
+      text: "--- agent.ts\n- old\n+ new",
+    });
+
+    const [request] = extractToolApprovalInputRequests({
+      approvalContents,
+      content: [
+        {
+          approvalId: "approval-1",
+          toolCall: {
+            input: {},
+            toolCallId: "call-1",
+            toolName: "change_files",
+            type: "tool-call",
+          },
+          type: "tool-approval-request",
+        },
+      ],
+    });
+
+    expect(request === undefined ? undefined : getToolApprovalContent(request)).toEqual({
+      type: "text",
+      text: "--- agent.ts\n- old\n+ new",
+    });
   });
 
   it("extracts an approval request from a sibling tool call", () => {

--- a/packages/eve/src/harness/input-extraction.ts
+++ b/packages/eve/src/harness/input-extraction.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import { ASK_QUESTION_TOOL_NAME } from "#runtime/framework-tools/ask-question.js";
 import type { InputRequest } from "#runtime/input/types.js";
 import { createRuntimeToolCallActionFromToolCall } from "#harness/input-requests.js";
+import type { ToolApprovalContentCollector } from "#harness/tool-approval-content.js";
+import type { InputRequestWithToolApprovalContent } from "#runtime/input/tool-approval-content.js";
 
 // Persisted history parts lose AI SDK typing on the storage round trip. The
 // schemas are the single source for the runtime narrowing and the static
@@ -99,6 +101,7 @@ function extractQuestionRequests(input: {
  * contain `tool-approval-request` entries.
  */
 export function extractToolApprovalInputRequests(input: {
+  readonly approvalContents?: ToolApprovalContentCollector;
   readonly content: readonly ContentPart<ToolSet>[];
   readonly excludedCallIds?: ReadonlySet<string>;
 }): InputRequest[] {
@@ -109,6 +112,7 @@ export function extractToolApprovalInputRequests(input: {
 // at runtime. The exported wrapper above keeps live call sites compile-checked
 // against the AI SDK shapes.
 function extractApprovalRequests(input: {
+  readonly approvalContents?: ToolApprovalContentCollector;
   readonly content: readonly unknown[];
   readonly excludedCallIds?: ReadonlySet<string>;
   readonly includedRequestIds?: ReadonlySet<string>;
@@ -154,7 +158,8 @@ function extractApprovalRequests(input: {
       continue;
     }
 
-    requests.push({
+    const content = input.approvalContents?.get(toolCall.toolCallId);
+    const request: InputRequest = {
       action: createRuntimeToolCallActionFromToolCall({ toolCall }),
       allowFreeform: false,
       display: "confirmation",
@@ -165,7 +170,13 @@ function extractApprovalRequests(input: {
       ],
       prompt: `Approve tool call: ${toolCall.toolName}`,
       requestId: approval.approvalId,
-    });
+    };
+    if (content === undefined) {
+      requests.push(request);
+    } else {
+      const requestWithContent: InputRequestWithToolApprovalContent = { ...request, content };
+      requests.push(requestWithContent);
+    }
   }
 
   return requests;

--- a/packages/eve/src/harness/tool-approval-content.ts
+++ b/packages/eve/src/harness/tool-approval-content.ts
@@ -1,0 +1,22 @@
+import type { ToolApprovalContent } from "#public/tools/approval/content.js";
+import { toolApprovalContentSchema } from "#shared/tool-approval-content-schema.js";
+
+const MAX_CONTENT_BYTES = 2 * 1024 * 1024;
+
+/** Per-model-attempt storage joining authored approval results to SDK approval requests. */
+export class ToolApprovalContentCollector {
+  readonly #contents = new Map<string, ToolApprovalContent>();
+
+  get(callId: string): ToolApprovalContent | undefined {
+    return this.#contents.get(callId);
+  }
+
+  set(callId: string, value: unknown): void {
+    const content = toolApprovalContentSchema.parse(value) as ToolApprovalContent;
+    const bytes = new TextEncoder().encode(JSON.stringify(content)).byteLength;
+    if (bytes > MAX_CONTENT_BYTES) {
+      throw new Error(`Tool approval content exceeds the ${MAX_CONTENT_BYTES}-byte payload limit.`);
+    }
+    this.#contents.set(callId, content);
+  }
+}

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -174,6 +174,7 @@ import {
   isInvalidToolCall,
 } from "#harness/tool-call-input-errors.js";
 import { buildStepHooks, emitStepActions, type HarnessStepResult } from "#harness/step-hooks.js";
+import { ToolApprovalContentCollector } from "#harness/tool-approval-content.js";
 import {
   buildToolApproval,
   buildToolSetFromDefinitions,
@@ -925,6 +926,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       trailingUserNote?: string;
     };
     let modelCallRuntimeActionTools = config.tools;
+    let modelCallApprovalContents = new ToolApprovalContentCollector();
 
     const runSingleModelCall = async (
       opts: ModelCallOptions & { readonly attemptIndex: number },
@@ -943,6 +945,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       const callMessages = opts.trailingUserNote
         ? [...modelMessages, { role: "user" as const, content: opts.trailingUserNote }]
         : modelMessages;
+      const approvalContents = new ToolApprovalContentCollector();
+      modelCallApprovalContents = approvalContents;
       const harnessTools = buildHarnessToolsWithDynamicSubagents(config.tools, ctx);
       const advertisedHarnessTools = getAdvertisedTools({
         session,
@@ -951,6 +955,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       modelCallRuntimeActionTools = advertisedHarnessTools;
 
       const flatTools = await buildToolSetWithProviderTools({
+        approvalContents,
         approvedTools,
         capabilities: config.capabilities,
         disabledProviderTools: opts.disabledProviderTools,
@@ -965,6 +970,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           tools: buildDynamicTools(ctx),
         });
         const dynamicToolSet = buildToolSetFromDefinitions({
+          approvalContents,
           approvedTools,
           capabilities: config.capabilities,
           disabledProviderTools: opts.disabledProviderTools,
@@ -1470,6 +1476,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // --- Handle result ------------------------------------------------------
 
     return handleStepResult({
+      approvalContents: modelCallApprovalContents,
       config,
       emit,
       emissionState,
@@ -1979,6 +1986,7 @@ async function attemptEmptyResponseRecovery(input: {
  * park, continue the tool loop, or terminate.
  */
 async function handleStepResult(input: {
+  readonly approvalContents: ToolApprovalContentCollector;
   readonly config: ToolLoopHarnessConfig;
   readonly emit?: ToolLoopHarnessConfig["handleEvent"];
   readonly emissionState: ReturnType<typeof getHarnessEmissionState>;
@@ -2060,6 +2068,7 @@ async function handleStepResult(input: {
   }
 
   const approvalRequests = extractToolApprovalInputRequests({
+    approvalContents: input.approvalContents,
     content: result.content ?? [],
     excludedCallIds: invalidInputToolCallIds,
   });

--- a/packages/eve/src/harness/tools.test.ts
+++ b/packages/eve/src/harness/tools.test.ts
@@ -21,6 +21,7 @@ import type { HarnessToolMap } from "#harness/types.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 import type { ToolContext } from "#public/definitions/tool.js";
 import type { ToolExecuteOptions } from "#shared/tool-definition.js";
+import { ToolApprovalContentCollector } from "#harness/tool-approval-content.js";
 
 function getJsonSchema(tool: unknown): unknown {
   return (tool as { inputSchema: { jsonSchema: unknown } }).inputSchema.jsonSchema;
@@ -779,6 +780,64 @@ describe("buildToolSet", () => {
         type: "denied",
         reason: "Account is protected.",
       });
+    });
+
+    it("collects review content while returning a plain SDK status", async () => {
+      const approvalContents = new ToolApprovalContentCollector();
+      const tools: HarnessToolMap = new Map([
+        [
+          "change_files",
+          {
+            approval: () => ({
+              type: "user-approval" as const,
+              content: {
+                type: "text" as const,
+                text: "--- agent.ts\n- old\n+ new",
+              },
+            }),
+            description: "Change files.",
+            execute: async () => "ok",
+            inputSchema: jsonSchema({}),
+            name: "change_files",
+          },
+        ],
+      ]);
+      const result = buildToolSet({ approvalContents, tools });
+
+      await expect(resolveApproval(result, "change_files", {})).resolves.toEqual({
+        type: "user-approval",
+      });
+      expect(approvalContents.get("call_1")).toEqual({
+        type: "text",
+        text: "--- agent.ts\n- old\n+ new",
+      });
+    });
+
+    it("rejects unsafe review content", async () => {
+      const approvalContents = new ToolApprovalContentCollector();
+      const tools: HarnessToolMap = new Map([
+        [
+          "unsafe",
+          {
+            approval: () => ({
+              type: "user-approval" as const,
+              content: {
+                type: "text" as const,
+                text: "agent.ts\u001b[2J",
+              },
+            }),
+            description: "Unsafe content.",
+            execute: async () => "ok",
+            inputSchema: jsonSchema({}),
+            name: "unsafe",
+          },
+        ],
+      ]);
+      const result = buildToolSet({ approvalContents, tools });
+
+      await expect(resolveApproval(result, "unsafe", {})).rejects.toThrow(
+        "terminal control characters",
+      );
     });
 
     it("always() requires approval", async () => {

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -21,6 +21,7 @@ import {
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { normalizeToolJsonOutput, normalizeToolModelOutput } from "#harness/tool-model-output.js";
 import type { ToolExecuteOptions } from "#shared/tool-definition.js";
+import type { ToolApprovalContentCollector } from "#harness/tool-approval-content.js";
 
 type NativeApprovalStatus = Exclude<ApprovalStatus, boolean>;
 
@@ -46,6 +47,7 @@ const toolApprovals = new WeakMap<
  * retry call so the request can proceed without it.
  */
 export function buildToolSet(input: {
+  readonly approvalContents?: ToolApprovalContentCollector;
   readonly approvedTools?: ReadonlySet<string>;
   readonly capabilities?: SessionCapabilities;
   readonly disabledProviderTools?: ReadonlySet<string>;
@@ -136,6 +138,7 @@ export function buildToolSet(input: {
  * ordering where step tools override turn/session tools.
  */
 export function buildToolSetFromDefinitions(input: {
+  readonly approvalContents?: ToolApprovalContentCollector;
   readonly approvedTools?: ReadonlySet<string>;
   readonly capabilities?: SessionCapabilities;
   readonly disabledProviderTools?: ReadonlySet<string>;
@@ -148,6 +151,7 @@ export function buildToolSetFromDefinitions(input: {
     }
   }
   return buildToolSet({
+    approvalContents: input.approvalContents,
     approvedTools: input.approvedTools,
     capabilities: input.capabilities,
     disabledProviderTools: input.disabledProviderTools,
@@ -202,6 +206,7 @@ export function wrapToolExecute(
  * a gateway fallback provider has rejected a provider-specific tool.
  */
 export async function buildToolSetWithProviderTools(input: {
+  readonly approvalContents?: ToolApprovalContentCollector;
   readonly approvedTools?: ReadonlySet<string>;
   readonly capabilities?: SessionCapabilities;
   readonly disabledProviderTools?: ReadonlySet<string>;
@@ -212,6 +217,7 @@ export async function buildToolSetWithProviderTools(input: {
   const disabled = input.disabledProviderTools;
   const tools: ToolSet = {
     ...buildToolSet({
+      approvalContents: input.approvalContents,
       approvedTools: input.approvedTools,
       capabilities: input.capabilities,
       disabledProviderTools: disabled,
@@ -238,7 +244,10 @@ export async function buildToolSetWithProviderTools(input: {
 
 function buildApprovalFn(
   definition: HarnessToolDefinition,
-  input: { readonly approvedTools?: ReadonlySet<string> },
+  input: {
+    readonly approvalContents?: ToolApprovalContentCollector;
+    readonly approvedTools?: ReadonlySet<string>;
+  },
 ): (toolInput: unknown, callId: string) => Promise<NativeApprovalStatus> {
   return async (toolInput: unknown, callId: string) => {
     if (definition.approval === undefined) return undefined;
@@ -252,6 +261,15 @@ function buildApprovalFn(
       toolInput: toolInputRecord,
       toolName: definition.name,
     });
+    if (
+      typeof status === "object" &&
+      status !== null &&
+      status.type === "user-approval" &&
+      "content" in status
+    ) {
+      input.approvalContents?.set(callId, status.content);
+      return { type: "user-approval" };
+    }
     return typeof status === "boolean" ? (status ? "user-approval" : "not-applicable") : status;
   };
 }

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -269,10 +269,13 @@ export async function bundleAuthoredModuleMapForGeneration(input: {
     moduleMapPath: input.moduleMapPath,
   });
   const extensionScopePlugin = createExtensionScopePlugin(
-    input.manifest.extensionMounts.map((mount) => ({
-      packageNamespace: mount.packageNamespace,
-      sourceRoot: mount.sourceRoot,
-    })),
+    [input.manifest, ...input.manifest.subagents.map((subagent) => subagent.agent)].flatMap(
+      (node) =>
+        node.extensionMounts.map((mount) => ({
+          packageNamespace: mount.packageNamespace,
+          sourceRoot: mount.sourceRoot,
+        })),
+    ),
   );
   const plugins = [
     createVirtualGenerationModuleMapPlugin({

--- a/packages/eve/src/internal/authored-module-map-loader.ts
+++ b/packages/eve/src/internal/authored-module-map-loader.ts
@@ -80,15 +80,21 @@ async function hydrateCompiledModuleMapFromManifest(
       })),
   ];
 
-  const scopeIndex: ExtensionScopeIndex = {
-    byMountNamespace: new Map(
-      manifest.extensionMounts.map((mount) => [mount.namespace, mount.packageNamespace]),
-    ),
-    byMountSourceId: new Map(
-      manifest.extensionMounts.map((mount) => [mount.mountSourceId, mount.packageNamespace]),
-    ),
-  };
   for (const nodeManifest of nodeManifests) {
+    const scopeIndex: ExtensionScopeIndex = {
+      byMountNamespace: new Map(
+        nodeManifest.manifest.extensionMounts.map((mount) => [
+          mount.namespace,
+          mount.packageNamespace,
+        ]),
+      ),
+      byMountSourceId: new Map(
+        nodeManifest.manifest.extensionMounts.map((mount) => [
+          mount.mountSourceId,
+          mount.packageNamespace,
+        ]),
+      ),
+    };
     nodes[nodeManifest.nodeId] = {
       modules: await hydrateCompiledNodeScope({
         agentRoot: nodeManifest.agentRoot,

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -621,10 +621,15 @@ function createApplicationNitroBundlerConfiguration(
     ).push(packageName);
   }
   const extensionScopePlugin = createExtensionScopePlugin(
-    (preparedHost.compileResult.manifest.extensionMounts ?? []).map((mount) => ({
-      sourceRoot: mount.sourceRoot,
-      packageNamespace: mount.packageNamespace,
-    })),
+    [
+      preparedHost.compileResult.manifest,
+      ...preparedHost.compileResult.manifest.subagents.map((subagent) => subagent.agent),
+    ].flatMap((node) =>
+      node.extensionMounts.map((mount) => ({
+        sourceRoot: mount.sourceRoot,
+        packageNamespace: mount.packageNamespace,
+      })),
+    ),
   );
   const nitroBundlerPlugins = [
     compiledSandboxBackendPrunePlugin,

--- a/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
+++ b/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
@@ -16,7 +16,8 @@ export async function computeDevelopmentHostFingerprint(
       externalDependencies: [
         ...new Set(agentNodes.flatMap((node) => node.config.build?.externalDependencies ?? [])),
       ].sort((left, right) => left.localeCompare(right)),
-      extensionScopes: (manifest.extensionMounts ?? [])
+      extensionScopes: agentNodes
+        .flatMap((node) => node.extensionMounts)
         .map((mount) => ({
           packageNamespace: mount.packageNamespace,
           sourceRoot: mount.sourceRoot,

--- a/packages/eve/src/internal/nitro/host/dev-workspace-extensions.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-workspace-extensions.integration.test.ts
@@ -92,6 +92,24 @@ describe("prepareDevelopmentWorkspaceExtensions", () => {
     );
   });
 
+  it("builds workspace extensions mounted by local subagents", async () => {
+    const appRoot = await createWorkspaceAgent(["alpha"]);
+    await rm(join(appRoot, "agent", "extensions", "alpha.ts"));
+    await writeText(
+      join(appRoot, "agent", "subagents", "researcher", "extensions", "alpha.ts"),
+      'export { default } from "../../../../packages/alpha";\n',
+    );
+
+    const extensions = await prepareDevelopmentWorkspaceExtensions({ appRoot });
+
+    expect(extensions).toHaveLength(1);
+    expect(mocks.buildExtensionPackage).toHaveBeenCalledOnce();
+    expect(mocks.buildExtensionPackage).toHaveBeenCalledWith(
+      join(appRoot, "packages", "alpha"),
+      expect.objectContaining({ packageName: "@acme/alpha" }),
+    );
+  });
+
   it("does not rebuild an extension for an unrelated workspace dependency edit", async () => {
     const appRoot = await createWorkspaceAgent(["alpha"]);
     const initial = await prepareDevelopmentWorkspaceExtensions({ appRoot });

--- a/packages/eve/src/internal/nitro/host/dev-workspace-extensions.ts
+++ b/packages/eve/src/internal/nitro/host/dev-workspace-extensions.ts
@@ -40,18 +40,18 @@ export async function prepareDevelopmentWorkspaceExtensions(input: {
   const appRoot = resolve(input.appRoot);
   const project = await resolveDiscoveryProject(appRoot);
   const source = createDiskProjectSource();
-  const discovered = await discoverExtensionMountDeclarations({
+  const discoveredMounts = await discoverExtensionMountGraph({
     agentRoot: project.agentRoot,
     source,
   });
   const workspaceSourceRoot = await toCanonicalPath(resolveDevelopmentSourceRoot(appRoot));
   const extensionsByPackageRoot = new Map<string, DevelopmentWorkspaceExtension>();
 
-  for (const mount of discovered.mounts) {
+  for (const discovered of discoveredMounts) {
     const extension = await resolveWorkspaceExtension({
       appRoot,
-      agentRoot: project.agentRoot,
-      mount,
+      agentRoot: discovered.agentRoot,
+      mount: discovered.mount,
       source,
       workspaceSourceRoot,
     });
@@ -87,6 +87,30 @@ export async function prepareDevelopmentWorkspaceExtensions(input: {
   );
 
   return extensions;
+}
+
+async function discoverExtensionMountGraph(input: {
+  readonly agentRoot: string;
+  readonly source: ReturnType<typeof createDiskProjectSource>;
+}): Promise<readonly { agentRoot: string; mount: ExtensionMountDescriptor }[]> {
+  const discovered = await discoverExtensionMountDeclarations(input);
+  const mounts = discovered.mounts.map((mount) => ({ agentRoot: input.agentRoot, mount }));
+  const subagentsRoot = join(input.agentRoot, "subagents");
+  if ((await input.source.stat(subagentsRoot)) !== "directory") return mounts;
+
+  const entries = await input.source.readDirectory(subagentsRoot);
+  const nestedMounts = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(
+        async (entry) =>
+          await discoverExtensionMountGraph({
+            agentRoot: join(subagentsRoot, entry.name),
+            source: input.source,
+          }),
+      ),
+  );
+  return [...mounts, ...nestedMounts.flat()];
 }
 
 async function resolveWorkspaceExtension(input: {

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -1,4 +1,4 @@
-import type { PublicAgentDefinition } from "#shared/agent-definition.js";
+import type { AgentBuildDefinition, PublicAgentDefinition } from "#shared/agent-definition.js";
 import type { ExactDefinition } from "#public/definitions/exact.js";
 import type { RemoteAgentDefinition } from "#public/definitions/remote-agent.js";
 import { defineDynamic as defineDynamicBase } from "#public/definitions/tool.js";
@@ -71,11 +71,7 @@ type DynamicSubagentDescriptionConstraint<TEvents extends DynamicEvents> =
     ? unknown
     : { readonly "Dynamic subagent definitions require a description": never };
 
-/**
- * Defines dynamic agent configuration. A returned subagent requires a
- * description so its parent knows when to delegate.
- */
-export const defineDynamic: {
+interface DefineDynamicAgent {
   <const TEvents extends DynamicEventsWithFallback, TFallback = unknown>(
     definition: {
       readonly fallback: TFallback;
@@ -84,10 +80,27 @@ export const defineDynamic: {
   ): DynamicSentinel<Exclude<DynamicEventResult<TEvents>, undefined>, TFallback>;
   <const TEvents extends DynamicEvents>(
     definition: {
+      readonly build?: AgentBuildDefinition;
       readonly events: TEvents;
     } & DynamicSubagentDescriptionConstraint<TEvents>,
   ): DynamicSentinel<DynamicEventResult<TEvents>>;
-} = defineDynamicBase;
+}
+
+/**
+ * Defines dynamic agent configuration. A returned subagent requires a
+ * description so its parent knows when to delegate. Use `build` for static
+ * packaging controls that must apply before the runtime resolver runs.
+ */
+export const defineDynamic: DefineDynamicAgent = ((definition: {
+  readonly build?: AgentBuildDefinition;
+  readonly events: DynamicEvents;
+  readonly fallback?: unknown;
+}) => {
+  const sentinel = Object.hasOwn(definition, "fallback")
+    ? defineDynamicBase({ events: definition.events, fallback: definition.fallback })
+    : defineDynamicBase({ events: definition.events });
+  return definition.build === undefined ? sentinel : { ...sentinel, build: definition.build };
+}) as DefineDynamicAgent;
 
 /**
  * Defines the agent configuration authored in `agent.ts` and returns it

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -61,6 +61,7 @@ function typeOnlyFixtures(): void {
   });
 
   defineDynamic({
+    build: { externalDependencies: ["just-bash"] },
     events: {
       "session.started": () =>
         Math.random() > 0.5

--- a/packages/eve/src/public/tools/approval/content.ts
+++ b/packages/eve/src/public/tools/approval/content.ts
@@ -1,0 +1,12 @@
+/** Optional text shown before a tool's approval prompt by supporting clients. */
+export interface ToolApprovalContent {
+  readonly text: string;
+  readonly type: "text";
+}
+
+/** A `user-approval` status carrying optional review content. */
+export interface ToolApprovalStatusWithContent {
+  readonly content: ToolApprovalContent;
+  readonly reason?: never;
+  readonly type: "user-approval";
+}

--- a/packages/eve/src/public/tools/approval/index.ts
+++ b/packages/eve/src/public/tools/approval/index.ts
@@ -3,4 +3,8 @@
  */
 
 export type { Approval, ApprovalContext, ApprovalStatus } from "#public/definitions/approval.js";
+export type {
+  ToolApprovalContent,
+  ToolApprovalStatusWithContent,
+} from "#public/tools/approval/content.js";
 export { always, never, once } from "#public/tools/approval/approval-helpers.js";

--- a/packages/eve/src/runtime/input/tool-approval-content.ts
+++ b/packages/eve/src/runtime/input/tool-approval-content.ts
@@ -1,0 +1,15 @@
+import type { ToolApprovalContent } from "#public/tools/approval/content.js";
+import type { InputRequest } from "#runtime/input/types.js";
+import { toolApprovalContentSchema } from "#shared/tool-approval-content-schema.js";
+
+/** Internal request carrying review content alongside the stable input protocol. */
+export type InputRequestWithToolApprovalContent = InputRequest & {
+  readonly content: ToolApprovalContent;
+};
+
+/** Reads validated review content from an internal tool-approval request. */
+export function getToolApprovalContent(value: InputRequest): ToolApprovalContent | undefined {
+  if (!("content" in value)) return undefined;
+  const parsed = toolApprovalContentSchema.safeParse(value.content);
+  return parsed.success ? parsed.data : undefined;
+}

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.test.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeResolvedDynamicSubagentDefinition } from "#runtime/resolve-dynamic-subagent.js";
+
+describe("normalizeResolvedDynamicSubagentDefinition", () => {
+  it("accepts and omits compile-time build configuration", () => {
+    const handler = () => null;
+    const resolved = normalizeResolvedDynamicSubagentDefinition(
+      {
+        eventNames: ["session.started"],
+        logicalPath: "agent.ts",
+        sourceId: "agent.ts",
+        sourceKind: "module",
+      },
+      {
+        build: { externalDependencies: ["eve-selfmod"] },
+        events: { "session.started": handler },
+        kind: "eve:dynamic",
+      },
+    );
+
+    expect(resolved.events["session.started"]).toBe(handler);
+    expect(resolved).not.toHaveProperty("build");
+  });
+});

--- a/packages/eve/src/runtime/resolve-dynamic-subagent.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-subagent.ts
@@ -46,7 +46,7 @@ export function normalizeResolvedDynamicSubagentDefinition(
 ): ResolvedDynamicSubagentDefinition {
   const message = `Expected the dynamic subagent export "${definition.exportName ?? "default"}" from "${definition.logicalPath}" to provide defineDynamic({ events }).`;
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["events", "kind"], message);
+  expectOnlyKnownKeys(record, ["build", "events", "kind"], message);
 
   if (record.kind !== "eve:dynamic") {
     throw new Error(message);

--- a/packages/eve/src/shared/tool-approval-content-schema.ts
+++ b/packages/eve/src/shared/tool-approval-content-schema.ts
@@ -1,0 +1,20 @@
+import { z } from "#compiled/zod/index.js";
+
+const safeString = z.string().refine((value) => !hasUnsafeControl(value), {
+  message: "Tool approval content must not contain terminal control characters.",
+});
+
+function hasUnsafeControl(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.codePointAt(0)!;
+    return (code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127 || code === 155;
+  });
+}
+
+/** Runtime schema for review content shown before a tool approval prompt. */
+export const toolApprovalContentSchema = z
+  .object({
+    text: safeString,
+    type: z.literal("text"),
+  })
+  .strict();

--- a/packages/eve/test/glob-tool.test.ts
+++ b/packages/eve/test/glob-tool.test.ts
@@ -15,15 +15,18 @@ import type { SandboxSession } from "../src/shared/sandbox-session.js";
 interface FakeAccessOptions {
   readonly pathResolver?: (path: string) => string;
   /**
-   * Exit code returned by the `command -v rg` probe that runs before
+   * Exit code returned by the ripgrep capability probe that runs before
    * each glob call. Defaults to `0` (ripgrep is available) so tests
    * exercise the ripgrep code path by default. Set to a non-zero
-   * code to force the POSIX fallback branch.
+   * code other than `0` or `1` to force the POSIX fallback branch.
    */
   readonly probeExitCode?: number;
 }
 
-const PROBE_COMMAND = "command -v rg >/dev/null 2>&1";
+const PROBE_COMMAND =
+  "command -v rg >/dev/null 2>&1 || exit 127; " +
+  "rg --line-number --color=never --hidden --glob '!.git/*' --max-count 1 -- " +
+  "'__eve_ripgrep_probe_never_matches__' /workspace";
 const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
 
 function createFakeAccess(
@@ -329,7 +332,7 @@ describe("executeGlobOnSandbox", () => {
       (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
     );
 
-    expect(capturedCommand).toMatch(/-- '\/workspace'/);
+    expect(capturedCommand).toMatch(/'\/workspace'$/);
   });
 
   it("preserves /workspace-rooted output paths exactly as emitted", async () => {
@@ -368,7 +371,7 @@ describe("executeGlobOnSandbox", () => {
         };
       },
       (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
-      { probeExitCode: 1 },
+      { probeExitCode: 127 },
     )) as GlobResult;
 
     // POSIX find, not ripgrep.
@@ -388,6 +391,15 @@ describe("executeGlobOnSandbox", () => {
         (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
       ),
     ).rejects.toThrow(/glob failed \(exit 2\).*IO error/s);
+  });
+
+  it("throws when ripgrep exits 1 with an error message", async () => {
+    await expect(
+      runInContext(
+        () => ({ exitCode: 1, stderr: "rg: unrecognized option '--'\n", stdout: "" }),
+        (sandbox) => executeGlobOnSandbox(sandbox, { pattern: "**/*.ts" }),
+      ),
+    ).rejects.toThrow(/glob failed \(exit 1\).*unrecognized option/s);
   });
 
   it("treats exit 1 as legitimate 'no files'", async () => {

--- a/packages/eve/test/grep-tool.test.ts
+++ b/packages/eve/test/grep-tool.test.ts
@@ -15,15 +15,18 @@ import type { SandboxSession } from "../src/shared/sandbox-session.js";
 interface FakeAccessOptions {
   readonly pathResolver?: (path: string) => string;
   /**
-   * Exit code returned by the `command -v rg` probe that runs before
+   * Exit code returned by the ripgrep capability probe that runs before
    * each grep call. Defaults to `0` (ripgrep is available) so the
-   * tests exercise the ripgrep code path by default. Set to a
-   * non-zero code to force the POSIX fallback branch.
+   * tests exercise the ripgrep code path by default. Set to a code
+   * other than `0` or `1` to force the POSIX fallback branch.
    */
   readonly probeExitCode?: number;
 }
 
-const PROBE_COMMAND = "command -v rg >/dev/null 2>&1";
+const PROBE_COMMAND =
+  "command -v rg >/dev/null 2>&1 || exit 127; " +
+  "rg --line-number --color=never --hidden --glob '!.git/*' --max-count 1 -- " +
+  "'__eve_ripgrep_probe_never_matches__' /workspace";
 const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
 
 function createFakeAccess(
@@ -490,7 +493,7 @@ describe("executeGrepOnSandbox", () => {
         };
       },
       (sandbox) => executeGrepOnSandbox(sandbox, { pattern: "foo" }),
-      { probeExitCode: 1 },
+      { probeExitCode: 127 },
     )) as GrepResult;
 
     // POSIX grep with -r -n, not ripgrep.
@@ -509,7 +512,7 @@ describe("executeGrepOnSandbox", () => {
           stdout: "",
         }),
         (sandbox) => executeGrepOnSandbox(sandbox, { pattern: "foo" }),
-        { probeExitCode: 1 },
+        { probeExitCode: 127 },
       ),
     ).rejects.toThrow(/grep failed \(exit 2\).*IO error/s);
   });
@@ -538,6 +541,15 @@ describe("executeGrepOnSandbox", () => {
     );
 
     expect(capturedCommand).not.toContain("--no-messages");
+  });
+
+  it("throws when ripgrep exits 1 with an error message", async () => {
+    await expect(
+      runInContext(
+        () => ({ exitCode: 1, stderr: "rg: invalid option\n", stdout: "" }),
+        (sandbox) => executeGrepOnSandbox(sandbox, { pattern: "needle" }),
+      ),
+    ).rejects.toThrow(/grep failed \(exit 1\).*invalid option/s);
   });
 
   it("treats exit 1 as legitimate 'no matches'", async () => {


### PR DESCRIPTION
### Description

Extends tool approval results so a tool can attach bounded text content to a `user-approval` decision. eve carries that content alongside the approval request, and the dev TUI renders it in a sanitized, wrapped, pageable review panel with keyboard scrolling before the user approves or denies the call.

The new content is optional, validated against an eve-owned schema, and limited to 2 MiB. Existing approval policies and clients that do not render review content continue to behave as before.

### Rationale

A tool name and JSON arguments are not always enough to make an informed approval decision. Operations such as source edits need to show the exact proposed change before execution. Attaching review material to the approval request keeps the content tied to the specific tool call and lets the user inspect it without granting the tool permission first.

### Testing

Adds harness tests for content collection, validation, input extraction, and payload limits, plus TUI tests for sanitization, wrapping, rendering, and scrolling. The stack is also covered by the repository lint, typecheck, unit, integration, scenario, and TUI checks.
