### PR TITLE
fix(eve): reject Slack's login HTML on private file fetch

### DIFF
--- a/.changeset/slack-reject-login-html.md
+++ b/.changeset/slack-reject-login-html.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack file fetches now reject the HTML sign-in page Slack returns when the bot token lacks the `files:read` scope, throwing an actionable error instead of passing the login HTML to the model as file content.

--- a/packages/eve/src/public/channels/slack/attachments.test.ts
+++ b/packages/eve/src/public/channels/slack/attachments.test.ts
@@ -232,6 +232,19 @@ describe("createSlackFetchFile", () => {
 
     await expect(fetchFile("https://files.slack.com/locked.csv")).rejects.toThrow("HTTP 403");
   });
+
+  it("rejects the HTML login page Slack serves without the files:read scope", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("<!DOCTYPE html><html><body>Sign in to Slack</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+
+    const fetchFile = createSlackFetchFile({ botToken: "xoxb-test-token" });
+
+    await expect(fetchFile("https://files.slack.com/private.csv")).rejects.toThrow(/files:read/);
+  });
 });
 
 describe("collectInboundFileParts", () => {

--- a/packages/eve/src/public/channels/slack/attachments.ts
+++ b/packages/eve/src/public/channels/slack/attachments.ts
@@ -179,9 +179,20 @@ export function createSlackFetchFile(input: {
     if (!response.ok) {
       throw new Error(`Slack file fetch returned HTTP ${response.status} for ${url}.`);
     }
+    const mediaType = response.headers.get("content-type") ?? undefined;
+    // Slack answers a private-file request with an HTTP 200 HTML sign-in page
+    // when the bot token lacks the `files:read` scope. Reject it so the login
+    // page never reaches the model as file content.
+    if (mediaType?.startsWith("text/html")) {
+      throw new Error(
+        `Slack returned an HTML login page instead of file bytes for ${url}. ` +
+          `The Slack bot token is likely missing the "files:read" scope — add it to ` +
+          `the app's bot scopes and reinstall the app to the workspace.`,
+      );
+    }
     return {
       bytes: Buffer.from(await response.arrayBuffer()),
-      mediaType: response.headers.get("content-type") ?? undefined,
+      mediaType,
     };
   };
 }


### PR DESCRIPTION
When the Slack bot token lacks the `files:read` scope, a private-file request returns an HTTP 200 HTML sign-in page instead of the file bytes. The fetch path only gated on `response.ok`, so the login HTML reached the model as file content with a `text/html` media type (#1317).

A `text/html` response is now rejected with an error naming the missing `files:read` scope and the reinstall requirement.