### PR TITLE
fix(eve): self-heal auto-injected web_search on endpoints without it

### DIFF
--- a/.changeset/websearch-selfheal.md
+++ b/.changeset/websearch-selfheal.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Agents on OpenAI-compatible endpoints without native web search (e.g. Bedrock Mantle) no longer hard-fail every turn when the framework auto-injects a web-search tool. The endpoint's rejection is now recognized, so the harness drops `web_search` and retries the step instead of failing terminally.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -476,6 +476,23 @@ describe("extractUnsupportedProviderToolTypes", () => {
     expect(extractUnsupportedProviderToolTypes(error)).toEqual(["web_search_20250305"]);
   });
 
+  it("returns the OpenAI web-search include value from an OpenAI-compatible endpoint rejection", () => {
+    // Bedrock Mantle and similar endpoints without native web search reject the
+    // injected OpenAI web-search tool by naming its Responses include value.
+    const error = directApiCallError({
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        error: {
+          message:
+            "Invalid value: 'web_search_call.action.sources'. Supported values are: 'reasoning.encrypted_content'.",
+          type: "invalid_request_error",
+        },
+      }),
+    });
+
+    expect(extractUnsupportedProviderToolTypes(error)).toEqual(["web_search_call.action.sources"]);
+  });
+
   it("deduplicates when multiple providerAttempts reference the same tool type", () => {
     const error = gatewayProviderToolFailure({
       unsupportedTypes: ["web_search_20250305", "web_search_20250305"],

--- a/packages/eve/src/harness/model-call-error.ts
+++ b/packages/eve/src/harness/model-call-error.ts
@@ -22,6 +22,15 @@ const GATEWAY_MODEL_REQUEST_REJECTED_MESSAGE =
 const UNSUPPORTED_TOOL_TYPE_REGEX = /tool type ['"]([\w.-]+)['"] is not supported/i;
 
 /**
+ * OpenAI-compatible endpoints without native web search (e.g. Bedrock Mantle)
+ * reject the injected OpenAI web-search tool by naming its Responses include
+ * value rather than a "tool type". The literal is unambiguously attributable
+ * to the injected tool, so surfacing it lets the recovery path drop
+ * `web_search` and retry.
+ */
+const OPENAI_WEB_SEARCH_INCLUDE_VALUE = "web_search_call.action.sources";
+
+/**
  * The most informative human-readable rejection a model-call error
  * carries, extracted from the upstream response. Not a semantic-error
  * classification: the message is arbitrary provider prose, so it carries
@@ -140,6 +149,9 @@ function collectUnsupportedToolTypesFromValue(value: unknown, out: Set<string>):
     const match = UNSUPPORTED_TOOL_TYPE_REGEX.exec(value);
     if (match?.[1] !== undefined) {
       out.add(match[1]);
+    }
+    if (value.includes(OPENAI_WEB_SEARCH_INCLUDE_VALUE)) {
+      out.add(OPENAI_WEB_SEARCH_INCLUDE_VALUE);
     }
     return;
   }

--- a/packages/eve/src/harness/provider-tools.test.ts
+++ b/packages/eve/src/harness/provider-tools.test.ts
@@ -200,6 +200,12 @@ describe("resolveFrameworkToolFromUpstreamType", () => {
     expect(resolveFrameworkToolFromUpstreamType("web_search_20250305")).toBe("web_search");
   });
 
+  it("maps the OpenAI web-search include value back to web_search", () => {
+    expect(resolveFrameworkToolFromUpstreamType("web_search_call.action.sources")).toBe(
+      "web_search",
+    );
+  });
+
   it("returns null for unknown upstream tool types", () => {
     expect(resolveFrameworkToolFromUpstreamType("computer_20251022")).toBeNull();
     expect(resolveFrameworkToolFromUpstreamType("some.future.tool")).toBeNull();

--- a/packages/eve/src/harness/provider-tools.ts
+++ b/packages/eve/src/harness/provider-tools.ts
@@ -33,6 +33,10 @@ const UPSTREAM_TOOL_TYPE_TO_FRAMEWORK_NAME: Readonly<Record<string, string>> = {
   // Anthropic backends reject this type because they only host the
   // older Claude Messages surface.
   web_search_20250305: WEB_SEARCH_TOOL_DEFINITION.name,
+  // OpenAI's Responses web-search include value. OpenAI-compatible endpoints
+  // without native web search (e.g. Bedrock Mantle) reject this include rather
+  // than a named tool type, so recovery drops the framework web_search tool.
+  "web_search_call.action.sources": WEB_SEARCH_TOOL_DEFINITION.name,
 };
 
 /**


### PR DESCRIPTION
OpenAI-compatible endpoints without native web search (e.g. Bedrock Mantle) reject the auto-injected web-search tool by naming its Responses include value (`web_search_call.action.sources`), not a tool type. The unsupported-tool recovery only matched "tool type 'X' is not supported", so this was terminal and every turn hard-failed.

The include value is now recognized and mapped back to `web_search`, so the existing recovery drops it and retries.
