### PR TITLE
feat(slack): keep thread statuses alive

### DIFF
--- a/.changeset/slow-slack-status-keepalive.md
+++ b/.changeset/slow-slack-status-keepalive.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack now keeps thread statuses visible during long-running work, including durable waits on subagents, instead of letting them expire after two minutes. Set `statusKeepalive: false` when an agent provides its own status refresh loop.

--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -171,6 +171,13 @@ export type ChannelAdapter<TCtx extends ChannelAdapterContext<any> = ChannelAdap
   readonly instrumentation?: {
     readonly metadata?: ChannelInstrumentationMetadataProjector;
   };
+
+  /** Framework-owned channel status lifecycle across durable waits. */
+  readonly statusKeepalive?: {
+    readonly suspend: (ctx: TCtx) => number | undefined;
+    readonly refresh: (ctx: TCtx) => number | undefined | Promise<number | undefined>;
+    readonly resume: (ctx: TCtx) => void;
+  };
 } & ChannelEventHandlers<TCtx>;
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -110,6 +110,7 @@ export async function dispatchRuntimeActionsStep(input: {
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<{
+  readonly statusKeepaliveDelayMs?: number;
   readonly results: readonly RuntimeSubagentResult[];
   readonly sessionState: DurableSessionState;
 }> {
@@ -119,7 +120,10 @@ export async function dispatchRuntimeActionsStep(input: {
   const batch = getPendingRuntimeActionBatch(durableSession.state);
 
   if (batch === undefined || batch.actions.length === 0) {
-    return { results: [], sessionState: input.sessionState };
+    return {
+      results: [],
+      sessionState: input.sessionState,
+    };
   }
 
   const ctx = await deserializeContext(input.serializedContext);
@@ -139,6 +143,7 @@ export async function dispatchRuntimeActionsStep(input: {
   const initiatorAuth = ctx.get(InitiatorAuthKey) ?? null;
 
   const adapterCtx = buildAdapterContext(adapter, ctx);
+  const statusKeepaliveDelayMs = adapter.statusKeepalive?.suspend(adapterCtx);
   // Read here, not in the child: trace state is scoped to one session's
   // context, so this is the last place the parent's window is visible.
   const parentTraceContext = readSessionTraceContext(input.serializedContext, session.sessionId);
@@ -231,6 +236,7 @@ export async function dispatchRuntimeActionsStep(input: {
   return {
     results,
     sessionState: nextState,
+    statusKeepaliveDelayMs,
   };
 }
 

--- a/packages/eve/src/execution/dispatch-workflow-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-workflow-runtime-actions-step.ts
@@ -33,6 +33,7 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<{
+  readonly statusKeepaliveDelayMs?: number;
   readonly results: readonly RuntimeSubagentResult[];
   readonly sessionState: DurableSessionState;
 }> {
@@ -40,10 +41,10 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
 
   const durableSession = await readDurableSession(input.sessionState);
   const pending = getPendingWorkflowInterrupt(durableSession.state);
-  if (pending === undefined) return { results: [], sessionState: input.sessionState };
+  if (pending === undefined) return emptyDispatchResult(input);
 
   const actions = buildRuntimeActionsFromWorkflowInterrupt(pending.interrupt);
-  if (actions.length === 0) return { results: [], sessionState: input.sessionState };
+  if (actions.length === 0) return emptyDispatchResult(input);
 
   const ctx = await deserializeContext(input.serializedContext);
   const bundle = ctx.require(BundleKey);
@@ -68,7 +69,7 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
   });
 
   if (plan.allowed.length === 0) {
-    return { results: blockedResults, sessionState: input.sessionState };
+    return { ...emptyDispatchResult(input), results: blockedResults };
   }
 
   const session = hydrateDurableSession({
@@ -99,8 +100,18 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
   }
 
   return {
+    ...dispatched,
     results: [...dispatched.results, ...blockedResults],
-    sessionState: dispatched.sessionState,
+  };
+}
+
+function emptyDispatchResult(input: {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}) {
+  return {
+    results: [] as readonly RuntimeSubagentResult[],
+    sessionState: input.sessionState,
   };
 }
 

--- a/packages/eve/src/execution/refresh-channel-status-step.ts
+++ b/packages/eve/src/execution/refresh-channel-status-step.ts
@@ -1,0 +1,32 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+
+export interface RefreshChannelStatusResult {
+  readonly delayMs?: number;
+  readonly serializedContext: Record<string, unknown>;
+}
+
+/** Refreshes a channel-owned status while its turn waits durably. */
+export async function refreshChannelStatusStep(input: {
+  readonly serializedContext: Record<string, unknown>;
+}): Promise<RefreshChannelStatusResult> {
+  "use step";
+
+  const ctx = await deserializeContext(input.serializedContext);
+  const adapter = ctx.require(ChannelKey);
+  const refresh = adapter.statusKeepalive?.refresh;
+  if (refresh === undefined) {
+    return { serializedContext: input.serializedContext };
+  }
+
+  const adapterCtx = buildAdapterContext(adapter, ctx);
+  let delayMs: number | undefined;
+  try {
+    delayMs = await refresh(adapterCtx);
+  } catch {
+    // Channel statuses are cosmetic and never fail an active turn.
+  }
+  ctx.set(ChannelKey, { ...adapter, state: { ...adapterCtx.state } });
+  return { delayMs, serializedContext: serializeContext(ctx) };
+}

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -648,7 +648,9 @@ describe("turnWorkflow", () => {
   });
 
   it("durably refreshes channel status while retaining one pending inbox read", async () => {
-    const pendingState = createSessionState();
+    const pendingState = withRunningChildren(createSessionState(), [
+      { callId: "call-1", sessionId: "child-session" },
+    ]);
     let deliverResult: ((value: IteratorResult<unknown>) => void) | undefined;
     const next = vi.fn(
       () =>

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -12,12 +12,15 @@ import {
   type TurnWorkflowInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+import { refreshChannelStatusStep } from "#execution/refresh-channel-status-step.js";
 import { turnStep } from "#execution/workflow-steps.js";
 import { AGENT_HANDLES_STATE_KEY } from "#harness/handles/store.js";
 
 const resumeHookMock = vi.fn();
 const createHookMock = vi.fn();
-const sleepMock = vi.fn(async (_duration: unknown) => {});
+const sleepMock = vi.fn((duration: unknown) =>
+  duration === 75_000 ? new Promise<void>(() => {}) : Promise.resolve(),
+);
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: (...args: unknown[]) => createHookMock(...args),
@@ -31,6 +34,10 @@ vi.mock("#compiled/@workflow/core/runtime.js", () => ({
 
 vi.mock("./route-child-delivery.js", () => ({
   routeDeliverToChildren: vi.fn(),
+}));
+
+vi.mock("./refresh-channel-status-step.js", () => ({
+  refreshChannelStatusStep: vi.fn(),
 }));
 
 vi.mock("./subagent-event-proxy-step.js", () => ({
@@ -62,7 +69,11 @@ describe("turnWorkflow", () => {
     vi.clearAllMocks();
     resumeHookMock.mockReset();
     createHookMock.mockReset();
-    sleepMock.mockClear();
+    sleepMock.mockReset();
+    sleepMock.mockImplementation((duration: unknown) =>
+      duration === 75_000 ? new Promise<void>(() => {}) : Promise.resolve(),
+    );
+    vi.mocked(refreshChannelStatusStep).mockResolvedValue({ serializedContext: {} });
   });
 
   it("notifies the driver when a turn completes", async () => {
@@ -632,6 +643,140 @@ describe("turnWorkflow", () => {
         action: expect.objectContaining({ kind: "dispatch-runtime-actions" }),
       }),
     );
+    expect(sleepMock).not.toHaveBeenCalledWith(75_000);
+    expect(refreshChannelStatusStep).not.toHaveBeenCalled();
+  });
+
+  it("durably refreshes channel status while retaining one pending inbox read", async () => {
+    const pendingState = createSessionState();
+    let deliverResult: ((value: IteratorResult<unknown>) => void) | undefined;
+    const next = vi.fn(
+      () =>
+        new Promise<IteratorResult<unknown>>((resolve) => {
+          deliverResult = resolve;
+        }),
+    );
+    const inbox = createInboxMock([], { stayOpen: true });
+    const hook = inbox.hook as { [Symbol.asyncIterator](): AsyncIterator<unknown> };
+    hook[Symbol.asyncIterator] = () => ({ next });
+    installHookDispatch([inbox]);
+    let wakeRefresh: (() => void) | undefined;
+    sleepMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          wakeRefresh = resolve;
+        }),
+    );
+    vi.mocked(refreshChannelStatusStep).mockResolvedValue({
+      delayMs: 75_000,
+      serializedContext: { state: "refreshed" },
+    });
+    vi.mocked(dispatchRuntimeActionsStep).mockResolvedValue({
+      statusKeepaliveDelayMs: 75_000,
+      results: [],
+      sessionState: pendingState,
+    });
+    vi.mocked(turnStep)
+      .mockResolvedValueOnce({
+        action: "park",
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        pendingRuntimeActionKeys: ["subagent-call:delegate:call-1"],
+        serializedContext: { state: "pending" },
+        sessionState: pendingState,
+      })
+      .mockResolvedValueOnce({
+        action: "done",
+        output: "done",
+        serializedContext: { state: "done" },
+        sessionState: pendingState,
+      });
+
+    const { input } = createInput({
+      driverCapabilities: { turnInbox: true },
+      sessionState: pendingState,
+    });
+    const workflow = turnWorkflow(input);
+    await vi.waitFor(() => expect(wakeRefresh).toBeDefined());
+    wakeRefresh?.();
+    await vi.waitFor(() => expect(refreshChannelStatusStep).toHaveBeenCalledOnce());
+    expect(next).toHaveBeenCalledOnce();
+
+    deliverResult?.({
+      done: false,
+      value: {
+        kind: "runtime-action-result",
+        results: [
+          { callId: "call-1", kind: "subagent-result", output: "ok", subagentName: "delegate" },
+        ],
+      },
+    });
+    await workflow;
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(turnStep).mock.calls[1]?.[0].serializedContext).toEqual({
+      state: "refreshed",
+    });
+  });
+
+  it("keeps the original status timer across intermediate inbox events", async () => {
+    const pendingState = createSessionState();
+    installInbox(
+      [
+        {
+          callId: "call-1",
+          childSessionId: "child",
+          event: { type: "authorization.required", data: {} },
+          kind: "subagent-authorization-event",
+          subagentName: "delegate",
+        },
+        {
+          callId: "call-1",
+          childSessionId: "child",
+          event: { type: "authorization.completed", data: {} },
+          kind: "subagent-authorization-event",
+          subagentName: "delegate",
+        },
+      ],
+      { stayOpen: true },
+    );
+    let wakeRefresh: (() => void) | undefined;
+    sleepMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          wakeRefresh = resolve;
+        }),
+    );
+    vi.mocked(refreshChannelStatusStep).mockResolvedValue({ serializedContext: {} });
+    vi.mocked(runProxySubagentEventStep).mockResolvedValue({
+      serializedContext: { state: "proxied" },
+      sessionState: pendingState,
+    });
+    vi.mocked(dispatchRuntimeActionsStep).mockResolvedValue({
+      statusKeepaliveDelayMs: 75_000,
+      results: [],
+      sessionState: pendingState,
+    });
+    vi.mocked(turnStep).mockResolvedValueOnce({
+      action: "park",
+      hasPendingAuthorization: false,
+      hasPendingInputBatch: false,
+      pendingRuntimeActionKeys: ["subagent-call:delegate:call-1"],
+      serializedContext: { state: "pending" },
+      sessionState: pendingState,
+    });
+
+    const { input } = createInput({
+      driverCapabilities: { turnInbox: true },
+      sessionState: pendingState,
+    });
+    const workflow = turnWorkflow(input);
+    await vi.waitFor(() => expect(runProxySubagentEventStep).toHaveBeenCalledTimes(2));
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    wakeRefresh?.();
+    await vi.waitFor(() => expect(refreshChannelStatusStep).toHaveBeenCalledOnce());
+
+    void workflow.catch(() => {});
   });
 
   it("waits for dispatch adoption before cascading a cancellation", async () => {
@@ -639,11 +784,16 @@ describe("turnWorkflow", () => {
     const pendingState = createSessionState({ continuationToken: "http:parent:turn" });
     const adoptedState = createSessionState({ continuationToken: "http:parent:turn:adopted" });
     let finishDispatch:
-      | ((value: { results: readonly []; sessionState: DurableSessionState }) => void)
+      | ((value: {
+          results: readonly [];
+          sessionState: DurableSessionState;
+          statusKeepaliveDelayMs?: number;
+        }) => void)
       | undefined;
     const dispatchResult = new Promise<{
       results: readonly [];
       sessionState: DurableSessionState;
+      statusKeepaliveDelayMs?: number;
     }>((resolve) => {
       finishDispatch = resolve;
     });
@@ -673,7 +823,10 @@ describe("turnWorkflow", () => {
     await vi.waitFor(() => expect(dispatchRuntimeActionsStep).toHaveBeenCalledOnce());
     expect(cancelDescendantTurnsStep).not.toHaveBeenCalled();
 
-    finishDispatch?.({ results: [], sessionState: adoptedState });
+    finishDispatch?.({
+      results: [],
+      sessionState: adoptedState,
+    });
     await workflow;
 
     expect(vi.mocked(turnStep).mock.calls[1]?.[0].abortSignal?.aborted).toBe(true);

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -18,6 +18,7 @@ import {
 import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+import { refreshChannelStatusStep } from "#execution/refresh-channel-status-step.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import {
   createTurnCancellationControl,
@@ -176,6 +177,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
         await cursor.adopt(dispatchResult);
 
         const results = await waitForRuntimeActionResults({
+          statusKeepaliveDelayMs: dispatchResult.statusKeepaliveDelayMs,
           bufferedDeliveries,
           cancellation,
           cursor,
@@ -269,6 +271,7 @@ async function waitForRuntimeActionResults(input: {
   readonly bufferedDeliveries: DeliverHookPayload[];
   readonly cancellation: TurnCancellationControl | undefined;
   readonly cursor: TurnExecutionCursor;
+  readonly statusKeepaliveDelayMs?: number;
   readonly inboxToken: string;
   readonly initialResults: readonly RuntimeActionResult[];
   readonly iterator: AsyncIterator<TurnInboxPayload>;
@@ -277,6 +280,12 @@ async function waitForRuntimeActionResults(input: {
 }): Promise<readonly RuntimeActionResult[] | "cancelled" | "cancel-turn"> {
   let pendingDeliveryRequest: string | undefined;
   const results: RuntimeActionResult[] = [...input.initialResults];
+  let nextPromise = input.iterator.next();
+  nextPromise.catch(() => {});
+  let statusRefresh =
+    input.statusKeepaliveDelayMs === undefined
+      ? undefined
+      : workflowSleep(input.statusKeepaliveDelayMs);
 
   while (true) {
     const ready = resolveRuntimeActionResultsForKeys({
@@ -305,14 +314,12 @@ async function waitForRuntimeActionResults(input: {
       });
     }
 
-    const nextPromise = input.iterator.next();
-    // When a cancel wins the race, the dangling inbox `next()` is dropped
-    // by disposal in teardown; pre-attach a handler so a late rejection
-    // never surfaces as unhandled.
-    nextPromise.catch(() => {});
+    const inbox = nextPromise.then((next) => ({ kind: "inbox" as const, next }));
+    const refresh = statusRefresh?.then(() => ({ kind: "refresh" as const }));
+    const pending = refresh === undefined ? [inbox] : [inbox, refresh];
     const next = await (input.cancellation === undefined
-      ? nextPromise
-      : Promise.race([nextPromise, input.cancellation.requested]));
+      ? Promise.race(pending)
+      : Promise.race([...pending, input.cancellation.requested]));
     if (next === "cancel") {
       if (pendingDeliveryRequest !== undefined) {
         // Release the raced public input back to the driver so it stays
@@ -324,9 +331,23 @@ async function waitForRuntimeActionResults(input: {
       }
       return "cancelled";
     }
-    if (next.done) throw new Error("Turn inbox closed before runtime actions completed.");
+    if (next.kind === "refresh") {
+      const refreshed = await refreshChannelStatusStep({
+        serializedContext: input.cursor.serializedContext,
+      });
+      await input.cursor.adopt({
+        ...refreshed,
+        sessionState: input.cursor.sessionState,
+      });
+      statusRefresh =
+        refreshed.delayMs === undefined ? undefined : workflowSleep(refreshed.delayMs);
+      continue;
+    }
+    if (next.next.done) throw new Error("Turn inbox closed before runtime actions completed.");
 
-    const value = next.value;
+    const value = next.next.value;
+    nextPromise = input.iterator.next();
+    nextPromise.catch(() => {});
     if (value.kind === "runtime-action-result") {
       // The inbox token is shared by every callee in the batch, so an inbox
       // subagent result must bind to a running agent handle in the adopted

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -163,12 +163,14 @@ function createStubSession(overrides: Partial<HarnessSession> = {}): HarnessSess
   };
 }
 
-function createSerializedContext(): Record<string, unknown> {
+function createSerializedContext(
+  adapter: ChannelAdapter = threadContextAdapter,
+): Record<string, unknown> {
   const ctx = new ContextContainer();
   ctx.set(AuthKey, null);
   ctx.set(BundleKey, {
     adapterRegistry: {
-      adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      adaptersByKind: new Map([[adapter.kind, adapter]]),
     },
     compiledArtifactsSource: {} as never,
     graph: {
@@ -184,7 +186,7 @@ function createSerializedContext(): Record<string, unknown> {
     toolRegistry: {},
     turnAgent: TestTurnAgent,
   } as never);
-  ctx.set(ChannelKey, threadContextAdapter);
+  ctx.set(ChannelKey, adapter);
   ctx.set(ContinuationTokenKey, "http:thread-context");
   ctx.set(ModeKey, "conversation");
   ctx.set(SessionIdKey, "session-1");
@@ -403,7 +405,7 @@ describe("dispatchRuntimeActionsStep", () => {
       sessionState,
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       results: [
         {
           callId: "call-2",
@@ -844,7 +846,7 @@ describe("dispatchRuntimeActionsStep", () => {
         serializedContext: createSerializedContext(),
         sessionState,
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       results: [
         {
           callId: "call-1",
@@ -941,7 +943,7 @@ describe("dispatchRuntimeActionsStep", () => {
         serializedContext: createSerializedContext(),
         sessionState,
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       results: [
         {
           callId: "call-dynamic",
@@ -1056,6 +1058,46 @@ describe("turnStep", () => {
     expect(createDurableSessionState).toHaveBeenLastCalledWith({
       session: expect.objectContaining({ sessionId: "turn-step-session" }),
     });
+  });
+
+  it("resumes local channel status before processing runtime-action results", async () => {
+    const resume = vi.fn();
+    const adapter = {
+      ...threadContextAdapter,
+      statusKeepalive: { suspend: vi.fn(), refresh: vi.fn(), resume },
+    };
+    const compiledBundle = {
+      adapterRegistry: { adaptersByKind: new Map([[adapter.kind, adapter]]) },
+      compiledArtifactsSource: {},
+      graph: {
+        nodesByNodeId: new Map(),
+        root: { sandboxRegistry: { sandbox: null }, turnAgent: TestTurnAgent },
+      },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    const serializedContext = createSerializedContext(adapter);
+    const session = createStubSession();
+    installSessionStoreMocks([session]);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (stepSession): Promise<StepResult> => ({
+        next: { done: true, output: "ok" },
+        session: stepSession,
+      });
+    });
+
+    await turnStep({
+      input: { kind: "runtime-action-result", results: [] },
+      parentWritable: createTestWritable(),
+      serializedContext,
+      sessionState: createStubSessionState(),
+    });
+
+    expect(resume).toHaveBeenCalledOnce();
   });
 
   it("projects a requested sleep onto the durable step result", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -247,13 +247,14 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     }
     resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
   } else if (input.input?.kind === "runtime-action-result") {
+    adapter.statusKeepalive?.resume(adapterCtx);
     recordSubagentUsageSpans(input.input.results);
     resolved = { runtimeActionResults: input.input.results };
   }
 
   // Pin adapter-state mutations back onto ctx so they survive the
   // step boundary.
-  if (input.input?.kind === "deliver") {
+  if (input.input?.kind === "deliver" || input.input?.kind === "runtime-action-result") {
     const updatedAdapter = { ...adapter, state: { ...adapterCtx.state } };
     setChannelContext(ctx, updatedAdapter);
   }

--- a/packages/eve/src/public/channels/slack/api.ts
+++ b/packages/eve/src/public/channels/slack/api.ts
@@ -32,8 +32,8 @@ import { isCardElement, type CardElement, type FileUpload } from "#compiled/chat
 
 import { createLogger, logError } from "#internal/logging.js";
 import { cardToBlocks, cardToFallbackText } from "#public/channels/slack/blocks.js";
-import { truncateTypingStatus } from "#public/channels/slack/limits.js";
 import { slackMrkdwnToGfm } from "#public/channels/slack/mrkdwn.js";
+import { createSlackThreadStatusController } from "#public/channels/slack/thread-status.js";
 
 const log = createLogger("slack.api");
 
@@ -364,6 +364,7 @@ export function buildSlackWorkspaceHandle(input: {
 interface SlackBinding {
   readonly thread: SlackThread;
   readonly slack: SlackHandle;
+  readonly status: ReturnType<typeof createSlackThreadStatusController>;
 }
 
 /**
@@ -385,6 +386,11 @@ export function buildSlackBinding(input: {
   readonly threadTs: string;
   readonly teamId: string | undefined;
   readonly onThreadTsChanged?: (ts: string) => void;
+  /** Keeps non-empty thread statuses alive until explicitly stopped. Defaults to true. */
+  readonly statusKeepalive?: boolean;
+  readonly statusKeepaliveState?: {
+    statusKeepaliveStatus?: string | null;
+  };
 }): SlackBinding {
   const request = createSlackRequester(input.botToken);
   let messages: readonly SlackThreadMessage[] = [];
@@ -392,6 +398,7 @@ export function buildSlackBinding(input: {
   let refreshInFlight: Promise<void> | undefined;
 
   function handleMessageTs(ts: string): void {
+    statusController.handleAnchor(ts);
     if (currentThreadTs || ts === currentThreadTs) return;
     currentThreadTs = ts;
     input.onThreadTsChanged?.(ts);
@@ -403,12 +410,16 @@ export function buildSlackBinding(input: {
   ): Promise<SlackUploadFilesResult> {
     const channelId = options?.channelId ?? input.channelId;
     const threadTs = options?.threadTs ?? currentThreadTs;
-    return uploadSlackFiles(files.map(toSlackFileUpload), {
+    const result = await uploadSlackFiles(files.map(toSlackFileUpload), {
       ...createSlackApiOptions(input.botToken),
       channelId: channelId || undefined,
       initialComment: options?.initialComment,
       threadTs: threadTs || undefined,
     });
+    if (channelId === input.channelId && threadTs === currentThreadTs) {
+      statusController.clear();
+    }
+    return result;
   }
 
   function refreshMessages(): Promise<void> {
@@ -447,6 +458,15 @@ export function buildSlackBinding(input: {
     refreshInFlight = refresh;
     return refresh;
   }
+
+  const statusController = createSlackThreadStatusController({
+    channelId: input.channelId,
+    enabled: input.statusKeepalive !== false,
+    getThreadTs: () => currentThreadTs,
+    logger: log,
+    request,
+    state: input.statusKeepaliveState,
+  });
 
   const thread: SlackThread = {
     get recentMessages() {
@@ -518,28 +538,7 @@ export function buildSlackBinding(input: {
       );
       return { id: response.id, raw: response.raw };
     },
-    async startTyping(status) {
-      if (!input.channelId || !currentThreadTs) return;
-      try {
-        const normalizedStatus = status === undefined ? "" : truncateTypingStatus(status);
-        const body: Record<string, unknown> = {
-          channel_id: input.channelId,
-          thread_ts: currentThreadTs,
-          status: normalizedStatus,
-        };
-        if (normalizedStatus.length > 0) {
-          body.loading_messages = [normalizedStatus];
-        }
-        const response = await request("assistant.threads.setStatus", body);
-        if (response.ok !== true) {
-          log.warn("assistant.threads.setStatus returned not-ok", {
-            error: response.error,
-          });
-        }
-      } catch (error) {
-        logError(log, "startTyping threw — swallowed", error, { channelId: input.channelId });
-      }
-    },
+    startTyping: (status) => statusController.start(status),
     refresh() {
       return refreshMessages();
     },
@@ -558,7 +557,7 @@ export function buildSlackBinding(input: {
     uploadFiles,
   };
 
-  return { thread, slack };
+  return { thread, slack, status: statusController };
 }
 
 /**

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -424,6 +424,7 @@ export async function handleInteractionPost(
         channelId: interaction.channelId,
         threadTs: interaction.threadTs,
         teamId: interaction.teamId,
+        statusKeepalive: deps.config.statusKeepalive,
       });
       const slackCtx: SlackInteractionContext = {
         cancel: (options = {}) =>

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -24,6 +24,7 @@ import {
   SLACK_SECTION_TEXT_MAX_LENGTH,
 } from "#public/channels/slack/limits.js";
 import { defaultSlackAuth } from "#public/channels/slack/index.js";
+import { setSlackStatusKeepaliveTestSeams } from "#public/channels/slack/status-keepalive.js";
 import {
   constrainAuthorizationRequired,
   slackChannel,
@@ -308,6 +309,7 @@ describe("slackChannel() default event handlers", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
   afterEach(() => {
+    setSlackStatusKeepaliveTestSeams();
     vi.useRealTimers();
   });
 
@@ -656,6 +658,98 @@ describe("slackChannel() default event handlers", () => {
       status: "Working...",
       loading_messages: ["Working..."],
     });
+  });
+
+  it("refreshes a status without polling thread replies", async () => {
+    const sleepers: Array<() => void> = [];
+    setSlackStatusKeepaliveTestSeams({
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          sleepers.push(resolve);
+        }),
+    });
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("turn.started", { sequence: 0, stepIndex: 0, turnId: "t1" }),
+      ctx,
+    );
+    await vi.waitFor(() => expect(sleepers).toHaveLength(1));
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    sleepers.shift()!();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      "https://slack.com/api/assistant.threads.setStatus",
+    );
+    expect(parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit).status).toBe(
+      "Working...",
+    );
+  });
+
+  it("terminal events stop status keepalives before custom handlers run", async () => {
+    const sleepers: Array<() => void> = [];
+    const onTurnCompleted = vi.fn(async () => {});
+    setSlackStatusKeepaliveTestSeams({
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          sleepers.push(resolve);
+        }),
+    });
+    const adapter = withState(
+      getAdapter(
+        slackChannel({
+          credentials: { botToken: "xoxb-test" },
+          events: { "turn.completed": onTurnCompleted },
+        }),
+      ),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("turn.started", { sequence: 0, stepIndex: 0, turnId: "t1" }),
+      ctx,
+    );
+    await vi.waitFor(() => expect(sleepers).toHaveLength(1));
+    await callEvent(
+      adapter,
+      makeEvent("turn.completed", { sequence: 0, stepIndex: 0, turnId: "t1" }),
+      ctx,
+    );
+    fetchMock.mockClear();
+    sleepers.shift()!();
+    await Promise.resolve();
+
+    expect(onTurnCompleted).toHaveBeenCalledOnce();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("can disable status keepalives", async () => {
+    const sleep = vi.fn(() => new Promise<void>(() => {}));
+    setSlackStatusKeepaliveTestSeams({ sleep });
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" }, statusKeepalive: false })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("turn.started", { sequence: 0, stepIndex: 0, turnId: "t1" }),
+      ctx,
+    );
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("refreshes triggeringUserId from the current Slack caller on every turn", async () => {
@@ -1046,6 +1140,10 @@ describe("slackChannel() inbound mention pipeline", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
+  afterEach(() => {
+    setSlackStatusKeepaliveTestSeams();
+  });
+
   afterAll(() => {
     if (ORIGINAL_SIGNING_SECRET === undefined) {
       delete process.env.SLACK_SIGNING_SECRET;
@@ -1398,6 +1496,24 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(typingCall).toBeDefined();
     const sent = parseSlackRequestBody(typingCall![1] as RequestInit);
     expect(sent.status).toBe("Thinking...");
+  });
+
+  it("does not start an inbound status keepalive when disabled", async () => {
+    const sleep = vi.fn(() => new Promise<void>(() => {}));
+    setSlackStatusKeepaliveTestSeams({ sleep });
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      statusKeepalive: false,
+    });
+    const { body } = buildMentionBody();
+
+    await firePost(channel, buildSignedRequest({ body }));
+
+    const typingCalls = fetchMock.mock.calls.filter((call) =>
+      String(call[0]).includes("assistant.threads.setStatus"),
+    );
+    expect(typingCalls).toHaveLength(1);
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("returns 200 OK without dispatching for non-app_mention events", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -49,6 +49,7 @@ import {
 } from "#public/channels/slack/thread.js";
 import { slackUserIdFromAuthContext } from "#public/channels/slack/auth.js";
 import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#public/channels/slack/constants.js";
+import { stopSlackStatusKeepalive } from "#public/channels/slack/status-keepalive.js";
 import { handleInteractionPost } from "#public/channels/slack/interactions.js";
 import {
   mergeUploadPolicy,
@@ -196,6 +197,8 @@ export interface SlackChannelState {
    */
   lastReasoningTypingAtMs?: number | null;
   lastReasoningTypingStatus?: string | null;
+  /** Latest non-empty status eligible for durable workflow refresh. */
+  statusKeepaliveStatus?: string | null;
   /**
    * Connection name to Slack message ts. Each entry is the public
    * link-free status post created by the default
@@ -491,6 +494,13 @@ export interface SlackChannelConfig {
   readonly credentials?: SlackChannelCredentials;
   readonly botName?: string;
 
+  /**
+   * Periodically refreshes non-empty thread statuses before Slack expires
+   * them. Defaults to `true`. Set to `false` when the agent owns a custom
+   * status keepalive.
+   */
+  readonly statusKeepalive?: boolean;
+
   /** Override the default webhook route path (`/eve/v1/slack`). */
   readonly route?: string;
 
@@ -606,13 +616,15 @@ export interface SlackChannelConfig {
 function rebuildSlackContext(
   state: SlackChannelState,
   session: SessionHandle,
-  credentials: SlackChannelCredentials | undefined,
+  config: Pick<SlackChannelConfig, "credentials" | "statusKeepalive">,
 ): SlackChannelContext {
   const { thread, slack } = buildSlackBinding({
-    botToken: credentials?.botToken,
+    botToken: config.credentials?.botToken,
     channelId: state.channelId ?? "",
     threadTs: state.threadTs ?? "",
     teamId: state.teamId ?? undefined,
+    statusKeepalive: config.statusKeepalive,
+    statusKeepaliveState: state,
     onThreadTsChanged(ts) {
       state.threadTs = ts;
       if (state.channelId) {
@@ -621,6 +633,27 @@ function rebuildSlackContext(
     },
   });
   return { thread, slack, state };
+}
+
+function createSlackStatusBinding(
+  state: SlackChannelState,
+  config: Pick<SlackChannelConfig, "credentials" | "statusKeepalive">,
+) {
+  return buildSlackBinding({
+    botToken: config.credentials?.botToken,
+    channelId: state.channelId ?? "",
+    threadTs: state.threadTs ?? "",
+    teamId: state.teamId ?? undefined,
+    statusKeepalive: config.statusKeepalive,
+    statusKeepaliveState: state,
+  });
+}
+
+function stopThreadStatusKeepalive(channel: SlackEventContext): void {
+  channel.state.statusKeepaliveStatus = null;
+  if (channel.slack.channelId && channel.slack.threadTs) {
+    stopSlackStatusKeepalive(`${channel.slack.channelId}:${channel.slack.threadTs}`);
+  }
 }
 
 /**
@@ -649,15 +682,42 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
   const slackFetchFile = createSlackFetchFile({ botToken: config.credentials?.botToken });
   const authorizationRequiredOverride = config.events?.["authorization.required"];
   const turnStartedHandler = config.events?.["turn.started"] ?? defaultEvents["turn.started"]!;
+  const turnCompletedHandler = config.events?.["turn.completed"] ?? defaultEvents["turn.completed"];
+  const turnFailedHandler = config.events?.["turn.failed"] ?? defaultEvents["turn.failed"];
+  const turnCancelledHandler = config.events?.["turn.cancelled"] ?? defaultEvents["turn.cancelled"];
+  const sessionCompletedHandler =
+    config.events?.["session.completed"] ?? defaultEvents["session.completed"];
+  const sessionFailedHandler = config.events?.["session.failed"] ?? defaultEvents["session.failed"];
   const mergedEvents: SlackChannelInternalEvents = {
     ...defaultEvents,
     ...config.events,
     async "turn.started"(data, channel, ctx) {
+      stopThreadStatusKeepalive(channel);
       const triggeringUserId = slackUserIdFromAuthContext(ctx.session.auth.current);
       if (triggeringUserId !== undefined) {
         channel.state.triggeringUserId = triggeringUserId;
       }
       await turnStartedHandler(data, channel, ctx);
+    },
+    async "turn.completed"(data, channel, ctx) {
+      stopThreadStatusKeepalive(channel);
+      await turnCompletedHandler?.(data, channel, ctx);
+    },
+    async "turn.failed"(data, channel, ctx) {
+      stopThreadStatusKeepalive(channel);
+      await turnFailedHandler?.(data, channel, ctx);
+    },
+    async "turn.cancelled"(data, channel, ctx) {
+      stopThreadStatusKeepalive(channel);
+      await turnCancelledHandler?.(data, channel, ctx);
+    },
+    async "session.completed"(data, channel, ctx) {
+      stopThreadStatusKeepalive(channel);
+      await sessionCompletedHandler?.(data, channel, ctx);
+    },
+    async "session.failed"(data, channel) {
+      stopThreadStatusKeepalive(channel);
+      await sessionFailedHandler?.(data, channel);
     },
     "input.requested": config.events?.["input.requested"] ?? defaultInputRequestedHandler(),
     "authorization.required":
@@ -685,6 +745,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       pendingToolCallMessage: null,
       lastReasoningTypingAtMs: null,
       lastReasoningTypingStatus: null,
+      statusKeepaliveStatus: null,
       pendingAuthMessageTs: {},
     },
     fetchFile: slackFetchFile,
@@ -698,8 +759,17 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     },
 
     context(state, session) {
-      return rebuildSlackContext(state, session, config.credentials);
+      return rebuildSlackContext(state, session, config);
     },
+
+    statusKeepalive:
+      config.statusKeepalive === false
+        ? undefined
+        : {
+            suspend: (state) => createSlackStatusBinding(state, config).status.suspend(),
+            refresh: async (state) => createSlackStatusBinding(state, config).status.refresh(),
+            resume: (state) => createSlackStatusBinding(state, config).status.resume(),
+          },
 
     routes: [
       POST<SlackChannelState>(
@@ -894,6 +964,7 @@ async function handleEventPost(input: {
             resolveActiveSession: input.resolveActiveSession,
             reset: input.reset,
             send: input.send,
+            statusKeepalive: config.statusKeepalive,
             threadContext: config.threadContext,
             uploadPolicy: input.uploadPolicy,
           });
@@ -912,6 +983,7 @@ async function handleEventPost(input: {
             resolveActiveSession: input.resolveActiveSession,
             reset: input.reset,
             send: input.send,
+            statusKeepalive: config.statusKeepalive,
             threadContext: config.threadContext,
             uploadPolicy: input.uploadPolicy,
           });
@@ -941,6 +1013,7 @@ async function handleEventPost(input: {
             resolveActiveSession: input.resolveActiveSession,
             reset: input.reset,
             send: input.send,
+            statusKeepalive: config.statusKeepalive,
             threadContext: config.threadContext,
             uploadPolicy: input.uploadPolicy,
           });
@@ -1006,6 +1079,7 @@ async function dispatchSlackMessage(input: {
   readonly handler: NonNullable<SlackChannelConfig["onMessage"]>;
   readonly kind: "app_mention" | "channel_message" | "direct_message";
   readonly message: SlackMessage;
+  readonly statusKeepalive: boolean | undefined;
   readonly resolveActiveSession: (options: {
     readonly continuationToken: string;
   }) => Promise<{ readonly sessionId: string } | undefined>;
@@ -1022,6 +1096,7 @@ async function dispatchSlackMessage(input: {
     channelId: input.message.channelId,
     threadTs: input.message.threadTs,
     teamId: input.message.teamId,
+    statusKeepalive: input.statusKeepalive,
   });
   const ctx: SlackInboundMessageContext = {
     cancel: (options = {}) =>

--- a/packages/eve/src/public/channels/slack/status-keepalive.test.ts
+++ b/packages/eve/src/public/channels/slack/status-keepalive.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  setSlackStatusKeepaliveTestSeams,
+  startSlackStatusKeepalive,
+  stopSlackStatusKeepalive,
+} from "#public/channels/slack/status-keepalive.js";
+
+describe("Slack status keepalive", () => {
+  afterEach(() => {
+    setSlackStatusKeepaliveTestSeams();
+  });
+
+  it("refreshes the latest status", async () => {
+    const sleepers: Array<() => void> = [];
+    const refresh = vi.fn(async () => {});
+    setSlackStatusKeepaliveTestSeams({
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          sleepers.push(resolve);
+        }),
+    });
+
+    startSlackStatusKeepalive({ key: "C01:1", refresh, status: "Working..." });
+    startSlackStatusKeepalive({ key: "C01:1", refresh, status: "Searching..." });
+
+    await vi.waitFor(() => expect(sleepers).toHaveLength(1));
+    sleepers.shift()!();
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledWith("Searching..."));
+    await vi.waitFor(() => expect(sleepers).toHaveLength(1));
+    sleepers.shift()!();
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(2));
+  });
+
+  it("transfers active ownership to a durable wait", async () => {
+    const sleepers: Array<() => void> = [];
+    const refresh = vi.fn(async () => {});
+    setSlackStatusKeepaliveTestSeams({
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          sleepers.push(resolve);
+        }),
+    });
+
+    startSlackStatusKeepalive({
+      key: "C01:1",
+      refresh,
+      status: "Working...",
+    });
+    await vi.waitFor(() => expect(sleepers).toHaveLength(1));
+    stopSlackStatusKeepalive("C01:1");
+    sleepers.shift()!();
+    await Promise.resolve();
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stopped keepalive refresh", async () => {
+    const sleepers: Array<() => void> = [];
+    const refresh = vi.fn(async () => {});
+    setSlackStatusKeepaliveTestSeams({
+      sleep: () =>
+        new Promise<void>((resolve) => {
+          sleepers.push(resolve);
+        }),
+    });
+
+    startSlackStatusKeepalive({
+      key: "C01:1",
+      refresh,
+      status: "Working...",
+    });
+    await vi.waitFor(() => expect(sleepers).toHaveLength(1));
+    stopSlackStatusKeepalive("C01:1");
+    sleepers.shift()!();
+    await Promise.resolve();
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/public/channels/slack/status-keepalive.ts
+++ b/packages/eve/src/public/channels/slack/status-keepalive.ts
@@ -1,0 +1,73 @@
+export const SLACK_STATUS_KEEPALIVE_REFRESH_INTERVAL_MS = 75_000;
+const STATUS_KEEPALIVE_MAX_LIFETIME_MS = 12 * 60_000;
+
+interface StatusKeepaliveEntry {
+  refresh: (status: string) => Promise<void>;
+  startedAt: number;
+  status: string;
+}
+
+interface StatusKeepaliveSeams {
+  readonly now: () => number;
+  readonly sleep: (durationMs: number) => Promise<void>;
+}
+
+const entries = new Map<string, StatusKeepaliveEntry>();
+let seams: StatusKeepaliveSeams = {
+  now: Date.now,
+  sleep: defaultSleep,
+};
+
+/** @internal Test seam for the Slack status keepalive. */
+export function setSlackStatusKeepaliveTestSeams(overrides?: Partial<StatusKeepaliveSeams>): void {
+  entries.clear();
+  seams = {
+    now: overrides?.now ?? Date.now,
+    sleep: overrides?.sleep ?? defaultSleep,
+  };
+}
+
+export function startSlackStatusKeepalive(input: {
+  readonly key: string;
+  readonly refresh: (status: string) => Promise<void>;
+  readonly status: string;
+}): void {
+  const existing = entries.get(input.key);
+  if (existing !== undefined) {
+    existing.refresh = input.refresh;
+    existing.startedAt = seams.now();
+    existing.status = input.status;
+    return;
+  }
+
+  const entry: StatusKeepaliveEntry = {
+    refresh: input.refresh,
+    startedAt: seams.now(),
+    status: input.status,
+  };
+  entries.set(input.key, entry);
+
+  void runStatusKeepalive(input.key, entry).catch(() => {
+    if (entries.get(input.key) === entry) entries.delete(input.key);
+  });
+}
+
+export function stopSlackStatusKeepalive(key: string): void {
+  entries.delete(key);
+}
+
+async function runStatusKeepalive(key: string, entry: StatusKeepaliveEntry): Promise<void> {
+  while (seams.now() - entry.startedAt < STATUS_KEEPALIVE_MAX_LIFETIME_MS) {
+    await seams.sleep(SLACK_STATUS_KEEPALIVE_REFRESH_INTERVAL_MS);
+    if (entries.get(key) !== entry) return;
+    await entry.refresh(entry.status);
+  }
+  if (entries.get(key) === entry) entries.delete(key);
+}
+
+function defaultSleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, durationMs);
+    timer.unref?.();
+  });
+}

--- a/packages/eve/src/public/channels/slack/thread-status.ts
+++ b/packages/eve/src/public/channels/slack/thread-status.ts
@@ -1,0 +1,104 @@
+import { logError, type Logger } from "#internal/logging.js";
+import { truncateTypingStatus } from "#public/channels/slack/limits.js";
+import {
+  SLACK_STATUS_KEEPALIVE_REFRESH_INTERVAL_MS,
+  startSlackStatusKeepalive,
+  stopSlackStatusKeepalive,
+} from "#public/channels/slack/status-keepalive.js";
+import type { SlackApiResponse } from "#public/channels/slack/api.js";
+
+export interface SlackThreadStatusController {
+  clear(): void;
+  handleAnchor(ts: string): void;
+  refresh(): Promise<number | undefined>;
+  resume(): void;
+  start(status?: string): Promise<void>;
+  suspend(): number | undefined;
+}
+
+export function createSlackThreadStatusController(input: {
+  readonly channelId: string;
+  readonly enabled: boolean;
+  readonly getThreadTs: () => string;
+  readonly logger: Logger;
+  readonly request: (operation: string, body: unknown) => Promise<SlackApiResponse>;
+  readonly state?: { statusKeepaliveStatus?: string | null };
+}): SlackThreadStatusController {
+  const key = (): string | undefined => {
+    const threadTs = input.getThreadTs();
+    return input.channelId && threadTs ? `${input.channelId}:${threadTs}` : undefined;
+  };
+
+  const clear = (): void => {
+    const currentKey = key();
+    if (currentKey !== undefined) stopSlackStatusKeepalive(currentKey);
+    if (input.state !== undefined) input.state.statusKeepaliveStatus = null;
+  };
+
+  const setStatus = async (threadTs: string, status: string): Promise<void> => {
+    try {
+      const body: Record<string, unknown> = {
+        channel_id: input.channelId,
+        thread_ts: threadTs,
+        status,
+      };
+      if (status.length > 0) body.loading_messages = [status];
+      const response = await input.request("assistant.threads.setStatus", body);
+      if (response.ok !== true) {
+        input.logger.warn("assistant.threads.setStatus returned not-ok", { error: response.error });
+      }
+    } catch (error) {
+      logError(input.logger, "startTyping threw — swallowed", error, {
+        channelId: input.channelId,
+      });
+    }
+  };
+
+  return {
+    clear,
+    handleAnchor() {
+      clear();
+    },
+    async refresh() {
+      const status = input.state?.statusKeepaliveStatus;
+      const threadTs = input.getThreadTs();
+      if (!input.enabled || !status || !input.channelId || !threadTs) return undefined;
+      await setStatus(threadTs, status);
+      return SLACK_STATUS_KEEPALIVE_REFRESH_INTERVAL_MS;
+    },
+    resume() {
+      const currentKey = key();
+      const status = input.state?.statusKeepaliveStatus;
+      const threadTs = input.getThreadTs();
+      if (!input.enabled || !currentKey || !status || !threadTs) return;
+      startSlackStatusKeepalive({
+        key: currentKey,
+        refresh: (nextStatus) => setStatus(threadTs, nextStatus),
+        status,
+      });
+    },
+    async start(status) {
+      const threadTs = input.getThreadTs();
+      if (!input.channelId || !threadTs) return;
+      const normalized = status === undefined ? "" : truncateTypingStatus(status);
+      await setStatus(threadTs, normalized);
+      if (!normalized || !input.enabled) {
+        clear();
+        return;
+      }
+      if (input.state !== undefined) input.state.statusKeepaliveStatus = normalized;
+      startSlackStatusKeepalive({
+        key: key()!,
+        refresh: (nextStatus) => setStatus(threadTs, nextStatus),
+        status: normalized,
+      });
+    },
+    suspend() {
+      const currentKey = key();
+      const status = input.state?.statusKeepaliveStatus;
+      if (!input.enabled || !currentKey || !status) return undefined;
+      stopSlackStatusKeepalive(currentKey);
+      return SLACK_STATUS_KEEPALIVE_REFRESH_INTERVAL_MS;
+    },
+  };
+}

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -383,7 +383,8 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
   const hasFetchFile = definition.fetchFile !== undefined;
   const metadata = definition.metadata;
   const hasMetadata = metadata !== undefined;
-  const hasBehavior = hasState || hasContext || hasMetadata;
+  const statusKeepalive = definition.statusKeepalive;
+  const hasBehavior = hasState || hasContext || hasMetadata || statusKeepalive !== undefined;
 
   const eventHandlers: Record<string, unknown> = {};
   let hasEventHandlers = false;
@@ -448,6 +449,18 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
     deliver(payload: DeliverPayload) {
       return defaultDeliverResult(payload);
     },
+
+    statusKeepalive:
+      statusKeepalive === undefined
+        ? undefined
+        : {
+            suspend: (adapterCtx: any) =>
+              statusKeepalive.suspend(adapterCtx.state, adapterCtx.session),
+            refresh: (adapterCtx: any) =>
+              statusKeepalive.refresh(adapterCtx.state, adapterCtx.session),
+            resume: (adapterCtx: any) =>
+              statusKeepalive.resume(adapterCtx.state, adapterCtx.session),
+          },
 
     ...eventHandlers,
   } as ChannelAdapter<any>;

--- a/packages/eve/src/runtime/channels/registry.ts
+++ b/packages/eve/src/runtime/channels/registry.ts
@@ -41,6 +41,7 @@ const ADAPTER_NON_EVENT_FIELDS: ReadonlySet<string> = new Set([
   "createAdapterContext",
   "fetchFile",
   "instrumentation",
+  "statusKeepalive",
 ]);
 
 /**

--- a/packages/eve/src/shared/channel-definition.ts
+++ b/packages/eve/src/shared/channel-definition.ts
@@ -105,4 +105,14 @@ export interface GenericChannelDefinition<
    * for stateful ones.
    */
   readonly kindHint?: string;
+
+  /** @internal Channel status lifecycle across durable workflow waits. */
+  readonly statusKeepalive?: {
+    readonly suspend: (state: NonNullable<TState>, session: SessionHandle) => number | undefined;
+    readonly refresh: (
+      state: NonNullable<TState>,
+      session: SessionHandle,
+    ) => Promise<number | undefined>;
+    readonly resume: (state: NonNullable<TState>, session: SessionHandle) => void;
+  };
 }


### PR DESCRIPTION
## Summary

Slack thread statuses now stay visible during long-running work by default instead of expiring after two minutes without an update.

Under the hood:
- While an invocation is active, eve reapplies the latest status every 75 seconds.
- While the parent waits on a subagent, the parent workflow takes over refreshing the status without keeping an invocation alive.
- When the subagent returns, refresh ownership moves back to the active invocation for the rest of the turn.

Refreshing stops when the agent posts a reply, the status is explicitly cleared, a new turn starts, or the active turn/session completes, fails, or is cancelled. Setting a new status replaces the current text and continues the keepalive.

Users can disable the behavior when providing a custom status refresh loop:

```ts
slackChannel({
  credentials,
  statusKeepalive: false,
});
```

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/api.test.ts src/public/channels/slack/status-keepalive.test.ts src/public/channels/slack/slackChannel.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`

## Notes

- `pnpm typecheck` reached the fixture builds but failed in `agent-tools-sandbox` because the local optional package `@superradcompany/microsandbox-linux-x64-gnu` is absent. The scoped `eve` typecheck passes.
