### PR TITLE
fix(eve): keep known media type for Telegram photos

### DIFF
--- a/.changeset/telegram-photo-media-type.md
+++ b/.changeset/telegram-photo-media-type.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Telegram photos now keep their known image media type instead of being overridden by the file endpoint's `application/octet-stream` content-type, so image upload policies accept them and vision models can read them.

--- a/packages/eve/.workflow-data/version.txt
+++ b/packages/eve/.workflow-data/version.txt
@@ -1,0 +1,1 @@
+@workflow/world-local@5.0.0-beta.21

--- a/packages/eve/src/public/channels/telegram/attachments.test.ts
+++ b/packages/eve/src/public/channels/telegram/attachments.test.ts
@@ -78,6 +78,41 @@ describe("createTelegramFetchFile", () => {
     ]);
   });
 
+  it("prefers the known attachment media type over the HTTP content-type header", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, result: { file_path: "photos/file_0.jpg" } }), {
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        // Telegram's file endpoint commonly serves photos as octet-stream.
+        new Response("JPEGBYTES", { headers: { "content-type": "application/octet-stream" } }),
+      );
+
+    const fetchFile = createTelegramFetchFile({
+      api: { apiBaseUrl: "https://telegram.example", fetch: fetchMock },
+      credentials: { botToken: "123456:ABCDEF" },
+      policy: { allowedMediaTypes: ["image/*"], maxBytes: 1024 },
+    });
+
+    const result = await fetchFile(
+      String(
+        createTelegramFileUrl({
+          fileId: "file-id",
+          filename: "photo.jpg",
+          mediaType: "image/jpeg",
+        }),
+      ),
+    );
+
+    expect(result).toMatchObject({
+      filename: "photo.jpg",
+      mediaType: "image/jpeg",
+    });
+  });
+
   it("returns null for non-Telegram file URLs", async () => {
     const fetchFile = createTelegramFetchFile({
       credentials: { botToken: "bot-token" },

--- a/packages/eve/src/public/channels/telegram/attachments.ts
+++ b/packages/eve/src/public/channels/telegram/attachments.ts
@@ -90,8 +90,12 @@ export function createTelegramFetchFile(input: {
     }
 
     const bytes = Buffer.from(await response.arrayBuffer());
+    // The media type known from the attachment reference wins over the HTTP
+    // content-type: Telegram's file endpoint routinely serves photos as
+    // application/octet-stream, which would fail an image upload policy and
+    // hide the image from vision models.
     const mediaType =
-      response.headers.get("content-type") ?? ref.mediaType ?? "application/octet-stream";
+      ref.mediaType ?? response.headers.get("content-type") ?? "application/octet-stream";
     const result: FetchFileResult = {
       bytes,
       filename: ref.filename,


### PR DESCRIPTION
Telegram's file endpoint serves photos as `application/octet-stream`, and the fetch path let that override the media type already known from the attachment. Photos then failed image-only upload policies and reached vision models as raw bytes.

The known media type now takes precedence over the HTTP header.
