### PR TITLE
feat(eve): carry background-task lifecycle receipts on the wire

### DIFF
--- a/.changeset/background-task-receipt-events.md
+++ b/.changeset/background-task-receipt-events.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Background task receipts now carry explicit lifecycle metadata so clients can distinguish dispatch acknowledgement from child completion.

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v7.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v7.ts
@@ -1,0 +1,10 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineInstructions({
+        markdown: `Use session ${ctx.session.id} when correlating evidence.`,
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v7.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v7.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineSkill({
+        description: `Review evidence for session ${ctx.session.id}.`,
+        markdown: "# Evidence review\n\nCheck every claim against its source.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v10.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v10.ts
@@ -1,0 +1,12 @@
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineTool({
+        description: "Return the active session identifier.",
+        inputSchema: { type: "object", properties: {} },
+        execute: () => ({ sessionId: ctx.session.id }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v8.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v8.ts
@@ -1,0 +1,13 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "subagent.completed"(event, ctx) {
+      console.info("subagent completed", {
+        output: event.data.output,
+        sessionId: ctx.session.id,
+        subagentName: event.data.subagentName,
+      });
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v7.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v7.ts
@@ -1,0 +1,12 @@
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Summarize a completed task.",
+  inputSchema: { type: "object", properties: {} },
+  async execute(_input, ctx) {
+    return { callId: ctx.callId, summary: "Task completed." };
+  },
+  toModelOutput(output) {
+    return { type: "text", value: output.summary };
+  },
+});

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v8.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v8.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 8,
+  "sha256": "2f160e8da5e5e9c019164a36e29520fca45ff3be63399eee91e235bb268c56ea",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v8.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v8.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 8,
+  "sha256": "2f160e8da5e5e9c019164a36e29520fca45ff3be63399eee91e235bb268c56ea",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v11.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v11.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 11,
+  "sha256": "137b1e3f0031f508e4902966823a9d00444c234c94bdaaa2ad772bfe14c364e0",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v9.json
+++ b/packages/eve/extension-contracts/reports/hook/v9.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 9,
+  "sha256": "6b46bf605ee89c3f7ce3a14f0ce5e0247fd03f9af9f1fd8fc15f2c7fdef58676",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/tool/v8.json
+++ b/packages/eve/extension-contracts/reports/tool/v8.json
@@ -1,0 +1,22 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 8,
+  "sha256": "d2c29a2f29a00db5c0ec65f5abf95c4ac57f2a55b6df034122c8e2dbe98c8406",
+  "exports": [
+    "defineBashTool",
+    "defineGlobTool",
+    "defineGrepTool",
+    "defineReadFileTool",
+    "defineTool",
+    "defineWriteFileTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -21,14 +21,14 @@ interface ExtensionCapabilityContract {
 
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
-  tool: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
-  dynamicTool: { current: 10, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dropped: {} },
+  tool: { current: 8, supported: [1, 2, 3, 4, 5, 6, 7, 8], dropped: {} },
+  dynamicTool: { current: 11, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], dropped: {} },
   connection: { current: 2, supported: [1, 2], dropped: {} },
-  hook: { current: 8, supported: [1, 2, 3, 4, 5, 6, 7, 8], dropped: {} },
+  hook: { current: 9, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9], dropped: {} },
   skill: { current: 1, supported: [1], dropped: {} },
-  dynamicSkill: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
+  dynamicSkill: { current: 8, supported: [1, 2, 3, 4, 5, 6, 7, 8], dropped: {} },
   instructions: { current: 1, supported: [1], dropped: {} },
-  dynamicInstructions: { current: 7, supported: [1, 2, 3, 4, 5, 6, 7], dropped: {} },
+  dynamicInstructions: { current: 8, supported: [1, 2, 3, 4, 5, 6, 7, 8], dropped: {} },
   config: { current: 1, supported: [1], dropped: {} },
   state: { current: 2, supported: [1, 2], dropped: {} },
 } as const satisfies Record<string, ExtensionCapabilityContract>;

--- a/packages/eve/src/execution/tasks/delegate.ts
+++ b/packages/eve/src/execution/tasks/delegate.ts
@@ -70,9 +70,10 @@ export async function settleDelegatedDispatch(input: {
     commandToken: input.task.commandToken,
     retryUnreachable: { attempts: 20, delayMs: 250 },
   });
-  const receiptOutput = { status: "working", taskId: input.task.taskId };
+  const receiptOutput = { status: "working" as const, taskId: input.task.taskId };
   return {
     receipt: {
+      backgroundTask: receiptOutput,
       callId: input.callId,
       kind: "subagent-result",
       origin: "child",

--- a/packages/eve/src/harness/runtime-actions.test.ts
+++ b/packages/eve/src/harness/runtime-actions.test.ts
@@ -20,6 +20,7 @@ import {
 import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
 import { getSessionTokenUsage, setTurnUsageState } from "#harness/turn-tag-state.js";
 import type { HarnessSession } from "#harness/types.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 
 const CHILD_SESSION_ID = "local-child-123456789012";
 const CHILD_CONTINUATION_TOKEN = "subagent:private-token";
@@ -103,6 +104,39 @@ function createSessionWithRunningChild(): HarnessSession {
 }
 
 describe("resolvePendingRuntimeActions", () => {
+  it("marks a working task receipt as backgrounded on subagent.completed", async () => {
+    const events: UnstampedMessageStreamEvent[] = [];
+    const taskId = "task_0123456789abcdef";
+
+    await resolvePendingRuntimeActions({
+      emit: async (event) => {
+        events.push(event);
+      },
+      session: createSessionWithRunningChild(),
+      stepInput: {
+        runtimeActionResults: [
+          {
+            backgroundTask: { status: "working", taskId },
+            callId: "call-1",
+            kind: "subagent-result",
+            origin: "child",
+            outcome: {
+              kind: "parked",
+              result: { kind: "succeeded", output: "delegated" },
+              usageDelta: ZERO_USAGE,
+            },
+            output: { status: "working", taskId },
+            subagentName: "researcher",
+          },
+        ],
+      },
+    });
+
+    expect(events.find((event) => event.type === "subagent.completed")).toMatchObject({
+      data: { backgroundTask: { status: "working", taskId } },
+    });
+  });
+
   it("settles the running handle terminally and deletes it with the batch", async () => {
     const session = createSessionWithRunningChild();
 

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -202,13 +202,14 @@ export async function resolvePendingRuntimeActions(input: {
   if (input.emit !== undefined) {
     for (const result of readyResults) {
       if (result.kind === "subagent-result" && result.isError !== true) {
+        const backgroundTask = readBackgroundTaskReceipt(result);
+        const data = {
+          callId: result.callId,
+          output: typeof result.output === "string" ? result.output : JSON.stringify(result.output),
+          subagentName: result.subagentName,
+        };
         await input.emit({
-          data: {
-            callId: result.callId,
-            output:
-              typeof result.output === "string" ? result.output : JSON.stringify(result.output),
-            subagentName: result.subagentName,
-          },
+          data: backgroundTask === undefined ? data : { ...data, backgroundTask },
           type: "subagent.completed",
         } satisfies Extract<UnstampedMessageStreamEvent, { type: "subagent.completed" }>);
       }
@@ -329,6 +330,12 @@ export async function resolvePendingRuntimeActions(input: {
     outcome: "resolved",
     session: nextSession,
   };
+}
+
+function readBackgroundTaskReceipt(
+  result: Extract<RuntimeActionResult, { kind: "subagent-result" }>,
+): { readonly status: "working"; readonly taskId: string } | undefined {
+  return "backgroundTask" in result ? result.backgroundTask : undefined;
 }
 
 /**

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -322,6 +322,15 @@ export interface SubagentChildEventStreamEvent {
  */
 export interface SubagentCompletedStreamEvent {
   data: {
+    /**
+     * Present when the originating call completed with a background-task
+     * receipt while the child itself kept running. Consumers must not treat
+     * this as the child's terminal boundary; the child stream owns that.
+     */
+    backgroundTask?: {
+      taskId: string;
+      status: "working";
+    };
     callId: string;
     output: string;
     subagentName: string;

--- a/packages/eve/src/runtime/actions/types.ts
+++ b/packages/eve/src/runtime/actions/types.ts
@@ -146,6 +146,11 @@ const runtimeToolResultActionResultSchema = z
  * so the parent never infers lifecycle from an absent field. `usage`
  * carries the turn's token spend so the caller can attribute the
  * subagent's tokens.
+ *
+ * `backgroundTask` marks the one parent-produced exception: delegated
+ * dispatch resolves the model's tool call with a parked task receipt before
+ * the child settles. Stream consumers use the marker to keep child lifecycle
+ * open while still recording the receipt as the tool result.
  */
 export type RuntimeSubagentChildResult = z.infer<typeof runtimeSubagentChildResultSchema>;
 
@@ -154,6 +159,12 @@ export type RuntimeSubagentChildResult = z.infer<typeof runtimeSubagentChildResu
  */
 const runtimeSubagentChildResultSchema = z
   .object({
+    backgroundTask: z
+      .strictObject({
+        status: z.literal("working"),
+        taskId: z.string(),
+      })
+      .optional(),
     callId: z.string(),
     isError: z.boolean().optional(),
     kind: z.literal("subagent-result"),


### PR DESCRIPTION
Protocol half of the background-task rendering work, split out so the wire contract lands before any consumer.

With tasks enabled, a delegated subagent call resolves twice from a client's perspective: once when the dispatch is acknowledged (receipt), once when the child actually finishes. Before this change both arrived as indistinguishable `subagent.completed` events; a client could not tell acknowledgement from completion.

- before: `subagent.completed` → one shape for both phases
- after: receipts carry a `backgroundTask` lifecycle marker; clients can key rendering (and any other consumer logic) off the phase

Second commit bumps the extension contract reports for the new field.

Scope: wire contract + emission path only. The TUI consumer lands later in the stack (`tasks/09-background-rendering`), after the semantics are proven by the eval suite.

Stacked on #1522.