### PR TITLE
feat(client): clarify connection authorization blocker (AX-4457)

### DIFF
--- a/.changeset/bright-cards-speak.md
+++ b/.changeset/bright-cards-speak.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Clarify connection authorization cards so users know they must authorize before the agent session can continue.

--- a/packages/eve/src/client/authorization-message-parts.ts
+++ b/packages/eve/src/client/authorization-message-parts.ts
@@ -73,7 +73,7 @@ function normalizeAuthorizationDescription(
   displayName: string,
 ): string {
   if (description === `Authorization required for ${name}`) {
-    return `Authorization required for ${displayName}`;
+    return `Authorize ${displayName} to continue this agent session.`;
   }
 
   return description;

--- a/packages/eve/src/client/message-reducer.test.ts
+++ b/packages/eve/src/client/message-reducer.test.ts
@@ -373,7 +373,7 @@ describe("defaultMessageReducer", () => {
               url: "https://connect.example.com/authorize/sca_123",
               userCode: "ABCD-EFGH",
             },
-            description: "Authorization required for Notion",
+            description: "Authorize Notion to continue this agent session.",
             displayName: "Notion",
             name: "notion",
             state: "required",

--- a/packages/eve/src/public/channels/slack/connections.test.ts
+++ b/packages/eve/src/public/channels/slack/connections.test.ts
@@ -24,7 +24,7 @@ describe("formatConnectionDisplayName", () => {
 describe("buildAuthRequiredPublicText", () => {
   it("invites the triggering user to connect when one is known", () => {
     expect(buildAuthRequiredPublicText({ displayName: "Linear", hasUser: true })).toBe(
-      "Connect with Linear to continue",
+      "Connect with Linear to continue this agent session",
     );
   });
 

--- a/packages/eve/src/public/channels/slack/connections.ts
+++ b/packages/eve/src/public/channels/slack/connections.ts
@@ -45,7 +45,7 @@ export function buildAuthRequiredPublicText(input: {
   if (!input.hasUser) {
     return `Authorization required for ${input.displayName} (no triggering user)`;
   }
-  return `Connect with ${input.displayName} to continue`;
+  return `Connect with ${input.displayName} to continue this agent session`;
 }
 
 /**

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -59,7 +59,7 @@ describe("defaultEvents authorization.required", () => {
 
     expect(post).toHaveBeenCalledTimes(1);
     const publicText = post.mock.calls[0]?.[0] as string;
-    expect(publicText).toBe("Connect with Notion to continue");
+    expect(publicText).toBe("Connect with Notion to continue this agent session");
     expect(publicText).not.toContain("https://");
     expect(postEphemeral).toHaveBeenCalledTimes(1);
     expect(postEphemeral.mock.calls[0]?.[0]).toBe("U777");
@@ -105,7 +105,9 @@ describe("defaultEvents authorization.required", () => {
       sessionCtx,
     );
 
-    expect(post.mock.calls[0]?.[0]).toBe("Connect with Notion Workspace to continue");
+    expect(post.mock.calls[0]?.[0]).toBe(
+      "Connect with Notion Workspace to continue this agent session",
+    );
     const message = postEphemeral.mock.calls[0]?.[1] as { text: string };
     expect(message.text).toContain("Sign in with Notion Workspace");
   });
@@ -131,7 +133,7 @@ describe("defaultEvents authorization.required", () => {
 
     expect(post).toHaveBeenCalledTimes(1);
     const publicText = post.mock.calls[0]?.[0] as string;
-    expect(publicText).toBe("Connect with Notion to continue");
+    expect(publicText).toBe("Connect with Notion to continue this agent session");
     expect(publicText).not.toContain("https://");
     expect(channel.state.pendingAuthMessageTs).toEqual({ notion: "ts1" });
   });


### PR DESCRIPTION
### Summary

Connection authorization prompts now explicitly say the agent session cannot continue without the connection. Generic browser cards use “Authorize [connection] to continue this agent session,” while Slack’s public, link-free status uses “Connect with [connection] to continue this agent session”; provider-specific instructions and private Slack authorization delivery remain unchanged.

Linear: [AX-4457](https://linear.app/vercel/issue/AX-4457/clarify-when-connection-authorization-blocks-an-agent-session)

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/client/message-reducer.test.ts src/public/channels/slack/connections.test.ts src/public/channels/slack/defaults.test.ts` (37 tests passed)
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
