### PR TITLE
Fix Markdown canonical ownership

### DIFF
--- a/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
@@ -7,8 +7,10 @@ import {
   getMarkdownFormat,
 } from "@/lib/analytics/events";
 import { trackServerEvent } from "@/lib/analytics/server";
+import { applyMarkdownRouteCanonical } from "@/lib/geistdocs/markdown-canonical";
 import { getMarkdownRequestedPath } from "@/lib/geistdocs/markdown-path";
 import { geistdocsSource } from "@/lib/geistdocs/source";
+import { getSiteOrigin } from "@/lib/geistdocs/url";
 import { integrationSource } from "@/lib/integrations/source";
 
 export const revalidate = false;
@@ -18,7 +20,7 @@ const markdownRoute = createDocsMarkdownRoute({
   sources: [geistdocsSource, integrationSource],
 });
 
-export const GET = async (request: Request, context: Parameters<typeof markdownRoute.GET>[1]) => {
+export const GET: typeof markdownRoute.GET = async (request, context) => {
   const response = await markdownRoute.GET(request, context);
 
   if (response.headers.get("x-geistdocs-not-found") === "1") {
@@ -31,6 +33,9 @@ export const GET = async (request: Request, context: Parameters<typeof markdownR
     });
   }
 
-  return response;
+  const { slug = [] } = await context.params;
+  const canonicalUrl = `${getSiteOrigin()}${getMarkdownRequestedPath({ slug })}`;
+
+  return applyMarkdownRouteCanonical(response, canonicalUrl);
 };
 export const generateStaticParams = markdownRoute.generateStaticParams;

--- a/apps/docs/lib/geistdocs/markdown-canonical.test.ts
+++ b/apps/docs/lib/geistdocs/markdown-canonical.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { applyMarkdownRouteCanonical, removeProxyMarkdownCanonical } from "./markdown-canonical";
+
+describe("Markdown canonical ownership", () => {
+  it("removes proxy canonicals from Markdown rewrites", () => {
+    const response = new Response(null, {
+      headers: {
+        link: '<https://eve.dev/docs/getting-started>; rel="canonical"',
+        "x-middleware-rewrite": "https://eve.dev/en/llms.mdx/getting-started",
+      },
+    });
+
+    removeProxyMarkdownCanonical(response);
+
+    expect(response.headers.get("link")).toBeNull();
+  });
+
+  it("keeps canonicals on unrelated proxy responses", () => {
+    const canonical = '<https://eve.dev/docs/getting-started>; rel="canonical"';
+    const response = new Response(null, {
+      headers: {
+        link: canonical,
+        "x-middleware-rewrite": "https://eve.dev/en/docs/getting-started",
+      },
+    });
+
+    removeProxyMarkdownCanonical(response);
+
+    expect(response.headers.get("link")).toBe(canonical);
+  });
+
+  it("adds one canonical for an existing Markdown page", () => {
+    const response = new Response("# Getting Started", {
+      headers: { "content-type": "text/markdown" },
+    });
+
+    applyMarkdownRouteCanonical(response, "https://eve.dev/docs/getting-started");
+
+    expect(response.headers.get("link")).toBe(
+      '<https://eve.dev/docs/getting-started>; rel="canonical"',
+    );
+  });
+
+  it("removes canonicals from useful not-found responses without changing their status", () => {
+    const response = new Response("# Page Not Found", {
+      status: 200,
+      headers: {
+        link: '</docs/installtion>; rel="canonical"',
+        "x-geistdocs-not-found": "1",
+        "x-robots-tag": "noindex",
+      },
+    });
+
+    applyMarkdownRouteCanonical(response, "https://eve.dev/docs/installtion");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("link")).toBeNull();
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+  });
+});

--- a/apps/docs/lib/geistdocs/markdown-canonical.ts
+++ b/apps/docs/lib/geistdocs/markdown-canonical.ts
@@ -1,0 +1,23 @@
+const MARKDOWN_ROUTE_PATTERN = /\/llms\.mdx(?:\/|$)/;
+
+export const removeProxyMarkdownCanonical = (response: Response): Response => {
+  const rewrite = response.headers.get("x-middleware-rewrite");
+  if (!rewrite) return response;
+
+  const pathname = new URL(rewrite, "https://eve.dev").pathname;
+  if (MARKDOWN_ROUTE_PATTERN.test(pathname)) {
+    response.headers.delete("link");
+  }
+
+  return response;
+};
+
+export const applyMarkdownRouteCanonical = (response: Response, canonicalUrl: string): Response => {
+  if (response.headers.get("x-geistdocs-not-found") === "1") {
+    response.headers.delete("link");
+  } else {
+    response.headers.set("link", `<${canonicalUrl}>; rel="canonical"`);
+  }
+
+  return response;
+};

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -1,14 +1,19 @@
 import { createProxy } from "@vercel/geistdocs/proxy";
+import type { NextFetchEvent, NextRequest } from "next/server";
 import { config as geistdocsConfig } from "@/lib/geistdocs/config";
+import { removeProxyMarkdownCanonical } from "@/lib/geistdocs/markdown-canonical";
 import { markdownRoutes } from "@/lib/geistdocs/markdown-routes";
 import { trackMdRequest } from "@/lib/geistdocs/md-tracking";
 
-const proxy = createProxy({
+const geistdocsProxy = createProxy({
   config: geistdocsConfig,
   markdownRoutes,
   trackMarkdownRequest: trackMdRequest,
   before: () => null,
 });
+
+const proxy = async (request: NextRequest, context: NextFetchEvent) =>
+  removeProxyMarkdownCanonical(await geistdocsProxy(request, context));
 
 export const config = {
   // These routes need the locale rewrite even though the general matcher ignores static extensions.


### PR DESCRIPTION
- Remove canonicals from smart Markdown misses while preserving the existing `200` and `noindex` behavior.
- Emit one canonical HTML URL for real Markdown pages.
