### PR TITLE
fix(eve): parse the final_output payload before emitting structured output

### DIFF
--- a/.changeset/final-output-parse.md
+++ b/.changeset/final-output-parse.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Structured output is now parsed before it lands in `result.completed`. When the model double-encodes the `final_output` payload as a JSON string, clients receive the parsed object instead of a raw string; an unparseable payload fails the turn as `OUTPUT_SCHEMA_NOT_FULFILLED` rather than being emitted verbatim.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -1676,6 +1676,34 @@ describe("createToolLoopHarness", () => {
     expect(result.next).toEqual({ done: true, output: { summary: "Done" } });
   });
 
+  it("parses a double-encoded final_output payload into the structured object", async () => {
+    const schema = {
+      properties: { summary: { type: "string" } },
+      required: ["summary"],
+      type: "object",
+    } as const;
+    // The model double-encodes the payload as a JSON string.
+    setupMockAgent(finalOutputResult("Done.", JSON.stringify({ summary: "Done" })));
+
+    const runStep = createToolLoopHarness(createTestConfig("task"));
+    const session = createTestSession({ outputSchema: schema });
+
+    const result = await runStep(session, { message: "Hi" });
+
+    expect(result.next).toEqual({ done: true, output: { summary: "Done" } });
+  });
+
+  it("fails the turn when the final_output payload is an unparseable string", async () => {
+    setupMockAgent(finalOutputResult("Done.", "not json at all"));
+
+    const runStep = createToolLoopHarness(createTestConfig("task"));
+    const session = createTestSession({ outputSchema: { type: "object" } });
+
+    const result = await runStep(session, { message: "Hi" });
+
+    expect(result.next).toMatchObject({ done: true, isError: true });
+  });
+
   it("fails a task turn as an error when structured output is not produced", async () => {
     setupMockAgent({
       finishReason: "stop",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -165,6 +165,7 @@ import { resolveFrameworkToolFromUpstreamType } from "#harness/provider-tools.js
 import {
   createRuntimeActionRequestFromToolCall,
   resolvePendingRuntimeActions,
+  resolveToolCallInputObject,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
 import {
@@ -2179,8 +2180,11 @@ async function handleStepResult(input: {
   // A `final_output` call is terminal even when the model emits it alongside
   // executing tools: continuing the loop would leave the no-execute call as a
   // dangling tool_use the next provider call rejects, and drop the result.
+  // Presence of the call — not whether its payload parses — decides that the
+  // turn is terminal, so an unparseable payload still ends the turn (as
+  // OUTPUT_SCHEMA_NOT_FULFILLED) instead of looping with a dangling tool_use.
   const calledFinalOutput =
-    nextSession.outputSchema !== undefined && extractFinalOutput(result) !== undefined;
+    nextSession.outputSchema !== undefined && findFinalOutputCall(result) !== undefined;
 
   const continueLoop =
     !calledFinalOutput &&
@@ -2231,10 +2235,32 @@ const OUTPUT_SCHEMA_NOT_FULFILLED = {
  * The structured value the model delivered by calling the framework
  * `final_output` tool, or `undefined` when the terminal turn ended in prose.
  */
-function extractFinalOutput(result: HarnessStepResult): JsonValue | undefined {
+function findFinalOutputCall(result: HarnessStepResult) {
   return (result.toolCalls ?? []).find(
     (call) => call.toolName === FINAL_OUTPUT_TOOL_NAME && !isInvalidToolCall(call),
-  )?.input as JsonValue | undefined;
+  );
+}
+
+/**
+ * Parses the `final_output` call's input into the structured object clients
+ * receive. The model sometimes double-encodes the payload as a JSON string, so
+ * the raw input is parsed rather than emitted verbatim. Returns `undefined`
+ * when there is no `final_output` call or its input is not a JSON object, which
+ * the terminal-turn handlers surface as `OUTPUT_SCHEMA_NOT_FULFILLED`.
+ */
+function extractFinalOutput(result: HarnessStepResult): JsonValue | undefined {
+  const call = findFinalOutputCall(result);
+  if (call === undefined) {
+    return undefined;
+  }
+  try {
+    return resolveToolCallInputObject(call.input, {
+      callId: call.toolCallId,
+      toolName: call.toolName,
+    });
+  } catch {
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
The `final_output` tool call's input was returned verbatim as the structured result, so when the model double-encoded the payload as a JSON string, `result.completed` carried a raw JSON string instead of the object — despite the documented contract that the server is authoritative for structured output (#894).

The payload is now parsed (reusing the existing `resolveToolCallInputObject`) before it becomes the result. Presence of the call — not whether its payload parses — still decides the turn is terminal, so an unparseable payload ends the turn as `OUTPUT_SCHEMA_NOT_FULFILLED` rather than looping with a dangling tool_use.

Tests: a double-encoded payload now yields the parsed object; an unparseable string fails the turn.