### PR TITLE
fix(eve): prevent sandbox abort listener accumulation

### DIFF
--- a/.changeset/sandbox-abort-listeners.md
+++ b/.changeset/sandbox-abort-listeners.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent sandbox abort listeners from accumulating across repeated operations in a turn.

--- a/packages/eve/src/context/build-base-tool-context.integration.test.ts
+++ b/packages/eve/src/context/build-base-tool-context.integration.test.ts
@@ -26,7 +26,11 @@ describe("buildBaseToolContext – getSandbox abort binding", () => {
       await live.run({ command: "echo ready" });
     });
 
-    expect(observed).toBe(controller.signal);
+    expect(observed).toBeDefined();
+    expect(observed).not.toBe(controller.signal);
+    expect(observed?.aborted).toBe(false);
+    controller.abort(new Error("turn cancelled"));
+    expect(observed?.aborted).toBe(true);
   });
 
   it("binds the inert fallback signal when no turn signal exists", async () => {

--- a/packages/eve/src/execution/sandbox/abort-bound-session.test.ts
+++ b/packages/eve/src/execution/sandbox/abort-bound-session.test.ts
@@ -1,3 +1,5 @@
+import { getEventListeners } from "node:events";
+
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -85,8 +87,44 @@ describe("bindSandboxAbortSignal", () => {
       "removePath",
     ]);
     for (const call of calls) {
-      expect(call.abortSignal).toBe(signal);
+      expect(call.abortSignal).not.toBe(signal);
+      expect(call.abortSignal?.aborted).toBe(false);
     }
+    expect(new Set(calls.map((call) => call.abortSignal)).size).toBe(calls.length);
+  });
+
+  it("does not accumulate backend listeners on the bound signal", async () => {
+    const calls: RecordedCall[] = [];
+    const recordingSession = createRecordingSession(calls);
+    const listenerSession: SandboxSession = {
+      ...recordingSession,
+      run: async (options) => {
+        options.abortSignal?.addEventListener("abort", () => {}, { once: true });
+        return recordingSession.run(options);
+      },
+    };
+    const controller = new AbortController();
+    const bound = bindSandboxAbortSignal(listenerSession, controller.signal);
+
+    for (let index = 0; index < 20; index += 1) {
+      await bound.run({ command: "echo hi" });
+    }
+
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+  });
+
+  it("propagates the bound abort signal to a default operation signal", async () => {
+    const calls: RecordedCall[] = [];
+    const controller = new AbortController();
+    const bound = bindSandboxAbortSignal(createRecordingSession(calls), controller.signal);
+
+    await bound.run({ command: "echo hi" });
+    const operationSignal = calls[0]?.abortSignal;
+    const reason = new Error("turn cancelled");
+    controller.abort(reason);
+
+    expect(operationSignal?.aborted).toBe(true);
+    expect(operationSignal?.reason).toBe(reason);
   });
 
   it("composes a call-level signal with the bound signal instead of replacing it", async () => {

--- a/packages/eve/src/execution/sandbox/abort-bound-session.ts
+++ b/packages/eve/src/execution/sandbox/abort-bound-session.ts
@@ -20,7 +20,7 @@ export function bindSandboxAbortSignal(
   abortSignal: AbortSignal,
 ): SandboxSession {
   const compose = (callSignal: AbortSignal | undefined): AbortSignal =>
-    callSignal === undefined ? abortSignal : AbortSignal.any([abortSignal, callSignal]);
+    AbortSignal.any(callSignal === undefined ? [abortSignal] : [abortSignal, callSignal]);
 
   return {
     ...session,


### PR DESCRIPTION
Closes #1624.

Repeated sandbox calls reused the turn-level abort signal, so backend listeners accumulated on it. Give each operation a dependent signal while preserving turn cancellation propagation.