### PR TITLE
fix(eve): keep the Braintrust reporter alive on a null eval output

### DIFF
--- a/.changeset/braintrust-null-output.md
+++ b/.changeset/braintrust-null-output.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The Braintrust eval reporter no longer aborts the entire run when an eval produces no agent turn. A null output is logged as an empty string instead of triggering Braintrust's "output must be specified" error.

--- a/packages/eve/src/evals/runner/reporters/braintrust.test.ts
+++ b/packages/eve/src/evals/runner/reporters/braintrust.test.ts
@@ -177,6 +177,19 @@ describe("Braintrust", () => {
     );
   });
 
+  it("logs an empty output instead of null when the eval produced no agent turn", async () => {
+    const reporter = Braintrust(makeConfig());
+    await reporter.onRunStart([makeEval()], makeTarget());
+
+    reporter.onEvalComplete(
+      makeEvalResult({
+        result: { ...makeEvalResult().result, output: null },
+      }),
+    );
+
+    expect(braintrustMocks.log).toHaveBeenCalledWith(expect.objectContaining({ output: "" }));
+  });
+
   it("keeps duplicate assertion scores under stable keys", async () => {
     const reporter = Braintrust(makeConfig());
     await reporter.onRunStart([makeEval()], makeTarget());

--- a/packages/eve/src/evals/runner/reporters/braintrust.ts
+++ b/packages/eve/src/evals/runner/reporters/braintrust.ts
@@ -175,7 +175,10 @@ class BraintrustReporter implements EvalReporter {
     this.#experiment.log({
       id: result.id,
       input: evaluation?.description ?? "",
-      output: result.result.output,
+      // Braintrust rejects a null/undefined output ("output must be specified"),
+      // which would otherwise abort the whole run. An eval that produced no
+      // agent turn has a null output, so fall back to an empty string.
+      output: result.result.output ?? "",
       error: result.error ?? undefined,
       scores,
       metadata,


### PR DESCRIPTION
An eval that produces no agent turn has a null output. The Braintrust reporter forwarded it to `experiment.log`, which rejects null with "output must be specified" — and because the reporter runs in the awaited queue, that aborted the whole run.

Null output is now logged as an empty string.
