### PR TITLE
feat(eve): build the OTel pipeline from a declared value

### DIFF
--- a/.changeset/otel-pipeline-primitive.md
+++ b/.changeset/otel-pipeline-primitive.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+eve now builds its OpenTelemetry pipeline from a declared `otel()` value with the local trace spool as an ordinary span processor, instead of registering the provider and the spool as one unit. Internal groundwork for authored instrumentation providers; the spans and attributes eve records are unchanged.

--- a/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
@@ -55,8 +55,13 @@ export interface TextMapGetter<Carrier = unknown> {
   keys(carrier: Carrier): string[];
 }
 
+export interface TextMapSetter<Carrier = unknown> {
+  set(carrier: Carrier, key: string, value: string): void;
+}
+
 export declare const propagation: {
   extract<Carrier>(context: Context, carrier: Carrier, getter: TextMapGetter<Carrier>): Context;
+  inject<Carrier>(context: Context, carrier: Carrier, setter: TextMapSetter<Carrier>): void;
 };
 
 export declare const trace: {

--- a/packages/eve/scripts/vendor-compiled/declarations/@vercel/otel.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@vercel/otel.d.ts
@@ -10,13 +10,38 @@ export interface IdGenerator {
   generateTraceId(): string;
 }
 
+/**
+ * A `TextMapPropagator`, or one of the names `@vercel/otel` resolves for you.
+ * Structural rather than imported: the instance comes from whichever
+ * `@opentelemetry/*` build the app installed, not from eve's.
+ */
+export type PropagatorOrName =
+  | { inject(...args: never[]): void; extract(...args: never[]): unknown; fields(): string[] }
+  | "auto"
+  | "none"
+  | "tracecontext"
+  | "baggage";
+
+/** A `Sampler`, or one of the names `@vercel/otel` resolves for you. */
+export type SamplerOrName =
+  | { shouldSample(...args: never[]): unknown; toString(): string }
+  | "auto"
+  | "always_off"
+  | "always_on"
+  | "parentbased_always_off"
+  | "parentbased_always_on"
+  | "parentbased_traceidratio"
+  | "traceidratio";
+
 export interface Configuration {
+  readonly attributes?: Readonly<Record<string, unknown>>;
   readonly autoDetectResources?: boolean;
   readonly idGenerator?: IdGenerator;
   readonly instrumentations?: readonly unknown[];
-  readonly propagators?: readonly ["none"];
+  readonly propagators?: readonly PropagatorOrName[];
   readonly serviceName?: string;
   readonly spanProcessors?: readonly SpanProcessor[];
+  readonly traceSampler?: SamplerOrName;
 }
 
 export declare function registerOTel(configuration?: Configuration | string): void;

--- a/packages/eve/src/tracing/agent-trace-span-processor.ts
+++ b/packages/eve/src/tracing/agent-trace-span-processor.ts
@@ -11,8 +11,6 @@ export class AgentTraceSpanProcessor implements SpanProcessor {
   readonly #children: readonly SpanProcessor[];
   readonly #ownedTraceIds = new Set<string>();
   readonly #sessionTraceIds = new Map<string, Set<string>>();
-  #attached = false;
-
   constructor(children: readonly SpanProcessor[]) {
     this.#children = children;
   }
@@ -21,12 +19,7 @@ export class AgentTraceSpanProcessor implements SpanProcessor {
     await Promise.all(this.#children.map((child) => child.forceFlush()));
   }
 
-  isAttached(): boolean {
-    return this.#attached;
-  }
-
   onStart(span: unknown, parentContext: unknown): void {
-    this.#attached = true;
     if (!isSpanLike(span)) return;
     const sessionId = span.attributes["agent.session.id"];
     if (typeof sessionId === "string") {

--- a/packages/eve/src/tracing/local-instrumentation-runtime-conflict.scenario.test.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime-conflict.scenario.test.ts
@@ -25,6 +25,6 @@ describe("local instrumentation runtime ownership", () => {
         frameworkVersion: "test",
         serviceName: "test-agent",
       }),
-    ).toThrow(/another runtime already exists/u);
+    ).toThrow(/another runtime already owns the global tracer provider/u);
   });
 });

--- a/packages/eve/src/tracing/local-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.ts
@@ -1,10 +1,7 @@
-import { context, trace } from "#compiled/@opentelemetry/api/index.js";
-import { registerOTel } from "#compiled/@vercel/otel/index.js";
+import { trace } from "#compiled/@opentelemetry/api/index.js";
 
 import { ContextAgentTraceStateStore } from "#tracing/agent-trace-context-store.js";
 import { createAgentOtelInstrumentation } from "#tracing/agent-otel-provider.js";
-import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
-import { AgentTraceSpanProcessor } from "#tracing/agent-trace-span-processor.js";
 import {
   createInstrumentationHooks,
   type InstrumentationProviderDefinition,
@@ -14,11 +11,9 @@ import {
   registerInstrumentationRuntime,
   type InstrumentationRuntime,
 } from "#harness/instrumentation-runtime.js";
-import {
-  requestLocalTraceStorePrune,
-  resolveLocalTraceRetentionSettings,
-} from "#tracing/local-trace-retention.js";
-import { LocalTraceSpanProcessor } from "#tracing/local-trace-span-processor.js";
+import { localTraces } from "#tracing/local-traces.js";
+import { mergeOtelDeclarations, otel } from "#tracing/otel-declaration.js";
+import { registerOtelPipeline } from "#tracing/otel-registration.js";
 
 /** Installs the zero-config local OTel runtime once in an `eve dev` worker. */
 export function installLocalInstrumentationRuntime(input: {
@@ -29,28 +24,15 @@ export function installLocalInstrumentationRuntime(input: {
   const existing = getInstrumentationRuntime();
   if (existing !== undefined) return existing;
 
-  const retention = resolveLocalTraceRetentionSettings();
-  // `EVE_TRACES=off` removes the writer but keeps the runtime: agent context
-  // still has to propagate so AI SDK and user spans nest correctly.
-  const processor = new AgentTraceSpanProcessor(
-    retention.enabled ? [new LocalTraceSpanProcessor(input.appRoot)] : [],
-  );
-  const idGenerator = new AgentSpanIdGenerator();
-  registerOTel({
-    autoDetectResources: false,
-    idGenerator,
-    instrumentations: [],
-    propagators: ["none"],
+  // The zero-config default expressed with the same primitive an authored
+  // `instrumentation.ts` would use, so this path exercises it.
+  const spool = localTraces({ appRoot: input.appRoot });
+  const merged = mergeOtelDeclarations([otel({ spanProcessors: [spool] })]);
+  const idGenerator = registerOtelPipeline({
+    options: merged ?? {},
     serviceName: input.serviceName,
-    spanProcessors: [processor],
   });
-  const probe = trace.getTracer("eve.registration").startSpan("eve.otel.registration");
-  const activeContext = trace.setSpan(context.active(), probe);
-  const contextAttached = context.with(activeContext, () => trace.getActiveSpan() === probe);
-  probe.end();
-  if (!processor.isAttached() || !contextAttached) {
-    throw new Error("eve could not register OpenTelemetry because another runtime already exists.");
-  }
+
   const agentOtel = createAgentOtelInstrumentation({
     captureContent: process.env.EVE_TRACES_CONTENT !== "off",
     frameworkVersion: input.frameworkVersion,
@@ -64,33 +46,14 @@ export function installLocalInstrumentationRuntime(input: {
       "session.failed": releaseSessionTrace,
     },
   };
-  // Startup sweep: a store left oversized by a killed dev server is bounded
-  // before this worker adds to it.
-  requestPrune();
 
   return registerInstrumentationRuntime({
-    forceFlush: () => processor.forceFlush(),
+    forceFlush: () => spool.forceFlush(),
     hooks: createInstrumentationHooks([agentOtel.hook, releaseTrace]),
     runInContext: agentOtel.runInContext,
   });
 
   async function releaseSessionTrace(event: { readonly sessionId: string }): Promise<void> {
-    // Settle pending segment writes before dropping liveness: a sweep already
-    // running reads the same live set, so releasing first would expose the
-    // trace to eviction while it is still being written.
-    await processor.forceFlush();
-    if (!processor.releaseSession(event.sessionId)) return;
-    requestPrune();
-  }
-
-  function requestPrune(): void {
-    if (!retention.enabled) return;
-    requestLocalTraceStorePrune({
-      activeTraceIds: processor.activeTraceIds(),
-      appRoot: input.appRoot,
-      maxAgeMs: retention.maxAgeMs,
-      maxTotalBytes: retention.maxTotalBytes,
-      retainCount: retention.retainCount,
-    });
+    await spool.releaseSession(event.sessionId);
   }
 }

--- a/packages/eve/src/tracing/local-traces.test.ts
+++ b/packages/eve/src/tracing/local-traces.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { localTraces } from "#tracing/local-traces.js";
+
+vi.mock("#tracing/local-trace-span-processor.js", () => ({
+  LocalTraceSpanProcessor: class {
+    async forceFlush(): Promise<void> {}
+    onEnd(): void {}
+    onStart(): void {}
+    async shutdown(): Promise<void> {}
+  },
+}));
+
+vi.mock("#tracing/local-trace-retention.js", () => ({
+  requestLocalTraceStorePrune: vi.fn(),
+  resolveLocalTraceRetentionSettings: () => ({
+    enabled: true,
+    maxAgeMs: 1,
+    maxTotalBytes: 1,
+    retainCount: 1,
+  }),
+}));
+
+function agentSpan(sessionId: string, traceId: string): unknown {
+  return {
+    attributes: { "agent.session.id": sessionId },
+    spanContext: () => ({ traceId }),
+  };
+}
+
+describe("localTraces", () => {
+  it("reports whether the released session owned any traces", async () => {
+    const spool = localTraces({ appRoot: "/tmp/eve-local-traces-test" });
+    spool.onStart(agentSpan("session-one", "a".repeat(32)), undefined);
+
+    // A subagent child owns none, so releasing it leaves the trace pinned.
+    await expect(spool.releaseSession("child-one")).resolves.toBe(false);
+    await expect(spool.releaseSession("session-one")).resolves.toBe(true);
+    // Releasing twice is not an error, it just owns nothing the second time.
+    await expect(spool.releaseSession("session-one")).resolves.toBe(false);
+  });
+
+  it("is a span processor, so it composes wherever one goes", () => {
+    const spool = localTraces({ appRoot: "/tmp/eve-local-traces-test" });
+    expect(typeof spool.onStart).toBe("function");
+    expect(typeof spool.onEnd).toBe("function");
+    expect(typeof spool.forceFlush).toBe("function");
+    expect(typeof spool.shutdown).toBe("function");
+  });
+});

--- a/packages/eve/src/tracing/local-traces.ts
+++ b/packages/eve/src/tracing/local-traces.ts
@@ -1,0 +1,77 @@
+import type { SpanProcessor } from "#compiled/@vercel/otel/index.js";
+
+import { AgentTraceSpanProcessor } from "#tracing/agent-trace-span-processor.js";
+import { LocalTraceSpanProcessor } from "#tracing/local-trace-span-processor.js";
+import {
+  requestLocalTraceStorePrune,
+  resolveLocalTraceRetentionSettings,
+} from "#tracing/local-trace-retention.js";
+
+/**
+ * The local spool, as a span processor.
+ *
+ * Session liveness and retention live in here rather than in the runtime that
+ * installs it, so nothing an author puts in the same `spanProcessors` list can
+ * see them — and eve's accept filter never reaches an author's exporters.
+ */
+export interface LocalTracesProcessor extends SpanProcessor {
+  /**
+   * Settles pending writes and drops one root session's liveness, then bounds
+   * the store. A subagent child owns no traces, so releasing one is a no-op
+   * and leaves the shared trace pinned until its root finishes.
+   */
+  releaseSession(sessionId: string): Promise<boolean>;
+}
+
+/**
+ * Writes the OTLP/JSON spool under `.eve/traces/v1`.
+ *
+ * `EVE_TRACES=off` removes the writer but keeps the processor: eve still has
+ * to observe spans to track which session owns which trace.
+ */
+export function localTraces(input: { readonly appRoot?: string } = {}): LocalTracesProcessor {
+  const appRoot = input.appRoot ?? resolveAppRoot();
+  const retention = resolveLocalTraceRetentionSettings();
+  const processor = new AgentTraceSpanProcessor(
+    retention.enabled ? [new LocalTraceSpanProcessor(appRoot)] : [],
+  );
+
+  const requestPrune = (): void => {
+    if (!retention.enabled) return;
+    requestLocalTraceStorePrune({
+      activeTraceIds: processor.activeTraceIds(),
+      appRoot,
+      maxAgeMs: retention.maxAgeMs,
+      maxTotalBytes: retention.maxTotalBytes,
+      retainCount: retention.retainCount,
+    });
+  };
+
+  // Startup sweep: a store left oversized by a killed dev server is bounded
+  // before this worker adds to it.
+  requestPrune();
+
+  return {
+    forceFlush: () => processor.forceFlush(),
+    onEnd: (span) => processor.onEnd(span),
+    onStart: (span, parentContext) => processor.onStart(span, parentContext),
+    async releaseSession(sessionId) {
+      // Settle pending segment writes before dropping liveness: a sweep already
+      // running reads the same live set, so releasing first would expose the
+      // trace to eviction while it is still being written.
+      await processor.forceFlush();
+      if (!processor.releaseSession(sessionId)) return false;
+      requestPrune();
+      return true;
+    },
+    shutdown: () => processor.shutdown(),
+  };
+}
+
+function resolveAppRoot(): string {
+  const appRoot = process.env["EVE_DEV_WORKER_APP_ROOT"];
+  if (appRoot === undefined) {
+    throw new Error("EVE_DEV_WORKER_APP_ROOT is required for local tracing.");
+  }
+  return appRoot;
+}

--- a/packages/eve/src/tracing/otel-declaration.test.ts
+++ b/packages/eve/src/tracing/otel-declaration.test.ts
@@ -1,0 +1,79 @@
+import type { SpanProcessor } from "#compiled/@vercel/otel/index.js";
+import { describe, expect, it } from "vitest";
+
+import { isOtelDeclaration, mergeOtelDeclarations, otel } from "#tracing/otel-declaration.js";
+
+/** The merge only ever moves processors, so a fresh no-op is identity enough. */
+function processor(): SpanProcessor {
+  return {
+    forceFlush: async () => undefined,
+    onEnd: () => undefined,
+    onStart: () => undefined,
+    shutdown: async () => undefined,
+  };
+}
+
+describe("otel", () => {
+  it("declares a pipeline without registering anything", () => {
+    const declaration = otel({ spanProcessors: [processor()] });
+    expect(isOtelDeclaration(declaration)).toBe(true);
+    expect(isOtelDeclaration({ options: {} })).toBe(false);
+  });
+});
+
+describe("mergeOtelDeclarations", () => {
+  it("is absent when nothing declared a pipeline", () => {
+    expect(mergeOtelDeclarations([])).toBeUndefined();
+  });
+
+  it("concatenates span processors in declaration order", () => {
+    const [first, second, third] = [processor(), processor(), processor()];
+    const merged = mergeOtelDeclarations([
+      otel({ spanProcessors: [first, second] }),
+      otel({ spanProcessors: [third] }),
+      otel(),
+    ]);
+
+    expect(merged?.spanProcessors).toStrictEqual([first, second, third]);
+  });
+
+  it("carries a singleton declared exactly once", () => {
+    const merged = mergeOtelDeclarations([
+      otel({ sampler: "always_on" }),
+      otel({ propagators: ["tracecontext"] }),
+      otel({ resource: { "service.version": "abc" } }),
+    ]);
+
+    expect(merged).toMatchObject({
+      propagators: ["tracecontext"],
+      resource: { "service.version": "abc" },
+      sampler: "always_on",
+    });
+  });
+
+  // A process has one tracer provider, so letting the first declaration win
+  // would silently discard the second — the failure this throw exists to stop.
+  it.each([
+    { key: "resource", one: otel({ resource: { a: "1" } }), two: otel({ resource: { b: "2" } }) },
+    { key: "sampler", one: otel({ sampler: "always_on" }), two: otel({ sampler: "always_off" }) },
+    {
+      key: "propagators",
+      one: otel({ propagators: ["tracecontext"] }),
+      two: otel({ propagators: ["baggage"] }),
+    },
+  ])("refuses a second $key rather than picking one", ({ key, one, two }) => {
+    expect(() => mergeOtelDeclarations([one, two])).toThrow(
+      new RegExp(`declares \`${key}\` in more than one`, "u"),
+    );
+  });
+
+  it("names both declarations in the collision, so the author can find them", () => {
+    expect(() =>
+      mergeOtelDeclarations([
+        otel(),
+        otel({ sampler: "always_on" }),
+        otel({ sampler: "always_off" }),
+      ]),
+    ).toThrow(/\(1 and 2\)/u);
+  });
+});

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -1,0 +1,95 @@
+import type {
+  PropagatorOrName,
+  SamplerOrName,
+  SpanProcessor,
+} from "#compiled/@vercel/otel/index.js";
+
+/**
+ * OpenTelemetry pipeline settings for one `otel()` declaration.
+ *
+ * `contextManager` and `instrumentations` are deliberately absent: eve's span
+ * nesting depends on the former, and the latter cannot reach anything eve
+ * imported before setup ran.
+ */
+export interface OtelOptions {
+  /**
+   * Resource attributes merged into eve's own, which already carry the
+   * service name.
+   */
+  readonly resource?: Readonly<Record<string, unknown>>;
+  /**
+   * Head sampling, and it is global: it decides whether a span is created at
+   * all, so it thins eve's own sinks and the `traceparent` eve propagates
+   * along with your exporters. To thin one backend only, drop spans in a
+   * processor.
+   */
+  readonly sampler?: SamplerOrName;
+  /** Composed into one propagator. All inject; the first to extract wins. */
+  readonly propagators?: readonly PropagatorOrName[];
+  /**
+   * Where eve exports this agent's traces, and the only field most agents set.
+   * Absent means nowhere, eve's own sinks included.
+   */
+  readonly spanProcessors?: readonly SpanProcessor[];
+}
+
+const OTEL_DECLARATION = Symbol.for("eve.instrumentation.otel");
+
+/**
+ * One declared OpenTelemetry pipeline. eve collects every declaration before
+ * building the tracer provider, so this is a value rather than a side effect.
+ */
+export interface OtelDeclaration {
+  readonly [OTEL_DECLARATION]: true;
+  readonly options: OtelOptions;
+}
+
+/** Declares the OpenTelemetry pipeline eve should build. */
+export function otel(options: OtelOptions = {}): OtelDeclaration {
+  return { [OTEL_DECLARATION]: true, options };
+}
+
+export function isOtelDeclaration(value: unknown): value is OtelDeclaration {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<OtelDeclaration>)[OTEL_DECLARATION] === true
+  );
+}
+
+/** The settings a process can only hold one of, so two declarations collide. */
+const SINGLETONS = ["resource", "sampler", "propagators"] as const;
+
+/**
+ * Merges every declaration into the one pipeline a process can register.
+ *
+ * `spanProcessors` concatenate in declaration order. The rest cannot: one
+ * process has one tracer provider, so it has one resource, one sampler, and
+ * one propagator set. Two declarations of the same one is a boot error rather
+ * than a silent win for whichever eve happened to visit first.
+ */
+export function mergeOtelDeclarations(
+  declarations: readonly OtelDeclaration[],
+): OtelOptions | undefined {
+  if (declarations.length === 0) return undefined;
+
+  const spanProcessors: SpanProcessor[] = [];
+  const owners = new Map<(typeof SINGLETONS)[number], number>();
+  let merged: OtelOptions = {};
+  declarations.forEach(({ options }, index) => {
+    spanProcessors.push(...(options.spanProcessors ?? []));
+    for (const key of SINGLETONS) {
+      if (options[key] === undefined) continue;
+      const owner = owners.get(key);
+      if (owner !== undefined) {
+        throw new Error(
+          `Instrumentation declares \`${key}\` in more than one \`otel()\` call (${String(owner)} and ${String(index)}). One process has one OpenTelemetry tracer provider, so it has one \`${key}\` — declare it once.`,
+        );
+      }
+      owners.set(key, index);
+      merged = { ...merged, [key]: options[key] };
+    }
+  });
+
+  return { ...merged, spanProcessors };
+}

--- a/packages/eve/src/tracing/otel-registration.scenario.test.ts
+++ b/packages/eve/src/tracing/otel-registration.scenario.test.ts
@@ -1,0 +1,54 @@
+import { context, propagation, trace, type Context } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { registerOtelPipeline } from "#tracing/otel-registration.js";
+
+afterEach(() => {
+  context.disable();
+  propagation.disable();
+  trace.disable();
+});
+
+describe("registerOtelPipeline", () => {
+  it("verifies tracer ownership when the sampler records nothing", () => {
+    expect(() =>
+      registerOtelPipeline({
+        options: { sampler: "always_off" },
+        serviceName: "weather",
+      }),
+    ).not.toThrow();
+  });
+
+  it("fails when another runtime already owns the global propagator", () => {
+    expect(
+      propagation.setGlobalPropagator({
+        extract: (carrierContext: Context) => carrierContext,
+        fields: () => [],
+        inject: () => {},
+      }),
+    ).toBe(true);
+
+    expect(() =>
+      registerOtelPipeline({
+        options: {},
+        serviceName: "weather",
+      }),
+    ).toThrow(/another runtime already owns the global propagator/u);
+  });
+
+  it("does not export the private registration span", async () => {
+    const exporter = new InMemorySpanExporter();
+    const processor = new SimpleSpanProcessor(exporter);
+    registerOtelPipeline({
+      options: { spanProcessors: [processor] },
+      serviceName: "weather",
+    });
+
+    trace.getTracer("test").startSpan("user.work").end();
+    await processor.forceFlush();
+
+    expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual(["user.work"]);
+    await processor.shutdown();
+  });
+});

--- a/packages/eve/src/tracing/otel-registration.test.ts
+++ b/packages/eve/src/tracing/otel-registration.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerOtelPipeline } from "#tracing/otel-registration.js";
+
+const { registerOTel } = vi.hoisted(() => ({ registerOTel: vi.fn() }));
+
+vi.mock("#compiled/@vercel/otel/index.js", () => ({ registerOTel }));
+
+describe("registerOtelPipeline", () => {
+  it("maps eve's option names onto the ones @vercel/otel accepts", () => {
+    registerOTel.mockImplementation(() => undefined);
+
+    expect(() =>
+      registerOtelPipeline({
+        options: {
+          propagators: ["tracecontext"],
+          resource: { "service.version": "abc" },
+          sampler: "always_on",
+        },
+        serviceName: "weather",
+      }),
+    ).toThrow();
+
+    expect(registerOTel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: { "service.version": "abc" },
+        autoDetectResources: false,
+        instrumentations: [],
+        propagators: expect.arrayContaining(["tracecontext", expect.any(Object)]),
+        serviceName: "weather",
+        traceSampler: "always_on",
+      }),
+    );
+  });
+
+  it("omits the sampler entirely rather than passing undefined", () => {
+    registerOTel.mockImplementation(() => undefined);
+
+    expect(() => registerOtelPipeline({ options: {}, serviceName: "weather" })).toThrow(
+      /already owns the global tracer provider/u,
+    );
+
+    const configuration = registerOTel.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect("traceSampler" in configuration).toBe(false);
+    // Absent propagators keep `"none"`; eve's private ownership marker follows it.
+    expect(configuration["propagators"]).toEqual(["none", expect.any(Object)]);
+  });
+
+  it("filters the private registration span from authored processors", () => {
+    const downstream = {
+      forceFlush: vi.fn(async () => {}),
+      onEnd: vi.fn(),
+      onStart: vi.fn(),
+      shutdown: vi.fn(async () => {}),
+    };
+    registerOTel.mockImplementation(() => undefined);
+
+    expect(() =>
+      registerOtelPipeline({
+        options: { spanProcessors: [downstream] },
+        serviceName: "weather",
+      }),
+    ).toThrow();
+
+    const configuration = registerOTel.mock.calls.at(-1)?.[0] as {
+      spanProcessors: {
+        onEnd(span: unknown): void;
+        onStart(span: unknown, parentContext: unknown): void;
+      }[];
+    };
+    const processor = configuration.spanProcessors[0]!;
+    processor.onStart({ name: "eve.otel.registration" }, {});
+    processor.onEnd({ name: "eve.otel.registration" });
+    processor.onStart({ name: "agent.turn" }, {});
+    processor.onEnd({ name: "agent.turn" });
+
+    expect(downstream.onStart).toHaveBeenCalledExactlyOnceWith({ name: "agent.turn" }, {});
+    expect(downstream.onEnd).toHaveBeenCalledExactlyOnceWith({ name: "agent.turn" });
+  });
+
+  it("throws when the registration never reached a processor", () => {
+    registerOTel.mockImplementation(() => undefined);
+
+    expect(() => registerOtelPipeline({ options: {}, serviceName: "weather" })).toThrow(
+      /another runtime already owns/u,
+    );
+  });
+});

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -1,0 +1,127 @@
+import { context, propagation, trace, type Context } from "#compiled/@opentelemetry/api/index.js";
+import {
+  registerOTel,
+  type Configuration,
+  type SpanProcessor,
+} from "#compiled/@vercel/otel/index.js";
+
+import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
+import type { OtelOptions } from "#tracing/otel-declaration.js";
+
+const REGISTRATION_SPAN_NAME = "eve.otel.registration";
+
+class RegistrationMarkerPropagator {
+  #injected = false;
+
+  extract(carrierContext: Context): Context {
+    return carrierContext;
+  }
+
+  fields(): string[] {
+    return [];
+  }
+
+  inject(): void {
+    this.#injected = true;
+  }
+
+  isInstalled(): boolean {
+    this.#injected = false;
+    propagation.inject(context.active(), {}, { set: () => {} });
+    return this.#injected;
+  }
+}
+
+/** Keeps eve's ownership check out of every authored destination. */
+class PrivateSpanFilteringProcessor implements SpanProcessor {
+  private readonly processors: readonly SpanProcessor[];
+
+  constructor(processors: readonly SpanProcessor[]) {
+    this.processors = processors;
+  }
+
+  async forceFlush(): Promise<void> {
+    await Promise.all(this.processors.map((processor) => processor.forceFlush()));
+  }
+
+  onEnd(span: unknown): void {
+    if (isRegistrationSpan(span)) return;
+    for (const processor of this.processors) processor.onEnd(span);
+  }
+
+  onStart(span: unknown, parentContext: unknown): void {
+    if (isRegistrationSpan(span)) return;
+    for (const processor of this.processors) processor.onStart(span, parentContext);
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(this.processors.map((processor) => processor.shutdown()));
+  }
+}
+
+/**
+ * Builds the process's one OpenTelemetry tracer provider from a merged
+ * declaration, then proves it took the global slot.
+ *
+ * `registerOTel` reports a refused registration only through `diag`, which
+ * goes nowhere unless `OTEL_LOG_LEVEL` is set, so a second caller would export
+ * nothing and say nothing. eve primes its id generator and installs a private
+ * propagator, then verifies both through the global APIs.
+ */
+export function registerOtelPipeline(input: {
+  readonly options: OtelOptions;
+  readonly serviceName: string;
+}): AgentSpanIdGenerator {
+  const { options } = input;
+  const idGenerator = new AgentSpanIdGenerator();
+  const markerPropagator = new RegistrationMarkerPropagator();
+  const configuration: Configuration = {
+    attributes: options.resource,
+    autoDetectResources: false,
+    idGenerator,
+    // eve imports the model SDK before any of this runs, so an auto
+    // instrumentation registered here could not patch it anyway.
+    instrumentations: [],
+    propagators: [...(options.propagators ?? ["none"]), markerPropagator],
+    serviceName: input.serviceName,
+    spanProcessors: [new PrivateSpanFilteringProcessor(options.spanProcessors ?? [])],
+  };
+  registerOTel(
+    // Absent means "let `@vercel/otel` decide", which is not the same as
+    // passing an explicit `undefined` sampler.
+    options.sampler === undefined
+      ? configuration
+      : { ...configuration, traceSampler: options.sampler },
+  );
+
+  if (!globalTracerUses(idGenerator)) {
+    throw new Error(
+      "eve could not register OpenTelemetry because another runtime already owns the global tracer provider. Remove the other `registerOTel` call, or move its exporters into eve's `otel({ spanProcessors: [...] })`.",
+    );
+  }
+  if (!markerPropagator.isInstalled()) {
+    throw new Error(
+      "eve could not register OpenTelemetry because another runtime already owns the global propagator. Remove the other global propagator registration and declare propagators through eve's `otel()` instead.",
+    );
+  }
+  return idGenerator;
+}
+
+function globalTracerUses(idGenerator: AgentSpanIdGenerator): boolean {
+  const spanId = idGenerator.allocateSpanId();
+  const probe = idGenerator.withSpanId(spanId, () =>
+    trace.getTracer("eve.registration").startSpan(REGISTRATION_SPAN_NAME),
+  );
+  // Deliberately not ended: named processors are resolved inside @vercel/otel
+  // and cannot be wrapped, while an unended span is never exported.
+  return probe.spanContext().spanId === spanId;
+}
+
+function isRegistrationSpan(span: unknown): boolean {
+  return (
+    typeof span === "object" &&
+    span !== null &&
+    "name" in span &&
+    span.name === REGISTRATION_SPAN_NAME
+  );
+}


### PR DESCRIPTION
### Summary

Related to #1659. This fourth PR in the instrumentation-provider stack, on top of #1677, separates the local trace spool from process-wide OpenTelemetry registration. Internal `otel()` values declare pipeline options without registering them; declarations concatenate span processors in order and reject duplicate resources, samplers, or propagator sets rather than silently choosing one.

`registerOtelPipeline` maps the declaration onto `@vercel/otel` and verifies ownership of the global tracer provider and propagator. Its registration probe is kept out of configured processors. `localTraces()` becomes an ordinary span processor that encapsulates local filtering, session liveness, flushing, and retention pruning.

The zero-config development runtime is migrated to these primitives, and the vendored OpenTelemetry declarations are widened for the options they require. This PR does not yet expose or load authored providers and does not change eve's span vocabulary or attributes.

### Validation

- `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`
- `pnpm --filter eve typecheck`
- `pnpm test:unit` - 5,907 passed
- `pnpm test:integration` - 575 passed
- `local-instrumentation-runtime.scenario.test.ts` - 2 passed
- Falsified both registration guards and the local-trace liveness path

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
