### PR TITLE
feat(eve): Add guided setup for Resend email channel

### DIFF
--- a/.changeset/fuzzy-melons-email.md
+++ b/.changeset/fuzzy-melons-email.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add guided Resend email setup through `eve add channel/resend`, with portable credentials or a generic Vercel Connect API-key connector, deployment, and webhook reconciliation.

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1057,10 +1057,10 @@ See the [Beeper Matrix adapter documentation](https://chat-sdk.dev/adapters/vend
       "transactional email",
       "attachments",
     ],
-    install: `Add this Chat SDK channel from eve's registry. This writes \`agent/channels/resend.ts\` and installs Chat SDK and its adapter dependencies:
+    install: `Run eve's guided setup. It can provision a generic Vercel Connect API-key connector, deploy the agent, and reconcile the Resend webhook, or scaffold portable environment credentials:
 
 \`\`\`bash
-eve add channel/chat-sdk-resend
+eve add channel/resend
 \`\`\``,
     quickStart: `Create \`agent/channels/resend.ts\`:
 

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1719,23 +1719,27 @@
       }
     },
     {
-      "name": "channel/chat-sdk-resend",
+      "name": "channel/resend",
       "type": "registry:item",
       "title": "Resend",
       "description": "Send and receive threaded email through Resend via the Chat SDK.",
-      "dependencies": ["chat", "@resend/chat-sdk-adapter", "@chat-adapter/state-memory"],
-      "envVars": {
-        "RESEND_API_KEY": "",
-        "RESEND_WEBHOOK_SECRET": "",
-        "RESEND_FROM_ADDRESS": ""
-      },
-      "files": [
-        {
-          "path": "registry/channels/chat-sdk-resend.ts",
-          "type": "registry:file",
-          "target": "agent/channels/resend.ts"
+      "dependencies": [
+        "chat",
+        "@resend/chat-sdk-adapter",
+        "@chat-adapter/state-memory",
+        "@vercel/connect"
+      ],
+      "meta": {
+        "eve": {
+          "setup": {
+            "command": "eve",
+            "package": "eve",
+            "bin": "eve",
+            "args": ["integration", "setup", "resend"]
+          },
+          "requires": ">=0.30.0"
         }
-      ]
+      }
     },
     {
       "name": "instrumentation/braintrust",

--- a/apps/docs/scripts/validate-channel-registry.ts
+++ b/apps/docs/scripts/validate-channel-registry.ts
@@ -31,12 +31,14 @@ interface Registry {
 const registrySlugsByCatalogSlug: Readonly<Record<string, string>> = {
   eve: "web",
   photon: "photon-imessage",
+  "chat-sdk-resend": "resend",
 };
 
 const setupKindsByCatalogSlug: Readonly<Record<string, string>> = {
   discord: "discord",
   eve: "web",
   photon: "photon",
+  "chat-sdk-resend": "resend",
 };
 
 const adapterDependenciesByCatalogSlug: Readonly<Record<string, string>> = {
@@ -115,7 +117,8 @@ for (const [index, item] of items.entries()) {
     entry.slug === "slack" ||
     entry.slug === "discord" ||
     entry.slug === "eve" ||
-    entry.slug === "photon"
+    entry.slug === "photon" ||
+    entry.slug === "chat-sdk-resend"
   ) {
     const expectedArgs = [
       "integration",

--- a/packages/eve/src/setup/integrations/registry.test.ts
+++ b/packages/eve/src/setup/integrations/registry.test.ts
@@ -38,6 +38,10 @@ describe("setup integrations", () => {
     });
   });
 
+  it("registers guided Resend setup", () => {
+    expect(setupIntegration("resend")).toMatchObject({ kind: "resend", label: "Resend" });
+  });
+
   it("rejects an unknown integration", () => {
     expect(() => setupIntegration("unknown")).toThrow(
       'Integration setup "unknown" is not available',

--- a/packages/eve/src/setup/integrations/registry.ts
+++ b/packages/eve/src/setup/integrations/registry.ts
@@ -1,5 +1,6 @@
 import { DISCORD_SETUP } from "./discord/setup.js";
 import { PHOTON_SETUP } from "./photon/setup.js";
+import { RESEND_SETUP } from "./resend/setup.js";
 import { SLACK_SETUP } from "./slack/setup.js";
 import type { SetupIntegration } from "./types.js";
 import { WEB_SETUP } from "./web/setup.js";
@@ -10,6 +11,7 @@ export const SETUP_INTEGRATIONS: readonly SetupIntegration[] = [
   SLACK_SETUP,
   DISCORD_SETUP,
   PHOTON_SETUP,
+  RESEND_SETUP,
 ];
 
 /** Resolves one built-in setup integration by its registry setup name. */

--- a/packages/eve/src/setup/integrations/resend/api.test.ts
+++ b/packages/eve/src/setup/integrations/resend/api.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createResendWebhook,
+  listResendWebhooks,
+  sameResendEndpoint,
+  validateResendApiKey,
+} from "./api.js";
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("Resend API", () => {
+  it("validates and lists webhooks without putting the key in the URL", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => response({ data: [] }));
+    await validateResendApiKey("re_secret", undefined, { fetch });
+    await listResendWebhooks("re_secret", undefined, { fetch });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[0]?.[0]).toBe("https://api.resend.com/webhooks");
+    expect(fetch.mock.calls[0]?.[1]).toMatchObject({
+      headers: { Authorization: "Bearer re_secret" },
+    });
+  });
+
+  it("creates only an email.received webhook", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      response({
+        data: {
+          id: "wh_1",
+          endpoint: "https://agent.test/eve/v1/resend",
+          events: ["email.received"],
+          signing_secret: "whsec_secret",
+        },
+      }),
+    );
+    await expect(
+      createResendWebhook("re_secret", "https://agent.test/eve/v1/resend", undefined, { fetch }),
+    ).resolves.toMatchObject({ id: "wh_1", signing_secret: "whsec_secret" });
+    expect(fetch.mock.calls[0]?.[1]?.body).toBe(
+      JSON.stringify({ endpoint: "https://agent.test/eve/v1/resend", events: ["email.received"] }),
+    );
+  });
+
+  it("normalizes exact endpoints without matching other paths", () => {
+    expect(
+      sameResendEndpoint("https://agent.test/eve/v1/resend/", "https://agent.test/eve/v1/resend"),
+    ).toBe(true);
+    expect(
+      sameResendEndpoint(
+        "https://agent.test/eve/v1/resend-old",
+        "https://agent.test/eve/v1/resend",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns an actionable authentication error without the key", async () => {
+    await expect(
+      validateResendApiKey("re_secret", undefined, {
+        fetch: async () => response({ message: "bad" }, 401),
+      }),
+    ).rejects.toThrow("full-access key");
+  });
+});

--- a/packages/eve/src/setup/integrations/resend/api.ts
+++ b/packages/eve/src/setup/integrations/resend/api.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+const RESEND_API_ORIGIN = "https://api.resend.com";
+const WebhookSchema = z.object({
+  id: z.string().min(1),
+  endpoint: z.string().url(),
+  events: z.array(z.string()).optional(),
+  signing_secret: z.string().min(1).optional(),
+});
+const WebhookListSchema = z.object({ data: z.array(WebhookSchema) });
+const CreatedWebhookSchema = z.object({
+  id: z.string().min(1),
+  signing_secret: z.string().min(1),
+});
+const WebhookResponseSchema = z.union([
+  CreatedWebhookSchema,
+  z.object({ data: CreatedWebhookSchema }),
+]);
+
+/** Resend webhook metadata used by guided setup. */
+export type ResendWebhook = z.infer<typeof WebhookSchema>;
+
+export interface ResendApiDeps {
+  fetch: typeof fetch;
+}
+
+function errorDetail(status: number): string {
+  if (status === 401 || status === 403) {
+    return "Resend rejected the API key. Use a full-access key and try again.";
+  }
+  return `Resend returned HTTP ${status}. Check Resend's status and try again.`;
+}
+
+async function request(
+  apiKey: string,
+  path: string,
+  init: RequestInit,
+  deps: ResendApiDeps,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+    if (init.body !== undefined) headers["Content-Type"] = "application/json";
+    response = await deps.fetch(`${RESEND_API_ORIGIN}${path}`, {
+      ...init,
+      headers,
+      signal: init.signal,
+    });
+  } catch {
+    throw new Error("Could not reach Resend. Check your network connection and try again.");
+  }
+  if (!response.ok) throw new Error(errorDetail(response.status));
+  if (response.status === 204) return undefined;
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new Error("Resend returned an invalid response.");
+  }
+}
+
+/** Validates a key with the bounded webhook-list endpoint. */
+export async function validateResendApiKey(
+  apiKey: string,
+  signal?: AbortSignal,
+  deps: ResendApiDeps = { fetch },
+): Promise<void> {
+  WebhookListSchema.parse(await request(apiKey, "/webhooks", { method: "GET", signal }, deps));
+}
+
+/** Lists account webhooks without exposing credentials in request URLs. */
+export async function listResendWebhooks(
+  apiKey: string,
+  signal?: AbortSignal,
+  deps: ResendApiDeps = { fetch },
+): Promise<ResendWebhook[]> {
+  const parsed = WebhookListSchema.safeParse(
+    await request(apiKey, "/webhooks", { method: "GET", signal }, deps),
+  );
+  if (!parsed.success) throw new Error("Resend returned an invalid webhook list.");
+  return parsed.data.data;
+}
+
+/** Creates an email.received webhook. */
+export async function createResendWebhook(
+  apiKey: string,
+  endpoint: string,
+  signal?: AbortSignal,
+  deps: ResendApiDeps = { fetch },
+): Promise<ResendWebhook> {
+  const parsed = WebhookResponseSchema.safeParse(
+    await request(
+      apiKey,
+      "/webhooks",
+      { method: "POST", body: JSON.stringify({ endpoint, events: ["email.received"] }), signal },
+      deps,
+    ),
+  );
+  if (!parsed.success) throw new Error("Resend returned an invalid webhook response.");
+  const created = "data" in parsed.data ? parsed.data.data : parsed.data;
+  return {
+    id: created.id,
+    endpoint,
+    events: ["email.received"],
+    signing_secret: created.signing_secret,
+  };
+}
+
+/** Deletes one setup-owned webhook by id. */
+export async function deleteResendWebhook(
+  apiKey: string,
+  webhookId: string,
+  signal?: AbortSignal,
+  deps: ResendApiDeps = { fetch },
+): Promise<void> {
+  await request(
+    apiKey,
+    `/webhooks/${encodeURIComponent(webhookId)}`,
+    { method: "DELETE", signal },
+    deps,
+  );
+}
+
+/** Compares webhook endpoints after URL normalization. */
+export function sameResendEndpoint(left: string, right: string): boolean {
+  try {
+    const normalize = (value: string) => {
+      const url = new URL(value);
+      url.hash = "";
+      if (url.pathname !== "/") url.pathname = url.pathname.replace(/\/+$/, "");
+      return url.href;
+    };
+    return normalize(left) === normalize(right);
+  } catch {
+    return false;
+  }
+}

--- a/packages/eve/src/setup/integrations/resend/connect.test.ts
+++ b/packages/eve/src/setup/integrations/resend/connect.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { provisionResendConnector, type ResendConnectDeps } from "./connect.js";
+
+function deps(list: unknown): ResendConnectDeps {
+  return {
+    captureVercel: vi.fn<ResendConnectDeps["captureVercel"]>(async () => ({
+      ok: true,
+      stdout: JSON.stringify(list),
+    })),
+    runVercel: vi.fn(async () => true),
+    runVercelCaptureStdout: vi.fn(async () => ({
+      ok: true,
+      stdout: JSON.stringify({
+        id: "scl_resend",
+        uid: "api-key/resend-agent",
+        type: "api-key",
+        service: "api.resend.com",
+        supportedSubjectTypes: ["app"],
+      }),
+    })),
+  };
+}
+
+function input(effects: ResendConnectDeps) {
+  return {
+    apiKey: "re_secret",
+    log: createFakePrompter().prompter.log,
+    project: { orgId: "team", projectId: "project" },
+    projectRoot: "/project",
+    slug: "resend-agent",
+    deps: effects,
+  };
+}
+
+describe("Resend Connect provisioning", () => {
+  it("creates with stdin secrets and attaches without triggers", async () => {
+    const effects = deps({ connectors: [] });
+    await provisionResendConnector(input(effects));
+
+    expect(effects.runVercelCaptureStdout).toHaveBeenCalledWith(
+      expect.arrayContaining(["--data", "@-", "--name", "resend-agent"]),
+      expect.objectContaining({
+        stdin: JSON.stringify({ values: [{ value: "re_secret" }] }),
+      }),
+    );
+    const argv = vi.mocked(effects.runVercelCaptureStdout).mock.calls[0]?.[0] ?? [];
+    expect(argv.join(" ")).not.toContain("re_secret");
+    expect(effects.runVercel).toHaveBeenCalledWith(
+      expect.not.arrayContaining(["--triggers"]),
+      expect.anything(),
+    );
+  });
+
+  it("reuses the deterministic compatible connector", async () => {
+    const effects = deps({
+      connectors: [
+        {
+          id: "scl_resend",
+          uid: "api-key/resend-agent",
+          type: "api-key",
+          service: "api.resend.com",
+          supportedSubjectTypes: ["app"],
+        },
+      ],
+    });
+    await expect(provisionResendConnector(input(effects))).resolves.toEqual({
+      id: "scl_resend",
+      uid: "api-key/resend-agent",
+    });
+    expect(effects.runVercelCaptureStdout).not.toHaveBeenCalled();
+  });
+
+  it("rejects an incompatible deterministic UID", async () => {
+    const effects = deps({
+      connectors: [
+        {
+          id: "scl_other",
+          uid: "api-key/resend-agent",
+          type: "oauth",
+          service: "other.example",
+        },
+      ],
+    });
+    await expect(provisionResendConnector(input(effects))).rejects.toThrow("not an API-key");
+  });
+});

--- a/packages/eve/src/setup/integrations/resend/connect.ts
+++ b/packages/eve/src/setup/integrations/resend/connect.ts
@@ -1,0 +1,151 @@
+import { createPromptCommandOutput, withPhase, type ChannelSetupLog } from "#setup/cli/index.js";
+import type { VercelProjectReference } from "#setup/project-resolution.js";
+import { captureVercel, runVercel, runVercelCaptureStdout } from "#setup/primitives/run-vercel.js";
+import { z } from "zod";
+
+const CONNECTOR_TYPE = "api-key";
+const SERVICE = "api.resend.com";
+
+const ConnectorSchema = z.object({
+  id: z.string().min(1),
+  uid: z.string().min(1),
+  type: z.string().optional(),
+  service: z.string().optional(),
+  supportedSubjectTypes: z.array(z.string()).optional(),
+});
+
+/** Identity of the generic API-key connector used for Resend. */
+export interface ResendConnectorRef {
+  id: string;
+  uid: string;
+}
+
+export interface ResendConnectDeps {
+  captureVercel: typeof captureVercel;
+  runVercel: typeof runVercel;
+  runVercelCaptureStdout: typeof runVercelCaptureStdout;
+}
+
+function connectorList(stdout: string): unknown[] {
+  try {
+    const body = JSON.parse(stdout) as { connectors?: unknown; clients?: unknown };
+    const connectors = body.connectors ?? body.clients;
+    return Array.isArray(connectors) ? connectors : [];
+  } catch {
+    throw new Error("Vercel returned an invalid connector list.");
+  }
+}
+
+function compatible(raw: z.infer<typeof ConnectorSchema>): boolean {
+  return (
+    (raw.type === undefined || raw.type === CONNECTOR_TYPE) &&
+    (raw.service === undefined || raw.service === SERVICE) &&
+    (raw.supportedSubjectTypes === undefined || raw.supportedSubjectTypes.includes("app"))
+  );
+}
+
+/** Creates or reuses the deterministic generic Connect connector and attaches it to production. */
+export async function provisionResendConnector(input: {
+  apiKey: string;
+  log: ChannelSetupLog;
+  project: VercelProjectReference;
+  projectRoot: string;
+  slug: string;
+  signal?: AbortSignal;
+  deps?: ResendConnectDeps;
+}): Promise<ResendConnectorRef> {
+  const deps = input.deps ?? { captureVercel, runVercel, runVercelCaptureStdout };
+  const uid = `${CONNECTOR_TYPE}/${input.slug}`;
+  const onOutput = createPromptCommandOutput(input.log);
+  const listed = await deps.captureVercel(["connect", "list", "-F", "json", "--all-projects"], {
+    cwd: input.projectRoot,
+    onOutput,
+    signal: input.signal,
+  });
+  if (!listed.ok) throw new Error("Could not inspect existing Vercel Connect connectors.");
+  const existingRaw = connectorList(listed.stdout).find(
+    (candidate) =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      (candidate as { uid?: unknown }).uid === uid,
+  );
+
+  let connector: ResendConnectorRef;
+  if (existingRaw !== undefined) {
+    const parsed = ConnectorSchema.safeParse(existingRaw);
+    if (!parsed.success || !compatible(parsed.data)) {
+      throw new Error(
+        `Connector ${uid} already exists but is not an API-key connector for ${SERVICE}. Choose a different agent name or remove the incompatible connector.`,
+      );
+    }
+    connector = { id: parsed.data.id, uid: parsed.data.uid };
+  } else {
+    const created = await withPhase(input.log, "Creating Resend connector...", () =>
+      deps.runVercelCaptureStdout(
+        [
+          "connect",
+          "create",
+          SERVICE,
+          "--connector-type",
+          CONNECTOR_TYPE,
+          "--data",
+          "@-",
+          "--name",
+          input.slug,
+          "-F",
+          "json",
+          "--scope",
+          input.project.orgId,
+        ],
+        {
+          cwd: input.projectRoot,
+          nonInteractive: true,
+          onOutput,
+          signal: input.signal,
+          stdin: JSON.stringify({ values: [{ value: input.apiKey }] }),
+        },
+      ),
+    );
+    if (!created.ok) throw new Error("Resend connector creation failed.");
+    let body: unknown;
+    try {
+      body = JSON.parse(created.stdout) as unknown;
+    } catch {
+      throw new Error("Vercel returned invalid JSON after creating the Resend connector.");
+    }
+    const parsed = ConnectorSchema.safeParse(body);
+    if (!parsed.success || !compatible(parsed.data)) {
+      throw new Error("Vercel returned an invalid Resend API-key connector.");
+    }
+    connector = { id: parsed.data.id, uid: parsed.data.uid };
+  }
+
+  const attached = await withPhase(input.log, "Attaching Resend credentials...", () =>
+    deps.runVercel(
+      [
+        "connect",
+        "attach",
+        connector.uid,
+        "--project",
+        input.project.projectId,
+        "--environment",
+        "production",
+        "--yes",
+        "--scope",
+        input.project.orgId,
+      ],
+      {
+        cwd: input.projectRoot,
+        nonInteractive: true,
+        onOutput,
+        signal: input.signal,
+      },
+    ),
+  );
+  if (!attached) {
+    throw new Error(
+      `Connector ${connector.uid} exists but could not be attached. Run \`vercel connect attach ${connector.uid} --project ${input.project.projectId} --environment production --yes --scope ${input.project.orgId}\`.`,
+    );
+  }
+  return connector;
+}

--- a/packages/eve/src/setup/integrations/resend/setup.test.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import type { Asker, Question } from "#setup/ask.js";
+import { integrationSetupEnvironment } from "../shared/environment.js";
+import { createIntegrationSetupUi } from "../shared/ui.js";
+import { setupResend, type ResendSetupDeps } from "./setup.js";
+
+function asker(answers: Record<string, string>): Asker {
+  return {
+    ask: async <T>(question: Question<T>) => answers[question.key] as T,
+    askMany: async () => [],
+  };
+}
+
+function deps(): ResendSetupDeps {
+  return {
+    appendEnv: vi.fn(async () => ({ written: [], skipped: [] })),
+    createWebhook: vi.fn(async () => ({
+      id: "wh_new",
+      endpoint: "https://agent.test/eve/v1/resend",
+      events: ["email.received"],
+      signing_secret: "whsec_secret",
+    })),
+    deleteWebhook: vi.fn(async () => {}),
+    deploy: vi
+      .fn()
+      .mockResolvedValueOnce({ kind: "deployed", productionUrl: "https://agent.test" })
+      .mockResolvedValueOnce({ kind: "deployed", productionUrl: "https://agent.test" }),
+    deriveConnectorSlug: vi.fn(async () => "agent" as never),
+    ensureVercelProject: vi.fn(async () => ({ orgId: "team", projectId: "project" })),
+    listWebhooks: vi.fn(async () => []),
+    provisionConnector: vi.fn(async () => ({
+      id: "scl_resend",
+      uid: "api-key/resend-agent",
+    })),
+    runVercel: vi.fn(async () => true),
+    validateApiKey: vi.fn(async () => {}),
+    writeTextFile: vi.fn(async () => {}),
+  };
+}
+
+function context(effects: ResendSetupDeps, select: "connect" | "portable" = "connect") {
+  const fake = createFakePrompter({ single: () => select });
+  return {
+    effects,
+    value: {
+      appRoot: "/project",
+      environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+      ui: createIntegrationSetupUi({
+        asker: asker({
+          "resend-api-key": "  re_secret  ",
+          "resend-from-address": "agent@example.com",
+          "resend-from-name": "Email Agent",
+        }),
+        prompter: fake.prompter,
+      }),
+    },
+  };
+}
+
+describe("Resend setup", () => {
+  it("uses one normalized key and orders deploy, webhook, env, and redeploy", async () => {
+    const effects = deps();
+    const events: string[] = [];
+    vi.mocked(effects.validateApiKey).mockImplementation(async (key) => {
+      events.push(`validate:${key}`);
+    });
+    vi.mocked(effects.provisionConnector).mockImplementation(async (input) => {
+      events.push(`connector:${input.apiKey}`);
+      return { id: "scl_resend", uid: "api-key/resend-agent" };
+    });
+    vi.mocked(effects.deploy).mockReset();
+    vi.mocked(effects.deploy).mockImplementation(async () => {
+      events.push("deploy");
+      return { kind: "deployed", productionUrl: "https://agent.test" };
+    });
+    vi.mocked(effects.createWebhook).mockImplementation(async (key) => {
+      events.push(`webhook:${key}`);
+      return {
+        id: "wh_new",
+        endpoint: "https://agent.test/eve/v1/resend",
+        signing_secret: "whsec_secret",
+      };
+    });
+    vi.mocked(effects.runVercel).mockImplementation(async (_args, options) => {
+      events.push(`env:${options.stdin}`);
+      return true;
+    });
+
+    const setup = context(effects);
+    await expect(setupResend(setup.value, effects)).resolves.toMatchObject({ kind: "done" });
+    expect(events).toEqual([
+      "validate:re_secret",
+      "connector:re_secret",
+      "deploy",
+      "webhook:re_secret",
+      "env:whsec_secret",
+      "deploy",
+    ]);
+    expect(effects.writeTextFile).toHaveBeenCalledWith(
+      "/project/agent/channels/resend.ts",
+      expect.stringContaining('getToken("api-key/resend-agent"'),
+      { force: undefined },
+    );
+  });
+
+  it("compensates a newly created webhook when saving the secret fails", async () => {
+    const effects = deps();
+    vi.mocked(effects.runVercel).mockResolvedValue(false);
+    const setup = context(effects);
+    await expect(setupResend(setup.value, effects)).rejects.toThrow("may persist");
+    expect(effects.deleteWebhook).toHaveBeenCalledWith("re_secret", "wh_new", undefined);
+  });
+
+  it("scaffolds portable environment credentials without Vercel effects", async () => {
+    const effects = deps();
+    const setup = context(effects, "portable");
+    await expect(setupResend(setup.value, effects)).resolves.toEqual({ kind: "done" });
+    expect(effects.appendEnv).toHaveBeenCalledWith("/project/.env.local", {
+      RESEND_API_KEY: "re_secret",
+    });
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+    expect(effects.writeTextFile).toHaveBeenCalledWith(
+      "/project/agent/channels/resend.ts",
+      expect.stringContaining("process.env.RESEND_API_KEY"),
+      { force: undefined },
+    );
+  });
+});

--- a/packages/eve/src/setup/integrations/resend/setup.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.ts
@@ -1,0 +1,284 @@
+import { join } from "node:path";
+
+import { text } from "#setup/ask.js";
+import { appendEnv } from "#setup/append-env.js";
+import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
+import { runDeployFlow } from "#setup/flows/deploy.js";
+import { deriveSlackConnectorSlug } from "#setup/scaffold/index.js";
+import { writeTextFile } from "#setup/scaffold/files.js";
+import { runVercel } from "#setup/primitives/run-vercel.js";
+import { WizardCancelledError } from "#setup/step.js";
+
+import type {
+  IntegrationSetupContext,
+  IntegrationSetupResult,
+  SetupIntegration,
+} from "../types.js";
+import {
+  createResendWebhook,
+  deleteResendWebhook,
+  listResendWebhooks,
+  sameResendEndpoint,
+  validateResendApiKey,
+} from "./api.js";
+import { provisionResendConnector } from "./connect.js";
+
+export interface ResendSetupDeps {
+  appendEnv: typeof appendEnv;
+  createWebhook: typeof createResendWebhook;
+  deleteWebhook: typeof deleteResendWebhook;
+  deploy: typeof runDeployFlow;
+  deriveConnectorSlug: typeof deriveSlackConnectorSlug;
+  ensureVercelProject: typeof ensureVercelProject;
+  listWebhooks: typeof listResendWebhooks;
+  provisionConnector: typeof provisionResendConnector;
+  runVercel: typeof runVercel;
+  validateApiKey: typeof validateResendApiKey;
+  writeTextFile: typeof writeTextFile;
+}
+
+const defaultDeps: ResendSetupDeps = {
+  appendEnv,
+  createWebhook: createResendWebhook,
+  deleteWebhook: deleteResendWebhook,
+  deploy: runDeployFlow,
+  deriveConnectorSlug: deriveSlackConnectorSlug,
+  ensureVercelProject,
+  listWebhooks: listResendWebhooks,
+  provisionConnector: provisionResendConnector,
+  runVercel,
+  validateApiKey: validateResendApiKey,
+  writeTextFile,
+};
+
+function validateEmail(value: string): string | null {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim()) ? null : "Enter a complete email address.";
+}
+
+function channelTemplate(input: {
+  apiKey: string;
+  connectorUid?: string;
+  fromAddress: string;
+  fromName: string;
+}): string {
+  const apiKey = input.connectorUid
+    ? `() => getToken(${JSON.stringify(input.connectorUid)}, { subject: { type: "app" } })`
+    : `() => {
+        const apiKey = process.env.RESEND_API_KEY;
+        if (!apiKey) throw new Error("RESEND_API_KEY is required.");
+        return Promise.resolve(apiKey);
+      }`;
+  return `import { createMemoryState } from "@chat-adapter/state-memory";
+import { createResendAdapter } from "@resend/chat-sdk-adapter";
+${input.connectorUid ? 'import { getToken } from "@vercel/connect";\n' : ""}import type { Message, Thread } from "chat";
+import { chatSdkChannel, messageToUserContent } from "eve/channels/chat-sdk";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: ${JSON.stringify(input.fromName || "Email Agent")},
+  adapters: {
+    resend: createResendAdapter({
+      apiKey: ${apiKey},
+      fromAddress: ${JSON.stringify(input.fromAddress)},
+      fromName: ${JSON.stringify(input.fromName || "Email Agent")},
+    }),
+  },
+  state: createMemoryState(),
+  streaming: false,
+});
+
+bot.onNewMention(async (thread: Thread, message: Message) => {
+  await thread.subscribe();
+  await send(messageToUserContent(message), { thread });
+});
+
+bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
+  await send(messageToUserContent(message), { thread });
+});
+
+export default channel;
+`;
+}
+
+async function chooseDestination(
+  context: IntegrationSetupContext,
+): Promise<"connect" | "portable"> {
+  if (context.yes) return "connect";
+  return context.ui.prompter.select<"connect" | "portable">({
+    message: "How would you like to configure Resend?",
+    options: [
+      {
+        value: "connect",
+        label: "Set up Vercel Connect",
+        hint: "Provision credentials, deploy, and configure the webhook",
+      },
+      {
+        value: "portable",
+        label: "Use portable credentials",
+        hint: "Store the API key locally and configure the webhook manually",
+      },
+    ],
+    initialValue: context.environment.vercel.kind === "available" ? "connect" : "portable",
+  });
+}
+
+async function writeProductionSecret(
+  context: IntegrationSetupContext,
+  secret: string,
+  deps: ResendSetupDeps,
+): Promise<void> {
+  const saved = await deps.runVercel(
+    ["env", "add", "RESEND_WEBHOOK_SECRET", "production", "--force", "--yes"],
+    {
+      cwd: context.appRoot,
+      nonInteractive: true,
+      signal: context.signal,
+      stdin: secret,
+    },
+  );
+  if (!saved) throw new Error("Could not save RESEND_WEBHOOK_SECRET to Vercel production.");
+}
+
+/** Runs guided Resend credential, deployment, webhook, and channel setup. */
+export async function setupResend(
+  context: IntegrationSetupContext,
+  deps: ResendSetupDeps = defaultDeps,
+): Promise<IntegrationSetupResult> {
+  try {
+    const destination = await chooseDestination(context);
+    if (destination === "connect" && context.environment.vercel.kind === "unavailable") {
+      throw new Error(
+        "Vercel Connect requires an authenticated Vercel CLI. Run `vercel login`, then retry Resend setup.",
+      );
+    }
+    const instructions = [
+      "Use a full-access Resend API key. Setup needs webhook access, and the adapter fetches received-email contents.",
+      "Create a key: https://resend.com/api-keys",
+    ];
+    if (context.ui.prompter.acknowledge) {
+      await context.ui.prompter.acknowledge({ message: "Resend API key", lines: instructions });
+    } else {
+      context.ui.prompter.log.info(instructions.join("\n"));
+    }
+    const apiKey = (
+      await context.ui.asker.ask(
+        text({ key: "resend-api-key", message: "Resend API key", required: true, sensitive: true }),
+      )
+    ).trim();
+    const fromAddress = (
+      await context.ui.asker.ask(
+        text({
+          key: "resend-from-address",
+          message: "From address",
+          required: true,
+          validate: validateEmail,
+        }),
+      )
+    ).trim();
+    const fromName = (
+      await context.ui.asker.ask(
+        text({ key: "resend-from-name", message: "From name (optional)", required: false }),
+      )
+    ).trim();
+    await deps.validateApiKey(apiKey, context.signal);
+
+    if (destination === "portable") {
+      await deps.appendEnv(join(context.appRoot, ".env.local"), { RESEND_API_KEY: apiKey });
+      await deps.appendEnv(join(context.appRoot, ".env.example"), {
+        RESEND_API_KEY: "",
+        RESEND_WEBHOOK_SECRET: "",
+      });
+      await deps.writeTextFile(
+        join(context.appRoot, "agent/channels/resend.ts"),
+        channelTemplate({ apiKey, fromAddress, fromName }),
+        { force: context.force },
+      );
+      context.ui.nextSteps([
+        "Deploy the agent and create a Resend webhook for https://<your-host>/eve/v1/resend subscribed only to email.received.",
+        "Store its signing secret as RESEND_WEBHOOK_SECRET in your host's encrypted environment variables.",
+      ]);
+      return { kind: "done" };
+    }
+
+    const project = await deps.ensureVercelProject({
+      appRoot: context.appRoot,
+      prompter: context.ui.prompter,
+      signal: context.signal,
+    });
+    const connector = await deps.provisionConnector({
+      apiKey,
+      log: context.ui.prompter.log,
+      project,
+      projectRoot: context.appRoot,
+      slug: `resend-${await deps.deriveConnectorSlug(context.appRoot)}`,
+      signal: context.signal,
+    });
+    try {
+      await deps.writeTextFile(
+        join(context.appRoot, "agent/channels/resend.ts"),
+        channelTemplate({ apiKey, connectorUid: connector.uid, fromAddress, fromName }),
+        { force: context.force },
+      );
+      const deployed = await deps.deploy({
+        appRoot: context.appRoot,
+        prompter: context.ui.prompter,
+        interactive: true,
+        signal: context.signal,
+      });
+      if (deployed.kind !== "deployed" || deployed.productionUrl === undefined) {
+        throw new Error(
+          `Connector ${connector.uid} is ready, but setup could not determine the production URL. Run \`vercel deploy --prod\`, then re-run Resend setup.`,
+        );
+      }
+      const endpoint = new URL("/eve/v1/resend", deployed.productionUrl).href;
+      const webhooks = await deps.listWebhooks(apiKey, context.signal);
+      const exact = webhooks.filter((webhook) => sameResendEndpoint(webhook.endpoint, endpoint));
+      let webhook = exact.find((candidate) => candidate.signing_secret !== undefined);
+      let created = false;
+      if (webhook === undefined) {
+        webhook = await deps.createWebhook(apiKey, endpoint, context.signal);
+        created = true;
+      }
+      try {
+        await writeProductionSecret(context, webhook.signing_secret!, deps);
+        const redeployed = await deps.deploy({
+          appRoot: context.appRoot,
+          prompter: context.ui.prompter,
+          interactive: true,
+          signal: context.signal,
+        });
+        if (redeployed.kind !== "deployed") throw new Error("Production redeploy was cancelled.");
+      } catch (error) {
+        if (created) await deps.deleteWebhook(apiKey, webhook.id, context.signal).catch(() => {});
+        throw error;
+      }
+      if (created) {
+        for (const previous of exact) {
+          if (previous.id !== webhook.id) {
+            await deps.deleteWebhook(apiKey, previous.id, context.signal).catch(() => {});
+          }
+        }
+      }
+      context.ui.nextSteps([
+        `Resend endpoint: ${endpoint}`,
+        `Send from ${fromAddress}; configure a receiving domain in Resend, then send an email and reply to smoke-test the thread.`,
+      ]);
+      return { kind: "done", facts: [{ label: "Resend webhook", value: endpoint, kind: "url" }] };
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${reason}\nResend connector ${connector.uid} may persist. Inspect it with \`vercel connect list\` and re-run \`eve add channel/resend\` to recover.`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof WizardCancelledError) return { kind: "cancelled" };
+    throw error;
+  }
+}
+
+/** Resend setup registration. */
+export const RESEND_SETUP: SetupIntegration = {
+  kind: "resend",
+  label: "Resend",
+  hint: "Threaded email through the Chat SDK",
+  setup: setupResend,
+};

--- a/research/resend-vercel-connect.md
+++ b/research/resend-vercel-connect.md
@@ -1,0 +1,215 @@
+---
+issue: TBD
+status: proposed
+last_updated: "2026-07-31"
+---
+
+# Resend email setup with a generic Connect API key
+
+## Recommendation
+
+Implement the initial Resend channel without a native `resend` Connect type.
+Use the existing generic `api-key` connector for the account credential, let
+eve setup create the Resend webhook on the user's behalf, and keep direct
+Resend signature verification in the official Chat SDK adapter.
+
+```text
+Resend ── Svix-signed email.received ──> eve /eve/v1/resend
+                                             │
+                                             │ app token
+                                             v
+                              generic Connect api-key connector
+                                             │
+                                             v
+                                         Resend API
+```
+
+This provides guided setup and Connect-managed outbound credentials now without
+competing with the planned Marketplace Native→Connect bridge. The bridge can
+later replace credential acquisition while the channel and webhook behavior
+remain unchanged.
+
+## Ownership
+
+- The generic Connect connector represents the Resend account API credential.
+  It stores one full-access `re_…` value as an app-scoped API-key token for
+  `api.resend.com`.
+- Resend calls the eve deployment directly. The official
+  `@resend/chat-sdk-adapter` owns Svix verification, received-email fetching,
+  attachments, threading, and delivery.
+- The Vercel project stores `RESEND_WEBHOOK_SECRET`. Setup creates and updates
+  it; it is not stored in the generic connector.
+- eve owns setup orchestration and generated channel code, not Resend account,
+  billing, domain, or DNS lifecycle.
+
+Recipient filtering stays in authored Chat SDK handlers. Resend receiving
+webhooks are account-wide and include the destination in the event payload.
+
+## Authoring result
+
+Setup writes `agent/channels/resend.ts` using the existing
+`chatSdkChannel`. The exact helper naming may follow the implementation landed
+in `@vercel/connect`, but the generated contract should be equivalent to:
+
+```ts
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createResendAdapter } from "@resend/chat-sdk-adapter";
+import { getToken } from "@vercel/connect";
+import type { Message, Thread } from "chat";
+import { chatSdkChannel, messageToUserContent } from "eve/channels/chat-sdk";
+
+const connector = "api-key/resend";
+
+export const { bot, channel, send } = chatSdkChannel({
+  userName: "Email Agent",
+  adapters: {
+    resend: createResendAdapter({
+      apiKey: () => getToken(connector, { subject: { type: "app" } }),
+      fromAddress: "agent@example.com",
+      fromName: "Email Agent",
+    }),
+  },
+  state: createMemoryState(),
+  streaming: false,
+});
+
+bot.onNewMention(async (thread: Thread, message: Message) => {
+  await thread.subscribe();
+  await send(messageToUserContent(message), { thread });
+});
+
+bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
+  await send(messageToUserContent(message), { thread });
+});
+
+export default channel;
+```
+
+Use a durable Chat SDK state adapter in production. Memory state is acceptable
+only as the generated local-development default.
+
+## Guided setup flow
+
+Register a `resend` setup integration in eve's setup integration registry,
+following Discord for orchestration and Photon for Connect/portable choices.
+The Connect path should:
+
+1. Require an authenticated Vercel CLI and ensure the directory is linked to a
+   Vercel project.
+2. Explain that the key needs full access because setup manages webhooks and the
+   adapter fetches received-email contents. Collect the key with a sensitive
+   prompt and trim it once.
+3. Collect `fromAddress` and optional `fromName`. These are application delivery
+   settings, not connector metadata.
+4. Validate the key with a bounded Resend request such as `GET /webhooks`. Map
+   authentication and provider failures to actionable errors without including
+   the key.
+5. Create or reuse a generic Connect API-key connector:
+   - `type: "api-key"`;
+   - `service: "api.resend.com"`;
+   - one unscoped value containing the full-access key;
+   - deterministic UID derived from the project/agent, not a hard-coded global
+     UID.
+     Send secret JSON through stdin (`--data @-`), never argv.
+6. Attach the connector to the linked project for production. Do not register a
+   Connect trigger destination; Resend calls eve directly.
+7. Add `chat`, `@resend/chat-sdk-adapter`, `@chat-adapter/state-memory`, and
+   `@vercel/connect`; scaffold the channel with the exact returned connector
+   UID.
+8. Deploy production so the canonical endpoint exists at
+   `https://<production-domain>/eve/v1/resend`.
+9. Reconcile the Resend webhook for that exact endpoint:
+   - list webhooks;
+   - leave unrelated endpoints untouched;
+   - reuse an exact match when its signing secret is available;
+   - otherwise create the replacement before deleting the old exact match;
+   - subscribe only to `email.received`.
+10. Save the returned signing secret as production
+    `RESEND_WEBHOOK_SECRET` through Vercel CLI stdin, then redeploy.
+11. Print the endpoint, sending address, receiving-domain guidance, and a
+    send/reply smoke test.
+
+If a failure occurs after connector creation, return recovery commands including
+the connector UID. Do not imply that persisted effects were rolled back.
+
+Offer a portable path that scaffolds the same channel with
+`RESEND_API_KEY` and `RESEND_WEBHOOK_SECRET` environment variables and explains
+manual webhook setup.
+
+## Idempotency and safety
+
+A rerun must not create duplicate connectors or webhooks. Resolve an existing
+connector by deterministic UID and verify it is an API-key connector for
+`api.resend.com` before reuse. Never overwrite an incompatible connector.
+
+Webhook reconciliation must compare normalized exact endpoint URLs and never
+delete manually created or unrelated webhooks. If a new webhook is created and
+saving its secret fails, delete that new webhook best-effort while preserving
+any previously working endpoint. Log only connector ID, webhook ID, and endpoint
+host/path—not credentials or signing secrets.
+
+The generated runtime resolves the API key lazily. Concurrent resolutions
+should share the Connect SDK's normal token caching, and a failed resolution
+must be retryable.
+
+## Required PR stack
+
+1. **Resend Chat SDK adapter** (`resend/resend-chat-sdk`): accept
+   `apiKey: string | () => Promise<string>` and resolve it for outbound sends
+   and received-email fetches. Preserve the existing `webhookSecret` path; no
+   custom Connect webhook verifier is needed in this design.
+2. **`@vercel/connect`** (`vercel/vercel`): optionally add a small typed
+   Resend/API-key config helper. Direct `getToken` is sufficient if the helper
+   would only rename arguments. Add tests for app subject, lazy resolution, and
+   exports.
+3. **eve** (`vercel/eve`): registry entry, setup coordinator, Resend API helper,
+   generic connector provisioning/attachment, webhook reconciliation,
+   scaffolding, package updates, tests, docs, and changeset.
+
+No `vercel/api` or Front change is required for the initial implementation;
+the generic API-key connector and existing Connect UI remain unchanged. The
+native Resend connector draft stack should not be a dependency of this plan.
+
+## Tests
+
+At minimum cover:
+
+- whitespace-padded key is normalized once and the same value reaches
+  validation, connector creation, and webhook setup;
+- secrets are sent on stdin and never argv/log output;
+- connector create versus deterministic-UID reuse;
+- incompatible existing connector rejection;
+- webhook exact-match reuse, create, replacement ordering, and compensation;
+- unrelated webhooks are untouched;
+- env write and redeploy ordering;
+- partial-failure recovery instructions;
+- generated source contains the returned UID and typechecks;
+- cancellation and unauthenticated Vercel behavior;
+- portable setup behavior;
+- packed eve package setup, `tsc --noEmit`, and `eve build` in a fresh fixture.
+
+## Future Marketplace bridge
+
+Do not read a Marketplace-provisioned API key back through project environment
+variables or copy it into Connect. The Native→Connect bridge under design lets
+the Marketplace provider create a confidential OAuth client and user-backed
+resource authorization, then supplies access/refresh tokens to Connect's app
+subject path.
+
+When that bridge ships, guided setup should offer Marketplace installation or
+resource selection ahead of the manual key path. The eventual managed flow may
+use a Marketplace-origin generic OAuth connector or a provider-specific trigger
+capability; coordinate that ownership before moving direct webhook verification
+into Connect. The manual generic API-key path remains useful for Resend accounts
+outside Marketplace.
+
+## Sources
+
+- [eve + Resend guide](https://vercel.com/kb/guide/eve-agent-with-resend)
+- [eve Chat SDK channel](https://eve.dev/docs/channels/chat-sdk)
+- [Resend Chat SDK adapter](https://chat-sdk.dev/adapters/vendor-official/resend)
+- [Receiving email](https://resend.com/docs/dashboard/receiving/introduction)
+- [Creating webhooks](https://resend.com/docs/api-reference/webhooks/create-webhook)
+- [Webhook verification](https://resend.com/docs/webhooks/verify-webhooks-requests)
+- [Vercel Marketplace integration](https://resend.com/docs/guides/vercel-marketplace-integration)
+- [Native→Connect bridge](https://app.notion.com/p/vercel/Native-Connect-bridge-3ace06b059c480508774c4813e1c4fe4)


### PR DESCRIPTION
## Summary

Adds guided Resend email setup through `eve add channel/resend`.

The flow can provision a generic Vercel Connect API-key connector, deploy the agent, reconcile an `email.received` webhook, save its signing secret, and redeploy. It also supports portable environment credentials and suggests `eve@<domain>` from a Resend domain with sending and receiving enabled.

## Dependencies

- Resend adapter lazy API-key support: resend/resend-chat-sdk#46
- `@vercel/connect` helper: vercel/vercel#17378

The adapter and Connect helper must be published before this eve change ships.

## Testing

- Resend setup/API/connector unit tests
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- `pnpm docs:check`
