### PR TITLE
refactor(eve): name the step lifecycle events for the span they produce

### DIFF
--- a/.changeset/lucky-actions-kind.md
+++ b/.changeset/lucky-actions-kind.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Trace spans now record what eve dispatched each action as. `agent.action.kind` was always `"tool"`, so a subagent or remote-agent call was indistinguishable from an ordinary tool in a trace; it now reports `subagent-call`, `remote-agent-call`, or `tool-call`, matching the kind on the corresponding `actions.requested` event.

--- a/.changeset/shiny-step-events.md
+++ b/.changeset/shiny-step-events.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Internal instrumentation lifecycle events named `attempt.*` are now named `step.*`, matching the `agent.step` span they produce. No authored surface changes — these events are not public yet.

--- a/.changeset/tidy-pugs-wander.md
+++ b/.changeset/tidy-pugs-wander.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Instrumentation providers now subscribe to flat lifecycle event names matching each payload's `type`, instead of paired `before`/`after` hooks. Internal groundwork for a public provider surface; no change to the spans or attributes eve records.

--- a/packages/eve/src/cli/commands/trace.integration.test.ts
+++ b/packages/eve/src/cli/commands/trace.integration.test.ts
@@ -164,7 +164,7 @@ describe("eve traces", () => {
       root,
       TRACE_ONE,
       span(action, "agent.action", 30, 80, step, {
-        "agent.action.kind": "tool",
+        "agent.action.kind": "tool-call",
         "agent.action.name": "\u001B[31mweather\u001B[0m",
         "agent.session.id": "session-one",
       }),
@@ -179,7 +179,7 @@ describe("eve traces", () => {
 
     expect(output.out[0]).toContain("agent.turn [turn-1]");
     expect(output.out[0]).toContain("└─ agent.step [step 0, attempt 0]");
-    expect(output.out[0]).toContain("└─ agent.action [tool: weather]");
+    expect(output.out[0]).toContain("└─ agent.action [tool-call: weather]");
     expect(output.out[0]).toContain("failed  10ms ERROR");
     expect(output.out[0]).not.toContain("\u001B");
   });

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -314,6 +314,7 @@ describe("createAiSdkHookBridge", () => {
         callId: "tool-1",
         id: `${scope.attemptId}:tool:tool-1:0`,
         input: { q: "eve" },
+        kind: "tool-call",
         scope,
         toolName: "search",
         type: "tool.call.started",
@@ -326,6 +327,25 @@ describe("createAiSdkHookBridge", () => {
       });
     },
   );
+
+  it("labels a tool call with the kind the harness resolves", async () => {
+    const started = vi.fn();
+    const hooks = createInstrumentationHooks([{ events: { "tool.call.started": started } }]);
+    const bridge = createAiSdkHookBridge(scope, hooks, undefined, (toolName) =>
+      toolName === "research" ? "subagent-call" : "tool-call",
+    );
+
+    for (const toolName of ["research", "search"]) {
+      await Reflect.apply(bridge.onToolExecutionStart!, bridge, [
+        { callId: `call-${toolName}`, toolCall: { input: {}, toolCallId: toolName, toolName } },
+      ]);
+    }
+
+    expect(started.mock.calls.map(([event]) => [event.toolName, event.kind])).toEqual([
+      ["research", "subagent-call"],
+      ["search", "tool-call"],
+    ]);
+  });
 
   it("keeps each provider's state to itself", async () => {
     const observed = new Map<string, unknown>();

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
 import {
   createInstrumentationHooks,
-  type InstrumentationAttemptMetadataEvent,
+  type InstrumentationStepMetadataEvent,
   type InstrumentationAttemptScope,
   type InstrumentationProviderDefinition,
 } from "#harness/instrumentation-lifecycle.js";
@@ -121,12 +121,12 @@ describe("createAiSdkHookBridge", () => {
     expect(adapterCalls).toBe(0);
   });
 
-  it("publishes step provider metadata as attempt.metadata, skipping steps without any", async () => {
-    const events: InstrumentationAttemptMetadataEvent[] = [];
+  it("publishes step provider metadata as step.metadata, skipping steps without any", async () => {
+    const events: InstrumentationStepMetadataEvent[] = [];
     const hooks = createInstrumentationHooks([
       {
         events: {
-          "attempt.metadata": (event) => {
+          "step.metadata": (event) => {
             events.push(event);
           },
         },
@@ -143,7 +143,7 @@ describe("createAiSdkHookBridge", () => {
       {
         providerMetadata: { gateway: { cost: "0.000082" } },
         scope,
-        type: "attempt.metadata",
+        type: "step.metadata",
       },
     ]);
   });
@@ -201,7 +201,7 @@ describe("createAiSdkHookBridge", () => {
 
   it("projects the operation callback onto eve fields only", async () => {
     const started = vi.fn();
-    const hooks = createInstrumentationHooks([{ events: { "attempt.started": started } }]);
+    const hooks = createInstrumentationHooks([{ events: { "step.started": started } }]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     Reflect.apply(bridge.onStart!, bridge, [
@@ -212,7 +212,7 @@ describe("createAiSdkHookBridge", () => {
     expect(started).toHaveBeenCalledExactlyOnceWith({
       operation: { modelId: "model", operationId: "ai.streamText", provider: "test" },
       scope,
-      type: "attempt.started",
+      type: "step.started",
     });
   });
 

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -19,19 +19,20 @@ const scope: InstrumentationAttemptScope = {
 describe("createAiSdkHookBridge", () => {
   it("publishes normalized model lifecycle to every provider", async () => {
     const calls: string[] = [];
-    const provider = (name: string): InstrumentationProviderDefinition => ({
-      events: {
-        "model.call": {
-          before(event) {
-            calls.push(`${name}:before:${event.id}`);
-            return `${name}-state`;
+    const provider = (name: string): InstrumentationProviderDefinition => {
+      const states = new Map<string, string>();
+      return {
+        events: {
+          "model.call.started"(event) {
+            calls.push(`${name}:started:${event.id}`);
+            states.set(event.id, `${name}-state`);
           },
-          after(event, state) {
-            calls.push(`${name}:after:${event.id}:${String(state)}`);
+          "model.call.completed"(event) {
+            calls.push(`${name}:completed:${event.id}:${String(states.get(event.id))}`);
           },
         },
-      },
-    });
+      };
+    };
     const hooks = createInstrumentationHooks([provider("a"), provider("b")]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -51,10 +52,10 @@ describe("createAiSdkHookBridge", () => {
 
     const id = `${scope.attemptId}:model:call-1:0`;
     expect(calls).toEqual([
-      `a:before:${id}`,
-      `b:before:${id}`,
-      `a:after:${id}:a-state`,
-      `b:after:${id}:b-state`,
+      `a:started:${id}`,
+      `b:started:${id}`,
+      `a:completed:${id}:a-state`,
+      `b:completed:${id}:b-state`,
     ]);
   });
 
@@ -85,7 +86,7 @@ describe("createAiSdkHookBridge", () => {
   it("passes the identity captured at model-call start to the context runner", async () => {
     const ids: string[] = [];
     const hooks = createInstrumentationHooks([
-      { events: { "model.call": { before: (event) => ids.push(event.id) } } },
+      { events: { "model.call.started": (event) => void ids.push(event.id) } },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks, (operation, execute) => {
       ids.push(operation.id);
@@ -152,14 +153,16 @@ describe("createAiSdkHookBridge", () => {
     const hooks = createInstrumentationHooks([
       {
         events: {
-          "model.call": {
-            before() {
-              throw new Error("provider failed");
-            },
+          "model.call.started"() {
+            throw new Error("provider failed");
           },
         },
       },
-      { events: { "model.call": { before: () => "state", after } } },
+      {
+        events: {
+          "model.call.completed": after,
+        },
+      },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -182,9 +185,7 @@ describe("createAiSdkHookBridge", () => {
 
   it("terminalizes started operations when the attempt errors", async () => {
     const after = vi.fn();
-    const hooks = createInstrumentationHooks([
-      { events: { "model.call": { before: () => "state", after } } },
-    ]);
+    const hooks = createInstrumentationHooks([{ events: { "model.call.failed": after } }]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
@@ -195,7 +196,6 @@ describe("createAiSdkHookBridge", () => {
 
     expect(after).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ error, type: "model.call.failed" }),
-      "state",
     );
   });
 
@@ -217,9 +217,11 @@ describe("createAiSdkHookBridge", () => {
   });
 
   it("projects the model call callbacks onto eve fields only", async () => {
-    const before = vi.fn(() => "state");
+    const before = vi.fn();
     const after = vi.fn();
-    const hooks = createInstrumentationHooks([{ events: { "model.call": { after, before } } }]);
+    const hooks = createInstrumentationHooks([
+      { events: { "model.call.completed": after, "model.call.started": before } },
+    ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
     await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
@@ -263,27 +265,24 @@ describe("createAiSdkHookBridge", () => {
     });
     // An unrecognized part kind is dropped rather than forwarded, so widening
     // InstrumentationContentPart is what makes a new kind reachable.
-    expect(after).toHaveBeenCalledExactlyOnceWith(
-      {
-        content: [
-          { text: "thinking", type: "reasoning" },
-          { text: "hello", type: "text" },
-          { input: { a: 1 }, toolName: "search", type: "tool-call" },
-          { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
-          { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
-        ],
-        finishReason: "tool-calls",
-        id: `${scope.attemptId}:model:call-1:0`,
-        scope,
-        type: "model.call.completed",
-        usage: {
-          inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
-          inputTokens: 1,
-          outputTokens: 2,
-        },
+    expect(after).toHaveBeenCalledExactlyOnceWith({
+      content: [
+        { text: "thinking", type: "reasoning" },
+        { text: "hello", type: "text" },
+        { input: { a: 1 }, toolName: "search", type: "tool-call" },
+        { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
+        { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
+      ],
+      finishReason: "tool-calls",
+      id: `${scope.attemptId}:model:call-1:0`,
+      scope,
+      type: "model.call.completed",
+      usage: {
+        inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
+        inputTokens: 1,
+        outputTokens: 2,
       },
-      "state",
-    );
+    });
   });
 
   it.each([
@@ -298,9 +297,11 @@ describe("createAiSdkHookBridge", () => {
   ])(
     "collapses tool output $toolOutput.type onto $expected.type",
     async ({ expected, toolOutput }) => {
-      const before = vi.fn(() => "state");
+      const before = vi.fn();
       const after = vi.fn();
-      const hooks = createInstrumentationHooks([{ events: { "tool.call": { after, before } } }]);
+      const hooks = createInstrumentationHooks([
+        { events: { "tool.call.completed": after, "tool.call.started": before } },
+      ]);
       const bridge = createAiSdkHookBridge(scope, hooks);
       const toolCall = { input: { q: "eve" }, toolCallId: "tool-1", toolName: "search" };
 
@@ -317,33 +318,91 @@ describe("createAiSdkHookBridge", () => {
         toolName: "search",
         type: "tool.call.started",
       });
-      expect(after).toHaveBeenCalledExactlyOnceWith(
-        {
-          id: `${scope.attemptId}:tool:tool-1:0`,
-          output: expected,
-          scope,
-          type: "tool.call.completed",
-        },
-        "state",
-      );
+      expect(after).toHaveBeenCalledExactlyOnceWith({
+        id: `${scope.attemptId}:tool:tool-1:0`,
+        output: expected,
+        scope,
+        type: "tool.call.completed",
+      });
     },
   );
 
+  it("keeps each provider's state to itself", async () => {
+    const observed = new Map<string, unknown>();
+    const provider = (name: string): InstrumentationProviderDefinition => {
+      const own = new Map<string, string>();
+      return {
+        events: {
+          "model.call.completed": (event) => {
+            observed.set(name, own.get(event.id));
+          },
+          "model.call.started": (event) => void own.set(event.id, `${name}-state`),
+        },
+      };
+    };
+    const hooks = createInstrumentationHooks([provider("a"), provider("b")]);
+    const bridge = createAiSdkHookBridge(scope, hooks);
+
+    await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
+      { callId: "call-1", modelId: "model", provider: "test", tools: undefined },
+    ]);
+    await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+      {
+        callId: "call-1",
+        content: [],
+        finishReason: "stop",
+        performance: { responseTimeMs: 1 },
+        responseId: "response-1",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      },
+    ]);
+
+    expect(observed).toEqual(
+      new Map([
+        ["a", "a-state"],
+        ["b", "b-state"],
+      ]),
+    );
+  });
+
+  it("skips a terminal handler when the operation never started", async () => {
+    const completed = vi.fn();
+    const hooks = createInstrumentationHooks([{ events: { "model.call.completed": completed } }]);
+    const bridge = createAiSdkHookBridge(scope, hooks);
+
+    // No onLanguageModelCallStart, so the bridge holds no id and publishes
+    // nothing — the handler must not run against empty state.
+    await Reflect.apply(bridge.onLanguageModelCallEnd!, bridge, [
+      {
+        callId: "call-1",
+        content: [],
+        finishReason: "stop",
+        performance: { responseTimeMs: 1 },
+        responseId: "response-1",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      },
+    ]);
+
+    expect(completed).not.toHaveBeenCalled();
+  });
+
   it("retains state for parallel tool starts", async () => {
     const resolvers = new Map<string, () => void>();
+    const started = new Map<string, string>();
     const terminalStates = new Map<string, unknown>();
     const hooks = createInstrumentationHooks([
       {
         events: {
-          "tool.call": {
-            before(event) {
-              return new Promise<string>((resolve) => {
+          async "tool.call.started"(event) {
+            started.set(
+              event.id,
+              await new Promise<string>((resolve) => {
                 resolvers.set(event.id, () => resolve(`state:${event.id}`));
-              });
-            },
-            after(event, state) {
-              terminalStates.set(event.id, state);
-            },
+              }),
+            );
+          },
+          "tool.call.completed"(event) {
+            terminalStates.set(event.id, started.get(event.id));
           },
         },
       },

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.ts
@@ -1,6 +1,7 @@
 import type { Telemetry } from "ai";
 
 import type {
+  InstrumentationActionKind,
   InstrumentationAttemptScope,
   InstrumentationAttemptStartedEvent,
   InstrumentationContentPart,
@@ -17,8 +18,15 @@ import type {
 
 type TelemetryEvent<TKey extends keyof Telemetry> = Parameters<NonNullable<Telemetry[TKey]>>[0];
 
+/**
+ * Reports what eve dispatches one tool name as. The AI SDK only knows the
+ * name, so the kind has to come back from the harness.
+ */
+export type ActionKindResolver = (toolName: string) => InstrumentationActionKind;
+
 interface AttemptState {
   readonly modelIds: Map<string, string>;
+  readonly resolveActionKind: ActionKindResolver;
   readonly scope: InstrumentationAttemptScope;
   readonly toolIds: Map<string, string>;
   operation?: InstrumentationOperationRef;
@@ -31,9 +39,11 @@ export function createAiSdkHookBridge(
   scope: InstrumentationAttemptScope,
   hooks: InstrumentationHooks,
   runInContext: InstrumentationContextRunner = directRunInContext,
+  resolveActionKind: ActionKindResolver = defaultResolveActionKind,
 ): Telemetry {
   const state: AttemptState = {
     modelIds: new Map(),
+    resolveActionKind,
     scope,
     toolIds: new Map(),
   };
@@ -122,6 +132,8 @@ export function createAiSdkHookBridge(
 }
 
 const directRunInContext: InstrumentationContextRunner = (_operation, execute) => execute();
+
+const defaultResolveActionKind: ActionKindResolver = () => "tool-call";
 
 function toAttemptStarted(state: AttemptState): InstrumentationAttemptStartedEvent | undefined {
   if (state.operation === undefined || state.stepNumber === undefined) return undefined;
@@ -226,6 +238,7 @@ function toToolCallStarted(
     callId: source.toolCall.toolCallId,
     id,
     input: source.toolCall.input,
+    kind: state.resolveActionKind(source.toolCall.toolName),
     scope: state.scope,
     toolName: source.toolCall.toolName,
     type: "tool.call.started",

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.ts
@@ -3,7 +3,7 @@ import type { Telemetry } from "ai";
 import type {
   InstrumentationActionKind,
   InstrumentationAttemptScope,
-  InstrumentationAttemptStartedEvent,
+  InstrumentationStepStartedLifecycleEvent,
   InstrumentationContentPart,
   InstrumentationContextRunner,
   InstrumentationHooks,
@@ -58,7 +58,7 @@ export function createAiSdkHookBridge(
     },
     async onStepStart(event) {
       state.stepNumber = event.stepNumber;
-      const started = toAttemptStarted(state);
+      const started = toStepStarted(state);
       if (started !== undefined) await hooks.publish(started);
     },
     async onLanguageModelCallStart(event) {
@@ -88,7 +88,7 @@ export function createAiSdkHookBridge(
       await hooks.publish({
         providerMetadata: event.providerMetadata,
         scope: state.scope,
-        type: "attempt.metadata",
+        type: "step.metadata",
       });
     },
     async onToolExecutionStart(event) {
@@ -135,12 +135,12 @@ const directRunInContext: InstrumentationContextRunner = (_operation, execute) =
 
 const defaultResolveActionKind: ActionKindResolver = () => "tool-call";
 
-function toAttemptStarted(state: AttemptState): InstrumentationAttemptStartedEvent | undefined {
+function toStepStarted(state: AttemptState): InstrumentationStepStartedLifecycleEvent | undefined {
   if (state.operation === undefined || state.stepNumber === undefined) return undefined;
   return {
     operation: state.operation,
     scope: state.scope,
-    type: "attempt.started",
+    type: "step.started",
   };
 }
 

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.ts
@@ -55,7 +55,7 @@ export function createAiSdkHookBridge(
       const id = createModelCallIdentity(state, event.callId);
       state.modelIds.set(event.callId, id);
       const started = toModelCallStarted(state, id, event);
-      await hooks.before("model.call", started);
+      await hooks.publish(started);
     },
     executeLanguageModelCall({ callId, execute }) {
       const id = state.modelIds.get(callId);
@@ -68,7 +68,7 @@ export function createAiSdkHookBridge(
       if (id === undefined) return;
       state.modelIds.delete(event.callId);
       const completed = toModelCallCompleted(state, id, event);
-      await hooks.after("model.call", completed);
+      await hooks.publish(completed);
     },
     async onStepEnd(event) {
       // Step results carry provider metadata (e.g. Vercel AI Gateway cost)
@@ -85,7 +85,7 @@ export function createAiSdkHookBridge(
       const id = createToolCallIdentity(state, event.toolCall.toolCallId);
       state.toolIds.set(event.toolCall.toolCallId, id);
       const started = toToolCallStarted(state, id, event);
-      await hooks.before("tool.call", started);
+      await hooks.publish(started);
     },
     executeTool({ toolCallId, execute }) {
       const id = state.toolIds.get(toolCallId);
@@ -97,7 +97,7 @@ export function createAiSdkHookBridge(
       if (id === undefined) return;
       state.toolIds.delete(toolCallId);
       const completed = toToolCallCompleted(state, id, event);
-      await hooks.after("tool.call", completed);
+      await hooks.publish(completed);
     },
     async onAbort(event) {
       await failOpenOperations(event);
@@ -110,10 +110,10 @@ export function createAiSdkHookBridge(
   async function failOpenOperations(error: unknown): Promise<void> {
     const pending: Promise<void>[] = [];
     for (const id of state.modelIds.values()) {
-      pending.push(hooks.after("model.call", { error, id, scope, type: "model.call.failed" }));
+      pending.push(hooks.publish({ error, id, scope, type: "model.call.failed" }));
     }
     for (const id of state.toolIds.values()) {
-      pending.push(hooks.after("tool.call", { error, id, scope, type: "tool.call.failed" }));
+      pending.push(hooks.publish({ error, id, scope, type: "tool.call.failed" }));
     }
     state.modelIds.clear();
     state.toolIds.clear();

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -61,6 +61,13 @@ export type InstrumentationContentPart =
       readonly toolName: string;
     };
 
+/**
+ * What eve dispatched a tool call as. The model sees every action as a tool,
+ * so this is the only thing that separates a subagent or remote-agent call
+ * from an ordinary tool in a trace.
+ */
+export type InstrumentationActionKind = "remote-agent-call" | "subagent-call" | "tool-call";
+
 /** How one tool execution ended. */
 export type InstrumentationToolOutput =
   | { readonly type: "result"; readonly output: unknown }
@@ -172,6 +179,7 @@ export interface InstrumentationToolCallStartedEvent {
   readonly callId: string;
   readonly id: string;
   readonly input: unknown;
+  readonly kind: InstrumentationActionKind;
   readonly scope: InstrumentationAttemptScope;
   readonly toolName: string;
 }

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -73,8 +73,8 @@ export type InstrumentationToolOutput =
   | { readonly type: "result"; readonly output: unknown }
   | { readonly type: "error"; readonly error: unknown };
 
-export interface InstrumentationAttemptStartedEvent {
-  readonly type: "attempt.started";
+export interface InstrumentationStepStartedLifecycleEvent {
+  readonly type: "step.started";
   readonly operation: InstrumentationOperationRef;
   readonly scope: InstrumentationAttemptScope;
 }
@@ -129,8 +129,8 @@ export interface InstrumentationTurnTerminalEvent {
   readonly turnId: string;
 }
 
-export interface InstrumentationAttemptTerminalEvent {
-  readonly type: "attempt.completed" | "attempt.failed";
+export interface InstrumentationStepTerminalEvent {
+  readonly type: "step.completed" | "step.failed";
   readonly error?: unknown;
   readonly scope: InstrumentationAttemptScope;
 }
@@ -140,8 +140,8 @@ export interface InstrumentationAttemptTerminalEvent {
  * (`StepResult.providerMetadata`). Carries Vercel AI Gateway cost data when
  * the request went through the gateway; absent for other providers.
  */
-export interface InstrumentationAttemptMetadataEvent {
-  readonly type: "attempt.metadata";
+export interface InstrumentationStepMetadataEvent {
+  readonly type: "step.metadata";
   readonly scope: InstrumentationAttemptScope;
   readonly providerMetadata: Readonly<Record<string, unknown>>;
 }
@@ -213,10 +213,10 @@ export type InstrumentationEventHandler<TEvent> = (event: TEvent) => void | Prom
 /** Internal provider shape mirrored by the future public hook contract. */
 export interface InstrumentationProviderDefinition {
   readonly events?: {
-    readonly "attempt.started"?: InstrumentationEventHandler<InstrumentationAttemptStartedEvent>;
-    readonly "attempt.completed"?: InstrumentationEventHandler<InstrumentationAttemptTerminalEvent>;
-    readonly "attempt.failed"?: InstrumentationEventHandler<InstrumentationAttemptTerminalEvent>;
-    readonly "attempt.metadata"?: InstrumentationEventHandler<InstrumentationAttemptMetadataEvent>;
+    readonly "step.started"?: InstrumentationEventHandler<InstrumentationStepStartedLifecycleEvent>;
+    readonly "step.completed"?: InstrumentationEventHandler<InstrumentationStepTerminalEvent>;
+    readonly "step.failed"?: InstrumentationEventHandler<InstrumentationStepTerminalEvent>;
+    readonly "step.metadata"?: InstrumentationEventHandler<InstrumentationStepMetadataEvent>;
     readonly "model.call.started"?: InstrumentationEventHandler<InstrumentationModelCallStartedEvent>;
     readonly "model.call.completed"?: InstrumentationEventHandler<InstrumentationModelCallCompletedEvent>;
     readonly "model.call.failed"?: InstrumentationEventHandler<InstrumentationModelCallFailedEvent>;
@@ -242,9 +242,9 @@ export type InstrumentationCorrelatedEvent =
   | InstrumentationToolCallTerminalEvent;
 
 export type InstrumentationPointEvent =
-  | InstrumentationAttemptStartedEvent
-  | InstrumentationAttemptMetadataEvent
-  | InstrumentationAttemptTerminalEvent
+  | InstrumentationStepStartedLifecycleEvent
+  | InstrumentationStepMetadataEvent
+  | InstrumentationStepTerminalEvent
   | InstrumentationSessionStartedEvent
   | InstrumentationSessionTransitionEvent
   | InstrumentationTurnStartedEvent

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -194,69 +194,44 @@ export type InstrumentationToolCallTerminalEvent =
   | InstrumentationToolCallCompletedEvent
   | InstrumentationToolCallFailedEvent;
 
-export interface RelatedLifecycleHook<TStart, TTerminal> {
-  readonly before?: (event: TStart) => unknown | PromiseLike<unknown>;
-  readonly after?: (event: TTerminal, state: unknown) => void | PromiseLike<void>;
-}
+/**
+ * eve balances every start with exactly one terminal — the bridge terminalizes
+ * open operations on abort and error, and a retry gets a fresh attempt id — so
+ * a provider that needs to carry a handle from a start to its terminal can keep
+ * its own map keyed by `event.id` and delete on the terminal.
+ */
+export type InstrumentationEventHandler<TEvent> = (event: TEvent) => void | PromiseLike<void>;
 
 /** Internal provider shape mirrored by the future public hook contract. */
 export interface InstrumentationProviderDefinition {
   readonly events?: {
-    readonly "model.call"?: RelatedLifecycleHook<
-      InstrumentationModelCallStartedEvent,
-      InstrumentationModelCallTerminalEvent
-    >;
-    readonly "attempt.started"?: (
-      event: InstrumentationAttemptStartedEvent,
-    ) => void | PromiseLike<void>;
-    readonly "attempt.completed"?: (
-      event: InstrumentationAttemptTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "attempt.failed"?: (
-      event: InstrumentationAttemptTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "attempt.metadata"?: (
-      event: InstrumentationAttemptMetadataEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.completed"?: (
-      event: InstrumentationSessionTransitionEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.failed"?: (
-      event: InstrumentationSessionTransitionEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.started"?: (
-      event: InstrumentationSessionStartedEvent,
-    ) => void | PromiseLike<void>;
-    readonly "session.waiting"?: (
-      event: InstrumentationSessionTransitionEvent,
-    ) => void | PromiseLike<void>;
-    readonly "tool.call"?: RelatedLifecycleHook<
-      InstrumentationToolCallStartedEvent,
-      InstrumentationToolCallTerminalEvent
-    >;
-    readonly "turn.cancelled"?: (
-      event: InstrumentationTurnTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "turn.completed"?: (
-      event: InstrumentationTurnTerminalEvent,
-    ) => void | PromiseLike<void>;
-    readonly "turn.failed"?: (event: InstrumentationTurnTerminalEvent) => void | PromiseLike<void>;
-    readonly "turn.started"?: (event: InstrumentationTurnStartedEvent) => void | PromiseLike<void>;
+    readonly "attempt.started"?: InstrumentationEventHandler<InstrumentationAttemptStartedEvent>;
+    readonly "attempt.completed"?: InstrumentationEventHandler<InstrumentationAttemptTerminalEvent>;
+    readonly "attempt.failed"?: InstrumentationEventHandler<InstrumentationAttemptTerminalEvent>;
+    readonly "attempt.metadata"?: InstrumentationEventHandler<InstrumentationAttemptMetadataEvent>;
+    readonly "model.call.started"?: InstrumentationEventHandler<InstrumentationModelCallStartedEvent>;
+    readonly "model.call.completed"?: InstrumentationEventHandler<InstrumentationModelCallCompletedEvent>;
+    readonly "model.call.failed"?: InstrumentationEventHandler<InstrumentationModelCallFailedEvent>;
+    readonly "session.completed"?: InstrumentationEventHandler<InstrumentationSessionTransitionEvent>;
+    readonly "session.failed"?: InstrumentationEventHandler<InstrumentationSessionTransitionEvent>;
+    readonly "session.started"?: InstrumentationEventHandler<InstrumentationSessionStartedEvent>;
+    readonly "session.waiting"?: InstrumentationEventHandler<InstrumentationSessionTransitionEvent>;
+    readonly "tool.call.started"?: InstrumentationEventHandler<InstrumentationToolCallStartedEvent>;
+    readonly "tool.call.completed"?: InstrumentationEventHandler<InstrumentationToolCallCompletedEvent>;
+    readonly "tool.call.failed"?: InstrumentationEventHandler<InstrumentationToolCallFailedEvent>;
+    readonly "turn.cancelled"?: InstrumentationEventHandler<InstrumentationTurnTerminalEvent>;
+    readonly "turn.completed"?: InstrumentationEventHandler<InstrumentationTurnTerminalEvent>;
+    readonly "turn.failed"?: InstrumentationEventHandler<InstrumentationTurnTerminalEvent>;
+    readonly "turn.started"?: InstrumentationEventHandler<InstrumentationTurnStartedEvent>;
   };
 }
 
-export interface InstrumentationRelatedEventMap {
-  readonly "model.call": {
-    readonly start: InstrumentationModelCallStartedEvent;
-    readonly terminal: InstrumentationModelCallTerminalEvent;
-  };
-  readonly "tool.call": {
-    readonly start: InstrumentationToolCallStartedEvent;
-    readonly terminal: InstrumentationToolCallTerminalEvent;
-  };
-}
-
-export type InstrumentationRelatedEventName = keyof InstrumentationRelatedEventMap;
+/** Events that carry an operation `id`, pairing a start with its terminal. */
+export type InstrumentationCorrelatedEvent =
+  | InstrumentationModelCallStartedEvent
+  | InstrumentationModelCallTerminalEvent
+  | InstrumentationToolCallStartedEvent
+  | InstrumentationToolCallTerminalEvent;
 
 export type InstrumentationPointEvent =
   | InstrumentationAttemptStartedEvent
@@ -266,6 +241,8 @@ export type InstrumentationPointEvent =
   | InstrumentationSessionTransitionEvent
   | InstrumentationTurnStartedEvent
   | InstrumentationTurnTerminalEvent;
+
+export type InstrumentationEvent = InstrumentationCorrelatedEvent | InstrumentationPointEvent;
 
 /** Trusted framework operation for activating context around AI SDK execution. */
 export type InstrumentationContextRunner = <T>(
@@ -288,15 +265,7 @@ export type InstrumentationExecutionOperation =
 
 /** Provider-neutral hook operations consumed by the AI SDK bridge. */
 export interface InstrumentationHooks {
-  after<TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["terminal"],
-  ): Promise<void>;
-  before<TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["start"],
-  ): Promise<void>;
-  publish(event: InstrumentationPointEvent): Promise<void>;
+  publish(event: InstrumentationEvent): Promise<void>;
 }
 
 const log = createLogger("harness.instrumentation-lifecycle");
@@ -305,71 +274,20 @@ const log = createLogger("harness.instrumentation-lifecycle");
 export function createInstrumentationHooks(
   providers: readonly InstrumentationProviderDefinition[],
 ): InstrumentationHooks {
-  const relatedState = new WeakMap<InstrumentationAttemptScope, Map<string, unknown>>();
-
-  const publish = async (event: InstrumentationPointEvent): Promise<void> => {
+  const publish = async (event: InstrumentationEvent): Promise<void> => {
     for (const provider of providers) {
       const handler = provider.events?.[event.type];
       if (handler === undefined) continue;
       try {
-        await (handler as (value: typeof event) => void | PromiseLike<void>)(event);
+        await (handler as InstrumentationEventHandler<InstrumentationEvent>)(event);
       } catch (error) {
-        warn(event.type, error);
+        log.warn("instrumentation provider failed", {
+          boundary: event.type,
+          error: formatError(error),
+        });
       }
     }
   };
 
-  const before = async <TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["start"],
-  ): Promise<void> => {
-    const attemptState = relatedState.get(event.scope) ?? new Map<string, unknown>();
-    relatedState.set(event.scope, attemptState);
-    for (const [providerIndex, provider] of providers.entries()) {
-      const handler = provider.events?.[name]?.before;
-      if (handler === undefined) continue;
-      try {
-        const state = await (handler as (value: typeof event) => unknown)(event);
-        attemptState.set(relatedStateKey(providerIndex, event.id), state);
-      } catch (error) {
-        warn(`${name}.before`, error);
-      }
-    }
-  };
-
-  const after = async <TKey extends InstrumentationRelatedEventName>(
-    name: TKey,
-    event: InstrumentationRelatedEventMap[TKey]["terminal"],
-  ): Promise<void> => {
-    const attemptState = relatedState.get(event.scope);
-    for (const [providerIndex, provider] of providers.entries()) {
-      const handler = provider.events?.[name]?.after;
-      const stateKey = relatedStateKey(providerIndex, event.id);
-      if (handler === undefined || !attemptState?.has(stateKey)) continue;
-      const state = attemptState.get(stateKey);
-      attemptState.delete(stateKey);
-      try {
-        await (handler as (value: typeof event, state: unknown) => void | PromiseLike<void>)(
-          event,
-          state,
-        );
-      } catch (error) {
-        warn(`${name}.after`, error);
-      }
-    }
-  };
-
-  const warn = (boundary: string, error: unknown): void => {
-    log.warn("instrumentation provider failed", { boundary, error: formatError(error) });
-  };
-
-  return {
-    after,
-    before,
-    publish,
-  };
-}
-
-function relatedStateKey(providerIndex: number, operationId: string): string {
-  return `${providerIndex}:${operationId}`;
+  return { publish };
 }

--- a/packages/eve/src/harness/instrumentation-native-events.test.ts
+++ b/packages/eve/src/harness/instrumentation-native-events.test.ts
@@ -15,8 +15,6 @@ describe("createInstrumentationHandleEvent", () => {
   it("publishes native lifecycle transitions after durable handling", async () => {
     const order: string[] = [];
     const hooks: InstrumentationHooks = {
-      after: async () => {},
-      before: async () => {},
       publish: async (event) => {
         order.push(`lifecycle:${event.type}`);
       },
@@ -62,8 +60,6 @@ describe("createInstrumentationHandleEvent", () => {
     expect(
       createInstrumentationHandleEvent({
         hooks: {
-          after: async () => {},
-          before: async () => {},
           publish: async () => {},
         },
         sessionId: "session-1",
@@ -76,8 +72,6 @@ describe("createInstrumentationHandleEvent", () => {
     const handleEvent = createInstrumentationHandleEvent({
       handleEvent: async () => {},
       hooks: {
-        after: async () => {},
-        before: async () => {},
         publish: async (event) => {
           events.push(event);
         },
@@ -102,8 +96,6 @@ describe("createInstrumentationHandleEvent", () => {
     const handleEvent = createInstrumentationHandleEvent({
       handleEvent: async () => {},
       hooks: {
-        after: async () => {},
-        before: async () => {},
         publish: async (event) => {
           events.push(event);
         },

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -9320,7 +9320,7 @@ describe("createToolLoopHarness", () => {
       });
       const attemptCompleted = vi.fn();
       const hooks = createInstrumentationHooks([
-        { events: { "attempt.completed": attemptCompleted } },
+        { events: { "step.completed": attemptCompleted } },
       ]);
       const runInContext: InstrumentationContextRunner = (_operation, execute) => execute();
       const config = createTestConfig("conversation", undefined, {
@@ -9358,7 +9358,7 @@ describe("createToolLoopHarness", () => {
       expect(attemptCompleted).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           scope: expect.objectContaining({ attemptIndex: 0 }),
-          type: "attempt.completed",
+          type: "step.completed",
         }),
       );
     });

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -9340,6 +9340,7 @@ describe("createToolLoopHarness", () => {
         }),
         hooks,
         runInContext,
+        expect.any(Function),
       );
       const bridge = mockCreateAiSdkHookBridge.mock.results[0]!.value;
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
@@ -9360,6 +9361,36 @@ describe("createToolLoopHarness", () => {
           type: "attempt.completed",
         }),
       );
+    });
+
+    it("resolves each action kind from the harness tool map", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", undefined, {
+          instrumentation: {
+            hooks: createInstrumentationHooks([]),
+            runInContext: (_operation, execute) => execute(),
+          },
+          tools: createDelegationToolMap(),
+        }),
+      );
+
+      await runStep(createTestSession(), { message: "hi" });
+
+      const resolveActionKind = mockCreateAiSdkHookBridge.mock.calls[0]![3] as (
+        toolName: string,
+      ) => string;
+      expect(resolveActionKind("delegate")).toBe("subagent-call");
+      expect(resolveActionKind("add")).toBe("tool-call");
+      // A name the harness never registered — a dynamic subagent resolved after
+      // the map was built lands here rather than throwing.
+      expect(resolveActionKind("absent")).toBe("tool-call");
     });
 
     it("composes lifecycle hooks with existing authored OTel", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -107,7 +107,7 @@ import {
 import { createToolResultMessagePartFromToolError } from "#harness/action-result-helpers.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
 import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-context.js";
-import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
+import { createAiSdkHookBridge, type ActionKindResolver } from "#harness/ai-sdk-hook-bridge.js";
 import { createInstrumentationHandleEvent } from "#harness/instrumentation-native-events.js";
 import type { InstrumentationAttemptScope } from "#harness/instrumentation-lifecycle.js";
 import { resolveParentLineage } from "#harness/parent-lineage.js";
@@ -509,6 +509,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
   }
   const tracer = telemetryConfig !== undefined ? trace.getTracer("eve") : undefined;
   const agentName = config.runtimeIdentity?.agentName;
+
+  // Resolved the same way `createRuntimeActionRequestFromToolCall` resolves it,
+  // so a trace and an `actions.requested` event name one call the same kind.
+  const resolveActionKind: ActionKindResolver = (toolName) =>
+    config.tools.get(toolName)?.runtimeAction?.kind ?? "tool-call";
 
   async function runStep(
     initialSession: Readonly<Parameters<StepFn>[0]>,
@@ -1016,6 +1021,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
               attemptScope,
               instrumentationHooks,
               config.instrumentation?.runInContext,
+              resolveActionKind,
             );
 
       const hooks = buildStepHooks({

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1150,7 +1150,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       try {
         const result = await executeModelCall();
         if (attemptScope !== undefined) {
-          await instrumentationHooks?.publish({ scope: attemptScope, type: "attempt.completed" });
+          await instrumentationHooks?.publish({ scope: attemptScope, type: "step.completed" });
         }
         return result;
       } catch (error) {
@@ -1158,7 +1158,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           await instrumentationHooks?.publish({
             error,
             scope: attemptScope,
-            type: "attempt.failed",
+            type: "step.failed",
           });
         }
         return rethrowNoOutputAsEmptyResponse(error);

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { describe, expect, it } from "vitest";
 
-import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
+import { createAiSdkHookBridge, type ActionKindResolver } from "#harness/ai-sdk-hook-bridge.js";
 import { createAgentOtelInstrumentation } from "#tracing/agent-otel-provider.js";
 import {
   InMemoryAgentTraceStateStore,
@@ -48,6 +48,7 @@ async function emitAttempt(input: {
   readonly hooks: InstrumentationHooks;
   readonly runInContext: InstrumentationContextRunner;
   readonly providerMetadata?: Readonly<Record<string, unknown>>;
+  readonly resolveActionKind?: ActionKindResolver;
   readonly sessionId: string;
   readonly toolError?: Error;
   readonly turnAlreadyStarted?: boolean;
@@ -66,7 +67,12 @@ async function emitAttempt(input: {
     await publishTurnStarted(input);
   }
 
-  const bridge = createAiSdkHookBridge(scope, input.hooks, input.runInContext);
+  const bridge = createAiSdkHookBridge(
+    scope,
+    input.hooks,
+    input.runInContext,
+    input.resolveActionKind,
+  );
   Reflect.apply(bridge.onStart!, bridge, [
     {
       callId: "call-1",
@@ -256,10 +262,29 @@ describe("createAgentOtelInstrumentation", () => {
       "gen_ai.usage.cache_read.input_tokens": 4,
     });
     expect(action.attributes).toMatchObject({
-      "agent.action.kind": "tool",
+      "agent.action.kind": "tool-call",
       "agent.action.name": "weather",
       "agent.framework.name": "eve",
       "agent.root.session.id": "session-1",
+    });
+  });
+
+  it("labels a subagent action by its kind, not as a plain tool", async () => {
+    const runtime = createRuntime();
+    await emitAttempt({
+      hooks: runtime.hooks,
+      resolveActionKind: () => "subagent-call",
+      runInContext: runtime.runInContext,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.provider.forceFlush();
+
+    const action = runtime.exporter.getFinishedSpans().find((span) => span.name === "agent.action");
+    expect(action?.attributes).toMatchObject({
+      "agent.action.kind": "subagent-call",
+      "agent.action.name": "weather",
     });
   });
 

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -160,11 +160,11 @@ async function emitAttempt(input: {
     await input.hooks.publish({
       providerMetadata: input.providerMetadata,
       scope,
-      type: "attempt.metadata",
+      type: "step.metadata",
     });
   }
 
-  await input.hooks.publish({ scope, type: "attempt.completed" });
+  await input.hooks.publish({ scope, type: "step.completed" });
   await input.hooks.publish({
     sessionId: input.sessionId,
     turnId: input.turnId,

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -8,11 +8,11 @@ import {
 import { describe, expect, it } from "vitest";
 
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
+import { createAgentOtelInstrumentation } from "#tracing/agent-otel-provider.js";
 import {
-  createAgentOtelInstrumentation,
   InMemoryAgentTraceStateStore,
   SESSION_WINDOW_TURN_LIMIT,
-} from "#tracing/agent-otel-provider.js";
+} from "#tracing/agent-trace-state.js";
 import {
   createInstrumentationHooks,
   type InstrumentationAttemptScope,

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -22,10 +22,10 @@ import {
   toolResultsContentAttribute,
 } from "#tracing/agent-otel-content.js";
 import type {
-  InstrumentationAttemptMetadataEvent,
+  InstrumentationStepMetadataEvent,
   InstrumentationAttemptScope,
-  InstrumentationAttemptStartedEvent,
-  InstrumentationAttemptTerminalEvent,
+  InstrumentationStepStartedLifecycleEvent,
+  InstrumentationStepTerminalEvent,
   InstrumentationContextRunner,
   InstrumentationModelCallTerminalEvent,
   InstrumentationModelCallStartedEvent,
@@ -137,7 +137,7 @@ export function createAgentOtelInstrumentation(
     span.end();
   };
 
-  const onAttemptStarted = async (event: InstrumentationAttemptStartedEvent): Promise<void> => {
+  const onStepStarted = async (event: InstrumentationStepStartedLifecycleEvent): Promise<void> => {
     const turn = await input.stateStore.getTurn(event.scope.sessionId, event.scope.turnId);
     if (turn === undefined) return;
     const turnContext = contextFromSpanContext(turn.context);
@@ -181,14 +181,12 @@ export function createAgentOtelInstrumentation(
     });
   };
 
-  const onAttemptTerminal = (event: InstrumentationAttemptTerminalEvent): void => {
+  const onStepTerminal = (event: InstrumentationStepTerminalEvent): void => {
     executionContexts.delete(event.scope);
     const attempt = steps.get(event.scope);
     if (attempt === undefined) return;
-    attempt.step.span.addEvent(
-      event.type === "attempt.completed" ? "step.completed" : "step.failed",
-    );
-    if (event.type === "attempt.failed") {
+    attempt.step.span.addEvent(event.type === "step.completed" ? "step.completed" : "step.failed");
+    if (event.type === "step.failed") {
       recordError(attempt.operation.span, event.error);
       recordError(attempt.step.span, event.error);
     }
@@ -463,7 +461,7 @@ export function createAgentOtelInstrumentation(
     };
   };
 
-  const onAttemptMetadata = (event: InstrumentationAttemptMetadataEvent): void => {
+  const onStepMetadata = (event: InstrumentationStepMetadataEvent): void => {
     const attempt = steps.get(event.scope);
     if (attempt === undefined) return;
     // Vercel AI Gateway reports per-call cost in providerMetadata.gateway;
@@ -479,10 +477,10 @@ export function createAgentOtelInstrumentation(
   return {
     hook: {
       events: {
-        "attempt.completed": onAttemptTerminal,
-        "attempt.failed": onAttemptTerminal,
-        "attempt.metadata": onAttemptMetadata,
-        "attempt.started": onAttemptStarted,
+        "step.completed": onStepTerminal,
+        "step.failed": onStepTerminal,
+        "step.metadata": onStepMetadata,
+        "step.started": onStepStarted,
         "model.call.completed": onModelCallTerminal,
         "model.call.failed": onModelCallTerminal,
         "model.call.started": onModelCallStarted,

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -332,7 +332,7 @@ export function createAgentOtelInstrumentation(
       {
         attributes: {
           "agent.action.call_id": event.callId,
-          "agent.action.kind": "tool",
+          "agent.action.kind": event.kind,
           "agent.action.name": event.toolName,
           "agent.framework.name": "eve",
           "agent.framework.version": input.frameworkVersion,

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -10,6 +10,11 @@ import {
 } from "#compiled/@opentelemetry/api/index.js";
 
 import {
+  SESSION_WINDOW_TURN_LIMIT,
+  type AgentSessionTraceState,
+  type AgentTraceStateStore,
+} from "#tracing/agent-trace-state.js";
+import {
   contentAttribute,
   messagesContentAttribute,
   systemPromptAttribute,
@@ -50,73 +55,6 @@ interface ToolSpanState extends SpanState {
   readonly toolSpan: Span;
 }
 
-/** Sized so an ordinary session stays one trace and only an outsized one rolls. */
-export const SESSION_WINDOW_TURN_LIMIT = 200;
-
-export interface AgentSessionTraceState {
-  readonly agentName?: string;
-  readonly channelKind?: string;
-  readonly context: SpanContext;
-  readonly rootSessionId: string;
-  readonly turnsInWindow: number;
-  readonly window: number;
-}
-
-export interface AgentTurnTraceState {
-  readonly context: SpanContext;
-  readonly rootSessionId: string;
-  readonly sequence: number;
-  readonly terminal?: {
-    readonly error?: unknown;
-    readonly type: InstrumentationTurnTerminalEvent["type"];
-  };
-}
-
-/** Provider-owned serializable storage for durable agent trace state. */
-export interface AgentTraceStateStore {
-  deleteSession(sessionId: string): void | PromiseLike<void>;
-  deleteTurn(sessionId: string, turnId: string): void | PromiseLike<void>;
-  getSession(
-    sessionId: string,
-  ): AgentSessionTraceState | undefined | PromiseLike<AgentSessionTraceState | undefined>;
-  getTurn(
-    sessionId: string,
-    turnId: string,
-  ): AgentTurnTraceState | undefined | PromiseLike<AgentTurnTraceState | undefined>;
-  setSession(sessionId: string, state: AgentSessionTraceState): void | PromiseLike<void>;
-  setTurn(sessionId: string, turnId: string, state: AgentTurnTraceState): void | PromiseLike<void>;
-}
-
-/** In-memory trace state used by tests and non-durable runtimes. */
-export class InMemoryAgentTraceStateStore implements AgentTraceStateStore {
-  readonly #sessions = new Map<string, AgentSessionTraceState>();
-  readonly #turns = new Map<string, AgentTurnTraceState>();
-
-  deleteSession(sessionId: string): void {
-    this.#sessions.delete(sessionId);
-  }
-
-  deleteTurn(sessionId: string, turnId: string): void {
-    this.#turns.delete(turnKey(sessionId, turnId));
-  }
-
-  getSession(sessionId: string): AgentSessionTraceState | undefined {
-    return this.#sessions.get(sessionId);
-  }
-
-  getTurn(sessionId: string, turnId: string): AgentTurnTraceState | undefined {
-    return this.#turns.get(turnKey(sessionId, turnId));
-  }
-
-  setSession(sessionId: string, state: AgentSessionTraceState): void {
-    this.#sessions.set(sessionId, state);
-  }
-
-  setTurn(sessionId: string, turnId: string, state: AgentTurnTraceState): void {
-    this.#turns.set(turnKey(sessionId, turnId), state);
-  }
-}
-
 export interface AgentOtelInstrumentationInput {
   /**
    * Capture model prompts/responses and tool call inputs/outputs as span
@@ -148,6 +86,10 @@ export function createAgentOtelInstrumentation(
   // that worker is lost, Workflow retries the whole step from entry rather
   // than resuming this callback sequence in a replacement process.
   const steps = new WeakMap<InstrumentationAttemptScope, AttemptSpanState>();
+  // eve balances every start with one terminal, so these are set on the start
+  // and deleted on the terminal; a lost worker takes them with it.
+  const modelSpans = new Map<string, SpanState>();
+  const toolSpans = new Map<string, ToolSpanState>();
 
   const onSessionStarted = async (event: InstrumentationSessionStartedEvent): Promise<void> => {
     await ensureSessionContext(event);
@@ -301,9 +243,9 @@ export function createAgentOtelInstrumentation(
     }
   };
 
-  const beforeModelCall = (event: InstrumentationModelCallStartedEvent): SpanState | undefined => {
+  const onModelCallStarted = (event: InstrumentationModelCallStartedEvent): void => {
     const attempt = steps.get(event.scope);
-    if (attempt === undefined) return undefined;
+    if (attempt === undefined) return;
     attempt.step.span.setAttribute("agent.model.id", event.model.modelId);
     attempt.step.span.setAttribute("agent.model.provider", event.model.provider);
     const span = input.tracer.startSpan(
@@ -325,12 +267,14 @@ export function createAgentOtelInstrumentation(
     }
     const state = { context: trace.setSpan(attempt.operation.context, span), span };
     getExecutionContexts(event.scope).models.set(event.id, state.context);
-    return state;
+    modelSpans.set(event.id, state);
   };
 
-  const afterModelCall = (event: InstrumentationModelCallTerminalEvent, state: unknown): void => {
+  const onModelCallTerminal = (event: InstrumentationModelCallTerminalEvent): void => {
     executionContexts.get(event.scope)?.models.delete(event.id);
-    if (!isSpanState(state)) return;
+    const state = modelSpans.get(event.id);
+    modelSpans.delete(event.id);
+    if (state === undefined) return;
     if (event.type === "model.call.failed") {
       recordError(state.span, event.error);
     } else {
@@ -380,11 +324,9 @@ export function createAgentOtelInstrumentation(
     state.span.end();
   };
 
-  const beforeToolCall = (
-    event: InstrumentationToolCallStartedEvent,
-  ): ToolSpanState | undefined => {
+  const onToolCallStarted = (event: InstrumentationToolCallStartedEvent): void => {
     const attempt = steps.get(event.scope);
-    if (attempt === undefined) return undefined;
+    if (attempt === undefined) return;
     const actionSpan = input.tracer.startSpan(
       "agent.action",
       {
@@ -425,12 +367,14 @@ export function createAgentOtelInstrumentation(
       toolSpan,
     };
     getExecutionContexts(event.scope).tools.set(event.id, state.context);
-    return state;
+    toolSpans.set(event.id, state);
   };
 
-  const afterToolCall = (event: InstrumentationToolCallTerminalEvent, state: unknown): void => {
+  const onToolCallTerminal = (event: InstrumentationToolCallTerminalEvent): void => {
     executionContexts.get(event.scope)?.tools.delete(event.id);
-    if (!isToolSpanState(state)) return;
+    const state = toolSpans.get(event.id);
+    toolSpans.delete(event.id);
+    if (state === undefined) return;
     if (event.type === "tool.call.failed") {
       recordError(state.toolSpan, event.error);
       recordError(state.span, event.error);
@@ -539,12 +483,16 @@ export function createAgentOtelInstrumentation(
         "attempt.failed": onAttemptTerminal,
         "attempt.metadata": onAttemptMetadata,
         "attempt.started": onAttemptStarted,
-        "model.call": { after: afterModelCall, before: beforeModelCall },
+        "model.call.completed": onModelCallTerminal,
+        "model.call.failed": onModelCallTerminal,
+        "model.call.started": onModelCallStarted,
         "session.completed": onSessionTransition,
         "session.failed": onSessionTransition,
         "session.started": onSessionStarted,
         "session.waiting": onSessionTransition,
-        "tool.call": { after: afterToolCall, before: beforeToolCall },
+        "tool.call.completed": onToolCallTerminal,
+        "tool.call.failed": onToolCallTerminal,
+        "tool.call.started": onToolCallStarted,
         "turn.cancelled": onTurnTerminal,
         "turn.completed": onTurnTerminal,
         "turn.failed": onTurnTerminal,
@@ -572,10 +520,6 @@ export function createAgentOtelInstrumentation(
     }
     return state;
   }
-}
-
-function turnKey(sessionId: string, turnId: string): string {
-  return `${sessionId}:${turnId}`;
 }
 
 function parentLineageAttributes(
@@ -639,14 +583,6 @@ function readUsd(value: unknown): number | undefined {
   if (typeof value !== "string") return undefined;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function isSpanState(value: unknown): value is SpanState {
-  return typeof value === "object" && value !== null && "context" in value && "span" in value;
-}
-
-function isToolSpanState(value: unknown): value is ToolSpanState {
-  return isSpanState(value) && "toolSpan" in value;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/tracing/agent-trace-context-store.ts
+++ b/packages/eve/src/tracing/agent-trace-context-store.ts
@@ -6,7 +6,7 @@ import type {
   AgentSessionTraceState,
   AgentTraceStateStore,
   AgentTurnTraceState,
-} from "#tracing/agent-otel-provider.js";
+} from "#tracing/agent-trace-state.js";
 
 interface AgentTraceContextState {
   readonly sessions: Readonly<Record<string, AgentSessionTraceState>>;

--- a/packages/eve/src/tracing/agent-trace-state.ts
+++ b/packages/eve/src/tracing/agent-trace-state.ts
@@ -1,0 +1,74 @@
+import type { SpanContext } from "#compiled/@opentelemetry/api/index.js";
+
+import type { InstrumentationTurnTerminalEvent } from "#harness/instrumentation-lifecycle.js";
+
+/** Sized so an ordinary session stays one trace and only an outsized one rolls. */
+export const SESSION_WINDOW_TURN_LIMIT = 200;
+
+export interface AgentSessionTraceState {
+  readonly agentName?: string;
+  readonly channelKind?: string;
+  readonly context: SpanContext;
+  readonly rootSessionId: string;
+  readonly turnsInWindow: number;
+  readonly window: number;
+}
+
+export interface AgentTurnTraceState {
+  readonly context: SpanContext;
+  readonly rootSessionId: string;
+  readonly sequence: number;
+  readonly terminal?: {
+    readonly error?: unknown;
+    readonly type: InstrumentationTurnTerminalEvent["type"];
+  };
+}
+
+/** Provider-owned serializable storage for durable agent trace state. */
+export interface AgentTraceStateStore {
+  deleteSession(sessionId: string): void | PromiseLike<void>;
+  deleteTurn(sessionId: string, turnId: string): void | PromiseLike<void>;
+  getSession(
+    sessionId: string,
+  ): AgentSessionTraceState | undefined | PromiseLike<AgentSessionTraceState | undefined>;
+  getTurn(
+    sessionId: string,
+    turnId: string,
+  ): AgentTurnTraceState | undefined | PromiseLike<AgentTurnTraceState | undefined>;
+  setSession(sessionId: string, state: AgentSessionTraceState): void | PromiseLike<void>;
+  setTurn(sessionId: string, turnId: string, state: AgentTurnTraceState): void | PromiseLike<void>;
+}
+
+/** In-memory trace state used by tests and non-durable runtimes. */
+export class InMemoryAgentTraceStateStore implements AgentTraceStateStore {
+  readonly #sessions = new Map<string, AgentSessionTraceState>();
+  readonly #turns = new Map<string, AgentTurnTraceState>();
+
+  deleteSession(sessionId: string): void {
+    this.#sessions.delete(sessionId);
+  }
+
+  deleteTurn(sessionId: string, turnId: string): void {
+    this.#turns.delete(turnKey(sessionId, turnId));
+  }
+
+  getSession(sessionId: string): AgentSessionTraceState | undefined {
+    return this.#sessions.get(sessionId);
+  }
+
+  getTurn(sessionId: string, turnId: string): AgentTurnTraceState | undefined {
+    return this.#turns.get(turnKey(sessionId, turnId));
+  }
+
+  setSession(sessionId: string, state: AgentSessionTraceState): void {
+    this.#sessions.set(sessionId, state);
+  }
+
+  setTurn(sessionId: string, turnId: string, state: AgentTurnTraceState): void {
+    this.#turns.set(turnKey(sessionId, turnId), state);
+  }
+}
+
+export function turnKey(sessionId: string, turnId: string): string {
+  return `${sessionId}:${turnId}`;
+}

--- a/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
@@ -109,7 +109,7 @@ describe("local instrumentation runtime", () => {
           toolOutput: { output: { temperature: 72 }, type: "tool-result" },
         },
       ]);
-      await runtime.hooks.publish({ scope, type: "attempt.completed" });
+      await runtime.hooks.publish({ scope, type: "step.completed" });
     });
     await runtime.forceFlush();
 


### PR DESCRIPTION
Fourth in the instrumentation-provider stack, on top of #1677.

## Why

The bus called one model attempt `attempt.*` while the span it produces is `agent.step`. A provider handler and the span it writes disagreed on the noun.

The proposal makes the bus a public provider contract, and its event list is `step.started` / `step.completed` / `step.failed` / `step.metadata`. Doing the rename first means that surface never ships `attempt.*` and renames a public event name immediately after.

## Approach

Mechanical rename of the four event names and their payload types:

| before | after |
| --- | --- |
| `attempt.started` | `step.started` |
| `attempt.completed` | `step.completed` |
| `attempt.failed` | `step.failed` |
| `attempt.metadata` | `step.metadata` |
| `InstrumentationAttemptStartedEvent` | `InstrumentationStepStartedLifecycleEvent` |
| `InstrumentationAttemptTerminalEvent` | `InstrumentationStepTerminalEvent` |
| `InstrumentationAttemptMetadataEvent` | `InstrumentationStepMetadataEvent` |

`InstrumentationAttemptScope` deliberately keeps its name — it identifies one *attempt* of a step, which is exactly what `agent.step.attempt` records.

The started payload takes the `…LifecycleEvent` suffix because `InstrumentationStepStartedEventInput` already exists on the public surface for the unrelated `step.started` runtime-context hook. That collision resolves when the proposal deletes that hook; until then the two names stay distinct.

## Scope

Publishes nothing — these events are internal. No changeset-visible behaviour change; included as `patch` because it touches published `eve` source.

## Verification

- `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`
- `pnpm --filter eve typecheck`
- `pnpm test:unit` — 5,894 passed
- `pnpm test:integration` — 575 passed