### PR TITLE
feat(eve): improve registry search output

### DIFF
--- a/.changeset/clear-registry-results.md
+++ b/.changeset/clear-registry-results.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Format registry search results as concise, width-aware entries and limit searches to 10 matches by default. Use `--limit` to request up to 100 results.

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -30,10 +30,10 @@ List every official integration and configured third-party source:
 eve registry list
 ```
 
-Search the catalog when you know what capability you need:
+Search the catalog when you know what capability you need. Search returns up to 10 matches by default; use `--limit` to request between 1 and 100:
 
 ```bash
-eve registry search browser
+eve registry search browser --limit 5
 ```
 
 Inspect an integration before you install it:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,6 +91,7 @@ eve add channel/slack --skip-install
 eve add https://example.com/r/my-extension.json --overwrite
 eve registry add @acme=https://example.com/r/{name}.json
 eve registry search browser
+eve registry search browser --limit 5
 eve registry search browser --registry @acme
 eve registry view @acme/my-extension
 eve add @acme/my-extension
@@ -98,7 +99,7 @@ eve add @acme/my-extension
 
 `eve add` asks before running setup declared by an official item and prints the matching `eve add <item> --skip-install` command when setup is skipped or cancelled. `--skip-install` reruns setup without reinstalling the item.
 
-`eve registry add` records configured sources in `package.json#registries`. `eve registry list` and `search` aggregate the official catalog and all configured sources by default, or browse one supplied URL or namespace. Official and other universal items with explicit file targets do not require shadcn project configuration.
+`eve registry add` records configured sources in `package.json#registries`. `eve registry list` and `search` aggregate the official catalog and all configured sources by default, or browse one supplied URL or namespace. Search returns up to 10 matches by default; pass `--limit <count>` to request between 1 and 100. Official and other universal items with explicit file targets do not require shadcn project configuration.
 
 ## `eve info`
 

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -1,8 +1,25 @@
-import type { Command } from "#compiled/commander/index.js";
+import { InvalidArgumentError, type Command } from "#compiled/commander/index.js";
 
 interface RegistryCommandLogger {
   error(message: string): void;
   log(message: string): void;
+}
+
+const DEFAULT_SEARCH_LIMIT = 10;
+const MAX_SEARCH_LIMIT = 100;
+
+function parseSearchLimit(value: string): number {
+  if (!/^\d+$/u.test(value)) {
+    throw new InvalidArgumentError(`Expected a positive integer, received "${value}".`);
+  }
+
+  const limit = Number(value);
+  if (limit < 1 || limit > MAX_SEARCH_LIMIT) {
+    throw new InvalidArgumentError(
+      `Expected a limit between 1 and ${MAX_SEARCH_LIMIT}, received "${value}".`,
+    );
+  }
+  return limit;
 }
 
 /** Registers registry installation, configuration, and discovery commands. */
@@ -56,11 +73,19 @@ export function registerRegistryCommands(input: {
     .command("search <query>")
     .description("Search all registries or one source.")
     .option("-r, --registry <source>", "Search one registry.")
+    .option(
+      "--limit <count>",
+      `Maximum results to return (default: ${DEFAULT_SEARCH_LIMIT}).`,
+      parseSearchLimit,
+      DEFAULT_SEARCH_LIMIT,
+    )
     .option("--json", "Output as JSON")
-    .action(async (query: string, options: { json?: boolean; registry?: string }) => {
-      const { runRegistrySearchCommand } = await import("./registry.js");
-      await runRegistrySearchCommand(logger, appRoot, query, options.registry, options);
-    });
+    .action(
+      async (query: string, options: { json?: boolean; limit: number; registry?: string }) => {
+        const { runRegistrySearchCommand } = await import("./registry.js");
+        await runRegistrySearchCommand(logger, appRoot, query, options.registry, options);
+      },
+    );
 
   registry
     .command("view <item>")

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -521,9 +521,12 @@ describe("registry commands", () => {
     await runRegistryListCommand(logger, "/project", "https://example.com/r/registry.json");
 
     expect(logger.logs).toEqual([
-      "Found 1 item in 1 registry",
-      "",
-      "https://example.com/r/search.json — External search tools",
+      [
+        "Found 1 item in 1 registry",
+        "",
+        "https://example.com/r/search.json",
+        "  External search tools",
+      ].join("\n"),
     ]);
   });
 
@@ -554,14 +557,106 @@ describe("registry commands", () => {
         registries: { "@acme": "https://example.com/r/{name}.json" },
       },
       continueOnError: true,
-      limit: 100,
+      limit: 10,
       query: "browser",
     });
     expect(logger.logs).toEqual([
-      'Found 2 items matching "browser" in 2 registries',
-      "",
-      "extension/agent-browser",
-      "@acme/browser",
+      [
+        'Found 2 items matching "browser" in 2 registries',
+        "",
+        "extension/agent-browser",
+        "  Browser automation",
+        "",
+        "@acme/browser",
+        "  Browser tools",
+      ].join("\n"),
+    ]);
+  });
+
+  it("limits search results and reports the total match count", async () => {
+    const logger = createLogger();
+    searchRegistries.mockResolvedValue({
+      items: Array.from({ length: 5 }, (_, index) => ({
+        registry: "@acme",
+        name: `result-${index + 1}`,
+        addCommandArgument: `@acme/result-${index + 1}`,
+      })),
+      pagination: { total: 21, offset: 0, limit: 5, hasMore: true },
+    });
+
+    await runRegistrySearchCommand(logger, "/project", "web", undefined, { limit: 5 });
+
+    expect(searchRegistries).toHaveBeenCalledWith(
+      ["https://eve.dev/r/registry.json", "@acme"],
+      expect.objectContaining({ limit: 5, query: "web" }),
+    );
+    expect(logger.logs[0]).toMatch(/^Showing 5 of 21 items matching "web" in 2 registries/);
+  });
+
+  it("sanitizes and wraps registry descriptions beneath their addresses", async () => {
+    const logger = createLogger();
+    const columnsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    Object.defineProperty(process.stdout, "columns", { configurable: true, value: 40 });
+    searchRegistries.mockResolvedValue({
+      items: [
+        {
+          registry: "@acme",
+          name: "browser",
+          addCommandArgument: "@acme/browser",
+          description:
+            "A long registry description that wraps cleanly\n beneath its \u001B]0;spoofed\u0007address.",
+        },
+      ],
+      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+    });
+
+    try {
+      await runRegistrySearchCommand(logger, "/project", "browser\u001B]0;spoofed\u0007");
+    } finally {
+      if (columnsDescriptor === undefined) {
+        Reflect.deleteProperty(process.stdout, "columns");
+      } else {
+        Object.defineProperty(process.stdout, "columns", columnsDescriptor);
+      }
+    }
+
+    expect(logger.logs).toEqual([
+      [
+        'Found 1 item matching "browser" in 2 registries',
+        "",
+        "@acme/browser",
+        "  A long registry description that wraps",
+        "  cleanly beneath its address.",
+      ].join("\n"),
+    ]);
+    expect(logger.logs[0]).not.toContain("spoofed");
+    expect(logger.logs[0]).not.toContain("\u001B");
+  });
+
+  it("shows a concise first sentence and fixes escaped quotes", async () => {
+    const logger = createLogger();
+    searchRegistries.mockResolvedValue({
+      items: [
+        {
+          registry: "@acme",
+          name: "resources",
+          addCommandArgument: "@acme/resources",
+          description:
+            'Use when asked to \\"list resources\\". WHEN: inventory, tags, subscriptions, resource groups, virtual machines, websites, storage accounts.',
+        },
+      ],
+      pagination: { total: 1, offset: 0, limit: 1, hasMore: false },
+    });
+
+    await runRegistrySearchCommand(logger, "/project", "resources");
+
+    expect(logger.logs).toEqual([
+      [
+        'Found 1 item matching "resources" in 2 registries',
+        "",
+        "@acme/resources",
+        '  Use when asked to "list resources".',
+      ].join("\n"),
     ]);
   });
 

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -5,6 +5,8 @@ import {
   type RegistryConfig,
   type RegistrySearchItem,
 } from "#compiled/shadcn-registry/index.js";
+import { createCliTheme, sanitizeForTerminal } from "#cli/ui/output.js";
+import { clipVisible, wrapVisibleLine } from "#cli/ui/terminal-text.js";
 import semver from "#compiled/semver/index.js";
 import { z } from "#compiled/zod/index.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
@@ -34,6 +36,12 @@ export interface AddCommandOptions {
 export interface RegistryCommandOptions {
   /** Emit the underlying registry result as JSON. */
   json?: boolean;
+}
+
+/** Options for searching registry catalogs. */
+export interface RegistrySearchCommandOptions extends RegistryCommandOptions {
+  /** Maximum number of matching items to return. */
+  limit?: number;
 }
 
 type SetupCommandOptions = Pick<AddCommandOptions, "yes"> & {
@@ -110,6 +118,7 @@ export function resolveOfficialRegistryUrl(
 const OFFICIAL_REGISTRY = resolveOfficialRegistryUrl();
 const OFFICIAL_CATALOG = `${OFFICIAL_REGISTRY}/registry.json`;
 const CATALOG_PAGE_SIZE = 100;
+const DEFAULT_SEARCH_LIMIT = 10;
 
 function isRegistryAddress(value: string): boolean {
   return value.startsWith("@") || /^https?:\/\//.test(value);
@@ -215,6 +224,40 @@ function validateRegistrySource(source: string | undefined): void {
   }
 }
 
+function normalizeRegistryText(value: string): string {
+  return sanitizeForTerminal(value)
+    .replaceAll('\\"', '"')
+    .replaceAll("\\'", "'")
+    .replaceAll(/\s+/gu, " ")
+    .trim();
+}
+
+function registryDescriptionSummary(description: string): string {
+  const normalized = normalizeRegistryText(description);
+  return normalized.match(/^.*?[.!?](?=\s|$)/u)?.[0] ?? normalized;
+}
+
+function renderSearchItem(
+  item: RegistrySearchItem,
+  width: number,
+  theme: ReturnType<typeof createCliTheme>,
+): string {
+  const rawAddress = item.registry === OFFICIAL_CATALOG ? item.name : item.addCommandArgument;
+  const address = theme.accent(normalizeRegistryText(rawAddress));
+  if (!item.description) return address;
+
+  const description = registryDescriptionSummary(item.description);
+  if (description.length === 0) return address;
+
+  const descriptionWidth = Math.max(1, width - 2);
+  const wrapped = wrapVisibleLine(description, descriptionWidth);
+  const lines =
+    wrapped.length <= 2
+      ? wrapped
+      : [wrapped[0]!, `${clipVisible(wrapped[1]!, Math.max(1, descriptionWidth - 1)).trimEnd()}…`];
+  return [address, ...lines.map((line) => theme.muted(`  ${line}`))].join("\n");
+}
+
 function printSearchResults(
   logger: RegistryCommandLogger,
   result: Awaited<ReturnType<typeof searchRegistries>>,
@@ -230,23 +273,25 @@ function printSearchResults(
     return;
   }
 
-  const count = `${result.pagination.total} item${result.pagination.total === 1 ? "" : "s"}`;
-  const query = options.query === undefined ? "" : ` matching "${options.query}"`;
+  const total = result.pagination.total;
+  const count = `${total} item${total === 1 ? "" : "s"}`;
+  const query =
+    options.query === undefined ? "" : ` matching "${normalizeRegistryText(options.query)}"`;
   const registries = `${options.sources.length} registr${options.sources.length === 1 ? "y" : "ies"}`;
-  logger.log(`Found ${count}${query} in ${registries}`);
-  logger.log("");
-
-  for (const item of result.items) {
-    const address = item.registry === OFFICIAL_CATALOG ? item.name : item.addCommandArgument;
-    const description =
-      options.query === undefined && item.description ? ` — ${item.description}` : "";
-    logger.log(`${address}${description}`);
-  }
+  const resultCount = result.items.length;
+  const summary =
+    resultCount < total
+      ? `Showing ${resultCount} of ${count}${query} in ${registries}`
+      : `Found ${count}${query} in ${registries}`;
+  const theme = createCliTheme();
+  const width = Math.max(20, process.stdout.columns ?? 80);
+  const items = result.items.map((item) => renderSearchItem(item, width, theme));
+  logger.log([summary, ...items].join("\n\n"));
 }
 
 async function searchRegistryCatalog(
   appRoot: string,
-  options: { query?: string; source?: string },
+  options: { limit?: number; query?: string; source?: string },
 ) {
   validateRegistrySource(options.source);
   const config = await readRegistryConfig(appRoot);
@@ -256,7 +301,7 @@ async function searchRegistryCatalog(
   const result = await searchRegistries(sources, {
     config,
     continueOnError: sources.length > 1,
-    limit: CATALOG_PAGE_SIZE,
+    limit: options.limit ?? CATALOG_PAGE_SIZE,
     query: options.query,
   });
   return { config, result, sources };
@@ -304,9 +349,13 @@ async function browseRegistryItems(
   appRoot: string,
   query: string | undefined,
   source: string | undefined,
-  options: RegistryCommandOptions = {},
+  options: RegistrySearchCommandOptions = {},
 ): Promise<void> {
-  const { result, sources } = await searchRegistryCatalog(appRoot, { query, source });
+  const { result, sources } = await searchRegistryCatalog(appRoot, {
+    limit: options.limit,
+    query,
+    source,
+  });
   const errors = result.errors ?? [];
   if (options.json || errors.length < sources.length) {
     printSearchResults(logger, result, { ...options, query, sources });
@@ -492,10 +541,13 @@ export async function runRegistrySearchCommand(
   appRoot: string,
   query: string,
   source?: string,
-  options: RegistryCommandOptions = {},
+  options: RegistrySearchCommandOptions = {},
 ): Promise<void> {
   await runRegistryAction(logger, appRoot, () =>
-    browseRegistryItems(logger, appRoot, query, source, options),
+    browseRegistryItems(logger, appRoot, query, source, {
+      ...options,
+      limit: options.limit ?? DEFAULT_SEARCH_LIMIT,
+    }),
   );
 }
 

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -75,7 +75,7 @@ describe("CLI command registration", () => {
     expect(help).not.toContain("--path");
   });
 
-  it("registers JSON output for registry discovery commands", async () => {
+  it("registers JSON output and a search result limit for registry discovery commands", async () => {
     const output: string[] = [];
     const logger = {
       error: (message: string) => output.push(message),
@@ -85,7 +85,10 @@ describe("CLI command registration", () => {
     await runCli(["registry", "list", "--help"], logger).catch(() => {});
     await runCli(["registry", "search", "--help"], logger).catch(() => {});
 
-    expect(output.join("\n")).toContain("--json");
+    const help = output.join("\n");
+    expect(help).toContain("--json");
+    expect(help).toContain("--limit <count>");
+    expect(help).toContain("default: 10");
   });
 
   it("registers only supported shadcn registry commands", async () => {
@@ -173,6 +176,15 @@ describe("eve CLI malformed argument handling", () => {
   it("still surfaces the usage error for commands other than init", async () => {
     await expect(
       runCli(["dev", "--unknown-flag"], { error: () => {}, log: () => {} }),
+    ).rejects.toThrow();
+  });
+
+  it.each(["0", "101", "many"])("rejects invalid registry search limit %s", async (limit) => {
+    await expect(
+      runCli(["registry", "search", "web", "--limit", limit], {
+        error: () => {},
+        log: () => {},
+      }),
     ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
### Description

Make human-readable registry results easier to scan by rendering each address and a concise, width-aware description as a separate block. Registry search now returns 10 matches by default, supports `--limit <count>` for 1–100 results, reports when results are truncated, and preserves the full response through `--json`.

### How did you test your changes?

<img width="1512" height="493" alt="image" src="https://github.com/user-attachments/assets/181e7528-df0a-4d3d-9215-4c754425f54a" />


### PR Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
