### PR TITLE
Redirect moved docs routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,8 @@ live under `packages/eve/test/tui-client` and run with `pnpm test:tui`. See
 - `docs/**` is the published documentation. If your change alters
   public behavior, update the relevant doc in the same PR and run
   `pnpm docs:check`.
+- When moving a published route, update authored links to the new URL and add a
+  permanent redirect from every old HTML and supported Markdown URL.
 - Sidebar order lives in `docs/meta.json`.
 - Keep markdown framework-agnostic — no MDX-only constructs unless the page is
   `.mdx`.

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -5,6 +5,7 @@ import { config } from "@/lib/geistdocs/config";
 import { defaultLanguage } from "@/lib/geistdocs/languages";
 import {
   compatibilityRedirects,
+  defaultLanguageRedirects,
   docsRedirects,
   rootMarkdownRedirects,
 } from "@/lib/geistdocs/redirects";
@@ -24,6 +25,7 @@ const redirectPathnames = [
   ...compatibilityRedirects.map(({ source }) => source),
   ...docsRedirects.map(({ source }) => source),
   ...rootMarkdownRedirects.map(({ source }) => source),
+  ...defaultLanguageRedirects.map(({ source }) => source),
 ].filter((pathname) => !pathname.includes(":"));
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/apps/docs/lib/geistdocs/redirects.test.ts
+++ b/apps/docs/lib/geistdocs/redirects.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   createDocsRedirects,
+  createIntegrationRedirects,
   createRootMarkdownRedirects,
   compatibilityRedirects,
+  defaultLanguageRedirects,
   docsRedirects,
   rootMarkdownRedirects,
 } from "./redirects";
@@ -16,8 +18,8 @@ describe("createDocsRedirects", () => {
         permanent: true,
       },
       {
-        source: "/:lang/docs/channels",
-        destination: "/:lang/docs/channels/overview",
+        source: "/en/docs/channels",
+        destination: "/docs/channels/overview",
         permanent: true,
       },
       {
@@ -26,8 +28,8 @@ describe("createDocsRedirects", () => {
         permanent: true,
       },
       {
-        source: "/:lang/docs/channels.md",
-        destination: "/:lang/docs/channels/overview.md",
+        source: "/en/docs/channels.md",
+        destination: "/docs/channels/overview.md",
         permanent: true,
       },
       {
@@ -36,8 +38,8 @@ describe("createDocsRedirects", () => {
         permanent: true,
       },
       {
-        source: "/:lang/docs/channels.mdx",
-        destination: "/:lang/docs/channels/overview.mdx",
+        source: "/en/docs/channels.mdx",
+        destination: "/docs/channels/overview.mdx",
         permanent: true,
       },
     ]);
@@ -55,6 +57,43 @@ describe("createRootMarkdownRedirects", () => {
       {
         source: "/installation.mdx",
         destination: "/docs/installation.mdx",
+        permanent: true,
+      },
+    ]);
+  });
+});
+
+describe("createIntegrationRedirects", () => {
+  it("preserves HTML and Markdown representations across default and localized paths", () => {
+    expect(createIntegrationRedirects("chat-sdk-photon", "photon")).toEqual([
+      {
+        source: "/integrations/chat-sdk-photon",
+        destination: "/integrations/photon",
+        permanent: true,
+      },
+      {
+        source: "/en/integrations/chat-sdk-photon",
+        destination: "/integrations/photon",
+        permanent: true,
+      },
+      {
+        source: "/integrations/chat-sdk-photon.md",
+        destination: "/integrations/photon.md",
+        permanent: true,
+      },
+      {
+        source: "/en/integrations/chat-sdk-photon.md",
+        destination: "/integrations/photon.md",
+        permanent: true,
+      },
+      {
+        source: "/integrations/chat-sdk-photon.mdx",
+        destination: "/integrations/photon.mdx",
+        permanent: true,
+      },
+      {
+        source: "/en/integrations/chat-sdk-photon.mdx",
+        destination: "/integrations/photon.mdx",
         permanent: true,
       },
     ]);
@@ -96,8 +135,35 @@ describe("rootMarkdownRedirects", () => {
   });
 });
 
+describe("defaultLanguageRedirects", () => {
+  it("redirects observed locale aliases directly to their canonical destination", () => {
+    expect(defaultLanguageRedirects).toEqual([
+      {
+        source: "/en/docs",
+        destination: "/docs/getting-started",
+        permanent: true,
+      },
+      {
+        source: "/en/resources",
+        destination: "/templates",
+        permanent: true,
+      },
+      {
+        source: "/en/:path*",
+        destination: "/:path*",
+        permanent: true,
+      },
+    ]);
+  });
+});
+
 describe("all redirects", () => {
-  const redirects = [...compatibilityRedirects, ...docsRedirects, ...rootMarkdownRedirects];
+  const redirects = [
+    ...compatibilityRedirects,
+    ...docsRedirects,
+    ...rootMarkdownRedirects,
+    ...defaultLanguageRedirects,
+  ];
 
   it("has no duplicate sources", () => {
     const sources = redirects.map(({ source }) => source);

--- a/apps/docs/lib/geistdocs/redirects.ts
+++ b/apps/docs/lib/geistdocs/redirects.ts
@@ -1,3 +1,5 @@
+import { defaultLanguage } from "./languages";
+
 interface DocsRedirect {
   destination: string;
   permanent: true;
@@ -15,8 +17,8 @@ export const createDocsRedirects = (source: string, destination: string): DocsRe
       permanent: true,
     },
     {
-      source: `/:lang/docs${source}${extension}`,
-      destination: `/:lang/docs${destination}${extension}`,
+      source: `/${defaultLanguage}/docs${source}${extension}`,
+      destination: `/docs${destination}${extension}`,
       permanent: true,
     },
   ]);
@@ -27,6 +29,20 @@ export const createRootMarkdownRedirects = (source: string, destination: string)
     destination: `/docs${destination}${extension}`,
     permanent: true,
   }));
+
+export const createIntegrationRedirects = (source: string, destination: string): DocsRedirect[] =>
+  extensions.flatMap((extension) => [
+    {
+      source: `/integrations/${source}${extension}`,
+      destination: `/integrations/${destination}${extension}`,
+      permanent: true,
+    },
+    {
+      source: `/${defaultLanguage}/integrations/${source}${extension}`,
+      destination: `/integrations/${destination}${extension}`,
+      permanent: true,
+    },
+  ]);
 
 export const docsRedirects: DocsRedirect[] = [
   ...createDocsRedirects("/introduction", "/getting-started"),
@@ -72,6 +88,7 @@ export const rootMarkdownRedirects: DocsRedirect[] = [
 ].flatMap(([source, destination]) => createRootMarkdownRedirects(source, destination));
 
 export const compatibilityRedirects: DocsRedirect[] = [
+  ...createIntegrationRedirects("chat-sdk-photon", "photon"),
   { source: "/feed", destination: "/rss.xml", permanent: true },
   { source: "/feed.xml", destination: "/rss.xml", permanent: true },
   { source: "/guides/hooks", destination: "/docs/guides/hooks", permanent: true },
@@ -88,6 +105,24 @@ export const compatibilityRedirects: DocsRedirect[] = [
   {
     source: "/apple-touch-icon-120x120-precomposed.png",
     destination: "/apple-touch-icon.png",
+    permanent: true,
+  },
+];
+
+export const defaultLanguageRedirects: DocsRedirect[] = [
+  {
+    source: `/${defaultLanguage}/docs`,
+    destination: "/docs/getting-started",
+    permanent: true,
+  },
+  {
+    source: `/${defaultLanguage}/resources`,
+    destination: "/templates",
+    permanent: true,
+  },
+  {
+    source: `/${defaultLanguage}/:path*`,
+    destination: "/:path*",
     permanent: true,
   },
 ];

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -3,6 +3,7 @@ import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
 import {
   compatibilityRedirects,
+  defaultLanguageRedirects,
   docsRedirects,
   rootMarkdownRedirects,
 } from "./lib/geistdocs/redirects";
@@ -56,14 +57,10 @@ const config: NextConfig = {
         destination: "/docs/getting-started",
         permanent: true,
       },
-      {
-        source: "/:lang/docs",
-        destination: "/:lang/docs/getting-started",
-        permanent: true,
-      },
       ...compatibilityRedirects,
       ...docsRedirects,
       ...rootMarkdownRedirects,
+      ...defaultLanguageRedirects,
     ];
   },
 };


### PR DESCRIPTION
- Redirect the renamed Photon integration and default-language aliases directly to canonical HTML and Markdown URLs.
- Require redirects when published routes move and keep redirect sources out of the sitemap.
