### PR TITLE
feat(docs): add Natural to integrations as an MCP connection

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1614,6 +1614,14 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     keywords: ["mcp", "events", "funnels", "insights", "analytics", "oauth", "connect"],
     authModes: ["user"],
   },
+  natural: {
+    logo: "natural",
+    docsHref: "/docs/connections/mcp",
+    keywords: ["mcp", "payments", "wallets", "transfers", "oauth", "connect"],
+    authModes: ["user"],
+    configureNote:
+      "Natural moves real money. Add an approval gate or tool filters before allowing unattended payment actions.",
+  },
   netlify: {
     logo: "netlify",
     docsHref: "/docs/connections/mcp",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -307,6 +307,17 @@ export const manufactLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const naturalLogo = (props: LogoProps) => (
+  // Cropped to the square mark; the source asset is a full wordmark lockup
+  // that renders illegibly small at icon sizes.
+  <svg fill="none" viewBox="0 0 17.5 18" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M0.773438 17.7891H16.6289C17.1211 17.7891 17.4023 17.543 17.4023 17.0156V0.914062C17.4023 0.421875 17.1211 0.140625 16.6289 0.140625H0.773438C0.246094 0.140625 0 0.421875 0 0.914062V17.0156C0 17.543 0.246094 17.7891 0.773438 17.7891Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const mem0Logo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" {...props}>
     <rect fill="#CBB2FF" height="100" rx="12" width="100" />
@@ -632,6 +643,7 @@ export const logos = {
   mem0: mem0Logo,
   miro: miroLogo,
   mixpanel: mixpanelLogo,
+  natural: naturalLogo,
   netlify: netlifyLogo,
   oreilly: oreillyLogo,
   planetscale: planetscaleLogo,

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -646,6 +646,31 @@
       ]
     },
     {
+      "name": "connection/natural",
+      "type": "registry:item",
+      "title": "Natural",
+      "description": "Send, request, and manage payments with Natural.",
+      "meta": {
+        "eve": {
+          "setup": {
+            "command": "eve",
+            "package": "eve",
+            "bin": "eve",
+            "args": ["integration", "connect", "natural", "mcp.natural.com", "natural"]
+          },
+          "requires": ">=0.29.0"
+        }
+      },
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/natural.ts",
+          "type": "registry:file",
+          "target": "agent/connections/natural.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/netlify",
       "type": "registry:item",
       "title": "Netlify",

--- a/apps/docs/registry/connections/natural.ts
+++ b/apps/docs/registry/connections/natural.ts
@@ -1,0 +1,13 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.natural.com/mcp",
+  description:
+    "Natural: agentic payments — send and request payments, check balances, and move funds.",
+  auth: connect("natural"),
+
+  // Natural moves real money. To require human approval for every
+  // tool call, add:
+  // approval: always(),  // from "eve/tools/approval"
+});

--- a/apps/docs/scripts/validate-connection-registry.ts
+++ b/apps/docs/scripts/validate-connection-registry.ts
@@ -42,6 +42,7 @@ const CONNECT_SERVICES: Readonly<Record<string, string>> = {
   notion: "mcp.notion.com",
   datadog: "mcp.datadoghq.com",
   honeycomb: "mcp.honeycomb.io",
+  natural: "mcp.natural.com",
 };
 
 if (JSON.stringify(actualSlugs) !== JSON.stringify(expectedSlugs)) {

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -104,4 +104,10 @@ describe("integration catalog", () => {
       "https://api.browser-use.com/v3/mcp",
     );
   });
+
+  it("uses Natural's streamable HTTP MCP endpoint", () => {
+    expect(getIntegrationEntry("natural")!.connection!.mcp!.url).toBe(
+      "https://mcp.natural.com/mcp",
+    );
+  });
 });

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -552,6 +552,18 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     },
   },
   {
+    slug: "natural",
+    name: "Natural",
+    kind: "connection",
+    tagline: "Send, request, and manage payments with Natural.",
+    surfaces: { scaffoldable: false, gallery: true },
+    connection: {
+      description:
+        "Natural: agentic payments — send and request payments, check balances, and move funds.",
+      mcp: { url: "https://mcp.natural.com/mcp" },
+    },
+  },
+  {
     slug: "netlify",
     name: "Netlify",
     kind: "connection",


### PR DESCRIPTION
### Description

Registers [Natural](https://natural.com) (agentic payments platform, hosted MCP server at `mcp.natural.com`) as a gallery connection, following the Stripe/Razorpay precedent:

- catalog identity in `@eve/catalog` (gallery-only, MCP transport at `https://mcp.natural.com/mcp`)
- docs gallery presentation with a real-money configure note recommending approval gates before unattended payment actions
- hand-authored logo (cropped to the square mark from Natural's published wordmark, embat-style)
- `connection/natural` registry item so `eve add connection/natural` works

The generated connection file is user-scoped (`connect("natural")`) and carries a commented `approval: always()` hint, since every money-moving tool on this server is non-reversible. The Connect service identifier in the setup args is `mcp.natural.com` (the MCP host, matching the Linear/Notion pattern) — verified end-to-end, see below.

### How did you test your changes?

- `pnpm --filter @eve/catalog test`, `pnpm --filter eve-docs registry:check`, `pnpm --filter eve-docs test:unit`, `pnpm typecheck`, `pnpm lint`, `pnpm fmt` — all pass
- Manual end-to-end: scaffolded a fresh agent with `npx eve@latest init`, installed the item via `eve add connection/natural` against a locally served build of this registry (`EVE_DEV_OFFICIAL_REGISTRY_URL` override), linked a Vercel project, provisioned the Connect connector (service `mcp.natural.com`, connector UID `natural`), completed Natural's OAuth consent, and confirmed a successful read-only `get_account_balance` tool call through the agent

### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not needed: docs + internal catalog only)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)