### PR TITLE
Improve agent docs discovery

### DIFF
--- a/apps/docs/app/[lang]/agents.md/route.ts
+++ b/apps/docs/app/[lang]/agents.md/route.ts
@@ -4,8 +4,8 @@ import { config } from "@/lib/geistdocs/config";
 import { templateEntries } from "@/lib/templates/data";
 
 // Static, CDN-cacheable. /agents.md surfaces the agent instructions from the
-// Geistdocs config and points agents at /llms.txt and individual /llms.mdx
-// pages. Keeping this route prerendered avoids a per-request function on an
+// Geistdocs config and points agents at the machine-readable documentation
+// surfaces. Keeping this route prerendered avoids a per-request function on an
 // endpoint crawlers and agents poll repeatedly.
 export const revalidate = false;
 

--- a/apps/docs/app/[lang]/llms-full.txt/route.ts
+++ b/apps/docs/app/[lang]/llms-full.txt/route.ts
@@ -1,0 +1,11 @@
+import { createLlmsRoute } from "@vercel/geistdocs/routes/llms";
+import { geistdocsSource } from "@/lib/geistdocs/source";
+import { integrationSource } from "@/lib/integrations/source";
+
+export const revalidate = false;
+
+const llmsRoute = createLlmsRoute({
+  sources: [geistdocsSource, integrationSource],
+});
+
+export const GET = llmsRoute.GET;

--- a/apps/docs/app/[lang]/llms.txt/route.ts
+++ b/apps/docs/app/[lang]/llms.txt/route.ts
@@ -1,11 +1,8 @@
-import { createLlmsRoute } from "@vercel/geistdocs/routes/llms";
-import { geistdocsSource } from "@/lib/geistdocs/source";
-import { integrationSource } from "@/lib/integrations/source";
+import { createLlmsIndex } from "@/lib/geistdocs/llms-index";
 
 export const revalidate = false;
 
-const llmsRoute = createLlmsRoute({
-  sources: [geistdocsSource, integrationSource],
-});
-
-export const GET = llmsRoute.GET;
+export const GET = () =>
+  new Response(createLlmsIndex(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -49,9 +49,10 @@ export const agent = {
     "To create or extend an eve agent for the user, start from the Getting Started guide — get it as Markdown from /llms.mdx/getting-started (or via /llms.txt).",
     "Ask the user only for genuine decisions (name, model, channels, provider, deploy) and for browser/OAuth steps (vercel login, vercel link, vercel connect create slack); automate everything else.",
     "Verify setup with `eve info --json` and `eve channels list --json` before reporting success.",
-    "Use /sitemap.md to identify the most relevant documentation pages before answering broad questions.",
-    "Use /llms.txt when you need the complete documentation corpus as Markdown context.",
+    "Use /llms.txt as a concise task-oriented index and /sitemap.md as the exhaustive page map.",
+    "Use /llms-full.txt only when you need the complete documentation corpus for offline indexing or a large context window.",
     "Fetch individual docs or integration pages with a .md or .mdx extension for focused page-level context. Template pages are HTML discovery pages and do not expose this alternate Markdown route.",
+    "Treat eve.dev as framework documentation, not a shared API, authorization server, MCP server, or A2A server. Every deployed eve app exposes its own /eve/v1 routes and authentication policy; external API, OpenAPI, and MCP URLs in the docs may describe third-party connections or examples.",
     "Do not assume API, authentication, OpenAPI, or MCP support unless it is listed in this file.",
   ],
 };

--- a/apps/docs/lib/geistdocs/agents-transform.test.ts
+++ b/apps/docs/lib/geistdocs/agents-transform.test.ts
@@ -7,6 +7,8 @@ const input = `# eve
 
 - Page-level Markdown: append .md or .mdx to a documentation URL
 
+- [Full documentation context](https://eve.dev/llms.txt): All configured documentation as Markdown
+
 - To create an agent, get it as Markdown from /llms.mdx/getting-started (or via /llms.txt).
 `;
 
@@ -22,6 +24,15 @@ describe("transformAgentsMarkdown", () => {
     expect(output).toContain("/docs/getting-started.md (or via /llms.txt)");
     expect(output).not.toContain("/llms.mdx/getting-started");
     expect(output).not.toContain("append .md or .mdx to a documentation URL");
+    expect(output).toContain(
+      "[Documentation index](https://eve.dev/llms.txt): Curated task-oriented map",
+    );
+    expect(output).toContain(
+      "[Full documentation context](https://eve.dev/llms-full.txt): All configured documentation",
+    );
+    expect(output).not.toContain(
+      "[Full documentation context](https://eve.dev/llms.txt): All configured documentation",
+    );
   });
 
   it("adds concise canonical template discovery entries", () => {

--- a/apps/docs/lib/geistdocs/agents-transform.ts
+++ b/apps/docs/lib/geistdocs/agents-transform.ts
@@ -8,6 +8,8 @@ const GENERIC_MARKDOWN_INSTRUCTION =
   "- Page-level Markdown: append .md or .mdx to a documentation URL";
 const INTERNAL_GETTING_STARTED_INSTRUCTION =
   "get it as Markdown from /llms.mdx/getting-started (or via /llms.txt)";
+const fullDocumentationInstruction = (origin: string): string =>
+  `- [Full documentation context](${origin}/llms.txt): All configured documentation as Markdown`;
 
 const escapeMarkdown = (value: string): string => value.replace(/([\\[\]])/g, "\\$1");
 
@@ -15,9 +17,12 @@ export const transformAgentsMarkdown = (
   markdown: string,
   { origin, templates }: { origin: string; templates: TemplateDiscoveryEntry[] },
 ): string => {
+  const upstreamFullDocumentationInstruction = fullDocumentationInstruction(origin);
+
   if (
     !markdown.includes(GENERIC_MARKDOWN_INSTRUCTION) ||
-    !markdown.includes(INTERNAL_GETTING_STARTED_INSTRUCTION)
+    !markdown.includes(INTERNAL_GETTING_STARTED_INSTRUCTION) ||
+    !markdown.includes(upstreamFullDocumentationInstruction)
   ) {
     throw new Error("Geistdocs agents.md Markdown guidance changed; update the eve transform.");
   }
@@ -34,6 +39,13 @@ export const transformAgentsMarkdown = (
     .replace(
       INTERNAL_GETTING_STARTED_INSTRUCTION,
       "get it as Markdown from /docs/getting-started.md (or via /llms.txt)",
+    )
+    .replace(
+      upstreamFullDocumentationInstruction,
+      [
+        `- [Documentation index](${origin}/llms.txt): Curated task-oriented map of the most useful documentation`,
+        `- [Full documentation context](${origin}/llms-full.txt): All configured documentation as Markdown`,
+      ].join("\n"),
     );
 
   const templateLines = templates.map(

--- a/apps/docs/lib/geistdocs/llms-index.test.ts
+++ b/apps/docs/lib/geistdocs/llms-index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { createLlmsIndex } from "./llms-index";
+
+describe("createLlmsIndex", () => {
+  it("follows the llms.txt index shape without frontmatter", () => {
+    const output = createLlmsIndex();
+
+    expect(output).toMatch(/^# eve\n\n> /);
+    expect(output).not.toMatch(/^---/);
+    expect(output).toContain("## Optional");
+  });
+
+  it("states scope and routes agents to focused, exhaustive, and version-matched docs", () => {
+    const output = createLlmsIndex();
+
+    expect(output).toContain("node_modules/eve/docs/");
+    expect(output).toContain(
+      "It is not a shared API, authorization server, MCP server, or A2A server",
+    );
+    expect(output).toContain("https://eve.dev/sitemap.md");
+    expect(output).toContain("https://eve.dev/agents.md");
+    expect(output).toContain("https://eve.dev/llms-full.txt");
+  });
+
+  it("uses unique absolute links and stays concise", () => {
+    const output = createLlmsIndex();
+    const urls = Array.from(output.matchAll(/\]\((https:\/\/[^)]+)\)/g), (match) => match[1]);
+
+    expect(urls.length).toBeGreaterThan(20);
+    expect(new Set(urls).size).toBe(urls.length);
+    expect(output.length).toBeLessThan(12_000);
+  });
+});

--- a/apps/docs/lib/geistdocs/llms-index.ts
+++ b/apps/docs/lib/geistdocs/llms-index.ts
@@ -1,0 +1,76 @@
+const EVE_ORIGIN = "https://eve.dev";
+
+export const createLlmsIndex = (): string => `# eve
+
+> eve is a filesystem-first, Apache-2.0 framework for building durable backend AI agents that run on Vercel or self-hosted infrastructure. eve is currently in beta.
+
+Use this file to choose the smallest relevant documentation set. Use \`/sitemap.md\` for the exhaustive page map and \`/llms-full.txt\` only for offline indexing or a large context window. For an installed project, prefer \`node_modules/eve/docs/\`: those docs match the installed eve version, while eve.dev documents the latest release.
+
+eve.dev publishes framework documentation. It is not a shared API, authorization server, MCP server, or A2A server. Every deployed eve app exposes its own \`/eve/v1\` routes and authentication policy. External API, OpenAPI, and MCP URLs in these docs describe third-party connections or examples unless stated otherwise.
+
+Documentation links below point directly to Markdown. Remove the \`.md\` suffix for the canonical HTML page.
+
+## Start here
+
+- [Getting started](${EVE_ORIGIN}/docs/getting-started.md): Choose the right path for a new or existing eve project.
+- [Installation](${EVE_ORIGIN}/docs/installation.md): Create a project, configure a model credential, and run it locally.
+- [Project structure](${EVE_ORIGIN}/docs/project-structure.md): Learn which files eve discovers and how paths define capabilities.
+- [First-agent tutorial](${EVE_ORIGIN}/docs/tutorial/first-agent.md): Build an agent with tools, durable state, and an interface.
+
+## Author an agent
+
+- [Agent configuration](${EVE_ORIGIN}/docs/agent-config.md): Configure the model, reasoning effort, compaction, and runtime behavior.
+- [Instructions](${EVE_ORIGIN}/docs/instructions.md): Write the agent's always-on system prompt.
+- [Tools](${EVE_ORIGIN}/docs/tools.md): Define typed actions and gate sensitive calls on human approval.
+- [Skills](${EVE_ORIGIN}/docs/skills.md): Add procedures that the model loads on demand.
+- [Channels](${EVE_ORIGIN}/docs/channels/overview.md): Expose the agent through HTTP, Slack, Discord, and other messaging surfaces.
+- [Connections](${EVE_ORIGIN}/docs/connections.md): Connect external MCP and OpenAPI servers without exposing credentials to the model.
+- [Extensions](${EVE_ORIGIN}/docs/extensions.md): Package and mount reusable eve capabilities.
+- [Sandbox](${EVE_ORIGIN}/docs/sandbox.md): Configure the isolated shell, filesystem, lifecycle, and network policy.
+- [Subagents](${EVE_ORIGIN}/docs/subagents.md): Delegate work to copies of the root agent or declared specialists.
+- [Schedules](${EVE_ORIGIN}/docs/schedules.md): Run prompts or handlers on a cron cadence.
+- [Evals](${EVE_ORIGIN}/docs/evals/overview.md): Define repeatable scored checks and run them with \`eve eval\`.
+
+## Connect clients and interfaces
+
+- [Base eve channel](${EVE_ORIGIN}/docs/channels/eve.md): Understand the HTTP API exposed by each running eve app.
+- [Frontend overview](${EVE_ORIGIN}/docs/guides/frontend/overview.md): Build browser chat interfaces with \`useEveAgent\`.
+- [Next.js](${EVE_ORIGIN}/docs/guides/frontend/nextjs.md): Mount eve routes and use the React client in Next.js.
+- [Nuxt](${EVE_ORIGIN}/docs/guides/frontend/nuxt.md): Mount eve routes and use the Vue client in Nuxt.
+- [SvelteKit](${EVE_ORIGIN}/docs/guides/frontend/sveltekit.md): Mount eve routes and use the Svelte client in SvelteKit.
+- [TypeScript SDK](${EVE_ORIGIN}/docs/guides/client/overview.md): Call an eve app from scripts, services, tests, or custom UIs.
+- [Sessions, runs, and streaming](${EVE_ORIGIN}/docs/concepts/sessions-runs-and-streaming.md): Understand continuation tokens, stream handles, NDJSON events, and reconnecting.
+- [Authentication and route protection](${EVE_ORIGIN}/docs/guides/auth-and-route-protection.md): Secure a deployed app's routes and connection OAuth.
+
+## Run and operate
+
+- [Execution model and durability](${EVE_ORIGIN}/docs/concepts/execution-model-and-durability.md): Understand sessions, checkpointed steps, and parked work.
+- [Default harness](${EVE_ORIGIN}/docs/concepts/default-harness.md): Understand the built-in loop, tools, workspace, and context assembly.
+- [Context control](${EVE_ORIGIN}/docs/concepts/context-control.md): Control context growth, compaction, and model-visible history.
+- [Security model](${EVE_ORIGIN}/docs/concepts/security-model.md): Review trust boundaries, secret handling, credentials, and fail-closed behavior.
+- [Deployment overview](${EVE_ORIGIN}/docs/guides/deployment/overview.md): Choose between Vercel and self-hosted infrastructure.
+- [Deploy to Vercel](${EVE_ORIGIN}/docs/guides/deployment/vercel.md): Build and deploy with Vercel Workflow and Vercel Sandbox.
+- [Self-hosting](${EVE_ORIGIN}/docs/guides/deployment/self-hosting.md): Run eve as a Node service or container.
+- [Instrumentation](${EVE_ORIGIN}/docs/guides/instrumentation.md): Trace agents with OpenTelemetry and inspect workflow metadata.
+- [Hooks](${EVE_ORIGIN}/docs/guides/hooks.md): Subscribe to runtime stream events.
+- [Durable state](${EVE_ORIGIN}/docs/guides/state.md): Persist per-session memory across step boundaries.
+- [Dynamic capabilities](${EVE_ORIGIN}/docs/guides/dynamic-capabilities.md): Resolve models, tools, skills, subagents, and instructions at runtime.
+- [Remote agents](${EVE_ORIGIN}/docs/guides/remote-agents.md): Call another eve deployment as a subagent.
+
+## Reference and discovery
+
+- [TypeScript API](${EVE_ORIGIN}/docs/reference/typescript-api.md): Find public \`define*\` helpers, runtime context, and import paths.
+- [CLI reference](${EVE_ORIGIN}/docs/reference/cli.md): Find every eve command and option.
+- [Project layout reference](${EVE_ORIGIN}/docs/reference/project-layout.md): Look up authored slots and path-derived naming rules.
+- [Install integrations](${EVE_ORIGIN}/docs/install-integrations.md): Discover and add official or third-party integrations.
+- [Documentation map](${EVE_ORIGIN}/sitemap.md): Browse every documentation, integration, and template page with type and summary metadata.
+- [Agent instructions](${EVE_ORIGIN}/agents.md): Read operational guidance for coding agents working with eve.
+- [Full documentation corpus](${EVE_ORIGIN}/llms-full.txt): Load all docs and integration content for offline indexing or a large context window.
+
+## Optional
+
+- [Integrations](${EVE_ORIGIN}/integrations): Browse official channels, connections, extensions, and instrumentation providers.
+- [Templates](${EVE_ORIGIN}/templates): Browse complete example projects and their source.
+- [Official eve skill](https://github.com/vercel/eve/blob/main/skills/eve/SKILL.md): Install or inspect the coding-agent skill; its guidance defers to version-matched bundled docs.
+- [Source repository](https://github.com/vercel/eve): Read source, releases, issues, and contribution guidance.
+`;

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -14,6 +14,7 @@ export const config = {
   // These routes need the locale rewrite even though the general matcher ignores static extensions.
   matcher: [
     "/llms.txt",
+    "/llms-full.txt",
     "/rss.xml",
     "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|eve\\.tgz$|.*\\.(?!mdx?$)[^/]+$).*)",
   ],

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -5,6 +5,8 @@ description: "The default HTTP API for an agent, covering session routes, auth, 
 
 The eve channel is the framework's default HTTP API. It's what the terminal UI, [`useEveAgent`](../guides/frontend/overview), `curl`, and any SDK client talk to when they start sessions, send messages, and stream events. `eveChannel()` mounts the canonical session routes under `/eve/v1/session*`, and they are enabled by default even when `agent/channels/eve.ts` does not exist.
 
+Every running eve app exposes its own API. `eve.dev` publishes framework documentation; it is not a shared API, authorization server, MCP server, or A2A server. Each deployment supplies its own host and authentication policy.
+
 Reach for it when something needs HTTP access to your agent, including local tooling, a browser frontend, the terminal UI, or another API client. Most apps never write this file. Add `agent/channels/eve.ts` only to override the defaults, usually the route auth policy.
 
 ```ts title="agent/channels/eve.ts"

--- a/docs/guides/client/messages.mdx
+++ b/docs/guides/client/messages.mdx
@@ -12,7 +12,7 @@ Pass a string to `send()` for plain text:
 ```ts
 import { Client } from "eve/client";
 
-const client = new Client({ host: "http://127.0.0.1:3000" });
+const client = new Client({ host: "http://127.0.0.1:2000" });
 const session = client.session();
 
 const response = await session.send("What is the weather in Brooklyn?");

--- a/docs/guides/client/output-schema.mdx
+++ b/docs/guides/client/output-schema.mdx
@@ -26,7 +26,7 @@ const outputSchema = {
   required: ["title", "count"],
 } as const;
 
-const client = new Client({ host: "http://127.0.0.1:3000" });
+const client = new Client({ host: "http://127.0.0.1:2000" });
 const session = client.session();
 
 const response = await session.send<Summary>({

--- a/docs/guides/client/overview.mdx
+++ b/docs/guides/client/overview.mdx
@@ -15,7 +15,7 @@ A `Client` binds one host, auth policy, and header policy:
 import { Client } from "eve/client";
 
 const client = new Client({
-  host: "http://127.0.0.1:3000",
+  host: "http://127.0.0.1:2000",
 });
 ```
 


### PR DESCRIPTION
- Replace the full-corpus `/llms.txt` with a concise task-oriented index and move bulk context to `/llms-full.txt`
- Clarify agent guidance and eve.dev scope across `/agents.md` and the HTTP channel docs
- Fix local TypeScript client examples to use the `eve dev` port and add regression coverage
