### PR TITLE
research: unify session operation addressing

### DIFF
--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -405,20 +405,32 @@ resolution.
 
 ### Channel lifecycle handlers
 
-Lifecycle handlers are already inside the owning workflow. They receive fixed
-session identity and optional routing state, not route-level operations:
+Lifecycle handlers are already inside the owning workflow. The `channel`
+argument carries platform state and optional continuation routing, not session
+identity:
 
 ```ts
 interface ChannelEventContext<TPlatformContext> extends TPlatformContext {
-  readonly session: {
-    readonly id: string;
-  };
   readonly continuation?: {
     readonly token: string;
     rekey(address: string): void;
   };
 }
+
+const events = {
+  "message.completed"(data, channel, ctx) {
+    console.log(ctx.session.id);
+  },
+
+  "session.failed"(data, channel) {
+    console.error(data.sessionId, data.message);
+  },
+};
 ```
+
+Normal lifecycle handlers read fixed session identity from `ctx.session.id`.
+`session.failed` runs outside session context, so its event data contains
+`sessionId` directly.
 
 Rekeying changes the dynamic channel alias while the stable session-ID alias
 continues to target the same inbox.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -277,15 +277,15 @@ Slack does not expose a conversation wrapper or reintroduce a generic public
 ### Chat SDK bridge
 
 The Chat SDK bridge binds delivery to the webhook that is currently running.
-Its `send` function takes one input object, with the originating thread beside
-the message and turn options:
+It retains its existing two-argument `send(input, options)` API. The first
+argument is a string, `UserContent`, or `SendPayload`; the second carries the
+originating thread and turn options:
 
 ```ts
 export const { bot, channel, send } = chatSdkChannel({ adapters, state });
 
 bot.onNewMention(async (thread, message) => {
-  await send({
-    message: message.text,
+  await send(message.text, {
     thread,
     title: "Support request",
     turnPolicy: "experimental-steer",
@@ -293,13 +293,10 @@ bot.onNewMention(async (thread, message) => {
 });
 ```
 
-HITL responses use the same shape without a message:
+HITL responses use a `SendPayload` as the first argument:
 
 ```ts
-await send({
-  inputResponses: [{ requestId, optionId: "approve" }],
-  thread,
-});
+await send({ inputResponses: [{ requestId, optionId: "approve" }] }, { thread });
 ```
 
 Methods that post eve output back through a platform SDK, such as
@@ -523,7 +520,6 @@ owner; an ownership conflict retries dispatch to the winner.
 | `getSession(sessionId)`                             | `attachSession(sessionId)`                          |
 | schedule `receive(channel, input)`                  | schedule `send(channel, input)`                     |
 | Slack `ctx.conversation` and `ctx.receive`          | flat `ctx.*` operations and `ctx.send(input)`       |
-| Chat SDK `send(message, options)`                   | `send({ message, thread, ... })`                    |
 | string arguments to client/eval/session `send()`    | `{ message, ... }` input objects                    |
 | split runtime delivery/control methods              | `dispatchContinuation` and `dispatchSession`        |
 
@@ -542,8 +538,9 @@ The migration must prove:
 - Reset releases aliases before replacement creation and an old ID cannot reach
   the replacement.
 - Built-in channels, custom routes, authored `receive` functions, schedule
-  sends, flat Slack operations, Chat SDK bridges, clients, evals, TUI,
-  fixtures, and docs use the final shapes.
+  sends, flat Slack operations, clients, evals, TUI, fixtures, and docs use the
+  final shapes.
+- Chat SDK bridges retain `send(input, options)` and its existing call sites.
 - E2E creates a session, sends a follow-up, cancels, compacts, clears, sends
   successfully afterward, proves a late accepted cancel is a no-op, resets,
   rejects the retired ID, and explicitly creates a replacement.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -4,305 +4,232 @@ status: proposed
 last_updated: "2026-08-04"
 ---
 
-# Unified session addressing and operations
+# Unified session operations
 
 ## Decision
 
-eve should expose two deliberately different handles over one session command
-inbox:
+eve exposes two identities with the same operation names:
 
-- `ChannelAddress` targets whichever session owns a channel continuation token
-  when an operation is invoked.
-- `Session` targets one immutable durable session ID.
+- Channel operations take a channel-local address on every call and target its
+  current owner.
+- `Session` is a fixed handle for one durable `sessionId`.
 
-```text
-ChannelAddress(continuationToken) ─┐
-                                  ├─> one durable session command inbox
-Session(sessionId) ────────────────┘
-```
-
-Both handles support `send`, `cancel`, `compact`, `clear`, and `reset`. The
-difference is identity, not operation names:
+`ChannelAddress` is not a public authoring API. eve may bind an address
+internally to implement the direct functions and platform conveniences such as
+Slack's `ctx.conversation`.
 
 ```text
-ChannelAddress.send() → resume current owner, or create when unowned
-ChannelAddress.clear() → clear current owner, never create
-
-Session.send()         → send to this exact ID, never create
-Session.clear()        → clear this exact ID, never follow a replacement
+channel-local address ──> current owner ─┐
+                                        ├─> one durable command inbox
+sessionId ───────────────────────────────┘
 ```
 
-No operation resolves a continuation token to a session ID and then resumes a
-second hook. It dispatches one command through the address the caller already
-has. Resolution exists only when code explicitly wants to convert a dynamic
-`ChannelAddress` into a fixed `Session`.
+The identity determines the behavior:
 
-A channel-created session owns two aliases for the same command inbox:
+- `send(address, input)` resumes the current owner, or creates and claims the
+  address when it is unowned.
+- `cancel(address)`, `compact(address)`, `clear(address)`, and
+  `reset(address)` target the current owner and never create.
+- `resolveSession(address)` is the only explicit conversion from a dynamic
+  address to a fixed `Session`.
+- Every `session.*` method targets exactly `session.id`. It never creates or
+  follows a replacement.
 
-```text
-<channel>:<continuationToken> ─┐
-                              ├─> session command inbox
-eve:session:<sessionId>:inbox ─┘
+This is intentionally a breaking API migration with no compatibility aliases.
+
+## Public authoring contract
+
+Custom channel routes and authored `receive` functions get direct operations:
+
+```ts
+interface ChannelOperations<TState = undefined> {
+  send(address: string, input: ChannelSendInput<TState>): Promise<Session>;
+  cancel(address: string, options?: { turnId?: string }): Promise<CancelTurnResult>;
+  compact(address: string): Promise<CompactSessionResult>;
+  clear(address: string): Promise<ClearSessionResult>;
+  reset(address: string, options?: { reason?: string }): Promise<ResetSessionResult>;
+  resolveSession(address: string): Promise<Session | undefined>;
+}
+
+interface BaseChannelSendInput {
+  auth: SessionAuthContext | null;
+  message?: string | UserContent;
+  inputResponses?: readonly InputResponse[];
+  context?: readonly string[];
+  outputSchema?: JsonObject;
+  callback?: SessionCallback;
+  initiatorAuth?: SessionAuthContext | null;
+  mode?: RunMode;
+  title?: string;
+}
+
+type ChannelSendInput<TState = undefined> = [TState] extends [undefined]
+  ? BaseChannelSendInput
+  : BaseChannelSendInput & { state: TState };
 ```
 
-The channel alias may be rekeyed; the ID alias is stable until termination.
-An HTTP-created session owns only the stable alias. All aliases must preserve
-eve's committed-delivery, deduplication, cancellation, and durable-ordering
-guarantees.
-
-This is intentionally a breaking proposal.
-
-## Identity model
-
-| Identifier          | Meaning                                                       | Lifetime                                | May create                                      |
-| ------------------- | ------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------- |
-| `continuationToken` | Channel address whose current owner receives channel commands | May be rekeyed, released, and reclaimed | `ChannelAddress.send()` may create when unowned |
-| `sessionId`         | Identity of one durable workflow session                      | Immutable                               | Never                                           |
-
-The same channel address can identify different sessions over time:
-
-```text
-thread-123 → wrun_A
-reset wrun_A
-thread-123 → wrun_B
-```
-
-A handle for `wrun_A` never follows `thread-123` to `wrun_B`.
-
-## Invariants
-
-1. A `ChannelAddress` denotes a mutable channel routing address, not a session.
-2. A `Session` always targets one immutable `sessionId`.
-3. Every address operation is one command dispatch; none performs a
-   resolve-then-dispatch sequence.
-4. `ChannelAddress.send()` is the only resume-or-create operation.
-5. Other `ChannelAddress` methods target the owner observed atomically when the
-   command is accepted and never create.
-6. No `Session` method creates or follows a continuation token.
-7. A continuation token has at most one active owner.
-8. Rekeying changes only the channel alias and cannot break ID operations.
-9. Reset terminally retires the ID and releases every alias. Only a later
-   `ChannelAddress.send()` or explicit HTTP create can create a replacement.
-10. HTTP session operations use only `sessionId`; HTTP never accepts or returns
-    a continuation token.
-11. `resolveSession()` is an explicit identity conversion, not an operation
-    prerequisite.
-12. A function named `get` or `resolve` performs I/O; a handle factory is named
-    `attach`.
-
-## Operation semantics
-
-| Operation                       | Address            | Creates         | Result when target is absent |
-| ------------------------------- | ------------------ | --------------- | ---------------------------- |
-| `ChannelAddress.send`           | Continuation token | Yes, if unowned | Creates and claims the token |
-| `ChannelAddress.cancel`         | Continuation token | No              | `no_active_turn`             |
-| `ChannelAddress.compact`        | Continuation token | No              | `no_active_session`          |
-| `ChannelAddress.clear`          | Continuation token | No              | `no_active_session`          |
-| `ChannelAddress.reset`          | Continuation token | No              | `no_active_session`          |
-| `ChannelAddress.resolveSession` | Continuation token | No              | `undefined`                  |
-| `Session.send`                  | Session ID         | No              | `session_not_active`         |
-| `Session.cancel`                | Session ID         | No              | `no_active_turn`             |
-| `Session.compact`               | Session ID         | No              | `no_active_session`          |
-| `Session.clear`                 | Session ID         | No              | `no_active_session`          |
-| `Session.reset`                 | Session ID         | No              | `no_active_session`          |
-| Session stream                  | Session ID         | No              | Not found                    |
-
-`ChannelAddress.send()` cannot create when the payload consists only of HITL
-`inputResponses`; those responses are meaningful only to the session that
-issued the request.
-
-`cancel()`, `compact()`, and `clear()` remain asynchronous controls. Acceptance
-means the command was durably queued. Awaited calls through the same address are
-committed and processed in order, so sequential `await address.clear()` and
-`await address.send(...)` calls cannot send before the clear. Stream events
-confirm when the effects complete. `reset()` resolves only after the targeted
-session is terminal and its aliases are released, so a subsequent channel send
-cannot fall back into the retired owner.
-
-## Public handles
-
-### Fixed `Session`
-
-The framework-side fixed session surface is:
+Fixed-ID operations use a `Session`:
 
 ```ts
 interface Session {
   readonly id: string;
 
-  send(input: SendInput, options: SessionSendOptions): Promise<SessionSendResult>;
-  cancel(options?: { turnId?: string }): Promise<CancelResult>;
-  compact(): Promise<CompactResult>;
-  clear(): Promise<ClearResult>;
-  reset(options?: { reason?: string }): Promise<ResetResult>;
+  send(
+    input: string | UserContent | SendPayload,
+    options: { auth: SessionAuthContext | null },
+  ): Promise<SessionSendCommandResult>;
+  cancel(options?: { turnId?: string }): Promise<CancelTurnResult>;
+  compact(): Promise<CompactSessionResult>;
+  clear(): Promise<ClearSessionResult>;
+  reset(options?: { reason?: string }): Promise<ResetSessionResult>;
 
-  getEventStream(options?: StreamOptions): Promise<ReadableStream<MessageStreamEvent>>;
+  getEventStream(options?: { startIndex?: number }): Promise<ReadableStream<MessageStreamEvent>>;
   getStreamTailIndex(): Promise<number>;
 }
 ```
 
-Every method is bound to `session.id`. `Session.continuationToken` is removed
-because it is a moving channel address and is necessarily stale on some
-fixed-ID handles.
+`attachSession(sessionId)` constructs this handle without I/O. The first
+operation reports whether the ID is active.
 
-Framework-side `Session.send()` requires the delivery auth context in
-`SessionSendOptions`. Remote clients resolve auth from their configured HTTP
-credentials instead. The accepted result may be wrapped by a transport-owned
-turn/stream handle, but all surfaces retain the same ID-only target semantics.
+## Semantics
 
-Constructing a handle is not an existence check:
+| Call                           | Identity used        | Can create        | Missing target       |
+| ------------------------------ | -------------------- | ----------------- | -------------------- |
+| `send(address, input)`         | continuation address | only when unowned | creates and claims   |
+| `cancel(address)`              | continuation address | no                | `no_active_turn`     |
+| `compact(address)`             | continuation address | no                | `no_active_session`  |
+| `clear(address)`               | continuation address | no                | `no_active_session`  |
+| `reset(address)`               | continuation address | no                | `no_active_session`  |
+| `resolveSession(address)`      | continuation address | no                | `undefined`          |
+| `session.send(input, options)` | session ID           | no                | `session_not_active` |
+| `session.cancel()`             | session ID           | no                | `no_active_turn`     |
+| `session.compact()`            | session ID           | no                | `no_active_session`  |
+| `session.clear()`              | session ID           | no                | `no_active_session`  |
+| `session.reset()`              | session ID           | no                | `no_active_session`  |
+| `session.getEventStream()`     | session ID           | no                | not found            |
 
-```ts
-const session = attachSession("wrun_A");
-```
+Address-only HITL `inputResponses` cannot create a session because only the
+session that issued the request can consume them.
 
-The first operation reports whether the ID is active. Dynamic channel routing
-is separate:
-
-```ts
-const thread = channelAddress("thread-123");
-const current = await thread.resolveSession();
-```
-
-### Dynamic `ChannelAddress`
-
-A `ChannelAddress` binds the channel-local continuation token once:
-
-```ts
-interface ChannelAddress<TState = undefined> {
-  readonly continuationToken: string;
-
-  send(input: SendInput, options: ChannelSendOptions<TState>): Promise<Session>;
-  cancel(options?: { turnId?: string }): Promise<CancelResult>;
-  compact(): Promise<CompactResult>;
-  clear(): Promise<ClearResult>;
-  reset(options?: { reason?: string }): Promise<ResetResult>;
-
-  resolveSession(): Promise<Session | undefined>;
-}
-```
-
-- `send()` delivers to the current owner or creates and claims the address.
-- Controls dispatch directly to the current owner and never create.
-- `resolveSession()` performs the optional token-to-fixed-ID conversion.
-
-The distinction remains visible at the call site:
-
-```ts
-const thread = channelAddress(threadId);
-
-const session = await thread.send("hello", { auth });
-await thread.clear(); // current owner of threadId
-await session.clear(); // exact session returned by send()
-```
-
-These two `clear()` calls normally target the same workflow, but encode
-different intent if the address is later rekeyed or reclaimed. Free-floating
-token control helpers are removed; the address object makes the dynamic target
-explicit.
+`cancel`, `compact`, and `clear` are durably queued asynchronous controls.
+`reset` retires the target and releases its aliases before returning. Awaited
+commands sent through the same address preserve commit order.
 
 ## Authoring shapes by surface
 
-There are only two operation-bearing objects in author code:
-
-```ts
-const conversation = channelAddress(continuationToken);
-// ChannelAddress → dispatchContinuation()
-// Targets the owner of this address when each call is accepted.
-
-const session = attachSession(sessionId);
-// Session → dispatchSession()
-// Always targets this exact durable session.
-```
-
 ### Custom channel route
 
-```ts
-POST("/threads/:threadId/messages", async (request, { channelAddress, params }) => {
-  const conversation = channelAddress(params.threadId);
+```ts title="agent/channels/support.ts"
+import { defineChannel, GET, POST } from "eve/channels";
 
-  // Resume the current owner, or create and claim the address.
-  const session = await conversation.send(await request.text(), {
-    auth: null,
-  });
+export default defineChannel({
+  routes: [
+    POST("/threads/:threadId/messages", async (request, { params, send }) => {
+      const body = await request.json();
+      const session = await send(params.threadId, {
+        auth: null,
+        message: body.message,
+      });
 
-  return Response.json({ sessionId: session.id });
+      return Response.json({ sessionId: session.id });
+    }),
+
+    POST("/threads/:threadId/cancel", async (_request, { cancel, params }) =>
+      Response.json(await cancel(params.threadId)),
+    ),
+
+    POST("/threads/:threadId/compact", async (_request, { compact, params }) =>
+      Response.json(await compact(params.threadId)),
+    ),
+
+    POST("/threads/:threadId/clear", async (_request, { clear, params }) =>
+      Response.json(await clear(params.threadId)),
+    ),
+
+    POST("/threads/:threadId/reset", async (_request, { params, reset }) =>
+      Response.json(await reset(params.threadId, { reason: "Start over" })),
+    ),
+
+    GET("/threads/:threadId/owner", async (_request, { params, resolveSession }) => {
+      const session = await resolveSession(params.threadId);
+      return Response.json({ sessionId: session?.id ?? null });
+    }),
+
+    POST("/admin/session/:sessionId", async (request, { attachSession, params }) => {
+      const session = attachSession(params.sessionId);
+      return Response.json(await session.send(await request.text(), { auth: null }));
+    }),
+  ],
 });
 ```
 
-All current-owner operations stay on the bound address and perform one command
-resume:
+The direct functions make dynamic routing visible without making authors build
+or name an intermediate address object.
+
+### Authored receive and cross-channel handoff
+
+A channel's `receive` implementation owns its continuation-address format and
+initial state:
 
 ```ts
-const conversation = channelAddress(threadId);
+export default defineChannel<State, Context, Target>({
+  async receive(input, { send }) {
+    const address = addressFromTarget(input.target);
 
-await conversation.send("hello", { auth });
-await conversation.cancel({ turnId });
-await conversation.compact();
-await conversation.clear();
-await conversation.reset({ reason: "Start over" });
+    return await send(address, {
+      auth: input.auth,
+      message: input.message,
+      state: initialState(input.target),
+    });
+  },
+});
 ```
 
-Use a fixed session only when the operation must not follow a replacement:
+A caller hands work to that implementation and receives a fixed session:
 
 ```ts
-const conversation = channelAddress(threadId);
+const session = await receive(slack, {
+  target: { channelId, threadTs },
+  message: "Investigate this incident",
+  auth,
+});
 
-const session = await conversation.resolveSession(); // The only lookup.
-if (session) {
-  await session.send("hello", { auth });
-  await session.cancel({ turnId });
-  await session.compact();
-  await session.clear();
-  await session.reset({ reason: "Retire this exact session" });
-
-  const stream = await session.getEventStream();
-}
-
-const attached = attachSession("wrun_A"); // No lookup.
+await session.send("Additional detail", { auth });
+await session.cancel();
+await session.compact();
+await session.clear();
+await session.reset();
 ```
 
-The examples list the available operations; they are not intended as one
-realistic sequence.
+The caller does not know the target channel's address format. Later operations
+on the returned `Session` cannot follow that address to a replacement.
 
-### Slack channel
+### Slack
 
-Bound message and interaction handlers receive a `ChannelAddress` as
-`ctx.conversation`:
+Message and interaction handlers get a conversation already bound to their
+Slack thread:
 
 ```ts
 async onAppMention(ctx) {
-  // Available current-owner controls; choose the one needed by the handler.
   await ctx.conversation.cancel({ turnId });
   await ctx.conversation.compact();
   await ctx.conversation.clear();
   await ctx.conversation.reset({ reason: "Start over" });
 
-  // The framework subsequently sends the inbound message through
-  // ctx.conversation.send(message, { auth }). It does not resolve first.
+  const fixed = await ctx.conversation.resolveSession();
   return { auth: null };
 }
 ```
 
-Resolve only to pin later work to the current durable session:
+The calls above show the available operations; a handler normally chooses one.
 
-```ts
-async onAppMention(ctx) {
-  const session = await ctx.conversation.resolveSession();
-  if (session) ctx.waitUntil(session.clear());
-  return { auth: null };
-}
-```
-
-Generic events construct a conversation from an explicit Slack target:
+Generic events bind any explicit Slack target:
 
 ```ts
 async onEvent(ctx) {
   const conversation = ctx.conversation({ channelId, threadTs });
 
-  await conversation.cancel();
-  await conversation.compact();
   await conversation.clear();
-  await conversation.reset();
 
   const session = await ctx.receive({
     target: { channelId, threadTs },
@@ -314,36 +241,17 @@ async onEvent(ctx) {
 }
 ```
 
-These are independent operation examples. A handler would normally perform
-only the control needed for that event.
-
-### Other built-in platform channels
-
-Discord, Teams, Telegram, Twilio, GitHub, Linear, Chat SDK, and Photon iMessage
-use the same contract. A channel may expose the object under its natural noun,
-but it remains a `ChannelAddress`:
-
-```ts
-const conversation = ctx.conversation; // or ctx.thread / ctx.chat
-
-// Available operations; choose as needed.
-await conversation.send(input, { auth });
-await conversation.cancel();
-await conversation.compact();
-await conversation.clear();
-await conversation.reset();
-
-const session = await conversation.resolveSession();
-```
-
-Authored `receive` implementations convert the platform target into a
-`ChannelAddress`, call `send`, and return the resulting `Session`.
+`SlackConversation` is a Slack-specific convenience over the same internal
+operations. It does not reintroduce a generic public `ChannelAddress` type.
 
 ### eve framework HTTP channel
 
-The built-in HTTP channel never exposes or accepts a continuation token:
+The default HTTP surface is singular and entirely session-ID addressed:
 
 ```http
+GET  /eve/v1/health
+GET  /eve/v1/info
+
 POST /eve/v1/session
 {"message":"hello"}
 
@@ -359,29 +267,16 @@ POST /eve/v1/session/wrun_A/clear
 POST /eve/v1/session/wrun_A/reset
 {"reason":"Start over"}
 
-GET /eve/v1/session/wrun_A/stream
+GET  /eve/v1/session/wrun_A/stream
 ```
 
-The create route calls `createSession()`. Every route containing `wrun_A`
-dispatches or reads directly by that session ID; none calls
-`resolveContinuation()`.
+`POST /eve/v1/session` explicitly creates. Every route containing `wrun_A`
+dispatches or reads directly by that ID. Follow-up delivery remains the default
+operation on `POST /eve/v1/session/:sessionId`; there is no `/messages` suffix.
 
-```http
-HTTP/1.1 202 Accepted
-{"sessionId":"wrun_A","status":"accepted"}
-```
-
-An unknown or terminal ID on the message route returns:
-
-```http
-HTTP/1.1 409 Conflict
-{"code":"session_not_active"}
-```
-
-Send, compact, and clear acceptance use `202`. Cancel/reset completion and
-benign inactive-control results use `200`. An unknown stream uses `404`.
-Creation does not return until the stable command hook is registered, so an
-immediate follow-up has no hook-readiness race.
+An unknown or terminal ID on the follow-up route returns
+`session_not_active`. Controls never create. HTTP accepts and returns no
+continuation token.
 
 ### JavaScript HTTP client
 
@@ -403,8 +298,10 @@ for await (const event of session.stream()) {
 Attach to a known ID without I/O:
 
 ```ts
-const session = client.sessions.attach("wrun_A");
+const session = client.sessions.attach("wrun_A", { streamIndex: 12 });
 ```
+
+The serializable cursor contains only fixed identity and stream position:
 
 ```ts
 interface ClientSessionState {
@@ -413,9 +310,8 @@ interface ClientSessionState {
 }
 ```
 
-The client stores no continuation token. Every method calls the corresponding
-ID-only HTTP route. Reset leaves the handle pinned to its terminal ID; callers
-discard it and explicitly create the replacement.
+Reset leaves the handle pinned to its retired ID. Creating a replacement is an
+explicit `client.sessions.create(...)` call.
 
 ### TUI
 
@@ -423,66 +319,22 @@ discard it and explicitly create the replacement.
 first prompt   → client.sessions.create(input)
 later prompt   → session.send(input)
 /cancel        → session.cancel()
-Esc / Ctrl+C   → session.cancel()
+Esc            → session.cancel()
+Ctrl+C         → session.cancel(); a repeated Ctrl+C exits
 /compact       → session.compact()
-/clear         → session.clear()
-/new           → session.clear()
-/reset         → session.reset(); discard session
+/clear, /new   → session.clear()
+/reset         → session.reset(); discard the handle
 event loop     → session.stream()
 ```
 
-The TUI has no `ChannelAddress`, continuation token, or resolution path.
+When no turn is running, the first Ctrl+C arms exit and prints the instruction
+to press it again. The TUI stores no continuation token and performs no
+resolution.
 
-### Cross-channel receive
+### Channel lifecycle handlers
 
-```ts
-const session = await args.receive(slack, {
-  target: { channelId, threadTs },
-  message: "Investigate this incident",
-  auth,
-});
-
-// The returned fixed-session operations are available independently.
-await session.send("Additional detail", { auth });
-await session.cancel();
-await session.compact();
-await session.clear();
-await session.reset();
-```
-
-The target channel implements `receive` with `ChannelAddress.send()`. The
-caller receives a fixed `Session`, so subsequent operations cannot follow the
-target address to a replacement.
-
-### Framework translation
-
-```ts
-// ChannelAddress.send/cancel/compact/clear/reset
-await runtime.dispatchContinuation({
-  continuationToken,
-  command,
-});
-
-// Session.send/cancel/compact/clear/reset
-await runtime.dispatchSession({
-  sessionId,
-  command,
-});
-
-// ChannelAddress.resolveSession() only
-await runtime.resolveContinuation(continuationToken);
-
-// Session.getEventStream() / client session.stream()
-await runtime.getEventStream(sessionId);
-```
-
-Only an unowned `ChannelAddress.send()` result enters `createSession()`.
-Controls and all fixed-session methods never create.
-
-## Channel lifecycle context
-
-Lifecycle handlers already run inside the owning workflow. They receive
-identity and channel routing state, not a recursive imperative session API:
+Lifecycle handlers are already inside the owning workflow. They receive fixed
+session identity and optional routing state, not route-level operations:
 
 ```ts
 interface ChannelEventContext<TPlatformContext> extends TPlatformContext {
@@ -491,37 +343,28 @@ interface ChannelEventContext<TPlatformContext> extends TPlatformContext {
   };
   readonly continuation?: {
     readonly token: string;
-    rekey(token: string): void;
+    rekey(address: string): void;
   };
 }
 ```
 
-`continuation` is absent for transports such as the eve HTTP protocol that do
-not own a channel address. Rekeying changes the channel alias while the stable
-command hook remains active.
-
-Top-level `continuationToken` and `setContinuationToken()` are removed in
-favor of this explicit routing object.
+Rekeying changes the dynamic channel alias while the stable session-ID alias
+continues to target the same inbox.
 
 ## Runtime boundary
 
-The runtime dispatches one command protocol through either address:
+Both public identity forms dispatch one shared command protocol:
 
 ```ts
 type SessionCommand =
-  | {
-      kind: "send";
-      auth: SessionAuthContext | null;
-      payload: DeliverPayload;
-      requestId?: string;
-    }
+  | { kind: "send"; auth: SessionAuthContext | null; payload: DeliverPayload; requestId?: string }
   | { kind: "cancel"; turnId?: string }
   | { kind: "compact" }
   | { kind: "clear" }
   | { kind: "reset"; reason?: string };
 
 interface Runtime {
-  createSession(input: CreateSessionInput): Promise<RunHandle>;
+  createSession(input: RunInput): Promise<{ sessionId: string }>;
 
   dispatchContinuation(input: {
     continuationToken: string;
@@ -534,231 +377,93 @@ interface Runtime {
   }): Promise<SessionCommandResult>;
 
   resolveContinuation(continuationToken: string): Promise<{ sessionId: string } | undefined>;
-
-  getEventStream(
-    sessionId: string,
-    options?: StreamOptions,
-  ): Promise<ReadableStream<MessageStreamEvent>>;
 }
 ```
 
-`dispatchContinuation()` resumes the channel hook with the command and returns
-the owning `sessionId` from that resume. It does not call
-`resolveContinuation()`. `dispatchSession()` computes the stable inbox token
-from the supplied ID and performs the same single resume.
-
-Only `ChannelAddress.send()` handles an unowned address by calling
-`createSession()`. Every other command reports the appropriate inactive result.
-Concurrent first sends must converge on one owner; an ownership conflict
-retries command dispatch to the winner rather than surfacing a second session.
-
-The current runtime-specific `deliver`, `cancelTurn`, `compactSession`,
-`clearSession`, and `terminateSession` entry points collapse behind the two
-dispatch methods. Streaming remains ID-addressed and read-only.
-
-The low-level public route `Agent` interface is removed. Routes use
-`ChannelAddress` and `Session`; framework internals use `Runtime`.
-
-## Driver command inbox
-
-The workflow driver creates its stable command hook before creation is
-acknowledged. A channel-created session additionally owns one rekeyable alias
-for the same command protocol.
+A channel-created session owns two aliases for one inbox:
 
 ```text
-create HTTP session:
-  create stable command hook
-  acknowledge session
-
-create channel session:
-  create stable command hook
-  claim channel alias
-  acknowledge session
-
-rekey channel session:
-  claim new alias
-  retire old alias
-  keep stable command hook
-
-reset:
-  consume reset command
-  dispose stable command hook
-  dispose current alias
-  terminate run
-  acknowledge terminal state
+<channel>:<address> ───────────┐
+                              ├─> session command inbox
+eve:session:<sessionId>:inbox ─┘
 ```
 
-The inbox multiplexes the stable hook, active alias, and already-committed
-retired-alias commands into one durable queue. The driver continuously services
-the inbox whether it is parked or supervising an active turn:
+`dispatchContinuation` resumes the current address owner and returns its
+`sessionId` in the same dispatch result. It does not resolve first.
+`dispatchSession` computes the stable inbox token from the ID and resumes it
+directly. Therefore normal send and control paths perform one command resume,
+not resolve-then-deliver.
 
-```text
-send    → deliver to the turn, buffer, or start the next turn
-cancel  → request cooperative cancellation of the active turn
-compact → run compaction at the next valid driver boundary
-clear   → clear model context at the next valid driver boundary
-reset   → terminally retire the session and every alias
-```
+Only explicit `resolveSession(address)` calls `resolveContinuation`. A future
+lightweight owner lookup can optimize that conversion without affecting normal
+operation latency.
 
-This replaces the split delivery, cancellation, and compact/clear hooks. A
-command is consumed once regardless of which alias received it.
+Internally eve may implement `ChannelOperations` by binding an address to a
+private handle and forwarding the method. That object must not be exported or
+accepted by authored channel APIs.
 
-Internal hook tokens use a framework-reserved namespace that authored channel
-tokens cannot claim.
+## Race and lifetime rules
 
-`dispatchSession({ sessionId, command })` computes the internal stable token
-locally:
-
-```ts
-resumeHook(sessionCommandHookToken(sessionId), command);
-```
-
-It never resolves a channel continuation token. Workflow still performs its
-normal hook and run lookup while resuming that stable hook; ID-addressed here
-describes eve's public identity semantics, not a new run-addressed Workflow
-transport.
-
-## Resolution cost
-
-Resolution is not part of any operation path:
-
-| Path                                      | Separate resolution | Command resumes |
-| ----------------------------------------- | ------------------- | --------------- |
-| `ChannelAddress.send()` to existing owner | None                | One             |
-| Any `ChannelAddress` control              | None                | One             |
-| Any `Session` operation                   | None                | One             |
-| HTTP follow-up or control                 | None                | One             |
-| Slack inbound send or control             | None                | One             |
-| Explicit `resolveSession()`               | One lookup          | None            |
-
-eve's current `resolveSession()` calls Workflow `getHookByToken()`, which also
-fetches the run, resolves encryption state, and may hydrate hook metadata.
-That is more work than identity resolution requires.
-
-Workflow should expose a lightweight owner lookup:
-
-```ts
-getHookOwnerByToken(token): Promise<{ runId: string } | undefined>
-```
-
-In workflow-server, this can read the token-ownership constraint that already
-stores `hookId` and `runId`, without fetching or hydrating the workflow run.
-This optimization improves the explicit identity-conversion method but is not
-placed on any command path.
-
-Resuming either inbox alias still performs Workflow's normal hook-resume work.
-A future atomic server-side resume endpoint may reduce its network round-trips,
-but this proposal does not depend on that optimization.
-
-## Race semantics
-
-### Dynamic address versus fixed session
-
-An address command targets the owner at command acceptance:
+A dynamic operation targets the owner when its command is accepted:
 
 ```text
 thread-123 → wrun_A
-thread.clear() → clears wrun_A
+clear(thread-123) clears wrun_A
 
 thread-123 → wrun_B
-thread.clear() → clears wrun_B
+clear(thread-123) clears wrun_B
 ```
 
-Resolution freezes that observation into a fixed handle:
+Resolution freezes one observation:
 
 ```ts
-const session = await thread.resolveSession(); // Session(wrun_A)
+const session = await resolveSession("thread-123"); // wrun_A
 // thread-123 is later reclaimed by wrun_B
-await session?.clear(); // still targets wrun_A
+await session?.clear(); // still wrun_A
 ```
 
-### Reset then send
-
-Address reset waits for the observed owner to terminate and release the alias:
+Reset followed by send is ordered:
 
 ```ts
-await thread.reset();
-const replacement = await thread.send("start again", { auth });
+await reset("thread-123");
+const replacement = await send("thread-123", { auth, message: "start again", state });
 ```
 
-The send may create a replacement only after reset completes. A fixed old
-handle remains terminal:
+The replacement may be created only after the prior owner releases the address.
+The old fixed handle remains terminal. Concurrent first sends converge on one
+owner; an ownership conflict retries dispatch to the winner.
 
-```ts
-await oldSession.send("late", { auth }); // session_not_active
-```
+## Removed public APIs
 
-A delayed duplicate operation on `ChannelAddress` is intentionally dynamic and
-may target a replacement. Code requiring duplicate safety resolves or retains
-the fixed `Session` before scheduling the operation.
+| Removed                                             | Replacement                                         |
+| --------------------------------------------------- | --------------------------------------------------- |
+| HTTP continuation-token fields and control bodies   | `/eve/v1/session/:sessionId/*`                      |
+| plural `/eve/v1/sessions` routes                    | singular `/eve/v1/session`                          |
+| follow-up `/:sessionId/messages`                    | `POST /:sessionId`                                  |
+| `client.session(token)`                             | `client.sessions.create()` or `.attach(id)`         |
+| client continuation-token state                     | `{ sessionId, streamIndex }`                        |
+| free token helpers                                  | direct `send(address, input)` and control functions |
+| public `ChannelAddress` / `channelAddress(address)` | direct channel operations                           |
+| `resolveActiveSession(address)`                     | `resolveSession(address)`                           |
+| `getSession(sessionId)`                             | `attachSession(sessionId)`                          |
+| split runtime delivery/control methods              | `dispatchContinuation` and `dispatchSession`        |
 
-### Mismatched HTTP identity
-
-The mismatch is impossible because HTTP carries one address:
-
-```http
-POST /eve/v1/session/wrun_A
-{"message":"hello"}
-```
-
-There is no body token that can redirect delivery to `wrun_B`.
-
-## Removed APIs
-
-| Removed                                            | Replacement                                         |
-| -------------------------------------------------- | --------------------------------------------------- |
-| HTTP `continuationToken` fields                    | ID-only session routes                              |
-| `ClientSessionState.continuationToken`             | `sessionId` and stream cursor                       |
-| `client.session(token)`                            | `client.sessions.create()` or `.attach(sessionId)`  |
-| `Session.continuationToken`                        | `ChannelAddress.continuationToken` where relevant   |
-| Free token-addressed route helpers                 | Methods on one bound `ChannelAddress`               |
-| `resolveActiveSession()` returning `{ sessionId }` | `ChannelAddress.resolveSession()`                   |
-| Misnamed `getSession(sessionId)` facade            | `attachSession(sessionId)`                          |
-| Slack bound and target-taking helpers              | Bound or constructed `ctx.conversation`             |
-| Top-level lifecycle continuation fields            | `channel.continuation.token/rekey()`                |
-| Public low-level `Agent`                           | `ChannelAddress`, `Session`, and internal `Runtime` |
-| Split runtime delivery/control methods             | `dispatchContinuation` and `dispatchSession`        |
-
-No deprecated aliases, fallback request parsing, or token-to-ID compatibility
+No deprecated aliases, alternate request parsing, or fallback compatibility
 paths remain.
 
 ## Verification
 
-The implementation is complete only when tests prove these boundaries:
+The migration must prove:
 
-- ID delivery works during active turns and while the driver is parked.
-- ID delivery never creates after reset, completion, failure, or unknown ID.
-- Every address send/control performs one resume and never calls
-  `resolveContinuation()`.
-- Channel send remains resume-or-create and concurrent first sends produce one
-  owner.
-- Address cancel reaches an active turn through the shared command inbox.
-- Rekey changes channel routing without interrupting ID delivery.
-- Reset releases both delivery addresses; an old ID cannot reach a replacement.
-- Commands committed to a retiring alias are consumed once.
-- Address reset completes before a subsequent send can create a replacement.
-- HTTP follow-up has no token field and cannot redirect or create.
-- Slack performs no separate owner resolution unless handler code explicitly
-  calls `resolveSession()`.
-- A resolved Slack/custom-channel session remains pinned across replacement.
-- Compact and clear are followed by successful address- and ID-addressed sends.
-- TUI commands use the same ID-only client session and post-reset creation is
-  explicit.
-- Public docs and examples contain no token-bearing HTTP/client session state,
-  free token helpers, or `getSession()` facade.
-
-The HTTP e2e sequence should create, send, cancel, compact, clear, send again,
-reset, reject an old-ID send, and explicitly create a replacement.
-
-## Outcome
-
-The complete model is:
-
-```text
-ChannelAddress: operate on the current owner of this channel address
-Session: operate on this exact durable session
-```
-
-Every operation dispatches directly through one of those addresses. Resolution
-is reserved for the deliberate transition from dynamic channel ownership to a
-fixed session identity.
+- Every address send/control performs one continuation dispatch and no implicit
+  resolution.
+- Address send resumes or creates; other address operations never create.
+- Every fixed-session and HTTP operation remains pinned to one ID.
+- Rekeying preserves fixed-ID delivery while moving only the channel alias.
+- Reset releases aliases before replacement creation and an old ID cannot reach
+  the replacement.
+- Built-in channels, custom routes, authored `receive` functions, Slack helpers,
+  clients, TUI, fixtures, and docs use the final shapes.
+- E2E creates a session, sends a follow-up, cancels, compacts, clears, sends
+  successfully afterward, resets, rejects the retired ID, and explicitly
+  creates a replacement.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1580
 status: proposed
-last_updated: "2026-08-03"
+last_updated: "2026-08-04"
 ---
 
 # Unified session addressing and operations
@@ -344,22 +344,22 @@ Authored `receive` implementations convert the platform target into a
 The built-in HTTP channel never exposes or accepts a continuation token:
 
 ```http
-POST /eve/v1/sessions
+POST /eve/v1/session
 {"message":"hello"}
 
-POST /eve/v1/sessions/wrun_A/messages
+POST /eve/v1/session/wrun_A
 {"message":"follow-up"}
 
-POST /eve/v1/sessions/wrun_A/cancel
+POST /eve/v1/session/wrun_A/cancel
 {"turnId":"turn_A"}
 
-POST /eve/v1/sessions/wrun_A/compact
-POST /eve/v1/sessions/wrun_A/clear
+POST /eve/v1/session/wrun_A/compact
+POST /eve/v1/session/wrun_A/clear
 
-POST /eve/v1/sessions/wrun_A/reset
+POST /eve/v1/session/wrun_A/reset
 {"reason":"Start over"}
 
-GET /eve/v1/sessions/wrun_A/stream
+GET /eve/v1/session/wrun_A/stream
 ```
 
 The create route calls `createSession()`. Every route containing `wrun_A`
@@ -697,7 +697,7 @@ the fixed `Session` before scheduling the operation.
 The mismatch is impossible because HTTP carries one address:
 
 ```http
-POST /eve/v1/sessions/wrun_A/messages
+POST /eve/v1/session/wrun_A
 {"message":"hello"}
 ```
 
@@ -708,7 +708,6 @@ There is no body token that can redirect delivery to `wrun_B`.
 | Removed                                            | Replacement                                         |
 | -------------------------------------------------- | --------------------------------------------------- |
 | HTTP `continuationToken` fields                    | ID-only session routes                              |
-| Singular `/eve/v1/session` route family            | Plural `/eve/v1/sessions` resources                 |
 | `ClientSessionState.continuationToken`             | `sessionId` and stream cursor                       |
 | `client.session(token)`                            | `client.sessions.create()` or `.attach(sessionId)`  |
 | `Session.continuationToken`                        | `ChannelAddress.continuationToken` where relevant   |

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -16,7 +16,7 @@ eve exposes two identities with the same operation names:
 
 `ChannelAddress` is not a public authoring API. eve may bind an address
 internally to implement the direct functions and platform conveniences such as
-Slack's `ctx.conversation`.
+Slack's thread-bound `ctx.send()` and `ctx.cancel()` methods.
 
 ```text
 channel-local address ──> current owner ─┐
@@ -74,10 +74,7 @@ Fixed-ID operations use a `Session`:
 interface Session {
   readonly id: string;
 
-  send(
-    input: string | UserContent | SendPayload,
-    options: { auth: SessionAuthContext | null },
-  ): Promise<SessionSendCommandResult>;
+  send(input: SessionSendInput): Promise<SessionSendCommandResult>;
   cancel(options?: { turnId?: string }): Promise<CancelTurnResult>;
   compact(): Promise<CompactSessionResult>;
   clear(): Promise<ClearSessionResult>;
@@ -86,6 +83,10 @@ interface Session {
   getEventStream(options?: { startIndex?: number }): Promise<ReadableStream<MessageStreamEvent>>;
   getStreamTailIndex(): Promise<number>;
 }
+
+interface SessionSendInput extends SendPayload {
+  auth: SessionAuthContext | null;
+}
 ```
 
 `attachSession(sessionId)` constructs this handle without I/O. The first
@@ -93,20 +94,20 @@ operation reports whether the ID is active.
 
 ## Semantics
 
-| Call                           | Identity used        | Can create        | Missing target       |
-| ------------------------------ | -------------------- | ----------------- | -------------------- |
-| `send(address, input)`         | continuation address | only when unowned | creates and claims   |
-| `cancel(address)`              | continuation address | no                | `no_active_turn`     |
-| `compact(address)`             | continuation address | no                | `no_active_session`  |
-| `clear(address)`               | continuation address | no                | `no_active_session`  |
-| `reset(address)`               | continuation address | no                | `no_active_session`  |
-| `resolveSession(address)`      | continuation address | no                | `undefined`          |
-| `session.send(input, options)` | session ID           | no                | `session_not_active` |
-| `session.cancel()`             | session ID           | no                | `no_active_turn`     |
-| `session.compact()`            | session ID           | no                | `no_active_session`  |
-| `session.clear()`              | session ID           | no                | `no_active_session`  |
-| `session.reset()`              | session ID           | no                | `no_active_session`  |
-| `session.getEventStream()`     | session ID           | no                | not found            |
+| Call                       | Identity used        | Can create        | Missing target       |
+| -------------------------- | -------------------- | ----------------- | -------------------- |
+| `send(address, input)`     | continuation address | only when unowned | creates and claims   |
+| `cancel(address)`          | continuation address | no                | `no_active_turn`     |
+| `compact(address)`         | continuation address | no                | `no_active_session`  |
+| `clear(address)`           | continuation address | no                | `no_active_session`  |
+| `reset(address)`           | continuation address | no                | `no_active_session`  |
+| `resolveSession(address)`  | continuation address | no                | `undefined`          |
+| `session.send(input)`      | session ID           | no                | `session_not_active` |
+| `session.cancel()`         | session ID           | no                | `no_active_turn`     |
+| `session.compact()`        | session ID           | no                | `no_active_session`  |
+| `session.clear()`          | session ID           | no                | `no_active_session`  |
+| `session.reset()`          | session ID           | no                | `no_active_session`  |
+| `session.getEventStream()` | session ID           | no                | not found            |
 
 Address-only HITL `inputResponses` cannot create a session because only the
 session that issued the request can consume them.
@@ -162,7 +163,7 @@ export default defineChannel({
 
     POST("/admin/session/:sessionId", async (request, { attachSession, params }) => {
       const session = attachSession(params.sessionId);
-      return Response.json(await session.send(await request.text(), { auth: null }));
+      return Response.json(await session.send({ auth: null, message: await request.text() }));
     }),
   ],
 });
@@ -190,64 +191,88 @@ export default defineChannel<State, Context, Target>({
 });
 ```
 
-A caller hands work to that implementation and receives a fixed session:
+A schedule hands work to that implementation with `send(channel, input)` and
+receives a fixed session:
 
 ```ts
-const session = await receive(slack, {
-  target: { channelId, threadTs },
-  message: "Investigate this incident",
-  auth,
-});
+export default defineSchedule({
+  cron: "0 9 * * *",
+  async run({ send, appAuth }) {
+    const session = await send(slack, {
+      auth: appAuth,
+      message: "Investigate this incident",
+      target: { channelId, threadTs },
+    });
 
-await session.send("Additional detail", { auth });
-await session.cancel();
-await session.compact();
-await session.clear();
-await session.reset();
+    await session.send({ auth: appAuth, message: "Additional detail" });
+    await session.cancel();
+    await session.compact();
+    await session.clear();
+    await session.reset();
+  },
+});
 ```
 
-The caller does not know the target channel's address format. Later operations
-on the returned `Session` cannot follow that address to a replacement.
+A channel route uses `args.receive(channel, input)` for the same cross-channel
+handoff because `args.send(address, input)` already means direct delivery on
+its own channel:
+
+```ts
+const session = await args.receive(slack, {
+  auth,
+  message: "Investigate this incident",
+  target: { channelId, threadTs },
+});
+```
+
+Neither caller knows the target channel's address format. Later operations on
+the returned `Session` cannot follow that address to a replacement.
 
 ### Slack
 
-Message and interaction handlers get a conversation already bound to their
-Slack thread:
+Message and interaction handlers get flat operations already bound to their
+Slack thread. `ctx.send()` derives auth from the inbound Slack user unless the
+input supplies `auth` explicitly:
 
 ```ts
 async onAppMention(ctx) {
-  await ctx.conversation.cancel({ turnId });
-  await ctx.conversation.compact();
-  await ctx.conversation.clear();
-  await ctx.conversation.reset({ reason: "Start over" });
+  await ctx.send({ message: "Run a separate turn" });
+  await ctx.cancel({ turnId });
+  await ctx.compact();
+  await ctx.clear();
+  await ctx.reset({ reason: "Start over" });
 
-  const fixed = await ctx.conversation.resolveSession();
+  const fixed = await ctx.resolveSession();
   return { auth: null };
 }
 ```
 
 The calls above show the available operations; a handler normally chooses one.
 
-Generic events bind any explicit Slack target:
+Generic events put the explicit Slack target in each operation's input:
 
 ```ts
 async onEvent(ctx) {
-  const conversation = ctx.conversation({ channelId, threadTs });
+  const target = { channelId, threadTs };
 
-  await conversation.clear();
+  await ctx.clear({ target });
+  await ctx.cancel({ target, turnId });
+  await ctx.compact({ target });
+  await ctx.reset({ reason: "Start over", target });
+  const fixed = await ctx.resolveSession({ target });
 
-  const session = await ctx.receive({
-    target: { channelId, threadTs },
-    message: "hello",
+  const session = await ctx.send({
     auth: null,
+    message: "hello",
+    target,
   });
 
-  await session.send("follow-up", { auth: null });
+  await session.send({ auth: null, message: "follow-up" });
 }
 ```
 
-`SlackConversation` is a Slack-specific convenience over the same internal
-operations. It does not reintroduce a generic public `ChannelAddress` type.
+Slack does not expose a conversation wrapper or reintroduce a generic public
+`ChannelAddress` type.
 
 ### eve framework HTTP channel
 
@@ -286,10 +311,10 @@ continuation token.
 ### JavaScript HTTP client
 
 ```ts
-const { session, response } = await client.sessions.create("hello");
+const { session, response } = await client.sessions.create({ message: "hello" });
 await response.result();
 
-await (await session.send("follow-up")).result();
+await (await session.send({ message: "follow-up" })).result();
 await session.cancel({ turnId });
 await session.compact();
 await session.clear();
@@ -318,11 +343,24 @@ interface ClientSessionState {
 Reset leaves the handle pinned to its retired ID. Creating a replacement is an
 explicit `client.sessions.create(...)` call.
 
+### Evals
+
+Eval sends use the same input object as the JavaScript client. The live-turn
+helper keeps its concise positional message because it only starts a text turn:
+
+```ts
+const completed = await t.send({ message: "Run the check" });
+const live = await t.start("Run the long check");
+
+await live.cancel();
+await live.result();
+```
+
 ### TUI
 
 ```text
-first prompt   → client.sessions.create(input)
-later prompt   → session.send(input)
+first prompt   → client.sessions.create({ message })
+later prompt   → session.send({ message })
 /cancel        → session.cancel()
 Esc            → session.cancel()
 Ctrl+C         → session.cancel(); a repeated Ctrl+C exits
@@ -451,6 +489,9 @@ owner; an ownership conflict retries dispatch to the winner.
 | public `ChannelAddress` / `channelAddress(address)` | direct channel operations                           |
 | `resolveActiveSession(address)`                     | `resolveSession(address)`                           |
 | `getSession(sessionId)`                             | `attachSession(sessionId)`                          |
+| schedule `receive(channel, input)`                  | schedule `send(channel, input)`                     |
+| Slack `ctx.conversation` and `ctx.receive`          | flat `ctx.*` operations and `ctx.send(input)`       |
+| string arguments to client/eval/session `send()`    | `{ message, ... }` input objects                    |
 | split runtime delivery/control methods              | `dispatchContinuation` and `dispatchSession`        |
 
 No deprecated aliases, alternate request parsing, or fallback compatibility
@@ -467,8 +508,9 @@ The migration must prove:
 - Rekeying preserves fixed-ID delivery while moving only the channel alias.
 - Reset releases aliases before replacement creation and an old ID cannot reach
   the replacement.
-- Built-in channels, custom routes, authored `receive` functions, Slack helpers,
-  clients, TUI, fixtures, and docs use the final shapes.
+- Built-in channels, custom routes, authored `receive` functions, schedule
+  sends, flat Slack operations, clients, evals, TUI, fixtures, and docs use the
+  final shapes.
 - E2E creates a session, sends a follow-up, cancels, compacts, clears, sends
   successfully afterward, proves a late accepted cancel is a no-op, resets,
   rejects the retired ID, and explicitly creates a replacement.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -274,6 +274,38 @@ async onEvent(ctx) {
 Slack does not expose a conversation wrapper or reintroduce a generic public
 `ChannelAddress` type.
 
+### Chat SDK bridge
+
+The Chat SDK bridge binds delivery to the webhook that is currently running.
+Its `send` function takes one input object, with the originating thread beside
+the message and turn options:
+
+```ts
+export const { bot, channel, send } = chatSdkChannel({ adapters, state });
+
+bot.onNewMention(async (thread, message) => {
+  await send({
+    message: message.text,
+    thread,
+    title: "Support request",
+    turnPolicy: "experimental-steer",
+  });
+});
+```
+
+HITL responses use the same shape without a message:
+
+```ts
+await send({
+  inputResponses: [{ requestId, optionId: "approve" }],
+  thread,
+});
+```
+
+Methods that post eve output back through a platform SDK, such as
+`thread.post(...)`, remain platform output APIs rather than session delivery
+operations.
+
 ### eve framework HTTP channel
 
 The default HTTP surface is singular and entirely session-ID addressed:
@@ -491,6 +523,7 @@ owner; an ownership conflict retries dispatch to the winner.
 | `getSession(sessionId)`                             | `attachSession(sessionId)`                          |
 | schedule `receive(channel, input)`                  | schedule `send(channel, input)`                     |
 | Slack `ctx.conversation` and `ctx.receive`          | flat `ctx.*` operations and `ctx.send(input)`       |
+| Chat SDK `send(message, options)`                   | `send({ message, thread, ... })`                    |
 | string arguments to client/eval/session `send()`    | `{ message, ... }` input objects                    |
 | split runtime delivery/control methods              | `dispatchContinuation` and `dispatchSession`        |
 
@@ -509,8 +542,8 @@ The migration must prove:
 - Reset releases aliases before replacement creation and an old ID cannot reach
   the replacement.
 - Built-in channels, custom routes, authored `receive` functions, schedule
-  sends, flat Slack operations, clients, evals, TUI, fixtures, and docs use the
-  final shapes.
+  sends, flat Slack operations, Chat SDK bridges, clients, evals, TUI,
+  fixtures, and docs use the final shapes.
 - E2E creates a session, sends a follow-up, cancels, compacts, clears, sends
   successfully afterward, proves a late accepted cancel is a no-op, resets,
   rejects the retired ID, and explicitly creates a replacement.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -115,6 +115,11 @@ session that issued the request can consume them.
 `reset` retires the target and releases its aliases before returning. Awaited
 commands sent through the same address preserve commit order.
 
+A live session returns `accepted` for `cancel` even when it is already parked;
+the driver consumes that late or duplicate command as a no-op. The stream is
+authoritative for whether a turn emitted `turn.cancelled`. `no_active_turn`
+means the session or channel address is unknown or terminal.
+
 ## Authoring shapes by surface
 
 ### Custom channel route
@@ -465,5 +470,5 @@ The migration must prove:
 - Built-in channels, custom routes, authored `receive` functions, Slack helpers,
   clients, TUI, fixtures, and docs use the final shapes.
 - E2E creates a session, sends a follow-up, cancels, compacts, clears, sends
-  successfully afterward, resets, rejects the retired ID, and explicitly
-  creates a replacement.
+  successfully afterward, proves a late accepted cancel is a no-op, resets,
+  rejects the retired ID, and explicitly creates a replacement.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -10,12 +10,12 @@ last_updated: "2026-08-04"
 
 eve exposes two identities with the same operation names:
 
-- Channel operations take a channel-local address on every call and target its
-  current owner.
+- `from(address)` binds a channel-local address and returns operations targeting
+  its current owner.
 - `Session` is a fixed handle for one durable `sessionId`.
 
 `ChannelAddress` is not a public authoring API. eve may bind an address
-internally to implement the direct functions and platform conveniences such as
+internally to implement `from` and platform conveniences such as
 Slack's thread-bound `ctx.send()` and `ctx.cancel()` methods.
 
 ```text
@@ -26,12 +26,13 @@ sessionId ───────────────────────�
 
 The identity determines the behavior:
 
-- `send(address, input)` resumes the current owner, or creates and claims the
-  address when it is unowned.
-- `cancel(address)`, `compact(address)`, `clear(address)`, and
-  `reset(address)` target the current owner and never create.
+- `from(address).send(message, options)` resumes the current owner, or creates
+  and claims the address when it is unowned.
+- The other `from(address).*` operations target the current owner and never
+  create.
 - `resolveSession(address)` is the only explicit conversion from a dynamic
-  address to a fixed `Session`.
+  address to a fixed `Session`. It is top-level beside `from`, not a method on
+  the bound source.
 - Every `session.*` method targets exactly `session.id`. It never creates or
   follows a replacement.
 
@@ -39,22 +40,29 @@ This is intentionally a breaking API migration with no compatibility aliases.
 
 ## Public authoring contract
 
-Custom channel routes and authored `receive` functions get direct operations:
+Custom channel routes and authored `receive` functions get two top-level
+identity selectors:
 
 ```ts
-interface ChannelOperations<TState = undefined> {
-  send(address: string, input: ChannelSendInput<TState>): Promise<Session>;
-  cancel(address: string, options?: { turnId?: string }): Promise<CancelTurnResult>;
-  compact(address: string): Promise<CompactSessionResult>;
-  clear(address: string): Promise<ClearSessionResult>;
-  reset(address: string, options?: { reason?: string }): Promise<ResetSessionResult>;
+interface ChannelReceiveContext<TState = undefined> {
+  from(address: string): ChannelSource<TState>;
   resolveSession(address: string): Promise<Session | undefined>;
 }
 
-interface BaseChannelSendInput {
+interface ChannelSource<TState = undefined> {
+  send(message: string | UserContent, options: ChannelSendOptions<TState>): Promise<Session>;
+  respond(
+    inputResponses: readonly InputResponse[],
+    options: ChannelRespondOptions,
+  ): Promise<Session>;
+  cancel(options?: { turnId?: string }): Promise<CancelTurnResult>;
+  compact(): Promise<CompactSessionResult>;
+  clear(): Promise<ClearSessionResult>;
+  reset(options?: { reason?: string }): Promise<ResetSessionResult>;
+}
+
+interface BaseChannelSendOptions {
   auth: SessionAuthContext | null;
-  message?: string | UserContent;
-  inputResponses?: readonly InputResponse[];
   context?: readonly string[];
   outputSchema?: JsonObject;
   callback?: SessionCallback;
@@ -63,9 +71,15 @@ interface BaseChannelSendInput {
   title?: string;
 }
 
-type ChannelSendInput<TState = undefined> = [TState] extends [undefined]
-  ? BaseChannelSendInput
-  : BaseChannelSendInput & { state: TState };
+type ChannelSendOptions<TState = undefined> = [TState] extends [undefined]
+  ? BaseChannelSendOptions
+  : BaseChannelSendOptions & { state: TState };
+
+interface ChannelRespondOptions {
+  auth: SessionAuthContext | null;
+  context?: readonly string[];
+  outputSchema?: JsonObject;
+}
 ```
 
 Fixed-ID operations use a `Session`:
@@ -74,7 +88,14 @@ Fixed-ID operations use a `Session`:
 interface Session {
   readonly id: string;
 
-  send(input: SessionSendInput): Promise<SessionSendCommandResult>;
+  send(
+    message: string | UserContent,
+    options: SessionSendOptions,
+  ): Promise<SessionSendCommandResult>;
+  respond(
+    inputResponses: readonly InputResponse[],
+    options: SessionRespondOptions,
+  ): Promise<SessionSendCommandResult>;
   cancel(options?: { turnId?: string }): Promise<CancelTurnResult>;
   compact(): Promise<CompactSessionResult>;
   clear(): Promise<ClearSessionResult>;
@@ -84,9 +105,14 @@ interface Session {
   getStreamTailIndex(): Promise<number>;
 }
 
-interface SessionSendInput extends SendPayload {
+interface SessionSendOptions {
   auth: SessionAuthContext | null;
+  caller?: TurnCaller;
+  context?: readonly string[];
+  outputSchema?: JsonObject;
 }
+
+type SessionRespondOptions = SessionSendOptions;
 ```
 
 `attachSession(sessionId)` constructs this handle without I/O. The first
@@ -96,13 +122,15 @@ operation reports whether the ID is active.
 
 | Call                       | Identity used        | Can create        | Missing target       |
 | -------------------------- | -------------------- | ----------------- | -------------------- |
-| `send(address, input)`     | continuation address | only when unowned | creates and claims   |
-| `cancel(address)`          | continuation address | no                | `no_active_turn`     |
-| `compact(address)`         | continuation address | no                | `no_active_session`  |
-| `clear(address)`           | continuation address | no                | `no_active_session`  |
-| `reset(address)`           | continuation address | no                | `no_active_session`  |
+| `from(address).send(...)`  | continuation address | only when unowned | creates and claims   |
+| `from(address).respond(…)` | continuation address | no                | throws               |
+| `from(address).cancel()`   | continuation address | no                | `no_active_turn`     |
+| `from(address).compact()`  | continuation address | no                | `no_active_session`  |
+| `from(address).clear()`    | continuation address | no                | `no_active_session`  |
+| `from(address).reset()`    | continuation address | no                | `no_active_session`  |
 | `resolveSession(address)`  | continuation address | no                | `undefined`          |
-| `session.send(input)`      | session ID           | no                | `session_not_active` |
+| `session.send(…)`          | session ID           | no                | `session_not_active` |
+| `session.respond(…)`       | session ID           | no                | `session_not_active` |
 | `session.cancel()`         | session ID           | no                | `no_active_turn`     |
 | `session.compact()`        | session ID           | no                | `no_active_session`  |
 | `session.clear()`          | session ID           | no                | `no_active_session`  |
@@ -130,30 +158,29 @@ import { defineChannel, GET, POST } from "eve/channels";
 
 export default defineChannel({
   routes: [
-    POST("/threads/:threadId/messages", async (request, { params, send }) => {
+    POST("/threads/:threadId/messages", async (request, { from, params }) => {
       const body = await request.json();
-      const session = await send(params.threadId, {
+      const session = await from(params.threadId).send(body.message, {
         auth: null,
-        message: body.message,
       });
 
       return Response.json({ sessionId: session.id });
     }),
 
-    POST("/threads/:threadId/cancel", async (_request, { cancel, params }) =>
-      Response.json(await cancel(params.threadId)),
+    POST("/threads/:threadId/cancel", async (_request, { from, params }) =>
+      Response.json(await from(params.threadId).cancel()),
     ),
 
-    POST("/threads/:threadId/compact", async (_request, { compact, params }) =>
-      Response.json(await compact(params.threadId)),
+    POST("/threads/:threadId/compact", async (_request, { from, params }) =>
+      Response.json(await from(params.threadId).compact()),
     ),
 
-    POST("/threads/:threadId/clear", async (_request, { clear, params }) =>
-      Response.json(await clear(params.threadId)),
+    POST("/threads/:threadId/clear", async (_request, { from, params }) =>
+      Response.json(await from(params.threadId).clear()),
     ),
 
-    POST("/threads/:threadId/reset", async (_request, { params, reset }) =>
-      Response.json(await reset(params.threadId, { reason: "Start over" })),
+    POST("/threads/:threadId/reset", async (_request, { from, params }) =>
+      Response.json(await from(params.threadId).reset({ reason: "Start over" })),
     ),
 
     GET("/threads/:threadId/owner", async (_request, { params, resolveSession }) => {
@@ -163,14 +190,15 @@ export default defineChannel({
 
     POST("/admin/session/:sessionId", async (request, { attachSession, params }) => {
       const session = attachSession(params.sessionId);
-      return Response.json(await session.send({ auth: null, message: await request.text() }));
+      return Response.json(await session.send(await request.text(), { auth: null }));
     }),
   ],
 });
 ```
 
-The direct functions make dynamic routing visible without making authors build
-or name an intermediate address object.
+`from` makes dynamic routing visible without exposing the internal
+`ChannelAddress` representation. `resolveSession` stays top-level because it
+snapshots an address rather than operating through the dynamic source.
 
 ### Authored receive and cross-channel handoff
 
@@ -179,32 +207,29 @@ initial state:
 
 ```ts
 export default defineChannel<State, Context, Target>({
-  async receive(input, { send }) {
+  async receive(input, { from }) {
     const address = addressFromTarget(input.target);
 
-    return await send(address, {
+    return await from(address).send(input.message, {
       auth: input.auth,
-      message: input.message,
       state: initialState(input.target),
     });
   },
 });
 ```
 
-A schedule hands work to that implementation with `send(channel, input)` and
-receives a fixed session:
+A schedule selects the target with `to(channel, target)` and receives a fixed
+session from `send`:
 
 ```ts
 export default defineSchedule({
   cron: "0 9 * * *",
-  async run({ send, appAuth }) {
-    const session = await send(slack, {
+  async run({ to, appAuth }) {
+    const session = await to(slack, { channelId, threadTs }).send("Investigate this incident", {
       auth: appAuth,
-      message: "Investigate this incident",
-      target: { channelId, threadTs },
     });
 
-    await session.send({ auth: appAuth, message: "Additional detail" });
+    await session.send("Additional detail", { auth: appAuth });
     await session.cancel();
     await session.compact();
     await session.clear();
@@ -213,16 +238,13 @@ export default defineSchedule({
 });
 ```
 
-A channel route uses `args.receive(channel, input)` for the same cross-channel
-handoff because `args.send(address, input)` already means direct delivery on
-its own channel:
+A channel route uses the same `to(channel, target).send(message, options)`
+handoff:
 
 ```ts
-const session = await args.receive(slack, {
-  auth,
-  message: "Investigate this incident",
-  target: { channelId, threadTs },
-});
+const session = await args
+  .to(slack, { channelId, threadTs })
+  .send("Investigate this incident", { auth });
 ```
 
 Neither caller knows the target channel's address format. Later operations on
@@ -236,7 +258,8 @@ input supplies `auth` explicitly:
 
 ```ts
 async onAppMention(ctx) {
-  await ctx.send({ message: "Run a separate turn" });
+  await ctx.send("Run a separate turn");
+  await ctx.respond(inputResponses);
   await ctx.cancel({ turnId });
   await ctx.compact();
   await ctx.clear();
@@ -261,13 +284,10 @@ async onEvent(ctx) {
   await ctx.reset({ reason: "Start over", target });
   const fixed = await ctx.resolveSession({ target });
 
-  const session = await ctx.send({
-    auth: null,
-    message: "hello",
-    target,
-  });
+  const session = await ctx.send("hello", { auth: null, target });
+  await ctx.respond(inputResponses, { auth: null, target });
 
-  await session.send({ auth: null, message: "follow-up" });
+  await session.send("follow-up", { auth: null });
 }
 ```
 
@@ -441,7 +461,13 @@ Both public identity forms dispatch one shared command protocol:
 
 ```ts
 type SessionCommand =
-  | { kind: "send"; auth: SessionAuthContext | null; payload: DeliverPayload; requestId?: string }
+  | {
+      kind: "send";
+      auth: SessionAuthContext | null;
+      caller?: TurnCaller;
+      payload: DeliverPayload;
+      requestId?: string;
+    }
   | { kind: "cancel"; turnId?: string }
   | { kind: "compact" }
   | { kind: "clear" }
@@ -482,9 +508,9 @@ Only explicit `resolveSession(address)` calls `resolveContinuation`. A future
 lightweight owner lookup can optimize that conversion without affecting normal
 operation latency.
 
-Internally eve may implement `ChannelOperations` by binding an address to a
-private handle and forwarding the method. That object must not be exported or
-accepted by authored channel APIs.
+Internally eve may bind an address to a private continuation handle. The public
+`ChannelSource` exposes only the dynamic operations; the underlying
+`ChannelAddress` must not be exported or accepted by authored channel APIs.
 
 ## Race and lifetime rules
 
@@ -509,8 +535,8 @@ await session?.clear(); // still wrun_A
 Reset followed by send is ordered:
 
 ```ts
-await reset("thread-123");
-const replacement = await send("thread-123", { auth, message: "start again", state });
+await from("thread-123").reset();
+const replacement = await from("thread-123").send("start again", { auth, state });
 ```
 
 The replacement may be created only after the prior owner releases the address.
@@ -519,21 +545,21 @@ owner; an ownership conflict retries dispatch to the winner.
 
 ## Removed public APIs
 
-| Removed                                             | Replacement                                         |
-| --------------------------------------------------- | --------------------------------------------------- |
-| HTTP continuation-token fields and control bodies   | `/eve/v1/session/:sessionId/*`                      |
-| plural `/eve/v1/sessions` routes                    | singular `/eve/v1/session`                          |
-| follow-up `/:sessionId/messages`                    | `POST /:sessionId`                                  |
-| `client.session(token)`                             | `client.sessions.create()` or `.attach(id)`         |
-| client continuation-token state                     | `{ sessionId, streamIndex }`                        |
-| free token helpers                                  | direct `send(address, input)` and control functions |
-| public `ChannelAddress` / `channelAddress(address)` | direct channel operations                           |
-| `resolveActiveSession(address)`                     | `resolveSession(address)`                           |
-| `getSession(sessionId)`                             | `attachSession(sessionId)`                          |
-| schedule `receive(channel, input)`                  | schedule `send(channel, input)`                     |
-| Slack `ctx.conversation` and `ctx.receive`          | flat `ctx.*` operations and `ctx.send(input)`       |
-| string arguments to client/eval/session `send()`    | `{ message, ... }` input objects                    |
-| split runtime delivery/control methods              | `dispatchContinuation` and `dispatchSession`        |
+| Removed                                             | Replacement                                          |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| HTTP continuation-token fields and control bodies   | `/eve/v1/session/:sessionId/*`                       |
+| plural `/eve/v1/sessions` routes                    | singular `/eve/v1/session`                           |
+| follow-up `/:sessionId/messages`                    | `POST /:sessionId`                                   |
+| `client.session(token)`                             | `client.sessions.create()` or `.attach(id)`          |
+| client continuation-token state                     | `{ sessionId, streamIndex }`                         |
+| free token helpers                                  | `from(address)` and `resolveSession(address)`        |
+| public `ChannelAddress` / `channelAddress(address)` | `from(address)`                                      |
+| `resolveActiveSession(address)`                     | `resolveSession(address)`                            |
+| `getSession(sessionId)`                             | `attachSession(sessionId)`                           |
+| schedule `receive(channel, input)`                  | `to(channel, target).send(message, options)`         |
+| Slack `ctx.conversation` and `ctx.receive`          | flat `ctx.send(message, options)` / `ctx.respond(…)` |
+| string arguments to client/eval `send()`            | `{ message, ... }` input objects                     |
+| split runtime delivery/control methods              | `dispatchContinuation` and `dispatchSession`         |
 
 No deprecated aliases, alternate request parsing, or fallback compatibility
 paths remain.
@@ -542,8 +568,8 @@ paths remain.
 
 The migration must prove:
 
-- Every address send/control performs one continuation dispatch and no implicit
-  resolution.
+- Every `from(address)` send/control performs one continuation dispatch and no
+  implicit resolution.
 - Address send resumes or creates; other address operations never create.
 - Every fixed-session and HTTP operation remains pinned to one ID.
 - Rekeying preserves fixed-ID delivery while moving only the channel alias.

--- a/research/session-operations/unified-session-operations-proposal.md
+++ b/research/session-operations/unified-session-operations-proposal.md
@@ -1,0 +1,765 @@
+---
+issue: https://github.com/vercel/eve/issues/1580
+status: proposed
+last_updated: "2026-08-03"
+---
+
+# Unified session addressing and operations
+
+## Decision
+
+eve should expose two deliberately different handles over one session command
+inbox:
+
+- `ChannelAddress` targets whichever session owns a channel continuation token
+  when an operation is invoked.
+- `Session` targets one immutable durable session ID.
+
+```text
+ChannelAddress(continuationToken) ─┐
+                                  ├─> one durable session command inbox
+Session(sessionId) ────────────────┘
+```
+
+Both handles support `send`, `cancel`, `compact`, `clear`, and `reset`. The
+difference is identity, not operation names:
+
+```text
+ChannelAddress.send() → resume current owner, or create when unowned
+ChannelAddress.clear() → clear current owner, never create
+
+Session.send()         → send to this exact ID, never create
+Session.clear()        → clear this exact ID, never follow a replacement
+```
+
+No operation resolves a continuation token to a session ID and then resumes a
+second hook. It dispatches one command through the address the caller already
+has. Resolution exists only when code explicitly wants to convert a dynamic
+`ChannelAddress` into a fixed `Session`.
+
+A channel-created session owns two aliases for the same command inbox:
+
+```text
+<channel>:<continuationToken> ─┐
+                              ├─> session command inbox
+eve:session:<sessionId>:inbox ─┘
+```
+
+The channel alias may be rekeyed; the ID alias is stable until termination.
+An HTTP-created session owns only the stable alias. All aliases must preserve
+eve's committed-delivery, deduplication, cancellation, and durable-ordering
+guarantees.
+
+This is intentionally a breaking proposal.
+
+## Identity model
+
+| Identifier          | Meaning                                                       | Lifetime                                | May create                                      |
+| ------------------- | ------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------- |
+| `continuationToken` | Channel address whose current owner receives channel commands | May be rekeyed, released, and reclaimed | `ChannelAddress.send()` may create when unowned |
+| `sessionId`         | Identity of one durable workflow session                      | Immutable                               | Never                                           |
+
+The same channel address can identify different sessions over time:
+
+```text
+thread-123 → wrun_A
+reset wrun_A
+thread-123 → wrun_B
+```
+
+A handle for `wrun_A` never follows `thread-123` to `wrun_B`.
+
+## Invariants
+
+1. A `ChannelAddress` denotes a mutable channel routing address, not a session.
+2. A `Session` always targets one immutable `sessionId`.
+3. Every address operation is one command dispatch; none performs a
+   resolve-then-dispatch sequence.
+4. `ChannelAddress.send()` is the only resume-or-create operation.
+5. Other `ChannelAddress` methods target the owner observed atomically when the
+   command is accepted and never create.
+6. No `Session` method creates or follows a continuation token.
+7. A continuation token has at most one active owner.
+8. Rekeying changes only the channel alias and cannot break ID operations.
+9. Reset terminally retires the ID and releases every alias. Only a later
+   `ChannelAddress.send()` or explicit HTTP create can create a replacement.
+10. HTTP session operations use only `sessionId`; HTTP never accepts or returns
+    a continuation token.
+11. `resolveSession()` is an explicit identity conversion, not an operation
+    prerequisite.
+12. A function named `get` or `resolve` performs I/O; a handle factory is named
+    `attach`.
+
+## Operation semantics
+
+| Operation                       | Address            | Creates         | Result when target is absent |
+| ------------------------------- | ------------------ | --------------- | ---------------------------- |
+| `ChannelAddress.send`           | Continuation token | Yes, if unowned | Creates and claims the token |
+| `ChannelAddress.cancel`         | Continuation token | No              | `no_active_turn`             |
+| `ChannelAddress.compact`        | Continuation token | No              | `no_active_session`          |
+| `ChannelAddress.clear`          | Continuation token | No              | `no_active_session`          |
+| `ChannelAddress.reset`          | Continuation token | No              | `no_active_session`          |
+| `ChannelAddress.resolveSession` | Continuation token | No              | `undefined`                  |
+| `Session.send`                  | Session ID         | No              | `session_not_active`         |
+| `Session.cancel`                | Session ID         | No              | `no_active_turn`             |
+| `Session.compact`               | Session ID         | No              | `no_active_session`          |
+| `Session.clear`                 | Session ID         | No              | `no_active_session`          |
+| `Session.reset`                 | Session ID         | No              | `no_active_session`          |
+| Session stream                  | Session ID         | No              | Not found                    |
+
+`ChannelAddress.send()` cannot create when the payload consists only of HITL
+`inputResponses`; those responses are meaningful only to the session that
+issued the request.
+
+`cancel()`, `compact()`, and `clear()` remain asynchronous controls. Acceptance
+means the command was durably queued. Awaited calls through the same address are
+committed and processed in order, so sequential `await address.clear()` and
+`await address.send(...)` calls cannot send before the clear. Stream events
+confirm when the effects complete. `reset()` resolves only after the targeted
+session is terminal and its aliases are released, so a subsequent channel send
+cannot fall back into the retired owner.
+
+## Public handles
+
+### Fixed `Session`
+
+The framework-side fixed session surface is:
+
+```ts
+interface Session {
+  readonly id: string;
+
+  send(input: SendInput, options: SessionSendOptions): Promise<SessionSendResult>;
+  cancel(options?: { turnId?: string }): Promise<CancelResult>;
+  compact(): Promise<CompactResult>;
+  clear(): Promise<ClearResult>;
+  reset(options?: { reason?: string }): Promise<ResetResult>;
+
+  getEventStream(options?: StreamOptions): Promise<ReadableStream<MessageStreamEvent>>;
+  getStreamTailIndex(): Promise<number>;
+}
+```
+
+Every method is bound to `session.id`. `Session.continuationToken` is removed
+because it is a moving channel address and is necessarily stale on some
+fixed-ID handles.
+
+Framework-side `Session.send()` requires the delivery auth context in
+`SessionSendOptions`. Remote clients resolve auth from their configured HTTP
+credentials instead. The accepted result may be wrapped by a transport-owned
+turn/stream handle, but all surfaces retain the same ID-only target semantics.
+
+Constructing a handle is not an existence check:
+
+```ts
+const session = attachSession("wrun_A");
+```
+
+The first operation reports whether the ID is active. Dynamic channel routing
+is separate:
+
+```ts
+const thread = channelAddress("thread-123");
+const current = await thread.resolveSession();
+```
+
+### Dynamic `ChannelAddress`
+
+A `ChannelAddress` binds the channel-local continuation token once:
+
+```ts
+interface ChannelAddress<TState = undefined> {
+  readonly continuationToken: string;
+
+  send(input: SendInput, options: ChannelSendOptions<TState>): Promise<Session>;
+  cancel(options?: { turnId?: string }): Promise<CancelResult>;
+  compact(): Promise<CompactResult>;
+  clear(): Promise<ClearResult>;
+  reset(options?: { reason?: string }): Promise<ResetResult>;
+
+  resolveSession(): Promise<Session | undefined>;
+}
+```
+
+- `send()` delivers to the current owner or creates and claims the address.
+- Controls dispatch directly to the current owner and never create.
+- `resolveSession()` performs the optional token-to-fixed-ID conversion.
+
+The distinction remains visible at the call site:
+
+```ts
+const thread = channelAddress(threadId);
+
+const session = await thread.send("hello", { auth });
+await thread.clear(); // current owner of threadId
+await session.clear(); // exact session returned by send()
+```
+
+These two `clear()` calls normally target the same workflow, but encode
+different intent if the address is later rekeyed or reclaimed. Free-floating
+token control helpers are removed; the address object makes the dynamic target
+explicit.
+
+## Authoring shapes by surface
+
+There are only two operation-bearing objects in author code:
+
+```ts
+const conversation = channelAddress(continuationToken);
+// ChannelAddress → dispatchContinuation()
+// Targets the owner of this address when each call is accepted.
+
+const session = attachSession(sessionId);
+// Session → dispatchSession()
+// Always targets this exact durable session.
+```
+
+### Custom channel route
+
+```ts
+POST("/threads/:threadId/messages", async (request, { channelAddress, params }) => {
+  const conversation = channelAddress(params.threadId);
+
+  // Resume the current owner, or create and claim the address.
+  const session = await conversation.send(await request.text(), {
+    auth: null,
+  });
+
+  return Response.json({ sessionId: session.id });
+});
+```
+
+All current-owner operations stay on the bound address and perform one command
+resume:
+
+```ts
+const conversation = channelAddress(threadId);
+
+await conversation.send("hello", { auth });
+await conversation.cancel({ turnId });
+await conversation.compact();
+await conversation.clear();
+await conversation.reset({ reason: "Start over" });
+```
+
+Use a fixed session only when the operation must not follow a replacement:
+
+```ts
+const conversation = channelAddress(threadId);
+
+const session = await conversation.resolveSession(); // The only lookup.
+if (session) {
+  await session.send("hello", { auth });
+  await session.cancel({ turnId });
+  await session.compact();
+  await session.clear();
+  await session.reset({ reason: "Retire this exact session" });
+
+  const stream = await session.getEventStream();
+}
+
+const attached = attachSession("wrun_A"); // No lookup.
+```
+
+The examples list the available operations; they are not intended as one
+realistic sequence.
+
+### Slack channel
+
+Bound message and interaction handlers receive a `ChannelAddress` as
+`ctx.conversation`:
+
+```ts
+async onAppMention(ctx) {
+  // Available current-owner controls; choose the one needed by the handler.
+  await ctx.conversation.cancel({ turnId });
+  await ctx.conversation.compact();
+  await ctx.conversation.clear();
+  await ctx.conversation.reset({ reason: "Start over" });
+
+  // The framework subsequently sends the inbound message through
+  // ctx.conversation.send(message, { auth }). It does not resolve first.
+  return { auth: null };
+}
+```
+
+Resolve only to pin later work to the current durable session:
+
+```ts
+async onAppMention(ctx) {
+  const session = await ctx.conversation.resolveSession();
+  if (session) ctx.waitUntil(session.clear());
+  return { auth: null };
+}
+```
+
+Generic events construct a conversation from an explicit Slack target:
+
+```ts
+async onEvent(ctx) {
+  const conversation = ctx.conversation({ channelId, threadTs });
+
+  await conversation.cancel();
+  await conversation.compact();
+  await conversation.clear();
+  await conversation.reset();
+
+  const session = await ctx.receive({
+    target: { channelId, threadTs },
+    message: "hello",
+    auth: null,
+  });
+
+  await session.send("follow-up", { auth: null });
+}
+```
+
+These are independent operation examples. A handler would normally perform
+only the control needed for that event.
+
+### Other built-in platform channels
+
+Discord, Teams, Telegram, Twilio, GitHub, Linear, Chat SDK, and Photon iMessage
+use the same contract. A channel may expose the object under its natural noun,
+but it remains a `ChannelAddress`:
+
+```ts
+const conversation = ctx.conversation; // or ctx.thread / ctx.chat
+
+// Available operations; choose as needed.
+await conversation.send(input, { auth });
+await conversation.cancel();
+await conversation.compact();
+await conversation.clear();
+await conversation.reset();
+
+const session = await conversation.resolveSession();
+```
+
+Authored `receive` implementations convert the platform target into a
+`ChannelAddress`, call `send`, and return the resulting `Session`.
+
+### eve framework HTTP channel
+
+The built-in HTTP channel never exposes or accepts a continuation token:
+
+```http
+POST /eve/v1/sessions
+{"message":"hello"}
+
+POST /eve/v1/sessions/wrun_A/messages
+{"message":"follow-up"}
+
+POST /eve/v1/sessions/wrun_A/cancel
+{"turnId":"turn_A"}
+
+POST /eve/v1/sessions/wrun_A/compact
+POST /eve/v1/sessions/wrun_A/clear
+
+POST /eve/v1/sessions/wrun_A/reset
+{"reason":"Start over"}
+
+GET /eve/v1/sessions/wrun_A/stream
+```
+
+The create route calls `createSession()`. Every route containing `wrun_A`
+dispatches or reads directly by that session ID; none calls
+`resolveContinuation()`.
+
+```http
+HTTP/1.1 202 Accepted
+{"sessionId":"wrun_A","status":"accepted"}
+```
+
+An unknown or terminal ID on the message route returns:
+
+```http
+HTTP/1.1 409 Conflict
+{"code":"session_not_active"}
+```
+
+Send, compact, and clear acceptance use `202`. Cancel/reset completion and
+benign inactive-control results use `200`. An unknown stream uses `404`.
+Creation does not return until the stable command hook is registered, so an
+immediate follow-up has no hook-readiness race.
+
+### JavaScript HTTP client
+
+```ts
+const { session, response } = await client.sessions.create("hello");
+await response.result();
+
+await (await session.send("follow-up")).result();
+await session.cancel({ turnId });
+await session.compact();
+await session.clear();
+await session.reset({ reason: "Start over" });
+
+for await (const event of session.stream()) {
+  // ...
+}
+```
+
+Attach to a known ID without I/O:
+
+```ts
+const session = client.sessions.attach("wrun_A");
+```
+
+```ts
+interface ClientSessionState {
+  readonly sessionId: string;
+  readonly streamIndex: number;
+}
+```
+
+The client stores no continuation token. Every method calls the corresponding
+ID-only HTTP route. Reset leaves the handle pinned to its terminal ID; callers
+discard it and explicitly create the replacement.
+
+### TUI
+
+```text
+first prompt   → client.sessions.create(input)
+later prompt   → session.send(input)
+/cancel        → session.cancel()
+Esc / Ctrl+C   → session.cancel()
+/compact       → session.compact()
+/clear         → session.clear()
+/new           → session.clear()
+/reset         → session.reset(); discard session
+event loop     → session.stream()
+```
+
+The TUI has no `ChannelAddress`, continuation token, or resolution path.
+
+### Cross-channel receive
+
+```ts
+const session = await args.receive(slack, {
+  target: { channelId, threadTs },
+  message: "Investigate this incident",
+  auth,
+});
+
+// The returned fixed-session operations are available independently.
+await session.send("Additional detail", { auth });
+await session.cancel();
+await session.compact();
+await session.clear();
+await session.reset();
+```
+
+The target channel implements `receive` with `ChannelAddress.send()`. The
+caller receives a fixed `Session`, so subsequent operations cannot follow the
+target address to a replacement.
+
+### Framework translation
+
+```ts
+// ChannelAddress.send/cancel/compact/clear/reset
+await runtime.dispatchContinuation({
+  continuationToken,
+  command,
+});
+
+// Session.send/cancel/compact/clear/reset
+await runtime.dispatchSession({
+  sessionId,
+  command,
+});
+
+// ChannelAddress.resolveSession() only
+await runtime.resolveContinuation(continuationToken);
+
+// Session.getEventStream() / client session.stream()
+await runtime.getEventStream(sessionId);
+```
+
+Only an unowned `ChannelAddress.send()` result enters `createSession()`.
+Controls and all fixed-session methods never create.
+
+## Channel lifecycle context
+
+Lifecycle handlers already run inside the owning workflow. They receive
+identity and channel routing state, not a recursive imperative session API:
+
+```ts
+interface ChannelEventContext<TPlatformContext> extends TPlatformContext {
+  readonly session: {
+    readonly id: string;
+  };
+  readonly continuation?: {
+    readonly token: string;
+    rekey(token: string): void;
+  };
+}
+```
+
+`continuation` is absent for transports such as the eve HTTP protocol that do
+not own a channel address. Rekeying changes the channel alias while the stable
+command hook remains active.
+
+Top-level `continuationToken` and `setContinuationToken()` are removed in
+favor of this explicit routing object.
+
+## Runtime boundary
+
+The runtime dispatches one command protocol through either address:
+
+```ts
+type SessionCommand =
+  | {
+      kind: "send";
+      auth: SessionAuthContext | null;
+      payload: DeliverPayload;
+      requestId?: string;
+    }
+  | { kind: "cancel"; turnId?: string }
+  | { kind: "compact" }
+  | { kind: "clear" }
+  | { kind: "reset"; reason?: string };
+
+interface Runtime {
+  createSession(input: CreateSessionInput): Promise<RunHandle>;
+
+  dispatchContinuation(input: {
+    continuationToken: string;
+    command: SessionCommand;
+  }): Promise<SessionCommandResult>;
+
+  dispatchSession(input: {
+    sessionId: string;
+    command: SessionCommand;
+  }): Promise<SessionCommandResult>;
+
+  resolveContinuation(continuationToken: string): Promise<{ sessionId: string } | undefined>;
+
+  getEventStream(
+    sessionId: string,
+    options?: StreamOptions,
+  ): Promise<ReadableStream<MessageStreamEvent>>;
+}
+```
+
+`dispatchContinuation()` resumes the channel hook with the command and returns
+the owning `sessionId` from that resume. It does not call
+`resolveContinuation()`. `dispatchSession()` computes the stable inbox token
+from the supplied ID and performs the same single resume.
+
+Only `ChannelAddress.send()` handles an unowned address by calling
+`createSession()`. Every other command reports the appropriate inactive result.
+Concurrent first sends must converge on one owner; an ownership conflict
+retries command dispatch to the winner rather than surfacing a second session.
+
+The current runtime-specific `deliver`, `cancelTurn`, `compactSession`,
+`clearSession`, and `terminateSession` entry points collapse behind the two
+dispatch methods. Streaming remains ID-addressed and read-only.
+
+The low-level public route `Agent` interface is removed. Routes use
+`ChannelAddress` and `Session`; framework internals use `Runtime`.
+
+## Driver command inbox
+
+The workflow driver creates its stable command hook before creation is
+acknowledged. A channel-created session additionally owns one rekeyable alias
+for the same command protocol.
+
+```text
+create HTTP session:
+  create stable command hook
+  acknowledge session
+
+create channel session:
+  create stable command hook
+  claim channel alias
+  acknowledge session
+
+rekey channel session:
+  claim new alias
+  retire old alias
+  keep stable command hook
+
+reset:
+  consume reset command
+  dispose stable command hook
+  dispose current alias
+  terminate run
+  acknowledge terminal state
+```
+
+The inbox multiplexes the stable hook, active alias, and already-committed
+retired-alias commands into one durable queue. The driver continuously services
+the inbox whether it is parked or supervising an active turn:
+
+```text
+send    → deliver to the turn, buffer, or start the next turn
+cancel  → request cooperative cancellation of the active turn
+compact → run compaction at the next valid driver boundary
+clear   → clear model context at the next valid driver boundary
+reset   → terminally retire the session and every alias
+```
+
+This replaces the split delivery, cancellation, and compact/clear hooks. A
+command is consumed once regardless of which alias received it.
+
+Internal hook tokens use a framework-reserved namespace that authored channel
+tokens cannot claim.
+
+`dispatchSession({ sessionId, command })` computes the internal stable token
+locally:
+
+```ts
+resumeHook(sessionCommandHookToken(sessionId), command);
+```
+
+It never resolves a channel continuation token. Workflow still performs its
+normal hook and run lookup while resuming that stable hook; ID-addressed here
+describes eve's public identity semantics, not a new run-addressed Workflow
+transport.
+
+## Resolution cost
+
+Resolution is not part of any operation path:
+
+| Path                                      | Separate resolution | Command resumes |
+| ----------------------------------------- | ------------------- | --------------- |
+| `ChannelAddress.send()` to existing owner | None                | One             |
+| Any `ChannelAddress` control              | None                | One             |
+| Any `Session` operation                   | None                | One             |
+| HTTP follow-up or control                 | None                | One             |
+| Slack inbound send or control             | None                | One             |
+| Explicit `resolveSession()`               | One lookup          | None            |
+
+eve's current `resolveSession()` calls Workflow `getHookByToken()`, which also
+fetches the run, resolves encryption state, and may hydrate hook metadata.
+That is more work than identity resolution requires.
+
+Workflow should expose a lightweight owner lookup:
+
+```ts
+getHookOwnerByToken(token): Promise<{ runId: string } | undefined>
+```
+
+In workflow-server, this can read the token-ownership constraint that already
+stores `hookId` and `runId`, without fetching or hydrating the workflow run.
+This optimization improves the explicit identity-conversion method but is not
+placed on any command path.
+
+Resuming either inbox alias still performs Workflow's normal hook-resume work.
+A future atomic server-side resume endpoint may reduce its network round-trips,
+but this proposal does not depend on that optimization.
+
+## Race semantics
+
+### Dynamic address versus fixed session
+
+An address command targets the owner at command acceptance:
+
+```text
+thread-123 → wrun_A
+thread.clear() → clears wrun_A
+
+thread-123 → wrun_B
+thread.clear() → clears wrun_B
+```
+
+Resolution freezes that observation into a fixed handle:
+
+```ts
+const session = await thread.resolveSession(); // Session(wrun_A)
+// thread-123 is later reclaimed by wrun_B
+await session?.clear(); // still targets wrun_A
+```
+
+### Reset then send
+
+Address reset waits for the observed owner to terminate and release the alias:
+
+```ts
+await thread.reset();
+const replacement = await thread.send("start again", { auth });
+```
+
+The send may create a replacement only after reset completes. A fixed old
+handle remains terminal:
+
+```ts
+await oldSession.send("late", { auth }); // session_not_active
+```
+
+A delayed duplicate operation on `ChannelAddress` is intentionally dynamic and
+may target a replacement. Code requiring duplicate safety resolves or retains
+the fixed `Session` before scheduling the operation.
+
+### Mismatched HTTP identity
+
+The mismatch is impossible because HTTP carries one address:
+
+```http
+POST /eve/v1/sessions/wrun_A/messages
+{"message":"hello"}
+```
+
+There is no body token that can redirect delivery to `wrun_B`.
+
+## Removed APIs
+
+| Removed                                            | Replacement                                         |
+| -------------------------------------------------- | --------------------------------------------------- |
+| HTTP `continuationToken` fields                    | ID-only session routes                              |
+| Singular `/eve/v1/session` route family            | Plural `/eve/v1/sessions` resources                 |
+| `ClientSessionState.continuationToken`             | `sessionId` and stream cursor                       |
+| `client.session(token)`                            | `client.sessions.create()` or `.attach(sessionId)`  |
+| `Session.continuationToken`                        | `ChannelAddress.continuationToken` where relevant   |
+| Free token-addressed route helpers                 | Methods on one bound `ChannelAddress`               |
+| `resolveActiveSession()` returning `{ sessionId }` | `ChannelAddress.resolveSession()`                   |
+| Misnamed `getSession(sessionId)` facade            | `attachSession(sessionId)`                          |
+| Slack bound and target-taking helpers              | Bound or constructed `ctx.conversation`             |
+| Top-level lifecycle continuation fields            | `channel.continuation.token/rekey()`                |
+| Public low-level `Agent`                           | `ChannelAddress`, `Session`, and internal `Runtime` |
+| Split runtime delivery/control methods             | `dispatchContinuation` and `dispatchSession`        |
+
+No deprecated aliases, fallback request parsing, or token-to-ID compatibility
+paths remain.
+
+## Verification
+
+The implementation is complete only when tests prove these boundaries:
+
+- ID delivery works during active turns and while the driver is parked.
+- ID delivery never creates after reset, completion, failure, or unknown ID.
+- Every address send/control performs one resume and never calls
+  `resolveContinuation()`.
+- Channel send remains resume-or-create and concurrent first sends produce one
+  owner.
+- Address cancel reaches an active turn through the shared command inbox.
+- Rekey changes channel routing without interrupting ID delivery.
+- Reset releases both delivery addresses; an old ID cannot reach a replacement.
+- Commands committed to a retiring alias are consumed once.
+- Address reset completes before a subsequent send can create a replacement.
+- HTTP follow-up has no token field and cannot redirect or create.
+- Slack performs no separate owner resolution unless handler code explicitly
+  calls `resolveSession()`.
+- A resolved Slack/custom-channel session remains pinned across replacement.
+- Compact and clear are followed by successful address- and ID-addressed sends.
+- TUI commands use the same ID-only client session and post-reset creation is
+  explicit.
+- Public docs and examples contain no token-bearing HTTP/client session state,
+  free token helpers, or `getSession()` facade.
+
+The HTTP e2e sequence should create, send, cancel, compact, clear, send again,
+reset, reject an old-ID send, and explicitly create a replacement.
+
+## Outcome
+
+The complete model is:
+
+```text
+ChannelAddress: operate on the current owner of this channel address
+Session: operate on this exact durable session
+```
+
+Every operation dispatches directly through one of those addresses. Resolution
+is reserved for the deliberate transition from dynamic channel ownership to a
+fixed session identity.


### PR DESCRIPTION
### Description

Closes #1580.

Proposes one aligned session-operation model across dynamic channel addresses and fixed durable session IDs.

The proposal is authoring-first and covers:

- custom-channel `from(address)` sources for dynamic send/respond/control operations
- top-level `resolveSession(address)` beside `from(address)` for explicit dynamic-to-fixed snapshots
- internal-only generic address handles, with no public `ChannelAddress` authoring API
- fixed `Session` and client handles for exact-ID operations that never create or follow replacements
- positional `session.send(message, options)` and `session.respond(inputResponses, options)`
- object inputs for client and eval sends, while eval `start(message)` stays positional
- cross-channel and schedule `to(channel, target).send(message, options)`
- flat Slack `ctx.send(message, options)` and `ctx.respond(inputResponses, options)`
- the preserved Chat SDK bridge API: `send(input, { thread, ... })`
- channel lifecycle identity through `ctx.session.id`, with `session.failed.data.sessionId` outside session context
- singular, session-ID-only eve HTTP routes with follow-up delivery at `POST /eve/v1/session/:sessionId`
- JavaScript client, eval, TUI, runtime, race, and removal semantics

Related: #942, #216, #671.

### How did you test your changes?

- `pnpm exec oxfmt research/session-operations/unified-session-operations-proposal.md`
- `git diff --check`
- verified the required research frontmatter and final implementation shapes

No package tests or changeset are needed because this PR contains only the proposal document.

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not applicable)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)