### PR TITLE
feat(eve): make Discord setup answerable

### DIFF
--- a/.changeset/cool-discord-answer.md
+++ b/.changeset/cool-discord-answer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make Discord integration setup fully answer-backed and require an existing Vercel project link for headless Connect setup.

--- a/packages/eve/src/setup/integrations/discord/setup.test.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.test.ts
@@ -1,58 +1,55 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
-import type { Asker, Question } from "#setup/ask.js";
+import { headlessAsker, InteractionRequired, withAnswers } from "#setup/ask.js";
+
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createIntegrationSetupUi } from "../shared/ui.js";
 import { setupDiscord, type DiscordSetupDeps } from "./setup.js";
 
-function asker(answers: Record<string, string>): Asker {
-  return {
-    ask: async <T>(question: Question<T>) => answers[question.key] as T,
-    askEditable: vi.fn(),
-    askMany: async () => [],
-  };
-}
+const ANSWERS = {
+  "discord-bot-token": "  bot-token  ",
+  "discord-command-name": "ask",
+  "discord-command-description": "Ask the eve agent",
+};
 
 function deps(): DiscordSetupDeps {
   return {
     configureEndpoint: vi.fn(async () => {}),
     deriveConnectorSlug: vi.fn(async () => "agent" as never),
     ensureVercelProject: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
+    readProjectLink: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
     provisionConnector: vi.fn(async () => ({ id: "scl_discord", uid: "discord/agent" })),
     registerCommand: vi.fn(async () => {}),
-    resolveApplication: vi.fn(async () => ({
-      id: "app-1",
-      name: "Agent",
-      publicKey: "public-key",
-    })),
+    resolveApplication: vi.fn(async () => ({ id: "app-1", name: "Agent", publicKey: "key" })),
     writeTextFile: vi.fn(async () => {}),
   };
 }
 
+function run(input: { answers?: Record<string, unknown>; effects?: DiscordSetupDeps }) {
+  const effects = input.effects ?? deps();
+  return {
+    effects,
+    result: setupDiscord(
+      {
+        appRoot: "/project",
+        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({
+          asker: withAnswers(input.answers ?? ANSWERS)(headlessAsker()),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
+        }),
+      },
+      effects,
+    ),
+  };
+}
+
 describe("Discord setup", () => {
-  it("provisions Connect, registers the command and callback, and scaffolds the channel", async () => {
-    const fake = createFakePrompter();
-    const effects = deps();
+  it("provisions and scaffolds entirely from keyed answers", async () => {
+    const { effects, result } = run({});
 
-    await expect(
-      setupDiscord(
-        {
-          appRoot: "/project",
-          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-          ui: createIntegrationSetupUi({
-            asker: asker({
-              "discord-bot-token": "  bot-token  ",
-              "discord-command-name": "ask",
-              "discord-command-description": "Ask the eve agent",
-            }),
-            prompter: fake.prompter,
-          }),
-        },
-        effects,
-      ),
-    ).resolves.toMatchObject({ kind: "done" });
-
+    await expect(result).resolves.toMatchObject({ kind: "done" });
     expect(effects.resolveApplication).toHaveBeenCalledWith("bot-token");
     expect(effects.provisionConnector).toHaveBeenCalledWith(
       expect.objectContaining({ botToken: "bot-token" }),
@@ -69,47 +66,37 @@ describe("Discord setup", () => {
     );
   });
 
-  it("prefills the command name and description", async () => {
-    const questions: Question<unknown>[] = [];
-    const effects = deps();
-    await setupDiscord(
-      {
-        appRoot: "/project",
-        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({
-          asker: {
-            ask: async <T>(question: Question<T>) => {
-              questions.push(question as Question<unknown>);
-              if (question.key === "discord-bot-token") return "bot-token" as T;
-              return question.detected as T;
-            },
-            askEditable: vi.fn(),
-            askMany: async () => [],
-          },
-          prompter: createFakePrompter().prompter,
-        }),
-      },
-      effects,
-    );
+  it("refuses a missing required answer before mutation", async () => {
+    const { effects, result } = run({ answers: {} });
 
-    expect(questions).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ key: "discord-command-name", detected: "ask" }),
-        expect.objectContaining({
-          key: "discord-command-description",
-          detected: "Ask the eve agent",
-        }),
-      ]),
-    );
+    await expect(result).rejects.toBeInstanceOf(InteractionRequired);
+    expect(effects.resolveApplication).not.toHaveBeenCalled();
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+  });
+
+  it("requires an existing Vercel link headlessly before remote mutation", async () => {
+    const effects = deps();
+    vi.mocked(effects.readProjectLink).mockResolvedValue(undefined);
+    const { result } = run({ effects });
+
+    await expect(result).rejects.toThrow("Run `eve link`");
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+    expect(effects.registerCommand).not.toHaveBeenCalled();
+    expect(effects.writeTextFile).not.toHaveBeenCalled();
   });
 
   it("requires an authenticated Vercel CLI", async () => {
-    const fake = createFakePrompter();
     await expect(
       setupDiscord({
         appRoot: "/project",
         environment: integrationSetupEnvironment("logged-out", { kind: "unresolved" }),
-        ui: createIntegrationSetupUi({ asker: asker({}), prompter: fake.prompter }),
+        ui: createIntegrationSetupUi({
+          asker: headlessAsker(),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
+        }),
       }),
     ).rejects.toThrow("vercel login");
   });

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -2,10 +2,15 @@ import { join } from "node:path";
 
 import { text } from "#setup/ask.js";
 import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
+import { readProjectLink } from "#setup/project-resolution.js";
 import { deriveSlackConnectorSlug } from "#setup/scaffold/index.js";
 import { writeTextFile } from "#setup/scaffold/files.js";
 import { WizardCancelledError } from "#setup/step.js";
 
+import {
+  resolveIntegrationVercelProject,
+  type IntegrationVercelProjectDeps,
+} from "../shared/vercel-project.js";
 import type {
   IntegrationSetupContext,
   IntegrationSetupResult,
@@ -22,6 +27,7 @@ export interface DiscordSetupDeps {
   configureEndpoint: typeof configureDiscordInteractionsEndpoint;
   deriveConnectorSlug: typeof deriveSlackConnectorSlug;
   ensureVercelProject: typeof ensureVercelProject;
+  readProjectLink: typeof readProjectLink;
   provisionConnector: typeof provisionDiscordConnector;
   registerCommand: typeof registerDiscordCommand;
   resolveApplication: typeof resolveDiscordApplication;
@@ -32,6 +38,7 @@ const defaultDeps: DiscordSetupDeps = {
   configureEndpoint: configureDiscordInteractionsEndpoint,
   deriveConnectorSlug: deriveSlackConnectorSlug,
   ensureVercelProject,
+  readProjectLink,
   provisionConnector: provisionDiscordConnector,
   registerCommand: registerDiscordCommand,
   resolveApplication: resolveDiscordApplication,
@@ -115,10 +122,12 @@ export async function setupDiscord(
       }),
     );
     const application = await deps.resolveApplication(botToken);
-    const project = await deps.ensureVercelProject({
+    const project = await resolveIntegrationVercelProject({
       appRoot: context.appRoot,
-      prompter: context.ui.prompter,
+      integration: "Discord",
+      ui: context.ui,
       signal: context.signal,
+      deps: deps satisfies IntegrationVercelProjectDeps,
     });
     const connector = await deps.provisionConnector({
       botToken,


### PR DESCRIPTION
### Summary

Related to #1786. Stacked on #1793.

Make Discord setup fully answer-backed. Its token, command name, and command description already had stable semantic keys; this PR moves the remaining Vercel project requirement to the shared interactive/headless resolver and verifies missing answers stop before remote mutation.

Headless setup now requires an existing project link before resolving the Discord application, creating a connector, registering commands, configuring the callback, or writing files. Interactive setup retains inline linking.

### Validation

- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit --pretty false`
- Full-stack focused suite: 149 tests passed
- `pnpm exec oxlint packages/eve/src/setup/ask.ts packages/eve/src/setup/ask.test.ts packages/eve/src/setup/integrations`
- `git diff --check origin/main...agent-setup-web`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
