### PR TITLE
fix(eve): resolve skill file reads home-root first with a workspace fallback

### DIFF
--- a/.changeset/skills-file-read-fallback.md
+++ b/.changeset/skills-file-read-fallback.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Skill file reads now resolve `$HOME/.agents/skills/<skill>/` first and fall back to `/workspace/skills/<skill>/`, as the docs and system prompt already describe. Previously `read_file` resolved a single root and hard-failed when the model named the other one, forcing a wasted retry.

--- a/packages/eve/src/execution/sandbox/read-file-tool.test.ts
+++ b/packages/eve/src/execution/sandbox/read-file-tool.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { executeReadFileOnSandbox } from "#execution/sandbox/read-file-tool.js";
+import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
+
+const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
+
+function readInContext(
+  sandbox: ReturnType<typeof mockSandbox>,
+  filePath: string,
+): Promise<{ content: string; path: string }> {
+  return contextStorage.run(new ContextContainer(), () =>
+    executeReadFileOnSandbox(sandbox.session, { filePath }),
+  );
+}
+
+describe("executeReadFileOnSandbox skill-root fallback", () => {
+  it("reads a skill file from the HOME root when given the /workspace/skills path", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+      initialFiles: {
+        "/home/agent/.agents/skills/research/references/catalog.md": "alpha\nbeta\n",
+      },
+    });
+
+    const result = await readInContext(sandbox, "/workspace/skills/research/references/catalog.md");
+
+    expect(result.path).toBe("/home/agent/.agents/skills/research/references/catalog.md");
+    expect(result.content).toContain("alpha");
+  });
+
+  it("falls back to /workspace/skills when the HOME candidate is absent", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+      initialFiles: {
+        "/workspace/skills/research/references/catalog.md": "gamma\n",
+      },
+    });
+
+    const result = await readInContext(
+      sandbox,
+      "$HOME/.agents/skills/research/references/catalog.md",
+    );
+
+    expect(result.path).toBe("/workspace/skills/research/references/catalog.md");
+    expect(result.content).toContain("gamma");
+  });
+});

--- a/packages/eve/src/execution/sandbox/read-file-tool.ts
+++ b/packages/eve/src/execution/sandbox/read-file-tool.ts
@@ -5,7 +5,7 @@ import {
   normalizeModelPath,
   setReadFileStamp,
 } from "#runtime/framework-tools/file-state.js";
-import { resolveAbsoluteFilePath } from "#execution/sandbox/require-sandbox.js";
+import { resolveSkillFilePathCandidates } from "#shared/skill-paths.js";
 import type { SandboxSession } from "#shared/sandbox-session.js";
 import { capLineLength, MAX_OUTPUT_BYTES } from "#execution/sandbox/truncate-output.js";
 
@@ -58,8 +58,20 @@ export async function executeReadFileOnSandbox(
 ): Promise<ReadFileResult> {
   const { filePath, offset, limit } = args;
 
-  const resolvedPath = await resolveAbsoluteFilePath(sandbox, filePath);
-  const normalizedPath = normalizeModelPath(resolvedPath);
+  // Skill files live under `$HOME/.agents/skills/<skill>/` with
+  // `/workspace/skills/<skill>/` as the documented fallback, so a skill path
+  // resolves to an ordered list of candidates and the first that exists wins.
+  // Every other path resolves to a single absolute candidate.
+  const candidatePaths = await resolveSkillFilePathCandidates({ path: filePath, sandbox });
+
+  for (const candidate of candidatePaths) {
+    if (!candidate.startsWith("/")) {
+      throw new Error(
+        `filePath must be an absolute path. Received: "${filePath}". ` +
+          "Use an absolute path such as /workspace/foo.ts or a path beginning with $HOME/.",
+      );
+    }
+  }
 
   // ── Validate offset / limit ─────────────────────────────────────────
   const effectiveOffset = offset ?? DEFAULT_OFFSET;
@@ -70,13 +82,24 @@ export async function executeReadFileOnSandbox(
   }
 
   // ── Read full file for fingerprinting ───────────────────────────────
-  const rawContent = await sandbox.readTextFile({ path: resolvedPath });
+  let resolvedPath: string | undefined;
+  let rawContent: string | null = null;
+  for (const candidate of candidatePaths) {
+    const content = await sandbox.readTextFile({ path: candidate });
+    if (content !== null) {
+      resolvedPath = candidate;
+      rawContent = content;
+      break;
+    }
+  }
 
-  if (rawContent === null) {
+  if (rawContent === null || resolvedPath === undefined) {
     throw new Error(
       `File not found: ${filePath}. Verify the path exists and is accessible in the sandbox.`,
     );
   }
+
+  const normalizedPath = normalizeModelPath(resolvedPath);
 
   // ── Reject non-text (NUL bytes) ─────────────────────────────────────
   if (rawContent.includes("\0")) {

--- a/packages/eve/src/execution/sandbox/write-file-tool.test.ts
+++ b/packages/eve/src/execution/sandbox/write-file-tool.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { executeReadFileOnSandbox } from "#execution/sandbox/read-file-tool.js";
+import { executeWriteFileOnSandbox } from "#execution/sandbox/write-file-tool.js";
+import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
+
+const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
+const HOME_SKILL_FILE = "/home/agent/.agents/skills/research/references/catalog.md";
+const WORKSPACE_SKILL_PATH = "/workspace/skills/research/references/catalog.md";
+
+describe("executeWriteFileOnSandbox skill-root consistency", () => {
+  it("edits the same file read_file served instead of a divergent shadow copy", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+      initialFiles: {
+        [HOME_SKILL_FILE]: "before\n",
+      },
+    });
+
+    const result = await contextStorage.run(new ContextContainer(), async () => {
+      // read_file serves the home-root copy from the /workspace/skills path...
+      await executeReadFileOnSandbox(sandbox.session, { filePath: WORKSPACE_SKILL_PATH });
+      // ...and write_file must update that same file, not create a shadow.
+      return executeWriteFileOnSandbox(sandbox.session, {
+        filePath: WORKSPACE_SKILL_PATH,
+        content: "after\n",
+      });
+    });
+
+    expect(result).toEqual({ existed: true, path: HOME_SKILL_FILE });
+    await expect(sandbox.session.readTextFile({ path: HOME_SKILL_FILE })).resolves.toBe("after\n");
+    // No shadow copy is written under the /workspace/skills root.
+    await expect(sandbox.session.readTextFile({ path: WORKSPACE_SKILL_PATH })).resolves.toBeNull();
+  });
+
+  it("creates a new skill file at the home-first candidate", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+    });
+
+    const result = await contextStorage.run(new ContextContainer(), () =>
+      executeWriteFileOnSandbox(sandbox.session, {
+        filePath: WORKSPACE_SKILL_PATH,
+        content: "fresh\n",
+      }),
+    );
+
+    expect(result).toEqual({ existed: false, path: HOME_SKILL_FILE });
+    await expect(sandbox.session.readTextFile({ path: HOME_SKILL_FILE })).resolves.toBe("fresh\n");
+  });
+});

--- a/packages/eve/src/execution/sandbox/write-file-tool.ts
+++ b/packages/eve/src/execution/sandbox/write-file-tool.ts
@@ -7,7 +7,7 @@ import {
   ReadFileStateKey,
   setReadFileStamp,
 } from "#runtime/framework-tools/file-state.js";
-import { resolveAbsoluteFilePath } from "#execution/sandbox/require-sandbox.js";
+import { resolveSkillFilePathCandidates } from "#shared/skill-paths.js";
 import type { SandboxSession } from "#shared/sandbox-session.js";
 
 // ---------------------------------------------------------------------------
@@ -47,10 +47,21 @@ export async function executeWriteFileOnSandbox(
 ): Promise<WriteFileResult> {
   const { filePath, content } = args;
 
-  const resolvedPath = await resolveAbsoluteFilePath(sandbox, filePath);
   const ctx = loadContext();
-  const normalizedPath = normalizeModelPath(resolvedPath);
-  const targetKey = buildReadFileTargetKey(normalizedPath);
+
+  // Resolve the skill-aware candidate list exactly as read_file does, so an
+  // edit lands on the same file read_file served rather than a divergent shadow
+  // copy under the other skill root. An existing file is written where it lives;
+  // a new file is created at the first (home-first) candidate.
+  const candidatePaths = await resolveSkillFilePathCandidates({ path: filePath, sandbox });
+  for (const candidate of candidatePaths) {
+    if (!candidate.startsWith("/")) {
+      throw new Error(
+        `filePath must be an absolute path. Received: "${filePath}". ` +
+          "Use an absolute path such as /workspace/foo.ts or a path beginning with $HOME/.",
+      );
+    }
+  }
 
   // ── Read current file ───────────────────────────────────────────────
   // The full read is required even for new-file detection because
@@ -58,7 +69,19 @@ export async function executeWriteFileOnSandbox(
   // cost: the entire file is read and hashed before every write. A
   // separate `exists()` primitive would avoid this for new files but
   // would require a sandbox session API change.
-  const currentContent = await sandbox.readTextFile({ path: resolvedPath });
+  let resolvedPath = candidatePaths[0]!;
+  let currentContent: string | null = null;
+  for (const candidate of candidatePaths) {
+    const existing = await sandbox.readTextFile({ path: candidate });
+    if (existing !== null) {
+      resolvedPath = candidate;
+      currentContent = existing;
+      break;
+    }
+  }
+
+  const normalizedPath = normalizeModelPath(resolvedPath);
+  const targetKey = buildReadFileTargetKey(normalizedPath);
 
   if (currentContent === null) {
     // ── File does not exist — write immediately, no prior read needed ──

--- a/packages/eve/src/shared/skill-paths.test.ts
+++ b/packages/eve/src/shared/skill-paths.test.ts
@@ -9,6 +9,7 @@ import {
   resolveSandboxModelPath,
   resolveSandboxSkillReadPaths,
   resolveSandboxSkillRoot,
+  resolveSkillFilePathCandidates,
 } from "#shared/skill-paths.js";
 
 const HOME_PROBE_COMMAND = `printf '%s\\n' "$HOME"`;
@@ -85,7 +86,7 @@ describe("skill path helpers", () => {
     ).resolves.toBe("/workspace/skills/research/references/catalog.md");
   });
 
-  it("reads only from the resolved HOME skill root when HOME is usable", async () => {
+  it("reads the resolved HOME skill root first, then the /workspace fallback", async () => {
     const sandbox = mockSandbox({
       commands: {
         [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
@@ -98,10 +99,13 @@ describe("skill path helpers", () => {
         relativePath: "SKILL.md",
         sandbox: sandbox.session,
       }),
-    ).resolves.toEqual(["/home/agent/.agents/skills/research/SKILL.md"]);
+    ).resolves.toEqual([
+      "/home/agent/.agents/skills/research/SKILL.md",
+      "/workspace/skills/research/SKILL.md",
+    ]);
   });
 
-  it("reads from /workspace/skills only when that root is selected", async () => {
+  it("reads from /workspace/skills only when HOME is unusable", async () => {
     const sandbox = mockSandbox({
       commands: {
         [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "\n" },
@@ -115,6 +119,57 @@ describe("skill path helpers", () => {
         sandbox: sandbox.session,
       }),
     ).resolves.toEqual(["/workspace/skills/research/SKILL.md"]);
+  });
+
+  it("resolves skill file candidates HOME-first from a literal /workspace/skills path", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+    });
+
+    await expect(
+      resolveSkillFilePathCandidates({
+        path: "/workspace/skills/research/references/catalog.md",
+        sandbox: sandbox.session,
+      }),
+    ).resolves.toEqual([
+      "/home/agent/.agents/skills/research/references/catalog.md",
+      "/workspace/skills/research/references/catalog.md",
+    ]);
+  });
+
+  it("resolves skill file candidates HOME-first from a symbolic $HOME path", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+    });
+
+    await expect(
+      resolveSkillFilePathCandidates({
+        path: `${MODEL_SKILL_ROOT}/research/references/catalog.md`,
+        sandbox: sandbox.session,
+      }),
+    ).resolves.toEqual([
+      "/home/agent/.agents/skills/research/references/catalog.md",
+      "/workspace/skills/research/references/catalog.md",
+    ]);
+  });
+
+  it("passes a non-skill path through as a single resolved candidate", async () => {
+    const sandbox = mockSandbox({
+      commands: {
+        [HOME_PROBE_COMMAND]: { exitCode: 0, stderr: "", stdout: "/home/agent\n" },
+      },
+    });
+
+    await expect(
+      resolveSkillFilePathCandidates({
+        path: "/workspace/src/index.ts",
+        sandbox: sandbox.session,
+      }),
+    ).resolves.toEqual(["/workspace/src/index.ts"]);
   });
 
   it("resolves model-facing seed paths before writing to the sandbox", async () => {

--- a/packages/eve/src/shared/skill-paths.ts
+++ b/packages/eve/src/shared/skill-paths.ts
@@ -72,13 +72,57 @@ export async function resolveSandboxSkillReadPaths(input: {
   readonly relativePath: string;
   readonly sandbox: SandboxSession;
 }): Promise<readonly string[]> {
-  return [
-    formatSkillPath({
-      name: input.name,
-      relativePath: input.relativePath,
-      root: await resolveSandboxSkillRoot({ sandbox: input.sandbox }),
-    }),
-  ];
+  return await resolveSkillRootCandidates({
+    suffix: `/${input.name}/${input.relativePath}`,
+    sandbox: input.sandbox,
+  });
+}
+
+/**
+ * Ordered sandbox paths to try when reading a model-supplied file. A path that
+ * targets the skill root — either the symbolic `$HOME/.agents/skills/…` form or
+ * the literal `/workspace/skills/…` fallback — resolves to the probed home root
+ * first and the `/workspace/skills` fallback second, matching the documented
+ * resolution order. Any other path resolves to a single entry via
+ * {@link resolveSandboxModelPath}.
+ */
+export async function resolveSkillFilePathCandidates(input: {
+  readonly path: string;
+  readonly sandbox: SandboxSession;
+}): Promise<readonly string[]> {
+  const suffix = skillRootSuffix(input.path);
+  if (suffix === null) {
+    return [await resolveSandboxModelPath({ path: input.path, sandbox: input.sandbox })];
+  }
+  return await resolveSkillRootCandidates({ suffix, sandbox: input.sandbox });
+}
+
+/**
+ * Extracts the `/<skill>/<relativePath>` remainder shared by both skill roots,
+ * or `null` when the path targets neither root.
+ */
+function skillRootSuffix(path: string): string | null {
+  if (path === MODEL_SKILL_ROOT || path.startsWith(`${MODEL_SKILL_ROOT}/`)) {
+    return path.slice(MODEL_SKILL_ROOT.length);
+  }
+  if (path === FALLBACK_SKILL_ROOT || path.startsWith(`${FALLBACK_SKILL_ROOT}/`)) {
+    return path.slice(FALLBACK_SKILL_ROOT.length);
+  }
+  return null;
+}
+
+async function resolveSkillRootCandidates(input: {
+  readonly suffix: string;
+  readonly sandbox: SandboxSession;
+}): Promise<readonly string[]> {
+  const candidates: string[] = [];
+  const home = await resolveSandboxHome(input.sandbox);
+  if (home !== null) {
+    const base = home === "/" ? "" : home;
+    candidates.push(`${base}${MODEL_SKILL_ROOT.slice(MODEL_HOME_ROOT.length)}${input.suffix}`);
+  }
+  candidates.push(`${FALLBACK_SKILL_ROOT}${input.suffix}`);
+  return candidates;
 }
 
 export async function resolveSandboxSkillWritePath(input: {


### PR DESCRIPTION
Skills live at `$HOME/.agents/skills/<skill>/`, with `/workspace/skills/<skill>/` as the documented fallback — but `read_file` resolved one root and read it once, so the other form hard-failed and the model wasted a retry guessing.

`read_file` now tries the home root first, then `/workspace/skills`. `write_file` resolves the same list so an edit lands on the file `read_file` served instead of a shadow copy under the other root.
