### PR TITLE
fix(eve): compose the bridge with registered telemetry integrations

### DIFF
--- a/.changeset/quiet-integrations-compose.md
+++ b/.changeset/quiet-integrations-compose.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Telemetry integrations registered with the AI SDK's `registerTelemetry` no longer stop receiving events once eve attaches its own instrumentation bridge to a model call. eve now composes its bridge with every registered integration instead of replacing them.

--- a/packages/eve/src/harness/ai-sdk-telemetry.test.ts
+++ b/packages/eve/src/harness/ai-sdk-telemetry.test.ts
@@ -1,0 +1,25 @@
+import type { Telemetry } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getRegisteredTelemetryIntegrations } from "#harness/ai-sdk-telemetry.js";
+
+describe("getRegisteredTelemetryIntegrations", () => {
+  const original = globalThis.AI_SDK_TELEMETRY_INTEGRATIONS;
+
+  afterEach(() => {
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = original;
+  });
+
+  it("is empty when nothing has registered", () => {
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
+    expect(getRegisteredTelemetryIntegrations()).toEqual([]);
+  });
+
+  it("reports the integrations in registration order", () => {
+    const first: Telemetry = { onStart() {} };
+    const second: Telemetry = { onStart() {} };
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [first, second];
+
+    expect(getRegisteredTelemetryIntegrations()).toEqual([first, second]);
+  });
+});

--- a/packages/eve/src/harness/ai-sdk-telemetry.ts
+++ b/packages/eve/src/harness/ai-sdk-telemetry.ts
@@ -16,10 +16,17 @@ export function ensureOtelIntegration(): void {
     return;
   }
   registered = true;
-  registerTelemetry(createOtelIntegration());
+  registerTelemetry(new OpenTelemetry({ runtimeContext: true }));
 }
 
-/** Creates the existing OTel integration for explicit per-call composition. */
-export function createOtelIntegration(): Telemetry {
-  return new OpenTelemetry({ runtimeContext: true });
+/**
+ * Every integration currently registered with the AI SDK — eve's own, plus any
+ * an authored instrumentation module added with `registerTelemetry`.
+ *
+ * A per-call `integrations` list replaces the registered ones rather than
+ * adding to them, so anything that passes integrations per call has to carry
+ * these forward or they stop receiving events.
+ */
+export function getRegisteredTelemetryIntegrations(): readonly Telemetry[] {
+  return globalThis.AI_SDK_TELEMETRY_INTEGRATIONS ?? [];
 }

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -73,18 +73,25 @@ vi.mock("ai", () => ({
   tool: vi.fn((t: unknown) => t),
 }));
 
-const { existingOtelIntegration, mockCreateAiSdkHookBridge } = vi.hoisted(() => ({
-  existingOtelIntegration: { onStart: vi.fn() },
+const {
+  mockCreateAiSdkHookBridge,
+  mockGetRegisteredTelemetryIntegrations,
+  registeredAuthorIntegration,
+  registeredOtelIntegration,
+} = vi.hoisted(() => ({
   mockCreateAiSdkHookBridge: vi.fn((..._args: unknown[]) => ({ onStart: vi.fn() })),
+  mockGetRegisteredTelemetryIntegrations: vi.fn((): unknown[] => []),
+  registeredAuthorIntegration: { onStart: vi.fn() },
+  registeredOtelIntegration: { onStart: vi.fn() },
 }));
 
 vi.mock("./ai-sdk-hook-bridge.js", () => ({
   createAiSdkHookBridge: (...args: unknown[]) => mockCreateAiSdkHookBridge(...args),
 }));
 
-vi.mock("./otel-integration.js", () => ({
-  createOtelIntegration: vi.fn(() => existingOtelIntegration),
+vi.mock("./ai-sdk-telemetry.js", () => ({
   ensureOtelIntegration: vi.fn(),
+  getRegisteredTelemetryIntegrations: () => mockGetRegisteredTelemetryIntegrations(),
 }));
 
 const mockGetInstrumentationConfig = vi.fn().mockReturnValue(undefined);
@@ -112,6 +119,7 @@ afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
   mockGetInstrumentationConfig.mockReturnValue(undefined);
+  mockGetRegisteredTelemetryIntegrations.mockReturnValue([]);
 });
 
 function createTestSession(overrides?: Partial<HarnessSession>): HarnessSession {
@@ -9362,7 +9370,7 @@ describe("createToolLoopHarness", () => {
       );
     });
 
-    it("composes lifecycle hooks with existing authored OTel", async () => {
+    it("composes the bridge with every registered integration", async () => {
       setupMockAgent({
         finishReason: "stop",
         response: { messages: [{ content: "Hello!", role: "assistant" }] },
@@ -9371,6 +9379,11 @@ describe("createToolLoopHarness", () => {
         toolResults: [],
       });
       mockGetInstrumentationConfig.mockReturnValue({ recordInputs: true, recordOutputs: false });
+      // An authored module can register its own integration alongside eve's.
+      mockGetRegisteredTelemetryIntegrations.mockReturnValue([
+        registeredOtelIntegration,
+        registeredAuthorIntegration,
+      ]);
       const hooks = createInstrumentationHooks([]);
       const runStep = createToolLoopHarness(
         createTestConfig("conversation", undefined, {
@@ -9392,7 +9405,7 @@ describe("createToolLoopHarness", () => {
         };
       };
       expect(agentCall.telemetry).toMatchObject({
-        integrations: [bridge, existingOtelIntegration],
+        integrations: [bridge, registeredOtelIntegration, registeredAuthorIntegration],
         recordInputs: true,
         recordOutputs: false,
       });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -153,7 +153,10 @@ import {
   hasEmptyDeliverySentinel,
 } from "#shared/empty-delivery.js";
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
-import { createOtelIntegration, ensureOtelIntegration } from "#harness/otel-integration.js";
+import {
+  ensureOtelIntegration,
+  getRegisteredTelemetryIntegrations,
+} from "#harness/ai-sdk-telemetry.js";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
 import {
   applyLastToolCacheBreakpoint,
@@ -271,12 +274,12 @@ function enrichTelemetry(
   return {
     functionId: authored?.functionId ?? agentName,
     includeRuntimeContext,
+    // Passing integrations replaces the registered ones for this call, so the
+    // bridge has to be composed with them rather than handed over on its own.
     integrations:
       bridgeIntegration === undefined
         ? undefined
-        : authored === undefined
-          ? [bridgeIntegration]
-          : [bridgeIntegration, createOtelIntegration()],
+        : [bridgeIntegration, ...getRegisteredTelemetryIntegrations()],
     isEnabled: true,
     recordInputs: authored?.recordInputs ?? true,
     recordOutputs: authored?.recordOutputs ?? true,


### PR DESCRIPTION
Third in the instrumentation-provider stack, on top of #1670.

## Why

The AI SDK treats a per-call `integrations` list as replacing the globally registered ones, not adding to them:

> When provided, these integrations will take precedence over the globally registered integrations for this call.

eve passes `integrations` whenever it attaches its instrumentation bridge, so anything an authored `agent/instrumentation.ts` installed with `registerTelemetry` stopped receiving events for exactly the calls it cared about. eve worked around this by hand-recomposing `createOtelIntegration()`, which covered eve's own OpenTelemetry integration and nothing else.

That is survivable today only because the bridge is dev-only. It has to be correct before the bridge runs everywhere, which the provider work depends on.

## Approach

Read the registered integrations and compose the bridge ahead of them.

```ts
integrations:
  bridgeIntegration === undefined
    ? undefined
    : [bridgeIntegration, ...getRegisteredTelemetryIntegrations()],
```

Both shapes eve produces today are unchanged. With no authored instrumentation eve never calls `ensureOtelIntegration`, so nothing is registered and the list is just the bridge. With authored instrumentation eve's OpenTelemetry integration is registered, so the list is the bridge and that integration — the same pair as before, now the registered instance rather than a fresh one per call. What changes is that an integration eve did not install also survives.

`otel-integration.ts` becomes `ai-sdk-telemetry.ts`, since it no longer only wraps the OTel integration, and `createOtelIntegration` stops being exported for per-call composition.

## Verification

- `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`
- `pnpm --filter eve typecheck`
- `pnpm test:unit` — 5,893 passed
- `pnpm test:integration` — 575 passed
- Falsified the new coverage: reverting `enrichTelemetry` to `[bridgeIntegration]` fails `composes the bridge with every registered integration`.