### PR TITLE
fix(eve): tolerate shared skill metadata

### DIFF
--- a/.changeset/quiet-skills-import.md
+++ b/.changeset/quiet-skills-import.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Import skills with structured or non-string metadata without failing, and warn when unsupported frontmatter requests model-invocation or tool-permission behavior that eve does not enforce.

--- a/.changeset/quiet-skills-import.md
+++ b/.changeset/quiet-skills-import.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Import skills with structured or non-string metadata without failing, and warn when unsupported frontmatter requests model-invocation or tool-permission behavior that eve does not enforce.
+Import skills with structured or non-string metadata without failing, treating metadata outside eve's modeled shape like other unmodeled frontmatter.

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -29,7 +29,7 @@ Use the weather tool before answering forecast or temperature questions.
 
 A flat markdown skill can skip the `description` frontmatter. When it does, eve advertises the first non-empty, non-code-fence line of the body with any leading `#`, `>`, `*`, or `-` marker stripped. If the body has no such line, eve falls back to the literal `Instructions for the <name> skill.`, which is a weak routing hint, so add a `description` when you want the model to route on intent.
 
-A packaged skill is a directory with a `SKILL.md` plus sibling files like `references/`, `assets/`, and `scripts/`. The packaged `SKILL.md` must carry `description` frontmatter; it has no filename slug to fall back on. eve ignores frontmatter it does not use so skills authored for other Agent Skills clients remain importable. It warns when `disable-model-invocation: true` or `allowed-tools` requests behavior that eve does not enforce; model loading and tool permissions remain controlled by eve.
+A packaged skill is a directory with a `SKILL.md` plus sibling files like `references/`, `assets/`, and `scripts/`. The packaged `SKILL.md` must carry `description` frontmatter; it has no filename slug to fall back on. eve ignores frontmatter it does not use so skills authored for other Agent Skills clients remain importable.
 
 ```md title="agent/skills/research/SKILL.md"
 ---

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -29,7 +29,7 @@ Use the weather tool before answering forecast or temperature questions.
 
 A flat markdown skill can skip the `description` frontmatter. When it does, eve advertises the first non-empty, non-code-fence line of the body with any leading `#`, `>`, `*`, or `-` marker stripped. If the body has no such line, eve falls back to the literal `Instructions for the <name> skill.`, which is a weak routing hint, so add a `description` when you want the model to route on intent.
 
-A packaged skill is a directory with a `SKILL.md` plus sibling files like `references/`, `assets/`, and `scripts/`. The packaged `SKILL.md` must carry `description` frontmatter; it has no filename slug to fall back on.
+A packaged skill is a directory with a `SKILL.md` plus sibling files like `references/`, `assets/`, and `scripts/`. The packaged `SKILL.md` must carry `description` frontmatter; it has no filename slug to fall back on. eve ignores frontmatter it does not use so skills authored for other Agent Skills clients remain importable. It warns when `disable-model-invocation: true` or `allowed-tools` requests behavior that eve does not enforce; model loading and tool permissions remain controlled by eve.
 
 ```md title="agent/skills/research/SKILL.md"
 ---

--- a/packages/eve/src/discover/skills.integration.test.ts
+++ b/packages/eve/src/discover/skills.integration.test.ts
@@ -8,6 +8,7 @@ import {
   DISCOVER_SKILL_COLLISION,
   DISCOVER_SKILL_ENTRY_NOT_DIRECTORY,
   DISCOVER_SKILL_FRONTMATTER_INVALID,
+  DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
   DISCOVER_SKILL_MARKDOWN_MISSING,
   discoverSkills,
 } from "#discover/skills.js";
@@ -158,6 +159,7 @@ describe("discoverSkills (memory)", () => {
           "name: other-name",
           "description: Use the weather tool before answering forecast questions.",
           "argument-hint: '[location]'",
+          "allowed-tools: Bash Read",
           "disable-model-invocation: true",
           "---",
           "When the user asks about weather, call the weather tool before answering.",
@@ -167,7 +169,7 @@ describe("discoverSkills (memory)", () => {
           "name: other-name",
           "description: Research complex weather questions.",
           "argument-hint: '[topic]'",
-          "disable-model-invocation: true",
+          "disable-model-invocation: false",
           "---",
           "Research weather patterns before replying.",
         ].join("\n"),
@@ -180,8 +182,25 @@ describe("discoverSkills (memory)", () => {
     });
     const namedPackageRoot = join(resolve(project.agentRoot), "skills", "named-package");
 
-    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
-      DISCOVER_SKILL_FRONTMATTER_INVALID,
+    expect(result.diagnostics).toEqual([
+      {
+        code: DISCOVER_SKILL_FRONTMATTER_INVALID,
+        message: expect.stringContaining('Expected "description" frontmatter to be a string.'),
+        severity: "error",
+        sourcePath: join(resolve(project.agentRoot), "skills", "bad-skill", "SKILL.md"),
+      },
+      {
+        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
+        message: expect.stringContaining('"disable-model-invocation"'),
+        severity: "warning",
+        sourcePath: join(resolve(project.agentRoot), "skills", "named-package", "SKILL.md"),
+      },
+      {
+        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
+        message: expect.stringContaining('"allowed-tools"'),
+        severity: "warning",
+        sourcePath: join(resolve(project.agentRoot), "skills", "named-package", "SKILL.md"),
+      },
     ]);
     expect(result.skills).toEqual([
       {

--- a/packages/eve/src/discover/skills.integration.test.ts
+++ b/packages/eve/src/discover/skills.integration.test.ts
@@ -8,7 +8,6 @@ import {
   DISCOVER_SKILL_COLLISION,
   DISCOVER_SKILL_ENTRY_NOT_DIRECTORY,
   DISCOVER_SKILL_FRONTMATTER_INVALID,
-  DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
   DISCOVER_SKILL_MARKDOWN_MISSING,
   discoverSkills,
 } from "#discover/skills.js";
@@ -182,25 +181,8 @@ describe("discoverSkills (memory)", () => {
     });
     const namedPackageRoot = join(resolve(project.agentRoot), "skills", "named-package");
 
-    expect(result.diagnostics).toEqual([
-      {
-        code: DISCOVER_SKILL_FRONTMATTER_INVALID,
-        message: expect.stringContaining('Expected "description" frontmatter to be a string.'),
-        severity: "error",
-        sourcePath: join(resolve(project.agentRoot), "skills", "bad-skill", "SKILL.md"),
-      },
-      {
-        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
-        message: expect.stringContaining('"disable-model-invocation"'),
-        severity: "warning",
-        sourcePath: join(resolve(project.agentRoot), "skills", "named-package", "SKILL.md"),
-      },
-      {
-        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
-        message: expect.stringContaining('"allowed-tools"'),
-        severity: "warning",
-        sourcePath: join(resolve(project.agentRoot), "skills", "named-package", "SKILL.md"),
-      },
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      DISCOVER_SKILL_FRONTMATTER_INVALID,
     ]);
     expect(result.skills).toEqual([
       {

--- a/packages/eve/src/discover/skills.ts
+++ b/packages/eve/src/discover/skills.ts
@@ -1,12 +1,8 @@
 import { join, relative, resolve } from "node:path";
 
-import { lowerSkillMarkdownWithFrontmatter } from "#internal/helpers/markdown.js";
+import { lowerSkillMarkdown } from "#internal/helpers/markdown.js";
 import { toErrorMessage } from "#shared/errors.js";
-import {
-  createDiscoverErrorDiagnostic,
-  createDiscoverWarningDiagnostic,
-  type DiscoverDiagnostic,
-} from "#discover/diagnostics.js";
+import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discover/diagnostics.js";
 import {
   classifySkillPackageEntry,
   classifySkillsDirectoryEntry,
@@ -30,7 +26,6 @@ export const DISCOVER_SKILLS_DIRECTORY_INVALID = "discover/skills-directory-inva
 export const DISCOVER_SKILL_COLLISION = "discover/skill-collision";
 export const DISCOVER_SKILL_ENTRY_NOT_DIRECTORY = "discover/skill-entry-not-directory";
 export const DISCOVER_SKILL_FRONTMATTER_INVALID = "discover/skill-frontmatter-invalid";
-export const DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED = "discover/skill-frontmatter-unsupported";
 export const DISCOVER_SKILL_MARKDOWN_MISSING = "discover/skill-markdown-missing";
 
 /**
@@ -238,10 +233,10 @@ async function discoverPackagedSkill(input: {
     };
   }
 
-  let lowered: ReturnType<typeof lowerSkillMarkdownWithFrontmatter>;
+  let definition: ReturnType<typeof lowerSkillMarkdown>;
 
   try {
-    lowered = lowerSkillMarkdownWithFrontmatter(await input.source.readTextFile(skillFilePath));
+    definition = lowerSkillMarkdown(await input.source.readTextFile(skillFilePath));
   } catch (error) {
     return {
       diagnostics: [
@@ -257,7 +252,6 @@ async function discoverPackagedSkill(input: {
     };
   }
 
-  const { definition, frontmatter } = lowered;
   const packagePaths = await discoverSkillPackagePaths(input.source, input.skillRootPath);
   const skillSourceRefInput: {
     assetsPath?: string;
@@ -305,7 +299,7 @@ async function discoverPackagedSkill(input: {
   }
 
   return {
-    diagnostics: createUnsupportedSkillFrontmatterDiagnostics(frontmatter, skillFilePath),
+    diagnostics: [],
     logicalPath,
     skill: createSkillPackageSourceRef(skillSourceRefInput),
     skillId: input.skillId,
@@ -325,15 +319,12 @@ async function discoverFlatMarkdownSkill(input: {
 }> {
   const skillId = stripMarkdownExtension(input.skillFileName);
   const logicalPath = normalizeLogicalPath(join(input.logicalSkillsPath, input.skillFileName));
-  let lowered: ReturnType<typeof lowerSkillMarkdownWithFrontmatter>;
+  let definition: ReturnType<typeof lowerSkillMarkdown>;
 
   try {
-    lowered = lowerSkillMarkdownWithFrontmatter(
-      await input.source.readTextFile(input.skillFilePath),
-      {
-        slug: skillId,
-      },
-    );
+    definition = lowerSkillMarkdown(await input.source.readTextFile(input.skillFilePath), {
+      slug: skillId,
+    });
   } catch (error) {
     return {
       diagnostics: [
@@ -350,13 +341,10 @@ async function discoverFlatMarkdownSkill(input: {
   }
 
   return {
-    diagnostics: createUnsupportedSkillFrontmatterDiagnostics(
-      lowered.frontmatter,
-      input.skillFilePath,
-    ),
+    diagnostics: [],
     logicalPath,
     skill: {
-      definition: lowered.definition,
+      definition,
       sourceKind: "markdown",
       logicalPath,
       sourceId: createPathDerivedSourceId(logicalPath),
@@ -432,35 +420,6 @@ async function discoverSkillPackagePaths(
   }
 
   return packagePaths;
-}
-
-function createUnsupportedSkillFrontmatterDiagnostics(
-  frontmatter: Readonly<Record<string, unknown>>,
-  skillFilePath: string,
-): DiscoverDiagnostic[] {
-  const diagnostics: DiscoverDiagnostic[] = [];
-
-  if (frontmatter["disable-model-invocation"] === true) {
-    diagnostics.push(
-      createDiscoverWarningDiagnostic({
-        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
-        message: `The "disable-model-invocation" frontmatter in "${skillFilePath}" has no effect in eve; this skill remains available for model-directed loading.`,
-        sourcePath: skillFilePath,
-      }),
-    );
-  }
-
-  if (frontmatter["allowed-tools"] !== undefined) {
-    diagnostics.push(
-      createDiscoverWarningDiagnostic({
-        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
-        message: `The "allowed-tools" frontmatter in "${skillFilePath}" has no effect in eve; skill frontmatter cannot grant tool permissions.`,
-        sourcePath: skillFilePath,
-      }),
-    );
-  }
-
-  return diagnostics;
 }
 
 function formatSkillDiscoveryError(skillFilePath: string, error: unknown): string {

--- a/packages/eve/src/discover/skills.ts
+++ b/packages/eve/src/discover/skills.ts
@@ -1,8 +1,12 @@
 import { join, relative, resolve } from "node:path";
 
-import { lowerSkillMarkdown } from "#internal/helpers/markdown.js";
+import { lowerSkillMarkdownWithFrontmatter } from "#internal/helpers/markdown.js";
 import { toErrorMessage } from "#shared/errors.js";
-import { createDiscoverErrorDiagnostic, type DiscoverDiagnostic } from "#discover/diagnostics.js";
+import {
+  createDiscoverErrorDiagnostic,
+  createDiscoverWarningDiagnostic,
+  type DiscoverDiagnostic,
+} from "#discover/diagnostics.js";
 import {
   classifySkillPackageEntry,
   classifySkillsDirectoryEntry,
@@ -26,6 +30,7 @@ export const DISCOVER_SKILLS_DIRECTORY_INVALID = "discover/skills-directory-inva
 export const DISCOVER_SKILL_COLLISION = "discover/skill-collision";
 export const DISCOVER_SKILL_ENTRY_NOT_DIRECTORY = "discover/skill-entry-not-directory";
 export const DISCOVER_SKILL_FRONTMATTER_INVALID = "discover/skill-frontmatter-invalid";
+export const DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED = "discover/skill-frontmatter-unsupported";
 export const DISCOVER_SKILL_MARKDOWN_MISSING = "discover/skill-markdown-missing";
 
 /**
@@ -233,10 +238,10 @@ async function discoverPackagedSkill(input: {
     };
   }
 
-  let definition: ReturnType<typeof lowerSkillMarkdown>;
+  let lowered: ReturnType<typeof lowerSkillMarkdownWithFrontmatter>;
 
   try {
-    definition = lowerSkillMarkdown(await input.source.readTextFile(skillFilePath));
+    lowered = lowerSkillMarkdownWithFrontmatter(await input.source.readTextFile(skillFilePath));
   } catch (error) {
     return {
       diagnostics: [
@@ -252,6 +257,7 @@ async function discoverPackagedSkill(input: {
     };
   }
 
+  const { definition, frontmatter } = lowered;
   const packagePaths = await discoverSkillPackagePaths(input.source, input.skillRootPath);
   const skillSourceRefInput: {
     assetsPath?: string;
@@ -299,7 +305,7 @@ async function discoverPackagedSkill(input: {
   }
 
   return {
-    diagnostics: [],
+    diagnostics: createUnsupportedSkillFrontmatterDiagnostics(frontmatter, skillFilePath),
     logicalPath,
     skill: createSkillPackageSourceRef(skillSourceRefInput),
     skillId: input.skillId,
@@ -319,12 +325,15 @@ async function discoverFlatMarkdownSkill(input: {
 }> {
   const skillId = stripMarkdownExtension(input.skillFileName);
   const logicalPath = normalizeLogicalPath(join(input.logicalSkillsPath, input.skillFileName));
-  let definition: ReturnType<typeof lowerSkillMarkdown>;
+  let lowered: ReturnType<typeof lowerSkillMarkdownWithFrontmatter>;
 
   try {
-    definition = lowerSkillMarkdown(await input.source.readTextFile(input.skillFilePath), {
-      slug: skillId,
-    });
+    lowered = lowerSkillMarkdownWithFrontmatter(
+      await input.source.readTextFile(input.skillFilePath),
+      {
+        slug: skillId,
+      },
+    );
   } catch (error) {
     return {
       diagnostics: [
@@ -341,10 +350,13 @@ async function discoverFlatMarkdownSkill(input: {
   }
 
   return {
-    diagnostics: [],
+    diagnostics: createUnsupportedSkillFrontmatterDiagnostics(
+      lowered.frontmatter,
+      input.skillFilePath,
+    ),
     logicalPath,
     skill: {
-      definition,
+      definition: lowered.definition,
       sourceKind: "markdown",
       logicalPath,
       sourceId: createPathDerivedSourceId(logicalPath),
@@ -420,6 +432,35 @@ async function discoverSkillPackagePaths(
   }
 
   return packagePaths;
+}
+
+function createUnsupportedSkillFrontmatterDiagnostics(
+  frontmatter: Readonly<Record<string, unknown>>,
+  skillFilePath: string,
+): DiscoverDiagnostic[] {
+  const diagnostics: DiscoverDiagnostic[] = [];
+
+  if (frontmatter["disable-model-invocation"] === true) {
+    diagnostics.push(
+      createDiscoverWarningDiagnostic({
+        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
+        message: `The "disable-model-invocation" frontmatter in "${skillFilePath}" has no effect in eve; this skill remains available for model-directed loading.`,
+        sourcePath: skillFilePath,
+      }),
+    );
+  }
+
+  if (frontmatter["allowed-tools"] !== undefined) {
+    diagnostics.push(
+      createDiscoverWarningDiagnostic({
+        code: DISCOVER_SKILL_FRONTMATTER_UNSUPPORTED,
+        message: `The "allowed-tools" frontmatter in "${skillFilePath}" has no effect in eve; skill frontmatter cannot grant tool permissions.`,
+        sourcePath: skillFilePath,
+      }),
+    );
+  }
+
+  return diagnostics;
 }
 
 function formatSkillDiscoveryError(skillFilePath: string, error: unknown): string {

--- a/packages/eve/src/internal/helpers/markdown.test.ts
+++ b/packages/eve/src/internal/helpers/markdown.test.ts
@@ -108,6 +108,24 @@ When the user asks about weather, call the weather tool before answering.`),
     );
   });
 
+  it("treats metadata outside eve's flat string map as a no-op", () => {
+    expect(
+      lowerSkillMarkdown(`---
+description: Use the Lark CLI before answering document questions.
+metadata:
+  requires:
+    bins: [lark-cli]
+  enabled: true
+---
+Use lark-cli to answer the question.`),
+    ).toEqual(
+      defineSkill({
+        description: "Use the Lark CLI before answering document questions.",
+        markdown: "Use lark-cli to answer the question.",
+      }),
+    );
+  });
+
   it("derives flat skill metadata from plain markdown when no frontmatter is present", () => {
     expect(
       lowerSkillMarkdown("Use the weather tool before answering forecast questions.", {

--- a/packages/eve/src/internal/helpers/markdown.ts
+++ b/packages/eve/src/internal/helpers/markdown.ts
@@ -141,20 +141,6 @@ export function lowerSkillMarkdown(
   source: string,
   input: LowerSkillMarkdownInput = {},
 ): SkillDefinition {
-  return lowerSkillMarkdownWithFrontmatter(source, input).definition;
-}
-
-/**
- * Lowers skill markdown while retaining its parsed frontmatter for discovery
- * diagnostics. Unmodeled frontmatter remains a no-op in the definition.
- */
-export function lowerSkillMarkdownWithFrontmatter(
-  source: string,
-  input: LowerSkillMarkdownInput = {},
-): {
-  readonly definition: SkillDefinition;
-  readonly frontmatter: Readonly<Record<string, unknown>>;
-} {
   const document = parseMarkdownDocument(source);
   const slug = input.slug;
 
@@ -179,15 +165,12 @@ export function lowerSkillMarkdownWithFrontmatter(
 
   applyOptionalSkillFrontmatter(rawDefinition, frontmatter);
 
-  return {
-    definition: defineSkill(
-      normalizeSkillDefinition(
-        rawDefinition,
-        "Expected authored skill markdown to match the public eve shape.",
-      ),
+  return defineSkill(
+    normalizeSkillDefinition(
+      rawDefinition,
+      "Expected authored skill markdown to match the public eve shape.",
     ),
-    frontmatter,
-  };
+  );
 }
 
 function startsWithFrontmatterFence(source: string): boolean {

--- a/packages/eve/src/internal/helpers/markdown.ts
+++ b/packages/eve/src/internal/helpers/markdown.ts
@@ -141,6 +141,20 @@ export function lowerSkillMarkdown(
   source: string,
   input: LowerSkillMarkdownInput = {},
 ): SkillDefinition {
+  return lowerSkillMarkdownWithFrontmatter(source, input).definition;
+}
+
+/**
+ * Lowers skill markdown while retaining its parsed frontmatter for discovery
+ * diagnostics. Unmodeled frontmatter remains a no-op in the definition.
+ */
+export function lowerSkillMarkdownWithFrontmatter(
+  source: string,
+  input: LowerSkillMarkdownInput = {},
+): {
+  readonly definition: SkillDefinition;
+  readonly frontmatter: Readonly<Record<string, unknown>>;
+} {
   const document = parseMarkdownDocument(source);
   const slug = input.slug;
 
@@ -165,12 +179,15 @@ export function lowerSkillMarkdown(
 
   applyOptionalSkillFrontmatter(rawDefinition, frontmatter);
 
-  return defineSkill(
-    normalizeSkillDefinition(
-      rawDefinition,
-      "Expected authored skill markdown to match the public eve shape.",
+  return {
+    definition: defineSkill(
+      normalizeSkillDefinition(
+        rawDefinition,
+        "Expected authored skill markdown to match the public eve shape.",
+      ),
     ),
-  );
+    frontmatter,
+  };
 }
 
 function startsWithFrontmatterFence(source: string): boolean {
@@ -194,7 +211,7 @@ function applyOptionalSkillFrontmatter(
     rawDefinition.license = license;
   }
 
-  const metadata = toOptionalStringRecord(frontmatter.metadata, "metadata");
+  const metadata = toOptionalStringRecord(frontmatter.metadata);
   if (metadata !== undefined) {
     rawDefinition.metadata = metadata;
   }
@@ -222,27 +239,17 @@ function requireStringFrontmatter(value: unknown, fieldName: string): string {
   return normalizedValue;
 }
 
-function toOptionalStringRecord(
-  value: unknown,
-  fieldName: string,
-): Record<string, string> | undefined {
-  if (value === undefined || value === null) {
+function toOptionalStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isObject(value)) {
     return undefined;
   }
 
-  if (!isObject(value)) {
-    throw new Error(`Expected "${fieldName}" frontmatter to be an object.`);
+  const entries = Object.entries(value);
+  if (entries.some(([, entryValue]) => typeof entryValue !== "string")) {
+    return undefined;
   }
 
-  const stringEntries = Object.entries(value).map(([key, entryValue]) => {
-    if (typeof entryValue !== "string") {
-      throw new Error(`Expected "${fieldName}.${key}" frontmatter to be a string.`);
-    }
-
-    return [key, entryValue] as const;
-  });
-
-  return Object.fromEntries(stringEntries);
+  return Object.fromEntries(entries) as Record<string, string>;
 }
 
 function deriveFlatSkillDescription(markdown: string, name: string): string {


### PR DESCRIPTION
## Summary

Currently, eve supports the full spec for skills frontmatter as defined by: https://agentskills.io/specification, outside of the experimental `allowed-tools`.

I did a search through the top N most popular skills on skills.sh to see if there are other popular keys that we should consider, and the short answer is no (lest we have eve's standard be an amalgamation of multiple other coding harness extensions).

The most popular non-standard conventions:

- version
  - just a skill version identifier
  - irrelevant for eve usage
- disable-model-invocation
  - means that the user has to invoke the skill directly (rather than the model directly invoking it)
  - this is claude code convention 
  - we don't currently have a concept of "explicitly invoking a skill" in the same way that in other TUIs you can use skills as slash-commands. debatable if this would be useful
- hidden
  - same as above
- argument-hint
  - when invoking as a slash command, gives you a hint of what arguments you should put into the skill
  - claude code convention 
  - again, we don't currently have a concept like this
- allowed-tools
  - experimental extension to the existing spec
  - doesn't really jive with our existing notion of what a skill is -- there's not a single skill invocation lifecycle for which that tool usage would be relevant for. could maybe apply to the rest of the turn but not enough evidence right now that this would be particularly useful

The one thing that did turn up though was that, even though the official spec indicates that metadata should be of type Record<string, string>, many existing skills do not abide by this and have arbitrary structured data underneath certain metadata keys (lists, dicts, etc.).

This PR avoids erroring in those cases by stripping out the non-conforming fields. 

## Testing

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/helpers/markdown.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/discover/skills.integration.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- targeted oxfmt and oxlint checks
