### PR TITLE
fix(eve): project execution-denied tool results to provider-safe outputs at the model-call boundary

### DIFF
--- a/.changeset/curly-donkeys-remember.md
+++ b/.changeset/curly-donkeys-remember.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix tool-approval denial breaking resumable sessions against OpenAI. When a HITL approval is denied, eve persists an `execution-denied` tool-result marker into the session transcript so the UI can render the denial; on the next turn, the replayed marker reached the AI SDK provider adapter unrecognised and OpenAI 400s the request with `Missing required parameter: 'input[N].output'`, permanently wedging the session. eve now down-projects the marker to a provider-safe `error-text` output on the model-call boundary only — persisted history and `action.result` projection preserve the authoritative `execution-denied` shape (with the original reason) for UI and telemetry consumers.

--- a/packages/eve/src/harness/model-call-messages.test.ts
+++ b/packages/eve/src/harness/model-call-messages.test.ts
@@ -1,0 +1,216 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+
+import { materializeExecutionDeniedToolResultsForModel } from "#harness/model-call-messages.js";
+
+describe("materializeExecutionDeniedToolResultsForModel", () => {
+  it("rewrites an execution-denied output to error-text", () => {
+    const messages: ModelMessage[] = [
+      { content: "Run the risky tool.", role: "user" },
+      {
+        content: [
+          {
+            input: { url: "https://example.com" },
+            toolCallId: "call-1",
+            toolName: "fetch",
+            type: "tool-call",
+          },
+          {
+            approvalId: "approval-1",
+            toolCallId: "call-1",
+            type: "tool-approval-request",
+          },
+        ],
+        role: "assistant",
+      },
+      {
+        content: [
+          {
+            approvalId: "approval-1",
+            approved: false,
+            reason: "Policy forbids external fetches.",
+            type: "tool-approval-response",
+          },
+          {
+            output: { type: "execution-denied", reason: "Policy forbids external fetches." },
+            toolCallId: "call-1",
+            toolName: "fetch",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+      { content: "Understood.", role: "user" },
+    ];
+
+    const result = materializeExecutionDeniedToolResultsForModel(messages);
+    // The persisted message is untouched.
+    const persistedToolMessage = messages[2];
+    if (persistedToolMessage?.role !== "tool" || typeof persistedToolMessage.content === "string") {
+      throw new Error("Expected the assistant-adjacent tool message to have array content.");
+    }
+    const persistedDenied = persistedToolMessage.content.find(
+      (part) => part.type === "tool-result",
+    );
+    expect(persistedDenied).toMatchObject({
+      output: { type: "execution-denied" },
+    });
+
+    // The model-bound message is rewritten to a recognized output shape.
+    const toolMessage = result[2];
+    if (toolMessage?.role !== "tool" || typeof toolMessage.content === "string") {
+      throw new Error("Expected a tool message with array content.");
+    }
+    const rewritten = toolMessage.content.find((part) => part.type === "tool-result");
+    expect(rewritten).toEqual({
+      output: {
+        type: "error-text",
+        value: "Tool execution was denied: Policy forbids external fetches.",
+      },
+      toolCallId: "call-1",
+      toolName: "fetch",
+      type: "tool-result",
+    });
+
+    // The approval response part is preserved.
+    expect(toolMessage.content).toContainEqual({
+      approvalId: "approval-1",
+      approved: false,
+      reason: "Policy forbids external fetches.",
+      type: "tool-approval-response",
+    });
+
+    // Non-tool messages pass through unchanged (deep equality; the helper
+    // does not promise index identity).
+    expect(result[0]).toEqual(messages[0]);
+    expect(result[1]).toEqual(messages[1]);
+    expect(result[3]).toEqual(messages[3]);
+  });
+
+  it("falls back to a default denial message when reason is empty or missing", () => {
+    const messages: ModelMessage[] = [
+      {
+        content: [
+          {
+            output: { type: "execution-denied" },
+            toolCallId: "call-x",
+            toolName: "guarded",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+    ];
+
+    const result = materializeExecutionDeniedToolResultsForModel(messages);
+    const toolMessage = result[0];
+    if (toolMessage?.role !== "tool" || typeof toolMessage.content === "string") {
+      throw new Error("Expected a tool message with array content.");
+    }
+    const rewritten = toolMessage.content.find((part) => part.type === "tool-result");
+    expect(rewritten).toEqual({
+      output: { type: "error-text", value: "Tool execution was denied." },
+      toolCallId: "call-x",
+      toolName: "guarded",
+      type: "tool-result",
+    });
+  });
+
+  it("leaves recognized tool-result outputs untouched", () => {
+    const messages: ModelMessage[] = [
+      {
+        content: [
+          {
+            output: { type: "text", value: "ok" },
+            toolCallId: "call-y",
+            toolName: "echo",
+            type: "tool-result",
+          },
+          {
+            output: { type: "error-text", value: "already an error" },
+            toolCallId: "call-z",
+            toolName: "echo",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+    ];
+
+    const result = materializeExecutionDeniedToolResultsForModel(messages);
+    expect(result[0]).toBe(messages[0]);
+  });
+
+  it("passes through non-tool messages by reference", () => {
+    const messages: ModelMessage[] = [
+      { content: "Hello.", role: "user" },
+      {
+        content: [{ text: "I can help with that.", type: "text" }],
+        role: "assistant",
+      },
+    ];
+
+    const result = materializeExecutionDeniedToolResultsForModel(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("handles string-content assistant messages without touching them", () => {
+    const messages: ModelMessage[] = [
+      { content: "plain tool payload", role: "assistant" },
+      { content: "plain user payload", role: "user" },
+      { content: "plain system payload", role: "system" },
+    ];
+    const result = materializeExecutionDeniedToolResultsForModel(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("rewrites multiple denied results in a single message", () => {
+    const messages: ModelMessage[] = [
+      {
+        content: [
+          {
+            output: { type: "execution-denied", reason: "denied A" },
+            toolCallId: "call-a",
+            toolName: "toolA",
+            type: "tool-result",
+          },
+          {
+            output: { type: "text", value: "ok" },
+            toolCallId: "call-b",
+            toolName: "toolB",
+            type: "tool-result",
+          },
+          {
+            output: { type: "execution-denied", reason: "denied C" },
+            toolCallId: "call-c",
+            toolName: "toolC",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      },
+    ];
+
+    const result = materializeExecutionDeniedToolResultsForModel(messages);
+    const toolMessage = result[0];
+    if (toolMessage?.role !== "tool" || typeof toolMessage.content === "string") {
+      throw new Error("Expected a tool message with array content.");
+    }
+    const denied = toolMessage.content.filter(
+      (part) => part.type === "tool-result" && part.output.type === "error-text",
+    );
+    expect(denied).toHaveLength(2);
+    expect(denied[0]).toEqual({
+      output: { type: "error-text", value: "Tool execution was denied: denied A" },
+      toolCallId: "call-a",
+      toolName: "toolA",
+      type: "tool-result",
+    });
+    expect(denied[1]).toEqual({
+      output: { type: "error-text", value: "Tool execution was denied: denied C" },
+      toolCallId: "call-c",
+      toolName: "toolC",
+      type: "tool-result",
+    });
+  });
+});

--- a/packages/eve/src/harness/model-call-messages.ts
+++ b/packages/eve/src/harness/model-call-messages.ts
@@ -1,0 +1,108 @@
+import type { ModelMessage, ToolResultPart } from "ai";
+
+/**
+ * Rewrites `execution-denied` tool-result outputs to `error-text` for
+ * consumption by language-model providers.
+ *
+ * The `execution-denied` marker is an eve-internal shape persisted in
+ * session history so that `action.result` projection can surface a
+ * structured `{ code: "TOOL_EXECUTION_DENIED", message }` payload. AI SDK
+ * provider adapters, however, only recognise `text | error-text | json |
+ * error-json | content` as `ToolResultOutput`; an `execution-denied`
+ * output reaches the provider's prompt-conversion path unrecognised and
+ * some providers (notably OpenAI) reject the resumed request with
+ * `Missing required parameter: 'input[N].output'`.
+ *
+ * This helper is the single boundary where persisted history is
+ * down-projected for a model call. When no rewrite is needed the input
+ * array is returned by reference; when a rewrite is needed a new array
+ * is allocated — the input is never mutated, so session history
+ * retains the `execution-denied` marker for UI and telemetry consumers.
+ */
+export function materializeExecutionDeniedToolResultsForModel(
+  messages: readonly ModelMessage[],
+): ModelMessage[] {
+  const rewrittenMessages: ModelMessage[] = [];
+  let didRewrite = false;
+
+  for (const message of messages) {
+    if (message.role !== "tool" || typeof message.content === "string") {
+      rewrittenMessages.push(message);
+      continue;
+    }
+
+    const rewrittenContent = rewriteToolContent(message.content);
+    if (rewrittenContent === null) {
+      rewrittenMessages.push(message);
+      continue;
+    }
+
+    didRewrite = true;
+    rewrittenMessages.push({ ...message, content: rewrittenContent });
+  }
+
+  return didRewrite ? rewrittenMessages : (messages as ModelMessage[]);
+}
+
+type ToolContentPart = Extract<ModelMessage, { role: "tool" }>["content"] extends string
+  ? never
+  : Extract<ModelMessage, { role: "tool" }>["content"] extends ReadonlyArray<infer P>
+    ? P
+    : never;
+
+/**
+ * Returns `null` when nothing needed rewriting so callers can keep the
+ * original array reference (no GC pressure on the happy path).
+ */
+function rewriteToolContent(parts: unknown): ToolContentPart[] | null {
+  if (!Array.isArray(parts)) {
+    return null;
+  }
+
+  let rewritten: ToolContentPart[] | null = null;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (
+      part !== null &&
+      typeof part === "object" &&
+      (part as { type?: unknown }).type === "tool-result" &&
+      isExecutionDeniedOutput((part as ToolResultPart).output)
+    ) {
+      const deniedReason = ((part as ToolResultPart).output as DeniedOutput).reason;
+      const replacement: ToolResultPart = {
+        output: { type: "error-text", value: executionDeniedToErrorText(deniedReason) },
+        toolCallId: (part as ToolResultPart).toolCallId,
+        toolName: (part as ToolResultPart).toolName,
+        type: "tool-result",
+      };
+      if (rewritten === null) {
+        rewritten = (parts as ToolContentPart[]).slice(0, i);
+      }
+      rewritten.push(replacement);
+      continue;
+    }
+
+    if (rewritten !== null) {
+      rewritten.push(part as ToolContentPart);
+    }
+  }
+
+  return rewritten;
+}
+
+type DeniedOutput = { readonly type: "execution-denied"; readonly reason?: string };
+
+function isExecutionDeniedOutput(output: unknown): output is DeniedOutput {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    (output as { type?: unknown }).type === "execution-denied"
+  );
+}
+
+function executionDeniedToErrorText(reason: string | undefined): string {
+  return reason === undefined || reason.length === 0
+    ? "Tool execution was denied."
+    : `Tool execution was denied: ${reason}`;
+}

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -7245,8 +7245,8 @@ describe("createToolLoopHarness", () => {
           },
           {
             output: {
-              type: "execution-denied",
-              reason: "Tool execution was denied.",
+              type: "error-text",
+              value: "Tool execution was denied: Tool execution was denied.",
             },
             toolCallId: "call-1",
             toolName: "bash",

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -115,6 +115,7 @@ import { createToolResultMessagePartFromToolError } from "#harness/action-result
 import { activeTurnId } from "#harness/active-turn-id.js";
 import { buildTelemetryRuntimeContext } from "#harness/instrumentation-runtime-context.js";
 import { createAiSdkHookBridge } from "#harness/ai-sdk-hook-bridge.js";
+import { materializeExecutionDeniedToolResultsForModel } from "#harness/model-call-messages.js";
 import { createInstrumentationHandleEvent } from "#harness/instrumentation-native-events.js";
 import type { InstrumentationAttemptScope } from "#harness/instrumentation-lifecycle.js";
 import { resolveParentLineage } from "#harness/parent-lineage.js";
@@ -877,7 +878,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       systemMessages.push({ role: "system", content: CONDITIONAL_DELIVERY_INSTRUCTION });
     }
 
-    const modelMessages = nonSystemMessages;
+    // Persisted history may carry `execution-denied` tool-result outputs
+    // (authoritative for UI/telemetry via action.result). Providers only
+    // accept the AI SDK `ToolResultOutput` union on this boundary — see
+    // model-call-messages.ts for the exact down-projection rule.
+    // Session history is not mutated.
+    const modelMessages = materializeExecutionDeniedToolResultsForModel(nonSystemMessages);
 
     const prepareModelCallInput = (extraSystemNote?: string) => {
       const extraSystemEntry: SystemModelMessage[] = extraSystemNote


### PR DESCRIPTION
## Summary

Fixes #1658.

When a HITL tool approval is denied, eve persists an `execution-denied` tool-result marker into the session transcript so the UI can render the denial and the `action.result` projection stays authoritative. On the next turn, that marker was replayed to the AI SDK provider adapter unrecognised, and OpenAI 400s the request:

    Missing required parameter: 'input[N].output'

… permanently wedging the session — every subsequent turn replays the same marker and fails the same way.

## Fix

Down-project the marker to a provider-safe `error-text` output **on the model-call boundary only** (new `materializeExecutionDeniedToolResultsForModel(messages)` in `harness/model-call-messages.ts`, wired into `tool-loop.ts` just before the agent call). Persisted history and the `action.result` projection keep the authoritative `execution-denied` shape with the original reason — the wire is translated, not the record.

## Tests

- New `model-call-messages.test.ts`: 6 unit tests covering rewrite of `execution-denied`, reason embedding, pass-through by reference when nothing matches, and non-interference with other tool-result output shapes.
- Updated `tool-loop.test.ts`: the model now observes `error-text` for a denied approval while persisted parts keep `execution-denied`.
- Full harness unit suite passes: 49 files / **735 tests**.

## Local gates

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/...` → all pass
- `tsc --noEmit` → clean (after `pnpm --filter eve build:compiled` for `#compiled/*` imports)
- `oxlint --fix <files>` → clean
- `oxfmt <files>` → clean
- `pnpm guard:invariants` → ok

## CI status note

`e2e-vercel` jobs fail on fork PRs because `VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` secrets are not exposed to fork runs — the fixture-deploy step exits with `No existing credentials found`. That matches the known fork-secret gap class (see also eve#1725 discussion). All other gates (local e2e, integration, scenario, tui, CI, bundle) pass.
