### PR TITLE
fix(chat-sdk-lark): template uses thread.post instead of webhook-only send

### DIFF
--- a/apps/docs/registry/channels/chat-sdk-lark.ts
+++ b/apps/docs/registry/channels/chat-sdk-lark.ts
@@ -3,7 +3,7 @@ import { createMemoryState } from "@chat-adapter/state-memory";
 import type { Message, Thread } from "chat";
 import { chatSdkChannel } from "eve/channels/chat-sdk";
 
-export const { bot, channel, send } = chatSdkChannel({
+export const { bot, channel } = chatSdkChannel({
   userName: "My Agent",
   adapters: {
     lark: createLarkAdapter(),
@@ -13,11 +13,11 @@ export const { bot, channel, send } = chatSdkChannel({
 
 bot.onNewMention(async (thread: Thread, message: Message) => {
   await thread.subscribe();
-  await send(message.text, { thread });
+  await thread.post({ markdown: message.text });
 });
 
 bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
-  await send(message.text, { thread });
+  await thread.post({ markdown: message.text });
 });
 
 await bot.initialize();


### PR DESCRIPTION
## Problem
The `@larksuite/vercel-chat-adapter` is WebSocket-only — `handleWebhook()` returns HTTP 501 by design. `chatSdkChannel().send` requires the active webhook request context (set only by the chat-sdk HTTP route handler). When the Lark bot received a message over WebSocket and tried to reply via `send(...)`, it threw:

```
Error: chatSdkChannel().send can only run during a Chat SDK webhook handler for this bridge.
```

The scaffolded channel could receive messages but could never reply. Reported as #1753.

## Fix
Replace the reply path in the generated Lark channel template from `send(...)` to `thread.post({ markdown: ... })` — the adapter-native delivery mechanism that works regardless of transport. Also remove `send` from the destructured surface so new projects don't reach for the webhook-only path.

## Validation
- [x] `pnpm fmt` passes
- [x] `pnpm typecheck` passes (catalog types unchanged; only template code)
- [x] Manual: template now compiles and replies via `thread.post`

Closes #1753.