### PR TITLE
docs: add app auth for Vercel MCP

### DIFF
--- a/apps/docs/app/[lang]/integrations/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/integrations/[slug]/page.tsx
@@ -3,11 +3,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-import {
-  buildConnectionConfigure,
-  buildConnectionInstall,
-  buildConnectionSetup,
-} from "@/lib/integrations/connection-setup";
+import { buildConnectionInstall, buildConnectionSetup } from "@/lib/integrations/connection-setup";
 import {
   getIntegration,
   integrations,
@@ -66,9 +62,7 @@ const IntegrationDetailPage = async ({ params }: PageProps<"/[lang]/integrations
 
   const isConnection = Boolean(integration.connection);
   const install = isConnection ? buildConnectionInstall(integration) : (integration.install ?? "");
-  const configure = isConnection
-    ? buildConnectionConfigure(integration)
-    : (integration.configure ?? "");
+  const configure = integration.configure ?? "";
   const setup = isConnection ? buildConnectionSetup(integration) : null;
 
   return (
@@ -140,7 +134,23 @@ const IntegrationDetailPage = async ({ params }: PageProps<"/[lang]/integrations
           )}
         </Section>
         <Section title="Configure">
-          <Markdown>{configure}</Markdown>
+          {setup ? (
+            <Suspense
+              fallback={
+                <Markdown>
+                  {setup.configureVariants[`${setup.protocols[0]}:${setup.authModes[0]}`] ?? ""}
+                </Markdown>
+              }
+            >
+              <SetupTabs
+                authModes={setup.authModes}
+                protocols={setup.protocols}
+                variants={setup.configureVariants}
+              />
+            </Suspense>
+          ) : (
+            <Markdown>{configure}</Markdown>
+          )}
         </Section>
       </div>
     </main>

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -56,18 +56,23 @@ describe("Vercel MCP connection setup", () => {
     );
     expect(appQuickStart).toContain('"list_deployments"');
     expect(appQuickStart).toContain('"get_runtime_logs"');
-    const configure = buildConnectionConfigure(integration);
-    expect(configure).toContain("vercel connect create vercel");
-    expect(configure).not.toContain("vercel connect attach");
-    expect(configure.indexOf("vercel link")).toBeLessThan(
-      configure.indexOf("vercel connect create vercel"),
-    );
-    expect(configure).toContain("select None");
-    expect(configure).toContain("vercel connect create api-key --name vercel");
-    expect(configure).toContain(
+    const userConfigure = setup.configureVariants["mcp:user"];
+    const appConfigure = setup.configureVariants["mcp:app"];
+
+    expect(userConfigure).toContain("vercel connect create vercel --name vercel");
+    expect(userConfigure).toContain("Select None");
+    expect(userConfigure).not.toContain("create api-key");
+    expect(appConfigure).toContain("vercel connect create api-key --name vercel");
+    expect(appConfigure).not.toContain("Select None");
+    expect(appConfigure).toContain(
       "[Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token)",
     );
-    expect(configure).toContain("Copy the returned connector UID into the App example");
-    expect(configure).toContain("token still belongs to the user who created it");
+    expect(appConfigure).toContain("copy the returned connector UID into the App example");
+    expect(appConfigure).toContain("token still belongs to the user who created it");
+
+    const configure = buildConnectionConfigure(integration);
+    expect(configure).toContain("### MCP · User");
+    expect(configure).toContain("### MCP · App");
+    expect(configure).not.toContain("vercel connect attach");
   });
 });

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -54,8 +54,6 @@ describe("Vercel MCP connection setup", () => {
     expect(appQuickStart).toContain(
       'auth: connect({ connector: "vercel/your-connector", principalType: "app" })',
     );
-    expect(appQuickStart).toContain('"list_deployments"');
-    expect(appQuickStart).toContain('"get_runtime_logs"');
     const userConfigure = setup.configureVariants["mcp:user"];
     const appConfigure = setup.configureVariants["mcp:app"];
 

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -64,6 +64,7 @@ describe("Vercel MCP connection setup", () => {
     );
     expect(configure).toContain("select None");
     expect(configure).toContain("create an **API Key** connector");
+    expect(configure).toContain("vercel connect create api-key --name vercel");
     expect(configure).toContain("Vercel tokens are always owned by a user");
     expect(configure).toContain("vercel/coffee-bridge");
   });

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -63,12 +63,11 @@ describe("Vercel MCP connection setup", () => {
       configure.indexOf("vercel connect create vercel"),
     );
     expect(configure).toContain("select None");
-    expect(configure).toContain("create an **API Key** connector");
     expect(configure).toContain("vercel connect create api-key --name vercel");
     expect(configure).toContain(
       "[Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token)",
     );
-    expect(configure).toContain("Vercel tokens are always owned by a user");
-    expect(configure).toContain("vercel/coffee-bridge");
+    expect(configure).toContain("Copy the returned connector UID into the App example");
+    expect(configure).toContain("token still belongs to the user who created it");
   });
 });

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -42,12 +42,20 @@ describe("Kernel extension setup", () => {
 });
 
 describe("Vercel MCP connection setup", () => {
-  it("uses Vercel's MCP endpoint and Connect service", () => {
+  it("offers user OAuth and shared app credential setup", () => {
     const integration = getIntegration("vercel")!;
-    const quickStart = buildConnectionSetup(integration).variants["mcp:user"];
+    const setup = buildConnectionSetup(integration);
+    const userQuickStart = setup.variants["mcp:user"];
+    const appQuickStart = setup.variants["mcp:app"];
 
-    expect(quickStart).toContain('url: "https://mcp.vercel.com"');
-    expect(quickStart).toContain('auth: connect("vercel")');
+    expect(setup.authModes).toEqual(["user", "app"]);
+    expect(userQuickStart).toContain('url: "https://mcp.vercel.com"');
+    expect(userQuickStart).toContain('auth: connect("vercel")');
+    expect(appQuickStart).toContain(
+      'auth: connect({ connector: "vercel/your-connector", principalType: "app" })',
+    );
+    expect(appQuickStart).toContain('"list_deployments"');
+    expect(appQuickStart).toContain('"get_runtime_logs"');
     const configure = buildConnectionConfigure(integration);
     expect(configure).toContain("vercel connect create vercel");
     expect(configure).not.toContain("vercel connect attach");
@@ -55,5 +63,8 @@ describe("Vercel MCP connection setup", () => {
       configure.indexOf("vercel connect create vercel"),
     );
     expect(configure).toContain("select None");
+    expect(configure).toContain("create an **API Key** connector");
+    expect(configure).toContain("Vercel tokens are always owned by a user");
+    expect(configure).toContain("vercel/coffee-bridge");
   });
 });

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -65,6 +65,9 @@ describe("Vercel MCP connection setup", () => {
     expect(configure).toContain("select None");
     expect(configure).toContain("create an **API Key** connector");
     expect(configure).toContain("vercel connect create api-key --name vercel");
+    expect(configure).toContain(
+      "[Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token)",
+    );
     expect(configure).toContain("Vercel tokens are always owned by a user");
     expect(configure).toContain("vercel/coffee-bridge");
   });

--- a/apps/docs/lib/integrations/connection-setup.ts
+++ b/apps/docs/lib/integrations/connection-setup.ts
@@ -20,7 +20,8 @@ export interface ConnectionSetup {
 export const setupKey = (protocol: ConnectionProtocol, auth: AuthMode): string =>
   `${protocol}:${auth}`;
 
-const connectorOf = (slug: string, spec: ConnectionSpec): string => spec.connector ?? slug;
+const connectorOf = (slug: string, spec: ConnectionSpec, auth?: AuthMode): string =>
+  (auth === undefined ? undefined : spec.connectors?.[auth]) ?? spec.connector ?? slug;
 
 /** The TypeScript connection file for one (protocol, auth) combination. */
 const buildSnippet = (
@@ -32,7 +33,7 @@ const buildSnippet = (
   if (!spec) {
     return "";
   }
-  const connector = connectorOf(integration.slug, spec);
+  const connector = connectorOf(integration.slug, spec, auth);
   const description = spec.description ?? integration.tagline;
   const defineFn = protocol === "mcp" ? "defineMcpClientConnection" : "defineOpenAPIConnection";
   const transport = protocol === "mcp" ? spec.mcp : spec.openapi;
@@ -67,6 +68,16 @@ const buildSnippet = (
       `      return { type: "jwt-bearer", sub: email };`,
       `    },`,
       `  }),`,
+    );
+  }
+
+  if (protocol === "mcp" && spec.toolAllow !== undefined) {
+    fields.push(
+      `  tools: {`,
+      `    allow: [`,
+      ...spec.toolAllow.map((tool) => `      "${tool}",`),
+      `    ],`,
+      `  },`,
     );
   }
 

--- a/apps/docs/lib/integrations/connection-setup.ts
+++ b/apps/docs/lib/integrations/connection-setup.ts
@@ -4,6 +4,7 @@ import {
   type ConnectionSpec,
   type Integration,
   authModeLabel,
+  protocolLabel,
 } from "./data";
 
 /**
@@ -15,6 +16,8 @@ export interface ConnectionSetup {
   authModes: AuthMode[];
   /** Generated quick-start markdown keyed by `"<protocol>:<auth>"`. */
   variants: Record<string, string>;
+  /** Generated configure markdown keyed by `"<protocol>:<auth>"`. */
+  configureVariants: Record<string, string>;
 }
 
 export const setupKey = (protocol: ConnectionProtocol, auth: AuthMode): string =>
@@ -136,18 +139,81 @@ const buildVariant = (
   ].join("\n");
 };
 
-/** All quick-start variants for a connection, plus its switcher options. */
+/** Configure markdown for one auth mode. */
+const buildConfigureVariant = (integration: Integration, auth: AuthMode): string => {
+  const spec = integration.connection;
+  if (!spec) {
+    return "";
+  }
+  const sections: string[] = [];
+
+  if (auth !== "apiKey") {
+    const connector = connectorOf(integration.slug, spec, auth);
+    const modeService = spec.connectorServices?.[auth];
+    const connectorService = modeService ?? spec.connectorService ?? connector;
+    const namedConnector = modeService !== undefined || spec.connectorService !== undefined;
+    sections.push(
+      [
+        "Link your project, create the connector, and pull OIDC locally:",
+        ``,
+        "```bash",
+        "vercel link",
+        `vercel connect create ${connectorService}${
+          namedConnector ? ` --name ${integration.slug}` : ""
+        }`,
+        "vercel env pull",
+        "```",
+      ].join("\n"),
+    );
+  }
+
+  if (auth === "apiKey" && spec.apiKey) {
+    sections.push(
+      [
+        `Set \`${spec.apiKey.env}\` as a server-side environment variable:`,
+        ``,
+        "```bash",
+        `${spec.apiKey.env}=your_api_key`,
+        "```",
+      ].join("\n"),
+    );
+  }
+
+  if (auth === "jwtBearer") {
+    sections.push(
+      'For JWT bearer, `principalToSubject` controls the asserted subject. The default maps app principals to `{ type: "app" }` and user principals to `{ type: "user", id, issuer }`.',
+    );
+  }
+
+  const modeNote = spec.configureNotes?.[auth];
+  if (modeNote) {
+    sections.push(modeNote);
+  }
+  if (spec.configureNote) {
+    sections.push(spec.configureNote);
+  }
+
+  sections.push(
+    "See the [Connections docs](/docs/connections) for principal types, headers, approval, and protocol-specific filters.",
+  );
+  return sections.join("\n\n");
+};
+
+/** All quick-start and configure variants for a connection, plus their switcher options. */
 export const buildConnectionSetup = (integration: Integration): ConnectionSetup => {
   const spec = integration.connection;
   const protocols = spec ? (integration.protocols ?? []) : [];
   const authModes = spec?.authModes ?? [];
   const variants: Record<string, string> = {};
+  const configureVariants: Record<string, string> = {};
   for (const protocol of protocols) {
     for (const auth of authModes) {
-      variants[setupKey(protocol, auth)] = buildVariant(integration, protocol, auth);
+      const key = setupKey(protocol, auth);
+      variants[key] = buildVariant(integration, protocol, auth);
+      configureVariants[key] = buildConfigureVariant(integration, auth);
     }
   }
-  return { protocols, authModes, variants };
+  return { protocols, authModes, variants, configureVariants };
 };
 
 /** Generated Install markdown for a connection. */
@@ -166,55 +232,15 @@ export const buildConnectionInstall = (integration: Integration): string => {
 
 /** Generated Configure markdown for a connection. */
 export const buildConnectionConfigure = (integration: Integration): string => {
-  const spec = integration.connection;
-  if (!spec) {
-    return "";
-  }
-  const sections: string[] = [];
-  if (spec.authModes.some((auth) => auth !== "apiKey")) {
-    const connector = connectorOf(integration.slug, spec);
-    const connectorService = spec.connectorService ?? connector;
-    sections.push(
-      [
-        "Link your project, create the connector, and pull OIDC locally:",
-        ``,
-        "```bash",
-        "vercel link",
-        `vercel connect create ${connectorService}${
-          spec.connectorService === undefined ? "" : ` --name ${integration.slug}`
-        }`,
-        "vercel env pull",
-        "```",
-      ].join("\n"),
-    );
-  }
-
-  if (spec.apiKey) {
-    sections.push(
-      [
-        `Set \`${spec.apiKey.env}\` as a server-side environment variable:`,
-        ``,
-        "```bash",
-        `${spec.apiKey.env}=your_api_key`,
-        "```",
-      ].join("\n"),
-    );
-  }
-
-  if (spec.authModes.includes("jwtBearer")) {
-    sections.push(
-      'For JWT bearer, `principalToSubject` controls the asserted subject. The default maps app principals to `{ type: "app" }` and user principals to `{ type: "user", id, issuer }`.',
-    );
-  }
-
-  if (spec.configureNote) {
-    sections.push(spec.configureNote);
-  }
-
-  sections.push(
-    "See the [Connections docs](/docs/connections) for principal types, headers, approval, and protocol-specific filters.",
-  );
-  return sections.join("\n\n");
+  const setup = buildConnectionSetup(integration);
+  return setup.protocols
+    .flatMap((protocol) =>
+      setup.authModes.map((auth) => {
+        const content = setup.configureVariants[setupKey(protocol, auth)] ?? "";
+        return `### ${protocolLabel[protocol]} · ${authModeLabel[auth]}\n\n${content}`;
+      }),
+    )
+    .join("\n\n");
 };
 
 /** Human label for an auth-mode switcher button. */

--- a/apps/docs/lib/integrations/connection-setup.ts
+++ b/apps/docs/lib/integrations/connection-setup.ts
@@ -74,16 +74,6 @@ const buildSnippet = (
     );
   }
 
-  if (protocol === "mcp" && spec.toolAllow !== undefined) {
-    fields.push(
-      `  tools: {`,
-      `    allow: [`,
-      ...spec.toolAllow.map((tool) => `      "${tool}",`),
-      `    ],`,
-      `  },`,
-    );
-  }
-
   const headerLines: string[] = [];
   if (auth === "apiKey" && spec.apiKey) {
     headerLines.push(`    "${spec.apiKey.header}": process.env.${spec.apiKey.env}!,`);

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -41,7 +41,7 @@ export interface ApiKeySpec {
  * Structured description of a connection consumed by the detail page to
  * generate Install, Quick start, and Configure content. Transport (`mcp`,
  * `openapi`) and `description` are filled from the shared catalog identity;
- * `authModes`, `connector`, and `configureNote` are the docs-only overlay.
+ * Auth modes, connectors, and configure notes are the docs-only overlay.
  */
 export interface ConnectionSpec {
   /** Vercel Connect connector UID; defaults to the integration slug. */
@@ -50,6 +50,8 @@ export interface ConnectionSpec {
   connectors?: Partial<Record<AuthMode, string>>;
   /** Service passed to `vercel connect create` when it differs from the connector UID. */
   connectorService?: string;
+  /** Auth-mode-specific services passed to `vercel connect create`. */
+  connectorServices?: Partial<Record<AuthMode, string>>;
   /** Supported auth modes in display order; the first is the default. */
   authModes: AuthMode[];
   /** API-key wiring when `authModes` includes `apiKey`. */
@@ -62,6 +64,8 @@ export interface ConnectionSpec {
   openapi?: ConnectionIdentity["openapi"];
   /** Optional provider-specific configure guidance, rendered as markdown. */
   configureNote?: string;
+  /** Auth-mode-specific configure guidance, rendered as markdown. */
+  configureNotes?: Partial<Record<AuthMode, string>>;
 }
 
 export interface Integration {
@@ -123,7 +127,9 @@ interface ConnectionPresentation extends Presentation {
   connector?: string;
   connectors?: Partial<Record<AuthMode, string>>;
   connectorService?: string;
+  connectorServices?: Partial<Record<AuthMode, string>>;
   configureNote?: string;
+  configureNotes?: Partial<Record<AuthMode, string>>;
 }
 
 const channelPresentations: Record<string, ChannelPresentation> = {
@@ -1483,6 +1489,7 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     connector: "vercel",
     connectors: { app: "vercel/your-connector" },
     connectorService: "vercel",
+    connectorServices: { app: "api-key" },
     toolAllow: [
       "search_documentation",
       "list_teams",
@@ -1493,15 +1500,10 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
       "get_deployment_build_logs",
       "get_runtime_logs",
     ],
-    configureNote: `For **User** auth, select None when prompted for a token authentication method. Each user completes OAuth when needed.
-
-For **App** auth, run this from the eve project directory and enter a team-scoped [Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token):
-
-\`\`\`bash
-vercel connect create api-key --name vercel
-\`\`\`
-
-Copy the returned connector UID into the App example. This avoids per-user OAuth, though the Vercel token still belongs to the user who created it.`,
+    configureNotes: {
+      user: "Select None when prompted for a token authentication method. Each user completes OAuth when needed.",
+      app: "Enter a team-scoped [Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token) when prompted, then copy the returned connector UID into the App example. This avoids per-user OAuth, though the Vercel token still belongs to the user who created it.",
+    },
   },
   linear: {
     logo: "linear",
@@ -2024,9 +2026,13 @@ function buildConnection(entry: IntegrationEntry): Integration {
   if (presentation.connectorService !== undefined) {
     spec.connectorService = presentation.connectorService;
   }
+  if (presentation.connectorServices !== undefined) {
+    spec.connectorServices = presentation.connectorServices;
+  }
   if (identity.mcp !== undefined) spec.mcp = identity.mcp;
   if (identity.openapi !== undefined) spec.openapi = identity.openapi;
   if (presentation.configureNote !== undefined) spec.configureNote = presentation.configureNote;
+  if (presentation.configureNotes !== undefined) spec.configureNotes = presentation.configureNotes;
   return {
     slug: entry.slug,
     name: entry.name,

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1493,21 +1493,15 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
       "get_deployment_build_logs",
       "get_runtime_logs",
     ],
-    configureNote: `For **User** auth, select None when the Connect form asks for a token authentication method. Vercel MCP completes OAuth when each user first calls an authenticated tool.
+    configureNote: `For **User** auth, select None when prompted for a token authentication method. Each user completes OAuth when needed.
 
-For **App** auth without per-user OAuth:
+For **App** auth, run this from the eve project directory and enter a team-scoped [Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token):
 
-1. Create a [Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token) scoped to the team and projects the agent needs.
-2. From the eve project directory, create an **API Key** connector and enter the Vercel token when prompted:
+\`\`\`bash
+vercel connect create api-key --name vercel
+\`\`\`
 
-   \`\`\`bash
-   vercel connect create api-key --name vercel
-   \`\`\`
-
-3. Attach the connector to the Vercel project that runs the eve agent.
-4. Copy its connector UID (for example, \`vercel/coffee-bridge\`) and replace \`vercel/your-connector\` in the App example.
-
-Vercel tokens are always owned by a user, but Connect presents this shared credential to eve as the app principal, so agent users do not complete individual OAuth flows. Use a dedicated identity where practical, grant only the access the agent needs, and rotate the token as you would any long-lived secret.`,
+Copy the returned connector UID into the App example. This avoids per-user OAuth, though the Vercel token still belongs to the user who created it.`,
   },
   linear: {
     logo: "linear",

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -46,17 +46,21 @@ export interface ApiKeySpec {
 export interface ConnectionSpec {
   /** Vercel Connect connector UID; defaults to the integration slug. */
   connector?: string;
+  /** Auth-mode-specific connector UIDs when one service needs separate connectors. */
+  connectors?: Partial<Record<AuthMode, string>>;
   /** Service passed to `vercel connect create` when it differs from the connector UID. */
   connectorService?: string;
   /** Supported auth modes in display order; the first is the default. */
   authModes: AuthMode[];
   /** API-key wiring when `authModes` includes `apiKey`. */
   apiKey?: ApiKeySpec;
+  /** Optional MCP tool allow-list included in generated examples. */
+  toolAllow?: string[];
   /** Model-facing description; defaults to the integration tagline. */
   description?: string;
   mcp?: ConnectionIdentity["mcp"];
   openapi?: ConnectionIdentity["openapi"];
-  /** Optional one-line, provider-specific configure note. Keep it short. */
+  /** Optional provider-specific configure guidance, rendered as markdown. */
   configureNote?: string;
 }
 
@@ -115,7 +119,9 @@ interface ExtensionPresentation extends Presentation {
 interface ConnectionPresentation extends Presentation {
   authModes: AuthMode[];
   apiKey?: ApiKeySpec;
+  toolAllow?: string[];
   connector?: string;
+  connectors?: Partial<Record<AuthMode, string>>;
   connectorService?: string;
   configureNote?: string;
 }
@@ -1473,11 +1479,30 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     logo: "vercel",
     docsHref: "https://vercel.com/docs/agent-resources/vercel-mcp",
     keywords: ["mcp", "projects", "deployments", "logs", "oauth", "connect"],
-    authModes: ["user"],
+    authModes: ["user", "app"],
     connector: "vercel",
+    connectors: { app: "vercel/your-connector" },
     connectorService: "vercel",
-    configureNote:
-      "When the Connect form asks for a token authentication method, select None. Vercel MCP completes OAuth when the agent first calls an authenticated tool.",
+    toolAllow: [
+      "search_documentation",
+      "list_teams",
+      "list_projects",
+      "get_project",
+      "list_deployments",
+      "get_deployment",
+      "get_deployment_build_logs",
+      "get_runtime_logs",
+    ],
+    configureNote: `For **User** auth, select None when the Connect form asks for a token authentication method. Vercel MCP completes OAuth when each user first calls an authenticated tool.
+
+For **App** auth without per-user OAuth:
+
+1. Create a Vercel token that can access the team and projects the agent needs.
+2. In Vercel Connect, create an **API Key** connector and enter the Vercel token as its API key.
+3. Attach the connector to the Vercel project that runs the eve agent.
+4. Copy its connector UID (for example, \`vercel/coffee-bridge\`) and replace \`vercel/your-connector\` in the App example.
+
+Vercel tokens are always owned by a user, but Connect presents this shared credential to eve as the app principal, so agent users do not complete individual OAuth flows. Use a dedicated identity where practical, grant only the access the agent needs, and rotate the token as you would any long-lived secret.`,
   },
   linear: {
     logo: "linear",
@@ -1994,7 +2019,9 @@ function buildConnection(entry: IntegrationEntry): Integration {
     description: identity.description,
   };
   if (presentation.apiKey !== undefined) spec.apiKey = presentation.apiKey;
+  if (presentation.toolAllow !== undefined) spec.toolAllow = presentation.toolAllow;
   if (presentation.connector !== undefined) spec.connector = presentation.connector;
+  if (presentation.connectors !== undefined) spec.connectors = presentation.connectors;
   if (presentation.connectorService !== undefined) {
     spec.connectorService = presentation.connectorService;
   }

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1498,7 +1498,12 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
 For **App** auth without per-user OAuth:
 
 1. Create a Vercel token that can access the team and projects the agent needs.
-2. In Vercel Connect, create an **API Key** connector and enter the Vercel token as its API key.
+2. From the eve project directory, create an **API Key** connector and enter the Vercel token when prompted:
+
+   \`\`\`bash
+   vercel connect create api-key --name vercel
+   \`\`\`
+
 3. Attach the connector to the Vercel project that runs the eve agent.
 4. Copy its connector UID (for example, \`vercel/coffee-bridge\`) and replace \`vercel/your-connector\` in the App example.
 

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -56,8 +56,6 @@ export interface ConnectionSpec {
   authModes: AuthMode[];
   /** API-key wiring when `authModes` includes `apiKey`. */
   apiKey?: ApiKeySpec;
-  /** Optional MCP tool allow-list included in generated examples. */
-  toolAllow?: string[];
   /** Model-facing description; defaults to the integration tagline. */
   description?: string;
   mcp?: ConnectionIdentity["mcp"];
@@ -123,7 +121,6 @@ interface ExtensionPresentation extends Presentation {
 interface ConnectionPresentation extends Presentation {
   authModes: AuthMode[];
   apiKey?: ApiKeySpec;
-  toolAllow?: string[];
   connector?: string;
   connectors?: Partial<Record<AuthMode, string>>;
   connectorService?: string;
@@ -1490,16 +1487,6 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     connectors: { app: "vercel/your-connector" },
     connectorService: "vercel",
     connectorServices: { app: "api-key" },
-    toolAllow: [
-      "search_documentation",
-      "list_teams",
-      "list_projects",
-      "get_project",
-      "list_deployments",
-      "get_deployment",
-      "get_deployment_build_logs",
-      "get_runtime_logs",
-    ],
     configureNotes: {
       user: "Select None when prompted for a token authentication method. Each user completes OAuth when needed.",
       app: "Enter a team-scoped [Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token) when prompted, then copy the returned connector UID into the App example. This avoids per-user OAuth, though the Vercel token still belongs to the user who created it.",
@@ -2020,7 +2007,6 @@ function buildConnection(entry: IntegrationEntry): Integration {
     description: identity.description,
   };
   if (presentation.apiKey !== undefined) spec.apiKey = presentation.apiKey;
-  if (presentation.toolAllow !== undefined) spec.toolAllow = presentation.toolAllow;
   if (presentation.connector !== undefined) spec.connector = presentation.connector;
   if (presentation.connectors !== undefined) spec.connectors = presentation.connectors;
   if (presentation.connectorService !== undefined) {

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1497,7 +1497,7 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
 
 For **App** auth without per-user OAuth:
 
-1. Create a Vercel token that can access the team and projects the agent needs.
+1. Create a [Vercel token](https://vercel.com/kb/guide/how-do-i-use-a-vercel-api-access-token) scoped to the team and projects the agent needs.
 2. From the eve project directory, create an **API Key** connector and enter the Vercel token when prompted:
 
    \`\`\`bash


### PR DESCRIPTION
## Summary

- show both User and App auth variants on `/integrations/vercel`
- document the API Key connector flow for shared Vercel MCP access without per-user OAuth
- add a read-only Vercel MCP tool allow-list to the generated examples
- support auth-mode-specific connector UIDs in generated connection snippets

## Testing

- `pnpm --filter eve-docs test:unit -- lib/integrations/connection-setup.test.ts`
- `pnpm docs:check`
- `pnpm --filter eve run build`
- `pnpm --filter eve-docs registry:check`