### PR TITLE
feat(eve): stream intermediate tool results via async-generator execute

### DIFF
--- a/.changeset/streaming-tool-partials.md
+++ b/.changeset/streaming-tool-partials.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Tools can stream intermediate results: `execute` may be an `async *` generator. Each yield streams to clients as an `action.partial` event carrying the full output snapshot so far, and the last yield becomes the tool result.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -47,6 +47,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | `message.received`        | An inbound user message was accepted; carries flattened text plus structured text/file parts.                    |
 | `step.started`            | A model step began.                                                                                              |
 | `actions.requested`       | The model requested one or more actions, including tool calls; calls stream before execution.                    |
+| `action.partial`          | A streaming tool yielded a preliminary output snapshot; each one supersedes the last for the same call.          |
 | `action.result`           | A tool call returned.                                                                                            |
 | `input.requested`         | The run paused for human input ([HITL](/docs/human-in-the-loop) approval or `ask_question`); carries `requests`. |
 | `subagent.called`         | A subagent was delegated; carries `childSessionId` to attach to.                                                 |
@@ -70,6 +71,8 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | `session.completed`       | The session reached a terminal end.                                                                              |
 
 `reasoning.appended` and `message.appended` stream incremental output as it arrives. When the durable stream writer is busy, eve may coalesce adjacent deltas of the same type; the text remains in source order, and any other event forms an ordering barrier. Each append carries both the new delta and the cumulative text for the current block. The finalized block shows up on `message.completed` and `reasoning.completed`, which is the compatibility path for clients that don't render incremental streaming.
+
+`action.partial` streams preliminary output from a [streaming tool](/docs/tools#stream-intermediate-results). Each event carries the complete snapshot so far — not a delta — and supersedes the previous `action.partial` for the same `result.callId`; the terminal `action.result` supersedes them all. When the durable writer is busy, adjacent snapshots for the same call coalesce to the latest. Always render the most recent snapshot rather than accumulating across events: a retried step can replay overlapping snapshot runs.
 
 Note: consider the privacy, confidentiality, and user-experience implications for displaying, storing, or transmitting reasoning events in your application.
 

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -99,6 +99,7 @@ The most common UI events are:
 | `reasoning.appended` | Render reasoning deltas when the model provides them.                          |
 | `message.appended`   | Render assistant text deltas.                                                  |
 | `actions.requested`  | Show tool calls as the model requests them, before execution.                  |
+| `action.partial`     | Show live progress from a streaming tool; each snapshot replaces the last.     |
 | `action.result`      | Show tool call results.                                                        |
 | `input.requested`    | Pause the UI for approval or a question answer.                                |
 | `result.completed`   | Read structured output from an [output schema](./output-schema).               |

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -28,7 +28,7 @@ A tool definition needs:
 - a filename slug under `agent/tools/`, the model-facing name.
 - a `description`: what the tool does, written for the model.
 - an `inputSchema`: a Zod schema (or any Standard Schema, or a plain JSON Schema object). Required. For no input, pass `z.object({})`. Zod and Standard Schema infer the `input` type in `execute`. Plain JSON Schema types it as `Record<string, unknown>`.
-- an `execute(input, ctx)`: the implementation. May be sync or async.
+- an `execute(input, ctx)`: the implementation. May be sync, async, or an `async *` generator (see [streaming intermediate results](#stream-intermediate-results)).
 
 When a tool returns structured data, add an optional `outputSchema`. With Zod or Standard Schema it also types the `execute` return.
 
@@ -46,6 +46,44 @@ When a tool returns structured data, add an optional `outputSchema`. With Zod or
 Running in the app runtime is what lets a tool import shared code from `lib/`, read `process.env`, and take part in eve’s durable pause/resume model.
 
 eve never runs authored tools during discovery. The model sees descriptors first, and only what it actually calls gets executed. Completed steps never re-run; eve replays the recorded result. A step interrupted mid-execution re-runs, so make non-idempotent side effects like charges or emails idempotent, or gate them with approval.
+
+## Stream intermediate results
+
+A long-running tool can stream progress to clients while it works. Write
+`execute` as an `async *` generator: each `yield` is a complete snapshot of the
+output so far, and the last yield becomes the tool result.
+
+```ts title="agent/tools/index_documents.ts"
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+export default defineTool({
+  description: "Index a document collection.",
+  inputSchema: z.object({ collection: z.string() }),
+  async *execute({ collection }) {
+    const documents = await listDocuments(collection);
+    let indexed = 0;
+    for (const document of documents) {
+      await indexDocument(document);
+      indexed += 1;
+      yield { indexed, total: documents.length };
+    }
+    yield { done: true, indexed, total: documents.length };
+  },
+});
+```
+
+Every yield streams to clients as an
+[`action.partial` event](/docs/concepts/sessions-runs-and-streaming) carrying
+the full snapshot; each one supersedes the previous snapshot for the same
+call, and the terminal `action.result` supersedes them all. Because retried
+steps can replay overlapping snapshot runs, consumers must always render the
+latest snapshot rather than accumulate across events.
+
+Each yield crosses the same boundary as a plain return: it must be
+JSON-serializable and satisfy `outputSchema`/the inferred output type. The
+model and `toModelOutput` only ever see the terminal value — partials are a
+client-facing progress surface, not model context.
 
 ## Gate a tool on human approval
 

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v6.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v6.ts
@@ -1,0 +1,10 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineInstructions({
+        markdown: `Prefer cached evidence when replying in session ${ctx.session.id}.`,
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v6.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v6.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineSkill({
+        description: `Summarize findings for session ${ctx.session.id}.`,
+        markdown: "# Findings summary\n\nGroup findings by severity before reporting.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v9.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v9.ts
@@ -1,0 +1,12 @@
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineTool({
+        description: "Return the active turn identifier.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => ({ sessionId: ctx.session.id }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v7.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v7.ts
@@ -1,0 +1,13 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "action.result"(event, ctx) {
+      console.info("action result", {
+        result: event.data.result,
+        sessionId: ctx.session.id,
+        status: event.data.status,
+      });
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v6.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v6.ts
@@ -1,0 +1,7 @@
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Return the word count of a document.",
+  inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+  execute: async (input) => ({ words: String(input.text).split(/\s+/u).length }),
+});

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v7.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v7.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 7,
+  "sha256": "21b997a3782ca550af622f02887bdad276145f4e5fb3988689117219bf0eb4c1",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v7.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v7.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 7,
+  "sha256": "21b997a3782ca550af622f02887bdad276145f4e5fb3988689117219bf0eb4c1",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v10.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v10.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 10,
+  "sha256": "c9b16b2dd52b1f73c69ae7ab137fb1f0c15df403ff184fb6b3d2b808eecfc5aa",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v8.json
+++ b/packages/eve/extension-contracts/reports/hook/v8.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 8,
+  "sha256": "0509469d75b0b882631932102f26d035dba7442c6ad91df838b28a4b80506954",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/tool/v7.json
+++ b/packages/eve/extension-contracts/reports/tool/v7.json
@@ -1,0 +1,22 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 7,
+  "sha256": "79e9c26038a96722657db877ccfd8f6a8977dcd4e49d6153e00a636375e95c72",
+  "exports": [
+    "defineBashTool",
+    "defineGlobTool",
+    "defineGrepTool",
+    "defineReadFileTool",
+    "defineTool",
+    "defineWriteFileTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/client/message-reducer-types.ts
+++ b/packages/eve/src/client/message-reducer-types.ts
@@ -182,6 +182,11 @@ export type EveDynamicToolPart = {
       readonly errorText?: never;
       readonly input: unknown;
       readonly output: unknown;
+      /**
+       * `true` while `output` is a preliminary snapshot from a streaming
+       * tool (`action.partial`); cleared by the terminal `action.result`.
+       */
+      readonly partial?: boolean;
       readonly state: "output-available";
     }
   | {

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { defaultMessageReducer } from "#client/message-reducer.js";
 import { stampTestEvents } from "#internal/testing/events.js";
 import {
+  createActionPartialEvent,
   createActionResultEvent,
   createActionsRequestedEvent,
   createAuthorizationCompletedEvent,
@@ -17,6 +18,7 @@ import {
   createTurnCancelledEvent,
   type UnstampedMessageStreamEvent,
 } from "#protocol/message.js";
+import type { JsonValue } from "#shared/json.js";
 
 function reduceServerEvents(
   reducer: ReturnType<typeof defaultMessageReducer>,
@@ -170,6 +172,123 @@ describe("defaultMessageReducer", () => {
               },
             },
             toolName: "eve:subagent:research",
+            type: "dynamic-tool",
+          },
+        ],
+        role: "assistant",
+      },
+    ]);
+  });
+
+  it("projects action.partial snapshots as partial output that the terminal result clears", () => {
+    const reducer = defaultMessageReducer();
+    const requested = createActionsRequestedEvent({
+      actions: [
+        { callId: "call_1", input: { task: "index" }, kind: "tool-call", toolName: "long_task" },
+      ],
+      sequence: 1,
+      stepIndex: 0,
+      turnId: "turn_1",
+    });
+    const partial = (output: JsonValue, sequence: number) =>
+      createActionPartialEvent({
+        result: { callId: "call_1", kind: "tool-result", output, toolName: "long_task" },
+        sequence,
+        stepIndex: 0,
+        turnId: "turn_1",
+      });
+    const expectedPart = (extra: Record<string, unknown>) => ({
+      input: { task: "index" },
+      stepIndex: 0,
+      toolCallId: "call_1",
+      toolMetadata: { eve: { kind: "tool-call", name: "long_task" } },
+      toolName: "long_task",
+      type: "dynamic-tool",
+      ...extra,
+    });
+    const findPart = (data: ReturnType<typeof reducer.initial>) =>
+      data.messages
+        .flatMap((message) => message.parts)
+        .find((part) => part.type === "dynamic-tool");
+
+    let data = reduceServerEvents(reducer, reducer.initial(), [
+      requested,
+      partial({ progress: 0.25 }, 2),
+    ]);
+    expect(findPart(data)).toEqual(
+      expectedPart({ output: { progress: 0.25 }, partial: true, state: "output-available" }),
+    );
+
+    // A newer snapshot overwrites the previous one wholesale.
+    data = reduceServerEvents(reducer, data, [partial({ progress: 0.5 }, 3)]);
+    expect(findPart(data)).toEqual(
+      expectedPart({ output: { progress: 0.5 }, partial: true, state: "output-available" }),
+    );
+
+    // The terminal result clears the partial flag.
+    data = reduceServerEvents(reducer, data, [
+      createActionResultEvent({
+        result: {
+          callId: "call_1",
+          kind: "tool-result",
+          output: { progress: 1 },
+          toolName: "long_task",
+        },
+        sequence: 4,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    ]);
+    expect(findPart(data)).toEqual(
+      expectedPart({ output: { progress: 1 }, state: "output-available" }),
+    );
+
+    // Replayed partials (e.g. from a retried step) never regress a terminal part.
+    data = reduceServerEvents(reducer, data, [partial({ progress: 0.75 }, 5)]);
+    expect(findPart(data)).toEqual(
+      expectedPart({ output: { progress: 1 }, state: "output-available" }),
+    );
+  });
+
+  it("projects an action.partial without a preceding action request", () => {
+    const reducer = defaultMessageReducer();
+    const data = reduceServerEvents(reducer, reducer.initial(), [
+      createActionPartialEvent({
+        result: {
+          callId: "call_1",
+          kind: "tool-result",
+          output: { progress: 0.1 },
+          toolName: "long_task",
+        },
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+    ]);
+
+    expect(data.messages).toEqual([
+      {
+        id: "turn_1:assistant",
+        metadata: {
+          status: "streaming",
+          turnId: "turn_1",
+        },
+        parts: [
+          { type: "step-start" },
+          {
+            input: undefined,
+            output: { progress: 0.1 },
+            partial: true,
+            state: "output-available",
+            stepIndex: 0,
+            toolCallId: "call_1",
+            toolMetadata: {
+              eve: {
+                kind: "tool-call",
+                name: "long_task",
+              },
+            },
+            toolName: "long_task",
             type: "dynamic-tool",
           },
         ],

--- a/packages/eve/src/client/message-reducer.ts
+++ b/packages/eve/src/client/message-reducer.ts
@@ -225,6 +225,36 @@ function reduceMessageData(data: EveMessageData, event: EveAgentReducerEvent): E
       );
     }
 
+    case "action.partial": {
+      const descriptor = normalizeActionResult(event.data.result);
+      const existing = findToolPart(data, event.data.result.callId);
+      // Step retries can replay partials after the terminal result; a
+      // settled part never regresses to a snapshot.
+      if (existing !== undefined && isTerminalToolPart(existing)) {
+        return data;
+      }
+      const nextPart: EveDynamicToolPart = {
+        approval: approvedApproval(existing),
+        input: existing?.input,
+        output: event.data.result.output,
+        partial: true,
+        state: "output-available",
+        stepIndex: event.data.stepIndex,
+        toolCallId: event.data.result.callId,
+        toolMetadata: mergeToolMetadata(existing?.toolMetadata, createToolMetadata(descriptor)),
+        toolName: existing?.toolName ?? descriptor.toolName,
+        type: "dynamic-tool",
+      };
+
+      if (existing !== undefined) {
+        return updateToolPart(data, event.data.result.callId, nextPart);
+      }
+
+      return updateAssistantMessage(data, event.data.turnId, (message) =>
+        upsertPart(ensureStepStartPart(message, event.data.stepIndex), nextPart),
+      );
+    }
+
     case "authorization.required":
       return updateAssistantMessage(data, event.data.turnId, (message) =>
         upsertPart(
@@ -496,6 +526,13 @@ function updateAuthorizationPart(
   }
 
   return upsertMessage(data, upsertPart(message, next));
+}
+
+function isTerminalToolPart(part: EveDynamicToolPart): boolean {
+  if (part.state === "output-error" || part.state === "output-denied") {
+    return true;
+  }
+  return part.state === "output-available" && part.partial !== true;
 }
 
 function findToolPart(data: EveMessageData, toolCallId: string): EveDynamicToolPart | undefined {

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -21,14 +21,14 @@ interface ExtensionCapabilityContract {
 
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
-  tool: { current: 6, supported: [1, 2, 3, 4, 5, 6], dropped: {} },
-  dynamicTool: { current: 9, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9], dropped: {} },
+  tool: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
+  dynamicTool: { current: 10, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dropped: {} },
   connection: { current: 2, supported: [1, 2], dropped: {} },
-  hook: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
+  hook: { current: 8, supported: [1, 2, 3, 4, 5, 6, 7, 8], dropped: {} },
   skill: { current: 1, supported: [1], dropped: {} },
-  dynamicSkill: { current: 6, supported: [1, 2, 3, 4, 5, 6], dropped: {} },
+  dynamicSkill: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
   instructions: { current: 1, supported: [1], dropped: {} },
-  dynamicInstructions: { current: 6, supported: [1, 2, 3, 4, 5, 6], dropped: {} },
+  dynamicInstructions: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
   config: { current: 1, supported: [1], dropped: {} },
   state: { current: 2, supported: [1, 2], dropped: {} },
 } as const satisfies Record<string, ExtensionCapabilityContract>;

--- a/packages/eve/src/context/providers/session.ts
+++ b/packages/eve/src/context/providers/session.ts
@@ -7,7 +7,7 @@ import {
   SessionKey,
 } from "#context/keys.js";
 import type { FrameworkContextProvider } from "#context/provider.js";
-import { getHarnessEmissionState } from "#harness/emission.js";
+import { getHarnessEmissionState } from "#harness/emission-state.js";
 
 export const sessionProvider: FrameworkContextProvider<Session> = {
   key: SessionKey,

--- a/packages/eve/src/execution/context.test.ts
+++ b/packages/eve/src/execution/context.test.ts
@@ -15,7 +15,7 @@ import {
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 import type { HarnessSession } from "#harness/types.js";
 
 vi.mock("./sandbox/ensure.js", () => ({

--- a/packages/eve/src/execution/durable-session-store.ts
+++ b/packages/eve/src/execution/durable-session-store.ts
@@ -17,7 +17,7 @@
  */
 import type { ModelMessage } from "ai";
 
-import { getHarnessEmissionState, type HarnessEmissionState } from "#harness/emission.js";
+import { getHarnessEmissionState, type HarnessEmissionState } from "#harness/emission-state.js";
 import { hasProxyInputRequests } from "#harness/proxy-input-requests.js";
 import type { HarnessSession, SessionStateMap } from "#harness/types.js";
 import { migrateDurableSessionSnapshot } from "#execution/durable-session-migrations/snapshot.js";

--- a/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
@@ -4,7 +4,7 @@ import { createTestRuntime } from "#internal/testing/app-harness.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { createDurableSessionState } from "#execution/durable-session-store.js";
 import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.js";
-import { setHarnessEmissionState } from "#harness/emission.js";
+import { setHarnessEmissionState } from "#harness/emission-state.js";
 import { deriveAgentOperationId } from "#harness/handles/operation-id.js";
 import {
   AGENT_HANDLES_STATE_KEY,

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -18,7 +18,7 @@ import {
   getHarnessEmissionState,
   isHarnessBetweenTurns,
   setHarnessEmissionState,
-} from "#harness/emission.js";
+} from "#harness/emission-state.js";
 import {
   clearAllProxyInputRequests,
   getProxyInputRequests,

--- a/packages/eve/src/execution/subagent-hitl-proxy.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.ts
@@ -1,9 +1,6 @@
 import type { DeliverPayload, SubagentInputRequestHookPayload } from "#channel/types.js";
-import {
-  emitTurnEpilogue,
-  getHarnessEmissionState,
-  setHarnessEmissionState,
-} from "#harness/emission.js";
+import { emitTurnEpilogue } from "#harness/emission.js";
+import { getHarnessEmissionState, setHarnessEmissionState } from "#harness/emission-state.js";
 import {
   getProxyInputRequests,
   toProxyInputRequestEntries,

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -23,7 +23,7 @@ import {
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
-import { getHarnessEmissionState } from "#harness/emission.js";
+import { getHarnessEmissionState } from "#harness/emission-state.js";
 import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
 import { readTurnSleepDurationMs } from "#harness/turn-sleep.js";
 import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellation.js";

--- a/packages/eve/src/harness/active-turn-id.ts
+++ b/packages/eve/src/harness/active-turn-id.ts
@@ -1,4 +1,4 @@
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 
 /**
  * Returns the id of the in-flight turn, or — between turns — the id the

--- a/packages/eve/src/harness/cancelled-turn-emission.ts
+++ b/packages/eve/src/harness/cancelled-turn-emission.ts
@@ -2,7 +2,7 @@ import { createSessionWaitingEvent, createTurnCancelledEvent } from "#protocol/m
 import type { HarnessEmitFn } from "#harness/types.js";
 
 import { activeTurnId } from "#harness/active-turn-id.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 
 /**
  * Emits the cancelled-turn epilogue: `turn.cancelled` → `session.waiting`

--- a/packages/eve/src/harness/emission-state.ts
+++ b/packages/eve/src/harness/emission-state.ts
@@ -1,0 +1,64 @@
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+
+/**
+ * Tracks emission lifecycle state across harness step invocations.
+ *
+ * Persisted on `session.state` so the state survives when the durable
+ * workflow runtime recreates the harness at each `"use step"` boundary.
+ */
+export interface HarnessEmissionState {
+  readonly sessionStarted: boolean;
+  readonly sequence: number;
+  readonly stepIndex: number;
+  readonly turnId: string;
+}
+
+const HARNESS_EMISSION_STATE_KEY = "eve.harness.emission";
+
+const DEFAULT_EMISSION_STATE: HarnessEmissionState = {
+  sessionStarted: false,
+  sequence: 0,
+  stepIndex: 0,
+  turnId: "",
+};
+
+/** Reads the emission state, returning defaults when absent. */
+export function getHarnessEmissionState(state: SessionStateMap | undefined): HarnessEmissionState {
+  const emissionState = state?.[HARNESS_EMISSION_STATE_KEY] as HarnessEmissionState | undefined;
+  return emissionState ?? DEFAULT_EMISSION_STATE;
+}
+
+/**
+ * Returns `true` when the harness is **between turns** — either no turn
+ * has started yet (initial state) or the previous turn has emitted its
+ * epilogue (or recoverable failure cascade) and reset.
+ *
+ * Returns `false` while a turn is in progress, including during
+ * tool-loop continuations and runtime-action resumes within the same
+ * turn. Callers that gate per-turn work (eg. lifecycle hook dispatch)
+ * use this predicate to distinguish a fresh delivery from a
+ * continuation of an in-flight turn.
+ *
+ * Implemented over the empty-`turnId` sentinel that `emitTurnEpilogue`
+ * and `emitRecoverableFailedTurn` write — clients should never read
+ * `state.turnId` directly to make this distinction.
+ */
+export function isHarnessBetweenTurns(session: HarnessSession): boolean {
+  return getHarnessEmissionState(session.state).turnId === "";
+}
+
+/**
+ * Writes the emission state onto a new copy of the session.
+ */
+export function setHarnessEmissionState(
+  session: HarnessSession,
+  state: HarnessEmissionState,
+): HarnessSession {
+  return {
+    ...session,
+    state: {
+      ...session.state,
+      [HARNESS_EMISSION_STATE_KEY]: state,
+    },
+  };
+}

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -1,12 +1,12 @@
 import { jsonSchema, type TextStreamPart, type ToolSet } from "ai";
 import { describe, expect, it, vi } from "vitest";
 
+import { emitStreamContent } from "#harness/emission.js";
 import {
-  emitStreamContent,
   getHarnessEmissionState,
-  type HarnessEmissionState,
   setHarnessEmissionState,
-} from "#harness/emission.js";
+  type HarnessEmissionState,
+} from "#harness/emission-state.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessEmitFn, HarnessSession } from "#harness/types.js";
 import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
@@ -440,8 +440,35 @@ describe("emitStreamContent action requests", () => {
     const localEvents = vi.mocked(localEmit).mock.calls.map(([event]) => event);
     const providerEvents = vi.mocked(providerEmit).mock.calls.map(([event]) => event);
 
-    expect(localEvents).toEqual(providerEvents);
     expect(localEvents.map((event) => event.type)).toEqual([
+      "message.appended",
+      "message.completed",
+      "actions.requested",
+      "action.partial",
+      "action.result",
+      "message.appended",
+      "message.completed",
+    ]);
+    expect(localEvents[3]).toMatchObject({
+      data: {
+        result: {
+          callId: "call-1",
+          kind: "tool-result",
+          output: { results: ["partial"] },
+          toolName: "web_search",
+        },
+      },
+      type: "action.partial",
+    });
+    expect(localEvents[4]).toMatchObject({
+      data: { result: { output: { results: ["eve"] } } },
+      type: "action.result",
+    });
+
+    // Provider-executed preliminary results stay dropped: provider streaming
+    // is out of scope, and the provider result already lives in the
+    // assistant response.
+    expect(providerEvents.map((event) => event.type)).toEqual([
       "message.appended",
       "message.completed",
       "actions.requested",
@@ -449,8 +476,86 @@ describe("emitStreamContent action requests", () => {
       "message.appended",
       "message.completed",
     ]);
-    expect(localEvents[3]).toMatchObject({
+    expect(providerEvents[3]).toMatchObject({
       data: { result: { output: { results: ["eve"] } } },
+      type: "action.result",
+    });
+  });
+
+  it("emits one action.partial snapshot per preliminary result for a streaming tool", async () => {
+    const tools = new Map<string, HarnessToolDefinition>([
+      [
+        "long_task",
+        {
+          description: "Run a long task.",
+          execute: async () => ({ progress: 1 }),
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "long_task",
+        },
+      ],
+    ]);
+    const emit = createEmitStub();
+
+    await emitStreamContent(
+      emit,
+      EMISSION_STATE,
+      streamOf([
+        { input: {}, toolCallId: "call-1", toolName: "long_task", type: "tool-call" },
+        {
+          output: { progress: 0.25 },
+          preliminary: true,
+          toolCallId: "call-1",
+          toolName: "long_task",
+          type: "tool-result",
+        },
+        {
+          output: { progress: 0.5 },
+          preliminary: true,
+          toolCallId: "call-1",
+          toolName: "long_task",
+          type: "tool-result",
+        },
+        {
+          output: { progress: 1 },
+          toolCallId: "call-1",
+          toolName: "long_task",
+          type: "tool-result",
+        },
+        { finishReason: "stop", type: "finish-step" },
+      ] as TextStreamPart<ToolSet>[]),
+      {
+        excludedActionToolNames: new Set(),
+        tools,
+      },
+    );
+
+    const events = vi.mocked(emit).mock.calls.map(([event]) => event);
+    expect(events.map((event) => event.type)).toEqual([
+      "actions.requested",
+      "action.partial",
+      "action.partial",
+      "action.result",
+    ]);
+    expect(events[1]).toMatchObject({
+      data: {
+        result: {
+          callId: "call-1",
+          kind: "tool-result",
+          output: { progress: 0.25 },
+          toolName: "long_task",
+        },
+        sequence: EMISSION_STATE.sequence,
+        stepIndex: EMISSION_STATE.stepIndex,
+        turnId: EMISSION_STATE.turnId,
+      },
+      type: "action.partial",
+    });
+    expect(events[2]).toMatchObject({
+      data: { result: { output: { progress: 0.5 } } },
+      type: "action.partial",
+    });
+    expect(events[3]).toMatchObject({
+      data: { result: { output: { progress: 1 } } },
       type: "action.result",
     });
   });
@@ -561,6 +666,13 @@ describe("emitStreamContent action requests", () => {
           toolCallId: "call-bad",
           toolName: "web_search",
           type: "tool-call",
+        },
+        {
+          output: { results: ["never"] },
+          preliminary: true,
+          toolCallId: "call-bad",
+          toolName: "web_search",
+          type: "tool-result",
         },
         { finishReason: "tool-calls", type: "finish-step" },
       ] as TextStreamPart<ToolSet>[]),

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -12,6 +12,7 @@ type InlineToolResultPart = Extract<ToolResponsePart, { type: "tool-result" }>;
 
 import type { AssistantStepFinishReason, RuntimeIdentity } from "#protocol/message.js";
 import {
+  createActionPartialEvent,
   createActionsRequestedEvent,
   createActionResultEvent,
   createMessageAppendedEvent,
@@ -52,80 +53,8 @@ import { normalizeModelStreamError } from "#harness/model-call-error.js";
 import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import { interruptStreamOnFailure } from "#harness/interruptible-stream.js";
 import { isInlineAuthorizationToolResult } from "#harness/inline-tool-authorization.js";
-import type {
-  HarnessEmitFn,
-  HarnessSession,
-  HarnessToolMap,
-  SessionStateMap,
-  StepInput,
-} from "#harness/types.js";
-
-// ---------------------------------------------------------------------------
-// Emission state
-// ---------------------------------------------------------------------------
-
-/**
- * Tracks emission lifecycle state across harness step invocations.
- *
- * Persisted on `session.state` so the state survives when the durable
- * workflow runtime recreates the harness at each `"use step"` boundary.
- */
-export interface HarnessEmissionState {
-  readonly sessionStarted: boolean;
-  readonly sequence: number;
-  readonly stepIndex: number;
-  readonly turnId: string;
-}
-
-const HARNESS_EMISSION_STATE_KEY = "eve.harness.emission";
-
-const DEFAULT_EMISSION_STATE: HarnessEmissionState = {
-  sessionStarted: false,
-  sequence: 0,
-  stepIndex: 0,
-  turnId: "",
-};
-
-/** Reads the emission state, returning defaults when absent. */
-export function getHarnessEmissionState(state: SessionStateMap | undefined): HarnessEmissionState {
-  const emissionState = state?.[HARNESS_EMISSION_STATE_KEY] as HarnessEmissionState | undefined;
-  return emissionState ?? DEFAULT_EMISSION_STATE;
-}
-
-/**
- * Returns `true` when the harness is **between turns** — either no turn
- * has started yet (initial state) or the previous turn has emitted its
- * epilogue (or recoverable failure cascade) and reset.
- *
- * Returns `false` while a turn is in progress, including during
- * tool-loop continuations and runtime-action resumes within the same
- * turn. Callers that gate per-turn work (eg. lifecycle hook dispatch)
- * use this predicate to distinguish a fresh delivery from a
- * continuation of an in-flight turn.
- *
- * Implemented over the empty-`turnId` sentinel that `emitTurnEpilogue`
- * and `emitRecoverableFailedTurn` write — clients should never read
- * `state.turnId` directly to make this distinction.
- */
-export function isHarnessBetweenTurns(session: HarnessSession): boolean {
-  return getHarnessEmissionState(session.state).turnId === "";
-}
-
-/**
- * Writes the emission state onto a new copy of the session.
- */
-export function setHarnessEmissionState(
-  session: HarnessSession,
-  state: HarnessEmissionState,
-): HarnessSession {
-  return {
-    ...session,
-    state: {
-      ...session.state,
-      [HARNESS_EMISSION_STATE_KEY]: state,
-    },
-  };
-}
+import type { HarnessEmissionState } from "#harness/emission-state.js";
+import type { HarnessEmitFn, HarnessToolMap, StepInput } from "#harness/types.js";
 
 // ---------------------------------------------------------------------------
 // Turn lifecycle helpers
@@ -571,8 +500,29 @@ async function consumeStreamContent(
       }
       case "tool-result": {
         const inlineToolResult = part as TypedToolResult<ToolSet>;
-        // Preliminary chunks can be superseded by the terminal result.
         if (inlineToolResult.preliminary === true) {
+          // Provider-executed streaming is out of scope; the provider result
+          // already lives in the assistant response.
+          if (inlineToolResult.providerExecuted === true) {
+            break;
+          }
+          if (invalidInputToolCallIds.has(part.toolCallId)) {
+            break;
+          }
+          await providerActionBatch.flush();
+          if (!toolCallIdsSeenInStream.has(part.toolCallId)) {
+            // An approved tool can resume with partials but no matching call
+            // in this step. Emit them before the message that consumes them.
+            await flushCurrentMessage();
+          }
+          await emitFn(
+            createActionPartialEvent({
+              result: createRuntimeToolResultFromStepResult(inlineToolResult),
+              sequence: state.sequence,
+              stepIndex: state.stepIndex,
+              turnId: state.turnId,
+            }),
+          );
           break;
         }
         if (inlineToolResult.providerExecuted === true) {

--- a/packages/eve/src/harness/instrumentation-runtime-context.test.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { AuthKey, ChannelInstrumentationKey } from "#context/keys.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 import {
   buildTelemetryRuntimeContext,
   type BuildTelemetryRuntimeContextInput,

--- a/packages/eve/src/harness/instrumentation-runtime-context.ts
+++ b/packages/eve/src/harness/instrumentation-runtime-context.ts
@@ -9,7 +9,7 @@ import {
   InitiatorAuthKey,
   ParentSessionKey,
 } from "#context/keys.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 import type { HarnessSession } from "#harness/types.js";
 import {
   normalizeInstrumentationChannelKind,

--- a/packages/eve/src/harness/ordered-stream-emitter.test.ts
+++ b/packages/eve/src/harness/ordered-stream-emitter.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createOrderedStreamEmitter } from "#harness/ordered-stream-emitter.js";
 import {
+  createActionPartialEvent,
   createMessageAppendedEvent,
   createMessageCompletedEvent,
   createReasoningAppendedEvent,
 } from "#protocol/message.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import type { JsonValue } from "#shared/json.js";
 
 function deferred(): { readonly promise: Promise<void>; resolve(): void } {
   let resolve!: () => void;
@@ -30,6 +32,15 @@ function reasoning(delta: string, soFar: string) {
   return createReasoningAppendedEvent({
     reasoningDelta: delta,
     reasoningSoFar: soFar,
+    sequence: 1,
+    stepIndex: 0,
+    turnId: "turn_1",
+  });
+}
+
+function partial(output: JsonValue, callId = "call-1") {
+  return createActionPartialEvent({
+    result: { callId, kind: "tool-result", output, toolName: "long_task" },
     sequence: 1,
     stepIndex: 0,
     turnId: "turn_1",
@@ -89,6 +100,50 @@ describe("createOrderedStreamEmitter", () => {
       message("CD", "CD", 1),
       reasoning("RS", "RS"),
       completed,
+    ]);
+  });
+
+  it("folds adjacent action.partial snapshots for the same call keeping the latest", async () => {
+    const firstWrite = deferred();
+    const events: UnstampedMessageStreamEvent[] = [];
+    const emitFn = vi.fn(async (event: UnstampedMessageStreamEvent) => {
+      events.push(event);
+      if (events.length === 1) await firstWrite.promise;
+    });
+    const emitter = createOrderedStreamEmitter(emitFn);
+
+    await emitter.emit(partial({ progress: 0.25 }));
+    await emitter.emit(partial({ progress: 0.5 }));
+    await emitter.emit(partial({ progress: 0.75 }));
+
+    firstWrite.resolve();
+    await emitter.closeAndDrain();
+
+    // Snapshots supersede each other, so only the latest pending one survives.
+    expect(events).toEqual([partial({ progress: 0.25 }), partial({ progress: 0.75 })]);
+  });
+
+  it("treats action.partial events for different calls as ordering barriers", async () => {
+    const firstWrite = deferred();
+    const events: UnstampedMessageStreamEvent[] = [];
+    const emitFn = vi.fn(async (event: UnstampedMessageStreamEvent) => {
+      events.push(event);
+      if (events.length === 1) await firstWrite.promise;
+    });
+    const emitter = createOrderedStreamEmitter(emitFn);
+
+    await emitter.emit(partial({ progress: 0.1 }, "call-1"));
+    await emitter.emit(partial({ progress: 0.2 }, "call-2"));
+    await emitter.emit(partial({ progress: 0.4 }, "call-2"));
+    await emitter.emit(partial({ progress: 0.9 }, "call-1"));
+
+    firstWrite.resolve();
+    await emitter.closeAndDrain();
+
+    expect(events).toEqual([
+      partial({ progress: 0.1 }, "call-1"),
+      partial({ progress: 0.4 }, "call-2"),
+      partial({ progress: 0.9 }, "call-1"),
     ]);
   });
 

--- a/packages/eve/src/harness/ordered-stream-emitter.ts
+++ b/packages/eve/src/harness/ordered-stream-emitter.ts
@@ -1,5 +1,6 @@
 import type {
   UnstampedMessageStreamEvent,
+  ActionPartialStreamEvent,
   MessageAppendedStreamEvent,
   ReasoningAppendedStreamEvent,
 } from "#protocol/message.js";
@@ -184,7 +185,25 @@ function mergeAdjacentAppends(
     return true;
   }
 
+  // Partial tool outputs are snapshots: a newer one for the same call
+  // supersedes the pending one outright, so keep only the latest.
+  if (left.event.type === "action.partial" && right.type === "action.partial") {
+    if (!samePartialCall(left.event, right)) return false;
+    left.event = right;
+    left.messages = messages;
+    return true;
+  }
+
   return false;
+}
+
+function samePartialCall(left: ActionPartialStreamEvent, right: ActionPartialStreamEvent): boolean {
+  return (
+    left.data.result.callId === right.data.result.callId &&
+    left.data.sequence === right.data.sequence &&
+    left.data.stepIndex === right.data.stepIndex &&
+    left.data.turnId === right.data.turnId
+  );
 }
 
 function appendDelta(event: UnstampedMessageStreamEvent): string | undefined {

--- a/packages/eve/src/harness/session-limit-enforcement.ts
+++ b/packages/eve/src/harness/session-limit-enforcement.ts
@@ -14,12 +14,8 @@
 import type { ModelMessage } from "ai";
 
 import { createInputRequestedEvent } from "#protocol/message.js";
-import {
-  emitFailedStep,
-  emitTurnEpilogue,
-  setHarnessEmissionState,
-  type HarnessEmissionState,
-} from "#harness/emission.js";
+import { emitFailedStep, emitTurnEpilogue } from "#harness/emission.js";
+import { setHarnessEmissionState, type HarnessEmissionState } from "#harness/emission-state.js";
 import { setPendingInputBatch } from "#harness/input-requests.js";
 import { createSessionLimitContinuationRequest } from "#harness/session-limit-continuation.js";
 import { SessionLimitDeclinedError } from "#harness/turn-cancellation.js";

--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -21,7 +21,7 @@ import {
   createRuntimeToolResultFromMessagePart,
   createRuntimeToolResultFromStepResult,
 } from "#harness/action-result-helpers.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 import { emitStepStarted, normalizeAssistantStepFinishReason } from "#harness/emission.js";
 import { extractToolApprovalInputRequests } from "#harness/input-extraction.js";
 import {

--- a/packages/eve/src/harness/tool-interrupts.test.ts
+++ b/packages/eve/src/harness/tool-interrupts.test.ts
@@ -119,3 +119,99 @@ describe("wrapToolExecute", () => {
     expect(wrapToolExecute(baseDef)).toBeUndefined();
   });
 });
+
+function isAsyncIterableValue(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function"
+  );
+}
+
+async function collect(value: unknown): Promise<unknown[]> {
+  expect(isAsyncIterableValue(value)).toBe(true);
+  const collected: unknown[] = [];
+  for await (const item of value as AsyncIterable<unknown>) {
+    collected.push(item);
+  }
+  return collected;
+}
+
+describe("wrapToolExecute (async-generator execute)", () => {
+  it("streams each yield in order and preserves value identity", async () => {
+    const first = { step: 1 };
+    const second = { step: 2 };
+    const wrapped = wrapToolExecute({
+      ...baseDef,
+      async *execute() {
+        yield first;
+        yield second;
+      },
+    })!;
+    const ctx = new ContextContainer();
+    const collected = await contextStorage.run(ctx, () =>
+      collect(wrapped({}, { messages: [], toolCallId: "call_s1" })),
+    );
+
+    expect(collected).toHaveLength(2);
+    expect(collected[0]).toBe(first);
+    expect(collected[1]).toBe(second);
+  });
+
+  it("normalizes top-level undefined yields to null", async () => {
+    const wrapped = wrapToolExecute({
+      ...baseDef,
+      async *execute() {
+        yield undefined;
+      },
+    })!;
+    const ctx = new ContextContainer();
+    const collected = await contextStorage.run(ctx, () =>
+      collect(wrapped({}, { messages: [], toolCallId: "call_s2" })),
+    );
+
+    expect(collected).toEqual([null]);
+  });
+
+  it("rejects a non-JSON-serializable yield at the tool boundary", async () => {
+    const wrapped = wrapToolExecute({
+      ...baseDef,
+      async *execute() {
+        yield { now: new Date("2026-01-02T03:04:05.000Z") };
+      },
+    })!;
+    const ctx = new ContextContainer();
+
+    await expect(
+      contextStorage.run(ctx, () => collect(wrapped({}, { messages: [], toolCallId: "call_s3" }))),
+    ).rejects.toThrow(
+      'Tool "t" call "call_s3" returned a non-JSON-serializable result. Expected a JSON-serializable value.',
+    );
+  });
+
+  it("stashes an authorization-signal yield and ends the stream with opaque model output", async () => {
+    const signal = signalWithVerifier();
+    let pulledPastSignal = false;
+    const wrapped = wrapToolExecute({
+      ...baseDef,
+      async *execute() {
+        yield { partial: true };
+        yield signal;
+        pulledPastSignal = true;
+        yield { never: true };
+      },
+    })!;
+    const ctx = new ContextContainer();
+    const collected = await contextStorage.run(ctx, () =>
+      collect(wrapped({}, { messages: [], toolCallId: "call_s4" })),
+    );
+
+    expect(collected).toHaveLength(2);
+    expect(collected[0]).toEqual({ partial: true });
+    expect(isAuthorizationPendingModelOutput(collected[1])).toBe(true);
+    expect(collected[1]).toEqual(modelFacingAuthorizationOutput(signal));
+    expect(collected[1]).not.toHaveProperty("challenges");
+    expect(readToolInterrupt(ctx, "call_s4")).toBe(signal);
+    expect(pulledPastSignal).toBe(false);
+  });
+});

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -31,7 +31,7 @@ import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import type { InstrumentationStepStartedEventInput } from "#public/instrumentation/index.js";
 import type { RunMode } from "#shared/run-mode.js";
 import { compactMessages, shouldCompact } from "#harness/compaction.js";
-import { getHarnessEmissionState, isHarnessBetweenTurns } from "#harness/emission.js";
+import { getHarnessEmissionState, isHarnessBetweenTurns } from "#harness/emission-state.js";
 import {
   getPendingAuthorization,
   modelFacingAuthorizationOutput,

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -104,9 +104,8 @@ import {
   emitStreamContent,
   emitTurnEpilogue,
   emitTurnPreamble,
-  getHarnessEmissionState,
-  setHarnessEmissionState,
 } from "#harness/emission.js";
+import { getHarnessEmissionState, setHarnessEmissionState } from "#harness/emission-state.js";
 import {
   extractQuestionInputRequests,
   extractToolApprovalInputRequests,

--- a/packages/eve/src/harness/tool-streaming.integration.test.ts
+++ b/packages/eve/src/harness/tool-streaming.integration.test.ts
@@ -1,0 +1,181 @@
+import { jsonSchema, type LanguageModel } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+
+import { createToolLoopHarness } from "#harness/tool-loop.js";
+import type { HarnessEmitFn, HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+
+type StreamResult = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>;
+type StreamPart = StreamResult["stream"] extends ReadableStream<infer Part> ? Part : never;
+
+const usage = {
+  inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+  outputTokens: { reasoning: 0, text: 1, total: 1 },
+} as const;
+
+function createSession(tools: HarnessSession["agent"]["tools"]): HarnessSession {
+  return {
+    agent: {
+      modelReference: { id: "tool-streaming-model" },
+      system: "You are a test assistant.",
+      tools,
+    },
+    compaction: { recentWindowSize: 10, threshold: 100_000 },
+    continuationToken: "http:tool-streaming-session",
+    history: [{ content: "Index the documents.", role: "user" }],
+    sessionId: "tool-streaming-session",
+  };
+}
+
+function createEventCollector(): {
+  readonly emit: HarnessEmitFn;
+  readonly events: UnstampedMessageStreamEvent[];
+} {
+  const events: UnstampedMessageStreamEvent[] = [];
+  return {
+    emit: async (event) => {
+      events.push(event);
+    },
+    events,
+  };
+}
+
+function enqueueToolCall(controller: ReadableStreamDefaultController<StreamPart>): void {
+  controller.enqueue({ type: "stream-start", warnings: [] });
+  controller.enqueue({
+    input: JSON.stringify({ target: "documents" }),
+    toolCallId: "call-stream-1",
+    toolName: "long_task",
+    type: "tool-call",
+  });
+  controller.enqueue({
+    finishReason: { raw: undefined, unified: "tool-calls" },
+    type: "finish",
+    usage,
+  });
+  controller.close();
+}
+
+function enqueueTextSuccess(
+  controller: ReadableStreamDefaultController<StreamPart>,
+  text: string,
+): void {
+  controller.enqueue({ type: "stream-start", warnings: [] });
+  controller.enqueue({ id: "answer", type: "text-start" });
+  controller.enqueue({ delta: text, id: "answer", type: "text-delta" });
+  controller.enqueue({ id: "answer", type: "text-end" });
+  controller.enqueue({
+    finishReason: { raw: undefined, unified: "stop" },
+    type: "finish",
+    usage,
+  });
+  controller.close();
+}
+
+describe("tool loop streaming tool execution", () => {
+  it("streams action.partial snapshots and records only the last yield as the result", async () => {
+    let attempt = 0;
+    const doStream = vi.fn(async () => ({
+      stream: new ReadableStream<StreamPart>({
+        start(controller) {
+          attempt += 1;
+          if (attempt === 1) {
+            enqueueToolCall(controller);
+            return;
+          }
+          enqueueTextSuccess(controller, "Indexing finished.");
+        },
+      }),
+    }));
+    const model = new MockLanguageModelV3({
+      doStream,
+      modelId: "tool-streaming-model",
+      provider: "eve-integration-mock",
+    });
+
+    const longTask: HarnessToolDefinition = {
+      description: "Index documents with progress updates.",
+      async *execute() {
+        yield { progress: 0.25 };
+        yield { progress: 0.5 };
+        yield { indexed: 42, progress: 1 };
+      },
+      inputSchema: jsonSchema({ type: "object" }),
+      name: "long_task",
+    };
+    const tools: ToolLoopHarnessConfig["tools"] = new Map([["long_task", longTask]]);
+    const { emit, events } = createEventCollector();
+    const config: ToolLoopHarnessConfig = {
+      handleEvent: emit,
+      mode: "task",
+      resolveModel: vi.fn().mockResolvedValue(model as LanguageModel),
+      tools,
+    };
+
+    let result = await createToolLoopHarness(config)(
+      createSession([
+        {
+          description: longTask.description,
+          inputSchema: { type: "object" },
+          name: "long_task",
+        },
+      ]),
+      { message: "Continue." },
+    );
+    while (typeof result.next === "function") {
+      result = await result.next(result.session);
+    }
+
+    expect(result.next).toEqual({ done: true, output: "Indexing finished." });
+
+    const actionEvents = events.filter(
+      (event) =>
+        event.type === "actions.requested" ||
+        event.type === "action.partial" ||
+        event.type === "action.result",
+    );
+    // Every yield surfaces as a preliminary snapshot — including the last
+    // one, which the SDK then repeats as the terminal result.
+    expect(actionEvents.map((event) => event.type)).toEqual([
+      "actions.requested",
+      "action.partial",
+      "action.partial",
+      "action.partial",
+      "action.result",
+    ]);
+    expect(actionEvents[1]).toMatchObject({
+      data: {
+        result: {
+          callId: "call-stream-1",
+          kind: "tool-result",
+          output: { progress: 0.25 },
+          toolName: "long_task",
+        },
+      },
+      type: "action.partial",
+    });
+    expect(actionEvents[2]).toMatchObject({
+      data: { result: { output: { progress: 0.5 } } },
+      type: "action.partial",
+    });
+    expect(actionEvents[3]).toMatchObject({
+      data: { result: { output: { indexed: 42, progress: 1 } } },
+      type: "action.partial",
+    });
+    // The terminal result is the last yield.
+    expect(actionEvents[4]).toMatchObject({
+      data: {
+        result: { callId: "call-stream-1", output: { indexed: 42, progress: 1 } },
+        status: "completed",
+      },
+      type: "action.result",
+    });
+
+    // Durable model-facing history records only the terminal value.
+    const history = JSON.stringify(result.session.history);
+    expect(history).toContain('"indexed":42');
+    expect(history).not.toContain("0.25");
+  });
+});

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -5,7 +5,7 @@ import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import type { WebSearchProvider } from "#shared/web-search.js";
 import { ASK_QUESTION_TOOL_NAME } from "#runtime/framework-tools/ask-question.js";
 import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
-import { isObject } from "#shared/guards.js";
+import { isAsyncIterable, isObject } from "#shared/guards.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { ApprovalStatus } from "#public/definitions/approval.js";
 import { resolveWebSearchBackend, resolveWebSearchProviderTool } from "#harness/provider-tools.js";
@@ -161,25 +161,66 @@ export function buildToolSetFromDefinitions(input: {
  * the AI SDK records an opaque {@link AuthorizationPendingModelOutput} that
  * omits OAuth URLs, user codes, and hook URLs from model-facing history.
  * Returns `undefined` for client-side tools (no `execute`).
+ *
+ * An `execute` that returns an `AsyncIterable` (e.g. an `async *` generator)
+ * streams: each yield is forwarded to the AI SDK as a preliminary result, and
+ * the SDK treats the last yield as the terminal output. Every yield crosses
+ * the same boundary checks as a plain return.
  */
 export function wrapToolExecute(
   definition: HarnessToolDefinition,
-): ((input: any, options: ToolExecuteOptions) => Promise<any>) | undefined {
+):
+  | ((input: any, options: ToolExecuteOptions) => Promise<any> | AsyncIterable<unknown>)
+  | undefined {
   const execute = definition.execute;
   if (execute === undefined) return undefined;
-  return async (input, options) => {
-    const output = await execute(input, options);
-    if (isAuthorizationSignal(output)) {
-      stashToolInterrupt(loadContext(), options.toolCallId, output);
-      return modelFacingAuthorizationOutput(output);
+  return (input, options) => {
+    const result = execute(input, options);
+    if (isAsyncIterable(result)) {
+      return wrapStreamingToolExecute(result, options, definition.name);
     }
-    return normalizeToolJsonOutput({
-      boundary: "execute",
-      output,
-      toolCallId: options.toolCallId,
-      toolName: definition.name,
-    });
+    return finalizeToolOutput(result, options, definition.name);
   };
+}
+
+async function finalizeToolOutput(
+  result: unknown,
+  options: ToolExecuteOptions,
+  toolName: string,
+): Promise<any> {
+  const output = await result;
+  if (isAuthorizationSignal(output)) {
+    stashToolInterrupt(loadContext(), options.toolCallId, output);
+    return modelFacingAuthorizationOutput(output);
+  }
+  return normalizeToolJsonOutput({
+    boundary: "execute",
+    output,
+    toolCallId: options.toolCallId,
+    toolName,
+  });
+}
+
+async function* wrapStreamingToolExecute(
+  iterable: AsyncIterable<unknown>,
+  options: ToolExecuteOptions,
+  toolName: string,
+): AsyncIterable<unknown> {
+  for await (const value of iterable) {
+    if (isAuthorizationSignal(value)) {
+      stashToolInterrupt(loadContext(), options.toolCallId, value);
+      // The SDK's terminal output is the last yield, so an authorization
+      // signal ends the stream; the author generator gets `.return()`.
+      yield modelFacingAuthorizationOutput(value);
+      return;
+    }
+    yield normalizeToolJsonOutput({
+      boundary: "execute",
+      output: value,
+      toolCallId: options.toolCallId,
+      toolName,
+    });
+  }
 }
 
 /**

--- a/packages/eve/src/harness/workflow-lifecycle.test.ts
+++ b/packages/eve/src/harness/workflow-lifecycle.test.ts
@@ -2,7 +2,7 @@ import { jsonSchema } from "ai";
 import { describe, expect, it } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 import { createWorkflowLifecycle } from "#harness/workflow-lifecycle.js";
 import type { HarnessToolMap } from "#harness/types.js";
 import { defineState } from "#public/definitions/state.js";

--- a/packages/eve/src/harness/workflow-lifecycle.ts
+++ b/packages/eve/src/harness/workflow-lifecycle.ts
@@ -1,7 +1,7 @@
 import type { ToolSet, TypedToolCall } from "ai";
 
 import { createRuntimeToolResultFromValue } from "#harness/action-result-helpers.js";
-import type { HarnessEmissionState } from "#harness/emission.js";
+import type { HarnessEmissionState } from "#harness/emission-state.js";
 import { createRuntimeActionRequestFromToolCall } from "#harness/runtime-actions.js";
 import type { HarnessToolMap } from "#harness/types.js";
 import { createLogger } from "#internal/logging.js";

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -22,7 +22,7 @@ import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 
 describe("message stream protocol", () => {
   it("pins the stream version for timed session events", () => {
-    expect(EVE_MESSAGE_STREAM_VERSION).toBe("20");
+    expect(EVE_MESSAGE_STREAM_VERSION).toBe("21");
   });
 
   it("publishes the channel-local continuation token on session.waiting", () => {

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -8,7 +8,11 @@ import {
 import { decodeSandboxRef, isSandboxRefUrl } from "#internal/attachments/sandbox-refs.js";
 import { createEventId } from "#protocol/event-id.js";
 import type { ConnectionAuthorizationChallenge } from "#public/connections/errors.js";
-import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
+import type {
+  RuntimeActionRequest,
+  RuntimeActionResult,
+  RuntimeToolResultActionResult,
+} from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import { toChannelLocalContinuationToken } from "#shared/continuation-token.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
@@ -19,7 +23,7 @@ export const EVE_STREAM_TAIL_INDEX_HEADER = "x-eve-stream-tail-index";
 export const EVE_STREAM_VERSION_HEADER = "x-eve-stream-version";
 export const EVE_MESSAGE_STREAM_CONTENT_TYPE = "application/x-ndjson; charset=utf-8";
 export const EVE_MESSAGE_STREAM_FORMAT = "ndjson";
-export const EVE_MESSAGE_STREAM_VERSION = "20";
+export const EVE_MESSAGE_STREAM_VERSION = "21";
 
 /**
  * eve-owned finish reason for one completed assistant step.
@@ -252,6 +256,26 @@ export interface ActionResultStreamEvent {
     turnId: string;
   };
   type: "action.result";
+}
+
+/**
+ * Stream event carrying one preliminary output snapshot for an in-flight
+ * tool call, produced by an `async *` tool `execute` yield.
+ *
+ * Snapshot semantics: each event carries the complete preliminary output and
+ * supersedes the previous `action.partial` for the same `result.callId`; the
+ * terminal `action.result` supersedes them all. Step retries can replay
+ * overlapping partial runs, so consumers must treat every event as
+ * last-write-wins — never accumulate deltas across events.
+ */
+export interface ActionPartialStreamEvent {
+  data: {
+    result: RuntimeToolResultActionResult;
+    sequence: number;
+    stepIndex: number;
+    turnId: string;
+  };
+  type: "action.partial";
 }
 
 /**
@@ -631,6 +655,7 @@ export type UnstampedMessageStreamEvent =
   | SubagentStartedStreamEvent
   | ActionsRequestedStreamEvent
   | InputRequestedStreamEvent
+  | ActionPartialStreamEvent
   | ActionResultStreamEvent
   | ReasoningCompletedStreamEvent
   | StepCompletedStreamEvent
@@ -1079,6 +1104,27 @@ export function createActionResultEvent(input: {
       turnId: input.turnId,
     },
     type: "action.result",
+  };
+}
+
+/**
+ * Creates the `action.partial` event for one preliminary tool-output
+ * snapshot of an in-flight tool call.
+ */
+export function createActionPartialEvent(input: {
+  readonly result: RuntimeToolResultActionResult;
+  readonly sequence: number;
+  readonly stepIndex: number;
+  readonly turnId: string;
+}): ActionPartialStreamEvent {
+  return {
+    data: {
+      result: input.result,
+      sequence: input.sequence,
+      stepIndex: input.stepIndex,
+      turnId: input.turnId,
+    },
+    type: "action.partial",
   };
 }
 

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -251,6 +251,7 @@ export interface ChannelEvents<TCtx = void> {
   readonly "compaction.completed"?: ChannelEventHandler<"compaction.completed", TCtx>;
   readonly "turn.started"?: ChannelEventHandler<"turn.started", TCtx>;
   readonly "actions.requested"?: ChannelEventHandler<"actions.requested", TCtx>;
+  readonly "action.partial"?: ChannelEventHandler<"action.partial", TCtx>;
   readonly "action.result"?: ChannelEventHandler<"action.result", TCtx>;
   readonly "message.completed"?: ChannelEventHandler<"message.completed", TCtx>;
   readonly "message.appended"?: ChannelEventHandler<"message.appended", TCtx>;
@@ -357,6 +358,7 @@ const channelEventTypes: Record<keyof ChannelEvents, null> = {
   "compaction.completed": null,
   "turn.started": null,
   "actions.requested": null,
+  "action.partial": null,
   "action.result": null,
   "message.completed": null,
   "message.appended": null,

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -17,7 +17,11 @@ import { defineInstrumentation } from "#public/definitions/instrumentation.js";
 import { defineSandbox } from "#public/definitions/sandbox.js";
 import { defineSchedule } from "#public/definitions/schedule.js";
 import { defineSkill } from "#public/definitions/skill.js";
-import { defineTool, experimental_workflow } from "#public/definitions/tool.js";
+import {
+  defineTool,
+  experimental_workflow,
+  type ToolDefinition,
+} from "#public/definitions/tool.js";
 
 describe("definition helper exact inputs", () => {
   it("preserves literal inference for valid definitions", () => {
@@ -46,6 +50,21 @@ describe("definition helper exact inputs", () => {
 
   it("keeps the public hook event map aligned with runtime stream events", () => {
     expectTypeOf<keyof HookEventMap>().toEqualTypeOf<UnstampedMessageStreamEvent["type"]>();
+  });
+
+  it("infers TOutput from async-generator execute yields", () => {
+    const streaming = defineTool({
+      description: "Stream partial counts.",
+      inputSchema: { type: "object" },
+      async *execute() {
+        yield { count: 1 };
+        yield { count: 2 };
+      },
+    });
+
+    expectTypeOf(streaming).toEqualTypeOf<
+      ToolDefinition<Record<string, unknown>, { count: number }>
+    >();
   });
 });
 

--- a/packages/eve/src/public/definitions/hook.ts
+++ b/packages/eve/src/public/definitions/hook.ts
@@ -16,6 +16,7 @@ type ProtocolEvent<TType extends MessageStreamEvent["type"]> = Extract<
  * until eve exposes them here.
  */
 export interface HookEventMap {
+  readonly "action.partial": ProtocolEvent<"action.partial">;
   readonly "action.result": ProtocolEvent<"action.result">;
   readonly "actions.requested": ProtocolEvent<"actions.requested">;
   readonly "authorization.completed": ProtocolEvent<"authorization.completed">;

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -118,7 +118,15 @@ export interface ToolDefinition<TInput = unknown, TOutput = unknown> extends Pub
   TInput,
   TOutput
 > {
-  execute(input: TInput, ctx: ToolContext): Promise<TOutput> | TOutput;
+  /**
+   * The tool implementation. May be sync, async, or an `async *` generator.
+   *
+   * A generator streams: each yielded `TOutput` is sent to clients as a
+   * preliminary `action.partial` snapshot superseding the previous one, and
+   * the last yield becomes the tool result. The model and `toModelOutput`
+   * only ever see the terminal value.
+   */
+  execute(input: TInput, ctx: ToolContext): Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
   /**
    * Optional per-tool approval gate. The return value determines whether
    * user approval is required before executing this tool.
@@ -161,7 +169,8 @@ export function defineTool<
     ctx: ToolContext,
   ):
     | Promise<StandardJSONSchemaV1.InferOutput<TOutputSchema>>
-    | StandardJSONSchemaV1.InferOutput<TOutputSchema>;
+    | StandardJSONSchemaV1.InferOutput<TOutputSchema>
+    | AsyncIterable<StandardJSONSchemaV1.InferOutput<TOutputSchema>>;
   approval?: ToolDefinition<StandardJSONSchemaV1.InferOutput<TInputSchema>, unknown>["approval"];
   toModelOutput?: ToolDefinition<
     unknown,
@@ -181,7 +190,7 @@ export function defineTool<
   execute(
     input: StandardJSONSchemaV1.InferOutput<TSchema>,
     ctx: ToolContext,
-  ): Promise<TOutput> | TOutput;
+  ): Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
   approval?: ToolDefinition<StandardJSONSchemaV1.InferOutput<TSchema>, unknown>["approval"];
   toModelOutput?: ToolDefinition<unknown, TOutput>["toModelOutput"];
 }): ToolDefinition<StandardJSONSchemaV1.InferOutput<TSchema>, TOutput>;
@@ -196,7 +205,8 @@ export function defineTool<
     ctx: ToolContext,
   ):
     | Promise<StandardJSONSchemaV1.InferOutput<TOutputSchema>>
-    | StandardJSONSchemaV1.InferOutput<TOutputSchema>;
+    | StandardJSONSchemaV1.InferOutput<TOutputSchema>
+    | AsyncIterable<StandardJSONSchemaV1.InferOutput<TOutputSchema>>;
   approval?: ToolDefinition<Record<string, unknown>, unknown>["approval"];
   toModelOutput?: ToolDefinition<
     unknown,
@@ -207,7 +217,10 @@ export function defineTool<TOutput>(definition: {
   description: ToolDefinition<unknown, unknown>["description"];
   inputSchema: JsonObject;
   outputSchema?: JsonObject;
-  execute(input: Record<string, unknown>, ctx: ToolContext): Promise<TOutput> | TOutput;
+  execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
   approval?: ToolDefinition<Record<string, unknown>, unknown>["approval"];
   toModelOutput?: ToolDefinition<unknown, TOutput>["toModelOutput"];
 }): ToolDefinition<Record<string, unknown>, TOutput>;

--- a/packages/eve/src/shared/guards.ts
+++ b/packages/eve/src/shared/guards.ts
@@ -42,6 +42,20 @@ export function readNonEmptyString(value: unknown): string | undefined {
 }
 
 /**
+ * Returns `true` when `value` is an `AsyncIterable` — an object with a
+ * `Symbol.asyncIterator` function. Calling an `async *` generator
+ * function produces such a value, so this is how the harness detects a
+ * streaming tool `execute`.
+ */
+export function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function"
+  );
+}
+
+/**
  * Returns `true` when `value` is a thenable — an object with a `then`
  * function. Used to reject async instrumentation metadata projectors
  * that accidentally return a Promise instead of a plain record.

--- a/packages/eve/src/shared/tool-definition.ts
+++ b/packages/eve/src/shared/tool-definition.ts
@@ -11,7 +11,7 @@ export type ToolExecuteOptions = Omit<ToolExecutionOptions<unknown>, "context">;
 export type ToolExecuteFn<TInput = unknown, TOutput = unknown> = (
   input: TInput,
   options: ToolExecuteOptions,
-) => Promise<TOutput> | TOutput;
+) => Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
 
 interface ToolDefinitionBase {
   readonly description: string;


### PR DESCRIPTION
### Summary

A long-running tool had no way to surface progress: the AI SDK under eve already streams preliminary tool results from async-iterable `execute` functions, but the harness dropped them on the floor with an explicit `break` ([`harness/emission.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/emission.ts)), so nothing reached clients until the terminal `action.result`.

This PR makes streaming tool output first-class, extending that existing SDK seam rather than adding a side-channel:

- **Authoring**: [`defineTool`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/public/definitions/tool.ts)'s `execute` may now be an `async *` generator (`Promise<TOutput> | TOutput | AsyncIterable<TOutput>`). Each yield crosses the same boundary checks as a plain return (JSON serialization, authorization-signal stashing), and per the SDK contract the **last yield becomes the tool result**. [`wrapToolExecute`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/tools.ts) previously `await`ed unconditionally, which would have swallowed a generator into an object.
- **Protocol**: a new [`action.partial` stream event](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/protocol/message.ts) (stream version 20 → 21) carries one complete preliminary-output snapshot per yield, shaped like `action.result` minus `status`/`error`. Snapshot semantics are deliberate: durable steps retry up to four times and can replay overlapping event runs, so consumers must treat events as last-write-wins per `callId` — the same discipline the `message.appended` reducer already applies via `messageSoFar`. Partials live only on the durable event stream; durable session history and the `runtime/actions` schemas are untouched, and the model plus `toModelOutput` only ever see the terminal value.
- **Backpressure**: the [ordered stream emitter](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/ordered-stream-emitter.ts) folds adjacent same-call partials keep-last while the durable writer is busy, preserving the one-chunk-per-event cursor invariant.
- **Client**: the [reducer](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/client/message-reducer.ts) projects partials onto [`EveDynamicToolPart`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/client/message-reducer-types.ts) as `state: "output-available"` with a new `partial: true` flag (the AI SDK UI convention), cleared by the terminal result; a settled part never regresses when a retried step replays a late partial. Consumers unaware of the flag degrade to a tool whose output progressively updates.
- **Fan-out**: [`HookEventMap`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/public/definitions/hook.ts) and [`ChannelEvents`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/public/definitions/channel.ts) gain `action.partial`; the tool/dynamicTool/hook/dynamicSkill/dynamicInstructions extension contracts gain retained epochs (all changes are additive widenings). Note: `pnpm update:extension-contracts --update <cap>` refuses to run while multiple capabilities are drifted at once, so the support-table bump replicates what the updater would write and the plain run then generated and validated the new epoch metadata.

Scope boundaries: provider-executed preliminary results stay dropped (provider streaming is out of scope), MCP progress notifications are untouched, and subagent content streaming keeps its existing child-session-stream model. `harness/emission.ts` also splits its emission-state helpers into `harness/emission-state.ts` to stay under the structural 700-line cap.

### Key changes

**Tool authoring surface**

- [`public/definitions/tool.ts#L129`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/public/definitions/tool.ts#L129) — `ToolDefinition.execute` widened to `Promise<TOutput> | TOutput | AsyncIterable<TOutput>` (plus the four typed `defineTool` overloads below it)
- [`shared/tool-definition.ts#L11-L14`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/shared/tool-definition.ts#L11-L14) — internal `ToolExecuteFn` widened to match
- [`shared/guards.ts#L50`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/shared/guards.ts#L50) — new `isAsyncIterable` guard

**Harness execution**

- [`harness/tools.ts#L170-L184`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/tools.ts#L170-L184) — `wrapToolExecute` detects async iterables instead of unconditionally awaiting
- [`harness/tools.ts#L204`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/tools.ts#L204) — `wrapStreamingToolExecute`: per-yield JSON normalization and authorization-signal handling

**Protocol**

- [`protocol/message.ts#L271`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/protocol/message.ts#L271) — `ActionPartialStreamEvent` (snapshot semantics documented on the type)
- [`protocol/message.ts#L1114`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/protocol/message.ts#L1114) — `createActionPartialEvent`
- [`protocol/message.ts#L26`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/protocol/message.ts#L26) — stream version 20 → 21

**Emission**

- [`harness/emission.ts#L503`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/emission.ts#L503) — the former drop-point: preliminary results now emit `action.partial` (provider-executed and invalid-input calls still dropped; approval-resume ordering preserved)
- [`harness/ordered-stream-emitter.ts#L190`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/ordered-stream-emitter.ts#L190) — keep-last coalescing of adjacent same-call partials ([`samePartialCall`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/ordered-stream-emitter.ts#L200))

**Client projection**

- [`client/message-reducer.ts#L228`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/client/message-reducer.ts#L228) — `action.partial` reducer case (last-write-wins snapshot, approval linkage preserved)
- [`client/message-reducer.ts#L531`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/client/message-reducer.ts#L531) — `isTerminalToolPart`: settled parts never regress on replayed partials
- [`client/message-reducer-types.ts#L189`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/client/message-reducer-types.ts#L189) — `partial?: boolean` on the `output-available` variant

**Extension surfaces**

- [`public/definitions/hook.ts#L19`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/public/definitions/hook.ts#L19), [`public/definitions/channel.ts#L254`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/public/definitions/channel.ts#L254) — `action.partial` exposed to hooks and channel handlers

**Tests**

- [`harness/tool-streaming.integration.test.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/tool-streaming.integration.test.ts) — end-to-end over real `streamText`: request → partials → terminal result = last yield
- [`harness/tool-interrupts.test.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/tool-interrupts.test.ts), [`harness/emission.test.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/emission.test.ts), [`harness/ordered-stream-emitter.test.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/ordered-stream-emitter.test.ts), [`client/message-reducer.test.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/client/message-reducer.test.ts) — per-layer unit coverage

### Validation

- `pnpm fmt`, `pnpm lint`, `pnpm typecheck`, `pnpm guard:invariants`, `pnpm docs:check`, `pnpm update:extension-contracts` — all pass
- `pnpm test:unit` — 5987 passed (new coverage: streaming `wrapToolExecute` incl. authorization-signal and serialization-error yields; `defineTool` type inference from generator yields; emission mapping incl. provider/invalid-input drops; ordered-emitter keep-last coalescing; reducer partial → terminal → replayed-partial lifecycle)
- `pnpm test:integration` — 597 passed. New [`tool-streaming.integration.test.ts`](https://github.com/CyrusNuevoDia/eve/blob/5e1537dd92b448990cf8bd23f59ae509d2100cc3/packages/eve/src/harness/tool-streaming.integration.test.ts) drives real `streamText` over `MockLanguageModelV3` with an async-generator tool and asserts `actions.requested` → `action.partial`×3 → `action.result`, terminal output = last yield, and that history records only the terminal value — this mechanically validates the ai@7.0.38 contract. (One pre-existing auth-callback integration test timed out once under a fully parallel `pnpm test` on a loaded machine and passes in isolation and in the standalone integration run.)

Reviewer attention: the emission-site ordering guards for approval-resumed partials (`emission.ts` `tool-result` case) and the reducer's terminal-part guard are where replay/retry correctness lives.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No prior issue exists — this change came out of a direct design discussion; the durability decision (partials are durable stream events, like `message.appended` deltas) and the single-snapshot-event design were settled there.

---

> a tool hums along —
> each yield a ripple streamed live,
> the last wave settles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QVz6DJZAuwy5JSyf2Wo6K
