### PR TITLE
fix(docs): correct Linear Agent eve requirement

### DIFF
--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1236,7 +1236,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "linear"]
           },
-          "requires": ">=0.31.0"
+          "requires": ">=0.30.6"
         }
       },
       "dependencies": ["@vercel/connect"]


### PR DESCRIPTION
### Summary

Closes #1654.

The Linear Agent registry item required `eve >=0.31.0`, so both `eve add` and the dev TUI's `/add` rejected it for projects using the current `eve 0.30.6` release. Lower the requirement to `>=0.30.6`, the first published version that contains the guided Linear Agent setup flow.

This only corrects official registry metadata; CLI and TUI compatibility behavior remains unchanged.

### Validation

- `pnpm --filter eve-docs registry:validate:channels`
- `git diff --check`

No tests, documentation, or changeset are needed because this is a registry metadata correction and does not touch the published `eve` package.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
