### PR TITLE
feat(eve): batch integration setup deploys

### DIFF
--- a/.changeset/tidy-add-deploy-loop.md
+++ b/.changeset/tidy-add-deploy-loop.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Let `/add` collect multiple deployable integrations before creating one production or preview deployment. Setup details are preserved through the registry protocol and shown together when the flow finishes.

--- a/.changeset/tidy-add-deploy-loop.md
+++ b/.changeset/tidy-add-deploy-loop.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Let `/add` collect multiple deployable integrations before creating one production or preview deployment. Setup details are preserved through the registry protocol and shown together when the flow finishes.
+Let `/add` collect multiple deployable integrations before creating one production deployment. After each deployable setup, `/add` offers to add more by default, deploy to production, or finish, while keeping setup details for the final result.

--- a/packages/eve/src/cli/commands/integration-setup.test.ts
+++ b/packages/eve/src/cli/commands/integration-setup.test.ts
@@ -26,7 +26,10 @@ afterEach(() => {
 
 describe("runIntegrationSetupCommand", () => {
   it("delegates registry-owned setup to the integration runner", async () => {
-    vi.mocked(runIntegrationSetup).mockResolvedValue({ kind: "done" });
+    vi.mocked(runIntegrationSetup).mockResolvedValue({
+      kind: "done",
+      completion: { facts: [] },
+    });
     const output = logger();
     const fake = createFakePrompter();
 

--- a/packages/eve/src/cli/commands/integration-setup.ts
+++ b/packages/eve/src/cli/commands/integration-setup.ts
@@ -1,5 +1,6 @@
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { createRegistrySetupClient } from "#setup/registry-setup-client.js";
+import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 import {
   runIntegrationSetup,
   type IntegrationSetupRunnerDeps,
@@ -54,7 +55,14 @@ export async function runIntegrationSetupCommand(
       return;
     }
     prompter.outro("Integration set up.");
-    client?.complete(result.facts);
+    const completion: RegistrySetupCompletion = { facts: result.facts ?? [] };
+    if (result.deploymentRequired === true) {
+      completion.deployment = { required: true };
+      if (result.productionDestinations !== undefined) {
+        completion.deployment.productionDestinations = result.productionDestinations;
+      }
+    }
+    client?.complete(completion);
   } catch (error) {
     client?.fail(error);
     logger.error(error instanceof Error ? error.message : String(error));

--- a/packages/eve/src/cli/commands/integration-setup.ts
+++ b/packages/eve/src/cli/commands/integration-setup.ts
@@ -1,6 +1,5 @@
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { createRegistrySetupClient } from "#setup/registry-setup-client.js";
-import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 import {
   runIntegrationSetup,
   type IntegrationSetupRunnerDeps,
@@ -55,14 +54,7 @@ export async function runIntegrationSetupCommand(
       return;
     }
     prompter.outro("Integration set up.");
-    const completion: RegistrySetupCompletion = { facts: result.facts ?? [] };
-    if (result.deploymentRequired === true) {
-      completion.deployment = { required: true };
-      if (result.productionDestinations !== undefined) {
-        completion.deployment.productionDestinations = result.productionDestinations;
-      }
-    }
-    client?.complete(completion);
+    client?.complete(result.completion);
   } catch (error) {
     client?.fail(error);
     logger.error(error instanceof Error ? error.message : String(error));

--- a/packages/eve/src/cli/commands/registry-declared-setups.ts
+++ b/packages/eve/src/cli/commands/registry-declared-setups.ts
@@ -1,0 +1,55 @@
+import { createPrompter, type Prompter } from "#setup/prompter.js";
+import {
+  emptyRegistrySetupCompletion,
+  mergeRegistrySetupCompletions,
+} from "#setup/registry-setup-completion.js";
+import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
+
+import type { RegistryCommandLogger, RegistrySetupDependencies } from "./registry.js";
+import type { RegistrySetupCommand } from "./registry-setup-command.js";
+
+export interface DeclaredSetupOptions {
+  yes?: boolean;
+  silent?: boolean;
+  prompter?: Prompter;
+  signal?: AbortSignal;
+}
+
+/** Runs and combines the setup commands declared by one registry item. */
+export async function runDeclaredSetups(input: {
+  logger: RegistryCommandLogger;
+  appRoot: string;
+  item: string;
+  setups: readonly RegistrySetupCommand[] | undefined;
+  options: DeclaredSetupOptions;
+  dependencies: RegistrySetupDependencies;
+  cancelledReminder: string;
+  resumeCommand: string;
+}): Promise<RegistrySetupCompletion | false> {
+  let completion = emptyRegistrySetupCompletion();
+  if (input.setups === undefined) return completion;
+  const runSetupCommand = await input.dependencies.loadSetupCommandRunner();
+  const prompter = input.options.prompter ?? createPrompter();
+  try {
+    for (const setup of input.setups) {
+      const result = await runSetupCommand(
+        input.appRoot,
+        { ...setup, args: [...setup.args, ...(input.options.yes ? ["--yes"] : [])] },
+        input.item,
+        { prompter, signal: input.options.signal },
+      );
+      if (result.kind === "cancelled") {
+        input.logger.log(input.cancelledReminder);
+        return false;
+      }
+      if (input.options.silent !== true) {
+        for (const fact of result.facts) input.logger.log(`${fact.label}: ${fact.value}`);
+      }
+      completion = mergeRegistrySetupCompletions(completion, result);
+    }
+    return completion;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message} Try again with \`${input.resumeCommand}\`.`);
+  }
+}

--- a/packages/eve/src/cli/commands/registry-declared-setups.ts
+++ b/packages/eve/src/cli/commands/registry-declared-setups.ts
@@ -1,8 +1,5 @@
 import { createPrompter, type Prompter } from "#setup/prompter.js";
-import {
-  emptyRegistrySetupCompletion,
-  mergeRegistrySetupCompletions,
-} from "#setup/registry-setup-completion.js";
+import { mergeRegistrySetupCompletions } from "#setup/registry-setup-completion.js";
 import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 
 import type { RegistryCommandLogger, RegistrySetupDependencies } from "./registry.js";
@@ -26,7 +23,7 @@ export async function runDeclaredSetups(input: {
   cancelledReminder: string;
   resumeCommand: string;
 }): Promise<RegistrySetupCompletion | false> {
-  let completion = emptyRegistrySetupCompletion();
+  let completion: RegistrySetupCompletion = { facts: [] };
   if (input.setups === undefined) return completion;
   const runSetupCommand = await input.dependencies.loadSetupCommandRunner();
   const prompter = input.options.prompter ?? createPrompter();

--- a/packages/eve/src/cli/commands/registry-package.ts
+++ b/packages/eve/src/cli/commands/registry-package.ts
@@ -5,6 +5,10 @@ import {
 } from "#compiled/shadcn-registry/index.js";
 import { z } from "#compiled/zod/index.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
+import {
+  emptyRegistrySetupCompletion,
+  mergeRegistrySetupCompletions,
+} from "#setup/registry-setup-completion.js";
 import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 
 import { hasInteractiveTerminal } from "./preconditions.js";
@@ -108,7 +112,7 @@ export async function runRegistryPackage(input: {
       silent: options.silent,
     });
   }
-  const completion: RegistrySetupCompletion = { facts: [] };
+  let completion = emptyRegistrySetupCompletion();
   if (options.skipSetup === true) return completion;
 
   if (options.yes !== true && options.prompter === undefined && !interactive) {
@@ -124,14 +128,7 @@ export async function runRegistryPackage(input: {
       prompter: getPrompter(),
     });
     if (result === false) return false;
-    completion.facts = [...completion.facts, ...result.facts];
-    if (result.deployment !== undefined) {
-      completion.deployment ??= { required: true };
-      completion.deployment.productionDestinations = [
-        ...(completion.deployment.productionDestinations ?? []),
-        ...(result.deployment.productionDestinations ?? []),
-      ];
-    }
+    completion = mergeRegistrySetupCompletions(completion, result);
   }
   return completion;
 }

--- a/packages/eve/src/cli/commands/registry-package.ts
+++ b/packages/eve/src/cli/commands/registry-package.ts
@@ -5,10 +5,7 @@ import {
 } from "#compiled/shadcn-registry/index.js";
 import { z } from "#compiled/zod/index.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
-import {
-  emptyRegistrySetupCompletion,
-  mergeRegistrySetupCompletions,
-} from "#setup/registry-setup-completion.js";
+import { mergeRegistrySetupCompletions } from "#setup/registry-setup-completion.js";
 import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 
 import { hasInteractiveTerminal } from "./preconditions.js";
@@ -112,7 +109,7 @@ export async function runRegistryPackage(input: {
       silent: options.silent,
     });
   }
-  let completion = emptyRegistrySetupCompletion();
+  let completion: RegistrySetupCompletion = { facts: [] };
   if (options.skipSetup === true) return completion;
 
   if (options.yes !== true && options.prompter === undefined && !interactive) {

--- a/packages/eve/src/cli/commands/registry-package.ts
+++ b/packages/eve/src/cli/commands/registry-package.ts
@@ -5,6 +5,7 @@ import {
 } from "#compiled/shadcn-registry/index.js";
 import { z } from "#compiled/zod/index.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
+import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 
 import { hasInteractiveTerminal } from "./preconditions.js";
 import type { AddCommandOptions, RegistryCommandLogger } from "./registry.js";
@@ -37,7 +38,7 @@ export interface RegistryPackageOperations {
     item: string;
     setups: RegistrySetupCommand[];
     prompter: Prompter;
-  }): Promise<boolean>;
+  }): Promise<RegistrySetupCompletion | false>;
   setupReminder(item: string): string;
 }
 
@@ -80,7 +81,7 @@ export async function runRegistryPackage(input: {
   options: AddCommandOptions & { prompter?: Prompter; signal?: AbortSignal };
   dependencies: RegistryPackageDependencies;
   operations: RegistryPackageOperations;
-}): Promise<void> {
+}): Promise<RegistrySetupCompletion | false> {
   const { logger, appRoot, item, components, config, options, dependencies, operations } = input;
   const interactive = dependencies.hasInteractiveTerminal?.() ?? hasInteractiveTerminal();
   let prompter = options.prompter;
@@ -107,16 +108,30 @@ export async function runRegistryPackage(input: {
       silent: options.silent,
     });
   }
-  if (options.skipSetup === true) return;
+  const completion: RegistrySetupCompletion = { facts: [] };
+  if (options.skipSetup === true) return completion;
 
   if (options.yes !== true && options.prompter === undefined && !interactive) {
     logger.log(operations.setupReminder(item));
-    return;
+    return completion;
   }
 
   for (const metadata of entries) {
     if (metadata?.setup === undefined) continue;
-    if (!(await operations.runSetups({ item, setups: metadata.setup, prompter: getPrompter() })))
-      return;
+    const result = await operations.runSetups({
+      item,
+      setups: metadata.setup,
+      prompter: getPrompter(),
+    });
+    if (result === false) return false;
+    completion.facts = [...completion.facts, ...result.facts];
+    if (result.deployment !== undefined) {
+      completion.deployment ??= { required: true };
+      completion.deployment.productionDestinations = [
+        ...(completion.deployment.productionDestinations ?? []),
+        ...(result.deployment.productionDestinations ?? []),
+      ];
+    }
   }
+  return completion;
 }

--- a/packages/eve/src/cli/commands/registry-setup-command.test.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.test.ts
@@ -119,7 +119,7 @@ describe("runRegistrySetupCommand", () => {
     );
   });
 
-  it("streams child output through the parent prompter", async () => {
+  it("streams child output through a plain parent prompter", async () => {
     const child = protocolChild();
     const prompter = createPrompter();
     spawn.mockReturnValue(child);
@@ -135,7 +135,33 @@ describe("runRegistrySetupCommand", () => {
     expect(prompter.log.commandOutput).toHaveBeenCalledWith("connecting");
   });
 
-  it("uses a structured child failure instead of the exit code", async () => {
+  it("keeps successful child presentation transient for replaceable TUI flows", async () => {
+    const child = protocolChild(0, null, (running) => {
+      running.emit("message", { type: "log", level: "success", text: "Scaffolded channel" });
+      running.emit("message", {
+        type: "note",
+        title: "Text your agent",
+        message: "+15551234567",
+        tone: "success",
+      });
+      running.emit("message", { type: "result", outcome: { kind: "completed", facts: [] } });
+    });
+    const prompter = createPrompter();
+    prompter.replaceContent = vi.fn();
+    spawn.mockReturnValue(child);
+
+    await runRegistrySetupCommand(
+      "/project",
+      { package: "@acme/slack", bin: "acme-slack", args: [] },
+      "channel/photon-imessage",
+      { prompter },
+    );
+
+    expect(prompter.log.success).not.toHaveBeenCalled();
+    expect(prompter.note).not.toHaveBeenCalled();
+  });
+
+  it("uses a structured child failure without exposing its stack", async () => {
     const child = protocolChild(1, null, (running) => {
       running.emit("message", {
         type: "result",
@@ -154,7 +180,7 @@ describe("runRegistrySetupCommand", () => {
         "channel/photon-imessage",
         options(),
       ),
-    ).rejects.toThrow("Photon approval was denied.\nat setupPhoton");
+    ).rejects.toThrow(/^Photon approval was denied\.$/);
   });
 
   it("preserves additive deployment metadata on protocol v1", async () => {

--- a/packages/eve/src/cli/commands/registry-setup-command.test.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.test.ts
@@ -76,7 +76,7 @@ describe("runRegistrySetupCommand", () => {
         "channel/slack",
         options(),
       ),
-    ).resolves.toEqual({ kind: "completed", output: [] });
+    ).resolves.toEqual({ kind: "completed", facts: [] });
 
     expect(spawn).toHaveBeenCalledWith(
       process.execPath,
@@ -86,7 +86,7 @@ describe("runRegistrySetupCommand", () => {
         env: expect.objectContaining({
           EVE_SETUP: "1",
           EVE_SETUP_ITEM: "channel/slack",
-          EVE_SETUP_PROTOCOL: "1",
+          EVE_SETUP_PROTOCOL: "2",
         }),
         stdio: ["ignore", "pipe", "pipe", "ipc"],
       }),
@@ -185,9 +185,13 @@ describe("runRegistrySetupCommand", () => {
       ),
     ).resolves.toEqual({
       kind: "completed",
-      output: [
-        "Text your agent: +15550000000",
-        "Photon project: https://app.photon.codes/dashboard/project-id",
+      facts: [
+        { label: "Text your agent", value: "+15550000000", kind: "phone" },
+        {
+          label: "Photon project",
+          value: "https://app.photon.codes/dashboard/project-id",
+          kind: "url",
+        },
       ],
     });
   });

--- a/packages/eve/src/cli/commands/registry-setup-command.test.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.test.ts
@@ -163,11 +163,8 @@ describe("runRegistrySetupCommand", () => {
         type: "result",
         outcome: {
           kind: "completed",
-          facts: [],
-          deployment: {
-            required: true,
-            productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
-          },
+          facts: [{ label: "Open Linear", value: "https://linear.app", kind: "url" }],
+          deploymentRequired: true,
         },
       });
     });
@@ -182,11 +179,8 @@ describe("runRegistrySetupCommand", () => {
       ),
     ).resolves.toEqual({
       kind: "completed",
-      facts: [],
-      deployment: {
-        required: true,
-        productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
-      },
+      facts: [{ label: "Open Linear", value: "https://linear.app", kind: "url" }],
+      deploymentRequired: true,
     });
   });
 

--- a/packages/eve/src/cli/commands/registry-setup-command.test.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.test.ts
@@ -86,7 +86,7 @@ describe("runRegistrySetupCommand", () => {
         env: expect.objectContaining({
           EVE_SETUP: "1",
           EVE_SETUP_ITEM: "channel/slack",
-          EVE_SETUP_PROTOCOL: "2",
+          EVE_SETUP_PROTOCOL: "1",
         }),
         stdio: ["ignore", "pipe", "pipe", "ipc"],
       }),
@@ -155,6 +155,39 @@ describe("runRegistrySetupCommand", () => {
         options(),
       ),
     ).rejects.toThrow("Photon approval was denied.\nat setupPhoton");
+  });
+
+  it("preserves additive deployment metadata on protocol v1", async () => {
+    const child = protocolChild(0, null, (running) => {
+      running.emit("message", {
+        type: "result",
+        outcome: {
+          kind: "completed",
+          facts: [],
+          deployment: {
+            required: true,
+            productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
+          },
+        },
+      });
+    });
+    spawn.mockReturnValue(child);
+
+    await expect(
+      runRegistrySetupCommand(
+        "/project",
+        { package: "@acme/slack", bin: "acme-slack", args: [] },
+        "channel/linear",
+        options(),
+      ),
+    ).resolves.toEqual({
+      kind: "completed",
+      facts: [],
+      deployment: {
+        required: true,
+        productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
+      },
+    });
   });
 
   it("returns durable setup notes with successful completion", async () => {

--- a/packages/eve/src/cli/commands/registry-setup-command.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.ts
@@ -282,7 +282,7 @@ export async function runRegistrySetupCommand(
           kind: "completed",
           facts: outcome.facts,
         };
-        if (outcome.deployment !== undefined) result.deployment = outcome.deployment;
+        if (outcome.deploymentRequired === true) result.deploymentRequired = true;
         resolveResult(result);
         return;
       }

--- a/packages/eve/src/cli/commands/registry-setup-command.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.ts
@@ -142,10 +142,19 @@ function handlePresentation(
 ): boolean {
   switch (message.type) {
     case "log":
-      prompter.log[message.level](message.text);
+      if (
+        prompter.replaceContent === undefined ||
+        message.level === "warning" ||
+        message.level === "error" ||
+        message.level === "commandOutput"
+      ) {
+        prompter.log[message.level](message.text);
+      }
       return true;
     case "note":
-      prompter.note(message.message, message.title, { tone: message.tone });
+      if (prompter.replaceContent === undefined || message.tone === "warning") {
+        prompter.note(message.message, message.title, { tone: message.tone });
+      }
       return true;
     case "intro":
       prompter.intro(message.text, message.subtitle);
@@ -291,10 +300,7 @@ export async function runRegistrySetupCommand(
         return;
       }
       if (outcome?.kind === "failed") {
-        const details = outcome.error.details?.length
-          ? `\n${outcome.error.details.join("\n")}`
-          : "";
-        reject(new Error(`${outcome.error.message}${details}`));
+        reject(new Error(outcome.error.message));
         return;
       }
       if (options.signal?.aborted === true || code === 130 || signal === "SIGINT") {

--- a/packages/eve/src/cli/commands/registry-setup-command.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.ts
@@ -11,6 +11,7 @@ import {
   isRegistrySetupChildMessage,
   REGISTRY_SETUP_PROTOCOL_VERSION,
   type RegistrySetupChildMessage,
+  type RegistrySetupCompletion,
   type RegistrySetupParentMessage,
 } from "#setup/registry-setup-protocol.js";
 import { WizardCancelledError } from "#setup/step.js";
@@ -22,7 +23,7 @@ export interface RegistrySetupCommand {
 }
 
 export type RegistrySetupCommandResult =
-  | { kind: "completed"; output: readonly string[] }
+  | ({ kind: "completed" } & RegistrySetupCompletion)
   | { kind: "cancelled" };
 
 export interface RegistrySetupCommandOptions {
@@ -277,10 +278,12 @@ export async function runRegistrySetupCommand(
           );
           return;
         }
-        resolveResult({
+        const result: RegistrySetupCommandResult = {
           kind: "completed",
-          output: outcome.facts.map((fact) => `${fact.label}: ${fact.value}`),
-        });
+          facts: outcome.facts,
+        };
+        if (outcome.deployment !== undefined) result.deployment = outcome.deployment;
+        resolveResult(result);
         return;
       }
       if (outcome?.kind === "cancelled") {

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -174,7 +174,7 @@ describe("registry commands", () => {
 
   it("lets interactive users select components from an official registry package", async () => {
     const logger = createLogger();
-    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     const fake = createFakePrompter({
       multiple: (options) => {
         expect(options).toMatchObject({
@@ -290,7 +290,7 @@ describe("registry commands", () => {
         _setup: RegistrySetupCommand,
         _item: string,
         _options?: RegistrySetupCommandOptions,
-      ) => ({ kind: "completed" as const, output: [] }),
+      ) => ({ kind: "completed" as const, facts: [] }),
     );
     getRegistryItems
       .mockResolvedValueOnce([
@@ -328,7 +328,7 @@ describe("registry commands", () => {
 
   it("installs a registry package's default components with --yes", async () => {
     const logger = createLogger();
-    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     getRegistryItems
       .mockResolvedValueOnce([
         {
@@ -364,7 +364,7 @@ describe("registry commands", () => {
 
   it("accepts a legacy singular setup command", async () => {
     const logger = createLogger();
-    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     getRegistryItems.mockResolvedValue([
       {
         meta: {
@@ -402,7 +402,7 @@ describe("registry commands", () => {
         options?: RegistrySetupCommandOptions,
       ) => {
         prompters.push(options?.prompter);
-        return { kind: "completed" as const, output: [] };
+        return { kind: "completed" as const, facts: [] };
       },
     );
     getRegistryItems.mockResolvedValue([

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -499,6 +499,31 @@ describe("registry commands", () => {
     ]);
   });
 
+  it("does not ask again after the TUI authorizes installation", async () => {
+    const fake = createFakePrompter();
+    const runSetup = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
+    getRegistryItems.mockResolvedValue([
+      {
+        meta: { eve: { setup: [{ package: "@acme/slack", bin: "eve-slack", args: ["setup"] }] } },
+      },
+    ]);
+
+    await installRegistryItem(
+      "/project",
+      "channel/slack",
+      { prompter: fake.prompter },
+      { loadSetupCommandRunner: async () => runSetup },
+    );
+
+    expect(fake.selectMessages).toEqual([]);
+    expect(runSetup).toHaveBeenCalledWith(
+      "/project",
+      { package: "@acme/slack", bin: "eve-slack", args: ["setup"] },
+      "channel/slack",
+      expect.objectContaining({ prompter: fake.prompter }),
+    );
+  });
+
   it("asks before setup and prints the resume command when declined", async () => {
     const logger = createLogger();
     const runSetup = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -132,7 +132,7 @@ describe("registry commands", () => {
     "installs the official %s item before running its declared setup",
     async (kind) => {
       const logger = createLogger();
-      const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+      const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
       getRegistryItems.mockResolvedValue([
         {
           name: `channel/${kind}`,
@@ -475,7 +475,7 @@ describe("registry commands", () => {
 
   it("skips setup in non-interactive use and prints the resume command", async () => {
     const logger = createLogger();
-    const runSetup = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetup = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     getRegistryItems.mockResolvedValue([
       {
         meta: { eve: { setup: [{ package: "@acme/slack", bin: "eve-slack", args: ["setup"] }] } },
@@ -501,7 +501,7 @@ describe("registry commands", () => {
 
   it("asks before setup and prints the resume command when declined", async () => {
     const logger = createLogger();
-    const runSetup = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetup = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     const fake = createFakePrompter({ single: () => "no" });
     getRegistryItems.mockResolvedValue([
       {
@@ -555,7 +555,7 @@ describe("registry commands", () => {
 
   it("runs setup directly without installing the item", async () => {
     const logger = createLogger();
-    const runSetup = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetup = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     getRegistryItems.mockResolvedValue([
       {
         meta: { eve: { setup: [{ package: "@acme/slack", bin: "eve-slack", args: ["setup"] }] } },
@@ -629,7 +629,7 @@ describe("registry commands", () => {
 
   it("does not infer setup from the item address", async () => {
     const logger = createLogger();
-    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     getRegistryItems.mockResolvedValue([{ name: "channel/web", type: "registry:item" }]);
 
     await runAddCommand(
@@ -648,7 +648,7 @@ describe("registry commands", () => {
 
   it("does not execute setup metadata from a URL item", async () => {
     const logger = createLogger();
-    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, output: [] }));
+    const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
     getRegistryItems.mockResolvedValue([
       {
         name: "channel/web",

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -15,6 +15,7 @@ import { isEveProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
 
 import { hasInteractiveTerminal, NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
+import { runDeclaredSetups } from "./registry-declared-setups.js";
 import { eveMetadataFromRegistryItem } from "./registry-metadata.js";
 import { runRegistryPackage } from "./registry-package.js";
 import type { runRegistrySetupCommand } from "./registry-setup-command.js";
@@ -45,11 +46,6 @@ export interface RegistrySearchCommandOptions extends RegistryCommandOptions {
   /** Maximum number of matching items to return. */
   limit?: number;
 }
-
-type SetupCommandOptions = Pick<AddCommandOptions, "yes" | "silent"> & {
-  prompter?: Prompter;
-  signal?: AbortSignal;
-};
 
 export interface RegistrySetupDependencies {
   loadSetupCommandRunner(): Promise<typeof runRegistrySetupCommand>;
@@ -450,48 +446,6 @@ export async function getRegistryItemManifest(appRoot: string, item: string): Pr
   return items.length === 1 ? items[0] : items;
 }
 
-async function runDeclaredSetups(
-  logger: RegistryCommandLogger,
-  appRoot: string,
-  item: string,
-  setups: NonNullable<ReturnType<typeof eveMetadataFromRegistryItem>>["setup"],
-  options: SetupCommandOptions,
-  dependencies: RegistrySetupDependencies,
-): Promise<RegistrySetupCompletion | false> {
-  const completion: RegistrySetupCompletion = { facts: [] };
-  if (setups === undefined) return completion;
-  const runSetupCommand = await dependencies.loadSetupCommandRunner();
-  const prompter = options.prompter ?? createPrompter();
-  try {
-    for (const setup of setups) {
-      const result = await runSetupCommand(
-        appRoot,
-        { ...setup, args: [...setup.args, ...(options.yes ? ["--yes"] : [])] },
-        item,
-        { prompter, signal: options.signal },
-      );
-      if (result.kind === "cancelled") {
-        logger.log(setupReminder(item, "cancelled"));
-        return false;
-      }
-      if (options.silent !== true) {
-        for (const fact of result.facts) logger.log(`${fact.label}: ${fact.value}`);
-      }
-      completion.facts = [...completion.facts, ...result.facts];
-      if (result.deployment !== undefined) {
-        completion.deployment ??= { required: true };
-        completion.deployment.productionDestinations = [
-          ...(completion.deployment.productionDestinations ?? []),
-          ...(result.deployment.productionDestinations ?? []),
-        ];
-      }
-    }
-    return completion;
-  } catch (error) {
-    throw new Error(`${errorMessage(error)} Try again with \`${setupResumeCommand(item)}\`.`);
-  }
-}
-
 /** Installs an official, configured, or URL-addressed registry item. */
 export async function installRegistryItem(
   appRoot: string,
@@ -568,14 +522,16 @@ export async function runAddCommand(
           metadata: eveMetadataFromRegistryItem,
           assertCompatibleVersion: assertCompatibleEveVersion,
           runSetups: ({ item: packageItem, setups, prompter }) =>
-            runDeclaredSetups(
+            runDeclaredSetups({
               logger,
               appRoot,
-              packageItem,
+              item: packageItem,
               setups,
-              { yes: options.yes, prompter, signal: options.signal },
+              options: { yes: options.yes, prompter, signal: options.signal },
               dependencies,
-            ),
+              cancelledReminder: setupReminder(packageItem, "cancelled"),
+              resumeCommand: setupResumeCommand(packageItem),
+            }),
           setupReminder: (packageItem) => setupReminder(packageItem, "skipped"),
         },
       });
@@ -586,14 +542,16 @@ export async function runAddCommand(
       if (eveMetadata?.setup === undefined) {
         throw new Error(`Registry item "${item}" does not declare a setup flow.`);
       }
-      const completion = await runDeclaredSetups(
+      const completion = await runDeclaredSetups({
         logger,
         appRoot,
         item,
-        eveMetadata.setup,
+        setups: eveMetadata.setup,
         options,
         dependencies,
-      );
+        cancelledReminder: setupReminder(item, "cancelled"),
+        resumeCommand: setupResumeCommand(item),
+      });
       return completion === false ? undefined : completion;
     }
 
@@ -638,14 +596,16 @@ export async function runAddCommand(
       }
     }
 
-    const completion = await runDeclaredSetups(
+    const completion = await runDeclaredSetups({
       logger,
       appRoot,
       item,
-      eveMetadata.setup,
+      setups: eveMetadata.setup,
       options,
       dependencies,
-    );
+      cancelledReminder: setupReminder(item, "cancelled"),
+      resumeCommand: setupResumeCommand(item),
+    });
     return completion === false ? undefined : completion;
   });
 }

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -56,6 +56,12 @@ export interface AddCommandDependencies extends RegistrySetupDependencies {
   hasInteractiveTerminal?: () => boolean;
 }
 
+type RunAddCommandOptions = AddCommandOptions & {
+  prompter?: Prompter;
+  signal?: AbortSignal;
+  setupAuthorized?: boolean;
+};
+
 /** One discoverable item from an eve-compatible registry catalog. */
 export interface RegistryCatalogItem {
   address: string;
@@ -466,7 +472,11 @@ export async function installRegistryItem(
     logger,
     appRoot,
     item,
-    { ...options, yes: options.prompter === undefined ? true : options.yes },
+    {
+      ...options,
+      yes: options.prompter === undefined ? true : options.yes,
+      setupAuthorized: options.prompter !== undefined,
+    },
     dependencies,
   );
   process.exitCode = previousExitCode;
@@ -481,7 +491,7 @@ export async function runAddCommand(
   logger: RegistryCommandLogger,
   appRoot: string,
   item: string,
-  options: AddCommandOptions & { prompter?: Prompter; signal?: AbortSignal },
+  options: RunAddCommandOptions,
   dependencies: AddCommandDependencies = defaultAddCommandDependencies,
 ): Promise<RegistrySetupCompletion | undefined> {
   return runRegistryAction(logger, appRoot, async () => {
@@ -566,12 +576,15 @@ export async function runAddCommand(
     const interactive =
       dependencies.hasInteractiveTerminal?.() ??
       defaultAddCommandDependencies.hasInteractiveTerminal!();
-    if (options.skipSetup === true || (!options.yes && !interactive)) {
+    if (
+      options.skipSetup === true ||
+      (!options.yes && !interactive && options.setupAuthorized !== true)
+    ) {
       logger.log(setupReminder(item, "skipped"));
       return;
     }
 
-    if (!options.yes) {
+    if (!options.yes && options.setupAuthorized !== true) {
       try {
         const prompter =
           options.prompter ??

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -10,6 +10,7 @@ import { clipVisible, wrapVisibleLine } from "#cli/ui/terminal-text.js";
 import semver from "#compiled/semver/index.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
+import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 import { isEveProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
 
@@ -45,7 +46,7 @@ export interface RegistrySearchCommandOptions extends RegistryCommandOptions {
   limit?: number;
 }
 
-type SetupCommandOptions = Pick<AddCommandOptions, "yes"> & {
+type SetupCommandOptions = Pick<AddCommandOptions, "yes" | "silent"> & {
   prompter?: Prompter;
   signal?: AbortSignal;
 };
@@ -175,23 +176,24 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-async function runRegistryAction(
+async function runRegistryAction<T>(
   logger: RegistryCommandLogger,
   appRoot: string,
-  action: () => Promise<void>,
-): Promise<void> {
+  action: () => Promise<T>,
+): Promise<T | undefined> {
   if (!(await isEveProject(appRoot))) {
     logger.error(NOT_AN_AGENT_MESSAGE);
     process.exitCode = 1;
-    return;
+    return undefined;
   }
 
   try {
-    await action();
+    return await action();
   } catch (error) {
-    if (error instanceof WizardCancelledError) return;
+    if (error instanceof WizardCancelledError) return undefined;
     logger.error(errorMessage(error));
     process.exitCode = 1;
+    return undefined;
   }
 }
 
@@ -455,8 +457,9 @@ async function runDeclaredSetups(
   setups: NonNullable<ReturnType<typeof eveMetadataFromRegistryItem>>["setup"],
   options: SetupCommandOptions,
   dependencies: RegistrySetupDependencies,
-): Promise<boolean> {
-  if (setups === undefined) return true;
+): Promise<RegistrySetupCompletion | false> {
+  const completion: RegistrySetupCompletion = { facts: [] };
+  if (setups === undefined) return completion;
   const runSetupCommand = await dependencies.loadSetupCommandRunner();
   const prompter = options.prompter ?? createPrompter();
   try {
@@ -471,9 +474,19 @@ async function runDeclaredSetups(
         logger.log(setupReminder(item, "cancelled"));
         return false;
       }
-      for (const line of result.output) logger.log(line);
+      if (options.silent !== true) {
+        for (const fact of result.facts) logger.log(`${fact.label}: ${fact.value}`);
+      }
+      completion.facts = [...completion.facts, ...result.facts];
+      if (result.deployment !== undefined) {
+        completion.deployment ??= { required: true };
+        completion.deployment.productionDestinations = [
+          ...(completion.deployment.productionDestinations ?? []),
+          ...(result.deployment.productionDestinations ?? []),
+        ];
+      }
     }
-    return true;
+    return completion;
   } catch (error) {
     throw new Error(`${errorMessage(error)} Try again with \`${setupResumeCommand(item)}\`.`);
   }
@@ -485,7 +498,7 @@ export async function installRegistryItem(
   item: string,
   options: AddCommandOptions & { prompter?: Prompter; signal?: AbortSignal } = {},
   dependencies: AddCommandDependencies = defaultAddCommandDependencies,
-): Promise<readonly string[]> {
+): Promise<{ output: readonly string[]; setup?: RegistrySetupCompletion }> {
   let failure: string | undefined;
   const output: string[] = [];
   const logger: RegistryCommandLogger = {
@@ -495,7 +508,7 @@ export async function installRegistryItem(
     log: (message) => output.push(message),
   };
   const previousExitCode = process.exitCode;
-  await runAddCommand(
+  const setup = await runAddCommand(
     logger,
     appRoot,
     item,
@@ -504,7 +517,9 @@ export async function installRegistryItem(
   );
   process.exitCode = previousExitCode;
   if (failure !== undefined) throw new Error(failure);
-  return output;
+  const result: { output: readonly string[]; setup?: RegistrySetupCompletion } = { output };
+  if (setup !== undefined) result.setup = setup;
+  return result;
 }
 
 /** Installs an official, configured, or URL-addressed registry item. */
@@ -514,8 +529,8 @@ export async function runAddCommand(
   item: string,
   options: AddCommandOptions & { prompter?: Prompter; signal?: AbortSignal },
   dependencies: AddCommandDependencies = defaultAddCommandDependencies,
-): Promise<void> {
-  await runRegistryAction(logger, appRoot, async () => {
+): Promise<RegistrySetupCompletion | undefined> {
+  return runRegistryAction(logger, appRoot, async () => {
     const config = await readEveRegistryConfig(appRoot);
     const address = itemAddress(item);
     if (options.skipInstall === true) {
@@ -540,7 +555,7 @@ export async function runAddCommand(
     if (eveMetadata?.components !== undefined) {
       if (!isOfficialItemAddress(address))
         throw new Error("Registry packages require the official eve registry.");
-      await runRegistryPackage({
+      const completion = await runRegistryPackage({
         logger,
         appRoot,
         item,
@@ -564,15 +579,22 @@ export async function runAddCommand(
           setupReminder: (packageItem) => setupReminder(packageItem, "skipped"),
         },
       });
-      return;
+      return completion === false ? undefined : completion;
     }
 
     if (options.skipInstall === true) {
       if (eveMetadata?.setup === undefined) {
         throw new Error(`Registry item "${item}" does not declare a setup flow.`);
       }
-      await runDeclaredSetups(logger, appRoot, item, eveMetadata.setup, options, dependencies);
-      return;
+      const completion = await runDeclaredSetups(
+        logger,
+        appRoot,
+        item,
+        eveMetadata.setup,
+        options,
+        dependencies,
+      );
+      return completion === false ? undefined : completion;
     }
 
     await addRegistryItems([address], {
@@ -616,7 +638,15 @@ export async function runAddCommand(
       }
     }
 
-    await runDeclaredSetups(logger, appRoot, item, eveMetadata.setup, options, dependencies);
+    const completion = await runDeclaredSetups(
+      logger,
+      appRoot,
+      item,
+      eveMetadata.setup,
+      options,
+      dependencies,
+    );
+    return completion === false ? undefined : completion;
   });
 }
 

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -344,6 +344,11 @@ describe("runTuiSetupCommand", () => {
       "Added Agent Browser",
     ],
     ["empty", { kind: "done", addedItems: [], items: [], facts: [] }, "No registry items added."],
+    [
+      "deployed",
+      { kind: "done", addedItems: [], items: [], facts: [], deployed: "production" },
+      "No registry items added.",
+    ],
     ["cancelled", { kind: "cancelled" }, "/add dismissed."],
   ] as const)("reports a %s registry flow", async (_case, result, message) => {
     const runRegistryFlow = vi.fn(async () => result);
@@ -352,11 +357,15 @@ describe("runTuiSetupCommand", () => {
       message: string;
       tone?: "success";
       preserveFlowDiagnostics: boolean;
+      effect?: { kind: "deployed" };
     } = {
       message,
       preserveFlowDiagnostics: true,
     };
     if (result.kind === "done" && result.addedItems.length > 0) expected.tone = "success";
+    if (result.kind === "done" && "deployed" in result && result.deployed === "production") {
+      expected.effect = { kind: "deployed" };
+    }
     expect(outcome).toEqual(expected);
     expect(runRegistryFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
   });

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
+import { RegistryFlowFailedError } from "#setup/flows/registry.js";
 
 import {
   runTuiSetupCommand,
@@ -29,6 +30,7 @@ function fakePanelRenderer(): TuiSetupCommandRenderer & {
     readChoice: vi.fn(() => ({ choice: Promise.resolve(undefined), close: vi.fn() })),
     setStatus: vi.fn(),
     renderLine: vi.fn(),
+    replaceContent: vi.fn(),
     renderOutput: vi.fn(),
     withInheritedStdio: (task) => task(),
     waitForInterrupt: vi.fn(() => ({
@@ -57,6 +59,7 @@ function fakeFlows(overrides: Partial<TuiSetupFlows> = {}): TuiSetupFlows {
     runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
       kind: "done",
       addedItems: [],
+      items: [],
       facts: [],
     })),
     runDeployFlow: vi.fn<TuiSetupFlows["runDeployFlow"]>(async () => ({
@@ -97,6 +100,7 @@ describe("runTuiSetupCommand", () => {
     const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
       kind: "done",
       addedItems: [],
+      items: [],
       facts: [],
     }));
 
@@ -331,10 +335,15 @@ describe("runTuiSetupCommand", () => {
   it.each([
     [
       "added",
-      { kind: "done", addedItems: ["extension/browser"], facts: [] },
-      "Registry items added: extension/browser.",
+      {
+        kind: "done",
+        addedItems: ["extension/browser"],
+        items: [{ address: "extension/browser", title: "Agent Browser", facts: [], output: [] }],
+        facts: [],
+      },
+      "Added Agent Browser",
     ],
-    ["empty", { kind: "done", addedItems: [], facts: [] }, "No registry items added."],
+    ["empty", { kind: "done", addedItems: [], items: [], facts: [] }, "No registry items added."],
     ["cancelled", { kind: "cancelled" }, "/add dismissed."],
   ] as const)("reports a %s registry flow", async (_case, result, message) => {
     const runRegistryFlow = vi.fn(async () => result);
@@ -350,6 +359,75 @@ describe("runTuiSetupCommand", () => {
     if (result.kind === "done" && result.addedItems.length > 0) expected.tone = "success";
     expect(outcome).toEqual(expected);
     expect(runRegistryFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
+  });
+
+  it("overrides a settled success tone when add is interrupted", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(
+        ({ signal }) =>
+          new Promise((resolve) => {
+            signal?.addEventListener(
+              "abort",
+              () =>
+                resolve({
+                  kind: "done",
+                  addedItems: ["channel/github"],
+                  items: [{ address: "channel/github", title: "GitHub", facts: [], output: [] }],
+                  facts: [],
+                }),
+              { once: true },
+            );
+          }),
+      ),
+    });
+
+    const result = run({ command: "add", flows, renderer });
+    renderer.fireInterrupt();
+
+    await expect(result).resolves.toEqual({
+      message: "/add interrupted.",
+      tone: "error",
+      preserveFlowDiagnostics: true,
+    });
+  });
+
+  it("reports completed items and facts when a later add fails", async () => {
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => {
+        throw new RegistryFlowFailedError(new Error("Refusing to overwrite github.ts"), {
+          kind: "done",
+          addedItems: ["channel/photon-imessage"],
+          items: [
+            {
+              address: "channel/photon-imessage",
+              title: "Photon iMessage",
+              output: [],
+              facts: [
+                { label: "Agent phone number", value: "+15551234567" },
+                { label: "Photon project dashboard", value: "https://app.photon.codes/project" },
+              ],
+            },
+          ],
+          output: [],
+          facts: [
+            { label: "Agent phone number", value: "+15551234567" },
+            { label: "Photon project dashboard", value: "https://app.photon.codes/project" },
+          ],
+        });
+      }),
+    });
+
+    await expect(run({ command: "add", flows })).resolves.toEqual({
+      message:
+        "Added Photon iMessage\n\n" +
+        "Photon iMessage\n" +
+        "  Agent phone number        +15551234567\n" +
+        "  Photon project dashboard  https://app.photon.codes/project\n\n" +
+        "Refusing to overwrite github.ts",
+      tone: "error",
+      preserveFlowDiagnostics: true,
+    });
   });
 
   it("reports the production URL after a deploy", async () => {
@@ -398,6 +476,7 @@ describe("runTuiSetupCommand", () => {
 
     await expect(result).resolves.toEqual({
       message: "/model interrupted.",
+      tone: "error",
       preserveFlowDiagnostics: true,
       effect: { kind: "model-access-changed" },
     });

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -57,6 +57,7 @@ function fakeFlows(overrides: Partial<TuiSetupFlows> = {}): TuiSetupFlows {
     runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
       kind: "done",
       addedItems: [],
+      facts: [],
     })),
     runDeployFlow: vi.fn<TuiSetupFlows["runDeployFlow"]>(async () => ({
       kind: "deployed",
@@ -96,6 +97,7 @@ describe("runTuiSetupCommand", () => {
     const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
       kind: "done",
       addedItems: [],
+      facts: [],
     }));
 
     await run({ command: "add", flows: fakeFlows({ runRegistryFlow }), renderer });
@@ -329,10 +331,10 @@ describe("runTuiSetupCommand", () => {
   it.each([
     [
       "added",
-      { kind: "done", addedItems: ["extension/browser"] },
+      { kind: "done", addedItems: ["extension/browser"], facts: [] },
       "Registry items added: extension/browser.",
     ],
-    ["empty", { kind: "done", addedItems: [] }, "No registry items added."],
+    ["empty", { kind: "done", addedItems: [], facts: [] }, "No registry items added."],
     ["cancelled", { kind: "cancelled" }, "/add dismissed."],
   ] as const)("reports a %s registry flow", async (_case, result, message) => {
     const runRegistryFlow = vi.fn(async () => result);

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -256,14 +256,16 @@ async function executeSetupCommand(
         if (result.kind === "cancelled") {
           return { message: "/add dismissed.", preserveFlowDiagnostics: true };
         }
-        if (result.addedItems.length > 0) {
-          return {
-            message: registryResultMessage(result),
-            tone: "success",
-            preserveFlowDiagnostics: true,
-          };
-        }
-        return { message: "No registry items added.", preserveFlowDiagnostics: true };
+        const outcome: TuiSetupCommandResult = {
+          message:
+            result.addedItems.length > 0
+              ? registryResultMessage(result)
+              : "No registry items added.",
+          preserveFlowDiagnostics: true,
+        };
+        if (result.addedItems.length > 0) outcome.tone = "success";
+        if (result.deployed === "production") outcome.effect = { kind: "deployed" };
+        return outcome;
       }
       case "deploy": {
         const result = await flows.runDeployFlow({ appRoot, prompter, interactive: true, signal });

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -236,6 +236,7 @@ async function executeSetupCommand(
             message: [
               `Registry items added: ${result.addedItems.join(", ")}.`,
               ...(result.output ?? []),
+              ...result.facts.map((fact) => `${fact.label}: ${fact.value}`),
             ].join("\n"),
             tone: "success",
             preserveFlowDiagnostics: true,

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -7,7 +7,7 @@ import {
 import { runLoginFlow, type LoginFlowResult } from "#setup/flows/login.js";
 import { runModelFlow, type ModelProviderOutcome } from "#setup/flows/model.js";
 import { runProviderFlow, type ProviderPicker } from "#setup/flows/provider.js";
-import { runRegistryFlow } from "#setup/flows/registry.js";
+import { RegistryFlowFailedError, runRegistryFlow } from "#setup/flows/registry.js";
 import type { Prompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 
@@ -63,6 +63,27 @@ export interface TuiSetupFlows {
   runDeployFlow: typeof runDeployFlow;
 }
 
+function joinedTitles(titles: readonly string[]): string {
+  if (titles.length === 0) return "";
+  if (titles.length === 1) return titles[0]!;
+  if (titles.length === 2) return `${titles[0]} and ${titles[1]}`;
+  return `${titles.slice(0, -1).join(", ")}, and ${titles.at(-1)}`;
+}
+
+function registryResultMessage(
+  result: Extract<Awaited<ReturnType<typeof runRegistryFlow>>, { kind: "done" }>,
+): string {
+  const lines = [`Added ${joinedTitles(result.items.map((item) => item.title))}`];
+  for (const item of result.items) {
+    if (item.facts.length === 0 && item.output.length === 0) continue;
+    lines.push("", item.title);
+    const width = Math.max(0, ...item.facts.map((fact) => fact.label.length));
+    for (const fact of item.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
+    for (const output of item.output) lines.push(`  ${output}`);
+  }
+  return lines.join("\n");
+}
+
 export interface TuiSetupCommandResult {
   message: string;
   /** Promotes an outcome to a top-level status. */
@@ -107,6 +128,9 @@ function muteableRenderer(
         renderer.renderLine(text, tone);
       }
     },
+    replaceContent: (content) => {
+      if (!isMuted()) renderer.replaceContent?.(content);
+    },
     renderOutput: (text) => {
       if (!isMuted()) renderer.renderOutput(text);
     },
@@ -146,6 +170,7 @@ export async function runTuiSetupCommand(
     return {
       ...settled,
       message: `/${command} interrupted.`,
+      tone: "error",
       preserveFlowDiagnostics: true,
     };
   } finally {
@@ -233,11 +258,7 @@ async function executeSetupCommand(
         }
         if (result.addedItems.length > 0) {
           return {
-            message: [
-              `Registry items added: ${result.addedItems.join(", ")}.`,
-              ...(result.output ?? []),
-              ...result.facts.map((fact) => `${fact.label}: ${fact.value}`),
-            ].join("\n"),
+            message: registryResultMessage(result),
             tone: "success",
             preserveFlowDiagnostics: true,
           };
@@ -264,6 +285,14 @@ async function executeSetupCommand(
       }
     }
   } catch (error) {
+    if (error instanceof RegistryFlowFailedError) {
+      const completed = error.completed;
+      return {
+        message: `${registryResultMessage(completed)}\n\n${error.message}`,
+        tone: "error",
+        preserveFlowDiagnostics: true,
+      };
+    }
     if (error instanceof WizardCancelledError) {
       return {
         message: `/${command} dismissed.`,

--- a/packages/eve/src/cli/dev/tui/setup-flow.ts
+++ b/packages/eve/src/cli/dev/tui/setup-flow.ts
@@ -103,6 +103,10 @@ export interface SetupFlowRenderer {
   readChoice(options: ChannelSetupChoiceOptions): ChannelSetupChoice;
   setStatus(status: SetupFlowStatus | undefined): void;
   renderLine(text: string, tone: "info" | "success" | "warning" | "error"): void;
+  replaceContent?(content?: {
+    headline: string;
+    facts: readonly { label: string; value: string }[];
+  }): void;
   renderOutput(text: string): void;
   /** Temporarily restores the terminal while a child process inherits stdio. */
   withInheritedStdio<T>(task: () => Promise<T>): Promise<T>;
@@ -132,6 +136,7 @@ export type SetupFlowPrompterRenderer = Pick<
   | "readChoice"
   | "setStatus"
   | "renderLine"
+  | "replaceContent"
   | "renderOutput"
   | "withInheritedStdio"
   | "withExclusiveTerminal"

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -4104,6 +4104,41 @@ describe("TerminalRenderer setup flow session", () => {
     renderer.shutdown();
   });
 
+  it("replaces setup lines with a compact current-item summary", async () => {
+    const { screen, input, renderer } = makeRenderer();
+
+    renderer.setupFlow.begin("Add to your agent");
+    renderer.setupFlow.renderLine("Scaffolded channel: photon", "success");
+    renderer.setupFlow.renderLine("Photon project: https://app.photon.codes", "success");
+    renderer.setupFlow.replaceContent?.({
+      headline: "Scaffolded channel/photon-imessage",
+      facts: [
+        { label: "Agent phone number", value: "+15551234567" },
+        { label: "Photon project dashboard", value: "https://app.photon.codes" },
+      ],
+    });
+    const answer = renderer.setupFlow.readSelect({
+      kind: "task-list",
+      message: "What would you like to do next?",
+      options: [
+        { value: "add-more", label: "Add more" },
+        { value: "finish", label: "Finish", trailingAction: true },
+      ],
+    });
+
+    const snapshot = screen.snapshot();
+    expect(snapshot).toContain("Scaffolded channel/photon-imessage");
+    expect(snapshot).toContain("Agent phone number: +15551234567");
+    expect(snapshot).toContain("Photon project dashboard: https://app.photon.codes");
+    expect(snapshot).not.toContain("Scaffolded channel: photon");
+    expect(snapshot).not.toContain("Photon project: https://app.photon.codes");
+
+    input.enter();
+    await expect(answer).resolves.toEqual(["add-more"]);
+    renderer.setupFlow.end({ preserveDiagnostics: false });
+    renderer.shutdown();
+  });
+
   it("keeps enter on a completed setup row as a no-op", async () => {
     const { input, renderer } = makeRenderer();
     const answer = renderer.setupFlow.readSelect({

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -242,6 +242,7 @@ type SetupFlowState = {
   title: string;
   indicator: SetupFlowIndicatorState;
   lines: FlowPanelLine[];
+  summary?: { headline: string; facts: readonly { label: string; value: string }[] };
   status?: SetupFlowStatusState;
   /** Latest subprocess output line; replaced per write, never persisted. */
   preview?: string;
@@ -581,6 +582,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
     readChoice: (options) => this.#readSetupChoice(options),
     setStatus: (text) => this.#setFlowStatus(text),
     renderLine: (text, tone) => this.#renderFlowLine(text, tone),
+    replaceContent: (content) => this.#replaceFlowContent(content),
     renderOutput: (text) => this.#renderFlowOutput(text),
     withInheritedStdio: (task) => this.#withInheritedStdio(task),
     withExclusiveTerminal: (task) => this.#withInheritedStdio(task),
@@ -1806,7 +1808,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
             line.tone === "success" || line.tone === "warning" || line.tone === "error",
         )
         .map((line) => ({ tone: line.tone, text: line.text }));
-      notices = [...(opts.notices ?? []), ...outcomes];
+      notices = opts.notices ?? outcomes;
       flow.taskListLineStart = flow.lines.length;
       flow.hideLinesWhileQuestion = true;
     }
@@ -2579,6 +2581,28 @@ export class TerminalRenderer implements AgentTUIRenderer {
     }
     this.#start();
     this.#pushBlock({ kind: "flow", title: tone, body: content, live: false });
+    this.#paint();
+  }
+
+  #replaceFlowContent(content?: {
+    headline: string;
+    facts: readonly { label: string; value: string }[];
+  }): void {
+    const flow = this.#setupFlow;
+    if (flow === undefined) return;
+    flow.lines = [];
+    flow.outputBuffer = [];
+    flow.preview = undefined;
+    flow.summary =
+      content === undefined
+        ? undefined
+        : {
+            headline: stripTerminalControls(content.headline),
+            facts: content.facts.map((fact) => ({
+              label: stripTerminalControls(fact.label),
+              value: stripTerminalControls(fact.value),
+            })),
+          };
     this.#paint();
   }
 
@@ -3897,7 +3921,18 @@ export class TerminalRenderer implements AgentTUIRenderer {
       }
       const state: Parameters<typeof renderFlowPanel>[0] = {
         title: flow.title,
-        lines: flow.hideLinesWhileQuestion === true ? [] : flow.lines,
+        lines:
+          flow.summary === undefined
+            ? flow.hideLinesWhileQuestion === true
+              ? []
+              : flow.lines
+            : [
+                { text: flow.summary.headline, tone: "success" },
+                ...flow.summary.facts.map((fact) => ({
+                  text: `${fact.label}: ${fact.value}`,
+                  tone: "info" as const,
+                })),
+              ],
         content,
       };
       rows.push(...renderFlowPanel(state, this.#theme, width));

--- a/packages/eve/src/cli/dev/tui/tui-prompter.ts
+++ b/packages/eve/src/cli/dev/tui/tui-prompter.ts
@@ -201,6 +201,8 @@ export function createTuiPrompter(renderer: TuiPrompterRenderer): Prompter {
 
     outro() {},
 
+    replaceContent: (content) => renderer.replaceContent?.(content),
+
     withInheritedStdio: (task) => renderer.withInheritedStdio(task),
 
     log: {

--- a/packages/eve/src/setup/boxes/deploy-project.test.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.test.ts
@@ -116,6 +116,19 @@ describe("deployProject box", () => {
     );
   });
 
+  it("creates a preview deployment without --prod", async () => {
+    const deps = createDeps();
+    const box = deployProject({ prompter: createPrompter(), deps, target: "preview" });
+
+    await runInteractive([box], pendingState(), silentSink);
+
+    expect(deps.runVercel).toHaveBeenNthCalledWith(
+      1,
+      ["deploy", "--yes"],
+      expect.objectContaining({ cwd: "/tmp/project", nonInteractive: false }),
+    );
+  });
+
   it("deploys with --yes but keeps stdin interactive on an interactive run", async () => {
     const deps = createDeps();
     const box = deployProject({ prompter: createPrompter(), deps });

--- a/packages/eve/src/setup/boxes/deploy-project.test.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.test.ts
@@ -116,19 +116,6 @@ describe("deployProject box", () => {
     );
   });
 
-  it("creates a preview deployment without --prod", async () => {
-    const deps = createDeps();
-    const box = deployProject({ prompter: createPrompter(), deps, target: "preview" });
-
-    await runInteractive([box], pendingState(), silentSink);
-
-    expect(deps.runVercel).toHaveBeenNthCalledWith(
-      1,
-      ["deploy", "--yes"],
-      expect.objectContaining({ cwd: "/tmp/project", nonInteractive: false }),
-    );
-  });
-
   it("deploys with --yes but keeps stdin interactive on an interactive run", async () => {
     const deps = createDeps();
     const box = deployProject({ prompter: createPrompter(), deps });

--- a/packages/eve/src/setup/boxes/deploy-project.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.ts
@@ -40,8 +40,6 @@ export interface DeployProjectOptions {
    * a plan or skips deploy with the channels).
    */
   ensureLinkedProject?: "interactive-vercel-link";
-  /** Deploy to production by default, or create a preview deployment. */
-  target?: "production" | "preview";
   /**
    * Headless mode: gates interactive `vercel` commands inside `perform`. The box
    * asks no questions, so the dispatch decision the gather faces used to encode
@@ -59,7 +57,6 @@ export interface DeployProjectOptions {
  */
 export interface DeployProjectInput {
   headless: boolean;
-  target: "production" | "preview";
 }
 
 /** The deploy facts `apply` records: the (re)deployed project and the cleared flags. */
@@ -110,7 +107,7 @@ export function deployProject(
     async gather(): Promise<DeployProjectInput> {
       // No questions: the deploy decision is the shouldRun gate, and the headless
       // dispatch is a composition-time fact, so one gather serves every mode.
-      return { headless: options.headless ?? false, target: options.target ?? "production" };
+      return { headless: options.headless ?? false };
     },
 
     async perform({ state, input, signal }): Promise<DeployProjectPayload> {
@@ -176,12 +173,11 @@ export function deployProject(
       // deploy.
       const deployArgs = [
         "deploy",
-        ...(input.target === "production" ? ["--prod"] : []),
+        "--prod",
         "--yes",
         ...(input.headless ? ["--non-interactive"] : []),
       ];
-      const targetLabel = input.target === "production" ? "production" : "preview";
-      const success = await withPhase(log, `Deploying the agent to Vercel ${targetLabel}...`, () =>
+      const success = await withPhase(log, "Deploying the agent to Vercel production...", () =>
         deps.runVercel(deployArgs, {
           cwd: projectPath,
           extraEnv: VERCEL_DEPLOY_ENV,
@@ -196,7 +192,7 @@ export function deployProject(
         // transient until a warning/error settles it) so the build failure is
         // visible instead of just the exit code.
         log.error(
-          `\`vercel deploy${input.target === "production" ? " --prod" : ""}\` failed. The deploy output above shows the cause; fix it, then retry.`,
+          "`vercel deploy --prod` failed. The deploy output above shows the cause; fix it, then retry.",
         );
         throw new Error("Deployment failed after channel setup.");
       }

--- a/packages/eve/src/setup/boxes/deploy-project.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.ts
@@ -40,6 +40,8 @@ export interface DeployProjectOptions {
    * a plan or skips deploy with the channels).
    */
   ensureLinkedProject?: "interactive-vercel-link";
+  /** Deploy to production by default, or create a preview deployment. */
+  target?: "production" | "preview";
   /**
    * Headless mode: gates interactive `vercel` commands inside `perform`. The box
    * asks no questions, so the dispatch decision the gather faces used to encode
@@ -57,6 +59,7 @@ export interface DeployProjectOptions {
  */
 export interface DeployProjectInput {
   headless: boolean;
+  target: "production" | "preview";
 }
 
 /** The deploy facts `apply` records: the (re)deployed project and the cleared flags. */
@@ -107,7 +110,7 @@ export function deployProject(
     async gather(): Promise<DeployProjectInput> {
       // No questions: the deploy decision is the shouldRun gate, and the headless
       // dispatch is a composition-time fact, so one gather serves every mode.
-      return { headless: options.headless ?? false };
+      return { headless: options.headless ?? false, target: options.target ?? "production" };
     },
 
     async perform({ state, input, signal }): Promise<DeployProjectPayload> {
@@ -171,10 +174,14 @@ export function deployProject(
       // Vercel projects may still need the CLI to skip deployment-setting
       // confirmation before the deployments API accepts the first production
       // deploy.
-      const deployArgs = input.headless
-        ? ["deploy", "--prod", "--yes", "--non-interactive"]
-        : ["deploy", "--prod", "--yes"];
-      const success = await withPhase(log, "Deploying the agent to Vercel production...", () =>
+      const deployArgs = [
+        "deploy",
+        ...(input.target === "production" ? ["--prod"] : []),
+        "--yes",
+        ...(input.headless ? ["--non-interactive"] : []),
+      ];
+      const targetLabel = input.target === "production" ? "production" : "preview";
+      const success = await withPhase(log, `Deploying the agent to Vercel ${targetLabel}...`, () =>
         deps.runVercel(deployArgs, {
           cwd: projectPath,
           extraEnv: VERCEL_DEPLOY_ENV,
@@ -189,7 +196,7 @@ export function deployProject(
         // transient until a warning/error settles it) so the build failure is
         // visible instead of just the exit code.
         log.error(
-          "`vercel deploy --prod` failed. The deploy output above shows the cause; fix it, then run `vercel deploy --prod` to retry.",
+          `\`vercel deploy${input.target === "production" ? " --prod" : ""}\` failed. The deploy output above shows the cause; fix it, then retry.`,
         );
         throw new Error("Deployment failed after channel setup.");
       }

--- a/packages/eve/src/setup/connection-connector.integration.test.ts
+++ b/packages/eve/src/setup/connection-connector.integration.test.ts
@@ -217,6 +217,21 @@ describe("setupConnectionConnector", () => {
     );
   });
 
+  it("surfaces the Vercel error when connector creation fails", async () => {
+    run.mockResolvedValueOnce(false);
+    capture.mockResolvedValue(jsonResult({ connectors: [] }));
+    create.mockResolvedValue({
+      ok: false,
+      stdout: "",
+      stderr: "Vercel CLI 58.5.1\nError: Connect is not enabled for this team.\n",
+    });
+    const fake = createFakePrompter({ single: () => "create", text: () => "acme" });
+
+    await expect(setupConnectionConnector(options(fake.prompter))).rejects.toThrow(
+      `Could not create the ${SERVICE} connector. Vercel returned: Error: Connect is not enabled for this team.`,
+    );
+  });
+
   it("recovers a partially created connector id from CLI progress and removes it", async () => {
     run.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     capture.mockResolvedValue(jsonResult({ connectors: [] }));

--- a/packages/eve/src/setup/connection-connector.ts
+++ b/packages/eve/src/setup/connection-connector.ts
@@ -45,6 +45,17 @@ function parseJson(source: string): unknown {
   }
 }
 
+function connectorCreationFailure(service: string, stderr: string | undefined): string {
+  const detail = stderr
+    ?.split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("Vercel CLI "))
+    .at(-1);
+  return detail === undefined
+    ? `Could not create the ${service} connector.`
+    : `Could not create the ${service} connector. Vercel returned: ${detail}`;
+}
+
 function parseConnectorRef(value: unknown): ConnectConnectorRef | undefined {
   if (!isRecord(value) || typeof value["uid"] !== "string" || typeof value["id"] !== "string") {
     return undefined;
@@ -305,7 +316,7 @@ async function resolveFallbackConnector(
     if (connector !== undefined) return { kind: "created", connector };
     const message = created.ok
       ? `The ${options.service} connector does not support user authorization.`
-      : `Could not create the ${options.service} connector.`;
+      : connectorCreationFailure(options.service, created.stderr);
     if (ownedId !== undefined) {
       try {
         await cleanupCreatedConnectionConnector({

--- a/packages/eve/src/setup/flows/deploy.test.ts
+++ b/packages/eve/src/setup/flows/deploy.test.ts
@@ -106,6 +106,27 @@ describe("runDeployFlow", () => {
     );
   });
 
+  it("creates a preview deployment when requested", async () => {
+    const fake = createFakePrompter({});
+    const deployDeps = createDeployProjectDeps();
+
+    await runDeployFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      interactive: true,
+      target: "preview",
+      deps: {
+        detectDeployment: vi.fn(async () => LINKED),
+        deployProject: deployDeps,
+      },
+    });
+
+    expect(deployDeps.runVercel).toHaveBeenCalledWith(
+      ["deploy", "--yes"],
+      expect.objectContaining({ cwd: APP_ROOT }),
+    );
+  });
+
   it("refuses an unlinked non-interactive run before any effect", async () => {
     const fake = createFakePrompter({});
     const deployDeps = createDeployProjectDeps();

--- a/packages/eve/src/setup/flows/deploy.test.ts
+++ b/packages/eve/src/setup/flows/deploy.test.ts
@@ -106,27 +106,6 @@ describe("runDeployFlow", () => {
     );
   });
 
-  it("creates a preview deployment when requested", async () => {
-    const fake = createFakePrompter({});
-    const deployDeps = createDeployProjectDeps();
-
-    await runDeployFlow({
-      appRoot: APP_ROOT,
-      prompter: fake.prompter,
-      interactive: true,
-      target: "preview",
-      deps: {
-        detectDeployment: vi.fn(async () => LINKED),
-        deployProject: deployDeps,
-      },
-    });
-
-    expect(deployDeps.runVercel).toHaveBeenCalledWith(
-      ["deploy", "--yes"],
-      expect.objectContaining({ cwd: APP_ROOT }),
-    );
-  });
-
   it("refuses an unlinked non-interactive run before any effect", async () => {
     const fake = createFakePrompter({});
     const deployDeps = createDeployProjectDeps();

--- a/packages/eve/src/setup/flows/deploy.ts
+++ b/packages/eve/src/setup/flows/deploy.ts
@@ -53,11 +53,9 @@ export async function runDeployFlow(input: {
   signal?: AbortSignal;
   /** False when no TTY: an unlinked directory refuses instead of prompting. */
   interactive: boolean;
-  /** Production by default; integration setup can explicitly request a preview. */
-  target?: "production" | "preview";
   deps?: Partial<DeployFlowDeps>;
 }): Promise<DeployFlowResult> {
-  const { appRoot, prompter, interactive, signal, target = "production" } = input;
+  const { appRoot, prompter, interactive, signal } = input;
   const deps: DeployFlowDeps = { detectDeployment, ...input.deps };
 
   const project = await withSpinner(prompter, "Checking the current Vercel link...", async () => {
@@ -73,7 +71,7 @@ export async function runDeployFlow(input: {
 
   const state = inProjectSetupState(appRoot, project, { deploymentPending: true });
   const boxes: AnySetupBox<SetupState>[] = linked
-    ? [deployProject({ prompter, headless: !interactive, target, deps: deps.deployProject })]
+    ? [deployProject({ prompter, headless: !interactive, deps: deps.deployProject })]
     : [
         resolveProvisioning({
           asker: withAnswers({ deploy: "vercel" })(interactiveAsker(prompter)),
@@ -83,7 +81,7 @@ export async function runDeployFlow(input: {
           deps: deps.resolveProvisioning,
         }),
         linkVercelProject({ prompter, deps: deps.linkProject }),
-        deployProject({ prompter, headless: !interactive, target, deps: deps.deployProject }),
+        deployProject({ prompter, headless: !interactive, deps: deps.deployProject }),
       ];
 
   const sink = prompterSink(prompter);

--- a/packages/eve/src/setup/flows/deploy.ts
+++ b/packages/eve/src/setup/flows/deploy.ts
@@ -53,9 +53,11 @@ export async function runDeployFlow(input: {
   signal?: AbortSignal;
   /** False when no TTY: an unlinked directory refuses instead of prompting. */
   interactive: boolean;
+  /** Production by default; integration setup can explicitly request a preview. */
+  target?: "production" | "preview";
   deps?: Partial<DeployFlowDeps>;
 }): Promise<DeployFlowResult> {
-  const { appRoot, prompter, interactive, signal } = input;
+  const { appRoot, prompter, interactive, signal, target = "production" } = input;
   const deps: DeployFlowDeps = { detectDeployment, ...input.deps };
 
   const project = await withSpinner(prompter, "Checking the current Vercel link...", async () => {
@@ -71,7 +73,7 @@ export async function runDeployFlow(input: {
 
   const state = inProjectSetupState(appRoot, project, { deploymentPending: true });
   const boxes: AnySetupBox<SetupState>[] = linked
-    ? [deployProject({ prompter, headless: !interactive, deps: deps.deployProject })]
+    ? [deployProject({ prompter, headless: !interactive, target, deps: deps.deployProject })]
     : [
         resolveProvisioning({
           asker: withAnswers({ deploy: "vercel" })(interactiveAsker(prompter)),
@@ -81,7 +83,7 @@ export async function runDeployFlow(input: {
           deps: deps.resolveProvisioning,
         }),
         linkVercelProject({ prompter, deps: deps.linkProject }),
-        deployProject({ prompter, headless: !interactive, deps: deps.deployProject }),
+        deployProject({ prompter, headless: !interactive, target, deps: deps.deployProject }),
       ];
 
   const sink = prompterSink(prompter);

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -115,7 +115,6 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
           prompter: input.prompter,
           signal: input.signal,
           interactive: true,
-          target: "production",
         });
         return result(deployResult.kind === "deployed" ? "production" : undefined);
       }

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -1,16 +1,8 @@
 import type { Prompter } from "#setup/prompter.js";
 import { openUrl } from "#setup/primitives/open-url.js";
 import { detectDeployment } from "#setup/project-resolution.js";
-import {
-  emptyRegistrySetupCompletion,
-  mergeRegistrySetupCompletions,
-  registrySetupCompletionFacts,
-} from "#setup/registry-setup-completion.js";
-import type {
-  RegistrySetupCompletion,
-  RegistrySetupDestination,
-  RegistrySetupFact,
-} from "#setup/registry-setup-protocol.js";
+import { mergeRegistrySetupCompletions } from "#setup/registry-setup-completion.js";
+import type { RegistrySetupCompletion, RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 
 import { runDeployFlow } from "./deploy.js";
 
@@ -42,13 +34,13 @@ export interface RegistrySession {
 export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
   const addedItems: string[] = [];
   const output: string[] = [];
-  let completion = emptyRegistrySetupCompletion();
+  let completion: RegistrySetupCompletion = { facts: [] };
 
   function result(deployed?: "production" | "preview"): RegistrySessionResult {
     const session: RegistrySessionResult = {
       kind: "done",
       addedItems,
-      facts: registrySetupCompletionFacts(completion),
+      facts: completion.facts,
       output,
     };
     if (deployed !== undefined) session.deployed = deployed;
@@ -56,7 +48,7 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
   }
 
   return {
-    add(item, itemOutput, setup = emptyRegistrySetupCompletion()) {
+    add(item, itemOutput, setup = { facts: [] }) {
       addedItems.push(item);
       output.push(...itemOutput);
       completion = mergeRegistrySetupCompletions(completion, setup);
@@ -65,7 +57,7 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
     result,
 
     async continueAfterInstall(input) {
-      if (completion.deployment === undefined) return result();
+      if (completion.deploymentRequired !== true) return result();
 
       const deployment = await deps.detectDeployment(input.appRoot, { signal: input.signal });
       const canDeploy = deployment.state === "linked" || deployment.state === "deployed";
@@ -94,36 +86,33 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
       });
       const deployed = deployResult.kind === "deployed" ? action : undefined;
       if (deployed === "production") {
-        await offerProductionDestination(
-          input.prompter,
-          deps.openUrl,
-          completion.deployment.productionDestinations ?? [],
-        );
+        await offerUrlFact(input.prompter, deps.openUrl, completion.facts);
       }
       return result(deployed);
     },
   };
 }
 
-async function offerProductionDestination(
+async function offerUrlFact(
   prompter: Prompter,
   open: typeof openUrl,
-  destinations: readonly RegistrySetupDestination[],
+  facts: readonly RegistrySetupFact[],
 ): Promise<void> {
-  if (destinations.length === 0) return;
-  const destination = await prompter.select<string>({
-    message: "Open a destination?",
+  const links = facts.filter((fact) => fact.kind === "url");
+  if (links.length === 0) return;
+  const selected = await prompter.select<string>({
+    message: "Open a link?",
     options: [
-      ...destinations.map((candidate, index) => ({
+      ...links.map((fact, index) => ({
         value: String(index),
-        label: candidate.label,
-        hint: candidate.url,
+        label: fact.label,
+        hint: fact.value,
       })),
       { value: "none", label: "Not now" },
     ],
     initialValue: "none",
   });
-  if (destination === "none") return;
-  const selected = destinations[Number(destination)];
-  if (selected !== undefined) open(selected.url);
+  if (selected === "none") return;
+  const fact = links[Number(selected)];
+  if (fact !== undefined) open(fact.value);
 }

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -1,5 +1,4 @@
 import type { Prompter } from "#setup/prompter.js";
-import { openUrl } from "#setup/primitives/open-url.js";
 import { detectDeployment } from "#setup/project-resolution.js";
 import { mergeRegistrySetupCompletions } from "#setup/registry-setup-completion.js";
 import type { RegistrySetupCompletion, RegistrySetupFact } from "#setup/registry-setup-protocol.js";
@@ -8,21 +7,33 @@ import { runDeployFlow } from "./deploy.js";
 
 export interface RegistrySessionDeps {
   detectDeployment: typeof detectDeployment;
-  openUrl: typeof openUrl;
   runDeployFlow: typeof runDeployFlow;
+}
+
+export interface RegistrySessionItemResult {
+  address: string;
+  title: string;
+  facts: readonly RegistrySetupFact[];
+  output: readonly string[];
 }
 
 export interface RegistrySessionResult {
   kind: "done";
   addedItems: readonly string[];
+  items: readonly RegistrySessionItemResult[];
   facts: readonly RegistrySetupFact[];
   output: readonly string[];
-  deployed?: "production" | "preview";
+  deployed?: "production";
 }
 
 export interface RegistrySession {
-  add(item: string, output: readonly string[], setup?: RegistrySetupCompletion): void;
-  result(deployed?: "production" | "preview"): RegistrySessionResult;
+  add(
+    item: string,
+    title: string,
+    output: readonly string[],
+    setup?: RegistrySetupCompletion,
+  ): void;
+  result(deployed?: "production"): RegistrySessionResult;
   continueAfterInstall(input: {
     appRoot: string;
     prompter: Prompter;
@@ -33,13 +44,17 @@ export interface RegistrySession {
 /** Owns the accumulated output and deployment decision for one `/add` session. */
 export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
   const addedItems: string[] = [];
+  const items: RegistrySessionItemResult[] = [];
   const output: string[] = [];
   let completion: RegistrySetupCompletion = { facts: [] };
+  let currentItem = "";
+  let currentFacts: readonly RegistrySetupFact[] = [];
 
-  function result(deployed?: "production" | "preview"): RegistrySessionResult {
+  function result(deployed?: "production"): RegistrySessionResult {
     const session: RegistrySessionResult = {
       kind: "done",
       addedItems,
+      items,
       facts: completion.facts,
       output,
     };
@@ -48,9 +63,12 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
   }
 
   return {
-    add(item, itemOutput, setup = { facts: [] }) {
+    add(item, title, itemOutput, setup = { facts: [] }) {
       addedItems.push(item);
+      items.push({ address: item, title, facts: setup.facts, output: itemOutput });
       output.push(...itemOutput);
+      currentItem = title;
+      currentFacts = setup.facts;
       completion = mergeRegistrySetupCompletions(completion, setup);
     },
 
@@ -61,58 +79,46 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
 
       const deployment = await deps.detectDeployment(input.appRoot, { signal: input.signal });
       const canDeploy = deployment.state === "linked" || deployment.state === "deployed";
-      const action = await input.prompter.select<"production" | "preview" | "add-more" | "finish">({
-        message: "What would you like to do next?",
-        options: [
-          ...(canDeploy
-            ? [
-                { value: "production" as const, label: "Deploy to production" },
-                { value: "preview" as const, label: "Deploy a preview" },
-              ]
-            : []),
-          { value: "add-more", label: "Add another integration" },
-          { value: "finish", label: "Finish without deploying" },
-        ],
+      input.prompter.replaceContent?.({
+        headline: `Added ${currentItem}`,
+        facts: currentFacts,
       });
-      if (action === "add-more") return "add-more";
-      if (action === "finish") return result();
+      while (true) {
+        const action = await input.prompter.select<"deploy" | "add-more" | "finish">({
+          message: "What would you like to do next?",
+          initialValue: "add-more",
+          hintLayout: "inline",
+          options: [
+            { value: "add-more", label: "Add more" },
+            ...(canDeploy ? [{ value: "deploy" as const, label: "Deploy" }] : []),
+            { value: "finish", label: "Finish" },
+          ],
+        });
+        if (action === "add-more") {
+          input.prompter.replaceContent?.();
+          return "add-more";
+        }
+        if (action === "finish") return result();
 
-      const deployResult = await deps.runDeployFlow({
-        appRoot: input.appRoot,
-        prompter: input.prompter,
-        signal: input.signal,
-        interactive: true,
-        target: action,
-      });
-      const deployed = deployResult.kind === "deployed" ? action : undefined;
-      if (deployed === "production") {
-        await offerUrlFact(input.prompter, deps.openUrl, completion.facts);
+        const confirmed = await input.prompter.select<"yes" | "back">({
+          message: "Deploy to prod?",
+          initialValue: "yes",
+          options: [
+            { value: "yes", label: "Yes" },
+            { value: "back", label: "Back" },
+          ],
+        });
+        if (confirmed === "back") continue;
+
+        const deployResult = await deps.runDeployFlow({
+          appRoot: input.appRoot,
+          prompter: input.prompter,
+          signal: input.signal,
+          interactive: true,
+          target: "production",
+        });
+        return result(deployResult.kind === "deployed" ? "production" : undefined);
       }
-      return result(deployed);
     },
   };
-}
-
-async function offerUrlFact(
-  prompter: Prompter,
-  open: typeof openUrl,
-  facts: readonly RegistrySetupFact[],
-): Promise<void> {
-  const links = facts.filter((fact) => fact.kind === "url");
-  if (links.length === 0) return;
-  const selected = await prompter.select<string>({
-    message: "Open a link?",
-    options: [
-      ...links.map((fact, index) => ({
-        value: String(index),
-        label: fact.label,
-        hint: fact.value,
-      })),
-      { value: "none", label: "Not now" },
-    ],
-    initialValue: "none",
-  });
-  if (selected === "none") return;
-  const fact = links[Number(selected)];
-  if (fact !== undefined) open(fact.value);
 }

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -1,0 +1,129 @@
+import type { Prompter } from "#setup/prompter.js";
+import { openUrl } from "#setup/primitives/open-url.js";
+import { detectDeployment } from "#setup/project-resolution.js";
+import {
+  emptyRegistrySetupCompletion,
+  mergeRegistrySetupCompletions,
+  registrySetupCompletionFacts,
+} from "#setup/registry-setup-completion.js";
+import type {
+  RegistrySetupCompletion,
+  RegistrySetupDestination,
+  RegistrySetupFact,
+} from "#setup/registry-setup-protocol.js";
+
+import { runDeployFlow } from "./deploy.js";
+
+export interface RegistrySessionDeps {
+  detectDeployment: typeof detectDeployment;
+  openUrl: typeof openUrl;
+  runDeployFlow: typeof runDeployFlow;
+}
+
+export interface RegistrySessionResult {
+  kind: "done";
+  addedItems: readonly string[];
+  facts: readonly RegistrySetupFact[];
+  output: readonly string[];
+  deployed?: "production" | "preview";
+}
+
+export interface RegistrySession {
+  add(item: string, output: readonly string[], setup?: RegistrySetupCompletion): void;
+  result(deployed?: "production" | "preview"): RegistrySessionResult;
+  continueAfterInstall(input: {
+    appRoot: string;
+    prompter: Prompter;
+    signal?: AbortSignal;
+  }): Promise<"add-more" | RegistrySessionResult>;
+}
+
+/** Owns the accumulated output and deployment decision for one `/add` session. */
+export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
+  const addedItems: string[] = [];
+  const output: string[] = [];
+  let completion = emptyRegistrySetupCompletion();
+
+  function result(deployed?: "production" | "preview"): RegistrySessionResult {
+    const session: RegistrySessionResult = {
+      kind: "done",
+      addedItems,
+      facts: registrySetupCompletionFacts(completion),
+      output,
+    };
+    if (deployed !== undefined) session.deployed = deployed;
+    return session;
+  }
+
+  return {
+    add(item, itemOutput, setup = emptyRegistrySetupCompletion()) {
+      addedItems.push(item);
+      output.push(...itemOutput);
+      completion = mergeRegistrySetupCompletions(completion, setup);
+    },
+
+    result,
+
+    async continueAfterInstall(input) {
+      if (completion.deployment === undefined) return result();
+
+      const deployment = await deps.detectDeployment(input.appRoot, { signal: input.signal });
+      const canDeploy = deployment.state === "linked" || deployment.state === "deployed";
+      const action = await input.prompter.select<"production" | "preview" | "add-more" | "finish">({
+        message: "What would you like to do next?",
+        options: [
+          ...(canDeploy
+            ? [
+                { value: "production" as const, label: "Deploy to production" },
+                { value: "preview" as const, label: "Deploy a preview" },
+              ]
+            : []),
+          { value: "add-more", label: "Add another integration" },
+          { value: "finish", label: "Finish without deploying" },
+        ],
+      });
+      if (action === "add-more") return "add-more";
+      if (action === "finish") return result();
+
+      const deployResult = await deps.runDeployFlow({
+        appRoot: input.appRoot,
+        prompter: input.prompter,
+        signal: input.signal,
+        interactive: true,
+        target: action,
+      });
+      const deployed = deployResult.kind === "deployed" ? action : undefined;
+      if (deployed === "production") {
+        await offerProductionDestination(
+          input.prompter,
+          deps.openUrl,
+          completion.deployment.productionDestinations ?? [],
+        );
+      }
+      return result(deployed);
+    },
+  };
+}
+
+async function offerProductionDestination(
+  prompter: Prompter,
+  open: typeof openUrl,
+  destinations: readonly RegistrySetupDestination[],
+): Promise<void> {
+  if (destinations.length === 0) return;
+  const destination = await prompter.select<string>({
+    message: "Open a destination?",
+    options: [
+      ...destinations.map((candidate, index) => ({
+        value: String(index),
+        label: candidate.label,
+        hint: candidate.url,
+      })),
+      { value: "none", label: "Not now" },
+    ],
+    initialValue: "none",
+  });
+  if (destination === "none") return;
+  const selected = destinations[Number(destination)];
+  if (selected !== undefined) open(selected.url);
+}

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -311,11 +311,11 @@ describe("runRegistryFlow", () => {
       installRegistryItem: vi.fn(async () => ({
         output: [],
         setup: {
-          facts: [{ label: "Workspace", value: "Acme" }],
-          deployment: {
-            required: true as const,
-            productionDestinations: [{ label: "Open Slack", url: "https://slack.com/app" }],
-          },
+          facts: [
+            { label: "Workspace", value: "Acme" },
+            { label: "Open Slack", value: "https://slack.com/app", kind: "url" as const },
+          ],
+          deploymentRequired: true as const,
         },
       })),
     });
@@ -328,15 +328,17 @@ describe("runRegistryFlow", () => {
       deployed: "production",
       facts: [
         { label: "Workspace", value: "Acme" },
+        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
         { label: "Workspace", value: "Acme" },
         { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
       ],
     });
     expect(flowDeps.runDeployFlow).toHaveBeenCalledTimes(1);
     expect(prompts.at(-1)).toMatchObject({
-      message: "Open a destination?",
+      message: "Open a link?",
       options: [
         { value: "0", label: "Open Slack", hint: "https://slack.com/app" },
+        { value: "1", label: "Open Slack", hint: "https://slack.com/app" },
         { value: "none", label: "Not now" },
       ],
     });

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 
-import { runRegistryFlow, type RegistryFlowDeps } from "./registry.js";
+import { RegistryFlowFailedError, runRegistryFlow, type RegistryFlowDeps } from "./registry.js";
 
 const APP_ROOT = "/tmp/agent";
 
@@ -31,7 +31,6 @@ function deps(overrides: Partial<RegistryFlowDeps> = {}): RegistryFlowDeps {
     })),
     installRegistryItem: vi.fn(async () => ({ output: [] })),
     detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
-    openUrl: vi.fn(),
     runDeployFlow: vi.fn(async () => ({ kind: "deployed" as const })),
     ...overrides,
   };
@@ -54,6 +53,14 @@ describe("runRegistryFlow", () => {
     ).resolves.toEqual({
       kind: "done",
       addedItems: ["extension/agent-browser"],
+      items: [
+        {
+          address: "extension/agent-browser",
+          title: "Agent Browser",
+          facts: [],
+          output: [],
+        },
+      ],
       facts: [],
       output: [],
     });
@@ -291,8 +298,8 @@ describe("runRegistryFlow", () => {
       "category:channel",
       "item:0",
       "add",
-      "production",
-      "0",
+      "deploy",
+      "yes",
     ];
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
@@ -334,15 +341,94 @@ describe("runRegistryFlow", () => {
       ],
     });
     expect(flowDeps.runDeployFlow).toHaveBeenCalledTimes(1);
-    expect(prompts.at(-1)).toMatchObject({
-      message: "Open a link?",
+    expect(prompts[3]).toMatchObject({
+      initialValue: "add-more",
+      hintLayout: "inline",
       options: [
-        { value: "0", label: "Open Slack", hint: "https://slack.com/app" },
-        { value: "1", label: "Open Slack", hint: "https://slack.com/app" },
-        { value: "none", label: "Not now" },
+        { value: "add-more", label: "Add more" },
+        { value: "deploy", label: "Deploy" },
+        { value: "finish", label: "Finish" },
       ],
     });
-    expect(flowDeps.openUrl).toHaveBeenCalledWith("https://slack.com/app");
+    expect(prompts[8]).toMatchObject({
+      message: "Deploy to prod?",
+      initialValue: "yes",
+      options: [
+        { value: "yes", label: "Yes" },
+        { value: "back", label: "Back" },
+      ],
+    });
+  });
+
+  it("returns to continuation options when production deployment is not confirmed", async () => {
+    const answers = ["category:channel", "item:0", "add", "deploy", "back", "finish"];
+    const fake = createFakePrompter({ single: () => answers.shift()! });
+    const flowDeps = deps({
+      browseRegistryCatalog: vi.fn(async () => ({
+        items: [{ address: "channel/github", name: "channel/github", source: "Vercel" }],
+        total: 1,
+        errors: [],
+      })),
+      detectDeployment: vi.fn(async () => ({ state: "linked" as const, projectId: "prj_1" })),
+      installRegistryItem: vi.fn(async () => ({
+        output: [],
+        setup: { facts: [], deploymentRequired: true as const },
+      })),
+    });
+
+    await expect(
+      runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
+    ).resolves.toMatchObject({ addedItems: ["channel/github"] });
+    expect(flowDeps.runDeployFlow).not.toHaveBeenCalled();
+  });
+
+  it("preserves earlier setup results when a later item fails", async () => {
+    const answers = [
+      "category:channel",
+      "item:0",
+      "add",
+      "add-more",
+      "category:channel",
+      "item:0",
+      "add",
+    ];
+    const fake = createFakePrompter({ single: () => answers.shift()! });
+    let installs = 0;
+    const flowDeps = deps({
+      browseRegistryCatalog: vi.fn(async () => ({
+        items: [
+          { address: "channel/photon-imessage", name: "channel/photon-imessage", source: "Vercel" },
+        ],
+        total: 1,
+        errors: [],
+      })),
+      installRegistryItem: vi.fn(async () => {
+        installs += 1;
+        if (installs === 2) throw new Error("Refusing to overwrite photon.ts");
+        return {
+          output: [],
+          setup: {
+            facts: [{ label: "Agent phone number", value: "+15551234567" }],
+            deploymentRequired: true as const,
+          },
+        };
+      }),
+    });
+
+    const error = await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      deps: flowDeps,
+    }).catch((reason: unknown) => reason);
+
+    expect(error).toBeInstanceOf(RegistryFlowFailedError);
+    expect(error).toMatchObject({
+      message: "Refusing to overwrite photon.ts",
+      completed: {
+        addedItems: ["channel/photon-imessage"],
+        facts: [{ label: "Agent phone number", value: "+15551234567" }],
+      },
+    });
   });
 
   it("does not offer another item or deployment after a non-deployable setup", async () => {
@@ -360,7 +446,7 @@ describe("runRegistryFlow", () => {
 
     await expect(
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() }),
-    ).resolves.toEqual({ kind: "done", addedItems: [], facts: [], output: [] });
+    ).resolves.toEqual({ kind: "done", addedItems: [], items: [], facts: [], output: [] });
 
     expect(fake.selectMessages).toEqual([
       "Add an integration",

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -29,7 +29,10 @@ function deps(overrides: Partial<RegistryFlowDeps> = {}): RegistryFlowDeps {
       envVars: { AGENT_BROWSER_TOKEN: "" },
       files: [{ target: "agent/extensions/browser.ts" }],
     })),
-    installRegistryItem: vi.fn(async () => []),
+    installRegistryItem: vi.fn(async () => ({ output: [] })),
+    detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
+    openUrl: vi.fn(),
+    runDeployFlow: vi.fn(async () => ({ kind: "deployed" as const })),
     ...overrides,
   };
 }
@@ -48,7 +51,12 @@ describe("runRegistryFlow", () => {
 
     await expect(
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
-    ).resolves.toEqual({ kind: "done", addedItems: ["extension/agent-browser"] });
+    ).resolves.toEqual({
+      kind: "done",
+      addedItems: ["extension/agent-browser"],
+      facts: [],
+      output: [],
+    });
     expect(flowDeps.installRegistryItem).toHaveBeenCalledWith(
       APP_ROOT,
       "extension/agent-browser",
@@ -274,13 +282,70 @@ describe("runRegistryFlow", () => {
     );
   });
 
+  it("collects deployable setups, adds another, then deploys once", async () => {
+    const answers = [
+      "category:channel",
+      "item:0",
+      "add",
+      "add-more",
+      "category:channel",
+      "item:0",
+      "add",
+      "production",
+      "0",
+    ];
+    const fake = createFakePrompter({ single: () => answers.shift()! });
+    const flowDeps = deps({
+      browseRegistryCatalog: vi.fn(async () => ({
+        items: [{ address: "channel/slack", name: "channel/slack", source: "Vercel" }],
+        total: 1,
+        errors: [],
+      })),
+      detectDeployment: vi.fn(async () => ({ state: "linked" as const, projectId: "prj_1" })),
+      installRegistryItem: vi.fn(async () => ({
+        output: [],
+        setup: {
+          facts: [{ label: "Workspace", value: "Acme" }],
+          deployment: {
+            required: true as const,
+            productionDestinations: [{ label: "Open Slack", url: "https://slack.com/app" }],
+          },
+        },
+      })),
+    });
+
+    await expect(
+      runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
+    ).resolves.toMatchObject({
+      kind: "done",
+      addedItems: ["channel/slack", "channel/slack"],
+      deployed: "production",
+      facts: [
+        { label: "Workspace", value: "Acme" },
+        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
+        { label: "Workspace", value: "Acme" },
+      ],
+    });
+    expect(flowDeps.runDeployFlow).toHaveBeenCalledTimes(1);
+    expect(flowDeps.openUrl).toHaveBeenCalledWith("https://slack.com/app");
+  });
+
+  it("does not offer another item or deployment after a non-deployable setup", async () => {
+    const answers = ["category:extension", "item:0", "add"];
+    const fake = createFakePrompter({ single: () => answers.shift()! });
+
+    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() });
+
+    expect(fake.selectMessages).not.toContain("What would you like to do next?");
+  });
+
   it("returns to the category hub from a registry list", async () => {
     const answers = ["category:channel", "action:back", "action:done"];
     const fake = createFakePrompter({ single: () => answers.shift()! });
 
     await expect(
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() }),
-    ).resolves.toEqual({ kind: "done", addedItems: [] });
+    ).resolves.toEqual({ kind: "done", addedItems: [], facts: [], output: [] });
 
     expect(fake.selectMessages).toEqual([
       "Add an integration",

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -294,7 +294,13 @@ describe("runRegistryFlow", () => {
       "production",
       "0",
     ];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
+    const prompts: unknown[] = [];
+    const fake = createFakePrompter({
+      single: (options) => {
+        prompts.push(options);
+        return answers.shift()!;
+      },
+    });
     const flowDeps = deps({
       browseRegistryCatalog: vi.fn(async () => ({
         items: [{ address: "channel/slack", name: "channel/slack", source: "Vercel" }],
@@ -322,11 +328,18 @@ describe("runRegistryFlow", () => {
       deployed: "production",
       facts: [
         { label: "Workspace", value: "Acme" },
-        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
         { label: "Workspace", value: "Acme" },
+        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
       ],
     });
     expect(flowDeps.runDeployFlow).toHaveBeenCalledTimes(1);
+    expect(prompts.at(-1)).toMatchObject({
+      message: "Open a destination?",
+      options: [
+        { value: "0", label: "Open Slack", hint: "https://slack.com/app" },
+        { value: "none", label: "Not now" },
+      ],
+    });
     expect(flowDeps.openUrl).toHaveBeenCalledWith("https://slack.com/app");
   });
 

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -9,12 +9,11 @@ import type {
 import { runDeployFlow } from "#setup/flows/deploy.js";
 import { openUrl } from "#setup/primitives/open-url.js";
 import { detectDeployment } from "#setup/project-resolution.js";
-import type {
-  RegistrySetupDestination,
-  RegistrySetupFact,
-} from "#setup/registry-setup-protocol.js";
+import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { withSpinner } from "#setup/with-spinner.js";
+
+import { createRegistrySession } from "./registry-session.js";
 
 const ADDRESS_PREFIX = "address:";
 const BACK = "action:back";
@@ -284,11 +283,7 @@ export async function runRegistryFlow(input: {
     runDeployFlow: input.deps?.runDeployFlow ?? runDeployFlow,
   };
   let notices: SelectNotice[] = [];
-  const addedItems: string[] = [];
-  const facts: RegistrySetupFact[] = [];
-  const output: string[] = [];
-  const productionDestinations: RegistrySetupDestination[] = [];
-  let deploymentPending = false;
+  const session = createRegistrySession(deps);
 
   try {
     while (true) {
@@ -310,7 +305,7 @@ export async function runRegistryFlow(input: {
         notices,
       });
       notices = [];
-      if (selectedCategory === DONE) return { kind: "done", addedItems, facts, output };
+      if (selectedCategory === DONE) return session.result();
 
       const categoryItems = itemsForCategory(catalog.items, selectedCategory);
       const rows = itemRows(categoryItems);
@@ -348,80 +343,14 @@ export async function runRegistryFlow(input: {
       );
       if (inspected.kind !== "added") continue;
 
-      addedItems.push(resolved.item.address);
-      output.push(...inspected.output);
-      facts.push(...(inspected.setup?.facts ?? []));
-      if (inspected.setup?.deployment !== undefined) {
-        deploymentPending = true;
-        const destinations = inspected.setup.deployment.productionDestinations ?? [];
-        productionDestinations.push(...destinations);
-        facts.push(
-          ...destinations
-            .filter(
-              (destination) =>
-                !facts.some((fact) => fact.kind === "url" && fact.value === destination.url),
-            )
-            .map((destination) => ({
-              label: destination.label,
-              value: destination.url,
-              kind: "url" as const,
-            })),
-        );
-      }
-      if (!deploymentPending) return { kind: "done", addedItems, facts, output };
-
-      const deployment = await deps.detectDeployment(input.appRoot, { signal: input.signal });
-      const canDeploy = deployment.state === "linked" || deployment.state === "deployed";
-      const action = await input.prompter.select<"production" | "preview" | "add-more" | "finish">({
-        message: "What would you like to do next?",
-        options: [
-          ...(canDeploy
-            ? [
-                { value: "production" as const, label: "Deploy to production" },
-                { value: "preview" as const, label: "Deploy a preview" },
-              ]
-            : []),
-          { value: "add-more", label: "Add another integration" },
-          { value: "finish", label: "Finish without deploying" },
-        ],
-      });
-      if (action === "add-more") continue;
-      if (action === "finish") return { kind: "done", addedItems, facts, output };
-
-      const deployResult = await deps.runDeployFlow({
+      session.add(resolved.item.address, inspected.output, inspected.setup);
+      const next = await session.continueAfterInstall({
         appRoot: input.appRoot,
         prompter: input.prompter,
         signal: input.signal,
-        interactive: true,
-        target: action,
       });
-      const deployed = deployResult.kind === "deployed" ? action : undefined;
-      if (deployed === "production" && productionDestinations.length > 0) {
-        const destination = await input.prompter.select<string>({
-          message: "Open a destination?",
-          options: [
-            ...productionDestinations.map((candidate, index) => ({
-              value: String(index),
-              label: candidate.label,
-              hint: candidate.url,
-            })),
-            { value: "none", label: "Not now" },
-          ],
-          initialValue: "none",
-        });
-        if (destination !== "none") {
-          const selectedDestination = productionDestinations[Number(destination)];
-          if (selectedDestination !== undefined) deps.openUrl(selectedDestination.url);
-        }
-      }
-      const result: Extract<RegistryFlowResult, { kind: "done" }> = {
-        kind: "done",
-        addedItems,
-        facts,
-        output,
-      };
-      if (deployed !== undefined) result.deployed = deployed;
-      return result;
+      if (next === "add-more") continue;
+      return next;
     }
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -7,7 +7,6 @@ import type {
   SingleSelectOptions,
 } from "#setup/prompter.js";
 import { runDeployFlow } from "#setup/flows/deploy.js";
-import { openUrl } from "#setup/primitives/open-url.js";
 import { detectDeployment } from "#setup/project-resolution.js";
 import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 import { WizardCancelledError } from "#setup/step.js";
@@ -65,7 +64,6 @@ export interface RegistryFlowDeps {
   detectDeployment: typeof detectDeployment;
   getRegistryItemManifest: (typeof import("#cli/commands/registry.js"))["getRegistryItemManifest"];
   installRegistryItem: (typeof import("#cli/commands/registry.js"))["installRegistryItem"];
-  openUrl: typeof openUrl;
   runDeployFlow: typeof runDeployFlow;
 }
 
@@ -73,11 +71,22 @@ export type RegistryFlowResult =
   | {
       kind: "done";
       addedItems: readonly string[];
+      items: readonly import("./registry-session.js").RegistrySessionItemResult[];
       facts: readonly RegistrySetupFact[];
       output?: readonly string[];
-      deployed?: "production" | "preview";
+      deployed?: "production";
     }
   | { kind: "cancelled" };
+
+export class RegistryFlowFailedError extends Error {
+  readonly completed: Extract<RegistryFlowResult, { kind: "done" }>;
+
+  constructor(error: unknown, completed: Extract<RegistryFlowResult, { kind: "done" }>) {
+    super(error instanceof Error ? error.message : String(error), { cause: error });
+    this.name = "RegistryFlowFailedError";
+    this.completed = completed;
+  }
+}
 
 function itemLabel(item: RegistryCatalogItem): string {
   if (item.title !== undefined) return item.title;
@@ -279,7 +288,6 @@ export async function runRegistryFlow(input: {
     detectDeployment: input.deps?.detectDeployment ?? detectDeployment,
     getRegistryItemManifest: input.deps?.getRegistryItemManifest ?? loaded!.getRegistryItemManifest,
     installRegistryItem: input.deps?.installRegistryItem ?? loaded!.installRegistryItem,
-    openUrl: input.deps?.openUrl ?? openUrl,
     runDeployFlow: input.deps?.runDeployFlow ?? runDeployFlow,
   };
   let notices: SelectNotice[] = [];
@@ -343,7 +351,12 @@ export async function runRegistryFlow(input: {
       );
       if (inspected.kind !== "added") continue;
 
-      session.add(resolved.item.address, inspected.output, inspected.setup);
+      session.add(
+        resolved.item.address,
+        itemLabel(resolved.item),
+        inspected.output,
+        inspected.setup,
+      );
       const next = await session.continueAfterInstall({
         appRoot: input.appRoot,
         prompter: input.prompter,
@@ -354,6 +367,8 @@ export async function runRegistryFlow(input: {
     }
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };
+    const completed = session.result();
+    if (completed.addedItems.length > 0) throw new RegistryFlowFailedError(error, completed);
     throw error;
   }
 }

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -6,6 +6,13 @@ import type {
   SelectOption,
   SingleSelectOptions,
 } from "#setup/prompter.js";
+import { runDeployFlow } from "#setup/flows/deploy.js";
+import { openUrl } from "#setup/primitives/open-url.js";
+import { detectDeployment } from "#setup/project-resolution.js";
+import type {
+  RegistrySetupDestination,
+  RegistrySetupFact,
+} from "#setup/registry-setup-protocol.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { withSpinner } from "#setup/with-spinner.js";
 
@@ -56,12 +63,21 @@ const REGISTRY_CATEGORIES: ReadonlyArray<{
 
 export interface RegistryFlowDeps {
   browseRegistryCatalog: (typeof import("#cli/commands/registry.js"))["browseRegistryCatalog"];
+  detectDeployment: typeof detectDeployment;
   getRegistryItemManifest: (typeof import("#cli/commands/registry.js"))["getRegistryItemManifest"];
   installRegistryItem: (typeof import("#cli/commands/registry.js"))["installRegistryItem"];
+  openUrl: typeof openUrl;
+  runDeployFlow: typeof runDeployFlow;
 }
 
 export type RegistryFlowResult =
-  | { kind: "done"; addedItems: readonly string[]; output?: readonly string[] }
+  | {
+      kind: "done";
+      addedItems: readonly string[];
+      facts: readonly RegistrySetupFact[];
+      output?: readonly string[];
+      deployed?: "production" | "preview";
+    }
   | { kind: "cancelled" };
 
 function itemLabel(item: RegistryCatalogItem): string {
@@ -178,7 +194,14 @@ async function inspectItem(
   item: RegistryCatalogItem,
   resolvedManifest?: Record<string, unknown>,
   signal?: AbortSignal,
-): Promise<{ kind: "added"; output: readonly string[] } | { kind: "back" }> {
+): Promise<
+  | {
+      kind: "added";
+      output: readonly string[];
+      setup?: Awaited<ReturnType<RegistryFlowDeps["installRegistryItem"]>>["setup"];
+    }
+  | { kind: "back" }
+> {
   const manifest =
     resolvedManifest ??
     manifestRecord(
@@ -209,8 +232,8 @@ async function inspectItem(
           prompter,
           signal,
         });
-      const output = await (prompter.withExclusiveTerminal?.(install) ?? install());
-      return { kind: "added", output };
+      const result = await (prompter.withExclusiveTerminal?.(install) ?? install());
+      return { kind: "added", ...result };
     } finally {
       spinner?.stop();
     }
@@ -254,10 +277,18 @@ export async function runRegistryFlow(input: {
   }
   const deps: RegistryFlowDeps = {
     browseRegistryCatalog: input.deps?.browseRegistryCatalog ?? loaded!.browseRegistryCatalog,
+    detectDeployment: input.deps?.detectDeployment ?? detectDeployment,
     getRegistryItemManifest: input.deps?.getRegistryItemManifest ?? loaded!.getRegistryItemManifest,
     installRegistryItem: input.deps?.installRegistryItem ?? loaded!.installRegistryItem,
+    openUrl: input.deps?.openUrl ?? openUrl,
+    runDeployFlow: input.deps?.runDeployFlow ?? runDeployFlow,
   };
   let notices: SelectNotice[] = [];
+  const addedItems: string[] = [];
+  const facts: RegistrySetupFact[] = [];
+  const output: string[] = [];
+  const productionDestinations: RegistrySetupDestination[] = [];
+  let deploymentPending = false;
 
   try {
     while (true) {
@@ -279,7 +310,7 @@ export async function runRegistryFlow(input: {
         notices,
       });
       notices = [];
-      if (selectedCategory === DONE) return { kind: "done", addedItems: [] };
+      if (selectedCategory === DONE) return { kind: "done", addedItems, facts, output };
 
       const categoryItems = itemsForCategory(catalog.items, selectedCategory);
       const rows = itemRows(categoryItems);
@@ -315,15 +346,82 @@ export async function runRegistryFlow(input: {
         "manifest" in resolved ? resolved.manifest : undefined,
         input.signal,
       );
-      if (inspected.kind === "added") {
-        return inspected.output.length === 0
-          ? { kind: "done", addedItems: [resolved.item.address] }
-          : {
-              kind: "done",
-              addedItems: [resolved.item.address],
-              output: inspected.output,
-            };
+      if (inspected.kind !== "added") continue;
+
+      addedItems.push(resolved.item.address);
+      output.push(...inspected.output);
+      facts.push(...(inspected.setup?.facts ?? []));
+      if (inspected.setup?.deployment !== undefined) {
+        deploymentPending = true;
+        const destinations = inspected.setup.deployment.productionDestinations ?? [];
+        productionDestinations.push(...destinations);
+        facts.push(
+          ...destinations
+            .filter(
+              (destination) =>
+                !facts.some((fact) => fact.kind === "url" && fact.value === destination.url),
+            )
+            .map((destination) => ({
+              label: destination.label,
+              value: destination.url,
+              kind: "url" as const,
+            })),
+        );
       }
+      if (!deploymentPending) return { kind: "done", addedItems, facts, output };
+
+      const deployment = await deps.detectDeployment(input.appRoot, { signal: input.signal });
+      const canDeploy = deployment.state === "linked" || deployment.state === "deployed";
+      const action = await input.prompter.select<"production" | "preview" | "add-more" | "finish">({
+        message: "What would you like to do next?",
+        options: [
+          ...(canDeploy
+            ? [
+                { value: "production" as const, label: "Deploy to production" },
+                { value: "preview" as const, label: "Deploy a preview" },
+              ]
+            : []),
+          { value: "add-more", label: "Add another integration" },
+          { value: "finish", label: "Finish without deploying" },
+        ],
+      });
+      if (action === "add-more") continue;
+      if (action === "finish") return { kind: "done", addedItems, facts, output };
+
+      const deployResult = await deps.runDeployFlow({
+        appRoot: input.appRoot,
+        prompter: input.prompter,
+        signal: input.signal,
+        interactive: true,
+        target: action,
+      });
+      const deployed = deployResult.kind === "deployed" ? action : undefined;
+      if (deployed === "production" && productionDestinations.length > 0) {
+        const destination = await input.prompter.select<string>({
+          message: "Open a destination?",
+          options: [
+            ...productionDestinations.map((candidate, index) => ({
+              value: String(index),
+              label: candidate.label,
+              hint: candidate.url,
+            })),
+            { value: "none", label: "Not now" },
+          ],
+          initialValue: "none",
+        });
+        if (destination !== "none") {
+          const selectedDestination = productionDestinations[Number(destination)];
+          if (selectedDestination !== undefined) deps.openUrl(selectedDestination.url);
+        }
+      }
+      const result: Extract<RegistryFlowResult, { kind: "done" }> = {
+        kind: "done",
+        addedItems,
+        facts,
+        output,
+      };
+      if (deployed !== undefined) result.deployed = deployed;
+      return result;
     }
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -152,7 +152,7 @@ export async function setupDiscord(
         deploymentRequired: true,
         facts: [
           {
-            label: "Discord application",
+            label: "Discord application dashboard",
             value: `https://discord.com/developers/applications/${application.id}/information`,
             kind: "url",
           },

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -149,7 +149,7 @@ export async function setupDiscord(
     return {
       kind: "done",
       completion: {
-        deployment: { required: true },
+        deploymentRequired: true,
         facts: [
           {
             label: "Discord application",

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -148,14 +148,16 @@ export async function setupDiscord(
     ]);
     return {
       kind: "done",
-      deploymentRequired: true,
-      facts: [
-        {
-          label: "Discord application",
-          value: `https://discord.com/developers/applications/${application.id}/information`,
-          kind: "url",
-        },
-      ],
+      completion: {
+        deployment: { required: true },
+        facts: [
+          {
+            label: "Discord application",
+            value: `https://discord.com/developers/applications/${application.id}/information`,
+            kind: "url",
+          },
+        ],
+      },
     };
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -148,6 +148,7 @@ export async function setupDiscord(
     ]);
     return {
       kind: "done",
+      deploymentRequired: true,
       facts: [
         {
           label: "Discord application",

--- a/packages/eve/src/setup/integrations/github/setup.test.ts
+++ b/packages/eve/src/setup/integrations/github/setup.test.ts
@@ -42,7 +42,7 @@ describe("GitHub setup", () => {
         },
         effects,
       ),
-    ).resolves.toMatchObject({ kind: "done" });
+    ).resolves.toMatchObject({ kind: "done", completion: { deploymentRequired: true } });
 
     expect(effects.provisionConnector).toHaveBeenCalledWith(
       expect.objectContaining({ events: selectedEvents }),

--- a/packages/eve/src/setup/integrations/github/setup.ts
+++ b/packages/eve/src/setup/integrations/github/setup.ts
@@ -142,7 +142,9 @@ export async function setupGitHub(
     ]);
     return {
       kind: "done",
-      facts: [{ label: "Vercel Connect", value: dashboardUrl, kind: "url" }],
+      completion: {
+        facts: [{ label: "Vercel Connect", value: dashboardUrl, kind: "url" }],
+      },
     };
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/github/setup.ts
+++ b/packages/eve/src/setup/integrations/github/setup.ts
@@ -143,7 +143,8 @@ export async function setupGitHub(
     return {
       kind: "done",
       completion: {
-        facts: [{ label: "Vercel Connect", value: dashboardUrl, kind: "url" }],
+        facts: [{ label: "GitHub App dashboard", value: dashboardUrl, kind: "url" }],
+        deploymentRequired: true,
       },
     };
   } catch (error) {

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -48,21 +48,21 @@ describe("Linear setup", () => {
       completion: {
         facts: [
           {
-            label: "Vercel Connect",
+            label: "Linear app dashboard",
             value: "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect",
             kind: "url",
           },
           {
-            label: "Next step",
+            label: "Linear installation next step",
             value:
               "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
           },
           {
-            label: "In Linear",
+            label: "How to invoke the Linear agent",
             value:
               "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
           },
-          { label: "Open Linear", value: "https://linear.app", kind: "url" },
+          { label: "Linear workspace", value: "https://linear.app", kind: "url" },
         ],
       },
     });

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -45,23 +45,25 @@ describe("Linear setup", () => {
 
     expect(result).toMatchObject({
       kind: "done",
-      facts: [
-        {
-          label: "Vercel Connect",
-          value: "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect",
-          kind: "url",
-        },
-        {
-          label: "Next step",
-          value:
-            "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
-        },
-        {
-          label: "In Linear",
-          value:
-            "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
-        },
-      ],
+      completion: {
+        facts: [
+          {
+            label: "Vercel Connect",
+            value: "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect",
+            kind: "url",
+          },
+          {
+            label: "Next step",
+            value:
+              "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
+          },
+          {
+            label: "In Linear",
+            value:
+              "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
+          },
+        ],
+      },
     });
 
     expect(effects.provisionConnector).toHaveBeenCalledWith(

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -62,6 +62,7 @@ describe("Linear setup", () => {
             value:
               "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
           },
+          { label: "Open Linear", value: "https://linear.app", kind: "url" },
         ],
       },
     });

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -150,21 +150,25 @@ export async function setupLinear(
     const dashboardUrl = "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect";
     return {
       kind: "done",
-      facts: [
-        { label: "Vercel Connect", value: dashboardUrl, kind: "url" },
-        {
-          label: "Next step",
-          value:
-            "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
+      completion: {
+        facts: [
+          { label: "Vercel Connect", value: dashboardUrl, kind: "url" },
+          {
+            label: "Next step",
+            value:
+              "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
+          },
+          {
+            label: "In Linear",
+            value:
+              "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
+          },
+        ],
+        deployment: {
+          required: true,
+          productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
         },
-        {
-          label: "In Linear",
-          value:
-            "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
-        },
-      ],
-      deploymentRequired: true,
-      productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
+      },
     };
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -152,18 +152,18 @@ export async function setupLinear(
       kind: "done",
       completion: {
         facts: [
-          { label: "Vercel Connect", value: dashboardUrl, kind: "url" },
+          { label: "Linear app dashboard", value: dashboardUrl, kind: "url" },
           {
-            label: "Next step",
+            label: "Linear installation next step",
             value:
               "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
           },
           {
-            label: "In Linear",
+            label: "How to invoke the Linear agent",
             value:
               "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
           },
-          { label: "Open Linear", value: "https://linear.app", kind: "url" },
+          { label: "Linear workspace", value: "https://linear.app", kind: "url" },
         ],
         deploymentRequired: true,
       },

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -163,6 +163,8 @@ export async function setupLinear(
             "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
         },
       ],
+      deploymentRequired: true,
+      productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
     };
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -163,11 +163,9 @@ export async function setupLinear(
             value:
               "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
           },
+          { label: "Open Linear", value: "https://linear.app", kind: "url" },
         ],
-        deployment: {
-          required: true,
-          productionDestinations: [{ label: "Open Linear", url: "https://linear.app" }],
-        },
+        deploymentRequired: true,
       },
     };
   } catch (error) {

--- a/packages/eve/src/setup/integrations/photon/setup.ts
+++ b/packages/eve/src/setup/integrations/photon/setup.ts
@@ -21,19 +21,21 @@ export const PHOTON_SETUP: SetupIntegration = {
     if (result.kind === "cancelled") return result;
     return {
       kind: "done",
-      deploymentRequired: true,
-      facts: [
-        ...(result.assignedPhoneNumber === undefined
-          ? []
-          : [
-              {
-                label: "Text your agent",
-                value: result.assignedPhoneNumber,
-                kind: "phone" as const,
-              },
-            ]),
-        { label: "Photon project", value: result.dashboardUrl, kind: "url" as const },
-      ],
+      completion: {
+        deployment: { required: true },
+        facts: [
+          ...(result.assignedPhoneNumber === undefined
+            ? []
+            : [
+                {
+                  label: "Text your agent",
+                  value: result.assignedPhoneNumber,
+                  kind: "phone" as const,
+                },
+              ]),
+          { label: "Photon project", value: result.dashboardUrl, kind: "url" as const },
+        ],
+      },
     };
   },
 };

--- a/packages/eve/src/setup/integrations/photon/setup.ts
+++ b/packages/eve/src/setup/integrations/photon/setup.ts
@@ -28,12 +28,12 @@ export const PHOTON_SETUP: SetupIntegration = {
             ? []
             : [
                 {
-                  label: "Text your agent",
+                  label: "Agent phone number",
                   value: result.assignedPhoneNumber,
                   kind: "phone" as const,
                 },
               ]),
-          { label: "Photon project", value: result.dashboardUrl, kind: "url" as const },
+          { label: "Photon project dashboard", value: result.dashboardUrl, kind: "url" as const },
         ],
       },
     };

--- a/packages/eve/src/setup/integrations/photon/setup.ts
+++ b/packages/eve/src/setup/integrations/photon/setup.ts
@@ -21,6 +21,7 @@ export const PHOTON_SETUP: SetupIntegration = {
     if (result.kind === "cancelled") return result;
     return {
       kind: "done",
+      deploymentRequired: true,
       facts: [
         ...(result.assignedPhoneNumber === undefined
           ? []

--- a/packages/eve/src/setup/integrations/photon/setup.ts
+++ b/packages/eve/src/setup/integrations/photon/setup.ts
@@ -22,7 +22,7 @@ export const PHOTON_SETUP: SetupIntegration = {
     return {
       kind: "done",
       completion: {
-        deployment: { required: true },
+        deploymentRequired: true,
         facts: [
           ...(result.assignedPhoneNumber === undefined
             ? []

--- a/packages/eve/src/setup/integrations/runner.ts
+++ b/packages/eve/src/setup/integrations/runner.ts
@@ -10,6 +10,7 @@ import {
 } from "./shared/environment.js";
 import { createIntegrationSetupUi } from "./shared/ui.js";
 import { setupIntegration } from "./registry.js";
+import type { RegistrySetupDestination } from "#setup/registry-setup-protocol.js";
 
 /** Inputs shared by every registry-owned integration setup flow. */
 export interface RunIntegrationSetupOptions {
@@ -33,7 +34,12 @@ const defaultDeps: IntegrationSetupRunnerDeps = {
 /** Outcome returned by one registry-owned integration setup flow. */
 export type IntegrationSetupOutcome =
   | { kind: "cancelled" }
-  | { kind: "done"; facts?: readonly RegistrySetupFact[] };
+  | {
+      kind: "done";
+      facts?: readonly RegistrySetupFact[];
+      deploymentRequired?: boolean;
+      productionDestinations?: readonly RegistrySetupDestination[];
+    };
 
 /** Runs one built-in integration setup flow selected by its registry setup name. */
 export async function runIntegrationSetup(
@@ -51,7 +57,7 @@ export async function runIntegrationSetup(
   const project = projectResolutionFromDeployment(deployment);
   const environment = integrationSetupEnvironment(authStatus, project);
   options.prompter.log.info(describeIntegrationSetupEnvironment(environment));
-  const result = await integration.setup({
+  const context = {
     environment,
     appRoot: options.appRoot,
     ui: createIntegrationSetupUi({
@@ -60,6 +66,6 @@ export async function runIntegrationSetup(
     }),
     yes: options.yes,
     signal: options.signal,
-  });
-  return result;
+  };
+  return integration.setup(context);
 }

--- a/packages/eve/src/setup/integrations/runner.ts
+++ b/packages/eve/src/setup/integrations/runner.ts
@@ -1,5 +1,4 @@
 import { interactiveAsker } from "#setup/ask.js";
-import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 import { detectDeployment, projectResolutionFromDeployment } from "#setup/project-resolution.js";
 import type { Prompter } from "#setup/prompter.js";
 import { getVercelAuthStatus } from "#setup/vercel-project.js";
@@ -10,7 +9,7 @@ import {
 } from "./shared/environment.js";
 import { createIntegrationSetupUi } from "./shared/ui.js";
 import { setupIntegration } from "./registry.js";
-import type { RegistrySetupDestination } from "#setup/registry-setup-protocol.js";
+import type { IntegrationSetupResult } from "./types.js";
 
 /** Inputs shared by every registry-owned integration setup flow. */
 export interface RunIntegrationSetupOptions {
@@ -31,22 +30,12 @@ const defaultDeps: IntegrationSetupRunnerDeps = {
   getVercelAuthStatus,
 };
 
-/** Outcome returned by one registry-owned integration setup flow. */
-export type IntegrationSetupOutcome =
-  | { kind: "cancelled" }
-  | {
-      kind: "done";
-      facts?: readonly RegistrySetupFact[];
-      deploymentRequired?: boolean;
-      productionDestinations?: readonly RegistrySetupDestination[];
-    };
-
 /** Runs one built-in integration setup flow selected by its registry setup name. */
 export async function runIntegrationSetup(
   kind: string,
   options: RunIntegrationSetupOptions,
   deps: IntegrationSetupRunnerDeps = defaultDeps,
-): Promise<IntegrationSetupOutcome> {
+): Promise<IntegrationSetupResult> {
   const integration = setupIntegration(kind);
   options.prompter.intro(`Set up ${integration.label}`);
   options.prompter.log.message("Checking Vercel setup...");

--- a/packages/eve/src/setup/integrations/slack/setup.test.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.test.ts
@@ -47,7 +47,7 @@ describe("setupSlack", () => {
         },
         effects,
       ),
-    ).resolves.toEqual({ kind: "done" });
+    ).resolves.toEqual({ kind: "done", deploymentRequired: true });
 
     expect(provisionSlackbot).toHaveBeenCalledOnce();
   });

--- a/packages/eve/src/setup/integrations/slack/setup.test.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.test.ts
@@ -49,7 +49,7 @@ describe("setupSlack", () => {
       ),
     ).resolves.toEqual({
       kind: "done",
-      completion: { facts: [], deployment: { required: true } },
+      completion: { facts: [], deploymentRequired: true },
     });
 
     expect(provisionSlackbot).toHaveBeenCalledOnce();

--- a/packages/eve/src/setup/integrations/slack/setup.test.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.test.ts
@@ -47,7 +47,10 @@ describe("setupSlack", () => {
         },
         effects,
       ),
-    ).resolves.toEqual({ kind: "done", deploymentRequired: true });
+    ).resolves.toEqual({
+      kind: "done",
+      completion: { facts: [], deployment: { required: true } },
+    });
 
     expect(provisionSlackbot).toHaveBeenCalledOnce();
   });

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -238,7 +238,7 @@ export async function setupSlack(
           ? []
           : [
               {
-                label: "Open Slack DM",
+                label: "Agent Slack DM",
                 value: slackMessageDeepLink(slackbot.chatUrl),
                 kind: "url",
               },

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -11,6 +11,7 @@ import {
   type ProvisionSlackbotResult,
 } from "#setup/slackbot.js";
 import { WizardCancelledError } from "#setup/step.js";
+import { slackMessageDeepLink } from "#setup/slack-connect.js";
 
 import { installScaffoldDependencies, reportOverwrittenFiles } from "../shared/scaffold.js";
 import type {
@@ -191,7 +192,7 @@ export async function setupSlack(
       "Set SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET in .env.local (listed in .env.example).",
       "Configure your Slack app to send events to /eve/v1/slack on your public agent URL.",
     ]);
-    return { kind: "done" };
+    return { kind: "done", deploymentRequired: true };
   }
 
   const project = await deps.ensureVercelProject({
@@ -226,7 +227,17 @@ export async function setupSlack(
     projectPath: context.appRoot,
     signal: context.signal,
   });
-  return { kind: "done" };
+  return {
+    kind: "done",
+    deploymentRequired: true,
+    ...(slackbot.chatUrl === undefined
+      ? {}
+      : {
+          productionDestinations: [
+            { label: "Open Slack DM", url: slackMessageDeepLink(slackbot.chatUrl) },
+          ],
+        }),
+  };
 }
 
 /** Slack setup registration. */

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -192,7 +192,10 @@ export async function setupSlack(
       "Set SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET in .env.local (listed in .env.example).",
       "Configure your Slack app to send events to /eve/v1/slack on your public agent URL.",
     ]);
-    return { kind: "done", deploymentRequired: true };
+    return {
+      kind: "done",
+      completion: { facts: [], deployment: { required: true } },
+    };
   }
 
   const project = await deps.ensureVercelProject({
@@ -229,14 +232,19 @@ export async function setupSlack(
   });
   return {
     kind: "done",
-    deploymentRequired: true,
-    ...(slackbot.chatUrl === undefined
-      ? {}
-      : {
-          productionDestinations: [
-            { label: "Open Slack DM", url: slackMessageDeepLink(slackbot.chatUrl) },
-          ],
-        }),
+    completion: {
+      facts: [],
+      deployment: {
+        required: true,
+        ...(slackbot.chatUrl === undefined
+          ? {}
+          : {
+              productionDestinations: [
+                { label: "Open Slack DM", url: slackMessageDeepLink(slackbot.chatUrl) },
+              ],
+            }),
+      },
+    },
   };
 }
 

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -194,7 +194,7 @@ export async function setupSlack(
     ]);
     return {
       kind: "done",
-      completion: { facts: [], deployment: { required: true } },
+      completion: { facts: [], deploymentRequired: true },
     };
   }
 
@@ -233,17 +233,17 @@ export async function setupSlack(
   return {
     kind: "done",
     completion: {
-      facts: [],
-      deployment: {
-        required: true,
-        ...(slackbot.chatUrl === undefined
-          ? {}
-          : {
-              productionDestinations: [
-                { label: "Open Slack DM", url: slackMessageDeepLink(slackbot.chatUrl) },
-              ],
-            }),
-      },
+      facts:
+        slackbot.chatUrl === undefined
+          ? []
+          : [
+              {
+                label: "Open Slack DM",
+                value: slackMessageDeepLink(slackbot.chatUrl),
+                kind: "url",
+              },
+            ],
+      deploymentRequired: true,
     },
   };
 }

--- a/packages/eve/src/setup/integrations/types.ts
+++ b/packages/eve/src/setup/integrations/types.ts
@@ -1,4 +1,7 @@
-import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
+import type {
+  RegistrySetupDestination,
+  RegistrySetupFact,
+} from "#setup/registry-setup-protocol.js";
 
 import type { IntegrationSetupEnvironment } from "./shared/environment.js";
 import type { IntegrationSetupUi } from "./shared/ui.js";
@@ -15,7 +18,14 @@ export interface IntegrationSetupContext {
 
 /** Outcome from one registry-owned integration setup flow. */
 export type IntegrationSetupResult =
-  | { readonly kind: "done"; readonly facts?: readonly RegistrySetupFact[] }
+  | {
+      readonly kind: "done";
+      readonly facts?: readonly RegistrySetupFact[];
+      /** Setup changed runtime behavior and should be included in the next deployment. */
+      readonly deploymentRequired?: boolean;
+      /** Destinations offered only after a successful production deployment. */
+      readonly productionDestinations?: readonly RegistrySetupDestination[];
+    }
   | { readonly kind: "cancelled" };
 
 /** One built-in registry-owned integration setup flow. */

--- a/packages/eve/src/setup/integrations/types.ts
+++ b/packages/eve/src/setup/integrations/types.ts
@@ -1,7 +1,4 @@
-import type {
-  RegistrySetupDestination,
-  RegistrySetupFact,
-} from "#setup/registry-setup-protocol.js";
+import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
 
 import type { IntegrationSetupEnvironment } from "./shared/environment.js";
 import type { IntegrationSetupUi } from "./shared/ui.js";
@@ -18,14 +15,7 @@ export interface IntegrationSetupContext {
 
 /** Outcome from one registry-owned integration setup flow. */
 export type IntegrationSetupResult =
-  | {
-      readonly kind: "done";
-      readonly facts?: readonly RegistrySetupFact[];
-      /** Setup changed runtime behavior and should be included in the next deployment. */
-      readonly deploymentRequired?: boolean;
-      /** Destinations offered only after a successful production deployment. */
-      readonly productionDestinations?: readonly RegistrySetupDestination[];
-    }
+  | { readonly kind: "done"; readonly completion: RegistrySetupCompletion }
   | { readonly kind: "cancelled" };
 
 /** One built-in registry-owned integration setup flow. */

--- a/packages/eve/src/setup/integrations/web/setup.ts
+++ b/packages/eve/src/setup/integrations/web/setup.ts
@@ -55,6 +55,6 @@ export const WEB_SETUP: SetupIntegration = {
       projectPath: context.appRoot,
       signal: context.signal,
     });
-    return { kind: "done" };
+    return { kind: "done", deploymentRequired: true };
   },
 };

--- a/packages/eve/src/setup/integrations/web/setup.ts
+++ b/packages/eve/src/setup/integrations/web/setup.ts
@@ -57,7 +57,7 @@ export const WEB_SETUP: SetupIntegration = {
     });
     return {
       kind: "done",
-      completion: { facts: [], deployment: { required: true } },
+      completion: { facts: [], deploymentRequired: true },
     };
   },
 };

--- a/packages/eve/src/setup/integrations/web/setup.ts
+++ b/packages/eve/src/setup/integrations/web/setup.ts
@@ -46,7 +46,7 @@ export const WEB_SETUP: SetupIntegration = {
     );
     if (result.action === "skipped") {
       context.ui.prompter.log.info("Next.js project detected. Skipping Web Chat scaffolding.");
-      return { kind: "done" };
+      return { kind: "done", completion: { facts: [] } };
     }
     context.ui.prompter.log.success("Scaffolded channel: web");
     await installScaffoldDependencies({
@@ -55,6 +55,9 @@ export const WEB_SETUP: SetupIntegration = {
       projectPath: context.appRoot,
       signal: context.signal,
     });
-    return { kind: "done", deploymentRequired: true };
+    return {
+      kind: "done",
+      completion: { facts: [], deployment: { required: true } },
+    };
   },
 };

--- a/packages/eve/src/setup/prompter.ts
+++ b/packages/eve/src/setup/prompter.ts
@@ -250,6 +250,12 @@ export interface Prompter {
   /** Prints a final green ● end-cap with the message. */
   outro(message: string): void;
 
+  /** Replaces transient setup output with one compact current-item summary. */
+  replaceContent?(content?: {
+    headline: string;
+    facts: readonly { label: string; value: string }[];
+  }): void;
+
   /** Temporarily hands terminal ownership to a command that inherits stdio. */
   withInheritedStdio?<T>(task: () => Promise<T>): Promise<T>;
 

--- a/packages/eve/src/setup/registry-setup-client.test.ts
+++ b/packages/eve/src/setup/registry-setup-client.test.ts
@@ -38,7 +38,7 @@ describe("createRegistrySetupClient", () => {
     const processStub = new SetupProcessStub();
     const setup = client(processStub);
 
-    setup.complete([{ label: "Connector", value: "linear/agent" }]);
+    setup.complete({ facts: [{ label: "Connector", value: "linear/agent" }] });
 
     expect(processStub.sent.at(-1)).toEqual({
       type: "result",

--- a/packages/eve/src/setup/registry-setup-client.ts
+++ b/packages/eve/src/setup/registry-setup-client.ts
@@ -10,7 +10,7 @@ import { WizardCancelledError } from "./step.js";
 import {
   REGISTRY_SETUP_PROTOCOL_VERSION,
   type RegistrySetupChildMessage,
-  type RegistrySetupFact,
+  type RegistrySetupCompletion,
   type RegistrySetupOutcome,
   type RegistrySetupParentMessage,
   type RegistrySetupPrompt,
@@ -46,7 +46,7 @@ function registrySetupError(error: unknown): { message: string; details?: readon
 export interface RegistrySetupClient {
   prompter: Prompter;
   signal: AbortSignal;
-  complete(facts?: readonly RegistrySetupFact[]): void;
+  complete(completion?: RegistrySetupCompletion): void;
   cancel(): void;
   fail(error: unknown): void;
 }
@@ -212,7 +212,7 @@ export function createRegistrySetupClient(
   return {
     prompter,
     signal: controller.signal,
-    complete: (facts = []) => finish({ kind: "completed", facts }),
+    complete: (completion = { facts: [] }) => finish({ kind: "completed", ...completion }),
     cancel: () => finish({ kind: "cancelled" }),
     fail: (error) => finish({ kind: "failed", error: registrySetupError(error) }),
   };

--- a/packages/eve/src/setup/registry-setup-completion.test.ts
+++ b/packages/eve/src/setup/registry-setup-completion.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  emptyRegistrySetupCompletion,
+  mergeRegistrySetupCompletions,
+  registrySetupCompletionFacts,
+} from "./registry-setup-completion.js";
+
+describe("registry setup completion", () => {
+  it("merges facts and deduplicates production destinations by URL", () => {
+    const completion = mergeRegistrySetupCompletions(
+      emptyRegistrySetupCompletion(),
+      {
+        facts: [{ label: "Workspace", value: "Acme" }],
+        deployment: {
+          required: true,
+          productionDestinations: [{ label: "Open Slack", url: "https://slack.com/app" }],
+        },
+      },
+      {
+        facts: [{ label: "Channel", value: "support" }],
+        deployment: {
+          required: true,
+          productionDestinations: [{ label: "Slack", url: "https://slack.com/app" }],
+        },
+      },
+    );
+
+    expect(completion).toEqual({
+      facts: [
+        { label: "Workspace", value: "Acme" },
+        { label: "Channel", value: "support" },
+      ],
+      deployment: {
+        required: true,
+        productionDestinations: [{ label: "Open Slack", url: "https://slack.com/app" }],
+      },
+    });
+    expect(registrySetupCompletionFacts(completion)).toEqual([
+      { label: "Workspace", value: "Acme" },
+      { label: "Channel", value: "support" },
+      { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
+    ]);
+  });
+
+  it("does not repeat destinations already represented by URL facts", () => {
+    const completion = {
+      facts: [{ label: "Dashboard", value: "https://example.com", kind: "url" as const }],
+      deployment: {
+        required: true as const,
+        productionDestinations: [{ label: "Open dashboard", url: "https://example.com" }],
+      },
+    };
+
+    expect(registrySetupCompletionFacts(completion)).toEqual(completion.facts);
+  });
+});

--- a/packages/eve/src/setup/registry-setup-completion.test.ts
+++ b/packages/eve/src/setup/registry-setup-completion.test.ts
@@ -1,57 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  emptyRegistrySetupCompletion,
-  mergeRegistrySetupCompletions,
-  registrySetupCompletionFacts,
-} from "./registry-setup-completion.js";
+import { mergeRegistrySetupCompletions } from "./registry-setup-completion.js";
 
 describe("registry setup completion", () => {
-  it("merges facts and deduplicates production destinations by URL", () => {
-    const completion = mergeRegistrySetupCompletions(
-      emptyRegistrySetupCompletion(),
-      {
-        facts: [{ label: "Workspace", value: "Acme" }],
-        deployment: {
-          required: true,
-          productionDestinations: [{ label: "Open Slack", url: "https://slack.com/app" }],
+  it("merges facts and preserves the deployment requirement", () => {
+    expect(
+      mergeRegistrySetupCompletions(
+        { facts: [{ label: "Workspace", value: "Acme" }] },
+        {
+          facts: [{ label: "Open Slack", value: "https://slack.com/app", kind: "url" }],
+          deploymentRequired: true,
         },
-      },
-      {
-        facts: [{ label: "Channel", value: "support" }],
-        deployment: {
-          required: true,
-          productionDestinations: [{ label: "Slack", url: "https://slack.com/app" }],
-        },
-      },
-    );
-
-    expect(completion).toEqual({
+      ),
+    ).toEqual({
       facts: [
         { label: "Workspace", value: "Acme" },
-        { label: "Channel", value: "support" },
+        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
       ],
-      deployment: {
-        required: true,
-        productionDestinations: [{ label: "Open Slack", url: "https://slack.com/app" }],
-      },
+      deploymentRequired: true,
     });
-    expect(registrySetupCompletionFacts(completion)).toEqual([
-      { label: "Workspace", value: "Acme" },
-      { label: "Channel", value: "support" },
-      { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
-    ]);
-  });
-
-  it("does not repeat destinations already represented by URL facts", () => {
-    const completion = {
-      facts: [{ label: "Dashboard", value: "https://example.com", kind: "url" as const }],
-      deployment: {
-        required: true as const,
-        productionDestinations: [{ label: "Open dashboard", url: "https://example.com" }],
-      },
-    };
-
-    expect(registrySetupCompletionFacts(completion)).toEqual(completion.facts);
   });
 });

--- a/packages/eve/src/setup/registry-setup-completion.ts
+++ b/packages/eve/src/setup/registry-setup-completion.ts
@@ -1,0 +1,56 @@
+import type {
+  RegistrySetupCompletion,
+  RegistrySetupDestination,
+  RegistrySetupFact,
+} from "./registry-setup-protocol.js";
+
+/** Creates an empty registry setup completion. */
+export function emptyRegistrySetupCompletion(): RegistrySetupCompletion {
+  return { facts: [] };
+}
+
+/** Combines setup completions while preserving facts and deduplicating destinations by URL. */
+export function mergeRegistrySetupCompletions(
+  ...completions: readonly RegistrySetupCompletion[]
+): RegistrySetupCompletion {
+  const facts = completions.flatMap((completion) => completion.facts);
+  const destinations = uniqueDestinations(
+    completions.flatMap((completion) => completion.deployment?.productionDestinations ?? []),
+  );
+  const deploymentRequired = completions.some((completion) => completion.deployment !== undefined);
+  if (!deploymentRequired) return { facts };
+  const deployment: NonNullable<RegistrySetupCompletion["deployment"]> = { required: true };
+  if (destinations.length > 0) deployment.productionDestinations = destinations;
+  return { facts, deployment };
+}
+
+/** Adds destination links to the durable facts shown when a setup session finishes. */
+export function registrySetupCompletionFacts(
+  completion: RegistrySetupCompletion,
+): readonly RegistrySetupFact[] {
+  const destinations = completion.deployment?.productionDestinations ?? [];
+  const knownUrls = new Set(
+    completion.facts.filter((fact) => fact.kind === "url").map((fact) => fact.value),
+  );
+  return [
+    ...completion.facts,
+    ...destinations
+      .filter((destination) => !knownUrls.has(destination.url))
+      .map((destination) => ({
+        label: destination.label,
+        value: destination.url,
+        kind: "url" as const,
+      })),
+  ];
+}
+
+function uniqueDestinations(
+  destinations: readonly RegistrySetupDestination[],
+): readonly RegistrySetupDestination[] {
+  const seen = new Set<string>();
+  return destinations.filter((destination) => {
+    if (seen.has(destination.url)) return false;
+    seen.add(destination.url);
+    return true;
+  });
+}

--- a/packages/eve/src/setup/registry-setup-completion.ts
+++ b/packages/eve/src/setup/registry-setup-completion.ts
@@ -1,56 +1,11 @@
-import type {
-  RegistrySetupCompletion,
-  RegistrySetupDestination,
-  RegistrySetupFact,
-} from "./registry-setup-protocol.js";
+import type { RegistrySetupCompletion } from "./registry-setup-protocol.js";
 
-/** Creates an empty registry setup completion. */
-export function emptyRegistrySetupCompletion(): RegistrySetupCompletion {
-  return { facts: [] };
-}
-
-/** Combines setup completions while preserving facts and deduplicating destinations by URL. */
+/** Combines setup completions while preserving their facts and deployment requirement. */
 export function mergeRegistrySetupCompletions(
   ...completions: readonly RegistrySetupCompletion[]
 ): RegistrySetupCompletion {
   const facts = completions.flatMap((completion) => completion.facts);
-  const destinations = uniqueDestinations(
-    completions.flatMap((completion) => completion.deployment?.productionDestinations ?? []),
-  );
-  const deploymentRequired = completions.some((completion) => completion.deployment !== undefined);
-  if (!deploymentRequired) return { facts };
-  const deployment: NonNullable<RegistrySetupCompletion["deployment"]> = { required: true };
-  if (destinations.length > 0) deployment.productionDestinations = destinations;
-  return { facts, deployment };
-}
-
-/** Adds destination links to the durable facts shown when a setup session finishes. */
-export function registrySetupCompletionFacts(
-  completion: RegistrySetupCompletion,
-): readonly RegistrySetupFact[] {
-  const destinations = completion.deployment?.productionDestinations ?? [];
-  const knownUrls = new Set(
-    completion.facts.filter((fact) => fact.kind === "url").map((fact) => fact.value),
-  );
-  return [
-    ...completion.facts,
-    ...destinations
-      .filter((destination) => !knownUrls.has(destination.url))
-      .map((destination) => ({
-        label: destination.label,
-        value: destination.url,
-        kind: "url" as const,
-      })),
-  ];
-}
-
-function uniqueDestinations(
-  destinations: readonly RegistrySetupDestination[],
-): readonly RegistrySetupDestination[] {
-  const seen = new Set<string>();
-  return destinations.filter((destination) => {
-    if (seen.has(destination.url)) return false;
-    seen.add(destination.url);
-    return true;
-  });
+  return completions.some((completion) => completion.deploymentRequired === true)
+    ? { facts, deploymentRequired: true }
+    : { facts };
 }

--- a/packages/eve/src/setup/registry-setup-protocol.ts
+++ b/packages/eve/src/setup/registry-setup-protocol.ts
@@ -8,7 +8,7 @@ import type {
   SingleSelectOptions,
 } from "./prompter.js";
 
-export const REGISTRY_SETUP_PROTOCOL_VERSION = 2;
+export const REGISTRY_SETUP_PROTOCOL_VERSION = 1;
 
 export type RegistrySetupFact = {
   label: string;

--- a/packages/eve/src/setup/registry-setup-protocol.ts
+++ b/packages/eve/src/setup/registry-setup-protocol.ts
@@ -8,12 +8,25 @@ import type {
   SingleSelectOptions,
 } from "./prompter.js";
 
-export const REGISTRY_SETUP_PROTOCOL_VERSION = 1;
+export const REGISTRY_SETUP_PROTOCOL_VERSION = 2;
 
 export type RegistrySetupFact = {
   label: string;
   value: string;
   kind?: "text" | "url" | "phone";
+};
+
+export type RegistrySetupDestination = {
+  label: string;
+  url: string;
+};
+
+export type RegistrySetupCompletion = {
+  facts: readonly RegistrySetupFact[];
+  deployment?: {
+    required: true;
+    productionDestinations?: readonly RegistrySetupDestination[];
+  };
 };
 
 export type RegistrySetupError = {
@@ -22,7 +35,7 @@ export type RegistrySetupError = {
 };
 
 export type RegistrySetupOutcome =
-  | { kind: "completed"; facts: readonly RegistrySetupFact[] }
+  | ({ kind: "completed" } & RegistrySetupCompletion)
   | { kind: "cancelled" }
   | { kind: "failed"; error: RegistrySetupError };
 

--- a/packages/eve/src/setup/registry-setup-protocol.ts
+++ b/packages/eve/src/setup/registry-setup-protocol.ts
@@ -16,17 +16,9 @@ export type RegistrySetupFact = {
   kind?: "text" | "url" | "phone";
 };
 
-export type RegistrySetupDestination = {
-  label: string;
-  url: string;
-};
-
 export type RegistrySetupCompletion = {
   facts: readonly RegistrySetupFact[];
-  deployment?: {
-    required: true;
-    productionDestinations?: readonly RegistrySetupDestination[];
-  };
+  deploymentRequired?: true;
 };
 
 export type RegistrySetupError = {


### PR DESCRIPTION
### Summary

Closes #1667.

For certain integration types, it's necessary to deploy your project to actually test out changes end-to-end, e.g. the slack channel requires you to deploy before you can actually chat with your agent.

This PR updates the `/add` TUI to prompt to deploy after those integrations, and alternatively offers the ability to loop back to add more integrations before doing the deploy. This means that if you were to want to install multiple deployment-requiring integrations at once, you could do so with just a single deploy in an intuitive way.

Preserves output that only makes sense after deployment until the end of the flow (e.g. a deeplink to slack).

### Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`
- Focused unit suites: 125 tests passed across registry setup, `/add`, integration setup, and deployment, including protocol v1 compatibility coverage
- `pnpm test:unit`: 5,977 passed and 1 skipped; 4 unrelated CLI bootstrap tests failed because this environment runs Node 22 while eve requires Node 24
- `pnpm typecheck`: blocked in fixture extension builds because this environment runs Node 22 while eve requires Node 24; the eve package typecheck passed separately

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
