### PR TITLE
feat(eve): forwarding delegated subagent stream events to the parent session stream (#666)

### DIFF
--- a/.changeset/tame-subagents-stream.md
+++ b/.changeset/tame-subagents-stream.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Forward delegated task-mode subagent stream events to the parent session stream as durable `subagent.event` entries while keeping the final subagent result unchanged.

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -85,6 +85,19 @@ export interface SessionTraceContext {
   readonly traceId: string;
 }
 
+/**
+ * Framework-internal stream forwarding target for delegated subagent sessions.
+ *
+ * When present on a child run, the runtime appends each child stream event to
+ * the child's own durable stream and also appends a wrapped `subagent.event`
+ * to the immediate parent's durable stream.
+ */
+export interface ForwardedSubagentStream {
+  readonly callId: string;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly subagentName: string;
+}
+
 // ---------------------------------------------------------------------------
 // Auth
 // ---------------------------------------------------------------------------
@@ -410,6 +423,7 @@ export interface RunInput {
   };
   readonly mode: RunMode;
   readonly parent?: SessionParent;
+  readonly forwardedSubagentStream?: ForwardedSubagentStream;
   /**
    * Dispatching parent's open trace window. Handed down rather than looked up
    * because trace state is scoped to one session's context.

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -215,6 +215,7 @@ export async function dispatchRuntimeActionsStep(input: {
             initiatorAuth,
             parentContinuationToken: input.parentContinuationToken,
             parentTraceContext,
+            parentWritable: input.parentWritable,
             persistentSessions,
             session,
             target: entry.target,
@@ -433,6 +434,7 @@ async function startSubagent(input: {
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
+  readonly parentWritable: WritableStream<Uint8Array>;
   readonly persistentSessions: boolean;
   readonly session: RuntimeSession;
   readonly target: DispatchStartTarget;
@@ -452,6 +454,7 @@ async function startSubagent(input: {
         initiatorAuth: input.initiatorAuth,
         parentContinuationToken: input.parentContinuationToken,
         parentTraceContext: input.parentTraceContext,
+        parentWritable: input.parentWritable,
         persistentSessions: input.persistentSessions,
         session: input.session,
         source: input.target.source,
@@ -490,6 +493,7 @@ async function startLocalSubagent(input: {
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
+  readonly parentWritable: WritableStream<Uint8Array>;
   readonly persistentSessions: boolean;
   readonly session: RuntimeSession;
   readonly source: SubagentInputSource;
@@ -536,7 +540,14 @@ async function startLocalSubagent(input: {
 
   let childSessionId: string;
   try {
-    const handle = await childRuntime.createSession(runInput);
+    const handle = await childRuntime.createSession({
+      ...runInput,
+      forwardedSubagentStream: {
+        callId: action.callId,
+        parentWritable: input.parentWritable,
+        subagentName: action.subagentName,
+      },
+    });
     childSessionId = handle.sessionId;
   } catch (error) {
     logError(log, "local subagent start failed", error, {

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -11,6 +11,7 @@
  * {@link TURN_WORKFLOW_INPUT_VERSION} and append a v{N} → v{N+1} migration.
  */
 import type {
+  ForwardedSubagentStream,
   HookPayload,
   RuntimeActionResultHookPayload,
   SessionCapabilities,
@@ -37,6 +38,7 @@ export type TurnStepPayload =
 export interface TurnStepInput {
   /** Cancellation signal forwarded into the turn step. */
   readonly abortSignal?: AbortSignal;
+  readonly forwardedSubagentStream?: ForwardedSubagentStream;
   readonly input: TurnStepPayload | undefined;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
@@ -65,6 +67,7 @@ export interface TurnWorkflowDispatchInput {
   readonly delivery: HookPayload;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
+  readonly forwardedSubagentStream?: ForwardedSubagentStream;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }
@@ -72,17 +75,25 @@ export interface TurnWorkflowDispatchInput {
 const turnWorkflowInputMigrations: readonly VersionMigration[] = [turnWorkflowInputV0ToV1];
 
 export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnWorkflowInput {
+  const stepInput: {
+    -readonly [K in keyof TurnStepInput]: TurnStepInput[K];
+  } = {
+    input: input.delivery,
+    parentWritable: input.parentWritable,
+    serializedContext: input.serializedContext,
+    sessionState: input.sessionState,
+  };
+
+  if (input.forwardedSubagentStream !== undefined) {
+    stepInput.forwardedSubagentStream = input.forwardedSubagentStream;
+  }
+
   return {
     capabilities: input.capabilities,
     completionToken: input.completionToken,
     driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
     mode: input.mode,
-    stepInput: {
-      input: input.delivery,
-      parentWritable: input.parentWritable,
-      serializedContext: input.serializedContext,
-      sessionState: input.sessionState,
-    },
+    stepInput,
     version: TURN_WORKFLOW_INPUT_VERSION,
   };
 }

--- a/packages/eve/src/execution/subagent-stream-forwarding.ts
+++ b/packages/eve/src/execution/subagent-stream-forwarding.ts
@@ -1,0 +1,42 @@
+import type { ForwardedSubagentStream } from "#channel/types.js";
+import {
+  createSubagentChildEvent,
+  encodeMessageStreamEvent,
+  stampMessageStreamEvent,
+  type MessageStreamEvent,
+  type UnstampedMessageStreamEvent,
+} from "#protocol/message.js";
+
+/**
+ * Writes one event to its owning session stream and, for delegated child runs,
+ * mirrors the same stamped event into the parent stream as `subagent.event`.
+ */
+export async function writeSessionEvent(input: {
+  readonly event: UnstampedMessageStreamEvent;
+  readonly forwardedSubagentStream?: ForwardedSubagentStream;
+  readonly writer: WritableStreamDefaultWriter<Uint8Array>;
+}): Promise<MessageStreamEvent> {
+  const stampedEvent = stampMessageStreamEvent(input.event);
+  await input.writer.write(encodeMessageStreamEvent(stampedEvent));
+
+  if (input.forwardedSubagentStream !== undefined) {
+    const forwardedWriter = input.forwardedSubagentStream.parentWritable.getWriter();
+    try {
+      await forwardedWriter.write(
+        encodeMessageStreamEvent(
+          stampMessageStreamEvent(
+            createSubagentChildEvent({
+              callId: input.forwardedSubagentStream.callId,
+              event: stampedEvent,
+              subagentName: input.forwardedSubagentStream.subagentName,
+            }),
+          ),
+        ),
+      );
+    } finally {
+      forwardedWriter.releaseLock();
+    }
+  }
+
+  return stampedEvent;
+}

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -1,4 +1,9 @@
-import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
+import type {
+  DeliverHookPayload,
+  ForwardedSubagentStream,
+  HookPayload,
+  SessionCapabilities,
+} from "#channel/types.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
@@ -30,6 +35,7 @@ export async function dispatchAndAwaitTurn(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
+  readonly forwardedSubagentStream?: ForwardedSubagentStream;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }): Promise<DispatchedTurn> {
@@ -47,6 +53,7 @@ export async function dispatchAndAwaitTurn(input: {
       delivery: input.delivery,
       mode: input.mode,
       parentWritable: input.parentWritable,
+      forwardedSubagentStream: input.forwardedSubagentStream,
       serializedContext: input.serializedContext,
       sessionState: input.sessionState,
     });

--- a/packages/eve/src/execution/turn-execution-cursor.ts
+++ b/packages/eve/src/execution/turn-execution-cursor.ts
@@ -1,4 +1,7 @@
-import type { DeliverHookPayload } from "#channel/types.js";
+import type {
+  DeliverHookPayload,
+  ForwardedSubagentStream,
+} from "#channel/types.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 import { sendTurnControlStep } from "#execution/turn-control-protocol.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
@@ -32,6 +35,7 @@ type TurnTerminalAction =
 /** Owns the mutable durable state cursor for one active turn workflow. */
 export class TurnExecutionCursor {
   readonly controlToken: string;
+  readonly forwardedSubagentStream: ForwardedSubagentStream | undefined;
   readonly parentWritable: WritableStream<Uint8Array>;
 
   private currentSerializedContext: Record<string, unknown>;
@@ -40,6 +44,7 @@ export class TurnExecutionCursor {
 
   constructor(input: {
     readonly controlToken: string;
+    readonly forwardedSubagentStream?: ForwardedSubagentStream;
     readonly parentWritable: WritableStream<Uint8Array>;
     readonly serializedContext: Record<string, unknown>;
     readonly sessionState: DurableSessionState;
@@ -47,6 +52,7 @@ export class TurnExecutionCursor {
     this.controlToken = input.controlToken;
     this.currentSerializedContext = input.serializedContext;
     this.currentSessionState = input.sessionState;
+    this.forwardedSubagentStream = input.forwardedSubagentStream;
     this.lastReportedContinuationToken = input.sessionState.continuationToken;
     this.parentWritable = input.parentWritable;
   }
@@ -74,13 +80,21 @@ export class TurnExecutionCursor {
 
   /** Builds the next atomic turn-step input from the cursor's current state. */
   createStepInput(input: TurnStepPayload | undefined, abortSignal?: AbortSignal): TurnStepInput {
-    return {
+    const stepInput: {
+      -readonly [K in keyof TurnStepInput]: TurnStepInput[K];
+    } = {
       abortSignal,
       input,
       parentWritable: this.parentWritable,
       serializedContext: this.currentSerializedContext,
       sessionState: this.currentSessionState,
     };
+
+    if (this.forwardedSubagentStream !== undefined) {
+      stepInput.forwardedSubagentStream = this.forwardedSubagentStream;
+    }
+
+    return stepInput;
   }
 
   /**

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -63,6 +63,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
   const iterator = inbox[Symbol.asyncIterator]();
   const cursor = new TurnExecutionCursor({
     controlToken: input.completionToken,
+    forwardedSubagentStream: input.stepInput.forwardedSubagentStream,
     parentWritable: input.stepInput.parentWritable,
     serializedContext: input.stepInput.serializedContext,
     sessionState: input.stepInput.sessionState,
@@ -449,6 +450,7 @@ async function runLegacyTurnWorkflow(input: TurnWorkflowInput): Promise<void> {
       currentStepInput = {
         input: undefined,
         parentWritable: currentStepInput.parentWritable,
+        forwardedSubagentStream: currentStepInput.forwardedSubagentStream,
         serializedContext: result.serializedContext,
         sessionState: result.sessionState,
       };

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -815,6 +815,58 @@ describe("workflowEntry", () => {
     });
   });
 
+  it("keeps delegated parent result notification unchanged when stream forwarding is active", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    const serializedContext = createSerializedContext({
+      "eve.channel": {
+        kind: "subagent",
+        state: {
+          callId: "call-1",
+          parentContinuationToken: "parent-token",
+          parentSessionId: "parent-session",
+          subagentName: "researcher",
+        },
+      },
+      "eve.mode": "task",
+    });
+    installHookMocks({
+      turnControls: [
+        turnResult({
+          action: "done",
+          output: "final child result",
+          serializedContext,
+          sessionState,
+        }),
+      ],
+    });
+
+    await expect(
+      workflowEntry({
+        forwardedSubagentStream: {
+          callId: "call-1",
+          parentWritable: new WritableStream<Uint8Array>(),
+          subagentName: "researcher",
+        },
+        input: { message: "delegate" },
+        serializedContext,
+      }),
+    ).resolves.toEqual({ output: "final child result" });
+
+    expect(notifyDelegatedParentStep).toHaveBeenCalledOnce();
+    expect(notifyDelegatedParentStep).toHaveBeenCalledWith({
+      result: expect.objectContaining({
+        callId: "call-1",
+        kind: "subagent-result",
+        origin: "child",
+        output: "final child result",
+        subagentName: "researcher",
+      }),
+      serializedContext,
+      usage: undefined,
+    });
+  });
+
   it("passes the resumed channel request id to the next turn", async () => {
     const sessionState = createBaseSessionState();
     vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -55,6 +55,7 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
  * and deserialized at each `"use step"` boundary.
  */
 export interface WorkflowEntryInput {
+  readonly forwardedSubagentStream?: RunInput["forwardedSubagentStream"];
   readonly input: RunInput["input"];
   readonly limits?: RunInput["limits"];
   readonly sessionTimeoutMs?: number | false;
@@ -182,6 +183,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
     const outcome = await runDriverLoop({
       capabilities,
       driverWritable,
+      forwardedSubagentStream: input.forwardedSubagentStream,
       initialInput: {
         kind: "deliver",
         payloads: [
@@ -284,6 +286,7 @@ function createSafeOuterWorkflowError(): Error {
 async function runDriverLoop(input: {
   readonly capabilities?: SessionCapabilities;
   readonly driverWritable: WritableStream<Uint8Array>;
+  readonly forwardedSubagentStream?: RunInput["forwardedSubagentStream"];
   readonly initialInput: HookPayload;
   readonly crashCleanupState: CrashCleanupState;
   readonly mode: RunMode;
@@ -322,6 +325,7 @@ async function runDriverLoop(input: {
   let disposeSettledTurnControl: (() => Promise<void>) | undefined;
   const runTurn = async (args: {
     readonly delivery: HookPayload;
+    readonly forwardedSubagentStream?: RunInput["forwardedSubagentStream"];
     readonly serializedContext: Record<string, unknown>;
     readonly sessionState: DurableSessionState;
   }): Promise<TurnDriverAction> => {
@@ -334,6 +338,7 @@ async function runDriverLoop(input: {
       delivery: args.delivery,
       mode: input.mode,
       parentWritable: input.driverWritable,
+      forwardedSubagentStream: args.forwardedSubagentStream,
       serializedContext: args.serializedContext,
       sessionState: args.sessionState,
     });
@@ -350,6 +355,7 @@ async function runDriverLoop(input: {
 
     let action: TurnDriverAction = await runTurn({
       delivery: input.initialInput,
+      forwardedSubagentStream: input.forwardedSubagentStream,
       serializedContext: input.serializedContext,
       sessionState: input.sessionState,
     });
@@ -411,6 +417,7 @@ async function runDriverLoop(input: {
             kind: "deliver",
             payloads: allPayloads,
           },
+          forwardedSubagentStream: input.forwardedSubagentStream,
           serializedContext: action.serializedContext,
           sessionState: action.sessionState,
         });
@@ -502,6 +509,7 @@ async function runDriverLoop(input: {
           payloads: [next.remainder],
           requestId: next.deliver.requestId,
         },
+        forwardedSubagentStream: input.forwardedSubagentStream,
         serializedContext: action.serializedContext,
         sessionState: action.sessionState,
       });

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -161,6 +161,9 @@ export function createWorkflowRuntime(config: {
 
       let run: Awaited<ReturnType<typeof startWorkflowPreferLatest>>;
       try {
+        if (input.forwardedSubagentStream !== undefined) {
+          workflowInput.forwardedSubagentStream = input.forwardedSubagentStream;
+        }
         run = await startWorkflowPreferLatest(workflowEntryReference, [workflowInput], {
           allowReservedAttributes: true,
           attributes: normalizeEveAttributes(attributes),

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -50,6 +50,12 @@ import {
   turnWorkflowReference,
   workflowEntryReference,
 } from "#execution/workflow-runtime.js";
+import {
+  createMessageAppendedEvent,
+  createMessageCompletedEvent,
+  type HandleMessageStreamEvent,
+  type SubagentChildEventStreamEvent,
+} from "#protocol/message.js";
 
 vi.mock("./durable-session-store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./durable-session-store.js")>();
@@ -111,6 +117,14 @@ function createTestWritable(
       workflowWritesByNamespace.set(namespace, existing);
     },
   });
+}
+
+const textDecoder = new TextDecoder();
+function decodeWrittenEvents(
+  namespace = DEFAULT_WORKFLOW_STREAM_NAMESPACE,
+): HandleMessageStreamEvent[] {
+  const writes = workflowWritesByNamespace.get(namespace) ?? [];
+  return writes.map((chunk) => JSON.parse(textDecoder.decode(chunk as Uint8Array)));
 }
 
 vi.mock("./node-step.js", () => ({
@@ -535,6 +549,88 @@ describe("dispatchRuntimeActionsStep", () => {
         }),
       ],
       expect.any(Object),
+    );
+  });
+
+  it("forwards delegated subagent stream events to the parent stream in child order", async () => {
+    const session = createStubSession({
+      continuationToken: "subagent:parent-session:call-1",
+      sessionId: "child-session",
+    });
+    installSessionStoreMocks([session]);
+    vi.mocked(createExecutionNodeStep).mockImplementation(({ handleEvent }) => {
+      return async (session): Promise<StepResult> => {
+        if (handleEvent === undefined) {
+          throw new Error("expected handleEvent");
+        }
+
+        await handleEvent(
+          createMessageAppendedEvent({
+            messageDelta: "hello",
+            messageSoFar: "hello",
+            sequence: 0,
+            stepIndex: 0,
+            turnId: "child-turn",
+          }),
+        );
+        await handleEvent(
+          createMessageCompletedEvent({
+            message: "hello",
+            sequence: 0,
+            stepIndex: 0,
+            turnId: "child-turn",
+          }),
+        );
+
+        return {
+          next: { done: true, output: "final child result" },
+          session,
+        };
+      };
+    });
+
+    const result = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "delegate" }],
+      },
+      forwardedSubagentStream: {
+        callId: "call-1",
+        parentWritable: createTestWritable("parent"),
+        subagentName: "researcher",
+      },
+      parentWritable: createTestWritable("child"),
+      serializedContext: createSerializedContext(),
+      sessionState: createStubSessionState({
+        continuationToken: "subagent:parent-session:call-1",
+        sessionId: "child-session",
+      }),
+    });
+
+    expect(result.action).toBe("done");
+    if (result.action === "done") {
+      expect(result.output).toBe("final child result");
+    }
+
+    expect(decodeWrittenEvents("child").map((event) => event.type)).toEqual([
+      "message.appended",
+      "message.completed",
+    ]);
+
+    const parentEvents = decodeWrittenEvents("parent") as SubagentChildEventStreamEvent[];
+    expect(parentEvents.map((event) => event.type)).toEqual(["subagent.event", "subagent.event"]);
+    expect(parentEvents.map((event) => event.data.callId)).toEqual(["call-1", "call-1"]);
+    expect(parentEvents.map((event) => event.data.subagentName)).toEqual([
+      "researcher",
+      "researcher",
+    ]);
+    expect(parentEvents.map((event) => event.data.event.type)).toEqual([
+      "message.appended",
+      "message.completed",
+    ]);
+    expect(parentEvents[0]?.data.event.meta?.at).toEqual(expect.any(String));
+    expect((parentEvents[0] as HandleMessageStreamEvent | undefined)?.meta?.at).toEqual(
+      expect.any(String),
     );
   });
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -45,10 +45,8 @@ import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
 import {
   createAuthorizationCompletedEvent,
   createSessionStartedEvent,
-  encodeMessageStreamEvent,
-  type UnstampedMessageStreamEvent,
-  stampMessageStreamEvent,
   type MessageStreamEvent,
+  type UnstampedMessageStreamEvent,
 } from "#protocol/message.js";
 import {
   CallbackBaseUrlKey,
@@ -74,6 +72,7 @@ import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-s
 import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
+import { writeSessionEvent } from "#execution/subagent-stream-forwarding.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
 import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
@@ -332,9 +331,11 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const emit = async (event: UnstampedMessageStreamEvent): Promise<MessageStreamEvent> => {
     const toEmit = await callAdapterEventHandler(adapter, event, adapterCtx);
     setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
-    const stamped = stampMessageStreamEvent(toEmit);
-    await writer.write(encodeMessageStreamEvent(stamped));
-    return stamped;
+    return writeSessionEvent({
+      event: toEmit,
+      forwardedSubagentStream: input.forwardedSubagentStream,
+      writer,
+    });
   };
 
   const handleEvent = async (

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -299,7 +299,7 @@ export interface SubagentStartedStreamEvent {
 export interface SubagentChildEventStreamEvent {
   data: {
     callId: string;
-    event: UnstampedMessageStreamEvent;
+    event: HandleMessageStreamEvent;
     subagentName: string;
   };
   type: "subagent.event";
@@ -1136,6 +1136,24 @@ export function createSubagentCalledEvent(input: {
       workflowId: input.workflowId,
     },
     type: "subagent.called",
+  };
+}
+
+/**
+ * Creates a `subagent.event` wrapper around one child stream event.
+ */
+export function createSubagentChildEvent(input: {
+  readonly callId: string;
+  readonly event: HandleMessageStreamEvent;
+  readonly subagentName: string;
+}): SubagentChildEventStreamEvent {
+  return {
+    data: {
+      callId: input.callId,
+      event: input.event,
+      subagentName: input.subagentName,
+    },
+    type: "subagent.event",
   };
 }
 


### PR DESCRIPTION
## Summary

Supersedes #667 (rebased onto latest main at `19862ccf`; the v1 branch drifted after upstream `session-delivery-hook`→`session-command-inbox` + `Runtime.run`→`createSession` renames).

- Child (delegated task-mode) turn stream events are durably autosaved into the parent session stream as `subagent.event` entries, ordered by child step index.
- The parent's final delegated subagent result is unchanged — only the stream path gains durable forwards.
- Type/index plumbing updated to the post-#616 rename map (`stampMessageStreamEvent`, `UnstampedMessageStreamEvent`, `createSession`, `session.continuation.rekey`).

## Validation

- `vitest run --config vitest.unit.config.ts src/execution/` — 594/594 pass (62 files).
- `tsc --noEmit` clean.

Closes #666.