### PR TITLE
feat(docs): document Svelte and Nuxt web chat setup

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -310,14 +310,26 @@ export default linearChannel({
   eve: {
     logo: "eve",
     docsHref: "/docs/channels/eve",
-    keywords: ["web", "chat", "ui", "embed", "frontend"],
+    keywords: [
+      "web",
+      "chat",
+      "ui",
+      "embed",
+      "frontend",
+      "next.js",
+      "svelte",
+      "sveltekit",
+      "nuxt",
+      "vue",
+      "react",
+    ],
     install: `The eve CLI scaffolds the full Next.js web chat app alongside \`agent/channels/eve.ts\`:
 
 \`\`\`bash
 eve add channel/web
 \`\`\`
 
-To wire it up by hand instead, install the framework:
+To wire it up by hand instead — including into a Svelte or Nuxt app you already have — install the framework:
 
 \`\`\`bash
 npm install eve@latest
@@ -331,8 +343,14 @@ import { eveChannel } from "eve/channels/eve";
 export default eveChannel();
 \`\`\`
 
-Point your frontend at the session routes eve serves (\`/eve/v1/session\`) and stream responses with the eve web client.`,
-    configure: `The eve channel is the lowest-friction way to talk to your agent, with no third-party provisioning required. Layer in auth and route protection as needed. See the [eve channel docs](/docs/channels/eve) and the [Frontend guide](/docs/guides/frontend/overview).`,
+Point your frontend at the session routes eve serves (\`/eve/v1/session\`) and stream responses with the eve web client. Next.js, Nuxt, and Svelte each have an integration that mounts those routes on your app's own origin, so there's no CORS to configure and no URL env var to keep in sync:
+
+- **Next.js.** Wrap \`next.config.ts\` with \`withEve()\` from \`eve/next\`, then call \`useEveAgent()\` from \`eve/react\`. See the [Next.js guide](/docs/guides/frontend/nextjs).
+- **Nuxt.** Add \`"eve/nuxt"\` to \`modules\` in \`nuxt.config.ts\`; the \`useEveAgent()\` composable from \`eve/vue\` is auto-imported. See the [Nuxt guide](/docs/guides/frontend/nuxt).
+- **Svelte.** Add the \`eveSvelteKit()\` Vite plugin before \`sveltekit()\` in \`vite.config.ts\`, then call \`useEveAgent()\` from \`eve/svelte\`. See the [SvelteKit guide](/docs/guides/frontend/sveltekit).
+
+On any other stack, wire it up by hand: run the agent as its own service and proxy \`/eve/v1/**\` to it, or pass its origin as \`host\` to \`useEveAgent()\` and enable \`cors\` on the channel. Server-side code and custom UIs can call the routes through \`Client\` from \`eve/client\`.`,
+    configure: `The eve channel is the lowest-friction way to talk to your agent, with no third-party provisioning required. Layer in auth and route protection as needed, and enable \`cors\` only when a browser reaches the channel from another origin. See the [eve channel docs](/docs/channels/eve), the [Frontend guide](/docs/guides/frontend/overview), and the per-framework guides for [Next.js](/docs/guides/frontend/nextjs), [Nuxt](/docs/guides/frontend/nuxt), and [SvelteKit](/docs/guides/frontend/sveltekit).`,
   },
   "chat-sdk-gchat": {
     logo: "googlechat",

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -32,6 +32,18 @@ describe("integration discovery", () => {
     expect(markdown).toContain("eve add channel/slack");
   });
 
+  it("renders the Web Chat setup for every host framework it documents", () => {
+    const web = getIntegration("eve");
+    expect(web).toBeDefined();
+
+    const markdown = integrationMarkdown(web!);
+    expect(markdown).toContain("eve add channel/web");
+    expect(markdown).toContain("/docs/guides/frontend/nextjs");
+    expect(markdown).toContain("/docs/guides/frontend/nuxt");
+    expect(markdown).toContain("/docs/guides/frontend/sveltekit");
+    expect(integrationSearchText(web!)).toContain("svelte");
+  });
+
   it("renders the Browserbase extension setup", () => {
     const browserbase = getIntegration("browserbase");
     expect(browserbase).toBeDefined();


### PR DESCRIPTION
### Description

The [Web Chat integration page](https://eve.dev/integrations/eve) described only two paths: the Next.js scaffold (`eve add channel/web`) and a generic "wire it up by hand" note. eve actually ships host-framework integrations for Nuxt (`eve/nuxt`) and SvelteKit (`eve/sveltekit`) alongside Next.js (`eve/next`), so the page under-sold its own support and never named Svelte or Nuxt — frameworks people search for.

This edits the Web Chat presentation overlay in `apps/docs/lib/integrations/data.ts`, which feeds both the rendered page and the agent-readable `/integrations/eve.md` variant:

- **Install** — the Next.js scaffold stays first and unchanged. The manual path now says it also covers adding web chat to a Svelte or Nuxt app you already have.
- **Quick start** — after the existing `agent/channels/eve.ts` snippet, a per-framework list names Next.js (`withEve()` + `useEveAgent()` from `eve/react`), Nuxt (`modules: ["eve/nuxt"]` + the auto-imported `eve/vue` composable), and Svelte (the `eveSvelteKit()` Vite plugin + `useEveAgent()` from `eve/svelte`), each linking to its existing frontend guide. It closes with the framework-agnostic fallback for any other stack: proxy `/eve/v1/**` to the agent, or pass `host` and enable `cors`; `Client` from `eve/client` for non-UI callers.
- **Configure** — adds links to the Next.js, Nuxt, and SvelteKit guides, and notes that `cors` is only needed for cross-origin browser callers.
- **Keywords** — `next.js`, `svelte`, `sveltekit`, `nuxt`, `vue`, `react` now feed the integration search index.

Formatting follows the page's existing style (prose + bold-labelled bullets, no new heading levels), since the gallery's markdown sections deliberately carry no headings of their own.

#### Why Nitro isn't listed

An earlier revision of this PR documented manual Nitro wiring, and it has been dropped as more confusing than helpful. There is no `eve/nitro` integration — the host-framework integrations are `eve/next`, `eve/nuxt`, and `eve/sveltekit` (see `EVE_FRAMEWORK_INTEGRATIONS` in `packages/eve/src/setup/vercel-project-framework.ts`). Nitro is eve's own internal server runtime rather than a host framework you mount eve into, so naming it beside the three real integrations implied support that doesn't exist. Nitro users are covered by the generic "any other stack" fallback.

### How did you test your changes?

```bash
pnpm --filter eve-docs test:unit   # 18 passed, including the new Web Chat markdown test
pnpm docs:check                    # 81 files validated, 259 import paths resolve
node ./scripts/guard-invariants.mjs
oxlint apps/docs/lib/integrations/ && oxfmt apps/docs/lib/integrations/{data.ts,discovery.test.ts}
```

`discovery.test.ts` gains a case asserting the Web Chat markdown keeps the `eve add channel/web` command and links all three frontend guides. Not run: `next build` for the docs site (the environment this was authored in has Node 22 and the repo requires 24), so the rendered page was not visually verified — the change is markdown content inside an existing `Markdown` section.

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted — no existing issue covers this; docs-only copy change, happy to open one if you'd like it tracked
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package — n/a, `apps/docs` only
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
