### PR TITLE
feat(eve): record the real action kind on trace spans

### DIFF
--- a/.changeset/lucky-actions-kind.md
+++ b/.changeset/lucky-actions-kind.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Trace spans now record what eve dispatched each action as. `agent.action.kind` was always `"tool"`, so a subagent or remote-agent call was indistinguishable from an ordinary tool in a trace; it now reports `subagent-call`, `remote-agent-call`, or `tool-call`, matching the kind on the corresponding `actions.requested` event.

--- a/packages/eve/src/cli/commands/trace.integration.test.ts
+++ b/packages/eve/src/cli/commands/trace.integration.test.ts
@@ -164,7 +164,7 @@ describe("eve traces", () => {
       root,
       TRACE_ONE,
       span(action, "agent.action", 30, 80, step, {
-        "agent.action.kind": "tool",
+        "agent.action.kind": "tool-call",
         "agent.action.name": "\u001B[31mweather\u001B[0m",
         "agent.session.id": "session-one",
       }),
@@ -179,7 +179,7 @@ describe("eve traces", () => {
 
     expect(output.out[0]).toContain("agent.turn [turn-1]");
     expect(output.out[0]).toContain("└─ agent.step [step 0, attempt 0]");
-    expect(output.out[0]).toContain("└─ agent.action [tool: weather]");
+    expect(output.out[0]).toContain("└─ agent.action [tool-call: weather]");
     expect(output.out[0]).toContain("failed  10ms ERROR");
     expect(output.out[0]).not.toContain("\u001B");
   });

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -349,6 +349,7 @@ describe("createAiSdkHookBridge", () => {
         callId: "tool-1",
         id: `${scope.attemptId}:tool:tool-1:0`,
         input: { q: "eve" },
+        kind: "tool-call",
         scope,
         toolName: "search",
         type: "tool.call.started",
@@ -361,6 +362,25 @@ describe("createAiSdkHookBridge", () => {
       });
     },
   );
+
+  it("labels a tool call with the kind the harness resolves", async () => {
+    const started = vi.fn();
+    const hooks = createInstrumentationHooks([{ events: { "tool.call.started": started } }]);
+    const bridge = createAiSdkHookBridge(scope, hooks, undefined, (toolName) =>
+      toolName === "research" ? "subagent-call" : "tool-call",
+    );
+
+    for (const toolName of ["research", "search"]) {
+      await Reflect.apply(bridge.onToolExecutionStart!, bridge, [
+        { callId: `call-${toolName}`, toolCall: { input: {}, toolCallId: toolName, toolName } },
+      ]);
+    }
+
+    expect(started.mock.calls.map(([event]) => [event.toolName, event.kind])).toEqual([
+      ["research", "subagent-call"],
+      ["search", "tool-call"],
+    ]);
+  });
 
   it("keeps each provider's state to itself", async () => {
     const observed = new Map<string, unknown>();

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.ts
@@ -1,6 +1,7 @@
 import type { Telemetry } from "ai";
 
 import type {
+  InstrumentationActionKind,
   InstrumentationAttemptScope,
   InstrumentationStepAttemptStartedEvent,
   InstrumentationContentPart,
@@ -17,8 +18,15 @@ import type {
 
 type TelemetryEvent<TKey extends keyof Telemetry> = Parameters<NonNullable<Telemetry[TKey]>>[0];
 
+/**
+ * Reports what eve dispatches one tool name as. The AI SDK only knows the
+ * name, so the kind has to come back from the harness.
+ */
+export type ActionKindResolver = (toolName: string) => InstrumentationActionKind;
+
 interface AttemptState {
   readonly modelIds: Map<string, string>;
+  readonly resolveActionKind: ActionKindResolver;
   readonly scope: InstrumentationAttemptScope;
   readonly toolIds: Map<string, string>;
   operation?: InstrumentationOperationRef;
@@ -31,9 +39,11 @@ export function createAiSdkHookBridge(
   scope: InstrumentationAttemptScope,
   hooks: InstrumentationHooks,
   runInContext: InstrumentationContextRunner = directRunInContext,
+  resolveActionKind: ActionKindResolver = defaultResolveActionKind,
 ): Telemetry {
   const state: AttemptState = {
     modelIds: new Map(),
+    resolveActionKind,
     scope,
     toolIds: new Map(),
   };
@@ -124,6 +134,8 @@ export function createAiSdkHookBridge(
 }
 
 const directRunInContext: InstrumentationContextRunner = (_operation, execute) => execute();
+
+const defaultResolveActionKind: ActionKindResolver = () => "tool-call";
 
 function toStepAttemptStarted(
   state: AttemptState,
@@ -239,6 +251,7 @@ function toToolCallStarted(
     callId: source.toolCall.toolCallId,
     id,
     input: source.toolCall.input,
+    kind: state.resolveActionKind(source.toolCall.toolName),
     scope: state.scope,
     toolName: source.toolCall.toolName,
     type: "tool.call.started",

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -69,6 +69,13 @@ export type InstrumentationContentPart =
       readonly toolName: string;
     };
 
+/**
+ * What eve dispatched a tool call as. The model sees every action as a tool,
+ * so this is the only thing that separates a subagent or remote-agent call
+ * from an ordinary tool in a trace.
+ */
+export type InstrumentationActionKind = "remote-agent-call" | "subagent-call" | "tool-call";
+
 /** How one tool execution ended. */
 export type InstrumentationToolOutput =
   | { readonly type: "result"; readonly output: unknown }
@@ -197,6 +204,7 @@ export interface InstrumentationToolCallStartedEvent {
   readonly callId: string;
   readonly id: string;
   readonly input: unknown;
+  readonly kind: InstrumentationActionKind;
   readonly scope: InstrumentationAttemptScope;
   readonly toolName: string;
 }

--- a/packages/eve/src/harness/instrumentation-native-events.test.ts
+++ b/packages/eve/src/harness/instrumentation-native-events.test.ts
@@ -1,6 +1,8 @@
+import { jsonSchema } from "ai";
 import { describe, expect, it } from "vitest";
 
 import {
+  createActionsRequestedEvent,
   createSessionStartedEvent,
   createSessionWaitingEvent,
   createStepCompletedEvent,
@@ -128,5 +130,112 @@ describe("createInstrumentationHandleEvent", () => {
         type: "turn.started",
       },
     ]);
+  });
+
+  it("publishes each non-executable delegation once from actions.requested", async () => {
+    const events: unknown[] = [];
+    const scope = {
+      attemptId: "session-1:turn-1:0:0",
+      attemptIndex: 0,
+      sessionId: "session-1",
+      stepIndex: 0,
+      turnId: "turn-1",
+    };
+    const tools = new Map([
+      [
+        "delegate",
+        {
+          description: "Delegate work.",
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "delegate",
+          runtimeAction: {
+            kind: "subagent-call" as const,
+            nodeId: "workers",
+            subagentName: "worker",
+          },
+        },
+      ],
+      [
+        "add",
+        {
+          description: "Add numbers.",
+          execute: () => 3,
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "add",
+        },
+      ],
+      [
+        "remote",
+        {
+          description: "Call a remote agent.",
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "remote",
+          runtimeAction: {
+            kind: "remote-agent-call" as const,
+            nodeId: "remote-agents",
+            remoteAgentName: "analyst",
+            subagentName: "analyst",
+          },
+        },
+      ],
+    ]);
+    const handleEvent = createInstrumentationHandleEvent({
+      getActionSource: () => ({ scope, tools }),
+      handleEvent: async () => {},
+      hooks: { publish: async (event) => void events.push(event) },
+      sessionId: "session-1",
+    })!;
+    const requested = createActionsRequestedEvent({
+      actions: [
+        {
+          callId: "delegate-1",
+          description: "Delegate work.",
+          input: { task: "research" },
+          kind: "subagent-call",
+          name: "delegate",
+          nodeId: "workers",
+          subagentName: "worker",
+        },
+        {
+          callId: "remote-1",
+          description: "Call a remote agent.",
+          input: { task: "analyze" },
+          kind: "remote-agent-call",
+          name: "remote",
+          nodeId: "remote-agents",
+          remoteAgentName: "analyst",
+        },
+        { callId: "add-1", input: { a: 1, b: 2 }, kind: "tool-call", toolName: "add" },
+      ],
+      sequence: 0,
+      stepIndex: 0,
+      turnId: "turn-1",
+    });
+
+    await handleEvent(requested);
+    await handleEvent(requested);
+
+    expect(events).toEqual([
+      {
+        callId: "delegate-1",
+        id: "session-1:turn-1:0:0:tool:delegate-1:0",
+        input: { task: "research" },
+        kind: "subagent-call",
+        scope,
+        toolName: "delegate",
+        type: "tool.call.started",
+      },
+      {
+        callId: "remote-1",
+        id: "session-1:turn-1:0:0:tool:remote-1:0",
+        input: { task: "analyze" },
+        kind: "remote-agent-call",
+        scope,
+        toolName: "remote",
+        type: "tool.call.started",
+      },
+    ]);
+    expect(Object.isFrozen(events[0])).toBe(true);
+    expect(Object.isFrozen(events[1])).toBe(true);
   });
 });

--- a/packages/eve/src/harness/instrumentation-native-events.ts
+++ b/packages/eve/src/harness/instrumentation-native-events.ts
@@ -1,14 +1,22 @@
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import type {
+  InstrumentationAttemptScope,
   InstrumentationHooks,
   InstrumentationParentLineage,
   InstrumentationPointEvent,
+  InstrumentationToolCallStartedEvent,
   InstrumentationTraceContext,
 } from "#harness/instrumentation-lifecycle.js";
-import type { HandleEventFn } from "#harness/types.js";
+import type { HandleEventFn, HarnessToolMap } from "#harness/types.js";
+
+export interface InstrumentationActionSource {
+  readonly scope: InstrumentationAttemptScope;
+  readonly tools: HarnessToolMap;
+}
 
 export interface CreateInstrumentationHandleEventInput {
   readonly agentName?: string;
+  readonly getActionSource?: () => InstrumentationActionSource | undefined;
   readonly handleEvent?: HandleEventFn;
   readonly hooks?: InstrumentationHooks;
   readonly parentLineage?: InstrumentationParentLineage;
@@ -27,13 +35,47 @@ export function createInstrumentationHandleEvent(
 
   const handleEvent = input.handleEvent;
   const hooks = input.hooks;
+  const publishedActions = new Set<string>();
   let activeTurnId = input.turnId;
   return async (event, messages) => {
     await handleEvent(event, messages);
     const lifecycleEvent = toLifecycleEvent(event, input, activeTurnId);
     if (event.type === "turn.started") activeTurnId = event.data.turnId;
     if (lifecycleEvent !== undefined) await hooks.publish(lifecycleEvent);
+    if (event.type === "actions.requested") {
+      await publishDelegationActions(event, input, hooks, publishedActions);
+    }
   };
+}
+
+async function publishDelegationActions(
+  event: Extract<UnstampedMessageStreamEvent, { type: "actions.requested" }>,
+  input: CreateInstrumentationHandleEventInput,
+  hooks: InstrumentationHooks,
+  published: Set<string>,
+): Promise<void> {
+  const source = input.getActionSource?.();
+  if (source === undefined) return;
+
+  for (const action of event.data.actions) {
+    if (action.kind !== "subagent-call" && action.kind !== "remote-agent-call") continue;
+    const tool = source.tools.get(action.name);
+    if (tool?.runtimeAction === undefined || tool.execute !== undefined) continue;
+    const deduplicationKey = `${source.scope.attemptId}:${action.callId}`;
+    if (published.has(deduplicationKey)) continue;
+    published.add(deduplicationKey);
+    await hooks.publish(
+      Object.freeze({
+        callId: action.callId,
+        id: `${source.scope.attemptId}:tool:${action.callId}:0`,
+        input: action.input,
+        kind: tool.runtimeAction.kind,
+        scope: source.scope,
+        toolName: tool.name,
+        type: "tool.call.started",
+      } satisfies InstrumentationToolCallStartedEvent),
+    );
+  }
 }
 
 function toLifecycleEvent(

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -9590,6 +9590,7 @@ describe("createToolLoopHarness", () => {
         }),
         hooks,
         runInContext,
+        expect.any(Function),
       );
       const bridge = mockCreateAiSdkHookBridge.mock.results[0]!.value;
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
@@ -9608,6 +9609,87 @@ describe("createToolLoopHarness", () => {
         expect.objectContaining({
           scope: expect.objectContaining({ attemptIndex: 0 }),
           type: "step.attempt.completed",
+        }),
+      );
+    });
+
+    it("resolves each action kind from the harness tool map", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", undefined, {
+          instrumentation: {
+            hooks: createInstrumentationHooks([]),
+            runInContext: (_operation, execute) => execute(),
+          },
+          tools: createDelegationToolMap(),
+        }),
+      );
+
+      await runStep(createTestSession(), { message: "hi" });
+
+      const resolveActionKind = mockCreateAiSdkHookBridge.mock.calls[0]![3] as (
+        toolName: string,
+      ) => string;
+      expect(resolveActionKind("delegate")).toBe("subagent-call");
+      expect(resolveActionKind("add")).toBe("tool-call");
+      // A name the harness never registered — a dynamic subagent resolved after
+      // the map was built lands here rather than throwing.
+      expect(resolveActionKind("absent")).toBe("tool-call");
+    });
+
+    it("publishes a delegation action when the AI SDK skips execution callbacks", async () => {
+      setupMockAgent({
+        finishReason: "tool-calls",
+        response: {
+          messages: [
+            {
+              content: [
+                {
+                  input: { message: "research this" },
+                  toolCallId: "call-delegate",
+                  toolName: "delegate",
+                  type: "tool-call",
+                },
+              ],
+              role: "assistant",
+            },
+          ],
+        },
+        text: "",
+        toolCalls: [
+          {
+            input: { message: "research this" },
+            toolCallId: "call-delegate",
+            toolName: "delegate",
+            type: "tool-call",
+          },
+        ],
+        toolResults: [],
+      });
+      const started = vi.fn();
+      const hooks = createInstrumentationHooks([{ events: { "tool.call.started": started } }]);
+      const { emit } = createEventCollector();
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", emit, {
+          instrumentation: { hooks, runInContext: (_operation, execute) => execute() },
+          tools: createDelegationToolMap(),
+        }),
+      );
+
+      await runStep(createTestSession(), { message: "delegate" });
+
+      expect(started).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          callId: "call-delegate",
+          kind: "subagent-call",
+          toolName: "delegate",
+          type: "tool.call.started",
         }),
       );
     });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -114,8 +114,11 @@ import {
 import { createToolResultMessagePartFromToolError } from "#harness/action-result-helpers.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
 import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-context.js";
-import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
-import { createInstrumentationHandleEvent } from "#harness/instrumentation-native-events.js";
+import { createAiSdkHookBridge, type ActionKindResolver } from "#harness/ai-sdk-hook-bridge.js";
+import {
+  createInstrumentationHandleEvent,
+  type InstrumentationActionSource,
+} from "#harness/instrumentation-native-events.js";
 import type { InstrumentationAttemptScope } from "#harness/instrumentation-lifecycle.js";
 import { resolveParentLineage } from "#harness/parent-lineage.js";
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
@@ -571,8 +574,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     let emissionState = getHarnessEmissionState(session.state);
     const store = contextStorage.getStore();
     const parent = store?.get(ParentSessionKey);
+    let actionSource: InstrumentationActionSource | undefined;
     const emit = createInstrumentationHandleEvent({
       agentName: config.runtimeIdentity?.agentName,
+      getActionSource: () => actionSource,
       handleEvent: baseEmit,
       hooks: config.instrumentation?.hooks,
       parentLineage: resolveParentLineage(parent, store?.get(ChannelKey)),
@@ -1031,6 +1036,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
               stepIndex: emissionState.stepIndex,
               turnId: instrumentationTurnId,
             };
+      actionSource =
+        attemptScope === undefined
+          ? undefined
+          : { scope: attemptScope, tools: advertisedHarnessTools };
+      const resolveActionKind: ActionKindResolver = (toolName) =>
+        advertisedHarnessTools.get(toolName)?.runtimeAction?.kind ?? "tool-call";
       const bridgeIntegration =
         attemptScope === undefined || instrumentationHooks === undefined
           ? undefined
@@ -1038,6 +1049,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
               attemptScope,
               instrumentationHooks,
               config.instrumentation?.runInContext,
+              resolveActionKind,
             );
 
       const hooks = buildStepHooks({

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { describe, expect, it } from "vitest";
 
-import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
+import { createAiSdkHookBridge, type ActionKindResolver } from "#harness/ai-sdk-hook-bridge.js";
 import { createAgentOtelInstrumentation } from "#tracing/agent-otel-provider.js";
 import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import {
@@ -52,6 +52,7 @@ async function emitAttempt(input: {
   readonly hooks: InstrumentationHooks;
   readonly runInContext: InstrumentationContextRunner;
   readonly providerMetadata?: Readonly<Record<string, unknown>>;
+  readonly resolveActionKind?: ActionKindResolver;
   readonly sessionId: string;
   readonly skipModelTerminal?: boolean;
   readonly skipToolTerminal?: boolean;
@@ -72,7 +73,12 @@ async function emitAttempt(input: {
     await publishTurnStarted(input);
   }
 
-  const bridge = createAiSdkHookBridge(scope, input.hooks, input.runInContext);
+  const bridge = createAiSdkHookBridge(
+    scope,
+    input.hooks,
+    input.runInContext,
+    input.resolveActionKind,
+  );
   Reflect.apply(bridge.onStart!, bridge, [
     {
       callId: "call-1",
@@ -283,7 +289,7 @@ describe("createAgentOtelInstrumentation", () => {
       "gen_ai.usage.cache_read.input_tokens": 4,
     });
     expect(action.attributes).toMatchObject({
-      "agent.action.kind": "tool",
+      "agent.action.kind": "tool-call",
       "agent.action.name": "weather",
       "agent.framework.name": "eve",
       "agent.root.session.id": "session-1",
@@ -308,6 +314,25 @@ describe("createAgentOtelInstrumentation", () => {
     expect(byName(spans, "agent.action")).toHaveLength(1);
     expect(byName(spans, "ai.toolCall")).toHaveLength(1);
     expect(byName(spans, "agent.step")).toHaveLength(1);
+  });
+
+  it("labels a subagent action by its kind, not as a plain tool", async () => {
+    const runtime = createRuntime();
+    await emitAttempt({
+      hooks: runtime.hooks,
+      resolveActionKind: () => "subagent-call",
+      runInContext: runtime.runInContext,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const action = runtime.exporter.getFinishedSpans().find((span) => span.name === "agent.action");
+    expect(action?.attributes).toMatchObject({
+      "agent.action.kind": "subagent-call",
+      "agent.action.name": "weather",
+    });
   });
 
   it("captures model and tool inputs/outputs on the operation spans", async () => {

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -342,7 +342,7 @@ export function createAgentOtelInstrumentation(
       {
         attributes: {
           "agent.action.call_id": event.callId,
-          "agent.action.kind": "tool",
+          "agent.action.kind": event.kind,
           "agent.action.name": event.toolName,
           "agent.framework.name": "eve",
           "agent.framework.version": input.frameworkVersion,


### PR DESCRIPTION
### Summary

Related to #1659. This third PR in the instrumentation-provider stack, on top of #1670, fixes `agent.action.kind`, which was always `"tool"`, by carrying eve's `"tool-call"`, `"subagent-call"`, or `"remote-agent-call"` kind on `tool.call.started` and writing it to the action span. The AI SDK bridge resolves the kind from the harness tool map and defaults unknown names to `"tool-call"`.

Non-executable subagent and remote-agent delegations do not receive AI SDK tool-execution callbacks, so durable handling of the existing `actions.requested` stream event now publishes one deduplicated `tool.call.started` event for each such action. No new stream-event type is introduced.

`eve traces` consequently renders the actual action kind instead of labeling every action as a tool.

### Validation

- `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`
- `pnpm --filter eve typecheck`
- `pnpm test:unit` - 5,894 passed
- `pnpm test:integration` - 575 passed
- Falsified both halves: hardcoding the resolver to `"tool-call"` fails the harness test, and reverting the provider to `"tool"` fails both provider tests

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
