### PR TITLE
fix(eve): ship every vendored declaration chunk its .d.ts files import

### DIFF
--- a/.changeset/vendor-declaration-chunks.md
+++ b/.changeset/vendor-declaration-chunks.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The published package now ships every sibling declaration chunk its vendored `.d.ts` files import. Chunk co-copying is discovered transitively from the actual relative imports instead of a hardcoded name pattern, so hash-named chunks (e.g. chat's `messages-<hash>`) no longer go missing when upstream renames them.

--- a/packages/eve/scripts/vendor-compiled/_shared.mjs
+++ b/packages/eve/scripts/vendor-compiled/_shared.mjs
@@ -305,7 +305,10 @@ function collectRelativeDeclarationImports(source) {
   for (const pattern of patterns) {
     for (const match of source.matchAll(pattern)) {
       const specifier = match[1];
-      if (specifier !== undefined && specifier.startsWith("./")) {
+      if (
+        specifier !== undefined &&
+        (specifier.startsWith("./") || specifier.startsWith("../"))
+      ) {
         specifiers.add(specifier);
       }
     }

--- a/packages/eve/scripts/vendor-compiled/_shared.mjs
+++ b/packages/eve/scripts/vendor-compiled/_shared.mjs
@@ -121,10 +121,13 @@ export function createDeclarationCopier({
           : [{ source: "index.d.ts", output: "index.d.ts" }];
 
     const declarations = await Promise.all(
-      declarationFiles.map(async (file) => ({
-        ...file,
-        sourceText: await readFile(join(distDir, file.source), "utf8"),
-      })),
+      declarationFiles.map(async (file) => {
+        const sourceText = await readFile(join(distDir, file.source), "utf8");
+        // Keep the upstream text so relative sibling-chunk discovery scans the
+        // original specifiers, before the rewrite loop rewrites bare external
+        // imports (e.g. `mdast`) into local stub specifiers (`./_mdast.js`).
+        return { ...file, sourceText, originalSourceText: sourceText };
+      }),
     );
     const externals = mergeExternalDeclarationImports(
       declarations.map((declaration) => declaration.sourceText),
@@ -178,6 +181,27 @@ export function createDeclarationCopier({
       }),
     );
 
+    // Co-copy every sibling declaration chunk the entry declarations import by
+    // relative path, transitively. Upstream splits its `.d.ts` into hash-named
+    // chunks (e.g. `./messages-<hash>.js`); their names change on every bump,
+    // so discovering them from the imports keeps the vendored tree complete
+    // without a per-package allowlist. Declarations already written above are
+    // pre-visited, so their rewritten output is never overwritten by a verbatim
+    // upstream copy.
+    const relativeSeeds = [];
+    for (const declaration of declarations) {
+      const baseDir = toPosixDir(declaration.output);
+      for (const specifier of collectRelativeDeclarationImports(declaration.originalSourceText)) {
+        relativeSeeds.push({ baseDir, specifier });
+      }
+    }
+    await copyRelativeDeclarationChunks({
+      declarationOutputs: declarations.map((declaration) => declaration.output),
+      destinationRoot,
+      distDir,
+      seeds: relativeSeeds,
+    });
+
     if (typeof discoverExtraFiles === "function") {
       const extras = discoverExtraFiles(distEntries);
       await Promise.all(
@@ -189,6 +213,105 @@ export function createDeclarationCopier({
       );
     }
   };
+}
+
+/**
+ * Copies every sibling declaration chunk reachable from `seeds` by relative
+ * import, transitively, from `distDir` into `destinationRoot`, preserving the
+ * package-relative path. Chunks are copied verbatim (they carry no external
+ * imports needing a rewrite). Files already emitted as rewritten declarations
+ * are pre-visited and never overwritten, and a specifier that does not resolve
+ * to a `.d.ts` under `distDir` is skipped.
+ */
+async function copyRelativeDeclarationChunks({
+  declarationOutputs,
+  destinationRoot,
+  distDir,
+  seeds,
+}) {
+  const visited = new Set(declarationOutputs.map((output) => output.replaceAll("\\", "/")));
+  const queue = [...seeds];
+
+  while (queue.length > 0) {
+    const { baseDir, specifier } = queue.shift();
+    const target = resolveRelativeDeclarationPath(baseDir, specifier);
+    if (target === null || visited.has(target)) {
+      continue;
+    }
+    visited.add(target);
+
+    let chunkSource;
+    try {
+      chunkSource = await readFile(join(distDir, target), "utf8");
+    } catch {
+      continue;
+    }
+
+    const outputPath = join(destinationRoot, target);
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, chunkSource, "utf8");
+
+    const nextBaseDir = posix.dirname(target);
+    for (const next of collectRelativeDeclarationImports(chunkSource)) {
+      queue.push({ baseDir: nextBaseDir === "." ? "" : nextBaseDir, specifier: next });
+    }
+  }
+}
+
+/**
+ * Resolves a relative import specifier against the importing declaration's
+ * package-relative directory and returns the package-relative `.d.ts` path it
+ * targets, or `null` when the specifier is not relative or escapes the package.
+ */
+function resolveRelativeDeclarationPath(baseDir, specifier) {
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
+    return null;
+  }
+  const base = specifier.endsWith(".d.ts")
+    ? specifier.slice(0, -".d.ts".length)
+    : specifier.endsWith(".js")
+      ? specifier.slice(0, -".js".length)
+      : specifier;
+  const joined = posix.normalize(posix.join(baseDir === "" ? "." : baseDir, base));
+  if (joined === "" || joined === "." || joined.startsWith("..")) {
+    return null;
+  }
+  return `${joined}.d.ts`;
+}
+
+/**
+ * Returns the package-relative posix directory of a declaration output path,
+ * or `""` for a top-level file.
+ */
+function toPosixDir(output) {
+  const dir = posix.dirname(output.replaceAll("\\", "/"));
+  return dir === "." ? "" : dir;
+}
+
+/**
+ * Collects the distinct relative import specifiers a declaration source
+ * references. Mirrors {@link collectExternalDeclarationImports} but keeps the
+ * `./`-prefixed specifiers it discards.
+ */
+function collectRelativeDeclarationImports(source) {
+  const patterns = [
+    /^(?:import|export)\s+(?:type\s+)?\{[^}]*\}\s+from\s+['"]([^'"]+)['"];/gm,
+    /^import\s+(?:type\s+)?\*\s+as\s+[A-Za-z_$][\w$]*\s+from\s+['"]([^'"]+)['"];/gm,
+    /^(?:import|export)\s+(?:type\s+)?['"]([^'"]+)['"];/gm,
+    /^export\s+(?:type\s+)?\*\s+from\s+['"]([^'"]+)['"];/gm,
+  ];
+  const specifiers = new Set();
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier !== undefined && specifier.startsWith("./")) {
+        specifiers.add(specifier);
+      }
+    }
+  }
+
+  return specifiers;
 }
 
 function mergeExternalDeclarationImports(sources) {

--- a/packages/eve/scripts/vendor-compiled/chat.mjs
+++ b/packages/eve/scripts/vendor-compiled/chat.mjs
@@ -11,15 +11,16 @@ import {
  * etc., so the public type contract has to be the *actual* chat shape —
  * hand-written stubs would drift on every version bump.
  *
- * Three transforms apply during the copy:
+ * Two transforms apply during the copy:
  *
- * 1. The sibling `jsx-runtime-<hash>.d.ts` chunk is co-copied so chat's
- *    relative import resolves locally. The chunk's filename has a content
- *    hash, so we discover it dynamically.
- * 2. `from '@workflow/serde'` is rewritten to a local stub that declares
+ * 1. `from '@workflow/serde'` is rewritten to a local stub that declares
  *    just the unique symbols chat references.
- * 3. `from 'mdast'` is rewritten to a local stub that aliases the names
+ * 2. `from 'mdast'` is rewritten to a local stub that aliases the names
  *    chat references to `unknown` — consumers don't need @types/mdast.
+ *
+ * The sibling declaration chunks chat imports by relative path (its
+ * hash-named `jsx-runtime-<hash>` and `messages-<hash>` chunks) are
+ * co-copied transitively by `createDeclarationCopier`.
  */
 export default {
   packageName: "chat",
@@ -37,7 +38,5 @@ export default {
         build: buildOpaqueTypesStub,
       },
     },
-    discoverExtraFiles: (distEntries) =>
-      distEntries.filter((name) => /^jsx-runtime-[^./]+\.d\.ts$/.test(name)),
   }),
 };

--- a/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
@@ -64,6 +65,32 @@ describe("compiled vendor assets", () => {
 
     expect(sourceMapFiles).toEqual([]);
     expect(javaScriptSources.some(containsSourceMapComment)).toBe(false);
+  });
+
+  it("ships every relative sibling declaration chunk its .d.ts files import", async () => {
+    const entries = await readdir(COMPILED_VENDOR_ROOT, { recursive: true });
+    const declarationFiles = entries.filter((entry) => entry.endsWith(".d.ts"));
+    // Anchored at line start so relative specifiers quoted inside JSDoc
+    // comments (which are prefixed with `*`) are not mistaken for imports.
+    const relativeSpecifierPattern = /^\s*(?:import|export)\b[^\n]*?['"](\.\.?\/[^'"]+)['"]/gm;
+
+    const missing: string[] = [];
+    await Promise.all(
+      declarationFiles.map(async (entry) => {
+        const source = await readFile(join(COMPILED_VENDOR_ROOT, entry), "utf8");
+        const fileDir = dirname(join(COMPILED_VENDOR_ROOT, entry));
+        for (const match of source.matchAll(relativeSpecifierPattern)) {
+          const specifier = match[1]!;
+          const base = specifier.replace(/\.d\.ts$/, "").replace(/\.js$/, "");
+          const declarationTarget = join(fileDir, `${base}.d.ts`);
+          if (!existsSync(declarationTarget) && !existsSync(join(fileDir, base))) {
+            missing.push(`${entry} -> ${specifier}`);
+          }
+        }
+      }),
+    );
+
+    expect(missing).toEqual([]);
   });
 
   it("suppresses dependency warnings without hiding actionable logs", async () => {


### PR DESCRIPTION
Vendored declaration copying co-copied sibling chunks with a hardcoded `jsx-runtime-<hash>` regex, so any other chunk an upstream `.d.ts` imports (e.g. chat's hash-named `messages-<hash>`) was dropped — the published package shipped a `.d.ts` importing a chunk that wasn't there (#1500).

Chunks are now discovered transitively from the actual relative imports, resolved against the importing file's directory and never overwriting a rewritten declaration. A scenario invariant checks every vendored `.d.ts`'s relative imports resolve on disk.
