### PR TITLE
fix(eve): convert HITL prompt markdown to Slack mrkdwn

### DIFF
--- a/.changeset/slack-hitl-mrkdwn.md
+++ b/.changeset/slack-hitl-mrkdwn.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack HITL prompts now convert GFM markdown to Slack mrkdwn across every surface — the input-request section, the option-approval card body, and the freeform-answer modal — so model-authored `**bold**`, links, and similar render correctly instead of appearing literally.

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -85,6 +85,33 @@ describe("isHitlAction", () => {
 });
 
 describe("renderInputRequestBlocks", () => {
+  it("converts GFM markdown in the freeform prompt section to Slack mrkdwn", () => {
+    const blocks = renderInputRequestBlocks(
+      makeRequest({ prompt: "Approve edit to **file.ts**?" }),
+    );
+
+    const section = blocks[0] as { type: string; text: { type: string; text: string } };
+    expect(section.type).toBe("section");
+    expect(section.text.text).toBe("Approve edit to *file.ts*?");
+  });
+
+  it("converts GFM markdown in the option-card body to Slack mrkdwn", () => {
+    const blocks = renderInputRequestBlocks(
+      makeRequest({
+        prompt: "Run **rm -rf**?",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "deny", label: "Deny" },
+        ],
+      }),
+    );
+
+    const card = blocks[0] as { type: string; body: { text: string } };
+    expect(card.type).toBe("card");
+    expect(card.body.text).toContain("*Run *rm -rf*?*");
+    expect(card.body.text).not.toContain("**");
+  });
+
   it("emits a card block for an option list with no display hint", () => {
     const blocks = renderInputRequestBlocks(
       makeRequest({
@@ -520,5 +547,26 @@ describe("buildAnsweredBlocks", () => {
     const answer = blocks[0] as { text: { text: string } };
     expect(answer.text.text.length).toBeLessThanOrEqual(SLACK_SECTION_TEXT_MAX_LENGTH);
     expect(answer.text.text).toMatch(/^:white_check_mark: \*x+\.\.\.\*$/u);
+  });
+});
+
+describe("buildFreeformModalView", () => {
+  it("converts GFM markdown in the re-displayed prompt to Slack mrkdwn", () => {
+    const view = buildFreeformModalView({
+      metadata: {
+        continuationToken: "tok",
+        channelId: "C1",
+        threadTs: "1.1",
+        messageTs: "1.2",
+        requestId: "call_abc123",
+      },
+      prompt: "Confirm **delete** now",
+    });
+
+    const blocks = view.blocks as Array<{ type: string; text?: { type: string; text: string } }>;
+    expect(blocks[0]).toMatchObject({
+      type: "section",
+      text: { type: "mrkdwn", text: "Confirm *delete* now" },
+    });
   });
 });

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -19,6 +19,7 @@ import {
   truncatePlainText,
   truncateSectionText,
 } from "#public/channels/slack/limits.js";
+import { gfmToSlackMrkdwn } from "#public/channels/slack/mrkdwn.js";
 import type { InputRequest } from "#runtime/input/types.js";
 
 /**
@@ -145,7 +146,7 @@ export function isHitlAction(actionId: string): boolean {
  */
 export function renderInputRequestBlocks(request: InputRequest): unknown[] {
   const prompt = {
-    text: { text: truncateSectionText(request.prompt), type: "mrkdwn" },
+    text: { text: truncateSectionText(gfmToSlackMrkdwn(request.prompt)), type: "mrkdwn" },
     type: "section",
   };
   const details = renderInputRequestDetailBlocks(request);
@@ -232,7 +233,12 @@ export function buildFreeformModalView(input: {
 }): Record<string, unknown> {
   const title = input.prompt ? truncateModalTitle(input.prompt) : "Your answer";
   const promptBlocks = input.prompt
-    ? [{ type: "section", text: { type: "mrkdwn", text: truncateSectionText(input.prompt) } }]
+    ? [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: truncateSectionText(gfmToSlackMrkdwn(input.prompt)) },
+        },
+      ]
     : [];
   return {
     type: "modal",
@@ -312,7 +318,7 @@ function renderInputRequestCardBlock(
     type: "card",
     body: {
       type: "mrkdwn",
-      text: truncateCardBodyText(`*${request.prompt}*`),
+      text: truncateCardBodyText(`*${gfmToSlackMrkdwn(request.prompt)}*`),
       verbatim: false,
     },
     actions: cardButtonOptions(request).map((opt, index) => buildCardButton(opt, actionId, index)),


### PR DESCRIPTION
Slack HITL prompts dropped the model's markdown into blocks without converting it, so `**bold**` rendered literally (Slack section mrkdwn uses `*bold*`). The input-request section, the option-approval card, and the freeform modal now run `gfmToSlackMrkdwn`, the same converter the normal post path already uses.
