### PR TITLE
fix(eve): guard late approval resume transcript

### DIFF
--- a/packages/eve/src/harness/ai-sdk-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/ai-sdk-approval-resume.integration.test.ts
@@ -46,7 +46,7 @@ function findApprovalRequest(messages: readonly ModelMessage[]): ToolApprovalReq
 }
 
 describe("AI SDK approval-resume streaming contract", () => {
-  it("streams a cross-invocation result and includes it in call-wide response messages", async () => {
+  it("streams a late cross-invocation result after an intervening completed turn", async () => {
     const execute = vi.fn(async ({ note }: { readonly note: string }) => ({ echoed: note }));
     const model = new MockLanguageModelV4({
       doStream: [
@@ -116,8 +116,16 @@ describe("AI SDK approval-resume streaming contract", () => {
       throw new Error("AI SDK did not produce a tool approval request.");
     }
 
+    const interveningMessages: ModelMessage[] = [
+      { content: "While that waits, summarize the request.", role: "user" },
+      {
+        content: [{ text: "The request is waiting for approval.", type: "text" }],
+        role: "assistant",
+      },
+    ];
     const resumeMessages: ModelMessage[] = [
       ...initialMessages,
+      ...interveningMessages,
       ...approvalResponseMessages,
       {
         content: [
@@ -174,6 +182,22 @@ describe("AI SDK approval-resume streaming contract", () => {
     });
 
     const providerPrompt = model.doStreamCalls[1]?.prompt ?? [];
+    const interveningAnswerIndex = providerPrompt.findIndex(
+      (message) =>
+        message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some(
+          (part) => part.type === "text" && part.text === "The request is waiting for approval.",
+        ),
+    );
+    const approvalCallIndex = providerPrompt.findIndex(
+      (message) =>
+        message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some((part) => part.type === "tool-call" && part.toolCallId === "call-1"),
+    );
+    expect(interveningAnswerIndex).toBeGreaterThanOrEqual(0);
+    expect(approvalCallIndex).toBeGreaterThan(interveningAnswerIndex);
     const providerToolResults = providerPrompt.flatMap((message) =>
       message.role === "tool" ? message.content.filter((part) => part.type === "tool-result") : [],
     );

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -33,20 +33,43 @@ const approvalRequest = {
   type: "tool-approval-request" as const,
 };
 
+const secondToolCall = {
+  input: { path: "notes.txt" },
+  toolCallId: "call-2",
+  toolName: "write_file",
+  type: "tool-call" as const,
+};
+
+const secondApprovalRequest = {
+  approvalId: "approval-2",
+  toolCallId: secondToolCall.toolCallId,
+  type: "tool-approval-request" as const,
+};
+
+interface ApprovalEntry {
+  readonly approvalRequest: typeof approvalRequest | typeof secondApprovalRequest;
+  readonly toolCall: typeof toolCall | typeof secondToolCall;
+}
+
+const singleApproval: readonly ApprovalEntry[] = [{ approvalRequest, toolCall }];
+const approvalGroup: readonly ApprovalEntry[] = [
+  { approvalRequest, toolCall },
+  { approvalRequest: secondApprovalRequest, toolCall: secondToolCall },
+];
+
 function createPendingApprovalSession(
   history: readonly ModelMessage[] = [{ content: "Run pwd.", role: "user" }],
+  approvals: readonly ApprovalEntry[] = singleApproval,
 ): HarnessSession {
   const session: HarnessSession = {
     agent: {
       modelReference: { id: "generate-approval-resume-model" },
       system: "You are a test assistant.",
-      tools: [
-        {
-          description: "Run a shell command.",
-          inputSchema: { type: "object" },
-          name: toolCall.toolName,
-        },
-      ],
+      tools: approvals.map(({ toolCall: entry }) => ({
+        description: `Run ${entry.toolName}.`,
+        inputSchema: { type: "object" },
+        name: entry.toolName,
+      })),
     },
     compaction: { recentWindowSize: 10, threshold: 100_000 },
     continuationToken: "http:generate-approval-resume-session",
@@ -55,13 +78,13 @@ function createPendingApprovalSession(
   };
 
   return setPendingInputBatch({
-    requests: [
-      {
+    requests: approvals.map(({ approvalRequest: request, toolCall: entry }) => {
+      return {
         action: {
-          callId: toolCall.toolCallId,
-          input: toolCall.input,
+          callId: entry.toolCallId,
+          input: entry.input,
           kind: "tool-call",
-          toolName: toolCall.toolName,
+          toolName: entry.toolName,
         },
         allowFreeform: false,
         display: "confirmation",
@@ -70,13 +93,16 @@ function createPendingApprovalSession(
           { id: "approve", label: "Yes" },
           { id: "deny", label: "No" },
         ],
-        prompt: "Approve tool call: bash",
-        requestId: approvalRequest.approvalId,
-      },
-    ],
+        prompt: `Approve tool call: ${entry.toolName}`,
+        requestId: request.approvalId,
+      } as const;
+    }),
     responseMessages: [
       {
-        content: [toolCall, approvalRequest],
+        content: approvals.flatMap(({ approvalRequest: request, toolCall: entry }) => [
+          entry,
+          request,
+        ]),
         role: "assistant",
       },
     ],
@@ -84,7 +110,7 @@ function createPendingApprovalSession(
   });
 }
 
-function createHarnessFixture() {
+function createHarnessFixture(approvals: readonly ApprovalEntry[] = singleApproval) {
   const execute = vi.fn(async () => "/workspace");
   const model = new MockLanguageModelV4({
     doGenerate: {
@@ -96,14 +122,14 @@ function createHarnessFixture() {
     modelId: "generate-approval-resume-model",
     provider: "eve-integration-mock",
   });
-  const tools: ToolLoopHarnessConfig["tools"] = new Map([
-    [
-      toolCall.toolName,
+  const tools: ToolLoopHarnessConfig["tools"] = new Map(
+    approvals.map(({ toolCall: entry }) => [
+      entry.toolName,
       {
         description: "Run a shell command.",
         execute,
         inputSchema: jsonSchema({ type: "object" }),
-        name: toolCall.toolName,
+        name: entry.toolName,
         toModelOutput: (output) => {
           if (typeof output !== "string") {
             throw new TypeError("Expected the bash test tool to return a string.");
@@ -111,8 +137,8 @@ function createHarnessFixture() {
           return { type: "text", value: `canonical:${output}` };
         },
       },
-    ],
-  ]);
+    ]),
+  );
   const harness = createToolLoopHarness({
     mode: "conversation",
     resolveModel: async (): Promise<LanguageModel> => model,
@@ -137,6 +163,23 @@ function findPart(
     if (part !== undefined) return part;
   }
   return undefined;
+}
+
+function findParts(
+  messages: readonly ModelMessage[],
+  type: "tool-approval-response" | "tool-call" | "tool-result",
+): unknown[] {
+  const parts: unknown[] = [];
+  for (const message of messages) {
+    if (
+      (message.role !== "assistant" && message.role !== "tool") ||
+      !Array.isArray(message.content)
+    ) {
+      continue;
+    }
+    parts.push(...message.content.filter((candidate) => candidate.type === type));
+  }
+  return parts;
 }
 
 describe("tool loop generate approval resume (real AI SDK)", () => {
@@ -182,6 +225,7 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       content: [{ text: "The command returned /workspace.", type: "text" }],
       role: "assistant",
     });
+    expect(hasPendingInputBatch(result.session.state)).toBe(false);
   });
 
   it("resumes an approval after an intervening completed turn", async () => {
@@ -191,6 +235,11 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       { content: "While that waits, explain the current directory.", role: "user" },
       {
         content: [{ text: "The current directory contains the active workspace.", type: "text" }],
+        role: "assistant",
+      },
+      { content: "What kind of files might it contain?", role: "user" },
+      {
+        content: [{ text: "It may contain source files and configuration.", type: "text" }],
         role: "assistant",
       },
     ];
@@ -212,8 +261,7 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
         Array.isArray(message.content) &&
         message.content.some(
           (part) =>
-            part.type === "text" &&
-            part.text === "The current directory contains the active workspace.",
+            part.type === "text" && part.text === "It may contain source files and configuration.",
         ),
     );
     const approvalCallIndex = providerPrompt.findIndex(
@@ -236,6 +284,8 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       "user",
       "user",
       "assistant",
+      "user",
+      "assistant",
       "assistant",
       "tool",
       "tool",
@@ -246,6 +296,79 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       approvalId: approvalRequest.approvalId,
       approved: true,
     });
+    expect(hasPendingInputBatch(result.session.state)).toBe(false);
+  });
+
+  it("denies an approval after an intervening completed turn", async () => {
+    const { execute, harness, model } = createHarnessFixture();
+    const interveningHistory: ModelMessage[] = [
+      { content: "Run pwd.", role: "user" },
+      { content: "While that waits, explain the current directory.", role: "user" },
+      {
+        content: [{ text: "The current directory contains the active workspace.", type: "text" }],
+        role: "assistant",
+      },
+    ];
+
+    const result = await harness(createPendingApprovalSession(interveningHistory), {
+      inputResponses: [{ optionId: "deny", requestId: approvalRequest.approvalId }],
+    });
+
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(execute).not.toHaveBeenCalled();
+    expect(findPart(model.doGenerateCalls[0]?.prompt ?? [], "tool-result")).toMatchObject({
+      output: { reason: "Tool execution was denied.", type: "execution-denied" },
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+    });
+    expect(findPart(result.session.history, "tool-approval-response")).toMatchObject({
+      approvalId: approvalRequest.approvalId,
+      approved: false,
+    });
+    expect(result.session.history.slice(0, interveningHistory.length)).toEqual(interveningHistory);
+    expect(hasPendingInputBatch(result.session.state)).toBe(false);
+  });
+
+  it("resumes a suffix group with mixed approval outcomes after an intervening turn", async () => {
+    const { execute, harness, model } = createHarnessFixture(approvalGroup);
+    const interveningHistory: ModelMessage[] = [
+      { content: "Run pwd and write notes.txt.", role: "user" },
+      { content: "While those wait, summarize the workspace.", role: "user" },
+      {
+        content: [{ text: "The workspace contains source and configuration files.", type: "text" }],
+        role: "assistant",
+      },
+    ];
+
+    const result = await harness(createPendingApprovalSession(interveningHistory, approvalGroup), {
+      inputResponses: [
+        { optionId: "approve", requestId: approvalRequest.approvalId },
+        { optionId: "deny", requestId: secondApprovalRequest.approvalId },
+      ],
+    });
+
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(execute).toHaveBeenCalledExactlyOnceWith(
+      toolCall.input,
+      expect.objectContaining({ toolCallId: toolCall.toolCallId }),
+    );
+    const providerPrompt = model.doGenerateCalls[0]?.prompt ?? [];
+    expect(findParts(providerPrompt, "tool-call")).toEqual([toolCall, secondToolCall]);
+    expect(findParts(result.session.history, "tool-approval-response")).toEqual([
+      expect.objectContaining({ approvalId: approvalRequest.approvalId, approved: true }),
+      expect.objectContaining({ approvalId: secondApprovalRequest.approvalId, approved: false }),
+    ]);
+    expect(findParts(providerPrompt, "tool-result")).toEqual([
+      expect.objectContaining({
+        output: { reason: "Tool execution was denied.", type: "execution-denied" },
+        toolCallId: secondToolCall.toolCallId,
+      }),
+      expect.objectContaining({
+        output: { type: "text", value: "canonical:/workspace" },
+        toolCallId: toolCall.toolCallId,
+      }),
+    ]);
+    expect(result.session.history.slice(0, interveningHistory.length)).toEqual(interveningHistory);
     expect(hasPendingInputBatch(result.session.state)).toBe(false);
   });
 });

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -2,7 +2,7 @@ import { jsonSchema, type LanguageModel, type ModelMessage } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 import { describe, expect, it, vi } from "vitest";
 
-import { setPendingInputBatch } from "#harness/input-requests.js";
+import { hasPendingInputBatch, setPendingInputBatch } from "#harness/input-requests.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 
@@ -33,7 +33,9 @@ const approvalRequest = {
   type: "tool-approval-request" as const,
 };
 
-function createPendingApprovalSession(): HarnessSession {
+function createPendingApprovalSession(
+  history: readonly ModelMessage[] = [{ content: "Run pwd.", role: "user" }],
+): HarnessSession {
   const session: HarnessSession = {
     agent: {
       modelReference: { id: "generate-approval-resume-model" },
@@ -48,7 +50,7 @@ function createPendingApprovalSession(): HarnessSession {
     },
     compaction: { recentWindowSize: 10, threshold: 100_000 },
     continuationToken: "http:generate-approval-resume-session",
-    history: [{ content: "Run pwd.", role: "user" }],
+    history: [...history],
     sessionId: "generate-approval-resume-session",
   };
 
@@ -82,6 +84,44 @@ function createPendingApprovalSession(): HarnessSession {
   });
 }
 
+function createHarnessFixture() {
+  const execute = vi.fn(async () => "/workspace");
+  const model = new MockLanguageModelV4({
+    doGenerate: {
+      content: [{ text: "The command returned /workspace.", type: "text" }],
+      finishReason: { raw: undefined, unified: "stop" },
+      usage,
+      warnings: [],
+    },
+    modelId: "generate-approval-resume-model",
+    provider: "eve-integration-mock",
+  });
+  const tools: ToolLoopHarnessConfig["tools"] = new Map([
+    [
+      toolCall.toolName,
+      {
+        description: "Run a shell command.",
+        execute,
+        inputSchema: jsonSchema({ type: "object" }),
+        name: toolCall.toolName,
+        toModelOutput: (output) => {
+          if (typeof output !== "string") {
+            throw new TypeError("Expected the bash test tool to return a string.");
+          }
+          return { type: "text", value: `canonical:${output}` };
+        },
+      },
+    ],
+  ]);
+  const harness = createToolLoopHarness({
+    mode: "conversation",
+    resolveModel: async (): Promise<LanguageModel> => model,
+    tools,
+  });
+
+  return { execute, harness, model };
+}
+
 function findPart(
   messages: readonly ModelMessage[],
   type: "tool-approval-response" | "tool-call" | "tool-result",
@@ -101,41 +141,9 @@ function findPart(
 
 describe("tool loop generate approval resume (real AI SDK)", () => {
   it("persists the approved pre-model tool result without an event handler", async () => {
-    const execute = vi.fn(async () => "/workspace");
-    const model = new MockLanguageModelV4({
-      doGenerate: {
-        content: [{ text: "The command returned /workspace.", type: "text" }],
-        finishReason: { raw: undefined, unified: "stop" },
-        usage,
-        warnings: [],
-      },
-      modelId: "generate-approval-resume-model",
-      provider: "eve-integration-mock",
-    });
-    const tools: ToolLoopHarnessConfig["tools"] = new Map([
-      [
-        toolCall.toolName,
-        {
-          description: "Run a shell command.",
-          execute,
-          inputSchema: jsonSchema({ type: "object" }),
-          name: toolCall.toolName,
-          toModelOutput: (output) => {
-            if (typeof output !== "string") {
-              throw new TypeError("Expected the bash test tool to return a string.");
-            }
-            return { type: "text", value: `canonical:${output}` };
-          },
-        },
-      ],
-    ]);
-    const config: ToolLoopHarnessConfig = {
-      mode: "conversation",
-      resolveModel: async (): Promise<LanguageModel> => model,
-      tools,
-    };
+    const { execute, harness, model } = createHarnessFixture();
 
-    const result = await createToolLoopHarness(config)(createPendingApprovalSession(), {
+    const result = await harness(createPendingApprovalSession(), {
       inputResponses: [{ optionId: "approve", requestId: approvalRequest.approvalId }],
     });
 
@@ -174,5 +182,70 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       content: [{ text: "The command returned /workspace.", type: "text" }],
       role: "assistant",
     });
+  });
+
+  it("resumes an approval after an intervening completed turn", async () => {
+    const { execute, harness, model } = createHarnessFixture();
+    const interveningHistory: ModelMessage[] = [
+      { content: "Run pwd.", role: "user" },
+      { content: "While that waits, explain the current directory.", role: "user" },
+      {
+        content: [{ text: "The current directory contains the active workspace.", type: "text" }],
+        role: "assistant",
+      },
+    ];
+
+    const result = await harness(createPendingApprovalSession(interveningHistory), {
+      inputResponses: [{ optionId: "approve", requestId: approvalRequest.approvalId }],
+    });
+
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(execute).toHaveBeenCalledExactlyOnceWith(
+      toolCall.input,
+      expect.objectContaining({ toolCallId: toolCall.toolCallId }),
+    );
+
+    const providerPrompt = model.doGenerateCalls[0]?.prompt ?? [];
+    const interveningAnswerIndex = providerPrompt.findIndex(
+      (message) =>
+        message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some(
+          (part) =>
+            part.type === "text" &&
+            part.text === "The current directory contains the active workspace.",
+        ),
+    );
+    const approvalCallIndex = providerPrompt.findIndex(
+      (message) =>
+        message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some(
+          (part) => part.type === "tool-call" && part.toolCallId === toolCall.toolCallId,
+        ),
+    );
+    expect(interveningAnswerIndex).toBeGreaterThanOrEqual(0);
+    expect(approvalCallIndex).toBeGreaterThan(interveningAnswerIndex);
+    expect(findPart(providerPrompt, "tool-result")).toMatchObject({
+      output: { type: "text", value: "canonical:/workspace" },
+      toolCallId: toolCall.toolCallId,
+      toolName: toolCall.toolName,
+    });
+
+    expect(result.session.history.map((message) => message.role)).toEqual([
+      "user",
+      "user",
+      "assistant",
+      "assistant",
+      "tool",
+      "tool",
+      "assistant",
+    ]);
+    expect(result.session.history.slice(0, interveningHistory.length)).toEqual(interveningHistory);
+    expect(findPart(result.session.history, "tool-approval-response")).toMatchObject({
+      approvalId: approvalRequest.approvalId,
+      approved: true,
+    });
+    expect(hasPendingInputBatch(result.session.state)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Expand the stage-1 acceptance gate from #1578 across both real AI SDK execution surfaces:

- immediate approval baseline;
- approval after two complete intervening turns;
- denial after an intervening turn;
- one shared suffix containing two approvals with mixed approve/deny outcomes;
- streaming resume after an intervening turn.

Each case asserts tool execution, canonical or denied output, durable history, and pending-state cleanup. The suffix-group case asserts exact call/response/result cardinality and order so duplicated stored suffixes cannot pass through SDK call-ID deduplication.

## Data flow

Before: approval resume coverage restored one stored suffix directly after the original user message. Nothing exercised intervening turns, denial, grouped requests, or the streaming surface.

After: committed turns remain ahead of the restored suffix; eve appends the approval response at the tail; approved tools execute once, denied tools do not execute, and generation continues with the complete history intact.

## Scope

Test-only acceptance gate for #1578. It validates AI SDK core through the real `ToolLoopAgent.generate` and `.stream` paths with `MockLanguageModelV4`. It does not claim to fix or validate the OpenAI-specific provider converter in #1658.