### PR TITLE
feat(tools): per-tool providerOptions passthrough + provider-native tool search (defer_loading)

### DIFF
--- a/.changeset/tool-provider-options-defer.md
+++ b/.changeset/tool-provider-options-defer.md
@@ -1,0 +1,11 @@
+---
+"eve": minor
+---
+
+Add per-tool `providerOptions` passthrough and provider-native tool search injection.
+
+`defineTool` (authored and dynamic) now accepts an optional `providerOptions` field that is forwarded verbatim to the AI SDK tool object, enabling provider features configured per tool — most notably `{ anthropic: { deferLoading: true } }` / `{ openai: { deferLoading: true } }`, which mark a tool as deferred for provider-native tool search.
+
+When any advertised tool is deferred, the harness now injects the provider's tool-search server tool (`tool_search_tool_regex` for Anthropic, `tool_search` for OpenAI) into the model request, so the model discovers and loads deferred schemas on demand. This keeps large or dynamically discovered tool sets out of the context window and keeps the tool prefix stable across steps, preserving the provider prompt cache (#716). On providers without tool-search support, deferred tools load eagerly exactly as before.
+
+Closes #1735.

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -50,6 +50,7 @@ function toHarnessToolDefinition(name: string, entry: DynamicToolEntry): Harness
     ...(entry.toModelOutput !== undefined
       ? { toModelOutput: entry.toModelOutput as (output: unknown) => unknown }
       : {}),
+    ...(entry.providerOptions !== undefined ? { providerOptions: entry.providerOptions } : {}),
   };
 }
 

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -265,6 +265,7 @@ function resolveHarnessToolDefinition(input: {
     approval: def.approval,
     outputSchema: def.outputSchema,
     toModelOutput: def.toModelOutput,
+    providerOptions: def.providerOptions,
   };
 }
 

--- a/packages/eve/src/harness/execute-tool.ts
+++ b/packages/eve/src/harness/execute-tool.ts
@@ -1,7 +1,7 @@
 import type { FlexibleSchema } from "ai";
 
 import type { Approval } from "#public/definitions/approval.js";
-import type { ToolExecuteOptions } from "#shared/tool-definition.js";
+import type { ToolExecuteOptions, ToolProviderOptions } from "#shared/tool-definition.js";
 
 /**
  * Runtime-owned action metadata attached to one harness-visible tool.
@@ -29,4 +29,5 @@ export interface HarnessToolDefinition {
   readonly outputSchema?: FlexibleSchema;
   readonly runtimeAction?: HarnessRuntimeActionDefinition;
   readonly toModelOutput?: (output: unknown) => unknown;
+  readonly providerOptions?: ToolProviderOptions;
 }

--- a/packages/eve/src/harness/provider-tools.ts
+++ b/packages/eve/src/harness/provider-tools.ts
@@ -185,17 +185,18 @@ export function isDeferredTool(candidate: ToolSet[string]): boolean {
 
 /**
  * Resolves which provider-native tool-search backend serves the current
- * model, mirroring {@link resolveWebSearchBackend}. Returns `null` when the
- * provider has no tool-search support — deferred tools then load eagerly,
+ * model. Unlike {@link resolveWebSearchBackend} there is no gateway
+ * fallback, and the id prefix is parsed for gateway model ids and authored
+ * instances alike — a gateway-routed Anthropic/OpenAI model forwards
+ * per-tool `providerOptions` upstream, so it needs the search tool just as
+ * much as a direct instance. Returns `null` when the provider has no
+ * tool-search support — the defer markers are then inert (providers only
+ * read their own `providerOptions` namespace) and tools load eagerly,
  * exactly as before this feature.
  */
 export function resolveToolSearchBackend(
   modelRef: RuntimeModelReference,
 ): ToolSearchBackend | null {
-  if (modelRef.source === undefined) {
-    return null;
-  }
-
   const providerId = modelRef.id.split("/")[0] ?? "";
 
   if (providerId === "openai" || providerId.startsWith("openai.")) {

--- a/packages/eve/src/harness/provider-tools.ts
+++ b/packages/eve/src/harness/provider-tools.ts
@@ -152,6 +152,86 @@ export async function resolveWebSearchProviderTool(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Provider-native tool search
+// ---------------------------------------------------------------------------
+
+/** Backends with provider-native tool search support. */
+export type ToolSearchBackend = "anthropic" | "openai";
+
+/**
+ * A resolved tool-search provider tool plus the tool-set key to mount it
+ * under. The key matches the provider's fixed wire name so tool-call parts
+ * round-trip cleanly.
+ */
+export interface ToolSearchProviderTool {
+  readonly name: string;
+  readonly tool: ToolSet[string];
+}
+
+/**
+ * Returns `true` when a built AI SDK tool is marked as deferred for
+ * provider-native tool search (`providerOptions.<provider>.deferLoading`).
+ */
+export function isDeferredTool(candidate: ToolSet[string]): boolean {
+  const providerOptions = candidate.providerOptions as
+    | Record<string, Record<string, unknown> | undefined>
+    | undefined;
+  return (
+    providerOptions?.anthropic?.deferLoading === true ||
+    providerOptions?.openai?.deferLoading === true
+  );
+}
+
+/**
+ * Resolves which provider-native tool-search backend serves the current
+ * model, mirroring {@link resolveWebSearchBackend}. Returns `null` when the
+ * provider has no tool-search support — deferred tools then load eagerly,
+ * exactly as before this feature.
+ */
+export function resolveToolSearchBackend(
+  modelRef: RuntimeModelReference,
+): ToolSearchBackend | null {
+  if (modelRef.source === undefined) {
+    return null;
+  }
+
+  const providerId = modelRef.id.split("/")[0] ?? "";
+
+  if (providerId === "openai" || providerId.startsWith("openai.")) {
+    return "openai";
+  }
+
+  if (providerId === "anthropic" || providerId.startsWith("anthropic.")) {
+    return "anthropic";
+  }
+
+  return null;
+}
+
+/**
+ * Constructs the AI SDK provider tool for tool search based on the resolved
+ * backend. Dynamic imports keep unused provider SDKs out of the bundle,
+ * mirroring {@link resolveWebSearchProviderTool}.
+ */
+export async function resolveToolSearchProviderTool(
+  backend: ToolSearchBackend,
+): Promise<ToolSearchProviderTool> {
+  switch (backend) {
+    case "openai": {
+      const { openai } = await import("#compiled/@ai-sdk/openai/index.js");
+      return { name: "tool_search", tool: openai.tools.toolSearch({}) as ToolSet[string] };
+    }
+    case "anthropic": {
+      const { anthropic } = await import("#compiled/@ai-sdk/anthropic/index.js");
+      return {
+        name: "tool_search_tool_regex",
+        tool: anthropic.tools.toolSearchRegex_20251119() as ToolSet[string],
+      };
+    }
+  }
+}
+
 function attachWebSearchOutputSchema(
   tool: ToolSet[string],
   backend: WebSearchBackend,

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -168,7 +168,12 @@ import {
   detectPromptCachePath,
   getAnthropicCacheMarker,
 } from "#harness/prompt-cache.js";
-import { resolveFrameworkToolFromUpstreamType } from "#harness/provider-tools.js";
+import {
+  isDeferredTool,
+  resolveFrameworkToolFromUpstreamType,
+  resolveToolSearchBackend,
+  resolveToolSearchProviderTool,
+} from "#harness/provider-tools.js";
 import {
   createRuntimeActionRequestFromToolCall,
   resolvePendingRuntimeActions,
@@ -959,7 +964,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       });
       modelCallRuntimeActionTools = advertisedHarnessTools;
 
-      const flatTools = await buildToolSetWithProviderTools({
+      let flatTools = await buildToolSetWithProviderTools({
         approvedTools,
         capabilities: config.capabilities,
         disabledProviderTools: opts.disabledProviderTools,
@@ -985,6 +990,24 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             throw new Error(`Dynamic tool "${name}" collides with a runtime-visible subagent.`);
           }
           flatTools[name] = toolDefinition;
+        }
+      }
+
+      // Provider-native tool search: when any advertised tool is deferred
+      // (`providerOptions.<provider>.deferLoading`), inject the provider's
+      // search tool so deferred schemas are discovered and loaded on demand.
+      // The search tool is prepended so applyLastToolCacheBreakpoint keeps
+      // landing the Anthropic cache marker on a function tool
+      // (provider-defined tools do not carry providerOptions on the wire).
+      // Object.assign preserves tool object identities, so per-tool approval
+      // registrations keyed on those objects stay valid.
+      if (Object.values(flatTools).some(isDeferredTool)) {
+        const toolSearchBackend = resolveToolSearchBackend(session.agent.modelReference);
+        if (toolSearchBackend !== null) {
+          const toolSearch = await resolveToolSearchProviderTool(toolSearchBackend);
+          if (flatTools[toolSearch.name] === undefined) {
+            flatTools = Object.assign({ [toolSearch.name]: toolSearch.tool }, flatTools);
+          }
         }
       }
 

--- a/packages/eve/src/harness/tool-provider-options.test.ts
+++ b/packages/eve/src/harness/tool-provider-options.test.ts
@@ -58,19 +58,40 @@ describe("isDeferredTool", () => {
 });
 
 describe("resolveToolSearchBackend", () => {
+  // Gateway model ids carry no source; authored LanguageModel instances do.
+  const AUTHORED_SOURCE = {
+    exportName: "default",
+    logicalPath: "agent/agent.ts",
+    sourceId: "agent/agent.ts",
+    sourceKind: "module",
+  } as unknown as RuntimeModelReference["source"];
+
   function modelRef(overrides: Partial<RuntimeModelReference>): RuntimeModelReference {
-    return { id: "openai/gpt-5.6-luna", source: "authored", ...overrides } as RuntimeModelReference;
+    return { id: "openai/gpt-5.6-luna", ...overrides } as RuntimeModelReference;
   }
 
-  it("maps gateway model ids to their tool-search backend", () => {
+  it("maps gateway model ids (no source) to their tool-search backend", () => {
     expect(resolveToolSearchBackend(modelRef({ id: "openai/gpt-5.6-luna" }))).toBe("openai");
     expect(resolveToolSearchBackend(modelRef({ id: "anthropic/claude-opus-5" }))).toBe("anthropic");
     expect(resolveToolSearchBackend(modelRef({ id: "google/gemini-3-pro" }))).toBeNull();
+    expect(resolveToolSearchBackend(modelRef({ id: "xai/grok-5" }))).toBeNull();
   });
 
-  it("returns null for direct model instances", () => {
+  it("maps authored model instances via their provider-prefixed id", () => {
     expect(
-      resolveToolSearchBackend(modelRef({ id: "claude-opus-5", source: undefined })),
+      resolveToolSearchBackend(
+        modelRef({ id: "anthropic.messages/claude-opus-5", source: AUTHORED_SOURCE }),
+      ),
+    ).toBe("anthropic");
+    expect(
+      resolveToolSearchBackend(
+        modelRef({ id: "openai.responses/gpt-5.6", source: AUTHORED_SOURCE }),
+      ),
+    ).toBe("openai");
+    expect(
+      resolveToolSearchBackend(
+        modelRef({ id: "google.generative-ai/gemini-3-pro", source: AUTHORED_SOURCE }),
+      ),
     ).toBeNull();
   });
 });

--- a/packages/eve/src/harness/tool-provider-options.test.ts
+++ b/packages/eve/src/harness/tool-provider-options.test.ts
@@ -1,0 +1,76 @@
+import { jsonSchema, type ToolSet } from "ai";
+import { describe, expect, it } from "vitest";
+
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import { isDeferredTool, resolveToolSearchBackend } from "#harness/provider-tools.js";
+import { buildToolSetFromDefinitions } from "#harness/tools.js";
+import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
+
+const DEFER = { anthropic: { deferLoading: true }, openai: { deferLoading: true } };
+
+function definition(overrides: Partial<HarnessToolDefinition>): HarnessToolDefinition {
+  return {
+    description: "d",
+    execute: async () => ({}),
+    inputSchema: jsonSchema({ type: "object" }),
+    name: "example_tool",
+    ...overrides,
+  };
+}
+
+function aiTool(providerOptions?: Record<string, Record<string, unknown>>): ToolSet[string] {
+  return {
+    description: "d",
+    inputSchema: jsonSchema({ type: "object" }),
+    ...(providerOptions !== undefined ? { providerOptions } : {}),
+  } as ToolSet[string];
+}
+
+describe("per-tool providerOptions passthrough", () => {
+  it("copies providerOptions onto the AI SDK tool object", () => {
+    const toolSet = buildToolSetFromDefinitions({
+      approvedTools: new Set<string>(),
+      capabilities: {},
+      tools: [definition({ providerOptions: DEFER })],
+    });
+    expect(toolSet.example_tool?.providerOptions).toEqual(DEFER);
+  });
+
+  it("omits providerOptions when the definition has none", () => {
+    const toolSet = buildToolSetFromDefinitions({
+      approvedTools: new Set<string>(),
+      capabilities: {},
+      tools: [definition({})],
+    });
+    expect(toolSet.example_tool).toBeDefined();
+    expect(toolSet.example_tool?.providerOptions).toBeUndefined();
+  });
+});
+
+describe("isDeferredTool", () => {
+  it("detects the deferLoading marker for either provider", () => {
+    expect(isDeferredTool(aiTool({ anthropic: { deferLoading: true } }))).toBe(true);
+    expect(isDeferredTool(aiTool({ openai: { deferLoading: true } }))).toBe(true);
+    expect(isDeferredTool(aiTool({ anthropic: { deferLoading: false } }))).toBe(false);
+    expect(isDeferredTool(aiTool({ gateway: { caching: false } }))).toBe(false);
+    expect(isDeferredTool(aiTool())).toBe(false);
+  });
+});
+
+describe("resolveToolSearchBackend", () => {
+  function modelRef(overrides: Partial<RuntimeModelReference>): RuntimeModelReference {
+    return { id: "openai/gpt-5.6-luna", source: "authored", ...overrides } as RuntimeModelReference;
+  }
+
+  it("maps gateway model ids to their tool-search backend", () => {
+    expect(resolveToolSearchBackend(modelRef({ id: "openai/gpt-5.6-luna" }))).toBe("openai");
+    expect(resolveToolSearchBackend(modelRef({ id: "anthropic/claude-opus-5" }))).toBe("anthropic");
+    expect(resolveToolSearchBackend(modelRef({ id: "google/gemini-3-pro" }))).toBeNull();
+  });
+
+  it("returns null for direct model instances", () => {
+    expect(
+      resolveToolSearchBackend(modelRef({ id: "claude-opus-5", source: undefined })),
+    ).toBeNull();
+  });
+});

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -72,6 +72,9 @@ export function buildToolSet(input: {
       execute: wrapToolExecute(definition),
       inputSchema: definition.inputSchema,
       outputSchema: definition.outputSchema,
+      ...(definition.providerOptions !== undefined
+        ? { providerOptions: definition.providerOptions as ToolSet[string]["providerOptions"] }
+        : {}),
       ...(definition.execute !== undefined
         ? {
             toModelOutput: async ({

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -1,7 +1,11 @@
 import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index.js";
 
 import { stampDefinitionKey } from "#public/tool-result-narrowing.js";
-import type { PublicToolDefinition, ToolModelOutput } from "#shared/tool-definition.js";
+import type {
+  PublicToolDefinition,
+  ToolModelOutput,
+  ToolProviderOptions,
+} from "#shared/tool-definition.js";
 import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { Approval } from "#public/definitions/approval.js";
 import type { JsonObject } from "#shared/json.js";
@@ -164,6 +168,8 @@ export function defineTool<
     | StandardJSONSchemaV1.InferOutput<TOutputSchema>
     | AsyncIterable<StandardJSONSchemaV1.InferOutput<TOutputSchema>>;
   approval?: ToolDefinition<StandardJSONSchemaV1.InferOutput<TInputSchema>, unknown>["approval"];
+  /** Provider-specific tool options — see {@link ToolProviderOptions}. */
+  providerOptions?: ToolProviderOptions;
   toModelOutput?: ToolDefinition<
     unknown,
     StandardJSONSchemaV1.InferOutput<TOutputSchema>
@@ -184,6 +190,8 @@ export function defineTool<
     ctx: ToolContext,
   ): Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
   approval?: ToolDefinition<StandardJSONSchemaV1.InferOutput<TSchema>, unknown>["approval"];
+  /** Provider-specific tool options — see {@link ToolProviderOptions}. */
+  providerOptions?: ToolProviderOptions;
   toModelOutput?: ToolDefinition<unknown, TOutput>["toModelOutput"];
 }): ToolDefinition<StandardJSONSchemaV1.InferOutput<TSchema>, TOutput>;
 export function defineTool<
@@ -200,6 +208,8 @@ export function defineTool<
     | StandardJSONSchemaV1.InferOutput<TOutputSchema>
     | AsyncIterable<StandardJSONSchemaV1.InferOutput<TOutputSchema>>;
   approval?: ToolDefinition<Record<string, unknown>, unknown>["approval"];
+  /** Provider-specific tool options — see {@link ToolProviderOptions}. */
+  providerOptions?: ToolProviderOptions;
   toModelOutput?: ToolDefinition<
     unknown,
     StandardJSONSchemaV1.InferOutput<TOutputSchema>
@@ -214,6 +224,8 @@ export function defineTool<TOutput>(definition: {
     ctx: ToolContext,
   ): Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
   approval?: ToolDefinition<Record<string, unknown>, unknown>["approval"];
+  /** Provider-specific tool options — see {@link ToolProviderOptions}. */
+  providerOptions?: ToolProviderOptions;
   toModelOutput?: ToolDefinition<unknown, TOutput>["toModelOutput"];
 }): ToolDefinition<Record<string, unknown>, TOutput>;
 export function defineTool<TInput = unknown, TOutput = unknown>(

--- a/packages/eve/src/runtime/resolve-tool.ts
+++ b/packages/eve/src/runtime/resolve-tool.ts
@@ -88,7 +88,7 @@ export async function resolveToolDefinition(
  * result without clobbering required fields with `undefined`.
  */
 type OptionalResolvedFields = {
-  -readonly [K in "approval" | "toModelOutput"]?: ResolvedToolDefinition[K];
+  -readonly [K in "approval" | "toModelOutput" | "providerOptions"]?: ResolvedToolDefinition[K];
 };
 
 /**
@@ -114,6 +114,10 @@ function extractOptionalHooks(
       record.toModelOutput,
       describe(definition, "to provide a toModelOutput function"),
     ) as ResolvedToolDefinition["toModelOutput"];
+  }
+
+  if (record.providerOptions !== undefined) {
+    optional.providerOptions = record.providerOptions as ResolvedToolDefinition["providerOptions"];
   }
 
   return optional;

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -4,6 +4,7 @@ import type {
   PublicToolInputSchema,
   PublicToolOutputSchema,
   ToolModelOutput,
+  ToolProviderOptions,
 } from "#shared/tool-definition.js";
 import type { Approval } from "#public/definitions/approval.js";
 import type { ToolContext } from "#public/definitions/tool.js";
@@ -93,6 +94,12 @@ export interface DynamicToolEntry<TInput = Record<string, unknown>, TOutput = an
    * carry a function across replay.
    */
   readonly approval?: Approval;
+  /**
+   * Optional provider-specific tool options forwarded verbatim to the AI
+   * SDK tool — for example `{ anthropic: { deferLoading: true } }` to mark
+   * the tool as deferred for provider-native tool search.
+   */
+  readonly providerOptions?: ToolProviderOptions;
 }
 
 /**

--- a/packages/eve/src/shared/tool-definition.ts
+++ b/packages/eve/src/shared/tool-definition.ts
@@ -13,8 +13,21 @@ export type ToolExecuteFn<TInput = unknown, TOutput = unknown> = (
   options: ToolExecuteOptions,
 ) => Promise<TOutput> | TOutput | AsyncIterable<TOutput>;
 
+/**
+ * Provider-specific tool options forwarded verbatim to the AI SDK tool.
+ * Enables provider features that are configured per tool — for example
+ * `{ anthropic: { deferLoading: true } }` marks the tool as deferred for
+ * provider-native tool search.
+ */
+export type ToolProviderOptions = Record<string, JsonObject>;
+
 interface ToolDefinitionBase {
   readonly description: string;
+  /**
+   * Optional provider-specific tool options forwarded verbatim to the AI
+   * SDK tool — see {@link ToolProviderOptions}.
+   */
+  readonly providerOptions?: ToolProviderOptions;
 }
 
 /**


### PR DESCRIPTION
Implements #1735: per-tool `providerOptions` passthrough plus automatic provider-native tool-search injection.

## What

1. **`defineTool` (authored and dynamic) accepts an optional `providerOptions`** (`ToolProviderOptions = Record<string, JsonObject>`, on `ToolDefinitionBase` so it flows through the public, internal, and resolved definition types). It is threaded through each resolution hop — `extractOptionalHooks` → `resolveHarnessToolDefinition` → `buildToolSet`, and `toHarnessToolDefinition` for dynamic tools — into the AI SDK `tool()` object, which already forwards per-tool `providerOptions` to providers. The vendored `@ai-sdk/anthropic` / `@ai-sdk/openai` map `deferLoading` to the wire's `defer_loading`.

2. **When any advertised tool is deferred** (`providerOptions.<provider>.deferLoading === true`), the tool loop injects the provider's tool-search server tool — `anthropic.tools.toolSearchRegex_20251119()` (mounted as `tool_search_tool_regex`) or `openai.tools.toolSearch()` (`tool_search`) — mirroring the existing web-search injection in `resolveWebSearchProviderTool`. On providers without tool-search support, deferred tools load eagerly exactly as before.

## Why

Large or dynamically discovered tool sets currently pay twice: every advertised schema occupies context on every call, and registering a newly discovered tool changes the `tools` prefix, invalidating the prompt cache (#716). Provider-native tool search addresses both — deferred schemas stay out of context until the model searches for them, and the tool prefix stays stable across steps.

## Implementation notes

- Injection happens in `tool-loop.ts` **after** the dynamic-tools merge (dynamic tools are the main source of deferred tools and merge in after `buildToolSetWithProviderTools`).
- The search tool is **prepended** so `applyLastToolCacheBreakpoint` keeps landing the Anthropic cache marker on a function tool — provider-defined tools don't carry `providerOptions` on the wire.
- `Object.assign` preserves tool object identities, so per-tool approval registrations keyed on those objects stay valid.
- `resolveToolSearchBackend` mirrors `resolveWebSearchBackend` but returns `null` for direct model instances and unsupported providers (no gateway fallback exists for tool search).

## Testing

- New `src/harness/tool-provider-options.test.ts`: passthrough into the built ToolSet (present and absent), `isDeferredTool` marker detection, backend resolution for gateway/direct model references.
- `pnpm typecheck` clean; harness + context unit suites pass (58 files, 832 tests); `oxlint`/`oxfmt` clean.
- Validated end-to-end against a real deployment: an equivalent dist-level patch of this change is running in [eve-chatgpt-connectors](https://github.com/ewhauser/eve-chatgpt-connectors) exposing a 189-tool per-user catalog as deferred tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
