### PR TITLE
feat(eve): create Connect triggers at channel routes

### DIFF
--- a/.changeset/atomic-connect-trigger-paths.md
+++ b/.changeset/atomic-connect-trigger-paths.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Create guided GitHub Connect integrations with the eve webhook route in one atomic command.

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -14,7 +14,7 @@ Run the registry setup from the agent directory:
 eve add channel/github
 ```
 
-The flow checks that the Vercel CLI is authenticated, creates or links a Vercel project when needed, provisions an app-scoped GitHub Connect client, and replaces its default trigger with `/eve/v1/github`. It then installs `@vercel/connect` and writes `agent/channels/github.ts` with the connector UID.
+The flow checks that the Vercel CLI is authenticated, creates or links a Vercel project when needed, and provisions an app-scoped GitHub Connect client with `/eve/v1/github` as its trigger path. It then installs `@vercel/connect` and writes `agent/channels/github.ts` with the connector UID.
 
 Vercel Connect creates the GitHub App, receives and verifies its webhooks, and forwards them to the deployed agent. After deploying, open the GitHub App in the Connect dashboard and install it in the organization or account where you want to use it. Add the generated invocation token (for example, `@my-agent`) to a new issue, pull request, or review comment to start a conversation. GitHub may not autocomplete the token or render it as a linked mention.
 

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -8,16 +8,14 @@ The Slack channel puts your agent inside a workspace. It answers `@mentions` and
 
 ## Set up Connect
 
-Create a Slack Connect client and copy its UID (e.g. `slack/my-agent`), then attach this project as the trigger destination at eve's Slack route:
+From your linked eve project, create a Slack Connect client with triggers routed to eve, then copy its UID (e.g. `slack/my-agent`):
 
 ```bash
 npm install -g vercel@latest
-vercel connect create slack --triggers
-vercel connect detach <uid> --yes
-vercel connect attach <uid> --triggers --trigger-path /eve/v1/slack --yes
+vercel connect create slack --triggers --trigger-path /eve/v1/slack
 ```
 
-The `create` step provisions a destination at the default Connect path. `detach` then `attach --trigger-path /eve/v1/slack` re-points the trigger at the eve Slack route, since eve does not serve the default Connect path. `--triggers` turns on Slack Event Subscriptions; without it, Slack never delivers `app_mention` or `message.im`. You can also create the client from the [Connect dashboard](https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Go+to+Connect).
+`--triggers` turns on Slack Event Subscriptions; without it, Slack never delivers `app_mention` or `message.im`. `--trigger-path` atomically registers the linked project's eve route as the forwarding destination, so no detach-and-reattach step is needed. You can also create the client from the [Connect dashboard](https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Go+to+Connect).
 
 ## Add the channel
 

--- a/packages/eve/src/setup/integrations/github/connect.test.ts
+++ b/packages/eve/src/setup/integrations/github/connect.test.ts
@@ -27,7 +27,7 @@ describe("GitHub Connect provisioning", () => {
     ).toEqual({ id: "scl_github", uid: "github/agent" });
   });
 
-  it("creates the connector and replaces its trigger", async () => {
+  it("creates the connector with the eve trigger path", async () => {
     const runVercelCaptureStdout = vi
       .fn()
       .mockResolvedValueOnce({
@@ -49,8 +49,6 @@ describe("GitHub Connect provisioning", () => {
         }),
         stderr: "",
       });
-    const runVercel = vi.fn(async () => true);
-
     await expect(
       provisionGitHubConnector({
         events: ["issue_comment", "pull_request_review_comment"],
@@ -58,7 +56,7 @@ describe("GitHub Connect provisioning", () => {
         project: { orgId: "team_123", projectId: "prj_123" },
         projectRoot: "/project",
         slug: "agent",
-        deps: { runVercel, runVercelCaptureStdout },
+        deps: { runVercelCaptureStdout },
       }),
     ).resolves.toEqual({ appSlug: "agent", id: "scl_github", uid: "github/agent" });
 
@@ -70,6 +68,8 @@ describe("GitHub Connect provisioning", () => {
         "--name",
         "agent",
         "--triggers",
+        "--trigger-path",
+        "/eve/v1/github",
         "--trigger-event",
         "issue_comment",
         "--trigger-event",
@@ -86,29 +86,6 @@ describe("GitHub Connect provisioning", () => {
       ["api", "/v1/connect/connectors/scl_github", "--scope", "team_123", "--raw"],
       expect.objectContaining({ cwd: "/project", nonInteractive: true }),
     );
-    expect(runVercel).toHaveBeenNthCalledWith(
-      1,
-      ["connect", "detach", "github/agent", "--project", "prj_123", "--yes", "--scope", "team_123"],
-      expect.objectContaining({ cwd: "/project", nonInteractive: true }),
-    );
-    expect(runVercel).toHaveBeenNthCalledWith(
-      2,
-      [
-        "connect",
-        "attach",
-        "github/agent",
-        "--project",
-        "prj_123",
-        "--environment",
-        "production",
-        "--triggers",
-        "--trigger-path",
-        "/eve/v1/github",
-        "--yes",
-        "--scope",
-        "team_123",
-      ],
-      expect.objectContaining({ cwd: "/project", nonInteractive: true }),
-    );
+    expect(runVercelCaptureStdout).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/eve/src/setup/integrations/github/connect.ts
+++ b/packages/eve/src/setup/integrations/github/connect.ts
@@ -1,7 +1,6 @@
 import { createPromptCommandOutput, withPhase, type ChannelSetupLog } from "#setup/cli/index.js";
-import { replaceConnectTrigger } from "#setup/connect-provisioning.js";
 import type { VercelProjectReference } from "#setup/project-resolution.js";
-import { runVercel, runVercelCaptureStdout } from "#setup/primitives/run-vercel.js";
+import { runVercelCaptureStdout } from "#setup/primitives/run-vercel.js";
 import { z } from "zod";
 
 export const GITHUB_TRIGGER_PATH = "/eve/v1/github";
@@ -16,7 +15,6 @@ export interface GitHubConnectorRef {
 
 /** Effects used to provision a GitHub Connect connector. */
 export interface ProvisionGitHubConnectorDeps {
-  runVercel: typeof runVercel;
   runVercelCaptureStdout: typeof runVercelCaptureStdout;
 }
 
@@ -72,7 +70,7 @@ export async function provisionGitHubConnector(input: {
   signal?: AbortSignal;
   deps?: ProvisionGitHubConnectorDeps;
 }): Promise<GitHubConnectorRef> {
-  const deps = input.deps ?? { runVercel, runVercelCaptureStdout };
+  const deps = input.deps ?? { runVercelCaptureStdout };
   const onOutput = createPromptCommandOutput(input.log);
   const result = await withPhase(input.log, "Creating GitHub connector...", () =>
     deps.runVercelCaptureStdout(
@@ -83,6 +81,8 @@ export async function provisionGitHubConnector(input: {
         "--name",
         input.slug,
         "--triggers",
+        "--trigger-path",
+        GITHUB_TRIGGER_PATH,
         ...input.events.flatMap((event) => ["--trigger-event", event]),
         "-F",
         "json",
@@ -132,24 +132,5 @@ export async function provisionGitHubConnector(input: {
   if (connector === undefined)
     throw new Error("Vercel returned invalid details for the GitHub connector.");
 
-  const attachment = await withPhase(input.log, "Connecting GitHub webhooks...", () =>
-    replaceConnectTrigger({
-      connectorUid: connector.uid,
-      projectRoot: input.projectRoot,
-      projectId: input.project.projectId,
-      orgId: input.project.orgId,
-      environment: "production",
-      triggerPath: GITHUB_TRIGGER_PATH,
-      onOutput,
-      signal: input.signal,
-      deps,
-    }),
-  );
-  input.signal?.throwIfAborted();
-  if (attachment.state !== "attached") {
-    throw new Error(
-      `GitHub connector was created, but its trigger could not be attached. Run \`vercel connect attach ${connector.uid} --project ${input.project.projectId} --environment production --triggers --trigger-path ${GITHUB_TRIGGER_PATH} --yes --scope ${input.project.orgId}\`.`,
-    );
-  }
   return connector;
 }


### PR DESCRIPTION
### Summary

Closes #1671.

Updates guided GitHub setup to pass `--trigger-path /eve/v1/github` directly to `vercel connect create`, removing the immediate detach/attach mutation. The GitHub and Slack channel docs now show the equivalent one-command setup.

### Dependencies

- vercel/api#84014
- vercel/front#79935
- vercel/vercel#17383

### Validation

- `pnpm --filter eve run test:unit` — 577 files passed, 5,984 tests passed, 1 skipped
- `pnpm docs:check` — 81 docs validated, 261 eve import paths resolved, and all 81 docs compiled
- `git diff --check`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

_Written by GPT-5_