### PR TITLE
refactor(eve): eve-owned instrumentation event payloads

### DIFF
--- a/.changeset/lucky-donkeys-listen.md
+++ b/.changeset/lucky-donkeys-listen.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Instrumentation lifecycle events now carry eve-owned payloads instead of the AI SDK's callback types. Internal groundwork for a public provider surface; no change to the spans or attributes eve records.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fix:deps": "syncpack fix-mismatches && syncpack format",
     "fmt": "oxfmt",
     "guard:fixtures": "node ./scripts/guard-test-fixtures.mjs",
-    "guard:invariants": "node ./scripts/guard-invariants.mjs",
+    "guard:invariants": "node --test ./scripts/guard-invariants-rule37.test.mjs && node ./scripts/guard-invariants.mjs",
     "konsistent": "konsistent",
     "lint": "oxlint --fix",
     "prepare": "simple-git-hooks",

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -5,7 +5,12 @@ import {
   createInstrumentationHooks,
   type InstrumentationAttemptMetadataEvent,
   type InstrumentationAttemptScope,
+  type InstrumentationAttemptStartedEvent,
+  type InstrumentationModelCallStartedEvent,
+  type InstrumentationModelCallTerminalEvent,
   type InstrumentationProviderDefinition,
+  type InstrumentationToolCallStartedEvent,
+  type InstrumentationToolCallTerminalEvent,
 } from "#harness/instrumentation-lifecycle.js";
 
 const scope: InstrumentationAttemptScope = {
@@ -36,7 +41,7 @@ describe("createAiSdkHookBridge", () => {
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
-      { callId: "call-1", modelId: "model", provider: "test", tools: undefined },
+      { callId: "call-1", messages: [], modelId: "model", provider: "test", tools: undefined },
     ]);
     await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
       {
@@ -69,7 +74,7 @@ describe("createAiSdkHookBridge", () => {
     });
     const execute = vi.fn(async () => "result");
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
-      { callId: "call-1", modelId: "model", provider: "test", tools: undefined },
+      { callId: "call-1", messages: [], modelId: "model", provider: "test", tools: undefined },
     ]);
 
     const result = await bridge.executeLanguageModelCall!({
@@ -96,7 +101,7 @@ describe("createAiSdkHookBridge", () => {
     ]);
     await Reflect.apply(bridge.onStepStart!, bridge, [{ callId: "call-1", stepNumber: 0 }]);
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
-      { callId: "call-1", modelId: "model", provider: "test", tools: undefined },
+      { callId: "call-1", messages: [], modelId: "model", provider: "test", tools: undefined },
     ]);
     await Reflect.apply(bridge.onStepStart!, bridge, [{ callId: "call-1", stepNumber: 1 }]);
 
@@ -164,7 +169,7 @@ describe("createAiSdkHookBridge", () => {
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
-      { callId: "call-1", modelId: "model", provider: "test", tools: undefined },
+      { callId: "call-1", messages: [], modelId: "model", provider: "test", tools: undefined },
     ]);
     await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
       {
@@ -188,7 +193,7 @@ describe("createAiSdkHookBridge", () => {
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
-      { callId: "call-1", modelId: "model", provider: "test", tools: undefined },
+      { callId: "call-1", messages: [], modelId: "model", provider: "test", tools: undefined },
     ]);
     const error = new Error("model failed");
     await Reflect.apply(bridge.onError!, bridge, [error]);
@@ -199,29 +204,167 @@ describe("createAiSdkHookBridge", () => {
     );
   });
 
-  it("publishes frozen callback snapshots", async () => {
+  it("publishes an immutable operation projection to every provider", async () => {
+    const mutator = vi.fn((event: InstrumentationAttemptStartedEvent) => {
+      expect(Object.isFrozen(event)).toBe(true);
+      expect(Object.isFrozen(event.operation)).toBe(true);
+      expect(Reflect.set(event.operation, "modelId", "corrupted-model")).toBe(false);
+      expect(Reflect.set(event.operation, "operationId", "corrupted-operation")).toBe(false);
+      expect(Reflect.set(event.operation, "provider", "corrupted-provider")).toBe(false);
+    });
     const started = vi.fn();
-    const hooks = createInstrumentationHooks([{ events: { "attempt.started": started } }]);
+    const hooks = createInstrumentationHooks([
+      { events: { "attempt.started": mutator } },
+      { events: { "attempt.started": started } },
+    ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
-    const operation = {
-      callId: "call-1",
-      modelId: "model",
-      operationId: "ai.streamText",
-      provider: "test",
+
+    Reflect.apply(bridge.onStart!, bridge, [
+      { callId: "call-1", modelId: "model", operationId: "ai.streamText", provider: "test" },
+    ]);
+    await Reflect.apply(bridge.onStepStart!, bridge, [{ callId: "call-1", stepNumber: 0 }]);
+
+    const expected = {
+      operation: { modelId: "model", operationId: "ai.streamText", provider: "test" },
+      scope,
+      type: "attempt.started",
     };
-    const step = { callId: "call-1", stepNumber: 0 };
-
-    Reflect.apply(bridge.onStart!, bridge, [operation]);
-    await Reflect.apply(bridge.onStepStart!, bridge, [step]);
-
-    expect(started).toHaveBeenCalledOnce();
-    const event = started.mock.calls[0]?.[0];
-    expect(event).toEqual({ operation, scope, step, type: "attempt.started" });
-    expect(event.operation).not.toBe(operation);
-    expect(event.step).not.toBe(step);
-    expect(Object.isFrozen(event.operation)).toBe(true);
-    expect(Object.isFrozen(event.step)).toBe(true);
+    expect(mutator).toHaveBeenCalledExactlyOnceWith(expected);
+    expect(started).toHaveBeenCalledExactlyOnceWith(expected);
   });
+
+  it("projects the model call callbacks onto eve fields only", async () => {
+    const before = vi.fn((event: InstrumentationModelCallStartedEvent) => {
+      expect(Object.isFrozen(event)).toBe(true);
+      expect(Object.isFrozen(event.input)).toBe(true);
+      expect(Object.isFrozen(event.input.messages)).toBe(true);
+      expect(Object.isFrozen(event.model)).toBe(true);
+      return "state";
+    });
+    const after = vi.fn((event: InstrumentationModelCallTerminalEvent) => {
+      if (event.type !== "model.call.completed") throw new Error("expected completed model call");
+      expect(Object.isFrozen(event)).toBe(true);
+      expect(Object.isFrozen(event.content)).toBe(true);
+      expect(event.content.every((part) => Object.isFrozen(part))).toBe(true);
+      expect(Object.isFrozen(event.usage)).toBe(true);
+      expect(Object.isFrozen(event.usage.inputTokenDetails)).toBe(true);
+    });
+    const hooks = createInstrumentationHooks([{ events: { "model.call": { after, before } } }]);
+    const bridge = createAiSdkHookBridge(scope, hooks);
+
+    await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
+      {
+        callId: "call-1",
+        instructions: "be brief",
+        messages: [{ content: "hi", role: "user" }],
+        modelId: "model",
+        provider: "test",
+        tools: undefined,
+      },
+    ]);
+    await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+      {
+        callId: "call-1",
+        content: [
+          { text: "thinking", type: "reasoning" },
+          { text: "hello", type: "text" },
+          { input: { a: 1 }, toolName: "search", type: "tool-call" },
+          { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
+          { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
+          { type: "some-future-kind" },
+        ],
+        finishReason: "tool-calls",
+        performance: { responseTimeMs: 1 },
+        responseId: "response-1",
+        usage: {
+          inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
+          inputTokens: 1,
+          outputTokens: 2,
+        },
+      },
+    ]);
+
+    expect(before).toHaveBeenCalledExactlyOnceWith({
+      id: `${scope.attemptId}:model:call-1:0`,
+      input: { instructions: "be brief", messages: [{ content: "hi", role: "user" }] },
+      model: { modelId: "model", provider: "test" },
+      scope,
+      type: "model.call.started",
+    });
+    // An unrecognized part kind is dropped rather than forwarded, so widening
+    // InstrumentationContentPart is what makes a new kind reachable.
+    expect(after).toHaveBeenCalledExactlyOnceWith(
+      {
+        content: [
+          { text: "thinking", type: "reasoning" },
+          { text: "hello", type: "text" },
+          { input: { a: 1 }, toolName: "search", type: "tool-call" },
+          { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
+          { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
+        ],
+        finishReason: "tool-calls",
+        id: `${scope.attemptId}:model:call-1:0`,
+        scope,
+        type: "model.call.completed",
+        usage: {
+          inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
+          inputTokens: 1,
+          outputTokens: 2,
+        },
+      },
+      "state",
+    );
+  });
+
+  it.each([
+    {
+      expected: { output: "ok", type: "result" },
+      toolOutput: { output: "ok", type: "tool-result" },
+    },
+    {
+      expected: { error: "boom", type: "error" },
+      toolOutput: { error: "boom", type: "tool-error" },
+    },
+  ])(
+    "collapses tool output $toolOutput.type onto $expected.type",
+    async ({ expected, toolOutput }) => {
+      const before = vi.fn((event: InstrumentationToolCallStartedEvent) => {
+        expect(Object.isFrozen(event)).toBe(true);
+        return "state";
+      });
+      const after = vi.fn((event: InstrumentationToolCallTerminalEvent) => {
+        if (event.type !== "tool.call.completed") throw new Error("expected completed tool call");
+        expect(Object.isFrozen(event)).toBe(true);
+        expect(Object.isFrozen(event.output)).toBe(true);
+      });
+      const hooks = createInstrumentationHooks([{ events: { "tool.call": { after, before } } }]);
+      const bridge = createAiSdkHookBridge(scope, hooks);
+      const toolCall = { input: { q: "eve" }, toolCallId: "tool-1", toolName: "search" };
+
+      await Reflect.apply(bridge.onToolExecutionStart!, bridge, [{ callId: "call-1", toolCall }]);
+      await Reflect.apply(bridge.onToolExecutionEnd!, bridge, [
+        { callId: "call-1", toolCall, toolExecutionMs: 1, toolOutput },
+      ]);
+
+      expect(before).toHaveBeenCalledExactlyOnceWith({
+        callId: "tool-1",
+        id: `${scope.attemptId}:tool:tool-1:0`,
+        input: { q: "eve" },
+        scope,
+        toolName: "search",
+        type: "tool.call.started",
+      });
+      expect(after).toHaveBeenCalledExactlyOnceWith(
+        {
+          id: `${scope.attemptId}:tool:tool-1:0`,
+          output: expected,
+          scope,
+          type: "tool.call.completed",
+        },
+        "state",
+      );
+    },
+  );
 
   it("retains state for parallel tool starts", async () => {
     const resolvers = new Map<string, () => void>();

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.ts
@@ -3,12 +3,16 @@ import type { Telemetry } from "ai";
 import type {
   InstrumentationAttemptScope,
   InstrumentationAttemptStartedEvent,
+  InstrumentationContentPart,
   InstrumentationContextRunner,
   InstrumentationHooks,
   InstrumentationModelCallCompletedEvent,
   InstrumentationModelCallStartedEvent,
+  InstrumentationOperationRef,
   InstrumentationToolCallCompletedEvent,
   InstrumentationToolCallStartedEvent,
+  InstrumentationToolOutput,
+  InstrumentationUsage,
 } from "#harness/instrumentation-lifecycle.js";
 
 type TelemetryEvent<TKey extends keyof Telemetry> = Parameters<NonNullable<Telemetry[TKey]>>[0];
@@ -17,8 +21,9 @@ interface AttemptState {
   readonly modelIds: Map<string, string>;
   readonly scope: InstrumentationAttemptScope;
   readonly toolIds: Map<string, string>;
-  operationStart?: Readonly<TelemetryEvent<"onStart">>;
-  stepStart?: Readonly<TelemetryEvent<"onStepStart">>;
+  operation?: InstrumentationOperationRef;
+  // Only the number is kept: it disambiguates call identities within an attempt.
+  stepNumber?: number;
 }
 
 /** Creates one provider-neutral AI SDK bridge for one actual model attempt. */
@@ -35,10 +40,14 @@ export function createAiSdkHookBridge(
 
   return {
     onStart(event) {
-      state.operationStart = snapshot(event);
+      state.operation = Object.freeze({
+        modelId: event.modelId,
+        operationId: event.operationId,
+        provider: event.provider,
+      });
     },
     async onStepStart(event) {
-      state.stepStart = snapshot(event);
+      state.stepNumber = event.stepNumber;
       const started = toAttemptStarted(state);
       if (started !== undefined) await hooks.publish(started);
     },
@@ -66,11 +75,13 @@ export function createAiSdkHookBridge(
       // that the per-call telemetry events don't. Publish it for providers
       // that know what to do with it; skip when there is none.
       if (event.providerMetadata === undefined) return;
-      await hooks.publish({
-        providerMetadata: event.providerMetadata,
-        scope: state.scope,
-        type: "attempt.metadata",
-      });
+      await hooks.publish(
+        Object.freeze({
+          providerMetadata: event.providerMetadata,
+          scope: state.scope,
+          type: "attempt.metadata",
+        }),
+      );
     },
     async onToolExecutionStart(event) {
       const id = createToolCallIdentity(state, event.toolCall.toolCallId);
@@ -101,10 +112,14 @@ export function createAiSdkHookBridge(
   async function failOpenOperations(error: unknown): Promise<void> {
     const pending: Promise<void>[] = [];
     for (const id of state.modelIds.values()) {
-      pending.push(hooks.after("model.call", { error, id, scope, type: "model.call.failed" }));
+      pending.push(
+        hooks.after("model.call", Object.freeze({ error, id, scope, type: "model.call.failed" })),
+      );
     }
     for (const id of state.toolIds.values()) {
-      pending.push(hooks.after("tool.call", { error, id, scope, type: "tool.call.failed" }));
+      pending.push(
+        hooks.after("tool.call", Object.freeze({ error, id, scope, type: "tool.call.failed" })),
+      );
     }
     state.modelIds.clear();
     state.toolIds.clear();
@@ -114,22 +129,17 @@ export function createAiSdkHookBridge(
 
 const directRunInContext: InstrumentationContextRunner = (_operation, execute) => execute();
 
-function snapshot<T extends object>(event: T): Readonly<T> {
-  return Object.freeze({ ...event });
-}
-
 function toAttemptStarted(state: AttemptState): InstrumentationAttemptStartedEvent | undefined {
-  if (state.operationStart === undefined || state.stepStart === undefined) return undefined;
-  return {
-    operation: state.operationStart,
+  if (state.operation === undefined || state.stepNumber === undefined) return undefined;
+  return Object.freeze({
+    operation: state.operation,
     scope: state.scope,
-    step: state.stepStart,
     type: "attempt.started",
-  };
+  });
 }
 
 function createModelCallIdentity(state: AttemptState, callId: string): string {
-  return `${state.scope.attemptId}:model:${callId}:${state.stepStart?.stepNumber ?? 0}`;
+  return `${state.scope.attemptId}:model:${callId}:${state.stepNumber ?? 0}`;
 }
 
 function toModelCallStarted(
@@ -137,12 +147,16 @@ function toModelCallStarted(
   id: string,
   source: TelemetryEvent<"onLanguageModelCallStart">,
 ): InstrumentationModelCallStartedEvent {
-  return {
+  return Object.freeze({
     id,
+    input: Object.freeze({
+      instructions: source.instructions,
+      messages: Object.freeze([...source.messages]),
+    }),
+    model: Object.freeze({ modelId: source.modelId, provider: source.provider }),
     scope: state.scope,
-    source: snapshot(source),
     type: "model.call.started",
-  };
+  });
 }
 
 function toModelCallCompleted(
@@ -150,16 +164,72 @@ function toModelCallCompleted(
   id: string,
   source: TelemetryEvent<"onLanguageModelCallEnd">,
 ): InstrumentationModelCallCompletedEvent {
-  return {
+  return Object.freeze({
+    content: toContentParts(source.content),
+    finishReason: source.finishReason,
     id,
     scope: state.scope,
-    source: snapshot(source),
     type: "model.call.completed",
-  };
+    usage: toUsage(source.usage),
+  });
+}
+
+function toUsage(usage: TelemetryEvent<"onLanguageModelCallEnd">["usage"]): InstrumentationUsage {
+  return Object.freeze({
+    inputTokenDetails: Object.freeze({
+      cacheReadTokens: usage.inputTokenDetails?.cacheReadTokens,
+      cacheWriteTokens: usage.inputTokenDetails?.cacheWriteTokens,
+    }),
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+  });
+}
+
+/** Drops kinds eve does not record; see {@link InstrumentationContentPart}. */
+function toContentParts(
+  content: TelemetryEvent<"onLanguageModelCallEnd">["content"],
+): readonly InstrumentationContentPart[] {
+  const parts: InstrumentationContentPart[] = [];
+  for (const part of content) {
+    switch (part.type) {
+      case "text":
+      case "reasoning":
+        parts.push(Object.freeze({ text: part.text, type: part.type }));
+        break;
+      case "tool-call":
+        parts.push(
+          Object.freeze({ input: part.input, toolName: part.toolName, type: "tool-call" }),
+        );
+        break;
+      case "tool-result":
+        parts.push(
+          Object.freeze({
+            input: part.input,
+            output: part.output,
+            toolName: part.toolName,
+            type: "tool-result",
+          }),
+        );
+        break;
+      case "tool-error":
+        parts.push(
+          Object.freeze({
+            error: part.error,
+            input: part.input,
+            toolName: part.toolName,
+            type: "tool-error",
+          }),
+        );
+        break;
+      default:
+        break;
+    }
+  }
+  return Object.freeze(parts);
 }
 
 function createToolCallIdentity(state: AttemptState, toolCallId: string): string {
-  return `${state.scope.attemptId}:tool:${toolCallId}:${state.stepStart?.stepNumber ?? 0}`;
+  return `${state.scope.attemptId}:tool:${toolCallId}:${state.stepNumber ?? 0}`;
 }
 
 function toToolCallStarted(
@@ -167,12 +237,14 @@ function toToolCallStarted(
   id: string,
   source: TelemetryEvent<"onToolExecutionStart">,
 ): InstrumentationToolCallStartedEvent {
-  return {
+  return Object.freeze({
+    callId: source.toolCall.toolCallId,
     id,
+    input: source.toolCall.input,
     scope: state.scope,
-    source: snapshot(source),
+    toolName: source.toolCall.toolName,
     type: "tool.call.started",
-  };
+  });
 }
 
 function toToolCallCompleted(
@@ -180,10 +252,18 @@ function toToolCallCompleted(
   id: string,
   source: TelemetryEvent<"onToolExecutionEnd">,
 ): InstrumentationToolCallCompletedEvent {
-  return {
+  return Object.freeze({
     id,
+    output: toToolOutput(source.toolOutput),
     scope: state.scope,
-    source: snapshot(source),
     type: "tool.call.completed",
-  };
+  });
+}
+
+function toToolOutput(
+  toolOutput: TelemetryEvent<"onToolExecutionEnd">["toolOutput"],
+): InstrumentationToolOutput {
+  return toolOutput.type === "tool-result"
+    ? Object.freeze({ output: toolOutput.output, type: "result" })
+    : Object.freeze({ error: toolOutput.error, type: "error" });
 }

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -1,8 +1,4 @@
-import type { Telemetry } from "ai";
-
 import { createLogger, formatError } from "#internal/logging.js";
-
-type TelemetryEvent<TKey extends keyof Telemetry> = Parameters<NonNullable<Telemetry[TKey]>>[0];
 
 /** Stable eve identity for one actual model attempt. */
 export interface InstrumentationAttemptScope {
@@ -15,11 +11,65 @@ export interface InstrumentationAttemptScope {
   readonly turnId: string;
 }
 
+/** The model SDK operation an attempt runs through. */
+export interface InstrumentationOperationRef {
+  readonly modelId: string;
+  readonly operationId: string;
+  readonly provider: string;
+}
+
+export interface InstrumentationModelRef {
+  readonly modelId: string;
+  readonly provider: string;
+}
+
+/** Token usage for one model call. A field is absent when the provider omits it. */
+export interface InstrumentationUsage {
+  readonly inputTokenDetails?: {
+    readonly cacheReadTokens?: number;
+    readonly cacheWriteTokens?: number;
+  };
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+}
+
+/** Final model input for one call. Message shape stays opaque to this layer. */
+export interface InstrumentationModelInput {
+  readonly instructions?: unknown;
+  readonly messages: readonly unknown[];
+}
+
+/**
+ * The model response parts eve records. A kind outside this union is dropped
+ * when the bridge maps a response, so widening the union is what makes a new
+ * kind reachable by a provider.
+ */
+export type InstrumentationContentPart =
+  | { readonly type: "text"; readonly text: string }
+  | { readonly type: "reasoning"; readonly text: string }
+  | { readonly type: "tool-call"; readonly input: unknown; readonly toolName: string }
+  | {
+      readonly type: "tool-result";
+      readonly input: unknown;
+      readonly output: unknown;
+      readonly toolName: string;
+    }
+  | {
+      readonly type: "tool-error";
+      readonly error: unknown;
+      readonly input: unknown;
+      readonly toolName: string;
+    };
+
+/** How one tool execution ended. */
+export type InstrumentationToolOutput =
+  | { readonly type: "result"; readonly output: unknown }
+  | { readonly type: "error"; readonly error: unknown };
+
 export interface InstrumentationAttemptStartedEvent {
   readonly type: "attempt.started";
+  readonly operation: InstrumentationOperationRef;
   readonly scope: InstrumentationAttemptScope;
-  readonly operation: TelemetryEvent<"onStart">;
-  readonly step: TelemetryEvent<"onStepStart">;
 }
 
 export interface InstrumentationSessionStartedEvent {
@@ -48,12 +98,29 @@ export interface InstrumentationParentLineage {
   readonly turnId: string;
 }
 
-export interface InstrumentationSessionTransitionEvent {
-  readonly type: "session.completed" | "session.failed" | "session.waiting";
-  readonly error?: unknown;
+/**
+ * A session transition that carries no failure.
+ *
+ * `session.waiting` sits here rather than with the failed shape because it is
+ * not terminal: the session suspends awaiting input or approval and may resume
+ * with a new turn.
+ */
+export interface InstrumentationSessionSettledEvent {
+  readonly type: "session.completed" | "session.waiting";
   readonly sessionId: string;
   readonly turnId?: string;
 }
+
+export interface InstrumentationSessionFailedEvent {
+  readonly type: "session.failed";
+  readonly error: unknown;
+  readonly sessionId: string;
+  readonly turnId?: string;
+}
+
+export type InstrumentationSessionTransitionEvent =
+  | InstrumentationSessionSettledEvent
+  | InstrumentationSessionFailedEvent;
 
 export interface InstrumentationTurnStartedEvent {
   readonly type: "turn.started";
@@ -92,15 +159,18 @@ export interface InstrumentationAttemptMetadataEvent {
 export interface InstrumentationModelCallStartedEvent {
   readonly type: "model.call.started";
   readonly id: string;
+  readonly input: InstrumentationModelInput;
+  readonly model: InstrumentationModelRef;
   readonly scope: InstrumentationAttemptScope;
-  readonly source: TelemetryEvent<"onLanguageModelCallStart">;
 }
 
 export interface InstrumentationModelCallCompletedEvent {
   readonly type: "model.call.completed";
+  readonly content: readonly InstrumentationContentPart[];
+  readonly finishReason: string;
   readonly id: string;
   readonly scope: InstrumentationAttemptScope;
-  readonly source: TelemetryEvent<"onLanguageModelCallEnd">;
+  readonly usage: InstrumentationUsage;
 }
 
 export interface InstrumentationModelCallFailedEvent {
@@ -116,16 +186,18 @@ export type InstrumentationModelCallTerminalEvent =
 
 export interface InstrumentationToolCallStartedEvent {
   readonly type: "tool.call.started";
+  readonly callId: string;
   readonly id: string;
+  readonly input: unknown;
   readonly scope: InstrumentationAttemptScope;
-  readonly source: TelemetryEvent<"onToolExecutionStart">;
+  readonly toolName: string;
 }
 
 export interface InstrumentationToolCallCompletedEvent {
   readonly type: "tool.call.completed";
   readonly id: string;
+  readonly output: InstrumentationToolOutput;
   readonly scope: InstrumentationAttemptScope;
-  readonly source: TelemetryEvent<"onToolExecutionEnd">;
 }
 
 export interface InstrumentationToolCallFailedEvent {
@@ -164,16 +236,16 @@ export interface InstrumentationProviderDefinition {
       event: InstrumentationAttemptMetadataEvent,
     ) => void | PromiseLike<void>;
     readonly "session.completed"?: (
-      event: InstrumentationSessionTransitionEvent,
+      event: InstrumentationSessionSettledEvent,
     ) => void | PromiseLike<void>;
     readonly "session.failed"?: (
-      event: InstrumentationSessionTransitionEvent,
+      event: InstrumentationSessionFailedEvent,
     ) => void | PromiseLike<void>;
     readonly "session.started"?: (
       event: InstrumentationSessionStartedEvent,
     ) => void | PromiseLike<void>;
     readonly "session.waiting"?: (
-      event: InstrumentationSessionTransitionEvent,
+      event: InstrumentationSessionSettledEvent,
     ) => void | PromiseLike<void>;
     readonly "tool.call"?: RelatedLifecycleHook<
       InstrumentationToolCallStartedEvent,

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -35,6 +35,7 @@ import type {
   InstrumentationToolCallTerminalEvent,
   InstrumentationTurnStartedEvent,
   InstrumentationTurnTerminalEvent,
+  InstrumentationUsage,
 } from "#harness/instrumentation-lifecycle.js";
 
 interface SpanState {
@@ -250,23 +251,23 @@ export function createAgentOtelInstrumentation(
   const beforeModelCall = (event: InstrumentationModelCallStartedEvent): SpanState | undefined => {
     const attempt = steps.get(event.scope);
     if (attempt === undefined) return undefined;
-    attempt.step.span.setAttribute("agent.model.id", event.source.modelId);
-    attempt.step.span.setAttribute("agent.model.provider", event.source.provider);
+    attempt.step.span.setAttribute("agent.model.id", event.model.modelId);
+    attempt.step.span.setAttribute("agent.model.provider", event.model.provider);
     const span = input.tracer.startSpan(
       modelSpanName(attempt.operation.name),
       {
         attributes: {
           "gen_ai.operation.name": attempt.operation.name,
-          "gen_ai.provider.name": event.source.provider,
-          "gen_ai.request.model": event.source.modelId,
+          "gen_ai.provider.name": event.model.provider,
+          "gen_ai.request.model": event.model.modelId,
         },
       },
       attempt.operation.context,
     );
     if (captureContent) {
-      const messages = messagesContentAttribute(event.source.messages);
+      const messages = messagesContentAttribute(event.input.messages);
       if (messages !== undefined) span.setAttribute("ai.prompt.messages", messages);
-      const system = systemPromptAttribute(event.source.instructions);
+      const system = systemPromptAttribute(event.input.instructions);
       if (system !== undefined) span.setAttribute("ai.prompt.system", system);
     }
     const state = { context: trace.setSpan(attempt.operation.context, span), span };
@@ -280,13 +281,13 @@ export function createAgentOtelInstrumentation(
     if (event.type === "model.call.failed") {
       recordError(state.span, event.error);
     } else {
-      setUsage(state.span, event.source.usage);
+      setUsage(state.span, event.usage);
       const attempt = steps.get(event.scope);
-      if (attempt !== undefined) setUsage(attempt.step.span, event.source.usage);
+      if (attempt !== undefined) setUsage(attempt.step.span, event.usage);
       if (captureContent) {
-        state.span.setAttribute("ai.response.finish_reason", event.source.finishReason);
+        state.span.setAttribute("ai.response.finish_reason", event.finishReason);
         const reasoning = textContentAttribute(
-          event.source.content
+          event.content
             .filter((part) => part.type === "reasoning")
             .map((part) => part.text)
             .filter((part) => part.trim().length > 0)
@@ -294,13 +295,13 @@ export function createAgentOtelInstrumentation(
         );
         if (reasoning !== undefined) state.span.setAttribute("ai.response.reasoning", reasoning);
         const text = textContentAttribute(
-          event.source.content
+          event.content
             .filter((part) => part.type === "text")
             .map((part) => part.text)
             .join(""),
         );
         if (text !== undefined) state.span.setAttribute("ai.response.text", text);
-        const toolCalls = event.source.content
+        const toolCalls = event.content
           .filter((part) => part.type === "tool-call")
           .map((part) => ({ input: part.input, toolName: part.toolName }));
         if (toolCalls.length > 0) {
@@ -310,7 +311,7 @@ export function createAgentOtelInstrumentation(
         // Provider-executed tools (e.g. web_search) run inside the model call,
         // never reach eve's tool loop, and so never get an ai.toolCall span.
         // Their results only exist as content parts on the model response.
-        const toolResults = event.source.content
+        const toolResults = event.content
           .filter((part) => part.type === "tool-result" || part.type === "tool-error")
           .map((part) =>
             part.type === "tool-result"
@@ -335,9 +336,9 @@ export function createAgentOtelInstrumentation(
       "agent.action",
       {
         attributes: {
-          "agent.action.call_id": event.source.toolCall.toolCallId,
+          "agent.action.call_id": event.callId,
           "agent.action.kind": "tool",
-          "agent.action.name": event.source.toolCall.toolName,
+          "agent.action.name": event.toolName,
           "agent.framework.name": "eve",
           "agent.framework.version": input.frameworkVersion,
           "agent.root.session.id": event.scope.rootSessionId ?? event.scope.sessionId,
@@ -355,14 +356,14 @@ export function createAgentOtelInstrumentation(
       {
         attributes: {
           "gen_ai.operation.name": "execute_tool",
-          "gen_ai.tool.call.id": event.source.toolCall.toolCallId,
-          "gen_ai.tool.name": event.source.toolCall.toolName,
+          "gen_ai.tool.call.id": event.callId,
+          "gen_ai.tool.name": event.toolName,
         },
       },
       actionContext,
     );
     if (captureContent) {
-      const args = contentAttribute(event.source.toolCall.input, false);
+      const args = contentAttribute(event.input, false);
       if (args !== undefined) toolSpan.setAttribute("gen_ai.tool.call.arguments", args);
     }
     const state: ToolSpanState = {
@@ -380,11 +381,11 @@ export function createAgentOtelInstrumentation(
     if (event.type === "tool.call.failed") {
       recordError(state.toolSpan, event.error);
       recordError(state.span, event.error);
-    } else if (event.source.toolOutput.type !== "tool-result") {
-      recordError(state.toolSpan, event.source.toolOutput.error);
-      recordError(state.span, event.source.toolOutput.error);
+    } else if (event.output.type === "error") {
+      recordError(state.toolSpan, event.output.error);
+      recordError(state.span, event.output.error);
     } else if (captureContent) {
-      const result = contentAttribute(event.source.toolOutput.output, false);
+      const result = contentAttribute(event.output.output, false);
       if (result !== undefined) state.toolSpan.setAttribute("gen_ai.tool.call.result", result);
     }
     state.toolSpan.end();
@@ -602,17 +603,7 @@ function modelSpanName(operationName: string): string {
     : "ai.streamText.doStream";
 }
 
-function setUsage(
-  span: Span,
-  usage: {
-    readonly inputTokenDetails?: {
-      readonly cacheReadTokens?: number;
-      readonly cacheWriteTokens?: number;
-    };
-    readonly inputTokens?: number;
-    readonly outputTokens?: number;
-  },
-): void {
+function setUsage(span: Span, usage: InstrumentationUsage): void {
   if (usage.inputTokens !== undefined) {
     span.setAttribute("agent.usage.input_tokens", usage.inputTokens);
   }

--- a/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
@@ -65,7 +65,7 @@ describe("local instrumentation runtime", () => {
       ]);
       await Reflect.apply(bridge.onStepStart!, bridge, [{ callId: "call-1", stepNumber: 0 }]);
       await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
-        { callId: "call-1", modelId: "model-1", provider: "test", tools: undefined },
+        { callId: "call-1", messages: [], modelId: "model-1", provider: "test", tools: undefined },
       ]);
       await bridge.executeLanguageModelCall!({
         callId: "call-1",

--- a/scripts/guard-invariants-rule37.mjs
+++ b/scripts/guard-invariants-rule37.mjs
@@ -1,0 +1,72 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const extractorRequire = createRequire(require.resolve("@microsoft/api-extractor/package.json"));
+const ts = extractorRequire("typescript");
+
+const LIFECYCLE_CONTRACT = "packages/eve/src/harness/instrumentation-lifecycle.ts";
+
+/**
+ * @param {string} posix
+ * @param {string} source
+ * @param {{ rule: number; file: string; line?: number; message: string }[]} violations
+ */
+export function checkRule37(posix, source, violations) {
+  if (posix !== LIFECYCLE_CONTRACT) return;
+
+  const sourceFile = ts.createSourceFile(
+    posix,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const visit = (node) => {
+    const specifier = importSpecifier(node);
+    if (specifier !== undefined && (specifier.text === "ai" || specifier.text.startsWith("ai/"))) {
+      violations.push({
+        rule: 37,
+        file: posix,
+        line: sourceFile.getLineAndCharacterOfPosition(specifier.getStart(sourceFile)).line + 1,
+        message: `imports from "ai". Lifecycle event payloads are eve's own shape, so an AI SDK type reaching them makes an SDK upgrade a breaking change for every provider. Add an eve type here and map to it in ai-sdk-hook-bridge.ts.`,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+}
+
+function importSpecifier(node) {
+  if (
+    (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+    node.moduleSpecifier !== undefined &&
+    ts.isStringLiteralLike(node.moduleSpecifier)
+  ) {
+    return node.moduleSpecifier;
+  }
+  if (
+    ts.isImportEqualsDeclaration(node) &&
+    ts.isExternalModuleReference(node.moduleReference) &&
+    node.moduleReference.expression !== undefined &&
+    ts.isStringLiteralLike(node.moduleReference.expression)
+  ) {
+    return node.moduleReference.expression;
+  }
+  if (
+    ts.isImportTypeNode(node) &&
+    ts.isLiteralTypeNode(node.argument) &&
+    ts.isStringLiteralLike(node.argument.literal)
+  ) {
+    return node.argument.literal;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+      (ts.isIdentifier(node.expression) && node.expression.text === "require")) &&
+    node.arguments[0] !== undefined &&
+    ts.isStringLiteralLike(node.arguments[0])
+  ) {
+    return node.arguments[0];
+  }
+  return undefined;
+}

--- a/scripts/guard-invariants-rule37.test.mjs
+++ b/scripts/guard-invariants-rule37.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkRule37 } from "./guard-invariants-rule37.mjs";
+
+const LIFECYCLE_CONTRACT = "packages/eve/src/harness/instrumentation-lifecycle.ts";
+
+const fixtures = [
+  {
+    line: 4,
+    name: "multiline static import",
+    source: `import type {
+  Telemetry,
+} from
+  "ai";`,
+  },
+  {
+    line: 2,
+    name: "multiline dynamic import type",
+    source: `type Telemetry = typeof import(
+  "ai"
+);`,
+  },
+  {
+    line: 2,
+    name: "multiline dynamic import expression",
+    source: `const sdk = await import(
+  "ai"
+);`,
+  },
+];
+
+for (const fixture of fixtures) {
+  test(`Rule 37 rejects ${fixture.name}`, () => {
+    const violations = [];
+
+    checkRule37(LIFECYCLE_CONTRACT, fixture.source, violations);
+
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0]?.line, fixture.line);
+  });
+}
+
+test("Rule 37 ignores import-like text and other packages", () => {
+  const violations = [];
+
+  checkRule37(
+    LIFECYCLE_CONTRACT,
+    `const example = 'import("ai")';
+// import type { Telemetry } from "ai";
+import type { SDK } from "ai-sdk";`,
+    violations,
+  );
+
+  assert.deepEqual(violations, []);
+});

--- a/scripts/guard-invariants.mjs
+++ b/scripts/guard-invariants.mjs
@@ -93,6 +93,12 @@
  *             dropped, every retained epoch needs a compiling fixture, and
  *             every public authoring value must belong to a capability.
  *
+ *   rule 37 — The instrumentation lifecycle contract stays provider-neutral.
+ *             `harness/instrumentation-lifecycle.ts` must not import from
+ *             `ai`: its event payloads are eve's published shape, so deriving
+ *             them from the model SDK's callback types would make an SDK
+ *             upgrade a breaking change for every provider. Map at the bridge.
+ *
  * Baselines for rules with pre-existing violations live in
  * `guard-invariants-baseline.json`. Counts and allowlists in that file
  * may only shrink (as offenders are removed) — they may never grow.
@@ -102,6 +108,7 @@ import { join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 import { checkExtensionCapabilityContracts } from "./extension-capability-contracts.mjs";
+import { checkRule37 } from "./guard-invariants-rule37.mjs";
 
 const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const BASELINE_PATH = join(REPO_ROOT, "scripts/guard-invariants-baseline.json");
@@ -182,6 +189,7 @@ function isTsLike(relPath) {
  *   rule28: Violation[];
  *   rule33: Violation[];
  *   rule35: Violation[];
+ *   rule37: Violation[];
  *   symlinks: string[];
  * }} state
  */
@@ -210,6 +218,7 @@ async function scanRepo(state) {
     checkRule28(posix, lines, state.rule28);
     checkRule33(posix, lines, state.rule33);
     checkRule35(posix, lines, state.rule35);
+    checkRule37(posix, content, state.rule37);
   }
 }
 
@@ -1066,6 +1075,7 @@ async function main() {
     rule28: /** @type {Violation[]} */ ([]),
     rule33: /** @type {Violation[]} */ ([]),
     rule35: /** @type {Violation[]} */ ([]),
+    rule37: /** @type {Violation[]} */ ([]),
     symlinks: /** @type {string[]} */ ([]),
   };
 
@@ -1156,6 +1166,7 @@ async function main() {
 
   // Rule 35
   violations.push(...state.rule35);
+  violations.push(...state.rule37);
 
   // Rule 36
   for (const issue of await checkExtensionCapabilityContracts()) {


### PR DESCRIPTION
### Summary

Related to #1659. This first PR in the instrumentation-provider stack replaces lifecycle payloads derived from AI SDK callback types with eve-owned projections at the AI SDK bridge. SDK upgrades now stay behind that mapping boundary, session failure and non-failure transitions have truthful payload types, and emitted spans and attributes remain unchanged. The projected event wrappers are frozen before sequential provider publication, and an AST-based invariant rejects static and dynamic imports from `ai` in the lifecycle contract.

This remains internal groundwork: it introduces no public provider API. #1670 builds the flat event vocabulary on top.

Review-significant details:

- `attempt.started.step` is removed because no consumer read it; the bridge retains only `stepNumber` to disambiguate call identities.
- Unknown model content-part kinds are dropped rather than leaked into the contract.
- Only eve-created wrappers and arrays are frozen; opaque model, tool, and provider payload values remain untouched.

### Validation

- `pnpm test:unit` — 6,033 passed, 1 skipped
- `pnpm typecheck`
- `pnpm guard:invariants` — includes multiline static import, import type, and dynamic import fixtures for Rule 37
- `ai-sdk-hook-bridge.test.ts` — 12 passed
- `local-instrumentation-runtime.scenario.test.ts` — 2 passed
- Targeted `oxfmt` and `oxlint` on changed files

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
