### PR TITLE
feat(registry): add connection/tinybird

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1750,6 +1750,12 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     keywords: ["mcp", "tasks", "habits", "todo", "oauth", "connect"],
     authModes: ["user"],
   },
+  tinybird: {
+    logo: "tinybird",
+    docsHref: "/docs/connections/mcp",
+    keywords: ["mcp", "sql", "analytics", "pipes", "datasources", "queries", "connect"],
+    authModes: ["app"],
+  },
   todoist: {
     logo: "todoist",
     docsHref: "/docs/connections/mcp",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -263,6 +263,16 @@ export const supabaseLogo = (props: LogoProps) => <SiSupabase color="default" {.
 
 export const ticktickLogo = (props: LogoProps) => <SiTicktick color="default" {...props} />;
 
+export const tinybirdLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 26 26" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M25 2.64 17.195.5 14.45 6.635zm-7.465 15.13-7.145-2.555L6.195 25.5z"
+      fill="currentColor"
+    />
+    <path d="m0 11.495 17.535 6.275L20.41 4.36z" fill="currentColor" />
+  </svg>
+);
+
 export const todoistLogo = (props: LogoProps) => <SiTodoist color="default" {...props} />;
 
 export const webflowLogo = (props: LogoProps) => <SiWebflow color="default" {...props} />;
@@ -676,6 +686,7 @@ export const logos = {
   supabase: supabaseLogo,
   "ticket-tailor": ticketTailorLogo,
   ticktick: ticktickLogo,
+  tinybird: tinybirdLogo,
   todoist: todoistLogo,
   webflow: webflowLogo,
   wix: wixLogo,

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1020,6 +1020,31 @@
       ]
     },
     {
+      "name": "connection/tinybird",
+      "type": "registry:item",
+      "title": "Tinybird",
+      "description": "Query pipes and data sources in your Tinybird Workspace.",
+      "meta": {
+        "eve": {
+          "setup": {
+            "command": "eve",
+            "package": "eve",
+            "bin": "eve",
+            "args": ["integration", "connect", "tinybird", "tinybird", "tinybird"]
+          },
+          "requires": ">=0.29.0"
+        }
+      },
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/tinybird.ts",
+          "type": "registry:file",
+          "target": "agent/connections/tinybird.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/todoist",
       "type": "registry:item",
       "title": "Todoist",

--- a/apps/docs/registry/connections/tinybird.ts
+++ b/apps/docs/registry/connections/tinybird.ts
@@ -5,5 +5,5 @@ export default defineMcpClientConnection({
   url: "https://mcp.tinybird.co",
   description:
     "Tinybird: query pipes and data sources, and run SQL. A token grants one Workspace, so add a connection per Workspace.",
-  auth: connect("tinybird"),
+  auth: connect({ connector: "tinybird", principalType: "app" }),
 });

--- a/apps/docs/registry/connections/tinybird.ts
+++ b/apps/docs/registry/connections/tinybird.ts
@@ -1,0 +1,9 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.tinybird.co",
+  description:
+    "Tinybird: query pipes and data sources, and run SQL. A token grants one Workspace, so add a connection per Workspace.",
+  auth: connect("tinybird"),
+});

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -704,6 +704,18 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     },
   },
   {
+    slug: "tinybird",
+    name: "Tinybird",
+    kind: "connection",
+    tagline: "Query pipes and data sources in your Tinybird Workspace.",
+    surfaces: { scaffoldable: false, gallery: true },
+    connection: {
+      description:
+        "Tinybird: query pipes and data sources, and run SQL. A token grants one Workspace, so add a connection per Workspace.",
+      mcp: { url: "https://mcp.tinybird.co" },
+    },
+  },
+  {
     slug: "todoist",
     name: "Todoist",
     kind: "connection",


### PR DESCRIPTION
## Problem

The registry has `connection/clickhouse`, `connection/datadog`, `connection/honeycomb`, and `connection/posthog`, but no Tinybird. So any agent that wants Tinybird hand-writes the connection instead of running `eve add connection/tinybird`.

## Change

| file | change |
| --- | --- |
| `apps/docs/registry/connections/tinybird.ts` | new, mirroring `clickhouse.ts` |
| `apps/docs/registry.json` | register `connection/tinybird` |
| `packages/eve-catalog/src/index.ts` | catalog entry — registry and gallery must match |
| `apps/docs/lib/integrations/data.ts` | docs presentation — gallery entries require one |
| `apps/docs/lib/integrations/logos.tsx` | logo component and map entry |

Inserted between `ticktick` and `todoist` in each, matching the alphabetical ordering of the non-curated block.

## Two deliberate choices

**App-scoped, spelled out rather than via the shorthand:**

```ts
auth: connect({ connector: "tinybird", principalType: "app" }),
```

`connect("tinybird")` would be user-scoped — `connect()` branches on `principalType` and otherwise falls through to `buildInteractiveDefinition`, which sets `'user'`. Agents that answer in a channel or fire on a schedule have no authenticated user and would fail with `principal_required`, so this declares `authModes: ["app"]`.

Most existing entries are `["user"]`, and `connection/datadog` uses `jwtBearer` keyed on the principal's email. Both work interactively but not unattended. A user-scoped Tinybird variant could be added alongside later.

**The description names the Workspace constraint:**

> "A token grants one Workspace, so add a connection per Workspace."

Tinybird tokens are Workspace-scoped, which is the part people get wrong — two Workspaces means two connectors and two connections, not one connection with a setting. Verified: a token for one Workspace cannot see another's pipes, same org, same region.

No `host` parameter on the URL. Current tokens embed their region, verified against `mcp.tinybird.co`.

## Logo

Hand-written, because Simple Icons has no `tinybird` mark, so the `Si*` pattern most entries use isn't available. Paths are taken verbatim from Tinybird's official wordmark with the text removed, and use `currentColor` to match the house style.

## No changeset

`packages/eve` depends on `@eve/catalog`, but its scaffold filters on `entry.surfaces.scaffoldable`, and the comment there says gallery-only connections live only in the shared catalog. This entry is `scaffoldable: false`, so the published package is unaffected. Happy to add one if you'd rather.

## Verification

With `packages/eve` built first:

- `pnpm --filter eve-docs registry:check` — exit 0, zero TypeScript errors
- `pnpm --filter eve-docs test:unit` — 136 tests, 21 files, all passing
- `pnpm --filter @eve/catalog test` — 18/18
- `pnpm fmt` — clean

CI is green.

One note for reproducing locally: `registry:check` fails with module-resolution errors unless `pnpm --filter eve build` has run first, since the registry typechecks against `eve/*` subpath exports.

Linear: AIG-452