### PR TITLE
fix(eve): reconcile channel state on delivery

### DIFF
--- a/.changeset/channel-state-reconciliation.md
+++ b/.changeset/channel-state-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Let stateful channels reconcile state supplied to `send()` when resuming an existing session. Channels retain durable state by default and can explicitly apply fresh delivery metadata; for example, GitHub webhook turns now update the checkout ref before each model call.

--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -141,6 +141,16 @@ export type ChannelAdapter<TCtx extends ChannelAdapterContext<any> = ChannelAdap
   deliver?(payload: DeliverPayload, ctx: TCtx): StepInput | void | Promise<StepInput | void>;
 
   /**
+   * Reconciles the latest state supplied by resumed `send()` calls with
+   * durable state before a coalesced turn. Channels opt in so inbound snapshots
+   * cannot overwrite channel-owned mutations unless explicitly permitted.
+   */
+  updateState?(
+    state: Record<string, unknown>,
+    incoming: Readonly<Record<string, unknown>>,
+  ): Record<string, unknown>;
+
+  /**
    * Optional factory that builds the adapter context for this adapter.
    *
    * @internal

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -73,8 +73,10 @@ export interface SendPayload {
 
 /**
  * Starts or continues a session on this channel. Accepts a plain string,
- * `UserContent`, or a {@link SendPayload}, plus {@link SendOptions}. Resolves
- * to the resulting {@link Session}.
+ * `UserContent`, or a {@link SendPayload}, plus {@link SendOptions} (auth,
+ * continuation token, run mode, and `state` for stateful channels). The state
+ * seeds a new session; an existing session applies it only when the channel
+ * defines an `updateState` reconciler. Resolves to the resulting {@link Session}.
  */
 export type SendFn<TState = undefined> = (
   input: string | UserContent | SendPayload,
@@ -117,8 +119,10 @@ type BaseSendOptions = {
  * Options for {@link SendFn}. The channel owns its continuation-token
  * format: pass the channel-local raw token (the framework prepends
  * the channel name). Stateful channels also seed initial adapter
- * state via {@link state}, which becomes the new session's `state`
- * on first `runtime.run()` and is ignored on subsequent `deliver`s.
+ * state via {@link state}. It seeds a new session on `runtime.run()`. On a
+ * subsequent `deliver`, it is ignored unless the channel defines an
+ * `updateState` reconciler. If deliveries coalesce into one turn, every
+ * payload observes the latest supplied state.
  */
 export type SendOptions<TState = undefined> = [TState] extends [undefined]
   ? BaseSendOptions

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -259,6 +259,31 @@ describe("createSendFn", () => {
     expect(vi.mocked(runtime.run).mock.calls[0]![0].continuationToken).toBe("stateful:C1:T1");
   });
 
+  it("forwards state from send() when resuming an existing session", async () => {
+    interface State {
+      channelId: string;
+      threadTs: string;
+    }
+    const runtime = createRuntime(undefined);
+    vi.mocked(runtime.deliver).mockResolvedValue({ sessionId: "existing-session-id" });
+    const stateful: ChannelAdapter = {
+      kind: "channel:stateful",
+      state: { channelId: null, threadTs: null },
+    };
+
+    const send = createSendFn<State>(runtime, stateful, "stateful");
+    await send("hello", {
+      auth: null,
+      continuationToken: "C1:T1",
+      state: { channelId: "C2", threadTs: "T2" },
+    });
+
+    expect(runtime.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({ adapterState: { channelId: "C2", threadTs: "T2" } }),
+    );
+    expect(runtime.run).not.toHaveBeenCalled();
+  });
+
   it("seeds adapter state from the send() call so the new session resumes with it", async () => {
     interface State {
       channelId: string;

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -36,6 +36,9 @@ export function createSendFn<TState = undefined>(
 
     try {
       const deliverInput: DeliverInput = {
+        ...(state === undefined
+          ? {}
+          : { adapterState: state as Readonly<Record<string, unknown>> }),
         auth,
         caller,
         continuationToken,

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -187,6 +187,8 @@ export interface DeliverPayload {
  * metadata so both cross the durable hook boundary outside adapter-owned data.
  */
 export interface DeliverHookPayload {
+  /** Latest channel state supplied by the coalesced inbound deliveries. */
+  readonly adapterState?: Readonly<Record<string, unknown>>;
   readonly auth?: SessionAuthContext | null;
   /** Delegated caller waiting for this turn's settled result. */
   readonly caller?: TurnCaller;
@@ -416,6 +418,8 @@ export interface RunInput {
 }
 
 export interface DeliverInput {
+  /** Channel state supplied by the inbound delivery. */
+  readonly adapterState?: Readonly<Record<string, unknown>>;
   /**
    * Authenticated principal for this follow-up message.
    * May differ from the session initiator when different users send

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -385,6 +385,9 @@ async function runDriverLoop(input: {
 
       action = await runTurn({
         delivery: {
+          ...(nextDeliver.adapterState === undefined
+            ? {}
+            : { adapterState: nextDeliver.adapterState }),
           auth: nextDeliver.auth,
           kind: "deliver",
           payloads: [routed.remainder],

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -125,6 +125,22 @@ describe("createWorkflowRuntime#deliver", () => {
     });
   });
 
+  it("forwards incoming adapter state with the delivery", async () => {
+    resumeHookMock.mockResolvedValue({ runId: "owner-session" });
+
+    await buildRuntime().deliver({
+      adapterState: { eventId: "A" },
+      auth: null,
+      continuationToken: "test:active-hook",
+      payload: { message: "hello" },
+    });
+
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      "test:active-hook",
+      expect.objectContaining({ adapterState: { eventId: "A" } }),
+    );
+  });
+
   it("returns the owner from the hook resumed by the delivery", async () => {
     resumeHookMock.mockResolvedValue({ runId: "owner-session" });
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -222,6 +222,7 @@ export function createWorkflowRuntime(config: {
 
     async deliver(input: DeliverInput): Promise<{ sessionId: string }> {
       const hookPayload: Extract<HookPayload, { kind: "deliver" }> = {
+        adapterState: input.adapterState,
         auth: input.auth,
         kind: "deliver",
         payloads: [input.payload],

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -8,6 +8,7 @@ import {
   AuthKey,
   ContinuationTokenKey,
   DynamicSubagentAgentConfigKey,
+  ChannelInstrumentationKey,
   ModeKey,
   SessionDynamicSubagentSelectionsKey,
   SessionDynamicToolMetadataKey,
@@ -140,7 +141,25 @@ const TestTurnAgent = {
 
 const threadContextAdapter: ChannelAdapter = {
   kind: "thread-context",
+  instrumentation: {
+    metadata(state) {
+      return { headSha: state?.headSha };
+    },
+  },
+  updateState(state, incoming) {
+    if (typeof incoming.eventId === "string") {
+      const seen = Array.isArray(state.seen) ? state.seen : [];
+      return { ...state, seen: [...seen, incoming.eventId] };
+    }
+    return { ...state, ...incoming };
+  },
   deliver(payload: DeliverPayload, adapterCtx: ChannelAdapterContext) {
+    if (payload.message === "review the update") {
+      expect(adapterCtx.ctx.require(ChannelKey).state?.headSha).toBe("new-head");
+      expect(adapterCtx.ctx.get(ChannelInstrumentationKey)?.metadata).toEqual({
+        headSha: "new-head",
+      });
+    }
     if (typeof payload.message === "string" && payload.message.startsWith("seed:")) {
       adapterCtx.ctx.set(ThreadKey, payload.message.slice(5));
     }
@@ -163,12 +182,14 @@ function createStubSession(overrides: Partial<HarnessSession> = {}): HarnessSess
   };
 }
 
-function createSerializedContext(): Record<string, unknown> {
+function createSerializedContext(
+  adapter: ChannelAdapter = threadContextAdapter,
+): Record<string, unknown> {
   const ctx = new ContextContainer();
   ctx.set(AuthKey, null);
   ctx.set(BundleKey, {
     adapterRegistry: {
-      adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      adaptersByKind: new Map([[adapter.kind, adapter]]),
     },
     compiledArtifactsSource: {} as never,
     graph: {
@@ -184,7 +205,7 @@ function createSerializedContext(): Record<string, unknown> {
     toolRegistry: {},
     turnAgent: TestTurnAgent,
   } as never);
-  ctx.set(ChannelKey, threadContextAdapter);
+  ctx.set(ChannelKey, adapter);
   ctx.set(ContinuationTokenKey, "http:thread-context");
   ctx.set(ModeKey, "conversation");
   ctx.set(SessionIdKey, "session-1");
@@ -1023,6 +1044,33 @@ describe("turnStep", () => {
     expect(createExecutionNodeStep).toHaveBeenCalledWith(
       expect.objectContaining({ node: effectiveNode }),
     );
+  });
+
+  it("lets the adapter reconcile deliver-time channel state before handling the turn", async () => {
+    const session = createStubSession();
+    installSessionStoreMocks([session]);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (stepSession): Promise<StepResult> => ({
+        next: { done: true, output: "ok" },
+        session: stepSession,
+      });
+    });
+
+    const result = await turnStep({
+      input: {
+        adapterState: { headSha: "new-head" },
+        kind: "deliver",
+        payloads: [{ message: "review the update" }],
+      },
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
+      sessionState: createStubSessionState(),
+    });
+
+    const channel = result.serializedContext[ChannelKey.name] as {
+      state: { headSha?: string };
+    };
+    expect(channel.state.headSha).toBe("new-head");
   });
 
   it("reads the durable session from normalized turn-step input", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -148,7 +148,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
   let durableSession = await readDurableSession(input.sessionState);
   const ctx = await deserializeContext(input.serializedContext);
-  const adapter = ctx.require(ChannelKey);
+  let adapter = ctx.require(ChannelKey);
   const bundle = ctx.require(BundleKey);
   const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
 
@@ -229,6 +229,17 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     turnAgent: effectiveAgent.turnAgent,
   });
 
+  if (
+    input.input?.kind === "deliver" &&
+    input.input.adapterState !== undefined &&
+    adapter.updateState !== undefined
+  ) {
+    adapter = {
+      ...adapter,
+      state: adapter.updateState(adapter.state ?? {}, input.input.adapterState),
+    };
+    setChannelContext(ctx, adapter);
+  }
   const adapterCtx = buildAdapterContext(adapter, ctx);
 
   // Run the adapter's deliver hook for each queued payload and

--- a/packages/eve/src/harness/messages.test.ts
+++ b/packages/eve/src/harness/messages.test.ts
@@ -1,6 +1,7 @@
 import type { FilePart, ModelMessage, UserContent } from "ai";
 import { describe, expect, it } from "vitest";
 import {
+  coalesceDeliveries,
   coalesceTurnInputs,
   normalizeUserContent,
   resolveAssistantStepText,
@@ -18,6 +19,34 @@ function textFilePart(overrides: {
     type: "file",
   };
 }
+
+describe("coalesceDeliveries", () => {
+  it("keeps the latest supplied adapter state for every payload in the coalesced turn", () => {
+    const result = coalesceDeliveries([
+      {
+        adapterState: { eventId: "A" },
+        kind: "deliver" as const,
+        payloads: [{ message: "first" }],
+      },
+      {
+        kind: "deliver" as const,
+        payloads: [{ message: "without state" }],
+      },
+      {
+        adapterState: { eventId: "B" },
+        kind: "deliver" as const,
+        payloads: [{ message: "second" }],
+      },
+    ]);
+
+    expect(result.adapterState).toEqual({ eventId: "B" });
+    expect(result.payloads).toEqual([
+      { message: "first" },
+      { message: "without state" },
+      { message: "second" },
+    ]);
+  });
+});
 
 describe("coalesceTurnInputs", () => {
   it("joins two messages with a double newline", () => {

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -214,19 +214,21 @@ function toUserContentArray(value: string | UserContent): UserContentArray {
  * runtime type.
  */
 interface DeliverLike {
+  readonly adapterState?: Readonly<Record<string, unknown>>;
   readonly auth?: SessionAuthContext | null;
   readonly kind: "deliver";
   readonly payloads: readonly DeliverPayload[];
 }
 
 /**
- * Coalesces an array of deliver-like items into a single item by
- * collecting all payloads and keeping the most recent auth value.
+ * Coalesces an array of deliver-like items into a single item by collecting
+ * all payloads and keeping the most recent auth and channel-state snapshots.
+ * Every payload in the resulting turn observes that final state.
  *
- * Used by the workflow runtime to batch follow-up deliveries that
- * arrived while a turn or subagent delegation was in progress. Each
- * payload is later passed to `onDeliver` individually so channel-
- * specific fields are never lost.
+ * Used by the workflow runtime to batch follow-up deliveries that arrived
+ * while a turn or subagent delegation was in progress. Each payload is later
+ * passed to `onDeliver` individually so channel-specific payload fields are
+ * never lost.
  */
 export function coalesceDeliveries<T extends DeliverLike>(items: readonly T[]): T {
   const [first, ...rest] = items;
@@ -235,15 +237,24 @@ export function coalesceDeliveries<T extends DeliverLike>(items: readonly T[]): 
     throw new Error("Cannot coalesce an empty delivery batch.");
   }
 
+  let adapterState = first.adapterState;
   let auth = first.auth;
   const payloads = [...first.payloads];
 
   for (const item of rest) {
+    if (item.adapterState !== undefined) {
+      adapterState = item.adapterState;
+    }
     if (item.auth !== undefined) {
       auth = item.auth;
     }
     payloads.push(...item.payloads);
   }
 
-  return { ...first, auth, payloads };
+  return {
+    ...first,
+    adapterState,
+    auth,
+    payloads,
+  };
 }

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -14,7 +14,7 @@ import {
 } from "#public/channels/github/auth.js";
 import { defaultGitHubAuth } from "#public/channels/github/defaults.js";
 import { githubChannel } from "#public/channels/github/githubChannel.js";
-import { type GitHubChannelState } from "#public/channels/github/state.js";
+import { initialGitHubState, type GitHubChannelState } from "#public/channels/github/state.js";
 import { signGitHubWebhookBody } from "#public/channels/github/verify.js";
 
 const SECRET = "github-secret";
@@ -509,6 +509,21 @@ describe("githubChannel", () => {
         repo: "eve",
       },
     });
+  });
+
+  it("reconciles webhook state into durable state for resumed turns", () => {
+    const channel = githubChannel();
+    const adapter = getAdapter(channel);
+    const current = {
+      ...initialGitHubState(),
+      checkoutPath: "/workspace",
+      headSha: "old-head",
+      owner: "vercel",
+      repo: "eve",
+    };
+    const incoming = { ...current, checkoutPath: null, headSha: "new-head" };
+
+    expect(adapter.updateState?.(current, incoming)).toEqual(incoming);
   });
 
   it("dispatches opt-in pull request webhook hooks with checkout-ready state", async () => {

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -232,6 +232,10 @@ export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
     kindHint: "github",
     state: initialGitHubState(),
 
+    updateState(state, incoming) {
+      return { ...state, ...incoming };
+    },
+
     context(state, session) {
       return rebuildGitHubContext(state, session, config);
     },

--- a/packages/eve/src/public/definitions/channel.test.ts
+++ b/packages/eve/src/public/definitions/channel.test.ts
@@ -214,6 +214,24 @@ describe("defineChannel", () => {
     void invalid;
   });
 
+  it("wires an updateState reconciler onto the built adapter", () => {
+    const channel = defineChannel({
+      state: { durable: "keep", inbound: "old" },
+      routes: [POST("/x", async () => new Response("ok"))],
+      updateState(state, incoming) {
+        return { ...state, inbound: incoming.inbound };
+      },
+    });
+
+    const adapter = getAdapter(channel);
+    expect(
+      adapter.updateState?.(adapter.state ?? {}, { durable: "replace", inbound: "new" }),
+    ).toEqual({
+      durable: "keep",
+      inbound: "new",
+    });
+  });
+
   it("wires a turn.cancelled handler onto the built adapter", () => {
     const channel = defineChannel({
       routes: [POST("/x", async () => new Response("ok"))],

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -276,10 +276,11 @@ export type ReceiveInput<TReceiveTarget = Record<string, unknown>> =
 
 /**
  * The object passed to {@link defineChannel}. `routes` is required; `state`
- * seeds durable adapter state, `context` builds the per-step `channel` argument
- * for `events` and `deliver`, `events` handle session lifecycle, `receive`
- * accepts cross-channel handoffs, `fetchFile` stages remote file URLs, and
- * `metadata` projects observability data.
+ * seeds durable adapter state, `updateState` reconciles state supplied by
+ * resumed sends, `context` builds the per-step `channel` argument for `events`
+ * and `deliver`, `events` handle session lifecycle, `receive` accepts
+ * cross-channel handoffs, `fetchFile` stages remote file URLs, and `metadata`
+ * projects observability data.
  *
  * Generics: `TState` (adapter state), `TCtx` (context factory return type),
  * `TReceiveTarget` (cross-channel target shape), `TMetadata` (instrumentation
@@ -383,7 +384,8 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
   const hasFetchFile = definition.fetchFile !== undefined;
   const metadata = definition.metadata;
   const hasMetadata = metadata !== undefined;
-  const hasBehavior = hasState || hasContext || hasMetadata;
+  const hasUpdateState = definition.updateState !== undefined;
+  const hasBehavior = hasState || hasContext || hasMetadata || hasUpdateState;
 
   const eventHandlers: Record<string, unknown> = {};
   let hasEventHandlers = false;
@@ -448,6 +450,15 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
     deliver(payload: DeliverPayload) {
       return defaultDeliverResult(payload);
     },
+
+    updateState:
+      definition.updateState === undefined
+        ? undefined
+        : (state, incoming) =>
+            definition.updateState!(
+              state as NonNullable<TState>,
+              incoming as Readonly<NonNullable<TState>>,
+            ) as Record<string, unknown>,
 
     ...eventHandlers,
   } as ChannelAdapter<any>;

--- a/packages/eve/src/runtime/channels/registry.ts
+++ b/packages/eve/src/runtime/channels/registry.ts
@@ -41,6 +41,7 @@ const ADAPTER_NON_EVENT_FIELDS: ReadonlySet<string> = new Set([
   "createAdapterContext",
   "fetchFile",
   "instrumentation",
+  "updateState",
 ]);
 
 /**
@@ -87,8 +88,9 @@ export function createRuntimeAdapterRegistry(input: {
           `Channel adapter kind "${kind}" is reserved by the framework. ` +
             `A route-declared adapter may share a framework kind only as a ` +
             `pass-through with no \`deliver\` hook, event handlers, ` +
-            `\`attachments\` resolver, or \`createAdapterContext\` factory. ` +
-            `Use a custom \`kind\` to add channel-specific behavior.`,
+            `\`attachments\` resolver, \`createAdapterContext\` factory, or ` +
+            `\`updateState\` reconciler. Use a custom \`kind\` to add ` +
+            `channel-specific behavior.`,
           { ...location, entryName: kind },
         );
       }
@@ -166,6 +168,10 @@ function carriesAdapterBehavior(adapter: ChannelAdapter): boolean {
   }
 
   if (adapter.createAdapterContext !== undefined) {
+    return true;
+  }
+
+  if (adapter.updateState !== undefined) {
     return true;
   }
 

--- a/packages/eve/src/shared/channel-definition.ts
+++ b/packages/eve/src/shared/channel-definition.ts
@@ -69,6 +69,18 @@ export interface GenericChannelDefinition<
    */
   context?(state: NonNullable<TState>, session: SessionHandle): TCtx;
 
+  /**
+   * Reconciles the latest state supplied to a resumed `send()` with the
+   * session's durable state. When deliveries are coalesced, every payload in
+   * the turn observes that latest supplied state. When omitted, resumed
+   * deliveries ignore supplied state, preserving mutations made by event
+   * handlers and channel context methods.
+   */
+  updateState?(
+    state: NonNullable<TState>,
+    incoming: Readonly<NonNullable<TState>>,
+  ): NonNullable<TState>;
+
   readonly routes: readonly RouteDefinition<TState>[];
   receive?(
     input: GenericReceiveInput<TReceiveTarget>,


### PR DESCRIPTION
Previously, state passed to `send()` was dropped when resuming an existing session.

Now, resumed sessions carry updated state. Channels can opt into reconciling it with durable state via `updateState(current, incoming)`; channels without this hook retain the previous ignore-on-resume behavior. The GitHub channel uses this API so later PR webhooks, including `pull_request.synchronize`, update the head SHA before checkout instead of reviewing the session’s original commit.

Fixes #1554.

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/channel/send.test.ts src/public/definitions/channel.test.ts src/public/channels/github/githubChannel.test.ts src/execution/workflow-steps.test.ts src/harness/messages.test.ts src/execution/workflow-runtime.test.ts src/execution/workflow-entry.test.ts src/runtime/channels/registry.test.ts`
- `pnpm --filter eve typecheck`
- `git diff --check`