### PR TITLE
feat(eve): offer existing connectors during setup

### DIFF
--- a/.changeset/bright-connectors-link.md
+++ b/.changeset/bright-connectors-link.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show compatible existing Vercel Connect connectors directly when adding an MCP connection. The recommended existing connector is selected first, while creating another connector remains an explicit final choice.

--- a/packages/eve/src/setup/connection-connector.integration.test.ts
+++ b/packages/eve/src/setup/connection-connector.integration.test.ts
@@ -70,15 +70,32 @@ describe("setupConnectionConnector", () => {
     };
   }
 
-  it("attaches the canonical connector only after confirming user authorization", async () => {
+  it("offers the canonical connector first instead of attaching it silently", async () => {
+    const selectOptions: SingleSelectOptions<PrompterValue>[] = [];
+    const fake = createFakePrompter({
+      single: (input) => {
+        selectOptions.push(input);
+        return CANONICAL_UID;
+      },
+    });
     capture
       .mockResolvedValueOnce(
-        jsonResult({ connectors: [{ uid: CANONICAL_UID, id: "scl_canonical" }] }),
+        jsonResult({
+          connectors: [
+            {
+              uid: "linear/shared",
+              id: "scl_shared",
+              projects: [{ id: "prj_1" }],
+            },
+            { uid: CANONICAL_UID, id: "scl_canonical" },
+          ],
+        }),
       )
+      .mockResolvedValueOnce(connectorResult("linear/shared", "scl_shared", "user"))
       .mockResolvedValueOnce(connectorResult(CANONICAL_UID, "scl_canonical", "user"));
     run.mockResolvedValue(true);
 
-    await expect(setupConnectionConnector(options())).resolves.toEqual({
+    await expect(setupConnectionConnector(options(fake.prompter))).resolves.toEqual({
       kind: "existing",
       connectorUid: CANONICAL_UID,
     });
@@ -91,6 +108,26 @@ describe("setupConnectionConnector", () => {
       expect.any(Object),
     );
     expect(create).not.toHaveBeenCalled();
+    expect(fake.selectMessages).toEqual(["Which connector should linear use?"]);
+    expect(selectOptions[0]).toMatchObject({
+      initialValue: CANONICAL_UID,
+      options: [
+        {
+          value: CANONICAL_UID,
+          label: CANONICAL_UID,
+          hint: "Existing connector · recommended",
+        },
+        {
+          value: "linear/shared",
+          label: "linear/shared",
+          hint: "Existing connector · already linked to this project",
+        },
+        {
+          label: "Create a new connector",
+          hint: "Opens your browser to configure another connector",
+        },
+      ],
+    });
     expect(run).toHaveBeenCalledWith(
       ["connect", "attach", CANONICAL_UID, "--yes", "--scope", "org_1"],
       expect.any(Object),
@@ -100,6 +137,7 @@ describe("setupConnectionConnector", () => {
   it("finds a canonical connector by name instead of assuming its UID namespace", async () => {
     const canonicalName = "linear";
     const actualUid = "linear/default";
+    const fake = createFakePrompter({ single: () => actualUid });
     capture
       .mockResolvedValueOnce(
         jsonResult({ connectors: [{ uid: actualUid, id: "scl_canonical", name: canonicalName }] }),
@@ -108,7 +146,10 @@ describe("setupConnectionConnector", () => {
     run.mockResolvedValue(true);
 
     await expect(
-      setupConnectionConnector({ ...options(), canonicalConnectorName: canonicalName }),
+      setupConnectionConnector({
+        ...options(fake.prompter),
+        canonicalConnectorName: canonicalName,
+      }),
     ).resolves.toEqual({
       kind: "existing",
       connectorUid: actualUid,
@@ -155,12 +196,11 @@ describe("setupConnectionConnector", () => {
       .mockResolvedValueOnce(jsonResult({ connectors: [{ uid: "linear/user", id: "scl_user" }] }))
       .mockResolvedValueOnce(connectorResult("linear/app", "scl_app", "app"))
       .mockResolvedValueOnce(connectorResult("linear/user", "scl_user", "user"));
-    const answers = ["find", "linear/user"];
     const selectOptions: SingleSelectOptions<PrompterValue>[] = [];
     const fake = createFakePrompter({
       single: (input) => {
         selectOptions.push(input);
-        return answers.shift()!;
+        return "linear/user";
       },
     });
 
@@ -176,23 +216,23 @@ describe("setupConnectionConnector", () => {
       expect.arrayContaining(["--scope", "org_1"]),
       expect.any(Object),
     );
-    expect(fake.selectMessages).toEqual([
-      "Which connector should linear use?",
-      "Select a connector for linear",
-    ]);
+    expect(fake.selectMessages).toEqual(["Which connector should linear use?"]);
     expect(selectOptions[0]).toMatchObject({
+      initialValue: "linear/user",
       hintLayout: "inline",
-      notices: [{ tone: "warning", text: `Could not find a connector named ${CANONICAL_NAME}.` }],
-    });
-    expect(selectOptions[1]).toMatchObject({
-      hintLayout: "inline",
-      placeholder: "type to search connectors",
-      search: true,
+      options: [
+        {
+          value: "linear/user",
+          label: "linear/user",
+          hint: "Existing connector",
+        },
+        { label: "Create a new connector" },
+      ],
     });
   });
 
   it("removes a created connector when attach fails", async () => {
-    run.mockResolvedValueOnce(false).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    run.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     capture
       .mockResolvedValueOnce(
         jsonResult({ connectors: [{ uid: CANONICAL_UID, id: "scl_existing", name: "Linear" }] }),
@@ -218,7 +258,7 @@ describe("setupConnectionConnector", () => {
   });
 
   it("recovers a partially created connector id from CLI progress and removes it", async () => {
-    run.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    run.mockResolvedValue(true);
     capture.mockResolvedValue(jsonResult({ connectors: [] }));
     create.mockImplementation(async (_args, createOptions) => {
       createOptions.onOutput?.({ stream: "stderr", text: "Connector created: scl_partial" });

--- a/packages/eve/src/setup/connection-connector.ts
+++ b/packages/eve/src/setup/connection-connector.ts
@@ -21,6 +21,7 @@ export interface ConnectConnectorRef {
   uid: string;
   id: string;
   name?: string;
+  projectIds?: readonly string[];
 }
 
 export type SetupConnectionConnectorResult =
@@ -32,6 +33,7 @@ type ConnectorResolution =
   | { kind: "created"; connector: ConnectConnectorRef };
 
 const CREATED_CONNECTOR = /\bConnector created:\s*(scl_[A-Za-z0-9_-]+)\b/u;
+const CREATE_NEW_CONNECTOR = "create";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -51,6 +53,11 @@ function parseConnectorRef(value: unknown): ConnectConnectorRef | undefined {
   }
   const connector: ConnectConnectorRef = { uid: value["uid"], id: value["id"] };
   if (typeof value["name"] === "string") connector.name = value["name"];
+  if (Array.isArray(value["projects"])) {
+    connector.projectIds = value["projects"]
+      .map((project) => (isRecord(project) ? project["id"] : undefined))
+      .filter((id): id is string => typeof id === "string");
+  }
   return connector;
 }
 
@@ -181,6 +188,39 @@ function nextConnectorName(slug: string, names: ReadonlySet<string>): string {
   return `${slug}-${suffix}`;
 }
 
+function rankConnectors(
+  connectors: readonly ConnectConnectorRef[],
+  canonicalName: string,
+  projectId: string,
+): ConnectConnectorRef[] {
+  return connectors
+    .map((connector, index) => ({
+      connector,
+      index,
+      rank: connectorMatchesCanonicalName(connector, canonicalName)
+        ? 0
+        : connector.projectIds?.includes(projectId)
+          ? 1
+          : 2,
+    }))
+    .sort((left, right) => left.rank - right.rank || left.index - right.index)
+    .map(({ connector }) => connector);
+}
+
+function existingConnectorHint(
+  connector: ConnectConnectorRef,
+  canonicalName: string,
+  projectId: string,
+): string {
+  if (connector.projectIds?.includes(projectId)) {
+    return "Existing connector · already linked to this project";
+  }
+  if (connectorMatchesCanonicalName(connector, canonicalName)) {
+    return "Existing connector · recommended";
+  }
+  return "Existing connector";
+}
+
 /** Removes a connector created by this setup attempt. */
 export async function cleanupCreatedConnectionConnector(input: {
   log: ChannelSetupLog;
@@ -216,140 +256,123 @@ async function attach(
   });
 }
 
-async function resolveFallbackConnector(
+async function createConnector(
   options: SetupConnectionConnectorOptions,
   project: VercelProjectReference,
   onOutput: ProcessOutputHandler,
   connectors: readonly ConnectConnectorRef[],
-  initialNotice: string,
 ): Promise<ConnectorResolution> {
-  let notice = initialNotice;
-  while (true) {
-    const choice = await options.prompter.select<"find" | "create">({
-      message: `Which connector should ${options.slug} use?`,
-      hintLayout: "inline",
-      notices: [{ tone: "warning", text: notice }],
-      options: [
-        { value: "find", label: "Find a new one", hint: "Browse existing connectors" },
-        { value: "create", label: "Create a new one", hint: "Register another connector" },
-      ],
-    });
-    if (choice === "find") {
-      const supported: ConnectConnectorRef[] = [];
-      for (const connector of connectors) {
-        if (await supportsUserAuthorization(options, project, connector, onOutput)) {
-          supported.push(connector);
-        }
-      }
-      if (supported.length === 0) {
-        notice = `No existing ${options.service} connectors support user authorization.`;
-        continue;
-      }
-      const byUid = new Map(supported.map((connector) => [connector.uid, connector]));
-      const uid = await options.prompter.select<string>({
-        message: `Select a connector for ${options.slug}`,
-        hintLayout: "inline",
-        search: true,
-        placeholder: "type to search connectors",
-        options: supported.map((connector) => ({
-          value: connector.uid,
-          label: connector.uid,
-          hint: connector.name ?? connector.id,
-        })),
+  const names = connectorNames(connectors);
+  const name = (
+    await options.prompter.text({
+      message: "New connector name",
+      defaultValue: nextConnectorName(options.slug, names),
+      validate: (value) => {
+        const normalized = value.trim().toLowerCase();
+        if (normalized.length === 0) return "A name is required.";
+        return names.has(normalized) ? "A connector with this name already exists." : undefined;
+      },
+    })
+  ).trim();
+  const transcript: string[] = [];
+  const createOutput: ProcessOutputHandler = (line) => {
+    transcript.push(line.text);
+    onOutput(line);
+  };
+  const created = await withPhase(
+    options.log,
+    "Waiting for you to complete setup in the browser…",
+    () =>
+      runVercelCaptureStdout(
+        [
+          "connect",
+          "create",
+          options.service,
+          "--name",
+          name,
+          "-F",
+          "json",
+          "--scope",
+          project.orgId,
+        ],
+        { cwd: options.projectRoot, onOutput: createOutput, signal: options.signal },
+      ),
+    { kind: "external-action", emphasis: "browser" },
+  );
+  const raw = parseConnectorRef(parseJson(created.stdout));
+  const ownedId = raw?.id ?? CREATED_CONNECTOR.exec(transcript.join("\n"))?.[1];
+  const connector = created.ok ? parseCreatedConnector(created.stdout) : undefined;
+  if (connector !== undefined) return { kind: "created", connector };
+  const message = created.ok
+    ? `The ${options.service} connector does not support user authorization.`
+    : `Could not create the ${options.service} connector.`;
+  if (ownedId !== undefined) {
+    try {
+      await cleanupCreatedConnectionConnector({
+        log: options.log,
+        projectRoot: options.projectRoot,
+        connectorId: ownedId,
+        orgId: project.orgId,
       });
-      const connector = byUid.get(uid);
-      if (connector === undefined) throw new Error(`Connector ${uid} is no longer available.`);
-      return { kind: "existing", connector };
+    } catch (error) {
+      const cleanup = error instanceof Error ? error.message : String(error);
+      throw new Error(`${message} ${cleanup}`);
     }
-
-    const names = connectorNames(connectors);
-    const name = (
-      await options.prompter.text({
-        message: "New connector name",
-        defaultValue: nextConnectorName(options.slug, names),
-        validate: (value) => {
-          const normalized = value.trim().toLowerCase();
-          if (normalized.length === 0) return "A name is required.";
-          return names.has(normalized) ? "A connector with this name already exists." : undefined;
-        },
-      })
-    ).trim();
-    const transcript: string[] = [];
-    const createOutput: ProcessOutputHandler = (line) => {
-      transcript.push(line.text);
-      onOutput(line);
-    };
-    const created = await withPhase(
-      options.log,
-      "Waiting for you to complete setup in the browser…",
-      () =>
-        runVercelCaptureStdout(
-          [
-            "connect",
-            "create",
-            options.service,
-            "--name",
-            name,
-            "-F",
-            "json",
-            "--scope",
-            project.orgId,
-          ],
-          { cwd: options.projectRoot, onOutput: createOutput, signal: options.signal },
-        ),
-      { kind: "external-action", emphasis: "browser" },
-    );
-    const raw = parseConnectorRef(parseJson(created.stdout));
-    const ownedId = raw?.id ?? CREATED_CONNECTOR.exec(transcript.join("\n"))?.[1];
-    const connector = created.ok ? parseCreatedConnector(created.stdout) : undefined;
-    if (connector !== undefined) return { kind: "created", connector };
-    const message = created.ok
-      ? `The ${options.service} connector does not support user authorization.`
-      : `Could not create the ${options.service} connector.`;
-    if (ownedId !== undefined) {
-      try {
-        await cleanupCreatedConnectionConnector({
-          log: options.log,
-          projectRoot: options.projectRoot,
-          connectorId: ownedId,
-          orgId: project.orgId,
-        });
-      } catch (error) {
-        const cleanup = error instanceof Error ? error.message : String(error);
-        throw new Error(`${message} ${cleanup}`);
-      }
-      options.signal?.throwIfAborted();
-    }
-    throw new Error(message);
+    options.signal?.throwIfAborted();
   }
+  throw new Error(message);
 }
 
-/** Attaches the canonical connector by name first, then offers explicit Find/Create fallbacks. */
+async function resolveConnector(
+  options: SetupConnectionConnectorOptions,
+  project: VercelProjectReference,
+  onOutput: ProcessOutputHandler,
+  connectors: readonly ConnectConnectorRef[],
+): Promise<ConnectorResolution> {
+  const supported: ConnectConnectorRef[] = [];
+  for (const connector of connectors) {
+    if (await supportsUserAuthorization(options, project, connector, onOutput)) {
+      supported.push(connector);
+    }
+  }
+  const ranked = rankConnectors(supported, options.canonicalConnectorName, project.projectId);
+  const byUid = new Map(ranked.map((connector) => [connector.uid, connector]));
+  const searchOptions =
+    ranked.length > 5 ? { search: true as const, placeholder: "type to search connectors" } : {};
+  const choice = await options.prompter.select<string>({
+    message: `Which connector should ${options.slug} use?`,
+    hintLayout: "inline",
+    initialValue: ranked[0]?.uid ?? CREATE_NEW_CONNECTOR,
+    ...searchOptions,
+    options: [
+      ...ranked.map((connector) => ({
+        value: connector.uid,
+        label: connector.uid,
+        hint: existingConnectorHint(connector, options.canonicalConnectorName, project.projectId),
+      })),
+      {
+        value: CREATE_NEW_CONNECTOR,
+        label: "Create a new connector",
+        hint: "Opens your browser to configure another connector",
+      },
+    ],
+  });
+  if (choice === CREATE_NEW_CONNECTOR) {
+    return createConnector(options, project, onOutput, connectors);
+  }
+  const connector = byUid.get(choice);
+  if (connector === undefined) throw new Error(`Connector ${choice} is no longer available.`);
+  return { kind: "existing", connector };
+}
+
+/** Lets the user choose a compatible existing connector or create a new one, then attaches it. */
 export async function setupConnectionConnector(
   options: SetupConnectionConnectorOptions,
 ): Promise<SetupConnectionConnectorResult> {
   const onOutput = createPromptCommandOutput(options.log);
   const project = options.project;
   const connectors = await listConnectors(options, project, onOutput);
-  const canonical = connectors.find((connector) =>
-    connectorMatchesCanonicalName(connector, options.canonicalConnectorName),
-  );
-  let notice = `Could not find a connector named ${options.canonicalConnectorName}.`;
-
-  if (canonical !== undefined) {
-    if (await supportsUserAuthorization(options, project, canonical, onOutput)) {
-      if (await attach(options, project, canonical.uid, onOutput)) {
-        options.log.success(`Attached ${canonical.uid} connector`);
-        return { kind: "existing", connectorUid: canonical.uid };
-      }
-      options.signal?.throwIfAborted();
-      notice = `Could not attach ${canonical.uid}.`;
-    } else {
-      notice = `${canonical.uid} does not support user authorization.`;
-    }
-  }
-
-  const resolution = await resolveFallbackConnector(options, project, onOutput, connectors, notice);
+  const resolution = await resolveConnector(options, project, onOutput, connectors);
   if (!(await attach(options, project, resolution.connector.uid, onOutput))) {
     if (resolution.kind === "created") {
       const message = `Could not attach ${resolution.connector.uid} to the linked project.`;


### PR DESCRIPTION
### Summary

Customer feedback showed that MCP connection setup feels creation-first even when compatible Vercel Connect connectors already exist. The current flow silently attaches a canonical-name match and hides every other reusable connector behind a nested Find action.

This change makes connector reuse explicit:

- validates every service-matched connector for user authorization
- shows compatible existing connectors directly in one picker
- ranks the canonical connector first, then connectors already linked to the project
- identifies already-linked and recommended choices inline
- keeps Create a new connector as the final browser-based option
- preserves cleanup when a newly created connector cannot be attached

### Validation

- `pnpm --filter eve run typecheck`
- `pnpm vitest run --config vitest.integration.config.ts ./src/setup/connection-connector.integration.test.ts`
- `pnpm vitest run --config vitest.unit.config.ts ./src/cli/commands/integration-connect.test.ts`
- `pnpm --filter eve run build`
- `pnpm exec oxlint packages/eve/src/setup/connection-connector.ts packages/eve/src/setup/connection-connector.integration.test.ts`
- `pnpm exec oxfmt --check packages/eve/src/setup/connection-connector.ts packages/eve/src/setup/connection-connector.integration.test.ts .changeset/bright-connectors-link.md`
- local built eve `v0.30.6` successfully inspected the workspace `test-agent`
- Vercel CLI `58.4.0` exposes the required `connect list` and `connect attach` commands

The existing dirty `test-agent` typecheck remains blocked by its unrelated `agent/tools/inline_auth_probe.ts` using an older installed eve API. Real connector attachment was not exercised to avoid mutating a live Connect project during draft validation.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)