### PR TITLE
fix(eve): render MCP connection auth across channels

### DIFF
--- a/.changeset/quiet-wolves-connect.md
+++ b/.changeset/quiet-wolves-connect.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Render MCP connection authorization prompts and outcomes in Chat SDK channels, including private direct-message delivery for Photon group conversations.
+Render MCP connection authorization prompts and outcomes across built-in channels, including private challenge delivery on shared chat surfaces and URL-less device flows.

--- a/.changeset/quiet-wolves-connect.md
+++ b/.changeset/quiet-wolves-connect.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Render MCP connection authorization prompts and outcomes in Chat SDK channels, including private direct-message delivery for Photon group conversations.

--- a/packages/eve/src/public/channels/authorization-rendering.test.ts
+++ b/packages/eve/src/public/channels/authorization-rendering.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  authorizationDisplayName,
   renderAuthorizationCompleted,
   renderAuthorizationRequired,
 } from "#public/channels/authorization-rendering.js";
 
 describe("connection authorization rendering", () => {
+  it("falls back to the connection name for a blank authored display name", () => {
+    expect(authorizationDisplayName("notion", "  ")).toBe("Notion");
+  });
+
   it("renders every challenge field", () => {
     expect(
       renderAuthorizationRequired({

--- a/packages/eve/src/public/channels/authorization-rendering.test.ts
+++ b/packages/eve/src/public/channels/authorization-rendering.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  renderAuthorizationCompleted,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
+
+describe("connection authorization rendering", () => {
+  it("renders every challenge field", () => {
+    expect(
+      renderAuthorizationRequired({
+        authorization: {
+          displayName: "Notion Workspace",
+          instructions: "Approve access in your browser.",
+          url: "https://connect.example.com/auth",
+          userCode: "ABCD-1234",
+        },
+        description: "Connect your account to continue.",
+        name: "notion",
+      }),
+    ).toBe(
+      [
+        "Authorization required for Notion Workspace.",
+        "Connect your account to continue.",
+        "Approve access in your browser.",
+        "Code: ABCD-1234",
+        "Sign in with Notion Workspace: https://connect.example.com/auth",
+      ].join("\n\n"),
+    );
+  });
+
+  it("can omit the credential URL for public status surfaces", () => {
+    const rendered = renderAuthorizationRequired({
+      authorization: { url: "https://connect.example.com/auth", userCode: "ABCD-1234" },
+      description: "Connect your account to continue.",
+      includeUrl: false,
+      name: "notion",
+    });
+
+    expect(rendered).not.toContain("https://");
+    expect(rendered).toContain("Code: ABCD-1234");
+  });
+
+  it("renders successful and timed-out outcomes", () => {
+    expect(renderAuthorizationCompleted({ name: "notion", outcome: "authorized" })).toBe(
+      "Notion connected. Resuming.",
+    );
+    expect(
+      renderAuthorizationCompleted({
+        name: "notion",
+        outcome: "timed-out",
+        reason: "Challenge expired",
+      }),
+    ).toBe("Notion authorization timed out (Challenge expired).");
+  });
+});

--- a/packages/eve/src/public/channels/authorization-rendering.ts
+++ b/packages/eve/src/public/channels/authorization-rendering.ts
@@ -1,14 +1,14 @@
 import type { AuthorizationOutcome } from "#protocol/message.js";
+import type { ConnectionAuthorizationChallenge } from "#public/connections/errors.js";
 
-interface AuthorizationPresentation {
-  readonly displayName?: string;
-  readonly instructions?: string;
-  readonly url?: string;
-  readonly userCode?: string;
-}
+type AuthorizationPresentation = Pick<
+  ConnectionAuthorizationChallenge,
+  "displayName" | "instructions" | "url" | "userCode"
+>;
 
 export function authorizationDisplayName(name: string, displayName: string | undefined): string {
-  if (displayName !== undefined) return displayName;
+  const authoredDisplayName = displayName?.trim();
+  if (authoredDisplayName) return authoredDisplayName;
   if (name.length === 0) return name;
   return name.charAt(0).toUpperCase() + name.slice(1);
 }

--- a/packages/eve/src/public/channels/authorization-rendering.ts
+++ b/packages/eve/src/public/channels/authorization-rendering.ts
@@ -1,0 +1,57 @@
+import type { AuthorizationOutcome } from "#protocol/message.js";
+
+interface AuthorizationPresentation {
+  readonly displayName?: string;
+  readonly instructions?: string;
+  readonly url?: string;
+  readonly userCode?: string;
+}
+
+export function authorizationDisplayName(name: string, displayName: string | undefined): string {
+  if (displayName !== undefined) return displayName;
+  if (name.length === 0) return name;
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+export function renderAuthorizationRequired(input: {
+  readonly authorization?: AuthorizationPresentation;
+  readonly description: string;
+  readonly includeUrl?: boolean;
+  readonly linkStyle?: "markdown" | "plain";
+  readonly name: string;
+}): string {
+  const displayName = authorizationDisplayName(input.name, input.authorization?.displayName);
+  const url = input.includeUrl === false ? undefined : input.authorization?.url;
+  const signIn =
+    url === undefined
+      ? undefined
+      : input.linkStyle === "markdown"
+        ? `[Sign in with ${displayName}](${url})`
+        : `Sign in with ${displayName}: ${url}`;
+  return [
+    `Authorization required for ${displayName}.`,
+    input.description,
+    input.authorization?.instructions === input.description
+      ? undefined
+      : input.authorization?.instructions,
+    input.authorization?.userCode === undefined
+      ? undefined
+      : `Code: ${input.authorization.userCode}`,
+    signIn,
+  ]
+    .filter((part): part is string => part !== undefined && part.length > 0)
+    .join("\n\n");
+}
+
+export function renderAuthorizationCompleted(input: {
+  readonly authorization?: Pick<AuthorizationPresentation, "displayName">;
+  readonly name: string;
+  readonly outcome: AuthorizationOutcome;
+  readonly reason?: string;
+}): string {
+  const displayName = authorizationDisplayName(input.name, input.authorization?.displayName);
+  if (input.outcome === "authorized") return `${displayName} connected. Resuming.`;
+  const outcome = input.outcome === "timed-out" ? "timed out" : input.outcome;
+  const reason = input.reason === undefined ? "" : ` (${input.reason})`;
+  return `${displayName} authorization ${outcome}${reason}.`;
+}

--- a/packages/eve/src/public/channels/chat-sdk/authorization.ts
+++ b/packages/eve/src/public/channels/chat-sdk/authorization.ts
@@ -1,0 +1,46 @@
+import { createLogger } from "#internal/logging.js";
+import {
+  authorizationDisplayName,
+  renderAuthorizationCompleted,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
+import type { ChatSdkChannelEvents } from "#public/channels/chat-sdk/chatSdkChannel.js";
+
+const log = createLogger("chat-sdk.authorization");
+
+export const defaultAuthorizationEvents = {
+  async "authorization.required"(event, channel, _ctx) {
+    const thread = channel.thread;
+    if (!thread) return;
+
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
+    const challenge = renderAuthorizationRequired({
+      authorization: event.authorization,
+      description: event.description,
+      linkStyle: "markdown",
+      name: event.name,
+    });
+
+    if (thread.isDM) {
+      await thread.post({ markdown: challenge });
+      return;
+    }
+
+    await thread.post({ markdown: `Authorization required for ${displayName}.` });
+    const author = channel.state.thread?.currentMessage?.author;
+    if (!author) return;
+
+    try {
+      await thread.postEphemeral(author, { markdown: challenge }, { fallbackToDM: true });
+    } catch (error) {
+      // The public status still explains why the session is blocked when an
+      // adapter cannot deliver a private challenge.
+      log.warn("failed to deliver connection authorization challenge privately", { error });
+    }
+  },
+
+  async "authorization.completed"(event, channel, _ctx) {
+    if (!channel.thread) return;
+    await channel.thread.post({ markdown: renderAuthorizationCompleted(event) });
+  },
+} satisfies Pick<ChatSdkChannelEvents, "authorization.required" | "authorization.completed">;

--- a/packages/eve/src/public/channels/chat-sdk/authorization.ts
+++ b/packages/eve/src/public/channels/chat-sdk/authorization.ts
@@ -49,7 +49,10 @@ export const defaultAuthorizationEvents = {
     } catch (error) {
       // The public status still explains why the session is blocked when an
       // adapter cannot deliver a private challenge.
-      log.warn("failed to deliver connection authorization challenge privately", { error });
+      log.warn("failed to deliver connection authorization challenge privately", {
+        error,
+        name: event.name,
+      });
     }
   },
 

--- a/packages/eve/src/public/channels/chat-sdk/authorization.ts
+++ b/packages/eve/src/public/channels/chat-sdk/authorization.ts
@@ -28,10 +28,24 @@ export const defaultAuthorizationEvents = {
 
     await thread.post({ markdown: `Authorization required for ${displayName}.` });
     const author = channel.state.thread?.currentMessage?.author;
-    if (!author) return;
+    if (!author) {
+      log.warn("cannot deliver connection authorization challenge privately without an author", {
+        name: event.name,
+      });
+      return;
+    }
 
     try {
-      await thread.postEphemeral(author, { markdown: challenge }, { fallbackToDM: true });
+      const delivered = await thread.postEphemeral(
+        author,
+        { markdown: challenge },
+        { fallbackToDM: true },
+      );
+      if (!delivered) {
+        log.warn("adapter cannot deliver connection authorization challenge privately", {
+          name: event.name,
+        });
+      }
     } catch (error) {
       // The public status still explains why the session is blocked when an
       // adapter cannot deliver a private challenge.

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -609,6 +609,130 @@ describe("chatSdkChannel", () => {
       },
     });
   });
+
+  it("posts connection authorization challenges directly in DM threads", async () => {
+    const adapter = testAdapter();
+    const bridge = chatSdkChannel({
+      adapters: { test: adapter },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const channelAdapter = withState(getAdapter(bridge.channel), {
+      thread: { ...serializedThread(), isDM: true },
+    });
+    const ctx = buildAdapterContext(channelAdapter, stubAccessor());
+
+    await callEvent(
+      channelAdapter,
+      makeEvent("authorization.required", {
+        authorization: {
+          displayName: "GitHub",
+          instructions: "Approve access in your browser.",
+          url: "https://connect.example.com/auth",
+          userCode: "ABCD-1234",
+        },
+        description: "Connect your account to continue.",
+        name: "github",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    expect(adapter.posted).toEqual([
+      {
+        message: {
+          markdown: [
+            "Authorization required for GitHub.",
+            "Connect your account to continue.",
+            "Approve access in your browser.",
+            "Code: ABCD-1234",
+            "[Sign in with GitHub](https://connect.example.com/auth)",
+          ].join("\n\n"),
+        },
+        threadId: THREAD_ID,
+      },
+    ]);
+  });
+
+  it("keeps connection authorization challenges private in shared threads", async () => {
+    const adapter = testAdapter();
+    const bridge = chatSdkChannel({
+      adapters: { test: adapter },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const channelAdapter = withState(getAdapter(bridge.channel), {
+      thread: { ...serializedThread(), currentMessage: message("connect").toJSON() },
+    });
+    const ctx = buildAdapterContext(channelAdapter, stubAccessor());
+
+    await callEvent(
+      channelAdapter,
+      makeEvent("authorization.required", {
+        authorization: {
+          url: "https://connect.example.com/auth",
+          userCode: "ABCD-1234",
+        },
+        description: "Connect your account to continue.",
+        name: "linear",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    expect(adapter.openedDMs).toEqual(["user-1"]);
+    expect(adapter.posted).toEqual([
+      {
+        message: { markdown: "Authorization required for Linear." },
+        threadId: THREAD_ID,
+      },
+      {
+        message: {
+          markdown: [
+            "Authorization required for Linear.",
+            "Connect your account to continue.",
+            "Code: ABCD-1234",
+            "[Sign in with Linear](https://connect.example.com/auth)",
+          ].join("\n\n"),
+        },
+        threadId: "test:dm:user-1",
+      },
+    ]);
+  });
+
+  it("posts connection authorization outcomes", async () => {
+    const adapter = testAdapter();
+    const bridge = chatSdkChannel({
+      adapters: { test: adapter },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const channelAdapter = withState(getAdapter(bridge.channel), {
+      thread: serializedThread(),
+    });
+    const ctx = buildAdapterContext(channelAdapter, stubAccessor());
+
+    await callEvent(
+      channelAdapter,
+      makeEvent("authorization.completed", {
+        authorization: { displayName: "GitHub" },
+        name: "github",
+        outcome: "authorized",
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    expect(adapter.posted).toEqual([
+      { message: { markdown: "GitHub connected. Resuming." }, threadId: THREAD_ID },
+    ]);
+  });
 });
 
 describe("messageToUserContent", () => {
@@ -715,6 +839,7 @@ class TestAdapter {
   chat: ChatInstance | null = null;
   posted: Array<{ message: AdapterPostableMessage; threadId: string }> = [];
   edited: Array<{ message: AdapterPostableMessage; messageId: string; threadId: string }> = [];
+  openedDMs: string[] = [];
   typingStatuses: Array<string | undefined> = [];
   startTypingError: Error | null = null;
   editError: Error | null = null;
@@ -801,6 +926,11 @@ class TestAdapter {
       isDM: false,
       metadata: {},
     };
+  }
+
+  async openDM(userId: string): Promise<string> {
+    this.openedDMs.push(userId);
+    return `test:dm:${userId}`;
   }
 
   async postMessage(threadId: string, posted: AdapterPostableMessage): Promise<RawMessage> {

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -385,6 +385,46 @@ function defaultEvents<TAdapters extends ChatSdkAdapters>(
       if (!channel.thread || event.requests.length === 0) return;
       await channel.thread.post(renderInputRequests(event.requests, inputActionPrefix));
     },
+    async "authorization.required"(event, channel, _ctx) {
+      const thread = channel.thread;
+      if (!thread) return;
+
+      const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
+      const challenge = renderAuthorizationRequired({
+        description: event.description,
+        displayName,
+        instructions: event.authorization?.instructions,
+        url: event.authorization?.url,
+        userCode: event.authorization?.userCode,
+      });
+
+      if (thread.isDM) {
+        await thread.post({ markdown: challenge });
+        return;
+      }
+
+      await thread.post({ markdown: `Authorization required for ${displayName}.` });
+      const author = channel.state.thread?.currentMessage?.author;
+      if (!author) return;
+
+      try {
+        await thread.postEphemeral(author, { markdown: challenge }, { fallbackToDM: true });
+      } catch (error) {
+        // The public status still explains why the session is blocked when an
+        // adapter cannot deliver a private challenge.
+        log.warn("failed to deliver connection authorization challenge privately", { error });
+      }
+    },
+    async "authorization.completed"(event, channel, _ctx) {
+      if (!channel.thread) return;
+      const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
+      const reason = event.reason === undefined ? "" : ` (${event.reason})`;
+      const message =
+        event.outcome === "authorized"
+          ? `${displayName} connected. Resuming.`
+          : `${displayName} authorization ${formatAuthorizationOutcome(event.outcome)}${reason}.`;
+      await channel.thread.post({ markdown: message });
+    },
     async "message.completed"(event, channel, _ctx) {
       if (event.finishReason === "tool-calls") {
         channel.state.pendingToolCallMessage = event.message
@@ -526,6 +566,34 @@ function renderInputRequest(request: InputRequest, inputActionPrefix: string) {
     CardText("This request needs a freeform answer. Continue from the eve session UI."),
   );
   return children;
+}
+
+function authorizationDisplayName(name: string, displayName: string | undefined): string {
+  if (displayName !== undefined) return displayName;
+  if (name.length === 0) return name;
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function renderAuthorizationRequired(input: {
+  readonly description: string;
+  readonly displayName: string;
+  readonly instructions?: string;
+  readonly url?: string;
+  readonly userCode?: string;
+}): string {
+  return [
+    `Authorization required for ${input.displayName}.`,
+    input.description,
+    input.instructions === input.description ? undefined : input.instructions,
+    input.userCode === undefined ? undefined : `Code: ${input.userCode}`,
+    input.url === undefined ? undefined : `[Sign in with ${input.displayName}](${input.url})`,
+  ]
+    .filter((part): part is string => part !== undefined && part.length > 0)
+    .join("\n\n");
+}
+
+function formatAuthorizationOutcome(outcome: "declined" | "failed" | "timed-out"): string {
+  return outcome === "timed-out" ? "timed out" : outcome;
 }
 
 async function postFailure(

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -33,6 +33,7 @@ import {
   ThreadImpl,
 } from "#compiled/chat/index.js";
 import { isNotImplemented } from "#public/channels/chat-sdk/notImplemented.js";
+import { defaultAuthorizationEvents } from "#public/channels/chat-sdk/authorization.js";
 import {
   defineChannel,
   GET,
@@ -343,6 +344,7 @@ function defaultEvents<TAdapters extends ChatSdkAdapters>(
   inputActionPrefix: string,
 ): ChatSdkChannelEvents<TAdapters> {
   return {
+    ...defaultAuthorizationEvents,
     async "turn.started"(_event, channel, _ctx) {
       channel.state.pendingToolCallMessage = null;
       clearStream(channel.state);
@@ -384,46 +386,6 @@ function defaultEvents<TAdapters extends ChatSdkAdapters>(
     async "input.requested"(event, channel, _ctx) {
       if (!channel.thread || event.requests.length === 0) return;
       await channel.thread.post(renderInputRequests(event.requests, inputActionPrefix));
-    },
-    async "authorization.required"(event, channel, _ctx) {
-      const thread = channel.thread;
-      if (!thread) return;
-
-      const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
-      const challenge = renderAuthorizationRequired({
-        description: event.description,
-        displayName,
-        instructions: event.authorization?.instructions,
-        url: event.authorization?.url,
-        userCode: event.authorization?.userCode,
-      });
-
-      if (thread.isDM) {
-        await thread.post({ markdown: challenge });
-        return;
-      }
-
-      await thread.post({ markdown: `Authorization required for ${displayName}.` });
-      const author = channel.state.thread?.currentMessage?.author;
-      if (!author) return;
-
-      try {
-        await thread.postEphemeral(author, { markdown: challenge }, { fallbackToDM: true });
-      } catch (error) {
-        // The public status still explains why the session is blocked when an
-        // adapter cannot deliver a private challenge.
-        log.warn("failed to deliver connection authorization challenge privately", { error });
-      }
-    },
-    async "authorization.completed"(event, channel, _ctx) {
-      if (!channel.thread) return;
-      const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
-      const reason = event.reason === undefined ? "" : ` (${event.reason})`;
-      const message =
-        event.outcome === "authorized"
-          ? `${displayName} connected. Resuming.`
-          : `${displayName} authorization ${formatAuthorizationOutcome(event.outcome)}${reason}.`;
-      await channel.thread.post({ markdown: message });
     },
     async "message.completed"(event, channel, _ctx) {
       if (event.finishReason === "tool-calls") {
@@ -566,34 +528,6 @@ function renderInputRequest(request: InputRequest, inputActionPrefix: string) {
     CardText("This request needs a freeform answer. Continue from the eve session UI."),
   );
   return children;
-}
-
-function authorizationDisplayName(name: string, displayName: string | undefined): string {
-  if (displayName !== undefined) return displayName;
-  if (name.length === 0) return name;
-  return name.charAt(0).toUpperCase() + name.slice(1);
-}
-
-function renderAuthorizationRequired(input: {
-  readonly description: string;
-  readonly displayName: string;
-  readonly instructions?: string;
-  readonly url?: string;
-  readonly userCode?: string;
-}): string {
-  return [
-    `Authorization required for ${input.displayName}.`,
-    input.description,
-    input.instructions === input.description ? undefined : input.instructions,
-    input.userCode === undefined ? undefined : `Code: ${input.userCode}`,
-    input.url === undefined ? undefined : `[Sign in with ${input.displayName}](${input.url})`,
-  ]
-    .filter((part): part is string => part !== undefined && part.length > 0)
-    .join("\n\n");
-}
-
-function formatAuthorizationOutcome(outcome: "declined" | "failed" | "timed-out"): string {
-  return outcome === "timed-out" ? "timed out" : outcome;
 }
 
 async function postFailure(

--- a/packages/eve/src/public/channels/discord/defaults.test.ts
+++ b/packages/eve/src/public/channels/discord/defaults.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionContext } from "#public/definitions/callback-context.js";
+import { defaultEvents } from "#public/channels/discord/defaults.js";
+import type { DiscordEventContext } from "#public/channels/discord/discordChannel.js";
+
+const sessionCtx = {} as SessionContext;
+
+function channelStub(input: { readonly guild: boolean }) {
+  const followup = vi.fn().mockResolvedValue({ id: "private" });
+  const post = vi.fn().mockResolvedValue({ id: "public" });
+  const startTyping = vi.fn().mockResolvedValue(undefined);
+  const channel = {
+    discord: {
+      applicationId: "APP1",
+      followup,
+      guildId: input.guild ? "G01" : undefined,
+      interactionToken: "token",
+      post,
+      startTyping,
+    },
+  } as unknown as DiscordEventContext;
+  return { channel, followup, post, startTyping };
+}
+
+function requiredEvent() {
+  return {
+    authorization: { url: "https://connect.example.com/auth", userCode: "ABCD-1234" },
+    description: "Connect your account to continue.",
+    name: "notion",
+    sequence: 0,
+    stepIndex: 0,
+    turnId: "turn-1",
+  };
+}
+
+describe("Discord connection authorization defaults", () => {
+  it("uses an ephemeral followup outside guilds", async () => {
+    const { channel, followup, post } = channelStub({ guild: false });
+
+    await defaultEvents["authorization.required"]!(requiredEvent(), channel, sessionCtx);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(followup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("https://connect.example.com/auth"),
+        flags: 64,
+      }),
+    );
+  });
+
+  it("keeps shared-channel status link-free and follows up ephemerally", async () => {
+    const { channel, followup, post } = channelStub({ guild: true });
+
+    await defaultEvents["authorization.required"]!(requiredEvent(), channel, sessionCtx);
+
+    expect(post).toHaveBeenCalledWith("Authorization required for Notion.");
+    expect(String(post.mock.calls[0]?.[0])).not.toContain("https://");
+    expect(followup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("https://connect.example.com/auth"),
+        flags: 64,
+      }),
+    );
+  });
+
+  it("posts authorization outcomes", async () => {
+    const { channel, post, startTyping } = channelStub({ guild: true });
+
+    await defaultEvents["authorization.completed"]!(
+      { name: "notion", outcome: "authorized", sequence: 1, stepIndex: 0, turnId: "turn-1" },
+      channel,
+      sessionCtx,
+    );
+
+    expect(startTyping).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith("Notion connected. Resuming.");
+  });
+});

--- a/packages/eve/src/public/channels/discord/defaults.test.ts
+++ b/packages/eve/src/public/channels/discord/defaults.test.ts
@@ -10,16 +10,18 @@ function channelStub(input: { readonly guild: boolean }) {
   const followup = vi.fn().mockResolvedValue({ id: "private" });
   const post = vi.fn().mockResolvedValue({ id: "public" });
   const startTyping = vi.fn().mockResolvedValue(undefined);
-  const channel = {
-    discord: {
-      applicationId: "APP1",
-      followup,
-      guildId: input.guild ? "G01" : undefined,
-      interactionToken: "token",
-      post,
-      startTyping,
-    },
-  } as unknown as DiscordEventContext;
+  const partialDiscord: Partial<DiscordEventContext["discord"]> = {
+    applicationId: "APP1",
+    followup,
+    guildId: input.guild ? "G01" : undefined,
+    interactionToken: "token",
+    post,
+    startTyping,
+  };
+  const partialChannel: Pick<DiscordEventContext, "discord"> = {
+    discord: partialDiscord as DiscordEventContext["discord"],
+  };
+  const channel = partialChannel as DiscordEventContext;
   return { channel, followup, post, startTyping };
 }
 

--- a/packages/eve/src/public/channels/discord/defaults.ts
+++ b/packages/eve/src/public/channels/discord/defaults.ts
@@ -1,14 +1,24 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
-import { extractErrorId, formatErrorHint } from "#internal/logging.js";
+import { createLogger, extractErrorId, formatErrorHint } from "#internal/logging.js";
+import {
+  authorizationDisplayName,
+  renderAuthorizationCompleted,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
 import { splitDiscordMessageContent } from "#public/channels/discord/api.js";
-import type { DiscordCommandInteraction } from "#public/channels/discord/inbound.js";
+import {
+  DISCORD_EPHEMERAL_MESSAGE_FLAG,
+  type DiscordCommandInteraction,
+} from "#public/channels/discord/inbound.js";
 import { renderInputRequestComponents } from "#public/channels/discord/hitl.js";
 import type {
   DiscordChannelEvents,
   DiscordCommandResult,
   DiscordContext,
 } from "#public/channels/discord/discordChannel.js";
+
+const log = createLogger("discord.defaults");
 
 /**
  * Builds the default {@link SessionAuthContext} for a Discord command
@@ -49,16 +59,49 @@ export function defaultOnCommand(
   return { auth: defaultDiscordAuth(interaction) };
 }
 
-/** Built-in Discord event handlers for typing, replies, HITL, and terminal errors. */
+/** Built-in Discord event handlers for typing, replies, auth, HITL, and terminal errors. */
 export const defaultEvents: DiscordChannelEvents = {
   async "turn.started"(_event, channel, _ctx) {
     await channel.discord.startTyping();
+  },
+
+  async "authorization.required"(event, channel, _ctx) {
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
+    const challenge = renderAuthorizationRequired({
+      authorization: event.authorization,
+      description: event.description,
+      name: event.name,
+    });
+
+    if (channel.discord.guildId) {
+      await channel.discord.post(`Authorization required for ${displayName}.`);
+    }
+    if (!channel.discord.interactionToken || !channel.discord.applicationId) {
+      if (!channel.discord.guildId) {
+        await channel.discord.post(
+          `Authorization required for ${displayName}. Open the matching eve session to continue.`,
+        );
+      }
+      return;
+    }
+    try {
+      await channel.discord.followup({
+        content: challenge,
+        flags: DISCORD_EPHEMERAL_MESSAGE_FLAG,
+      });
+    } catch (error) {
+      log.error("Discord ephemeral auth challenge delivery failed", {
+        name: event.name,
+        error,
+      });
+    }
   },
 
   async "authorization.completed"(event, channel, _ctx) {
     if (event.outcome === "authorized") {
       await channel.discord.startTyping();
     }
+    await channel.discord.post(renderAuthorizationCompleted(event));
   },
 
   async "actions.requested"(_event, channel, _ctx) {

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -405,8 +405,11 @@ describe("discordChannel() default event handlers", () => {
       ctx,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    for (const [url, init] of fetchMock.mock.calls) {
+    const typingCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith("/channels/C01/typing"),
+    );
+    expect(typingCalls).toHaveLength(3);
+    for (const [url, init] of typingCalls) {
       expect(String(url)).toBe("https://discord.com/api/v10/channels/C01/typing");
       expect(new Headers((init as RequestInit).headers).get("authorization")).toBe("Bot bot-token");
       expect((init as RequestInit).body).toBeUndefined();

--- a/packages/eve/src/public/channels/github/defaults.test.ts
+++ b/packages/eve/src/public/channels/github/defaults.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionContext } from "#public/definitions/callback-context.js";
+import { createDefaultEvents } from "#public/channels/github/defaults.js";
+import type { GitHubEventContext } from "#public/channels/github/githubChannel.js";
+
+describe("GitHub connection authorization defaults", () => {
+  it("posts a link-free status and the eventual outcome", async () => {
+    const post = vi.fn().mockResolvedValue({ id: 1 });
+    const channel = { thread: { post } } as unknown as GitHubEventContext;
+    const events = createDefaultEvents();
+    const ctx = {} as SessionContext;
+
+    await events["authorization.required"]!(
+      {
+        authorization: { url: "https://connect.example.com/auth" },
+        description: "Connect your account to continue.",
+        name: "notion",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      channel,
+      ctx,
+    );
+    await events["authorization.completed"]!(
+      { name: "notion", outcome: "authorized", sequence: 1, stepIndex: 0, turnId: "turn-1" },
+      channel,
+      ctx,
+    );
+
+    expect(post.mock.calls[0]?.[0]).toBe(
+      "Authorization required for Notion. Open the matching eve session to continue.",
+    );
+    expect(post.mock.calls[0]?.[0]).not.toContain("https://");
+    expect(post.mock.calls[1]?.[0]).toBe("Notion connected. Resuming.");
+  });
+});

--- a/packages/eve/src/public/channels/github/defaults.test.ts
+++ b/packages/eve/src/public/channels/github/defaults.test.ts
@@ -7,7 +7,11 @@ import type { GitHubEventContext } from "#public/channels/github/githubChannel.j
 describe("GitHub connection authorization defaults", () => {
   it("posts a link-free status and the eventual outcome", async () => {
     const post = vi.fn().mockResolvedValue({ id: 1 });
-    const channel = { thread: { post } } as unknown as GitHubEventContext;
+    const partialThread: Partial<GitHubEventContext["thread"]> = { post };
+    const partialChannel: Pick<GitHubEventContext, "thread"> = {
+      thread: partialThread as GitHubEventContext["thread"],
+    };
+    const channel = partialChannel as GitHubEventContext;
     const events = createDefaultEvents();
     const ctx = {} as SessionContext;
 

--- a/packages/eve/src/public/channels/github/defaults.ts
+++ b/packages/eve/src/public/channels/github/defaults.ts
@@ -1,6 +1,10 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { createLogger, extractErrorId, formatErrorHint, logError } from "#internal/logging.js";
+import {
+  authorizationDisplayName,
+  renderAuthorizationCompleted,
+} from "#public/channels/authorization-rendering.js";
 import type { GitHubApiOptions } from "#public/channels/github/api.js";
 import type { GitHubChannelCredentials } from "#public/channels/github/auth.js";
 import { checkoutGitHubRepository } from "#public/channels/github/checkout.js";
@@ -90,6 +94,18 @@ export function createDefaultEvents(options: GitHubDefaultEventOptions = {}): Gi
       }
 
       await checkoutRepositoryForTurn(channel, ctx, options);
+    },
+
+    async "authorization.required"(event, channel, _ctx) {
+      const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
+      await postCommentChunks(
+        channel,
+        `Authorization required for ${displayName}. Open the matching eve session to continue.`,
+      );
+    },
+
+    async "authorization.completed"(event, channel, _ctx) {
+      await postCommentChunks(channel, renderAuthorizationCompleted(event));
     },
 
     async "message.completed"(event, channel, _ctx) {

--- a/packages/eve/src/public/channels/slack/connections.test.ts
+++ b/packages/eve/src/public/channels/slack/connections.test.ts
@@ -81,6 +81,18 @@ describe("buildAuthEphemeralBlocks", () => {
     expect(button.style).toBe("primary");
   });
 
+  it("renders URL-less device-flow instructions without an action button", () => {
+    const blocks = buildAuthEphemeralBlocks({
+      displayName: "Notion",
+      instructions: "Open the provider app.",
+      userCode: "OTB-DGO",
+    });
+
+    expect(JSON.stringify(blocks)).toContain("Open the provider app.");
+    expect(JSON.stringify(blocks)).toContain("OTB-DGO");
+    expect(JSON.stringify(blocks)).not.toContain("button");
+  });
+
   it("prepends a section with the device user code when one is provided", () => {
     const blocks = buildAuthEphemeralBlocks({
       displayName: "Notion",

--- a/packages/eve/src/public/channels/slack/connections.test.ts
+++ b/packages/eve/src/public/channels/slack/connections.test.ts
@@ -6,6 +6,10 @@ import {
   buildAuthRequiredPublicText,
   formatConnectionDisplayName,
 } from "#public/channels/slack/connections.js";
+import {
+  SLACK_BLOCK_KIT_PLAIN_TEXT_MAX_LENGTH,
+  SLACK_SECTION_TEXT_MAX_LENGTH,
+} from "#public/channels/slack/limits.js";
 
 describe("formatConnectionDisplayName", () => {
   it("title-cases the first character", () => {
@@ -104,5 +108,20 @@ describe("buildAuthEphemeralBlocks", () => {
     expect(section.type).toBe("section");
     expect(section.text.text).toBe("Use code `OTB-DGO` when prompted.");
     expect((blocks[1] as { type: string }).type).toBe("actions");
+  });
+
+  it("caps authored text at Slack Block Kit limits", () => {
+    const blocks = buildAuthEphemeralBlocks({
+      displayName: "x".repeat(SLACK_BLOCK_KIT_PLAIN_TEXT_MAX_LENGTH + 100),
+      instructions: "y".repeat(SLACK_SECTION_TEXT_MAX_LENGTH + 100),
+      url: "https://connect.example.com/authorize/sca_abc",
+    });
+    const section = blocks[0] as { text: { text: string } };
+    const actions = blocks[1] as { elements: Array<{ text: { text: string } }> };
+
+    expect(section.text.text.length).toBeLessThanOrEqual(SLACK_SECTION_TEXT_MAX_LENGTH);
+    expect(actions.elements[0]?.text.text.length).toBeLessThanOrEqual(
+      SLACK_BLOCK_KIT_PLAIN_TEXT_MAX_LENGTH,
+    );
   });
 });

--- a/packages/eve/src/public/channels/slack/connections.ts
+++ b/packages/eve/src/public/channels/slack/connections.ts
@@ -74,26 +74,35 @@ export function buildAuthCompletedText(input: {
  */
 export function buildAuthEphemeralBlocks(input: {
   readonly displayName: string;
-  readonly url: string;
+  readonly instructions?: string;
+  readonly url?: string;
   readonly userCode?: string;
 }): unknown[] {
   const blocks: unknown[] = [];
+  if (input.instructions !== undefined && input.instructions.length > 0) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: input.instructions },
+    });
+  }
   if (input.userCode !== undefined && input.userCode.length > 0) {
     blocks.push({
       type: "section",
       text: { type: "mrkdwn", text: `Use code \`${input.userCode}\` when prompted.` },
     });
   }
-  blocks.push({
-    type: "actions",
-    elements: [
-      {
-        type: "button",
-        text: { type: "plain_text", text: `Sign in with ${input.displayName}` },
-        url: input.url,
-        style: "primary",
-      },
-    ],
-  });
+  if (input.url !== undefined) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: `Sign in with ${input.displayName}` },
+          url: input.url,
+          style: "primary",
+        },
+      ],
+    });
+  }
   return blocks;
 }

--- a/packages/eve/src/public/channels/slack/connections.ts
+++ b/packages/eve/src/public/channels/slack/connections.ts
@@ -9,15 +9,15 @@
  * delivering the actual challenge as an ephemeral "Sign in with X"
  * message visible only to the triggering user.
  *
- * When no user can be targeted (no triggering user id, no challenge
- * URL, or the ephemeral delivery fails), the public status still leaves
- * the shared thread with safe progress feedback. The matching
- * `authorization.completed` handler edits that status post in place to
- * surface the outcome (`authorized` / `declined` / `failed` /
+ * When no user can be targeted, or private delivery fails, the public
+ * status still leaves the shared thread with safe progress feedback. The
+ * matching `authorization.completed` handler edits that status post in place
+ * to surface the outcome (`authorized` / `declined` / `failed` /
  * `timed-out`).
  */
 
 import type { ConnectionAuthorizationOutcome } from "#protocol/message.js";
+import { truncatePlainText, truncateSectionText } from "#public/channels/slack/limits.js";
 
 export type { ConnectionAuthorizationOutcome };
 
@@ -66,11 +66,11 @@ export function buildAuthCompletedText(input: {
 }
 
 /**
- * Block Kit blocks for the ephemeral "Sign in with X" link button.
- * Device-code flows carry a `userCode` the user must enter after
- * following the link, so it is rendered alongside the button. Slack
- * ephemerals accept the same block list shape as regular messages so the
- * helper returns blocks directly.
+ * Block Kit blocks for the ephemeral authorization challenge. URL flows
+ * render a "Sign in with X" button; URL-less flows can render instructions
+ * and a device code without an action block. Slack ephemerals accept the
+ * same block list shape as regular messages, so the helper returns blocks
+ * directly.
  */
 export function buildAuthEphemeralBlocks(input: {
   readonly displayName: string;
@@ -82,13 +82,16 @@ export function buildAuthEphemeralBlocks(input: {
   if (input.instructions !== undefined && input.instructions.length > 0) {
     blocks.push({
       type: "section",
-      text: { type: "mrkdwn", text: input.instructions },
+      text: { type: "mrkdwn", text: truncateSectionText(input.instructions) },
     });
   }
   if (input.userCode !== undefined && input.userCode.length > 0) {
     blocks.push({
       type: "section",
-      text: { type: "mrkdwn", text: `Use code \`${input.userCode}\` when prompted.` },
+      text: {
+        type: "mrkdwn",
+        text: truncateSectionText(`Use code \`${input.userCode}\` when prompted.`),
+      },
     });
   }
   if (input.url !== undefined) {
@@ -97,7 +100,10 @@ export function buildAuthEphemeralBlocks(input: {
       elements: [
         {
           type: "button",
-          text: { type: "plain_text", text: `Sign in with ${input.displayName}` },
+          text: {
+            type: "plain_text",
+            text: truncatePlainText(`Sign in with ${input.displayName}`),
+          },
           url: input.url,
           style: "primary",
         },

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -93,7 +93,31 @@ describe("defaultEvents authorization.required", () => {
 
     const message = postEphemeral.mock.calls[0]?.[1] as { text: string; blocks: unknown[] };
     expect(JSON.stringify(message.blocks)).toContain("OTB-DGO");
-    expect(message.text).toContain("(code: OTB-DGO)");
+    expect(message.text).toContain("Code: OTB-DGO");
+  });
+
+  it("delivers URL-less device instructions and codes ephemerally", async () => {
+    const { channel, post, postEphemeral } = buildChannelStub({ triggeringUserId: "U777" });
+
+    await defaultEvents["authorization.required"]!(
+      {
+        authorization: { instructions: "Open the provider app.", userCode: "OTB-DGO" },
+        description: "Connect your account.",
+        name: "notion",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_0",
+      },
+      channel,
+      sessionCtx,
+    );
+
+    expect(String(post.mock.calls[0]?.[0])).not.toContain("OTB-DGO");
+    const message = postEphemeral.mock.calls[0]?.[1] as { text: string; blocks: unknown[] };
+    expect(message.text).toContain("Open the provider app.");
+    expect(message.text).toContain("Code: OTB-DGO");
+    expect(JSON.stringify(message.blocks)).toContain("Open the provider app.");
+    expect(JSON.stringify(message.blocks)).toContain("OTB-DGO");
   });
 
   it("renders the challenge displayName instead of the title-cased connection name", async () => {

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -120,6 +120,26 @@ describe("defaultEvents authorization.required", () => {
     expect(JSON.stringify(message.blocks)).toContain("OTB-DGO");
   });
 
+  it("delivers description-only challenges ephemerally", async () => {
+    const { channel, postEphemeral } = buildChannelStub({ triggeringUserId: "U777" });
+
+    await defaultEvents["authorization.required"]!(
+      {
+        description: "Approve the request in your provider app.",
+        name: "notion",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_0",
+      },
+      channel,
+      sessionCtx,
+    );
+
+    expect(postEphemeral).toHaveBeenCalledWith("U777", {
+      text: expect.stringContaining("Approve the request in your provider app."),
+    });
+  });
+
   it("renders the challenge displayName instead of the title-cased connection name", async () => {
     const { channel, post, postEphemeral } = buildChannelStub({ triggeringUserId: "U777" });
 

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -1,14 +1,16 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { createLogger, extractErrorId, formatErrorHint } from "#internal/logging.js";
-import { renderAuthorizationRequired } from "#public/channels/authorization-rendering.js";
+import {
+  authorizationDisplayName,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
 import { describeActionRequests } from "#public/channels/slack/action-status.js";
 import { buildSlackAuthContext, slackUserIdFromAuthContext } from "#public/channels/slack/auth.js";
 import {
   buildAuthCompletedText,
   buildAuthEphemeralBlocks,
   buildAuthRequiredPublicText,
-  formatConnectionDisplayName,
   type ConnectionAuthorizationOutcome,
 } from "#public/channels/slack/connections.js";
 import {
@@ -229,7 +231,7 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "authorization.required"(event, channel, ctx) {
-    const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
     const triggeringUserId =
       slackUserIdFromAuthContext(ctx.session.auth.current) ??
       channel.state.triggeringUserId ??
@@ -261,31 +263,32 @@ export const defaultEvents: SlackChannelInternalEvents = {
       }
     }
 
-    // The challenge is user-specific: the sign-in link (and device code)
-    // must only ever be visible to the triggering user, never posted into
-    // the shared thread.
-    const hasPrivateChallenge =
-      challengeUrl !== undefined ||
-      event.authorization?.userCode !== undefined ||
-      event.authorization?.instructions !== undefined;
-    if (triggeringUserId && hasPrivateChallenge) {
+    // The challenge is user-specific: its description, sign-in link, and
+    // device code must only ever be visible to the triggering user, never
+    // posted into the shared thread. `authorization` itself is optional,
+    // so description-only challenges still require private delivery.
+    if (triggeringUserId) {
       const userCode = event.authorization?.userCode;
-      try {
-        await channel.thread.postEphemeral(triggeringUserId, {
-          blocks: buildAuthEphemeralBlocks({
-            displayName,
-            instructions: event.authorization?.instructions,
-            url: challengeUrl,
-            userCode,
-          }),
-          // Fallback text mirrors the blocks: clients that render only the
-          // notification text still get everything needed to complete the flow.
-          text: renderAuthorizationRequired({
+      const blocks = buildAuthEphemeralBlocks({
+        displayName,
+        instructions: event.authorization?.instructions,
+        url: challengeUrl,
+        userCode,
+      });
+      const privateMessage: { blocks?: unknown[]; text: string } = {
+        text: truncateMessageText(
+          renderAuthorizationRequired({
             authorization: event.authorization,
             description: event.description,
             name: event.name,
           }),
-        });
+        ),
+      };
+      if (blocks.length > 0) privateMessage.blocks = blocks;
+      try {
+        // Fallback text complements the blocks: clients that render only
+        // notification text still get everything needed to complete the flow.
+        await channel.thread.postEphemeral(triggeringUserId, privateMessage);
       } catch (error) {
         log.error("Slack auth ephemeral delivery failed", {
           name: event.name,
@@ -296,7 +299,7 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "authorization.completed"(event, channel, _ctx) {
-    const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
     if (event.outcome === "authorized") {
       await channel.thread.startTyping(`Connected to ${displayName}. Resuming...`);
     }

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -1,6 +1,7 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { createLogger, extractErrorId, formatErrorHint } from "#internal/logging.js";
+import { renderAuthorizationRequired } from "#public/channels/authorization-rendering.js";
 import { describeActionRequests } from "#public/channels/slack/action-status.js";
 import { buildSlackAuthContext, slackUserIdFromAuthContext } from "#public/channels/slack/auth.js";
 import {
@@ -263,20 +264,27 @@ export const defaultEvents: SlackChannelInternalEvents = {
     // The challenge is user-specific: the sign-in link (and device code)
     // must only ever be visible to the triggering user, never posted into
     // the shared thread.
-    if (triggeringUserId && challengeUrl) {
+    const hasPrivateChallenge =
+      challengeUrl !== undefined ||
+      event.authorization?.userCode !== undefined ||
+      event.authorization?.instructions !== undefined;
+    if (triggeringUserId && hasPrivateChallenge) {
       const userCode = event.authorization?.userCode;
       try {
         await channel.thread.postEphemeral(triggeringUserId, {
           blocks: buildAuthEphemeralBlocks({
             displayName,
+            instructions: event.authorization?.instructions,
             url: challengeUrl,
             userCode,
           }),
           // Fallback text mirrors the blocks: clients that render only the
           // notification text still get everything needed to complete the flow.
-          text: userCode
-            ? `Sign in with ${displayName}: ${challengeUrl} (code: ${userCode})`
-            : `Sign in with ${displayName}: ${challengeUrl}`,
+          text: renderAuthorizationRequired({
+            authorization: event.authorization,
+            description: event.description,
+            name: event.name,
+          }),
         });
       } catch (error) {
         log.error("Slack auth ephemeral delivery failed", {

--- a/packages/eve/src/public/channels/teams/defaults.test.ts
+++ b/packages/eve/src/public/channels/teams/defaults.test.ts
@@ -47,9 +47,8 @@ describe("defaultEvents authorization.required", () => {
     await defaultEvents["authorization.required"]!(authRequiredEvent(), channel, sessionCtx);
 
     const message = post.mock.calls[0]?.[0] as { text: string };
-    expect(message.text).toBe(
-      "Authorization required for Notion: https://connect.example.com/a/sca_1",
-    );
+    expect(message.text).toContain("Authorization required for Notion.");
+    expect(message.text).toContain("https://connect.example.com/a/sca_1");
     expect(channel.state.pendingAuthActivityId).toBe("act1");
   });
 
@@ -63,10 +62,44 @@ describe("defaultEvents authorization.required", () => {
     );
 
     const message = post.mock.calls[0]?.[0] as { text: string; attachments: unknown[] };
-    expect(message.text).toBe(
-      "Authorization required for Notion Workspace: https://connect.example.com/a/sca_1",
-    );
+    expect(message.text).toContain("Authorization required for Notion Workspace.");
+    expect(message.text).toContain("https://connect.example.com/a/sca_1");
     expect(JSON.stringify(message.attachments)).toContain("Sign in with Notion Workspace");
+  });
+
+  it("keeps the authorization credential out of shared conversations", async () => {
+    const { channel, post } = buildChannelStub({ conversationType: "channel" });
+
+    await defaultEvents["authorization.required"]!(authRequiredEvent(), channel, sessionCtx);
+
+    const message = post.mock.calls[0]?.[0] as { text: string; attachments?: unknown[] };
+    expect(message.text).toBe(
+      "Authorization required for Notion. Open the matching eve session to continue.",
+    );
+    expect(message.text).not.toContain("https://");
+    expect(message.attachments).toBeUndefined();
+  });
+
+  it("renders URL-less device instructions and codes in personal chats", async () => {
+    const { channel, post } = buildChannelStub();
+
+    await defaultEvents["authorization.required"]!(
+      {
+        authorization: { instructions: "Open the provider app.", userCode: "ABCD-1234" },
+        description: "Connect your account.",
+        name: "notion",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      channel,
+      sessionCtx,
+    );
+
+    const message = post.mock.calls[0]?.[0] as { text: string; attachments: unknown[] };
+    expect(message.text).toContain("Open the provider app.");
+    expect(message.text).toContain("Code: ABCD-1234");
+    expect(JSON.stringify(message.attachments)).toContain("ABCD-1234");
   });
 });
 

--- a/packages/eve/src/public/channels/teams/defaults.ts
+++ b/packages/eve/src/public/channels/teams/defaults.ts
@@ -1,6 +1,7 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { extractErrorId, formatErrorHint } from "#internal/logging.js";
+import { renderAuthorizationRequired } from "#public/channels/authorization-rendering.js";
 import type { ConnectionAuthorizationOutcome } from "#protocol/message.js";
 import { splitTeamsMessageText, type TeamsMention } from "#public/channels/teams/api.js";
 import {
@@ -114,44 +115,50 @@ export const defaultEvents: TeamsChannelEvents = {
   async "authorization.required"(event, channel, _ctx) {
     const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
     const url = event.authorization?.url;
-    const text = url
-      ? `Authorization required for ${displayName}: ${url}`
-      : `Authorization required for ${displayName}.`;
+    const isPersonal = channel.state.conversationType === "personal";
+    const text = isPersonal
+      ? renderAuthorizationRequired({
+          authorization: event.authorization,
+          description: event.description,
+          name: event.name,
+        })
+      : `Authorization required for ${displayName}. Open the matching eve session to continue.`;
     const posted = await channel.thread.post({
-      attachments: [
-        {
-          content: parseJsonObject({
-            $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-            actions: url
-              ? [
-                  {
-                    title: `Sign in with ${displayName}`,
-                    type: "Action.OpenUrl",
-                    url,
-                  },
-                ]
-              : [],
-            body: [
+      ...(isPersonal
+        ? {
+            attachments: [
               {
-                text: `Authorization required for ${displayName}`,
-                type: "TextBlock",
-                weight: "Bolder",
-                wrap: true,
-              },
-              {
-                text: channel.state.triggeringUser
-                  ? `Requested by ${channel.state.triggeringUser.name ?? channel.state.triggeringUser.id}.`
-                  : "No triggering user is available for a private prompt.",
-                type: "TextBlock",
-                wrap: true,
+                content: parseJsonObject({
+                  $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                  actions: url
+                    ? [
+                        {
+                          title: `Sign in with ${displayName}`,
+                          type: "Action.OpenUrl",
+                          url,
+                        },
+                      ]
+                    : [],
+                  body: [
+                    {
+                      text: renderAuthorizationRequired({
+                        authorization: event.authorization,
+                        description: event.description,
+                        includeUrl: false,
+                        name: event.name,
+                      }),
+                      type: "TextBlock",
+                      wrap: true,
+                    },
+                  ],
+                  type: "AdaptiveCard",
+                  version: channel.adaptiveCardVersion,
+                }),
+                contentType: "application/vnd.microsoft.card.adaptive",
               },
             ],
-            type: "AdaptiveCard",
-            version: channel.adaptiveCardVersion,
-          }),
-          contentType: "application/vnd.microsoft.card.adaptive",
-        },
-      ],
+          }
+        : {}),
       text,
     });
     if (posted.id) {

--- a/packages/eve/src/public/channels/teams/defaults.ts
+++ b/packages/eve/src/public/channels/teams/defaults.ts
@@ -1,7 +1,10 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { extractErrorId, formatErrorHint } from "#internal/logging.js";
-import { renderAuthorizationRequired } from "#public/channels/authorization-rendering.js";
+import {
+  authorizationDisplayName,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
 import type { ConnectionAuthorizationOutcome } from "#protocol/message.js";
 import { splitTeamsMessageText, type TeamsMention } from "#public/channels/teams/api.js";
 import {
@@ -113,7 +116,7 @@ export const defaultEvents: TeamsChannelEvents = {
   },
 
   async "authorization.required"(event, channel, _ctx) {
-    const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
     const url = event.authorization?.url;
     const isPersonal = channel.state.conversationType === "personal";
     const text = isPersonal
@@ -173,7 +176,7 @@ export const defaultEvents: TeamsChannelEvents = {
 
     const activityId = channel.state.pendingAuthActivityId;
     if (!activityId) return;
-    const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
     const text = buildAuthCompletedText({
       displayName,
       outcome: event.outcome as ConnectionAuthorizationOutcome,

--- a/packages/eve/src/public/channels/telegram/defaults.test.ts
+++ b/packages/eve/src/public/channels/telegram/defaults.test.ts
@@ -27,9 +27,16 @@ function channelStub(chatType: "private" | "group") {
   const post = vi.fn().mockResolvedValue({ id: "message-1" });
   const request = vi.fn().mockResolvedValue({ body: {}, ok: true, status: 200 });
   const startTyping = vi.fn().mockResolvedValue(undefined);
-  const channel = {
-    telegram: { chatType, post, request, startTyping },
-  } as unknown as TelegramEventContext;
+  const partialTelegram: Partial<TelegramEventContext["telegram"]> = {
+    chatType,
+    post,
+    request,
+    startTyping,
+  };
+  const partialChannel: Pick<TelegramEventContext, "telegram"> = {
+    telegram: partialTelegram as TelegramEventContext["telegram"],
+  };
+  const channel = partialChannel as TelegramEventContext;
   return { channel, post, request, startTyping };
 }
 

--- a/packages/eve/src/public/channels/telegram/defaults.test.ts
+++ b/packages/eve/src/public/channels/telegram/defaults.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionContext } from "#public/definitions/callback-context.js";
+import { defaultEvents } from "#public/channels/telegram/defaults.js";
+import type { TelegramEventContext } from "#public/channels/telegram/telegramChannel.js";
+
+function sessionContext(userId?: string): SessionContext {
+  return {
+    session: {
+      auth: {
+        current:
+          userId === undefined
+            ? null
+            : {
+                attributes: { user_id: userId },
+                authenticator: "telegram-webhook",
+                principalId: `telegram:${userId}`,
+                principalType: "user",
+              },
+        initiator: null,
+      },
+    },
+  } as SessionContext;
+}
+
+function channelStub(chatType: "private" | "group") {
+  const post = vi.fn().mockResolvedValue({ id: "message-1" });
+  const request = vi.fn().mockResolvedValue({ body: {}, ok: true, status: 200 });
+  const startTyping = vi.fn().mockResolvedValue(undefined);
+  const channel = {
+    telegram: { chatType, post, request, startTyping },
+  } as unknown as TelegramEventContext;
+  return { channel, post, request, startTyping };
+}
+
+function requiredEvent() {
+  return {
+    authorization: { url: "https://connect.example.com/auth", userCode: "ABCD-1234" },
+    description: "Connect your account to continue.",
+    name: "notion",
+    sequence: 0,
+    stepIndex: 0,
+    turnId: "turn-1",
+  };
+}
+
+describe("Telegram connection authorization defaults", () => {
+  it("posts the challenge directly in private chats", async () => {
+    const { channel, post, request } = channelStub("private");
+
+    await defaultEvents["authorization.required"]!(requiredEvent(), channel, sessionContext("42"));
+
+    expect(post.mock.calls[0]?.[0]).toContain("https://connect.example.com/auth");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("keeps group status link-free and sends the challenge to the user chat", async () => {
+    const { channel, post, request } = channelStub("group");
+
+    await defaultEvents["authorization.required"]!(requiredEvent(), channel, sessionContext("42"));
+
+    expect(post).toHaveBeenCalledWith("Authorization required for Notion.");
+    expect(request).toHaveBeenCalledWith(
+      "sendMessage",
+      expect.objectContaining({
+        chat_id: "42",
+        protect_content: true,
+        text: expect.stringContaining("https://connect.example.com/auth"),
+      }),
+    );
+  });
+});

--- a/packages/eve/src/public/channels/telegram/defaults.test.ts
+++ b/packages/eve/src/public/channels/telegram/defaults.test.ts
@@ -76,4 +76,15 @@ describe("Telegram connection authorization defaults", () => {
       }),
     );
   });
+
+  it("keeps the safe group status when private challenge delivery throws", async () => {
+    const { channel, post, request } = channelStub("group");
+    request.mockRejectedValueOnce(new Error("network unavailable"));
+
+    await expect(
+      defaultEvents["authorization.required"]!(requiredEvent(), channel, sessionContext("42")),
+    ).resolves.toBeUndefined();
+
+    expect(post).toHaveBeenCalledWith("Authorization required for Notion.");
+  });
 });

--- a/packages/eve/src/public/channels/telegram/defaults.ts
+++ b/packages/eve/src/public/channels/telegram/defaults.ts
@@ -81,7 +81,12 @@ export const defaultEvents: TelegramChannelEvents = {
 
     await channel.telegram.post(`Authorization required for ${displayName}.`);
     const userId = ctx.session.auth.current?.attributes.user_id;
-    if (!userId) return;
+    if (!userId) {
+      log.warn("Telegram private auth challenge delivery skipped without a user id", {
+        name: event.name,
+      });
+      return;
+    }
     try {
       const response = await channel.telegram.request("sendMessage", {
         chat_id: userId,

--- a/packages/eve/src/public/channels/telegram/defaults.ts
+++ b/packages/eve/src/public/channels/telegram/defaults.ts
@@ -1,6 +1,11 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
-import { extractErrorId, formatErrorHint } from "#internal/logging.js";
+import { createLogger, extractErrorId, formatErrorHint } from "#internal/logging.js";
+import {
+  authorizationDisplayName,
+  renderAuthorizationCompleted,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
 import {
   registerTelegramFreeformPrompt,
   renderTelegramInputRequest,
@@ -11,6 +16,8 @@ import type {
   TelegramContext,
   TelegramInboundResult,
 } from "#public/channels/telegram/telegramChannel.js";
+
+const log = createLogger("telegram.defaults");
 
 /** Default auth projection for Telegram webhook actors. */
 export function defaultTelegramAuth(message: TelegramMessage): SessionAuthContext | null {
@@ -53,16 +60,47 @@ export async function defaultOnMessage(
   return { auth: defaultTelegramAuth(message) };
 }
 
-/** Built-in Telegram event handlers for typing, replies, HITL, and terminal errors. */
+/** Built-in Telegram event handlers for typing, replies, auth, HITL, and terminal errors. */
 export const defaultEvents: TelegramChannelEvents = {
   async "turn.started"(_event, channel, _ctx) {
     await channel.telegram.startTyping();
+  },
+
+  async "authorization.required"(event, channel, ctx) {
+    const displayName = authorizationDisplayName(event.name, event.authorization?.displayName);
+    const challenge = renderAuthorizationRequired({
+      authorization: event.authorization,
+      description: event.description,
+      name: event.name,
+    });
+
+    if (channel.telegram.chatType === "private") {
+      await channel.telegram.post(challenge);
+      return;
+    }
+
+    await channel.telegram.post(`Authorization required for ${displayName}.`);
+    const userId = ctx.session.auth.current?.attributes.user_id;
+    if (!userId) return;
+    const response = await channel.telegram.request("sendMessage", {
+      chat_id: userId,
+      link_preview_options: { is_disabled: true },
+      protect_content: true,
+      text: challenge,
+    });
+    if (!response.ok) {
+      log.error("Telegram private auth challenge delivery failed", {
+        name: event.name,
+        status: response.status,
+      });
+    }
   },
 
   async "authorization.completed"(event, channel, _ctx) {
     if (event.outcome === "authorized") {
       await channel.telegram.startTyping();
     }
+    await channel.telegram.post(renderAuthorizationCompleted(event));
   },
 
   async "actions.requested"(_event, channel, _ctx) {

--- a/packages/eve/src/public/channels/telegram/defaults.ts
+++ b/packages/eve/src/public/channels/telegram/defaults.ts
@@ -82,16 +82,25 @@ export const defaultEvents: TelegramChannelEvents = {
     await channel.telegram.post(`Authorization required for ${displayName}.`);
     const userId = ctx.session.auth.current?.attributes.user_id;
     if (!userId) return;
-    const response = await channel.telegram.request("sendMessage", {
-      chat_id: userId,
-      link_preview_options: { is_disabled: true },
-      protect_content: true,
-      text: challenge,
-    });
-    if (!response.ok) {
+    try {
+      const response = await channel.telegram.request("sendMessage", {
+        chat_id: userId,
+        link_preview_options: { is_disabled: true },
+        protect_content: true,
+        text: challenge,
+      });
+      if (!response.ok) {
+        log.error("Telegram private auth challenge delivery failed", {
+          name: event.name,
+          status: response.status,
+        });
+      }
+    } catch (error) {
+      // The public status still explains why the session is blocked when the
+      // private user chat cannot be reached.
       log.error("Telegram private auth challenge delivery failed", {
+        error,
         name: event.name,
-        status: response.status,
       });
     }
   },

--- a/packages/eve/src/public/channels/twilio/defaults.test.ts
+++ b/packages/eve/src/public/channels/twilio/defaults.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionContext } from "#public/definitions/callback-context.js";
+import { defaultEvents } from "#public/channels/twilio/defaults.js";
+import type { TwilioEventContext } from "#public/channels/twilio/twilioChannel.js";
+
+describe("Twilio connection authorization defaults", () => {
+  it("sends challenges and outcomes to the bound phone number", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true });
+    const channel = { twilio: { sendMessage } } as unknown as TwilioEventContext;
+    const ctx = {} as SessionContext;
+
+    await defaultEvents["authorization.required"]!(
+      {
+        authorization: { url: "https://connect.example.com/auth", userCode: "ABCD-1234" },
+        description: "Connect your account to continue.",
+        name: "notion",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      channel,
+      ctx,
+    );
+    await defaultEvents["authorization.completed"]!(
+      { name: "notion", outcome: "authorized", sequence: 1, stepIndex: 0, turnId: "turn-1" },
+      channel,
+      ctx,
+    );
+
+    expect(sendMessage.mock.calls[0]?.[0]).toContain("https://connect.example.com/auth");
+    expect(sendMessage.mock.calls[1]?.[0]).toBe("Notion connected. Resuming.");
+  });
+});

--- a/packages/eve/src/public/channels/twilio/defaults.test.ts
+++ b/packages/eve/src/public/channels/twilio/defaults.test.ts
@@ -7,7 +7,11 @@ import type { TwilioEventContext } from "#public/channels/twilio/twilioChannel.j
 describe("Twilio connection authorization defaults", () => {
   it("sends challenges and outcomes to the bound phone number", async () => {
     const sendMessage = vi.fn().mockResolvedValue({ ok: true });
-    const channel = { twilio: { sendMessage } } as unknown as TwilioEventContext;
+    const partialTwilio: Partial<TwilioEventContext["twilio"]> = { sendMessage };
+    const partialChannel: Pick<TwilioEventContext, "twilio"> = {
+      twilio: partialTwilio as TwilioEventContext["twilio"],
+    };
+    const channel = partialChannel as TwilioEventContext;
     const ctx = {} as SessionContext;
 
     await defaultEvents["authorization.required"]!(

--- a/packages/eve/src/public/channels/twilio/defaults.ts
+++ b/packages/eve/src/public/channels/twilio/defaults.ts
@@ -1,6 +1,10 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { extractErrorId, formatErrorHint } from "#internal/logging.js";
+import {
+  renderAuthorizationCompleted,
+  renderAuthorizationRequired,
+} from "#public/channels/authorization-rendering.js";
 import type {
   TwilioTextMessage,
   TwilioVoiceCall,
@@ -67,8 +71,22 @@ export function defaultOnVoiceTranscription(
   };
 }
 
-/** Built-in Twilio event handlers for text delivery and terminal errors. */
+/** Built-in Twilio event handlers for text delivery, auth, and terminal errors. */
 export const defaultEvents: TwilioChannelEvents = {
+  async "authorization.required"(event, channel, _ctx) {
+    await channel.twilio.sendMessage(
+      renderAuthorizationRequired({
+        authorization: event.authorization,
+        description: event.description,
+        name: event.name,
+      }),
+    );
+  },
+
+  async "authorization.completed"(event, channel, _ctx) {
+    await channel.twilio.sendMessage(renderAuthorizationCompleted(event));
+  },
+
   async "message.completed"(event, channel, _ctx) {
     if (event.finishReason === "tool-calls" || !event.message) return;
     await channel.twilio.sendMessage(event.message);


### PR DESCRIPTION
## Summary

- render MCP connection authorization challenges and outcomes across eve's built-in channels
- fix Photon at the shared Chat SDK layer, so all Chat SDK adapters get the same default behavior
- preserve URL-less device-flow instructions and user codes
- treat authorization URLs and device codes as session-bound credentials: direct surfaces render the full challenge, while shared surfaces use private delivery or a link-free public status
- keep private-delivery failures non-fatal after a safe public blocked status, while logging missing/unsupported private delivery

## Audit

| Surface | Result |
| --- | --- |
| eve HTTP/browser client, ACP, CLI/TUI, subagents | Already handled both authorization events |
| Chat SDK / Photon | Full challenge in DMs; private ephemeral/DM fallback in groups |
| Slack | Private delivery retained; URL-less and description-only challenges render within Block Kit limits |
| Linear | Existing native user-targeted auth elicitation retained |
| Discord | Ephemeral interaction follow-up; no credential posted publicly |
| Telegram | Full challenge in private chats; protected DM plus link-free group status |
| Twilio | Full challenge and outcome sent to the bound phone number |
| Teams | Full challenge in personal chats; link-free status in shared conversations |
| GitHub | Link-free status in public issue/PR threads; continue from the matching eve session |

Custom event handlers still override these defaults.

## Verification

- full eve unit suite — 584 files, 6,051 passed, 1 skipped
- eve typecheck and package build
- formatting, oxlint, fixture guard, and invariant guard
- local `test-agent`: confirmed `node_modules/eve` resolves to this worktree at eve 0.31.2, then passed `npm run typecheck` and `npm run build`

## Smoke-test note

`test-agent` builds against this local package, but its existing `eve start` server exits with code 0 before the CLI health check, including with a fresh `WORKFLOW_LOCAL_DATA_DIR`. The channel delivery paths are covered by the unit suites above.
