### PR TITLE
fix(eve): gate localDev() on the dev environment, not the request host

### DIFF
--- a/.changeset/local-dev-env-gated.md
+++ b/.changeset/local-dev-env-gated.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+`localDev()` now grants the synthetic local principal based on the deployment (an `eve dev` or `vercel dev` process) instead of the request URL host, so a request `Host` header can no longer obtain local-dev access on a self-hosted server. The previously exported `isLoopbackRequest` helper is removed. The default eve channel now falls back to `[vercelOidc(), localDev(), placeholderAuth()]`, which keeps local dev working and rejects all production traffic.

--- a/.github/workflows/e2e-postgres.yml
+++ b/.github/workflows/e2e-postgres.yml
@@ -151,7 +151,7 @@ jobs:
           pnpm exec eve build
 
           server_log="$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}-server.log"
-          pnpm exec eve start --host 127.0.0.1 --port 3000 >"$server_log" 2>&1 &
+          EVE_DEV=1 pnpm exec eve start --host 127.0.0.1 --port 3000 >"$server_log" 2>&1 &
           server_pid=$!
 
           cleanup() {

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -113,7 +113,7 @@ The `auth` option decides who can call `/eve/v1/info` and the session routes. Th
 
 Neither admits browser users or external clients in production. For a public app, wire the channel to your own auth (Clerk, Auth.js, your own OIDC/JWT verification, an API-key verifier, or any custom `AuthFn`). Vercel OIDC is optional; use it only when Vercel-issued deployment tokens are part of your trust model.
 
-`eve init` scaffolds an `agent/channels/eve.ts` with a production placeholder so you replace it before going live. The generated channel checks Vercel OIDC before falling back to localhost access, and includes `placeholderAuth()`, which returns a setup-focused 401 in production until you swap it for real auth. Delete the file and eve falls back to `[vercelOidc(), localDev()]`, which still does not admit browser users in production.
+`eve init` scaffolds an `agent/channels/eve.ts` with a production placeholder so you replace it before going live. The generated channel checks Vercel OIDC before falling back to localhost access, and includes `placeholderAuth()`, which returns a setup-focused 401 in production until you swap it for real auth. Delete the file and eve falls back to `[vercelOidc(), localDev(), placeholderAuth()]`, which rejects all production traffic.
 
 For the full auth model and helper list, see [Auth & route protection](../guides/auth-and-route-protection).
 

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -208,7 +208,7 @@ Start with the [TypeScript SDK](../guides/client/overview) guide. It covers basi
 curl http://127.0.0.1:2000/eve/v1/info
 ```
 
-With the default auth chain (`[vercelOidc(), localDev()]`), a local Vercel OIDC bearer takes precedence and other local requests fall back to development access. A deployed Vercel target requires a valid OIDC bearer, with a same-project bypass for in-deployment callers. See [auth & route protection](../guides/auth-and-route-protection).
+With the default auth chain (`[vercelOidc(), localDev(), placeholderAuth()]`), a Vercel OIDC bearer takes precedence, an `eve dev` or `vercel dev` server authenticates local requests, and everything else is rejected. A deployed Vercel target requires a valid OIDC bearer, with a same-project bypass for in-deployment callers. See [auth & route protection](../guides/auth-and-route-protection).
 
 ## Dispatch order
 

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -18,7 +18,7 @@ The route-auth policy lives on the HTTP channel factory (`agent/channels/eve.ts`
 - `POST /eve/v1/session/:sessionId`
 - `GET /eve/v1/session/:sessionId/stream`
 
-These routes are protected by the channel's auth policy. eve fails closed by default: production browser traffic is rejected unless you configure an authenticator that accepts it, and anonymous access requires an explicit `none()`.
+These routes are protected by the channel's auth policy. eve fails closed by default: production traffic is rejected unless you configure an authenticator that accepts it, and anonymous access requires an explicit `none()`.
 
 `GET /eve/v1/health` is always public and skips the walk entirely, so load balancers and uptime monitors can probe it without credentials.
 
@@ -86,15 +86,15 @@ Any other thrown error follows the normal channel failure path. When building a 
 
 `eve/channels/auth` ships these channel-auth helpers:
 
-| Helper           | Use when                                                                  |
-| ---------------- | ------------------------------------------------------------------------- |
-| `localDev()`     | Local development. Accepts requests addressed to a loopback hostname.     |
-| `vercelOidc()`   | The common Vercel deployment path. Verifies a Vercel OIDC bearer JWT.     |
-| `none()`         | You want to accept anonymous traffic explicitly (use as the final entry). |
-| `httpBasic(...)` | Operator or service access via a shared username/password.                |
-| `jwtHmac(...)`   | You control a shared-secret JWT signer.                                   |
-| `jwtEcdsa(...)`  | You verify asymmetric JWTs minted by another system.                      |
-| `oidc(...)`      | You want eve to verify OIDC-issued tokens from an arbitrary issuer.       |
+| Helper           | Use when                                                                                           |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| `localDev()`     | Local development. Accepts requests only while the process is an `eve dev` or `vercel dev` server. |
+| `vercelOidc()`   | The common Vercel deployment path. Verifies a Vercel OIDC bearer JWT.                              |
+| `none()`         | You want to accept anonymous traffic explicitly (use as the final entry).                          |
+| `httpBasic(...)` | Operator or service access via a shared username/password.                                         |
+| `jwtHmac(...)`   | You control a shared-secret JWT signer.                                                            |
+| `jwtEcdsa(...)`  | You verify asymmetric JWTs minted by another system.                                               |
+| `oidc(...)`      | You want eve to verify OIDC-issued tokens from an arbitrary issuer.                                |
 
 `httpBasic(credentials, { realm })` accepts an optional `realm`, rendered on the `WWW-Authenticate: Basic` challenge (e.g. `Basic realm="agent", charset="UTF-8"`) so browsers label their native login prompt. It defaults to `"eve"`, ensuring every Basic challenge includes the required realm. Usernames and passwords are normalized to Unicode NFC before comparison, matching the advertised UTF-8 credential encoding.
 
@@ -102,9 +102,9 @@ Exercise caution for agents that process non-public, sensitive, regulated, or pr
 
 ### `localDev()`
 
-Authenticates a synthetic `local-dev` principal, but only when the inbound request is addressed to a loopback hostname (`localhost`, `*.localhost`, `127.0.0.0/8`, or `::1`). The check keys off the request URL's hostname rather than the bare `process.env.VERCEL` flag, and that's deliberate: a deployment outside Vercel leaves `VERCEL` unset, so sniffing that flag alone would wave through all public traffic. There's one process-level exception. `vercel dev`, detected by `VERCEL=1` and `VERCEL_ENV=development` together, opens the local dev server even when it serves over a non-loopback host. Every other non-loopback request returns `null` and falls through.
+Authenticates a synthetic `local-dev` principal, but only while the process is a local development server: `eve dev` (which sets `EVE_DEV=1`) or `vercel dev` (detected by `VERCEL=1` and `VERCEL_ENV=development` together). This is a property of the deployment, not the request, so no request header can flip it. A production deployment (`eve start`, a Vercel deployment, or any container host) sets neither flag, so `localDev()` authenticates nothing there and every request falls through to the next entry.
 
-`localDev()` trusts the advertised hostname, so an attacker who can inject a `Host` header (no normalizing proxy in front of your origin) can spoof it. Always layer a real authenticator on top; never run on `localDev()` alone.
+Because it never opens a production deployment, `localDev()` is safe to leave in the walk. Still put a real authenticator ahead of it so production traffic has something to match.
 
 ### `vercelOidc()`
 
@@ -214,7 +214,7 @@ export default eveChannel({
 });
 ```
 
-In production, `placeholderAuth()` returns a structured `401` so a generated web chat app can say "auth isn't configured yet" instead of throwing an internal error. Replace it before a browser caller submits a production request: swap in your app's `AuthFn` or one of the shipped helpers. Delete the authored channel file entirely and eve falls back to the framework default `[vercelOidc(), localDev()]`, which also rejects production browser traffic.
+In production, `placeholderAuth()` returns a structured `401` so a generated web chat app can say "auth isn't configured yet" instead of throwing an internal error. Replace it before a browser caller submits a production request: swap in your app's `AuthFn` or one of the shipped helpers. Delete the authored channel file entirely and eve falls back to the framework default `[vercelOidc(), localDev(), placeholderAuth()]`, which also rejects production traffic.
 
 You do not have to keep `vercelOidc()` in the final policy. For a self-hosted app, an app-embedded frontend, or any deployment that uses a non-Vercel identity system, use `httpBasic()`, `jwtHmac()`, `jwtEcdsa()`, generic `oidc()`, or a custom `AuthFn` that maps your verified user/session/API key into a `SessionAuthContext`.
 

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -88,7 +88,7 @@ const agent = useEveAgent({
 });
 ```
 
-The default eve channel is fail-closed. With no `agent/channels/eve.ts` authored, eve registers `eveChannel({ auth: [vercelOidc(), localDev()] })`: `vercelOidc()` gets the first chance to resolve a Vercel caller, `localDev()` opens the remaining localhost requests, and everything else gets a `401`. To run your app's own auth policy, add `agent/channels/eve.ts`:
+The default eve channel is fail-closed. With no `agent/channels/eve.ts` authored, eve registers `eveChannel({ auth: [vercelOidc(), localDev(), placeholderAuth()] })`: `vercelOidc()` gets the first chance to resolve a Vercel caller, `localDev()` authenticates while the process is an `eve dev` or `vercel dev` server, and everything else gets a `401`. To run your app's own auth policy, add `agent/channels/eve.ts`:
 
 ```ts title="agent/channels/eve.ts"
 import { eveChannel } from "eve/channels/eve";

--- a/docs/guides/frontend/nuxt.mdx
+++ b/docs/guides/frontend/nuxt.mdx
@@ -60,7 +60,7 @@ async function handleSubmit() {
 </template>
 ```
 
-The default eve channel is fail-closed. With no `agent/channels/eve.ts` authored, eve registers `eveChannel({ auth: [vercelOidc(), localDev()] })`: `vercelOidc()` gets the first chance to resolve a Vercel caller, `localDev()` opens the remaining localhost requests, and everything else gets a `401`. To run your own auth policy, add `agent/channels/eve.ts`:
+The default eve channel is fail-closed. With no `agent/channels/eve.ts` authored, eve registers `eveChannel({ auth: [vercelOidc(), localDev(), placeholderAuth()] })`: `vercelOidc()` gets the first chance to resolve a Vercel caller, `localDev()` authenticates while the process is an `eve dev` or `vercel dev` server, and everything else gets a `401`. To run your own auth policy, add `agent/channels/eve.ts`:
 
 ```ts title="agent/channels/eve.ts"
 import { eveChannel } from "eve/channels/eve";

--- a/docs/guides/frontend/sveltekit.mdx
+++ b/docs/guides/frontend/sveltekit.mdx
@@ -69,7 +69,7 @@ With the plugin in `vite.config.ts`, components call [`useEveAgent`](./use-eve-a
 </form>
 ```
 
-The default eve channel is fail-closed. With no `agent/channels/eve.ts` authored, eve registers `eveChannel({ auth: [vercelOidc(), localDev()] })`: `vercelOidc()` gets the first chance to resolve a Vercel caller, `localDev()` opens the remaining localhost requests, and everything else gets a `401`. To set your own auth policy, add `agent/channels/eve.ts`:
+The default eve channel is fail-closed. With no `agent/channels/eve.ts` authored, eve registers `eveChannel({ auth: [vercelOidc(), localDev(), placeholderAuth()] })`: `vercelOidc()` gets the first chance to resolve a Vercel caller, `localDev()` authenticates while the process is an `eve dev` or `vercel dev` server, and everything else gets a `401`. To set your own auth policy, add `agent/channels/eve.ts`:
 
 ```ts title="agent/channels/eve.ts"
 import { eveChannel } from "eve/channels/eve";

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -324,19 +324,22 @@ describe("none", () => {
 });
 
 describe("localDev", () => {
-  // `localDev()` checks the request URL's hostname, not `process.env`.
-  // The env-based check it used to perform was unsafe on non-Vercel
-  // deployments (any host where `VERCEL` happens to be unset) and these
-  // tests pin the correct behaviour: only requests addressed to a
-  // loopback hostname authenticate, regardless of which platform the
-  // process happens to be running on.
+  // `localDev()` keys off the deployment (an `eve dev` or `vercel dev`
+  // process), never the inbound request. A spoofable request header such as
+  // `Host` must not be able to authenticate the local-dev principal.
   function requestFor(url: string): Request {
     return new Request(url, { method: "POST" });
   }
 
-  it("authenticates requests addressed to `localhost`", () => {
-    const result = localDev()(requestFor("http://localhost:3000/eve/v1/info"));
-    expect(result).toEqual({
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("authenticates when the process is an `eve dev` server", () => {
+    vi.stubEnv("EVE_DEV", "1");
+    vi.stubEnv("VERCEL", "");
+    vi.stubEnv("VERCEL_ENV", "");
+    expect(localDev()(requestFor("http://localhost:3000/eve/v1/info"))).toEqual({
       attributes: {},
       authenticator: "local-dev",
       principalId: "local-dev",
@@ -344,75 +347,35 @@ describe("localDev", () => {
     });
   });
 
-  it("authenticates requests addressed to `127.0.0.1`", () => {
-    expect(localDev()(requestFor("http://127.0.0.1:3000/eve/v1/info"))).toMatchObject({
+  it("authenticates when the process is a `vercel dev` server", () => {
+    vi.stubEnv("EVE_DEV", "");
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_ENV", "development");
+    expect(localDev()(requestFor("http://localhost:3000/"))).toMatchObject({
       principalType: "local-dev",
     });
   });
 
-  it("authenticates any address in the `127.0.0.0/8` loopback range", () => {
-    // Some dev setups bind to addresses other than `127.0.0.1` (e.g.
-    // `127.0.0.2` for multi-instance scenarios). The whole `/8` block
-    // is loopback per RFC 1122.
-    expect(localDev()(requestFor("http://127.5.6.7:3000/"))).toMatchObject({
-      principalType: "local-dev",
-    });
+  it("rejects a `Host: localhost` request on a production deployment", () => {
+    // On a self-hosted Node server the request URL host comes from the `Host`
+    // header. Neither dev flag is set on a production deployment, so a localhost
+    // host must not authenticate.
+    vi.stubEnv("EVE_DEV", "");
+    vi.stubEnv("VERCEL", "");
+    vi.stubEnv("VERCEL_ENV", "");
+    expect(localDev()(requestFor("http://localhost:3000/eve/v1/info"))).toBeNull();
+    expect(localDev()(requestFor("http://127.0.0.1:3000/"))).toBeNull();
+    expect(localDev()(requestFor("http://[::1]:3000/"))).toBeNull();
+    expect(localDev()(requestFor("http://agent.localhost:3000/"))).toBeNull();
   });
 
-  it("authenticates requests addressed to the IPv6 loopback `::1`", () => {
-    expect(localDev()(requestFor("http://[::1]:3000/"))).toMatchObject({
-      principalType: "local-dev",
-    });
-  });
-
-  it("authenticates any `*.localhost` subdomain per RFC 6761", () => {
-    // RFC 6761 reserves the entire `.localhost` TLD for loopback;
-    // dev setups that use subdomains (e.g. `agent.localhost`,
-    // `web.localhost`) must still authenticate.
-    expect(localDev()(requestFor("http://agent.localhost:3000/"))).toMatchObject({
-      principalType: "local-dev",
-    });
-  });
-
-  it("rejects requests addressed to a public hostname (returns null)", () => {
-    // Critical security case: a deployment behind any non-Vercel
-    // platform (Fly, Railway, self-hosted, etc.) must not authenticate
-    // arbitrary public traffic just because `process.env.VERCEL` is
-    // unset. The previous env-based implementation had this hole.
-    expect(localDev()(requestFor("https://example.com/eve/v1/info"))).toBeNull();
-    expect(localDev()(requestFor("https://myapp.fly.dev/eve/v1/info"))).toBeNull();
-    expect(localDev()(requestFor("https://myapp.vercel.app/eve/v1/info"))).toBeNull();
-  });
-
-  it("rejects requests addressed to a private (non-loopback) IP", () => {
-    // `192.168.x.x`, `10.x.x.x`, and other RFC 1918 ranges are LAN
-    // addresses, not loopback. A request from another machine on the
-    // dev network should not authenticate via `localDev`.
-    expect(localDev()(requestFor("http://192.168.1.5:3000/"))).toBeNull();
-    expect(localDev()(requestFor("http://10.0.0.5:3000/"))).toBeNull();
-  });
-
-  it("rejects requests addressed to `0.0.0.0`", () => {
-    // `0.0.0.0` is the "all interfaces" sentinel, not a loopback
-    // address. A request claiming `0.0.0.0` as its host could
-    // originate anywhere and is intentionally excluded.
-    expect(localDev()(requestFor("http://0.0.0.0:3000/"))).toBeNull();
-  });
-
-  it("ignores `process.env.VERCEL` and `VERCEL_ENV` entirely", () => {
-    // The host check is the only signal. Setting any combination of
-    // Vercel env vars must not change the decision for a given URL —
-    // this guards against regressions back to env-sniffing.
+  it("rejects public and preview requests when no dev flag is set", () => {
+    vi.stubEnv("EVE_DEV", "");
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_ENV", "production");
-    try {
-      expect(localDev()(requestFor("http://localhost:3000/"))).toMatchObject({
-        principalType: "local-dev",
-      });
-      expect(localDev()(requestFor("https://example.com/"))).toBeNull();
-    } finally {
-      vi.unstubAllEnvs();
-    }
+    expect(localDev()(requestFor("https://example.com/eve/v1/info"))).toBeNull();
+    vi.stubEnv("VERCEL_ENV", "preview");
+    expect(localDev()(requestFor("https://myapp.fly.dev/"))).toBeNull();
   });
 });
 
@@ -1458,6 +1421,7 @@ describe("vercelOidc strategy helper", () => {
     vi.stubEnv("VERCEL_PROJECT_ID", "");
     vi.stubEnv("VERCEL_TARGET_ENV", "");
     vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("EVE_DEV", "1");
     const issuer = await installMockedVercelIssuer("local-host-binding");
 
     try {

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -8,6 +8,7 @@
 import { decodeJwt } from "#compiled/jose/index.js";
 
 import type { SessionAuthContext } from "#channel/types.js";
+import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
 import { createLogger } from "#internal/logging.js";
 import { authenticateHttpBasicStrategy } from "#runtime/governance/auth/http-basic.js";
 import { authenticateJwtEcdsaStrategy } from "#runtime/governance/auth/jwt-ecdsa.js";
@@ -658,82 +659,28 @@ export function none<TEvent = unknown>(): AuthFn<TEvent> {
 }
 
 /**
- * Returns an {@link AuthFn} that authenticates requests during local
- * development, keyed on the request URL's hostname (not the host process).
- * A hostname is treated as loopback when it is `localhost` or any
- * `*.localhost` subdomain (RFC 6761 routes the `.localhost` TLD to
- * loopback), any IPv4 in `127.0.0.0/8`, or the IPv6 loopback `::1`.
+ * Returns an {@link AuthFn} that authenticates a synthetic `local-dev`
+ * principal while the process is a local development server, and returns
+ * `null` everywhere else so the {@link routeAuth} walk falls through to the
+ * next entry.
  *
- * Matching requests get a synthetic principal with `principalType:
- * "local-dev"`. Every other request returns `null`, skipping to the next
- * entry under {@link routeAuth}, which makes `[vercelOidc(), localDev()]`
- * the canonical "Vercel OIDC when present, open on localhost otherwise" pattern.
- *
- * The check is not based on bare `process.env.VERCEL`: a deployment
- * outside Vercel (Fly, Railway, raw container) leaves `VERCEL` unset and
- * would then accept every public request. The one process-level exception
- * is `vercel dev`, detected by `VERCEL=1` and `VERCEL_ENV=development`
- * together. Only the local `vercel dev` server sets that pair (preview and
- * production report `VERCEL_ENV=preview`/`production`), so it opens the
- * dev server (which may serve over a non-loopback host) without opening a
- * real deployment.
- *
- * Caveat: this assumes a sane edge in front of public origins. An origin
- * that trusts an attacker-controlled `Host` header (no CDN, no normalizing
- * reverse proxy) lets an attacker spoof `Host: localhost` and reach
- * `localDev()`. Layer a real authenticator on such deployments.
+ * A process counts as a local development server when it is `eve dev`
+ * (`EVE_DEV=1`) or `vercel dev` (`VERCEL=1` with `VERCEL_ENV=development`).
+ * This is a property of the deployment, never of the inbound request, so no
+ * request header (for example `Host`) can flip the decision. A production
+ * deployment (`eve start`, a Vercel deployment, or any container host) sets
+ * neither flag, so `localDev()` authenticates nothing there. Layer a real
+ * authenticator on those hosts.
  */
 export function localDev(): AuthFn<Request> {
-  return (request) => {
-    if (process.env.VERCEL && process.env.VERCEL_ENV === "development") {
-      return LOCAL_DEV_SESSION_AUTH_CONTEXT;
-    }
-    if (!isLoopbackRequest(request)) {
-      return null;
-    }
-    return LOCAL_DEV_SESSION_AUTH_CONTEXT;
-  };
+  return () => (isLocalDevelopmentServer() ? LOCAL_DEV_SESSION_AUTH_CONTEXT : null);
 }
 
-/**
- * Hostnames {@link localDev} treats as loopback, in addition to the
- * `*.localhost` wildcard and the `127.0.0.0/8` range. `0.0.0.0` is
- * intentionally excluded — it is the "all interfaces" sentinel, not a
- * loopback address, and requests claiming it as their host generally
- * originate from somewhere else on the network.
- *
- * Node's `URL.hostname` preserves brackets around IPv6 addresses (the
- * WHATWG-serialized form), so the IPv6 loopback is recognized as the
- * literal `"[::1]"` rather than `"::1"`.
- */
-const LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set(["localhost", "[::1]"]);
-
-/**
- * `127.0.0.0/8` is the full IPv4 loopback block — every `127.x.x.x`
- * address resolves to the same machine, and dev tools sometimes bind
- * to addresses other than `127.0.0.1` for multi-instance setups.
- */
-const LOOPBACK_IPV4_PREFIX = /^127\./;
-
-/** Returns whether a request URL names a loopback host accepted by {@link localDev}. */
-export function isLoopbackRequest(request: Request): boolean {
-  let hostname: string;
-  try {
-    hostname = new URL(request.url).hostname;
-  } catch {
-    return false;
-  }
-  if (LOOPBACK_HOSTNAMES.has(hostname)) {
+function isLocalDevelopmentServer(): boolean {
+  if (process.env.VERCEL && process.env.VERCEL_ENV === "development") {
     return true;
   }
-  if (LOOPBACK_IPV4_PREFIX.test(hostname)) {
-    return true;
-  }
-  // RFC 6761: the entire `.localhost` TLD is reserved for loopback.
-  if (hostname.endsWith(".localhost")) {
-    return true;
-  }
-  return false;
+  return isEveDevEnvironment();
 }
 
 const ANONYMOUS_SESSION_AUTH_CONTEXT: SessionAuthContext = {
@@ -1000,7 +947,7 @@ export function vercelOidc(opts: VerifyVercelOidcOptions = {}): AuthFn<Request> 
       const token = extractBearerToken(request.headers.get("authorization"));
       const currentVercelProject =
         opts.currentVercelProject ??
-        (token !== null && isLocalDevelopmentVercelOidcRequest(request)
+        (token !== null && isLocalDevelopmentVercelOidc()
           ? await resolveVercelOidcCurrentProject(request)
           : undefined);
       const result = await verifyVercelOidc(
@@ -1013,12 +960,12 @@ export function vercelOidc(opts: VerifyVercelOidcOptions = {}): AuthFn<Request> 
   );
 }
 
-function isLocalDevelopmentVercelOidcRequest(request: Request): boolean {
+function isLocalDevelopmentVercelOidc(): boolean {
   if (process.env.VERCEL_ENV === "development") return true;
   if (process.env.VERCEL_ENV === "preview" || process.env.VERCEL_ENV === "production") {
     return false;
   }
-  return isLoopbackRequest(request);
+  return isEveDevEnvironment();
 }
 
 /**

--- a/packages/eve/src/runtime/framework-channels/index.test.ts
+++ b/packages/eve/src/runtime/framework-channels/index.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   localDev: vi.fn(),
+  placeholderAuth: vi.fn(),
   vercelOidc: vi.fn(),
 }));
 
@@ -12,6 +13,7 @@ let capturedAuth: EveChannelInput["auth"] | undefined;
 vi.mock("#public/channels/auth.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#public/channels/auth.js")>()),
   localDev: mocks.localDev,
+  placeholderAuth: mocks.placeholderAuth,
   vercelOidc: mocks.vercelOidc,
 }));
 
@@ -27,20 +29,24 @@ import { getFrameworkChannelDefinitions } from "./index.js";
 afterEach(() => {
   capturedAuth = undefined;
   mocks.localDev.mockReset();
+  mocks.placeholderAuth.mockReset();
   mocks.vercelOidc.mockReset();
 });
 
 describe("framework eve channel auth", () => {
-  it("uses Vercel OIDC before the local-development fallback", () => {
+  it("checks Vercel OIDC, then local dev, then the fail-closed placeholder", () => {
     const vercelAuth: AuthFn<Request> = () => null;
-    const localAuth: AuthFn<Request> = () => null;
+    const local: AuthFn<Request> = () => null;
+    const placeholder: AuthFn<Request> = () => null;
     mocks.vercelOidc.mockReturnValue(vercelAuth);
-    mocks.localDev.mockReturnValue(localAuth);
+    mocks.localDev.mockReturnValue(local);
+    mocks.placeholderAuth.mockReturnValue(placeholder);
 
     getFrameworkChannelDefinitions();
 
-    expect(capturedAuth).toEqual([vercelAuth, localAuth]);
+    expect(capturedAuth).toEqual([vercelAuth, local, placeholder]);
     expect(mocks.vercelOidc).toHaveBeenCalledWith();
     expect(mocks.localDev).toHaveBeenCalledWith();
+    expect(mocks.placeholderAuth).toHaveBeenCalledWith();
   });
 });

--- a/packages/eve/src/runtime/framework-channels/index.ts
+++ b/packages/eve/src/runtime/framework-channels/index.ts
@@ -1,4 +1,4 @@
-import { localDev, vercelOidc } from "#public/channels/auth.js";
+import { localDev, placeholderAuth, vercelOidc } from "#public/channels/auth.js";
 import { eveChannel } from "#public/channels/eve.js";
 import type { CompiledChannel } from "#channel/compiled-channel.js";
 import { isHttpRouteDefinition } from "#channel/routes.js";
@@ -19,7 +19,7 @@ const EVE_CHANNEL_NAME = "eve";
  */
 export function getFrameworkChannelDefinitions(): readonly ResolvedChannelDefinition[] {
   const compiled = eveChannel({
-    auth: [vercelOidc(), localDev()],
+    auth: [vercelOidc(), localDev(), placeholderAuth()],
   }) as CompiledChannel;
 
   const result: ResolvedChannelDefinition[] = [];

--- a/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
+++ b/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { H3Event } from "nitro";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { compileAgent } from "../../src/compiler/compile-agent.js";
 import { createDevelopmentNitroArtifactsConfig } from "../../src/internal/nitro/host/artifacts-config.js";
@@ -18,14 +18,13 @@ const EVE_CHANNEL_IMPORT_URL = new URL("../../dist/src/public/channels/eve.js", 
 const EVE_TOOLS_IMPORT_URL = new URL("../../dist/src/public/tools/index.js", import.meta.url);
 const INFO_ROUTE_KEY = `GET ${EVE_INFO_ROUTE_PATH}`;
 
-// Loopback request — `localDev()` authenticates this one. Models a
-// developer hitting `eve start` or `vercel dev` on their machine.
+// A request to the local server. The deployment environment, not this
+// URL, decides auth: `localDev()` authenticates only when the process
+// is an `eve dev` or `vercel dev` server (stubbed via EVE_DEV below).
 const LOOPBACK_REQUEST = new Request("http://localhost/eve/v1/info");
 
-// Public-hostname request — what a real Vercel (or self-hosted)
-// deployment sees on the wire. `localDev()` skips this because the
-// request was not addressed to a loopback hostname, so the walk falls
-// through to `vercelOidc()`.
+// A request a real deployment sees on the wire. With no dev flag set,
+// `localDev()` skips it and the walk falls through to `vercelOidc()`.
 const DEPLOYED_REQUEST = new Request("https://weather-agent.vercel.app/eve/v1/info");
 const AUTHORIZED_DEPLOYED_REQUEST = new Request("https://weather-agent.vercel.app/eve/v1/info", {
   headers: {
@@ -92,7 +91,13 @@ async function requestAgentInfo(appRoot: string, request: Request): Promise<Resp
 }
 
 describe("eve agent info route", () => {
-  it("returns inspection JSON when the request is addressed to a loopback hostname", async () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns inspection JSON in a local dev environment", async () => {
+    vi.stubEnv("EVE_DEV", "1");
+
     const { agentRoot, appRoot } = await createAppRoot("eve-agent-info-route-", APP_ROOT_OPTIONS);
 
     await writeFile(join(agentRoot, "agent.mjs"), 'export default { model: "openai/gpt-5.4" };\n');
@@ -160,11 +165,10 @@ describe("eve agent info route", () => {
     });
   });
 
-  it("returns 401 without a Vercel OIDC bearer token when the request is addressed to a public hostname", async () => {
-    // The default chain `[vercelOidc(), localDev()]` must reject public
-    // traffic that arrives without a token, regardless of `process.env`.
-    // `vercelOidc()` skips because there is no bearer token; `localDev()`
-    // skips because the request URL is not loopback.
+  it("returns 401 for a deployment request without a Vercel OIDC bearer token", async () => {
+    // With no dev flag set, the default chain must reject a request that
+    // carries no token: `vercelOidc()` skips without a bearer token and
+    // `localDev()` skips outside an `eve dev` or `vercel dev` server.
     const { agentRoot, appRoot } = await createAppRoot(
       "eve-agent-info-route-deployed-",
       APP_ROOT_OPTIONS,

--- a/packages/eve/test/tui-client/lib/server.ts
+++ b/packages/eve/test/tui-client/lib/server.ts
@@ -58,9 +58,13 @@ export async function startAgentServer(input: {
 
   console.log(theme.muted(`[tui] starting "${input.appName}" ${mode} server on ${baseUrl} ...`));
 
+  // Built smoke servers run on the local machine. `eve start` does not set
+  // EVE_DEV, so set it here to let `localDev()` authenticate local requests.
+  const serverEnv = { ...(input.startEnv ?? process.env), EVE_DEV: "1" };
+
   const child = spawnServerProcess({
     args: plan.start.args,
-    env: input.startEnv ?? process.env,
+    env: serverEnv,
   });
 
   // Forward the server's stdout/stderr to ours while running. Once we


### PR DESCRIPTION
`localDev()` and the `vercelOidc()` local bypass now decide "am I a local dev server?" from the process environment (`EVE_DEV=1` from `eve dev`, or `VERCEL=1` + `VERCEL_ENV=development` from `vercel dev`) rather than the request URL host. On a self-hosted Node server the request host comes from the `Host` header, so header content no longer influences the auth decision.

## Changes
- `localDev()` reads the deployment environment; the `Request` no longer affects the result.
- Removed the `isLoopbackRequest` export (public API break, hence `minor`).
- Framework default is now `[vercelOidc(), localDev(), placeholderAuth()]`, matching the scaffold template: local dev still works, and production/self-hosted deployments fail closed with a `401`.
- Docs and tests updated to match.

## Verification
`pnpm fmt`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit`, `pnpm guard:invariants`, and `pnpm docs:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)