### PR TITLE
fix(eve): target connection searches before auth

### DIFF
--- a/.changeset/calm-connections-search.md
+++ b/.changeset/calm-connections-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Avoid prompting for authorization to unrelated connections by requiring connection searches to target one connection before loading remote tool metadata.

--- a/docs/connections/overview.mdx
+++ b/docs/connections/overview.mdx
@@ -8,6 +8,8 @@ A connection wires an agent into an external server you don't author, either an 
 
 Connections live under `agent/connections/`. The runtime name comes from the filename, so `agent/connections/linear.ts` registers as `"linear"`. The model never sees a connection's URL or credentials. It discovers tools through the built-in `connection_search` and calls them by their qualified name, `<connection>__<tool>` (e.g. `linear__list_issues`).
 
+When an agent has multiple connections, `connection_search` targets one connection at a time. An untargeted search returns the locally available connection names and descriptions without contacting their servers; the model then searches the relevant connection for its tools. This avoids prompting for authorization to an unrelated connection.
+
 ## MCP connections
 
 Use an MCP connection when the external service already exposes an MCP server. The server publishes its tools and schemas, and eve makes the matched tools callable by the model.

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
@@ -250,22 +250,24 @@ describe("connection_search", () => {
     ]);
   });
 
-  it("returns matches and errors when at least one connection loads", async () => {
+  it("returns local summaries without loading tools when multiple connections are untargeted", async () => {
     const incident = connection("incident");
     const linear = connection("linear");
+    const loadIncidentTools = vi.fn(async () => {
+      throw new ConnectionAuthorizationRequiredError("incident");
+    });
+    const loadLinearTools = vi.fn(async () => [
+      {
+        description: "List issues",
+        inputSchema: { type: "object" },
+        name: "list_issues",
+      },
+    ]);
     const connectionRegistry = registry({
       connections: [incident, linear],
       loadTools: {
-        incident: async () => {
-          throw new Error("MCP SSE Transport Error: 400 Bad Request");
-        },
-        linear: async () => [
-          {
-            description: "List issues",
-            inputSchema: { type: "object" },
-            name: "list_issues",
-          },
-        ],
+        incident: loadIncidentTools,
+        linear: loadLinearTools,
       },
     });
 
@@ -273,19 +275,77 @@ describe("connection_search", () => {
       executeConnectionSearch(connectionRegistry, { keywords: "list issues" }),
     ).resolves.toEqual([
       {
-        connection: "linear",
-        description: "List issues",
-        inputSchema: { type: "object" },
-        outputSchema: undefined,
-        qualifiedName: "linear__list_issues",
-        tool: "list_issues",
-      },
-      {
         connection: "incident",
         description: "incident connection",
-        error: 'Failed to load tools for "incident": MCP SSE Transport Error: 400 Bad Request',
+      },
+      {
+        connection: "linear",
+        description: "linear connection",
       },
     ]);
+    expect(loadIncidentTools).not.toHaveBeenCalled();
+    expect(loadLinearTools).not.toHaveBeenCalled();
+  });
+
+  it("resumes an authorization callback from an older untargeted search", async () => {
+    const notion = connection("notion");
+    let linearCompletions = 0;
+    const linear: ResolvedConnectionDefinition = {
+      ...connection("linear"),
+      authorization: {
+        completeAuthorization: async () => {
+          linearCompletions += 1;
+          return { token: "linear-token" };
+        },
+        getToken: async () => ({ token: "linear-token" }),
+        principalType: "user",
+        startAuthorization: async () => ({
+          challenge: { url: "https://idp.example.com/authorize" },
+        }),
+      },
+    };
+    const loadNotionTools = vi.fn(async () => []);
+    const loadLinearTools = vi.fn(async () => [
+      {
+        description: "List issues",
+        inputSchema: { type: "object" },
+        name: "list_issues",
+      },
+    ]);
+    const connectionRegistry = registry({
+      connections: [notion, linear],
+      loadTools: {
+        notion: loadNotionTools,
+        linear: loadLinearTools,
+      },
+    });
+
+    await expect(
+      executeConnectionSearch(connectionRegistry, { keywords: "list issues" }, (ctx) => {
+        ctx.set(AuthKey, {
+          attributes: {},
+          authenticator: "test-idp",
+          issuer: "test-idp",
+          principalId: "user-1",
+          principalType: "user",
+        });
+        ctx.set(PendingAuthorizationResultKey, [
+          {
+            callback: { method: "GET", params: { code: "oauth-code" } },
+            hookUrl: "https://agent.example.com/eve/v1/connections/linear/callback/auth",
+            name: "linear",
+          },
+        ]);
+      }),
+    ).resolves.toMatchObject([
+      {
+        connection: "linear",
+        qualifiedName: "linear__list_issues",
+      },
+    ]);
+    expect(linearCompletions).toBe(1);
+    expect(loadLinearTools).toHaveBeenCalledOnce();
+    expect(loadNotionTools).not.toHaveBeenCalled();
   });
 
   it("does not complete an unrelated connection authorization", async () => {

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -7,6 +7,7 @@ import {
   type AuthorizationSignal,
   consumeAuthorizationResult,
   getHookUrl,
+  PendingAuthorizationResultKey,
   requestAuthorization,
 } from "#harness/authorization.js";
 import {
@@ -42,7 +43,9 @@ const logger = createLogger("framework.connection-search-dynamic");
 const CONNECTION_SEARCH_INPUT_SCHEMA = z.strictObject({
   connection: z
     .string()
-    .describe("Optional: limit search to a specific connection name.")
+    .describe(
+      "Connection to search. Required when multiple connections are available; use the connection summaries returned by an untargeted search to choose one.",
+    )
     .optional(),
   keywords: z
     .string()
@@ -187,15 +190,34 @@ async function executeConnectionSearch(
   const queryTokens = tokenize(input.keywords);
   const results: Array<{ item: ConnectionSearchResultItem; score: number }> = [];
   const failedConnections: ConnectionSearchResultItem[] = [];
+  const connections = registry.getConnections();
+  const requestedConnection = input.connection?.trim();
+  const resumedConnections = new Set(
+    (ctx.get(PendingAuthorizationResultKey) ?? []).map((result) => result.name),
+  );
+
+  // Listing tools can itself require authorization. Avoid probing every
+  // connection for an untargeted search: return the local catalog so the
+  // model can select one, then discover tools only from that connection. An
+  // authorization callback from an in-flight older search still takes priority
+  // so sessions created before this behavior change can resume normally.
+  if (!requestedConnection && resumedConnections.size === 0 && connections.length > 1) {
+    return connections.map((connection) => ({
+      connection: connection.connectionName,
+      description: connection.description,
+    }));
+  }
 
   const targetConnections =
-    input.connection !== undefined && input.connection !== ""
-      ? registry.getConnections().filter((c) => c.connectionName === input.connection)
-      : registry.getConnections();
+    requestedConnection !== undefined && requestedConnection !== ""
+      ? connections.filter((connection) => connection.connectionName === requestedConnection)
+      : resumedConnections.size > 0
+        ? connections.filter((connection) => resumedConnections.has(connection.connectionName))
+        : connections;
 
-  if (input.connection && targetConnections.length === 0) {
+  if (requestedConnection && targetConnections.length === 0) {
     throw new Error(
-      `Connection "${input.connection}" is not registered. Available connections: ${registry.getConnectionNames().join(", ")}.`,
+      `Connection "${requestedConnection}" is not registered. Available connections: ${registry.getConnectionNames().join(", ")}.`,
     );
   }
 
@@ -418,6 +440,8 @@ const connectionSearchDynamicDefinition = defineDynamic({
       tools["connection_search"] = defineTool({
         description:
           "Search for tools across your connections. " +
+          "When multiple connections are available, specify one with `connection`; " +
+          "an untargeted search returns connection summaries without contacting them. " +
           "Discovered tools become directly callable by their qualified name " +
           "(e.g. `linear__list_issues`) in your next response. " +
           `Available connections: ${connectionNames.join(", ")}.`,

--- a/packages/eve/src/runtime/prompt/connections.ts
+++ b/packages/eve/src/runtime/prompt/connections.ts
@@ -21,6 +21,6 @@ export function formatConnectionsSection(
     "Available connections:",
     ...connectionList,
     "",
-    "Use connection_search to discover specific tools within a connection. Discovered tools become directly callable by their qualified name (e.g. linear__list_issues) in your next response.",
+    "Use connection_search to discover specific tools within a connection. When multiple connections are available, choose the relevant connection from the list above and pass its name as `connection`. Discovered tools become directly callable by their qualified name (e.g. linear__list_issues) in your next response.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

- return local connection summaries when `connection_search` is untargeted and multiple connections are configured
- load remote tool metadata, and therefore trigger authorization, only after the model selects a connection
- preserve callback handling for in-flight sessions created by the previous untargeted-search behavior
- update connection guidance and add a patch changeset

## Testing

- `pnpm exec vitest run --config vitest.unit.config.ts src/runtime/framework-tools/connection-search-dynamic.test.ts` (15 passed)
- `pnpm --filter eve run typecheck`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`

The full eve unit suite also reached 6,025 passing tests; its only failure was the unrelated sandbox restriction `listen EPERM: operation not permitted 127.0.0.1` in `start-production-server.test.ts`.