### PR TITLE
Fix spurious invoke shutdown queue errors

### DIFF
--- a/.changeset/calm-queues-drain.md
+++ b/.changeset/calm-queues-drain.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent successful local `eve invoke` commands from logging a spurious Workflow queue 503 while their temporary development server shuts down.

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -262,12 +262,12 @@ async function closeDevelopmentServerResources(input: {
   if (authoredSourceWatcher !== undefined) {
     await attempt(() => authoredSourceWatcher.close());
   }
-  const devServer = input.devServer;
-  const listenerClosed = devServer === undefined ? true : await attempt(() => devServer.close());
   const workflowWorld = input.workflowWorld;
   if (workflowWorld !== undefined) {
     await attempt(() => workflowWorld.close());
   }
+  const devServer = input.devServer;
+  const listenerClosed = devServer === undefined ? true : await attempt(() => devServer.close());
   const nitro = input.nitro;
   if (nitro !== undefined) {
     await attempt(() => nitro.close());


### PR DESCRIPTION
## What changed

A successful local eve invoke could print an HTTP 503 after its result. The temporary development listener was closing before the local Workflow World had acknowledged its in-flight queue delivery.

This changes shutdown order so the Workflow World closes first, then the development listener.

## Before

    {
      "status": "ready",
      "outcome": {
        "status": "completed",
        "message": "Mock reply: Say jonas"
      },
      "resume": {
        "session": {
          "continuationToken": "eve:<token>",
          "sessionId": "wrun_<session>",
          "streamIndex": 9
        },
        "target": { "kind": "local" }
      }
    }
    [world-local] Queue message failed (attempt 2, HTTP 503) {
      queueName: "<queue>/turnWorkflow",
      messageId: "msg_<message>",
      runId: "wrun_<turn>",
      handlerError: "{\"error\":\"socket hang up\"}"
    }

## After

    {
      "status": "ready",
      "outcome": {
        "status": "completed",
        "message": "Mock reply: Say jonas"
      },
      "resume": {
        "session": {
          "continuationToken": "eve:<token>",
          "sessionId": "wrun_<session>",
          "streamIndex": 9
        },
        "target": { "kind": "local" }
      }
    }

No queue retry or socket error is logged.

## Verification

- reproduced the before behavior with the original shutdown order
- reran the identical mock-backed local invocation after the fix
- focused unit suite: 35 passed
- eve typecheck, formatting, and lint passed