### PR TITLE
chore: enforce concise PR descriptions in gh-pr-description skill

### DIFF
--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -6,7 +6,7 @@ description: Drafts and reviews GitHub pull request descriptions for the eve rep
 # GitHub PR description
 
 See [review notes](references/review-notes.md) for the maintainer patterns behind
-this workflow.
+this workflow; they describe what to cover, not how much to write.
 
 Read `CONTRIBUTING.md` and `.github/pull_request_template.md`, then inspect the
 branch diff, commits, related issue, tests, docs, and changesets. If updating a
@@ -19,21 +19,39 @@ Fill in the repository template. Write for a reviewer:
 - mention breaking changes, preserved behavior, scope boundaries, or stacked
   PRs only when relevant
 - link the prior issue with `Closes #N`, `Related to #N`, or equivalent
-- keep the detail proportional to the change
+- scale length with risk, not diff size
 
-Keep the description concise and reviewer-focused. Prefer plain language; omit
-unnecessary implementation detail and technical jargon, but include either when
-needed to understand behavior, risk, scope, or a non-obvious decision. Do not
-restate the issue, template guidance, or checklist. For a small, low-risk
-change, prefer a single Summary sentence; use bullets only when they improve
-clarity.
+Default to the shortest body that answers the four questions below. Keep the
+Summary under 5 sentences for most PRs; exceed 10 lines only for breaking or
+cross-cutting changes. Prefer plain language. Include implementation detail or
+jargon only when the reviewer cannot assess behavior or risk without it. Do not
+restate the issue, template guidance, or checklist. Use bullets only when they
+improve clarity.
+
+A typical small PR body:
+
+```markdown
+### Summary
+
+Closes #412. `eve dev` crashed when an agent had no `connections/` directory;
+the compiler now treats missing optional directories as empty.
+
+### Validation
+
+- Reproduced the crash with the weather fixture, then confirmed a clean boot
+- `pnpm test:unit`, `pnpm typecheck`
+
+### Checklist
+
+(preserved from the template; only verified items checked)
+```
 
 Under validation, list exact checks actually run and useful manual coverage. State
 limitations honestly. Do not infer results or claim checks that only CI will
 run.
 
-Preserve the checklist and check only verified items. Explain when tests, docs,
-or a changeset are not applicable.
+Preserve the checklist and check only verified items. If tests, docs, or a
+changeset are not applicable, say so in one short line at most.
 
 Before returning or publishing the description, confirm that it answers:
 
@@ -41,6 +59,10 @@ Before returning or publishing the description, confirm that it answers:
 2. What meaningfully changes?
 3. How was it validated?
 4. What should the reviewer pay special attention to?
+
+Then prune: delete any sentence that restates the diff, the issue, or the
+template, and any detail the reviewer does not need. If the answer to question
+4 is "nothing," leave it out.
 
 When asked only to draft, return the body for review. When asked to create or
 update the PR, pass a body file to `gh pr create` or `gh pr edit`.


### PR DESCRIPTION
### Summary

The gh-pr-description skill asked for concise output but gave no length budget and mostly listed things to include, so drafts kept running long. It now sets an explicit budget (Summary under 5 sentences, more only for breaking or cross-cutting changes), scales length with risk rather than diff size, adds a short example body, caps not-applicable explanations at one line, and adds a pruning pass before publishing.

Agent-facing instructions only; no framework code or public behavior changes.

### Validation

- Reviewed the rendered markdown and diff; no code paths touched
- Tests, docs, and changeset not applicable — internal skill change

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
