### PR TITLE
Flush pending dev stream response headers

### DIFF
--- a/.changeset/flush-dev-workflow-stream-headers.md
+++ b/.changeset/flush-dev-workflow-stream-headers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Flush local development streaming response headers immediately so pending Workflow streams can be cancelled without accumulating listeners.

--- a/packages/eve/src/internal/nitro/host/dev-server-http.ts
+++ b/packages/eve/src/internal/nitro/host/dev-server-http.ts
@@ -59,6 +59,10 @@ export async function writeResponse(
     return;
   }
 
+  // Flush the headers now so the client can obtain / cancel the response body
+  // avoiding, the accumulation of listeners if the stream has a long delay
+  // before first byte
+  response.flushHeaders();
   const body = Readable.fromWeb(webResponse.body as import("node:stream/web").ReadableStream);
   const cancelBody = () => body.destroy(signal.reason as Error | undefined);
   signal.addEventListener("abort", cancelBody, { once: true });

--- a/packages/eve/src/internal/nitro/host/drained-nitro-dev-server.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/drained-nitro-dev-server.scenario.test.ts
@@ -1,4 +1,7 @@
+import { mkdtemp, rm } from "node:fs/promises";
 import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -15,6 +18,12 @@ import type {
   DevelopmentRunner,
   DevelopmentRunnerFactory,
 } from "#internal/nitro/host/dev-runner.js";
+import { createDevelopmentWorkflowWorld } from "#internal/workflow/development-world-client.js";
+import { createParentDevelopmentWorkflowWorld } from "#internal/workflow/development-world-server.js";
+import {
+  DEVELOPMENT_WORKER_APP_ROOT_ENV,
+  DEVELOPMENT_WORKFLOW_SECRET_ENV,
+} from "#internal/workflow/development-world-protocol.js";
 
 const TEST_DEADLINE_MS = 5_000;
 const LOGGER = { error: () => undefined };
@@ -576,6 +585,50 @@ describe("drained Nitro dev server", () => {
     await server.close();
   });
 
+  it("cancels parent-owned Workflow streams before their first chunk", async () => {
+    const appRoot = await mkdtemp(join(tmpdir(), "eve-dev-world-stream-cancel-"));
+    const secret = "scenario-workflow-transport-secret";
+    const world = createParentDevelopmentWorkflowWorld({
+      agentName: "dev-world-stream-cancel-test",
+      appRoot,
+      resolveActiveGenerationId: () => "generation-a",
+      transportSecret: secret,
+    });
+    const server = new DrainedNitroDevServer(LOGGER);
+    server.setControlHandler(async (request) => await world.handleRequest(request));
+    const listener = await listen(server);
+    const previousBaseUrl = process.env.WORKFLOW_LOCAL_BASE_URL;
+    const previousSecret = process.env[DEVELOPMENT_WORKFLOW_SECRET_ENV];
+    const previousAppRoot = process.env[DEVELOPMENT_WORKER_APP_ROOT_ENV];
+    process.env.WORKFLOW_LOCAL_BASE_URL = listener.url;
+    process.env[DEVELOPMENT_WORKFLOW_SECRET_ENV] = secret;
+    process.env[DEVELOPMENT_WORKER_APP_ROOT_ENV] = appRoot;
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+    try {
+      await world.start();
+      const worker = createDevelopmentWorkflowWorld();
+      const streamName = "strm_http_cancel_test_system_abort";
+      for (let index = 0; index < 12; index += 1) {
+        const stream = await withinDeadline(
+          worker.streams.get("wrun_http_cancel_test", streamName),
+          "Timed out waiting for Workflow stream response headers.",
+        );
+        await stream.cancel();
+      }
+
+      expect(maxListenerWarningTypes(emitWarning.mock.calls)).toEqual([]);
+    } finally {
+      emitWarning.mockRestore();
+      restoreEnvironmentVariable("WORKFLOW_LOCAL_BASE_URL", previousBaseUrl);
+      restoreEnvironmentVariable(DEVELOPMENT_WORKFLOW_SECRET_ENV, previousSecret);
+      restoreEnvironmentVariable(DEVELOPMENT_WORKER_APP_ROOT_ENV, previousAppRoot);
+      await server.close();
+      await world.close();
+      await rm(appRoot, { force: true, recursive: true });
+    }
+  });
+
   it("answers control requests without admitting them to the worker", async () => {
     const fetchMock = vi.fn(async () => new Response("worker"));
     const { createRunner } = createRunnerFactory(fetchMock);
@@ -597,3 +650,27 @@ describe("drained Nitro dev server", () => {
     await server.close();
   });
 });
+
+function maxListenerWarningTypes(calls: readonly (readonly unknown[])[]): string[] {
+  return calls.flatMap(([warning]) => {
+    if (
+      typeof warning !== "object" ||
+      warning === null ||
+      !("name" in warning) ||
+      warning.name !== "MaxListenersExceededWarning" ||
+      !("type" in warning) ||
+      typeof warning.type !== "string"
+    ) {
+      return [];
+    }
+    return [warning.type];
+  });
+}
+
+function restoreEnvironmentVariable(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}


### PR DESCRIPTION
### Summary

Closes #1695.

In local development, Workflow streams that have not emitted their first chunk also withhold their HTTP response headers. Clients therefore cannot obtain and cancel the response, causing abort listeners to accumulate and eventually emit `MaxListenersExceededWarning`.

This change:

- flushes headers immediately for body-bearing dev-server responses, allowing pending streams to be cancelled before their first chunk
- leaves bodyless response handling unchanged
- adds scenario coverage that repeatedly opens and cancels a parent-owned Workflow stream and verifies that listeners do not accumulate
- affects only the local development HTTP server

### Validation

- `pnpm build` — passed
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/host/drained-nitro-dev-server.scenario.test.ts` — 15 tests passed
- Documentation is not applicable because this fixes existing local-development behavior without changing the authoring API.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
