### PR TITLE
fix(eve): gate localDev() on NODE_ENV

### DIFF
--- a/.changeset/local-dev-node-env.md
+++ b/.changeset/local-dev-node-env.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`localDev()` now recognizes a local development server by `NODE_ENV=development` (set by `eve dev`) or a `vercel dev` session instead of `EVE_DEV`. `eve start` and directly launched built servers default to `NODE_ENV=production`, so the synthetic local-dev principal is never granted on a production deployment. An explicit `NODE_ENV` in the environment is still respected.

--- a/.github/workflows/e2e-postgres.yml
+++ b/.github/workflows/e2e-postgres.yml
@@ -151,7 +151,7 @@ jobs:
           pnpm exec eve build
 
           server_log="$EVE_EVAL_JUNIT_DIR/${{ matrix.name }}-server.log"
-          EVE_DEV=1 pnpm exec eve start --host 127.0.0.1 --port 3000 >"$server_log" 2>&1 &
+          NODE_ENV=development pnpm exec eve start --host 127.0.0.1 --port 3000 >"$server_log" 2>&1 &
           server_pid=$!
 
           cleanup() {

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -86,15 +86,15 @@ Any other thrown error follows the normal channel failure path. When building a 
 
 `eve/channels/auth` ships these channel-auth helpers:
 
-| Helper           | Use when                                                                                           |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| `localDev()`     | Local development. Accepts requests only while the process is an `eve dev` or `vercel dev` server. |
-| `vercelOidc()`   | The common Vercel deployment path. Verifies a Vercel OIDC bearer JWT.                              |
-| `none()`         | You want to accept anonymous traffic explicitly (use as the final entry).                          |
-| `httpBasic(...)` | Operator or service access via a shared username/password.                                         |
-| `jwtHmac(...)`   | You control a shared-secret JWT signer.                                                            |
-| `jwtEcdsa(...)`  | You verify asymmetric JWTs minted by another system.                                               |
-| `oidc(...)`      | You want eve to verify OIDC-issued tokens from an arbitrary issuer.                                |
+| Helper           | Use when                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| `localDev()`     | Local development. Accepts requests only on a development server (`NODE_ENV=development`). |
+| `vercelOidc()`   | The common Vercel deployment path. Verifies a Vercel OIDC bearer JWT.                      |
+| `none()`         | You want to accept anonymous traffic explicitly (use as the final entry).                  |
+| `httpBasic(...)` | Operator or service access via a shared username/password.                                 |
+| `jwtHmac(...)`   | You control a shared-secret JWT signer.                                                    |
+| `jwtEcdsa(...)`  | You verify asymmetric JWTs minted by another system.                                       |
+| `oidc(...)`      | You want eve to verify OIDC-issued tokens from an arbitrary issuer.                        |
 
 `httpBasic(credentials, { realm })` accepts an optional `realm`, rendered on the `WWW-Authenticate: Basic` challenge (e.g. `Basic realm="agent", charset="UTF-8"`) so browsers label their native login prompt. It defaults to `"eve"`, ensuring every Basic challenge includes the required realm. Usernames and passwords are normalized to Unicode NFC before comparison, matching the advertised UTF-8 credential encoding.
 
@@ -102,7 +102,7 @@ Exercise caution for agents that process non-public, sensitive, regulated, or pr
 
 ### `localDev()`
 
-Authenticates a synthetic `local-dev` principal, but only while the process is a local development server: `eve dev` (which sets `EVE_DEV=1`) or `vercel dev` (detected by `VERCEL=1` and `VERCEL_ENV=development` together). This is a property of the deployment, not the request, so no request header can flip it. A production deployment (`eve start`, a Vercel deployment, or any container host) sets neither flag, so `localDev()` authenticates nothing there and every request falls through to the next entry.
+Authenticates a synthetic `local-dev` principal, but only on a local development server: `NODE_ENV=development` (set by `eve dev` and by `vercel dev`). This is a property of the deployment, not the request, so no request header can flip it. A production deployment (`eve start`, a Vercel deployment, or any container host) runs with `NODE_ENV=production`, so `localDev()` authenticates nothing there and every request falls through to the next entry.
 
 Because it never opens a production deployment, `localDev()` is safe to leave in the walk. Still put a real authenticator ahead of it so production traffic has something to match.
 

--- a/packages/eve/src/cli/dev/local-server-process.ts
+++ b/packages/eve/src/cli/dev/local-server-process.ts
@@ -25,6 +25,7 @@ import { fork, type ChildProcess } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
+import { defaultNodeEnv } from "#internal/application/dev-environment.js";
 import { EVE_DEV_ENV_FLAG } from "#internal/application/optional-package-install.js";
 import type {
   DevelopmentServer,
@@ -88,6 +89,7 @@ export function createDevelopmentServer(
     const shellEnvironment = { ...process.env };
     loadDevelopmentEnvironmentFiles(appRoot);
     process.env[EVE_DEV_ENV_FLAG] ??= "1";
+    defaultNodeEnv("development");
     const spawned = fork(
       childPath,
       [
@@ -100,7 +102,11 @@ export function createDevelopmentServer(
       {
         cwd: appRoot,
         detached: true,
-        env: { ...shellEnvironment, [EVE_DEV_ENV_FLAG]: "1" },
+        env: {
+          ...shellEnvironment,
+          [EVE_DEV_ENV_FLAG]: "1",
+          NODE_ENV: shellEnvironment.NODE_ENV ?? "development",
+        },
         stdio: ["ignore", "pipe", "pipe", "ipc"],
       },
     );

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -253,7 +253,9 @@ function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Comm
     .option("--port <port>", "Port to listen on (defaults to $PORT, then 3000)", parsePortOption)
     .action(async (options: ProductionCliOptions) => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
+      const { defaultNodeEnv } = await import("#internal/application/dev-environment.js");
 
+      defaultNodeEnv("production");
       loadDevelopmentEnvironmentFiles(appRoot);
 
       const startProductionHost = runtime.startProductionHost ?? (await loadStartProductionHost());

--- a/packages/eve/src/internal/application/dev-environment.ts
+++ b/packages/eve/src/internal/application/dev-environment.ts
@@ -5,3 +5,14 @@ export const EVE_DEV_ENV_FLAG = "EVE_DEV";
 export function isEveDevEnvironment(): boolean {
   return process.env[EVE_DEV_ENV_FLAG] === "1";
 }
+
+/**
+ * Sets `NODE_ENV` to `mode` when it has no non-empty value, leaving an
+ * operator's explicit value untouched.
+ */
+export function defaultNodeEnv(mode: "development" | "production"): void {
+  const env = process.env as Record<string, string | undefined>;
+  if (!env.NODE_ENV) {
+    env.NODE_ENV = mode;
+  }
+}

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -649,6 +649,12 @@ describe("application Nitro creation", () => {
     expect(devPlugins).not.toEqual(
       expect.arrayContaining([expect.stringContaining("sandbox-shutdown-plugin.ts")]),
     );
+    expect(productionPlugins).toEqual(
+      expect.arrayContaining([expect.stringContaining("production-node-env-plugin.ts")]),
+    );
+    expect(devPlugins).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("production-node-env-plugin.ts")]),
+    );
   });
 
   it("deduplicates defaults when the app also lists them", async () => {

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -797,6 +797,9 @@ export async function createProductionApplicationNitro(
   const preset = resolveProductionNitroPreset();
   const bundler = createApplicationNitroBundlerConfiguration(preparedHost, preset);
   const nitroPlugins = createApplicationNitroPlugins(preparedHost);
+  nitroPlugins.unshift(
+    resolvePackageSourceFilePath("src/internal/nitro/host/production-node-env-plugin.ts"),
+  );
   nitroPlugins.push(
     resolvePackageSourceFilePath("src/internal/nitro/host/sandbox-shutdown-plugin.ts"),
   );

--- a/packages/eve/src/internal/nitro/host/production-node-env-plugin.test.ts
+++ b/packages/eve/src/internal/nitro/host/production-node-env-plugin.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import productionNodeEnvPlugin from "#internal/nitro/host/production-node-env-plugin.js";
+
+describe("productionNodeEnvPlugin", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults NODE_ENV to production when unset", () => {
+    vi.stubEnv("NODE_ENV", undefined);
+    productionNodeEnvPlugin();
+    expect(process.env.NODE_ENV).toBe("production");
+  });
+
+  it("leaves an explicit NODE_ENV untouched", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    productionNodeEnvPlugin();
+    expect(process.env.NODE_ENV).toBe("development");
+  });
+});

--- a/packages/eve/src/internal/nitro/host/production-node-env-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/production-node-env-plugin.ts
@@ -1,0 +1,10 @@
+import { defaultNodeEnv } from "#internal/application/dev-environment.js";
+
+/**
+ * Defaults `NODE_ENV` to `production` at server boot for a built server
+ * launched directly (for example `node .output/server/index.mjs`) rather than
+ * through `eve start`. An explicit `NODE_ENV` is left untouched.
+ */
+export default function productionNodeEnvPlugin(): void {
+  defaultNodeEnv("production");
+}

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -1,3 +1,4 @@
+import { defaultNodeEnv } from "#internal/application/dev-environment.js";
 import { EVE_DEV_ENV_FLAG } from "#internal/application/optional-package-install.js";
 
 import type { Nitro } from "nitro/types";
@@ -368,6 +369,7 @@ async function startNitroDevelopmentServer(
   // that must never run in production (for example auto-installing
   // optional sandbox engine packages) can gate on it.
   process.env[EVE_DEV_ENV_FLAG] ??= "1";
+  defaultNodeEnv("development");
 
   const project = await resolveDiscoveryProject(rootDir);
   loadDevelopmentEnvironmentFiles(project.appRoot);

--- a/packages/eve/src/internal/nitro/host/start-production-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-production-server.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
+import { defaultNodeEnv } from "#internal/application/dev-environment.js";
 import { prewarmBuiltAppSandboxes } from "#execution/sandbox/prewarm.js";
 import { EVE_HEALTH_ROUTE_PATH } from "#protocol/routes.js";
 import type { ProductionServerHandle } from "#internal/nitro/host/types.js";
@@ -240,6 +241,8 @@ export async function startProductionServer(
     );
   }
 
+  // Default before loading env files so a committed .env cannot flip the mode.
+  defaultNodeEnv("production");
   loadDevelopmentEnvironmentFiles(appRoot);
   await prewarmBuiltAppSandboxes({
     appRoot,

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -324,7 +324,7 @@ describe("none", () => {
 });
 
 describe("localDev", () => {
-  // `localDev()` keys off the deployment (an `eve dev` or `vercel dev`
+  // `localDev()` keys off the deployment (`NODE_ENV` or a `vercel dev`
   // process), never the inbound request. A spoofable request header such as
   // `Host` must not be able to authenticate the local-dev principal.
   function requestFor(url: string): Request {
@@ -335,8 +335,8 @@ describe("localDev", () => {
     vi.unstubAllEnvs();
   });
 
-  it("authenticates when the process is an `eve dev` server", () => {
-    vi.stubEnv("EVE_DEV", "1");
+  it("authenticates when the process is a development server", () => {
+    vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("VERCEL", "");
     vi.stubEnv("VERCEL_ENV", "");
     expect(localDev()(requestFor("http://localhost:3000/eve/v1/info"))).toEqual({
@@ -348,7 +348,7 @@ describe("localDev", () => {
   });
 
   it("authenticates when the process is a `vercel dev` server", () => {
-    vi.stubEnv("EVE_DEV", "");
+    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_ENV", "development");
     expect(localDev()(requestFor("http://localhost:3000/"))).toMatchObject({
@@ -358,9 +358,9 @@ describe("localDev", () => {
 
   it("rejects a `Host: localhost` request on a production deployment", () => {
     // On a self-hosted Node server the request URL host comes from the `Host`
-    // header. Neither dev flag is set on a production deployment, so a localhost
-    // host must not authenticate.
-    vi.stubEnv("EVE_DEV", "");
+    // header. A production deployment is not a development server, so a
+    // localhost host must not authenticate.
+    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "");
     vi.stubEnv("VERCEL_ENV", "");
     expect(localDev()(requestFor("http://localhost:3000/eve/v1/info"))).toBeNull();
@@ -369,8 +369,8 @@ describe("localDev", () => {
     expect(localDev()(requestFor("http://agent.localhost:3000/"))).toBeNull();
   });
 
-  it("rejects public and preview requests when no dev flag is set", () => {
-    vi.stubEnv("EVE_DEV", "");
+  it("rejects public and preview requests on a production deployment", () => {
+    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_ENV", "production");
     expect(localDev()(requestFor("https://example.com/eve/v1/info"))).toBeNull();
@@ -1421,7 +1421,7 @@ describe("vercelOidc strategy helper", () => {
     vi.stubEnv("VERCEL_PROJECT_ID", "");
     vi.stubEnv("VERCEL_TARGET_ENV", "");
     vi.stubEnv("VERCEL_ENV", "");
-    vi.stubEnv("EVE_DEV", "1");
+    vi.stubEnv("NODE_ENV", "development");
     const issuer = await installMockedVercelIssuer("local-host-binding");
 
     try {

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -8,7 +8,6 @@
 import { decodeJwt } from "#compiled/jose/index.js";
 
 import type { SessionAuthContext } from "#channel/types.js";
-import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
 import { createLogger } from "#internal/logging.js";
 import { authenticateHttpBasicStrategy } from "#runtime/governance/auth/http-basic.js";
 import { authenticateJwtEcdsaStrategy } from "#runtime/governance/auth/jwt-ecdsa.js";
@@ -664,13 +663,12 @@ export function none<TEvent = unknown>(): AuthFn<TEvent> {
  * `null` everywhere else so the {@link routeAuth} walk falls through to the
  * next entry.
  *
- * A process counts as a local development server when it is `eve dev`
- * (`EVE_DEV=1`) or `vercel dev` (`VERCEL=1` with `VERCEL_ENV=development`).
- * This is a property of the deployment, never of the inbound request, so no
- * request header (for example `Host`) can flip the decision. A production
- * deployment (`eve start`, a Vercel deployment, or any container host) sets
- * neither flag, so `localDev()` authenticates nothing there. Layer a real
- * authenticator on those hosts.
+ * A process counts as a local development server when `NODE_ENV=development`
+ * (set by `eve dev`) or when it is a `vercel dev` session
+ * (`VERCEL_ENV=development`), a property of the deployment rather than the
+ * inbound request. A production deployment runs with `NODE_ENV=production`, so
+ * `localDev()` authenticates nothing there; layer a real authenticator on those
+ * hosts.
  */
 export function localDev(): AuthFn<Request> {
   return () => (isLocalDevelopmentServer() ? LOCAL_DEV_SESSION_AUTH_CONTEXT : null);
@@ -680,7 +678,7 @@ function isLocalDevelopmentServer(): boolean {
   if (process.env.VERCEL && process.env.VERCEL_ENV === "development") {
     return true;
   }
-  return isEveDevEnvironment();
+  return process.env.NODE_ENV === "development";
 }
 
 const ANONYMOUS_SESSION_AUTH_CONTEXT: SessionAuthContext = {
@@ -965,7 +963,7 @@ function isLocalDevelopmentVercelOidc(): boolean {
   if (process.env.VERCEL_ENV === "preview" || process.env.VERCEL_ENV === "production") {
     return false;
   }
-  return isEveDevEnvironment();
+  return process.env.NODE_ENV === "development";
 }
 
 /**

--- a/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
+++ b/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
@@ -19,12 +19,12 @@ const EVE_TOOLS_IMPORT_URL = new URL("../../dist/src/public/tools/index.js", imp
 const INFO_ROUTE_KEY = `GET ${EVE_INFO_ROUTE_PATH}`;
 
 // A request to the local server. The deployment environment, not this
-// URL, decides auth: `localDev()` authenticates only when the process
-// is an `eve dev` or `vercel dev` server (stubbed via EVE_DEV below).
+// URL, decides auth: `localDev()` authenticates only on a development
+// server (stubbed via NODE_ENV below).
 const LOOPBACK_REQUEST = new Request("http://localhost/eve/v1/info");
 
-// A request a real deployment sees on the wire. With no dev flag set,
-// `localDev()` skips it and the walk falls through to `vercelOidc()`.
+// A request a real deployment sees on the wire. Outside a development
+// server, `localDev()` skips it and the walk falls through to `vercelOidc()`.
 const DEPLOYED_REQUEST = new Request("https://weather-agent.vercel.app/eve/v1/info");
 const AUTHORIZED_DEPLOYED_REQUEST = new Request("https://weather-agent.vercel.app/eve/v1/info", {
   headers: {
@@ -96,7 +96,7 @@ describe("eve agent info route", () => {
   });
 
   it("returns inspection JSON in a local dev environment", async () => {
-    vi.stubEnv("EVE_DEV", "1");
+    vi.stubEnv("NODE_ENV", "development");
 
     const { agentRoot, appRoot } = await createAppRoot("eve-agent-info-route-", APP_ROOT_OPTIONS);
 
@@ -166,9 +166,10 @@ describe("eve agent info route", () => {
   });
 
   it("returns 401 for a deployment request without a Vercel OIDC bearer token", async () => {
-    // With no dev flag set, the default chain must reject a request that
-    // carries no token: `vercelOidc()` skips without a bearer token and
-    // `localDev()` skips outside an `eve dev` or `vercel dev` server.
+    // On a production deployment the default chain must reject a request
+    // that carries no token: `vercelOidc()` skips without a bearer token
+    // and `localDev()` skips outside a development server.
+    vi.stubEnv("NODE_ENV", "production");
     const { agentRoot, appRoot } = await createAppRoot(
       "eve-agent-info-route-deployed-",
       APP_ROOT_OPTIONS,

--- a/packages/eve/test/scenarios/dev-server-harness.ts
+++ b/packages/eve/test/scenarios/dev-server-harness.ts
@@ -76,9 +76,10 @@ export async function signalEveDevDuringStartup(
 
 /**
  * Spawns `eve dev --no-ui` for the app and resolves once the server URL is
- * printed and the state record exists. `NODE_ENV=test` activates the
- * deterministic mock-model adapter so streamed turns complete without model
- * credentials.
+ * printed and the state record exists. `EVE_MOCK_AUTHORED_MODELS=1` activates
+ * the deterministic mock-model adapter so streamed turns complete without model
+ * credentials, while `NODE_ENV=development` keeps the server a real dev server
+ * so `localDev()` authenticates requests.
  */
 export async function startEveDev(
   appRoot: string,
@@ -225,7 +226,8 @@ function spawnEveDev(
     env: {
       ...process.env,
       ...options.env,
-      NODE_ENV: "test",
+      NODE_ENV: "development",
+      EVE_MOCK_AUTHORED_MODELS: "1",
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/packages/eve/test/tui-client/lib/server.ts
+++ b/packages/eve/test/tui-client/lib/server.ts
@@ -58,9 +58,8 @@ export async function startAgentServer(input: {
 
   console.log(theme.muted(`[tui] starting "${input.appName}" ${mode} server on ${baseUrl} ...`));
 
-  // Built smoke servers run on the local machine. `eve start` does not set
-  // EVE_DEV, so set it here to let `localDev()` authenticate local requests.
-  const serverEnv = { ...(input.startEnv ?? process.env), EVE_DEV: "1" };
+  // NODE_ENV=development so `localDev()` authenticates the smoke requests.
+  const serverEnv = { ...(input.startEnv ?? process.env), NODE_ENV: "development" };
 
   const child = spawnServerProcess({
     args: plan.start.args,


### PR DESCRIPTION
`localDev()` now recognizes a local development server by `NODE_ENV=development` instead of `EVE_DEV`. `eve dev` defaults `NODE_ENV=development` and `eve start` defaults it to `production`, so the synthetic local-dev principal is never granted on a production deployment. An explicit `NODE_ENV` is still respected.