### PR TITLE
feat(eve): give background task agents a stable identity

### DIFF
--- a/.changeset/task-agent-ownership.md
+++ b/.changeset/task-agent-ownership.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make background tasks the lifecycle authority for persistent subagents. Task receipts and views now include the stable agent id, busy agents remain visible in the agent listing, and follow-ups cannot overlap work on the same child session.

--- a/packages/eve/src/execution/agent-handle-dispatch.ts
+++ b/packages/eve/src/execution/agent-handle-dispatch.ts
@@ -10,8 +10,18 @@
 
 import { AGENT_BUSY, AGENT_MISMATCH, AGENT_UNREACHABLE } from "#harness/agent-handle-errors.js";
 import { deriveAgentOperationId } from "#harness/handles/operation-id.js";
-import type { AgentAddress, AgentHandle, ContinueOperation } from "#harness/handles/store.js";
-import { prepareAgentContinuation, rejectAgentEffect } from "#harness/handles/transitions.js";
+import {
+  getAgentHandleStore,
+  type AgentAddress,
+  type AgentHandle,
+  type AgentIdentity,
+  type ContinueOperation,
+} from "#harness/handles/store.js";
+import {
+  prepareAgentContinuation,
+  rejectAgentEffect,
+  removeTaskAgentAddress,
+} from "#harness/handles/transitions.js";
 import type {
   RuntimeActionRequest,
   RuntimeRemoteAgentCallActionRequest,
@@ -165,10 +175,11 @@ export async function dispatchToAgentHandle(input: {
   // accepted for child starts. The callee has no receiver-side dedup for
   // this; `prepareAgentContinuation` treating the recorded operation as a
   // replay only makes the parent-side transition idempotent.
-  const delivery = await deliverToAgentHandle({
+  const delivery = await deliverToAgentAddress({
     action,
+    address: handle.address,
     bundle,
-    handle,
+    identity: handle.identity,
     parentToken: input.parentToken,
   });
   if (!delivery.ok) {
@@ -209,6 +220,85 @@ export async function dispatchToAgentHandle(input: {
   };
 }
 
+/** Delivers a tasks-mode continuation without creating a second lifecycle claim. */
+export async function dispatchToTaskAgentAddress(input: {
+  readonly action: RuntimeAgentHandleAction;
+  readonly agentId: string;
+  readonly bundle: CompiledBundle;
+  readonly currentSession: RuntimeSession;
+  readonly parentToken: string;
+}): Promise<DispatchOutcome> {
+  const { action, agentId } = input;
+  const invokedName =
+    action.kind === "remote-agent-call" ? action.remoteAgentName : action.subagentName;
+  const record = (getAgentHandleStore(input.currentSession.state)?.handles ?? []).find(
+    (handle): handle is Extract<AgentHandle, { phase: "addressed" }> =>
+      handle.phase === "addressed" && handle.identity.id === agentId,
+  );
+  if (record === undefined) {
+    return {
+      kind: "error",
+      result: createAgentErrorResult({
+        action,
+        code: AGENT_UNREACHABLE,
+        message: `Agent with id "${agentId}" is no longer reachable.`,
+      }),
+      session: input.currentSession,
+    };
+  }
+  if (record.identity.name !== invokedName) {
+    return {
+      kind: "error",
+      result: createAgentErrorResult({
+        action,
+        code: AGENT_MISMATCH,
+        message: `Agent "${agentId}" from the <agents> list does not belong to "${invokedName}".`,
+      }),
+      session: input.currentSession,
+    };
+  }
+
+  const delivery = await deliverToAgentAddress({
+    action,
+    address: record.address,
+    bundle: input.bundle,
+    identity: record.identity,
+    parentToken: input.parentToken,
+  });
+  if (!delivery.ok) {
+    const { cause, permanent } = delivery.error;
+    logError(log, "task agent delivery failed", cause, {
+      agentId,
+      callId: action.callId,
+      nodeId: record.identity.nodeId,
+      permanent,
+      subagentName: record.identity.name,
+    });
+    return {
+      kind: "error",
+      result: createAgentErrorResult({
+        action,
+        code: AGENT_UNREACHABLE,
+        message: permanent
+          ? `Agent "${record.identity.name}" with id "${agentId}" is no longer reachable.`
+          : `Agent "${record.identity.name}" with id "${agentId}" is temporarily unreachable. Try again.`,
+      }),
+      session: permanent
+        ? removeTaskAgentAddress(input.currentSession, agentId)
+        : input.currentSession,
+    };
+  }
+
+  return {
+    address: record.address,
+    callId: action.callId,
+    kind: "called",
+    name: action.name,
+    session: input.currentSession,
+    toolName: record.identity.name,
+  };
+}
+
 /**
  * Attempts the continuation delivery once and classifies the failure.
  *
@@ -219,14 +309,14 @@ export async function dispatchToAgentHandle(input: {
  * Throwing is equally unsafe — a durable-step retry would re-dispatch
  * already-started siblings.
  */
-async function deliverToAgentHandle(input: {
+async function deliverToAgentAddress(input: {
   readonly action: RuntimeAgentHandleAction;
+  readonly address: AgentAddress;
   readonly bundle: CompiledBundle;
-  readonly handle: Extract<AgentHandle, { phase: "running" }>;
+  readonly identity: AgentIdentity;
   readonly parentToken: string;
 }): Promise<Result<void, { readonly cause: unknown; readonly permanent: boolean }>> {
-  const { action, bundle, handle } = input;
-  const { address, identity } = handle;
+  const { action, address, bundle, identity } = input;
 
   if (address.kind === "agent/remote") {
     // A remote deployment old enough to omit a continuationToken cannot
@@ -311,7 +401,7 @@ async function deliverToAgentHandle(input: {
   return ok(undefined);
 }
 
-function createAgentErrorResult(input: {
+export function createAgentErrorResult(input: {
   readonly action: RuntimeAgentHandleAction;
   readonly code: string;
   readonly message: string;

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
@@ -17,6 +17,9 @@ import {
   type AgentHandle,
 } from "#harness/handles/store.js";
 import type { HarnessSession } from "#harness/types.js";
+import { getSessionTaskIndex } from "#tasks/session-index.js";
+import { recordSessionTask } from "#tasks/session-index.js";
+import * as taskRunControl from "#execution/tasks/run-control.js";
 import {
   AuthKey,
   CapabilitiesKey,
@@ -34,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   readDurableSession: vi.fn(),
   createSession: vi.fn(),
   startRemoteAgentSession: vi.fn(),
+  startWorkflowPreferLatest: vi.fn(),
 }));
 
 vi.mock("#context/serialize.js", () => ({
@@ -56,6 +60,8 @@ vi.mock("#execution/workflow-runtime.js", () => ({
     dispatchSession: mocks.dispatchSession,
   }),
   workflowEntryReference: { workflowId: "workflow//eve//workflowEntry" },
+  startWorkflowPreferLatest: mocks.startWorkflowPreferLatest,
+  taskRunWorkflowReference: { workflowId: "workflow//eve//taskRun" },
 }));
 
 // Only the network calls are mocked; error classification and registry
@@ -135,6 +141,7 @@ beforeEach(() => {
     continuationToken: "remote-child-token",
     sessionId: "remote-session-123456789012",
   });
+  mocks.startWorkflowPreferLatest.mockResolvedValue({ runId: "task-run-1" });
   mocks.hydrateDurableSession.mockImplementation(({ durable }) => durable);
   mocks.createDurableSessionState.mockImplementation(({ session }) => ({
     ...BASE_STATE,
@@ -190,6 +197,84 @@ describe("dispatchRuntimeActionsStep child starts", () => {
       ],
     });
     expect(writes).toHaveLength(1);
+  });
+
+  it("records a tasks-mode child as an address and derives task identity separately", async () => {
+    const session = createStartSession({ kind: "local" });
+    installContext(
+      session,
+      { definition: { description: "Research", kind: "subagent" }, nodeId: "subagents/research" },
+      true,
+    );
+    vi.spyOn(taskRunControl, "sendTaskCommandToOwner").mockResolvedValue({
+      runId: "task-run-1",
+    });
+
+    const result = await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+    const state = readResultSessionState(result, session);
+    const agentId = deriveAgentId("research", startOperationId);
+
+    expect(result.results[0]).toMatchObject({
+      origin: "child",
+      output: { agentId, status: "working" },
+    });
+    expect(getAgentHandleStore(state)).toEqual({
+      handles: [
+        {
+          address: {
+            continuationToken: "subagent:parent-session:call-1",
+            kind: "agent/local",
+            sessionId: CHILD_SESSION_ID,
+          },
+          identity: {
+            id: agentId,
+            name: "research",
+            nodeId: "subagents/research",
+          },
+          phase: "addressed",
+        },
+      ],
+    });
+    expect(getSessionTaskIndex(state)).toEqual([
+      expect.objectContaining({
+        metadata: expect.objectContaining({ agentId }),
+        taskRunId: "task-run-1",
+      }),
+    ]);
+  });
+
+  it("adopts the child a replayed start already created instead of failing it", async () => {
+    const session = createStartSession({ kind: "local" });
+    installContext(session, {
+      definition: { description: "Research", kind: "subagent" },
+      nodeId: "subagents/research",
+    });
+    // A retried dispatch step re-derives the same deterministic child
+    // continuation token, so the first attempt's child owns it.
+    mocks.createSession.mockRejectedValue(
+      new RuntimeSessionOwnershipConflictError({
+        continuationToken: "subagent:parent-session:call-1",
+        ownerSessionId: CHILD_SESSION_ID,
+        sessionId: "duplicate-child",
+      }),
+    );
+
+    const result = await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(result.results).toEqual([]);
+    expect(getAgentHandleStore(readResultSessionState(result, session))?.handles[0]).toMatchObject({
+      address: { kind: "agent/local", sessionId: CHILD_SESSION_ID },
+    });
   });
 
   it("rejects the prepared handle when the local start fails", async () => {
@@ -390,6 +475,56 @@ describe("dispatchRuntimeActionsStep child starts", () => {
 });
 
 describe("dispatchRuntimeActionsStep agent delivery", () => {
+  it("rejects a tasks-mode continuation while the addressed agent has active work", async () => {
+    const addressedHandle: AgentHandle = {
+      address: LOCAL_PARKED_HANDLE.address,
+      identity: LOCAL_PARKED_HANDLE.identity,
+      phase: "addressed",
+    };
+    let session = createPendingSession({
+      handle: addressedHandle,
+      agentId: addressedHandle.identity.id,
+    });
+    session = recordSessionTask(session, {
+      commandToken: "task-token",
+      createdByTurnId: "turn-previous",
+      metadata: {
+        agentId: addressedHandle.identity.id,
+        kind: "subagent",
+        mode: "local",
+        name: addressedHandle.identity.name,
+      },
+      operationId: "operation-active",
+      taskId: "task_active",
+      taskRunId: "task-run-active",
+    });
+    installContext(session, undefined, true);
+    vi.spyOn(taskRunControl, "readLatestTaskSnapshot").mockResolvedValue({
+      metadata: {
+        agentId: addressedHandle.identity.id,
+        kind: "subagent",
+        mode: "local",
+        name: addressedHandle.identity.name,
+      },
+      status: "working",
+      taskId: "task_active",
+    });
+
+    const result = await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(result.results[0]).toMatchObject({
+      isError: true,
+      output: { code: "AGENT_BUSY", message: expect.stringContaining("task_active") },
+    });
+    expect(mocks.dispatchSession).not.toHaveBeenCalled();
+    expect(mocks.startWorkflowPreferLatest).not.toHaveBeenCalled();
+  });
+
   const continueOperationId = deriveAgentOperationId({
     callId: "call-1",
     parentSessionId: "parent-session",
@@ -784,6 +919,7 @@ function createPendingSession(input: {
 function installContext(
   session: HarnessSession,
   remote?: { readonly definition: unknown; readonly nodeId: string },
+  tasks = false,
 ): void {
   const subagentsByNodeId = new Map<string, { definition: unknown }>();
   if (remote !== undefined) {
@@ -791,7 +927,7 @@ function installContext(
   }
   const bundle = {
     compiledArtifactsSource: {},
-    resolvedAgent: { config: {} },
+    resolvedAgent: { config: tasks ? { experimental: { tasks: true } } : {} },
     subagentRegistry: { subagentsByNodeId },
     turnAgent: {
       id: "test-agent",

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -26,6 +26,7 @@ import {
 import { deserializeContext } from "#context/serialize.js";
 import {
   dispatchToAgentHandle,
+  dispatchToTaskAgentAddress,
   isAgentHandleAction,
   type DispatchOutcome,
   type RuntimeAgentHandleAction,
@@ -73,9 +74,9 @@ import { readSessionTraceContext } from "#tracing/agent-trace-context-store.js";
 import { resolveSubagentDepth } from "#harness/subagent-depth.js";
 import { getDynamicSubagentSelection } from "#context/dynamic-subagent-lifecycle.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
-import { reconcileSettledTaskHandles } from "#execution/tasks/control-shared.js";
 import {
   checkTaskContinuationAdmission,
+  describeTaskDispatch,
   reserveTaskContinuation,
   settleTaskDispatchError,
   type ReservedTaskContinuation,
@@ -144,7 +145,7 @@ export async function dispatchRuntimeActionsStep(input: {
   const ctx = await deserializeContext(input.serializedContext);
   const bundle = ctx.require(BundleKey);
   const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
-  let session = hydrateDurableSession({
+  const session = hydrateDurableSession({
     compactionOverrides: {
       thresholdPercent: effectiveAgent.thresholdPercent,
     },
@@ -160,7 +161,6 @@ export async function dispatchRuntimeActionsStep(input: {
   const adapterCtx = buildAdapterContext(adapter, ctx);
   const parentTraceContext = readSessionTraceContext(input.serializedContext, session.sessionId);
   const tasksEnabled = bundle.resolvedAgent.config.experimental?.tasks === true;
-  if (tasksEnabled) session = await reconcileSettledTaskHandles(session);
   // Background tasks require resumable children: the flag implies
   // conversation-mode dispatch so `experimental.tasks` and
   // `experimental.subagentPersistentSessions` never produce a third mode.
@@ -222,9 +222,17 @@ export async function dispatchRuntimeActionsStep(input: {
         }
       }
 
+      const delegatedAction = entry.kind === "resume" ? entry.action : entry.target.action;
+      const delegatedDescription = describeTaskDispatch({
+        action: delegatedAction,
+        agentId: entry.kind === "resume" ? entry.agentId : undefined,
+        parentSessionId: session.sessionId,
+        parentTurnId: batch.event.turnId,
+        session: nextSession,
+      });
       const delegated = tasksEnabled
         ? await beginDelegatedTask({
-            ...describeDelegatedEntry(entry),
+            ...delegatedDescription,
             parentSessionId: session.sessionId,
             parentStepIndex: batch.event.stepIndex,
             parentTurnId: batch.event.turnId,
@@ -246,7 +254,7 @@ export async function dispatchRuntimeActionsStep(input: {
       let outcome: DispatchOutcome;
       switch (entry.kind) {
         case "resume":
-          outcome = await dispatchToAgentHandle({
+          outcome = await (tasksEnabled ? dispatchToTaskAgentAddress : dispatchToAgentHandle)({
             action: entry.action,
             agentId: entry.agentId,
             bundle: createAgentContinuationBundle({
@@ -275,6 +283,7 @@ export async function dispatchRuntimeActionsStep(input: {
             parentTraceContext,
             persistentSessions,
             session,
+            taskOwned: tasksEnabled,
             target: entry.target,
           });
           break;
@@ -300,7 +309,6 @@ export async function dispatchRuntimeActionsStep(input: {
         } else {
           const settled = await settleDelegatedDispatch({
             callId: outcome.callId,
-            childSessionId: outcome.address.sessionId,
             session: nextSession,
             subagentName: outcome.toolName,
             task: delegated,
@@ -521,6 +529,7 @@ async function startSubagent(input: {
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
   readonly persistentSessions: boolean;
   readonly session: RuntimeSession;
+  readonly taskOwned: boolean;
   readonly target: DispatchStartTarget;
 }): Promise<DispatchOutcome> {
   switch (input.target.kind) {
@@ -541,6 +550,7 @@ async function startSubagent(input: {
         persistentSessions: input.persistentSessions,
         session: input.session,
         source: input.target.source,
+        taskOwned: input.taskOwned,
       });
     case "remote":
       return startRemoteSubagent({
@@ -555,6 +565,7 @@ async function startSubagent(input: {
         parentContinuationToken: input.parentContinuationToken,
         persistentSessions: input.persistentSessions,
         session: input.session,
+        taskOwned: input.taskOwned,
       });
     default: {
       const _exhaustive: never = input.target;
@@ -563,17 +574,6 @@ async function startSubagent(input: {
   }
 }
 
-/** Names one delegated dispatch for its task record, before any child exists. */
-function describeDelegatedEntry(entry: Extract<DispatchPlanEntry, { kind: "resume" | "start" }>): {
-  readonly callId: string;
-  readonly mode: "local" | "remote";
-  readonly name: string;
-} {
-  const action = entry.kind === "resume" ? entry.action : entry.target.action;
-  return action.kind === "remote-agent-call"
-    ? { callId: action.callId, mode: "remote", name: action.remoteAgentName }
-    : { callId: action.callId, mode: "local", name: action.subagentName };
-}
 function isRecursiveAgentAction(
   action: RuntimeActionRequest,
   subagentsByNodeId: ReadonlyMap<string, unknown>,

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -112,6 +112,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     mode: input.mode,
     onCompaction: preserveFrameworkStateOnCompaction,
     persistentSubagentSessions:
+      input.node.agent.config?.experimental?.tasks === true ||
       input.node.agent.config?.experimental?.subagentPersistentSessions === true,
     dispatchDynamicModelEvent: dispatchModelEvent,
     resolveModel,
@@ -218,6 +219,7 @@ export function createNodeHarnessTools(input: {
     tools.set(AGENT_TOOL_NAME, {
       description: AGENT_TOOL_DESCRIPTION,
       inputSchema:
+        input.node.agent.config?.experimental?.tasks === true ||
         input.node.agent.config?.experimental?.subagentPersistentSessions === true
           ? PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA
           : SUBAGENT_TOOL_INPUT_SCHEMA,

--- a/packages/eve/src/execution/subagent-hitl-proxy.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.ts
@@ -95,7 +95,7 @@ export function routeDeliverPayload(input: {
     {
       readonly childContinuationToken: string;
       readonly responses: InputResponse[];
-      readonly taskId?: string;
+      taskId?: string;
     }
   >();
   const unroutedResponses: InputResponse[] = [];
@@ -120,13 +120,13 @@ export function routeDeliverPayload(input: {
     const existing = responsesByChild.get(bucketKey);
 
     if (existing === undefined) {
-      const bucket: {
-        childContinuationToken: string;
-        responses: InputResponse[];
-        taskId?: string;
-      } = {
+      const bucket = {
         childContinuationToken: route.childContinuationToken,
         responses: [response],
+      } as {
+        readonly childContinuationToken: string;
+        readonly responses: InputResponse[];
+        taskId?: string;
       };
       if (route.taskId !== undefined) bucket.taskId = route.taskId;
       responsesByChild.set(bucketKey, bucket);
@@ -137,16 +137,16 @@ export function routeDeliverPayload(input: {
 
   const forChildren: RoutedDeliverPayload["forChildren"] = [...responsesByChild.values()].map(
     ({ childContinuationToken, responses, taskId }) => {
-      const routed: {
-        childContinuationToken: string;
-        payload: { inputResponses: InputResponse[] };
+      const bucket: {
+        readonly childContinuationToken: string;
+        readonly payload: { readonly inputResponses: readonly InputResponse[] };
         taskId?: string;
       } = {
         childContinuationToken,
         payload: { inputResponses: responses },
       };
-      if (taskId !== undefined) routed.taskId = taskId;
-      return routed;
+      if (taskId !== undefined) bucket.taskId = taskId;
+      return bucket;
     },
   );
 

--- a/packages/eve/src/execution/subagent-start-local.ts
+++ b/packages/eve/src/execution/subagent-start-local.ts
@@ -6,6 +6,7 @@ import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { SUBAGENT_START_FAILED } from "#harness/agent-handle-errors.js";
 import {
   confirmAgentStarted,
+  confirmTaskAgentAddress,
   prepareAgentStart,
   rejectAgentEffect,
 } from "#harness/handles/transitions.js";
@@ -37,6 +38,7 @@ export async function startLocalSubagent(input: {
   readonly persistentSessions: boolean;
   readonly session: RuntimeSession;
   readonly source: SubagentInputSource;
+  readonly taskOwned: boolean;
 }): Promise<DispatchOutcome> {
   const { action, source } = input;
   const childRuntime = createWorkflowRuntime({
@@ -125,10 +127,9 @@ export async function startLocalSubagent(input: {
     callId: action.callId,
     kind: "called",
     name: action.name,
-    session: confirmAgentStarted(preparedSession, {
-      address,
-      operationId: operation.id,
-    }),
+    session: input.taskOwned
+      ? confirmTaskAgentAddress(preparedSession, { address, operationId: operation.id })
+      : confirmAgentStarted(preparedSession, { address, operationId: operation.id }),
     toolName: action.subagentName,
   };
 }

--- a/packages/eve/src/execution/subagent-start-remote.ts
+++ b/packages/eve/src/execution/subagent-start-remote.ts
@@ -7,6 +7,7 @@ import {
 } from "#execution/remote-agent-dispatch.js";
 import {
   confirmAgentStarted,
+  confirmTaskAgentAddress,
   prepareAgentStart,
   rejectAgentEffect,
 } from "#harness/handles/transitions.js";
@@ -31,6 +32,7 @@ export async function startRemoteSubagent(input: {
   readonly parentContinuationToken: string | undefined;
   readonly persistentSessions: boolean;
   readonly session: RuntimeSession;
+  readonly taskOwned: boolean;
 }): Promise<DispatchOutcome> {
   const { action } = input;
 
@@ -101,10 +103,9 @@ export async function startRemoteSubagent(input: {
       callId: action.callId,
       kind: "called",
       name: action.name,
-      session: confirmAgentStarted(preparedSession, {
-        address,
-        operationId: operation.id,
-      }),
+      session: input.taskOwned
+        ? confirmTaskAgentAddress(preparedSession, { address, operationId: operation.id })
+        : confirmAgentStarted(preparedSession, { address, operationId: operation.id }),
       toolName: action.remoteAgentName,
     };
   } catch (error) {

--- a/packages/eve/src/execution/tasks/agent-identity.ts
+++ b/packages/eve/src/execution/tasks/agent-identity.ts
@@ -1,0 +1,33 @@
+import { mintStartOperation } from "#execution/dispatch-start-operation.js";
+import type { RuntimeAgentHandleAction } from "#execution/agent-handle-dispatch.js";
+
+/** Resolves the persistent agent identity attached to one delegated task. */
+export function describeTaskAgent(input: {
+  readonly action: RuntimeAgentHandleAction;
+  readonly agentId?: string;
+  readonly parentSessionId: string;
+  readonly parentTurnId: string;
+}): {
+  readonly agentId: string;
+  readonly callId: string;
+  readonly mode: "local" | "remote";
+  readonly name: string;
+} {
+  const { action } = input;
+  const name = action.kind === "remote-agent-call" ? action.remoteAgentName : action.subagentName;
+  const agentId =
+    input.agentId ??
+    mintStartOperation({
+      callId: action.callId,
+      name,
+      nodeId: action.nodeId,
+      parentSessionId: input.parentSessionId,
+      parentTurnId: input.parentTurnId,
+    }).identity.id;
+  return {
+    agentId,
+    callId: action.callId,
+    mode: action.kind === "remote-agent-call" ? "remote" : "local",
+    name,
+  };
+}

--- a/packages/eve/src/execution/tasks/agent-views.test.ts
+++ b/packages/eve/src/execution/tasks/agent-views.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { appendTaskAgentAnnouncement, readTaskAgentViews } from "#execution/tasks/agent-views.js";
+import { findActiveTaskForAgent } from "#execution/tasks/control-shared.js";
+import { readLatestTaskSnapshot } from "#execution/tasks/run-control.js";
+import { AGENT_HANDLES_STATE_KEY } from "#harness/handles/store.js";
+import type { HarnessSession } from "#harness/types.js";
+import { SESSION_TASKS_STATE_KEY } from "#tasks/session-index.js";
+import type { TaskStatus, TaskView } from "#tasks/types.js";
+
+vi.mock("#execution/tasks/run-control.js", () => ({
+  readLatestTaskSnapshot: vi.fn(),
+}));
+
+const metadata = {
+  agentId: "ag_research:abcdef123456",
+  kind: "subagent" as const,
+  mode: "local" as const,
+  name: "research",
+};
+
+function createSession(taskRunIds: readonly string[]): HarnessSession {
+  return {
+    agent: { modelReference: { id: "model" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 4, threshold: 1_000_000 },
+    continuationToken: "parent-token",
+    history: [],
+    sessionId: "parent-session",
+    state: {
+      [AGENT_HANDLES_STATE_KEY]: {
+        handles: [
+          {
+            address: {
+              continuationToken: "child-token",
+              kind: "agent/local",
+              sessionId: "child-session",
+            },
+            identity: { id: metadata.agentId, name: metadata.name, nodeId: "node-research" },
+            phase: "addressed",
+          },
+        ],
+      },
+      [SESSION_TASKS_STATE_KEY]: {
+        tasks: taskRunIds.map((taskRunId, index) => ({
+          commandToken: `task-token-${index}`,
+          createdByTurnId: `turn-${index}`,
+          metadata,
+          operationId: `operation-${index}`,
+          taskId: `task_${index}`,
+          taskRunId,
+        })),
+      },
+    },
+  };
+}
+
+function task(taskId: string, status: TaskStatus): TaskView {
+  return { metadata, status, taskId };
+}
+
+describe("task-derived agent availability", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("renders a nonterminal task as busy and a terminal task as available", async () => {
+    vi.mocked(readLatestTaskSnapshot)
+      .mockResolvedValueOnce(task("task_0", "working"))
+      .mockResolvedValueOnce(task("task_0", "completed"));
+    const session = createSession(["run-0"]);
+
+    await expect(readTaskAgentViews(session)).resolves.toEqual([
+      {
+        availability: "busy",
+        id: metadata.agentId,
+        name: metadata.name,
+        statusLine: undefined,
+        taskId: "task_0",
+        taskStatus: "working",
+      },
+    ]);
+    await expect(readTaskAgentViews(session)).resolves.toEqual([
+      {
+        availability: "available",
+        id: metadata.agentId,
+        name: metadata.name,
+        statusLine: undefined,
+      },
+    ]);
+  });
+
+  it("finds the active task used for continuation admission", async () => {
+    vi.mocked(readLatestTaskSnapshot).mockResolvedValue(task("task_0", "input_required"));
+
+    await expect(
+      findActiveTaskForAgent(createSession(["run-0"]), metadata.agentId),
+    ).resolves.toMatchObject({
+      view: { status: "input_required", taskId: "task_0" },
+    });
+  });
+
+  it("appends the busy projection without exposing routing coordinates", async () => {
+    vi.mocked(readLatestTaskSnapshot).mockResolvedValue(task("task_0", "working"));
+
+    const next = await appendTaskAgentAnnouncement(createSession(["run-0"]));
+    const announcement = next.history.at(-1)?.content;
+
+    expect(announcement).toContain('availability="busy"');
+    expect(announcement).toContain('taskId="task_0"');
+    expect(announcement).not.toContain("child-token");
+    expect(announcement).not.toContain("child-session");
+  });
+
+  it("rejects two nonterminal tasks bound to one child agent", async () => {
+    vi.mocked(readLatestTaskSnapshot)
+      .mockResolvedValueOnce(task("task_0", "working"))
+      .mockResolvedValueOnce(task("task_1", "input_required"));
+
+    await expect(readTaskAgentViews(createSession(["run-0", "run-1"]))).rejects.toThrow(
+      "more than one nonterminal task",
+    );
+  });
+});

--- a/packages/eve/src/execution/tasks/agent-views.ts
+++ b/packages/eve/src/execution/tasks/agent-views.ts
@@ -1,0 +1,71 @@
+import type { HarnessSession } from "#harness/types.js";
+import { resolveAgentsAnnouncement, type AgentView } from "#harness/handles/prompt.js";
+import { formatAgentStatus, getAgentHandleStore } from "#harness/handles/store.js";
+import { readTaskViews } from "#execution/tasks/control-shared.js";
+import { getSessionTaskIndex } from "#tasks/session-index.js";
+
+/** Derives model-visible task-agent availability from authoritative task snapshots. */
+export async function readTaskAgentViews(session: HarnessSession): Promise<readonly AgentView[]> {
+  const addresses = (getAgentHandleStore(session.state)?.handles ?? []).filter(
+    (handle) => handle.phase === "addressed",
+  );
+  if (addresses.length === 0) return [];
+
+  const entries = getSessionTaskIndex(session.state);
+  const views = await readTaskViews(entries);
+  const byAgent = new Map<string, typeof views>();
+  for (const view of views) {
+    const current = byAgent.get(view.metadata.agentId) ?? [];
+    byAgent.set(view.metadata.agentId, [...current, view]);
+  }
+
+  return addresses.map((address) => {
+    const agentTasks = byAgent.get(address.identity.id) ?? [];
+    const active = agentTasks.filter(
+      (view) => view.status === "working" || view.status === "input_required",
+    );
+    if (active.length > 1) {
+      throw new Error(`Agent "${address.identity.id}" has more than one nonterminal task.`);
+    }
+    const task = active[0];
+    if (task !== undefined) {
+      const taskStatus = task.status === "input_required" ? "input_required" : "working";
+      return {
+        availability: "busy",
+        id: address.identity.id,
+        name: address.identity.name,
+        statusLine: task.statusMessage,
+        taskId: task.taskId,
+        taskStatus,
+      };
+    }
+
+    const latest = agentTasks.at(-1);
+    return {
+      availability: "available",
+      id: address.identity.id,
+      name: address.identity.name,
+      statusLine:
+        latest?.statusMessage ??
+        (latest?.lastOutput === undefined ? undefined : formatAgentStatus(latest.lastOutput.data)),
+    };
+  });
+}
+
+/** Appends the changed task-agent projection before the next model call. */
+export async function appendTaskAgentAnnouncement(
+  session: HarnessSession,
+): Promise<HarnessSession> {
+  const agentViews = await readTaskAgentViews(session);
+  const announcement = resolveAgentsAnnouncement({
+    agentViews,
+    messages: session.history,
+    store: getAgentHandleStore(session.state),
+  });
+  return announcement === undefined
+    ? session
+    : {
+        ...session,
+        history: [...session.history, { content: announcement, role: "assistant" }],
+      };
+}

--- a/packages/eve/src/execution/tasks/continuation-admission.ts
+++ b/packages/eve/src/execution/tasks/continuation-admission.ts
@@ -1,22 +1,41 @@
-import type {
-  DispatchOutcome,
-  RuntimeAgentHandleAction,
-  RuntimeSession,
+import {
+  createAgentErrorResult,
+  type DispatchOutcome,
+  type RuntimeAgentHandleAction,
+  type RuntimeSession,
 } from "#execution/agent-handle-dispatch.js";
+import { findActiveTaskForAgent, findTaskAgentAddress } from "#execution/tasks/control-shared.js";
 import {
   failDelegatedDispatch,
   settleDelegatedDispatch,
   type DelegatedTask,
 } from "#execution/tasks/delegate.js";
-import { findConflictingTaskForChildSession } from "#execution/tasks/control-shared.js";
+import { describeTaskAgent } from "#execution/tasks/agent-identity.js";
 import { AGENT_BUSY, AGENT_UNREACHABLE } from "#harness/agent-handle-errors.js";
-import { getAgentHandleStore } from "#harness/handles/store.js";
 import type { RuntimeSubagentDispatchFailure } from "#runtime/actions/types.js";
 import type { JsonValue } from "#shared/json.js";
 
 export type ReservedTaskContinuation = Awaited<ReturnType<typeof settleDelegatedDispatch>>;
 
-/** Returns the task-derived busy result for one persistent-agent continuation. */
+/** Describes task identity from the stored address when continuing an agent. */
+export function describeTaskDispatch(input: {
+  readonly action: RuntimeAgentHandleAction;
+  readonly agentId: string | undefined;
+  readonly parentSessionId: string;
+  readonly parentTurnId: string;
+  readonly session: RuntimeSession;
+}): ReturnType<typeof describeTaskAgent> {
+  const described = describeTaskAgent(input);
+  const handle =
+    input.agentId === undefined ? undefined : findTaskAgentAddress(input.session, input.agentId);
+  return handle === undefined
+    ? described
+    : {
+        ...described,
+        mode: handle.address.kind === "agent/remote" ? "remote" : "local",
+      };
+}
+
 export async function checkTaskContinuationAdmission(input: {
   readonly action: RuntimeAgentHandleAction;
   readonly agentId: string;
@@ -24,34 +43,21 @@ export async function checkTaskContinuationAdmission(input: {
   readonly parentTurnId: string;
   readonly session: RuntimeSession;
 }): Promise<RuntimeSubagentDispatchFailure | undefined> {
-  const handle = getAgentHandleStore(input.session.state)?.handles.find(
-    (candidate) => candidate.identity.id === input.agentId,
+  const active = await findActiveTaskForAgent(
+    input.session,
+    input.agentId,
+    input.parentTurnId,
+    input.parentStepIndex,
   );
-  if (handle?.phase !== "running" && handle?.phase !== "parked") return undefined;
-  const conflicting = await findConflictingTaskForChildSession({
-    childSessionId: handle.address.sessionId,
-    parentStepIndex: input.parentStepIndex,
-    parentTurnId: input.parentTurnId,
-    session: input.session,
-  });
-  if (conflicting === undefined) return undefined;
-  return {
-    callId: input.action.callId,
-    isError: true,
-    kind: "subagent-result",
-    origin: "dispatch",
-    output: {
-      code: AGENT_BUSY,
-      message: `Agent "${input.agentId}" is busy with task "${conflicting.view.taskId}" (${conflicting.view.status}).`,
-    },
-    subagentName:
-      input.action.kind === "remote-agent-call"
-        ? input.action.remoteAgentName
-        : input.action.subagentName,
-  };
+  return active === undefined
+    ? undefined
+    : createAgentErrorResult({
+        action: input.action,
+        code: AGENT_BUSY,
+        message: `Agent "${input.agentId}" is busy with task "${active.view.taskId}" (${active.view.status}).`,
+      });
 }
 
-/** Reserves a persistent child before its ambiguous continuation side effect. */
 export async function reserveTaskContinuation(input: {
   readonly action: RuntimeAgentHandleAction;
   readonly agentId: string;
@@ -59,24 +65,16 @@ export async function reserveTaskContinuation(input: {
   readonly session: RuntimeSession;
 }): Promise<ReservedTaskContinuation | undefined> {
   if (input.delegated === undefined) return undefined;
-  const handle = getAgentHandleStore(input.session.state)?.handles.find(
-    (candidate) =>
-      (candidate.phase === "running" || candidate.phase === "parked") &&
-      candidate.identity.id === input.agentId,
-  );
-  if (handle === undefined || (handle.phase !== "running" && handle.phase !== "parked")) {
-    return undefined;
-  }
+  const handle = findTaskAgentAddress(input.session, input.agentId);
+  if (handle === undefined) return undefined;
   return settleDelegatedDispatch({
     callId: input.action.callId,
-    childSessionId: handle.address.sessionId,
     session: input.session,
     subagentName: handle.identity.name,
     task: input.delegated,
   });
 }
 
-/** Terminates definitive failures while retaining ambiguous reservations. */
 export async function settleTaskDispatchError(input: {
   readonly agentId: string | undefined;
   readonly delegated: DelegatedTask | undefined;
@@ -84,15 +82,12 @@ export async function settleTaskDispatchError(input: {
   readonly reserved: ReservedTaskContinuation | undefined;
   readonly session: RuntimeSession;
 }): Promise<RuntimeSubagentDispatchFailure> {
-  const retainedHandle =
-    input.agentId !== undefined &&
-    getAgentHandleStore(input.session.state)?.handles.some(
-      (handle) => handle.identity.id === input.agentId,
-    ) === true;
+  const retainedAddress =
+    input.agentId !== undefined && findTaskAgentAddress(input.session, input.agentId) !== undefined;
   const ambiguous =
     input.reserved !== undefined &&
     readErrorCode(input.outcome.result.output) === AGENT_UNREACHABLE &&
-    retainedHandle;
+    retainedAddress;
   if (input.delegated !== undefined && !ambiguous) {
     await failDelegatedDispatch({ error: input.outcome.result.output, task: input.delegated });
   }

--- a/packages/eve/src/execution/tasks/control-shared.ts
+++ b/packages/eve/src/execution/tasks/control-shared.ts
@@ -1,7 +1,6 @@
 import type { RuntimeSession } from "#execution/agent-handle-dispatch.js";
 import { readLatestTaskSnapshot } from "#execution/tasks/run-control.js";
 import { getAgentHandleStore, type AgentHandle } from "#harness/handles/store.js";
-import { settleAgentTurn } from "#harness/handles/transitions.js";
 import type { RuntimeActionResult, RuntimeToolCallActionRequest } from "#runtime/actions/types.js";
 import { taskViewsToJson } from "#tasks/json.js";
 import {
@@ -9,7 +8,7 @@ import {
   getSessionTaskIndex,
   type SessionTaskIndexEntry,
 } from "#tasks/session-index.js";
-import { isTerminalTaskStatus, type TaskView } from "#tasks/types.js";
+import type { TaskView } from "#tasks/types.js";
 
 /**
  * Result and lookup helpers shared by the task-control executors
@@ -45,94 +44,53 @@ export async function readTaskViews(
     entries.map(
       async (entry) =>
         (await readLatestTaskSnapshot({ taskRunId: entry.taskRunId })) ??
-        createPendingTaskView(entry.taskId),
+        createPendingTaskView(entry),
     ),
   );
 }
 
 /** The view of a run that has not published its first snapshot yet. */
-export function createPendingTaskView(taskId: string): TaskView {
+export function createPendingTaskView(entry: SessionTaskIndexEntry): TaskView {
   return {
-    metadata: { kind: "subagent", mode: "local", name: "unknown" },
+    metadata: entry.metadata,
     status: "working",
-    taskId,
+    taskId: entry.taskId,
   };
 }
 
-/** Finds the handle owning one child session's address, any live phase. */
-export function findAddressableHandle(
+/** Finds the persistent address record for one task-owned agent. */
+export function findTaskAgentAddress(
   session: RuntimeSession,
-  childSessionId: string | undefined,
-): Extract<AgentHandle, { phase: "running" | "parked" }> | undefined {
-  if (childSessionId === undefined) return undefined;
+  agentId: string,
+): Extract<AgentHandle, { phase: "addressed" }> | undefined {
   const handles = getAgentHandleStore(session.state)?.handles ?? [];
-  return handles
-    .filter(
-      (candidate): candidate is Extract<AgentHandle, { phase: "running" | "parked" }> =>
-        candidate.phase === "running" || candidate.phase === "parked",
-    )
-    .find((candidate) => candidate.address.sessionId === childSessionId);
+  return handles.find(
+    (candidate): candidate is Extract<AgentHandle, { phase: "addressed" }> =>
+      candidate.phase === "addressed" && candidate.identity.id === agentId,
+  );
 }
 
-/** Finds the task that reserves a child for this batch or is still nonterminal. */
-export async function findConflictingTaskForChildSession(input: {
-  readonly childSessionId: string;
-  readonly parentStepIndex?: number;
-  readonly parentTurnId: string;
-  readonly session: RuntimeSession;
-}): Promise<{ readonly entry: SessionTaskIndexEntry; readonly view: TaskView } | undefined> {
-  for (const entry of getSessionTaskIndex(input.session.state)) {
-    if (entry.childSessionId !== input.childSessionId) continue;
-    const view =
-      (await readLatestTaskSnapshot({ taskRunId: entry.taskRunId })) ??
-      createPendingTaskView(entry.taskId);
-    if (
-      (entry.createdByTurnId === input.parentTurnId &&
-        entry.createdByStepIndex === input.parentStepIndex) ||
-      !isTerminalTaskStatus(view.status)
-    ) {
-      return { entry, view };
-    }
-  }
-  return undefined;
-}
-
-/** Applies actual terminal task outcomes to handles left running by task receipts. */
-export async function reconcileSettledTaskHandles(
+/** Returns the one nonterminal task owning an agent, if any. */
+export async function findActiveTaskForAgent(
   session: RuntimeSession,
-): Promise<RuntimeSession> {
-  let nextSession = session;
-  for (const entry of getSessionTaskIndex(session.state)) {
-    const view = await readLatestTaskSnapshot({ taskRunId: entry.taskRunId });
-    if (
-      view === undefined ||
-      !isTerminalTaskStatus(view.status) ||
-      view.metadata.childLifecycle === undefined
-    ) {
-      continue;
-    }
-    const result =
-      view.status === "completed"
-        ? { kind: "succeeded" as const, output: view.lastOutput?.data ?? "" }
-        : view.status === "failed"
-          ? { error: view.lastOutput?.data ?? "Task failed.", kind: "failed" as const }
-          : { kind: "cancelled" as const };
-    const settled = settleAgentTurn(nextSession, {
-      operationId: entry.operationId,
-      outcome: {
-        kind: view.metadata.childLifecycle,
-        result,
-        usageDelta: {
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-          inputTokens: 0,
-          outputTokens: 0,
-        },
-      },
-    });
-    if (settled.kind === "settled") nextSession = settled.session;
-  }
-  return nextSession;
+  agentId: string,
+  parentTurnId?: string,
+  parentStepIndex?: number,
+): Promise<{ readonly entry: SessionTaskIndexEntry; readonly view: TaskView } | undefined> {
+  const entries = getSessionTaskIndex(session.state).filter(
+    (entry) => entry.metadata.agentId === agentId,
+  );
+  const views = await readTaskViews(entries);
+  const active = entries.flatMap((entry, index) => {
+    const view = views[index];
+    return view !== undefined &&
+      ((entry.createdByTurnId === parentTurnId && entry.createdByStepIndex === parentStepIndex) ||
+        view.status === "working" ||
+        view.status === "input_required")
+      ? [{ entry, view }]
+      : [];
+  });
+  return active[0];
 }
 
 /** One successful task-control result carrying full task views. */

--- a/packages/eve/src/execution/tasks/delegate.test.ts
+++ b/packages/eve/src/execution/tasks/delegate.test.ts
@@ -1,23 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { RuntimeSession } from "#execution/agent-handle-dispatch.js";
 import { settleDelegatedDispatch, type DelegatedTask } from "#execution/tasks/delegate.js";
 import { sendTaskCommandToOwner } from "#execution/tasks/run-control.js";
-import type { RuntimeSession } from "#execution/agent-handle-dispatch.js";
 import { getSessionTaskIndex } from "#tasks/session-index.js";
 
 vi.mock("#execution/tasks/run-control.js", () => ({
   sendTaskCommandToOwner: vi.fn(),
 }));
-
-function createSession(): RuntimeSession {
-  return {
-    agent: { modelReference: { id: "model" }, system: "", tools: [] },
-    compaction: { recentWindowSize: 4, threshold: 1_000_000 },
-    continuationToken: "parent-token",
-    history: [],
-    sessionId: "parent-session",
-  } as RuntimeSession;
-}
 
 describe("delegated task settlement", () => {
   beforeEach(() => {
@@ -25,10 +15,23 @@ describe("delegated task settlement", () => {
     vi.mocked(sendTaskCommandToOwner).mockResolvedValue({ runId: "run-owner" });
   });
 
-  it("indexes the command-hook owner rather than a replay-losing candidate run", async () => {
+  it("indexes the command-hook owner after the readiness barrier", async () => {
+    const session = {
+      agent: { modelReference: { id: "model" }, system: "", tools: [] },
+      compaction: { recentWindowSize: 4, threshold: 1_000_000 },
+      continuationToken: "parent-token",
+      history: [],
+      sessionId: "parent-session",
+    } as RuntimeSession;
     const task: DelegatedTask = {
       commandToken: "task-token",
       createdByTurnId: "turn-parent",
+      metadata: {
+        agentId: "agent-1",
+        kind: "subagent",
+        mode: "local",
+        name: "research",
+      },
       operationId: "operation-1",
       taskId: "task-1",
       taskRunId: "run-candidate",
@@ -36,14 +39,13 @@ describe("delegated task settlement", () => {
 
     const result = await settleDelegatedDispatch({
       callId: "call-task",
-      childSessionId: "child-session",
-      session: createSession(),
+      session,
       subagentName: "research",
       task,
     });
 
     expect(sendTaskCommandToOwner).toHaveBeenCalledWith(
-      expect.objectContaining({ command: { childSessionId: "child-session", kind: "describe" } }),
+      expect.objectContaining({ command: { kind: "ready" } }),
     );
     expect(getSessionTaskIndex(result.session.state)[0]).toMatchObject({
       taskId: "task-1",

--- a/packages/eve/src/execution/tasks/delegate.ts
+++ b/packages/eve/src/execution/tasks/delegate.ts
@@ -4,18 +4,20 @@ import {
   sendTaskCommandToOwner,
   startTaskRun,
 } from "#execution/tasks/run-control.js";
-import type { RuntimeSubagentChildResult } from "#runtime/actions/types.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { deriveAgentOperationId } from "#harness/handles/operation-id.js";
+import type { RuntimeSubagentChildResult } from "#runtime/actions/types.js";
 import type { JsonValue } from "#shared/json.js";
 import { recordSessionTask } from "#tasks/session-index.js";
 import { deriveTaskCommandToken, deriveTaskId } from "#tasks/task-id.js";
+import type { TaskMetadata } from "#tasks/types.js";
 
 /** A prepared delegated task: identity plus its started durable run. */
 export interface DelegatedTask {
   readonly commandToken: string;
-  readonly createdByTurnId: string;
   readonly createdByStepIndex?: number;
+  readonly createdByTurnId: string;
+  readonly metadata: TaskMetadata;
   readonly operationId: string;
   readonly taskId: string;
   readonly taskRunId: string;
@@ -28,6 +30,7 @@ export interface DelegatedTask {
  * re-derives the same token and the loser exits on the hook claim.
  */
 export async function beginDelegatedTask(input: {
+  readonly agentId: string;
   readonly callId: string;
   readonly mode: "local" | "remote";
   readonly name: string;
@@ -41,19 +44,25 @@ export async function beginDelegatedTask(input: {
     parentSessionId: input.parentSessionId,
     parentTurnId: input.parentTurnId,
   });
+  const commandToken = deriveTaskCommandToken({
+    parentContinuationToken: input.session.continuationToken,
+    taskId,
+  });
   const operationId = deriveAgentOperationId({
     callId: input.callId,
     parentSessionId: input.parentSessionId,
     parentTurnId: input.parentTurnId,
   });
-  const commandToken = deriveTaskCommandToken({
-    parentContinuationToken: input.session.continuationToken,
-    taskId,
-  });
+  const metadata: TaskMetadata = {
+    agentId: input.agentId,
+    kind: "subagent",
+    mode: input.mode,
+    name: input.name,
+  };
   const run = await startTaskRun({
     commandToken,
     initialView: {
-      metadata: { kind: "subagent", mode: input.mode, name: input.name },
+      metadata,
       status: "working",
       taskId,
     },
@@ -63,6 +72,7 @@ export async function beginDelegatedTask(input: {
     commandToken,
     createdByStepIndex: input.parentStepIndex ?? 0,
     createdByTurnId: input.parentTurnId,
+    metadata,
     operationId,
     taskId,
     taskRunId: run.runId,
@@ -70,35 +80,33 @@ export async function beginDelegatedTask(input: {
 }
 
 /**
- * Settles a delegated dispatch that acknowledged a child: attaches the
- * child session to the task, records the task in the session index, and
- * returns the receipt that resolves the originating tool call.
- *
- * The receipt carries a `parked` outcome so the existing resolve path
- * settles the agent handle to `parked` — the handle keeps the child
- * address for follow-ups while the task run owns the outstanding work.
+ * Settles a delegated dispatch that acknowledged a child: records the task
+ * in the session index and returns the receipt that resolves the originating
+ * tool call. Agent identity and routing remain in the persistent address
+ * record; task state owns execution availability.
  */
 export async function settleDelegatedDispatch(input: {
   readonly callId: string;
-  readonly childSessionId: string;
   readonly session: RuntimeSession;
   readonly subagentName: string;
   readonly task: DelegatedTask;
 }): Promise<{ readonly receipt: RuntimeSubagentChildResult; readonly session: RuntimeSession }> {
-  // The freshly started task run may not have registered its hook yet;
-  // ride out that startup window instead of dropping the acknowledgement.
   const owner = await sendTaskCommandToOwner({
-    command: { childSessionId: input.childSessionId, kind: "describe" },
+    command: { kind: "ready" },
     commandToken: input.task.commandToken,
     retryUnreachable: { attempts: 20, delayMs: 250 },
   });
   if (owner === undefined) {
-    throw new Error(`Task run "${input.task.taskId}" did not accept its child acknowledgement.`);
+    throw new Error(`Task run "${input.task.taskId}" did not accept its readiness command.`);
   }
-  const receiptOutput = { status: "working" as const, taskId: input.task.taskId };
+  const receiptOutput = {
+    agentId: input.task.metadata.agentId,
+    status: "working" as const,
+    taskId: input.task.taskId,
+  };
   return {
     receipt: {
-      backgroundTask: receiptOutput,
+      backgroundTask: { status: receiptOutput.status, taskId: receiptOutput.taskId },
       callId: input.callId,
       kind: "subagent-result",
       origin: "child",
@@ -114,10 +122,10 @@ export async function settleDelegatedDispatch(input: {
       subagentName: input.subagentName,
     },
     session: recordSessionTask(input.session, {
-      childSessionId: input.childSessionId,
       commandToken: input.task.commandToken,
       createdByStepIndex: input.task.createdByStepIndex,
       createdByTurnId: input.task.createdByTurnId,
+      metadata: input.task.metadata,
       operationId: input.task.operationId,
       taskId: input.task.taskId,
       taskRunId: owner.runId,

--- a/packages/eve/src/execution/tasks/dispatch.test.ts
+++ b/packages/eve/src/execution/tasks/dispatch.test.ts
@@ -57,23 +57,21 @@ function createSession(mode: "local" | "remote"): RuntimeSession {
           {
             address,
             identity: { id: "agent-1", name: "research", nodeId: "node-1" },
-            operation: {
-              callId: "call-task",
-              id: "operation-1",
-              kind: "continue",
-              parentTurnId: "turn-parent",
-              previousStatus: "idle",
-            },
-            phase: "running",
+            phase: "addressed",
           },
         ],
       },
       [SESSION_TASKS_STATE_KEY]: {
         tasks: [
           {
-            childSessionId: "child-1",
             commandToken: "task-token",
             createdByTurnId: "turn-1",
+            metadata: {
+              agentId: "agent-1",
+              kind: "subagent",
+              mode,
+              name: "research",
+            },
             operationId: "operation-1",
             taskId: "task-1",
             taskRunId: "run-1",
@@ -90,6 +88,7 @@ describe("task cancellation identity", () => {
     vi.mocked(sendTaskCommand).mockResolvedValue("delivered");
     vi.mocked(readLatestTaskSnapshot).mockResolvedValue({
       metadata: {
+        agentId: "agent-1",
         childSessionId: "child-1",
         childTurnId: "turn_child_7",
         kind: "subagent",
@@ -133,14 +132,14 @@ describe("task cancellation identity", () => {
       }
       expect(result.result).toMatchObject({ output: { tasks: [{ status: "cancelled" }] } });
       expect(result.session.state?.[AGENT_HANDLES_STATE_KEY]).toMatchObject({
-        handles: [{ phase: "parked" }],
+        handles: [{ phase: "addressed" }],
       });
     },
   );
 
   it("uses task-scoped cancellation before child-turn identity arrives", async () => {
     vi.mocked(readLatestTaskSnapshot).mockResolvedValue({
-      metadata: { childSessionId: "child-1", kind: "subagent", mode: "local", name: "research" },
+      metadata: { agentId: "agent-1", kind: "subagent", mode: "local", name: "research" },
       status: "cancelled",
       taskId: "task-1",
     });

--- a/packages/eve/src/execution/tasks/dispatch.ts
+++ b/packages/eve/src/execution/tasks/dispatch.ts
@@ -8,7 +8,7 @@ import {
   createTaskControlError,
   createTaskViewsResult,
   createUnknownTasksError,
-  findAddressableHandle,
+  findTaskAgentAddress,
   lookupTaskEntries,
   readTaskViews,
 } from "#execution/tasks/control-shared.js";
@@ -30,7 +30,6 @@ import {
 } from "#runtime/framework-tools/tasks.js";
 import type { SessionTaskIndexEntry } from "#tasks/session-index.js";
 import { isTerminalTaskStatus, type TaskView } from "#tasks/types.js";
-import { settleAgentTurn } from "#harness/handles/transitions.js";
 
 export {
   beginDelegatedTask,
@@ -95,18 +94,11 @@ export async function executeTaskControlAction(input: {
       return { result: createTaskViewsResult(action, views), session };
     }
     case TASK_CANCEL_TOOL_NAME: {
-      let nextSession = session;
       const views: TaskView[] = [];
       for (const entry of entries) {
-        const cancelled = await cancelOneTask({
-          bundle: input.bundle,
-          entry,
-          session: nextSession,
-        });
-        nextSession = cancelled.session;
-        views.push(cancelled.view);
+        views.push(await cancelOneTask({ bundle: input.bundle, entry, session }));
       }
-      return { result: createTaskViewsResult(action, views), session: nextSession };
+      return { result: createTaskViewsResult(action, views), session };
     }
     default:
       return {
@@ -120,7 +112,7 @@ async function cancelOneTask(input: {
   readonly bundle: CompiledBundle;
   readonly entry: SessionTaskIndexEntry;
   readonly session: RuntimeSession;
-}): Promise<{ readonly session: RuntimeSession; readonly view: TaskView }> {
+}): Promise<TaskView> {
   const { entry } = input;
   const delivery = await sendTaskCommand({
     command: { kind: "cancel" },
@@ -139,18 +131,12 @@ async function cancelOneTask(input: {
     await new Promise((resolve) => setTimeout(resolve, CANCEL_COMMIT_POLL_DELAY_MS));
     view = await readLatestTaskSnapshot({ taskRunId: entry.taskRunId });
   }
-  const settledView = view ?? createPendingTaskView(entry.taskId);
+  const settledView = view ?? createPendingTaskView(entry);
 
   if (settledView.status === "cancelled" && delivery === "delivered") {
-    const session = await propagateTaskCancel({
-      bundle: input.bundle,
-      entry,
-      session: input.session,
-      view: settledView,
-    });
-    return { session, view: settledView };
+    await propagateTaskCancel({ bundle: input.bundle, session: input.session, view: settledView });
   }
-  return { session: input.session, view: settledView };
+  return settledView;
 }
 
 /**
@@ -160,16 +146,19 @@ async function cancelOneTask(input: {
  */
 async function propagateTaskCancel(input: {
   readonly bundle: CompiledBundle;
-  readonly entry: SessionTaskIndexEntry;
   readonly session: RuntimeSession;
   readonly view: TaskView;
-}): Promise<RuntimeSession> {
-  const childSessionId = input.view.metadata.childSessionId;
+}): Promise<void> {
+  const handle = findTaskAgentAddress(input.session, input.view.metadata.agentId);
+  if (handle === undefined) return;
+  const childSessionId = handle.address.sessionId;
   const childTurnId = input.view.metadata.childTurnId;
-  if (childSessionId === undefined || childSessionId !== input.entry.childSessionId) {
-    return input.session;
+  if (
+    input.view.metadata.childSessionId !== undefined &&
+    input.view.metadata.childSessionId !== childSessionId
+  ) {
+    return;
   }
-  const handle = findAddressableHandle(input.session, childSessionId);
 
   try {
     if (handle !== undefined && handle.address.kind === "agent/remote") {
@@ -179,9 +168,9 @@ async function propagateTaskCancel(input: {
         registry: input.bundle.subagentRegistry.subagentsByNodeId,
       });
       const cancelInput: {
-        remote: typeof resolved;
-        sessionId: string;
-        taskId: string;
+        readonly remote: typeof resolved & { readonly url: string };
+        readonly sessionId: string;
+        readonly taskId: string;
         turnId?: string;
       } = {
         remote: { ...resolved, url: handle.address.url },
@@ -197,44 +186,29 @@ async function propagateTaskCancel(input: {
           taskId: input.view.taskId,
         });
       }
-    } else {
-      const cancelInput: {
-        sessionId: string;
-        taskId: string;
-        turnId?: string;
-      } = {
+      return;
+    }
+    const cancelInput: {
+      readonly sessionId: string;
+      readonly taskId: string;
+      turnId?: string;
+    } = {
+      sessionId: childSessionId,
+      taskId: input.view.taskId,
+    };
+    if (childTurnId !== undefined) cancelInput.turnId = childTurnId;
+    const result = await requestWorkflowTurnCancellation(cancelInput);
+    if (result.status === "no_active_turn") {
+      await requestWorkflowTurnCancellation({
         sessionId: childSessionId,
         taskId: input.view.taskId,
-      };
-      if (childTurnId !== undefined) cancelInput.turnId = childTurnId;
-      const result = await requestWorkflowTurnCancellation(cancelInput);
-      if (result.status === "no_active_turn") {
-        await requestWorkflowTurnCancellation({
-          sessionId: childSessionId,
-          taskId: input.view.taskId,
-        });
-      }
+      });
     }
-    const settled = settleAgentTurn(input.session, {
-      operationId: input.entry.operationId,
-      outcome: {
-        kind: "parked",
-        result: { kind: "cancelled" },
-        usageDelta: {
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-          inputTokens: 0,
-          outputTokens: 0,
-        },
-      },
-    });
-    return settled.kind === "settled" ? settled.session : input.session;
   } catch (error) {
     logError(log, "task cancel propagation failed; the child may run to completion", error, {
       childSessionId,
       taskId: input.view.taskId,
     });
-    return input.session;
   }
 }
 

--- a/packages/eve/src/execution/tasks/hitl-proxy-steps.ts
+++ b/packages/eve/src/execution/tasks/hitl-proxy-steps.ts
@@ -5,8 +5,9 @@ import {
   toProxyInputRequestEntries,
   upsertProxyInputRequestState,
 } from "#harness/proxy-input-requests.js";
-import { findSessionTaskEntry } from "#tasks/session-index.js";
+import { getAgentHandleStore } from "#harness/handles/store.js";
 import { isInputRequest } from "#runtime/input/types.js";
+import { findSessionTaskEntry } from "#tasks/session-index.js";
 
 /** Validates and durably records one task-owned child HITL route batch. */
 export async function recordTaskInputRequestStep(input: {
@@ -19,7 +20,16 @@ export async function recordTaskInputRequestStep(input: {
 
   const durableSession = await readDurableSession(input.sessionState);
   const entry = findSessionTaskEntry(durableSession.state, input.taskId);
-  if (entry === undefined || entry.childSessionId !== input.hookPayload.childSessionId) {
+  const handle = (getAgentHandleStore(durableSession.state)?.handles ?? []).find(
+    (candidate) =>
+      candidate.phase === "addressed" && candidate.identity.id === entry?.metadata.agentId,
+  );
+  if (
+    entry === undefined ||
+    handle?.phase !== "addressed" ||
+    handle.address.kind === "agent/remote" ||
+    handle.address.sessionId !== input.hookPayload.childSessionId
+  ) {
     return { accepted: false, sessionState: input.sessionState };
   }
   const view = await readLatestTaskSnapshot({ taskRunId: entry.taskRunId });
@@ -34,6 +44,7 @@ export async function recordTaskInputRequestStep(input: {
     view?.status !== "input_required" ||
     !input.hookPayload.event.requests.every(isInputRequest) ||
     view.metadata.mode !== "local" ||
+    view.metadata.agentId !== entry.metadata.agentId ||
     view.metadata.childSessionId !== input.hookPayload.childSessionId ||
     new Set(eventRequestIds).size !== eventRequestIds.length ||
     eventRequestIds.length !== viewRequestIds.length ||

--- a/packages/eve/src/execution/tasks/run-workflow.test.ts
+++ b/packages/eve/src/execution/tasks/run-workflow.test.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 function createWorkingView(): TaskView {
   return {
     metadata: {
-      childSessionId: "child-session-1",
+      agentId: "ag_research:abcdef123456",
       kind: "subagent",
       mode: "local",
       name: "research",
@@ -127,7 +127,6 @@ describe("taskRunWorkflow", () => {
   it("translates a settled child turn from the wire and wakes the parent once ready", async () => {
     const ZERO = { cacheReadTokens: 0, cacheWriteTokens: 0, inputTokens: 0, outputTokens: 0 };
     mockCommandHook([
-      { command: { childSessionId: "child-session-1", kind: "describe" }, kind: "task-command" },
       {
         kind: "runtime-action-result",
         results: [
@@ -147,12 +146,17 @@ describe("taskRunWorkflow", () => {
       commandToken: "task-token",
       initialView: {
         ...createWorkingView(),
-        metadata: { kind: "subagent", mode: "local", name: "research" },
+        metadata: {
+          agentId: "ag_research:abcdef123456",
+          kind: "subagent",
+          mode: "local",
+          name: "research",
+        },
       },
       wakeToken: "parent-session-token",
     });
 
-    expect(appendedStatuses()).toEqual(["working", "working", "completed"]);
+    expect(appendedStatuses()).toEqual(["working", "completed"]);
     expect(wakeTaskParentStep).toHaveBeenCalledTimes(1);
     expect(vi.mocked(wakeTaskParentStep).mock.calls[0]?.[0]).toMatchObject({
       token: "parent-session-token",
@@ -174,7 +178,7 @@ describe("taskRunWorkflow", () => {
           },
         ],
       },
-      { command: { childSessionId: "child-session-1", kind: "describe" }, kind: "task-command" },
+      { command: { kind: "ready" }, kind: "task-command" },
     ]);
 
     await taskRunWorkflow({
@@ -185,6 +189,41 @@ describe("taskRunWorkflow", () => {
 
     expect(appendedStatuses()).toEqual(["working", "completed"]);
     expect(disposeHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a fast input request when the readiness barrier arrives", async () => {
+    mockCommandHook([
+      {
+        callId: "call-task",
+        childContinuationToken: "child-token",
+        childSessionId: "child-session",
+        event: {
+          requests: [
+            {
+              action: { callId: "call-q", input: {}, kind: "tool-call", toolName: "ask" },
+              kind: "question",
+              prompt: "Which?",
+              requestId: "q1",
+            },
+          ],
+          sequence: 1,
+          stepIndex: 2,
+          turnId: "turn-child",
+        },
+        kind: "subagent-input-request",
+        subagentName: "research",
+      },
+      { command: { kind: "ready" }, kind: "task-command" },
+    ]);
+
+    await taskRunWorkflow({
+      commandToken: "task-token",
+      initialView: createWorkingView(),
+      wakeToken: "parent-session-token",
+    });
+
+    expect(wakeTaskInputRequestParentStep).toHaveBeenCalledTimes(1);
+    expect(wakeTaskParentStep).not.toHaveBeenCalled();
   });
 
   it("does not wake without a wake token and never wakes twice for one blocked child", async () => {
@@ -232,6 +271,7 @@ describe("taskRunWorkflow", () => {
       subagentName: "research",
     });
     mockCommandHook([
+      { command: { kind: "ready" }, kind: "task-command" },
       inbound("q1"),
       inbound("q2"),
       { command: { data: "done", kind: "complete" }, kind: "task-command" },
@@ -258,47 +298,8 @@ describe("taskRunWorkflow", () => {
     const firstInputWakeOrder =
       vi.mocked(wakeTaskInputRequestParentStep).mock.invocationCallOrder[0] ?? 0;
     const firstInputAppendOrder =
-      vi.mocked(appendTaskSnapshotStep).mock.invocationCallOrder[1] ?? 0;
+      vi.mocked(appendTaskSnapshotStep).mock.invocationCallOrder[2] ?? 0;
     expect(firstInputAppendOrder).toBeLessThan(firstInputWakeOrder);
-  });
-
-  it("defers a fast HITL batch until describe binds the child session", async () => {
-    mockCommandHook([
-      {
-        callId: "call-task",
-        childContinuationToken: "child-token",
-        childSessionId: "child-session-1",
-        event: {
-          requests: [
-            {
-              action: { callId: "call-q", input: {}, kind: "tool-call", toolName: "ask" },
-              kind: "question",
-              prompt: "q",
-              requestId: "q1",
-            },
-          ],
-          sequence: 1,
-          stepIndex: 2,
-          turnId: "turn_child",
-        },
-        kind: "subagent-input-request",
-        subagentName: "research",
-      },
-      { command: { childSessionId: "child-session-1", kind: "describe" }, kind: "task-command" },
-    ]);
-
-    await taskRunWorkflow({
-      commandToken: "task-token",
-      initialView: {
-        ...createWorkingView(),
-        metadata: { kind: "subagent", mode: "local", name: "research" },
-      },
-      wakeToken: "parent-session-token",
-    });
-
-    expect(wakeTaskInputRequestParentStep).toHaveBeenCalledTimes(1);
-    expect(wakeTaskParentStep).not.toHaveBeenCalled();
-    expect(appendedStatuses()).toEqual(["working", "input_required", "input_required"]);
   });
 });
 

--- a/packages/eve/src/execution/tasks/run-workflow.ts
+++ b/packages/eve/src/execution/tasks/run-workflow.ts
@@ -101,11 +101,7 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       await appendTaskSnapshotStep({ view });
       const routableInputRequest =
         pendingInputRequest !== undefined &&
-        view.status === "input_required" &&
-        view.metadata.mode === "local" &&
-        view.metadata.childSessionId === pendingInputRequest.childSessionId;
-      const deferredLocalInputRequest =
-        pendingInputRequest !== undefined &&
+        dispatchAcknowledged &&
         view.status === "input_required" &&
         view.metadata.mode === "local";
       if (routableInputRequest && input.wakeToken !== undefined) {
@@ -116,7 +112,9 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
         });
         pendingInputRequest = undefined;
       } else if (
-        (becameTerminal || (becameReady && !deferredLocalInputRequest)) &&
+        (becameTerminal ||
+          (becameReady &&
+            !(pendingInputRequest !== undefined && view.metadata.mode === "local"))) &&
         input.wakeToken !== undefined
       ) {
         await wakeTaskParentStep({ token: input.wakeToken, view });

--- a/packages/eve/src/execution/tasks/send.test.ts
+++ b/packages/eve/src/execution/tasks/send.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { dispatchToAgentHandle, type RuntimeSession } from "#execution/agent-handle-dispatch.js";
+import {
+  dispatchToTaskAgentAddress,
+  type RuntimeSession,
+} from "#execution/agent-handle-dispatch.js";
 import {
   beginDelegatedTask,
   failDelegatedDispatch,
@@ -11,51 +14,55 @@ import { executeTaskSend } from "#execution/tasks/send.js";
 import { AGENT_HANDLES_STATE_KEY } from "#harness/handles/store.js";
 import type { RuntimeToolCallActionRequest } from "#runtime/actions/types.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
-import { SESSION_TASKS_STATE_KEY, type SessionTaskIndexEntry } from "#tasks/session-index.js";
+import { SESSION_TASKS_STATE_KEY } from "#tasks/session-index.js";
 import type { TaskStatus, TaskView } from "#tasks/types.js";
 
 vi.mock("#execution/agent-handle-dispatch.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#execution/agent-handle-dispatch.js")>()),
-  dispatchToAgentHandle: vi.fn(),
+  dispatchToTaskAgentAddress: vi.fn(),
 }));
+
 vi.mock("#execution/tasks/delegate.js", () => ({
   beginDelegatedTask: vi.fn(),
   failDelegatedDispatch: vi.fn(),
   settleDelegatedDispatch: vi.fn(),
 }));
+
 vi.mock("#execution/tasks/run-control.js", () => ({
   readLatestTaskSnapshot: vi.fn(),
+  sendTaskCommand: vi.fn(),
 }));
 
-const childSessionId = "child-session";
-const metadata = {
-  childSessionId,
-  kind: "subagent" as const,
-  mode: "local" as const,
-  name: "research",
-};
+const agentId = "ag_research:abcdef123456";
+const metadata = { agentId, kind: "subagent" as const, mode: "local" as const, name: "research" };
 
-function entry(
-  taskId: string,
-  createdByTurnId: string,
-  createdByStepIndex?: number,
-): SessionTaskIndexEntry {
-  return {
-    childSessionId,
-    commandToken: `token-${taskId}`,
-    createdByStepIndex,
-    createdByTurnId,
-    operationId: `operation-${taskId}`,
-    taskId,
-    taskRunId: `run-${taskId}`,
-  };
-}
-
-function view(taskId: string, status: TaskStatus): TaskView {
+function task(taskId: string, status: TaskStatus): TaskView {
   return { metadata, status, taskId };
 }
 
-function session(tasks: readonly SessionTaskIndexEntry[]): RuntimeSession {
+function createSession(includeActive = false, activeCreatedByTurnId = "turn-1"): RuntimeSession {
+  const tasks = [
+    {
+      commandToken: "task-token-terminal",
+      createdByTurnId: "turn-1",
+      metadata,
+      operationId: "operation-terminal",
+      taskId: "task_terminal",
+      taskRunId: "run-terminal",
+    },
+    ...(includeActive
+      ? [
+          {
+            commandToken: "task-token-active",
+            createdByTurnId: activeCreatedByTurnId,
+            metadata,
+            operationId: "operation-active",
+            taskId: "task_active",
+            taskRunId: "run-active",
+          },
+        ]
+      : []),
+  ];
   return {
     agent: { modelReference: { id: "model" }, system: "", tools: [] },
     compaction: { recentWindowSize: 4, threshold: 1_000_000 },
@@ -69,11 +76,10 @@ function session(tasks: readonly SessionTaskIndexEntry[]): RuntimeSession {
             address: {
               continuationToken: "child-token",
               kind: "agent/local",
-              sessionId: childSessionId,
+              sessionId: "child-session",
             },
-            identity: { id: "agent-1", name: "research", nodeId: "node-research" },
-            lastStatus: "idle",
-            phase: "parked",
+            identity: { id: agentId, name: "research", nodeId: "node-research" },
+            phase: "addressed",
           },
         ],
       },
@@ -89,28 +95,90 @@ const action: RuntimeToolCallActionRequest = {
   toolName: "task_send",
 };
 
-describe("task_send child-session admission", () => {
+describe("task_send persistent-agent admission", () => {
   beforeEach(() => vi.resetAllMocks());
 
-  it.each([
-    ["nonterminal task", "turn-old", "working" as const],
-    ["task admitted in this batch", "turn-current", "completed" as const],
-  ])("rejects a follow-up for a %s", async (_name, createdByTurnId, conflictingStatus) => {
-    const current = session([
-      entry("task_terminal", "turn-old"),
-      entry("task_conflict", createdByTurnId),
-    ]);
+  it("starts a new task on the same address after terminal work", async () => {
+    const session = createSession();
+    vi.mocked(readLatestTaskSnapshot).mockResolvedValue(task("task_terminal", "completed"));
+    vi.mocked(beginDelegatedTask).mockResolvedValue({
+      commandToken: "task-token-new",
+      createdByTurnId: "turn-2",
+      metadata,
+      operationId: "operation-new",
+      taskId: "task_new",
+      taskRunId: "run-new",
+    });
+    vi.mocked(dispatchToTaskAgentAddress).mockResolvedValue({
+      address: {
+        continuationToken: "child-token",
+        kind: "agent/local",
+        sessionId: "child-session",
+      },
+      callId: action.callId,
+      kind: "called",
+      name: "research",
+      session,
+      toolName: "research",
+    });
+    vi.mocked(settleDelegatedDispatch).mockResolvedValue({
+      receipt: {} as never,
+      session,
+    });
+
+    const result = await executeTaskSend({
+      action,
+      bundle: {} as CompiledBundle,
+      parentTurnId: "turn-2",
+      session,
+    });
+
+    expect(beginDelegatedTask).toHaveBeenCalledWith(expect.objectContaining({ agentId }));
+    expect(dispatchToTaskAgentAddress).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId, currentSession: session }),
+    );
+    expect(result.result).toMatchObject({
+      output: { agentId, status: "working", taskId: "task_new" },
+    });
+  });
+
+  it("rejects a follow-up while another nonterminal task owns the agent", async () => {
+    const session = createSession(true);
     vi.mocked(readLatestTaskSnapshot).mockImplementation(async ({ taskRunId }) =>
-      taskRunId === "run-task_terminal"
-        ? view("task_terminal", "completed")
-        : view("task_conflict", conflictingStatus),
+      taskRunId === "run-active"
+        ? task("task_active", "input_required")
+        : task("task_terminal", "completed"),
     );
 
     const result = await executeTaskSend({
       action,
       bundle: {} as CompiledBundle,
-      parentTurnId: "turn-current",
-      session: current,
+      parentTurnId: "turn-2",
+      session,
+    });
+
+    expect(result.result).toMatchObject({
+      isError: true,
+      output: { message: expect.stringContaining("task_active") },
+    });
+    expect(beginDelegatedTask).not.toHaveBeenCalled();
+    expect(dispatchToTaskAgentAddress).not.toHaveBeenCalled();
+    expect(failDelegatedDispatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a second same-batch follow-up even if the first task already completed", async () => {
+    const session = createSession(true, "turn-2");
+    vi.mocked(readLatestTaskSnapshot).mockImplementation(async ({ taskRunId }) =>
+      taskRunId === "run-active"
+        ? task("task_active", "completed")
+        : task("task_terminal", "completed"),
+    );
+
+    const result = await executeTaskSend({
+      action,
+      bundle: {} as CompiledBundle,
+      parentTurnId: "turn-2",
+      session,
     });
 
     expect(result.result).toMatchObject({
@@ -118,66 +186,26 @@ describe("task_send child-session admission", () => {
       output: { message: expect.stringContaining("AGENT_BUSY") },
     });
     expect(beginDelegatedTask).not.toHaveBeenCalled();
-    expect(dispatchToAgentHandle).not.toHaveBeenCalled();
+    expect(dispatchToTaskAgentAddress).not.toHaveBeenCalled();
   });
 
-  it("allows reuse in a later batch of the same turn after terminal settlement", async () => {
-    const current = session([
-      entry("task_terminal", "turn-old"),
-      entry("task_previous", "turn-current", 0),
-    ]);
-    vi.mocked(readLatestTaskSnapshot).mockResolvedValue(view("task_terminal", "completed"));
+  it("reserves the addressed agent before an ambiguous delivery", async () => {
+    const current = createSession();
+    const reserved = createSession(true, "turn-2");
+    vi.mocked(readLatestTaskSnapshot).mockResolvedValue(task("task_terminal", "completed"));
     vi.mocked(beginDelegatedTask).mockResolvedValue({
       commandToken: "task-token-new",
-      createdByTurnId: "turn-current",
+      createdByTurnId: "turn-2",
+      metadata,
       operationId: "operation-new",
-      taskId: "task_new",
-      taskRunId: "run-new",
-    });
-    vi.mocked(dispatchToAgentHandle).mockResolvedValue({
-      address: { continuationToken: "child-token", kind: "agent/local", sessionId: childSessionId },
-      callId: action.callId,
-      kind: "called",
-      name: "research",
-      session: current,
-      toolName: "research",
-    });
-    vi.mocked(settleDelegatedDispatch).mockResolvedValue({
-      receipt: {} as never,
-      session: current,
-    });
-
-    const result = await executeTaskSend({
-      action,
-      bundle: {} as CompiledBundle,
-      parentStepIndex: 1,
-      parentTurnId: "turn-current",
-      session: current,
-    });
-
-    expect(result.result).toMatchObject({ output: { status: "working", taskId: "task_new" } });
-    expect(failDelegatedDispatch).not.toHaveBeenCalled();
-  });
-
-  it("reserves the child before an ambiguous continuation delivery", async () => {
-    const current = session([entry("task_terminal", "turn-old")]);
-    const reserved = session([
-      entry("task_terminal", "turn-old"),
-      entry("task_new", "turn-current"),
-    ]);
-    vi.mocked(readLatestTaskSnapshot).mockResolvedValue(view("task_terminal", "completed"));
-    vi.mocked(beginDelegatedTask).mockResolvedValue({
-      commandToken: "task-token-new",
-      createdByTurnId: "turn-current",
-      operationId: "operation-new",
-      taskId: "task_new",
-      taskRunId: "run-new",
+      taskId: "task_active",
+      taskRunId: "run-active",
     });
     vi.mocked(settleDelegatedDispatch).mockResolvedValue({
       receipt: {} as never,
       session: reserved,
     });
-    vi.mocked(dispatchToAgentHandle).mockResolvedValue({
+    vi.mocked(dispatchToTaskAgentAddress).mockResolvedValue({
       kind: "error",
       result: {
         callId: action.callId,
@@ -193,20 +221,17 @@ describe("task_send child-session admission", () => {
     const result = await executeTaskSend({
       action,
       bundle: {} as CompiledBundle,
-      parentTurnId: "turn-current",
+      parentTurnId: "turn-2",
       session: current,
     });
 
     expect(vi.mocked(settleDelegatedDispatch).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(dispatchToAgentHandle).mock.invocationCallOrder[0] ?? 0,
+      vi.mocked(dispatchToTaskAgentAddress).mock.invocationCallOrder[0] ?? 0,
     );
-    expect(dispatchToAgentHandle).toHaveBeenCalledWith(
+    expect(dispatchToTaskAgentAddress).toHaveBeenCalledWith(
       expect.objectContaining({ currentSession: reserved }),
     );
-    expect(result.result).toMatchObject({
-      isError: true,
-      output: { taskId: "task_new" },
-    });
+    expect(result.result).toMatchObject({ isError: true, output: { taskId: "task_active" } });
     expect(result.session).toBe(reserved);
   });
 });

--- a/packages/eve/src/execution/tasks/send.ts
+++ b/packages/eve/src/execution/tasks/send.ts
@@ -1,5 +1,5 @@
 import {
-  dispatchToAgentHandle,
+  dispatchToTaskAgentAddress,
   type RuntimeAgentHandleAction,
   type RuntimeSession,
 } from "#execution/agent-handle-dispatch.js";
@@ -7,8 +7,8 @@ import {
   createPendingTaskView,
   createTaskControlError,
   createUnknownTasksError,
-  findAddressableHandle,
-  findConflictingTaskForChildSession,
+  findActiveTaskForAgent,
+  findTaskAgentAddress,
 } from "#execution/tasks/control-shared.js";
 import {
   beginDelegatedTask,
@@ -54,8 +54,7 @@ export async function executeTaskSend(input: {
   }
 
   const view =
-    (await readLatestTaskSnapshot({ taskRunId: entry.taskRunId })) ??
-    createPendingTaskView(entry.taskId);
+    (await readLatestTaskSnapshot({ taskRunId: entry.taskRunId })) ?? createPendingTaskView(entry);
 
   if (view.status === "working") {
     return {
@@ -98,7 +97,22 @@ async function followUpTerminalTask(input: {
   readonly view: TaskView;
 }): Promise<{ readonly result: RuntimeActionResult; readonly session: RuntimeSession }> {
   const { action, view } = input;
-  const handle = findAddressableHandle(input.session, view.metadata.childSessionId);
+  const active = await findActiveTaskForAgent(
+    input.session,
+    view.metadata.agentId,
+    input.parentTurnId,
+    input.parentStepIndex,
+  );
+  if (active !== undefined) {
+    return {
+      result: createTaskControlError(
+        action,
+        `${AGENT_BUSY}: agent "${view.metadata.agentId}" is busy with task "${active.view.taskId}" (${active.view.status}).`,
+      ),
+      session: input.session,
+    };
+  }
+  const handle = findTaskAgentAddress(input.session, view.metadata.agentId);
   if (handle === undefined) {
     return {
       result: createTaskControlError(
@@ -108,22 +122,6 @@ async function followUpTerminalTask(input: {
       session: input.session,
     };
   }
-  const conflicting = await findConflictingTaskForChildSession({
-    childSessionId: handle.address.sessionId,
-    parentStepIndex: input.parentStepIndex,
-    parentTurnId: input.parentTurnId,
-    session: input.session,
-  });
-  if (conflicting !== undefined) {
-    return {
-      result: createTaskControlError(
-        action,
-        `${AGENT_BUSY}: agent "${handle.identity.id}" is busy with task "${conflicting.view.taskId}" (${conflicting.view.status}).`,
-      ),
-      session: input.session,
-    };
-  }
-
   const continuation: RuntimeAgentHandleAction =
     handle.address.kind === "agent/remote"
       ? {
@@ -146,6 +144,7 @@ async function followUpTerminalTask(input: {
         };
 
   const task = await beginDelegatedTask({
+    agentId: handle.identity.id,
     callId: action.callId,
     mode: handle.address.kind === "agent/remote" ? "remote" : "local",
     name: handle.identity.name,
@@ -154,25 +153,22 @@ async function followUpTerminalTask(input: {
     parentTurnId: input.parentTurnId,
     session: input.session,
   });
-  // Reserve the child before the ambiguous delivery side effect. If the
-  // transport response is lost, this task remains the sole admitted owner.
+  // Reserve the addressed agent before the ambiguous delivery side effect.
   const reserved = await settleDelegatedDispatch({
     callId: action.callId,
-    childSessionId: handle.address.sessionId,
     session: input.session,
     subagentName: handle.identity.name,
     task,
   });
-  const outcome = await dispatchToAgentHandle({
+  const outcome = await dispatchToTaskAgentAddress({
     action: continuation,
     agentId: handle.identity.id,
     bundle: input.bundle,
     currentSession: reserved.session,
     parentToken: task.commandToken,
-    parentTurnId: input.parentTurnId,
   });
   if (outcome.kind === "error") {
-    if (findAddressableHandle(outcome.session, handle.address.sessionId) === undefined) {
+    if (findTaskAgentAddress(outcome.session, handle.identity.id) === undefined) {
       await failDelegatedDispatch({ error: outcome.result.output, task });
     }
     return {
@@ -191,7 +187,7 @@ async function followUpTerminalTask(input: {
     result: {
       callId: action.callId,
       kind: "tool-result",
-      output: { status: "working", taskId: task.taskId },
+      output: { agentId: task.metadata.agentId, status: "working", taskId: task.taskId },
       toolName: action.toolName,
     },
     session: outcome.session,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -17,7 +17,7 @@ import {
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { serializeContext } from "#context/serialize.js";
 import { setPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
-import { getAgentHandleStore } from "#harness/handles/store.js";
+import { AGENT_HANDLES_STATE_KEY, getAgentHandleStore } from "#harness/handles/store.js";
 import { requestTurnSleep } from "#harness/turn-sleep.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
 import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
@@ -276,9 +276,14 @@ describe("routeProxiedDeliverStep", () => {
                 "eve.tasks": {
                   tasks: [
                     {
-                      childSessionId: "child-session",
                       commandToken: "task-token",
                       createdByTurnId: "turn-parent",
+                      metadata: {
+                        agentId: "agent-1",
+                        kind: "subagent",
+                        mode: "local",
+                        name: "research",
+                      },
                       operationId: "operation-1",
                       taskId: "task-1",
                       taskRunId: "run-1",
@@ -291,7 +296,6 @@ describe("routeProxiedDeliverStep", () => {
   }
 
   const taskRouteInput = {
-    parentWritable: createTestWritable(),
     payload: { inputResponses: [{ optionId: "approve", requestId: "request-1" }] },
     sessionState: createStubSessionState({ hasProxyInputRequests: true }),
   };
@@ -382,12 +386,30 @@ describe("recordTaskInputRequestStep", () => {
   it("records an exact route only for a current task owned by this parent", async () => {
     const session = createStubSession({
       state: {
+        [AGENT_HANDLES_STATE_KEY]: {
+          handles: [
+            {
+              address: {
+                continuationToken: "child-token",
+                kind: "agent/local",
+                sessionId: "child-session",
+              },
+              identity: { id: "agent-1", name: "research", nodeId: "node-1" },
+              phase: "addressed",
+            },
+          ],
+        },
         "eve.tasks": {
           tasks: [
             {
-              childSessionId: "child-session",
               commandToken: "task-token",
               createdByTurnId: "turn-parent",
+              metadata: {
+                agentId: "agent-1",
+                kind: "subagent",
+                mode: "local",
+                name: "research",
+              },
               operationId: "operation-1",
               taskId: "task-1",
               taskRunId: "run-1",
@@ -399,6 +421,7 @@ describe("recordTaskInputRequestStep", () => {
     installSessionStoreMocks([session]);
     vi.mocked(readLatestTaskSnapshot).mockResolvedValue({
       metadata: {
+        agentId: "agent-1",
         childSessionId: "child-session",
         kind: "subagent",
         mode: "local",

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -72,6 +72,7 @@ import {
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
+import { appendTaskAgentAnnouncement } from "#execution/tasks/agent-views.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
@@ -286,8 +287,9 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const dynamicInstructionsResolvers = bundle.resolvedAgent.dynamicInstructionsResolvers ?? [];
   const dynamicSkillResolvers = bundle.resolvedAgent.dynamicSkillResolvers ?? [];
   const dynamicSubagentResolvers = bundle.subagentRegistry.dynamicResolvers ?? [];
+  const tasksEnabled = bundle.resolvedAgent.config.experimental?.tasks === true;
   const persistentSubagentSessions =
-    bundle.resolvedAgent.config.experimental?.subagentPersistentSessions === true;
+    tasksEnabled || bundle.resolvedAgent.config.experimental?.subagentPersistentSessions === true;
   const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
   const effectiveNode = {
     ...bundle.graph.root,
@@ -425,6 +427,9 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           session: lifecycleSession,
           turnAgent: effectiveAgent.turnAgent,
         });
+        const modelSession = tasksEnabled
+          ? await appendTaskAgentAnnouncement(refreshedSession)
+          : refreshedSession;
 
         const step = createExecutionNodeStep({
           abortSignal: input.abortSignal,
@@ -441,7 +446,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           node: effectiveNode,
           workflowMaxSubagents: refreshedSession.workflowMaxSubagents,
         });
-        return step(refreshedSession, stepInput);
+        return step(modelSession, stepInput);
       };
 
       return runHarnessStep(schemaSession, resolved);

--- a/packages/eve/src/harness/handles/prompt.test.ts
+++ b/packages/eve/src/harness/handles/prompt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   projectParkedAgentHandles,
+  renderAgentViewsSnippet,
   renderAgentsSnippet,
   resolveAgentsAnnouncement,
 } from "#harness/handles/prompt.js";
@@ -67,6 +68,26 @@ describe("projectParkedAgentHandles / renderAgentsSnippet", () => {
     expect(snippet).not.toContain(parkedRemoteHandle.address.continuationToken);
     expect(snippet).not.toContain("URL_SENTINEL");
     expect(snippet).not.toContain("CALLBACK_SENTINEL");
+  });
+});
+
+describe("renderAgentViewsSnippet", () => {
+  it("keeps task-owned agents visible with derived busy state", () => {
+    const snippet = renderAgentViewsSnippet([
+      {
+        availability: "busy",
+        id: identity.id,
+        name: identity.name,
+        taskId: "task_123",
+        taskStatus: "input_required",
+      },
+    ]);
+
+    expect(snippet).toContain(
+      `<agent id="${identity.id}" name="research" availability="busy" taskId="task_123" taskStatus="input_required">(busy)</agent>`,
+    );
+    expect(snippet).not.toContain("SESSION_ID_SENTINEL");
+    expect(snippet).not.toContain("CONTINUATION_TOKEN_SENTINEL");
   });
 });
 

--- a/packages/eve/src/harness/handles/prompt.ts
+++ b/packages/eve/src/harness/handles/prompt.ts
@@ -4,6 +4,16 @@ import type { AgentHandle, AgentHandleStore } from "#harness/handles/store.js";
 
 const AGENTS_SNIPPET_LABEL = "[Agents]";
 
+/** Model-safe projection of one persistent task-mode agent. */
+export interface AgentView {
+  readonly availability: "available" | "busy";
+  readonly id: string;
+  readonly name: string;
+  readonly statusLine?: string;
+  readonly taskId?: string;
+  readonly taskStatus?: "working" | "input_required";
+}
+
 /** Returns the resumable handles: the only phase the model may continue. */
 export function projectParkedAgentHandles(
   store: AgentHandleStore,
@@ -24,12 +34,26 @@ export function renderAgentsSnippet(store: AgentHandleStore): string {
   return [AGENTS_SNIPPET_LABEL, "<agents>", ...agents, "</agents>"].join("\n");
 }
 
+/** Renders task-derived availability without exposing private addresses. */
+export function renderAgentViewsSnippet(views: readonly AgentView[]): string {
+  const agents = views.map((view) => {
+    const task =
+      view.taskId === undefined || view.taskStatus === undefined
+        ? ""
+        : ` taskId="${escapeXml(view.taskId)}" taskStatus="${view.taskStatus}"`;
+    const status = view.statusLine ?? (view.availability === "busy" ? "(busy)" : "(available)");
+    return `<agent id="${escapeXml(view.id)}" name="${escapeXml(view.name)}" availability="${view.availability}"${task}>${escapeXml(status)}</agent>`;
+  });
+  return [AGENTS_SNIPPET_LABEL, "<agents>", ...agents, "</agents>"].join("\n");
+}
+
 /**
  * Returns an append-only model announcement when the visible handle listing
  * changed. Keeping volatile handles in conversation history preserves the
  * stable system prompt cache prefix.
  */
 export function resolveAgentsAnnouncement(input: {
+  readonly agentViews?: readonly AgentView[];
   readonly messages: readonly ModelMessage[];
   readonly store: AgentHandleStore | undefined;
 }): string | undefined {
@@ -40,12 +64,16 @@ export function resolveAgentsAnnouncement(input: {
       message.content.startsWith(AGENTS_SNIPPET_LABEL),
   );
   const store = input.store ?? { handles: [] };
+  const visibleCount = input.agentViews?.length ?? projectParkedAgentHandles(store).length;
 
-  if (latest === undefined && projectParkedAgentHandles(store).length === 0) {
+  if (latest === undefined && visibleCount === 0) {
     return undefined;
   }
 
-  const rendered = renderAgentsSnippet(store);
+  const rendered =
+    input.agentViews === undefined
+      ? renderAgentsSnippet(store)
+      : renderAgentViewsSnippet(input.agentViews);
   return latest?.content === rendered ? undefined : rendered;
 }
 

--- a/packages/eve/src/harness/handles/query.ts
+++ b/packages/eve/src/harness/handles/query.ts
@@ -64,7 +64,7 @@ export function isResultBoundToRunningHandle(
   if (result.kind !== "subagent-result") {
     return true;
   }
-  if (result.origin === "dispatch") {
+  if (result.origin === "dispatch" || result.backgroundTask !== undefined) {
     return true;
   }
   return findRunningAgentHandle(state, { callId: result.callId }) !== undefined;

--- a/packages/eve/src/harness/handles/store.test.ts
+++ b/packages/eve/src/harness/handles/store.test.ts
@@ -43,6 +43,12 @@ const parkedHandle: AgentHandle = {
   phase: "parked",
 };
 
+const addressedHandle: AgentHandle = {
+  address,
+  identity,
+  phase: "addressed",
+};
+
 describe("deriveAgentOperationId / deriveAgentId", () => {
   it("is deterministic on parent-controlled inputs and independent of the child session", () => {
     const again = deriveAgentOperationId({
@@ -105,8 +111,8 @@ describe("getAgentHandleStore", () => {
 
 describe("assertPersistableAgentHandleStore", () => {
   it("returns a valid store unchanged in shape", () => {
-    expect(assertPersistableAgentHandleStore({ handles: [parkedHandle] })).toEqual({
-      handles: [parkedHandle],
+    expect(assertPersistableAgentHandleStore({ handles: [addressedHandle] })).toEqual({
+      handles: [addressedHandle],
     });
   });
 

--- a/packages/eve/src/harness/handles/store.ts
+++ b/packages/eve/src/harness/handles/store.ts
@@ -97,7 +97,7 @@ export type AgentAddress =
 /**
  * Durable ownership record for one delegated child.
  *
- * The store owns the full nonterminal lifecycle:
+ * Outside tasks mode, the store owns the full nonterminal lifecycle:
  *
  * - `starting` — the parent committed intent to start; the child may or
  *   may not exist yet.
@@ -105,7 +105,9 @@ export type AgentAddress =
  * - `parked` — the child is idle and resumable; only this phase is
  *   model-visible.
  *
- * A terminal child has no handle: settlement deletes it.
+ * A terminal child has no legacy handle: settlement deletes it. Tasks mode
+ * instead keeps an `addressed` record whose availability is derived from the
+ * tasks bound to its persistent child session.
  */
 export type AgentHandle =
   | {
@@ -125,6 +127,12 @@ export type AgentHandle =
       readonly identity: AgentIdentity;
       readonly address: AgentAddress;
       readonly lastStatus: string;
+    }
+  | {
+      /** Persistent task-mode identity and routing, with no execution claim. */
+      readonly phase: "addressed";
+      readonly identity: AgentIdentity;
+      readonly address: AgentAddress;
     };
 
 /** Lifecycle phase of a delegated agent handle. */
@@ -206,6 +214,11 @@ const agentHandleSchema: z.ZodType<AgentHandle> = z.discriminatedUnion("phase", 
     identity: identitySchema,
     lastStatus: z.string().max(MAX_STATUS_LENGTH),
     phase: z.literal("parked"),
+  }),
+  z.strictObject({
+    address: addressSchema,
+    identity: identitySchema,
+    phase: z.literal("addressed"),
   }),
 ]);
 

--- a/packages/eve/src/harness/handles/transitions.test.ts
+++ b/packages/eve/src/harness/handles/transitions.test.ts
@@ -13,9 +13,11 @@ import {
 import {
   abandonRunningAgentTurns,
   confirmAgentStarted,
+  confirmTaskAgentAddress,
   prepareAgentContinuation,
   prepareAgentStart,
   rejectAgentEffect,
+  removeTaskAgentAddress,
   settleAgentTurn,
 } from "#harness/handles/transitions.js";
 import type { HarnessSession } from "#harness/types.js";
@@ -140,6 +142,26 @@ describe("confirmAgentStarted", () => {
     expect(() =>
       confirmAgentStarted(createSession(), { address, operationId: "op_unprepared" }),
     ).toThrow("op_unprepared");
+  });
+});
+
+describe("task agent addresses", () => {
+  it("confirms a persistent address without an execution phase", () => {
+    const addressed = confirmTaskAgentAddress(preparedSession(), {
+      address,
+      operationId: startOperation.id,
+    });
+
+    expect(handlesOf(addressed)).toEqual([{ address, identity, phase: "addressed" }]);
+  });
+
+  it("removes only the addressed task agent", () => {
+    const addressed = confirmTaskAgentAddress(preparedSession(), {
+      address,
+      operationId: startOperation.id,
+    });
+
+    expect(handlesOf(removeTaskAgentAddress(addressed, identity.id))).toEqual([]);
   });
 });
 

--- a/packages/eve/src/harness/handles/transitions.ts
+++ b/packages/eve/src/harness/handles/transitions.ts
@@ -124,7 +124,8 @@ function findActiveHandle(
 ): ActiveAgentHandle | undefined {
   return handles.find(
     (handle): handle is ActiveAgentHandle =>
-      handle.phase !== "parked" && handle.operation.id === operationId,
+      (handle.phase === "starting" || handle.phase === "running") &&
+      handle.operation.id === operationId,
   );
 }
 
@@ -163,6 +164,48 @@ export function confirmAgentStarted(
           }
         : handle,
     ),
+  );
+}
+
+/** Confirms a task-mode child as a persistent identity/address record. */
+export function confirmTaskAgentAddress(
+  session: HarnessSession,
+  input: {
+    readonly operationId: string;
+    readonly address: AgentAddress;
+  },
+): HarnessSession {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existing = findActiveHandle(handles, input.operationId);
+  if (existing === undefined) {
+    throw new Error(`No prepared agent handle for operation "${input.operationId}".`);
+  }
+  if (existing.phase === "running") {
+    throw new Error(
+      `Task agent operation "${input.operationId}" was confirmed as a running handle.`,
+    );
+  }
+
+  return writeHandles(
+    session,
+    handles.map((handle) =>
+      handle === existing
+        ? {
+            address: input.address,
+            identity: existing.identity,
+            phase: "addressed" as const,
+          }
+        : handle,
+    ),
+  );
+}
+
+/** Removes a task-mode address after permanent delivery failure. */
+export function removeTaskAgentAddress(session: HarnessSession, agentId: string): HarnessSession {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  return writeHandles(
+    session,
+    handles.filter((handle) => !(handle.phase === "addressed" && handle.identity.id === agentId)),
   );
 }
 

--- a/packages/eve/src/harness/proxy-input-requests.ts
+++ b/packages/eve/src/harness/proxy-input-requests.ts
@@ -155,8 +155,8 @@ export function toProxyInputRequestEntries(
 ): readonly (readonly [requestId: string, route: ProxyInputRequest])[] {
   return payload.event.requests.map((request) => {
     const route: {
-      childContinuationToken: string;
-      kind: InputRequestKind;
+      readonly childContinuationToken: string;
+      readonly kind: InputRequestKind;
       taskId?: string;
     } = {
       childContinuationToken: payload.childContinuationToken,
@@ -216,7 +216,11 @@ function parseProxyInputRequest(value: unknown): ProxyInputRequest | undefined {
   if (taskId !== undefined && (typeof taskId !== "string" || taskId.length === 0)) {
     return undefined;
   }
-  const request: { childContinuationToken: string; kind: InputRequestKind; taskId?: string } = {
+  const request: {
+    readonly childContinuationToken: string;
+    readonly kind: InputRequestKind;
+    taskId?: string;
+  } = {
     childContinuationToken: value.childContinuationToken,
     kind: value.kind,
   };

--- a/packages/eve/src/harness/runtime-actions.test.ts
+++ b/packages/eve/src/harness/runtime-actions.test.ts
@@ -14,6 +14,7 @@ import { deriveAgentOperationId } from "#harness/handles/operation-id.js";
 import { deriveAgentId, getAgentHandleStore } from "#harness/handles/store.js";
 import {
   confirmAgentStarted,
+  confirmTaskAgentAddress,
   prepareAgentContinuation,
   prepareAgentStart,
 } from "#harness/handles/transitions.js";
@@ -103,16 +104,41 @@ function createSessionWithRunningChild(): HarnessSession {
   });
 }
 
+function createSessionWithTaskAddress(): HarnessSession {
+  const prepared = prepareAgentStart(createParkedSession(), {
+    identity: {
+      id: deriveAgentId("researcher", OPERATION_ID),
+      name: "researcher",
+      nodeId: "subagents/researcher",
+    },
+    operation: {
+      callId: "call-1",
+      id: OPERATION_ID,
+      kind: "start",
+      parentTurnId: "turn_0",
+    },
+    target: { continuationToken: CHILD_CONTINUATION_TOKEN, kind: "agent/local" },
+  });
+  return confirmTaskAgentAddress(prepared, {
+    address: {
+      continuationToken: CHILD_CONTINUATION_TOKEN,
+      kind: "agent/local",
+      sessionId: CHILD_SESSION_ID,
+    },
+    operationId: OPERATION_ID,
+  });
+}
+
 describe("resolvePendingRuntimeActions", () => {
   it("marks a working task receipt as backgrounded on subagent.completed", async () => {
     const events: UnstampedMessageStreamEvent[] = [];
     const taskId = "task_0123456789abcdef";
 
-    await resolvePendingRuntimeActions({
+    const resolved = await resolvePendingRuntimeActions({
       emit: async (event) => {
         events.push(event);
       },
-      session: createSessionWithRunningChild(),
+      session: createSessionWithTaskAddress(),
       stepInput: {
         runtimeActionResults: [
           {
@@ -125,7 +151,11 @@ describe("resolvePendingRuntimeActions", () => {
               result: { kind: "succeeded", output: "delegated" },
               usageDelta: ZERO_USAGE,
             },
-            output: { status: "working", taskId },
+            output: {
+              agentId: deriveAgentId("researcher", OPERATION_ID),
+              status: "working",
+              taskId,
+            },
             subagentName: "researcher",
           },
         ],
@@ -135,6 +165,9 @@ describe("resolvePendingRuntimeActions", () => {
     expect(events.find((event) => event.type === "subagent.completed")).toMatchObject({
       data: { backgroundTask: { status: "working", taskId } },
     });
+    expect(getAgentHandleStore(resolved.session.state)?.handles).toEqual([
+      expect.objectContaining({ phase: "addressed" }),
+    ]);
   });
 
   it("settles the running handle terminally and deletes it with the batch", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -760,12 +760,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = continuation.session;
 
     if (config.persistentSubagentSessions === true) {
-      const announcement = resolveAgentsAnnouncement({
-        messages,
-        store: getAgentHandleStore(session.state),
-      });
-      if (announcement !== undefined) {
-        messages.push({ content: announcement, role: "assistant" });
+      const store = getAgentHandleStore(session.state);
+      if (store?.handles.some((handle) => handle.phase === "addressed") !== true) {
+        const announcement = resolveAgentsAnnouncement({ messages, store });
+        if (announcement !== undefined) {
+          messages.push({ content: announcement, role: "assistant" });
+        }
       }
     }
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -521,9 +521,11 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           if (agent === undefined) {
             throw new Error("Missing route agent.");
           }
-          const cancelInput: { sessionId: string; taskId?: string; turnId?: string } = {
-            sessionId,
-          };
+          const cancelInput: {
+            readonly sessionId: string;
+            taskId?: string;
+            turnId?: string;
+          } = { sessionId };
           if (body.taskId !== undefined) cancelInput.taskId = body.taskId;
           if (body.turnId !== undefined) cancelInput.turnId = body.turnId;
           result = await agent.cancelTurn(cancelInput);
@@ -776,7 +778,7 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     );
   }
 
-  const body: ParsedCreateBody = {
+  const result: ParsedCreateBody = {
     callback,
     capabilities,
     message,
@@ -784,8 +786,8 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     context,
     outputSchema,
   };
-  if (typeof rawOperationId === "string") body.operationId = rawOperationId;
-  return body;
+  if (typeof rawOperationId === "string") result.operationId = rawOperationId;
+  return result;
 }
 
 interface ParsedContinueBody {
@@ -916,10 +918,10 @@ async function parseCancelTurnBody(req: Request): Promise<ParsedCancelTurnBody |
       { status: 400 },
     );
   }
-  const body: ParsedCancelTurnBody = {};
-  if (typeof taskId === "string") body.taskId = taskId;
-  if (typeof turnId === "string") body.turnId = turnId;
-  return body;
+  const result: ParsedCancelTurnBody = {};
+  if (typeof taskId === "string") result.taskId = taskId;
+  if (typeof turnId === "string") result.turnId = turnId;
+  return result;
 }
 
 function createSendPayload(

--- a/packages/eve/src/runtime/agent/bootstrap.test.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.test.ts
@@ -44,6 +44,22 @@ describe("createResolvedRuntimeTurnAgent agent-messaging gating", () => {
     expect(turnAgent.instructions).not.toContainEqual(expect.stringContaining("Pass `agentId`"));
   });
 
+  it("explains task-derived busy agents when tasks imply persistent sessions", () => {
+    const turnAgent = createResolvedRuntimeTurnAgent({
+      agent: createResolvedAgentForTest({
+        config: {
+          experimental: { tasks: true },
+          name: "test-agent",
+        } as ResolvedAgent["config"],
+      }),
+      nodeId: ROOT_RUNTIME_AGENT_NODE_ID,
+      tools: [],
+    });
+
+    expect(turnAgent.instructions).toContainEqual(expect.stringContaining("availability=busy"));
+    expect(turnAgent.instructions).toContainEqual(expect.stringContaining("taskId"));
+  });
+
   it("omits the messaging instruction when an authored tool named agent shadows the framework tool", () => {
     const turnAgent = createResolvedRuntimeTurnAgent({
       agent: createResolvedAgentForTest({

--- a/packages/eve/src/runtime/agent/bootstrap.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.ts
@@ -87,8 +87,11 @@ export function createResolvedRuntimeTurnAgent(input: {
     instructions: composeRuntimeBasePrompt({
       connections: agent.connections,
       instructions: agent.instructions,
-      persistentSubagentSessions: agent.config.experimental?.subagentPersistentSessions === true,
+      persistentSubagentSessions:
+        agent.config.experimental?.tasks === true ||
+        agent.config.experimental?.subagentPersistentSessions === true,
       subagentsAvailable: subagentDeclaredTool || subagentImplicitRootTool,
+      tasksEnabled: agent.config.experimental?.tasks === true,
       toolsAvailable: input.tools.length > 0 || subagentImplicitRootTool,
       workspaceSpec: agent.workspaceSpec,
     }),

--- a/packages/eve/src/runtime/framework-tools/tasks.ts
+++ b/packages/eve/src/runtime/framework-tools/tasks.ts
@@ -67,11 +67,10 @@ const TASK_VIEW_SCHEMA = z.object({
     })
     .optional(),
   metadata: z.object({
-    childSessionId: z.string(),
+    agentId: z.string(),
     kind: z.literal("subagent"),
     mode: z.enum(["local", "remote"]),
     name: z.string(),
-    url: z.string().optional(),
   }),
   status: z.enum(["working", "input_required", "completed", "failed", "cancelled"]),
   statusMessage: z.string().optional(),

--- a/packages/eve/src/runtime/prompt/compose.ts
+++ b/packages/eve/src/runtime/prompt/compose.ts
@@ -14,6 +14,9 @@ const PARALLEL_ACTION_INSTRUCTION =
 const AGENT_MESSAGING_INSTRUCTION =
   "Agent messaging\nAgents you have already delegated to stay available after they answer. The system-message `<agents>` list is only a record of those existing agents — their `agentId`, name, and latest status. It does not limit which subagent tools you can call: your tool list is the source of truth, and any subagent tool can always be called without `agentId` to start a new agent, including when the `<agents>` list is empty or absent. Pass `agentId` to the same subagent tool only to continue one of those existing agents' sessions.";
 
+const TASK_AGENT_MESSAGING_INSTRUCTION =
+  "Agent messaging\nAgents you have already delegated to remain visible in the system-message `<agents>` list. `availability=busy` means the listed task still owns that agent session: use task_peek, task_send, or task_cancel with its taskId instead of starting a continuation. `availability=available` means no nonterminal task owns the session, so you may pass agentId to the same subagent tool to continue it. Calling a subagent without agentId always starts a new agent session.";
+
 /**
  * Input for composing the base authored instructions prompt for one
  * resolved agent.
@@ -27,6 +30,7 @@ interface ComposeRuntimeBasePromptInput {
    * continuation and the `<agents>` listing.
    */
   persistentSubagentSessions?: boolean;
+  tasksEnabled?: boolean;
   skills?: readonly ResolvedSkillDefinition[];
   subagentsAvailable?: boolean;
   toolsAvailable?: boolean;
@@ -43,7 +47,7 @@ export function composeRuntimeBasePrompt(input: ComposeRuntimeBasePromptInput): 
     ...createWorkspacePromptBlocks(input.workspaceSpec),
     ...(input.toolsAvailable ? [PARALLEL_ACTION_INSTRUCTION] : []),
     ...(input.subagentsAvailable && input.persistentSubagentSessions
-      ? [AGENT_MESSAGING_INSTRUCTION]
+      ? [input.tasksEnabled ? TASK_AGENT_MESSAGING_INSTRUCTION : AGENT_MESSAGING_INSTRUCTION]
       : []),
     ...createConnectionsPromptBlocks(input.connections),
     ...createSkillsPromptBlocks(input.skills),

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -215,7 +215,9 @@ async function resolveRuntimeAgentNode(
     workspaceResourceRoot: agent.workspaceResourceRoot,
   });
   const subagentRegistry = createRuntimeSubagentRegistry({
-    persistentSessions: agent.config.experimental?.subagentPersistentSessions === true,
+    persistentSessions:
+      agent.config.experimental?.tasks === true ||
+      agent.config.experimental?.subagentPersistentSessions === true,
     reservedToolNames: [
       LOAD_SKILL_TOOL_NAME,
       ...toolRegistry.preparedTools.map((tool) => tool.name),

--- a/packages/eve/src/tasks/json.ts
+++ b/packages/eve/src/tasks/json.ts
@@ -9,16 +9,11 @@ import type { TaskView } from "#tasks/types.js";
  */
 export function taskViewToJson(view: TaskView): JsonObject {
   const metadata: Record<string, JsonValue> = {
+    agentId: view.metadata.agentId,
     kind: view.metadata.kind,
     mode: view.metadata.mode,
     name: view.metadata.name,
   };
-  if (view.metadata.childSessionId !== undefined) {
-    metadata.childSessionId = view.metadata.childSessionId;
-  }
-  if (view.metadata.url !== undefined) {
-    metadata.url = view.metadata.url;
-  }
 
   const json: Record<string, JsonValue> = {
     metadata,

--- a/packages/eve/src/tasks/session-index.test.ts
+++ b/packages/eve/src/tasks/session-index.test.ts
@@ -8,20 +8,6 @@ import {
   recordSessionTask,
 } from "#tasks/session-index.js";
 import { deriveTaskId } from "#tasks/task-id.js";
-import type { SessionTaskIndexEntry } from "#tasks/session-index.js";
-
-function taskEntry(overrides: Partial<SessionTaskIndexEntry> = {}): SessionTaskIndexEntry {
-  return {
-    childSessionId: "child-1",
-    commandToken: "task:token-1",
-    createdByTurnId: "turn-1",
-    operationId: "operation-1",
-    taskId: "task_a",
-    taskRunId: "run-1",
-    ...overrides,
-  };
-}
-
 function createSession(state?: HarnessSession["state"]): HarnessSession {
   return {
     agent: {
@@ -38,18 +24,31 @@ function createSession(state?: HarnessSession["state"]): HarnessSession {
 }
 
 describe("session task index", () => {
+  const metadata = {
+    agentId: "ag_research:abcdef123456",
+    kind: "subagent" as const,
+    mode: "local" as const,
+    name: "research",
+  };
   it("returns an empty index when the key is absent", () => {
     expect(getSessionTaskIndex({})).toEqual([]);
     expect(getSessionTaskIndex(undefined)).toEqual([]);
   });
 
   it("records a task and finds it by id", () => {
-    const session = recordSessionTask(createSession(), taskEntry());
-
-    expect(findSessionTaskEntry(session.state, "task_a")).toEqual({
-      childSessionId: "child-1",
+    const session = recordSessionTask(createSession(), {
       commandToken: "task:token-1",
       createdByTurnId: "turn-1",
+      metadata,
+      operationId: "operation-1",
+      taskId: "task_a",
+      taskRunId: "run-1",
+    });
+
+    expect(findSessionTaskEntry(session.state, "task_a")).toEqual({
+      commandToken: "task:token-1",
+      createdByTurnId: "turn-1",
+      metadata,
       operationId: "operation-1",
       taskId: "task_a",
       taskRunId: "run-1",
@@ -58,14 +57,22 @@ describe("session task index", () => {
   });
 
   it("replaces the entry on replayed creation instead of duplicating it", () => {
-    let session = recordSessionTask(createSession(), taskEntry());
-    session = recordSessionTask(
-      session,
-      taskEntry({
-        commandToken: "task:token-2",
-        taskRunId: "run-2",
-      }),
-    );
+    let session = recordSessionTask(createSession(), {
+      commandToken: "task:token-1",
+      createdByTurnId: "turn-1",
+      metadata,
+      operationId: "operation-1",
+      taskId: "task_a",
+      taskRunId: "run-1",
+    });
+    session = recordSessionTask(session, {
+      commandToken: "task:token-2",
+      createdByTurnId: "turn-1",
+      metadata,
+      operationId: "operation-1",
+      taskId: "task_a",
+      taskRunId: "run-2",
+    });
 
     const entries = getSessionTaskIndex(session.state);
     expect(entries).toHaveLength(1);

--- a/packages/eve/src/tasks/session-index.ts
+++ b/packages/eve/src/tasks/session-index.ts
@@ -1,6 +1,7 @@
 import { z } from "#compiled/zod/index.js";
 
 import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+import type { TaskMetadata } from "#tasks/types.js";
 
 /**
  * Session-state key for the parent's live-task index.
@@ -14,7 +15,8 @@ import type { HarnessSession, SessionStateMap } from "#harness/types.js";
 export const SESSION_TASKS_STATE_KEY = "eve.tasks";
 
 /**
- * One task owned by this session.
+ * One task owned by this session. Immutable model-safe metadata keeps the
+ * task-to-agent join available before the task run publishes its first view.
  *
  * `commandToken` is the private routing credential for the task run's
  * command hook. It must never render into model context, history, task
@@ -22,20 +24,30 @@ export const SESSION_TASKS_STATE_KEY = "eve.tasks";
  * `taskId` only, and lookup verifies ownership through this index.
  */
 export interface SessionTaskIndexEntry {
-  readonly childSessionId: string;
   readonly taskId: string;
   readonly taskRunId: string;
   readonly commandToken: string;
-  readonly createdByTurnId: string;
   readonly createdByStepIndex?: number;
+  readonly createdByTurnId: string;
+  readonly metadata: TaskMetadata;
   readonly operationId: string;
 }
 
+const taskMetadataSchema: z.ZodType<TaskMetadata> = z.strictObject({
+  agentId: z.string().min(1),
+  childSessionId: z.string().min(1).optional(),
+  childTurnId: z.string().min(1).optional(),
+  childLifecycle: z.enum(["parked", "terminal"]).optional(),
+  kind: z.literal("subagent"),
+  mode: z.enum(["local", "remote"]),
+  name: z.string().min(1),
+});
+
 const sessionTaskIndexEntrySchema: z.ZodType<SessionTaskIndexEntry> = z.strictObject({
-  childSessionId: z.string().min(1),
   commandToken: z.string().min(1),
-  createdByTurnId: z.string().min(1),
   createdByStepIndex: z.number().int().nonnegative().optional(),
+  createdByTurnId: z.string().min(1),
+  metadata: taskMetadataSchema,
   operationId: z.string().min(1),
   taskId: z.string().min(1),
   taskRunId: z.string().min(1),

--- a/packages/eve/src/tasks/transitions.test.ts
+++ b/packages/eve/src/tasks/transitions.test.ts
@@ -6,7 +6,7 @@ import type { TaskCommand, TaskStatus, TaskView } from "#tasks/types.js";
 function createView(status: TaskStatus, overrides: Partial<TaskView> = {}): TaskView {
   return {
     metadata: {
-      childSessionId: "child-session-1",
+      agentId: "ag_research:abcdef123456",
       kind: "subagent",
       mode: "local",
       name: "research",
@@ -23,8 +23,8 @@ const ALL_COMMANDS: readonly TaskCommand[] = [
   { data: { message: "boom" }, kind: "fail" },
   { kind: "cancel" },
   { inputRequests: [{ question: "which?" }], kind: "require-input" },
+  { kind: "ready" },
   { kind: "answered", requestIds: ["req-1"] },
-  { childSessionId: "child-session-2", kind: "describe" },
 ];
 
 describe("applyTaskTransition", () => {
@@ -190,37 +190,6 @@ describe("applyTaskTransition", () => {
     }
   });
 
-  it("attaches the child session through describe without changing status", () => {
-    const described = applyTaskTransition(
-      createView("working", {
-        metadata: { kind: "subagent", mode: "local", name: "research" },
-      }),
-      { childSessionId: "child-session-9", kind: "describe" },
-    );
-
-    expect(described.outcome).toBe("accepted");
-    expect(described.view.status).toBe("working");
-    expect(described.view.metadata.childSessionId).toBe("child-session-9");
-
-    const again = applyTaskTransition(described.view, {
-      childSessionId: "child-session-9",
-      kind: "describe",
-    });
-    expect(again.outcome).toBe("noop");
-  });
-
-  it("never rebinds a task turn to a different child session", () => {
-    const result = applyTaskTransition(createView("working"), {
-      childSessionId: "other-child",
-      childTurnId: "turn_9",
-      kind: "start-turn",
-      taskId: "task_abc123",
-    });
-
-    expect(result.outcome).toBe("rejected");
-    expect(result.view.metadata.childSessionId).toBe("child-session-1");
-  });
-
   it("is deterministic for replayed commands", () => {
     const view = createView("working");
     const command: TaskCommand = { data: { answer: 1 }, kind: "complete" };
@@ -229,5 +198,28 @@ describe("applyTaskTransition", () => {
     const second = applyTaskTransition(view, command);
 
     expect(first).toEqual(second);
+  });
+
+  it("never rebinds a task turn to a different child session", () => {
+    const result = applyTaskTransition(
+      createView("working", {
+        metadata: {
+          agentId: "ag_research:abcdef123456",
+          childSessionId: "child-session-1",
+          kind: "subagent",
+          mode: "local",
+          name: "research",
+        },
+      }),
+      {
+        childSessionId: "other-child",
+        childTurnId: "turn_9",
+        kind: "start-turn",
+        taskId: "task_abc123",
+      },
+    );
+
+    expect(result.outcome).toBe("rejected");
+    expect(result.view.metadata.childSessionId).toBe("child-session-1");
   });
 });

--- a/packages/eve/src/tasks/transitions.ts
+++ b/packages/eve/src/tasks/transitions.ts
@@ -98,6 +98,10 @@ export function applyTaskTransition(view: TaskView, command: TaskCommand): TaskT
           taskId: view.taskId,
         },
       };
+    case "ready":
+      // The readiness command is also the barrier that releases a fast,
+      // pre-acknowledgement HITL batch, so the workflow must observe it.
+      return { outcome: "accepted", view };
     case "answered": {
       if (view.status !== "input_required") {
         return { outcome: "noop", view };
@@ -136,30 +140,6 @@ export function applyTaskTransition(view: TaskView, command: TaskCommand): TaskT
           status: "working",
           statusMessage: view.statusMessage,
           taskId: view.taskId,
-        },
-      };
-    }
-    case "describe": {
-      if (
-        view.metadata.childTurnId !== undefined &&
-        view.metadata.childSessionId !== undefined &&
-        view.metadata.childSessionId !== command.childSessionId
-      ) {
-        return {
-          outcome: "rejected",
-          reason: `Task child session "${command.childSessionId}" does not match the active turn owner.`,
-          view,
-        };
-      }
-      if (view.metadata.childSessionId === command.childSessionId) {
-        return { outcome: "noop", view };
-      }
-
-      return {
-        outcome: "accepted",
-        view: {
-          ...view,
-          metadata: { ...view.metadata, childSessionId: command.childSessionId },
         },
       };
     }

--- a/packages/eve/src/tasks/types.ts
+++ b/packages/eve/src/tasks/types.ts
@@ -23,25 +23,23 @@ export type TaskStatus = "working" | "input_required" | "completed" | "failed" |
 /**
  * Immutable identity of the delegated work behind a task.
  *
- * `childSessionId` is optional because the task run is created before
- * the child acknowledges its session — the durable record must exist
- * before the dispatch side effect so a fast child always has a live
- * command hook to answer. The `describe` command attaches the id at
- * acknowledgement.
+ * `agentId` is parent-controlled and exists before the child acknowledges its
+ * private address, so the durable task can bind to persistent identity before
+ * the dispatch side effect runs.
  */
 export interface TaskMetadata {
+  /** Stable model-visible identity of the persistent child session. */
+  readonly agentId: string;
+  /** Child session paired with {@link childTurnId}; private and never projected to the model. */
+  readonly childSessionId?: string;
+  /** Exact child turn executing this task; retained privately for guarded cancellation. */
+  readonly childTurnId?: string;
+  /** Child engine verdict retained for lifecycle reconciliation. */
+  readonly childLifecycle?: "parked" | "terminal";
   readonly kind: "subagent";
   readonly mode: "local" | "remote";
   /** Authored subagent name the parent dispatched. */
   readonly name: string;
-  /** Child session acknowledged at dispatch. */
-  readonly childSessionId?: string;
-  /** Exact child turn executing this task; retained privately for guarded cancellation. */
-  readonly childTurnId?: string;
-  /** Child engine verdict used to reconcile the persistent agent handle. */
-  readonly childLifecycle?: "parked" | "terminal";
-  /** Remote children only: the child agent's base URL. */
-  readonly url?: string;
 }
 
 /**
@@ -115,13 +113,13 @@ export type TaskCommand =
   | { readonly kind: "fail"; readonly data: JsonValue; readonly lifecycle?: "parked" | "terminal" }
   | { readonly kind: "cancel"; readonly lifecycle?: "parked" | "terminal" }
   | { readonly kind: "require-input"; readonly inputRequests: readonly TaskInputRequest[] }
+  | { readonly kind: "ready" }
   /**
    * Clears the listed requests from the outstanding batch. Bound to
    * ids rather than unbound like the former `resume`, so an answer can
    * only ever release the batch it was written against.
    */
   | { readonly kind: "answered"; readonly requestIds: readonly string[] }
-  | { readonly kind: "describe"; readonly childSessionId: string }
   | {
       readonly kind: "start-turn";
       readonly childSessionId: string;

--- a/research/subagents-as-tasks-implementation.md
+++ b/research/subagents-as-tasks-implementation.md
@@ -93,7 +93,7 @@ New `packages/eve/src/tasks/` module cluster:
   appends a full `TaskView` snapshot per accepted command. Competing completion, cancellation,
   and input-response commands serialize here.
 - The **session task index**: one new namespaced session-state key holding
-  `{ taskId, taskRunId }` entries. Adding a key to `SessionStateMap` needs no session-version
+  `{ taskId, taskRunId, metadata }` entries. Adding a key to `SessionStateMap` needs no session-version
   migration.
 
 Verification: exhaustive unit tests on transitions (late completion after `cancelled`,
@@ -172,14 +172,16 @@ deliberately; they get their own plans if anything nontrivial surfaces.
 
 ## Settled decisions
 
-1. **Wake policy.** Terminal and `input_required` transitions wake a parked parent through the
+1. **Lifecycle ownership.** In tasks mode, the task run is the sole execution-lifecycle writer.
+   Agent records retain stable identity and private address only. Availability is derived from
+   nonterminal tasks, with at most one such task per child session; busy agents remain visible in
+   `<agents>` with their active task id and status.
+2. **Wake policy.** Terminal and `input_required` transitions wake a parked parent through the
    session delivery path; they are the only wake triggers. Progress never wakes on its own.
-2. **`task_send` to a busy child.** A send to a `working` task surfaces `AGENT_BUSY` as a tool
+3. **`task_send` to a busy child.** A send to a `working` task surfaces `AGENT_BUSY` as a tool
    error, matching handle-continuation semantics. Queuing on the task run is deferred; it is
    the reversible follow-up if busy errors prove noisy in practice.
-3. **One task per child session.** A child session owns at most one nonterminal task. Admission
-   rejects a second task in the same batch or a later turn; cancellation carries the recorded
-   child turn id, and queued task sends are unsupported.
+   The same agent is reserved for the whole dispatch batch even if its first task settles quickly.
 4. **Failure taxonomy.** Child failure maps to the `failed` status, and as a consequence of
    that transition the task's output carries the error (`TaskOutput.error`). Failure is the
    state; the error output is its consequence. This intentionally diverges from MCP, which

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -11,7 +11,7 @@ last_updated: "2026-08-01"
 Under an opt-in `experimental.tasks` mode, eve should represent long-running work as durable,
 addressable tasks. This plan applies that model only to local and remote subagents. A subagent call
 returns a task receipt after dispatch instead of keeping the parent turn blocked until the child
-finishes. The parent can inspect, await, message, or cancel the task with framework-owned tools,
+finishes. The parent can inspect, message, or cancel the task with framework-owned tools,
 and the child can intentionally report progress to its parent with one framework-owned tool.
 
 Without the flag, current tool and subagent behavior must remain unchanged.
@@ -91,6 +91,11 @@ model step in the same turn.
 
 A **background task** is owned by the parent session, not the originating turn. It may complete,
 request input, or emit progress after that turn ends.
+
+An **agent address** is the persistent identity and private routing record for one child session.
+Tasks own execution lifecycle and availability; agent addresses do not duplicate `working` or
+`input_required`. At most one nonterminal task may target one child session. The model-visible
+`<agents>` projection keeps an occupied agent visible as busy and names its active task.
 
 **Delegated execution** is a runtime execution mode, not a tool-authoring surface. A delegated
 dispatch returns once the executor acknowledges the work; the task stays `working`, and every
@@ -173,11 +178,10 @@ interface TaskView {
 }
 
 interface TaskMetadata {
+  readonly agentId: string;
   readonly kind: "subagent";
   readonly mode: "local" | "remote";
   readonly name: string;
-  readonly childSessionId: string;
-  readonly url: string;
 }
 
 type TaskOutput =
@@ -200,6 +204,7 @@ gets one receipt:
 
 ```json
 {
+  "agentId": "ag_research:...",
   "taskId": "task_01K...",
   "status": "working"
 }
@@ -219,6 +224,7 @@ The parent session stores only a live-task index:
 
 ```ts
 interface SessionTaskIndexEntry {
+  readonly metadata: TaskMetadata;
   readonly taskId: string;
   readonly taskRunId: string;
 }
@@ -258,7 +264,7 @@ replaces the park-and-wait mechanism in the same dispatch codepath:
 
 1. The harness creates a durable `working` task for the subagent call.
 2. It dispatches the child with the task binding.
-3. The child acknowledges its `childSessionId`, which is persisted immediately.
+3. The child acknowledges its private address, which is persisted on the agent record immediately.
 4. The originating call receives its receipt and the turn continues.
 
 Everything after acknowledgement — progress, input requests, authorization, terminal outcome —
@@ -417,15 +423,16 @@ than MCP compatibility.
 - Replay returns the same task ID for the same originating call and never dispatches the child
   twice.
 - Completing the parent session cancels its live tasks.
-- Resuming an existing child session creates a new task with a new task ID and the same
-  `childSessionId`.
+- Resuming an existing child session creates a new task with a new task ID and the same `agentId`.
 
 ## Open questions
 
-1. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
-2. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
-3. Which task events enter model context, and how are repeated progress messages coalesced?
-4. How are child token usage and remaining parent budgets accounted after a background child
+1. Should `TaskView` include a monotonic revision for notification deduplication, or can the task
+   run's stream index remain internal?
+2. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
+3. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
+4. Which task events enter model context, and how are repeated progress messages coalesced?
+5. How are child token usage and remaining parent budgets accounted after a background child
    completes on a later turn?
 
 Two former open questions are settled and recorded in the [delivery plan]: failure taxonomy


### PR DESCRIPTION
Adds a stable `agentId` as the join key between agent handles and tasks.

The problem it solves: handles and tasks each held a partial view of "which agent is this and can I talk to it". Reusing an agent after its task finished resolved through a stale handle, and availability questions had no single authority.

- before: handle phase approximated availability; continuation admission keyed by session
- after: handles are the address book, tasks are the availability authority; `handle.identity.id = task.metadata.agentId` joins them, and continuation admission re-keys by `agentId` so a reused agent resolves to its live task

Adds the `addressed` handle phase for a handle that has an address but no live task.

Stacked on the lifecycle PR; the eval suite directly above proves the semantics of the whole chain.