### PR TITLE
refactor(eve): flat lifecycle event names

### DIFF
--- a/.changeset/tidy-pugs-wander.md
+++ b/.changeset/tidy-pugs-wander.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Instrumentation providers now subscribe to flat lifecycle event names matching each payload's `type`, instead of paired `before`/`after` hooks, and the events for one model attempt are named `step.*` rather than `attempt.*` to match the `agent.step` span they produce. Internal groundwork for a public provider surface; no change to the spans or attributes eve records.

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
 import {
   createInstrumentationHooks,
-  type InstrumentationAttemptMetadataEvent,
   type InstrumentationAttemptScope,
-  type InstrumentationAttemptStartedEvent,
   type InstrumentationModelCallStartedEvent,
   type InstrumentationModelCallTerminalEvent,
   type InstrumentationProviderDefinition,
+  type InstrumentationStepAttemptMetadataEvent,
+  type InstrumentationStepAttemptStartedEvent,
   type InstrumentationToolCallStartedEvent,
   type InstrumentationToolCallTerminalEvent,
 } from "#harness/instrumentation-lifecycle.js";
@@ -24,19 +24,20 @@ const scope: InstrumentationAttemptScope = {
 describe("createAiSdkHookBridge", () => {
   it("publishes normalized model lifecycle to every provider", async () => {
     const calls: string[] = [];
-    const provider = (name: string): InstrumentationProviderDefinition => ({
-      events: {
-        "model.call": {
-          before(event) {
-            calls.push(`${name}:before:${event.id}`);
-            return `${name}-state`;
+    const provider = (name: string): InstrumentationProviderDefinition => {
+      const states = new Map<string, string>();
+      return {
+        events: {
+          "model.call.started"(event) {
+            calls.push(`${name}:started:${event.id}`);
+            states.set(event.id, `${name}-state`);
           },
-          after(event, state) {
-            calls.push(`${name}:after:${event.id}:${String(state)}`);
+          "model.call.completed"(event) {
+            calls.push(`${name}:completed:${event.id}:${String(states.get(event.id))}`);
           },
         },
-      },
-    });
+      };
+    };
     const hooks = createInstrumentationHooks([provider("a"), provider("b")]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -56,10 +57,10 @@ describe("createAiSdkHookBridge", () => {
 
     const id = `${scope.attemptId}:model:call-1:0`;
     expect(calls).toEqual([
-      `a:before:${id}`,
-      `b:before:${id}`,
-      `a:after:${id}:a-state`,
-      `b:after:${id}:b-state`,
+      `a:started:${id}`,
+      `b:started:${id}`,
+      `a:completed:${id}:a-state`,
+      `b:completed:${id}:b-state`,
     ]);
   });
 
@@ -90,7 +91,7 @@ describe("createAiSdkHookBridge", () => {
   it("passes the identity captured at model-call start to the context runner", async () => {
     const ids: string[] = [];
     const hooks = createInstrumentationHooks([
-      { events: { "model.call": { before: (event) => ids.push(event.id) } } },
+      { events: { "model.call.started": (event) => void ids.push(event.id) } },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks, (operation, execute) => {
       ids.push(operation.id);
@@ -125,12 +126,12 @@ describe("createAiSdkHookBridge", () => {
     expect(adapterCalls).toBe(0);
   });
 
-  it("publishes step provider metadata as attempt.metadata, skipping steps without any", async () => {
-    const events: InstrumentationAttemptMetadataEvent[] = [];
+  it("publishes step provider metadata as step.metadata, skipping steps without any", async () => {
+    const events: InstrumentationStepAttemptMetadataEvent[] = [];
     const hooks = createInstrumentationHooks([
       {
         events: {
-          "attempt.metadata": (event) => {
+          "step.attempt.metadata": (event) => {
             events.push(event);
           },
         },
@@ -147,7 +148,7 @@ describe("createAiSdkHookBridge", () => {
       {
         providerMetadata: { gateway: { cost: "0.000082" } },
         scope,
-        type: "attempt.metadata",
+        type: "step.attempt.metadata",
       },
     ]);
   });
@@ -157,14 +158,16 @@ describe("createAiSdkHookBridge", () => {
     const hooks = createInstrumentationHooks([
       {
         events: {
-          "model.call": {
-            before() {
-              throw new Error("provider failed");
-            },
+          "model.call.started"() {
+            throw new Error("provider failed");
           },
         },
       },
-      { events: { "model.call": { before: () => "state", after } } },
+      {
+        events: {
+          "model.call.completed": after,
+        },
+      },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -187,9 +190,7 @@ describe("createAiSdkHookBridge", () => {
 
   it("terminalizes started operations when the attempt errors", async () => {
     const after = vi.fn();
-    const hooks = createInstrumentationHooks([
-      { events: { "model.call": { before: () => "state", after } } },
-    ]);
+    const hooks = createInstrumentationHooks([{ events: { "model.call.failed": after } }]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
@@ -200,12 +201,11 @@ describe("createAiSdkHookBridge", () => {
 
     expect(after).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ error, type: "model.call.failed" }),
-      "state",
     );
   });
 
   it("publishes an immutable operation projection to every provider", async () => {
-    const mutator = vi.fn((event: InstrumentationAttemptStartedEvent) => {
+    const mutator = vi.fn((event: InstrumentationStepAttemptStartedEvent) => {
       expect(Object.isFrozen(event)).toBe(true);
       expect(Object.isFrozen(event.operation)).toBe(true);
       expect(Reflect.set(event.operation, "modelId", "corrupted-model")).toBe(false);
@@ -214,8 +214,8 @@ describe("createAiSdkHookBridge", () => {
     });
     const started = vi.fn();
     const hooks = createInstrumentationHooks([
-      { events: { "attempt.started": mutator } },
-      { events: { "attempt.started": started } },
+      { events: { "step.attempt.started": mutator } },
+      { events: { "step.attempt.started": started } },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -227,7 +227,7 @@ describe("createAiSdkHookBridge", () => {
     const expected = {
       operation: { modelId: "model", operationId: "ai.streamText", provider: "test" },
       scope,
-      type: "attempt.started",
+      type: "step.attempt.started",
     };
     expect(mutator).toHaveBeenCalledExactlyOnceWith(expected);
     expect(started).toHaveBeenCalledExactlyOnceWith(expected);
@@ -239,7 +239,6 @@ describe("createAiSdkHookBridge", () => {
       expect(Object.isFrozen(event.input)).toBe(true);
       expect(Object.isFrozen(event.input.messages)).toBe(true);
       expect(Object.isFrozen(event.model)).toBe(true);
-      return "state";
     });
     const after = vi.fn((event: InstrumentationModelCallTerminalEvent) => {
       if (event.type !== "model.call.completed") throw new Error("expected completed model call");
@@ -249,7 +248,9 @@ describe("createAiSdkHookBridge", () => {
       expect(Object.isFrozen(event.usage)).toBe(true);
       expect(Object.isFrozen(event.usage.inputTokenDetails)).toBe(true);
     });
-    const hooks = createInstrumentationHooks([{ events: { "model.call": { after, before } } }]);
+    const hooks = createInstrumentationHooks([
+      { events: { "model.call.completed": after, "model.call.started": before } },
+    ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
@@ -293,27 +294,24 @@ describe("createAiSdkHookBridge", () => {
     });
     // An unrecognized part kind is dropped rather than forwarded, so widening
     // InstrumentationContentPart is what makes a new kind reachable.
-    expect(after).toHaveBeenCalledExactlyOnceWith(
-      {
-        content: [
-          { text: "thinking", type: "reasoning" },
-          { text: "hello", type: "text" },
-          { input: { a: 1 }, toolName: "search", type: "tool-call" },
-          { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
-          { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
-        ],
-        finishReason: "tool-calls",
-        id: `${scope.attemptId}:model:call-1:0`,
-        scope,
-        type: "model.call.completed",
-        usage: {
-          inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
-          inputTokens: 1,
-          outputTokens: 2,
-        },
+    expect(after).toHaveBeenCalledExactlyOnceWith({
+      content: [
+        { text: "thinking", type: "reasoning" },
+        { text: "hello", type: "text" },
+        { input: { a: 1 }, toolName: "search", type: "tool-call" },
+        { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
+        { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
+      ],
+      finishReason: "tool-calls",
+      id: `${scope.attemptId}:model:call-1:0`,
+      scope,
+      type: "model.call.completed",
+      usage: {
+        inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
+        inputTokens: 1,
+        outputTokens: 2,
       },
-      "state",
-    );
+    });
   });
 
   it.each([
@@ -330,14 +328,15 @@ describe("createAiSdkHookBridge", () => {
     async ({ expected, toolOutput }) => {
       const before = vi.fn((event: InstrumentationToolCallStartedEvent) => {
         expect(Object.isFrozen(event)).toBe(true);
-        return "state";
       });
       const after = vi.fn((event: InstrumentationToolCallTerminalEvent) => {
         if (event.type !== "tool.call.completed") throw new Error("expected completed tool call");
         expect(Object.isFrozen(event)).toBe(true);
         expect(Object.isFrozen(event.output)).toBe(true);
       });
-      const hooks = createInstrumentationHooks([{ events: { "tool.call": { after, before } } }]);
+      const hooks = createInstrumentationHooks([
+        { events: { "tool.call.completed": after, "tool.call.started": before } },
+      ]);
       const bridge = createAiSdkHookBridge(scope, hooks);
       const toolCall = { input: { q: "eve" }, toolCallId: "tool-1", toolName: "search" };
 
@@ -354,33 +353,91 @@ describe("createAiSdkHookBridge", () => {
         toolName: "search",
         type: "tool.call.started",
       });
-      expect(after).toHaveBeenCalledExactlyOnceWith(
-        {
-          id: `${scope.attemptId}:tool:tool-1:0`,
-          output: expected,
-          scope,
-          type: "tool.call.completed",
-        },
-        "state",
-      );
+      expect(after).toHaveBeenCalledExactlyOnceWith({
+        id: `${scope.attemptId}:tool:tool-1:0`,
+        output: expected,
+        scope,
+        type: "tool.call.completed",
+      });
     },
   );
 
+  it("keeps each provider's state to itself", async () => {
+    const observed = new Map<string, unknown>();
+    const provider = (name: string): InstrumentationProviderDefinition => {
+      const own = new Map<string, string>();
+      return {
+        events: {
+          "model.call.completed": (event) => {
+            observed.set(name, own.get(event.id));
+          },
+          "model.call.started": (event) => void own.set(event.id, `${name}-state`),
+        },
+      };
+    };
+    const hooks = createInstrumentationHooks([provider("a"), provider("b")]);
+    const bridge = createAiSdkHookBridge(scope, hooks);
+
+    await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
+      { callId: "call-1", messages: [], modelId: "model", provider: "test", tools: undefined },
+    ]);
+    await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+      {
+        callId: "call-1",
+        content: [],
+        finishReason: "stop",
+        performance: { responseTimeMs: 1 },
+        responseId: "response-1",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      },
+    ]);
+
+    expect(observed).toEqual(
+      new Map([
+        ["a", "a-state"],
+        ["b", "b-state"],
+      ]),
+    );
+  });
+
+  it("skips a terminal handler when the operation never started", async () => {
+    const completed = vi.fn();
+    const hooks = createInstrumentationHooks([{ events: { "model.call.completed": completed } }]);
+    const bridge = createAiSdkHookBridge(scope, hooks);
+
+    // No onLanguageModelCallStart, so the bridge holds no id and publishes
+    // nothing — the handler must not run against empty state.
+    await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+      {
+        callId: "call-1",
+        content: [],
+        finishReason: "stop",
+        performance: { responseTimeMs: 1 },
+        responseId: "response-1",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      },
+    ]);
+
+    expect(completed).not.toHaveBeenCalled();
+  });
+
   it("retains state for parallel tool starts", async () => {
     const resolvers = new Map<string, () => void>();
+    const started = new Map<string, string>();
     const terminalStates = new Map<string, unknown>();
     const hooks = createInstrumentationHooks([
       {
         events: {
-          "tool.call": {
-            before(event) {
-              return new Promise<string>((resolve) => {
+          async "tool.call.started"(event) {
+            started.set(
+              event.id,
+              await new Promise<string>((resolve) => {
                 resolvers.set(event.id, () => resolve(`state:${event.id}`));
-              });
-            },
-            after(event, state) {
-              terminalStates.set(event.id, state);
-            },
+              }),
+            );
+          },
+          "tool.call.completed"(event) {
+            terminalStates.set(event.id, started.get(event.id));
           },
         },
       },

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.ts
@@ -2,7 +2,7 @@ import type { Telemetry } from "ai";
 
 import type {
   InstrumentationAttemptScope,
-  InstrumentationAttemptStartedEvent,
+  InstrumentationStepAttemptStartedEvent,
   InstrumentationContentPart,
   InstrumentationContextRunner,
   InstrumentationHooks,
@@ -48,14 +48,14 @@ export function createAiSdkHookBridge(
     },
     async onStepStart(event) {
       state.stepNumber = event.stepNumber;
-      const started = toAttemptStarted(state);
+      const started = toStepAttemptStarted(state);
       if (started !== undefined) await hooks.publish(started);
     },
     async onLanguageModelCallStart(event) {
       const id = createModelCallIdentity(state, event.callId);
       state.modelIds.set(event.callId, id);
       const started = toModelCallStarted(state, id, event);
-      await hooks.before("model.call", started);
+      await hooks.publish(started);
     },
     executeLanguageModelCall({ callId, execute }) {
       const id = state.modelIds.get(callId);
@@ -68,7 +68,7 @@ export function createAiSdkHookBridge(
       if (id === undefined) return;
       state.modelIds.delete(event.callId);
       const completed = toModelCallCompleted(state, id, event);
-      await hooks.after("model.call", completed);
+      await hooks.publish(completed);
     },
     async onStepEnd(event) {
       // Step results carry provider metadata (e.g. Vercel AI Gateway cost)
@@ -79,7 +79,7 @@ export function createAiSdkHookBridge(
         Object.freeze({
           providerMetadata: event.providerMetadata,
           scope: state.scope,
-          type: "attempt.metadata",
+          type: "step.attempt.metadata",
         }),
       );
     },
@@ -87,7 +87,7 @@ export function createAiSdkHookBridge(
       const id = createToolCallIdentity(state, event.toolCall.toolCallId);
       state.toolIds.set(event.toolCall.toolCallId, id);
       const started = toToolCallStarted(state, id, event);
-      await hooks.before("tool.call", started);
+      await hooks.publish(started);
     },
     executeTool({ toolCallId, execute }) {
       const id = state.toolIds.get(toolCallId);
@@ -99,7 +99,7 @@ export function createAiSdkHookBridge(
       if (id === undefined) return;
       state.toolIds.delete(toolCallId);
       const completed = toToolCallCompleted(state, id, event);
-      await hooks.after("tool.call", completed);
+      await hooks.publish(completed);
     },
     async onAbort(event) {
       await failOpenOperations(event);
@@ -112,14 +112,10 @@ export function createAiSdkHookBridge(
   async function failOpenOperations(error: unknown): Promise<void> {
     const pending: Promise<void>[] = [];
     for (const id of state.modelIds.values()) {
-      pending.push(
-        hooks.after("model.call", Object.freeze({ error, id, scope, type: "model.call.failed" })),
-      );
+      pending.push(hooks.publish(Object.freeze({ error, id, scope, type: "model.call.failed" })));
     }
     for (const id of state.toolIds.values()) {
-      pending.push(
-        hooks.after("tool.call", Object.freeze({ error, id, scope, type: "tool.call.failed" })),
-      );
+      pending.push(hooks.publish(Object.freeze({ error, id, scope, type: "tool.call.failed" })));
     }
     state.modelIds.clear();
     state.toolIds.clear();
@@ -129,12 +125,14 @@ export function createAiSdkHookBridge(
 
 const directRunInContext: InstrumentationContextRunner = (_operation, execute) => execute();
 
-function toAttemptStarted(state: AttemptState): InstrumentationAttemptStartedEvent | undefined {
+function toStepAttemptStarted(
+  state: AttemptState,
+): InstrumentationStepAttemptStartedEvent | undefined {
   if (state.operation === undefined || state.stepNumber === undefined) return undefined;
   return Object.freeze({
     operation: state.operation,
     scope: state.scope,
-    type: "attempt.started",
+    type: "step.attempt.started",
   });
 }
 

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -1,6 +1,14 @@
 import { createLogger, formatError } from "#internal/logging.js";
 
-/** Stable eve identity for one actual model attempt. */
+/**
+ * Stable eve identity for one actual model attempt.
+ *
+ * A step retried three times produces three of these, all sharing `stepIndex`
+ * and separated by `attemptIndex` — which is why the events carrying this
+ * scope are named `step.attempt.*` and not `step.*`. The protocol's `step.*`
+ * and the `events["step.started"]` resolver hook fire once per step; these
+ * fire once per attempt.
+ */
 export interface InstrumentationAttemptScope {
   readonly attemptId: string;
   readonly attemptIndex: number;
@@ -66,8 +74,8 @@ export type InstrumentationToolOutput =
   | { readonly type: "result"; readonly output: unknown }
   | { readonly type: "error"; readonly error: unknown };
 
-export interface InstrumentationAttemptStartedEvent {
-  readonly type: "attempt.started";
+export interface InstrumentationStepAttemptStartedEvent {
+  readonly type: "step.attempt.started";
   readonly operation: InstrumentationOperationRef;
   readonly scope: InstrumentationAttemptScope;
 }
@@ -139,19 +147,19 @@ export interface InstrumentationTurnTerminalEvent {
   readonly turnId: string;
 }
 
-export interface InstrumentationAttemptTerminalEvent {
-  readonly type: "attempt.completed" | "attempt.failed";
+export interface InstrumentationStepAttemptTerminalEvent {
+  readonly type: "step.attempt.completed" | "step.attempt.failed";
   readonly error?: unknown;
   readonly scope: InstrumentationAttemptScope;
 }
 
 /**
- * Provider metadata for one completed step, as reported by the AI SDK
+ * Provider metadata for one completed attempt, as reported by the AI SDK
  * (`StepResult.providerMetadata`). Carries Vercel AI Gateway cost data when
  * the request went through the gateway; absent for other providers.
  */
-export interface InstrumentationAttemptMetadataEvent {
-  readonly type: "attempt.metadata";
+export interface InstrumentationStepAttemptMetadataEvent {
+  readonly type: "step.attempt.metadata";
   readonly scope: InstrumentationAttemptScope;
   readonly providerMetadata: Readonly<Record<string, unknown>>;
 }
@@ -211,78 +219,54 @@ export type InstrumentationToolCallTerminalEvent =
   | InstrumentationToolCallCompletedEvent
   | InstrumentationToolCallFailedEvent;
 
-export interface RelatedLifecycleHook<TStart, TTerminal> {
-  readonly before?: (event: TStart) => unknown | PromiseLike<unknown>;
-  readonly after?: (event: TTerminal, state: unknown) => void | PromiseLike<void>;
-}
+/**
+ * The AI SDK can omit a model terminal when an incomplete stream closes. A
+ * provider that correlates starts with terminals must scope that state to the
+ * attempt and release anything still open when the step attempt terminates.
+ */
+export type InstrumentationEventHandler<TEvent> = (event: TEvent) => void | PromiseLike<void>;
 
 /** Internal provider shape mirrored by the future public hook contract. */
 export interface InstrumentationProviderDefinition {
   readonly events?: {
-    readonly "model.call"?: RelatedLifecycleHook<
-      InstrumentationModelCallStartedEvent,
-      InstrumentationModelCallTerminalEvent
-    >;
-    readonly "attempt.started"?: (
-      event: InstrumentationAttemptStartedEvent,
-    ) => void | PromiseLike<void>;
-    readonly "attempt.completed"?: (
-      event: InstrumentationAttemptTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "attempt.failed"?: (
-      event: InstrumentationAttemptTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "attempt.metadata"?: (
-      event: InstrumentationAttemptMetadataEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.completed"?: (
-      event: InstrumentationSessionSettledEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.failed"?: (
-      event: InstrumentationSessionFailedEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.started"?: (
-      event: InstrumentationSessionStartedEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.waiting"?: (
-      event: InstrumentationSessionSettledEvent,
-    ) => void | PromiseLike<void>;
-    readonly "tool.call"?: RelatedLifecycleHook<
-      InstrumentationToolCallStartedEvent,
-      InstrumentationToolCallTerminalEvent
-    >;
-    readonly "turn.cancelled"?: (
-      event: InstrumentationTurnTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "turn.completed"?: (
-      event: InstrumentationTurnTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "turn.failed"?: (event: InstrumentationTurnTerminalEvent) => void | PromiseLike<void>;
-    readonly "turn.started"?: (event: InstrumentationTurnStartedEvent) => void | PromiseLike<void>;
+    readonly "step.attempt.started"?: InstrumentationEventHandler<InstrumentationStepAttemptStartedEvent>;
+    readonly "step.attempt.completed"?: InstrumentationEventHandler<InstrumentationStepAttemptTerminalEvent>;
+    readonly "step.attempt.failed"?: InstrumentationEventHandler<InstrumentationStepAttemptTerminalEvent>;
+    readonly "step.attempt.metadata"?: InstrumentationEventHandler<InstrumentationStepAttemptMetadataEvent>;
+    readonly "model.call.started"?: InstrumentationEventHandler<InstrumentationModelCallStartedEvent>;
+    readonly "model.call.completed"?: InstrumentationEventHandler<InstrumentationModelCallCompletedEvent>;
+    readonly "model.call.failed"?: InstrumentationEventHandler<InstrumentationModelCallFailedEvent>;
+    readonly "session.completed"?: InstrumentationEventHandler<InstrumentationSessionSettledEvent>;
+    readonly "session.failed"?: InstrumentationEventHandler<InstrumentationSessionFailedEvent>;
+    readonly "session.started"?: InstrumentationEventHandler<InstrumentationSessionStartedEvent>;
+    readonly "session.waiting"?: InstrumentationEventHandler<InstrumentationSessionSettledEvent>;
+    readonly "tool.call.started"?: InstrumentationEventHandler<InstrumentationToolCallStartedEvent>;
+    readonly "tool.call.completed"?: InstrumentationEventHandler<InstrumentationToolCallCompletedEvent>;
+    readonly "tool.call.failed"?: InstrumentationEventHandler<InstrumentationToolCallFailedEvent>;
+    readonly "turn.cancelled"?: InstrumentationEventHandler<InstrumentationTurnTerminalEvent>;
+    readonly "turn.completed"?: InstrumentationEventHandler<InstrumentationTurnTerminalEvent>;
+    readonly "turn.failed"?: InstrumentationEventHandler<InstrumentationTurnTerminalEvent>;
+    readonly "turn.started"?: InstrumentationEventHandler<InstrumentationTurnStartedEvent>;
   };
 }
 
-export interface InstrumentationRelatedEventMap {
-  readonly "model.call": {
-    readonly start: InstrumentationModelCallStartedEvent;
-    readonly terminal: InstrumentationModelCallTerminalEvent;
-  };
-  readonly "tool.call": {
-    readonly start: InstrumentationToolCallStartedEvent;
-    readonly terminal: InstrumentationToolCallTerminalEvent;
-  };
-}
-
-export type InstrumentationRelatedEventName = keyof InstrumentationRelatedEventMap;
+/** Events that carry an operation `id`, pairing a start with its terminal. */
+export type InstrumentationCorrelatedEvent =
+  | InstrumentationModelCallStartedEvent
+  | InstrumentationModelCallTerminalEvent
+  | InstrumentationToolCallStartedEvent
+  | InstrumentationToolCallTerminalEvent;
 
 export type InstrumentationPointEvent =
-  | InstrumentationAttemptStartedEvent
-  | InstrumentationAttemptMetadataEvent
-  | InstrumentationAttemptTerminalEvent
+  | InstrumentationStepAttemptStartedEvent
+  | InstrumentationStepAttemptMetadataEvent
+  | InstrumentationStepAttemptTerminalEvent
   | InstrumentationSessionStartedEvent
   | InstrumentationSessionTransitionEvent
   | InstrumentationTurnStartedEvent
   | InstrumentationTurnTerminalEvent;
+
+export type InstrumentationEvent = InstrumentationCorrelatedEvent | InstrumentationPointEvent;
 
 /** Trusted framework operation for activating context around AI SDK execution. */
 export type InstrumentationContextRunner = <T>(
@@ -305,15 +289,7 @@ export type InstrumentationExecutionOperation =
 
 /** Provider-neutral hook operations consumed by the AI SDK bridge. */
 export interface InstrumentationHooks {
-  after<TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["terminal"],
-  ): Promise<void>;
-  before<TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["start"],
-  ): Promise<void>;
-  publish(event: InstrumentationPointEvent): Promise<void>;
+  publish(event: InstrumentationEvent): Promise<void>;
 }
 
 const log = createLogger("harness.instrumentation-lifecycle");
@@ -322,71 +298,20 @@ const log = createLogger("harness.instrumentation-lifecycle");
 export function createInstrumentationHooks(
   providers: readonly InstrumentationProviderDefinition[],
 ): InstrumentationHooks {
-  const relatedState = new WeakMap<InstrumentationAttemptScope, Map<string, unknown>>();
-
-  const publish = async (event: InstrumentationPointEvent): Promise<void> => {
+  const publish = async (event: InstrumentationEvent): Promise<void> => {
     for (const provider of providers) {
       const handler = provider.events?.[event.type];
       if (handler === undefined) continue;
       try {
-        await (handler as (value: typeof event) => void | PromiseLike<void>)(event);
+        await (handler as InstrumentationEventHandler<InstrumentationEvent>)(event);
       } catch (error) {
-        warn(event.type, error);
+        log.warn("instrumentation provider failed", {
+          boundary: event.type,
+          error: formatError(error),
+        });
       }
     }
   };
 
-  const before = async <TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["start"],
-  ): Promise<void> => {
-    const attemptState = relatedState.get(event.scope) ?? new Map<string, unknown>();
-    relatedState.set(event.scope, attemptState);
-    for (const [providerIndex, provider] of providers.entries()) {
-      const handler = provider.events?.[name]?.before;
-      if (handler === undefined) continue;
-      try {
-        const state = await (handler as (value: typeof event) => unknown)(event);
-        attemptState.set(relatedStateKey(providerIndex, event.id), state);
-      } catch (error) {
-        warn(`${name}.before`, error);
-      }
-    }
-  };
-
-  const after = async <TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["terminal"],
-  ): Promise<void> => {
-    const attemptState = relatedState.get(event.scope);
-    for (const [providerIndex, provider] of providers.entries()) {
-      const handler = provider.events?.[name]?.after;
-      const stateKey = relatedStateKey(providerIndex, event.id);
-      if (handler === undefined || !attemptState?.has(stateKey)) continue;
-      const state = attemptState.get(stateKey);
-      attemptState.delete(stateKey);
-      try {
-        await (handler as (value: typeof event, state: unknown) => void | PromiseLike<void>)(
-          event,
-          state,
-        );
-      } catch (error) {
-        warn(`${name}.after`, error);
-      }
-    }
-  };
-
-  const warn = (boundary: string, error: unknown): void => {
-    log.warn("instrumentation provider failed", { boundary, error: formatError(error) });
-  };
-
-  return {
-    after,
-    before,
-    publish,
-  };
-}
-
-function relatedStateKey(providerIndex: number, operationId: string): string {
-  return `${providerIndex}:${operationId}`;
+  return { publish };
 }

--- a/packages/eve/src/harness/instrumentation-native-events.test.ts
+++ b/packages/eve/src/harness/instrumentation-native-events.test.ts
@@ -15,8 +15,6 @@ describe("createInstrumentationHandleEvent", () => {
   it("publishes native lifecycle transitions after durable handling", async () => {
     const order: string[] = [];
     const hooks: InstrumentationHooks = {
-      after: async () => {},
-      before: async () => {},
       publish: async (event) => {
         order.push(`lifecycle:${event.type}`);
       },
@@ -62,8 +60,6 @@ describe("createInstrumentationHandleEvent", () => {
     expect(
       createInstrumentationHandleEvent({
         hooks: {
-          after: async () => {},
-          before: async () => {},
           publish: async () => {},
         },
         sessionId: "session-1",
@@ -76,8 +72,6 @@ describe("createInstrumentationHandleEvent", () => {
     const handleEvent = createInstrumentationHandleEvent({
       handleEvent: async () => {},
       hooks: {
-        after: async () => {},
-        before: async () => {},
         publish: async (event) => {
           events.push(event);
         },
@@ -102,8 +96,6 @@ describe("createInstrumentationHandleEvent", () => {
     const handleEvent = createInstrumentationHandleEvent({
       handleEvent: async () => {},
       hooks: {
-        after: async () => {},
-        before: async () => {},
         publish: async (event) => {
           events.push(event);
         },

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -9570,7 +9570,7 @@ describe("createToolLoopHarness", () => {
       });
       const attemptCompleted = vi.fn();
       const hooks = createInstrumentationHooks([
-        { events: { "attempt.completed": attemptCompleted } },
+        { events: { "step.attempt.completed": attemptCompleted } },
       ]);
       const runInContext: InstrumentationContextRunner = (_operation, execute) => execute();
       const config = createTestConfig("conversation", undefined, {
@@ -9607,7 +9607,7 @@ describe("createToolLoopHarness", () => {
       expect(attemptCompleted).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           scope: expect.objectContaining({ attemptIndex: 0 }),
-          type: "attempt.completed",
+          type: "step.attempt.completed",
         }),
       );
     });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1166,7 +1166,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       try {
         const result = await executeModelCall();
         if (attemptScope !== undefined) {
-          await instrumentationHooks?.publish({ scope: attemptScope, type: "attempt.completed" });
+          await instrumentationHooks?.publish({
+            scope: attemptScope,
+            type: "step.attempt.completed",
+          });
         }
         return result;
       } catch (error) {
@@ -1174,7 +1177,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           await instrumentationHooks?.publish({
             error,
             scope: attemptScope,
-            type: "attempt.failed",
+            type: "step.attempt.failed",
           });
         }
         return rethrowNoOutputAsEmptyResponse(error);

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -8,12 +8,12 @@ import {
 import { describe, expect, it } from "vitest";
 
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
-import {
-  createAgentOtelInstrumentation,
-  SESSION_WINDOW_TURN_LIMIT,
-} from "#tracing/agent-otel-provider.js";
+import { createAgentOtelInstrumentation } from "#tracing/agent-otel-provider.js";
 import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
-import { InMemoryAgentTraceStateStore } from "#tracing/agent-trace-state.js";
+import {
+  InMemoryAgentTraceStateStore,
+  SESSION_WINDOW_TURN_LIMIT,
+} from "#tracing/agent-trace-state.js";
 import {
   createInstrumentationHooks,
   type InstrumentationAttemptScope,
@@ -53,6 +53,8 @@ async function emitAttempt(input: {
   readonly runInContext: InstrumentationContextRunner;
   readonly providerMetadata?: Readonly<Record<string, unknown>>;
   readonly sessionId: string;
+  readonly skipModelTerminal?: boolean;
+  readonly skipToolTerminal?: boolean;
   readonly toolError?: Error;
   readonly turnAlreadyStarted?: boolean;
   readonly turnId: string;
@@ -98,38 +100,40 @@ async function emitAttempt(input: {
     },
   ]);
   await bridge.executeLanguageModelCall!({ callId: "call-1", execute: async () => undefined });
-  await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
-    {
-      callId: "call-1",
-      content: [
-        { type: "reasoning", text: "thinking about weather" },
-        { type: "text", text: "Checking the weather." },
-        {
-          input: { query: "weather today" },
-          providerExecuted: true,
-          toolCallId: "search-1",
-          toolName: "web_search",
-          type: "tool-call",
+  if (input.skipModelTerminal !== true) {
+    await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+      {
+        callId: "call-1",
+        content: [
+          { type: "reasoning", text: "thinking about weather" },
+          { type: "text", text: "Checking the weather." },
+          {
+            input: { query: "weather today" },
+            providerExecuted: true,
+            toolCallId: "search-1",
+            toolName: "web_search",
+            type: "tool-call",
+          },
+          {
+            input: { query: "weather today" },
+            output: { results: ["sunny"] },
+            providerExecuted: true,
+            toolCallId: "search-1",
+            toolName: "web_search",
+            type: "tool-result",
+          },
+        ],
+        finishReason: "tool-calls",
+        performance: { responseTimeMs: 10 },
+        responseId: "response-1",
+        usage: {
+          inputTokenDetails: { cacheReadTokens: 4, cacheWriteTokens: 2 },
+          inputTokens: 10,
+          outputTokens: 5,
         },
-        {
-          input: { query: "weather today" },
-          output: { results: ["sunny"] },
-          providerExecuted: true,
-          toolCallId: "search-1",
-          toolName: "web_search",
-          type: "tool-result",
-        },
-      ],
-      finishReason: "tool-calls",
-      performance: { responseTimeMs: 10 },
-      responseId: "response-1",
-      usage: {
-        inputTokenDetails: { cacheReadTokens: 4, cacheWriteTokens: 2 },
-        inputTokens: 10,
-        outputTokens: 5,
       },
-    },
-  ]);
+    ]);
+  }
   await Reflect.apply(bridge.onToolExecutionStart!, bridge, [
     {
       callId: "call-1",
@@ -141,28 +145,30 @@ async function emitAttempt(input: {
     execute: async () => undefined,
     toolCallId: "tool-1",
   });
-  await Reflect.apply(bridge.onToolExecutionEnd!, bridge, [
-    {
-      callId: "call-1",
-      messages: [],
-      toolCall: { input: {}, toolCallId: "tool-1", toolName: "weather" },
-      toolExecutionMs: 1,
-      toolOutput:
-        input.toolError === undefined
-          ? { output: { temperature: 72 }, type: "tool-result" }
-          : { error: input.toolError, type: "tool-error" },
-    },
-  ]);
+  if (input.skipToolTerminal !== true) {
+    await Reflect.apply(bridge.onToolExecutionEnd!, bridge, [
+      {
+        callId: "call-1",
+        messages: [],
+        toolCall: { input: {}, toolCallId: "tool-1", toolName: "weather" },
+        toolExecutionMs: 1,
+        toolOutput:
+          input.toolError === undefined
+            ? { output: { temperature: 72 }, type: "tool-result" }
+            : { error: input.toolError, type: "tool-error" },
+      },
+    ]);
+  }
 
   if (input.providerMetadata !== undefined) {
     await input.hooks.publish({
       providerMetadata: input.providerMetadata,
       scope,
-      type: "attempt.metadata",
+      type: "step.attempt.metadata",
     });
   }
 
-  await input.hooks.publish({ scope, type: "attempt.completed" });
+  await input.hooks.publish({ scope, type: "step.attempt.completed" });
   await input.hooks.publish({
     sessionId: input.sessionId,
     turnId: input.turnId,
@@ -282,6 +288,26 @@ describe("createAgentOtelInstrumentation", () => {
       "agent.framework.name": "eve",
       "agent.root.session.id": "session-1",
     });
+  });
+
+  it("ends model and tool spans still open when the step attempt terminates", async () => {
+    const runtime = createRuntime();
+    await emitAttempt({
+      hooks: runtime.hooks,
+      runInContext: runtime.runInContext,
+      sessionId: "session-1",
+      skipModelTerminal: true,
+      skipToolTerminal: true,
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const spans = runtime.exporter.getFinishedSpans();
+    expect(byName(spans, "ai.streamText.doStream")).toHaveLength(1);
+    expect(byName(spans, "agent.action")).toHaveLength(1);
+    expect(byName(spans, "ai.toolCall")).toHaveLength(1);
+    expect(byName(spans, "agent.step")).toHaveLength(1);
   });
 
   it("captures model and tool inputs/outputs on the operation spans", async () => {

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -10,6 +10,11 @@ import {
 } from "#compiled/@opentelemetry/api/index.js";
 
 import {
+  SESSION_WINDOW_TURN_LIMIT,
+  type AgentSessionTraceState,
+  type AgentTraceStateStore,
+} from "#tracing/agent-trace-state.js";
+import {
   contentAttribute,
   messagesContentAttribute,
   systemPromptAttribute,
@@ -17,12 +22,11 @@ import {
   toolResultsContentAttribute,
 } from "#tracing/agent-otel-content.js";
 import type { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
-import type { AgentSessionTraceState, AgentTraceStateStore } from "#tracing/agent-trace-state.js";
 import type {
-  InstrumentationAttemptMetadataEvent,
+  InstrumentationStepAttemptMetadataEvent,
   InstrumentationAttemptScope,
-  InstrumentationAttemptStartedEvent,
-  InstrumentationAttemptTerminalEvent,
+  InstrumentationStepAttemptStartedEvent,
+  InstrumentationStepAttemptTerminalEvent,
   InstrumentationContextRunner,
   InstrumentationModelCallTerminalEvent,
   InstrumentationModelCallStartedEvent,
@@ -51,9 +55,6 @@ interface AttemptSpanState {
 interface ToolSpanState extends SpanState {
   readonly toolSpan: Span;
 }
-
-/** Sized so an ordinary session stays one trace and only an outsized one rolls. */
-export const SESSION_WINDOW_TURN_LIMIT = 200;
 
 export interface AgentOtelInstrumentationInput {
   /**
@@ -87,6 +88,8 @@ export function createAgentOtelInstrumentation(
   // that worker is lost, Workflow retries the whole step from entry rather
   // than resuming this callback sequence in a replacement process.
   const steps = new WeakMap<InstrumentationAttemptScope, AttemptSpanState>();
+  const modelSpans = new WeakMap<InstrumentationAttemptScope, Map<string, SpanState>>();
+  const toolSpans = new WeakMap<InstrumentationAttemptScope, Map<string, ToolSpanState>>();
 
   const onSessionStarted = async (event: InstrumentationSessionStartedEvent): Promise<void> => {
     await ensureSessionContext(event);
@@ -127,7 +130,7 @@ export function createAgentOtelInstrumentation(
     });
   };
 
-  const onAttemptStarted = async (event: InstrumentationAttemptStartedEvent): Promise<void> => {
+  const onStepStarted = async (event: InstrumentationStepAttemptStartedEvent): Promise<void> => {
     const turn = await input.stateStore.getTurn(event.scope.sessionId, event.scope.turnId);
     if (turn === undefined) return;
     const turnContext = contextFromSpanContext(turn.context);
@@ -171,14 +174,17 @@ export function createAgentOtelInstrumentation(
     });
   };
 
-  const onAttemptTerminal = (event: InstrumentationAttemptTerminalEvent): void => {
+  const onStepTerminal = (event: InstrumentationStepAttemptTerminalEvent): void => {
     executionContexts.delete(event.scope);
+    drainOpenSpans(event.scope);
     const attempt = steps.get(event.scope);
     if (attempt === undefined) return;
+    // The span event drops the `attempt` segment: this span *is* one attempt,
+    // and `agent.step.attempt` on it already says which.
     attempt.step.span.addEvent(
-      event.type === "attempt.completed" ? "step.completed" : "step.failed",
+      event.type === "step.attempt.completed" ? "step.completed" : "step.failed",
     );
-    if (event.type === "attempt.failed") {
+    if (event.type === "step.attempt.failed") {
       recordError(attempt.operation.span, event.error);
       recordError(attempt.step.span, event.error);
     }
@@ -248,9 +254,9 @@ export function createAgentOtelInstrumentation(
     }
   };
 
-  const beforeModelCall = (event: InstrumentationModelCallStartedEvent): SpanState | undefined => {
+  const onModelCallStarted = (event: InstrumentationModelCallStartedEvent): void => {
     const attempt = steps.get(event.scope);
-    if (attempt === undefined) return undefined;
+    if (attempt === undefined) return;
     attempt.step.span.setAttribute("agent.model.id", event.model.modelId);
     attempt.step.span.setAttribute("agent.model.provider", event.model.provider);
     const span = input.tracer.startSpan(
@@ -272,12 +278,13 @@ export function createAgentOtelInstrumentation(
     }
     const state = { context: trace.setSpan(attempt.operation.context, span), span };
     getExecutionContexts(event.scope).models.set(event.id, state.context);
-    return state;
+    getSpanStates(modelSpans, event.scope).set(event.id, state);
   };
 
-  const afterModelCall = (event: InstrumentationModelCallTerminalEvent, state: unknown): void => {
+  const onModelCallTerminal = (event: InstrumentationModelCallTerminalEvent): void => {
     executionContexts.get(event.scope)?.models.delete(event.id);
-    if (!isSpanState(state)) return;
+    const state = takeSpanState(modelSpans, event.scope, event.id);
+    if (state === undefined) return;
     if (event.type === "model.call.failed") {
       recordError(state.span, event.error);
     } else {
@@ -327,11 +334,9 @@ export function createAgentOtelInstrumentation(
     state.span.end();
   };
 
-  const beforeToolCall = (
-    event: InstrumentationToolCallStartedEvent,
-  ): ToolSpanState | undefined => {
+  const onToolCallStarted = (event: InstrumentationToolCallStartedEvent): void => {
     const attempt = steps.get(event.scope);
-    if (attempt === undefined) return undefined;
+    if (attempt === undefined) return;
     const actionSpan = input.tracer.startSpan(
       "agent.action",
       {
@@ -372,12 +377,13 @@ export function createAgentOtelInstrumentation(
       toolSpan,
     };
     getExecutionContexts(event.scope).tools.set(event.id, state.context);
-    return state;
+    getSpanStates(toolSpans, event.scope).set(event.id, state);
   };
 
-  const afterToolCall = (event: InstrumentationToolCallTerminalEvent, state: unknown): void => {
+  const onToolCallTerminal = (event: InstrumentationToolCallTerminalEvent): void => {
     executionContexts.get(event.scope)?.tools.delete(event.id);
-    if (!isToolSpanState(state)) return;
+    const state = takeSpanState(toolSpans, event.scope, event.id);
+    if (state === undefined) return;
     if (event.type === "tool.call.failed") {
       recordError(state.toolSpan, event.error);
       recordError(state.span, event.error);
@@ -467,7 +473,7 @@ export function createAgentOtelInstrumentation(
     };
   };
 
-  const onAttemptMetadata = (event: InstrumentationAttemptMetadataEvent): void => {
+  const onStepMetadata = (event: InstrumentationStepAttemptMetadataEvent): void => {
     const attempt = steps.get(event.scope);
     if (attempt === undefined) return;
     // Vercel AI Gateway reports per-call cost in providerMetadata.gateway;
@@ -483,16 +489,20 @@ export function createAgentOtelInstrumentation(
   return {
     hook: {
       events: {
-        "attempt.completed": onAttemptTerminal,
-        "attempt.failed": onAttemptTerminal,
-        "attempt.metadata": onAttemptMetadata,
-        "attempt.started": onAttemptStarted,
-        "model.call": { after: afterModelCall, before: beforeModelCall },
+        "step.attempt.completed": onStepTerminal,
+        "step.attempt.failed": onStepTerminal,
+        "step.attempt.metadata": onStepMetadata,
+        "step.attempt.started": onStepStarted,
+        "model.call.completed": onModelCallTerminal,
+        "model.call.failed": onModelCallTerminal,
+        "model.call.started": onModelCallStarted,
         "session.completed": onSessionTransition,
         "session.failed": onSessionTransition,
         "session.started": onSessionStarted,
         "session.waiting": onSessionTransition,
-        "tool.call": { after: afterToolCall, before: beforeToolCall },
+        "tool.call.completed": onToolCallTerminal,
+        "tool.call.failed": onToolCallTerminal,
+        "tool.call.started": onToolCallStarted,
         "turn.cancelled": onTurnTerminal,
         "turn.completed": onTurnTerminal,
         "turn.failed": onTurnTerminal,
@@ -520,6 +530,41 @@ export function createAgentOtelInstrumentation(
     }
     return state;
   }
+
+  function drainOpenSpans(scope: InstrumentationAttemptScope): void {
+    for (const state of modelSpans.get(scope)?.values() ?? []) state.span.end();
+    modelSpans.delete(scope);
+    for (const state of toolSpans.get(scope)?.values() ?? []) {
+      state.toolSpan.end();
+      state.span.end();
+    }
+    toolSpans.delete(scope);
+  }
+}
+
+function getSpanStates<T>(
+  spans: WeakMap<InstrumentationAttemptScope, Map<string, T>>,
+  scope: InstrumentationAttemptScope,
+): Map<string, T> {
+  let scoped = spans.get(scope);
+  if (scoped === undefined) {
+    scoped = new Map();
+    spans.set(scope, scoped);
+  }
+  return scoped;
+}
+
+function takeSpanState<T>(
+  spans: WeakMap<InstrumentationAttemptScope, Map<string, T>>,
+  scope: InstrumentationAttemptScope,
+  id: string,
+): T | undefined {
+  const scoped = spans.get(scope);
+  const state = scoped?.get(id);
+  if (scoped === undefined) return undefined;
+  scoped.delete(id);
+  if (scoped.size === 0) spans.delete(scope);
+  return state;
 }
 
 function parentLineageAttributes(
@@ -583,14 +628,6 @@ function readUsd(value: unknown): number | undefined {
   if (typeof value !== "string") return undefined;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function isSpanState(value: unknown): value is SpanState {
-  return typeof value === "object" && value !== null && "context" in value && "span" in value;
-}
-
-function isToolSpanState(value: unknown): value is ToolSpanState {
-  return isSpanState(value) && "toolSpan" in value;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/tracing/agent-trace-state.ts
+++ b/packages/eve/src/tracing/agent-trace-state.ts
@@ -5,6 +5,9 @@ import type {
   InstrumentationTurnTerminalEvent,
 } from "#harness/instrumentation-lifecycle.js";
 
+/** Sized so an ordinary session stays one trace and only an outsized one rolls. */
+export const SESSION_WINDOW_TURN_LIMIT = 200;
+
 export interface AgentSessionTraceState {
   readonly agentName?: string;
   readonly channelKind?: string;
@@ -72,6 +75,6 @@ export class InMemoryAgentTraceStateStore implements AgentTraceStateStore {
   }
 }
 
-function turnKey(sessionId: string, turnId: string): string {
+export function turnKey(sessionId: string, turnId: string): string {
   return `${sessionId}:${turnId}`;
 }

--- a/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
@@ -109,7 +109,7 @@ describe("local instrumentation runtime", () => {
           toolOutput: { output: { temperature: 72 }, type: "tool-result" },
         },
       ]);
-      await runtime.hooks.publish({ scope, type: "attempt.completed" });
+      await runtime.hooks.publish({ scope, type: "step.attempt.completed" });
       await runtime.hooks.publish({
         sessionId: "session-1",
         turnId: "turn-1",


### PR DESCRIPTION
### Summary

Related to #1659. This second PR in the instrumentation-provider stack, on top of #1618, replaces paired `before`/`after` model and tool hooks with independent handlers keyed by each event's full `type` and one `publish` path. Retryable attempt events become `step.attempt.*`; model and tool events become `model.call.*` and `tool.call.*`.

The OpenTelemetry provider now owns per-attempt model and tool span correlation. Normal terminals close those spans, while `step.attempt.completed` or `step.attempt.failed` drains any still open when the AI SDK omits a terminal callback. Normal-path span names and attributes remain unchanged; previously unfinished operations are now closed.

This remains internal groundwork and exposes no public provider API.

### Validation

- `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`
- `pnpm --filter eve typecheck`
- `pnpm test:unit` - 5,894 passed
- `pnpm test:integration` - 575 passed

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
