### PR TITLE
docs: mention React in homepage native interop heading

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/nextjs-interop.tsx
+++ b/apps/docs/app/[lang]/(home)/components/nextjs-interop.tsx
@@ -60,7 +60,7 @@ export async function NextjsInterop() {
     <section className="px-4 py-24">
       <div className="mx-auto max-w-5xl">
         <h2 className="text-center text-heading-32 text-gray-1000 sm:text-heading-40">
-          Works natively with Next.js
+          Works natively with React and Next.js
         </h2>
         <p className="mx-auto mt-4 max-w-2xl text-center text-gray-900">
           Wrap your config with <span className="text-gray-1000">withEve()</span> and the agent


### PR DESCRIPTION
## Summary
- Updates the eve.dev homepage heading from `Works natively with Next.js` to `Works natively with React and Next.js`.

## Validation
- Confirmed the updated string is present in `apps/docs/app/[lang]/(home)/components/nextjs-interop.tsx`.
- Local package checks not run; dependencies are not installed in this checkout and this is a copy-only change.