### PR TITLE
feat(eve): use Connect Resend API key helper

### DIFF
--- a/packages/eve/src/setup/integrations/resend/api.test.ts
+++ b/packages/eve/src/setup/integrations/resend/api.test.ts
@@ -4,6 +4,7 @@ import {
   createResendWebhook,
   listResendWebhooks,
   sameResendEndpoint,
+  suggestResendFromAddress,
   validateResendApiKey,
 } from "./api.js";
 
@@ -22,6 +23,49 @@ describe("Resend API", () => {
     expect(fetch.mock.calls[0]?.[1]).toMatchObject({
       headers: { Authorization: "Bearer re_secret" },
     });
+  });
+
+  it("suggests eve on a custom receiving domain before the default Resend domain", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      response({
+        data: [
+          {
+            name: "phipelaan.resend.app",
+            capabilities: { sending: "enabled", receiving: "enabled" },
+          },
+          {
+            name: "example.com",
+            capabilities: { sending: "enabled", receiving: "enabled" },
+          },
+          {
+            name: "send-only.example",
+            capabilities: { sending: "enabled", receiving: "disabled" },
+          },
+        ],
+      }),
+    );
+
+    await expect(suggestResendFromAddress("re_secret", undefined, { fetch })).resolves.toBe(
+      "eve@example.com",
+    );
+    expect(fetch.mock.calls[0]?.[0]).toBe("https://api.resend.com/domains");
+  });
+
+  it("uses the default Resend receiving domain when no custom receiving domain exists", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      response({
+        data: [
+          {
+            name: "phipelaan.resend.app",
+            capabilities: { sending: "enabled", receiving: "enabled" },
+          },
+        ],
+      }),
+    );
+
+    await expect(suggestResendFromAddress("re_secret", undefined, { fetch })).resolves.toBe(
+      "eve@phipelaan.resend.app",
+    );
   });
 
   it("creates only an email.received webhook", async () => {

--- a/packages/eve/src/setup/integrations/resend/api.test.ts
+++ b/packages/eve/src/setup/integrations/resend/api.test.ts
@@ -51,7 +51,7 @@ describe("Resend API", () => {
     expect(fetch.mock.calls[0]?.[0]).toBe("https://api.resend.com/domains");
   });
 
-  it("uses the default Resend receiving domain when no custom receiving domain exists", async () => {
+  it("does not suggest the managed receiving-only Resend domain", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () =>
       response({
         data: [
@@ -63,9 +63,9 @@ describe("Resend API", () => {
       }),
     );
 
-    await expect(suggestResendFromAddress("re_secret", undefined, { fetch })).resolves.toBe(
-      "eve@phipelaan.resend.app",
-    );
+    await expect(
+      suggestResendFromAddress("re_secret", undefined, { fetch }),
+    ).resolves.toBeUndefined();
   });
 
   it("creates only an email.received webhook", async () => {

--- a/packages/eve/src/setup/integrations/resend/api.ts
+++ b/packages/eve/src/setup/integrations/resend/api.ts
@@ -91,7 +91,8 @@ export async function suggestResendFromAddress(
   );
   if (!parsed.success) throw new Error("Resend returned an invalid domain list.");
   const receivingDomains = parsed.data.data.filter(
-    (domain) => domain.capabilities?.receiving === "enabled",
+    (domain) =>
+      domain.capabilities?.receiving === "enabled" && domain.capabilities.sending === "enabled",
   );
   const domain =
     receivingDomains.find((candidate) => !candidate.name.endsWith(".resend.app")) ??

--- a/packages/eve/src/setup/integrations/resend/api.ts
+++ b/packages/eve/src/setup/integrations/resend/api.ts
@@ -94,9 +94,7 @@ export async function suggestResendFromAddress(
     (domain) =>
       domain.capabilities?.receiving === "enabled" && domain.capabilities.sending === "enabled",
   );
-  const domain =
-    receivingDomains.find((candidate) => !candidate.name.endsWith(".resend.app")) ??
-    receivingDomains[0];
+  const domain = receivingDomains.find((candidate) => !candidate.name.endsWith(".resend.app"));
   return domain === undefined ? undefined : `eve@${domain.name}`;
 }
 

--- a/packages/eve/src/setup/integrations/resend/api.ts
+++ b/packages/eve/src/setup/integrations/resend/api.ts
@@ -8,6 +8,19 @@ const WebhookSchema = z.object({
   signing_secret: z.string().min(1).optional(),
 });
 const WebhookListSchema = z.object({ data: z.array(WebhookSchema) });
+const DomainListSchema = z.object({
+  data: z.array(
+    z.object({
+      name: z.string().min(1),
+      capabilities: z
+        .object({
+          receiving: z.string(),
+          sending: z.string(),
+        })
+        .optional(),
+    }),
+  ),
+});
 const CreatedWebhookSchema = z.object({
   id: z.string().min(1),
   signing_secret: z.string().min(1),
@@ -65,6 +78,25 @@ export async function validateResendApiKey(
   deps: ResendApiDeps = { fetch },
 ): Promise<void> {
   WebhookListSchema.parse(await request(apiKey, "/webhooks", { method: "GET", signal }, deps));
+}
+
+/** Suggests an agent address on a receiving-enabled Resend domain. */
+export async function suggestResendFromAddress(
+  apiKey: string,
+  signal?: AbortSignal,
+  deps: ResendApiDeps = { fetch },
+): Promise<string | undefined> {
+  const parsed = DomainListSchema.safeParse(
+    await request(apiKey, "/domains", { method: "GET", signal }, deps),
+  );
+  if (!parsed.success) throw new Error("Resend returned an invalid domain list.");
+  const receivingDomains = parsed.data.data.filter(
+    (domain) => domain.capabilities?.receiving === "enabled",
+  );
+  const domain =
+    receivingDomains.find((candidate) => !candidate.name.endsWith(".resend.app")) ??
+    receivingDomains[0];
+  return domain === undefined ? undefined : `eve@${domain.name}`;
 }
 
 /** Lists account webhooks without exposing credentials in request URLs. */

--- a/packages/eve/src/setup/integrations/resend/setup.test.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.test.ts
@@ -35,7 +35,7 @@ function deps(): ResendSetupDeps {
       uid: "api-key/resend-agent",
     })),
     runVercel: vi.fn(async () => true),
-    suggestFromAddress: vi.fn(async () => "eve@phipelaan.resend.app"),
+    suggestFromAddress: vi.fn(async () => "eve@example.com"),
     validateApiKey: vi.fn(async () => {}),
     writeTextFile: vi.fn(async () => {}),
   };
@@ -61,7 +61,7 @@ function context(effects: ResendSetupDeps, select: "connect" | "portable" = "con
 }
 
 describe("Resend setup", () => {
-  it("prefills the agent address from a receiving-enabled Resend domain", async () => {
+  it("prefills the agent address from a send-and-receive custom Resend domain", async () => {
     const effects = deps();
     const questions: Question<unknown>[] = [];
     const setup = context(effects, "portable");
@@ -86,13 +86,29 @@ describe("Resend setup", () => {
     expect(questions).toContainEqual(
       expect.objectContaining({
         key: "resend-from-address",
-        detected: "eve@phipelaan.resend.app",
+        detected: "eve@example.com",
       }),
     );
     expect(effects.writeTextFile).toHaveBeenCalledWith(
       "/project/agent/channels/resend.ts",
-      expect.stringContaining('fromAddress: "eve@phipelaan.resend.app"'),
+      expect.stringContaining('fromAddress: "eve@example.com"'),
       { force: undefined },
+    );
+  });
+
+  it("warns when the account has no custom domain that can send and receive", async () => {
+    const effects = deps();
+    vi.mocked(effects.suggestFromAddress).mockResolvedValue(undefined);
+    const setup = context(effects, "portable");
+
+    await expect(setupResend(setup.value, effects)).resolves.toEqual({ kind: "done" });
+    expect(setup.value.ui.prompter.acknowledge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Resend sending domain required",
+        lines: expect.arrayContaining([
+          expect.stringContaining("*.resend.app domain receives email but cannot send replies"),
+        ]),
+      }),
     );
   });
 

--- a/packages/eve/src/setup/integrations/resend/setup.test.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.test.ts
@@ -35,6 +35,7 @@ function deps(): ResendSetupDeps {
       uid: "api-key/resend-agent",
     })),
     runVercel: vi.fn(async () => true),
+    suggestFromAddress: vi.fn(async () => "eve@phipelaan.resend.app"),
     validateApiKey: vi.fn(async () => {}),
     writeTextFile: vi.fn(async () => {}),
   };
@@ -60,6 +61,41 @@ function context(effects: ResendSetupDeps, select: "connect" | "portable" = "con
 }
 
 describe("Resend setup", () => {
+  it("prefills the agent address from a receiving-enabled Resend domain", async () => {
+    const effects = deps();
+    const questions: Question<unknown>[] = [];
+    const setup = context(effects, "portable");
+    const value = {
+      ...setup.value,
+      ui: {
+        ...setup.value.ui,
+        asker: {
+          ask: async <T>(question: Question<T>) => {
+            questions.push(question as Question<unknown>);
+            if (question.key === "resend-api-key") return "re_secret" as T;
+            if (question.key === "resend-from-name") return "Email Agent" as T;
+            return question.detected as T;
+          },
+          askMany: async () => [],
+        },
+      },
+    };
+
+    await expect(setupResend(value, effects)).resolves.toEqual({ kind: "done" });
+    expect(effects.suggestFromAddress).toHaveBeenCalledWith("re_secret", undefined);
+    expect(questions).toContainEqual(
+      expect.objectContaining({
+        key: "resend-from-address",
+        detected: "eve@phipelaan.resend.app",
+      }),
+    );
+    expect(effects.writeTextFile).toHaveBeenCalledWith(
+      "/project/agent/channels/resend.ts",
+      expect.stringContaining('fromAddress: "eve@phipelaan.resend.app"'),
+      { force: undefined },
+    );
+  });
+
   it("uses one normalized key and orders deploy, webhook, env, and redeploy", async () => {
     const effects = deps();
     const events: string[] = [];

--- a/packages/eve/src/setup/integrations/resend/setup.test.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.test.ts
@@ -118,14 +118,12 @@ describe("Resend setup", () => {
     };
 
     await expect(setupResend(value, effects)).resolves.toEqual({ kind: "done" });
-    expect(setup.value.ui.prompter.acknowledge).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "No custom Resend sending domain found",
-        lines: expect.arrayContaining([
-          expect.stringContaining("*.resend.app domain receives email but cannot send replies"),
-          expect.stringContaining("onboarding@resend.dev is prefilled"),
-        ]),
-      }),
+    expect(setup.value.ui.prompter.note).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /\*\.resend\.app domain receives email but cannot send replies[\s\S]*onboarding@resend\.dev is prefilled/,
+      ),
+      "Warning: No custom Resend sending domain found",
+      { tone: "warning" },
     );
     expect(questions).toContainEqual(
       expect.objectContaining({

--- a/packages/eve/src/setup/integrations/resend/setup.test.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.test.ts
@@ -100,7 +100,7 @@ describe("Resend setup", () => {
     ]);
     expect(effects.writeTextFile).toHaveBeenCalledWith(
       "/project/agent/channels/resend.ts",
-      expect.stringContaining('getToken("api-key/resend-agent"'),
+      expect.stringContaining('connectResendApiKey("api-key/resend-agent")'),
       { force: undefined },
     );
   });

--- a/packages/eve/src/setup/integrations/resend/setup.test.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.test.ts
@@ -100,15 +100,43 @@ describe("Resend setup", () => {
     const effects = deps();
     vi.mocked(effects.suggestFromAddress).mockResolvedValue(undefined);
     const setup = context(effects, "portable");
+    const questions: Question<unknown>[] = [];
+    const value = {
+      ...setup.value,
+      ui: {
+        ...setup.value.ui,
+        asker: {
+          ask: async <T>(question: Question<T>) => {
+            questions.push(question as Question<unknown>);
+            if (question.key === "resend-api-key") return "re_secret" as T;
+            if (question.key === "resend-from-name") return "Email Agent" as T;
+            return question.detected as T;
+          },
+          askMany: async () => [],
+        },
+      },
+    };
 
-    await expect(setupResend(setup.value, effects)).resolves.toEqual({ kind: "done" });
+    await expect(setupResend(value, effects)).resolves.toEqual({ kind: "done" });
     expect(setup.value.ui.prompter.acknowledge).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Resend sending domain required",
+        message: "No custom Resend sending domain found",
         lines: expect.arrayContaining([
           expect.stringContaining("*.resend.app domain receives email but cannot send replies"),
+          expect.stringContaining("onboarding@resend.dev is prefilled"),
         ]),
       }),
+    );
+    expect(questions).toContainEqual(
+      expect.objectContaining({
+        key: "resend-from-address",
+        detected: "onboarding@resend.dev",
+      }),
+    );
+    expect(effects.writeTextFile).toHaveBeenCalledWith(
+      "/project/agent/channels/resend.ts",
+      expect.stringContaining('fromAddress: "onboarding@resend.dev"'),
+      { force: undefined },
     );
   });
 

--- a/packages/eve/src/setup/integrations/resend/setup.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.ts
@@ -177,14 +177,11 @@ export async function setupResend(
         "For real conversations, add and verify a custom sending domain in Resend, then enter an address on that domain.",
         "Configure domains: https://resend.com/domains",
       ];
-      if (context.ui.prompter.acknowledge) {
-        await context.ui.prompter.acknowledge({
-          message: "No custom Resend sending domain found",
-          lines: senderInstructions,
-        });
-      } else {
-        context.ui.prompter.log.warning(senderInstructions.join("\n"));
-      }
+      context.ui.prompter.note(
+        senderInstructions.join("\n"),
+        "Warning: No custom Resend sending domain found",
+        { tone: "warning" },
+      );
     }
     const fromAddressQuestion = text({
       key: "resend-from-address",

--- a/packages/eve/src/setup/integrations/resend/setup.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.ts
@@ -169,37 +169,30 @@ export async function setupResend(
     ).trim();
     await deps.validateApiKey(apiKey, context.signal);
     const suggestedFromAddress = await deps.suggestFromAddress(apiKey, context.signal);
+    const defaultFromAddress = suggestedFromAddress ?? "onboarding@resend.dev";
     if (suggestedFromAddress === undefined) {
       const senderInstructions = [
         "Resend's managed *.resend.app domain receives email but cannot send replies.",
-        "Add and verify a custom sending domain in Resend, then enter an address on that domain.",
-        "For a limited test, onboarding@resend.dev can send only to your Resend account email and may not preserve normal reply behavior.",
+        "For this test, onboarding@resend.dev is prefilled. It can send only to your Resend account email, may go to spam, and may not preserve normal reply behavior.",
+        "For real conversations, add and verify a custom sending domain in Resend, then enter an address on that domain.",
         "Configure domains: https://resend.com/domains",
       ];
       if (context.ui.prompter.acknowledge) {
         await context.ui.prompter.acknowledge({
-          message: "Resend sending domain required",
+          message: "No custom Resend sending domain found",
           lines: senderInstructions,
         });
       } else {
         context.ui.prompter.log.warning(senderInstructions.join("\n"));
       }
     }
-    const fromAddressQuestion =
-      suggestedFromAddress === undefined
-        ? text({
-            key: "resend-from-address",
-            message: "Agent email address",
-            required: true,
-            validate: validateEmail,
-          })
-        : text({
-            key: "resend-from-address",
-            message: "Agent email address",
-            detected: suggestedFromAddress,
-            required: true,
-            validate: validateEmail,
-          });
+    const fromAddressQuestion = text({
+      key: "resend-from-address",
+      message: "Agent email address",
+      detected: defaultFromAddress,
+      required: true,
+      validate: validateEmail,
+    });
     const fromAddress = (await context.ui.asker.ask(fromAddressQuestion)).trim();
     const fromName = (
       await context.ui.asker.ask(

--- a/packages/eve/src/setup/integrations/resend/setup.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.ts
@@ -19,6 +19,7 @@ import {
   deleteResendWebhook,
   listResendWebhooks,
   sameResendEndpoint,
+  suggestResendFromAddress,
   validateResendApiKey,
 } from "./api.js";
 import { provisionResendConnector } from "./connect.js";
@@ -33,6 +34,7 @@ export interface ResendSetupDeps {
   listWebhooks: typeof listResendWebhooks;
   provisionConnector: typeof provisionResendConnector;
   runVercel: typeof runVercel;
+  suggestFromAddress: typeof suggestResendFromAddress;
   validateApiKey: typeof validateResendApiKey;
   writeTextFile: typeof writeTextFile;
 }
@@ -47,6 +49,7 @@ const defaultDeps: ResendSetupDeps = {
   listWebhooks: listResendWebhooks,
   provisionConnector: provisionResendConnector,
   runVercel,
+  suggestFromAddress: suggestResendFromAddress,
   validateApiKey: validateResendApiKey,
   writeTextFile,
 };
@@ -164,22 +167,29 @@ export async function setupResend(
         text({ key: "resend-api-key", message: "Resend API key", required: true, sensitive: true }),
       )
     ).trim();
-    const fromAddress = (
-      await context.ui.asker.ask(
-        text({
-          key: "resend-from-address",
-          message: "From address",
-          required: true,
-          validate: validateEmail,
-        }),
-      )
-    ).trim();
+    await deps.validateApiKey(apiKey, context.signal);
+    const suggestedFromAddress = await deps.suggestFromAddress(apiKey, context.signal);
+    const fromAddressQuestion =
+      suggestedFromAddress === undefined
+        ? text({
+            key: "resend-from-address",
+            message: "Agent email address",
+            required: true,
+            validate: validateEmail,
+          })
+        : text({
+            key: "resend-from-address",
+            message: "Agent email address",
+            detected: suggestedFromAddress,
+            required: true,
+            validate: validateEmail,
+          });
+    const fromAddress = (await context.ui.asker.ask(fromAddressQuestion)).trim();
     const fromName = (
       await context.ui.asker.ask(
         text({ key: "resend-from-name", message: "From name (optional)", required: false }),
       )
     ).trim();
-    await deps.validateApiKey(apiKey, context.signal);
 
     if (destination === "portable") {
       await deps.appendEnv(join(context.appRoot, ".env.local"), { RESEND_API_KEY: apiKey });

--- a/packages/eve/src/setup/integrations/resend/setup.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.ts
@@ -169,6 +169,22 @@ export async function setupResend(
     ).trim();
     await deps.validateApiKey(apiKey, context.signal);
     const suggestedFromAddress = await deps.suggestFromAddress(apiKey, context.signal);
+    if (suggestedFromAddress === undefined) {
+      const senderInstructions = [
+        "Resend's managed *.resend.app domain receives email but cannot send replies.",
+        "Add and verify a custom sending domain in Resend, then enter an address on that domain.",
+        "For a limited test, onboarding@resend.dev can send only to your Resend account email and may not preserve normal reply behavior.",
+        "Configure domains: https://resend.com/domains",
+      ];
+      if (context.ui.prompter.acknowledge) {
+        await context.ui.prompter.acknowledge({
+          message: "Resend sending domain required",
+          lines: senderInstructions,
+        });
+      } else {
+        context.ui.prompter.log.warning(senderInstructions.join("\n"));
+      }
+    }
     const fromAddressQuestion =
       suggestedFromAddress === undefined
         ? text({

--- a/packages/eve/src/setup/integrations/resend/setup.ts
+++ b/packages/eve/src/setup/integrations/resend/setup.ts
@@ -62,7 +62,7 @@ function channelTemplate(input: {
   fromName: string;
 }): string {
   const apiKey = input.connectorUid
-    ? `() => getToken(${JSON.stringify(input.connectorUid)}, { subject: { type: "app" } })`
+    ? `connectResendApiKey(${JSON.stringify(input.connectorUid)})`
     : `() => {
         const apiKey = process.env.RESEND_API_KEY;
         if (!apiKey) throw new Error("RESEND_API_KEY is required.");
@@ -70,7 +70,7 @@ function channelTemplate(input: {
       }`;
   return `import { createMemoryState } from "@chat-adapter/state-memory";
 import { createResendAdapter } from "@resend/chat-sdk-adapter";
-${input.connectorUid ? 'import { getToken } from "@vercel/connect";\n' : ""}import type { Message, Thread } from "chat";
+${input.connectorUid ? 'import { connectResendApiKey } from "@vercel/connect/eve";\n' : ""}import type { Message, Thread } from "chat";
 import { chatSdkChannel, messageToUserContent } from "eve/channels/chat-sdk";
 
 export const { bot, channel, send } = chatSdkChannel({


### PR DESCRIPTION
## Summary

Updates the Resend guided setup introduced by #1603 to generate `connectResendApiKey(...)` from `@vercel/connect/eve` instead of spelling out the app-scoped `getToken(...)` request.

This depends on the new `@vercel/connect` helper in vercel/vercel#17378 being published before this eve change ships.

## Generated code

```ts
import { connectResendApiKey } from "@vercel/connect/eve";

createResendAdapter({
  apiKey: connectResendApiKey("api-key/resend-my-agent"),
  fromAddress: "agent@example.com",
});
```

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/resend/setup.test.ts`
- `pnpm --filter eve typecheck`
