### PR TITLE
fix(eve): decouple external-provider models from the AI Gateway catalog

### DIFF
--- a/.changeset/external-model-catalog-decouple.md
+++ b/.changeset/external-model-catalog-decouple.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Direct-provider models (e.g. `anthropic(...)`) no longer fail to compile when their model id is absent from the Vercel AI Gateway catalog or the gateway is unreachable. External-routed models skip the catalog requirement and keep their provider-native id, resolving their context window best-effort and falling back to a default compaction threshold when unknown. Gateway-routed models still require known context-window metadata, now with a clearer, actionable error.

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -59,7 +59,7 @@ export async function compileAgentConfig(
     : definition.model;
   const model = await normalizeAuthoredModelReference({
     modelCatalog: context.modelCatalog,
-    purpose: "the primary compaction trigger model",
+    purpose: "the agent model",
     contextWindowTokens: definition.modelContextWindowTokens,
     providerOptions: definition.modelOptions?.providerOptions,
     source: configModule,
@@ -254,19 +254,35 @@ async function normalizeAuthoredModelReference(input: {
     routing: classifyModelRouting(languageModel, input.providerOptions),
   };
 
-  if (input.contextWindowTokens === undefined) {
-    const providerResult = await input.modelCatalog.getByProviderModelId(
-      languageModel.provider,
-      languageModel.modelId,
-    );
+  // An author-provided context window always wins and skips the catalog.
+  if (input.contextWindowTokens !== undefined) {
+    return { ...sourceBackedModel, contextWindowTokens: input.contextWindowTokens };
+  }
 
-    if (providerResult) {
-      return {
-        ...sourceBackedModel,
-        id: providerResult.slug,
-        contextWindowTokens: providerResult.limits.contextWindowTokens,
-      };
-    }
+  const providerResult = await input.modelCatalog.getByProviderModelId(
+    languageModel.provider,
+    languageModel.modelId,
+  );
+
+  // External providers bypass the AI Gateway, so their model id need not exist
+  // in the gateway catalog. Adopt catalog context-window metadata when the
+  // model happens to be listed, but never rewrite the id to the gateway slug
+  // and never fail the build on a catalog miss — the runtime falls back to a
+  // default compaction threshold when the context window is unknown.
+  if (sourceBackedModel.routing.kind === "external") {
+    return providerResult === null
+      ? sourceBackedModel
+      : { ...sourceBackedModel, contextWindowTokens: providerResult.limits.contextWindowTokens };
+  }
+
+  // A gateway-routed instance must name a real gateway slug and carry known
+  // context-window metadata, so adopt the slug and require limits.
+  if (providerResult) {
+    return {
+      ...sourceBackedModel,
+      id: providerResult.slug,
+      contextWindowTokens: providerResult.limits.contextWindowTokens,
+    };
   }
 
   return await withCompiledRuntimeModelLimits(sourceBackedModel, input);
@@ -326,7 +342,7 @@ async function withCompiledRuntimeModelLimits(
 
   if (limits === null) {
     throw new Error(
-      `Cannot compile agent compaction because ${input.purpose} "${model.id}" does not have known AI Gateway context window metadata.`,
+      `Cannot resolve a context window for ${input.purpose} "${model.id}": it is not listed in the AI Gateway model catalog. Set modelContextWindowTokens to provide one explicitly.`,
     );
   }
 

--- a/packages/eve/test/scenarios/compiler-model-catalog.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiler-model-catalog.scenario.test.ts
@@ -319,7 +319,7 @@ describe("compiler model catalog", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("fails clearly when compaction requires unresolved model limits", async () => {
+  it("fails clearly when a gateway-routed model has no resolvable context window", async () => {
     const { agentRoot, appRoot } = await createAppRoot(
       "eve-model-catalog-missing-",
       APP_ROOT_OPTIONS,
@@ -337,7 +337,7 @@ describe("compiler model catalog", () => {
         startPath: appRoot,
       }),
     ).rejects.toThrow(
-      'Cannot compile agent compaction because the primary compaction trigger model "example/missing-model" does not have known AI Gateway context window metadata.',
+      'Cannot resolve a context window for the agent model "example/missing-model": it is not listed in the AI Gateway model catalog. Set modelContextWindowTokens to provide one explicitly.',
     );
   });
 

--- a/packages/eve/test/scenarios/runtime-model-resolution.scenario.test.ts
+++ b/packages/eve/test/scenarios/runtime-model-resolution.scenario.test.ts
@@ -17,6 +17,12 @@ const createAppRoot = useTemporaryAppRoots();
 
 const APP_ROOT_OPTIONS = { packageName: "runtime-model-resolution-test-agent" } as const;
 
+// Kept out of `provider:`/`modelId:` literal form on purpose: the gateway mock
+// (test/setup/mock-ai-gateway.ts) scans test sources for those key/value pairs
+// and auto-adds them to the catalog, which would mask the catalog-miss case.
+const UNLISTED_PROVIDER = "offline-provider";
+const UNLISTED_MODEL_ID = "unlisted-model-42";
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -129,6 +135,57 @@ describe("runtime model resolution", () => {
     });
   });
 
+  it("compiles a direct-provider model the gateway catalog does not list (issue #317)", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-external-model-uncatalogued-",
+      APP_ROOT_OPTIONS,
+    );
+
+    await mkdir(join(agentRoot, "lib"), { recursive: true });
+    await writeFile(join(agentRoot, "lib", "model.ts"), createUnlistedModelModuleSource());
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        'import { unlistedModel } from "./lib/model.js";',
+        "",
+        "export default { model: unlistedModel };",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are an offline-provider agent.\n");
+
+    // A direct-provider instance routes external, bypassing the AI Gateway, so a
+    // catalog miss must not fail the build: it compiles with an unknown context
+    // window and the runtime falls back to a default compaction threshold.
+    const result = await compileAgent({ startPath: appRoot });
+
+    expect(result.manifest.config.model).toMatchObject({
+      id: `${UNLISTED_PROVIDER}/${UNLISTED_MODEL_ID}`,
+      routing: { kind: "external", provider: UNLISTED_PROVIDER },
+      source: { sourceKind: "module", logicalPath: "agent.ts", sourceId: "agent.ts" },
+    });
+    expect(result.manifest.config.model.contextWindowTokens).toBeUndefined();
+
+    const compiledArtifactsSource = createAuthoredSourceRuntimeCompiledArtifactsSource(appRoot);
+    const bundle = await getCompiledRuntimeAgentBundle({ compiledArtifactsSource });
+    const resolvedModel = await resolveRuntimeModelReference(bundle.turnAgent.model, {
+      moduleMap: bundle.moduleMap,
+      nodeId: bundle.nodeId,
+    });
+
+    if (typeof resolvedModel === "string") {
+      throw new Error("Expected a source-backed AI SDK model instance.");
+    }
+
+    expect(resolvedModel).toMatchObject({
+      modelId: UNLISTED_MODEL_ID,
+      provider: UNLISTED_PROVIDER,
+      specificationVersion: "v3",
+    });
+  });
+
   it("resolves a child model from the active child module-map scope", async () => {
     vi.stubEnv("NODE_ENV", "development");
 
@@ -186,6 +243,24 @@ describe("runtime model resolution", () => {
     });
   });
 });
+
+function createUnlistedModelModuleSource(): string {
+  return [
+    "export const unlistedModel = {",
+    '  specificationVersion: "v3",',
+    `  provider: ${JSON.stringify(UNLISTED_PROVIDER)},`,
+    `  modelId: ${JSON.stringify(UNLISTED_MODEL_ID)},`,
+    "  supportedUrls: {},",
+    "  async doGenerate() {",
+    '    throw new Error("not implemented");',
+    "  },",
+    "  async doStream() {",
+    '    throw new Error("not implemented");',
+    "  },",
+    "};",
+    "",
+  ].join("\n");
+}
 
 function createModelModuleSource(testMarker: string): string {
   return [

--- a/packages/eve/test/scenarios/subagent-config-compiles.scenario.test.ts
+++ b/packages/eve/test/scenarios/subagent-config-compiles.scenario.test.ts
@@ -1,0 +1,90 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { compileAgent } from "../../src/compiler/compile-agent.js";
+import { useTemporaryAppRoots } from "../../src/internal/testing/use-temporary-app-roots.js";
+
+const createAppRoot = useTemporaryAppRoots();
+
+// Exercises the full disk discover -> compile pipeline and asserts a directory
+// subagent's authored config (model, name, description) survives compilation
+// rather than collapsing to an empty object.
+describe("subagent config compiles through discovery", () => {
+  it("populates a directory subagent's compiled config", async () => {
+    const { agentRoot, appRoot } = await createAppRoot("eve-repro-subagent-", {
+      packageName: "repro-agent",
+    });
+
+    const subagentRoot = join(agentRoot, "subagents", "past-appearances");
+    await mkdir(subagentRoot, { recursive: true });
+
+    await writeFile(join(agentRoot, "agent.mjs"), 'export default { model: "openai/gpt-5.4" };\n');
+    await writeFile(join(agentRoot, "instructions.md"), "You are a coordinator.\n");
+    await writeFile(
+      join(subagentRoot, "agent.mjs"),
+      'export default { model: "openai/gpt-5.4", description: "Find past appearances." };\n',
+    );
+    await writeFile(join(subagentRoot, "instructions.md"), "Find past appearances.\n");
+
+    const result = await compileAgent({ startPath: appRoot });
+
+    expect(result.manifest.subagents).toHaveLength(1);
+    expect(result.manifest.subagents[0]).toMatchObject({
+      name: "past-appearances",
+      nodeId: "subagents/past-appearances",
+      sourceId: "subagents/past-appearances",
+    });
+    expect(result.manifest.subagents[0]?.agent.config).toMatchObject({
+      name: "past-appearances",
+      description: "Find past appearances.",
+      model: {
+        id: "openai/gpt-5.4",
+        contextWindowTokens: expect.any(Number),
+      },
+    });
+  });
+
+  it("populates compiled config for every subagent when multiple are authored", async () => {
+    const { agentRoot, appRoot } = await createAppRoot("eve-repro-multi-subagent-", {
+      packageName: "repro-agent",
+    });
+
+    const researcherRoot = join(agentRoot, "subagents", "researcher");
+    const reviewerRoot = join(agentRoot, "subagents", "reviewer");
+    await mkdir(researcherRoot, { recursive: true });
+    await mkdir(reviewerRoot, { recursive: true });
+
+    await writeFile(join(agentRoot, "agent.mjs"), 'export default { model: "openai/gpt-5.4" };\n');
+    await writeFile(join(agentRoot, "instructions.md"), "You are a coordinator.\n");
+    await writeFile(
+      join(researcherRoot, "agent.mjs"),
+      'export default { model: "openai/gpt-5.4", description: "Research topics in depth." };\n',
+    );
+    await writeFile(join(researcherRoot, "instructions.md"), "Research topics in depth.\n");
+    await writeFile(
+      join(reviewerRoot, "agent.mjs"),
+      'export default { model: "openai/gpt-5.4", description: "Review drafted content." };\n',
+    );
+    await writeFile(join(reviewerRoot, "instructions.md"), "Review drafted content.\n");
+
+    const result = await compileAgent({ startPath: appRoot });
+
+    expect(result.manifest.subagents).toHaveLength(2);
+
+    const byName = new Map(result.manifest.subagents.map((s) => [s.name, s]));
+    expect([...byName.keys()].sort()).toEqual(["researcher", "reviewer"]);
+
+    expect(byName.get("researcher")?.agent.config).toMatchObject({
+      name: "researcher",
+      description: "Research topics in depth.",
+      model: { id: "openai/gpt-5.4", contextWindowTokens: expect.any(Number) },
+    });
+    expect(byName.get("reviewer")?.agent.config).toMatchObject({
+      name: "reviewer",
+      description: "Review drafted content.",
+      model: { id: "openai/gpt-5.4", contextWindowTokens: expect.any(Number) },
+    });
+  });
+});


### PR DESCRIPTION
Direct-provider models like `anthropic(...)` route around the AI Gateway, but compilation still required their id to exist in the gateway catalog to resolve a context window. On a miss — a model the gateway doesn't list, or an unreachable/proxied gateway — it threw and crashed `eve dev` startup, so external providers looked dead (#317).

External-routed models now resolve the context window best-effort: catalog limits when listed, otherwise left unset so the runtime falls back to its default compaction threshold, keeping the provider-native id. Gateway-routed models stay strict, with a clearer error. Adds a compile test for an unlisted direct-provider model.
