### PR TITLE
Stabilize docs RSS dates

### DIFF
--- a/apps/docs/app/[lang]/rss.xml/route.ts
+++ b/apps/docs/app/[lang]/rss.xml/route.ts
@@ -1,6 +1,7 @@
 import { Feed } from "feed";
 import type { NextRequest } from "next/server";
 import { title } from "@/geistdocs";
+import { getFeedUpdatedAt, selectDatedFeedPages } from "@/lib/geistdocs/rss";
 import { source } from "@/lib/geistdocs/source";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
 
@@ -8,28 +9,25 @@ const baseUrl = getSiteOrigin();
 
 export const revalidate = false;
 
-const getLastModified = (data: object) =>
-  "lastModified" in data && data.lastModified instanceof Date ? data.lastModified : undefined;
-
 export const GET = async (_req: NextRequest, { params }: RouteContext<"/[lang]/rss.xml">) => {
   const { lang } = await params;
+  const pages = selectDatedFeedPages(source.getPages(lang));
   const feed = new Feed({
     title,
     id: baseUrl,
     link: baseUrl,
     language: lang,
+    updated: getFeedUpdatedAt(pages),
     copyright: `All rights reserved ${new Date().getFullYear()}, Vercel`,
   });
 
-  for (const page of source.getPages(lang)) {
-    const lastModified = getLastModified(page.data);
-
+  for (const { lastModified, page } of pages) {
     feed.addItem({
       id: page.url,
       title: page.data.title ?? page.url,
       description: page.data.description,
       link: `${baseUrl}${page.url}`,
-      date: lastModified ?? new Date(),
+      date: lastModified,
       author: [
         {
           name: "Vercel",

--- a/apps/docs/lib/geistdocs/rss.test.ts
+++ b/apps/docs/lib/geistdocs/rss.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getFeedUpdatedAt, selectDatedFeedPages } from "./rss";
+
+describe("RSS dates", () => {
+  it("keeps every page and uses a stable fallback for untrustworthy source dates", () => {
+    const dated = new Date("2026-07-01T00:00:00.000Z");
+    const pages = [
+      { url: "/dated", data: { lastModified: dated } },
+      { url: "/undated", data: {} },
+      { url: "/invalid", data: { lastModified: "2026-08-04" } },
+    ];
+
+    expect(selectDatedFeedPages(pages)).toEqual([
+      { page: pages[0], lastModified: dated },
+      { page: pages[1], lastModified: new Date("2026-06-17T00:00:00.000Z") },
+      { page: pages[2], lastModified: new Date("2026-06-17T00:00:00.000Z") },
+    ]);
+  });
+
+  it("uses the latest source date without request-time fallback", () => {
+    const pages = selectDatedFeedPages([
+      { data: { lastModified: new Date("2026-07-01T00:00:00.000Z") } },
+      { data: { lastModified: new Date("2026-07-03T00:00:00.000Z") } },
+    ]);
+
+    expect(getFeedUpdatedAt(pages).toISOString()).toBe("2026-07-03T00:00:00.000Z");
+    expect(getFeedUpdatedAt([]).toISOString()).toBe("2026-06-17T00:00:00.000Z");
+  });
+});

--- a/apps/docs/lib/geistdocs/rss.ts
+++ b/apps/docs/lib/geistdocs/rss.ts
@@ -1,0 +1,29 @@
+const FEED_BASELINE_TIMESTAMP = Date.parse("2026-06-17T00:00:00.000Z");
+
+interface FeedPage {
+  data: object;
+}
+
+interface DatedFeedPage<Page extends FeedPage> {
+  lastModified: Date;
+  page: Page;
+}
+
+const getLastModified = (data: object): Date | undefined =>
+  "lastModified" in data && data.lastModified instanceof Date ? data.lastModified : undefined;
+
+export const selectDatedFeedPages = <Page extends FeedPage>(
+  pages: readonly Page[],
+): DatedFeedPage<Page>[] =>
+  pages.map((page) => ({
+    lastModified: getLastModified(page.data) ?? new Date(FEED_BASELINE_TIMESTAMP),
+    page,
+  }));
+
+export const getFeedUpdatedAt = <Page extends FeedPage>(
+  pages: readonly DatedFeedPage<Page>[],
+): Date =>
+  pages.reduce(
+    (latest, { lastModified }) => (lastModified > latest ? lastModified : latest),
+    new Date(FEED_BASELINE_TIMESTAMP),
+  );


### PR DESCRIPTION
- Stop assigning request-time dates to docs without source modification metadata.
- Keep every feed item with a stable fallback date while honoring real modification dates.
