### PR TITLE
Use eve-docs tracking site

### DIFF
--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -70,4 +70,4 @@ export const eveAgent = {
 
 export const basePath: string | undefined = undefined;
 
-export const siteId: string | undefined = "agent-framework";
+export const siteId: string | undefined = "eve-docs";


### PR DESCRIPTION
- Send eve.dev Markdown tracking as `eve-docs`, matching the allowlist added in [vercel/geistdocs#225](https://github.com/vercel/geistdocs/pull/225).
- Restore tracking events currently rejected under the legacy `agent-framework` ID.
- Docs-only configuration change; no `eve` package changeset required.
