### PR TITLE
Track smart 404 paths

### DIFF
--- a/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
@@ -2,6 +2,7 @@ import { createDocsMarkdownRoute } from "@vercel/geistdocs/routes/llms";
 import {
   analyticsEvents,
   countMarkdownSuggestions,
+  getAnalyticsPathname,
   getCountBucket,
   getDocsSurface,
   getMarkdownFormat,
@@ -28,6 +29,7 @@ export const GET: typeof markdownRoute.GET = async (request, context) => {
     const body = await response.clone().text();
     trackServerEvent(request, analyticsEvents.smartMarkdownNotFound, {
       format: getMarkdownFormat(pathname, request.headers.get("accept")),
+      path: getAnalyticsPathname(request.url),
       suggestions: getCountBucket(countMarkdownSuggestions(body)),
       surface: getDocsSurface(pathname),
     });

--- a/apps/docs/lib/analytics/events.test.ts
+++ b/apps/docs/lib/analytics/events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   analyticsEvents,
   countMarkdownSuggestions,
+  getAnalyticsPathname,
   getAskAiContext,
   getCountBucket,
   getDocsSurface,
@@ -67,6 +68,13 @@ describe("docs analytics", () => {
     expect(normalizeSearchQuery("  Durable   Agents  ")).toBe("durable agents");
     expect(normalizeSearchQuery("ＡＧＥＮＴ")).toBe("agent");
     expect(normalizeSearchQuery("a".repeat(200))).toHaveLength(120);
+  });
+
+  it("records a bounded pathname without query data or fragments", () => {
+    expect(getAnalyticsPathname("https://eve.dev/docs/env-vars.md?token=secret#section")).toBe(
+      "/docs/env-vars.md",
+    );
+    expect(getAnalyticsPathname(`/docs/${"a".repeat(300)}.md`)).toHaveLength(255);
   });
 
   it.each([

--- a/apps/docs/lib/analytics/events.ts
+++ b/apps/docs/lib/analytics/events.ts
@@ -32,6 +32,9 @@ export const isQueryFreeUrl = (url: string): boolean => {
 export const normalizeSearchQuery = (query: string): string =>
   query.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase().slice(0, 120);
 
+export const getAnalyticsPathname = (url: string): string =>
+  new URL(url, "https://eve.dev").pathname.slice(0, 255);
+
 export const getDocsSurface = (value: unknown): DocsSurface => {
   if (typeof value !== "string") return "other";
 


### PR DESCRIPTION
- Add the requested pathname to smart Markdown 404 events so high-volume misses can be identified.
- Strip query strings and fragments, cap values at 255 characters, and cover both behaviors with unit tests.