### PR TITLE
fix(eve): silence Node 24 unmanaged-fd warnings in eve dev

### DIFF
--- a/.changeset/dev-worker-fd-warnings.md
+++ b/.changeset/dev-worker-fd-warnings.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve dev` no longer floods startup with spurious Node 24 "File descriptor … opened/closed in unmanaged mode" warnings. The dev build worker now disables unmanaged-fd tracking, which it never relied on.

--- a/packages/eve/src/internal/nitro/host/dev-runner.ts
+++ b/packages/eve/src/internal/nitro/host/dev-runner.ts
@@ -117,6 +117,11 @@ class NodeDevelopmentRunner extends BaseEnvRunner implements DevelopmentRunner {
 
     const worker = new Worker(this._workerEntry, {
       env: process.env,
+      // The dev worker manages its own resources and is torn down wholesale via
+      // terminate(), so Node's unmanaged-fd tracking (default on) adds no safety
+      // here — it only emits spurious "File descriptor … unmanaged mode"
+      // warnings on Node 24 as the worker's embedded server opens and closes fds.
+      trackUnmanagedFds: false,
       workerData: {
         name: this._name,
         ...this._data,


### PR DESCRIPTION
The dev build worker is created with Node's `trackUnmanagedFds` at its default (on), so on Node 24 the worker's embedded server opening and closing raw file descriptors triggers repeated "File descriptor … opened/closed in unmanaged mode" warnings during `eve dev` startup (#945).

The worker owns its resources and is torn down via `terminate()`, so the tracker's auto-close provides no benefit here. Disabling it removes the warnings. Cosmetic, Node-version-specific — verified manually on Node 24; no functional change.