### PR TITLE
docs: add inbound links to orphaned pages

### DIFF
--- a/docs/concepts/security-model.md
+++ b/docs/concepts/security-model.md
@@ -103,3 +103,4 @@ Before exposing an agent to real traffic:
 - [Sandbox](../sandbox): backends, network policy, and brokering config
 - [Execution model and durability](./execution-model-and-durability): how durable sessions run
 - [Connections](../connections): static-token and OAuth connections
+- [Responsible use](../responsible-use): deployer responsibilities and safeguards to review before production

--- a/docs/guides/state.md
+++ b/docs/guides/state.md
@@ -76,3 +76,4 @@ Every [subagent](../subagents) starts with its own fresh state, whether it's a b
 - Read state inside dynamic resolvers → [Dynamic capabilities](./dynamic-capabilities)
 - How step durability works → [Execution model & durability](../concepts/execution-model-and-durability)
 - The `ctx` accessors available alongside state → [TypeScript API](../reference/typescript-api)
+- Tenant-scoped long-term memory in your own store → [Multi-tenant memory](../patterns/multi-tenant-memory)

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -116,3 +116,4 @@ The gotcha is custom hosting. If you adapt the generated output to a process man
 
 - [Channels](./channels/overview): deliver schedule output to users.
 - [Sessions, runs & streaming](./concepts/sessions-runs-and-streaming): inspect a schedule run.
+- [Dynamic scheduling](./patterns/dynamic-scheduling): manage schedule rows in your own store behind one dispatcher schedule.

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -125,3 +125,4 @@ From your own frontend, read the pending request off the latest message and answ
 - [Default harness](/docs/concepts/default-harness): the built-in tools, including `ask_question`
 - [Sessions, runs & streaming](/docs/concepts/sessions-runs-and-streaming): the event and resume contract behind the pause
 - [Building a frontend](/docs/guides/frontend/overview): render and answer requests from your own UI
+- [Multi-tenant approvals](/docs/patterns/multi-tenant-approvals): resolve per-tenant approval policy for authored and connection tools


### PR DESCRIPTION
These pages had no inbound links from other docs pages, so they're only reachable via the sidebar. Adds minimal cross-links from their parent or related pages.

- `/docs/patterns/dynamic-scheduling` ← linked from Schedules
- `/docs/patterns/multi-tenant-approvals` ← linked from Human in the Loop
- `/docs/patterns/multi-tenant-memory` ← linked from State
- `/docs/responsible-use` ← linked from Security Model

Note: the original orphan list (51 pages from the docs link graph) predates recent main — tutorial chaining, section-overview child links, and overview inbound links already exist on `main`, so only these 4 remained. Verified all links resolve; `pnpm docs:check` passes.