### PR TITLE
feat(eve): make Linear setup answerable

### DIFF
--- a/.changeset/bright-setup-foundations.md
+++ b/.changeset/bright-setup-foundations.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add stable editable setup questions and shared interactive/headless Vercel project prerequisite handling for answer-backed integration setup flows.

--- a/.changeset/calm-photons-ask.md
+++ b/.changeset/calm-photons-ask.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Route Photon setup choices through stable semantic questions while preserving its editable interactive picker. Headless Photon Connect setup now requires an existing Vercel project link instead of opening an interactive linking flow.

--- a/.changeset/fuzzy-linear-answer.md
+++ b/.changeset/fuzzy-linear-answer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make Linear integration setup answer-backed and require an existing Vercel project link for headless Connect setup.

--- a/.changeset/tough-setup-headless.md
+++ b/.changeset/tough-setup-headless.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a structured `eve add --headless --json` flow with stable setup answers, component selection, and resumable setup refusals for coding agents.

--- a/.changeset/wise-slacks-answer.md
+++ b/.changeset/wise-slacks-answer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Route Slack credential and connector choices through stable semantic setup questions. Headless Slack Connect setup now requires an existing Vercel project link instead of opening an interactive linking flow.

--- a/packages/eve/src/cli/commands/integration-setup.test.ts
+++ b/packages/eve/src/cli/commands/integration-setup.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { InteractionRequired, select } from "#setup/ask.js";
 import { runIntegrationSetup } from "#setup/integrations/runner.js";
 
 import { runIntegrationSetupCommand } from "./integration-setup.js";
@@ -49,5 +50,45 @@ describe("runIntegrationSetupCommand", () => {
       undefined,
     );
     expect(output.errors).toEqual([]);
+  });
+
+  it("passes answer-backed headless setup to the runner", async () => {
+    vi.mocked(runIntegrationSetup).mockImplementation(async (_kind, options) => {
+      await expect(
+        options.asker?.ask(
+          select({
+            key: "mode",
+            message: "Mode?",
+            options: [{ id: "portable", label: "Portable", value: "environment" }],
+            required: true,
+          }),
+        ),
+      ).resolves.toBe("environment");
+      expect(options.interaction).toBe("headless");
+      return { kind: "done", completion: { facts: [] } };
+    });
+
+    await runIntegrationSetupCommand(logger(), "/project", "web", {
+      headless: true,
+      json: true,
+      answers: { mode: "portable" },
+    });
+  });
+
+  it("serializes structured missing input in headless JSON mode", async () => {
+    vi.mocked(runIntegrationSetup).mockRejectedValue(
+      new InteractionRequired(
+        select({ key: "mode", message: "Mode?", options: [], required: true }),
+      ),
+    );
+    const output = logger();
+
+    await runIntegrationSetupCommand(output, "/project", "web", { headless: true, json: true });
+
+    expect(JSON.parse(output.errors[0]!)).toMatchObject({
+      status: "input_required",
+      setup_mutated: false,
+      question: { key: "mode" },
+    });
   });
 });

--- a/packages/eve/src/cli/commands/integration-setup.ts
+++ b/packages/eve/src/cli/commands/integration-setup.ts
@@ -1,3 +1,6 @@
+import { headlessAsker, InteractionRequired, withAnswers, withPolicy } from "#setup/ask.js";
+import { createHeadlessPrompter } from "#setup/headless.js";
+import { SetupPrerequisiteRequired } from "#setup/integrations/shared/prerequisite.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { createRegistrySetupClient } from "#setup/registry-setup-client.js";
 import {
@@ -11,6 +14,9 @@ import type { RegistryCommandLogger } from "./registry.js";
 
 export interface IntegrationSetupOptions {
   yes?: boolean;
+  headless?: boolean;
+  json?: boolean;
+  answers?: Record<string, unknown>;
   signal?: AbortSignal;
 }
 
@@ -37,12 +43,22 @@ export async function runIntegrationSetupCommand(
 
   const client = createRegistrySetupClient({ signal: options.signal });
   try {
-    const prompter = client?.prompter ?? dependencies.createPrompter?.() ?? createPrompter();
+    const headless = options.headless === true;
+    const prompter =
+      client?.prompter ??
+      dependencies.createPrompter?.() ??
+      (headless ? createHeadlessPrompter(() => {}) : createPrompter());
+    const base = headlessAsker();
+    const asker = headless
+      ? withAnswers(options.answers ?? {})(options.yes ? withPolicy("assume")(base) : base)
+      : undefined;
     const result = await runIntegrationSetup(
       kind,
       {
         appRoot,
         prompter,
+        asker,
+        interaction: headless ? "headless" : "interactive",
         signal: client?.signal ?? options.signal,
         yes: options.yes,
       },
@@ -57,7 +73,25 @@ export async function runIntegrationSetupCommand(
     client?.complete(result.completion);
   } catch (error) {
     client?.fail(error);
-    logger.error(error instanceof Error ? error.message : String(error));
+    if (options.headless && options.json && error instanceof InteractionRequired) {
+      logger.error(
+        JSON.stringify({
+          status: "input_required",
+          setup_mutated: false,
+          question: error.question,
+        }),
+      );
+    } else if (options.headless && options.json && error instanceof SetupPrerequisiteRequired) {
+      logger.error(
+        JSON.stringify({
+          status: "prerequisite_required",
+          setup_mutated: false,
+          prerequisite: { code: error.code, message: error.message, command: error.command },
+        }),
+      );
+    } else {
+      logger.error(error instanceof Error ? error.message : String(error));
+    }
     process.exitCode = 1;
   }
 }

--- a/packages/eve/src/cli/commands/register-integration-commands.ts
+++ b/packages/eve/src/cli/commands/register-integration-commands.ts
@@ -1,5 +1,7 @@
 import type { Command } from "#compiled/commander/index.js";
 
+import { parseSetupAnswer } from "./setup-answers.js";
+
 interface IntegrationCommandLogger {
   error(message: string): void;
   log(message: string): void;
@@ -18,10 +20,28 @@ export function registerIntegrationCommands(input: {
   integration
     .command("setup <kind>")
     .option("-y, --yes")
-    .action(async (kind: string, options: { yes?: boolean }) => {
-      const { runIntegrationSetupCommand } = await import("./integration-setup.js");
-      await runIntegrationSetupCommand(logger, appRoot, kind, { yes: options.yes });
-    });
+    .option("--headless")
+    .option("--json")
+    .option("--answer <key=value>", "Answer a setup question.", parseSetupAnswer, {})
+    .action(
+      async (
+        kind: string,
+        options: {
+          yes?: boolean;
+          headless?: boolean;
+          json?: boolean;
+          answer?: Record<string, unknown>;
+        },
+      ) => {
+        const { runIntegrationSetupCommand } = await import("./integration-setup.js");
+        await runIntegrationSetupCommand(logger, appRoot, kind, {
+          yes: options.yes,
+          headless: options.headless,
+          json: options.json,
+          answers: options.answer,
+        });
+      },
+    );
 
   integration
     .command("connect <slug> <service> [canonical-name]")

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -1,5 +1,7 @@
 import { InvalidArgumentError, type Command } from "#compiled/commander/index.js";
 
+import { parseSetupAnswer } from "./setup-answers.js";
+
 interface RegistryCommandLogger {
   error(message: string): void;
   log(message: string): void;
@@ -36,14 +38,33 @@ export function registerRegistryCommands(input: {
     .option("-o, --overwrite", "Overwrite existing files.")
     .option("--skip-install", "Run the item's setup flow without installing it.")
     .option("--skip-setup", "Skip the item's setup flow.")
+    .option(
+      "--headless",
+      "Never prompt; return structured setup instructions when input is needed.",
+    )
+    .option("--json", "Output headless setup results as JSON.")
+    .option(
+      "--answer <key=value>",
+      "Answer a setup question; repeat for multiple answers.",
+      parseSetupAnswer,
+      {},
+    )
     .option("-y, --yes", "Run setup and accept its recommended defaults.")
     .action(
       async (
         item: string,
-        options: { skipInstall?: boolean; overwrite?: boolean; skipSetup?: boolean; yes?: boolean },
+        options: {
+          skipInstall?: boolean;
+          overwrite?: boolean;
+          skipSetup?: boolean;
+          headless?: boolean;
+          json?: boolean;
+          answer?: Record<string, unknown>;
+          yes?: boolean;
+        },
       ) => {
         const { runAddCommand } = await import("./registry.js");
-        await runAddCommand(logger, appRoot, item, options);
+        await runAddCommand(logger, appRoot, item, { ...options, answers: options.answer });
       },
     );
 

--- a/packages/eve/src/cli/commands/registry-declared-setups.ts
+++ b/packages/eve/src/cli/commands/registry-declared-setups.ts
@@ -1,3 +1,4 @@
+import { createHeadlessPrompter } from "#setup/headless.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import {
   emptyRegistrySetupCompletion,
@@ -7,9 +8,17 @@ import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js"
 
 import type { RegistryCommandLogger, RegistrySetupDependencies } from "./registry.js";
 import type { RegistrySetupCommand } from "./registry-setup-command.js";
+import {
+  formatHeadlessSetupRefusal,
+  headlessSetupContinuation,
+  type HeadlessSetupRefusal,
+} from "./setup-headless.js";
 
 export interface DeclaredSetupOptions {
   yes?: boolean;
+  headless?: boolean;
+  json?: boolean;
+  answers?: Record<string, unknown>;
   silent?: boolean;
   prompter?: Prompter;
   signal?: AbortSignal;
@@ -29,17 +38,53 @@ export async function runDeclaredSetups(input: {
   let completion = emptyRegistrySetupCompletion();
   if (input.setups === undefined) return completion;
   const runSetupCommand = await input.dependencies.loadSetupCommandRunner();
-  const prompter = input.options.prompter ?? createPrompter();
+  const prompter =
+    input.options.prompter ??
+    (input.options.headless ? createHeadlessPrompter(input.logger.log) : createPrompter());
   try {
     for (const setup of input.setups) {
       const result = await runSetupCommand(
         input.appRoot,
-        { ...setup, args: [...setup.args, ...(input.options.yes ? ["--yes"] : [])] },
+        {
+          ...setup,
+          args: [
+            ...setup.args,
+            ...(input.options.yes ? ["--yes"] : []),
+            ...(input.options.headless ? ["--headless"] : []),
+            ...(input.options.json ? ["--json"] : []),
+            ...Object.entries(input.options.answers ?? {}).flatMap(([key, value]) => [
+              "--answer",
+              `${key}=${JSON.stringify(value)}`,
+            ]),
+          ],
+        },
         input.item,
         { prompter, signal: input.options.signal },
       );
       if (result.kind === "cancelled") {
         input.logger.log(input.cancelledReminder);
+        return false;
+      }
+      if (result.kind === "refused") {
+        if (!input.options.headless || !input.options.json) {
+          throw new Error("Setup requires more input.");
+        }
+        const installed = true;
+        const refusal: HeadlessSetupRefusal = {
+          ...result.refusal,
+          item: input.item,
+          installed,
+          setup_mutated: false,
+          next: {
+            command: headlessSetupContinuation({
+              item: input.item,
+              installed,
+              answers: input.options.answers ?? {},
+            }),
+          },
+        };
+        input.logger.error(formatHeadlessSetupRefusal(refusal));
+        process.exitCode = 2;
         return false;
       }
       if (input.options.silent !== true) {

--- a/packages/eve/src/cli/commands/registry-package.ts
+++ b/packages/eve/src/cli/commands/registry-package.ts
@@ -14,6 +14,7 @@ import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js"
 import { hasInteractiveTerminal } from "./preconditions.js";
 import type { AddCommandOptions, RegistryCommandLogger } from "./registry.js";
 import type { RegistrySetupCommand } from "./registry-setup-command.js";
+import { formatHeadlessSetupRefusal, headlessSetupContinuation } from "./setup-headless.js";
 
 export const RegistryPackageComponentSchema = z.object({
   item: z.string().min(1),
@@ -47,12 +48,26 @@ export interface RegistryPackageOperations {
 }
 
 async function selectComponents(
+  logger: RegistryCommandLogger,
   item: string,
   components: readonly RegistryPackageComponent[],
   options: AddCommandOptions & { prompter?: Prompter },
   interactive: boolean,
   getPrompter: () => Prompter,
-): Promise<readonly RegistryPackageComponent[]> {
+): Promise<readonly RegistryPackageComponent[] | undefined> {
+  if (options.headless) {
+    const raw = options.answers?.components;
+    if (raw === undefined && !options.yes) {
+      loggerHeadlessComponentRefusal(logger, item, components, options);
+      return undefined;
+    }
+    const selected = raw === undefined ? components.filter((component) => component.default) : raw;
+    if (!Array.isArray(selected)) throw new Error('Setup answer "components" must be an array.');
+    const ids = new Set(selected.map(String));
+    const unknown = [...ids].find((id) => !components.some((component) => component.item === id));
+    if (unknown !== undefined) throw new Error(`Unknown component: ${unknown}.`);
+    return components.filter((component) => ids.has(component.item));
+  }
   if (options.prompter === undefined && (options.yes === true || !interactive)) {
     return components.filter((component) => component.default);
   }
@@ -75,6 +90,45 @@ async function selectComponents(
   return components.filter((component) => selectedItems.has(component.item));
 }
 
+function loggerHeadlessComponentRefusal(
+  logger: RegistryCommandLogger,
+  item: string,
+  components: readonly RegistryPackageComponent[],
+  options: AddCommandOptions,
+): void {
+  const command = headlessSetupContinuation({
+    item,
+    installed: false,
+    answers: options.answers ?? {},
+  });
+  const question = {
+    key: "components",
+    kind: "multi-select" as const,
+    message: `Which ${item} components should be installed?`,
+    required: true,
+    recommended: components
+      .filter((component) => component.default)
+      .map((component) => component.item),
+    options: components.map((component) => ({
+      id: component.item,
+      label: component.label,
+      value: component.item,
+      hint: component.description,
+    })),
+  };
+  logger.error(
+    formatHeadlessSetupRefusal({
+      status: "input_required",
+      item,
+      installed: false,
+      setup_mutated: false,
+      question,
+      next: { command },
+    }),
+  );
+  process.exitCode = 2;
+}
+
 /** Resolves, installs, and configures the selected components of a registry package. */
 export async function runRegistryPackage(input: {
   logger: RegistryCommandLogger;
@@ -92,7 +146,15 @@ export async function runRegistryPackage(input: {
   const getPrompter = (): Prompter =>
     (prompter ??= dependencies.createPrompter?.() ?? createPrompter());
 
-  const selected = await selectComponents(item, components, options, interactive, getPrompter);
+  const selected = await selectComponents(
+    logger,
+    item,
+    components,
+    options,
+    interactive,
+    getPrompter,
+  );
+  if (selected === undefined) return false;
   const addresses = selected.map((component) => operations.itemAddress(component.item));
   const manifests = await getRegistryItems(addresses, { config });
   if (manifests.length !== selected.length) {
@@ -115,7 +177,7 @@ export async function runRegistryPackage(input: {
   let completion = emptyRegistrySetupCompletion();
   if (options.skipSetup === true) return completion;
 
-  if (options.yes !== true && options.prompter === undefined && !interactive) {
+  if (!options.headless && options.yes !== true && options.prompter === undefined && !interactive) {
     logger.log(operations.setupReminder(item));
     return completion;
   }

--- a/packages/eve/src/cli/commands/registry-setup-command.test.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.test.ts
@@ -278,6 +278,38 @@ describe("runRegistrySetupCommand", () => {
     ).rejects.toThrow("exited with code 0 before reporting a result");
   });
 
+  it("returns a structured setup refusal from the child", async () => {
+    spawn.mockReturnValue(
+      protocolChild(0, null, (child) =>
+        child.emit("message", {
+          type: "result",
+          outcome: {
+            kind: "failed",
+            error: {
+              message: "Input required",
+              refusal: {
+                status: "input_required",
+                question: { key: "mode", kind: "confirm", message: "Mode?", required: true },
+              },
+            },
+          },
+        }),
+      ),
+    );
+
+    await expect(
+      runRegistrySetupCommand(
+        "/project",
+        { package: "@acme/slack", bin: "acme-slack", args: [] },
+        "channel/slack",
+        options(),
+      ),
+    ).resolves.toMatchObject({
+      kind: "refused",
+      refusal: { status: "input_required", question: { key: "mode" } },
+    });
+  });
+
   it("rejects a binary the installed package does not declare", async () => {
     await expect(
       runRegistrySetupCommand(

--- a/packages/eve/src/cli/commands/registry-setup-command.ts
+++ b/packages/eve/src/cli/commands/registry-setup-command.ts
@@ -13,6 +13,7 @@ import {
   type RegistrySetupChildMessage,
   type RegistrySetupCompletion,
   type RegistrySetupParentMessage,
+  type RegistrySetupRefusal,
 } from "#setup/registry-setup-protocol.js";
 import { WizardCancelledError } from "#setup/step.js";
 
@@ -24,7 +25,8 @@ export interface RegistrySetupCommand {
 
 export type RegistrySetupCommandResult =
   | ({ kind: "completed" } & RegistrySetupCompletion)
-  | { kind: "cancelled" };
+  | { kind: "cancelled" }
+  | { kind: "refused"; refusal: RegistrySetupRefusal };
 
 export interface RegistrySetupCommandOptions {
   prompter: Prompter;
@@ -288,6 +290,10 @@ export async function runRegistrySetupCommand(
       }
       if (outcome?.kind === "cancelled") {
         resolveResult({ kind: "cancelled" });
+        return;
+      }
+      if (outcome?.kind === "failed" && outcome.error.refusal !== undefined) {
+        resolveResult({ kind: "refused", refusal: outcome.error.refusal });
         return;
       }
       if (outcome?.kind === "failed") {

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -172,6 +172,71 @@ describe("registry commands", () => {
     },
   );
 
+  it("returns a structured component question before installing a package headlessly", async () => {
+    const logger = createLogger();
+    getRegistryItems.mockResolvedValueOnce([
+      {
+        meta: {
+          eve: {
+            components: [
+              { item: "channel/linear-agent", label: "Linear Channel", default: true },
+              { item: "connection/linear", label: "Linear MCP", default: true },
+            ],
+          },
+        },
+      },
+    ]);
+
+    await runAddCommand(
+      logger,
+      "/project",
+      "linear",
+      { headless: true, json: true },
+      { loadSetupCommandRunner: vi.fn() },
+    );
+
+    expect(addRegistryItems).not.toHaveBeenCalled();
+    expect(JSON.parse(logger.errors[0]!)).toMatchObject({
+      status: "input_required",
+      item: "linear",
+      installed: false,
+      question: { key: "components" },
+      next: { command: "eve add linear --headless --json" },
+    });
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("uses an answered component selection headlessly", async () => {
+    const logger = createLogger();
+    getRegistryItems
+      .mockResolvedValueOnce([
+        {
+          meta: {
+            eve: {
+              components: [
+                { item: "channel/linear-agent", label: "Linear Channel", default: true },
+                { item: "connection/linear", label: "Linear MCP", default: true },
+              ],
+            },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([{ meta: { eve: {} } }]);
+
+    await runAddCommand(
+      logger,
+      "/project",
+      "linear",
+      { headless: true, json: true, answers: { components: ["channel/linear-agent"] } },
+      { loadSetupCommandRunner: vi.fn() },
+    );
+
+    expect(addRegistryItems).toHaveBeenCalledWith(
+      ["https://eve.dev/r/channel/linear-agent.json"],
+      expect.objectContaining({ cwd: "/project" }),
+    );
+  });
+
   it("lets interactive users select components from an official registry package", async () => {
     const logger = createLogger();
     const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -31,6 +31,9 @@ export interface AddCommandOptions {
   overwrite?: boolean;
   skipSetup?: boolean;
   yes?: boolean;
+  headless?: boolean;
+  json?: boolean;
+  answers?: Record<string, unknown>;
   /** Suppresses the registry SDK's terminal-native progress output. */
   silent?: boolean;
 }
@@ -527,7 +530,14 @@ export async function runAddCommand(
               appRoot,
               item: packageItem,
               setups,
-              options: { yes: options.yes, prompter, signal: options.signal },
+              options: {
+                yes: options.yes,
+                headless: options.headless,
+                json: options.json,
+                answers: options.answers,
+                prompter,
+                signal: options.signal,
+              },
               dependencies,
               cancelledReminder: setupReminder(packageItem, "cancelled"),
               resumeCommand: setupResumeCommand(packageItem),
@@ -566,12 +576,12 @@ export async function runAddCommand(
     const interactive =
       dependencies.hasInteractiveTerminal?.() ??
       defaultAddCommandDependencies.hasInteractiveTerminal!();
-    if (options.skipSetup === true || (!options.yes && !interactive)) {
+    if (options.skipSetup === true || (!options.headless && !options.yes && !interactive)) {
       logger.log(setupReminder(item, "skipped"));
       return;
     }
 
-    if (!options.yes) {
+    if (!options.headless && !options.yes) {
       try {
         const prompter =
           options.prompter ??

--- a/packages/eve/src/cli/commands/setup-answers.test.ts
+++ b/packages/eve/src/cli/commands/setup-answers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSetupAnswer } from "./setup-answers.js";
+import { headlessSetupContinuation } from "./setup-headless.js";
+
+describe("setup answers", () => {
+  it("accumulates strings and JSON values", () => {
+    const first = parseSetupAnswer("mode=portable");
+    const answers = parseSetupAnswer('events=["issues","pull_request"]', first);
+
+    expect(answers).toEqual({ mode: "portable", events: ["issues", "pull_request"] });
+  });
+
+  it("builds a safe resume command with prior answers", () => {
+    expect(
+      headlessSetupContinuation({
+        item: "channel/github",
+        installed: true,
+        answers: { "github-events": ["issues"] },
+      }),
+    ).toBe(
+      "eve add channel/github --headless --json --skip-install --answer github-events='[\"issues\"]'",
+    );
+  });
+});

--- a/packages/eve/src/cli/commands/setup-answers.ts
+++ b/packages/eve/src/cli/commands/setup-answers.ts
@@ -1,0 +1,18 @@
+import { InvalidArgumentError } from "#compiled/commander/index.js";
+
+/** Parses one repeatable `--answer key=value`; JSON values retain arrays, booleans, and numbers. */
+export function parseSetupAnswer(
+  value: string,
+  previous: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const separator = value.indexOf("=");
+  if (separator < 1) throw new InvalidArgumentError('Expected "key=value".');
+  const key = value.slice(0, separator).trim();
+  const raw = value.slice(separator + 1);
+  if (key.length === 0) throw new InvalidArgumentError("Setup answer key cannot be empty.");
+  let answer: unknown = raw;
+  try {
+    answer = JSON.parse(raw);
+  } catch {}
+  return { ...previous, [key]: answer };
+}

--- a/packages/eve/src/cli/commands/setup-headless.ts
+++ b/packages/eve/src/cli/commands/setup-headless.ts
@@ -1,0 +1,36 @@
+import type { AnyQuestion } from "#setup/ask.js";
+
+export interface HeadlessSetupRefusal {
+  status: "input_required" | "prerequisite_required";
+  item: string;
+  installed: boolean;
+  setup_mutated: false;
+  question?: AnyQuestion;
+  prerequisite?: { code: string; message: string; command: string };
+  next: { command: string };
+}
+
+function shell(value: string): string {
+  return /^[\w@./:-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function formatAnswer(key: string, value: unknown): string {
+  return `${shell(key)}=${shell(JSON.stringify(value))}`;
+}
+
+export function headlessSetupContinuation(input: {
+  item: string;
+  installed: boolean;
+  answers: Readonly<Record<string, unknown>>;
+}): string {
+  const args = ["eve", "add", shell(input.item), "--headless", "--json"];
+  if (input.installed) args.push("--skip-install");
+  for (const [key, value] of Object.entries(input.answers)) {
+    args.push("--answer", formatAnswer(key, value));
+  }
+  return args.join(" ");
+}
+
+export function formatHeadlessSetupRefusal(refusal: HeadlessSetupRefusal): string {
+  return JSON.stringify(refusal);
+}

--- a/packages/eve/src/setup/ask.test.ts
+++ b/packages/eve/src/setup/ask.test.ts
@@ -30,6 +30,9 @@ function untouchableAsker(): Asker {
     ask(question): Promise<never> {
       throw new Error(`untouchableAsker was asked "${question.key}"`);
     },
+    askEditable(question): Promise<never> {
+      throw new Error(`untouchableAsker was asked "${question.key}"`);
+    },
     askMany(question): Promise<never> {
       throw new Error(`untouchableAsker was asked "${question.key}"`);
     },
@@ -122,6 +125,44 @@ describe("interactiveAsker", () => {
     expect(single).toHaveBeenCalledWith(
       expect.objectContaining({ initialValue: "blue", search: true, placeholder: "filter" }),
     );
+  });
+
+  it("preserves an editable select as one interactive prompter control", async () => {
+    const { prompter } = createFakePrompter();
+    prompter.selectEditable = async <T>() => ({
+      kind: "edited" as const,
+      value: "red" as T,
+      text: "crimson",
+    });
+    const editable = vi.spyOn(prompter, "selectEditable");
+    const events = recordingEvents();
+
+    const value = await interactiveAsker(prompter, events).askEditable({
+      key: "color",
+      message: "Pick a color",
+      options: COLOR_OPTIONS,
+      recommended: RED,
+      required: true,
+      editable: {
+        key: "color-name",
+        value: RED,
+        label: "Name",
+        recommended: "scarlet",
+      },
+    });
+
+    expect(value).toEqual({ value: RED, text: "crimson" });
+    expect(editable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Pick a color",
+        initialValue: "red",
+        editable: expect.objectContaining({ value: "red", defaultValue: "scarlet" }),
+      }),
+    );
+    expect(events.resolutions).toEqual([
+      { key: "color", value: RED, source: "asked" },
+      { key: "color-name", value: "crimson", source: "asked" },
+    ]);
   });
 
   it("renders a confirm as the repo's yes/no select and returns a boolean", async () => {
@@ -341,6 +382,45 @@ describe("withAnswers", () => {
     expect(events.resolutions).toEqual([
       { key: "colors", value: [BLUE, RED, WHITE], source: "answer" },
     ]);
+  });
+
+  it("resolves an editable selection and its text from separate stable keys", async () => {
+    const events = recordingEvents();
+    const asker = withAnswers(
+      { color: "red", "color-name": "crimson" },
+      events,
+    )(untouchableAsker());
+
+    const value = await asker.askEditable({
+      key: "color",
+      message: "Pick a color",
+      options: COLOR_OPTIONS,
+      required: true,
+      editable: { key: "color-name", value: RED, label: "Name", recommended: "scarlet" },
+    });
+
+    expect(value).toEqual({ value: RED, text: "crimson" });
+    expect(events.resolutions).toEqual([
+      { key: "color", value: RED, source: "answer" },
+      { key: "color-name", value: "crimson", source: "answer" },
+    ]);
+  });
+
+  it("refuses the editable text before mutation when only its option is answered", async () => {
+    const asker = withAnswers({ color: "red" })(headlessAsker());
+
+    await expect(
+      asker.askEditable({
+        key: "color",
+        message: "Pick a color",
+        options: COLOR_OPTIONS,
+        required: true,
+        editable: { key: "color-name", value: RED, label: "Name", recommended: "scarlet" },
+      }),
+    ).rejects.toMatchObject({
+      name: "InteractionRequired",
+      question: expect.objectContaining({ key: "color-name" }),
+    });
   });
 
   it("rejects an unknown multi-select id naming the alternatives, and a non-array answer", async () => {

--- a/packages/eve/src/setup/ask.ts
+++ b/packages/eve/src/setup/ask.ts
@@ -102,6 +102,30 @@ export type Question<T> = {
  * {@link Asker.askMany} instead of being a {@link Question} kind: forcing it
  * through `ask<T>` would make the channel lie about the answer type.
  */
+export interface EditableSelectQuestion<T> {
+  /** Stable key for the selected option. */
+  key: string;
+  message: string;
+  options: readonly SelectOption<T>[];
+  recommended?: T;
+  required?: boolean;
+  editable: {
+    /** Stable key for the editable row's text value. */
+    key: string;
+    value: T;
+    /** Short label rendered before the editable value, such as "Name". */
+    label: string;
+    recommended: string;
+    validate?: (raw: string) => string | null;
+  };
+}
+
+export interface EditableSelectAnswer<T> {
+  value: T;
+  /** Present when the editable option was selected. */
+  text?: string;
+}
+
 export interface MultiSelectQuestion<T> {
   key: string;
   message: string;
@@ -163,6 +187,8 @@ export const text = (q: {
 /** The capability boxes see. Pure and flow-agnostic: Prompter's successor. */
 export interface Asker {
   ask<T>(question: Question<T>): Promise<T>;
+  /** A single choice whose one row carries an editable string value. */
+  askEditable<T>(question: EditableSelectQuestion<T>): Promise<EditableSelectAnswer<T>>;
   /**
    * The multi-select channel. Paired with {@link ask} instead of being a
    * question kind because the answer type (`T[]`) differs from the option type
@@ -192,7 +218,10 @@ export class SkippedSignal extends Error {
 }
 
 /** Any question the channel can carry, for signals that quote one. */
-export type AnyQuestion = Question<unknown> | MultiSelectQuestion<unknown>;
+export type AnyQuestion =
+  | Question<unknown>
+  | EditableSelectQuestion<unknown>
+  | MultiSelectQuestion<unknown>;
 
 /**
  * Headless refusal that keeps the whole question: an agent driver can relay
@@ -369,6 +398,69 @@ async function renderQuestion<T>(prompter: Prompter, question: Question<T>): Pro
   return coerceAnswer(question, raw);
 }
 
+async function renderEditableQuestion<T>(
+  prompter: Prompter,
+  question: EditableSelectQuestion<T>,
+): Promise<EditableSelectAnswer<T>> {
+  const editableOption = question.options.find(
+    (option) => option.value === question.editable.value,
+  );
+  if (editableOption === undefined) {
+    throw new Error(`Editable question "${question.key}" does not contain its editable value.`);
+  }
+  const options = question.options.map((option) => ({
+    value: option.id,
+    label: option.label,
+    hint: option.hint,
+    featured: option.featured,
+  }));
+  const editableId = editableOption.id;
+  if (prompter.selectEditable !== undefined) {
+    const result = await prompter.selectEditable({
+      message: question.message,
+      options,
+      initialValue:
+        question.recommended === undefined
+          ? undefined
+          : question.options.find((option) => option.value === question.recommended)?.id,
+      editable: {
+        value: editableId,
+        defaultValue: question.editable.recommended,
+        formatHint: (value) => `${question.editable.label}: ${value}`,
+        validate: (value) => question.editable.validate?.(value) ?? undefined,
+      },
+    });
+    const value = coerceAnswer(
+      select({ key: question.key, message: question.message, options: question.options }),
+      result.value,
+    );
+    return value === question.editable.value
+      ? {
+          value,
+          text:
+            result.kind === "edited" ? result.text.trim() : question.editable.recommended.trim(),
+        }
+      : { value };
+  }
+  const selectedId = await prompter.select({
+    message: question.message,
+    options,
+    initialValue:
+      question.recommended === undefined
+        ? undefined
+        : question.options.find((option) => option.value === question.recommended)?.id,
+  });
+  const value = coerceAnswer(
+    select({ key: question.key, message: question.message, options: question.options }),
+    selectedId,
+  );
+  if (value !== question.editable.value) return { value };
+  // Plain CLI historically cannot edit a select row inline. Preserve its
+  // one-question flow by accepting the recommended text; repainting TUIs use
+  // selectEditable above, while external answer stacks address the text key.
+  return { value, text: question.editable.recommended.trim() };
+}
+
 async function renderManyQuestion<T>(
   prompter: Prompter,
   question: MultiSelectQuestion<T>,
@@ -429,6 +521,12 @@ export function interactiveAsker(prompter: Prompter, events?: AskerEvents): Aske
       if (question.internal) return value;
       return announce(events, question.key, value, "asked");
     },
+    async askEditable<T>(question: EditableSelectQuestion<T>): Promise<EditableSelectAnswer<T>> {
+      const result = await renderEditableQuestion(prompter, question);
+      announce(events, question.key, result.value, "asked");
+      if (result.text !== undefined) announce(events, question.editable.key, result.text, "asked");
+      return result;
+    },
     async askMany<T>(question: MultiSelectQuestion<T>): Promise<T[]> {
       const value = await renderManyQuestion(prompter, question);
       if (question.internal) return value;
@@ -455,6 +553,9 @@ export function headlessAsker(events?: AskerEvents): Asker {
     async ask<T>(question: Question<T>): Promise<T> {
       return refuse(question as Question<unknown>);
     },
+    async askEditable<T>(question: EditableSelectQuestion<T>): Promise<EditableSelectAnswer<T>> {
+      return refuse(question as EditableSelectQuestion<unknown>);
+    },
     async askMany<T>(question: MultiSelectQuestion<T>): Promise<T[]> {
       return refuse(question as MultiSelectQuestion<unknown>);
     },
@@ -479,6 +580,35 @@ export function withAnswers(
       }
       return inner.ask(question);
     },
+    async askEditable<T>(question: EditableSelectQuestion<T>): Promise<EditableSelectAnswer<T>> {
+      if (!(question.key in answers)) return inner.askEditable(question);
+      const selection = coerceAnswer(
+        select({ key: question.key, message: question.message, options: question.options }),
+        answers[question.key],
+      );
+      announce(events, question.key, selection, "answer");
+      if (selection !== question.editable.value) return { value: selection };
+      if (!(question.editable.key in answers)) {
+        const value = await inner.ask(
+          text({
+            key: question.editable.key,
+            message:
+              question.options.find((option) => option.value === selection)?.label ??
+              question.message,
+            recommended: question.editable.recommended,
+            required: question.required,
+            validate: question.editable.validate,
+          }),
+        );
+        return { value: selection, text: value.trim() };
+      }
+      const raw = String(answers[question.editable.key]);
+      const problem = question.editable.validate?.(raw);
+      if (problem) throw new InvalidAnswerError(question.editable.key, problem);
+      const value = raw.trim();
+      announce(events, question.editable.key, value, "answer");
+      return { value: selection, text: value };
+    },
     async askMany<T>(question: MultiSelectQuestion<T>): Promise<T[]> {
       if (question.key in answers) {
         const value = coerceManyAnswer(question, answers[question.key]);
@@ -502,6 +632,13 @@ export function withRequired(keys: readonly string[]): AskerDecorator {
         return inner.ask({ ...question, required: true });
       }
       return inner.ask(question);
+    },
+    async askEditable<T>(question: EditableSelectQuestion<T>): Promise<EditableSelectAnswer<T>> {
+      return inner.askEditable(
+        !question.required && keys.includes(question.key)
+          ? { ...question, required: true }
+          : question,
+      );
     },
     async askMany<T>(question: MultiSelectQuestion<T>): Promise<T[]> {
       if (!question.required && keys.includes(question.key)) {
@@ -551,6 +688,20 @@ export function withPolicy(policy: AnswerPolicy, events?: AskerEvents): AskerDec
         if (accepted) return announce(events, question.key, question.detected, "detected");
       }
       return inner.ask(question);
+    },
+    async askEditable<T>(question: EditableSelectQuestion<T>): Promise<EditableSelectAnswer<T>> {
+      if (policy !== "assume" || question.recommended === undefined) {
+        return inner.askEditable(question);
+      }
+      const result: EditableSelectAnswer<T> =
+        question.recommended === question.editable.value
+          ? { value: question.recommended, text: question.editable.recommended }
+          : { value: question.recommended };
+      announce(events, question.key, result.value, "assumed");
+      if (result.text !== undefined) {
+        announce(events, question.editable.key, result.text, "assumed");
+      }
+      return result;
     },
     async askMany<T>(question: MultiSelectQuestion<T>): Promise<T[]> {
       if (policy === "assume") {

--- a/packages/eve/src/setup/boxes/select-model.test.ts
+++ b/packages/eve/src/setup/boxes/select-model.test.ts
@@ -86,6 +86,9 @@ function untouchableAsker(): Asker {
     ask(question): Promise<never> {
       throw new Error(`untouchableAsker was asked "${question.key}"`);
     },
+    askEditable(question): Promise<never> {
+      throw new Error(`untouchableAsker was asked "${question.key}"`);
+    },
     askMany(question): Promise<never> {
       throw new Error(`untouchableAsker was asked "${question.key}"`);
     },

--- a/packages/eve/src/setup/integrations/discord/setup.test.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.test.ts
@@ -9,6 +9,7 @@ import { setupDiscord, type DiscordSetupDeps } from "./setup.js";
 function asker(answers: Record<string, string>): Asker {
   return {
     ask: async <T>(question: Question<T>) => answers[question.key] as T,
+    askEditable: vi.fn(),
     askMany: async () => [],
   };
 }
@@ -82,6 +83,7 @@ describe("Discord setup", () => {
               if (question.key === "discord-bot-token") return "bot-token" as T;
               return question.detected as T;
             },
+            askEditable: vi.fn(),
             askMany: async () => [],
           },
           prompter: createFakePrompter().prompter,

--- a/packages/eve/src/setup/integrations/github/setup.test.ts
+++ b/packages/eve/src/setup/integrations/github/setup.test.ts
@@ -24,6 +24,7 @@ describe("GitHub setup", () => {
   function asker(events = ["issue_comment", "pull_request_review_comment"]): Asker {
     return {
       ask: vi.fn(),
+      askEditable: vi.fn(),
       askMany: vi.fn(async () => events) as Asker["askMany"],
     };
   }
@@ -69,7 +70,10 @@ describe("GitHub setup", () => {
       {
         appRoot: "/project",
         environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({ asker: { ask: vi.fn(), askMany }, prompter: fake.prompter }),
+        ui: createIntegrationSetupUi({
+          asker: { ask: vi.fn(), askEditable: vi.fn(), askMany },
+          prompter: fake.prompter,
+        }),
       },
       deps(),
     );

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
-import type { Asker, Question } from "#setup/ask.js";
+import { headlessAsker, withAnswers, withPolicy } from "#setup/ask.js";
 
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createIntegrationSetupUi } from "../shared/ui.js";
@@ -12,16 +12,30 @@ function deps(): LinearSetupDeps {
     attachConnector: vi.fn(async () => {}),
     deriveConnectorSlug: vi.fn(async () => "agent" as never),
     ensureVercelProject: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
+    readProjectLink: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
     findConnector: vi.fn(async () => undefined),
     provisionConnector: vi.fn(async () => ({ id: "scl_linear", uid: "linear/agent" })),
     writeTextFile: vi.fn(async () => {}),
   };
 }
 
-function recommendedAsker(): Asker {
-  const ask = async <T>(question: Question<T>): Promise<T> => question.recommended as T;
-  const askMany: Asker["askMany"] = async () => [];
-  return { ask, askEditable: vi.fn(), askMany };
+function run(input: { answers?: Record<string, unknown>; effects?: LinearSetupDeps }) {
+  const effects = input.effects ?? deps();
+  return {
+    effects,
+    result: setupLinear(
+      {
+        appRoot: "/project",
+        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({
+          asker: withAnswers(input.answers ?? {})(withPolicy("assume")(headlessAsker())),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
+        }),
+      },
+      effects,
+    ),
+  };
 }
 
 describe("Linear setup", () => {
@@ -30,42 +44,10 @@ describe("Linear setup", () => {
     expect(linearSafeConnectorSlug("linear")).toBe("agent");
   });
 
-  it("provisions Connect, routes Agent Session events, and scaffolds the channel", async () => {
-    const fake = createFakePrompter();
-    const effects = deps();
+  it("provisions and scaffolds from recommended keyed choices", async () => {
+    const { effects, result } = run({});
 
-    const result = await setupLinear(
-      {
-        appRoot: "/project",
-        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({ asker: recommendedAsker(), prompter: fake.prompter }),
-      },
-      effects,
-    );
-
-    expect(result).toMatchObject({
-      kind: "done",
-      completion: {
-        facts: [
-          {
-            label: "Vercel Connect",
-            value: "https://vercel.com/d?to=/%5Bteam%5D/~/connect&title=Open+Vercel+Connect",
-            kind: "url",
-          },
-          {
-            label: "Next step",
-            value:
-              "Deploy the agent, then open the Linear app in Vercel Connect and install it in the workspace where you want to delegate issues and comments.",
-          },
-          {
-            label: "In Linear",
-            value:
-              "Delegate an issue or mention the agent in an Agent Session to start a conversation.",
-          },
-        ],
-      },
-    });
-
+    await expect(result).resolves.toMatchObject({ kind: "done" });
     expect(effects.provisionConnector).toHaveBeenCalledWith(
       expect.objectContaining({ slug: "agent" }),
     );
@@ -76,36 +58,43 @@ describe("Linear setup", () => {
     );
   });
 
-  it("reuses an existing connector when selected", async () => {
-    const fake = createFakePrompter();
+  it("reuses an existing connector selected by stable answer", async () => {
     const effects = deps();
     vi.mocked(effects.findConnector).mockResolvedValue({ id: "scl_existing", uid: "linear/agent" });
-    const asker = recommendedAsker();
+    const { result } = run({
+      effects,
+      answers: { "linear.existing-connector": "reuse" },
+    });
 
-    await expect(
-      setupLinear(
-        {
-          appRoot: "/project",
-          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-          ui: createIntegrationSetupUi({ asker, prompter: fake.prompter }),
-        },
-        effects,
-      ),
-    ).resolves.toMatchObject({ kind: "done" });
-
+    await expect(result).resolves.toMatchObject({ kind: "done" });
     expect(effects.attachConnector).toHaveBeenCalledWith(
       expect.objectContaining({ connector: { id: "scl_existing", uid: "linear/agent" } }),
     );
     expect(effects.provisionConnector).not.toHaveBeenCalled();
   });
 
+  it("requires an existing Vercel link headlessly before mutation", async () => {
+    const effects = deps();
+    vi.mocked(effects.readProjectLink).mockResolvedValue(undefined);
+    const { result } = run({ effects });
+
+    await expect(result).rejects.toThrow("Run `eve link`");
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.findConnector).not.toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+    expect(effects.writeTextFile).not.toHaveBeenCalled();
+  });
+
   it("requires an authenticated Vercel CLI", async () => {
-    const fake = createFakePrompter();
     await expect(
       setupLinear({
         appRoot: "/project",
         environment: integrationSetupEnvironment("logged-out", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({ asker: recommendedAsker(), prompter: fake.prompter }),
+        ui: createIntegrationSetupUi({
+          asker: headlessAsker(),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
+        }),
       }),
     ).rejects.toThrow("vercel login");
   });

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -21,7 +21,7 @@ function deps(): LinearSetupDeps {
 function recommendedAsker(): Asker {
   const ask = async <T>(question: Question<T>): Promise<T> => question.recommended as T;
   const askMany: Asker["askMany"] = async () => [];
-  return { ask, askMany };
+  return { ask, askEditable: vi.fn(), askMany };
 }
 
 describe("Linear setup", () => {

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -2,10 +2,15 @@ import { join } from "node:path";
 
 import { select, text } from "#setup/ask.js";
 import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
+import { readProjectLink } from "#setup/project-resolution.js";
 import { deriveSlackConnectorSlug, normalizeSlackConnectorSlug } from "#setup/scaffold/index.js";
 import { writeTextFile } from "#setup/scaffold/files.js";
 import { WizardCancelledError } from "#setup/step.js";
 
+import {
+  resolveIntegrationVercelProject,
+  type IntegrationVercelProjectDeps,
+} from "../shared/vercel-project.js";
 import type {
   IntegrationSetupContext,
   IntegrationSetupResult,
@@ -22,6 +27,7 @@ export interface LinearSetupDeps {
   attachConnector: typeof attachLinearConnector;
   deriveConnectorSlug: typeof deriveSlackConnectorSlug;
   ensureVercelProject: typeof ensureVercelProject;
+  readProjectLink: typeof readProjectLink;
   findConnector: typeof findLinearConnector;
   provisionConnector: typeof provisionLinearConnector;
   writeTextFile: typeof writeTextFile;
@@ -31,6 +37,7 @@ const defaultDeps: LinearSetupDeps = {
   attachConnector: attachLinearConnector,
   deriveConnectorSlug: deriveSlackConnectorSlug,
   ensureVercelProject,
+  readProjectLink,
   findConnector: findLinearConnector,
   provisionConnector: provisionLinearConnector,
   writeTextFile,
@@ -135,10 +142,12 @@ export async function setupLinear(
     );
   }
   try {
-    const project = await deps.ensureVercelProject({
+    const project = await resolveIntegrationVercelProject({
       appRoot: context.appRoot,
-      prompter: context.ui.prompter,
+      integration: "Linear",
+      ui: context.ui,
       signal: context.signal,
+      deps: deps satisfies IntegrationVercelProjectDeps,
     });
     const connector = await chooseConnector(context, deps, project);
     if (connector === undefined) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/photon/setup-flow.test.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.test.ts
@@ -1,26 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { headlessAsker, InteractionRequired, interactiveAsker, withAnswers } from "#setup/ask.js";
 
-import type { Asker, Question } from "../../ask.js";
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createIntegrationSetupUi } from "../shared/ui.js";
-import { setupPhoton, type PhotonSetupDeps } from "./setup-flow.js";
+import { setupPhoton, type PhotonSetupDeps, type PhotonSetupOptions } from "./setup-flow.js";
 
-function asker(answers: Record<string, string>): Asker {
-  return {
-    ask: async <T>(question: Question<T>) => answers[question.key] as T,
-    askMany: async () => [],
-  };
-}
+const PORTABLE_ANSWERS = {
+  "photon-credentials": "portable",
+  "photon-project-source": "create",
+  "photon-project-name": "eve · agent",
+  "photon-phone-number": "+15551234567",
+};
 
 function deps(): PhotonSetupDeps {
   return {
     appendEnv: vi.fn(async () => ({ written: [], skipped: [] })),
     deriveConnectorSlug: vi.fn(async () => "agent" as never),
     ensureVercelProject: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
+    readProjectLink: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
     openUrl: vi.fn(),
-    provisionConnector: vi.fn(),
+    provisionConnector: vi.fn(async () => ({ id: "connector-id", uid: "photon/agent" })),
     provisionProject: vi.fn(async () => ({
       projectId: "project-id",
       projectSecret: "project-secret",
@@ -31,24 +32,63 @@ function deps(): PhotonSetupDeps {
   };
 }
 
-describe("Photon setup", () => {
-  it("scaffolds portable credentials when Vercel Connect is unavailable", async () => {
-    const fake = createFakePrompter({ single: () => "portable" });
-    const effects = deps();
-
-    await expect(
-      setupPhoton({
-        agentName: "agent",
-        projectPath: "/project",
-        environment: integrationSetupEnvironment("cli-missing", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({
-          asker: asker({ "photon-phone-number": "+15551234567" }),
-          prompter: fake.prompter,
-        }),
-        deps: effects,
+function run(input: {
+  answers?: Record<string, unknown>;
+  effects?: PhotonSetupDeps;
+  auth?: "authenticated" | "cli-missing";
+  interaction?: "interactive" | "headless";
+  ui?: PhotonSetupOptions["ui"];
+  agentName?: string;
+}) {
+  const effects = input.effects ?? deps();
+  const interaction = input.interaction ?? "headless";
+  const prompter = createFakePrompter().prompter;
+  const ui =
+    input.ui ??
+    createIntegrationSetupUi({
+      asker: withAnswers(input.answers ?? PORTABLE_ANSWERS)(headlessAsker()),
+      prompter,
+      interaction,
+    });
+  return {
+    effects,
+    result: setupPhoton({
+      agentName: input.agentName ?? "agent",
+      projectPath: "/project",
+      environment: integrationSetupEnvironment(input.auth ?? "authenticated", {
+        kind: "unresolved",
       }),
-    ).resolves.toMatchObject({ kind: "done" });
+      ui,
+      deps: effects,
+    }),
+  };
+}
 
+function expectNoMutation(effects: PhotonSetupDeps): void {
+  for (const effect of [
+    effects.ensureVercelProject,
+    effects.readProjectLink,
+    effects.provisionProject,
+    effects.useProject,
+    effects.provisionConnector,
+    effects.appendEnv,
+    effects.writeTextFile,
+  ]) {
+    expect(effect).not.toHaveBeenCalled();
+  }
+}
+
+describe("Photon setup", () => {
+  it("scaffolds portable credentials entirely from keyed answers", async () => {
+    const { effects, result } = run({
+      auth: "cli-missing",
+      answers: { ...PORTABLE_ANSWERS, "photon-project-name": "Agent Messages" },
+    });
+
+    await expect(result).resolves.toMatchObject({ kind: "done" });
+    expect(effects.provisionProject).toHaveBeenCalledWith(
+      expect.objectContaining({ projectName: "Agent Messages", phoneNumber: "+15551234567" }),
+    );
     expect(effects.appendEnv).toHaveBeenCalledWith("/project/.env.local", {
       IMESSAGE_PROJECT_ID: "project-id",
       IMESSAGE_PROJECT_SECRET: "project-secret",
@@ -61,37 +101,98 @@ describe("Photon setup", () => {
     );
   });
 
-  it("uses the agent name in the default Photon project name", async () => {
-    const fake = createFakePrompter({ single: () => "portable" });
-    const effects = deps();
-
-    await setupPhoton({
-      agentName: "weather-agent",
-      projectPath: "/project",
-      environment: integrationSetupEnvironment("cli-missing", { kind: "unresolved" }),
-      ui: createIntegrationSetupUi({
-        asker: asker({ "photon-phone-number": "+15551234567" }),
-        prompter: fake.prompter,
-      }),
-      deps: effects,
+  it("rejects Connect without Vercel authentication", async () => {
+    const { result } = run({
+      auth: "cli-missing",
+      answers: { "photon-credentials": "vercel" },
     });
 
+    await expect(result).rejects.toThrow("vercel login");
+  });
+
+  it("collects every Photon decision before mutation", async () => {
+    const { effects, result } = run({
+      answers: {
+        "photon-credentials": "portable",
+        "photon-project-source": "create",
+      },
+    });
+
+    await expect(result).rejects.toBeInstanceOf(InteractionRequired);
+    expectNoMutation(effects);
+  });
+
+  it("preserves the one-screen editable project picker interactively", async () => {
+    const answers: Record<string, string> = {
+      "How would you like to configure Photon?": "portable",
+      "Your iMessage phone number": "+15551234567",
+    };
+    const fake = createFakePrompter({
+      single: (options) => answers[options.message]!,
+      text: (options) => answers[options.message]!,
+    });
+    fake.prompter.selectEditable = async <T>() => ({
+      kind: "edited" as const,
+      value: "create" as T,
+      text: "My Photon project",
+    });
+    const selectEditable = vi.spyOn(fake.prompter, "selectEditable");
+    const effects = deps();
+
+    await run({
+      auth: "cli-missing",
+      effects,
+      interaction: "interactive",
+      ui: createIntegrationSetupUi({
+        asker: interactiveAsker(fake.prompter),
+        prompter: fake.prompter,
+      }),
+    }).result;
+
+    expect(fake.selectMessages).toEqual(["How would you like to configure Photon?"]);
+    expect(selectEditable).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Photon project" }),
+    );
     expect(effects.provisionProject).toHaveBeenCalledWith(
-      expect.objectContaining({ projectName: "eve · weather-agent" }),
+      expect.objectContaining({ projectName: "My Photon project" }),
     );
   });
 
-  it("requires Vercel login when Connect is selected without an authenticated CLI", async () => {
-    const fake = createFakePrompter({ single: () => "vercel" });
+  it("requires an existing Vercel link headlessly before Photon mutation", async () => {
+    const effects = deps();
+    vi.mocked(effects.readProjectLink).mockResolvedValue(undefined);
+    const { result } = run({
+      effects,
+      answers: { ...PORTABLE_ANSWERS, "photon-credentials": "vercel" },
+    });
 
-    await expect(
-      setupPhoton({
-        agentName: "agent",
-        projectPath: "/project",
-        environment: integrationSetupEnvironment("cli-missing", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({ asker: asker({}), prompter: fake.prompter }),
-        deps: deps(),
-      }),
-    ).rejects.toThrow("vercel login");
+    await expect(result).rejects.toThrow("Run `eve link`");
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.provisionProject).not.toHaveBeenCalled();
+  });
+
+  it("links Vercel interactively before creating a Photon project", async () => {
+    const order: string[] = [];
+    const effects = deps();
+    vi.mocked(effects.ensureVercelProject).mockImplementation(async () => {
+      order.push("vercel");
+      return { orgId: "team-id", projectId: "project-id" };
+    });
+    vi.mocked(effects.provisionProject).mockImplementation(async () => {
+      order.push("photon");
+      return {
+        projectId: "project-id",
+        projectSecret: "project-secret",
+        cleanup: vi.fn(async () => {}),
+      };
+    });
+
+    await run({
+      effects,
+      interaction: "interactive",
+      answers: { ...PORTABLE_ANSWERS, "photon-credentials": "vercel" },
+    }).result;
+
+    expect(order).toEqual(["vercel", "photon"]);
   });
 });

--- a/packages/eve/src/setup/integrations/photon/setup-flow.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { text } from "../../ask.js";
+import { select, text } from "../../ask.js";
 import { appendEnv } from "../../append-env.js";
 import { provisionPhotonConnector } from "./connect.js";
 import {
@@ -15,7 +15,12 @@ import { writeTextFile } from "../../scaffold/files.js";
 import { WizardCancelledError } from "../../step.js";
 import type { IntegrationSetupEnvironment } from "../shared/environment.js";
 import type { IntegrationSetupUi } from "../shared/ui.js";
+import {
+  resolveIntegrationVercelProject,
+  type IntegrationVercelProjectDeps,
+} from "../shared/vercel-project.js";
 import { ensureVercelProject } from "../../flows/ensure-vercel-project.js";
+import { readProjectLink } from "../../project-resolution.js";
 
 /** Inputs for Photon project provisioning and channel scaffolding. */
 export interface PhotonSetupOptions {
@@ -33,16 +38,18 @@ export type PhotonSetupResult =
   | { kind: "done"; assignedPhoneNumber?: string; dashboardUrl: string }
   | { kind: "cancelled" };
 
-interface PhotonSetupPlan {
+export interface PhotonSetupPlan {
   credentials: "vercel-connect" | "environment";
   photonProject: "create" | { projectId: string; projectSecret: string };
   photonProjectName?: string;
+  phoneNumber: string;
 }
 
 export interface PhotonSetupDeps {
   appendEnv: typeof appendEnv;
   deriveConnectorSlug: typeof deriveSlackConnectorSlug;
   ensureVercelProject: typeof ensureVercelProject;
+  readProjectLink: typeof readProjectLink;
   openUrl: typeof openUrl;
   provisionConnector: typeof provisionPhotonConnector;
   provisionProject: typeof provisionPhotonProject;
@@ -54,6 +61,7 @@ const defaultDeps: PhotonSetupDeps = {
   appendEnv,
   deriveConnectorSlug: deriveSlackConnectorSlug,
   ensureVercelProject,
+  readProjectLink,
   openUrl,
   provisionConnector: provisionPhotonConnector,
   provisionProject: provisionPhotonProject,
@@ -90,40 +98,34 @@ async function choosePhotonProject(
   options: PhotonSetupOptions,
 ): Promise<Pick<PhotonSetupPlan, "photonProject" | "photonProjectName">> {
   const defaultName = `eve · ${options.agentName || "agent"}`;
-  const projectOptions = [
-    {
+  const project = await options.ui.asker.askEditable({
+    key: "photon-project-source",
+    message: "Photon project",
+    options: [
+      {
+        id: "create",
+        value: "create" as const,
+        label: "Create a new Photon project",
+        hint: `Name: ${defaultName}`,
+      },
+      {
+        id: "existing",
+        value: "existing" as const,
+        label: "Use an existing Photon project",
+        hint: "Enter its project credentials",
+      },
+    ],
+    recommended: "create" as const,
+    required: true,
+    editable: {
+      key: "photon-project-name",
       value: "create" as const,
-      label: "Create a new Photon project",
-      hint: `Name: ${defaultName}`,
+      label: "Name",
+      recommended: defaultName,
+      validate: (value) => (value.trim().length === 0 ? "Project name cannot be empty." : null),
     },
-    {
-      value: "existing" as const,
-      label: "Use an existing Photon project",
-      hint: "Enter its project credentials",
-    },
-  ];
-  const editable = options.ui.prompter.selectEditable
-    ? await options.ui.prompter.selectEditable<"create" | "existing">({
-        message: "Photon project",
-        options: projectOptions,
-        initialValue: "create",
-        editable: {
-          value: "create",
-          defaultValue: defaultName,
-          formatHint: (value) => `Name: ${value}`,
-          validate: (value) =>
-            value.trim().length === 0 ? "Project name cannot be empty." : undefined,
-        },
-      })
-    : undefined;
-  const source =
-    editable?.value ??
-    (await options.ui.prompter.select<"create" | "existing">({
-      message: "Photon project",
-      options: projectOptions,
-      initialValue: "create",
-    }));
-  if (source === "existing") {
+  });
+  if (project.value === "existing") {
     const projectId = await options.ui.asker.ask(
       text({ key: "photon-project-id", message: "Photon project ID", required: true }),
     );
@@ -138,21 +140,19 @@ async function choosePhotonProject(
     return { photonProject: { projectId: projectId.trim(), projectSecret: projectSecret.trim() } };
   }
 
-  return {
-    photonProject: "create",
-    photonProjectName: editable?.kind === "edited" ? editable.text.trim() : defaultName,
-  };
+  return { photonProject: "create", photonProjectName: project.text ?? defaultName };
 }
 
-async function chooseSetupPlan(
-  options: PhotonSetupOptions,
-): Promise<PhotonSetupPlan | "cancelled"> {
-  try {
-    const destination = await options.ui.prompter.select<"vercel" | "portable">({
+/** Resolves every Photon-owned decision without mutating local or remote state. */
+export async function preparePhotonSetup(options: PhotonSetupOptions): Promise<PhotonSetupPlan> {
+  const destination = await options.ui.asker.ask(
+    select({
+      key: "photon-credentials",
       message: "How would you like to configure Photon?",
       options: [
         {
-          value: "vercel",
+          id: "vercel",
+          value: "vercel-connect" as const,
           label: "Set up Vercel Connect",
           hint:
             options.environment.vercel.kind === "available"
@@ -160,24 +160,35 @@ async function chooseSetupPlan(
               : "Log in to Vercel and link this project",
         },
         {
-          value: "portable",
+          id: "portable",
+          value: "environment" as const,
           label: "Use portable credentials",
           hint: "Configure the Photon webhook manually after deployment",
         },
       ],
-      initialValue: options.environment.vercel.kind === "available" ? "vercel" : "portable",
-    });
-    if (destination === "vercel" && options.environment.vercel.kind === "unavailable") {
-      throw new Error(
-        "Vercel Connect requires an authenticated Vercel CLI. Run `vercel login`, then retry Photon setup.",
-      );
-    }
-    const photon = await choosePhotonProject(options);
-    return { credentials: destination === "vercel" ? "vercel-connect" : "environment", ...photon };
-  } catch (error) {
-    if (error instanceof WizardCancelledError) return "cancelled";
-    throw error;
+      recommended:
+        options.environment.vercel.kind === "available"
+          ? ("vercel-connect" as const)
+          : ("environment" as const),
+      required: true,
+    }),
+  );
+  if (destination === "vercel-connect" && options.environment.vercel.kind === "unavailable") {
+    throw new Error(
+      "Vercel Connect requires an authenticated Vercel CLI. Run `vercel login`, then retry Photon setup.",
+    );
   }
+  const photon = await choosePhotonProject(options);
+  const phoneNumber = await options.ui.asker.ask(
+    text({
+      key: "photon-phone-number",
+      message: "Your iMessage phone number",
+      placeholder: "+15551234567",
+      required: true,
+      validate: validatePhotonPhoneNumber,
+    }),
+  );
+  return { credentials: destination, ...photon, phoneNumber };
 }
 
 async function resolvePhotonProject(
@@ -209,35 +220,34 @@ async function resolvePhotonProject(
   }
 }
 
-async function scaffoldPhoton(
+/** Applies a fully resolved Photon plan. No Photon-owned questions are asked here. */
+export async function applyPhotonSetup(
   options: PhotonSetupOptions,
   plan: PhotonSetupPlan,
-  deps: PhotonSetupDeps,
 ): Promise<{ assignedPhoneNumber?: string; dashboardUrl: string }> {
-  const phoneNumber = await options.ui.asker.ask(
-    text({
-      key: "photon-phone-number",
-      message: "Your iMessage phone number",
-      placeholder: "+15551234567",
-      required: true,
-      validate: validatePhotonPhoneNumber,
-    }),
-  );
+  const deps = options.deps ?? defaultDeps;
   const projectRoot = options.projectPath;
-  const managedProject = await resolvePhotonProject(options, plan, phoneNumber, deps);
+  // Vercel's existing ensure flow may still ask while linking an unresolved project.
+  // Resolve it before Photon provisioning so cancellation cannot abandon a Photon project.
+  const vercelProject =
+    plan.credentials === "vercel-connect"
+      ? await resolveIntegrationVercelProject({
+          appRoot: projectRoot,
+          integration: "Photon",
+          ui: options.ui,
+          signal: options.signal,
+          deps: deps satisfies IntegrationVercelProjectDeps,
+        })
+      : undefined;
+  const managedProject = await resolvePhotonProject(options, plan, plan.phoneNumber, deps);
   try {
     const channelPath = join(projectRoot, "agent/channels/photon.ts");
     if (plan.credentials === "vercel-connect") {
       const slug = await deps.deriveConnectorSlug(projectRoot, options.agentName);
-      const project = await deps.ensureVercelProject({
-        appRoot: projectRoot,
-        prompter: options.ui.prompter,
-        signal: options.signal,
-      });
       const connector = await deps.provisionConnector({
         credentials: managedProject,
         log: options.ui.prompter.log,
-        project,
+        project: vercelProject!,
         projectRoot,
         slug,
         signal: options.signal,
@@ -276,9 +286,8 @@ async function scaffoldPhoton(
 /** Provisions a Photon project and scaffolds its iMessage channel. */
 export async function setupPhoton(options: PhotonSetupOptions): Promise<PhotonSetupResult> {
   try {
-    const plan = await chooseSetupPlan(options);
-    if (plan === "cancelled") return { kind: "cancelled" };
-    return { kind: "done", ...(await scaffoldPhoton(options, plan, options.deps ?? defaultDeps)) };
+    const plan = await preparePhotonSetup(options);
+    return { kind: "done", ...(await applyPhotonSetup(options, plan)) };
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };
     throw error;

--- a/packages/eve/src/setup/integrations/registry.test.ts
+++ b/packages/eve/src/setup/integrations/registry.test.ts
@@ -9,6 +9,7 @@ import { WizardCancelledError } from "../step.js";
 
 const unusedAsker: Asker = {
   ask: async <T>() => undefined as T,
+  askEditable: async <T>() => ({ value: undefined as T }),
   askMany: async () => [],
 };
 
@@ -19,6 +20,7 @@ function context(prompter = createFakePrompter().prompter) {
     ui: {
       asker: unusedAsker,
       prompter,
+      interaction: "interactive" as const,
       confirm: async () => false,
       nextSteps: () => {},
     },

--- a/packages/eve/src/setup/integrations/registry.test.ts
+++ b/packages/eve/src/setup/integrations/registry.test.ts
@@ -29,13 +29,16 @@ function context(prompter = createFakePrompter().prompter) {
 
 describe("setup integrations", () => {
   it("keeps Slack credential-picker cancellation as a structured result", async () => {
-    const fake = createFakePrompter({
-      single: () => {
+    const fake = createFakePrompter();
+    const cancelled = context(fake.prompter);
+    cancelled.ui.asker = {
+      ...unusedAsker,
+      ask: async () => {
         throw new WizardCancelledError();
       },
-    });
+    };
 
-    await expect(setupIntegration("slack").setup(context(fake.prompter))).resolves.toEqual({
+    await expect(setupIntegration("slack").setup(cancelled)).resolves.toEqual({
       kind: "cancelled",
     });
   });

--- a/packages/eve/src/setup/integrations/runner.ts
+++ b/packages/eve/src/setup/integrations/runner.ts
@@ -1,4 +1,4 @@
-import { interactiveAsker } from "#setup/ask.js";
+import { interactiveAsker, type Asker } from "#setup/ask.js";
 import { detectDeployment, projectResolutionFromDeployment } from "#setup/project-resolution.js";
 import type { Prompter } from "#setup/prompter.js";
 import { getVercelAuthStatus } from "#setup/vercel-project.js";
@@ -15,6 +15,9 @@ import type { IntegrationSetupResult } from "./types.js";
 export interface RunIntegrationSetupOptions {
   appRoot: string;
   prompter: Prompter;
+  /** Defaults to the interactive adapter; agent drivers inject an answer-backed asker. */
+  asker?: Asker;
+  interaction?: "interactive" | "headless";
   signal?: AbortSignal;
   yes?: boolean;
 }
@@ -50,8 +53,9 @@ export async function runIntegrationSetup(
     environment,
     appRoot: options.appRoot,
     ui: createIntegrationSetupUi({
-      asker: interactiveAsker(options.prompter),
+      asker: options.asker ?? interactiveAsker(options.prompter),
       prompter: options.prompter,
+      interaction: options.interaction,
     }),
     yes: options.yes,
     signal: options.signal,

--- a/packages/eve/src/setup/integrations/shared/prerequisite.ts
+++ b/packages/eve/src/setup/integrations/shared/prerequisite.ts
@@ -1,0 +1,12 @@
+/** A read-only setup refusal whose prerequisite must be satisfied by a separate command. */
+export class SetupPrerequisiteRequired extends Error {
+  readonly code: string;
+  readonly command: string;
+
+  constructor(input: { code: string; message: string; command: string }) {
+    super(input.message);
+    this.name = "SetupPrerequisiteRequired";
+    this.code = input.code;
+    this.command = input.command;
+  }
+}

--- a/packages/eve/src/setup/integrations/shared/ui.ts
+++ b/packages/eve/src/setup/integrations/shared/ui.ts
@@ -5,6 +5,7 @@ import type { Prompter } from "../../prompter.js";
 export interface IntegrationSetupUi {
   readonly asker: Asker;
   readonly prompter: Prompter;
+  readonly interaction: "interactive" | "headless";
   confirm(input: { key: string; message: string; recommended?: boolean }): Promise<boolean>;
   nextSteps(lines: readonly string[]): void;
 }
@@ -13,9 +14,11 @@ export interface IntegrationSetupUi {
 export function createIntegrationSetupUi(input: {
   asker: Asker;
   prompter: Prompter;
+  interaction?: "interactive" | "headless";
 }): IntegrationSetupUi {
   return {
     ...input,
+    interaction: input.interaction ?? "interactive",
     async confirm(question) {
       try {
         return await input.asker.ask(confirm(question));

--- a/packages/eve/src/setup/integrations/shared/vercel-project.test.ts
+++ b/packages/eve/src/setup/integrations/shared/vercel-project.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { headlessAsker } from "#setup/ask.js";
+
+import { SetupPrerequisiteRequired } from "./prerequisite.js";
+import { createIntegrationSetupUi } from "./ui.js";
+import { resolveIntegrationVercelProject } from "./vercel-project.js";
+
+function ui(interaction: "interactive" | "headless") {
+  return createIntegrationSetupUi({
+    asker: headlessAsker(),
+    prompter: createFakePrompter().prompter,
+    interaction,
+  });
+}
+
+describe("resolveIntegrationVercelProject", () => {
+  it("lets interactive setup ensure the project inline", async () => {
+    const ensureVercelProject = vi.fn(async () => ({ orgId: "org-id", projectId: "project-id" }));
+    const readProjectLink = vi.fn();
+
+    await expect(
+      resolveIntegrationVercelProject({
+        appRoot: "/project",
+        integration: "Photon",
+        ui: ui("interactive"),
+        deps: { ensureVercelProject, readProjectLink },
+      }),
+    ).resolves.toEqual({ orgId: "org-id", projectId: "project-id" });
+
+    expect(ensureVercelProject).toHaveBeenCalledOnce();
+    expect(readProjectLink).not.toHaveBeenCalled();
+  });
+
+  it("only reads an existing link for headless setup", async () => {
+    const ensureVercelProject = vi.fn();
+    const readProjectLink = vi.fn(async () => ({ orgId: "org-id", projectId: "project-id" }));
+
+    await expect(
+      resolveIntegrationVercelProject({
+        appRoot: "/project",
+        integration: "Slack",
+        ui: ui("headless"),
+        deps: { ensureVercelProject, readProjectLink },
+      }),
+    ).resolves.toEqual({ orgId: "org-id", projectId: "project-id" });
+
+    expect(ensureVercelProject).not.toHaveBeenCalled();
+  });
+
+  it("returns a typed prerequisite when headless setup is unlinked", async () => {
+    await expect(
+      resolveIntegrationVercelProject({
+        appRoot: "/project",
+        integration: "Slack",
+        ui: ui("headless"),
+        deps: { ensureVercelProject: vi.fn(), readProjectLink: vi.fn(async () => undefined) },
+      }),
+    ).rejects.toMatchObject({
+      name: "SetupPrerequisiteRequired",
+      code: "vercel-project-link",
+      command: "eve link",
+      message: expect.stringContaining("retry Slack setup"),
+    } satisfies Partial<SetupPrerequisiteRequired>);
+  });
+});

--- a/packages/eve/src/setup/integrations/shared/vercel-project.ts
+++ b/packages/eve/src/setup/integrations/shared/vercel-project.ts
@@ -1,0 +1,38 @@
+import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
+import { readProjectLink, type VercelProjectReference } from "#setup/project-resolution.js";
+
+import { SetupPrerequisiteRequired } from "./prerequisite.js";
+import type { IntegrationSetupUi } from "./ui.js";
+
+export interface IntegrationVercelProjectDeps {
+  ensureVercelProject: typeof ensureVercelProject;
+  readProjectLink: typeof readProjectLink;
+}
+
+const defaultDeps: IntegrationVercelProjectDeps = { ensureVercelProject, readProjectLink };
+
+/** Resolves inline for people, but treats linking as a separate prerequisite for headless setup. */
+export async function resolveIntegrationVercelProject(input: {
+  appRoot: string;
+  integration: string;
+  ui: IntegrationSetupUi;
+  signal?: AbortSignal;
+  deps?: IntegrationVercelProjectDeps;
+}): Promise<VercelProjectReference> {
+  const deps = input.deps ?? defaultDeps;
+  const project =
+    input.ui.interaction === "interactive"
+      ? await deps.ensureVercelProject({
+          appRoot: input.appRoot,
+          prompter: input.ui.prompter,
+          signal: input.signal,
+        })
+      : await deps.readProjectLink(input.appRoot);
+  if (project !== undefined) return project;
+
+  throw new SetupPrerequisiteRequired({
+    code: "vercel-project-link",
+    message: `Vercel Connect setup requires a linked Vercel project. Run \`eve link\`, then retry ${input.integration} setup.`,
+    command: "eve link",
+  });
+}

--- a/packages/eve/src/setup/integrations/slack/setup.test.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.test.ts
@@ -40,7 +40,7 @@ describe("setupSlack", () => {
           appRoot: "/project",
           environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
           ui: createIntegrationSetupUi({
-            asker: { ask: vi.fn(), askMany: vi.fn() },
+            asker: { ask: vi.fn(), askEditable: vi.fn(), askMany: vi.fn() },
             prompter: fake.prompter,
           }),
           yes: true,

--- a/packages/eve/src/setup/integrations/slack/setup.test.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.test.ts
@@ -1,57 +1,121 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { headlessAsker, InteractionRequired, withAnswers } from "#setup/ask.js";
 import type { SlackConnectorSlug } from "#setup/scaffold/index.js";
 
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createIntegrationSetupUi } from "../shared/ui.js";
 import { setupSlack, type SlackSetupDeps } from "./setup.js";
 
-describe("setupSlack", () => {
-  it("uses Vercel Connect without prompting for credentials in non-interactive mode", async () => {
-    const fake = createFakePrompter({
-      single: () => {
-        throw new Error("credential selection must not be prompted");
-      },
-    });
-    const provisionSlackbot = vi.fn(async () => ({
+function channelResult() {
+  return {
+    kind: "slack" as const,
+    action: "created" as const,
+    filesWritten: [],
+    filesOverwritten: [],
+    filesSkipped: [],
+    packageJsonUpdated: [],
+    slackConnectorSlug: "agent" as SlackConnectorSlug,
+  };
+}
+
+function deps(): SlackSetupDeps {
+  return {
+    deriveSlackConnectorSlug: vi.fn(async () => "agent" as SlackConnectorSlug),
+    ensureChannel: vi.fn(async () => channelResult()),
+    ensureVercelProject: vi.fn(async () => ({ orgId: "org-id", projectId: "project-id" })),
+    readProjectLink: vi.fn(async () => ({ orgId: "org-id", projectId: "project-id" })),
+    provisionSlackbot: vi.fn(async () => ({
       state: "attached" as const,
-      connectorUid: "uid",
-    }));
-    const effects = {
-      deriveSlackConnectorSlug: vi.fn(async () => "agent" as SlackConnectorSlug),
-      ensureChannel: vi.fn(async () => ({
-        kind: "slack" as const,
-        action: "created" as const,
-        filesWritten: [],
-        filesOverwritten: [],
-        filesSkipped: [],
-        packageJsonUpdated: [],
-        slackConnectorSlug: "agent" as SlackConnectorSlug,
-      })),
-      ensureVercelProject: vi.fn(async () => ({ orgId: "org-id", projectId: "project-id" })),
-      provisionSlackbot,
-      reconcileSlackUid: vi.fn(),
-    } as SlackSetupDeps;
+      connectorUid: "slack/agent",
+    })),
+    reconcileSlackUid: vi.fn(),
+  };
+}
 
-    await expect(
-      setupSlack(
-        {
-          appRoot: "/project",
-          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-          ui: createIntegrationSetupUi({
-            asker: { ask: vi.fn(), askEditable: vi.fn(), askMany: vi.fn() },
-            prompter: fake.prompter,
-          }),
-          yes: true,
-        },
-        effects,
-      ),
-    ).resolves.toEqual({
-      kind: "done",
-      completion: { facts: [], deployment: { required: true } },
-    });
+function run(input: {
+  answers?: Record<string, unknown>;
+  effects?: SlackSetupDeps;
+  yes?: boolean;
+  interaction?: "interactive" | "headless";
+}) {
+  const effects = input.effects ?? deps();
+  const interaction = input.interaction ?? "headless";
+  return {
+    effects,
+    result: setupSlack(
+      {
+        appRoot: "/project",
+        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({
+          asker: withAnswers(input.answers ?? {})(headlessAsker()),
+          prompter: createFakePrompter().prompter,
+          interaction,
+        }),
+        yes: input.yes,
+      },
+      effects,
+    ),
+  };
+}
 
-    expect(provisionSlackbot).toHaveBeenCalledOnce();
+describe("setupSlack", () => {
+  it("uses Vercel Connect without asking for credentials with --yes", async () => {
+    const { effects, result } = run({ yes: true, interaction: "interactive" });
+
+    await expect(result).resolves.toMatchObject({ kind: "done" });
+    expect(effects.provisionSlackbot).toHaveBeenCalledOnce();
+  });
+
+  it("scaffolds portable credentials entirely from one keyed answer", async () => {
+    const { effects, result } = run({ answers: { "slack-credentials": "portable" } });
+
+    await expect(result).resolves.toMatchObject({ kind: "done" });
+    expect(effects.ensureChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ slackCredentials: "environment" }),
+    );
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.readProjectLink).not.toHaveBeenCalled();
+    expect(effects.provisionSlackbot).not.toHaveBeenCalled();
+  });
+
+  it("refuses a missing credential answer before mutation", async () => {
+    const { effects, result } = run({});
+
+    await expect(result).rejects.toBeInstanceOf(InteractionRequired);
+    expect(effects.deriveSlackConnectorSlug).not.toHaveBeenCalled();
+    expect(effects.ensureChannel).not.toHaveBeenCalled();
+    expect(effects.provisionSlackbot).not.toHaveBeenCalled();
+  });
+
+  it("requires an existing project link headlessly before Slack provisioning", async () => {
+    const effects = deps();
+    vi.mocked(effects.readProjectLink).mockResolvedValue(undefined);
+    const { result } = run({ effects, answers: { "slack-credentials": "vercel" } });
+
+    await expect(result).rejects.toThrow("Run `eve link`");
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.provisionSlackbot).not.toHaveBeenCalled();
+    expect(effects.ensureChannel).not.toHaveBeenCalled();
+  });
+
+  it("answers dynamic connector discovery by stable UID", async () => {
+    const connector = { id: "scl_existing", uid: "slack/existing" };
+    const effects = deps();
+    effects.provisionSlackbot = vi.fn(async (_log, _root, _slug, _deps, options) => {
+      expect(await options?.selectConnector?.([connector], connector)).toBe(connector);
+      return { state: "attached", connectorUid: connector.uid };
+    }) as SlackSetupDeps["provisionSlackbot"];
+
+    await run({
+      effects,
+      answers: {
+        "slack-credentials": "vercel",
+        "slack-connector": connector.uid,
+      },
+    }).result;
+
+    expect(effects.provisionSlackbot).toHaveBeenCalledOnce();
   });
 });

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -1,3 +1,5 @@
+import { select } from "#setup/ask.js";
+import { readProjectLink } from "#setup/project-resolution.js";
 import {
   deriveSlackConnectorSlug,
   ensureChannel,
@@ -14,6 +16,10 @@ import { WizardCancelledError } from "#setup/step.js";
 import { slackMessageDeepLink } from "#setup/slack-connect.js";
 
 import { installScaffoldDependencies, reportOverwrittenFiles } from "../shared/scaffold.js";
+import {
+  resolveIntegrationVercelProject,
+  type IntegrationVercelProjectDeps,
+} from "../shared/vercel-project.js";
 import type {
   IntegrationSetupContext,
   IntegrationSetupResult,
@@ -79,6 +85,7 @@ export interface SlackSetupDeps {
   deriveSlackConnectorSlug: typeof deriveSlackConnectorSlug;
   ensureChannel: typeof ensureChannel;
   ensureVercelProject: typeof ensureVercelProject;
+  readProjectLink: typeof readProjectLink;
   provisionSlackbot: typeof provisionSlackbot;
   reconcileSlackUid: typeof reconcileSlackUid;
 }
@@ -87,32 +94,37 @@ const defaultDeps: SlackSetupDeps = {
   deriveSlackConnectorSlug,
   ensureChannel,
   ensureVercelProject,
+  readProjectLink,
   provisionSlackbot,
   reconcileSlackUid,
 };
 
 async function chooseCredentials(
   context: IntegrationSetupContext,
-): Promise<"vercel-connect" | "environment" | "cancelled"> {
+): Promise<"vercel-connect" | "environment"> {
   if (context.yes) return "vercel-connect";
-  try {
-    return (await context.ui.prompter.select<"vercel" | "portable">({
+  return context.ui.asker.ask(
+    select({
+      key: "slack-credentials",
       message: "How would you like to configure Slack?",
       options: [
-        { value: "vercel", label: "Set up Vercel Connect", hint: "Sign in and link this project" },
         {
-          value: "portable",
+          id: "vercel",
+          value: "vercel-connect" as const,
+          label: "Set up Vercel Connect",
+          hint: "Sign in and link this project",
+        },
+        {
+          id: "portable",
+          value: "environment" as const,
           label: "Use portable credentials",
           hint: "Read Slack tokens from environment variables",
         },
       ],
-    })) === "portable"
-      ? "environment"
-      : "vercel-connect";
-  } catch (error) {
-    if (error instanceof WizardCancelledError) return "cancelled";
-    throw error;
-  }
+      recommended: "vercel-connect" as const,
+      required: true,
+    }),
+  );
 }
 
 async function provisionSlack(
@@ -123,24 +135,23 @@ async function provisionSlack(
   const provisionOptions: ProvisionSlackbotOptions = {
     selectConnector: async (connectors, preferred) => {
       if (context.yes) return preferred ?? connectors[0]!;
-      const selected = await context.ui.prompter.select<string>({
-        message: "Which Slack app would you like to use?",
-        options: [
-          ...connectors.map((connector) => {
-            const option: { value: string; label: string; hint?: string } = {
-              value: connector.uid,
+      return context.ui.asker.ask(
+        select({
+          key: "slack-connector",
+          message: "Which Slack app would you like to use?",
+          options: [
+            ...connectors.map((connector) => ({
+              id: connector.uid,
+              value: connector,
               label: `Use ${connector.uid}`,
-            };
-            if (connector.uid === preferred?.uid) option.hint = "Matches this agent";
-            return option;
-          }),
-          { value: "create", label: "Create a new Slack app" },
-        ],
-        initialValue: preferred?.uid,
-      });
-      return selected === "create"
-        ? "create"
-        : connectors.find((connector) => connector.uid === selected)!;
+              hint: connector.uid === preferred?.uid ? "Matches this agent" : undefined,
+            })),
+            { id: "create", value: "create" as const, label: "Create a new Slack app" },
+          ],
+          recommended: preferred ?? connectors[0] ?? ("create" as const),
+          required: true,
+        }),
+      );
     },
   };
   if (context.signal !== undefined) provisionOptions.signal = context.signal;
@@ -168,8 +179,13 @@ export async function setupSlack(
   context: IntegrationSetupContext,
   deps: SlackSetupDeps = defaultDeps,
 ): Promise<IntegrationSetupResult> {
-  const credentials = await chooseCredentials(context);
-  if (credentials === "cancelled") return { kind: "cancelled" };
+  let credentials: "vercel-connect" | "environment";
+  try {
+    credentials = await chooseCredentials(context);
+  } catch (error) {
+    if (error instanceof WizardCancelledError) return { kind: "cancelled" };
+    throw error;
+  }
   if (credentials === "vercel-connect" && context.environment.vercel.kind === "unavailable") {
     throw new Error(
       "Vercel Connect requires an authenticated Vercel CLI. Run `vercel login`, then retry Slack setup.",
@@ -198,10 +214,12 @@ export async function setupSlack(
     };
   }
 
-  const project = await deps.ensureVercelProject({
+  const project = await resolveIntegrationVercelProject({
     appRoot: context.appRoot,
-    prompter: context.ui.prompter,
+    integration: "Slack",
+    ui: context.ui,
     signal: context.signal,
+    deps: deps satisfies IntegrationVercelProjectDeps,
   });
   if (project.projectId.length === 0) throw new Error(SLACK_REQUIRES_VERCEL);
   const slackbot = await provisionSlack(context, deps, slug);

--- a/packages/eve/src/setup/registry-setup-client.ts
+++ b/packages/eve/src/setup/registry-setup-client.ts
@@ -1,3 +1,5 @@
+import { InteractionRequired } from "./ask.js";
+import { SetupPrerequisiteRequired } from "./integrations/shared/prerequisite.js";
 import type {
   EditableSelectOptions,
   MultiSelectOptions,
@@ -31,7 +33,26 @@ function send(process: SetupProcess, message: RegistrySetupChildMessage): void {
   process.send(message);
 }
 
-function registrySetupError(error: unknown): { message: string; details?: readonly string[] } {
+function registrySetupError(error: unknown): {
+  message: string;
+  details?: readonly string[];
+  refusal?: import("./registry-setup-protocol.js").RegistrySetupRefusal;
+} {
+  if (error instanceof InteractionRequired) {
+    return {
+      message: error.message,
+      refusal: { status: "input_required", question: error.question },
+    };
+  }
+  if (error instanceof SetupPrerequisiteRequired) {
+    return {
+      message: error.message,
+      refusal: {
+        status: "prerequisite_required",
+        prerequisite: { code: error.code, message: error.message, command: error.command },
+      },
+    };
+  }
   if (!(error instanceof Error)) return { message: String(error) };
   const details = error.stack
     ?.split("\n")

--- a/packages/eve/src/setup/registry-setup-protocol.ts
+++ b/packages/eve/src/setup/registry-setup-protocol.ts
@@ -29,9 +29,17 @@ export type RegistrySetupCompletion = {
   };
 };
 
+export type RegistrySetupRefusal =
+  | { status: "input_required"; question: import("./ask.js").AnyQuestion }
+  | {
+      status: "prerequisite_required";
+      prerequisite: { code: string; message: string; command: string };
+    };
+
 export type RegistrySetupError = {
   message: string;
   details?: readonly string[];
+  refusal?: RegistrySetupRefusal;
 };
 
 export type RegistrySetupOutcome =


### PR DESCRIPTION
### Summary

Related to #1786. Stacked on #1788.

Complete Linear's answer-backed setup path by routing its Vercel project requirement through the shared interactive/headless resolver. Linear's connector names and existing-connector branch already used stable `Asker` keys; this PR makes the remaining nested Vercel flow deterministic for headless callers.

Headless setup now requires an existing project link before connector discovery or mutation, while interactive setup retains inline linking.

### Validation

- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit --pretty false`
- Full-stack focused suite: 149 tests passed
- `pnpm exec oxlint packages/eve/src/setup/ask.ts packages/eve/src/setup/ask.test.ts packages/eve/src/setup/integrations`
- `git diff --check origin/main...agent-setup-web`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
