### PR TITLE
feat(docs): add Hindsight memory extension

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1407,6 +1407,65 @@ export default githubExtension({
 
 For local or non-Vercel deployments, omit \`connector\` and set \`GITHUB_TOKEN\`; the extension also accepts an explicit \`token\`. Prefer fine-grained credentials, expose only the presets the agent needs, and keep approval enabled for writes. See the [GitHub Tools eve documentation](https://github-tools.com/frameworks/eve#eve-extension) for token authentication, per-tool overrides, commit attribution, and the complete tool catalog.`,
   },
+  hindsight: {
+    logo: "hindsight",
+    docsHref: "https://hindsight.vectorize.io/sdks/integrations/eve",
+    keywords: [
+      "memory",
+      "long-term memory",
+      "automatic recall",
+      "retention",
+      "user profile",
+      "context",
+      "Hindsight Cloud",
+      "self-hosted",
+      "Vectorize",
+    ],
+    install: `Install Hindsight memory for eve:
+
+\`\`\`bash
+eve add extension/hindsight
+\`\`\`
+
+This installs \`@vectorize-io/hindsight-eve\` and writes \`agent/instructions/hindsight.ts\` for recall plus \`agent/hooks/hindsight.ts\` for retention. The package requires Node.js 24 or later.`,
+    quickStart: `Create a Hindsight Cloud API key and add it to the agent's environment. The API URL defaults to Hindsight Cloud, and the bank defaults to \`default\`:
+
+\`\`\`bash title=".env.local"
+HINDSIGHT_API_KEY=...
+HINDSIGHT_BANK_ID=my-agent
+\`\`\`
+
+The registry creates both capability files:
+
+\`\`\`ts title="agent/instructions/hindsight.ts"
+import { hindsightMemory } from "@vectorize-io/hindsight-eve";
+
+export default hindsightMemory();
+\`\`\`
+
+\`\`\`ts title="agent/hooks/hindsight.ts"
+import { hindsightRetainHook } from "@vectorize-io/hindsight-eve";
+
+export default hindsightRetainHook();
+\`\`\`
+
+Before each turn, the dynamic instructions resolver recalls the user's ambient profile and working context. After the turn, the hook retains the user message and assistant reply. Neither path depends on the model choosing to call a tool.`,
+    configure: `Recall uses a fixed broad query rather than the live user message. Tune the profile context and response budget in the instructions file when needed:
+
+\`\`\`ts title="agent/instructions/hindsight.ts"
+import { hindsightMemory } from "@vectorize-io/hindsight-eve";
+
+export default hindsightMemory({
+  recallQuery: "user preferences, identity, projects, and working context",
+  budget: "high",
+  maxTokens: 2048,
+});
+\`\`\`
+
+For a self-hosted server, set \`HINDSIGHT_API_URL\` and pass \`apiKey: null\` to both factories when the server has no authentication. Other shared options include \`bankId\`, \`context\`, \`includeAssistantReply\`, \`timeoutMs\`, and \`onError\`.
+
+A bank is one isolated memory store, and both files must use the same bank. Do not share the default bank across untrusted users; use separate agent deployments with distinct \`HINDSIGHT_BANK_ID\` values for separate users or tenants. See the [Hindsight eve integration guide](https://hindsight.vectorize.io/sdks/integrations/eve) for Cloud, self-hosted, and factory configuration.`,
+  },
   "agent-browser": {
     logo: "agent-browser",
     docsHref:

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -80,6 +80,19 @@ describe("integration discovery", () => {
     expect(integrationSearchText(agentkit!)).toContain("long-term memory");
   });
 
+  it("renders the Hindsight memory extension setup", () => {
+    const hindsight = getIntegration("hindsight");
+    expect(hindsight).toBeDefined();
+
+    const markdown = integrationMarkdown(hindsight!);
+    expect(markdown).toContain("eve add extension/hindsight");
+    expect(markdown).toContain('import { hindsightMemory } from "@vectorize-io/hindsight-eve"');
+    expect(markdown).toContain("hindsightRetainHook");
+    expect(markdown).toContain("HINDSIGHT_API_KEY");
+    expect(markdown).toContain("HINDSIGHT_BANK_ID");
+    expect(integrationSearchText(hindsight!)).toContain("long-term memory");
+  });
+
   it("renders the GitHub Tools extension setup", () => {
     const githubTools = getIntegration("github-tools");
     expect(githubTools).toBeDefined();

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -177,6 +177,24 @@ export const notionLogo = (props: LogoProps) => <SiNotion {...props} />;
 
 export const upstashLogo = (props: LogoProps) => <SiUpstash color="default" {...props} />;
 
+export const hindsightLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 186 139" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g stroke="#078BC2" strokeLinecap="round" strokeLinejoin="round" strokeWidth="8">
+      <path d="m65 53-14-23M121 53l14-23M42 69l-20-5M144 69l20-5M61 96l-16 17M125 96l16 17" />
+      <circle cx="44" cy="19" fill="white" r="11" />
+      <circle cx="142" cy="19" fill="white" r="11" />
+      <circle cx="12" cy="61" fill="white" r="9" />
+      <circle cx="174" cy="61" fill="white" r="9" />
+      <circle cx="35" cy="121" fill="white" r="9" />
+      <circle cx="151" cy="121" fill="white" r="9" />
+    </g>
+    <path d="M37 72c14-21 34-33 56-33s42 12 56 33c-14 23-34 35-56 35S51 95 37 72Z" fill="#078BC2" />
+    <ellipse cx="93" cy="73" fill="white" rx="30" ry="21" />
+    <circle cx="93" cy="73" fill="#111827" r="17" />
+    <circle cx="102" cy="64" fill="white" r="7" />
+  </svg>
+);
+
 export const datadogLogo = (props: LogoProps) => <SiDatadog color="default" {...props} />;
 
 export const honeycombLogo = (props: LogoProps) => (
@@ -616,6 +634,7 @@ export const logos = {
   raindrop: raindropLogo,
   kernel: kernelLogo,
   upstash: upstashLogo,
+  hindsight: hindsightLogo,
   airtable: airtableLogo,
   bitly: bitlyLogo,
   brex: brexLogo,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -77,6 +77,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@upstash/agentkit-eve-extension": "^0.4.0",
+    "@vectorize-io/hindsight-eve": "^0.2.1",
     "@veltdev/chat-sdk-adapter": "0.2.4",
     "@vercel/connect": "catalog:",
     "@vercel/otel": "catalog:",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -52,6 +52,30 @@
       ]
     },
     {
+      "name": "extension/hindsight",
+      "type": "registry:item",
+      "title": "Hindsight",
+      "description": "Recall relevant context before every turn and retain each exchange automatically.",
+      "dependencies": ["@vectorize-io/hindsight-eve"],
+      "envVars": {
+        "HINDSIGHT_API_KEY": "",
+        "HINDSIGHT_API_URL": "",
+        "HINDSIGHT_BANK_ID": ""
+      },
+      "files": [
+        {
+          "path": "registry/extensions/hindsight-instructions.ts",
+          "type": "registry:file",
+          "target": "agent/instructions/hindsight.ts"
+        },
+        {
+          "path": "registry/extensions/hindsight-hook.ts",
+          "type": "registry:file",
+          "target": "agent/hooks/hindsight.ts"
+        }
+      ]
+    },
+    {
       "name": "extension/jetty",
       "type": "registry:item",
       "title": "Jetty",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -52,30 +52,6 @@
       ]
     },
     {
-      "name": "extension/hindsight",
-      "type": "registry:item",
-      "title": "Hindsight",
-      "description": "Recall relevant context before every turn and retain each exchange automatically.",
-      "dependencies": ["@vectorize-io/hindsight-eve"],
-      "envVars": {
-        "HINDSIGHT_API_KEY": "",
-        "HINDSIGHT_API_URL": "",
-        "HINDSIGHT_BANK_ID": ""
-      },
-      "files": [
-        {
-          "path": "registry/extensions/hindsight-instructions.ts",
-          "type": "registry:file",
-          "target": "agent/instructions/hindsight.ts"
-        },
-        {
-          "path": "registry/extensions/hindsight-hook.ts",
-          "type": "registry:file",
-          "target": "agent/hooks/hindsight.ts"
-        }
-      ]
-    },
-    {
       "name": "extension/jetty",
       "type": "registry:item",
       "title": "Jetty",
@@ -125,6 +101,30 @@
           "path": "registry/extensions/upstash-agentkit.ts",
           "type": "registry:file",
           "target": "agent/extensions/agentkit.ts"
+        }
+      ]
+    },
+    {
+      "name": "extension/hindsight",
+      "type": "registry:item",
+      "title": "Hindsight",
+      "description": "Recall relevant context before every turn and retain each exchange automatically.",
+      "dependencies": ["@vectorize-io/hindsight-eve"],
+      "envVars": {
+        "HINDSIGHT_API_KEY": "",
+        "HINDSIGHT_API_URL": "",
+        "HINDSIGHT_BANK_ID": ""
+      },
+      "files": [
+        {
+          "path": "registry/extensions/hindsight-instructions.ts",
+          "type": "registry:file",
+          "target": "agent/instructions/hindsight.ts"
+        },
+        {
+          "path": "registry/extensions/hindsight-hook.ts",
+          "type": "registry:file",
+          "target": "agent/hooks/hindsight.ts"
         }
       ]
     },

--- a/apps/docs/registry/extensions/hindsight-hook.ts
+++ b/apps/docs/registry/extensions/hindsight-hook.ts
@@ -1,0 +1,3 @@
+import { hindsightRetainHook } from "@vectorize-io/hindsight-eve";
+
+export default hindsightRetainHook();

--- a/apps/docs/registry/extensions/hindsight-instructions.ts
+++ b/apps/docs/registry/extensions/hindsight-instructions.ts
@@ -1,0 +1,3 @@
+import { hindsightMemory } from "@vectorize-io/hindsight-eve";
+
+export default hindsightMemory();

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -93,6 +93,11 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("upstash-agentkit")?.connection).toBeUndefined();
   });
 
+  it("exposes Hindsight as an extension", () => {
+    expect(getIntegrationEntry("hindsight")?.kind).toBe("extension");
+    expect(getIntegrationEntry("hindsight")?.connection).toBeUndefined();
+  });
+
   it("exposes GitHub Tools as an extension distinct from the GitHub channel", () => {
     expect(getIntegrationEntry("github")?.kind).toBe("channel");
     expect(getIntegrationEntry("github-tools")?.kind).toBe("extension");

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -281,13 +281,6 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
-    slug: "hindsight",
-    name: "Hindsight",
-    kind: "extension",
-    tagline: "Recall relevant context before every turn and retain each exchange automatically.",
-    surfaces: { scaffoldable: false, gallery: true },
-  },
-  {
     slug: "jetty",
     name: "Jetty",
     kind: "extension",
@@ -307,6 +300,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     name: "Upstash AgentKit",
     kind: "extension",
     tagline: "Add long-term memory, Redis Search, and durable chat history with Upstash Redis.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
+    slug: "hindsight",
+    name: "Hindsight",
+    kind: "extension",
+    tagline: "Recall relevant context before every turn and retain each exchange automatically.",
     surfaces: { scaffoldable: false, gallery: true },
   },
   {

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -281,6 +281,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "hindsight",
+    name: "Hindsight",
+    kind: "extension",
+    tagline: "Recall relevant context before every turn and retain each exchange automatically.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "jetty",
     name: "Jetty",
     kind: "extension",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@upstash/agentkit-eve-extension':
         specifier: ^0.4.0
         version: 0.4.0(eve@packages+eve)
+      '@vectorize-io/hindsight-eve':
+        specifier: ^0.2.1
+        version: 0.2.1(eve@packages+eve)
       '@veltdev/chat-sdk-adapter':
         specifier: 0.2.4
         version: 0.2.4(ai@7.0.38(zod@4.4.3))(chat@4.34.0(ai@7.0.38(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
@@ -7492,6 +7495,12 @@ packages:
 
   '@upstash/redis@1.38.0':
     resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
+  '@vectorize-io/hindsight-eve@0.2.1':
+    resolution: {integrity: sha512-dFrCRgX/fXNV7bCCXfifmKTEQnj4insbxOQ79GU9mHMwZ9XfjQ1Oq8679C9xHwpItCtx6cDPqWZkluq8iY+qNg==}
+    engines: {node: '>=24'}
+    peerDependencies:
+      eve: '>=0.11.0'
 
   '@veltdev/chat-sdk-adapter@0.2.4':
     resolution: {integrity: sha512-Amzn9rMKpkDjpC1uxpn9ztsIdFSF6sC+6KOUhyIPkQhinKCS5AUI1XCO8aLZTlolyDObPt4Gmib8XSmSg9Uclg==}
@@ -21748,6 +21757,10 @@ snapshots:
   '@upstash/redis@1.38.0':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vectorize-io/hindsight-eve@0.2.1(eve@packages+eve)':
+    dependencies:
+      eve: link:packages/eve
 
   '@veltdev/chat-sdk-adapter@0.2.4(ai@7.0.38(zod@4.4.3))(chat@4.34.0(ai@7.0.38(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,6 +74,7 @@ minimumReleaseAgeExclude:
   - "@photon-ai/chat-adapter-imessage"
   - "@resend/chat-sdk-adapter"
   - "@upstash/agentkit-eve-extension"
+  - "@vectorize-io/hindsight-eve"
   - "@veltdev/chat-sdk-adapter"
   - "@zernio/chat-sdk-adapter"
   - chat


### PR DESCRIPTION
### Description

Add Hindsight as an official memory extension in eve's integration catalog and registry. `eve add extension/hindsight` installs `@vectorize-io/hindsight-eve` and writes the dynamic instructions and hook files that recall context before each turn and retain completed exchanges afterward.

The integrations gallery now includes Hindsight setup for Cloud and self-hosted deployments, its shared configuration options, a bank-isolation warning for multi-user agents, search metadata, and a branded icon. This is a follow-up to #55 using Hindsight's package-backed eve integration instead of an MCP connection.

No changeset is required because this only touches docs and the private catalog package, not the published `eve` package.

### How did you test your changes?

- `pnpm --filter eve build`
- `pnpm --filter eve-docs registry:check`
- `pnpm --filter @eve/catalog test:unit`
- `pnpm --filter eve-docs test:unit`
- `pnpm --filter @eve/catalog typecheck`
- `pnpm --filter eve-docs exec next typegen && pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm --filter eve-docs build`

### PR Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
