### PR TITLE
docs: show evals in homepage file tree

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/file-tree.tsx
+++ b/apps/docs/app/[lang]/(home)/components/file-tree.tsx
@@ -181,6 +181,25 @@ cron: "0 8 * * *"
 Send the user a daily weather
 digest for their saved cities.`,
   },
+  {
+    label: "Evals",
+    name: "evals/",
+    fileName: "evals/weather/brooklyn-forecast.eval.ts",
+    lang: "typescript",
+    NavIcon: IconFileText,
+    description:
+      "Evals run the agent through real sessions and score the result, so you can catch regressions as it evolves.",
+    code: `import { defineEval } from "eve/evals";
+import { includes } from "eve/evals/expect";
+
+export default defineEval({
+  async test(t) {
+    await t.send("What is the weather in Brooklyn?");
+    t.succeeded();
+    t.check(t.reply, includes("Sunny"));
+  },
+});`,
+  },
 ];
 
 export async function FileTree() {


### PR DESCRIPTION
### Summary

Closes #1729

Add an optional `evals/` entry to the homepage file-tree example, including a scored weather-session check that shows how eve users can catch regressions.

<img width="773" height="569" alt="image" src="https://github.com/user-attachments/assets/876b73fc-66b5-4f5c-b950-decef9fd1618" />

### Validation

- `pnpm exec oxfmt --check 'apps/docs/app/[lang]/(home)/components/file-tree.tsx'`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
