### PR TITLE
chore: keep PR descriptions concise

### DIFF
--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -21,6 +21,13 @@ Fill in the repository template. Write for a reviewer:
 - link the prior issue with `Closes #N`, `Related to #N`, or equivalent
 - keep the detail proportional to the change
 
+Keep the description concise and reviewer-focused. Prefer plain language; omit
+unnecessary implementation detail and technical jargon, but include either when
+needed to understand behavior, risk, scope, or a non-obvious decision. Do not
+restate the issue, template guidance, or checklist. For a small, low-risk
+change, prefer a single Summary sentence; use bullets only when they improve
+clarity.
+
 Under validation, list exact checks actually run and useful manual coverage. State
 limitations honestly. Do not infer results or claim checks that only CI will
 run.


### PR DESCRIPTION
### Summary

Related to #1641. Clarifies that PR descriptions should be concise, use plain language, and avoid unnecessary technical detail; small, low-risk changes may use a single summary sentence instead of bullets.

### Validation

- `git diff --check`
- Pre-commit formatter ran during `git commit`

No automated tests: contributor guidance only.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
