### PR TITLE
fix(docs): bundle Shiki in Turbopack

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -20,10 +20,10 @@ const config: NextConfig = {
       process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL ?? localSiteHost,
   },
 
-  // The integrations gallery sources identity from the workspace package
-  // `@eve/catalog`; transpile it from source so dev and build compile
-  // its TypeScript without a separate prebuild step.
-  transpilePackages: ["@eve/catalog"],
+  // The integrations gallery consumes `@eve/catalog` directly from source.
+  // Keep Shiki bundled because Turbopack's dev external loader preserves its
+  // synthetic symlink and loses pnpm's sibling links to the Shiki engines.
+  transpilePackages: ["@eve/catalog", "shiki"],
 
   experimental: {
     globalNotFound: true,


### PR DESCRIPTION
### Summary

Closes #1674.

On affected clean macOS checkouts, `next dev --turbo` externalizes both transitive Shiki versions through synthetic links such as `.next/dev/node_modules/shiki-<hash>`. The generated server chunk then fails while Shiki resolves its declared `@shikijs/*` engine dependencies from that synthetic location. Importing the same generated Shiki path directly with Node succeeds because Node follows the link to its real pnpm package location.

This does not appear to be a recent eve or Next.js regression. I reproduced the failure from clean installs on revisions before the August docs routing work and before the Next.js 16.3 preview upgrade (using Next.js 16.2.6), with each revision's lockfile and pinned pnpm version. It also reproduces on Node.js 24.15 and 24.18. Conversely, an older checkout with a long-lived Turbopack filesystem cache still returns 200, and issue triage could not reproduce the failure in another environment. The exact state or platform condition that selects the broken external loading behavior remains unclear.

Keep Shiki in `transpilePackages` so Turbopack bundles it instead of relying on the environment-sensitive external-package path. This is a defensive docs configuration change: it restores clean local development without changing dependencies or production behavior.

### Validation

- `pnpm --filter eve build`
- `pnpm --filter eve-docs build` — 181 static pages generated
- `pnpm --filter eve-docs dev` — `GET /` returned 200 with Shiki bundled
- Historical reproduction checks:
  - current `main`, Node.js 24.15 and 24.18
  - `c8bd9c0a` (before the August docs routing changes)
  - `42d3166a` (Next.js 16.2.6, before the 16.3 preview upgrade)

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant (not applicable: focused docs build and dev smoke cover this configuration fix)
- [x] I added a changeset if this touches the published `eve` package (not applicable)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
