### PR TITLE
feat(eve): add authenticated create-once sessions

### DIFF
--- a/.changeset/session-create-once.md
+++ b/.changeset/session-create-once.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add authenticated create-once session requests through `operationId`. Concurrent or retried creates adopt the active session that first claimed the operation without dispatching duplicate input.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -41,6 +41,19 @@ curl -X POST https://<deployment>/eve/v1/session \
 # {"continuationToken":"eve:7f3c...","ok":true,"sessionId":"ses_01h..."}
 ```
 
+Authenticated callers that may retry a create request can pass their own `operationId` for
+create-once semantics. The same operation under the same authenticated principal returns the
+active session it already created instead of dispatching the input again. The first accepted
+payload wins; retries with different input still return that first session. Anonymous callers
+cannot use `operationId`, and operation ownership expires when the session is no longer resumable.
+
+```bash
+curl -X POST https://<deployment>/eve/v1/session \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"What is the weather in Paris?","operationId":"order-4213-research"}'
+```
+
 Stream that session's events as newline-delimited JSON (`application/x-ndjson; charset=utf-8`), one event object per line:
 
 ```bash

--- a/e2e/fixtures/agent-basic-runtime/agent/channels/eve.ts
+++ b/e2e/fixtures/agent-basic-runtime/agent/channels/eve.ts
@@ -1,0 +1,25 @@
+import type { AuthFn } from "eve/channels/auth";
+import { eveChannel } from "eve/channels/eve";
+import type { SessionAuthContext } from "eve/context";
+
+const PRINCIPAL_A = "Bearer e2e-create-once-a";
+const PRINCIPAL_B = "Bearer e2e-create-once-b";
+
+function principal(issuer: string): SessionAuthContext {
+  return {
+    attributes: {},
+    authenticator: "e2e-create-once",
+    issuer,
+    principalId: "shared-principal-id",
+    principalType: "user",
+    subject: "shared-subject",
+  };
+}
+
+const authenticateA: AuthFn<Request> = (request) =>
+  request.headers.get("authorization") === PRINCIPAL_A ? principal("issuer-a") : null;
+const authenticateB: AuthFn<Request> = (request) =>
+  request.headers.get("authorization") === PRINCIPAL_B ? principal("issuer-b") : null;
+const authenticateEvalDriver: AuthFn<Request> = () => principal("eval-driver");
+
+export default eveChannel({ auth: [authenticateA, authenticateB, authenticateEvalDriver] });

--- a/e2e/fixtures/agent-basic-runtime/evals/runtime/session-create-idempotency.eval.ts
+++ b/e2e/fixtures/agent-basic-runtime/evals/runtime/session-create-idempotency.eval.ts
@@ -1,0 +1,98 @@
+import { defineEval, type EveEvalTargetHandle } from "eve/evals";
+import { equals, satisfies } from "eve/evals/expect";
+
+interface CreateSessionResponse {
+  readonly continuationToken: string;
+  readonly ok: true;
+  readonly sessionId: string;
+}
+
+const PRINCIPAL_A = "Bearer e2e-create-once-a";
+const PRINCIPAL_B = "Bearer e2e-create-once-b";
+
+export default defineEval({
+  description:
+    "Concurrent and serial create retries dispatch once and remain isolated across issuers.",
+  async test(t) {
+    const operationId = `session-create-idempotency-${crypto.randomUUID()}`;
+    const message = `CREATE-ONCE-INITIAL-${crypto.randomUUID()}`;
+    const [first, concurrent] = await Promise.all([
+      createSession(t.target, PRINCIPAL_A, operationId, message),
+      createSession(t.target, PRINCIPAL_A, operationId, message),
+    ]);
+    const replay = await createSession(t.target, PRINCIPAL_A, operationId, message);
+    const otherIssuer = await createSession(t.target, PRINCIPAL_B, operationId, message);
+
+    for (const retry of [concurrent, replay]) {
+      await t.require(retry.sessionId, equals(first.sessionId));
+      await t.require(retry.continuationToken, equals(first.continuationToken));
+    }
+    await t.require(
+      otherIssuer,
+      satisfies(
+        (value: CreateSessionResponse) =>
+          value.sessionId !== first.sessionId &&
+          value.continuationToken !== first.continuationToken,
+        "the same operation under another issuer owns a distinct session",
+      ),
+    );
+
+    const [firstTurn, issuerTurn] = await Promise.all([
+      t.target.watchTurn(first.sessionId).result(),
+      t.target.watchTurn(otherIssuer.sessionId).result(),
+    ]);
+    firstTurn.expectOk();
+    firstTurn.event("message.received", { count: 1, data: { message } });
+    firstTurn.event("step.started", { count: 1 });
+    issuerTurn.expectOk();
+    issuerTurn.event("message.received", { count: 1, data: { message } });
+    issuerTurn.event("step.started", { count: 1 });
+
+    const probe = `CREATE-ONCE-PROBE-${crypto.randomUUID()}`;
+    const liveProbe = t.target.watchTurn(first.sessionId, { startIndex: firstTurn.events.length });
+    await continueSession(
+      t.target,
+      PRINCIPAL_A,
+      first.sessionId,
+      first.continuationToken,
+      probe,
+    );
+    const probeTurn = await liveProbe.result();
+    probeTurn.expectOk();
+    probeTurn.event("message.received", { count: 1, data: { message: probe } });
+    probeTurn.event("step.started", { count: 1 });
+  },
+});
+
+async function createSession(
+  target: EveEvalTargetHandle,
+  authorization: string,
+  operationId: string,
+  message: string,
+): Promise<CreateSessionResponse> {
+  const response = await target.fetch("/eve/v1/session", {
+    body: JSON.stringify({ message, operationId }),
+    headers: { authorization, "content-type": "application/json" },
+    method: "POST",
+  });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`POST /eve/v1/session failed (${response.status}): ${text}`);
+  return JSON.parse(text) as CreateSessionResponse;
+}
+
+async function continueSession(
+  target: EveEvalTargetHandle,
+  authorization: string,
+  sessionId: string,
+  continuationToken: string,
+  message: string,
+): Promise<void> {
+  const response = await target.fetch(`/eve/v1/session/${encodeURIComponent(sessionId)}`, {
+    body: JSON.stringify({ continuationToken, message }),
+    headers: { authorization, "content-type": "application/json" },
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`POST continuation failed (${response.status}): ${await response.text()}`);
+  }
+}

--- a/packages/eve/src/channel/routes.ts
+++ b/packages/eve/src/channel/routes.ts
@@ -95,9 +95,11 @@ type BaseSendOptions = {
   continuationToken: string;
   /**
    * `"resume"` requires an active session and propagates a typed no-active-session
-   * error. `"resume-or-start"` preserves the default channel behavior.
+   * error. `"create-once"` adopts an existing or concurrently-created owner
+   * without delivering the duplicate input. `"resume-or-start"` preserves the
+   * default channel behavior.
    */
-  intent?: "resume" | "resume-or-start";
+  intent?: "create-once" | "resume" | "resume-or-start";
   /**
    * The original (top-level) caller's auth for a newly started session,
    * becoming `session.auth.initiator`. Defaults to {@link auth} when omitted

--- a/packages/eve/src/channel/send.test.ts
+++ b/packages/eve/src/channel/send.test.ts
@@ -144,6 +144,50 @@ describe("createSendFn", () => {
     expect(runtime.dispatchContinuation).toHaveBeenCalledTimes(2);
   });
 
+  it("adopts a concurrent create-once winner without delivering duplicate input", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.createSession).mockRejectedValue(
+      new RuntimeSessionOwnershipConflictError({
+        continuationToken: "test:token",
+        ownerSessionId: "winner",
+        sessionId: "loser",
+      }),
+    );
+    vi.mocked(runtime.resolveContinuation).mockResolvedValue(undefined);
+
+    await expect(
+      createSendFn(
+        runtime,
+        ADAPTER,
+        "test",
+      )("hello", {
+        auth: null,
+        continuationToken: "token",
+        intent: "create-once",
+      }),
+    ).resolves.toMatchObject({ id: "winner" });
+    expect(runtime.dispatchContinuation).not.toHaveBeenCalled();
+  });
+
+  it("adopts an existing create-once owner without delivering duplicate input", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.resolveContinuation).mockResolvedValue({ sessionId: "winner" });
+
+    await expect(
+      createSendFn(
+        runtime,
+        ADAPTER,
+        "test",
+      )("hello", {
+        auth: null,
+        continuationToken: "token",
+        intent: "create-once",
+      }),
+    ).resolves.toMatchObject({ id: "winner" });
+    expect(runtime.dispatchContinuation).not.toHaveBeenCalled();
+    expect(runtime.createSession).not.toHaveBeenCalled();
+  });
+
   it("forwards the turn caller on the session command", async () => {
     const runtime = createRuntime({ sessionId: "existing-session-id", status: "accepted" });
     const caller = {

--- a/packages/eve/src/channel/send.ts
+++ b/packages/eve/src/channel/send.ts
@@ -55,7 +55,11 @@ export function createSendFn<TState = undefined>(
         : undefined;
     };
 
-    const existing = await dispatch();
+    const existingOwner = async (): Promise<Session | undefined> => {
+      const owner = await runtime.resolveContinuation(continuationToken);
+      return owner === undefined ? undefined : createSession(owner.sessionId, rawToken, runtime);
+    };
+    const existing = intent === "create-once" ? await existingOwner() : await dispatch();
     if (existing !== undefined) return existing;
     if (intent === "resume") throw new RuntimeNoActiveSessionError(continuationToken);
 
@@ -91,6 +95,9 @@ export function createSendFn<TState = undefined>(
       return createSession(handle.sessionId, rawToken, runtime);
     } catch (error) {
       if (!isRuntimeSessionOwnershipConflictError(error)) throw error;
+      if (intent === "create-once") {
+        return createSession(error.ownerSessionId, rawToken, runtime);
+      }
       const winner = await dispatch();
       if (winner !== undefined) return winner;
       throw error;

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -198,7 +198,7 @@ describe("workflowEntry", () => {
     expect(terminateChildSessionsStep).toHaveBeenCalledWith({ sessionState });
   });
 
-  it("fails a conflicting delivery hook before dispatching the first turn", async () => {
+  it("exits a conflicting initial continuation before dispatching the first turn", async () => {
     const sessionState = createBaseSessionState();
     const dispose = vi.fn();
     vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
@@ -218,25 +218,14 @@ describe("workflowEntry", () => {
         input: { message: "duplicate" },
         serializedContext: createSerializedContext(),
       }),
-    ).rejects.toMatchObject({
-      message: "Agent workflow failed. Inspect the private session trace for details.",
-      name: "EveWorkflowFailure",
-    });
+    ).resolves.toEqual({ output: "" });
 
-    expect(emitTerminalSessionFailureStep).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: expect.objectContaining({
-          conflictingRunId: "wrun_owner",
-          name: "HookConflictError",
-          token: "http:test",
-        }),
-      }),
-    );
+    expect(emitTerminalSessionFailureStep).not.toHaveBeenCalled();
     expect(dispatchTurnStep).not.toHaveBeenCalled();
     expect(dispose).toHaveBeenCalledOnce();
   });
 
-  it("normalizes the getConflict fallback error before dispatching the first turn", async () => {
+  it("also exits when a legacy world reports the initial continuation conflict", async () => {
     const sessionState = createBaseSessionState();
     const dispose = vi.fn();
     const fallbackError = Object.assign(new Error("legacy hook conflict"), {
@@ -262,20 +251,9 @@ describe("workflowEntry", () => {
         input: { message: "duplicate" },
         serializedContext: createSerializedContext(),
       }),
-    ).rejects.toMatchObject({
-      message: "Agent workflow failed. Inspect the private session trace for details.",
-      name: "EveWorkflowFailure",
-    });
+    ).resolves.toEqual({ output: "" });
 
-    expect(emitTerminalSessionFailureStep).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: expect.objectContaining({
-          message: 'Hook token "http:test" is already in use',
-          name: "HookConflictError",
-          token: "http:test",
-        }),
-      }),
-    );
+    expect(emitTerminalSessionFailureStep).not.toHaveBeenCalled();
     expect(dispatchTurnStep).not.toHaveBeenCalled();
     expect(dispose).toHaveBeenCalledOnce();
   });

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -31,7 +31,7 @@ import { createSessionStep } from "#execution/create-session-step.js";
 import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.js";
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
 import { fireSessionCallbackStep } from "#execution/session-callback-step.js";
-import { disposeHook } from "#execution/hook-ownership.js";
+import { disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
 import { createSessionCommandInbox } from "#execution/session-command-inbox.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { DEFAULT_SESSION_TIMEOUT_MS } from "#execution/session-timeout.js";
@@ -344,7 +344,14 @@ async function runDriverLoop(input: {
 
   try {
     if (input.sessionState.continuationToken) {
-      await commandInbox.rekeyContinuation(input.sessionState.continuationToken);
+      try {
+        await commandInbox.rekeyContinuation(input.sessionState.continuationToken);
+      } catch (error) {
+        // A concurrent create may start multiple candidates before one owns
+        // the shared alias. The loser exits before dispatching its first turn.
+        if (!isHookConflictError(error)) throw error;
+        return { kind: "result", result: { output: "" } };
+      }
     }
     await sessionTimeout?.start();
 

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -179,7 +179,6 @@ export function createWorkflowRuntime(config: {
         throw error;
       }
 
-      await waitForOwnedCommandHook(sessionCommandHookToken(run.runId), run.runId);
       if (input.continuationToken) {
         const owner = await waitForCommandHookOwner(input.continuationToken);
         if (owner.runId !== run.runId) {
@@ -190,6 +189,7 @@ export function createWorkflowRuntime(config: {
           });
         }
       }
+      await waitForOwnedCommandHook(sessionCommandHookToken(run.runId), run.runId);
 
       let events: ReadableStream<MessageStreamEvent> | undefined;
       const getEvents = () => {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -52,12 +52,20 @@ const OVERRIDE_AUTH: SessionAuthContext = {
  * Returns a `fetch(req)` function and a `send` mock so tests can inspect
  * what the handler passed through.
  */
-function createEveCreateHandler(input: EveChannelInput) {
+function createEveCreateHandler(
+  input: EveChannelInput,
+  options: { readonly activeSessionId?: string } = {},
+) {
   const channel = eveChannel(input);
   const createRoute = channel.routes.find(
     (r) => r.method === "POST" && r.path === "/eve/v1/session",
   );
   if (!createRoute) throw new Error("No create POST route found");
+  const resolveActiveSession = vi
+    .fn<RouteHandlerArgs["resolveActiveSession"]>()
+    .mockResolvedValue(
+      options.activeSessionId === undefined ? undefined : { sessionId: options.activeSessionId },
+    );
 
   const mockSend = vi.fn<SendFn>().mockResolvedValue({
     id: "test-session-id",
@@ -74,11 +82,12 @@ function createEveCreateHandler(input: EveChannelInput) {
   } satisfies ChannelSession);
 
   return {
+    resolveActiveSession,
     send: mockSend,
     async fetch(req: Request) {
       const args: RouteHandlerArgs = {
         send: mockSend,
-        resolveActiveSession: async () => undefined,
+        resolveActiveSession,
         cancel: vi.fn(),
         clear: vi.fn(),
         compact: vi.fn(),
@@ -812,6 +821,106 @@ describe("eveChannel — onMessage", () => {
       error: "Session is not active and cannot be resumed.",
       ok: false,
     });
+  });
+});
+
+describe("eveChannel — create session idempotency", () => {
+  it("creates once for an operation id and reuses its continuation token", async () => {
+    const handler = createEveCreateHandler({ auth: () => ACCEPTED_AUTH });
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({ message: "hi", operationId: "operation-1" }),
+    );
+
+    expect(response.status).toBe(202);
+    const token = handler.send.mock.calls[0]?.[1]?.continuationToken;
+    expect(token).toMatch(/^eve:op:[0-9a-f]{32}$/);
+    expect(handler.send.mock.calls[0]?.[1]?.intent).toBe("create-once");
+    expect(handler.resolveActiveSession).toHaveBeenCalledWith({ continuationToken: token });
+  });
+
+  it("returns the existing child for a replayed operation without dispatching again", async () => {
+    const handler = createEveCreateHandler(
+      { auth: () => ACCEPTED_AUTH },
+      { activeSessionId: "child-1" },
+    );
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({ message: "hi", operationId: "operation-1" }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, sessionId: "child-1" });
+    expect(handler.send).not.toHaveBeenCalled();
+  });
+
+  it("scopes the operation token to the complete authenticated principal", async () => {
+    const tokenFor = async (identity: {
+      issuer?: string;
+      principalId?: string;
+      principalType?: string;
+      subject?: string;
+    }): Promise<unknown> => {
+      const handler = createEveCreateHandler({
+        auth: () => {
+          const context: {
+            attributes: Record<string, string>;
+            authenticator: string;
+            issuer?: string;
+            principalId: string;
+            principalType: string;
+            subject?: string;
+          } = {
+            attributes: {},
+            authenticator: "test",
+            principalId: identity.principalId ?? "caller",
+            principalType: identity.principalType ?? "service",
+          };
+          if (identity.issuer !== undefined) context.issuer = identity.issuer;
+          if (identity.subject !== undefined) context.subject = identity.subject;
+          return context;
+        },
+      });
+      await handler.fetch(createJsonMessageRequest({ message: "hi", operationId: "operation-1" }));
+      return handler.send.mock.calls[0]?.[1]?.continuationToken;
+    };
+
+    const original = await tokenFor({ issuer: "issuer-a" });
+    expect(await tokenFor({ issuer: "issuer-b" })).not.toBe(original);
+    expect(await tokenFor({ issuer: "issuer-a", principalType: "user" })).not.toBe(original);
+    expect(await tokenFor({ issuer: "issuer-a", principalId: "other" })).not.toBe(original);
+    expect(await tokenFor({ issuer: "issuer-a", subject: "different-provenance" })).toBe(original);
+  });
+
+  it("rejects operation ids for anonymous callers", async () => {
+    const handler = createEveCreateHandler({ auth: none() });
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({ message: "hi", operationId: "operation-1" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(handler.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string operation id", async () => {
+    const handler = createEveCreateHandler({ auth: none() });
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({ message: "hi", operationId: 42 }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(handler.send).not.toHaveBeenCalled();
+  });
+
+  it("mints a random continuation token when no operation id is supplied", async () => {
+    const handler = createEveCreateHandler({ auth: none() });
+
+    await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(handler.send.mock.calls[0]?.[1]?.continuationToken).toMatch(/^eve:(?!op:)/);
+    expect(handler.resolveActiveSession).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -223,7 +223,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         return await respond();
       }),
 
-      POST("/eve/v1/session", async (req, { send }) => {
+      POST("/eve/v1/session", async (req, { resolveActiveSession, send }) => {
         const authResult = await routeAuth(req, input.auth);
         if (authResult instanceof Response) return authResult;
         const sessionAuth = authResult;
@@ -252,6 +252,35 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         const policyRejection = checkUploadPolicy(body, uploadPolicy);
         if (policyRejection !== null) return policyRejection;
 
+        if (body.operationId !== undefined && sessionAuth.principalType === "anonymous") {
+          return Response.json(
+            { error: "operationId requires an authenticated principal.", ok: false },
+            { status: 400 },
+          );
+        }
+        const operationToken =
+          body.operationId === undefined
+            ? undefined
+            : await deriveOperationContinuationToken({
+                auth: sessionAuth,
+                operationId: body.operationId,
+              });
+        if (operationToken !== undefined) {
+          const owner = await resolveActiveSession({ continuationToken: operationToken });
+          if (owner !== undefined) {
+            return Response.json(
+              { continuationToken: operationToken, ok: true, sessionId: owner.sessionId },
+              {
+                headers: {
+                  "cache-control": "no-store",
+                  [EVE_SESSION_ID_HEADER]: owner.sessionId,
+                },
+                status: 202,
+              },
+            );
+          }
+        }
+
         const messageResult = await resolveOnMessage({
           auth: forwarded.auth,
           config: input,
@@ -261,7 +290,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         if (messageResult instanceof Response) return messageResult;
         if (!messageResult.dispatch) return droppedMessageResponse();
 
-        const token = `eve:${crypto.randomUUID()}`;
+        const token = operationToken ?? `eve:${crypto.randomUUID()}`;
         const context = mergeContext(body.context, messageResult.context);
 
         const sendOptions: SendOptions = {
@@ -271,6 +300,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           continuationToken: token,
           mode: body.mode,
         };
+        if (operationToken !== undefined) sendOptions.intent = "create-once";
         if (forwarded.accepted) {
           sendOptions.initiatorAuth = forwarded.initiatorAuth;
         }
@@ -683,7 +713,28 @@ interface ParsedCreateBody {
   message: string | UserContent;
   mode?: RunMode;
   context?: readonly string[];
+  operationId?: string;
   outputSchema?: JsonObject;
+}
+
+/** Replay-stable identity for one authenticated create operation. */
+async function deriveOperationContinuationToken(input: {
+  readonly auth: SessionAuthContext;
+  readonly operationId: string;
+}): Promise<string> {
+  const identity = JSON.stringify([
+    "eve:create-session:v1",
+    input.auth.authenticator,
+    input.auth.issuer ?? null,
+    input.auth.principalType,
+    input.auth.principalId,
+    input.operationId,
+  ]);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(identity));
+  const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  return `eve:op:${hex.slice(0, 32)}`;
 }
 
 function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | Response {
@@ -712,7 +763,24 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     );
   }
 
-  return { callback, capabilities, message, mode, context, outputSchema };
+  const rawOperationId = payload.operationId;
+  if (rawOperationId !== undefined && (typeof rawOperationId !== "string" || !rawOperationId)) {
+    return Response.json(
+      { error: "Expected 'operationId' to be a non-empty string.", ok: false },
+      { status: 400 },
+    );
+  }
+
+  const result: ParsedCreateBody = {
+    callback,
+    capabilities,
+    message,
+    mode,
+    context,
+    outputSchema,
+  };
+  if (typeof rawOperationId === "string") result.operationId = rawOperationId;
+  return result;
 }
 
 interface ParsedContinueBody {


### PR DESCRIPTION
Adds `operationId` to authenticated session creation as an independently complete channel feature.

- before: retrying `POST /eve/v1/session` could start and dispatch more than one session
- after: the first active owner of `(principal, operationId)` wins; existing and concurrent retries return that session without dispatching duplicate input

Principal identity is a domain-separated tuple of authenticator, issuer, principal type, and principal ID. Anonymous callers cannot use the shared operation namespace. The included basic-runtime eval proves concurrent and serial retries produce one initial message/model step, and that the same operation under another issuer owns a different session.

This PR contains no task or subagent consumer. PR 3 uses the API for replay-safe remote child creation.