### PR TITLE
docs(eve): memory - propose first-class lifecycle

### DIFF
--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -801,14 +801,16 @@ Mounted extensions cannot contribute memory slots.
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807561187)
       once that boundary is unambiguous.
 
-- [ ] **Give the model a safe memory-slot purpose.** Decide whether the
-      consuming definition or provider configuration supplies a model-facing
-      description that distinguishes destinations such as personal preferences
-      and channel conventions. Keep raw namespace and scope values out of model
-      input, and state that descriptions guide tool choice rather than enforce
-      authorization. Verify that multiple `fileMemory()` slots expose enough
-      information for the model to choose the intended qualified tool. Then
-      close the [model-facing attribution
+- [x] **Give the model a safe memory-slot purpose.** The consuming
+      `defineMemory(...)` may supply an optional static `description`. eve
+      validates it and prepends it to every provider tool description before
+      storing durable dynamic metadata. Omitting it preserves provider
+      descriptions unchanged. The implementation neither derives nor exposes
+      namespace or scope values, and the docs distinguish model routing
+      guidance from authorization. Unit coverage verifies two slots sharing one
+      provider receive different descriptions without mutating provider tools;
+      file-memory integration and e2e coverage exercise described
+      `fileMemory()` slots. This resolves the [model-facing attribution
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
 
 - [ ] **Explain projection placement and tool invocation semantics.** Keep or

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -33,12 +33,12 @@ turn-start recall through the same durable dynamic-capability machinery as a
 `turn.started` `defineDynamic` tool resolver.
 
 Memory definitions and provider tools compile through eve's canonical source
-graph. Each selected memory slot retains its authored binding and projects one
-compiler-owned programmatic `tools/<slot>.ts` wrapper that exports an ordinary
-`defineDynamic` resolver. The wrapper qualifies provider tool keys and passes
-them through the existing source composition, binding, module-map, dynamic-tool,
-approval, authorization, and replay paths. Memory does not add a runtime tool
-contribution seam or a second executable registry.
+graph. Each selected memory slot retains its direct binding and induces one
+derived `tools/<slot>.ts` module from a registered programmatic template. The
+template exports an ordinary `defineDynamic` resolver. It qualifies provider
+tool keys and passes them through the existing source composition, binding,
+module-map, dynamic-tool, approval, authorization, and replay paths. Memory
+does not add a runtime tool contribution seam or a second executable registry.
 
 ```text
 turn.started          ---> recall(phase: "turn.started") ---> tools
@@ -139,16 +139,35 @@ surface, because provider tools are ordinary dynamic tools.
 
 Memory is a source-graph primitive, not a post-compile runtime attachment. For
 `agent/memory/user.ts`, the compiler selects and binds the memory definition,
-then projects its provider-tool adapter as a programmatic source at
-`tools/user.ts`:
+then instantiates its registered provider-tool template at `tools/user.ts`:
 
 ```text
 memory/user.ts
   └─ selected memory definition
-       └─ programmatic tools/user.ts wrapper
+       └─ registered tools/user.ts template instance
             └─ compiled defineDynamic resolver
                  └─ user__<provider tool key>
 ```
+
+The instantiation API takes the memory candidate as its anchor and dependency:
+
+```ts
+instantiateProgrammaticTemplate({
+  anchor: memoryCandidate,
+  dependencies: { memory: memoryCandidate },
+  logicalPath: `tools/${slot}.ts`,
+  owner: { kind: "framework", feature: "memory" },
+  parameters: { memoryExportName, memoryLogicalPath, slot },
+  template: memoryWrapperTemplate,
+});
+```
+
+The registry-issued template handle fixes the loader and module identity. The
+constructor inherits the anchor's node and layer, derives the source ID from
+the template, target path, and anchor, and rejects dependencies from another
+node. A direct target in the same layer wins over the derived module. Memory
+therefore needs no special registration mode, source layer, or source-ID
+convention.
 
 The memory definition and wrapper each use the canonical candidate,
 composition, binding-validation, artifact, module-map, hydration, and runtime
@@ -172,20 +191,24 @@ slot, `tools: false`, `null`, or an empty result contributes no tools. Provider
 factories use eve's durable callback helpers when their callbacks cannot be
 stamped by authored-source transformation.
 
+Every module-map load also memoizes zero-argument definition-factory results
+within each module namespace. The direct memory binding and its derived wrapper
+therefore receive the same definition and provider instance, including when a
+module exports `() => defineMemory(...)`. A separately loaded compile or runtime
+module map gets a fresh materialization; there is no process-global provider
+registry.
+
 This architecture is a completion gate for the core implementation:
 filesystem, in-memory, generated, bundled, and hydrated module maps must load
 the same selected wrapper binding, and a parked provider tool must resume after
 a fresh-process callback rebind. A memory-only registry, post-resolution tool
 merge, or logical-path loading fallback fails that gate.
 
-Current eve automatically rebinds missing callbacks by rerunning
-`session.started` resolvers; it does not rerun an arbitrary
-`turn.started` resolver. The memory core must therefore prove that loading the
-selected wrapper binding registers the callbacks needed by persisted provider
-tools, or extend cold rebinding at the generic compiled-resolver boundary. Any
-such extension belongs to the ordinary dynamic-tool lifecycle, contains no
-memory types, preserves the parked call's captured closure values, and never
-reruns provider mutation.
+Compiled dynamic resolvers may opt into missing-callback rebinding at the
+generic compiled-resolver boundary. The memory wrapper uses that path to
+register the callback implementation needed by a persisted provider tool. The
+rebind machinery contains no memory types, preserves the parked call's captured
+closure values, and never reruns provider mutation.
 
 ## Model-facing description
 
@@ -197,7 +220,7 @@ interface MemoryDefinition {
   readonly namespace?: MemoryNamespaceDefinition;
   readonly provider: MemoryProvider;
   readonly scope: MemoryScopeDefinition;
-  readonly tools?: boolean;
+  readonly tools?: false;
   readonly visibility?: MemoryVisibility;
 }
 ```
@@ -515,7 +538,7 @@ boundaries. `recall` is required. `capture` and `tools` are optional.
 ```ts
 import type { ModelMessage } from "ai";
 import type { SessionContext } from "eve/context";
-import type { DynamicResolveContext, ToolDefinition } from "eve/tools";
+import type { DynamicResolveContext } from "eve/tools";
 
 interface MemoryRecallMessage {
   /** Provider context recalled into durable model history as a user-role message. */
@@ -597,7 +620,7 @@ interface MemoryToolsContext extends DynamicResolveContext {
   };
 }
 
-type MemoryToolSet = Readonly<Record<string, ToolDefinition>>;
+type MemoryToolSet = Readonly<Record<string, MemoryToolDefinition>>;
 
 interface MemoryProvider {
   recall(context: MemoryRecallContext): MemoryRecallResult | Promise<MemoryRecallResult>;
@@ -794,14 +817,13 @@ omit, or do nothing.
 
 Compaction is the canonicalization boundary for memory records. Trusted
 internal code partitions every attributed memory record — across every slot,
-namespace, scope, and visibility mode — away from ordinary conversation, folds
-keyed records to one live version or deletion tombstone per identity, and
-retains every immutable unkeyed append with its attribution. The free-form
-summary prompt is built from projected ordinary conversation only; no
-attributed memory record of any kind enters it. Canonical private memory state
-is reattached to the rewritten history, so items hidden from the currently
-active scope survive another scope's compaction, and sparse retrieval stays
-accumulative across compaction.
+namespace, scope, and visibility mode — away from ordinary conversation, keeps
+one live keyed record per identity, and retains every immutable unkeyed append
+with its attribution. The free-form summary prompt is built from projected
+ordinary conversation only; no attributed memory record of any kind enters it.
+Canonical private memory state is reattached to the rewritten history, so items
+hidden from the currently active scope survive another scope's compaction, and
+sparse retrieval stays accumulative across compaction.
 
 Because superseded versions and hidden scopes can grow while the visible
 prompt stays constant, eve triggers canonicalization on raw attributed-record
@@ -1146,9 +1168,10 @@ The generic prerequisites are on `main`: the projected-history seam
 ([#2352](https://github.com/vercel/eve/pull/2352)), durable dynamic callbacks
 ([#2354](https://github.com/vercel/eve/pull/2354)), name-and-phase callback
 identity ([#2384](https://github.com/vercel/eve/pull/2384)), and the canonical
-source graph and binding table
+source graph, binding table, and invariant-safe derived-template API
 ([#2404](https://github.com/vercel/eve/pull/2404),
-[#2516](https://github.com/vercel/eve/pull/2516)). The runtime-tool contribution
+[#2516](https://github.com/vercel/eve/pull/2516),
+[#2539](https://github.com/vercel/eve/pull/2539)). The runtime-tool contribution
 proposal in [#2347](https://github.com/vercel/eve/issues/2347) is superseded;
 memory uses the compile-time wrapper described above. The kernel-effects
 follow-up to #2516 is not a prerequisite because provider tools have ordinary
@@ -1157,12 +1180,13 @@ executors rather than native kernel effects.
 Implementation proceeds in two pull requests:
 
 1. The first-class memory core is implemented in
-   [#2534](https://github.com/vercel/eve/pull/2534), based directly on current
-   `main`. It adds the authoring and compiler surface, source-graph wrapper,
-   namespace and scope locks, recall records and projection, lifecycle,
-   compaction, agent-info v4, published documentation, and deterministic
-   end-to-end coverage. It does not restack or reuse the custom runtime
-   lifecycle from [#2142](https://github.com/vercel/eve/pull/2142).
+   [#2534](https://github.com/vercel/eve/pull/2534), rebased directly onto
+   current `main`. It uses #2539's registered template API and generic
+   per-module-map factory materialization, then adds the memory authoring and
+   compiler surface, namespace and scope locks, recall records and projection,
+   lifecycle, compaction, agent-info v4, published documentation, and
+   deterministic end-to-end coverage. It does not restack or reuse the custom
+   runtime lifecycle from [#2142](https://github.com/vercel/eve/pull/2142).
 2. After #2534 merges, the bounded `fileMemory()` provider in
    [#2144](https://github.com/vercel/eve/pull/2144) will be rebased onto current
    `main`. It retains only provider storage, document, backend, and concurrency
@@ -1170,7 +1194,8 @@ Implementation proceeds in two pull requests:
    [#2145](https://github.com/vercel/eve/pull/2145) is superseded.
 
 #2534 implements the core boundary through one selected source and binding
-authority for every memory definition and provider-tool wrapper, one projected
+authority for every memory definition and provider-tool wrapper, one
+materialization per definition factory in a module-map load, one projected
 history for message-bearing consumers, private memory canonicalization outside
 ordinary summarization, and generic cold callback rebinding with captured
 closures. Those invariants, the committed E2E fixture, and the required CI

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -13,8 +13,9 @@ session. A memory provider owns how it stores, retrieves, and updates memory.
 eve owns when the provider participates in the agent lifecycle.
 
 Each memory definition binds a provider to an application namespace, a trusted
-scope, and a projection visibility policy. The provider contract has three
-methods:
+scope, and a projection visibility policy. It may also describe the slot's
+purpose to the model through provider tool descriptions. The provider contract
+has three methods:
 
 - `recall` updates the context projected into model calls.
 - `save` observes history before compaction and after a completed turn.
@@ -79,8 +80,8 @@ agent/memory/              # directory of named slots
 
 The flat file and directory forms are mutually exclusive. Each module
 default-exports `defineMemory(...)`. The definition contains the provider, an
-optional namespace, a required trusted scope, and optional eve-owned projection
-policy:
+optional model-facing description, an optional namespace, a required trusted
+scope, and optional eve-owned projection policy:
 
 ```ts title="agent/memory/user.ts"
 import { defineMemory } from "eve/memory";
@@ -88,6 +89,7 @@ import { byPrincipal } from "eve/memory/scope";
 import { customMemory } from "../lib/custom-memory";
 
 export default defineMemory({
+  description: "Personal preferences and durable facts for the authenticated user.",
   provider: customMemory,
   namespace: () => `acme:${process.env.DEPLOYMENT_REGION ?? "local"}`,
   scope: byPrincipal,
@@ -98,6 +100,65 @@ The same provider instance may back several slots. Their projections, tools,
 and provider invocations remain independent. The default namespace includes the
 slot identity, so each slot receives a distinct provider address. Definitions
 that resolve the same custom namespace and scope intentionally share an address.
+
+## Model-facing description
+
+`description` is an optional static description of the slot's purpose:
+
+```ts
+interface MemoryDefinition {
+  readonly description?: string;
+  readonly namespace?: MemoryNamespaceDefinition;
+  readonly provider: MemoryProvider;
+  readonly scope: MemoryScopeDefinition;
+  readonly visibility?: MemoryVisibility;
+}
+```
+
+The consuming definition owns this description because one provider may back
+several destinations with different purposes. For example, two `fileMemory()`
+slots can distinguish personal preferences from shared channel conventions:
+
+```ts title="agent/memory/personal.ts"
+import { defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Personal preferences belonging only to the authenticated user.",
+  provider: fileMemory(),
+  scope: byPrincipal,
+});
+```
+
+```ts title="agent/memory/channel.ts"
+import { defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+import { channelScope } from "../lib/channel-scope";
+
+export default defineMemory({
+  description: "Shared conventions for this channel. Do not store personal preferences here.",
+  provider: fileMemory(),
+  scope: channelScope,
+});
+```
+
+When the provider returns tools, eve prepends the slot description and two
+newline characters to every provider-authored tool description. For example,
+the first slot's `save_memory` description begins with its personal-memory
+purpose before the provider's generic save guidance. eve performs this
+composition after the `tools` resolver returns and before the dynamic tool
+metadata is captured, so every model step and parked continuation sees the same
+description. Omitting `description` preserves each provider tool description
+unchanged. An empty or whitespace-only description is invalid; authors omit the
+field when no slot-specific purpose is needed.
+
+The description is trusted application-authored model guidance. eve does not
+derive it from the slot name, namespace, scope, or request context, and does not
+expose those values through it. The description is not added to projections or
+the prompt separately, so a provider without tools does not expose it to the
+model. It helps the model choose among qualified tools but does not enforce
+authorization or replace scope isolation.
 
 ## Namespace
 
@@ -688,6 +749,9 @@ Mounted extensions cannot contribute memory slots.
 - Provider tools are slot-qualified, scope-bound `turn.started` dynamic tools.
   Each turn resolves one complete tool set, every model step uses it, and a
   durable call keeps its originating definition until settlement.
+- An optional static slot description is prepended to every provider tool
+  description before durable capture. It never derives from or exposes the
+  namespace or scope, and it guides model routing without granting access.
 - Completed-turn save settles before the next ready boundary.
 
 ## Non-goals

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-18"
+last_updated: "2026-08-19"
 ---
 
 # First-class memory
@@ -13,11 +13,11 @@ session. A memory provider owns how it stores, retrieves, and updates memory.
 eve owns when the provider participates in the agent lifecycle.
 
 Each memory definition binds a provider to an application namespace, a trusted
-scope, and a projection visibility policy. It may also describe the slot's
+scope, and a recall visibility policy. It may also describe the slot's
 purpose to the model through provider tool descriptions. The provider contract
 has three methods:
 
-- `recall` updates the context projected into model calls.
+- `recall` appends provider context to durable history as a user-role message.
 - `save` observes history before compaction and after a completed turn.
 - `tools` contributes model tools bound to the active memory scope.
 
@@ -34,8 +34,8 @@ compaction.completed  ---> recall(phase: "compaction.completed")
 turn.completed        ---> save(phase: "turn.completed")
 ```
 
-eve owns namespace and scope resolution, invocation order, scope-bound context
-projection, projection visibility, tool qualification, and replay behavior. The
+eve owns namespace and scope resolution, invocation order, recall-message
+attribution and visibility, tool qualification, and replay behavior. The
 provider owns storage, retrieval, ranking, extraction, formatting, retention,
 and its model-facing operations. A hosted semantic service and a bounded text
 file can therefore implement the same provider contract without sharing a
@@ -43,12 +43,12 @@ record or storage model.
 
 ## Public API at a glance
 
-| Import path              | Public surface                                                                                                        |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, addressing types, and projection types |
-| `eve/memory/scope`       | `byPrincipal`                                                                                                         |
-| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                                  |
-| `eve/memory/file/vercel` | `vercelBlob`                                                                                                          |
+| Import path              | Public surface                                                                                                    |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, addressing types, and recall types |
+| `eve/memory/scope`       | `byPrincipal`                                                                                                     |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                              |
+| `eve/memory/file/vercel` | `vercelBlob`                                                                                                      |
 
 The smallest complete memory slot uses the built-in file provider:
 
@@ -81,7 +81,7 @@ agent/memory/              # directory of named slots
 The flat file and directory forms are mutually exclusive. Each module
 default-exports `defineMemory(...)`. The definition contains the provider, an
 optional model-facing description, an optional namespace, a required trusted
-scope, and optional eve-owned projection policy:
+scope, and an optional eve-owned visibility policy:
 
 ```ts title="agent/memory/user.ts"
 import { defineMemory } from "eve/memory";
@@ -96,10 +96,11 @@ export default defineMemory({
 });
 ```
 
-The same provider instance may back several slots. Their projections, tools,
-and provider invocations remain independent. The default namespace includes the
-slot identity, so each slot receives a distinct provider address. Definitions
-that resolve the same custom namespace and scope intentionally share an address.
+The same provider instance may back several slots. Their recalled messages,
+tools, and provider invocations remain independent. The default namespace
+includes the slot identity, so each slot receives a distinct provider address.
+Definitions that resolve the same custom namespace and scope intentionally
+share an address.
 
 ## Model-facing description
 
@@ -155,10 +156,10 @@ field when no slot-specific purpose is needed.
 
 The description is trusted application-authored model guidance. eve does not
 derive it from the slot name, namespace, scope, or request context, and does not
-expose those values through it. The description is not added to projections or
-the prompt separately, so a provider without tools does not expose it to the
-model. It helps the model choose among qualified tools but does not enforce
-authorization or replace scope isolation.
+expose those values through it. The description is not added to recalled
+messages or the prompt separately, so a provider without tools does not expose
+it to the model. It helps the model choose among qualified tools but does not
+enforce authorization or replace scope isolation.
 
 ## Namespace
 
@@ -242,7 +243,7 @@ component must be a non-empty string. eve resolves scope before namespace. A
 `null` scope disables the slot without invoking its namespace resolver.
 Otherwise eve resolves the namespace. A `null` namespace also disables the
 slot. A disabled slot does not call the provider, expose its tools, or include
-any of its projections in model context.
+its recalled messages in model context.
 
 For an active slot, eve validates both values and derives the provider scope key
 from exactly the resolved namespace and scope:
@@ -270,8 +271,8 @@ unscoped provider invocation path.
 
 eve locks scope for the active turn, including model steps and durable approved
 call continuations. A standalone manual compaction resolves and locks scope for
-that operation. Every projection remains attributed to the slot and scope key
-under which it was recalled.
+that operation. Every recalled message remains attributed to the slot and scope
+key under which it was appended.
 
 Passing `byPrincipal` as the scope resolver identifies the authenticated caller
 from principal type, authenticator, optional issuer, and principal ID. It is a
@@ -311,10 +312,10 @@ data must not cross that boundary. Resolver output is evaluated once when eve
 locks the operation's memory scopes, and every provider call and tool in that
 operation uses the locked value.
 
-## Projection visibility across scope changes
+## Recall visibility across scope changes
 
 `visibility` is an eve-owned `defineMemory` option. It controls which
-previously recalled projections enter a model request when the slot resolves a
+previously recalled messages enter a model request when the slot resolves a
 different scope. The option belongs to the consuming memory definition rather
 than the provider because eve owns prompt assembly and the application owns the
 session's audience boundary:
@@ -335,37 +336,38 @@ export default defineMemory({
 type MemoryVisibility = "scope" | "session";
 ```
 
-| Value               | Model context after a scope change                                                                                                          | Prompt cache                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `"scope"` (default) | Include only the projection whose scope key matches the active turn. Exclude projections recalled for earlier participants.                 | Filtering an anchored projection changes the prompt prefix and invalidates the affected cache.     |
-| `"session"`         | Keep projections recalled for earlier scopes visible, then add the active scope's first projection immediately before its first turn input. | A scope change keeps earlier messages in place; replacing or clearing a projection may still bust. |
+| Value               | Model context after a scope change                                                                                            | Prompt cache                                                                                  |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `"scope"` (default) | Include recalled messages whose slot and scope key match the active turn. Exclude recalled messages for earlier participants. | Filtering earlier messages changes the prompt prefix and invalidates the affected cache.      |
+| `"session"`         | Keep every recalled message for the slot visible in its durable history position.                                             | Existing prompt messages remain in place; later recall results only extend the cached prefix. |
 
-The default favors projection isolation over cache reuse when the authenticated
-participant changes.
+The default favors recalled-context isolation over cache reuse when the
+authenticated participant changes.
 
 For a Slack thread where one authenticated participant follows another,
 `"scope"` removes the first participant's recalled memory before the second
-participant's model call. `"session"` keeps both projections visible. The
+participant's model call. `"session"` keeps both recalled messages visible. The
 second mode is an explicit cross-scope disclosure policy and is appropriate
 only when the session participants form one trusted audience.
 
 ```text
-scope:   ... -> participant A turn -> assistant -> participant B projection -> participant B turn
-session: ... -> participant A projection -> participant A turn -> assistant -> participant B projection -> participant B turn
+durable: ... -> participant A memory -> participant A turn -> assistant -> participant B memory -> participant B turn
+scope:   ... -> participant A turn -> assistant -> participant B memory -> participant B turn
+session: ... -> participant A memory -> participant A turn -> assistant -> participant B memory -> participant B turn
 ```
 
 This option never changes provider scope. `recall`, `save`, and `tools` still
 receive only the active turn's locked scope. The provider cannot select the
-visibility mode, and eve never passes another scope or its projection into a
-provider method. A `null` scope suppresses all of the slot's projections in both
-modes.
+visibility mode. A `null` scope suppresses all recalled messages belonging to
+the slot in both modes.
 
-Projection visibility does not remove ordinary user, assistant, or tool
-messages already in the conversation. It also cannot undo information an
-earlier assistant response derived from memory. Applications that require hard
-isolation between participants must use separate sessions. Provider tools that
-return memory content place that content in ordinary tool history and therefore
-own the same shared-session risk.
+Recall visibility changes only scope-attributed recall messages in the model
+request. It does not remove ordinary user, assistant, or tool messages from
+durable history, and it cannot undo information an earlier assistant response
+derived from memory. Applications that require hard isolation between
+participants must use separate sessions. Provider tools that return memory
+content place that content in ordinary tool history and therefore own the same
+shared-session risk.
 
 ## Provider contract
 
@@ -377,10 +379,18 @@ import type { ModelMessage } from "ai";
 import type { SessionContext } from "eve/context";
 import type { DynamicResolveContext, ToolDefinition } from "eve/tools";
 
-interface MemoryProjection {
-  /** Non-empty provider context projected as one synthetic user-role message. */
+interface MemoryRecallMessage {
+  /** Provider context appended to durable model history. */
   readonly content: string;
+  readonly role: "user";
 }
+
+interface MemoryMessageAttribution {
+  readonly scope: MemoryScope;
+  readonly slot: string;
+}
+
+function getMemoryMessageAttribution(message: ModelMessage): MemoryMessageAttribution | null;
 
 interface MemoryTurnContext {
   readonly turnId: string;
@@ -392,13 +402,11 @@ interface MemoryTurnContext {
 
 interface MemoryOperationContext extends SessionContext {
   readonly abortSignal: AbortSignal;
-  /** Durable model history at this lifecycle boundary. Excludes memory projections. */
+  /** Durable model history at this lifecycle boundary, including prior recalls. */
   readonly messages: readonly ModelMessage[];
   /** Identifies one logical recall or save operation across workflow replay. */
   readonly operationId: string;
   readonly memory: {
-    /** Current projection for this slot and the active scope, if one exists. */
-    readonly current: MemoryProjection | null;
     readonly scope: MemoryScope;
     /** Path-derived slot identity, such as "memory" or "user". */
     readonly slot: string;
@@ -443,15 +451,13 @@ type MemorySaveContext = MemoryOperationContext &
 interface MemoryToolsContext extends DynamicResolveContext {
   readonly turn: MemoryTurnContext;
   readonly memory: {
-    /** Current projection after turn-start recall. */
-    readonly current: MemoryProjection | null;
     readonly scope: MemoryScope;
     /** Path-derived slot identity, such as "memory" or "user". */
     readonly slot: string;
   };
 }
 
-type MemoryRecallResult = MemoryProjection | null | undefined;
+type MemoryRecallResult = MemoryRecallMessage | null | undefined;
 type MemoryToolSet = Readonly<Record<string, ToolDefinition>>;
 
 interface MemoryProvider {
@@ -472,7 +478,8 @@ import { defineTool } from "eve/tools";
 
 const customMemory = defineMemoryProvider({
   async recall(ctx) {
-    return loadProjection(ctx.memory.scope.key);
+    const content = await loadMemory(ctx.memory.scope.key);
+    return content === null ? null : { content, role: "user" };
   },
   tools: async (ctx) => {
     const policy = await loadToolPolicy(ctx.session.auth.current);
@@ -488,64 +495,46 @@ const customMemory = defineMemoryProvider({
 });
 ```
 
-The result of `recall` updates the active scope's projection:
+The result of `recall` is append-only:
 
-| Result                          | Effect                                                  |
-| ------------------------------- | ------------------------------------------------------- |
-| `{ content: non-empty string }` | Replace the current projection for this slot and scope. |
-| `null`                          | Clear the current projection for this slot and scope.   |
-| `undefined` / no return         | Keep the current projection without changing it.        |
+| Result                              | Effect                                         |
+| ----------------------------------- | ---------------------------------------------- |
+| `{ content: string, role: "user" }` | Append one scope-attributed user-role message. |
+| `null`, `undefined`, or no return   | Append nothing at this boundary.               |
 
-This distinction lets a provider skip routine turn-start retrieval without
-losing previously recalled context. It can still clear stale context explicitly.
-An empty string is invalid and fails recall at that lifecycle boundary; it does
-not mean clear or skip. Providers return `null` to clear or `undefined` to
-preserve the current projection.
+eve applies the same content normalization as user-role instructions. It trims
+the returned content and appends nothing when the result is empty after
+trimming. A recall result never replaces, clears, or mutates an earlier message.
 
 `defineMemoryProvider(...)` is an identity-with-types helper. It does not add
 storage behavior or impose a record model.
 
-## Memory projection
+## Recalled messages
 
-Each slot stores at most one projection for every scope key it encounters in a
-session. The durable projection state includes the slot, scope key, content, and
-prompt anchor. `ctx.memory.current` exposes only the projection belonging to the
-active scope.
+Every non-empty recall result becomes one durable user-role message, using the
+same message shape and append behavior as user-role instructions. Turn-start
+recalls are appended immediately before the admitted turn input. Post-compaction
+recalls are appended after the rewritten checkpoint and retained tail. Multiple
+slots append in stable slot-path order.
 
-The first valid projection for a scope anchors one synthetic user-role
-message immediately before that scope's current turn input. Later recall results
-update the projection at the same anchor according to the result table above.
-Replacing, clearing, or filtering an anchored projection changes the prompt
-prefix and may invalidate the provider prompt cache.
+eve records internal slot and scope attribution on each recalled message. The
+attribution is not sent to the model or exposed as tool input. It exists so eve
+can apply `visibility` at model assembly and so provider code can distinguish
+recalled context from ordinary conversation messages. The message itself remains
+part of `ctx.messages`, completed-turn saves, and later compaction input.
 
-At model assembly, eve applies the slot's `visibility`. `"scope"` includes only
-projections matching the active scope. `"session"` includes all of the slot's
-projections in anchor order. Projections created at the same boundary use stable
-slot-path order. The slot and scope attribution remain attached to each
-projection throughout model assembly.
+Recalled messages are not emitted as `message.received`; they are framework
+context rather than new channel input. Compaction may summarize or discard them
+like other durable user-role context. Before compaction, eve applies the active
+visibility policy, so a scope-hidden recall cannot enter the checkpoint and is
+removed with the rewritten history. The post-compaction recall boundary lets a
+provider append fresh context when the rewritten history no longer contains it.
 
-A projection remains separate from ordinary conversation history:
-
-- It is not emitted as `message.received`.
-- It is not summarized by compaction.
-- It is not included in `ctx.messages` passed back to a provider.
-- Its slot and scope attribution are not exposed to the model as tool input.
-
-Although projections occupy stable positions among model messages for prompt
-caching, they remain tagged framework state rather than ordinary durable
-messages. That attribution is what lets eve filter them by scope.
-
-Compaction removes anchors attached to the rewritten history. After the new
-checkpoint, eve reanchors the projections visible for that operation and then
-runs post-compaction recall for the active scope. A hidden projection reanchors
-at the next turn boundary if its scope becomes visible again.
-
-Providers own the content inside a projection. eve owns its user-role placement,
-slot and scope attribution, filtering, and anchoring.
-
-User-role instructions append application context to durable conversation
-history at their lifecycle boundary. Memory projections are replaceable,
-scope-bound provider context kept outside that history.
+Append-only recall preserves the existing prompt prefix in the normal case. It
+also means a provider owns repetition and correction policy. Returning the same
+snapshot at every turn appends duplicates, while a later correction does not
+delete an earlier claim. A provider returns `null` or `undefined` when it has no
+new context to append.
 
 ## Lifecycle
 
@@ -555,35 +544,32 @@ After eve admits and normalizes a new turn, it resolves each memory scope and,
 for a non-null scope, its namespace. It then calls `recall` with
 `phase: "turn.started"` for every active slot. The context contains the
 zero-based turn sequence, stable turn ID, normalized input, durable history
-before the turn, and current projection for the active scope.
+before the turn, and prior recalled messages that remain in that history.
 
 The first turn has `ctx.turn.sequence === 0`. A provider may use that coordinate
-to recall only on the first turn. A provider may check
-`ctx.memory.current === null` when it only needs to recall scopes without a
-projection, including a new participant's scope on a later turn. A provider that
-returns no projection or clears one will see `null` again at the next boundary.
-A semantic provider may recall on every turn using the current input as its
-query.
+to recall only on the first turn. It may use `getMemoryMessageAttribution` to
+find earlier recalls from the same slot and scope, return nothing when its
+current context is already present, or recall on every turn using the current
+input as its query.
 
-The result is ready before the first model call. If automatic compaction runs at
-the same opening boundary, the projection remains outside compaction input and
-the post-compaction recall may replace it before the model runs.
+The results are appended in stable slot order before the first model call. If
+automatic compaction runs at the same opening boundary, the new messages enter
+compaction input. Post-compaction recall may append fresh context after the
+rewritten checkpoint before the model runs.
 
 ### Compaction save and recall
 
 Before automatic or manual compaction rewrites history, eve calls an implemented
 `save` method with `phase: "compaction.requested"`. The provider receives the
-complete durable history about to be compacted, the active projection separately
-as `ctx.memory.current`, and the compaction model and usage metadata. A provider
-may persist a checkpoint, extract facts the summary could omit, or do nothing.
+complete durable history about to be compacted and the compaction model and
+usage metadata. A provider may persist a checkpoint, extract facts the summary
+could omit, or do nothing.
 
 After a checkpoint is durably appended, eve calls `recall` with
 `phase: "compaction.completed"`. The provider receives the settled
-post-compaction history and can replace, clear, or preserve its current
-projection. The call occurs after every successful automatic or manual
-compaction, even when the provider skipped ordinary turn-start recall. Only the
-active scope's projection can change during this call; visibility of other
-projections remains eve-owned policy.
+post-compaction history and may append one fresh user-role message. The call
+occurs after every successful automatic or manual compaction, even when the
+provider skipped ordinary turn-start recall.
 
 Provider tools are not resolved during a standalone compaction because no model
 call follows that boundary.
@@ -593,7 +579,8 @@ call follows that boundary.
 After turn-start recall settles, eve resolves `tools` once for the active turn.
 The function may be synchronous or asynchronous. Its context contains the same
 session, authentication, channel, and message fields as a `defineDynamic`
-resolver, plus the locked memory scope, current projection, slot, and turn.
+resolver, plus the locked memory scope, slot, and turn. Its messages include the
+turn-start recall results followed by the admitted turn input.
 Returning `null` or an empty record exposes no tools for the slot.
 
 The memory definition is implicit `defineDynamic` authoring: eve adapts each
@@ -644,9 +631,9 @@ the turn, update a remote profile, enqueue its own work, or do nothing.
 Every recall and save invocation receives an `operationId` for one logical slot
 operation. eve reuses the ID across workflow replay, so it is not a unique
 callback-attempt identifier. A provider must use it as the idempotency key for
-externally visible `save` side effects. eve records recall results, scope
-attribution, prompt anchors, and turn-scoped dynamic tool metadata in durable
-session state.
+externally visible `save` side effects. eve records recalled messages with their
+scope attribution and keeps turn-scoped dynamic tool metadata in durable session
+state.
 
 Failure behavior follows the point at which the method runs:
 
@@ -676,8 +663,10 @@ function fileMemory(options?: FileMemoryOptions): MemoryProvider;
 ```
 
 Its `recall` method loads the current document at every turn start and after
-every successful compaction. Its `tools` method exposes
-`save_memory({ text })` and `remove_memory({ index })`. Each tool completes after
+every successful compaction. It appends the formatted document when the active
+slot and scope do not already have an identical latest recall in durable
+history. An empty or unchanged document appends nothing. Its `tools` method
+exposes `save_memory({ text })` and `remove_memory({ index })`. Each tool completes after
 its conditional write, and the next recall reflects the updated document.
 `save_memory` normalizes whitespace, returns the existing index for duplicate
 text, and fails when the document reaches `maxEntries`. `remove_memory` is a
@@ -713,8 +702,8 @@ The same lifecycle also supports a hosted semantic provider:
 
 | Boundary               | Bounded file provider       | Hosted semantic provider                    |
 | ---------------------- | --------------------------- | ------------------------------------------- |
-| `turn.started` recall  | Load the current document   | Retrieve against the current turn input     |
-| Post-compaction recall | Reload the current document | Refresh against the compacted history       |
+| `turn.started` recall  | Append a changed document   | Retrieve against the current turn input     |
+| Post-compaction recall | Append if context is absent | Refresh against the compacted history       |
 | Pre-compaction save    | Omit                        | Preserve facts or checkpoint provider state |
 | Completed-turn save    | Omit                        | Capture the completed interaction           |
 | Turn tools             | Save and remove entries     | Provider-defined search, save, or forget    |
@@ -726,7 +715,7 @@ nothing in `save`, or return `null` from `tools`.
 
 A provider package exports a `MemoryProvider` or provider factory. It may own
 credentials, remote APIs, migrations, retrieval, capture, and model tools. The
-consuming agent owns the slot path, namespace, scope, and projection visibility.
+consuming agent owns the slot path, namespace, scope, and recall visibility.
 Mounted extensions cannot contribute memory slots.
 
 ## Design invariants
@@ -736,16 +725,16 @@ Mounted extensions cannot contribute memory slots.
   slot.
 - The resolved namespace and scope are the only variable inputs to the provider
   key. Custom namespaces receive no path or deployment suffixes.
-- One scope lock applies to every provider call, projection, model step, and
+- One scope lock applies to every provider call, recalled message, model step, and
   durable tool continuation in an operation.
 - Recall and save phases identify their exact lifecycle boundary. Every provider
-  context includes durable history, the current projection, and a replay-stable
-  operation ID.
-- Projections enter model calls as scope-attributed user-role context but remain
-  outside durable history and compaction input. `visibility` controls which
-  projections enter the prompt after a scope change.
-- A recall result can replace, clear, or preserve only the active scope's
-  projection. Empty projection content is invalid.
+  context includes durable history and a replay-stable operation ID.
+- A non-empty recall result appends one scope-attributed user-role message to
+  durable history. `null`, `undefined`, and empty normalized content append
+  nothing; recall never mutates an earlier message.
+- `visibility` controls which attributed recall messages enter a model request
+  after a scope change. Session visibility preserves append-only prompt order;
+  scope visibility may filter an earlier prefix.
 - Provider tools are slot-qualified, scope-bound `turn.started` dynamic tools.
   Each turn resolves one complete tool set, every model step uses it, and a
   durable call keeps its originating definition until settlement.
@@ -763,7 +752,7 @@ Mounted extensions cannot contribute memory slots.
   guarantee.
 - Cross-provider search, mutation, or record reconciliation.
 - Model-selected alternate scopes or unscoped provider invocations.
-- Treating projection visibility as complete participant isolation for ordinary
+- Treating recall visibility as complete participant isolation for ordinary
   conversation messages or provider tool results.
 - Preventing faulty or malicious provider code from ignoring the supplied scope.
 - Standardizing provider credentials, migrations, inspection tools, or
@@ -813,27 +802,31 @@ Mounted extensions cannot contribute memory slots.
       `fileMemory()` slots. This resolves the [model-facing attribution
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
 
-- [ ] **Explain projection placement and tool invocation semantics.** Keep or
-      revise the current replaceable, scope-attributed projection model only
-      after documenting its prompt-cache, chronology, stale-context, and suffix
-      placement tradeoffs. State directly that eve invokes `recall` at fixed
-      lifecycle boundaries and resolves the tool set once per turn, while the
-      model decides whether to call an exposed tool. Close the [replacement and
-      cache thread](https://github.com/vercel/eve/pull/1581#discussion_r3807382863),
+- [x] **Define recall placement and tool invocation semantics.** Every non-empty
+      recall result appends one scope-attributed user-role message to durable
+      history at its lifecycle boundary. `null`, `undefined`, and normalized
+      empty content append nothing and never clear earlier history. Session
+      visibility preserves append-only prompt order; scope visibility may
+      filter earlier recalled messages after a scope change. eve invokes
+      `recall` deterministically and resolves one tool set per turn, while the
+      model decides whether to call an exposed tool. This resolves the
+      [replacement and cache
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807382863),
       [suffix placement
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807481674),
-      and [recall versus tool
-      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807408005)
-      after the proposal records the chosen rationale.
+      [recall versus tool
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807408005),
+      [null sentinel
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807387086),
+      and [falsy return
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807755029).
 
 - [ ] **Reconcile the remaining review threads with the final contract.**
-      Correct the earlier additive-recall reply: the current contract keeps one
-      replaceable projection per slot and scope. Correct the cross-provider
-      reply: provider `ctx.messages` excludes other memory projections, and
-      cross-provider reconciliation remains a non-goal. Reply to or resolve the
-      remaining no-change questions about `phase`, `null` and `undefined`,
-      visibility, and the namespace/scope split, then resolve the outdated and
-      approval-only threads. Start with the [cross-provider
+      Provider `ctx.messages` includes recalled history, and
+      `getMemoryMessageAttribution` identifies its originating slot and scope.
+      Reply to or resolve the remaining questions about settled-turn metadata,
+      the namespace/scope split, and cross-provider coordination, then resolve
+      outdated and approval-only threads. Start with the [cross-provider
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807280622)
       and the [outdated turn-input
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3772094622).

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -622,6 +622,14 @@ and the settled durable history, including the assistant response and tool
 results. The method does not run for failed, cancelled, input-deferred, or
 adapter-consumed turns.
 
+Completed-turn save is a semantic memory boundary, not an instrumentation
+export. It does not receive token usage, provider cost, latency, trace
+identifiers, or unsuccessful outcomes. A provider that also consumes
+instrumentation can correlate the two surfaces with `ctx.session.id` and
+`ctx.turn.turnId`. The `usageInputTokens` field on `compaction.requested` is
+specific to that boundary because it describes the context about to be
+compacted.
+
 eve awaits completed-turn saves before emitting `session.waiting` in
 conversation mode or `session.completed` in task mode. A provider may capture
 the turn, update a remote profile, enqueue its own work, or do nothing.
@@ -750,6 +758,8 @@ Mounted extensions cannot contribute memory slots.
 - Framework-provided remember, forget, purge, export, or administrative APIs.
 - A built-in capture model, extractor, formatter, retention policy, or erasure
   guarantee.
+- A memory-specific observability feed for usage, cost, latency, traces, errors,
+  or cancelled turns.
 - Cross-provider search, mutation, or record reconciliation.
 - Model-selected alternate scopes or unscoped provider invocations.
 - Treating recall visibility as complete participant isolation for ordinary
@@ -778,17 +788,17 @@ Mounted extensions cannot contribute memory slots.
       coordinates for private memory. This resolves the [scope and Slack privacy
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807248748).
 
-- [ ] **Decide what settled-turn metadata memory receives.** Determine whether
-      `save` with `phase: "turn.completed"` receives aggregate input, output,
-      cache, and cost usage, and document how `session.id` plus `turnId` link a
-      memory operation to instrumentation. Explicitly keep failed, cancelled,
-      and deferred turns in instrumentation, or add separate typed phases if
-      memory providers are expected to learn from those outcomes. Close the
+- [x] **Keep settled-turn telemetry out of memory.** `save` with
+      `phase: "turn.completed"` receives completed input and durable history,
+      but not usage, cost, latency, trace identifiers, or unsuccessful
+      outcomes. Instrumentation owns that data and can be correlated through
+      `session.id` plus `turnId`. `compaction.requested` retains its input-token
+      count because that value describes the context being compacted. This
+      resolves the
       [usage and trace
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807526107)
       and [terminal outcome
-      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807561187)
-      once that boundary is unambiguous.
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807561187).
 
 - [x] **Give the model a safe memory-slot purpose.** The consuming
       `defineMemory(...)` may supply an optional static `description`. eve
@@ -821,12 +831,13 @@ Mounted extensions cannot contribute memory slots.
       and [falsy return
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807755029).
 
-- [ ] **Reconcile the remaining review threads with the final contract.**
-      Provider `ctx.messages` includes recalled history, and
+- [x] **Reconcile review threads with the final contract.** Provider
+      `ctx.messages` includes recalled history, and
       `getMemoryMessageAttribution` identifies its originating slot and scope.
-      Reply to or resolve the remaining questions about settled-turn metadata,
-      the namespace/scope split, and cross-provider coordination, then resolve
-      outdated and approval-only threads. Start with the [cross-provider
+      The namespace/scope split, lifecycle phases, telemetry boundary, and
+      cross-provider behavior now match the implementation. All outdated,
+      approval-only, and superseded threads are resolved, including the
+      [cross-provider
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807280622)
       and the [outdated turn-input
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3772094622).

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-19"
+last_updated: "2026-08-20"
 ---
 
 # First-class memory
@@ -17,21 +17,22 @@ scope, and a recall visibility policy. It may also describe the slot's
 purpose to the model through provider tool descriptions. The provider contract
 has three methods:
 
-- `recall` appends provider context to durable history as a user-role message.
-- `save` observes history before compaction and after a completed turn.
+- `recall` appends provider context to durable history as a user- or
+  system-role message.
+- `capture` observes history before compaction and after a completed turn.
 - `tools` contributes model tools bound to the active memory scope.
 
-eve calls each method at fixed boundaries. Recall and save receive a
+eve calls each method at fixed boundaries. Recall and capture receive a
 discriminated `phase`, current turn coordinates, a stable operation ID, and the
-address resolved for the slot. Tools are resolved once after turn-start recall
+locked memory scope resolved for the slot. Tools are resolved once after turn-start recall
 through the same durable dynamic-capability machinery as a `turn.started`
 `defineDynamic` tool resolver.
 
 ```text
 turn.started          ---> recall(phase: "turn.started") ---> tools
-compaction.requested  ---> save(phase: "compaction.requested")
+compaction.requested  ---> capture(phase: "compaction.requested")
 compaction.completed  ---> recall(phase: "compaction.completed")
-turn.completed        ---> save(phase: "turn.completed")
+turn.completed        ---> capture(phase: "turn.completed")
 ```
 
 eve owns namespace and scope resolution, invocation order, recall-message
@@ -43,12 +44,12 @@ record or storage model.
 
 ## Public API at a glance
 
-| Import path              | Public surface                                                                                                    |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, addressing types, and recall types |
-| `eve/memory/scope`       | `byPrincipal`                                                                                                     |
-| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                              |
-| `eve/memory/file/vercel` | `vercelBlob`                                                                                                      |
+| Import path              | Public surface                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, scope types, and recall types |
+| `eve/memory/scope`       | `byPrincipal`                                                                                                |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                         |
+| `eve/memory/file/vercel` | `vercelBlob`                                                                                                 |
 
 The smallest complete memory slot uses the built-in file provider:
 
@@ -98,9 +99,9 @@ export default defineMemory({
 
 The same provider instance may back several slots. Their recalled messages,
 tools, and provider invocations remain independent. The default namespace
-includes the slot identity, so each slot receives a distinct provider address.
-Definitions that resolve the same custom namespace and scope intentionally
-share an address.
+includes the slot identity, so each slot receives a distinct provider scope
+key. Definitions that resolve the same custom namespace and scope intentionally
+share a scope key.
 
 ## Model-facing description
 
@@ -147,7 +148,7 @@ export default defineMemory({
 When the provider returns tools, eve prepends the slot description and two
 newline characters to every provider-authored tool description. For example,
 the first slot's `save_memory` description begins with its personal-memory
-purpose before the provider's generic save guidance. eve performs this
+purpose before the provider's generic save-tool guidance. eve performs this
 composition after the `tools` resolver returns and before the dynamic tool
 metadata is captured, so every model step and parked continuation sees the same
 description. Omitting `description` preserves each provider tool description
@@ -164,21 +165,34 @@ enforce authorization or replace scope isolation.
 ## Namespace
 
 Namespace identifies the application-owned memory domain. It may be a string,
-`null`, a promise, or a zero-argument resolver:
+`null`, or a resolver:
 
 ```ts
-type MemoryNamespaceDefinition =
-  string | null | Promise<string | null> | (() => string | null | Promise<string | null>);
+interface MemoryNamespaceContext {
+  /** Graph node that owns the slot. */
+  readonly node: string;
+  /** Path-derived slot identity, such as "memory" or "user". */
+  readonly slot: string;
+}
 
-function defaultNamespace(): string;
+type MemoryNamespaceDefinition =
+  string | null | ((context: MemoryNamespaceContext) => string | null | Promise<string | null>);
+
+function defaultNamespace(context: MemoryNamespaceContext): string;
 ```
 
-After resolving a non-null scope, eve awaits or invokes the namespace when it
+After resolving a non-null scope, eve invokes the namespace resolver when it
 locks memory for a lifecycle operation. A resolved `null` disables the slot for
 that operation. If `namespace` is omitted, eve uses the exported
 `defaultNamespace` function as the resolver. Its value includes the Vercel
 project when available, otherwise a hash of the local application root, plus
-the deployment environment, graph node, and path-derived memory slot.
+the deployment environment and the node and slot from the supplied context.
+`defaultNamespace` is a pure function of its context and the deployment
+environment, so a custom resolver composes with it:
+
+```ts
+namespace: (ctx) => `${defaultNamespace(ctx)}:${process.env.DEPLOYMENT_REGION ?? "local"}`,
+```
 
 Set `namespace` to define a custom application domain:
 
@@ -223,7 +237,6 @@ interface MemoryScopeContext {
 type MemoryScopeDefinition =
   | string
   | null
-  | Promise<string | null>
   | ((
       context: MemoryScopeContext,
     ) => MemoryScopeResolverResult | Promise<MemoryScopeResolverResult>);
@@ -262,7 +275,7 @@ audiences or containers inside that domain. The resolved pair is the only
 variable input to the provider key. eve canonically encodes the pair before
 hashing, so values cannot collide through string concatenation.
 
-Every `recall`, `save`, and `tools` call receives this scope. Tools close over
+Every `recall`, `capture`, and `tools` call receives this scope. Tools close over
 the same locked scope, so the model never selects a different user, tenant, or
 container. A conforming provider must apply `scope.key` or the namespace and
 value to every downstream read and write. eve cannot prevent faulty provider
@@ -277,8 +290,12 @@ key under which it was appended.
 Passing `byPrincipal` as the scope resolver identifies the authenticated caller
 from principal type, authenticator, optional issuer, and principal ID. It is a
 pure consumer of the supplied `MemoryScopeContext`; it does not read ambient or
-private runtime state. The function returns `null` for an unauthenticated
-caller. Anonymous callers never share a memory scope.
+private runtime state. The function returns `null` — disabling the slot — when
+`auth.current` is `null`, for anonymous principals such as `none()` traffic,
+and for runtime principals such as scheduled turns. Anonymous callers never
+receive a memory scope, shared or otherwise. Local development authenticates
+every request as the shared `local-dev` principal, so one development machine
+resolves one scope.
 
 Principal scope follows the same authenticated caller across channels. Memory
 that is safe only within one channel or conversation must include the trusted
@@ -356,7 +373,7 @@ scope:   ... -> participant A turn -> assistant -> participant B memory -> parti
 session: ... -> participant A memory -> participant A turn -> assistant -> participant B memory -> participant B turn
 ```
 
-This option never changes provider scope. `recall`, `save`, and `tools` still
+This option never changes provider scope. `recall`, `capture`, and `tools` still
 receive only the active turn's locked scope. The provider cannot select the
 visibility mode. A `null` scope suppresses all recalled messages belonging to
 the slot in both modes.
@@ -372,7 +389,7 @@ shared-session risk.
 ## Provider contract
 
 `MemoryProvider` defines the operations available at memory lifecycle
-boundaries. `recall` is required. `save` and `tools` are optional.
+boundaries. `recall` is required. `capture` and `tools` are optional.
 
 ```ts
 import type { ModelMessage } from "ai";
@@ -382,7 +399,8 @@ import type { DynamicResolveContext, ToolDefinition } from "eve/tools";
 interface MemoryRecallMessage {
   /** Provider context appended to durable model history. */
   readonly content: string;
-  readonly role: "user";
+  /** Defaults to "user". */
+  readonly role?: "system" | "user";
 }
 
 interface MemoryMessageAttribution {
@@ -392,8 +410,10 @@ interface MemoryMessageAttribution {
 
 function getMemoryMessageAttribution(message: ModelMessage): MemoryMessageAttribution | null;
 
+/** Mirrors the ambient `ctx.session.turn` coordinates plus the turn input. */
 interface MemoryTurnContext {
-  readonly turnId: string;
+  /** Stable turn ID, matching `ctx.session.turn.id`. */
+  readonly id: string;
   /** Zero-based durable turn sequence. The first turn is sequence 0. */
   readonly sequence: number;
   /** Normalized model messages accepted as input for this turn. */
@@ -404,7 +424,7 @@ interface MemoryOperationContext extends SessionContext {
   readonly abortSignal: AbortSignal;
   /** Durable model history at this lifecycle boundary, including prior recalls. */
   readonly messages: readonly ModelMessage[];
-  /** Identifies one logical recall or save operation across workflow replay. */
+  /** Identifies one logical recall or capture operation across workflow replay. */
   readonly operationId: string;
   readonly memory: {
     readonly scope: MemoryScope;
@@ -430,7 +450,7 @@ type MemoryRecallContext = MemoryOperationContext &
       }
   );
 
-type MemorySaveContext = MemoryOperationContext &
+type MemoryCaptureContext = MemoryOperationContext &
   (
     | {
         readonly phase: "compaction.requested";
@@ -463,7 +483,7 @@ type MemoryToolSet = Readonly<Record<string, ToolDefinition>>;
 interface MemoryProvider {
   recall(context: MemoryRecallContext): MemoryRecallResult | Promise<MemoryRecallResult>;
 
-  save?(context: MemorySaveContext): void | Promise<void>;
+  capture?(context: MemoryCaptureContext): void | Promise<void>;
 
   tools?(context: MemoryToolsContext): MemoryToolSet | null | Promise<MemoryToolSet | null>;
 }
@@ -497,12 +517,12 @@ const customMemory = defineMemoryProvider({
 
 The result of `recall` is append-only:
 
-| Result                              | Effect                                         |
-| ----------------------------------- | ---------------------------------------------- |
-| `{ content: string, role: "user" }` | Append one scope-attributed user-role message. |
-| `null`, `undefined`, or no return   | Append nothing at this boundary.               |
+| Result                                           | Effect                                                                                   |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `{ content: string, role?: "system" \| "user" }` | Append one scope-attributed message with the resolved role. `role` defaults to `"user"`. |
+| `null`, `undefined`, or no return                | Append nothing at this boundary.                                                         |
 
-eve applies the same content normalization as user-role instructions. It trims
+eve applies the same content normalization as instructions. It trims
 the returned content and appends nothing when the result is empty after
 trimming. A recall result never replaces, clears, or mutates an earlier message.
 
@@ -511,21 +531,24 @@ storage behavior or impose a record model.
 
 ## Recalled messages
 
-Every non-empty recall result becomes one durable user-role message, using the
-same message shape and append behavior as user-role instructions. Turn-start
-recalls are appended immediately before the admitted turn input. Post-compaction
-recalls are appended after the rewritten checkpoint and retained tail. Multiple
-slots append in stable slot-path order.
+Every non-empty recall result becomes one durable message with the resolved
+role, using the same message shape and append behavior as instructions.
+Turn-start recalls are appended immediately before the admitted turn input.
+Post-compaction recalls are appended after the rewritten checkpoint and
+retained tail. Multiple slots append in stable slot-path order. A user-role
+recall enters model context in its durable history position. A system-role
+recall keeps the same durable position and attribution but follows the same
+model-request routing as system-role instructions.
 
 eve records internal slot and scope attribution on each recalled message. The
 attribution is not sent to the model or exposed as tool input. It exists so eve
 can apply `visibility` at model assembly and so provider code can distinguish
 recalled context from ordinary conversation messages. The message itself remains
-part of `ctx.messages`, completed-turn saves, and later compaction input.
+part of `ctx.messages`, completed-turn captures, and later compaction input.
 
 Recalled messages are not emitted as `message.received`; they are framework
 context rather than new channel input. Compaction may summarize or discard them
-like other durable user-role context. Before compaction, eve applies the active
+like other durable context. Before compaction, eve applies the active
 visibility policy, so a scope-hidden recall cannot enter the checkpoint and is
 removed with the rewritten history. The post-compaction recall boundary lets a
 provider append fresh context when the rewritten history no longer contains it.
@@ -534,7 +557,9 @@ Append-only recall preserves the existing prompt prefix in the normal case. It
 also means a provider owns repetition and correction policy. Returning the same
 snapshot at every turn appends duplicates, while a later correction does not
 delete an earlier claim. A provider returns `null` or `undefined` when it has no
-new context to append.
+new context to append. Because system-role recalls join the system prompt,
+changed system-role content invalidates the cached prompt prefix; a provider
+that recalls frequently changing context should prefer the default user role.
 
 ## Lifecycle
 
@@ -557,17 +582,17 @@ automatic compaction runs at the same opening boundary, the new messages enter
 compaction input. Post-compaction recall may append fresh context after the
 rewritten checkpoint before the model runs.
 
-### Compaction save and recall
+### Compaction capture and recall
 
 Before automatic or manual compaction rewrites history, eve calls an implemented
-`save` method with `phase: "compaction.requested"`. The provider receives the
+`capture` method with `phase: "compaction.requested"`. The provider receives the
 complete durable history about to be compacted and the compaction model and
 usage metadata. A provider may persist a checkpoint, extract facts the summary
 could omit, or do nothing.
 
 After a checkpoint is durably appended, eve calls `recall` with
 `phase: "compaction.completed"`. The provider receives the settled
-post-compaction history and may append one fresh user-role message. The call
+post-compaction history and may append one fresh recall message. The call
 occurs after every successful automatic or manual compaction, even when the
 provider skipped ordinary turn-start recall.
 
@@ -614,45 +639,46 @@ returns the recorded result. Provider mutations belong in the returned tool's
 `execute` function. eve never substitutes the current turn's definition or
 scope for a parked call's captured definition.
 
-### Completed-turn save
+### Completed-turn capture
 
-After a turn reaches `turn.completed`, eve calls an implemented `save` method
+After a turn reaches `turn.completed`, eve calls an implemented `capture` method
 with `phase: "turn.completed"`. The provider receives the completed turn input
 and the settled durable history, including the assistant response and tool
 results. The method does not run for failed, cancelled, input-deferred, or
 adapter-consumed turns.
 
-Completed-turn save is a semantic memory boundary, not an instrumentation
+Completed-turn capture is a semantic memory boundary, not an instrumentation
 export. It does not receive token usage, provider cost, latency, trace
 identifiers, or unsuccessful outcomes. A provider that also consumes
 instrumentation can correlate the two surfaces with `ctx.session.id` and
-`ctx.turn.turnId`. The `usageInputTokens` field on `compaction.requested` is
+`ctx.turn.id`. The `usageInputTokens` field on `compaction.requested` is
 specific to that boundary because it describes the context about to be
 compacted.
 
-eve awaits completed-turn saves before emitting `session.waiting` in
+eve awaits completed-turn captures before emitting `session.waiting` in
 conversation mode or `session.completed` in task mode. A provider may capture
 the turn, update a remote profile, enqueue its own work, or do nothing.
 
 ## Replay and failures
 
-Every recall and save invocation receives an `operationId` for one logical slot
-operation. eve reuses the ID across workflow replay, so it is not a unique
+Every recall and capture invocation receives an `operationId` for one logical
+slot operation. eve reuses the ID across workflow replay, so it is not a unique
 callback-attempt identifier. A provider must use it as the idempotency key for
-externally visible `save` side effects. eve records recalled messages with their
-scope attribution and keeps turn-scoped dynamic tool metadata in durable session
-state.
+externally visible `capture` side effects. eve records recalled messages with
+their scope attribution and keeps turn-scoped dynamic tool metadata in durable
+session state.
 
 Failure behavior follows the point at which the method runs:
 
 - A turn-start `recall` failure fails the active turn before the model runs.
-- A `compaction.requested` save failure aborts compaction before history changes.
+- A `compaction.requested` capture failure aborts compaction before history
+  changes.
 - A post-compaction `recall` failure cannot undo the checkpoint. It fails the
   active turn when compaction was automatic; standalone compaction emits a
   diagnostic and returns the session to waiting.
 - A throwing or invalid `tools` result is diagnosed and omitted for the turn,
   matching `defineDynamic` tool resolution.
-- A completed-turn `save` failure cannot rewrite the completed response. eve
+- A completed-turn `capture` failure cannot rewrite the completed response. eve
   emits a content-free diagnostic and continues to the ready boundary.
 
 ## Built-in file memory
@@ -675,11 +701,11 @@ every successful compaction. It appends the formatted document when the active
 slot and scope do not already have an identical latest recall in durable
 history. An empty or unchanged document appends nothing. Its `tools` method
 exposes `save_memory({ text })` and `remove_memory({ index })`. Each tool completes after
-its conditional write, and the next recall reflects the updated document.
-`save_memory` normalizes whitespace, returns the existing index for duplicate
-text, and fails when the document reaches `maxEntries`. `remove_memory` is a
-no-op when its index is absent. The provider omits `save`: it does not run a
-capture model or persist whole conversations.
+its conditional write and returns no output; the next recall reflects the
+updated document. `save_memory` normalizes whitespace, treats duplicate text as
+a successful no-op, and fails when the document reaches `maxEntries`.
+`remove_memory` is a no-op when its index is absent. The provider omits
+`capture`: it does not run an extraction model or persist whole conversations.
 
 The provider uses one portable conditional-document backend:
 
@@ -712,12 +738,12 @@ The same lifecycle also supports a hosted semantic provider:
 | ---------------------- | --------------------------- | ------------------------------------------- |
 | `turn.started` recall  | Append a changed document   | Retrieve against the current turn input     |
 | Post-compaction recall | Append if context is absent | Refresh against the compacted history       |
-| Pre-compaction save    | Omit                        | Preserve facts or checkpoint provider state |
-| Completed-turn save    | Omit                        | Capture the completed interaction           |
+| Pre-compaction capture | Omit                        | Preserve facts or checkpoint provider state |
+| Completed-turn capture | Omit                        | Capture the completed interaction           |
 | Turn tools             | Save and remove entries     | Provider-defined search, save, or forget    |
 
 At each boundary, a provider may return `undefined` from `recall`, omit or do
-nothing in `save`, or return `null` from `tools`.
+nothing in `capture`, or return `null` from `tools`.
 
 ## Provider packaging
 
@@ -735,11 +761,12 @@ Mounted extensions cannot contribute memory slots.
   key. Custom namespaces receive no path or deployment suffixes.
 - One scope lock applies to every provider call, recalled message, model step, and
   durable tool continuation in an operation.
-- Recall and save phases identify their exact lifecycle boundary. Every provider
-  context includes durable history and a replay-stable operation ID.
-- A non-empty recall result appends one scope-attributed user-role message to
-  durable history. `null`, `undefined`, and empty normalized content append
-  nothing; recall never mutates an earlier message.
+- Recall and capture phases identify their exact lifecycle boundary. Every
+  provider context includes durable history and a replay-stable operation ID.
+- A non-empty recall result appends one scope-attributed message with the
+  resolved role, defaulting to user, to durable history. `null`, `undefined`,
+  and empty normalized content append nothing; recall never mutates an earlier
+  message.
 - `visibility` controls which attributed recall messages enter a model request
   after a scope change. Session visibility preserves append-only prompt order;
   scope visibility may filter an earlier prefix.
@@ -747,9 +774,9 @@ Mounted extensions cannot contribute memory slots.
   Each turn resolves one complete tool set, every model step uses it, and a
   durable call keeps its originating definition until settlement.
 - An optional static slot description is prepended to every provider tool
-  description before durable capture. It never derives from or exposes the
-  namespace or scope, and it guides model routing without granting access.
-- Completed-turn save settles before the next ready boundary.
+  description before durable metadata capture. It never derives from or exposes
+  the namespace or scope, and it guides model routing without granting access.
+- Completed-turn capture settles before the next ready boundary.
 
 ## Non-goals
 
@@ -788,11 +815,11 @@ Mounted extensions cannot contribute memory slots.
       coordinates for private memory. This resolves the [scope and Slack privacy
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807248748).
 
-- [x] **Keep settled-turn telemetry out of memory.** `save` with
+- [x] **Keep settled-turn telemetry out of memory.** `capture` with
       `phase: "turn.completed"` receives completed input and durable history,
       but not usage, cost, latency, trace identifiers, or unsuccessful
       outcomes. Instrumentation owns that data and can be correlated through
-      `session.id` plus `turnId`. `compaction.requested` retains its input-token
+      `session.id` plus `turn.id`. `compaction.requested` retains its input-token
       count because that value describes the context being compacted. This
       resolves the
       [usage and trace
@@ -813,8 +840,8 @@ Mounted extensions cannot contribute memory slots.
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
 
 - [x] **Define recall placement and tool invocation semantics.** Every non-empty
-      recall result appends one scope-attributed user-role message to durable
-      history at its lifecycle boundary. `null`, `undefined`, and normalized
+      recall result appends one scope-attributed message with its resolved role
+      to durable history at its lifecycle boundary. `null`, `undefined`, and normalized
       empty content append nothing and never clear earlier history. Session
       visibility preserves append-only prompt order; scope visibility may
       filter earlier recalled messages after a scope change. eve invokes

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -470,7 +470,7 @@ call follows that boundary.
 
 ### Step tools
 
-Before each model call, eve calls `tools` with `phase: "step.started"`. For an
+Before each model step, eve calls `tools` with `phase: "step.started"`. For an
 ordinary step, that result replaces the slot's prior tool set rather than
 merging with it. Returning `null` or an empty record exposes no new tools for
 that slot and step.

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -159,6 +159,11 @@ optional manifest side table. Ordinary source composition owns replacement and
 disablement, and the ordinary dynamic-tool lifecycle owns public-name
 collisions and complete-result failure.
 
+The inspection projection advances `/eve/v1/info` to version 4. It lists each
+selected memory slot with its source provenance and preserves the generated
+tool wrapper's required memory-source dependency in the public binding data.
+Subagent summaries include their memory-slot count.
+
 The wrapper resolves on `turn.started` after recall commits. It reads the
 already locked slot, invokes `provider.tools(context)`, requires a map of
 branded `defineTool()` values, qualifies each key as
@@ -800,12 +805,8 @@ accumulative across compaction.
 
 Because superseded versions and hidden scopes can grow while the visible
 prompt stays constant, eve triggers canonicalization on raw attributed-record
-growth independently of visible prompt size. If canonical memory state alone
-exceeds its configured bound, compaction fails with an actionable error — and
-the failure is recoverable by design: the next recall boundary still runs, so
-providers can supersede their keyed items with smaller content, and the bound
-is application-configurable. eve never silently summarizes, evicts, or
-truncates provider items.
+growth independently of visible prompt size. eve never silently summarizes,
+evicts, or truncates provider items.
 
 After a checkpoint is durably appended, eve calls `recall` with
 `phase: "compaction.completed"`. The provider receives the settled
@@ -954,7 +955,6 @@ implementation uses exactly the reviewed constants.
 | Provider item ID            | non-empty, 1,024 UTF-8 bytes         | keyed message `id`                                       |
 | Key prefixes                | `memns1_`, `memscope1_`, `memitem1_` | SHA-256 digests, base64url                               |
 | Raw-record canonicalization | 512 records or 262,144 bytes         | superseded/hidden attributed records between compactions |
-| Canonical private state     | 131,072 bytes, configurable          | folded memory state that must survive compaction         |
 | File entry                  | 2,048 UTF-8 bytes                    | normalized `save_memory` text                            |
 | File document               | 65,536 UTF-8 bytes                   | exact serialized stored document, including header       |
 | File entries                | `maxEntries`, default 100            | live entries per scope key                               |
@@ -1103,8 +1103,7 @@ recall visibility. Mounted extensions cannot contribute memory slots.
   boundary.
 - Compaction canonicalizes memory records without laundering any attributed
   record into a free-form summary and without dropping items hidden from the
-  active scope. Canonical-state overflow fails recoverably: recall still runs
-  so providers can supersede keyed items with smaller content.
+  active scope.
 - Provider tools are slot-qualified, scope-bound ordinary dynamic tools built
   entirely on the generic dynamic-tool engine. Each turn resolves one complete
   tool set, every model step uses it, and callback replay uses the captured

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -11,17 +11,18 @@ last_updated: "2026-08-20"
 Memory is a path-authored capability for scoped context that outlives one
 session. A memory provider owns how it stores, retrieves, and updates memory.
 eve owns when the provider participates in the agent lifecycle, and eve owns a
-small projection record model — item identity, supersede, hide — so recalled
-context can be updated and deleted deterministically without a stale copy
-surviving in the prompt.
+small projection record model — item identity and supersession — so recalled
+context can be updated deterministically without a stale copy surviving in the
+prompt.
 
 Each memory definition binds a provider to an application namespace, a trusted
 scope, and a recall visibility policy. It may also describe the slot's
 purpose to the model through provider tool descriptions. The provider contract
 has three methods:
 
-- `recall` returns changes — append, upsert, or retract — that eve applies to
-  the slot's recalled context in durable history as user-role messages.
+- `recall` returns messages that eve applies to the slot's recalled context in
+  durable history as user-role context. A message with an `id` inserts or
+  replaces that item; a message without one appends immutably.
 - `capture` observes history before compaction and after a completed turn.
 - `tools` contributes model tools bound to the active memory scope.
 
@@ -38,7 +39,7 @@ compaction.completed  ---> recall(phase: "compaction.completed")
 turn.completed        ---> capture(phase: "turn.completed")
 ```
 
-eve owns namespace and scope resolution, invocation order, change validation
+eve owns namespace and scope resolution, invocation order, recall validation
 and application, recall-record attribution and visibility, projection, tool
 qualification, and replay behavior. The provider owns storage, retrieval,
 ranking, extraction, formatting, retention, and its model-facing operations. A
@@ -47,12 +48,12 @@ contract without sharing a storage model.
 
 ## Public API at a glance
 
-| Import path              | Public surface                                                                                                      |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, scope types, and recall change types |
-| `eve/memory/scope`       | `byPrincipal`                                                                                                       |
-| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                                |
-| `eve/memory/file/vercel` | `vercelBlob`                                                                                                        |
+| Import path              | Public surface                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, scope types, and recall types |
+| `eve/memory/scope`       | `byPrincipal`                                                                                                |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                         |
+| `eve/memory/file/vercel` | `vercelBlob`                                                                                                 |
 
 The smallest complete memory slot uses the built-in file provider:
 
@@ -459,25 +460,15 @@ import type { DynamicResolveContext, ToolDefinition } from "eve/tools";
 interface MemoryRecallMessage {
   /** Provider context recalled into durable model history as a user-role message. */
   readonly content: string;
+  /**
+   * Optional provider-owned item identity, unique within the slot, namespace,
+   * and scope. A keyed message inserts or replaces its item; an unkeyed
+   * message appends immutably.
+   */
+  readonly id?: string;
 }
 
-type MemoryRecallChange =
-  | {
-      readonly type: "append";
-      readonly message: MemoryRecallMessage;
-    }
-  | {
-      readonly type: "upsert";
-      /** Provider-owned opaque item identity, unique within the slot, namespace, and scope. */
-      readonly id: string;
-      readonly message: MemoryRecallMessage;
-    }
-  | {
-      readonly type: "retract";
-      readonly id: string;
-    };
-
-type MemoryRecallResult = MemoryRecallMessage | readonly MemoryRecallChange[] | null | undefined;
+type MemoryRecallResult = { readonly messages: readonly MemoryRecallMessage[] } | null | undefined;
 
 /** Mirrors the ambient `ctx.session.turn` coordinates plus the turn input. */
 interface MemoryTurnContext {
@@ -560,48 +551,45 @@ interface MemoryProvider {
 Recalled context is always user-role. Recall is framework context appended
 after the durable prefix and before the admitted turn input, so it preserves
 the prompt-cache prefix in the normal case. eve does not offer a system-role
-recall option: system-role content is position-independent, so upsert and
-retract semantics cannot compose with it, and any change to it invalidates the
+recall option: system-role content is position-independent, so keyed
+supersession cannot compose with it, and any change to it invalidates the
 prompt cache from message zero. Standing system-role guidance derived from
 runtime state belongs in `defineDynamic` instructions.
 
 `defineMemoryProvider(...)` is an identity-with-types helper. It does not add
 storage behavior.
 
-## Recall changes
+## Recall messages
 
-A recall result is a set of changes to the slot's recalled context, not a
-replacement snapshot. The result is a bare ordered array; a bare
-`MemoryRecallMessage` is shorthand for one append.
+A recall result is a set of messages applied to the slot's recalled context,
+not a replacement snapshot. The optional `id` on each message selects the
+semantics:
 
-| Change                            | Effect                                                                                                                                 |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `{ type: "append", message }`     | Add one immutable, unkeyed record. It cannot be updated or retracted later.                                                            |
-| `{ type: "upsert", id, message }` | Insert or replace the one item identified by `id`. An identical upsert is a no-op; a changed upsert supersedes only the older version. |
-| `{ type: "retract", id }`         | Hide the item identified by `id`. Idempotent; retracting an unknown or never-active ID is a valid no-op.                               |
-| `MemoryRecallMessage`             | Shorthand for one append.                                                                                                              |
-| `null`, `undefined`, `[]`         | Change nothing at this boundary.                                                                                                       |
+| Message           | Effect                                                                                                                                                     |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{ content, id }` | Insert or replace the one item identified by `id`. Identical content is a no-op; changed content supersedes the older version, which leaves model context. |
+| `{ content }`     | Append one immutable, unkeyed record. It cannot be updated later.                                                                                          |
 
-The semantics that hold at every boundary:
+A result of `{ messages: [] }`, `null`, or `undefined` changes nothing at this
+boundary. The semantics that hold at every boundary:
 
 - **Recall is observational.** Providers must not use it for external
-  mutations. eve makes the durable change commit atomic, but it cannot roll
-  back provider side effects.
+  mutations. eve makes the durable commit atomic, but it cannot roll back
+  provider side effects.
 - **Accumulation is the only mode.** An item missing from a later result
-  remains active. Missing top-k retrieval results never imply deletion. A
-  provider that wants something gone returns an explicit retract or a
-  superseding upsert.
+  remains visible. Missing top-k retrieval results never imply removal. A
+  provider that wants content replaced returns the same `id` with new content.
 - **Item identity is `(slot, namespaceKey, scopeKey, idKey)`**, where each key
   is an eve-owned opaque digest. The same provider `id` under two slots,
-  namespaces, or scopes identifies two independent items; neither can update,
-  retract, or reveal the other.
-- **Appends are never content-deduplicated.** A repeated identical bare append
-  adds a second copy. Content a provider might return again must be keyed.
-- **A retracted item can be reactivated** by a later upsert of the same ID.
-- **Batches validate completely before applying.** Empty or blank append and
-  upsert content, empty or oversized item IDs, duplicate upsert or retract IDs
-  within one batch, and unknown change keys are rejected, and a rejected batch
-  applies nothing. Change order within a batch is preserved.
+  namespaces, or scopes identifies two independent items; neither can update
+  or reveal the other.
+- **Unkeyed messages are never content-deduplicated.** A repeated identical
+  unkeyed message adds a second copy. Content a provider might return again
+  must be keyed.
+- **Batches validate completely before applying.** Empty or blank content,
+  empty or oversized IDs, duplicate IDs within one batch, and unknown message
+  keys are rejected, and a rejected batch applies nothing. Message order
+  within a batch is preserved.
 
 For example, keyed retrieval results `[A, B]` followed by `[B, C]` leave `A`,
 `B`, and `C` visible, with `B` present once.
@@ -609,7 +597,7 @@ For example, keyed retrieval results `[A, B]` followed by `[B, C]` leave `A`,
 ### Example: append-only event log
 
 A principal-scoped provider that surfaces each new observation exactly once
-uses the bare-message shorthand and never needs identity. Because appends are
+uses unkeyed messages and never needs identity. Because unkeyed messages are
 never deduplicated, the provider consumes each note rather than re-reading the
 latest state:
 
@@ -620,7 +608,7 @@ const auditMemory = defineMemoryProvider({
   async recall(ctx) {
     if (ctx.phase !== "turn.started") return null;
     const note = await takeUnreadNote(ctx.memory.scope.key);
-    return note === null ? null : { content: note };
+    return note === null ? null : { messages: [{ content: note }] };
   },
 });
 ```
@@ -630,7 +618,7 @@ const auditMemory = defineMemoryProvider({
 A vector-retrieval provider returns a different top-k subset each turn.
 Because accumulation is monotonic, an unbounded stream of new IDs would grow
 context forever. Keying results by window position bounds the visible set by
-construction: each recall re-upserts the same `k` identities, superseding the
+construction: each recall reuses the same `k` identities, superseding the
 previous occupant of each position:
 
 ```ts
@@ -640,34 +628,42 @@ const retrievalMemory = defineMemoryProvider({
   async recall(ctx) {
     if (ctx.phase !== "turn.started") return null;
     const hits = await search(ctx.memory.scope.key, ctx.turn.input, { limit: 3 });
-    return hits.map((hit, rank) => ({
-      type: "upsert" as const,
-      id: `rank:${rank}`,
-      message: { content: hit.text },
-    }));
+    return {
+      messages: hits.map((hit, rank) => ({ id: `rank:${rank}`, content: hit.text })),
+    };
   },
 });
 ```
 
 A provider that keys by document identity instead (`id: hit.documentId`) keeps
-every previously recalled document visible until it explicitly retracts one.
+every previously recalled document visible until it overwrites that identity.
 Both are valid; the provider chooses its window policy.
 
-### Rejected alternative: inventory coverage
+### Rejected and deferred alternatives
 
-An earlier revision included a `coverage: "complete"` flag: a keyed result
-asserting a full inventory, from which eve synthesized retractions for omitted
-IDs. It was cut because no first-party provider consumes it — `fileMemory()`
-returns one whole-document upsert — and because omission-means-deletion
-semantics are the sharpest foot-gun in a sparse-retrieval API. If a real
-enumerable provider needs framework diffing later, an inventory result shape is
-an additive union arm, not a breaking change.
+Two richer recall shapes were considered and cut:
+
+- **A tagged change union with an explicit `retract`.** No current provider
+  needs a keyed item to disappear rather than be replaced: `fileMemory()`
+  supersedes its whole document, including an empty-state rendering when the
+  last entry is removed, and bounded retrieval reuses window identities. If a
+  provider later needs true keyed removal, a retract form is an additive
+  extension, and dropping it now also drops the private tombstone
+  representation that projection would otherwise have to hide.
+- **A `coverage: "complete"` inventory flag**, from which eve synthesized
+  retractions for omitted IDs. No first-party provider consumes it, and
+  omission-means-deletion is the sharpest foot-gun in a sparse-retrieval API.
+  An inventory result shape remains an additive extension if a real enumerable
+  provider needs framework diffing.
+
+The `{ messages }` wrapper leaves room for future result-level metadata
+without a breaking change.
 
 ## Durable records and projection
 
-Every accepted change becomes an internal durable record attributed with the
-slot, opaque namespace key, opaque scope key, change kind, opaque item key for
-keyed changes, operation ID, and batch position. Raw durable history is
+Every accepted recall message becomes an internal durable record attributed
+with the slot, opaque namespace key, opaque scope key, opaque item key for
+keyed messages, operation ID, and batch position. Raw durable history is
 storage-only. Every message-bearing consumer — providers, dynamic resolvers,
 approval and tool contexts, token accounting, compaction, instrumentation
 callbacks, and the model request — receives a view derived from one canonical
@@ -675,11 +671,9 @@ scope projection, never raw durable history.
 
 Projection folds records per slot and identity:
 
-- visible unkeyed appends always remain, in position;
-- only the latest active upsert of each identity is visible, in the position of
-  its accepted batch;
-- a superseded version and a retracted item are hidden, along with the retract
-  itself;
+- visible unkeyed records always remain, in position;
+- only the latest version of each keyed identity is visible, in the position of
+  its accepted batch; superseded versions are hidden;
 - attribution is stripped before any authored callback, tool, or model
   boundary. There is no public accessor for recall attribution; providers use
   stable item IDs instead of scanning history.
@@ -690,22 +684,21 @@ rather than new channel input.
 ### Cache consequences
 
 New items append at the tail and preserve the existing prompt prefix. Repeated
-identical keyed items change nothing. An explicit update or retraction must
-stop the model from seeing the prior value, and filtering that older occurrence
-necessarily invalidates the prompt cache from that point forward. This is a
-deliberate trade: pure append-only recall is strictly better for prompt cache
-on updates, because the old copy would keep its position — but it leaves the
-contradicted copy model-visible, which makes update and deletion
-nondeterministic after compaction. The change model spends a mutation-driven
-cache invalidation to buy deterministic visibility; it is not cache-neutral,
-and it never substitutes a natural-language correction while leaving the
-contradicted content visible.
+identical keyed items change nothing. An explicit update must stop the model
+from seeing the prior value, and filtering that older occurrence necessarily
+invalidates the prompt cache from that point forward. This is a deliberate
+trade: pure append-only recall is strictly better for prompt cache on updates,
+because the old copy would keep its position — but it leaves the contradicted
+copy model-visible, which makes updates and removals nondeterministic after
+compaction. Keyed supersession spends a mutation-driven cache invalidation to
+buy deterministic visibility; it is not cache-neutral, and it never substitutes
+a natural-language correction while leaving the contradicted content visible.
 
 Within one session, the model also sees the mutation narrative — the old
-recalled copy, then the tool calls that changed storage. The change model earns
-its complexity at the boundaries where that narrative dies: compaction drops
-tool results first, so a stale recalled copy can outlive the story of its own
-deletion and be summarized as fact. Deterministic deletion, not model
+recalled copy, then the tool calls that changed storage. Keyed supersession
+earns its complexity at the boundaries where that narrative dies: compaction
+drops tool results first, so a stale recalled copy can outlive the story of its
+own removal and be summarized as fact. Deterministic supersession, not model
 competence, is the design driver.
 
 ## Lifecycle
@@ -721,15 +714,15 @@ history before the turn, including prior visible recalled context.
 Every active slot resolves independently against that same pre-recall view.
 Each result is normalized and validated, and the whole turn-wide batch commits
 atomically: one failing slot or one invalid batch applies nothing for any slot.
-Accepted changes are applied in stable slot-path order, after the durable
+Accepted messages are applied in stable slot-path order, after the durable
 prefix and before the admitted turn input, and the projected view is recomputed
 before tools resolve and the model runs.
 
 The first turn has `ctx.turn.sequence === 0`. A provider does not need to
-deduplicate its own recall: returning the current state as keyed upserts every
-turn is the intended pattern, because identical upserts are no-ops. A provider
-may still use the turn coordinates to recall only on the first turn, or use the
-current input as a retrieval query on every turn.
+deduplicate its own recall: returning the current state as keyed messages every
+turn is the intended pattern, because identical keyed messages are no-ops. A
+provider may still use the turn coordinates to recall only on the first turn,
+or use the current input as a retrieval query on every turn.
 
 ### Compaction capture, canonicalization, and recall
 
@@ -750,19 +743,19 @@ is reattached to the rewritten history, so items hidden from the currently
 active scope survive another scope's compaction, and sparse retrieval stays
 accumulative across compaction.
 
-Because superseded versions, hidden scopes, and tombstones can grow while the
-visible prompt stays constant, eve triggers canonicalization on raw
-attributed-record growth independently of visible prompt size. If canonical
-memory state alone exceeds its configured bound, compaction fails with an
-actionable error — and the failure is recoverable by design: the next recall
-boundary still runs, so providers can retract items, and the bound is
-application-configurable. eve never silently summarizes, evicts, or truncates
-provider items.
+Because superseded versions and hidden scopes can grow while the visible
+prompt stays constant, eve triggers canonicalization on raw attributed-record
+growth independently of visible prompt size. If canonical memory state alone
+exceeds its configured bound, compaction fails with an actionable error — and
+the failure is recoverable by design: the next recall boundary still runs, so
+providers can supersede their keyed items with smaller content, and the bound
+is application-configurable. eve never silently summarizes, evicts, or
+truncates provider items.
 
 After a checkpoint is durably appended, eve calls `recall` with
 `phase: "compaction.completed"`. The provider receives the settled
-post-compaction projected history and may return fresh changes, applied through
-the same atomic path. Identical retained items are no-ops. The call occurs
+post-compaction projected history and may return fresh messages, applied
+through the same atomic path. Identical retained items are no-ops. The call occurs
 after every successful automatic or manual compaction, even when the provider
 skipped ordinary turn-start recall.
 
@@ -801,9 +794,10 @@ contribution seam ([#2347](https://github.com/vercel/eve/issues/2347)). Memory
 adds no tool machinery of its own: no memory-specific approval methods, no
 separate callback registry, and no `defineMemoryTool` wrapper.
 
-Tools never emit recall changes. A tool executor mutates provider storage and
-returns ordinary tool output; recall is the single writer of recalled context,
-and the consistency contract is that the next recall boundary reflects storage.
+Tools never write recalled context. A tool executor mutates provider storage
+and returns ordinary tool output; recall is the single writer of recalled
+context, and the consistency contract is that the next recall boundary reflects
+storage.
 Within the turn that mutated storage, the stale recalled item remains visible
 and the model's own tool-call narrative covers the gap; the next turn-start or
 post-compaction recall trues it up.
@@ -865,7 +859,7 @@ externally visible `capture` side effects.
 
 Recall operations for one session are serialized by construction: turn steps
 serialize through workflow hook-ownership claims, so two recall operations for
-the same slot, namespace, and scope cannot complete out of order. The change
+the same slot, namespace, and scope cannot complete out of order. The message
 shape is therefore revision-free. eve persists each operation's accepted
 normalized batch, or its canonical digest, and a cold replay must reuse the
 stored batch or match its digest exactly; a replay that returns a reordered or
@@ -900,7 +894,7 @@ implementation uses exactly the reviewed constants.
 | Scope component             | 1,024 UTF-8 bytes                    | each scalar or tuple component                           |
 | Scope tuple                 | 16 components                        | resolver array results                                   |
 | Canonical key input         | 4,096 UTF-8 bytes                    | total namespace-plus-scope encoding                      |
-| Provider item ID            | non-empty, 1,024 UTF-8 bytes         | upsert and retract `id`                                  |
+| Provider item ID            | non-empty, 1,024 UTF-8 bytes         | keyed message `id`                                       |
 | Key prefixes                | `memns1_`, `memscope1_`, `memitem1_` | SHA-256 digests, base64url                               |
 | Raw-record canonicalization | 512 records or 262,144 bytes         | superseded/hidden attributed records between compactions |
 | Canonical private state     | 131,072 bytes, configurable          | folded memory state that must survive compaction         |
@@ -923,24 +917,27 @@ interface FileMemoryOptions {
 function fileMemory(options?: FileMemoryOptions): MemoryProvider;
 ```
 
-### Recall: one whole-document upsert
+### Recall: one whole-document keyed message
 
 `recall` loads the current document at every turn start and after every
 successful compaction, renders it — a heading that names the slot, explains the
 indexed entries, and states the exact qualified removal tool name, followed by
-each live `index: text` line — and returns exactly one upsert under a single
-stable provider ID. An unchanged document is an identical upsert and therefore
-a no-op; the provider never scans history. A mutated document supersedes the
-previous copy, so a removed or edited entry deterministically leaves model
-context at the next recall boundary, with no stale copy left visible. A missing
-document or one with zero live entries returns a retract of the document ID,
-which is a no-op when nothing was ever recalled.
+each live `index: text` line — and returns exactly one keyed message under a
+single stable provider ID. An unchanged document is an identical keyed message
+and therefore a no-op; the provider never scans history. A mutated document
+supersedes the previous copy, so a removed or edited entry deterministically
+leaves model context at the next recall boundary, with no stale copy left
+visible. A document whose last entry was removed renders an empty state — the
+heading plus a line stating no memories are saved — so removal of the final
+entry supersedes the old content the same way. A missing document, one never
+created for this scope key, recalls nothing, so sessions that never save
+memories carry no recalled context.
 
 Whole-document granularity is a provider choice, not an API requirement: each
 mutation re-sends the document and invalidates the cache from the document's
-previous position, while non-mutation turns cost nothing. Per-entry upserts
-remain a legal finer-grained alternative for providers that can enumerate their
-own deletions.
+previous position, while non-mutation turns cost nothing. Per-entry keyed
+messages remain a legal finer-grained alternative for providers whose removals
+can supersede per item.
 
 ### Tools
 
@@ -960,10 +957,10 @@ monotonically and never renumbered or reused, including after the highest live
 index is removed, so a model-facing index from earlier context can never alias
 a different, later fact. `maxEntries` counts live entries, so removal frees
 capacity without resetting the high-water mark. When `lastAllocatedIndex`
-reaches `Number.MAX_SAFE_INTEGER`, the next save fails explicitly. Deletion
-visibility comes from the changed document upsert superseding the previous
-copy, so the document needs no deletion tombstones. Header bytes count toward
-the document limit.
+reaches `Number.MAX_SAFE_INTEGER`, the next save fails explicitly. Removal
+visibility comes from the changed document superseding the previous copy, so
+the document needs no deletion tombstones. Header bytes count toward the
+document limit.
 
 ### Backend contract and selection
 
@@ -1004,13 +1001,13 @@ environment. Tests pass `inMemory()` explicitly.
 
 The same lifecycle also supports a hosted semantic provider:
 
-| Boundary               | Bounded file provider       | Hosted semantic provider                    |
-| ---------------------- | --------------------------- | ------------------------------------------- |
-| `turn.started` recall  | Upsert the current document | Upsert retrieval results for the turn input |
-| Post-compaction recall | Upsert if context is absent | Refresh against the compacted history       |
-| Pre-compaction capture | Omit                        | Preserve facts or checkpoint provider state |
-| Completed-turn capture | Omit                        | Capture the completed interaction           |
-| Turn tools             | Save and remove entries     | Provider-defined search, save, or forget    |
+| Boundary               | Bounded file provider       | Hosted semantic provider                     |
+| ---------------------- | --------------------------- | -------------------------------------------- |
+| `turn.started` recall  | Recall the current document | Recall keyed retrieval results for the input |
+| Post-compaction recall | Recall if context is absent | Refresh against the compacted history        |
+| Pre-compaction capture | Omit                        | Preserve facts or checkpoint provider state  |
+| Completed-turn capture | Omit                        | Capture the completed interaction            |
+| Turn tools             | Save and remove entries     | Provider-defined search, save, or forget     |
 
 At each boundary, a provider may return `undefined` from `recall`, omit or do
 nothing in `capture`, or return `null` from `tools`.
@@ -1038,10 +1035,10 @@ recall visibility. Mounted extensions cannot contribute memory slots.
 - Raw durable history is storage-only. Every message-bearing consumer receives
   one canonical scope projection with attribution stripped; no authored
   callback or model boundary sees hidden items or eve-owned metadata.
-- A recall result is a validated batch of append/upsert/retract changes,
-  committed atomically per turn across all active slots. Omission never
-  retracts; appends are immutable; identical upserts are no-ops; retracts are
-  idempotent.
+- A recall result is a validated batch of recalled messages, committed
+  atomically per turn across all active slots. Omission never removes; unkeyed
+  messages are immutable; an identical keyed message is a no-op; a changed
+  keyed message supersedes only its own prior version.
 - Item identity is `(slot, namespaceKey, scopeKey, idKey)`. The same provider
   ID under different locks is a different item.
 - `visibility` controls which attributed records enter a model request after a
@@ -1050,11 +1047,11 @@ recall visibility. Mounted extensions cannot contribute memory slots.
 - Compaction canonicalizes memory records without laundering any attributed
   record into a free-form summary and without dropping items hidden from the
   active scope. Canonical-state overflow fails recoverably: recall still runs
-  so providers can retract.
+  so providers can supersede keyed items with smaller content.
 - Provider tools are slot-qualified, scope-bound ordinary dynamic tools built
   entirely on the generic dynamic-tool engine. Each turn resolves one complete
   tool set, every model step uses it, and a durable call keeps its originating
-  definition until settlement. Tools never emit recall changes.
+  definition until settlement. Tools never write recalled context.
 - An optional static slot description is prepended to every provider tool
   description before durable metadata capture. It never derives from or exposes
   the namespace or scope, and it guides model routing without granting access.
@@ -1063,15 +1060,15 @@ recall visibility. Mounted extensions cannot contribute memory slots.
 ## Non-goals
 
 One earlier non-goal is explicitly reversed: this proposal gives eve a
-projection record model — item identity, supersede, and hide semantics for
-recalled context. eve owns how recalled items appear, update, and disappear in
-model context. eve still owns no storage model: what a provider persists, how
-it ranks, embeds, extracts, or retains data remains entirely provider-defined.
+projection record model — item identity and supersession semantics for
+recalled context. eve owns how recalled items appear and update in model
+context. eve still owns no storage model: what a provider persists, how it
+ranks, embeds, extracts, or retains data remains entirely provider-defined.
 
 Still out of scope:
 
 - Framework-provided remember, forget, purge, export, or administrative APIs.
-  A retract changes model-visible context; it is not a storage-erasure
+  Supersession changes model-visible context; it is not a storage-erasure
   guarantee, and storage erasure remains a provider operation.
 - A built-in capture model, extractor, formatter, retention policy, or erasure
   guarantee.
@@ -1132,10 +1129,11 @@ Still out of scope:
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
 
 - [x] **Define recall placement and tool invocation semantics.** A recall
-      result is a validated batch of append/upsert/retract changes applied
-      atomically at its lifecycle boundary as user-role context. `null`,
-      `undefined`, empty batches, and normalized empty content change nothing
-      and never clear earlier history; omission never retracts. Session
+      result is a validated batch of recalled messages applied atomically at
+      its lifecycle boundary as user-role context; a keyed message supersedes
+      its prior version. `null`, `undefined`, empty batches, and normalized
+      empty content change nothing and never clear earlier history; omission
+      never removes. Session
       visibility retains records across scope-key changes within one namespace;
       scope visibility filters earlier scopes. eve invokes `recall`
       deterministically and resolves one tool set per turn, while the model

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-14"
+last_updated: "2026-08-18"
 ---
 
 # First-class memory
@@ -12,54 +12,53 @@ Memory is a path-authored capability for scoped context that outlives one
 session. A memory provider owns how it stores, retrieves, and updates memory.
 eve owns when the provider participates in the agent lifecycle.
 
-The provider contract has three semantic methods:
+Each memory definition binds a provider to an application namespace, a trusted
+scope, and a projection visibility policy. The provider contract has three
+methods:
 
 - `recall` updates the context projected into model calls.
 - `save` observes history before compaction and after a completed turn.
 - `tools` contributes model tools bound to the active memory scope.
 
-These methods replace a generic map of lifecycle event handlers. eve calls each
-method at fixed boundaries and supplies a discriminated `phase`, the current
-turn coordinates, a stable operation ID, and the scope resolved for the slot.
-The provider may vary its behavior by phase or turn. For example, a provider can
-recall on turn sequence `0`, keep that projection across later turns, and
-refresh it after compaction.
+eve calls each method at fixed boundaries. Recall and save receive a
+discriminated `phase`, current turn coordinates, a stable operation ID, and the
+address resolved for the slot. Tools are resolved once after turn-start recall
+through the same durable dynamic-capability machinery as a `turn.started`
+`defineDynamic` tool resolver.
 
 ```text
-turn.started          ---> recall(phase: "turn.started")
+turn.started          ---> recall(phase: "turn.started") ---> tools
 compaction.requested  ---> save(phase: "compaction.requested")
 compaction.completed  ---> recall(phase: "compaction.completed")
-step.started          ---> tools(phase: "step.started")
 turn.completed        ---> save(phase: "turn.completed")
 ```
 
-eve owns path-derived identity, trusted scope resolution, invocation order,
-scope-bound context projection, projection visibility, tool qualification, and
-replay behavior. The provider owns storage, retrieval, ranking, extraction,
-formatting, retention, and its model-facing operations. A hosted semantic
-service and a bounded text file can therefore use the same slot without sharing
-a record or storage model. An ordinary extension can call either store, but it
-cannot provide these scope-locked lifecycle and projection guarantees without
-recreating memory inside the runtime. Those guarantees justify the dedicated
-slot.
+eve owns namespace and scope resolution, invocation order, scope-bound context
+projection, projection visibility, tool qualification, and replay behavior. The
+provider owns storage, retrieval, ranking, extraction, formatting, retention,
+and its model-facing operations. A hosted semantic service and a bounded text
+file can therefore implement the same provider contract without sharing a
+record or storage model.
 
 ## Public API at a glance
 
-| Import path              | Public surface                                                                                              |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `byPrincipal`, provider contexts, scope types, and projection types |
-| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                        |
-| `eve/memory/file/vercel` | `vercelBlob`                                                                                                |
+| Import path              | Public surface                                                                                                        |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, addressing types, and projection types |
+| `eve/memory/scope`       | `byPrincipal`                                                                                                         |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                                  |
+| `eve/memory/file/vercel` | `vercelBlob`                                                                                                          |
 
 The smallest complete memory slot uses the built-in file provider:
 
 ```ts title="agent/memory/user.ts"
-import { byPrincipal, defineMemory } from "eve/memory";
+import { defineMemory } from "eve/memory";
 import { fileMemory } from "eve/memory/file";
+import { byPrincipal } from "eve/memory/scope";
 
 export default defineMemory({
   provider: fileMemory(),
-  scope: byPrincipal(),
+  scope: byPrincipal,
 });
 ```
 
@@ -73,84 +72,126 @@ An agent may declare one flat slot or a directory of named slots:
 
 ```text
 agent/memory.ts            # one slot named "memory"
-agent/memory/              # XOR with the flat file
+agent/memory/              # directory of named slots
   user.ts                  # slot named "user"
   workspace.ts             # slot named "workspace"
 ```
 
-Each module default-exports `defineMemory(...)`. The definition contains the
-provider, the trusted scope resolver, and optional eve-owned projection policy:
+The flat file and directory forms are mutually exclusive. Each module
+default-exports `defineMemory(...)`. The definition contains the provider, an
+optional namespace, a required trusted scope, and optional eve-owned projection
+policy:
 
 ```ts title="agent/memory/user.ts"
 import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
 import { customMemory } from "../lib/custom-memory";
-import { resolveWorkspaceId } from "../lib/workspaces";
 
 export default defineMemory({
   provider: customMemory,
-  async scope(ctx) {
-    const principal = ctx.session.auth.current;
-    if (principal === null) return null;
-
-    const workspaceId = await resolveWorkspaceId(principal, {
-      signal: ctx.abortSignal,
-    });
-    return workspaceId === null ? null : [workspaceId, principal.principalId];
-  },
+  namespace: () => `acme:${process.env.DEPLOYMENT_REGION ?? "local"}`,
+  scope: byPrincipal,
 });
 ```
 
-The same provider instance may back several slots. Their path identities,
-scopes, projections, tools, and provider invocations remain independent.
+The same provider instance may back several slots. Their projections, tools,
+and provider invocations remain independent. The default namespace includes the
+slot identity, so each slot receives a distinct provider address. Definitions
+that resolve the same custom namespace and scope intentionally share an address.
+
+## Namespace
+
+Namespace identifies the application-owned memory domain. It may be a string,
+`null`, a promise, or a zero-argument resolver:
+
+```ts
+type MemoryNamespaceDefinition =
+  string | null | Promise<string | null> | (() => string | null | Promise<string | null>);
+
+function defaultNamespace(): string;
+```
+
+After resolving a non-null scope, eve awaits or invokes the namespace when it
+locks memory for a lifecycle operation. A resolved `null` disables the slot for
+that operation. If `namespace` is omitted, eve uses the exported
+`defaultNamespace` function as the resolver. Its value includes the Vercel
+project when available, otherwise a hash of the local application root, plus
+the deployment environment, graph node, and path-derived memory slot.
+
+Set `namespace` to define a custom application domain:
+
+```ts
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+import { customMemory } from "../lib/custom-memory";
+
+export default defineMemory({
+  provider: customMemory,
+  namespace: "acme:production:support-agent:user-memory",
+  scope: byPrincipal,
+});
+```
+
+A custom namespace is the complete namespace. eve does not append the
+application root, deployment environment, graph node, or slot to the resolved
+value.
 
 ## Scope
 
-Scope is the required addressing contract between an agent and a provider. A
-scope resolver returns an ordered tuple of trusted identifiers or `null`:
+Scope identifies the trusted audience or container within a namespace. It may
+be a string, `null`, a promise, or a zero-argument resolver:
 
 ```ts
-interface MemoryScopeContext extends SessionContext {
-  readonly abortSignal: AbortSignal;
-}
-
-type MemoryScopeDefinition = (
-  context: MemoryScopeContext,
-) => readonly string[] | null | Promise<readonly string[] | null>;
+type MemoryScopeDefinition =
+  string | null | Promise<string | null> | (() => string | null | Promise<string | null>);
 ```
 
-Scope parts must come from authenticated session context, application data, or
-trusted channel state. They never come from model input. Returning `null`
-disables the slot for the active turn or standalone compaction; eve does not
-call the provider, expose its tools, or include any of its projections in model
-context.
+`eve/memory/scope` exports the built-in principal resolver:
 
-eve turns the authored tuple into a provider scope:
+```ts
+function byPrincipal(): string | null;
+```
+
+Scope must come from authenticated session context, application data, or trusted
+channel state. It never comes from model input. eve resolves scope before
+namespace. A `null` scope disables the slot without invoking its namespace
+resolver. Otherwise eve resolves the namespace. A `null` namespace also
+disables the slot. A disabled slot does not call the provider, expose its tools,
+or include any of its projections in model context.
+
+For an active slot, eve validates both values and derives the provider scope key
+from exactly the resolved namespace and scope:
 
 ```ts
 interface MemoryScope {
-  /** Stable eve namespace derived from the app, environment, graph node, slot, and parts. */
+  /** Stable key derived from namespace and value. */
   readonly key: string;
-  /** Ordered identifiers returned by the authored resolver. */
-  readonly parts: readonly string[];
+  readonly namespace: string;
+  readonly value: string;
 }
 ```
 
+The namespace separates independent application domains. The scope separates
+audiences or containers inside that domain. The resolved pair is the only
+variable input to the provider key. eve canonically encodes the pair before
+hashing, so values cannot collide through string concatenation.
+
 Every `recall`, `save`, and `tools` call receives this scope. Tools close over
 the same locked scope, so the model never selects a different user, tenant, or
-container. A conforming provider must apply `scope.key` or `scope.parts` to
-every downstream read and write. eve cannot prevent faulty provider code from
-discarding the supplied scope, but the public contract provides no unscoped
-provider invocation path.
+container. A conforming provider must apply `scope.key` or the namespace and
+value to every downstream read and write. eve cannot prevent faulty provider
+code from discarding the supplied scope, but the public contract provides no
+unscoped provider invocation path.
 
 eve locks scope for the active turn, including model steps and durable approved
 call continuations. A standalone manual compaction resolves and locks scope for
-that operation.
-Every projection remains attributed to the slot and scope key under which it
-was recalled.
+that operation. Every projection remains attributed to the slot and scope key
+under which it was recalled.
 
-`byPrincipal()` scopes a slot to the authenticated caller and disables it for an
-unauthenticated caller. It includes the principal type, authenticator, optional
-issuer, and principal ID in the returned tuple.
+Passing `byPrincipal` as the scope resolver identifies the authenticated caller
+from principal type, authenticator, optional issuer, and principal ID. The
+function returns `null` for an unauthenticated caller. Anonymous callers never
+share a memory scope.
 
 ## Projection visibility across scope changes
 
@@ -161,12 +202,13 @@ than the provider because eve owns prompt assembly and the application owns the
 session's audience boundary:
 
 ```ts title="agent/memory/user.ts"
-import { byPrincipal, defineMemory } from "eve/memory";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
 import { customMemory } from "../lib/custom-memory";
 
 export default defineMemory({
   provider: customMemory,
-  scope: byPrincipal(),
+  scope: byPrincipal,
   visibility: "session",
 });
 ```
@@ -175,10 +217,10 @@ export default defineMemory({
 type MemoryVisibility = "scope" | "session";
 ```
 
-| Value               | Model context after a scope change                                                                                                          | Prompt cache                                                                                          |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `"scope"` (default) | Include only the projection whose scope key matches the active turn. Exclude projections recalled for earlier participants.                 | Filtering an earlier projection changes the existing prefix and invalidates the affected cache.       |
-| `"session"`         | Keep projections recalled for earlier scopes visible, then add the active scope's first projection immediately before its first turn input. | The scope change alone preserves the prior prefix; replacing or clearing a projection may still bust. |
+| Value               | Model context after a scope change                                                                                                          | Prompt cache                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `"scope"` (default) | Include only the projection whose scope key matches the active turn. Exclude projections recalled for earlier participants.                 | Filtering an anchored projection changes the prompt prefix and invalidates the affected cache.     |
+| `"session"`         | Keep projections recalled for earlier scopes visible, then add the active scope's first projection immediately before its first turn input. | A scope change keeps earlier messages in place; replacing or clearing a projection may still bust. |
 
 The default favors projection isolation over cache reuse when the authenticated
 participant changes.
@@ -209,13 +251,13 @@ own the same shared-session risk.
 
 ## Provider contract
 
-`MemoryProvider` describes memory behavior rather than exposing the complete
-hook lifecycle. `recall` is required. `save` and `tools` are optional.
+`MemoryProvider` defines the operations available at memory lifecycle
+boundaries. `recall` is required. `save` and `tools` are optional.
 
 ```ts
 import type { ModelMessage } from "ai";
 import type { SessionContext } from "eve/context";
-import type { ToolDefinition } from "eve/tools";
+import type { DynamicResolveContext, ToolDefinition } from "eve/tools";
 
 interface MemoryProjection {
   /** Non-empty provider context projected as one synthetic user-role message. */
@@ -280,14 +322,16 @@ type MemorySaveContext = MemoryOperationContext &
       }
   );
 
-type MemoryToolsContext = MemoryOperationContext & {
-  readonly phase: "step.started";
+interface MemoryToolsContext extends DynamicResolveContext {
   readonly turn: MemoryTurnContext;
-  readonly step: {
-    readonly stepIndex: number;
-    readonly modelId: string;
+  readonly memory: {
+    /** Current projection after turn-start recall. */
+    readonly current: MemoryProjection | null;
+    readonly scope: MemoryScope;
+    /** Path-derived slot identity, such as "memory" or "user". */
+    readonly slot: string;
   };
-};
+}
 
 type MemoryRecallResult = MemoryProjection | null | undefined;
 type MemoryToolSet = Readonly<Record<string, ToolDefinition>>;
@@ -299,6 +343,31 @@ interface MemoryProvider {
 
   tools?(context: MemoryToolsContext): MemoryToolSet | null | Promise<MemoryToolSet | null>;
 }
+```
+
+A provider can resolve tools asynchronously from authenticated or channel
+context and capture the result in its executors:
+
+```ts
+import { defineMemoryProvider } from "eve/memory";
+import { defineTool } from "eve/tools";
+
+const customMemory = defineMemoryProvider({
+  async recall(ctx) {
+    return loadProjection(ctx.memory.scope.key);
+  },
+  tools: async (ctx) => {
+    const policy = await loadToolPolicy(ctx.session.auth.current);
+
+    return {
+      search: defineTool({
+        description: "Search memory",
+        inputSchema: searchSchema,
+        execute: (input) => searchMemory(ctx.memory.scope.key, policy, input),
+      }),
+    };
+  },
+});
 ```
 
 The result of `recall` updates the active scope's projection:
@@ -318,70 +387,6 @@ preserve the current projection.
 `defineMemoryProvider(...)` is an identity-with-types helper. It does not add
 storage behavior or impose a record model.
 
-## Reference provider shape
-
-This provider recalls once for each scope that enters the session, refreshes
-after compaction, saves pre-compaction and completed-turn views through
-different service operations, and exposes one scope-bound tool:
-
-```ts title="agent/lib/provider.ts"
-import { defineMemoryProvider } from "eve/memory";
-import { defineTool } from "eve/tools";
-import { z } from "zod";
-import { service } from "./service";
-
-export const provider = defineMemoryProvider({
-  async recall(ctx) {
-    if (ctx.phase === "turn.started" && ctx.turn.sequence > 0 && ctx.memory.current !== null) {
-      return;
-    }
-
-    const content = await service.recall({
-      history: ctx.messages,
-      input: ctx.turn?.input ?? [],
-      scope: ctx.memory.scope,
-      signal: ctx.abortSignal,
-    });
-    return content === null || content.length === 0 ? null : { content };
-  },
-
-  async save(ctx) {
-    if (ctx.phase === "compaction.requested") {
-      await service.checkpoint({
-        history: ctx.messages,
-        operationId: ctx.operationId,
-        scope: ctx.memory.scope,
-        signal: ctx.abortSignal,
-      });
-      return;
-    }
-
-    await service.capture({
-      history: ctx.messages,
-      operationId: ctx.operationId,
-      scope: ctx.memory.scope,
-      signal: ctx.abortSignal,
-      turn: ctx.turn,
-    });
-  },
-
-  tools(ctx) {
-    const scope = ctx.memory.scope;
-    return {
-      forget: defineTool({
-        description: "Forget one saved memory.",
-        inputSchema: z.object({ id: z.string() }),
-        execute: ({ id }) => service.forget({ id, scope }),
-      }),
-    };
-  },
-});
-```
-
-The provider receives the same scope in all three methods. The `forget` tool is
-exposed as `<slot>__forget`; for a slot named `user`, its model-facing name is
-`user__forget`.
-
 ## Memory projection
 
 Each slot stores at most one projection for every scope key it encounters in a
@@ -390,17 +395,16 @@ prompt anchor. `ctx.memory.current` exposes only the projection belonging to the
 active scope.
 
 The first valid projection for a scope anchors one synthetic user-role
-message immediately before that scope's current turn input. A later
-`{ content }` result replaces the projection at the same anchor, `null` removes
-it, and `undefined` leaves it unchanged. Replacing, clearing, or filtering an
-already anchored projection changes the earlier prompt prefix and may invalidate
-the provider prompt cache.
+message immediately before that scope's current turn input. Later recall results
+update the projection at the same anchor according to the result table above.
+Replacing, clearing, or filtering an anchored projection changes the prompt
+prefix and may invalidate the provider prompt cache.
 
 At model assembly, eve applies the slot's `visibility`. `"scope"` includes only
 projections matching the active scope. `"session"` includes all of the slot's
 projections in anchor order. Projections created at the same boundary use stable
-slot-path order. This is the framework behavior a provider or ordinary
-extension cannot reproduce from an untagged user message.
+slot-path order. The slot and scope attribution remain attached to each
+projection throughout model assembly.
 
 A projection remains separate from ordinary conversation history:
 
@@ -421,29 +425,27 @@ at the next turn boundary if its scope becomes visible again.
 Providers own the content inside a projection. eve owns its user-role placement,
 slot and scope attribution, filtering, and anchoring.
 
-This differs from user-role instructions. A user-role instruction appends
-application context to durable conversation history at its lifecycle boundary.
-A memory projection is replaceable, scope-bound provider context kept outside
-that history.
+User-role instructions append application context to durable conversation
+history at their lifecycle boundary. Memory projections are replaceable,
+scope-bound provider context kept outside that history.
 
 ## Lifecycle
 
 ### Turn-start recall
 
-After eve admits and normalizes a new turn, it resolves each memory scope and
-calls `recall` with `phase: "turn.started"`. The context contains the zero-based
-turn sequence, stable turn ID, current input, prior durable history, and current
-projection for the active scope.
-
-`phase` names the lifecycle boundary; provider methods are framework calls, not
-hook subscribers. Turn-start recall therefore receives normalized input even
-though existing public stream events keep their current emission order.
+After eve admits and normalizes a new turn, it resolves each memory scope and,
+for a non-null scope, its namespace. It then calls `recall` with
+`phase: "turn.started"` for every active slot. The context contains the
+zero-based turn sequence, stable turn ID, normalized input, durable history
+before the turn, and current projection for the active scope.
 
 The first turn has `ctx.turn.sequence === 0`. A provider may use that coordinate
-to recall only on the first turn. A provider that wants one recall per scope can
-also recall whenever `ctx.memory.current === null`, including when a new
-participant changes the scope on a later turn. A semantic provider may recall
-on every turn using the current input as its query.
+to recall only on the first turn. A provider may check
+`ctx.memory.current === null` when it only needs to recall scopes without a
+projection, including a new participant's scope on a later turn. A provider that
+returns no projection or clears one will see `null` again at the next boundary.
+A semantic provider may recall on every turn using the current input as its
+query.
 
 The result is ready before the first model call. If automatic compaction runs at
 the same opening boundary, the projection remains outside compaction input and
@@ -451,11 +453,11 @@ the post-compaction recall may replace it before the model runs.
 
 ### Compaction save and recall
 
-Before automatic or manual compaction rewrites history, eve calls `save` with
-`phase: "compaction.requested"`. The provider receives the complete durable
-history about to be compacted, the active projection separately as
-`ctx.memory.current`, and the compaction model and usage metadata. A provider may
-persist a checkpoint, extract facts the summary could omit, or do nothing.
+Before automatic or manual compaction rewrites history, eve calls an implemented
+`save` method with `phase: "compaction.requested"`. The provider receives the
+complete durable history about to be compacted, the active projection separately
+as `ctx.memory.current`, and the compaction model and usage metadata. A provider
+may persist a checkpoint, extract facts the summary could omit, or do nothing.
 
 After a checkpoint is durably appended, eve calls `recall` with
 `phase: "compaction.completed"`. The provider receives the settled
@@ -468,46 +470,51 @@ projections remains eve-owned policy.
 Provider tools are not resolved during a standalone compaction because no model
 call follows that boundary.
 
-### Step tools
+### Turn tools
 
-Before each model step, eve calls `tools` with `phase: "step.started"`. For an
-ordinary step, that result replaces the slot's prior tool set rather than
-merging with it. Returning `null` or an empty record exposes no new tools for
-that slot and step.
+After turn-start recall settles, eve resolves `tools` once for the active turn.
+The function may be synchronous or asynchronous. Its context contains the same
+session, authentication, channel, and message fields as a `defineDynamic`
+resolver, plus the locked memory scope, current projection, slot, and turn.
+Returning `null` or an empty record exposes no tools for the slot.
+
+The memory definition is implicit `defineDynamic` authoring: eve adapts each
+implemented `tools` function to a `turn.started` dynamic resolver. The existing
+dynamic tool engine owns asynchronous resolution, schema capture, closure
+capture, approval and authorization behavior, durable replay, and executor
+reconstruction for provider tools.
 
 eve qualifies every returned key as `<slot>__<tool>` and binds the locked scope
-to the tool implementation. Provider tools otherwise use the ordinary tool
-contract, including input and output schemas, approval, authorization, and
-model-output projection. In particular, `once()` approval remains session-wide:
+to the tool implementation. Provider tools use the standard tool contract,
+including input and output schemas, approval, authorization, and model-output
+projection. In particular, `once()` approval is session-wide:
 approving one qualified tool name also approves that name after a scope change.
 Providers should use `always()` or a custom policy when approval must be
 participant- or scope-specific.
 
-A call that parks for approval is an exception to ordinary replacement. eve
-reconstructs it by calling `tools` again with the captured originating context
-and the same `operationId`. That definition handles the approved call even when
-the current step exposes no new tools; the latest ordinary result still handles
-unrelated new calls. The same reconstruction applies if that durable historical
-call later parks for authorization.
+The resolved tool set remains stable across every model step in the turn. When
+a call parks on approval or authorization, eve retains that call's dynamic tool
+metadata. The continuation reconstructs the exact originating definition,
+including its captured scope, even if another participant has since started a
+turn and replaced the current turn's tools. Resolver code does not run again.
 
 A direct inline-authorization park follows the ordinary tool contract. The
 unfinished assistant/tool exchange does not enter durable history, and the
 callback makes the credential available only to its matching principal. It does
-not replay the original tool execution. A later model step resolves the latest
-tool set under its current turn and receives a new `operationId`.
+not replay the original tool execution. A later model step uses the same
+turn-scoped tool set.
 
-Any tool key that can remain parked must stay present with compatible input and
-output schemas until its calls settle. The same logical tool operation may be
-resolved more than once, so `tools` must be deterministic and side-effect-free.
-Provider mutations belong in the returned tool's `execute` function. A missing
-parked key fails the continuation instead of changing its scope or definition.
+Resolver side effects occur once per admitted turn, while workflow replay
+returns the recorded result. Provider mutations belong in the returned tool's
+`execute` function. eve never substitutes the current turn's definition or
+scope for a parked call's captured definition.
 
 ### Completed-turn save
 
-After a turn reaches `turn.completed`, eve calls `save` with
-`phase: "turn.completed"`. The provider receives the completed turn input and
-the settled durable history, including the assistant response and tool results.
-The method does not run for failed, cancelled, input-deferred, or
+After a turn reaches `turn.completed`, eve calls an implemented `save` method
+with `phase: "turn.completed"`. The provider receives the completed turn input
+and the settled durable history, including the assistant response and tool
+results. The method does not run for failed, cancelled, input-deferred, or
 adapter-consumed turns.
 
 eve awaits completed-turn saves before emitting `session.waiting` in
@@ -516,12 +523,12 @@ the turn, update a remote profile, enqueue its own work, or do nothing.
 
 ## Replay and failures
 
-Every provider invocation receives an `operationId` for one logical slot
-operation. eve reuses the ID across workflow replay and when it reconstructs a
-parked tool, so it is not a unique callback-attempt identifier. A provider must
-use it as the idempotency key for externally visible `save` side effects. eve
-records recall results, scope attribution, and prompt anchors in durable session
-state.
+Every recall and save invocation receives an `operationId` for one logical slot
+operation. eve reuses the ID across workflow replay, so it is not a unique
+callback-attempt identifier. A provider must use it as the idempotency key for
+externally visible `save` side effects. eve records recall results, scope
+attribution, prompt anchors, and turn-scoped dynamic tool metadata in durable
+session state.
 
 Failure behavior follows the point at which the method runs:
 
@@ -530,22 +537,34 @@ Failure behavior follows the point at which the method runs:
 - A post-compaction `recall` failure cannot undo the checkpoint. It fails the
   active turn when compaction was automatic; standalone compaction emits a
   diagnostic and returns the session to waiting.
-- A `tools` failure fails the model step rather than silently changing the
-  available memory operations.
+- A throwing or invalid `tools` result is diagnosed and omitted for the turn,
+  matching `defineDynamic` tool resolution.
 - A completed-turn `save` failure cannot rewrite the completed response. eve
   emits a content-free diagnostic and continues to the ready boundary.
 
 ## Built-in file memory
 
 `fileMemory()` is the reference bounded-document provider. It stores one indexed
-`MEMORY.md`-style document per scope.
+`MEMORY.md`-style document per memory scope key.
+
+```ts
+interface FileMemoryOptions {
+  readonly backend?: MemoryDocumentBackend;
+  /** Defaults to 100. */
+  readonly maxEntries?: number;
+}
+
+function fileMemory(options?: FileMemoryOptions): MemoryProvider;
+```
 
 Its `recall` method loads the current document at every turn start and after
 every successful compaction. Its `tools` method exposes
-`save_memory({ text })` and `remove_memory({ index })`. A mutation is reflected
-immediately in the tool result and in the projection recalled on the next turn.
-It omits `save`: the provider does not run a hidden capture model or persist
-whole conversations.
+`save_memory({ text })` and `remove_memory({ index })`. Each tool completes after
+its conditional write, and the next recall reflects the updated document.
+`save_memory` normalizes whitespace, returns the existing index for duplicate
+text, and fails when the document reaches `maxEntries`. `remove_memory` is a
+no-op when its index is absent. The provider omits `save`: it does not run a
+capture model or persist whole conversations.
 
 The provider uses one portable conditional-document backend:
 
@@ -567,9 +586,10 @@ interface MemoryDocumentBackend {
 }
 ```
 
-Process-local memory supports tests and development. Vercel Blob provides the
-hosted backend. Other stores can implement the same optimistic read/replace
-contract without becoming part of eve's memory model.
+Process-local memory supports tests and non-Vercel development. A Vercel
+deployment with an attached Blob store uses private Vercel Blob storage. Every
+other production configuration requires an explicit backend. Every backend
+implements the same optimistic read/replace contract.
 
 The same lifecycle also supports a hosted semantic provider:
 
@@ -579,44 +599,38 @@ The same lifecycle also supports a hosted semantic provider:
 | Post-compaction recall | Reload the current document | Refresh against the compacted history       |
 | Pre-compaction save    | Omit                        | Preserve facts or checkpoint provider state |
 | Completed-turn save    | Omit                        | Capture the completed interaction           |
-| Step tools             | Save and remove entries     | Provider-defined search, save, or forget    |
+| Turn tools             | Save and remove entries     | Provider-defined search, save, or forget    |
 
-These are provider choices, not additional framework modes. A provider may
-skip a phase by returning `undefined` from `recall`, doing nothing in `save`, or
-returning `null` from `tools`.
+At each boundary, a provider may return `undefined` from `recall`, omit or do
+nothing in `save`, or return `null` from `tools`.
 
 ## Provider packaging
 
 A provider package exports a `MemoryProvider` or provider factory. It may own
 credentials, remote APIs, migrations, retrieval, capture, and model tools. The
-consuming agent still owns the slot path, scope resolver, and projection
-visibility. Mounting an extension cannot contribute a memory slot without an
-explicit consumer-owned scope and visibility policy.
+consuming agent owns the slot path, namespace, scope, and projection visibility.
+Mounted extensions cannot contribute memory slots.
 
-## Observable guarantees
+## Design invariants
 
-- Every memory slot has path-derived identity and an explicit trusted scope.
-- Projection visibility defaults to the active scope. Session-wide visibility
-  is an explicit `defineMemory` option.
-- `recall`, `save`, and `tools` always receive the same locked scope for one
-  lifecycle operation.
-- Recall phases distinguish ordinary turn start from post-compaction refresh.
-- Save phases distinguish pre-compaction preservation from completed-turn
-  capture.
-- Providers receive zero-based turn sequence, stable turn ID, normalized turn
-  input, durable history, current projection, and a replay-stable operation ID.
-- A recall result replaces, clears, or preserves the active scope's projection
-  without changing another scope's projection.
-- An empty projection is invalid; clearing and preserving require `null` and
-  `undefined`, respectively.
-- Projections enter model calls as user-role context but remain outside durable
-  conversation history and compaction input.
-- Scope visibility filters earlier projections and may bust the prompt cache;
-  session visibility retains them in anchor order and intentionally shares
-  their content across scope boundaries.
-- Provider tools are unconditionally slot-qualified and scope-bound. Ordinary
-  step results replace the prior set, while durable approved calls retain their
-  originating definition until settlement.
+- A slot is active only when both namespace and scope resolve to non-empty
+  strings. Omitting `namespace` selects `defaultNamespace`; `null` disables the
+  slot.
+- The resolved namespace and scope are the only variable inputs to the provider
+  key. Custom namespaces receive no path or deployment suffixes.
+- One scope lock applies to every provider call, projection, model step, and
+  durable tool continuation in an operation.
+- Recall and save phases identify their exact lifecycle boundary. Every provider
+  context includes durable history, the current projection, and a replay-stable
+  operation ID.
+- Projections enter model calls as scope-attributed user-role context but remain
+  outside durable history and compaction input. `visibility` controls which
+  projections enter the prompt after a scope change.
+- A recall result can replace, clear, or preserve only the active scope's
+  projection. Empty projection content is invalid.
+- Provider tools are slot-qualified, scope-bound `turn.started` dynamic tools.
+  Each turn resolves one complete tool set, every model step uses it, and a
+  durable call keeps its originating definition until settlement.
 - Completed-turn save settles before the next ready boundary.
 
 ## Non-goals

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1156,24 +1156,25 @@ executors rather than native kernel effects.
 
 Implementation proceeds in two pull requests:
 
-1. A new first-class memory core branch starts from current `main`. It adds the
-   authoring and compiler surface, source-graph wrapper, namespace and scope
-   locks, recall records and projection, lifecycle, compaction, published
-   documentation, and deterministic end-to-end coverage. It does not restack
-   or reuse the custom runtime lifecycle from
-   [#2142](https://github.com/vercel/eve/pull/2142).
-2. The bounded `fileMemory()` provider in
-   [#2144](https://github.com/vercel/eve/pull/2144) is rebased onto the merged
-   core. It retains only provider storage, document, backend, and concurrency
+1. The first-class memory core is implemented in
+   [#2534](https://github.com/vercel/eve/pull/2534), based directly on current
+   `main`. It adds the authoring and compiler surface, source-graph wrapper,
+   namespace and scope locks, recall records and projection, lifecycle,
+   compaction, agent-info v4, published documentation, and deterministic
+   end-to-end coverage. It does not restack or reuse the custom runtime
+   lifecycle from [#2142](https://github.com/vercel/eve/pull/2142).
+2. After #2534 merges, the bounded `fileMemory()` provider in
+   [#2144](https://github.com/vercel/eve/pull/2144) will be rebased onto current
+   `main`. It retains only provider storage, document, backend, and concurrency
    work, and absorbs final file-provider e2e coverage. The separate e2e tail in
    [#2145](https://github.com/vercel/eve/pull/2145) is superseded.
 
-The core implementation is complete only when one selected source and binding
-authority explains every memory definition and provider-tool wrapper, every
-message-bearing consumer receives the same projected history, compaction
-cannot summarize or lose private memory records, and a parked provider tool
-survives a real fresh-process reconstruction without memory-specific callback
-or origin machinery.
+#2534 implements the core boundary through one selected source and binding
+authority for every memory definition and provider-tool wrapper, one projected
+history for message-bearing consumers, private memory canonicalization outside
+ordinary summarization, and generic cold callback rebinding with captured
+closures. Those invariants, the committed E2E fixture, and the required CI
+checks remain the merge gate. M2 must not begin on the pre-M1 base.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-20"
+last_updated: "2026-08-25"
 ---
 
 # First-class memory
@@ -31,6 +31,14 @@ discriminated `phase`, current turn coordinates, a stable operation ID, and the
 locked memory scope resolved for the slot. Tools are resolved once after
 turn-start recall through the same durable dynamic-capability machinery as a
 `turn.started` `defineDynamic` tool resolver.
+
+Memory definitions and provider tools compile through eve's canonical source
+graph. Each selected memory slot retains its authored binding and projects one
+compiler-owned programmatic `tools/<slot>.ts` wrapper that exports an ordinary
+`defineDynamic` resolver. The wrapper qualifies provider tool keys and passes
+them through the existing source composition, binding, module-map, dynamic-tool,
+approval, authorization, and replay paths. Memory does not add a runtime tool
+contribution seam or a second executable registry.
 
 ```text
 turn.started          ---> recall(phase: "turn.started") ---> tools
@@ -126,6 +134,53 @@ export default defineMemory({
 `tools: false` is the only memory-specific tool control. Finer policy — per-tool
 approval, overrides, or denial — reuses the ordinary dynamic-tool approval
 surface, because provider tools are ordinary dynamic tools.
+
+## Compilation and provider tools
+
+Memory is a source-graph primitive, not a post-compile runtime attachment. For
+`agent/memory/user.ts`, the compiler selects and binds the memory definition,
+then projects its provider-tool adapter as a programmatic source at
+`tools/user.ts`:
+
+```text
+memory/user.ts
+  └─ selected memory definition
+       └─ programmatic tools/user.ts wrapper
+            └─ compiled defineDynamic resolver
+                 └─ user__<provider tool key>
+```
+
+The memory definition and wrapper each use the canonical candidate,
+composition, binding-validation, artifact, module-map, hydration, and runtime
+resolution pipeline used by other eve sources. The wrapper participates in
+source selection before normalization; it is never appended to a resolved
+agent, contributed after preamble resolution, or reconstructed from an
+optional manifest side table. Ordinary source composition owns replacement and
+disablement, and the ordinary dynamic-tool lifecycle owns public-name
+collisions and complete-result failure.
+
+The wrapper resolves on `turn.started` after recall commits. It reads the
+already locked slot, invokes `provider.tools(context)`, requires a map of
+branded `defineTool()` values, qualifies each key as
+`<slot>__<provider tool key>`, and prepends the slot description. A disabled
+slot, `tools: false`, `null`, or an empty result contributes no tools. Provider
+factories use eve's durable callback helpers when their callbacks cannot be
+stamped by authored-source transformation.
+
+This architecture is a completion gate for the core implementation:
+filesystem, in-memory, generated, bundled, and hydrated module maps must load
+the same selected wrapper binding, and a parked provider tool must resume after
+a fresh-process callback rebind. A memory-only registry, post-resolution tool
+merge, or logical-path loading fallback fails that gate.
+
+Current eve automatically rebinds missing callbacks by rerunning
+`session.started` resolvers; it does not rerun an arbitrary
+`turn.started` resolver. The memory core must therefore prove that loading the
+selected wrapper binding registers the callbacks needed by persisted provider
+tools, or extend cold rebinding at the generic compiled-resolver boundary. Any
+such extension belongs to the ordinary dynamic-tool lifecycle, contains no
+memory types, preserves the parked call's captured closure values, and never
+reruns provider mutation.
 
 ## Model-facing description
 
@@ -783,16 +838,14 @@ slot, and turn. Its messages include the projected turn-start recall results
 followed by the admitted turn input. Returning `null` or an empty record
 exposes no tools for the slot.
 
-The memory definition is implicit `defineDynamic` authoring: eve adapts each
-implemented `tools` function to a `turn.started` dynamic resolver. Provider
-tools are ordinary branded `defineTool()` entries and depend entirely on the
-generic dynamic-tool engine — durable callback descriptors that survive fresh
-processes ([#2345](https://github.com/vercel/eve/issues/2345)), per-call
-origins that resume against the originating definition
-([#2346](https://github.com/vercel/eve/issues/2346)), and the runtime-tool
-contribution seam ([#2347](https://github.com/vercel/eve/issues/2347)). Memory
-adds no tool machinery of its own: no memory-specific approval methods, no
-separate callback registry, and no `defineMemoryTool` wrapper.
+The compiler-owned wrapper makes the memory definition implicit
+`defineDynamic` authoring: it adapts each implemented `tools` method to a
+`turn.started` dynamic resolver before source selection and normalization.
+Provider tools are ordinary branded `defineTool()` entries and depend entirely
+on the generic dynamic-tool engine and canonical source graph. Memory adds no
+tool machinery of its own: no runtime contribution seam, memory-specific
+approval methods, separate callback registry, parked-call origin store, or
+`defineMemoryTool` wrapper.
 
 Tools never write recalled context. A tool executor mutates provider storage
 and returns ordinary tool output; recall is the single writer of recalled
@@ -810,13 +863,16 @@ qualified tool name also approves that name after a scope change. Providers
 should use `always()` or a custom policy when approval must be participant- or
 scope-specific.
 
-The resolved tool set remains stable across every model step in the turn. When
-a call parks on approval or authorization, the continuation reconstructs the
-exact originating definition — including its captured scope — through the
-generic durable-descriptor and call-origin machinery, even in a fresh process
-and even if another participant has since replaced the current turn's tools.
-Callback forms the descriptor mechanism cannot express fail with an explicit
-diagnostic at resolution time rather than silently degrading at replay.
+The resolved tool set remains stable across every model step in the turn.
+Dynamic callback identity is the final qualified tool name plus callback phase,
+and closure values — including the locked memory scope — are snapshotted when
+the tool set resolves. After callback-registry loss or a redeploy, the compiled
+wrapper binding re-registers a missing implementation through the generic
+dynamic-tool lifecycle. A resumed call runs the latest deployed callback
+implementation with the captured closure values; a renamed or removed tool
+fails closed. Callback forms the descriptor mechanism cannot express fail with
+an explicit diagnostic at resolution time rather than silently degrading at
+replay.
 
 A direct inline-authorization park follows the ordinary tool contract. The
 unfinished assistant/tool exchange does not enter durable history, and the
@@ -826,9 +882,10 @@ turn-scoped tool set.
 
 Workflow replay returns recorded results for committed resolutions. Resolver
 code may run again when an uncommitted delivery is re-executed after a crash,
-so resolver side effects must be idempotent; provider mutations belong in the
-returned tools' `execute` functions. eve never substitutes the current turn's
-definition or scope for a parked call's captured definition.
+or once to rebind a missing session-scoped callback, so resolver side effects
+must be idempotent; provider mutations belong in the returned tools' `execute`
+functions. Callback rebinding may select newer deployed code, but it never
+replaces the parked call's captured scope values with another turn's scope.
 
 ### Completed-turn capture
 
@@ -1050,8 +1107,9 @@ recall visibility. Mounted extensions cannot contribute memory slots.
   so providers can supersede keyed items with smaller content.
 - Provider tools are slot-qualified, scope-bound ordinary dynamic tools built
   entirely on the generic dynamic-tool engine. Each turn resolves one complete
-  tool set, every model step uses it, and a durable call keeps its originating
-  definition until settlement. Tools never write recalled context.
+  tool set, every model step uses it, and callback replay uses the captured
+  closure values with the implementation registered for the same qualified
+  name and phase. Tools never write recalled context.
 - An optional static slot description is prepended to every provider tool
   description before durable metadata capture. It never derives from or exposes
   the namespace or scope, and it guides model routing without granting access.
@@ -1083,8 +1141,44 @@ Still out of scope:
 - Standardizing provider credentials, migrations, inspection tools, or
   deployment operations.
 
+## Implementation boundary
+
+The generic prerequisites are on `main`: the projected-history seam
+([#2352](https://github.com/vercel/eve/pull/2352)), durable dynamic callbacks
+([#2354](https://github.com/vercel/eve/pull/2354)), name-and-phase callback
+identity ([#2384](https://github.com/vercel/eve/pull/2384)), and the canonical
+source graph and binding table
+([#2404](https://github.com/vercel/eve/pull/2404),
+[#2516](https://github.com/vercel/eve/pull/2516)). The runtime-tool contribution
+proposal in [#2347](https://github.com/vercel/eve/issues/2347) is superseded;
+memory uses the compile-time wrapper described above. The kernel-effects
+follow-up to #2516 is not a prerequisite because provider tools have ordinary
+executors rather than native kernel effects.
+
+Implementation proceeds in two pull requests:
+
+1. A new first-class memory core branch starts from current `main`. It adds the
+   authoring and compiler surface, source-graph wrapper, namespace and scope
+   locks, recall records and projection, lifecycle, compaction, published
+   documentation, and deterministic end-to-end coverage. It does not restack
+   or reuse the custom runtime lifecycle from
+   [#2142](https://github.com/vercel/eve/pull/2142).
+2. The bounded `fileMemory()` provider in
+   [#2144](https://github.com/vercel/eve/pull/2144) is rebased onto the merged
+   core. It retains only provider storage, document, backend, and concurrency
+   work, and absorbs final file-provider e2e coverage. The separate e2e tail in
+   [#2145](https://github.com/vercel/eve/pull/2145) is superseded.
+
+The core implementation is complete only when one selected source and binding
+authority explains every memory definition and provider-tool wrapper, every
+message-bearing consumer receives the same projected history, compaction
+cannot summarize or lose private memory records, and a parked provider tool
+survives a real fresh-process reconstruction without memory-specific callback
+or origin machinery.
+
 ## Primary references
 
+- [Programmatic agent sources](./programmatic-agent-sources.md)
 - [Supermemory: how it works](https://supermemory.ai/docs/concepts/how-it-works)
 - [Hermes Agent memory](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/memory.md)
 - [eve dynamic capabilities](../docs/guides/dynamic-capabilities.md)
@@ -1120,11 +1214,11 @@ Still out of scope:
       `defineMemory(...)` may supply an optional static `description`. eve
       validates it and prepends it to every provider tool description before
       storing durable dynamic metadata. Omitting it preserves provider
-      descriptions unchanged. The implementation neither derives nor exposes
-      namespace or scope values, and the docs distinguish model routing
-      guidance from authorization. Unit coverage verifies two slots sharing one
-      provider receive different descriptions without mutating provider tools;
-      file-memory integration and e2e coverage exercise described
+      descriptions unchanged. The proposed wrapper neither derives nor exposes
+      namespace or scope values, and the contract distinguishes model routing
+      guidance from authorization. Core coverage must verify that two slots
+      sharing one provider receive different descriptions without mutating
+      provider tools; file-memory integration and e2e must exercise described
       `fileMemory()` slots. This resolves the [model-facing attribution
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -276,7 +276,7 @@ interface MemoryOperationContext extends SessionContext {
   readonly abortSignal: AbortSignal;
   /** Durable model history at this lifecycle boundary. Excludes memory projections. */
   readonly messages: readonly ModelMessage[];
-  /** Identifies one logical slot operation and may repeat across replay or reconstruction. */
+  /** Identifies one logical recall or save operation across workflow replay. */
   readonly operationId: string;
   readonly memory: {
     /** Current projection for this slot and the active scope, if one exists. */

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,0 +1,643 @@
+---
+issue: https://github.com/vercel/eve/issues/1510
+status: proposed
+last_updated: "2026-08-14"
+---
+
+# First-class memory
+
+## Proposal
+
+Memory is a path-authored capability for scoped context that outlives one
+session. A memory provider owns how it stores, retrieves, and updates memory.
+eve owns when the provider participates in the agent lifecycle.
+
+The provider contract has three semantic methods:
+
+- `recall` updates the context projected into model calls.
+- `save` observes history before compaction and after a completed turn.
+- `tools` contributes model tools bound to the active memory scope.
+
+These methods replace a generic map of lifecycle event handlers. eve calls each
+method at fixed boundaries and supplies a discriminated `phase`, the current
+turn coordinates, a stable operation ID, and the scope resolved for the slot.
+The provider may vary its behavior by phase or turn. For example, a provider can
+recall on turn sequence `0`, keep that projection across later turns, and
+refresh it after compaction.
+
+```text
+turn.started          ---> recall(phase: "turn.started")
+compaction.requested  ---> save(phase: "compaction.requested")
+compaction.completed  ---> recall(phase: "compaction.completed")
+step.started          ---> tools(phase: "step.started")
+turn.completed        ---> save(phase: "turn.completed")
+```
+
+eve owns path-derived identity, trusted scope resolution, invocation order,
+scope-bound context projection, projection visibility, tool qualification, and
+replay behavior. The provider owns storage, retrieval, ranking, extraction,
+formatting, retention, and its model-facing operations. A hosted semantic
+service and a bounded text file can therefore use the same slot without sharing
+a record or storage model. An ordinary extension can call either store, but it
+cannot provide these scope-locked lifecycle and projection guarantees without
+recreating memory inside the runtime. Those guarantees justify the dedicated
+slot.
+
+## Public API at a glance
+
+| Import path              | Public surface                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `byPrincipal`, provider contexts, scope types, and projection types |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                        |
+| `eve/memory/file/vercel` | `vercelBlob`                                                                                                |
+
+The smallest complete memory slot uses the built-in file provider:
+
+```ts title="agent/memory/user.ts"
+import { byPrincipal, defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+
+export default defineMemory({
+  provider: fileMemory(),
+  scope: byPrincipal(),
+});
+```
+
+For `agent/memory/user.ts`, eve derives the slot name `user`. Provider tools are
+qualified with that identity, such as `user__save_memory` and
+`user__remove_memory`.
+
+## Authoring experience
+
+An agent may declare one flat slot or a directory of named slots:
+
+```text
+agent/memory.ts            # one slot named "memory"
+agent/memory/              # XOR with the flat file
+  user.ts                  # slot named "user"
+  workspace.ts             # slot named "workspace"
+```
+
+Each module default-exports `defineMemory(...)`. The definition contains the
+provider, the trusted scope resolver, and optional eve-owned projection policy:
+
+```ts title="agent/memory/user.ts"
+import { defineMemory } from "eve/memory";
+import { customMemory } from "../lib/custom-memory";
+import { resolveWorkspaceId } from "../lib/workspaces";
+
+export default defineMemory({
+  provider: customMemory,
+  async scope(ctx) {
+    const principal = ctx.session.auth.current;
+    if (principal === null) return null;
+
+    const workspaceId = await resolveWorkspaceId(principal, {
+      signal: ctx.abortSignal,
+    });
+    return workspaceId === null ? null : [workspaceId, principal.principalId];
+  },
+});
+```
+
+The same provider instance may back several slots. Their path identities,
+scopes, projections, tools, and provider invocations remain independent.
+
+## Scope
+
+Scope is the required addressing contract between an agent and a provider. A
+scope resolver returns an ordered tuple of trusted identifiers or `null`:
+
+```ts
+interface MemoryScopeContext extends SessionContext {
+  readonly abortSignal: AbortSignal;
+}
+
+type MemoryScopeDefinition = (
+  context: MemoryScopeContext,
+) => readonly string[] | null | Promise<readonly string[] | null>;
+```
+
+Scope parts must come from authenticated session context, application data, or
+trusted channel state. They never come from model input. Returning `null`
+disables the slot for the active turn or standalone compaction; eve does not
+call the provider, expose its tools, or include any of its projections in model
+context.
+
+eve turns the authored tuple into a provider scope:
+
+```ts
+interface MemoryScope {
+  /** Stable eve namespace derived from the app, environment, graph node, slot, and parts. */
+  readonly key: string;
+  /** Ordered identifiers returned by the authored resolver. */
+  readonly parts: readonly string[];
+}
+```
+
+Every `recall`, `save`, and `tools` call receives this scope. Tools close over
+the same locked scope, so the model never selects a different user, tenant, or
+container. A conforming provider must apply `scope.key` or `scope.parts` to
+every downstream read and write. eve cannot prevent faulty provider code from
+discarding the supplied scope, but the public contract provides no unscoped
+provider invocation path.
+
+eve locks scope for the active turn, including model steps and durable approved
+call continuations. A standalone manual compaction resolves and locks scope for
+that operation.
+Every projection remains attributed to the slot and scope key under which it
+was recalled.
+
+`byPrincipal()` scopes a slot to the authenticated caller and disables it for an
+unauthenticated caller. It includes the principal type, authenticator, optional
+issuer, and principal ID in the returned tuple.
+
+## Projection visibility across scope changes
+
+`visibility` is an eve-owned `defineMemory` option. It controls which
+previously recalled projections enter a model request when the slot resolves a
+different scope. The option belongs to the consuming memory definition rather
+than the provider because eve owns prompt assembly and the application owns the
+session's audience boundary:
+
+```ts title="agent/memory/user.ts"
+import { byPrincipal, defineMemory } from "eve/memory";
+import { customMemory } from "../lib/custom-memory";
+
+export default defineMemory({
+  provider: customMemory,
+  scope: byPrincipal(),
+  visibility: "session",
+});
+```
+
+```ts
+type MemoryVisibility = "scope" | "session";
+```
+
+| Value               | Model context after a scope change                                                                                                          | Prompt cache                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `"scope"` (default) | Include only the projection whose scope key matches the active turn. Exclude projections recalled for earlier participants.                 | Filtering an earlier projection changes the existing prefix and invalidates the affected cache.       |
+| `"session"`         | Keep projections recalled for earlier scopes visible, then add the active scope's first projection immediately before its first turn input. | The scope change alone preserves the prior prefix; replacing or clearing a projection may still bust. |
+
+The default favors projection isolation over cache reuse when the authenticated
+participant changes.
+
+For a Slack thread where one authenticated participant follows another,
+`"scope"` removes the first participant's recalled memory before the second
+participant's model call. `"session"` keeps both projections visible. The
+second mode is an explicit cross-scope disclosure policy and is appropriate
+only when the session participants form one trusted audience.
+
+```text
+scope:   ... -> participant A turn -> assistant -> participant B projection -> participant B turn
+session: ... -> participant A projection -> participant A turn -> assistant -> participant B projection -> participant B turn
+```
+
+This option never changes provider scope. `recall`, `save`, and `tools` still
+receive only the active turn's locked scope. The provider cannot select the
+visibility mode, and eve never passes another scope or its projection into a
+provider method. A `null` scope suppresses all of the slot's projections in both
+modes.
+
+Projection visibility does not remove ordinary user, assistant, or tool
+messages already in the conversation. It also cannot undo information an
+earlier assistant response derived from memory. Applications that require hard
+isolation between participants must use separate sessions. Provider tools that
+return memory content place that content in ordinary tool history and therefore
+own the same shared-session risk.
+
+## Provider contract
+
+`MemoryProvider` describes memory behavior rather than exposing the complete
+hook lifecycle. `recall` is required. `save` and `tools` are optional.
+
+```ts
+import type { ModelMessage } from "ai";
+import type { SessionContext } from "eve/context";
+import type { ToolDefinition } from "eve/tools";
+
+interface MemoryProjection {
+  /** Non-empty provider context projected as one synthetic user-role message. */
+  readonly content: string;
+}
+
+interface MemoryTurnContext {
+  readonly turnId: string;
+  /** Zero-based durable turn sequence. The first turn is sequence 0. */
+  readonly sequence: number;
+  /** Normalized model messages accepted as input for this turn. */
+  readonly input: readonly ModelMessage[];
+}
+
+interface MemoryOperationContext extends SessionContext {
+  readonly abortSignal: AbortSignal;
+  /** Durable model history at this lifecycle boundary. Excludes memory projections. */
+  readonly messages: readonly ModelMessage[];
+  /** Identifies one logical slot operation and may repeat across replay or reconstruction. */
+  readonly operationId: string;
+  readonly memory: {
+    /** Current projection for this slot and the active scope, if one exists. */
+    readonly current: MemoryProjection | null;
+    readonly scope: MemoryScope;
+    /** Path-derived slot identity, such as "memory" or "user". */
+    readonly slot: string;
+  };
+}
+
+type MemoryRecallContext = MemoryOperationContext &
+  (
+    | {
+        readonly phase: "turn.started";
+        readonly turn: MemoryTurnContext;
+        readonly compaction?: never;
+      }
+    | {
+        readonly phase: "compaction.completed";
+        /** Null for standalone manual compaction. */
+        readonly turn: MemoryTurnContext | null;
+        readonly compaction: {
+          readonly modelId: string;
+        };
+      }
+  );
+
+type MemorySaveContext = MemoryOperationContext &
+  (
+    | {
+        readonly phase: "compaction.requested";
+        /** Null for standalone manual compaction. */
+        readonly turn: MemoryTurnContext | null;
+        readonly compaction: {
+          readonly modelId: string;
+          readonly usageInputTokens: number | null;
+        };
+      }
+    | {
+        readonly phase: "turn.completed";
+        readonly turn: MemoryTurnContext;
+        readonly compaction?: never;
+      }
+  );
+
+type MemoryToolsContext = MemoryOperationContext & {
+  readonly phase: "step.started";
+  readonly turn: MemoryTurnContext;
+  readonly step: {
+    readonly stepIndex: number;
+    readonly modelId: string;
+  };
+};
+
+type MemoryRecallResult = MemoryProjection | null | undefined;
+type MemoryToolSet = Readonly<Record<string, ToolDefinition>>;
+
+interface MemoryProvider {
+  recall(context: MemoryRecallContext): MemoryRecallResult | Promise<MemoryRecallResult>;
+
+  save?(context: MemorySaveContext): void | Promise<void>;
+
+  tools?(context: MemoryToolsContext): MemoryToolSet | null | Promise<MemoryToolSet | null>;
+}
+```
+
+The result of `recall` updates the active scope's projection:
+
+| Result                          | Effect                                                  |
+| ------------------------------- | ------------------------------------------------------- |
+| `{ content: non-empty string }` | Replace the current projection for this slot and scope. |
+| `null`                          | Clear the current projection for this slot and scope.   |
+| `undefined` / no return         | Keep the current projection without changing it.        |
+
+This distinction lets a provider skip routine turn-start retrieval without
+losing previously recalled context. It can still clear stale context explicitly.
+An empty string is invalid and fails recall at that lifecycle boundary; it does
+not mean clear or skip. Providers return `null` to clear or `undefined` to
+preserve the current projection.
+
+`defineMemoryProvider(...)` is an identity-with-types helper. It does not add
+storage behavior or impose a record model.
+
+## Reference provider shape
+
+This provider recalls once for each scope that enters the session, refreshes
+after compaction, saves pre-compaction and completed-turn views through
+different service operations, and exposes one scope-bound tool:
+
+```ts title="agent/lib/provider.ts"
+import { defineMemoryProvider } from "eve/memory";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { service } from "./service";
+
+export const provider = defineMemoryProvider({
+  async recall(ctx) {
+    if (ctx.phase === "turn.started" && ctx.turn.sequence > 0 && ctx.memory.current !== null) {
+      return;
+    }
+
+    const content = await service.recall({
+      history: ctx.messages,
+      input: ctx.turn?.input ?? [],
+      scope: ctx.memory.scope,
+      signal: ctx.abortSignal,
+    });
+    return content === null || content.length === 0 ? null : { content };
+  },
+
+  async save(ctx) {
+    if (ctx.phase === "compaction.requested") {
+      await service.checkpoint({
+        history: ctx.messages,
+        operationId: ctx.operationId,
+        scope: ctx.memory.scope,
+        signal: ctx.abortSignal,
+      });
+      return;
+    }
+
+    await service.capture({
+      history: ctx.messages,
+      operationId: ctx.operationId,
+      scope: ctx.memory.scope,
+      signal: ctx.abortSignal,
+      turn: ctx.turn,
+    });
+  },
+
+  tools(ctx) {
+    const scope = ctx.memory.scope;
+    return {
+      forget: defineTool({
+        description: "Forget one saved memory.",
+        inputSchema: z.object({ id: z.string() }),
+        execute: ({ id }) => service.forget({ id, scope }),
+      }),
+    };
+  },
+});
+```
+
+The provider receives the same scope in all three methods. The `forget` tool is
+exposed as `<slot>__forget`; for a slot named `user`, its model-facing name is
+`user__forget`.
+
+## Memory projection
+
+Each slot stores at most one projection for every scope key it encounters in a
+session. The durable projection state includes the slot, scope key, content, and
+prompt anchor. `ctx.memory.current` exposes only the projection belonging to the
+active scope.
+
+The first valid projection for a scope anchors one synthetic user-role
+message immediately before that scope's current turn input. A later
+`{ content }` result replaces the projection at the same anchor, `null` removes
+it, and `undefined` leaves it unchanged. Replacing, clearing, or filtering an
+already anchored projection changes the earlier prompt prefix and may invalidate
+the provider prompt cache.
+
+At model assembly, eve applies the slot's `visibility`. `"scope"` includes only
+projections matching the active scope. `"session"` includes all of the slot's
+projections in anchor order. Projections created at the same boundary use stable
+slot-path order. This is the framework behavior a provider or ordinary
+extension cannot reproduce from an untagged user message.
+
+A projection remains separate from ordinary conversation history:
+
+- It is not emitted as `message.received`.
+- It is not summarized by compaction.
+- It is not included in `ctx.messages` passed back to a provider.
+- Its slot and scope attribution are not exposed to the model as tool input.
+
+Although projections occupy stable positions among model messages for prompt
+caching, they remain tagged framework state rather than ordinary durable
+messages. That attribution is what lets eve filter them by scope.
+
+Compaction removes anchors attached to the rewritten history. After the new
+checkpoint, eve reanchors the projections visible for that operation and then
+runs post-compaction recall for the active scope. A hidden projection reanchors
+at the next turn boundary if its scope becomes visible again.
+
+Providers own the content inside a projection. eve owns its user-role placement,
+slot and scope attribution, filtering, and anchoring.
+
+This differs from user-role instructions. A user-role instruction appends
+application context to durable conversation history at its lifecycle boundary.
+A memory projection is replaceable, scope-bound provider context kept outside
+that history.
+
+## Lifecycle
+
+### Turn-start recall
+
+After eve admits and normalizes a new turn, it resolves each memory scope and
+calls `recall` with `phase: "turn.started"`. The context contains the zero-based
+turn sequence, stable turn ID, current input, prior durable history, and current
+projection for the active scope.
+
+`phase` names the lifecycle boundary; provider methods are framework calls, not
+hook subscribers. Turn-start recall therefore receives normalized input even
+though existing public stream events keep their current emission order.
+
+The first turn has `ctx.turn.sequence === 0`. A provider may use that coordinate
+to recall only on the first turn. A provider that wants one recall per scope can
+also recall whenever `ctx.memory.current === null`, including when a new
+participant changes the scope on a later turn. A semantic provider may recall
+on every turn using the current input as its query.
+
+The result is ready before the first model call. If automatic compaction runs at
+the same opening boundary, the projection remains outside compaction input and
+the post-compaction recall may replace it before the model runs.
+
+### Compaction save and recall
+
+Before automatic or manual compaction rewrites history, eve calls `save` with
+`phase: "compaction.requested"`. The provider receives the complete durable
+history about to be compacted, the active projection separately as
+`ctx.memory.current`, and the compaction model and usage metadata. A provider may
+persist a checkpoint, extract facts the summary could omit, or do nothing.
+
+After a checkpoint is durably appended, eve calls `recall` with
+`phase: "compaction.completed"`. The provider receives the settled
+post-compaction history and can replace, clear, or preserve its current
+projection. The call occurs after every successful automatic or manual
+compaction, even when the provider skipped ordinary turn-start recall. Only the
+active scope's projection can change during this call; visibility of other
+projections remains eve-owned policy.
+
+Provider tools are not resolved during a standalone compaction because no model
+call follows that boundary.
+
+### Step tools
+
+Before each model call, eve calls `tools` with `phase: "step.started"`. For an
+ordinary step, that result replaces the slot's prior tool set rather than
+merging with it. Returning `null` or an empty record exposes no new tools for
+that slot and step.
+
+eve qualifies every returned key as `<slot>__<tool>` and binds the locked scope
+to the tool implementation. Provider tools otherwise use the ordinary tool
+contract, including input and output schemas, approval, authorization, and
+model-output projection. In particular, `once()` approval remains session-wide:
+approving one qualified tool name also approves that name after a scope change.
+Providers should use `always()` or a custom policy when approval must be
+participant- or scope-specific.
+
+A call that parks for approval is an exception to ordinary replacement. eve
+reconstructs it by calling `tools` again with the captured originating context
+and the same `operationId`. That definition handles the approved call even when
+the current step exposes no new tools; the latest ordinary result still handles
+unrelated new calls. The same reconstruction applies if that durable historical
+call later parks for authorization.
+
+A direct inline-authorization park follows the ordinary tool contract. The
+unfinished assistant/tool exchange does not enter durable history, and the
+callback makes the credential available only to its matching principal. It does
+not replay the original tool execution. A later model step resolves the latest
+tool set under its current turn and receives a new `operationId`.
+
+Any tool key that can remain parked must stay present with compatible input and
+output schemas until its calls settle. The same logical tool operation may be
+resolved more than once, so `tools` must be deterministic and side-effect-free.
+Provider mutations belong in the returned tool's `execute` function. A missing
+parked key fails the continuation instead of changing its scope or definition.
+
+### Completed-turn save
+
+After a turn reaches `turn.completed`, eve calls `save` with
+`phase: "turn.completed"`. The provider receives the completed turn input and
+the settled durable history, including the assistant response and tool results.
+The method does not run for failed, cancelled, input-deferred, or
+adapter-consumed turns.
+
+eve awaits completed-turn saves before emitting `session.waiting` in
+conversation mode or `session.completed` in task mode. A provider may capture
+the turn, update a remote profile, enqueue its own work, or do nothing.
+
+## Replay and failures
+
+Every provider invocation receives an `operationId` for one logical slot
+operation. eve reuses the ID across workflow replay and when it reconstructs a
+parked tool, so it is not a unique callback-attempt identifier. A provider must
+use it as the idempotency key for externally visible `save` side effects. eve
+records recall results, scope attribution, and prompt anchors in durable session
+state.
+
+Failure behavior follows the point at which the method runs:
+
+- A turn-start `recall` failure fails the active turn before the model runs.
+- A `compaction.requested` save failure aborts compaction before history changes.
+- A post-compaction `recall` failure cannot undo the checkpoint. It fails the
+  active turn when compaction was automatic; standalone compaction emits a
+  diagnostic and returns the session to waiting.
+- A `tools` failure fails the model step rather than silently changing the
+  available memory operations.
+- A completed-turn `save` failure cannot rewrite the completed response. eve
+  emits a content-free diagnostic and continues to the ready boundary.
+
+## Built-in file memory
+
+`fileMemory()` is the reference bounded-document provider. It stores one indexed
+`MEMORY.md`-style document per scope.
+
+Its `recall` method loads the current document at every turn start and after
+every successful compaction. Its `tools` method exposes
+`save_memory({ text })` and `remove_memory({ index })`. A mutation is reflected
+immediately in the tool result and in the projection recalled on the next turn.
+It omits `save`: the provider does not run a hidden capture model or persist
+whole conversations.
+
+The provider uses one portable conditional-document backend:
+
+```ts
+interface MemoryDocument {
+  readonly content: string;
+  readonly version: string;
+}
+
+interface MemoryDocumentBackend {
+  read(input: { key: string; signal: AbortSignal }): Promise<MemoryDocument | null>;
+
+  write(input: {
+    content: string;
+    expectedVersion: string | null;
+    key: string;
+    signal: AbortSignal;
+  }): Promise<MemoryDocument>;
+}
+```
+
+Process-local memory supports tests and development. Vercel Blob provides the
+hosted backend. Other stores can implement the same optimistic read/replace
+contract without becoming part of eve's memory model.
+
+The same lifecycle also supports a hosted semantic provider:
+
+| Boundary               | Bounded file provider       | Hosted semantic provider                    |
+| ---------------------- | --------------------------- | ------------------------------------------- |
+| `turn.started` recall  | Load the current document   | Retrieve against the current turn input     |
+| Post-compaction recall | Reload the current document | Refresh against the compacted history       |
+| Pre-compaction save    | Omit                        | Preserve facts or checkpoint provider state |
+| Completed-turn save    | Omit                        | Capture the completed interaction           |
+| Step tools             | Save and remove entries     | Provider-defined search, save, or forget    |
+
+These are provider choices, not additional framework modes. A provider may
+skip a phase by returning `undefined` from `recall`, doing nothing in `save`, or
+returning `null` from `tools`.
+
+## Provider packaging
+
+A provider package exports a `MemoryProvider` or provider factory. It may own
+credentials, remote APIs, migrations, retrieval, capture, and model tools. The
+consuming agent still owns the slot path, scope resolver, and projection
+visibility. Mounting an extension cannot contribute a memory slot without an
+explicit consumer-owned scope and visibility policy.
+
+## Observable guarantees
+
+- Every memory slot has path-derived identity and an explicit trusted scope.
+- Projection visibility defaults to the active scope. Session-wide visibility
+  is an explicit `defineMemory` option.
+- `recall`, `save`, and `tools` always receive the same locked scope for one
+  lifecycle operation.
+- Recall phases distinguish ordinary turn start from post-compaction refresh.
+- Save phases distinguish pre-compaction preservation from completed-turn
+  capture.
+- Providers receive zero-based turn sequence, stable turn ID, normalized turn
+  input, durable history, current projection, and a replay-stable operation ID.
+- A recall result replaces, clears, or preserves the active scope's projection
+  without changing another scope's projection.
+- An empty projection is invalid; clearing and preserving require `null` and
+  `undefined`, respectively.
+- Projections enter model calls as user-role context but remain outside durable
+  conversation history and compaction input.
+- Scope visibility filters earlier projections and may bust the prompt cache;
+  session visibility retains them in anchor order and intentionally shares
+  their content across scope boundaries.
+- Provider tools are unconditionally slot-qualified and scope-bound. Ordinary
+  step results replace the prior set, while durable approved calls retain their
+  originating definition until settlement.
+- Completed-turn save settles before the next ready boundary.
+
+## Non-goals
+
+- A framework record, revision, citation, CRUD, query, ranking, embedding, or
+  vector model.
+- Framework-provided remember, forget, purge, export, or administrative APIs.
+- A built-in capture model, extractor, formatter, retention policy, or erasure
+  guarantee.
+- Cross-provider search, mutation, or record reconciliation.
+- Model-selected alternate scopes or unscoped provider invocations.
+- Treating projection visibility as complete participant isolation for ordinary
+  conversation messages or provider tool results.
+- Preventing faulty or malicious provider code from ignoring the supplied scope.
+- Standardizing provider credentials, migrations, inspection tools, or
+  deployment operations.
+
+## Primary references
+
+- [Supermemory: how it works](https://supermemory.ai/docs/concepts/how-it-works)
+- [Hermes Agent memory](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/memory.md)
+- [eve dynamic capabilities](../docs/guides/dynamic-capabilities.md)
+- [eve agent configuration](../docs/agent-config.md)
+- [eve turn execution](../packages/eve/src/execution/workflow-steps.ts)

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -138,26 +138,50 @@ value.
 
 ## Scope
 
-Scope identifies the trusted audience or container within a namespace. It may
-be a string, `null`, a promise, or a zero-argument resolver:
+Scope identifies the trusted audience or container within a namespace. A scope
+resolver receives a read-only snapshot of the authenticated session and active
+channel. It may return a string, an array of string components, or `null`:
 
 ```ts
+type MemoryScopeResolverResult = string | readonly string[] | null;
+
+interface MemoryScopeContext {
+  readonly abortSignal: AbortSignal;
+  readonly session: {
+    readonly id: string;
+    readonly auth: SessionAuth;
+  };
+  readonly channel: {
+    readonly kind?: string;
+    readonly continuationToken?: string;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+  };
+}
+
 type MemoryScopeDefinition =
-  string | null | Promise<string | null> | (() => string | null | Promise<string | null>);
+  | string
+  | null
+  | Promise<string | null>
+  | ((
+      context: MemoryScopeContext,
+    ) => MemoryScopeResolverResult | Promise<MemoryScopeResolverResult>);
 ```
 
 `eve/memory/scope` exports the built-in principal resolver:
 
 ```ts
-function byPrincipal(): string | null;
+function byPrincipal(context: MemoryScopeContext): string | null;
 ```
 
 Scope must come from authenticated session context, application data, or trusted
-channel state. It never comes from model input. eve resolves scope before
-namespace. A `null` scope disables the slot without invoking its namespace
-resolver. Otherwise eve resolves the namespace. A `null` namespace also
-disables the slot. A disabled slot does not call the provider, expose its tools,
-or include any of its projections in model context.
+channel state. Scope context deliberately excludes messages and current turn
+input. A resolver that returns an array receives the convenience semantics of
+`value.join(":")`; the array is not a collision-resistant tuple encoding. Each
+component must be a non-empty string. eve resolves scope before namespace. A
+`null` scope disables the slot without invoking its namespace resolver.
+Otherwise eve resolves the namespace. A `null` namespace also disables the
+slot. A disabled slot does not call the provider, expose its tools, or include
+any of its projections in model context.
 
 For an active slot, eve validates both values and derives the provider scope key
 from exactly the resolved namespace and scope:
@@ -189,9 +213,42 @@ that operation. Every projection remains attributed to the slot and scope key
 under which it was recalled.
 
 Passing `byPrincipal` as the scope resolver identifies the authenticated caller
-from principal type, authenticator, optional issuer, and principal ID. The
-function returns `null` for an unauthenticated caller. Anonymous callers never
-share a memory scope.
+from principal type, authenticator, optional issuer, and principal ID. It is a
+pure consumer of the supplied `MemoryScopeContext`; it does not read ambient or
+private runtime state. The function returns `null` for an unauthenticated
+caller. Anonymous callers never share a memory scope.
+
+Principal scope follows the same authenticated caller across channels. Memory
+that is safe only within one channel or conversation must include the trusted
+channel coordinates explicitly. Use `isChannel` to narrow authored channel
+metadata before reading it:
+
+```ts title="agent/memory/channel.ts"
+import { isChannel } from "eve/channels";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+import slack from "../channels/slack";
+import { customMemory } from "../lib/custom-memory";
+
+export default defineMemory({
+  provider: customMemory,
+  scope: (ctx) => {
+    if (!isChannel(ctx.channel, slack)) return null;
+
+    const principal = byPrincipal(ctx);
+    const { channelId, teamId } = ctx.channel.metadata;
+    return principal === null || channelId === null || teamId === null
+      ? null
+      : [principal, teamId, channelId];
+  },
+});
+```
+
+The returned array resolves to `<principal>:<teamId>:<channelId>`. Include a
+thread or conversation identifier as another component when the provider's
+data must not cross that boundary. Resolver output is evaluated once when eve
+locks the operation's memory scopes, and every provider call and tool in that
+operation uses the locked value.
 
 ## Projection visibility across scope changes
 
@@ -655,3 +712,62 @@ Mounted extensions cannot contribute memory slots.
 - [eve dynamic capabilities](../docs/guides/dynamic-capabilities.md)
 - [eve agent configuration](../docs/agent-config.md)
 - [eve turn execution](../packages/eve/src/execution/workflow-steps.ts)
+
+## Review checklist
+
+- [x] **Make channel-aware scope authorable.** Custom scope resolvers receive a
+      read-only `MemoryScopeContext` with the abort signal, authenticated
+      session, and channel metadata, but no messages or turn input.
+      `byPrincipal` consumes that public context without private runtime access.
+      Resolver arrays join non-empty components with `:`, while `null` preserves
+      slot disablement. The authoring guidance states that principal scope
+      crosses channels and shows how to add team, channel, and conversation
+      coordinates for private memory. This resolves the [scope and Slack privacy
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807248748).
+
+- [ ] **Decide what settled-turn metadata memory receives.** Determine whether
+      `save` with `phase: "turn.completed"` receives aggregate input, output,
+      cache, and cost usage, and document how `session.id` plus `turnId` link a
+      memory operation to instrumentation. Explicitly keep failed, cancelled,
+      and deferred turns in instrumentation, or add separate typed phases if
+      memory providers are expected to learn from those outcomes. Close the
+      [usage and trace
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807526107)
+      and [terminal outcome
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807561187)
+      once that boundary is unambiguous.
+
+- [ ] **Give the model a safe memory-slot purpose.** Decide whether the
+      consuming definition or provider configuration supplies a model-facing
+      description that distinguishes destinations such as personal preferences
+      and channel conventions. Keep raw namespace and scope values out of model
+      input, and state that descriptions guide tool choice rather than enforce
+      authorization. Verify that multiple `fileMemory()` slots expose enough
+      information for the model to choose the intended qualified tool. Then
+      close the [model-facing attribution
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
+
+- [ ] **Explain projection placement and tool invocation semantics.** Keep or
+      revise the current replaceable, scope-attributed projection model only
+      after documenting its prompt-cache, chronology, stale-context, and suffix
+      placement tradeoffs. State directly that eve invokes `recall` at fixed
+      lifecycle boundaries and resolves the tool set once per turn, while the
+      model decides whether to call an exposed tool. Close the [replacement and
+      cache thread](https://github.com/vercel/eve/pull/1581#discussion_r3807382863),
+      [suffix placement
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807481674),
+      and [recall versus tool
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807408005)
+      after the proposal records the chosen rationale.
+
+- [ ] **Reconcile the remaining review threads with the final contract.**
+      Correct the earlier additive-recall reply: the current contract keeps one
+      replaceable projection per slot and scope. Correct the cross-provider
+      reply: provider `ctx.messages` excludes other memory projections, and
+      cross-provider reconciliation remains a non-goal. Reply to or resolve the
+      remaining no-change questions about `phase`, `null` and `undefined`,
+      visibility, and the namespace/scope split, then resolve the outdated and
+      approval-only threads. Start with the [cross-provider
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3807280622)
+      and the [outdated turn-input
+      thread](https://github.com/vercel/eve/pull/1581#discussion_r3772094622).

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -10,23 +10,26 @@ last_updated: "2026-08-20"
 
 Memory is a path-authored capability for scoped context that outlives one
 session. A memory provider owns how it stores, retrieves, and updates memory.
-eve owns when the provider participates in the agent lifecycle.
+eve owns when the provider participates in the agent lifecycle, and eve owns a
+small projection record model — item identity, supersede, hide — so recalled
+context can be updated and deleted deterministically without a stale copy
+surviving in the prompt.
 
 Each memory definition binds a provider to an application namespace, a trusted
 scope, and a recall visibility policy. It may also describe the slot's
 purpose to the model through provider tool descriptions. The provider contract
 has three methods:
 
-- `recall` appends provider context to durable history as a user- or
-  system-role message.
+- `recall` returns changes — append, upsert, or retract — that eve applies to
+  the slot's recalled context in durable history as user-role messages.
 - `capture` observes history before compaction and after a completed turn.
 - `tools` contributes model tools bound to the active memory scope.
 
 eve calls each method at fixed boundaries. Recall and capture receive a
 discriminated `phase`, current turn coordinates, a stable operation ID, and the
-locked memory scope resolved for the slot. Tools are resolved once after turn-start recall
-through the same durable dynamic-capability machinery as a `turn.started`
-`defineDynamic` tool resolver.
+locked memory scope resolved for the slot. Tools are resolved once after
+turn-start recall through the same durable dynamic-capability machinery as a
+`turn.started` `defineDynamic` tool resolver.
 
 ```text
 turn.started          ---> recall(phase: "turn.started") ---> tools
@@ -35,21 +38,21 @@ compaction.completed  ---> recall(phase: "compaction.completed")
 turn.completed        ---> capture(phase: "turn.completed")
 ```
 
-eve owns namespace and scope resolution, invocation order, recall-message
-attribution and visibility, tool qualification, and replay behavior. The
-provider owns storage, retrieval, ranking, extraction, formatting, retention,
-and its model-facing operations. A hosted semantic service and a bounded text
-file can therefore implement the same provider contract without sharing a
-record or storage model.
+eve owns namespace and scope resolution, invocation order, change validation
+and application, recall-record attribution and visibility, projection, tool
+qualification, and replay behavior. The provider owns storage, retrieval,
+ranking, extraction, formatting, retention, and its model-facing operations. A
+hosted semantic service and a bounded text file implement the same provider
+contract without sharing a storage model.
 
 ## Public API at a glance
 
-| Import path              | Public surface                                                                                               |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, scope types, and recall types |
-| `eve/memory/scope`       | `byPrincipal`                                                                                                |
-| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                         |
-| `eve/memory/file/vercel` | `vercelBlob`                                                                                                 |
+| Import path              | Public surface                                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, `defaultNamespace`, provider contexts, scope types, and recall change types |
+| `eve/memory/scope`       | `byPrincipal`                                                                                                       |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, and the portable document backend contract                                                |
+| `eve/memory/file/vercel` | `vercelBlob`                                                                                                        |
 
 The smallest complete memory slot uses the built-in file provider:
 
@@ -82,7 +85,8 @@ agent/memory/              # directory of named slots
 The flat file and directory forms are mutually exclusive. Each module
 default-exports `defineMemory(...)`. The definition contains the provider, an
 optional model-facing description, an optional namespace, a required trusted
-scope, and an optional eve-owned visibility policy:
+scope, an optional eve-owned visibility policy, and an optional switch that
+suppresses provider tools:
 
 ```ts title="agent/memory/user.ts"
 import { defineMemory } from "eve/memory";
@@ -92,16 +96,35 @@ import { customMemory } from "../lib/custom-memory";
 export default defineMemory({
   description: "Personal preferences and durable facts for the authenticated user.",
   provider: customMemory,
-  namespace: () => `acme:${process.env.DEPLOYMENT_REGION ?? "local"}`,
+  namespace: (ctx) => `${defaultNamespace(ctx)}:${process.env.DEPLOYMENT_REGION ?? "local"}`,
   scope: byPrincipal,
 });
 ```
 
-The same provider instance may back several slots. Their recalled messages,
+The same provider instance may back several slots. Their recalled context,
 tools, and provider invocations remain independent. The default namespace
 includes the slot identity, so each slot receives a distinct provider scope
 key. Definitions that resolve the same custom namespace and scope intentionally
 share a scope key.
+
+A read-only slot sets `tools: false`. The provider's `tools` method is not
+invoked and the slot exposes no model tools, while recall and capture continue
+to run:
+
+```ts title="agent/memory/policies.ts"
+import { defineMemory } from "eve/memory";
+import { policyMemory } from "../lib/policy-memory";
+
+export default defineMemory({
+  provider: policyMemory,
+  scope: "workspace",
+  tools: false,
+});
+```
+
+`tools: false` is the only memory-specific tool control. Finer policy — per-tool
+approval, overrides, or denial — reuses the ordinary dynamic-tool approval
+surface, because provider tools are ordinary dynamic tools.
 
 ## Model-facing description
 
@@ -113,6 +136,7 @@ interface MemoryDefinition {
   readonly namespace?: MemoryNamespaceDefinition;
   readonly provider: MemoryProvider;
   readonly scope: MemoryScopeDefinition;
+  readonly tools?: boolean;
   readonly visibility?: MemoryVisibility;
 }
 ```
@@ -158,7 +182,7 @@ field when no slot-specific purpose is needed.
 The description is trusted application-authored model guidance. eve does not
 derive it from the slot name, namespace, scope, or request context, and does not
 expose those values through it. The description is not added to recalled
-messages or the prompt separately, so a provider without tools does not expose
+context or the prompt separately, so a provider without tools does not expose
 it to the model. It helps the model choose among qualified tools but does not
 enforce authorization or replace scope isolation.
 
@@ -169,6 +193,8 @@ Namespace identifies the application-owned memory domain. It may be a string,
 
 ```ts
 interface MemoryNamespaceContext {
+  /** Absolute application root, used only for local namespace derivation. */
+  readonly appRoot: string;
   /** Graph node that owns the slot. */
   readonly node: string;
   /** Path-derived slot identity, such as "memory" or "user". */
@@ -184,15 +210,23 @@ function defaultNamespace(context: MemoryNamespaceContext): string;
 After resolving a non-null scope, eve invokes the namespace resolver when it
 locks memory for a lifecycle operation. A resolved `null` disables the slot for
 that operation. If `namespace` is omitted, eve uses the exported
-`defaultNamespace` function as the resolver. Its value includes the Vercel
-project when available, otherwise a hash of the local application root, plus
-the deployment environment and the node and slot from the supplied context.
-`defaultNamespace` is a pure function of its context and the deployment
-environment, so a custom resolver composes with it:
+`defaultNamespace` function as the resolver. `defaultNamespace` is a pure
+function of its context and the deployment environment, so a custom resolver
+composes with it:
 
 ```ts
 namespace: (ctx) => `${defaultNamespace(ctx)}:${process.env.DEPLOYMENT_REGION ?? "local"}`,
 ```
+
+The default policy separates deployment classes deliberately:
+
+- **Production** combines the Vercel project, the stable target environment,
+  the graph node, and the slot. Redeployments keep the same namespace.
+- **Preview** additionally includes the deployment's branch or deployment
+  identity, so unrelated Preview deployments in one project never share memory
+  by accident. Redeployments of the same branch keep that branch's namespace.
+- **Local development** combines a digest of the application root with the node
+  and slot. The raw filesystem path is never persisted.
 
 Set `namespace` to define a custom application domain:
 
@@ -249,43 +283,57 @@ function byPrincipal(context: MemoryScopeContext): string | null;
 ```
 
 Scope must come from authenticated session context, application data, or trusted
-channel state. Scope context deliberately excludes messages and current turn
-input. A resolver that returns an array receives the convenience semantics of
-`value.join(":")`; the array is not a collision-resistant tuple encoding. Each
-component must be a non-empty string. eve resolves scope before namespace. A
-`null` scope disables the slot without invoking its namespace resolver.
-Otherwise eve resolves the namespace. A `null` namespace also disables the
-slot. A disabled slot does not call the provider, expose its tools, or include
-its recalled messages in model context.
+channel state. Scope is an authorization partition, not a model-selected
+routing hint: the resolver context deliberately excludes messages, user-authored
+turn input, and unprojected durable history. eve resolves scope before
+namespace. A `null` scope disables the slot without invoking its namespace
+resolver. Otherwise eve resolves the namespace. A `null` namespace also disables
+the slot. A disabled slot does not call the provider, expose its tools, or
+include its recalled context in the model request.
 
 For an active slot, eve validates both values and derives the provider scope key
 from exactly the resolved namespace and scope:
 
 ```ts
 interface MemoryScope {
-  /** Stable key derived from namespace and value. */
+  /** Opaque scope key: a versioned digest of the canonical namespace and scope encodings. */
   readonly key: string;
+  /** Resolved application-owned memory domain. */
   readonly namespace: string;
-  readonly value: string;
+  /** Resolved scope exactly as the resolver returned it: a scalar or a tuple. */
+  readonly value: string | readonly string[];
 }
 ```
 
-The namespace separates independent application domains. The scope separates
-audiences or containers inside that domain. The resolved pair is the only
-variable input to the provider key. eve canonically encodes the pair before
-hashing, so values cannot collide through string concatenation.
+### Scope-key encoding
 
-Every `recall`, `capture`, and `tools` call receives this scope. Tools close over
-the same locked scope, so the model never selects a different user, tenant, or
-container. A conforming provider must apply `scope.key` or the namespace and
-value to every downstream read and write. eve cannot prevent faulty provider
-code from discarding the supplied scope, but the public contract provides no
-unscoped provider invocation path.
+The namespace-plus-scope pair is the slot's scope key, and it is
+collision-free by construction. eve never flattens a tuple with a delimiter.
+Each input is canonically encoded with a versioned, type-tagged,
+length-prefixed UTF-8 representation that distinguishes a scalar from a
+one-element tuple, preserves tuple boundaries, and is safe for
+delimiter-containing component values. Each encoding is hashed with SHA-256 and
+emitted as a typed base64url key (`memns1_…` for namespaces, `memscope1_…` for
+scopes). The provider-facing composite `scope.key` is derived from a versioned
+encoding of those two opaque keys. Provider item IDs receive the same treatment
+(`memitem1_…`) before they enter durable attribution.
+
+Scalar `"a:b:c"`, tuple `["a:b", "c"]`, tuple `["a", "b:c"]`, and scalar `"a"`
+versus tuple `["a"]` all produce distinct keys. Durable attribution stores only
+the opaque namespace, scope, and item keys — never raw principal, channel,
+namespace, scope, or provider item-ID values.
+
+Every `recall`, `capture`, and `tools` call receives this scope. Tools close
+over the same locked scope, so the model never selects a different user,
+tenant, or container. A conforming provider must apply `scope.key` to every
+downstream read and write. eve cannot prevent faulty provider code from
+discarding the supplied scope, but the public contract provides no unscoped
+provider invocation path.
 
 eve locks scope for the active turn, including model steps and durable approved
 call continuations. A standalone manual compaction resolves and locks scope for
-that operation. Every recalled message remains attributed to the slot and scope
-key under which it was appended.
+that operation. Every recalled record remains attributed to the slot, namespace
+key, and scope key under which it was accepted.
 
 Passing `byPrincipal` as the scope resolver identifies the authenticated caller
 from principal type, authenticator, optional issuer, and principal ID. It is a
@@ -323,16 +371,26 @@ export default defineMemory({
 });
 ```
 
-The returned array resolves to `<principal>:<teamId>:<channelId>`. Include a
-thread or conversation identifier as another component when the provider's
+The returned array is a three-component tuple. Components may contain any
+characters, including delimiters, without colliding with another scope. Include
+a thread or conversation identifier as another component when the provider's
 data must not cross that boundary. Resolver output is evaluated once when eve
 locks the operation's memory scopes, and every provider call and tool in that
 operation uses the locked value.
 
+### Disabled-slot diagnostics
+
+A `null` scope or namespace silently disables a slot — no provider call, no
+tools, no recalled context. Because `byPrincipal` returns `null` for anonymous
+and runtime principals, disablement is a common and correct state. In
+development mode, eve emits a diagnostic when a slot resolves disabled, naming
+the slot and whether the scope or namespace resolver returned `null`, without
+logging resolved values. Disablement is never an error.
+
 ## Recall visibility across scope changes
 
 `visibility` is an eve-owned `defineMemory` option. It controls which
-previously recalled messages enter a model request when the slot resolves a
+previously recalled records enter a model request when the slot resolves a
 different scope. The option belongs to the consuming memory definition rather
 than the provider because eve owns prompt assembly and the application owns the
 session's audience boundary:
@@ -353,19 +411,21 @@ export default defineMemory({
 type MemoryVisibility = "scope" | "session";
 ```
 
-| Value               | Model context after a scope change                                                                                            | Prompt cache                                                                                  |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `"scope"` (default) | Include recalled messages whose slot and scope key match the active turn. Exclude recalled messages for earlier participants. | Filtering earlier messages changes the prompt prefix and invalidates the affected cache.      |
-| `"session"`         | Keep every recalled message for the slot visible in its durable history position.                                             | Existing prompt messages remain in place; later recall results only extend the cached prefix. |
+| Value               | Model context after a scope change                                                                                            |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `"scope"` (default) | Include recalled records whose slot, namespace key, and scope key match the active locks. Exclude records for earlier scopes. |
+| `"session"`         | Require slot and namespace key to match, but keep records across scope-key changes within that namespace visible in place.    |
 
-The default favors recalled-context isolation over cache reuse when the
-authenticated participant changes.
+Namespace is always an isolation boundary. `"session"` intentionally retains
+prior recall across scope-key changes within one namespace; it never exposes
+recall from an earlier namespace. The default favors recalled-context isolation
+over cache reuse when the authenticated participant changes.
 
 For a Slack thread where one authenticated participant follows another,
 `"scope"` removes the first participant's recalled memory before the second
-participant's model call. `"session"` keeps both recalled messages visible. The
-second mode is an explicit cross-scope disclosure policy and is appropriate
-only when the session participants form one trusted audience.
+participant's model call. `"session"` keeps both visible. The second mode is an
+explicit cross-scope disclosure policy and is appropriate only when the session
+participants form one trusted audience.
 
 ```text
 durable: ... -> participant A memory -> participant A turn -> assistant -> participant B memory -> participant B turn
@@ -373,12 +433,12 @@ scope:   ... -> participant A turn -> assistant -> participant B memory -> parti
 session: ... -> participant A memory -> participant A turn -> assistant -> participant B memory -> participant B turn
 ```
 
-This option never changes provider scope. `recall`, `capture`, and `tools` still
-receive only the active turn's locked scope. The provider cannot select the
-visibility mode. A `null` scope suppresses all recalled messages belonging to
-the slot in both modes.
+This option never changes provider scope. `recall`, `capture`, and `tools`
+still receive only the active turn's locked scope. The provider cannot select
+the visibility mode. A `null` scope suppresses all recalled context belonging
+to the slot in both modes.
 
-Recall visibility changes only scope-attributed recall messages in the model
+Recall visibility changes only scope-attributed recall records in the model
 request. It does not remove ordinary user, assistant, or tool messages from
 durable history, and it cannot undo information an earlier assistant response
 derived from memory. Applications that require hard isolation between
@@ -397,18 +457,27 @@ import type { SessionContext } from "eve/context";
 import type { DynamicResolveContext, ToolDefinition } from "eve/tools";
 
 interface MemoryRecallMessage {
-  /** Provider context appended to durable model history. */
+  /** Provider context recalled into durable model history as a user-role message. */
   readonly content: string;
-  /** Defaults to "user". */
-  readonly role?: "system" | "user";
 }
 
-interface MemoryMessageAttribution {
-  readonly scope: MemoryScope;
-  readonly slot: string;
-}
+type MemoryRecallChange =
+  | {
+      readonly type: "append";
+      readonly message: MemoryRecallMessage;
+    }
+  | {
+      readonly type: "upsert";
+      /** Provider-owned opaque item identity, unique within the slot, namespace, and scope. */
+      readonly id: string;
+      readonly message: MemoryRecallMessage;
+    }
+  | {
+      readonly type: "retract";
+      readonly id: string;
+    };
 
-function getMemoryMessageAttribution(message: ModelMessage): MemoryMessageAttribution | null;
+type MemoryRecallResult = MemoryRecallMessage | readonly MemoryRecallChange[] | null | undefined;
 
 /** Mirrors the ambient `ctx.session.turn` coordinates plus the turn input. */
 interface MemoryTurnContext {
@@ -422,7 +491,7 @@ interface MemoryTurnContext {
 
 interface MemoryOperationContext extends SessionContext {
   readonly abortSignal: AbortSignal;
-  /** Durable model history at this lifecycle boundary, including prior recalls. */
+  /** Projected model history at this lifecycle boundary, including visible recalled context. */
   readonly messages: readonly ModelMessage[];
   /** Identifies one logical recall or capture operation across workflow replay. */
   readonly operationId: string;
@@ -477,7 +546,6 @@ interface MemoryToolsContext extends DynamicResolveContext {
   };
 }
 
-type MemoryRecallResult = MemoryRecallMessage | null | undefined;
 type MemoryToolSet = Readonly<Record<string, ToolDefinition>>;
 
 interface MemoryProvider {
@@ -489,77 +557,156 @@ interface MemoryProvider {
 }
 ```
 
-A provider can resolve tools asynchronously from authenticated or channel
-context and capture the result in its executors:
+Recalled context is always user-role. Recall is framework context appended
+after the durable prefix and before the admitted turn input, so it preserves
+the prompt-cache prefix in the normal case. eve does not offer a system-role
+recall option: system-role content is position-independent, so upsert and
+retract semantics cannot compose with it, and any change to it invalidates the
+prompt cache from message zero. Standing system-role guidance derived from
+runtime state belongs in `defineDynamic` instructions.
+
+`defineMemoryProvider(...)` is an identity-with-types helper. It does not add
+storage behavior.
+
+## Recall changes
+
+A recall result is a set of changes to the slot's recalled context, not a
+replacement snapshot. The result is a bare ordered array; a bare
+`MemoryRecallMessage` is shorthand for one append.
+
+| Change                            | Effect                                                                                                                                 |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `{ type: "append", message }`     | Add one immutable, unkeyed record. It cannot be updated or retracted later.                                                            |
+| `{ type: "upsert", id, message }` | Insert or replace the one item identified by `id`. An identical upsert is a no-op; a changed upsert supersedes only the older version. |
+| `{ type: "retract", id }`         | Hide the item identified by `id`. Idempotent; retracting an unknown or never-active ID is a valid no-op.                               |
+| `MemoryRecallMessage`             | Shorthand for one append.                                                                                                              |
+| `null`, `undefined`, `[]`         | Change nothing at this boundary.                                                                                                       |
+
+The semantics that hold at every boundary:
+
+- **Recall is observational.** Providers must not use it for external
+  mutations. eve makes the durable change commit atomic, but it cannot roll
+  back provider side effects.
+- **Accumulation is the only mode.** An item missing from a later result
+  remains active. Missing top-k retrieval results never imply deletion. A
+  provider that wants something gone returns an explicit retract or a
+  superseding upsert.
+- **Item identity is `(slot, namespaceKey, scopeKey, idKey)`**, where each key
+  is an eve-owned opaque digest. The same provider `id` under two slots,
+  namespaces, or scopes identifies two independent items; neither can update,
+  retract, or reveal the other.
+- **Appends are never content-deduplicated.** A repeated identical bare append
+  adds a second copy. Content a provider might return again must be keyed.
+- **A retracted item can be reactivated** by a later upsert of the same ID.
+- **Batches validate completely before applying.** Empty or blank append and
+  upsert content, empty or oversized item IDs, duplicate upsert or retract IDs
+  within one batch, and unknown change keys are rejected, and a rejected batch
+  applies nothing. Change order within a batch is preserved.
+
+For example, keyed retrieval results `[A, B]` followed by `[B, C]` leave `A`,
+`B`, and `C` visible, with `B` present once.
+
+### Example: append-only event log
+
+A principal-scoped provider that surfaces each new observation exactly once
+uses the bare-message shorthand and never needs identity. Because appends are
+never deduplicated, the provider consumes each note rather than re-reading the
+latest state:
 
 ```ts
 import { defineMemoryProvider } from "eve/memory";
-import { defineTool } from "eve/tools";
 
-const customMemory = defineMemoryProvider({
+const auditMemory = defineMemoryProvider({
   async recall(ctx) {
-    const content = await loadMemory(ctx.memory.scope.key);
-    return content === null ? null : { content, role: "user" };
-  },
-  tools: async (ctx) => {
-    const policy = await loadToolPolicy(ctx.session.auth.current);
-
-    return {
-      search: defineTool({
-        description: "Search memory",
-        inputSchema: searchSchema,
-        execute: (input) => searchMemory(ctx.memory.scope.key, policy, input),
-      }),
-    };
+    if (ctx.phase !== "turn.started") return null;
+    const note = await takeUnreadNote(ctx.memory.scope.key);
+    return note === null ? null : { content: note };
   },
 });
 ```
 
-The result of `recall` is append-only:
+### Example: bounded sparse retrieval
 
-| Result                                           | Effect                                                                                   |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `{ content: string, role?: "system" \| "user" }` | Append one scope-attributed message with the resolved role. `role` defaults to `"user"`. |
-| `null`, `undefined`, or no return                | Append nothing at this boundary.                                                         |
+A vector-retrieval provider returns a different top-k subset each turn.
+Because accumulation is monotonic, an unbounded stream of new IDs would grow
+context forever. Keying results by window position bounds the visible set by
+construction: each recall re-upserts the same `k` identities, superseding the
+previous occupant of each position:
 
-eve applies the same content normalization as instructions. It trims
-the returned content and appends nothing when the result is empty after
-trimming. A recall result never replaces, clears, or mutates an earlier message.
+```ts
+import { defineMemoryProvider } from "eve/memory";
 
-`defineMemoryProvider(...)` is an identity-with-types helper. It does not add
-storage behavior or impose a record model.
+const retrievalMemory = defineMemoryProvider({
+  async recall(ctx) {
+    if (ctx.phase !== "turn.started") return null;
+    const hits = await search(ctx.memory.scope.key, ctx.turn.input, { limit: 3 });
+    return hits.map((hit, rank) => ({
+      type: "upsert" as const,
+      id: `rank:${rank}`,
+      message: { content: hit.text },
+    }));
+  },
+});
+```
 
-## Recalled messages
+A provider that keys by document identity instead (`id: hit.documentId`) keeps
+every previously recalled document visible until it explicitly retracts one.
+Both are valid; the provider chooses its window policy.
 
-Every non-empty recall result becomes one durable message with the resolved
-role, using the same message shape and append behavior as instructions.
-Turn-start recalls are appended immediately before the admitted turn input.
-Post-compaction recalls are appended after the rewritten checkpoint and
-retained tail. Multiple slots append in stable slot-path order. A user-role
-recall enters model context in its durable history position. A system-role
-recall keeps the same durable position and attribution but follows the same
-model-request routing as system-role instructions.
+### Rejected alternative: inventory coverage
 
-eve records internal slot and scope attribution on each recalled message. The
-attribution is not sent to the model or exposed as tool input. It exists so eve
-can apply `visibility` at model assembly and so provider code can distinguish
-recalled context from ordinary conversation messages. The message itself remains
-part of `ctx.messages`, completed-turn captures, and later compaction input.
+An earlier revision included a `coverage: "complete"` flag: a keyed result
+asserting a full inventory, from which eve synthesized retractions for omitted
+IDs. It was cut because no first-party provider consumes it — `fileMemory()`
+returns one whole-document upsert — and because omission-means-deletion
+semantics are the sharpest foot-gun in a sparse-retrieval API. If a real
+enumerable provider needs framework diffing later, an inventory result shape is
+an additive union arm, not a breaking change.
 
-Recalled messages are not emitted as `message.received`; they are framework
-context rather than new channel input. Compaction may summarize or discard them
-like other durable context. Before compaction, eve applies the active
-visibility policy, so a scope-hidden recall cannot enter the checkpoint and is
-removed with the rewritten history. The post-compaction recall boundary lets a
-provider append fresh context when the rewritten history no longer contains it.
+## Durable records and projection
 
-Append-only recall preserves the existing prompt prefix in the normal case. It
-also means a provider owns repetition and correction policy. Returning the same
-snapshot at every turn appends duplicates, while a later correction does not
-delete an earlier claim. A provider returns `null` or `undefined` when it has no
-new context to append. Because system-role recalls join the system prompt,
-changed system-role content invalidates the cached prompt prefix; a provider
-that recalls frequently changing context should prefer the default user role.
+Every accepted change becomes an internal durable record attributed with the
+slot, opaque namespace key, opaque scope key, change kind, opaque item key for
+keyed changes, operation ID, and batch position. Raw durable history is
+storage-only. Every message-bearing consumer — providers, dynamic resolvers,
+approval and tool contexts, token accounting, compaction, instrumentation
+callbacks, and the model request — receives a view derived from one canonical
+scope projection, never raw durable history.
+
+Projection folds records per slot and identity:
+
+- visible unkeyed appends always remain, in position;
+- only the latest active upsert of each identity is visible, in the position of
+  its accepted batch;
+- a superseded version and a retracted item are hidden, along with the retract
+  itself;
+- attribution is stripped before any authored callback, tool, or model
+  boundary. There is no public accessor for recall attribution; providers use
+  stable item IDs instead of scanning history.
+
+Recalled context is not emitted as `message.received`; it is framework context
+rather than new channel input.
+
+### Cache consequences
+
+New items append at the tail and preserve the existing prompt prefix. Repeated
+identical keyed items change nothing. An explicit update or retraction must
+stop the model from seeing the prior value, and filtering that older occurrence
+necessarily invalidates the prompt cache from that point forward. This is a
+deliberate trade: pure append-only recall is strictly better for prompt cache
+on updates, because the old copy would keep its position — but it leaves the
+contradicted copy model-visible, which makes update and deletion
+nondeterministic after compaction. The change model spends a mutation-driven
+cache invalidation to buy deterministic visibility; it is not cache-neutral,
+and it never substitutes a natural-language correction while leaving the
+contradicted content visible.
+
+Within one session, the model also sees the mutation narrative — the old
+recalled copy, then the tool calls that changed storage. The change model earns
+its complexity at the boundaries where that narrative dies: compaction drops
+tool results first, so a stale recalled copy can outlive the story of its own
+deletion and be summarized as fact. Deterministic deletion, not model
+competence, is the design driver.
 
 ## Lifecycle
 
@@ -568,65 +715,114 @@ that recalls frequently changing context should prefer the default user role.
 After eve admits and normalizes a new turn, it resolves each memory scope and,
 for a non-null scope, its namespace. It then calls `recall` with
 `phase: "turn.started"` for every active slot. The context contains the
-zero-based turn sequence, stable turn ID, normalized input, durable history
-before the turn, and prior recalled messages that remain in that history.
+zero-based turn sequence, stable turn ID, normalized input, and the projected
+history before the turn, including prior visible recalled context.
 
-The first turn has `ctx.turn.sequence === 0`. A provider may use that coordinate
-to recall only on the first turn. It may use `getMemoryMessageAttribution` to
-find earlier recalls from the same slot and scope, return nothing when its
-current context is already present, or recall on every turn using the current
-input as its query.
+Every active slot resolves independently against that same pre-recall view.
+Each result is normalized and validated, and the whole turn-wide batch commits
+atomically: one failing slot or one invalid batch applies nothing for any slot.
+Accepted changes are applied in stable slot-path order, after the durable
+prefix and before the admitted turn input, and the projected view is recomputed
+before tools resolve and the model runs.
 
-The results are appended in stable slot order before the first model call. If
-automatic compaction runs at the same opening boundary, the new messages enter
-compaction input. Post-compaction recall may append fresh context after the
-rewritten checkpoint before the model runs.
+The first turn has `ctx.turn.sequence === 0`. A provider does not need to
+deduplicate its own recall: returning the current state as keyed upserts every
+turn is the intended pattern, because identical upserts are no-ops. A provider
+may still use the turn coordinates to recall only on the first turn, or use the
+current input as a retrieval query on every turn.
 
-### Compaction capture and recall
+### Compaction capture, canonicalization, and recall
 
-Before automatic or manual compaction rewrites history, eve calls an implemented
-`capture` method with `phase: "compaction.requested"`. The provider receives the
-complete durable history about to be compacted and the compaction model and
-usage metadata. A provider may persist a checkpoint, extract facts the summary
-could omit, or do nothing.
+Before automatic or manual compaction rewrites history, eve calls an
+implemented `capture` method with `phase: "compaction.requested"`. The provider
+receives the projected pre-rewrite history and the compaction model and usage
+metadata. A provider may persist a checkpoint, extract facts the summary could
+omit, or do nothing.
+
+Compaction is the canonicalization boundary for memory records. Trusted
+internal code partitions every attributed memory record — across every slot,
+namespace, scope, and visibility mode — away from ordinary conversation, folds
+keyed records to one live version or deletion tombstone per identity, and
+retains every immutable unkeyed append with its attribution. The free-form
+summary prompt is built from projected ordinary conversation only; no
+attributed memory record of any kind enters it. Canonical private memory state
+is reattached to the rewritten history, so items hidden from the currently
+active scope survive another scope's compaction, and sparse retrieval stays
+accumulative across compaction.
+
+Because superseded versions, hidden scopes, and tombstones can grow while the
+visible prompt stays constant, eve triggers canonicalization on raw
+attributed-record growth independently of visible prompt size. If canonical
+memory state alone exceeds its configured bound, compaction fails with an
+actionable error — and the failure is recoverable by design: the next recall
+boundary still runs, so providers can retract items, and the bound is
+application-configurable. eve never silently summarizes, evicts, or truncates
+provider items.
 
 After a checkpoint is durably appended, eve calls `recall` with
 `phase: "compaction.completed"`. The provider receives the settled
-post-compaction history and may append one fresh recall message. The call
-occurs after every successful automatic or manual compaction, even when the
-provider skipped ordinary turn-start recall.
+post-compaction projected history and may return fresh changes, applied through
+the same atomic path. Identical retained items are no-ops. The call occurs
+after every successful automatic or manual compaction, even when the provider
+skipped ordinary turn-start recall.
 
 Provider tools are not resolved during a standalone compaction because no model
 call follows that boundary.
 
+### Context clear
+
+`context.cleared` rewrites history outside compaction. A clear wipes attributed
+memory records together with the conversation: the cleared session starts with
+no recalled context, and the next turn-start recall repopulates it from
+provider storage through the normal path. Memory durability lives in provider
+storage, not in session records, so a cleared conversation recalls current
+memory exactly once, with no stale copies. This behavior requires a direct
+test: clear, then assert the next turn recalls the provider's current state
+exactly once.
+
 ### Turn tools
 
-After turn-start recall settles, eve resolves `tools` once for the active turn.
-The function may be synchronous or asynchronous. Its context contains the same
-session, authentication, channel, and message fields as a `defineDynamic`
-resolver, plus the locked memory scope, slot, and turn. Its messages include the
-turn-start recall results followed by the admitted turn input.
-Returning `null` or an empty record exposes no tools for the slot.
+After turn-start recall settles, eve resolves `tools` once for the active turn
+unless the definition sets `tools: false`. The function may be synchronous or
+asynchronous. Its context contains the same session, authentication, channel,
+and message fields as a `defineDynamic` resolver, plus the locked memory scope,
+slot, and turn. Its messages include the projected turn-start recall results
+followed by the admitted turn input. Returning `null` or an empty record
+exposes no tools for the slot.
 
 The memory definition is implicit `defineDynamic` authoring: eve adapts each
-implemented `tools` function to a `turn.started` dynamic resolver. The existing
-dynamic tool engine owns asynchronous resolution, schema capture, closure
-capture, approval and authorization behavior, durable replay, and executor
-reconstruction for provider tools.
+implemented `tools` function to a `turn.started` dynamic resolver. Provider
+tools are ordinary branded `defineTool()` entries and depend entirely on the
+generic dynamic-tool engine — durable callback descriptors that survive fresh
+processes ([#2345](https://github.com/vercel/eve/issues/2345)), per-call
+origins that resume against the originating definition
+([#2346](https://github.com/vercel/eve/issues/2346)), and the runtime-tool
+contribution seam ([#2347](https://github.com/vercel/eve/issues/2347)). Memory
+adds no tool machinery of its own: no memory-specific approval methods, no
+separate callback registry, and no `defineMemoryTool` wrapper.
+
+Tools never emit recall changes. A tool executor mutates provider storage and
+returns ordinary tool output; recall is the single writer of recalled context,
+and the consistency contract is that the next recall boundary reflects storage.
+Within the turn that mutated storage, the stale recalled item remains visible
+and the model's own tool-call narrative covers the gap; the next turn-start or
+post-compaction recall trues it up.
 
 eve qualifies every returned key as `<slot>__<tool>` and binds the locked scope
 to the tool implementation. Provider tools use the standard tool contract,
 including input and output schemas, approval, authorization, and model-output
-projection. In particular, `once()` approval is session-wide:
-approving one qualified tool name also approves that name after a scope change.
-Providers should use `always()` or a custom policy when approval must be
-participant- or scope-specific.
+projection. In particular, `once()` approval is session-wide: approving one
+qualified tool name also approves that name after a scope change. Providers
+should use `always()` or a custom policy when approval must be participant- or
+scope-specific.
 
 The resolved tool set remains stable across every model step in the turn. When
-a call parks on approval or authorization, eve retains that call's dynamic tool
-metadata. The continuation reconstructs the exact originating definition,
-including its captured scope, even if another participant has since started a
-turn and replaced the current turn's tools. Resolver code does not run again.
+a call parks on approval or authorization, the continuation reconstructs the
+exact originating definition — including its captured scope — through the
+generic durable-descriptor and call-origin machinery, even in a fresh process
+and even if another participant has since replaced the current turn's tools.
+Callback forms the descriptor mechanism cannot express fail with an explicit
+diagnostic at resolution time rather than silently degrading at replay.
 
 A direct inline-authorization park follows the ordinary tool contract. The
 unfinished assistant/tool exchange does not enter durable history, and the
@@ -634,17 +830,18 @@ callback makes the credential available only to its matching principal. It does
 not replay the original tool execution. A later model step uses the same
 turn-scoped tool set.
 
-Resolver side effects occur once per admitted turn, while workflow replay
-returns the recorded result. Provider mutations belong in the returned tool's
-`execute` function. eve never substitutes the current turn's definition or
-scope for a parked call's captured definition.
+Workflow replay returns recorded results for committed resolutions. Resolver
+code may run again when an uncommitted delivery is re-executed after a crash,
+so resolver side effects must be idempotent; provider mutations belong in the
+returned tools' `execute` functions. eve never substitutes the current turn's
+definition or scope for a parked call's captured definition.
 
 ### Completed-turn capture
 
-After a turn reaches `turn.completed`, eve calls an implemented `capture` method
-with `phase: "turn.completed"`. The provider receives the completed turn input
-and the settled durable history, including the assistant response and tool
-results. The method does not run for failed, cancelled, input-deferred, or
+After a turn reaches `turn.completed`, eve calls an implemented `capture`
+method with `phase: "turn.completed"`. The provider receives the completed turn
+input and the settled projected history, including the assistant response and
+tool results. The method does not run for failed, cancelled, input-deferred, or
 adapter-consumed turns.
 
 Completed-turn capture is a semantic memory boundary, not an instrumentation
@@ -664,13 +861,22 @@ the turn, update a remote profile, enqueue its own work, or do nothing.
 Every recall and capture invocation receives an `operationId` for one logical
 slot operation. eve reuses the ID across workflow replay, so it is not a unique
 callback-attempt identifier. A provider must use it as the idempotency key for
-externally visible `capture` side effects. eve records recalled messages with
-their scope attribution and keeps turn-scoped dynamic tool metadata in durable
-session state.
+externally visible `capture` side effects.
+
+Recall operations for one session are serialized by construction: turn steps
+serialize through workflow hook-ownership claims, so two recall operations for
+the same slot, namespace, and scope cannot complete out of order. The change
+shape is therefore revision-free. eve persists each operation's accepted
+normalized batch, or its canonical digest, and a cold replay must reuse the
+stored batch or match its digest exactly; a replay that returns a reordered or
+changed batch for the same operation ID fails explicitly and mutates nothing.
+Batch ordinals identify entries only within that fixed accepted batch.
 
 Failure behavior follows the point at which the method runs:
 
 - A turn-start `recall` failure fails the active turn before the model runs.
+  Any slot failure or invalid batch applies nothing for the entire turn-wide
+  recall batch.
 - A `compaction.requested` capture failure aborts compaction before history
   changes.
 - A post-compaction `recall` failure cannot undo the checkpoint. It fails the
@@ -680,11 +886,32 @@ Failure behavior follows the point at which the method runs:
   matching `defineDynamic` tool resolution.
 - A completed-turn `capture` failure cannot rewrite the completed response. eve
   emits a content-free diagnostic and continues to the ready boundary.
+- A `null` scope skips operations; it never falls back to a shared key.
+
+## Limits
+
+All limits reject invalid or oversized input with actionable errors. eve never
+silently truncates or evicts. Values below are the proposal-review targets;
+implementation uses exactly the reviewed constants.
+
+| Constant                    | Value                                | Applies to                                               |
+| --------------------------- | ------------------------------------ | -------------------------------------------------------- |
+| Namespace                   | 1,024 UTF-8 bytes                    | resolved namespace value                                 |
+| Scope component             | 1,024 UTF-8 bytes                    | each scalar or tuple component                           |
+| Scope tuple                 | 16 components                        | resolver array results                                   |
+| Canonical key input         | 4,096 UTF-8 bytes                    | total namespace-plus-scope encoding                      |
+| Provider item ID            | non-empty, 1,024 UTF-8 bytes         | upsert and retract `id`                                  |
+| Key prefixes                | `memns1_`, `memscope1_`, `memitem1_` | SHA-256 digests, base64url                               |
+| Raw-record canonicalization | 512 records or 262,144 bytes         | superseded/hidden attributed records between compactions |
+| Canonical private state     | 131,072 bytes, configurable          | folded memory state that must survive compaction         |
+| File entry                  | 2,048 UTF-8 bytes                    | normalized `save_memory` text                            |
+| File document               | 65,536 UTF-8 bytes                   | exact serialized stored document, including header       |
+| File entries                | `maxEntries`, default 100            | live entries per scope key                               |
 
 ## Built-in file memory
 
-`fileMemory()` is the reference bounded-document provider. It stores one indexed
-`MEMORY.md`-style document per memory scope key.
+`fileMemory()` is the reference bounded-document provider. It stores one
+indexed `MEMORY.md`-style document per memory scope key.
 
 ```ts
 interface FileMemoryOptions {
@@ -696,16 +923,49 @@ interface FileMemoryOptions {
 function fileMemory(options?: FileMemoryOptions): MemoryProvider;
 ```
 
-Its `recall` method loads the current document at every turn start and after
-every successful compaction. It appends the formatted document when the active
-slot and scope do not already have an identical latest recall in durable
-history. An empty or unchanged document appends nothing. Its `tools` method
-exposes `save_memory({ text })` and `remove_memory({ index })`. Each tool completes after
-its conditional write and returns no output; the next recall reflects the
-updated document. `save_memory` normalizes whitespace, treats duplicate text as
-a successful no-op, and fails when the document reaches `maxEntries`.
-`remove_memory` is a no-op when its index is absent. The provider omits
-`capture`: it does not run an extraction model or persist whole conversations.
+### Recall: one whole-document upsert
+
+`recall` loads the current document at every turn start and after every
+successful compaction, renders it — a heading that names the slot, explains the
+indexed entries, and states the exact qualified removal tool name, followed by
+each live `index: text` line — and returns exactly one upsert under a single
+stable provider ID. An unchanged document is an identical upsert and therefore
+a no-op; the provider never scans history. A mutated document supersedes the
+previous copy, so a removed or edited entry deterministically leaves model
+context at the next recall boundary, with no stale copy left visible. A missing
+document or one with zero live entries returns a retract of the document ID,
+which is a no-op when nothing was ever recalled.
+
+Whole-document granularity is a provider choice, not an API requirement: each
+mutation re-sends the document and invalidates the cache from the document's
+previous position, while non-mutation turns cost nothing. Per-entry upserts
+remain a legal finer-grained alternative for providers that can enumerate their
+own deletions.
+
+### Tools
+
+`tools` exposes `save_memory({ text })` and `remove_memory({ index })`. Each
+tool completes after its conditional write and returns no output; the next
+recall reflects the updated document. `save_memory` normalizes whitespace,
+treats duplicate text as a successful no-op, and fails when the document
+reaches `maxEntries`. `remove_memory` is a no-op when its index is absent. The
+provider omits `capture`: it does not run an extraction model or persist whole
+conversations.
+
+### Storage format
+
+The stored document has a versioned header that persists `lastAllocatedIndex`
+(starting at `-1`) alongside the live indexed lines. Indexes are allocated
+monotonically and never renumbered or reused, including after the highest live
+index is removed, so a model-facing index from earlier context can never alias
+a different, later fact. `maxEntries` counts live entries, so removal frees
+capacity without resetting the high-water mark. When `lastAllocatedIndex`
+reaches `Number.MAX_SAFE_INTEGER`, the next save fails explicitly. Deletion
+visibility comes from the changed document upsert superseding the previous
+copy, so the document needs no deletion tombstones. Header bytes count toward
+the document limit.
+
+### Backend contract and selection
 
 The provider uses one portable conditional-document backend:
 
@@ -727,17 +987,27 @@ interface MemoryDocumentBackend {
 }
 ```
 
-Process-local memory supports tests and non-Vercel development. A Vercel
-deployment with an attached Blob store uses private Vercel Blob storage. Every
-other production configuration requires an explicit backend. Every backend
-implements the same optimistic read/replace contract.
+Every backend implements the same optimistic read/replace contract. The default
+backend fails closed and resolves lazily on first storage access:
+
+| Environment                                                       | Default backend                         |
+| ----------------------------------------------------------------- | --------------------------------------- |
+| Vercel with Blob credentials (token, or attached store with OIDC) | Private Vercel Blob                     |
+| Vercel without Blob configuration                                 | Error: attach a store or pass a backend |
+| eve development environment (`eve dev`)                           | Shared process-local in-memory backend  |
+| Every other environment, including unset or unknown `NODE_ENV`    | Error: explicit backend required        |
+
+Vercel detection takes precedence over development flags, a Blob token outside
+Vercel never silently selects Blob, and `NODE_ENV` alone never proves a
+development environment. An explicit `fileMemory({ backend })` is used in every
+environment. Tests pass `inMemory()` explicitly.
 
 The same lifecycle also supports a hosted semantic provider:
 
 | Boundary               | Bounded file provider       | Hosted semantic provider                    |
 | ---------------------- | --------------------------- | ------------------------------------------- |
-| `turn.started` recall  | Append a changed document   | Retrieve against the current turn input     |
-| Post-compaction recall | Append if context is absent | Refresh against the compacted history       |
+| `turn.started` recall  | Upsert the current document | Upsert retrieval results for the turn input |
+| Post-compaction recall | Upsert if context is absent | Refresh against the compacted history       |
 | Pre-compaction capture | Omit                        | Preserve facts or checkpoint provider state |
 | Completed-turn capture | Omit                        | Capture the completed interaction           |
 | Turn tools             | Save and remove entries     | Provider-defined search, save, or forget    |
@@ -749,30 +1019,42 @@ nothing in `capture`, or return `null` from `tools`.
 
 A provider package exports a `MemoryProvider` or provider factory. It may own
 credentials, remote APIs, migrations, retrieval, capture, and model tools. The
-consuming agent owns the slot path, namespace, scope, and recall visibility.
-Mounted extensions cannot contribute memory slots.
+consuming agent owns the slot path, namespace, scope, tool suppression, and
+recall visibility. Mounted extensions cannot contribute memory slots.
 
 ## Design invariants
 
 - A slot is active only when both namespace and scope resolve to non-empty
-  strings. Omitting `namespace` selects `defaultNamespace`; `null` disables the
-  slot.
+  values. Omitting `namespace` selects `defaultNamespace`; `null` disables the
+  slot, with a development-mode diagnostic and never an error.
 - The resolved namespace and scope are the only variable inputs to the provider
-  key. Custom namespaces receive no path or deployment suffixes.
-- One scope lock applies to every provider call, recalled message, model step, and
-  durable tool continuation in an operation.
+  key, canonically encoded and digested so scalars, tuples, and
+  delimiter-containing values cannot collide. Custom namespaces receive no path
+  or deployment suffixes.
+- One scope lock applies to every provider call, recalled record, model step,
+  and durable tool continuation in an operation.
 - Recall and capture phases identify their exact lifecycle boundary. Every
-  provider context includes durable history and a replay-stable operation ID.
-- A non-empty recall result appends one scope-attributed message with the
-  resolved role, defaulting to user, to durable history. `null`, `undefined`,
-  and empty normalized content append nothing; recall never mutates an earlier
-  message.
-- `visibility` controls which attributed recall messages enter a model request
-  after a scope change. Session visibility preserves append-only prompt order;
-  scope visibility may filter an earlier prefix.
-- Provider tools are slot-qualified, scope-bound `turn.started` dynamic tools.
-  Each turn resolves one complete tool set, every model step uses it, and a
-  durable call keeps its originating definition until settlement.
+  provider context includes projected history and a replay-stable operation ID.
+- Raw durable history is storage-only. Every message-bearing consumer receives
+  one canonical scope projection with attribution stripped; no authored
+  callback or model boundary sees hidden items or eve-owned metadata.
+- A recall result is a validated batch of append/upsert/retract changes,
+  committed atomically per turn across all active slots. Omission never
+  retracts; appends are immutable; identical upserts are no-ops; retracts are
+  idempotent.
+- Item identity is `(slot, namespaceKey, scopeKey, idKey)`. The same provider
+  ID under different locks is a different item.
+- `visibility` controls which attributed records enter a model request after a
+  scope-key change within one namespace. Namespace is always an isolation
+  boundary.
+- Compaction canonicalizes memory records without laundering any attributed
+  record into a free-form summary and without dropping items hidden from the
+  active scope. Canonical-state overflow fails recoverably: recall still runs
+  so providers can retract.
+- Provider tools are slot-qualified, scope-bound ordinary dynamic tools built
+  entirely on the generic dynamic-tool engine. Each turn resolves one complete
+  tool set, every model step uses it, and a durable call keeps its originating
+  definition until settlement. Tools never emit recall changes.
 - An optional static slot description is prepended to every provider tool
   description before durable metadata capture. It never derives from or exposes
   the namespace or scope, and it guides model routing without granting access.
@@ -780,18 +1062,27 @@ Mounted extensions cannot contribute memory slots.
 
 ## Non-goals
 
-- A framework record, revision, citation, CRUD, query, ranking, embedding, or
-  vector model.
+One earlier non-goal is explicitly reversed: this proposal gives eve a
+projection record model — item identity, supersede, and hide semantics for
+recalled context. eve owns how recalled items appear, update, and disappear in
+model context. eve still owns no storage model: what a provider persists, how
+it ranks, embeds, extracts, or retains data remains entirely provider-defined.
+
+Still out of scope:
+
 - Framework-provided remember, forget, purge, export, or administrative APIs.
+  A retract changes model-visible context; it is not a storage-erasure
+  guarantee, and storage erasure remains a provider operation.
 - A built-in capture model, extractor, formatter, retention policy, or erasure
   guarantee.
-- A memory-specific observability feed for usage, cost, latency, traces, errors,
-  or cancelled turns.
+- A memory-specific observability feed for usage, cost, latency, traces,
+  errors, or cancelled turns.
 - Cross-provider search, mutation, or record reconciliation.
 - Model-selected alternate scopes or unscoped provider invocations.
 - Treating recall visibility as complete participant isolation for ordinary
   conversation messages or provider tool results.
-- Preventing faulty or malicious provider code from ignoring the supplied scope.
+- Preventing faulty or malicious provider code from ignoring the supplied
+  scope.
 - Standardizing provider credentials, migrations, inspection tools, or
   deployment operations.
 
@@ -809,14 +1100,15 @@ Mounted extensions cannot contribute memory slots.
       read-only `MemoryScopeContext` with the abort signal, authenticated
       session, and channel metadata, but no messages or turn input.
       `byPrincipal` consumes that public context without private runtime access.
-      Resolver arrays join non-empty components with `:`, while `null` preserves
-      slot disablement. The authoring guidance states that principal scope
-      crosses channels and shows how to add team, channel, and conversation
-      coordinates for private memory. This resolves the [scope and Slack privacy
+      Resolver arrays are canonically encoded as collision-free tuples, while
+      `null` preserves slot disablement. The authoring guidance states that
+      principal scope crosses channels and shows how to add team, channel, and
+      conversation coordinates for private memory. This resolves the [scope and
+      Slack privacy
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807248748).
 
 - [x] **Keep settled-turn telemetry out of memory.** `capture` with
-      `phase: "turn.completed"` receives completed input and durable history,
+      `phase: "turn.completed"` receives completed input and projected history,
       but not usage, cost, latency, trace identifiers, or unsuccessful
       outcomes. Instrumentation owns that data and can be correlated through
       `session.id` plus `turn.id`. `compaction.requested` retains its input-token
@@ -839,14 +1131,15 @@ Mounted extensions cannot contribute memory slots.
       `fileMemory()` slots. This resolves the [model-facing attribution
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807269437).
 
-- [x] **Define recall placement and tool invocation semantics.** Every non-empty
-      recall result appends one scope-attributed message with its resolved role
-      to durable history at its lifecycle boundary. `null`, `undefined`, and normalized
-      empty content append nothing and never clear earlier history. Session
-      visibility preserves append-only prompt order; scope visibility may
-      filter earlier recalled messages after a scope change. eve invokes
-      `recall` deterministically and resolves one tool set per turn, while the
-      model decides whether to call an exposed tool. This resolves the
+- [x] **Define recall placement and tool invocation semantics.** A recall
+      result is a validated batch of append/upsert/retract changes applied
+      atomically at its lifecycle boundary as user-role context. `null`,
+      `undefined`, empty batches, and normalized empty content change nothing
+      and never clear earlier history; omission never retracts. Session
+      visibility retains records across scope-key changes within one namespace;
+      scope visibility filters earlier scopes. eve invokes `recall`
+      deterministically and resolves one tool set per turn, while the model
+      decides whether to call an exposed tool. This resolves the
       [replacement and cache
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807382863),
       [suffix placement
@@ -859,11 +1152,12 @@ Mounted extensions cannot contribute memory slots.
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807755029).
 
 - [x] **Reconcile review threads with the final contract.** Provider
-      `ctx.messages` includes recalled history, and
-      `getMemoryMessageAttribution` identifies its originating slot and scope.
-      The namespace/scope split, lifecycle phases, telemetry boundary, and
-      cross-provider behavior now match the implementation. All outdated,
-      approval-only, and superseded threads are resolved, including the
+      `ctx.messages` is the projected history at each boundary, and framework
+      identity deduplication replaces provider-side history scanning — there is
+      no public attribution accessor. The namespace/scope split, lifecycle
+      phases, telemetry boundary, and cross-provider behavior match the
+      intended implementation. All outdated, approval-only, and superseded
+      threads are resolved, including the
       [cross-provider
       thread](https://github.com/vercel/eve/pull/1581#discussion_r3807280622)
       and the [outdated turn-input


### PR DESCRIPTION
### Summary

Related to #1510. This proposal defines path-authored memory with provider-owned recall, capture, and tools; trusted namespace and scope locks; keyed recall supersession; one projected-history boundary; and memory-safe compaction.

The source-composition design reflects merged #2539. Each selected memory binding induces `tools/<slot>.ts` through a registry-issued template anchored to the memory candidate. The derived module inherits the anchor's node and layer, records the memory binding as a dependency, derives a stable source ID, and yields to a direct target in the same layer. Memory therefore needs no custom source layer, registration mode, executable registry, or post-resolution tool merge.

The proposal also records the generic provider-instance boundary implemented in #2534: zero-argument definition factories are materialized once per module namespace in one module-map load, so a direct memory slot and its derived wrapper share one provider instance without a global cache. Provider tools otherwise use ordinary `defineDynamic` compilation, binding, hydration, approval, authorization, and replay.

The M1 core in #2534 is rebased and simplified on current `main`, with agent-info v4, generic cold callback rebinding, published docs, extension contracts, and deterministic E2E coverage. #2142 and #2145 remain superseded; #2144 remains the file-provider salvage branch to rebase only after M1 merges.

Reviewer attention should focus on the public namespace/scope contract, lifecycle failure semantics, durable recall projection, and compaction behavior. The wrapper-construction invariants themselves are supplied by #2539.

### Validation

Cross-checked the proposal against merged #2539, the rebased #2534 implementation, current dynamic-tool callback identity and rebind behavior, and the projected-history seam. `pnpm docs:check` and `pnpm guard:invariants` pass, and the proposal is formatted with oxfmt.

No runtime tests apply to this research-only change. Runtime validation lives in #2534.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] Every commit is cryptographically signed and includes the DCO trailer

Changeset not applicable: this PR changes research documentation only.

### Diff size

**Docs** — 1 file · `+1,281 / -0`

The research proposal defines the public contract and records the final source-template, provider-materialization, replay, lifecycle, projection, compaction, and two-PR delivery boundaries.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable for a research-only change.
