### PR TITLE
test(eve): cover headless Web setup

### DIFF
--- a/.changeset/tidy-web-headless.md
+++ b/.changeset/tidy-web-headless.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Cover Web Chat integration setup as a decision-free headless setup flow.

--- a/packages/eve/src/setup/integrations/web/setup.test.ts
+++ b/packages/eve/src/setup/integrations/web/setup.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { headlessAsker } from "#setup/ask.js";
+
+import { integrationSetupEnvironment } from "../shared/environment.js";
+import { createIntegrationSetupUi } from "../shared/ui.js";
+import { setupWeb, type WebSetupDeps } from "./setup.js";
+
+function deps(): WebSetupDeps {
+  return {
+    detectPackageManager: vi.fn(async () => ({
+      kind: "pnpm" as const,
+      source: "lockfile" as const,
+    })),
+    ensureChannel: vi.fn(async () => ({
+      kind: "web" as const,
+      action: "created" as const,
+      filesWritten: [],
+      filesOverwritten: [],
+      filesSkipped: [],
+      packageJsonUpdated: [
+        { path: "/project/package.json", dependencies: ["eve"], devDependencies: [], scripts: [] },
+      ],
+      nodeEngineOverride: undefined,
+      competingNextConfigFiles: [],
+    })),
+    installScaffoldDependencies: vi.fn(async () => {}),
+  };
+}
+
+describe("Web setup", () => {
+  it("runs headlessly without asking any semantic questions", async () => {
+    const effects = deps();
+
+    await expect(
+      setupWeb(
+        {
+          appRoot: "/project",
+          environment: integrationSetupEnvironment("cli-missing", { kind: "unresolved" }),
+          ui: createIntegrationSetupUi({
+            asker: headlessAsker(),
+            prompter: createFakePrompter().prompter,
+            interaction: "headless",
+          }),
+        },
+        effects,
+      ),
+    ).resolves.toMatchObject({ kind: "done" });
+
+    expect(effects.ensureChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: "/project",
+        configureVercelServices: false,
+        skipDependencyMutation: true,
+      }),
+    );
+    expect(effects.installScaffoldDependencies).toHaveBeenCalledWith(
+      expect.objectContaining({ changed: true, projectPath: "/project" }),
+    );
+  });
+});

--- a/packages/eve/src/setup/integrations/web/setup.ts
+++ b/packages/eve/src/setup/integrations/web/setup.ts
@@ -16,48 +16,63 @@ function reportCompetingNextConfigFiles(
   }
 }
 
+export interface WebSetupDeps {
+  detectPackageManager: typeof detectPackageManager;
+  ensureChannel: typeof ensureChannel;
+  installScaffoldDependencies: typeof installScaffoldDependencies;
+}
+
+const defaultDeps: WebSetupDeps = {
+  detectPackageManager,
+  ensureChannel,
+  installScaffoldDependencies,
+};
+
+/** Runs Web Chat setup without requiring any semantic decisions. */
+export async function setupWeb(
+  context: Parameters<SetupIntegration["setup"]>[0],
+  deps: WebSetupDeps = defaultDeps,
+): Promise<Awaited<ReturnType<SetupIntegration["setup"]>>> {
+  context.ui.prompter.log.message("Scaffolding Web Chat channel files...");
+  const options: EnsureChannelOptions = {
+    projectRoot: context.appRoot,
+    kind: "web",
+    packageManager: (await deps.detectPackageManager(context.appRoot)).kind,
+    configureVercelServices: context.environment.vercel.kind === "available",
+    force: context.force,
+    skipDependencyMutation: true,
+  };
+  const result = await deps.ensureChannel(options);
+  reportOverwrittenFiles(context.ui.prompter.log, result.filesOverwritten);
+  if (
+    result.kind === "web" &&
+    result.action !== "skipped" &&
+    result.nodeEngineOverride !== undefined
+  ) {
+    context.ui.prompter.log.warning(formatNodeEngineOverrideWarning(result.nodeEngineOverride));
+  }
+  reportCompetingNextConfigFiles(
+    context.ui.prompter.log,
+    "competingNextConfigFiles" in result ? result.competingNextConfigFiles : undefined,
+  );
+  if (result.action === "skipped") {
+    context.ui.prompter.log.info("Next.js project detected. Skipping Web Chat scaffolding.");
+    return { kind: "done", completion: { facts: [] } };
+  }
+  context.ui.prompter.log.success("Scaffolded channel: web");
+  await deps.installScaffoldDependencies({
+    changed: result.packageJsonUpdated.length > 0,
+    log: context.ui.prompter.log,
+    projectPath: context.appRoot,
+    signal: context.signal,
+  });
+  return { kind: "done", completion: { facts: [], deployment: { required: true } } };
+}
+
 /** Web Chat scaffolding. */
 export const WEB_SETUP: SetupIntegration = {
   kind: "web",
   label: "Web Chat",
   hint: "Browser-based chat interface",
-  async setup(context) {
-    context.ui.prompter.log.message("Scaffolding Web Chat channel files...");
-    const options: EnsureChannelOptions = {
-      projectRoot: context.appRoot,
-      kind: "web",
-      packageManager: (await detectPackageManager(context.appRoot)).kind,
-      configureVercelServices: context.environment.vercel.kind === "available",
-      force: context.force,
-      skipDependencyMutation: true,
-    };
-    const result = await ensureChannel(options);
-    reportOverwrittenFiles(context.ui.prompter.log, result.filesOverwritten);
-    if (
-      result.kind === "web" &&
-      result.action !== "skipped" &&
-      result.nodeEngineOverride !== undefined
-    ) {
-      context.ui.prompter.log.warning(formatNodeEngineOverrideWarning(result.nodeEngineOverride));
-    }
-    reportCompetingNextConfigFiles(
-      context.ui.prompter.log,
-      "competingNextConfigFiles" in result ? result.competingNextConfigFiles : undefined,
-    );
-    if (result.action === "skipped") {
-      context.ui.prompter.log.info("Next.js project detected. Skipping Web Chat scaffolding.");
-      return { kind: "done", completion: { facts: [] } };
-    }
-    context.ui.prompter.log.success("Scaffolded channel: web");
-    await installScaffoldDependencies({
-      changed: result.packageJsonUpdated.length > 0,
-      log: context.ui.prompter.log,
-      projectPath: context.appRoot,
-      signal: context.signal,
-    });
-    return {
-      kind: "done",
-      completion: { facts: [], deployment: { required: true } },
-    };
-  },
+  setup: setupWeb,
 };


### PR DESCRIPTION
### Summary

Related to #1786. Stacked on #1795.

Document Web Chat setup's place in the answer-backed contract: it has no semantic decisions and already runs headlessly without a Vercel project prerequisite. This PR extracts the flow behind a narrow dependency seam and adds a focused contract test covering headless scaffolding and deferred dependency installation.

There is no user-facing prompt or setup behavior change.

### Validation

- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit --pretty false`
- Full-stack focused suite: 149 tests passed
- `pnpm exec oxlint packages/eve/src/setup/ask.ts packages/eve/src/setup/ask.test.ts packages/eve/src/setup/integrations`
- `git diff --check origin/main...agent-setup-web`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
