### PR TITLE
feat(eve): make GitHub setup answerable

### DIFF
--- a/.changeset/gentle-github-answer.md
+++ b/.changeset/gentle-github-answer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make GitHub integration setup answer-backed and require an existing Vercel project link for headless Connect setup.

--- a/packages/eve/src/setup/integrations/github/setup.test.ts
+++ b/packages/eve/src/setup/integrations/github/setup.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
-import type { Asker } from "#setup/ask.js";
+import { headlessAsker, InteractionRequired, withAnswers } from "#setup/ask.js";
 
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createIntegrationSetupUi } from "../shared/ui.js";
 import { setupGitHub, type GitHubSetupDeps } from "./setup.js";
 
+const DEFAULT_EVENTS = ["issue_comment", "pull_request_review_comment"];
+
 function deps(): GitHubSetupDeps {
   return {
     deriveConnectorSlug: vi.fn(async () => "agent" as never),
     ensureVercelProject: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
+    readProjectLink: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
     provisionConnector: vi.fn(async () => ({
       appSlug: "agent",
       id: "scl_github",
@@ -20,81 +23,79 @@ function deps(): GitHubSetupDeps {
   };
 }
 
+function run(input: { events?: string[]; effects?: GitHubSetupDeps }) {
+  const effects = input.effects ?? deps();
+  return {
+    effects,
+    result: setupGitHub(
+      {
+        appRoot: "/project",
+        environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({
+          asker: withAnswers({ "github-events": input.events ?? DEFAULT_EVENTS })(headlessAsker()),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
+        }),
+      },
+      effects,
+    ),
+  };
+}
+
 describe("GitHub setup", () => {
-  function asker(events = ["issue_comment", "pull_request_review_comment"]): Asker {
-    return {
-      ask: vi.fn(),
-      askEditable: vi.fn(),
-      askMany: vi.fn(async () => events) as Asker["askMany"],
-    };
-  }
+  it("provisions and scaffolds selected events from a keyed answer", async () => {
+    const events = ["issue_comment", "issues", "pull_request"];
+    const { effects, result } = run({ events });
 
-  it("provisions Connect, routes the selected webhooks, and scaffolds matching handlers", async () => {
-    const fake = createFakePrompter();
-    const effects = deps();
-    const selectedEvents = ["issue_comment", "issues", "pull_request"];
-
-    await expect(
-      setupGitHub(
-        {
-          appRoot: "/project",
-          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-          ui: createIntegrationSetupUi({ asker: asker(selectedEvents), prompter: fake.prompter }),
-        },
-        effects,
-      ),
-    ).resolves.toMatchObject({ kind: "done" });
-
-    expect(effects.provisionConnector).toHaveBeenCalledWith(
-      expect.objectContaining({ events: selectedEvents }),
-    );
-    expect(effects.writeTextFile).toHaveBeenCalledWith(
-      "/project/agent/channels/github.ts",
-      expect.stringContaining('connectGitHubCredentials("github/agent")'),
-      { force: undefined },
-    );
+    await expect(result).resolves.toMatchObject({ kind: "done" });
+    expect(effects.provisionConnector).toHaveBeenCalledWith(expect.objectContaining({ events }));
     const scaffold = vi.mocked(effects.writeTextFile).mock.calls[0]?.[1] ?? "";
+    expect(scaffold).toContain('connectGitHubCredentials("github/agent")');
     expect(scaffold).toContain('botName: "agent"');
     expect(scaffold).toContain("onIssue(ctx, issue)");
     expect(scaffold).toContain("onPullRequest(ctx, pullRequest)");
   });
 
-  it("recommends comment events that the default scaffold handles", async () => {
-    const fake = createFakePrompter();
-    const askMany = vi.fn(async () => [
-      "issue_comment",
-      "pull_request_review_comment",
-    ]) as Asker["askMany"];
-
-    await setupGitHub(
+  it("refuses a missing event answer before mutation", async () => {
+    const effects = deps();
+    const result = setupGitHub(
       {
         appRoot: "/project",
         environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
         ui: createIntegrationSetupUi({
-          asker: { ask: vi.fn(), askEditable: vi.fn(), askMany },
-          prompter: fake.prompter,
+          asker: headlessAsker(),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
         }),
       },
-      deps(),
+      effects,
     );
 
-    expect(askMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        key: "github-events",
-        recommended: ["issue_comment", "pull_request_review_comment"],
-      }),
-    );
+    await expect(result).rejects.toBeInstanceOf(InteractionRequired);
+    expect(effects.readProjectLink).not.toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+  });
+
+  it("requires an existing Vercel link headlessly before mutation", async () => {
+    const effects = deps();
+    vi.mocked(effects.readProjectLink).mockResolvedValue(undefined);
+    const { result } = run({ effects });
+
+    await expect(result).rejects.toThrow("Run `eve link`");
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+    expect(effects.writeTextFile).not.toHaveBeenCalled();
   });
 
   it("requires an authenticated Vercel CLI", async () => {
-    const fake = createFakePrompter();
     await expect(
       setupGitHub({
         appRoot: "/project",
         environment: integrationSetupEnvironment("logged-out", { kind: "unresolved" }),
         ui: createIntegrationSetupUi({
-          asker: asker(),
-          prompter: fake.prompter,
+          asker: headlessAsker(),
+          prompter: createFakePrompter().prompter,
+          interaction: "headless",
         }),
       }),
     ).rejects.toThrow("vercel login");

--- a/packages/eve/src/setup/integrations/github/setup.ts
+++ b/packages/eve/src/setup/integrations/github/setup.ts
@@ -2,10 +2,15 @@ import { join } from "node:path";
 
 import type { MultiSelectQuestion } from "#setup/ask.js";
 import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
+import { readProjectLink } from "#setup/project-resolution.js";
 import { deriveSlackConnectorSlug } from "#setup/scaffold/index.js";
 import { writeTextFile } from "#setup/scaffold/files.js";
 import { WizardCancelledError } from "#setup/step.js";
 
+import {
+  resolveIntegrationVercelProject,
+  type IntegrationVercelProjectDeps,
+} from "../shared/vercel-project.js";
 import type {
   IntegrationSetupContext,
   IntegrationSetupResult,
@@ -16,6 +21,7 @@ import { provisionGitHubConnector } from "./connect.js";
 export interface GitHubSetupDeps {
   deriveConnectorSlug: typeof deriveSlackConnectorSlug;
   ensureVercelProject: typeof ensureVercelProject;
+  readProjectLink: typeof readProjectLink;
   provisionConnector: typeof provisionGitHubConnector;
   writeTextFile: typeof writeTextFile;
 }
@@ -23,6 +29,7 @@ export interface GitHubSetupDeps {
 const defaultDeps: GitHubSetupDeps = {
   deriveConnectorSlug: deriveSlackConnectorSlug,
   ensureVercelProject,
+  readProjectLink,
   provisionConnector: provisionGitHubConnector,
   writeTextFile,
 };
@@ -66,6 +73,7 @@ const githubEventsQuestion: MultiSelectQuestion<GitHubWebhookEvent> = {
   message: "What should this GitHub App respond to?",
   options: GITHUB_EVENT_OPTIONS,
   recommended: DEFAULT_GITHUB_EVENTS,
+  required: true,
   requireSelection: true,
 };
 
@@ -117,10 +125,12 @@ export async function setupGitHub(
       "Vercel Connect creates a GitHub App and routes verified webhooks to your deployed agent.",
     );
     const events = await context.ui.asker.askMany(githubEventsQuestion);
-    const project = await deps.ensureVercelProject({
+    const project = await resolveIntegrationVercelProject({
       appRoot: context.appRoot,
-      prompter: context.ui.prompter,
+      integration: "GitHub",
+      ui: context.ui,
       signal: context.signal,
+      deps: deps satisfies IntegrationVercelProjectDeps,
     });
     const connector = await deps.provisionConnector({
       log: context.ui.prompter.log,


### PR DESCRIPTION
### Summary

Related to #1786. Stacked on #1794.

Make GitHub setup fully answer-backed. Webhook event selection is now explicitly required in headless mode, so a missing answer produces structured input-required before mutation rather than an optional-question skip. The Vercel project requirement uses the shared resolver: headless setup requires an existing link, while interactive setup retains inline linking.

Existing event recommendations and interactive selection behavior are preserved.

### Validation

- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit --pretty false`
- Full-stack focused suite: 149 tests passed
- `pnpm exec oxlint packages/eve/src/setup/ask.ts packages/eve/src/setup/ask.test.ts packages/eve/src/setup/integrations`
- `git diff --check origin/main...agent-setup-web`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
