### PR TITLE
fix(eve): ignore .devtools in eve dev watcher

### DIFF
--- a/.changeset/ignore-ai-sdk-devtools.md
+++ b/.changeset/ignore-ai-sdk-devtools.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Treat AI SDK `.devtools` like other generated directories: ignore it in `eve dev` watching, agent discovery, and source snapshots so generation writes do not recompile or warn.

--- a/packages/eve/src/discover/agent.integration.test.ts
+++ b/packages/eve/src/discover/agent.integration.test.ts
@@ -486,7 +486,7 @@ describe("discoverAgent (memory)", () => {
 
   it("silently ignores generated runtime directories", async () => {
     const project = buildMemoryAgentProject({
-      agentDirectories: [".eve", ".next", ".output", ".vercel", "node_modules"],
+      agentDirectories: [".devtools", ".eve", ".next", ".output", ".vercel", "node_modules"],
       agentFiles: {
         "instructions.md": "You are a precise assistant.",
       },

--- a/packages/eve/src/discover/filesystem.ts
+++ b/packages/eve/src/discover/filesystem.ts
@@ -21,6 +21,7 @@ export const PROJECT_MARKER_FILE_NAMES = ["package.json", "vercel.json"] as cons
 
 const PROJECT_MARKER_FILE_NAME_SET = new Set<string>(PROJECT_MARKER_FILE_NAMES);
 const GENERATED_AGENT_DIRECTORY_NAMES = new Set<string>([
+  ".devtools",
   ".eve",
   ".next",
   ".output",

--- a/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
+++ b/packages/eve/src/internal/nitro/dev-runtime-source-snapshot-copy.ts
@@ -17,6 +17,7 @@ import {
 } from "#internal/nitro/dev-runtime-source-snapshot.js";
 
 const SNAPSHOT_SKIP_NAMES = new Set([
+  ".devtools",
   ".generated",
   ".eve",
   ".git",

--- a/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts
@@ -131,6 +131,7 @@ describe("startAuthoredSourceWatcher", () => {
 
     try {
       const ignored = getIgnoredPredicate();
+      expect(ignored(join(host.appRoot, ".devtools", "generations.json"))).toBe(true);
       expect(ignored(join(host.appRoot, ".eve", "dev-hosts", "candidate"))).toBe(true);
       expect(ignored(join(host.appRoot, "node_modules", "eve"))).toBe(true);
       expect(ignored(join(host.appRoot, "agent", "tools", "weather.ts"))).toBe(false);

--- a/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.ts
+++ b/packages/eve/src/internal/nitro/host/dev-authored-source-watcher.ts
@@ -26,6 +26,7 @@ const WATCHED_LOCKFILE_NAMES = [
 const WATCH_ROOT_MARKER_NAMES = [".git", "pnpm-workspace.yaml"] as const;
 const TS_CONFIG_GLOB_NAME = "tsconfig.*.json";
 const WATCHER_IGNORED_DIRECTORY_NAMES = new Set([
+  ".devtools",
   ".generated",
   ".eve",
   ".git",


### PR DESCRIPTION
### Summary

Closes #1720.

AI SDK DevTools stores generation data in `.devtools`. That caused two problems in `eve dev`:

- The authored-source watcher treated writes as source changes and recompiled.
- Agent discovery treated `.devtools/` as an unsupported directory and warned: `Ignoring unsupported directory ".devtools/" in the agent root.`

`.eve` is already a silent generated directory. This change treats `.devtools` the same way: ignore it in the watcher, classify it as an ignored agent-root directory (no warning), and skip it in source snapshots.

### Validation

- `pnpm --filter eve build`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/nitro/host/dev-authored-source-watcher.scenario.test.ts -t "ignores generated directories"` — 1 passed, 10 skipped
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/discover/agent.integration.test.ts -t "silently ignores generated runtime directories"` — 1 passed

Docs are not applicable.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)