### PR TITLE
fix(eve): sandbox - batch Vercel workspace seed uploads

### DIFF
--- a/.changeset/fast-seeds-upload.md
+++ b/.changeset/fast-seeds-upload.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Upload Vercel sandbox workspace seed files in one compressed SDK request instead of one request per file, substantially reducing fresh template build times for large workspaces.

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -26,15 +26,17 @@ function createMockCommandResult() {
 /*
  * A detached command, as returned by `runCommand({ detached: true })`,
  * is adapted into the `Experimental_SandboxProcess` shape — the adapter
- * drains `logs()` alongside `wait()`. This mock yields no log lines and
- * exits 0 so `spawn` and `run` resolve without real I/O.
+ * drains `logs()` alongside `wait()`. By default this mock yields no log
+ * lines and exits 0 so `spawn` and `run` resolve without real I/O.
  */
-function createMockDetachedCommand() {
+function createMockDetachedCommand(
+  logs: ReadonlyArray<{ readonly data: string; readonly stream: "stderr" | "stdout" }> = [],
+) {
   return {
     kill: vi.fn().mockResolvedValue(undefined),
     logs() {
       return (async function* () {
-        yield* [];
+        yield* logs;
       })();
     },
     wait: vi.fn().mockResolvedValue({ exitCode: 0 }),
@@ -294,9 +296,17 @@ describe("createVercelSandbox", () => {
     ).rejects.toThrow(/The sandbox request is invalid/);
   });
 
-  it("writes /workspace seed paths through to the sandbox filesystem unchanged", async () => {
+  it("resolves and writes all seed paths to the sandbox filesystem in one batch", async () => {
     const templateSandbox = createMockSandbox({ name: "template" });
     const sessionSandbox = createMockSandbox({ name: "session" });
+    vi.mocked(templateSandbox.runCommand).mockImplementation(
+      async (options: { readonly detached?: boolean }) =>
+        options.detached === true
+          ? (createMockDetachedCommand([
+              { data: "/home/vercel-sandbox\n", stream: "stdout" },
+            ]) as never)
+          : createMockCommandResult(),
+    );
     const sandboxModule = {
       Sandbox: {
         create: vi
@@ -322,6 +332,14 @@ describe("createVercelSandbox", () => {
           content: "skill body",
           path: "/workspace/skills/weather/SKILL.md",
         },
+        {
+          content: Buffer.from([0, 1, 2, 3]),
+          path: "/workspace/assets/fixture.bin",
+        },
+        {
+          content: "model skill body",
+          path: "$HOME/.agents/skills/research/SKILL.md",
+        },
       ],
       templateKey: "template-key",
     });
@@ -341,13 +359,14 @@ describe("createVercelSandbox", () => {
     expect(templateSandbox.writeFiles).toHaveBeenCalledTimes(1);
 
     const files = vi.mocked(templateSandbox.writeFiles).mock.calls[0]?.[0];
-    expect(files).toHaveLength(1);
-    expect(files?.[0]).toEqual(
-      expect.objectContaining({
-        path: "/workspace/skills/weather/SKILL.md",
-      }),
-    );
-    expect(files?.[0]?.content).toBeInstanceOf(Buffer);
+    expect(files?.map((file) => file.path)).toEqual([
+      "/workspace/skills/weather/SKILL.md",
+      "/workspace/assets/fixture.bin",
+      "/home/vercel-sandbox/.agents/skills/research/SKILL.md",
+    ]);
+    expect(files?.[0]?.content).toEqual(Buffer.from("skill body"));
+    expect(files?.[1]?.content).toEqual(Buffer.from([0, 1, 2, 3]));
+    expect(files?.[2]?.content).toEqual(Buffer.from("model skill body"));
   });
 
   it("writes seed files before bootstrap and snapshots bootstrap outputs", async () => {
@@ -374,13 +393,20 @@ describe("createVercelSandbox", () => {
         });
       },
       runtimeContext: { appRoot: "/tmp/test-app-root" },
-      seedFiles: [{ content: "authored seed", path: "/workspace/seed.txt" }],
+      seedFiles: [
+        { content: "authored seed", path: "/workspace/seed.txt" },
+        { content: "second seed", path: "/workspace/second.txt" },
+      ],
       templateKey: "template-key",
     });
 
     const writes = vi.mocked(templateSandbox.writeFiles);
-    expect(writes.mock.calls.map(([files]) => files[0]?.path)).toEqual([
+    expect(writes).toHaveBeenCalledTimes(2);
+    expect(writes.mock.calls[0]?.[0].map((file) => file.path)).toEqual([
       "/workspace/seed.txt",
+      "/workspace/second.txt",
+    ]);
+    expect(writes.mock.calls[1]?.[0].map((file) => file.path)).toEqual([
       "/workspace/bootstrap.txt",
     ]);
     expect(writes.mock.invocationCallOrder[1]).toBeLessThan(

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -9,6 +9,7 @@ import type {
   SandboxProcess,
   SandboxReadFileOptions,
   SandboxRemovePathOptions,
+  SandboxSession,
   SandboxSpawnOptions,
   SandboxWriteFileOptions,
 } from "#shared/sandbox-session.js";
@@ -42,7 +43,7 @@ import {
 } from "#execution/sandbox/bindings/vercel-errors.js";
 import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
 import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
-import { writeSandboxSeedFiles } from "#execution/sandbox/bindings/local-backend-utils.js";
+import { resolveSandboxModelPath } from "#shared/skill-paths.js";
 import type {
   VercelCreateOptions,
   VercelModule,
@@ -320,7 +321,11 @@ async function ensureTemplate(input: EnsureTemplateInput): Promise<EnsureTemplat
     createVercelNetworkPolicySetter(sandbox),
   );
 
-  await writeSandboxSeedFiles(templateSession, input.seedFiles);
+  await writeVercelSandboxSeedFiles({
+    sandbox,
+    seedFiles: input.seedFiles,
+    session: templateSession,
+  });
 
   if (input.bootstrap !== undefined) {
     input.log?.("running sandbox bootstrap");
@@ -519,6 +524,28 @@ function createVercelInternalSandboxSession(
       });
     },
   };
+}
+
+async function writeVercelSandboxSeedFiles(input: {
+  readonly sandbox: VercelSandbox;
+  readonly seedFiles: ReadonlyArray<SandboxSeedFile>;
+  readonly session: SandboxSession;
+}): Promise<void> {
+  if (input.seedFiles.length === 0) {
+    return;
+  }
+
+  const files = await Promise.all(
+    input.seedFiles.map(async (file) => ({
+      content: typeof file.content === "string" ? Buffer.from(file.content) : file.content,
+      path: await resolveSandboxModelPath({
+        path: file.path,
+        sandbox: input.session,
+      }),
+    })),
+  );
+
+  await input.sandbox.writeFiles(files);
 }
 
 function resolveVercelSandboxPath(path: string): string {


### PR DESCRIPTION
## Summary

- upload all Vercel sandbox workspace and skill seed files through one multi-file SDK request during template prewarm
- preserve `$HOME` skill path resolution and text/binary content
- keep seed files available before bootstrap and snapshot capture, with focused regression coverage

Closes #1601

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/vercel.test.ts`