### PR TITLE
fix(eve): retain background child usage on terminal task snapshots

### DIFF
--- a/.changeset/task-usage-retention.md
+++ b/.changeset/task-usage-retention.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Background task terminal snapshots now retain the child's reported token usage instead of dropping it at the task wire. Accounting is unchanged: background children get a best-effort budget capped at dispatch time, and aggregate spend across sequential dispatches is not yet reserved against the parent's session limits.

--- a/packages/eve/src/tasks/json.ts
+++ b/packages/eve/src/tasks/json.ts
@@ -29,6 +29,8 @@ export function taskViewToJson(view: TaskView): JsonObject {
   if (view.inputRequests !== undefined) {
     json.inputRequests = [...view.inputRequests];
   }
+  // `view.usage` is deliberately not disclosed: it is internal retention
+  // for future budget accounting, not part of the model-visible contract.
   return json;
 }
 

--- a/packages/eve/src/tasks/transitions.test.ts
+++ b/packages/eve/src/tasks/transitions.test.ts
@@ -39,6 +39,31 @@ describe("applyTaskTransition", () => {
     expect(result.view.lastOutput).toEqual({ data: { answer: 42 }, type: "result" });
   });
 
+  it("retains reported child usage on the terminal snapshot only", () => {
+    const usage = { cacheReadTokens: 1, cacheWriteTokens: 2, inputTokens: 300, outputTokens: 40 };
+    for (const command of [
+      { data: "done", kind: "complete", usage },
+      { data: "boom", kind: "fail", usage },
+      { kind: "cancel", usage },
+    ] as const) {
+      const result = applyTaskTransition(createView("working"), command);
+      expect(result.outcome).toBe("accepted");
+      expect(result.view.usage).toEqual(usage);
+    }
+
+    const withoutUsage = applyTaskTransition(createView("working"), {
+      data: "done",
+      kind: "complete",
+    });
+    expect(withoutUsage.view.usage).toBeUndefined();
+
+    const blocked = applyTaskTransition(createView("working"), {
+      inputRequests: [{ question: "which?", requestId: "req-1" }],
+      kind: "require-input",
+    });
+    expect(blocked.view.usage).toBeUndefined();
+  });
+
   it("fails a working task and carries the error as its output", () => {
     const result = applyTaskTransition(createView("working"), {
       data: { message: "boom" },

--- a/packages/eve/src/tasks/transitions.ts
+++ b/packages/eve/src/tasks/transitions.ts
@@ -1,4 +1,4 @@
-import type { TaskCommand, TaskView } from "#tasks/types.js";
+import type { TaskCommand, TaskOutput, TaskStatus, TaskUsage, TaskView } from "#tasks/types.js";
 import { isTerminalTaskStatus, readTaskInputRequestId } from "#tasks/types.js";
 
 /**
@@ -32,6 +32,37 @@ export type TaskTransitionResult =
  * what serializes competing completion, cancellation, and input
  * transitions.
  */
+/**
+ * Builds the settled snapshot for one terminal command, carrying the
+ * child's lifecycle verdict and reported usage when present. Usage is
+ * retention-only: nothing folds it into parent budgets yet.
+ */
+function terminalView(
+  view: TaskView,
+  command: Extract<TaskCommand, { kind: "complete" | "fail" | "cancel" }>,
+  settled: { readonly lastOutput?: TaskOutput; readonly status: TaskStatus },
+): TaskView {
+  const next: {
+    lastOutput?: TaskOutput;
+    metadata: TaskView["metadata"];
+    status: TaskStatus;
+    statusMessage?: string;
+    taskId: string;
+    usage?: TaskUsage;
+  } = {
+    metadata:
+      command.lifecycle === undefined
+        ? view.metadata
+        : { ...view.metadata, childLifecycle: command.lifecycle },
+    status: settled.status,
+    statusMessage: view.statusMessage,
+    taskId: view.taskId,
+  };
+  if (settled.lastOutput !== undefined) next.lastOutput = settled.lastOutput;
+  if (command.usage !== undefined) next.usage = command.usage;
+  return next;
+}
+
 export function applyTaskTransition(view: TaskView, command: TaskCommand): TaskTransitionResult {
   if (isTerminalTaskStatus(view.status)) {
     if (command.kind === "cancel" && view.status === "cancelled") {
@@ -49,43 +80,23 @@ export function applyTaskTransition(view: TaskView, command: TaskCommand): TaskT
     case "complete":
       return {
         outcome: "accepted",
-        view: {
-          metadata:
-            command.lifecycle === undefined
-              ? view.metadata
-              : { ...view.metadata, childLifecycle: command.lifecycle },
+        view: terminalView(view, command, {
           lastOutput: { data: command.data, type: "result" },
           status: "completed",
-          statusMessage: view.statusMessage,
-          taskId: view.taskId,
-        },
+        }),
       };
     case "fail":
       return {
         outcome: "accepted",
-        view: {
-          metadata:
-            command.lifecycle === undefined
-              ? view.metadata
-              : { ...view.metadata, childLifecycle: command.lifecycle },
+        view: terminalView(view, command, {
           lastOutput: { data: command.data, type: "error" },
           status: "failed",
-          statusMessage: view.statusMessage,
-          taskId: view.taskId,
-        },
+        }),
       };
     case "cancel":
       return {
         outcome: "accepted",
-        view: {
-          metadata:
-            command.lifecycle === undefined
-              ? view.metadata
-              : { ...view.metadata, childLifecycle: command.lifecycle },
-          status: "cancelled",
-          statusMessage: view.statusMessage,
-          taskId: view.taskId,
-        },
+        view: terminalView(view, command, { status: "cancelled" }),
       };
     case "require-input":
       return {

--- a/packages/eve/src/tasks/types.ts
+++ b/packages/eve/src/tasks/types.ts
@@ -60,6 +60,45 @@ export type TaskOutput =
 export type TaskInputRequest = JsonValue;
 
 /**
+ * Provider token usage a child turn reported. Structural on purpose: it
+ * mirrors `TokenUsage` (#shared/token-usage.js) without importing its
+ * zod-backed module into a workflow-bundled file.
+ */
+export interface TaskUsage {
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+}
+
+/**
+ * Validates one wire-carried usage value into {@link TaskUsage}.
+ * Anything malformed is dropped rather than rejected: retention is
+ * best-effort and must never fail a lifecycle transition.
+ */
+export function readTaskUsage(value: unknown): TaskUsage | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const cacheReadTokens = readUsageAxis(value, "cacheReadTokens");
+  const cacheWriteTokens = readUsageAxis(value, "cacheWriteTokens");
+  const inputTokens = readUsageAxis(value, "inputTokens");
+  const outputTokens = readUsageAxis(value, "outputTokens");
+  if (
+    cacheReadTokens === undefined ||
+    cacheWriteTokens === undefined ||
+    inputTokens === undefined ||
+    outputTokens === undefined
+  ) {
+    return undefined;
+  }
+  return { cacheReadTokens, cacheWriteTokens, inputTokens, outputTokens };
+}
+
+function readUsageAxis(value: object, key: string): number | undefined {
+  const field = Reflect.get(value, key);
+  return typeof field === "number" && Number.isFinite(field) && field >= 0 ? field : undefined;
+}
+
+/**
  * One human answer to an outstanding request. Structural on purpose: it
  * mirrors the input contract's `InputResponse` without importing its
  * zod-backed module into a workflow-bundled file.
@@ -101,6 +140,13 @@ export interface TaskView {
   readonly lastOutput?: TaskOutput;
   /** Outstanding requests; present exactly when `status` is `input_required`. */
   readonly inputRequests?: readonly TaskInputRequest[];
+  /**
+   * Provider usage the child reported at settlement; present when the
+   * terminal command carried it. Retained for later accounting only —
+   * budgets stay best-effort until a reservation model lands — and
+   * deliberately excluded from model-visible task views (tasks/json.ts).
+   */
+  readonly usage?: TaskUsage;
 }
 
 /** Commands accepted by the durable task run's transition function. */
@@ -109,9 +155,19 @@ export type TaskCommand =
       readonly kind: "complete";
       readonly data: JsonValue;
       readonly lifecycle?: "parked" | "terminal";
+      readonly usage?: TaskUsage;
     }
-  | { readonly kind: "fail"; readonly data: JsonValue; readonly lifecycle?: "parked" | "terminal" }
-  | { readonly kind: "cancel"; readonly lifecycle?: "parked" | "terminal" }
+  | {
+      readonly kind: "fail";
+      readonly data: JsonValue;
+      readonly lifecycle?: "parked" | "terminal";
+      readonly usage?: TaskUsage;
+    }
+  | {
+      readonly kind: "cancel";
+      readonly lifecycle?: "parked" | "terminal";
+      readonly usage?: TaskUsage;
+    }
   | { readonly kind: "require-input"; readonly inputRequests: readonly TaskInputRequest[] }
   | { readonly kind: "ready" }
   /**
@@ -153,7 +209,11 @@ export interface TaskInboundChildResult {
         | { readonly kind: "succeeded"; readonly output: JsonValue }
         | { readonly error: JsonValue; readonly kind: "failed" }
         | { readonly kind: "cancelled" };
-      /** Provider usage this turn added; accounting is deferred to a later stage. */
+      /**
+       * Provider usage this turn added. Retained on the terminal task
+       * snapshot ({@link TaskView.usage}); folding it into parent
+       * budgets is deferred until a reservation model lands.
+       */
       readonly usageDelta?: unknown;
     };
     readonly output: JsonValue;

--- a/packages/eve/src/tasks/wire.test.ts
+++ b/packages/eve/src/tasks/wire.test.ts
@@ -4,6 +4,7 @@ import { TASK_AUTHORIZATION_REQUEST_ID } from "#tasks/types.js";
 import { translateTaskInboundPayload } from "#tasks/wire.js";
 
 const ZERO_USAGE = { cacheReadTokens: 0, cacheWriteTokens: 0, inputTokens: 0, outputTokens: 0 };
+const USAGE = { cacheReadTokens: 1, cacheWriteTokens: 2, inputTokens: 300, outputTokens: 40 };
 
 describe("translateTaskInboundPayload", () => {
   it("passes explicit task commands through", () => {
@@ -28,7 +29,46 @@ describe("translateTaskInboundPayload", () => {
             },
           ],
         }),
-      ).toEqual({ data: "answer", kind: "complete", lifecycle: kind });
+      ).toEqual({ data: "answer", kind: "complete", lifecycle: kind, usage: ZERO_USAGE });
+    }
+  });
+
+  it("retains nonzero child usage on complete, fail, and cancel commands", () => {
+    const outcomes = [
+      {
+        expected: { data: "done", kind: "complete" },
+        result: { kind: "succeeded", output: "done" },
+      },
+      { expected: { data: "done", kind: "fail" }, result: { error: "boom", kind: "failed" } },
+      { expected: { kind: "cancel" }, result: { kind: "cancelled" } },
+    ] as const;
+    for (const { expected, result } of outcomes) {
+      expect(
+        translateTaskInboundPayload({
+          kind: "runtime-action-result",
+          results: [{ outcome: { kind: "terminal", result, usageDelta: USAGE }, output: "done" }],
+        }),
+      ).toEqual({ ...expected, lifecycle: "terminal", usage: USAGE });
+    }
+  });
+
+  it("drops malformed usage rather than failing the transition command", () => {
+    for (const usageDelta of [null, "n/a", { inputTokens: -1 }, { inputTokens: 1 }]) {
+      expect(
+        translateTaskInboundPayload({
+          kind: "runtime-action-result",
+          results: [
+            {
+              outcome: {
+                kind: "terminal",
+                result: { kind: "succeeded", output: "ok" },
+                usageDelta,
+              },
+              output: "ok",
+            },
+          ],
+        }),
+      ).toEqual({ data: "ok", kind: "complete", lifecycle: "terminal" });
     }
   });
 
@@ -47,7 +87,12 @@ describe("translateTaskInboundPayload", () => {
           },
         ],
       }),
-    ).toEqual({ data: { message: "boom" }, kind: "fail", lifecycle: "terminal" });
+    ).toEqual({
+      data: { message: "boom" },
+      kind: "fail",
+      lifecycle: "terminal",
+      usage: ZERO_USAGE,
+    });
 
     expect(
       translateTaskInboundPayload({
@@ -59,7 +104,7 @@ describe("translateTaskInboundPayload", () => {
           },
         ],
       }),
-    ).toEqual({ kind: "cancel", lifecycle: "terminal" });
+    ).toEqual({ kind: "cancel", lifecycle: "terminal", usage: ZERO_USAGE });
   });
 
   it("falls back to isError when a result carries no outcome", () => {

--- a/packages/eve/src/tasks/wire.ts
+++ b/packages/eve/src/tasks/wire.ts
@@ -1,5 +1,5 @@
-import type { TaskCommand, TaskRunInboundPayload } from "#tasks/types.js";
-import { TASK_AUTHORIZATION_REQUEST_ID } from "#tasks/types.js";
+import type { TaskCommand, TaskRunInboundPayload, TaskUsage } from "#tasks/types.js";
+import { TASK_AUTHORIZATION_REQUEST_ID, readTaskUsage } from "#tasks/types.js";
 
 /**
  * Translates one inbound hook payload into a lifecycle command.
@@ -35,13 +35,22 @@ export function translateTaskInboundPayload(
       const result = payload.results[0];
       if (result === undefined) return undefined;
       if (result.outcome !== undefined) {
+        // Usage retention: the settled outcome's `usageDelta` survives into
+        // the terminal command so the snapshot keeps the child's spend.
+        const usage = readTaskUsage(result.outcome.usageDelta);
         switch (result.outcome.result.kind) {
           case "succeeded":
-            return { data: result.output, kind: "complete", lifecycle: result.outcome.kind };
+            return withUsage(
+              { data: result.output, kind: "complete", lifecycle: result.outcome.kind },
+              usage,
+            );
           case "failed":
-            return { data: result.output, kind: "fail", lifecycle: result.outcome.kind };
+            return withUsage(
+              { data: result.output, kind: "fail", lifecycle: result.outcome.kind },
+              usage,
+            );
           case "cancelled":
-            return { kind: "cancel", lifecycle: result.outcome.kind };
+            return withUsage({ kind: "cancel", lifecycle: result.outcome.kind }, usage);
         }
       }
       return result.isError === true
@@ -69,4 +78,12 @@ export function translateTaskInboundPayload(
     default:
       return undefined;
   }
+}
+
+function withUsage(
+  command: Extract<TaskCommand, { kind: "complete" | "fail" | "cancel" }>,
+  usage: TaskUsage | undefined,
+): TaskCommand {
+  if (usage === undefined) return command;
+  return { ...command, usage };
 }

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -424,6 +424,11 @@ than MCP compatibility.
   twice.
 - Completing the parent session cancels its live tasks.
 - Resuming an existing child session creates a new task with a new task ID and the same `agentId`.
+- Background budgets are best-effort: each local child is capped from the parent's remainder at
+  its dispatch time, but no reservation couples sequential dispatches, so aggregate grants can
+  exceed the parent's remaining session limits. The child's reported usage is retained on the
+  terminal task snapshot (internal, not model-visible) so strict accounting can land later
+  without data loss.
 
 ## Open questions
 


### PR DESCRIPTION
A background child's reported token usage is retained on its terminal task snapshot (internal, not model-visible), so strict budget accounting can land later without data loss.

Background budgets stay best-effort for now: each local child is capped from the parent's remainder at dispatch time, but no reservation couples sequential dispatches. The research doc records that boundary.

Moved here from the closed #1746 (it was orthogonal to the lifecycle work it rode on).