### PR TITLE
fix(eve): dynamic tool schemas - preserve live validation

### DIFF
--- a/.changeset/preserve-dynamic-tool-refinements.md
+++ b/.changeset/preserve-dynamic-tool-refinements.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve live input and output validators for replayed dynamic tools, so Zod refinements and transforms continue to run after session- and turn-scoped schemas cross durable workflow steps. eve now warns when a live schema cannot be reconstructed instead of silently relying on a potentially lossy JSON Schema representation.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -122,6 +122,8 @@ export default defineDynamic({
 
 Write `execute` as an inline function expression, arrow, or method shorthand placed directly as the property value. The bundler transform does not detect `execute: myFn` or `execute: makeFn()`, so those tools work on the first step but do not survive replay (re-running a step after a crash or resume; see [Execution model & durability](../concepts/execution-model-and-durability)). On later steps the transform reconstructs each `execute` from its stored closure variables instead of re-running the resolver, which is why it has to be inline.
 
+For a Zod or other live Standard Schema with custom validation, reference a module-scoped schema or construct it directly in the `inputSchema` or `outputSchema` property. eve registers a schema factory beside the inline executor so refinements and transforms survive replay. A live schema first assigned to a handler-local variable cannot be serialized; eve warns and falls back to its JSON Schema representation, which may omit custom validation.
+
 ### Naming
 
 | Return shape            | File                       | Tool name(s)      |

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -6,21 +6,25 @@ import {
   LiveStepToolsKey,
 } from "#context/keys.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
+import {
+  replayDynamicToolInputSchema,
+  replayDynamicToolOutputSchema,
+  type DynamicToolStepFunction,
+} from "#context/dynamic-tool-schema-replay.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 import { createLogger } from "#internal/logging.js";
 import type { ApprovalContext, ApprovalStatus } from "#public/definitions/approval.js";
-import { toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
 
 const log = createLogger("dynamic-tools");
 
-function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) | null {
+function lookupStepFunction(stepId: string): DynamicToolStepFunction | null {
   try {
     const registry = (globalThis as Record<symbol, Map<string, Function> | undefined>)[
       Symbol.for("@workflow/core//registeredSteps")
     ];
     if (registry === undefined) return null;
     const fn = registry.get(stepId);
-    return fn ? (fn as (...args: unknown[]) => unknown) : null;
+    return fn ? (fn as DynamicToolStepFunction) : null;
   } catch {
     return null;
   }
@@ -53,10 +57,20 @@ function replayTools(metadata: readonly DurableDynamicToolMetadata[]): HarnessTo
         scope: m.name,
         execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
       }),
-      inputSchema: toInputSchema(m.inputSchema),
+      inputSchema: replayDynamicToolInputSchema({
+        closureVars: m.closureVars,
+        fallback: m.inputSchema,
+        stepFn,
+        toolName: m.name,
+      }),
       name: m.name,
       approval: buildReplayedApproval(m),
-      outputSchema: toOutputSchema(m.outputSchema),
+      outputSchema: replayDynamicToolOutputSchema({
+        closureVars: m.closureVars,
+        fallback: m.outputSchema,
+        stepFn,
+        toolName: m.name,
+      }),
     });
   }
 

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { asSchema } from "ai";
 import { describe, expect, it, vi } from "vitest";
+import { z } from "#compiled/zod/index.js";
 
 import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
@@ -894,6 +895,110 @@ describe("dispatchDynamicToolEvent", () => {
         toolName: "query",
       });
     } finally {
+      registry.delete(stepId);
+    }
+  });
+
+  it("preserves live input validation when replaying a session tool", async () => {
+    const ctx = createCtx();
+    const stepId = "eve:dynamic-tool//__eve_dispatch_live_schema_test";
+    const inputSchema = z
+      .strictObject({
+        estimatedReviewMinutes: z.number().optional(),
+        itemType: z.enum(["issue", "pull_request"]),
+      })
+      .superRefine((assessment, refinementCtx) => {
+        if (
+          assessment.itemType === "pull_request" &&
+          assessment.estimatedReviewMinutes === undefined
+        ) {
+          refinementCtx.addIssue({
+            code: "custom",
+            message: "Pull requests require estimatedReviewMinutes.",
+            path: ["estimatedReviewMinutes"],
+          });
+        }
+      });
+    const stepFn = Object.assign(() => ({ ok: true }), {
+      __eveInputSchemaFactory: () => inputSchema,
+      stepId,
+    });
+    const registry = getOrCreateStepRegistry(registrySym);
+    registry.set(stepId, stepFn);
+
+    try {
+      const resolver = createResolver("assessment", ["session.started"], () => {
+        const entry = defineTool({
+          description: "submit assessment",
+          inputSchema,
+          execute: async () => ({ ok: true }),
+        });
+        Object.assign(entry, {
+          __executeStepFn: stepFn,
+          __closureVars: {},
+        });
+        return entry;
+      });
+
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        messages: [],
+        event: makeEvent("session.started"),
+      });
+
+      ctx.clearVirtualContext();
+      const schema = asSchema(buildDynamicTools(ctx)[0]!.inputSchema);
+      await expect(schema.validate?.({ itemType: "pull_request" })).resolves.toMatchObject({
+        success: false,
+      });
+      await expect(
+        schema.validate?.({ estimatedReviewMinutes: 30, itemType: "pull_request" }),
+      ).resolves.toEqual({
+        success: true,
+        value: { estimatedReviewMinutes: 30, itemType: "pull_request" },
+      });
+    } finally {
+      registry.delete(stepId);
+    }
+  });
+
+  it("warns when a live session-tool schema cannot be reconstructed", async () => {
+    const ctx = createCtx();
+    const stepId = "eve:dynamic-tool//__eve_dispatch_missing_schema_factory_test";
+    const stepFn = Object.assign(() => ({ ok: true }), { stepId });
+    const registry = getOrCreateStepRegistry(registrySym);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    registry.set(stepId, stepFn);
+
+    try {
+      const resolver = createResolver("assessment", ["session.started"], () => {
+        const entry = defineTool({
+          description: "submit assessment",
+          inputSchema: z.object({ itemType: z.string() }).superRefine(() => {}),
+          execute: async () => ({ ok: true }),
+        });
+        Object.assign(entry, {
+          __executeStepFn: stepFn,
+          __closureVars: {},
+        });
+        return entry;
+      });
+
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        messages: [],
+        event: makeEvent("session.started"),
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Dynamic tool "assessment" has a live input schema that cannot be reconstructed',
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
       registry.delete(stepId);
     }
   });

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -13,6 +13,7 @@ import { createLogger } from "#internal/logging.js";
 import {
   serializeInputSchema,
   serializeOutputSchema,
+  isToolSchema,
   toInputSchema,
   toOutputSchema,
 } from "#shared/tool-schema.js";
@@ -26,6 +27,13 @@ import {
   LiveStepToolsKey,
 } from "#context/keys.js";
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
+import {
+  DYNAMIC_TOOL_INPUT_SCHEMA_FACTORY_PROPERTY,
+  DYNAMIC_TOOL_OUTPUT_SCHEMA_FACTORY_PROPERTY,
+  replayDynamicToolInputSchema,
+  replayDynamicToolOutputSchema,
+  type DynamicToolStepFunction,
+} from "#context/dynamic-tool-schema-replay.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 
@@ -121,9 +129,19 @@ export function replayDynamicSessionTools(
         scope: m.name,
         execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
       }),
-      inputSchema: toInputSchema(m.inputSchema),
+      inputSchema: replayDynamicToolInputSchema({
+        closureVars: m.closureVars,
+        fallback: m.inputSchema,
+        stepFn,
+        toolName: m.name,
+      }),
       name: m.name,
-      outputSchema: toOutputSchema(m.outputSchema),
+      outputSchema: replayDynamicToolOutputSchema({
+        closureVars: m.closureVars,
+        fallback: m.outputSchema,
+        stepFn,
+        toolName: m.name,
+      }),
     });
   }
 
@@ -145,10 +163,10 @@ function getStepRegistry(): Map<string, Function> {
   return registry;
 }
 
-function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) | null {
+function lookupStepFunction(stepId: string): DynamicToolStepFunction | null {
   try {
     const fn = getStepRegistry().get(stepId);
-    return fn ? (fn as (...args: unknown[]) => unknown) : null;
+    return fn ? (fn as DynamicToolStepFunction) : null;
   } catch {
     return null;
   }
@@ -298,15 +316,28 @@ async function resolveToolsFromEvent(
       if (executeStepFnName === undefined) {
         const syntheticId = `eve:framework-dynamic:${resolver.slug}:${entryKey}`;
         const originalExecute = entry.execute.bind(entry);
-        registerStepFunction(syntheticId, (_closureVars: unknown, input: unknown, ctx: unknown) =>
-          originalExecute(
-            input as Record<string, unknown>,
-            ctx as Parameters<typeof entry.execute>[1],
-          ),
+        const syntheticStepFn: DynamicToolStepFunction = Object.assign(
+          (_closureVars: unknown, input: unknown, ctx: unknown) =>
+            originalExecute(
+              input as Record<string, unknown>,
+              ctx as Parameters<typeof entry.execute>[1],
+            ),
+          {
+            [DYNAMIC_TOOL_INPUT_SCHEMA_FACTORY_PROPERTY]: () => entry.inputSchema,
+            [DYNAMIC_TOOL_OUTPUT_SCHEMA_FACTORY_PROPERTY]: () => entry.outputSchema,
+          },
         );
+        registerStepFunction(syntheticId, syntheticStepFn);
         executeStepFnName = syntheticId;
         serializedClosureVars = {};
       }
+
+      const replayableStepFn =
+        stepFn === undefined
+          ? lookupStepFunction(executeStepFnName)
+          : (stepFn as DynamicToolStepFunction);
+      warnIfLiveSchemaCannotReplay(name, "input", entry.inputSchema, replayableStepFn);
+      warnIfLiveSchemaCannotReplay(name, "output", entry.outputSchema, replayableStepFn);
 
       let approvalStepFnName: string | undefined;
       if (entry.approval !== undefined) {
@@ -332,6 +363,26 @@ async function resolveToolsFromEvent(
   }
 
   return { metadata, liveTools };
+}
+
+function warnIfLiveSchemaCannotReplay(
+  toolName: string,
+  direction: "input" | "output",
+  schema: unknown,
+  stepFn: DynamicToolStepFunction | null,
+): void {
+  if (!isToolSchema(schema)) return;
+  const property =
+    direction === "input"
+      ? DYNAMIC_TOOL_INPUT_SCHEMA_FACTORY_PROPERTY
+      : DYNAMIC_TOOL_OUTPUT_SCHEMA_FACTORY_PROPERTY;
+  if (stepFn?.[property] !== undefined) return;
+
+  log.warn(
+    `Dynamic tool "${toolName}" has a live ${direction} schema that cannot be reconstructed ` +
+      "across workflow steps; refinements, transforms, and other custom validation may be lost. " +
+      "Keep the schema expression directly on defineTool() or move the schema to module scope.",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/context/dynamic-tool-schema-replay.ts
+++ b/packages/eve/src/context/dynamic-tool-schema-replay.ts
@@ -1,0 +1,86 @@
+import { createLogger } from "#internal/logging.js";
+import { toErrorMessage } from "#shared/errors.js";
+import type { JsonObject } from "#shared/json.js";
+import {
+  toInputSchema,
+  toOutputSchema,
+  type ToolSchema,
+  type ToolSchemaSource,
+} from "#shared/tool-schema.js";
+
+const log = createLogger("dynamic-tools");
+
+export const DYNAMIC_TOOL_INPUT_SCHEMA_FACTORY_PROPERTY = "__eveInputSchemaFactory";
+export const DYNAMIC_TOOL_OUTPUT_SCHEMA_FACTORY_PROPERTY = "__eveOutputSchemaFactory";
+
+type DynamicToolSchemaFactory = (
+  closureVars: Record<string, unknown>,
+) => ToolSchemaSource | undefined;
+
+/** Registered dynamic-tool execute function with optional live schema factories. */
+export type DynamicToolStepFunction = ((...args: unknown[]) => unknown) & {
+  [DYNAMIC_TOOL_INPUT_SCHEMA_FACTORY_PROPERTY]?: DynamicToolSchemaFactory;
+  [DYNAMIC_TOOL_OUTPUT_SCHEMA_FACTORY_PROPERTY]?: DynamicToolSchemaFactory;
+};
+
+/** Restores the original live input validator when the transform registered one. */
+export function replayDynamicToolInputSchema(input: {
+  readonly closureVars: Record<string, unknown>;
+  readonly fallback: JsonObject;
+  readonly stepFn: DynamicToolStepFunction;
+  readonly toolName: string;
+}): ToolSchema {
+  return replayDynamicToolSchema({
+    ...input,
+    direction: "input",
+  }) as ToolSchema;
+}
+
+/** Restores the original live output validator when the transform registered one. */
+export function replayDynamicToolOutputSchema(input: {
+  readonly closureVars: Record<string, unknown>;
+  readonly fallback: JsonObject | undefined;
+  readonly stepFn: DynamicToolStepFunction;
+  readonly toolName: string;
+}): ToolSchema | undefined {
+  return replayDynamicToolSchema({
+    ...input,
+    direction: "output",
+  });
+}
+
+function replayDynamicToolSchema(input: {
+  readonly closureVars: Record<string, unknown>;
+  readonly direction: "input" | "output";
+  readonly fallback: JsonObject | undefined;
+  readonly stepFn: DynamicToolStepFunction;
+  readonly toolName: string;
+}): ToolSchema | undefined {
+  const property =
+    input.direction === "input"
+      ? DYNAMIC_TOOL_INPUT_SCHEMA_FACTORY_PROPERTY
+      : DYNAMIC_TOOL_OUTPUT_SCHEMA_FACTORY_PROPERTY;
+  const factory = input.stepFn[property];
+  if (factory === undefined) {
+    return input.direction === "input"
+      ? toInputSchema(input.fallback)
+      : toOutputSchema(input.fallback);
+  }
+
+  try {
+    const source = factory(input.closureVars);
+    if (input.direction === "input" && source === undefined) {
+      throw new Error("The input schema factory returned undefined.");
+    }
+    return input.direction === "input" ? toInputSchema(source) : toOutputSchema(source);
+  } catch (error) {
+    log.warn(
+      `Dynamic tool "${input.toolName}" could not restore its live ${input.direction} schema; ` +
+        "falling back to serialized JSON Schema. Custom validation may not be enforced.",
+      { error: toErrorMessage(error) },
+    );
+    return input.direction === "input"
+      ? toInputSchema(input.fallback)
+      : toOutputSchema(input.fallback);
+  }
+}

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-schema-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-schema-transform.ts
@@ -1,0 +1,78 @@
+import {
+  findProperty,
+  type DynamicToolAstNode as AstNode,
+  walkNode,
+} from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
+
+/** One schema expression and its exact authored source. */
+export interface SchemaExpressionInfo {
+  readonly node: AstNode;
+  readonly source: string;
+}
+
+/** Reads a direct schema property from one `defineTool` object argument. */
+export function findSchemaExpression(
+  source: string,
+  toolArg: AstNode,
+  propertyName: "inputSchema" | "outputSchema",
+): SchemaExpressionInfo | undefined {
+  const property = findProperty(toolArg, propertyName);
+  const value = property?.value;
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    !("type" in value) ||
+    typeof value.type !== "string"
+  ) {
+    return undefined;
+  }
+  const node = value as AstNode;
+  if (node.start === undefined || node.end === undefined) {
+    return undefined;
+  }
+  return {
+    node,
+    source: source.slice(node.start, node.end),
+  };
+}
+
+/** Returns whether a schema expression can be safely rebuilt at module scope. */
+export function canReplaySchemaExpression(
+  schema: SchemaExpressionInfo | undefined,
+  candidateVars: readonly string[],
+): boolean {
+  if (schema === undefined) return false;
+  if (
+    schema.node.type === "Identifier" &&
+    schema.node.name !== undefined &&
+    candidateVars.includes(schema.node.name)
+  ) {
+    return false;
+  }
+
+  let hasUnsupportedSyntax = false;
+  walkNode(schema.node, (node) => {
+    if (
+      node.type === "AwaitExpression" ||
+      node.type === "YieldExpression" ||
+      node.type === "ThisExpression"
+    ) {
+      hasUnsupportedSyntax = true;
+      return false;
+    }
+    return true;
+  });
+  return !hasUnsupportedSyntax;
+}
+
+/** Emits the assignment that attaches one schema factory to a step function. */
+export function buildSchemaFactoryRegistration(
+  hoistedName: string,
+  propertyName: "__eveInputSchemaFactory" | "__eveOutputSchemaFactory",
+  schemaSource: string,
+  capturedVars: readonly string[],
+): string {
+  const destructure =
+    capturedVars.length === 0 ? "" : `const { ${capturedVars.join(", ")} } = __vars; `;
+  return `${hoistedName}.${propertyName} = (__vars) => { ${destructure}return ${schemaSource}; };`;
+}

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
+import { z } from "#compiled/zod/index.js";
 
 import { transformDynamicToolExecute } from "./dynamic-tool-transform.js";
 
@@ -49,8 +50,8 @@ async function transformAndEval(
 
   // Evaluate in a function scope to provide our stubs. The transform
   // prepends its own __eveStepRegistry setup, so we don't need to add it.
-  const evalFn = new Function("defineDynamic", "defineTool", `${code}\nreturn __exported;`);
-  evalFn(defineDynamic, defineTool);
+  const evalFn = new Function("defineDynamic", "defineTool", "z", `${code}\nreturn __exported;`);
+  evalFn(defineDynamic, defineTool, z);
 
   const registrySym = Symbol.for("@workflow/core//registeredSteps");
   const registry = (globalThis as Record<symbol, Map<string, Function>>)[registrySym] ?? new Map();
@@ -182,6 +183,115 @@ export default defineDynamic({
     // Calling the step function directly with __vars and input should work
     const result = stepFn({ multiplier: 10 }, { x: 5 });
     expect(result).toBe(50);
+  });
+
+  it("registers live input and output schema factories on the step function", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+const sharedInputSchema = { kind: "input" };
+const sharedOutputSchema = { kind: "output" };
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const tenant = "acme";
+      return defineTool({
+        description: "Submit",
+        inputSchema: sharedInputSchema,
+        outputSchema: { ...sharedOutputSchema, tenant },
+        execute(input) { return input; },
+      });
+    },
+  },
+});
+`;
+
+    const { callHandler } = await transformAndEval("tools/submit.ts", source);
+    const tool = await callHandler();
+    const stepFn = tool.__executeStepFn as Function & {
+      __eveInputSchemaFactory?: (vars: Record<string, unknown>) => unknown;
+      __eveOutputSchemaFactory?: (vars: Record<string, unknown>) => unknown;
+    };
+
+    expect(stepFn.__eveInputSchemaFactory?.({})).toEqual({
+      kind: "input",
+    });
+    expect(stepFn.__eveOutputSchemaFactory?.({ tenant: "acme" })).toEqual({
+      kind: "output",
+      tenant: "acme",
+    });
+  });
+
+  it("rebuilds a module-scoped Zod schema with superRefine intact", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+import { z } from "zod";
+
+const assessmentSchema = z
+  .strictObject({
+    estimatedReviewMinutes: z.number().optional(),
+    itemType: z.enum(["issue", "pull_request"]),
+  })
+  .superRefine((assessment, ctx) => {
+    if (assessment.itemType === "pull_request" && assessment.estimatedReviewMinutes === undefined) {
+      ctx.addIssue({ code: "custom", message: "Required", path: ["estimatedReviewMinutes"] });
+    }
+  });
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      return defineTool({
+        description: "Submit",
+        inputSchema: assessmentSchema,
+        execute(input) { return input; },
+      });
+    },
+  },
+});
+`;
+
+    const { callHandler } = await transformAndEval("tools/assessment.ts", source);
+    const tool = await callHandler();
+    const stepFn = tool.__executeStepFn as Function & {
+      __eveInputSchemaFactory?: (vars: Record<string, unknown>) => {
+        safeParse(value: unknown): { success: boolean };
+      };
+    };
+    const rebuiltSchema = stepFn.__eveInputSchemaFactory?.({});
+
+    expect(rebuiltSchema?.safeParse({ itemType: "pull_request" }).success).toBe(false);
+    expect(
+      rebuiltSchema?.safeParse({
+        estimatedReviewMinutes: 30,
+        itemType: "pull_request",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("does not capture a handler-local schema object in durable closure vars", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const inputSchema = makeSchema();
+      return defineTool({
+        description: "Submit",
+        inputSchema,
+        execute(input) { return input; },
+      });
+    },
+  },
+});
+`;
+
+    const { code } = await transformAndEval("tools/local-schema.ts", source);
+
+    expect(code).not.toContain("__eveInputSchemaFactory");
+    expect(code).toContain("__closureVars: {}");
   });
 
   it("replay path: step function + stored closure vars produce correct result", async () => {

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -1,10 +1,11 @@
 /**
  * Compiler transform for dynamic tool files.
  *
- * Hoists inline `execute` functions from `defineDynamic`
- * event handler return values to module-scope named functions
- * registered in the global step registry. The workflow SDK then
- * handles serialization and replay.
+ * Hoists inline `execute` functions from `defineDynamic` event handler return
+ * values to module-scope named functions registered in the global step
+ * registry. Direct input and output schema expressions become factories on
+ * those functions so replay can restore live validators after serializing the
+ * durable tool metadata.
  *
  * The walker enters nested functions (helpers, callbacks, IIFEs) so
  * patterns like `function buildTool(n) { return { execute() {} } }`
@@ -17,6 +18,11 @@
  * - A wrapper that passes referenced scope values as `__vars`
  * - `__executeStepFn`: reference to the hoisted function
  * - `__closureVars`: snapshot for durable serialization
+ *
+ * The registered execute function also carries schema factories when the
+ * corresponding schema is inline or module-scoped. A handler-local schema
+ * variable is intentionally not captured because validator objects are not
+ * durable; runtime lifecycle code warns before falling back to JSON Schema.
  *
  * Limitation: `execute` must be an inline function literal (function
  * expression, arrow, or method shorthand). Variable references
@@ -32,6 +38,12 @@ import {
   type DynamicToolAstNode as AstNode,
   walkNode,
 } from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
+import {
+  buildSchemaFactoryRegistration,
+  canReplaySchemaExpression,
+  findSchemaExpression,
+  type SchemaExpressionInfo,
+} from "#internal/workflow-bundle/dynamic-tool-schema-transform.js";
 
 interface HandlerInfo {
   /** The handler function AST node */
@@ -64,6 +76,10 @@ interface ExecuteInfo {
   bodyNode: AstNode;
   /** Scope entries from nested functions between handler and this execute */
   nestedScopes: readonly ScopeEntry[];
+  /** Direct input schema expression from the containing defineTool call. */
+  inputSchema?: SchemaExpressionInfo;
+  /** Direct output schema expression from the containing defineTool call. */
+  outputSchema?: SchemaExpressionInfo;
 }
 
 interface ScopeEntry {
@@ -346,6 +362,8 @@ function walkForExecuteProps(
     (node.arguments[0] as AstNode).type === "ObjectExpression"
   ) {
     const toolArg = node.arguments[0] as AstNode;
+    const inputSchema = findSchemaExpression(source, toolArg, "inputSchema");
+    const outputSchema = findSchemaExpression(source, toolArg, "outputSchema");
     for (const prop of toolArg.properties ?? []) {
       if (
         prop.type === "Property" &&
@@ -377,7 +395,9 @@ function walkForExecuteProps(
               body,
               bodyNode,
               hoistedName: `__eve_dynamic_exec_${transformCounter++}`,
+              inputSchema,
               nestedScopes,
+              outputSchema,
             });
           }
         }
@@ -477,25 +497,47 @@ function applyTransform(source: string, handlers: HandlerInfo[]): { code: string
         }
       }
 
-      // Only capture vars the execute body actually references. This
-      // avoids TDZ errors when the execute is inside a nested function
-      // that runs before later handler-level declarations are initialized.
-      const referencedNames = collectReferencedIdentifierNames(exec.bodyNode);
+      const inputSchema = canReplaySchemaExpression(exec.inputSchema, deduped)
+        ? exec.inputSchema
+        : undefined;
+      const outputSchema = canReplaySchemaExpression(exec.outputSchema, deduped)
+        ? exec.outputSchema
+        : undefined;
 
+      // Capture only values needed by the execute body and schema factories.
+      // This avoids TDZ errors from unrelated later declarations and keeps
+      // non-serializable local schema objects out of durable closure vars.
+      const executeReferencedNames = collectReferencedIdentifierNames(exec.bodyNode);
+      const inputSchemaReferencedNames =
+        inputSchema === undefined
+          ? new Set<string>()
+          : collectReferencedIdentifierNames(inputSchema.node);
+      const outputSchemaReferencedNames =
+        outputSchema === undefined
+          ? new Set<string>()
+          : collectReferencedIdentifierNames(outputSchema.node);
       // Exclude names that collide with the execute function's own
       // parameters — the hoisted function already has those as formal
       // params, and a `const { name } = __vars` would be a duplicate
       // binding SyntaxError.
       const execParamNames = extractExecuteParamNames(exec.params);
 
+      const executeVars = deduped.filter(
+        (name) => !execParamNames.has(name) && executeReferencedNames.has(name),
+      );
+      const schemaVars = deduped.filter(
+        (name) => inputSchemaReferencedNames.has(name) || outputSchemaReferencedNames.has(name),
+      );
       const allVars = deduped.filter(
-        (name) => !execParamNames.has(name) && referencedNames.has(name),
+        (name) => executeVars.includes(name) || schemaVars.includes(name),
       );
 
       const varsObj = allVars.length > 0 ? `{ ${allVars.join(", ")} }` : "{}";
 
       const asyncPrefix = exec.isAsync ? "async " : "";
-      const varsDestructure = allVars.length > 0 ? `const ${varsObj} = __vars;\n  ` : "";
+      const executeVarsObject = executeVars.length > 0 ? `{ ${executeVars.join(", ")} }` : "{}";
+      const varsDestructure =
+        executeVars.length > 0 ? `const ${executeVarsObject} = __vars;\n  ` : "";
       const originalParams = exec.params;
       const hoistedParams = originalParams ? `__vars, ${originalParams}` : "__vars";
       const bodyContent = exec.body.slice(1, -1).trim();
@@ -508,6 +550,26 @@ function applyTransform(source: string, handlers: HandlerInfo[]): { code: string
       );
 
       registrations.push(`${exec.hoistedName}.stepId = ${JSON.stringify(stepId)};`);
+      if (inputSchema !== undefined) {
+        registrations.push(
+          buildSchemaFactoryRegistration(
+            exec.hoistedName,
+            "__eveInputSchemaFactory",
+            inputSchema.source,
+            allVars.filter((name) => inputSchemaReferencedNames.has(name)),
+          ),
+        );
+      }
+      if (outputSchema !== undefined) {
+        registrations.push(
+          buildSchemaFactoryRegistration(
+            exec.hoistedName,
+            "__eveOutputSchemaFactory",
+            outputSchema.source,
+            allVars.filter((name) => outputSchemaReferencedNames.has(name)),
+          ),
+        );
+      }
       registrations.push(`__eveStepRegistry.set(${JSON.stringify(stepId)}, ${exec.hoistedName});`);
       allExecNames.push(exec.hoistedName);
 


### PR DESCRIPTION
### Summary

Closes #1682

Session- and turn-scoped dynamic tools persisted only their JSON Schema representation. Zod callbacks such as `superRefine` are not representable there, so replay built a weaker validator and could pass invalid model input to the executor.

- Registers live input and output schema factories beside transformed dynamic-tool execute functions and rebuilds those validators from durable closure variables during replay.
- Keeps JSON Schema as the durable, model-visible representation while using the live Standard Schema for local validation. If reconstruction is unavailable or fails, eve now warns before falling back.
- Covers the production-shaped module-scoped `superRefine` case, warning fallback, input and output factories, and handler-local schema constraints.
- Documents the replayable schema pattern and includes a patch changeset.

### Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` — eve: 5,981 passed, 1 skipped; docs: 135 passed; catalog: 18 passed
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/context/dynamic-tool-lifecycle.test.ts src/internal/workflow-bundle/dynamic-tool-transform.test.ts` — 109 passed
- `pnpm docs:check`
- `pnpm guard:invariants`
- `git diff --check`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
