### PR TITLE
fix(eve): coalesce task-await results with task wakes

### DIFF
--- a/.changeset/task-await-wake-coalescing.md
+++ b/.changeset/task-await-wake-coalescing.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent task completion from starting a duplicate parent turn when `task_await` already reports that ready transition. Cancelled awaits release their wake claims so later task completion still wakes the parent.

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -153,6 +153,11 @@ export interface DeliverPayload {
   readonly message?: string | UserContent;
   readonly context?: readonly string[];
   readonly outputSchema?: JsonObject;
+  /** Framework task-ready notification; never authored by a channel caller. */
+  readonly taskNotification?: {
+    readonly status: "input_required" | "completed" | "failed" | "cancelled";
+    readonly taskId: string;
+  };
   readonly [key: string]: unknown;
 }
 

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DeliverHookPayload } from "#channel/types.js";
+import { nextTurnDelivery } from "#execution/parked-delivery-wait.js";
+import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
+import { filterAwaitedTaskWakePayloadsStep } from "#execution/tasks/wake-suppression-step.js";
+import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
+
+vi.mock("./tasks/wake-suppression-step.js", () => ({
+  filterAwaitedTaskWakePayloadsStep: vi.fn(),
+}));
+
+vi.mock("./route-child-delivery.js", () => ({
+  routeDeliverToChildren: vi.fn(),
+}));
+
+describe("nextTurnDelivery task wake suppression", () => {
+  it("routes only unsuppressed payloads and carries the updated session state", async () => {
+    const taskWake = {
+      kind: "deliver",
+      payloads: [
+        {
+          message: "task done",
+          taskNotification: { status: "completed", taskId: "task_1" },
+        },
+        { message: "ordinary delivery" },
+      ],
+    } satisfies DeliverHookPayload;
+    const initialState = {
+      continuationToken: "token",
+      emissionState: { sequence: 0, sessionStarted: false, stepIndex: 0, turnId: "turn" },
+      hasProxyInputRequests: false,
+      sessionId: "session",
+      version: 1,
+    } as const;
+    const filteredState = { ...initialState, continuationToken: "next-token" };
+    vi.mocked(filterAwaitedTaskWakePayloadsStep).mockResolvedValue({
+      payloads: [{ message: "ordinary delivery" }],
+      sessionState: filteredState,
+    });
+    vi.mocked(routeDeliverToChildren).mockResolvedValue({
+      kind: "continue",
+      remainder: { message: "ordinary delivery" },
+    });
+    const hook: SessionDeliveryHook = {
+      consumeNext: vi.fn(),
+      consumeSessionTimeout: () => false,
+      next: vi.fn(),
+      rekey: vi.fn(),
+    };
+
+    const result = await nextTurnDelivery({
+      bufferedDeliveries: [taskWake],
+      deliveryHook: hook,
+      driverWritable: new WritableStream<Uint8Array>(),
+      serializedContext: {},
+      sessionState: initialState,
+    });
+
+    expect(result).toMatchObject({
+      kind: "turn",
+      remainder: { message: "ordinary delivery" },
+      sessionState: filteredState,
+    });
+    expect(routeDeliverToChildren).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [{ message: "ordinary delivery" }],
+        sessionState: filteredState,
+      }),
+    );
+  });
+});

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -2,6 +2,7 @@ import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import type { SessionDeliveryHook } from "#execution/session-delivery-hook.js";
+import { filterAwaitedTaskWakePayloadsStep } from "#execution/tasks/wake-suppression-step.js";
 import { coalesceDeliveries } from "#harness/messages.js";
 
 type NextSessionAction =
@@ -20,6 +21,7 @@ export type NextTurnInstruction =
       readonly kind: "turn";
       readonly deliver: DeliverHookPayload;
       readonly remainder: DeliverPayload;
+      readonly sessionState: DurableSessionState;
     };
 
 /**
@@ -33,8 +35,10 @@ export async function nextTurnDelivery(input: {
   readonly bufferedDeliveries: DeliverHookPayload[];
   readonly deliveryHook: SessionDeliveryHook;
   readonly driverWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<NextTurnInstruction> {
+  let sessionState = input.sessionState;
   while (true) {
     const nextAction = await waitForNextSessionAction({
       bufferedDeliveries: input.bufferedDeliveries,
@@ -50,11 +54,22 @@ export async function nextTurnDelivery(input: {
       return { kind: "closed" };
     }
 
+    const filtered = await filterAwaitedTaskWakePayloadsStep({
+      payloads: deliver.payloads,
+      serializedContext: input.serializedContext,
+      sessionState,
+    });
+    sessionState = filtered.sessionState;
+    if (filtered.payloads.length === 0) {
+      // A completed task_await already reported every task in this delivery.
+      continue;
+    }
+
     const routed = await routeDeliverToChildren({
       auth: deliver.auth,
       parentWritable: input.driverWritable,
-      payloads: deliver.payloads,
-      sessionState: input.sessionState,
+      payloads: filtered.payloads,
+      sessionState,
     });
 
     if (routed.kind === "cancel-turn") {
@@ -66,7 +81,7 @@ export async function nextTurnDelivery(input: {
       continue;
     }
 
-    return { deliver, kind: "turn", remainder: routed.remainder };
+    return { deliver, kind: "turn", remainder: routed.remainder, sessionState };
   }
 }
 

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -33,6 +33,7 @@ import {
   type UnstampedMessageStreamEvent,
   stampMessageStreamEvent,
 } from "#protocol/message.js";
+import { clearAwaitedTaskWakeSuppressions } from "#tasks/wake-suppression.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 
 export interface CancelledTurnSettleResult {
@@ -124,15 +125,17 @@ export async function settleCancelledTurnStep(input: {
   // discarded turn state). The pre-model gate re-raises the prompt while the
   // violation holds, so the next delivery gets a fresh prompt instead of
   // queueing forever behind a stale one.
-  const cancelledSession = reconcileSessionContinuationToken(
-    ctx,
-    setHarnessEmissionState(
-      clearPendingSessionLimitPrompt(
-        clearAllProxyInputRequests(
-          clearPendingWorkflowInterrupt(clearPendingRuntimeActionBatch(session)),
+  const cancelledSession = clearAwaitedTaskWakeSuppressions(
+    reconcileSessionContinuationToken(
+      ctx,
+      setHarnessEmissionState(
+        clearPendingSessionLimitPrompt(
+          clearAllProxyInputRequests(
+            clearPendingWorkflowInterrupt(clearPendingRuntimeActionBatch(session)),
+          ),
         ),
+        emissionState,
       ),
-      emissionState,
     ),
   );
 

--- a/packages/eve/src/execution/tasks/dispatch.ts
+++ b/packages/eve/src/execution/tasks/dispatch.ts
@@ -36,6 +36,7 @@ import {
 } from "#runtime/framework-tools/tasks.js";
 import type { SessionTaskIndexEntry } from "#tasks/session-index.js";
 import { isReadyTaskStatus, type TaskView } from "#tasks/types.js";
+import { suppressAwaitedTaskWakes } from "#tasks/wake-suppression.js";
 
 export {
   beginDelegatedTask,
@@ -110,7 +111,10 @@ export async function executeTaskControlAction(input: {
     case TASK_AWAIT_TOOL_NAME: {
       const views = await readTaskViews(entries);
       if (views.every((view) => isReadyTaskStatus(view.status))) {
-        return { result: createTaskViewsResult(action, views), session };
+        return {
+          result: createTaskViewsResult(action, views),
+          session: suppressAwaitedTaskWakes(session, taskIds),
+        };
       }
       if (input.parentContinuationToken === undefined) {
         return {
@@ -133,7 +137,10 @@ export async function executeTaskControlAction(input: {
           toolName: action.toolName,
         },
       ]);
-      return { result: undefined, session };
+      return {
+        result: undefined,
+        session: suppressAwaitedTaskWakes(session, taskIds),
+      };
     }
     default:
       return {

--- a/packages/eve/src/execution/tasks/run-steps.ts
+++ b/packages/eve/src/execution/tasks/run-steps.ts
@@ -10,7 +10,7 @@ import type { DeliverHookPayload } from "#channel/types.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 import { createLogger } from "#internal/logging.js";
 import { walkCauseChain } from "#shared/errors.js";
-import { TASK_SNAPSHOT_STREAM_NAMESPACE, type TaskView } from "#tasks/types.js";
+import { TASK_SNAPSHOT_STREAM_NAMESPACE, type TaskStatus, type TaskView } from "#tasks/types.js";
 
 const log = createLogger("execution.tasks.run");
 
@@ -50,6 +50,10 @@ export async function wakeTaskParentStep(input: {
     payloads: [
       {
         message: formatTaskNotification(input.view),
+        taskNotification: {
+          status: readyNotificationStatus(input.view.status),
+          taskId: input.view.taskId,
+        },
       },
     ],
   };
@@ -65,6 +69,13 @@ export async function wakeTaskParentStep(input: {
     }
     throw error;
   }
+}
+
+function readyNotificationStatus(status: TaskStatus): Exclude<TaskStatus, "working"> {
+  if (status === "working") {
+    throw new Error("Cannot wake a parent for a working task.");
+  }
+  return status;
 }
 
 function formatTaskNotification(view: TaskView): string {

--- a/packages/eve/src/execution/tasks/wake-suppression-step.ts
+++ b/packages/eve/src/execution/tasks/wake-suppression-step.ts
@@ -1,0 +1,41 @@
+import type { DeliverPayload } from "#channel/types.js";
+import { deserializeContext } from "#context/serialize.js";
+import {
+  createDurableSessionState,
+  type DurableSessionState,
+  readDurableSession,
+} from "#execution/durable-session-store.js";
+import { hydrateDurableSession } from "#execution/session.js";
+import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
+import { consumeAwaitedTaskWakes } from "#tasks/wake-suppression.js";
+
+/** Filters task wake payloads already consumed by a completed `task_await`. */
+export async function filterAwaitedTaskWakePayloadsStep(input: {
+  readonly payloads: readonly DeliverPayload[];
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<{
+  readonly payloads: readonly DeliverPayload[];
+  readonly sessionState: DurableSessionState;
+}> {
+  "use step";
+
+  const durable = await readDurableSession(input.sessionState);
+  const ctx = await deserializeContext(input.serializedContext);
+  const bundle = ctx.require(BundleKey);
+  const session = hydrateDurableSession({
+    compactionOverrides: {
+      thresholdPercent: bundle.resolvedAgent.config.compaction?.thresholdPercent,
+    },
+    durable,
+    turnAgent: bundle.turnAgent,
+  });
+  const filtered = consumeAwaitedTaskWakes(session, input.payloads);
+  return {
+    payloads: filtered.payloads,
+    sessionState:
+      filtered.session === session
+        ? input.sessionState
+        : createDurableSessionState({ session: filtered.session }),
+  };
+}

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -62,6 +62,12 @@ vi.mock("./route-child-delivery.js", () => ({
   })),
 }));
 
+vi.mock("./tasks/wake-suppression-step.js", () => ({
+  filterAwaitedTaskWakePayloadsStep: vi
+    .fn()
+    .mockImplementation(async ({ payloads, sessionState }) => ({ payloads, sessionState })),
+}));
+
 vi.mock("./delegated-parent-notification.js", () => ({
   notifyDelegatedParentStep: vi.fn().mockResolvedValue(undefined),
   notifyTurnCallerStep: vi.fn().mockResolvedValue(undefined),

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -399,6 +399,7 @@ async function runDriverLoop(input: {
         bufferedDeliveries,
         deliveryHook,
         driverWritable: input.driverWritable,
+        serializedContext: action.serializedContext,
         sessionState: action.sessionState,
       });
 
@@ -449,7 +450,7 @@ async function runDriverLoop(input: {
           requestId: next.deliver.requestId,
         },
         serializedContext: action.serializedContext,
-        sessionState: action.sessionState,
+        sessionState: next.sessionState,
       });
       input.crashCleanupState.lastSessionState = action.sessionState;
     }

--- a/packages/eve/src/tasks/wake-suppression.test.ts
+++ b/packages/eve/src/tasks/wake-suppression.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeliverPayload } from "#channel/types.js";
+import type { HarnessSession } from "#harness/types.js";
+import {
+  clearAwaitedTaskWakeSuppressions,
+  consumeAwaitedTaskWakes,
+  suppressAwaitedTaskWakes,
+} from "#tasks/wake-suppression.js";
+
+function createSession(): HarnessSession {
+  return {
+    agent: { modelReference: { id: "test-model" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 4, threshold: 1_000_000 },
+    continuationToken: "continuation_parent",
+    history: [],
+    sessionId: "session_parent",
+  };
+}
+
+const taskWake: DeliverPayload = {
+  message: "Background task task_1 is completed.",
+  taskNotification: { status: "completed", taskId: "task_1" },
+};
+
+describe("task wake suppression", () => {
+  it("drops the wake claimed by task_await", () => {
+    const session = suppressAwaitedTaskWakes(createSession(), ["task_1"]);
+
+    const consumed = consumeAwaitedTaskWakes(session, [taskWake]);
+
+    expect(consumed.payloads).toEqual([]);
+  });
+
+  it("keeps the wake after a cancelled await releases its claim", () => {
+    const session = clearAwaitedTaskWakeSuppressions(
+      suppressAwaitedTaskWakes(createSession(), ["task_1"]),
+    );
+
+    const consumed = consumeAwaitedTaskWakes(session, [taskWake]);
+
+    expect(consumed.payloads).toEqual([taskWake]);
+  });
+
+  it("leaves unrelated deliveries and their later suppression intact", () => {
+    const session = suppressAwaitedTaskWakes(createSession(), ["task_1"]);
+    const unrelated = { message: "hello" };
+
+    const first = consumeAwaitedTaskWakes(session, [unrelated]);
+    const second = consumeAwaitedTaskWakes(first.session, [taskWake]);
+
+    expect(first.payloads).toEqual([unrelated]);
+    expect(second.payloads).toEqual([]);
+  });
+});

--- a/packages/eve/src/tasks/wake-suppression.ts
+++ b/packages/eve/src/tasks/wake-suppression.ts
@@ -1,0 +1,91 @@
+import type { DeliverPayload } from "#channel/types.js";
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+
+const TASK_WAKE_SUPPRESSIONS_STATE_KEY = "eve.tasks.wakeSuppressions";
+
+interface TaskWakeSuppression {
+  readonly taskId: string;
+}
+
+interface TaskWakeSuppressionStore {
+  readonly entries: readonly TaskWakeSuppression[];
+}
+
+/** Claims each task's next ready wake for the active `task_await`. */
+export function suppressAwaitedTaskWakes(
+  session: HarnessSession,
+  taskIds: readonly string[],
+): HarnessSession {
+  const existing = readSuppressions(session.state);
+  return writeSuppressions(session, [...existing, ...taskIds.map((taskId) => ({ taskId }))]);
+}
+
+/**
+ * Drops task wake payloads claimed by `task_await`. Every matching entry is
+ * consumed: one await suppresses only the ready transition it observes.
+ * Turn cancellation clears outstanding claims before the parent parks again.
+ */
+export function consumeAwaitedTaskWakes(
+  session: HarnessSession,
+  payloads: readonly DeliverPayload[],
+): { readonly payloads: readonly DeliverPayload[]; readonly session: HarnessSession } {
+  const existing = readSuppressions(session.state);
+  if (existing.length === 0) return { payloads, session };
+
+  const consumedTaskIds = new Set<string>();
+  const kept = payloads.filter((payload) => {
+    const taskId = payload.taskNotification?.taskId;
+    if (taskId === undefined || !existing.some((entry) => entry.taskId === taskId)) return true;
+    consumedTaskIds.add(taskId);
+    return false;
+  });
+  if (consumedTaskIds.size === 0) return { payloads, session };
+
+  return {
+    payloads: kept,
+    session: writeSuppressions(
+      session,
+      existing.filter((entry) => !consumedTaskIds.has(entry.taskId)),
+    ),
+  };
+}
+
+/** Releases claims from a cancelled task-await turn. */
+export function clearAwaitedTaskWakeSuppressions(session: HarnessSession): HarnessSession {
+  return writeSuppressions(session, []);
+}
+
+function readSuppressions(state: SessionStateMap | undefined): readonly TaskWakeSuppression[] {
+  const raw = state?.[TASK_WAKE_SUPPRESSIONS_STATE_KEY];
+  if (raw === undefined) return [];
+  if (raw === null || typeof raw !== "object" || !("entries" in raw)) {
+    throw new Error(`Corrupt task wake suppressions under "${TASK_WAKE_SUPPRESSIONS_STATE_KEY}".`);
+  }
+  const entries = raw.entries;
+  if (!Array.isArray(entries)) {
+    throw new Error(`Corrupt task wake suppressions under "${TASK_WAKE_SUPPRESSIONS_STATE_KEY}".`);
+  }
+  return entries.map((entry) => {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      !("taskId" in entry) ||
+      typeof entry.taskId !== "string"
+    ) {
+      throw new Error(
+        `Corrupt task wake suppressions under "${TASK_WAKE_SUPPRESSIONS_STATE_KEY}".`,
+      );
+    }
+    return { taskId: entry.taskId };
+  });
+}
+
+function writeSuppressions(
+  session: HarnessSession,
+  entries: readonly TaskWakeSuppression[],
+): HarnessSession {
+  const state = { ...session.state };
+  if (entries.length === 0) delete state[TASK_WAKE_SUPPRESSIONS_STATE_KEY];
+  else state[TASK_WAKE_SUPPRESSIONS_STATE_KEY] = { entries } satisfies TaskWakeSuppressionStore;
+  return { ...session, state: Object.keys(state).length === 0 ? undefined : state };
+}


### PR DESCRIPTION
Stacked on #1564. The newly visible duplicate transcript was two real parent turns:

1. `task_await` reported the ready task inside the active turn.
2. The task run's unconditional completion wake was buffered, then started another turn that peeked and reported the same task again.

## Data flow

| | Before | After |
| --- | --- | --- |
| `task_await` starts | aggregator waits for task snapshots | aggregator waits, and parent session state claims those task ids' next ready wakes |
| task becomes ready | task run delivers a plain wake message | wake payload also carries framework-owned `{ taskId, status }` metadata |
| parent parks | buffered wake always starts a turn | parked delivery filter consumes a matching await claim and drops that wake; unrelated payloads still run |
| await turn cancels | no explicit wake ownership | cancellation releases outstanding claims, so later completion still wakes the parent |

The filter sits at the parked delivery boundary because that is where both facts are durable: the task-await dispatch's updated parent session state and any task wake buffered while the turn was active. It runs before child-response routing and before a new parent turn is started.

Claims are one-shot. A matching wake consumes its claim; `input_required` followed by `task_send` can therefore wake again on completion. `task_peek`, plain background completion, and cancelled awaits keep their existing wake behavior.

Manual transcript checks against shape 08:

- synchronous workshop: one `Awaited task`, one `BUILD LOG v1`, no queued `Checked task` turn;
- natural-language background continuation: receipt in 6s with no await, then one `Checked task` and one `BUILD LOG v2` on completion.

Part of #1084.