### PR TITLE
fix(eve): keep the vitest cache out of dev runtime snapshots

### DIFF
--- a/.changeset/skip-workflow-vitest-cache.md
+++ b/.changeset/skip-workflow-vitest-cache.md
@@ -1,0 +1,8 @@
+---
+"eve": patch
+---
+
+Dev runtime snapshots no longer copy the `.workflow-vitest` test cache. In
+workspaces that had run integration tests, this directory was duplicated into
+every generation under `.eve/dev-runtime/snapshots` — tens of megabytes per
+rebuild that nothing at dev runtime reads.

--- a/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-artifacts.integration.test.ts
@@ -239,6 +239,7 @@ describe("development runtime artifact snapshots", () => {
     await mkdir(join(appRoot, ".next", "cache"), { recursive: true });
     await mkdir(join(appRoot, ".generated", "compiled"), { recursive: true });
     await mkdir(join(appRoot, ".workflow-data", "streams"), { recursive: true });
+    await mkdir(join(appRoot, ".workflow-vitest"), { recursive: true });
     await mkdir(join(appRoot, "build"), { recursive: true });
     await mkdir(join(appRoot, "dist"), { recursive: true });
     await mkdir(compileDirectoryPath, { recursive: true });
@@ -251,6 +252,7 @@ describe("development runtime artifact snapshots", () => {
     await writeFile(join(appRoot, ".next", "cache", "webpack.bin"), "cache\n");
     await writeFile(join(appRoot, ".generated", "compiled", "bundle.js"), "generated\n");
     await writeFile(join(appRoot, ".workflow-data", "streams", "events.bin"), "events\n");
+    await writeFile(join(appRoot, ".workflow-vitest", "steps.mjs"), "export {}\n");
     await writeFile(join(appRoot, "build", "server.js"), "build\n");
     await writeFile(join(appRoot, "dist", "index.js"), "dist\n");
     await writeFile(manifestPath, `${JSON.stringify({ agentRoot, appRoot }, null, 2)}\n`);
@@ -268,6 +270,7 @@ describe("development runtime artifact snapshots", () => {
     expect(existsSync(join(snapshot.runtimeAppRoot, ".next"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, ".generated"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, ".workflow-data"))).toBe(false);
+    expect(existsSync(join(snapshot.runtimeAppRoot, ".workflow-vitest"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, "build"))).toBe(false);
     expect(existsSync(join(snapshot.runtimeAppRoot, "dist"))).toBe(false);
   });

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -25,6 +25,7 @@ const SNAPSHOT_SKIP_NAMES = new Set([
   ".turbo",
   ".vercel",
   ".workflow-data",
+  ".workflow-vitest",
   "node_modules",
 ]);
 const SNAPSHOT_APP_ROOT_SKIP_NAMES = new Set(["build", "dist"]);


### PR DESCRIPTION
## Summary

`.workflow-vitest` should not be copied into each snapshot locally it's 22 MB of each 73 MB snapshot.

Replaces #1557, which bounded the same symptom by decaying snapshots harder instead.

## Testing Done

Added tests to make sure it's not copied over