### PR TITLE
feat(docs): add Kybernesis Arcana memory extension

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1404,6 +1404,64 @@ export default githubExtension({
 
 For local or non-Vercel deployments, omit \`connector\` and set \`GITHUB_TOKEN\`; the extension also accepts an explicit \`token\`. Prefer fine-grained credentials, expose only the presets the agent needs, and keep approval enabled for writes. See the [GitHub Tools eve documentation](https://github-tools.com/frameworks/eve#eve-extension) for token authentication, per-tool overrides, commit attribution, and the complete tool catalog.`,
   },
+  arcana: {
+    logo: "arcana",
+    docsHref: "https://github.com/KybernesisAI/platform/tree/master/packages/arcana#readme",
+    keywords: [
+      "memory",
+      "long-term memory",
+      "mcp",
+      "semantic search",
+      "entity graph",
+      "timeline",
+      "brain notes",
+      "Kybernesis",
+    ],
+    install: `Install Kybernesis Arcana for eve:
+
+\`\`\`bash
+eve add extension/arcana
+\`\`\`
+
+This installs \`@kybernesis/arcana\` and writes an extension mount. The package requires Node.js 24 or later.`,
+    quickStart: `Create an Arcana workspace and workspace-scoped API key, then add both values to the agent's environment:
+
+\`\`\`bash title=".env.local"
+ARCANA_API_KEY=kb_your_api_key_here
+ARCANA_WORKSPACE=your-workspace
+\`\`\`
+
+The registry creates this mount:
+
+\`\`\`ts title="agent/extensions/arcana.ts"
+import arcana from "@kybernesis/arcana";
+
+export default arcana({
+  apiKey: process.env.ARCANA_API_KEY!,
+  workspace: process.env.ARCANA_WORKSPACE!,
+});
+\`\`\`
+
+The filename supplies the \`arcana\` namespace. The extension adds an MCP memory connection, recall, remember, and brain-note skills, and instructions that tell the model to search the workspace before it claims not to know something.`,
+    configure: `An Arcana key is scoped to a workspace. Keep the key in a sensitive environment variable and use a separate workspace and key when people or tenants must not share memory. The model can choose what to store and retrieve, but it cannot choose the configured key or default workspace.
+
+You can select a workspace per session with \`resolveWorkspace\`. Derive it only from verified session context, and only return workspaces that the configured key can access:
+
+\`\`\`ts title="agent/extensions/arcana.ts"
+import arcana from "@kybernesis/arcana";
+
+export default arcana({
+  apiKey: process.env.ARCANA_API_KEY!,
+  workspace: process.env.ARCANA_WORKSPACE!,
+  resolveWorkspace: (ctx) =>
+    ctx.session.auth.current?.attributes.surface === "dm"
+      ? process.env.ARCANA_DM_WORKSPACE
+      : undefined,
+});
+\`\`\`
+
+Arcana stores memories, embeddings, timeline entries, and brain notes in the selected workspace. The shipped instructions tell the model not to store passwords, access tokens, payment data, private keys, or one-time codes; add approval rules to memory-write tools when you need an enforced control. See the [Arcana package documentation](https://github.com/KybernesisAI/platform/tree/master/packages/arcana#readme) for the full configuration and tool reference.`,
+  },
   hindsight: {
     logo: "hindsight",
     docsHref: "https://hindsight.vectorize.io/sdks/integrations/eve",

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -80,6 +80,18 @@ describe("integration discovery", () => {
     expect(integrationSearchText(agentkit!)).toContain("long-term memory");
   });
 
+  it("renders the Kybernesis Arcana memory extension setup", () => {
+    const arcana = getIntegration("arcana");
+    expect(arcana).toBeDefined();
+
+    const markdown = integrationMarkdown(arcana!);
+    expect(markdown).toContain("eve add extension/arcana");
+    expect(markdown).toContain('import arcana from "@kybernesis/arcana"');
+    expect(markdown).toContain("ARCANA_API_KEY");
+    expect(markdown).toContain("ARCANA_WORKSPACE");
+    expect(integrationSearchText(arcana!)).toContain("long-term memory");
+  });
+
   it("renders the Hindsight memory extension setup", () => {
     const hindsight = getIntegration("hindsight");
     expect(hindsight).toBeDefined();

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -177,6 +177,21 @@ export const notionLogo = (props: LogoProps) => <SiNotion {...props} />;
 
 export const upstashLogo = (props: LogoProps) => <SiUpstash color="default" {...props} />;
 
+export const arcanaLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <circle cx="12" cy="12" r="3" fill="#1A1C1A" />
+    <circle cx="5" cy="7" r="2" fill="#1A1C1A" />
+    <circle cx="19" cy="7" r="2" fill="#69BE8B" />
+    <circle cx="6" cy="18" r="2" fill="#69BE8B" />
+    <circle cx="18" cy="18" r="2" fill="#1A1C1A" />
+    <path
+      d="m6.7 7.8 3.4 2.7m7.2-2.7-3.4 2.7m-6.5 6 3-2.7m4.2 0 3 2.7"
+      stroke="#1A1C1A"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
 export const hindsightLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 186 139" xmlns="http://www.w3.org/2000/svg" {...props}>
     <g stroke="#078BC2" strokeLinecap="round" strokeLinejoin="round" strokeWidth="8">
@@ -655,6 +670,7 @@ export const logos = {
   raindrop: raindropLogo,
   kernel: kernelLogo,
   upstash: upstashLogo,
+  arcana: arcanaLogo,
   hindsight: hindsightLogo,
   airtable: airtableLogo,
   bitly: bitlyLogo,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -60,6 +60,7 @@
     "@github-tools/eve-extension": "^0.1.0",
     "@jetty/eve": "^0.3.0",
     "@kapso/chat-adapter": "0.1.1",
+    "@kybernesis/arcana": "0.1.1",
     "@larksuite/vercel-chat-adapter": "0.1.2",
     "@linqapp/chat-sdk-adapter": "0.1.0",
     "@liveblocks/chat-sdk-adapter": "3.23.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -60,7 +60,7 @@
     "@github-tools/eve-extension": "^0.1.0",
     "@jetty/eve": "^0.3.0",
     "@kapso/chat-adapter": "0.1.1",
-    "@kybernesis/arcana": "0.1.1",
+    "@kybernesis/arcana": "0.2.0",
     "@larksuite/vercel-chat-adapter": "0.1.2",
     "@linqapp/chat-sdk-adapter": "0.1.0",
     "@liveblocks/chat-sdk-adapter": "3.23.0",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -130,6 +130,24 @@
       ]
     },
     {
+      "name": "extension/arcana",
+      "type": "registry:item",
+      "title": "Kybernesis Arcana",
+      "description": "Give an eve agent a workspace-scoped long-term memory with recall, storage, and brain notes.",
+      "dependencies": ["@kybernesis/arcana"],
+      "envVars": {
+        "ARCANA_API_KEY": "",
+        "ARCANA_WORKSPACE": ""
+      },
+      "files": [
+        {
+          "path": "registry/extensions/arcana.ts",
+          "type": "registry:file",
+          "target": "agent/extensions/arcana.ts"
+        }
+      ]
+    },
+    {
       "name": "extension/hindsight",
       "type": "registry:item",
       "title": "Hindsight",

--- a/apps/docs/registry/extensions/arcana.ts
+++ b/apps/docs/registry/extensions/arcana.ts
@@ -1,0 +1,6 @@
+import arcana from "@kybernesis/arcana";
+
+export default arcana({
+  apiKey: process.env.ARCANA_API_KEY!,
+  workspace: process.env.ARCANA_WORKSPACE!,
+});

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -93,6 +93,11 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("upstash-agentkit")?.connection).toBeUndefined();
   });
 
+  it("exposes Kybernesis Arcana as an extension", () => {
+    expect(getIntegrationEntry("arcana")?.kind).toBe("extension");
+    expect(getIntegrationEntry("arcana")?.connection).toBeUndefined();
+  });
+
   it("exposes Hindsight as an extension", () => {
     expect(getIntegrationEntry("hindsight")?.kind).toBe("extension");
     expect(getIntegrationEntry("hindsight")?.connection).toBeUndefined();

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -304,6 +304,14 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     surfaces: { scaffoldable: false, gallery: true },
   },
   {
+    slug: "arcana",
+    name: "Kybernesis Arcana",
+    kind: "extension",
+    tagline:
+      "Give your agent workspace-scoped long-term memory with recall, storage, and brain notes.",
+    surfaces: { scaffoldable: false, gallery: true },
+  },
+  {
     slug: "hindsight",
     name: "Hindsight",
     kind: "extension",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@kapso/chat-adapter':
         specifier: 0.1.1
         version: 0.1.1(ai@7.0.38(zod@4.4.3))(chat@4.34.0(ai@7.0.38(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
+      '@kybernesis/arcana':
+        specifier: 0.1.1
+        version: 0.1.1(eve@packages+eve)
       '@larksuite/vercel-chat-adapter':
         specifier: 0.1.2
         version: 0.1.2(ai@7.0.38(zod@4.4.3))(bufferutil@4.1.0)(chat@4.34.0(ai@7.0.38(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3)
@@ -3234,6 +3237,12 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@kybernesis/arcana@0.1.1':
+    resolution: {integrity: sha512-lLpFmhsRy8FWNdE/nZqI+D3ZHEdWxUUV6rO75aMLh2R7Snzwg2EL5xUq3wBBcU3d7CRJ7UzV/tYKfMl3sglGJw==}
+    engines: {node: 24.x}
+    peerDependencies:
+      eve: '*'
 
   '@langchain/core@1.2.4':
     resolution: {integrity: sha512-GIrJktdsFPx8gM0C3VyikkeYGZAV7iRIzUJuS5tFatiKLExybou0LI0MuxH9kksN38quyfWdQDl20lIEAEVkVA==}
@@ -17331,6 +17340,11 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
+
+  '@kybernesis/arcana@0.1.1(eve@packages+eve)':
+    dependencies:
+      eve: link:packages/eve
+      zod: 4.4.3
 
   '@langchain/core@1.2.4(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.39.1(ws@8.21.1(bufferutil@4.1.0))(zod@4.4.3))(ws@8.21.1(bufferutil@4.1.0))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: 0.1.1
         version: 0.1.1(ai@7.0.38(zod@4.4.3))(chat@4.34.0(ai@7.0.38(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
       '@kybernesis/arcana':
-        specifier: 0.1.1
-        version: 0.1.1(eve@packages+eve)
+        specifier: 0.2.0
+        version: 0.2.0(eve@packages+eve)
       '@larksuite/vercel-chat-adapter':
         specifier: 0.1.2
         version: 0.1.2(ai@7.0.38(zod@4.4.3))(bufferutil@4.1.0)(chat@4.34.0(ai@7.0.38(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3)
@@ -3238,11 +3238,11 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@kybernesis/arcana@0.1.1':
-    resolution: {integrity: sha512-lLpFmhsRy8FWNdE/nZqI+D3ZHEdWxUUV6rO75aMLh2R7Snzwg2EL5xUq3wBBcU3d7CRJ7UzV/tYKfMl3sglGJw==}
+  '@kybernesis/arcana@0.2.0':
+    resolution: {integrity: sha512-9F0zw/SDgutjOFXqnpgyJhBuePVbGKJRS+p0V37ejbcNe+GH/LTWLowEz8t/o9d98JgnJfxK0cuJcEPqjI2qrQ==}
     engines: {node: 24.x}
     peerDependencies:
-      eve: '*'
+      eve: '>=0.30.0 <0.31.0'
 
   '@langchain/core@1.2.4':
     resolution: {integrity: sha512-GIrJktdsFPx8gM0C3VyikkeYGZAV7iRIzUJuS5tFatiKLExybou0LI0MuxH9kksN38quyfWdQDl20lIEAEVkVA==}
@@ -17341,7 +17341,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@kybernesis/arcana@0.1.1(eve@packages+eve)':
+  '@kybernesis/arcana@0.2.0(eve@packages+eve)':
     dependencies:
       eve: link:packages/eve
       zod: 4.4.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,6 +66,7 @@ minimumReleaseAgeExclude:
   - "@getdial/chat-sdk-adapter"
   - "@github-tools/eve-extension"
   - "@github-tools/sdk"
+  - "@kybernesis/arcana"
   - "@kapso/chat-adapter"
   - "@larksuite/vercel-chat-adapter"
   - "@linqapp/chat-sdk-adapter"


### PR DESCRIPTION
### Summary

Closes #1576.

Adds Kybernesis Arcana to the official registry and integrations gallery. `eve add extension/arcana` installs the published extension and creates a workspace-scoped API-key mount with its recall, storage, and brain-note capabilities.

The gallery documents workspace isolation, sensitive key handling, and the constraint that dynamic workspace selection must use verified session context and remain within the configured key's scope.

### Validation

- `pnpm fmt`
- `pnpm --filter eve-docs registry:check`
- `pnpm --filter @eve/catalog test:unit`
- `pnpm --filter eve-docs test:unit -- lib/integrations/discovery.test.ts`
- `pnpm --filter @eve/catalog typecheck`
- `pnpm --filter eve-docs exec next typegen && pnpm --filter eve-docs exec tsc --noEmit`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
