### PR TITLE
feat(eve): compile agent/instrumentation/ behind a flag

### DIFF
--- a/.changeset/instrumentation-provider-layout.md
+++ b/.changeset/instrumentation-provider-layout.md
@@ -1,0 +1,11 @@
+---
+"eve": patch
+---
+
+Add `experimental.instrumentationProviders`, an off-by-default flag that swaps
+the single `agent/instrumentation.ts` config for an `agent/instrumentation/`
+directory holding one provider per file. With the flag off nothing changes.
+With it on, eve compiles every file in that directory, awaits each provider's
+`setup` at startup, and fails the build if `agent/instrumentation.ts` is still
+present. Authored `setup` now receives `environment` and `frameworkVersion`
+alongside `agentName` in both layouts.

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -428,6 +428,7 @@ const compiledAgentConfigSchema: z.ZodType<CompiledAgentDefinition> = z
     dynamicModel: compiledDynamicModelDefinitionSchema.optional(),
     experimental: z
       .object({
+        instrumentationProviders: z.boolean().optional(),
         subagentPersistentSessions: z.boolean().optional(),
         workflow: compiledAgentWorkflowDefinitionSchema.optional(),
       })
@@ -833,6 +834,7 @@ export function createCompiledAgentNodeManifest(input: {
         input.config.experimental === undefined
           ? undefined
           : {
+              instrumentationProviders: input.config.experimental.instrumentationProviders,
               subagentPersistentSessions: input.config.experimental.subagentPersistentSessions,
               workflow:
                 input.config.experimental.workflow === undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -176,6 +176,10 @@ function normalizeExperimentalDefinition(
 
   const compiledExperimental: Mutable<NonNullable<CompiledAgentDefinition["experimental"]>> = {};
 
+  if (experimental.instrumentationProviders !== undefined) {
+    compiledExperimental.instrumentationProviders = experimental.instrumentationProviders;
+  }
+
   if (experimental.subagentPersistentSessions !== undefined) {
     compiledExperimental.subagentPersistentSessions = experimental.subagentPersistentSessions;
   }

--- a/packages/eve/src/harness/instrumentation-config.test.ts
+++ b/packages/eve/src/harness/instrumentation-config.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { InstrumentationSetupContext } from "#public/instrumentation/index.js";
+
 /**
  * Regression coverage for the instrumentation-config chunk-isolation failure.
  *
@@ -25,7 +27,7 @@ describe("instrumentation-config chunk-isolation regression", () => {
     vi.resetModules();
     const moduleA = await import("#harness/instrumentation-config.js");
     const config = { functionId: "test.instrumentation.cross-module.alice" };
-    moduleA.registerInstrumentationConfig(config, { agentName: "test-agent" });
+    await moduleA.registerInstrumentationConfig(config, { agentName: "test-agent" });
 
     vi.resetModules();
     const moduleB = await import("#harness/instrumentation-config.js");
@@ -40,7 +42,7 @@ describe("instrumentation-config chunk-isolation regression", () => {
     const { registerInstrumentationConfig } = await import("#harness/instrumentation-config.js");
 
     const canary = { functionId: "test.instrumentation.global-mount.canary" };
-    registerInstrumentationConfig(canary, { agentName: "test-agent" });
+    await registerInstrumentationConfig(canary, { agentName: "test-agent" });
 
     expect((globalThis as Record<symbol, unknown>)[globalKey]).toBe(canary);
   });
@@ -51,7 +53,7 @@ describe("instrumentation-config chunk-isolation regression", () => {
     vi.resetModules();
     const moduleA = await import("#harness/instrumentation-config.js");
     const config = { functionId: "test.instrumentation.reimport.canary" };
-    moduleA.registerInstrumentationConfig(config, { agentName: "test-agent" });
+    await moduleA.registerInstrumentationConfig(config, { agentName: "test-agent" });
     const firstRef = (globalThis as Record<symbol, unknown>)[globalKey];
 
     vi.resetModules();
@@ -61,13 +63,23 @@ describe("instrumentation-config chunk-isolation regression", () => {
     expect(secondRef).toBe(firstRef);
   });
 
-  it("invokes the setup callback with the supplied context", async () => {
+  it("awaits the setup callback with the resolved context", async () => {
     vi.resetModules();
     const { registerInstrumentationConfig } = await import("#harness/instrumentation-config.js");
 
-    const setup = vi.fn();
-    registerInstrumentationConfig({ setup }, { agentName: "weather-agent" });
+    const contexts: InstrumentationSetupContext[] = [];
+    await registerInstrumentationConfig(
+      {
+        setup: (context) => {
+          contexts.push(context);
+        },
+      },
+      { agentName: "weather-agent" },
+    );
 
-    expect(setup).toHaveBeenCalledExactlyOnceWith({ agentName: "weather-agent" });
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.agentName).toBe("weather-agent");
+    expect(contexts[0]?.environment).toMatch(/^(development|production)$/);
+    expect(contexts[0]?.frameworkVersion).toEqual(expect.any(String));
   });
 });

--- a/packages/eve/src/harness/instrumentation-config.ts
+++ b/packages/eve/src/harness/instrumentation-config.ts
@@ -1,7 +1,5 @@
-import type {
-  InstrumentationDefinition,
-  InstrumentationSetupContext,
-} from "#public/instrumentation/index.js";
+import { createInstrumentationSetupContext } from "#harness/instrumentation-setup-context.js";
+import type { InstrumentationDefinition } from "#public/instrumentation/index.js";
 
 /**
  * Process-global store for the authored instrumentation config.
@@ -28,22 +26,23 @@ interface InstrumentationConfigGlobal {
 const globalContainer = globalThis as typeof globalThis & InstrumentationConfigGlobal;
 
 /**
- * Registers the authored instrumentation config and invokes its `setup`
- * callback with the resolved agent name.
+ * Registers the authored instrumentation config and awaits its `setup`
+ * callback.
  *
  * Called once by the generated instrumentation Nitro plugin at server
  * startup. Subsequent calls overwrite the previous value.
  *
+ * The store write lands before `setup` runs so a synchronous caller sees the
+ * config without waiting on the returned promise.
+ *
  * @internal — not part of the public API.
  */
-export function registerInstrumentationConfig(
+export async function registerInstrumentationConfig(
   config: InstrumentationDefinition,
-  context: InstrumentationSetupContext,
-): void {
-  if (config.setup !== undefined) {
-    config.setup(context);
-  }
+  input: { readonly agentName: string },
+): Promise<void> {
   globalContainer[INSTRUMENTATION_CONFIG_GLOBAL_KEY] = config;
+  await config.setup?.(createInstrumentationSetupContext(input.agentName));
 }
 
 /**

--- a/packages/eve/src/harness/instrumentation-providers.test.ts
+++ b/packages/eve/src/harness/instrumentation-providers.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getInstrumentationProviders,
+  registerInstrumentationProvider,
+} from "#harness/instrumentation-providers.js";
+import { defineInstrumentation } from "#public/instrumentation/index.js";
+import {
+  disableInstrumentation,
+  type ProviderSetupContext,
+} from "#public/instrumentation/provider.js";
+
+const REGISTRY_GLOBAL_KEY = Symbol.for("eve.harness-instrumentation-providers");
+
+function register(slot: string, value: unknown): Promise<void> {
+  return registerInstrumentationProvider({ agentName: "weather-agent", slot, value });
+}
+
+describe("registerInstrumentationProvider", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    delete (globalThis as Record<symbol, unknown>)[REGISTRY_GLOBAL_KEY];
+  });
+
+  it("registers a provider under its slot", async () => {
+    const provider = defineInstrumentation({ events: {} });
+    await register("otel", provider);
+
+    expect(getInstrumentationProviders()).toEqual([{ provider, slot: "otel" }]);
+  });
+
+  it("preserves registration order across slots", async () => {
+    await register("agent-runs", defineInstrumentation({}));
+    await register("local", defineInstrumentation({}));
+
+    expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["agent-runs", "local"]);
+  });
+
+  it("awaits setup with the resolved provider context", async () => {
+    const contexts: ProviderSetupContext[] = [];
+    await register(
+      "otel",
+      defineInstrumentation({
+        setup: (context) => {
+          contexts.push(context);
+        },
+        shutdown: () => {},
+      }),
+    );
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.agentName).toBe("weather-agent");
+    expect(contexts[0]?.environment).toMatch(/^(development|preview|production)$/);
+    expect(contexts[0]?.frameworkVersion).toEqual(expect.any(String));
+  });
+
+  it("reports Vercel preview separately from production", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    const contexts: ProviderSetupContext[] = [];
+
+    await register(
+      "otel",
+      defineInstrumentation({ setup: (context) => void contexts.push(context) }),
+    );
+
+    expect(contexts[0]?.environment).toBe("preview");
+  });
+
+  it("registers nothing for a disabled slot", async () => {
+    await register("local", disableInstrumentation());
+
+    expect(getInstrumentationProviders()).toEqual([]);
+  });
+
+  it("removes an already-registered provider when a later file disables the slot", async () => {
+    await register("local", defineInstrumentation({}));
+    await register("local", disableInstrumentation());
+
+    expect(getInstrumentationProviders()).toEqual([]);
+  });
+
+  // A slot that registers nothing is telemetry that silently does nothing —
+  // the failure this surface exists to prevent — so the shape check throws
+  // rather than skipping the file.
+  it.each([
+    ["a bare object", { events: {} }],
+    ["a function", () => {}],
+    ["undefined", undefined],
+    ["null", null],
+  ])("throws when the default export is %s", async (_label, value) => {
+    await expect(register("otel", value)).rejects.toThrow(
+      /The default export of "instrumentation\/otel" is not an instrumentation provider/,
+    );
+  });
+});

--- a/packages/eve/src/harness/instrumentation-providers.ts
+++ b/packages/eve/src/harness/instrumentation-providers.ts
@@ -1,0 +1,76 @@
+import { createInstrumentationSetupContext } from "#harness/instrumentation-setup-context.js";
+import {
+  isInstrumentationDisabled,
+  isInstrumentationProvider,
+  type InstrumentationProvider,
+} from "#public/instrumentation/provider.js";
+
+/**
+ * Process-global registry of the providers authored under
+ * `agent/instrumentation/`.
+ *
+ * Rooted on `globalThis` for the same reason the single-config store is: the
+ * generated Nitro plugin stays external by `file://` URL while the harness
+ * chunk is inlined, so the two resolve to distinct ESM module instances and
+ * need one shared source of truth.
+ */
+const INSTRUMENTATION_PROVIDERS_GLOBAL_KEY = Symbol.for("eve.harness-instrumentation-providers");
+
+/** One provider and the `instrumentation/<slot>.ts` file it came from. */
+export interface RegisteredInstrumentationProvider {
+  readonly provider: InstrumentationProvider;
+  readonly slot: string;
+}
+
+interface InstrumentationProvidersGlobal {
+  [INSTRUMENTATION_PROVIDERS_GLOBAL_KEY]?: Map<string, InstrumentationProvider>;
+}
+
+const globalContainer = globalThis as typeof globalThis & InstrumentationProvidersGlobal;
+
+function providerRegistry(): Map<string, InstrumentationProvider> {
+  const existing = globalContainer[INSTRUMENTATION_PROVIDERS_GLOBAL_KEY];
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const created = new Map<string, InstrumentationProvider>();
+  globalContainer[INSTRUMENTATION_PROVIDERS_GLOBAL_KEY] = created;
+  return created;
+}
+
+/**
+ * Registers one authored provider and awaits its `setup`.
+ *
+ * Called once per `instrumentation/<slot>.ts` by the generated Nitro plugin at
+ * server startup, before any event is published. A default export that is not
+ * a `defineInstrumentation` result throws rather than being skipped: a slot
+ * that registers nothing is telemetry that silently does nothing, which is the
+ * failure this surface exists to prevent.
+ *
+ * @internal — not part of the public API.
+ */
+export async function registerInstrumentationProvider(input: {
+  readonly agentName: string;
+  readonly slot: string;
+  readonly value: unknown;
+}): Promise<void> {
+  if (isInstrumentationDisabled(input.value)) {
+    providerRegistry().delete(input.slot);
+    return;
+  }
+
+  if (!isInstrumentationProvider(input.value)) {
+    throw new Error(
+      `The default export of "instrumentation/${input.slot}" is not an instrumentation provider. Return the result of \`defineInstrumentation\` or \`disableInstrumentation\` from it.`,
+    );
+  }
+
+  providerRegistry().set(input.slot, input.value);
+  await input.value.setup?.(createInstrumentationSetupContext(input.agentName));
+}
+
+/** Registered providers in slot order. @internal */
+export function getInstrumentationProviders(): readonly RegisteredInstrumentationProvider[] {
+  return [...providerRegistry()].map(([slot, provider]) => ({ provider, slot }));
+}

--- a/packages/eve/src/harness/instrumentation-setup-context.ts
+++ b/packages/eve/src/harness/instrumentation-setup-context.ts
@@ -1,0 +1,26 @@
+import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
+import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import type { ProviderSetupContext } from "#public/instrumentation/provider.js";
+
+/**
+ * Builds the context handed to an authored `setup` at server startup.
+ *
+ * Shared by both layouts so the two cannot drift: a divergent context type
+ * would leave `defineInstrumentation`'s union without a contextual signature
+ * for `setup`, silently making every authored `setup(context)` parameter an
+ * implicit `any`.
+ *
+ * @internal — not part of the public API.
+ */
+export function createInstrumentationSetupContext(agentName: string): ProviderSetupContext {
+  return {
+    agentName,
+    environment: resolveInstrumentationEnvironment(),
+    frameworkVersion: resolveInstalledPackageInfo().version,
+  };
+}
+
+function resolveInstrumentationEnvironment(): ProviderSetupContext["environment"] {
+  if (isEveDevEnvironment() || process.env.VERCEL_ENV === "development") return "development";
+  return process.env.VERCEL_ENV === "preview" ? "preview" : "production";
+}

--- a/packages/eve/src/internal/application/compiled-artifacts.ts
+++ b/packages/eve/src/internal/application/compiled-artifacts.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -12,11 +11,22 @@ import {
 } from "#internal/application/package.js";
 import { buildPackageUserAgent } from "#internal/user-agent.js";
 import type { AgentWorkflowWorldDefinition } from "#shared/agent-definition.js";
-import { readMaterializedAuthoredModuleIndex } from "#internal/materialized-authored-modules.js";
+import {
+  readMaterializedAuthoredModuleIndex,
+  type MaterializedInstrumentation,
+} from "#internal/materialized-authored-modules.js";
+import {
+  resolveInstrumentationLayout,
+  type InstrumentationLayout,
+} from "#internal/instrumentation-layout.js";
 import { usesParentDevelopmentWorkflowWorld } from "#internal/workflow/development-world-protocol.js";
 import { resolveWorkflowWorldImport } from "#internal/workflow/world-target.js";
 
 export type BuiltInWorkflowWorldTarget = "local" | "vercel";
+
+export type GeneratedInstrumentationLayout =
+  | { readonly kind: "config" }
+  | { readonly kind: "providers"; readonly slots: readonly string[] };
 
 /**
  * Paths to the generated compiled-artifacts files shared by Nitro and the
@@ -31,15 +41,18 @@ export interface GeneratedCompiledArtifactsFiles {
   /** Nitro plugin that installs the selected vendored Workflow world. */
   workflowWorldPluginPath: string;
   /**
-   * Optional Nitro plugin that imports the authored instrumentation module
+   * Optional Nitro plugin that imports the authored instrumentation modules
    * from the application when present.
    */
   instrumentationPluginPath?: string;
+  /** Layout identity used by dev plugin selection and structural fingerprinting. */
+  instrumentationLayout?: GeneratedInstrumentationLayout;
   /**
-   * Absolute path to the authored instrumentation module when present.
-   * Nitro uses this to preserve the module's side effects during bundling.
+   * Absolute paths to the authored instrumentation modules when present — one
+   * for the single-config layout, one per provider otherwise. Nitro uses these
+   * to preserve each module's side effects during bundling.
    */
-  instrumentationSourcePath?: string;
+  instrumentationSourcePaths?: readonly string[];
 }
 
 /**
@@ -57,7 +70,11 @@ export async function writeCompiledArtifactsFiles(input: {
   const bootstrapPath = join(input.outDir, "compiled-artifacts-bootstrap.mjs");
   const instrumentationPluginPath = join(input.outDir, "compiled-artifacts-instrumentation.mjs");
   const workflowWorldPluginPath = join(input.outDir, "compiled-artifacts-workflow-world.mjs");
-  const instrumentationPath = resolveInstrumentationModule(input.compileResult.manifest.agentRoot);
+  const layout = resolveInstrumentationLayout({
+    agentRoot: input.compileResult.manifest.agentRoot,
+    providersEnabled:
+      input.compileResult.manifest.config.experimental?.instrumentationProviders ?? false,
+  });
 
   await mkdir(input.outDir, { recursive: true });
   await writeFile(
@@ -78,28 +95,29 @@ export async function writeCompiledArtifactsFiles(input: {
     }),
   );
 
-  if (instrumentationPath !== undefined) {
-    await writeFile(
-      instrumentationPluginPath,
-      createInstrumentationPluginSource({
-        agentName: input.compileResult.manifest.config.name,
-        instrumentationPath,
-        registerConfigPath: resolvePackageSourceFilePath("src/harness/instrumentation-config.ts"),
-      }),
-    );
-  }
-
   const generatedArtifacts: GeneratedCompiledArtifactsFiles = {
     bootstrapPath,
     workflowWorldPluginPath,
   };
 
-  if (instrumentationPath !== undefined) {
+  if (layout !== undefined) {
+    await writeFile(
+      instrumentationPluginPath,
+      createInstrumentationPluginSource({
+        agentName: input.compileResult.manifest.config.name,
+        layout,
+      }),
+    );
     generatedArtifacts.instrumentationPluginPath = instrumentationPluginPath;
-    generatedArtifacts.instrumentationSourcePath = instrumentationPath;
+    generatedArtifacts.instrumentationLayout = generatedInstrumentationLayout(layout);
+    generatedArtifacts.instrumentationSourcePaths = instrumentationSourcePathsOf(layout);
   }
 
   return generatedArtifacts;
+}
+
+function instrumentationSourcePathsOf(layout: InstrumentationLayout): readonly string[] {
+  return layout.kind === "config" ? [layout.modulePath] : Object.values(layout.modulePathsBySlot);
 }
 
 // The dev host's Nitro inputs outlive any single generation, so nothing
@@ -113,10 +131,6 @@ export async function writeDevelopmentCompiledArtifactsFiles(input: {
 }): Promise<GeneratedCompiledArtifactsFiles> {
   const bootstrapPath = join(input.outDir, "compiled-artifacts-bootstrap.mjs");
   const instrumentationPluginPath = join(input.outDir, "compiled-artifacts-instrumentation.mjs");
-  const instrumentationSourcePath = join(
-    input.outDir,
-    "compiled-artifacts-instrumentation-source.mjs",
-  );
   const workflowWorldPluginPath = join(input.outDir, "compiled-artifacts-workflow-world.mjs");
   const materializedIndex = await readMaterializedAuthoredModuleIndex(input.runtimeAppRoot);
 
@@ -143,23 +157,64 @@ export async function writeDevelopmentCompiledArtifactsFiles(input: {
   };
 
   if (materializedIndex.instrumentation !== undefined) {
-    await copyFile(
-      join(input.runtimeAppRoot, ".eve", "compile", materializedIndex.instrumentation),
-      instrumentationSourcePath,
-    );
+    const layout = await copyMaterializedInstrumentation({
+      instrumentation: materializedIndex.instrumentation,
+      outDir: input.outDir,
+      runtimeAppRoot: input.runtimeAppRoot,
+    });
+
     await writeFile(
       instrumentationPluginPath,
       createInstrumentationPluginSource({
         agentName: input.compileResult.manifest.config.name,
-        instrumentationPath: instrumentationSourcePath,
-        registerConfigPath: resolvePackageSourceFilePath("src/harness/instrumentation-config.ts"),
+        layout,
       }),
     );
     generatedArtifacts.instrumentationPluginPath = instrumentationPluginPath;
-    generatedArtifacts.instrumentationSourcePath = instrumentationSourcePath;
+    generatedArtifacts.instrumentationLayout = generatedInstrumentationLayout(layout);
+    generatedArtifacts.instrumentationSourcePaths = instrumentationSourcePathsOf(layout);
   }
 
   return generatedArtifacts;
+}
+
+function generatedInstrumentationLayout(
+  layout: InstrumentationLayout,
+): GeneratedInstrumentationLayout {
+  return layout.kind === "config"
+    ? { kind: "config" }
+    : { kind: "providers", slots: Object.keys(layout.modulePathsBySlot) };
+}
+
+/**
+ * Copies each materialized instrumentation bundle out of the prunable
+ * generation and into the stable dev-host directory, returning the layout in
+ * terms of the copies.
+ */
+async function copyMaterializedInstrumentation(input: {
+  readonly instrumentation: MaterializedInstrumentation;
+  readonly outDir: string;
+  readonly runtimeAppRoot: string;
+}): Promise<InstrumentationLayout> {
+  const compileRoot = join(input.runtimeAppRoot, ".eve", "compile");
+  const copyOne = async (sourceId: string, modulePath: string): Promise<string> => {
+    const destination = join(input.outDir, `compiled-artifacts-instrumentation-${sourceId}.mjs`);
+    await copyFile(join(compileRoot, modulePath), destination);
+    return destination;
+  };
+
+  if (input.instrumentation.kind === "config") {
+    return {
+      kind: "config",
+      modulePath: await copyOne("source", input.instrumentation.modulePath),
+    };
+  }
+
+  const modulePathsBySlot: Record<string, string> = {};
+  for (const [slot, modulePath] of Object.entries(input.instrumentation.modulePathsBySlot)) {
+    modulePathsBySlot[slot] = await copyOne(slot, modulePath);
+  }
+  return { kind: "providers", modulePathsBySlot };
 }
 
 function createDevelopmentCompiledArtifactsBootstrapSource(agentName: string): string {
@@ -172,23 +227,6 @@ function createDevelopmentCompiledArtifactsBootstrapSource(agentName: string): s
     "export default function installDevelopmentCompiledArtifactsPlugin() {}",
     "",
   ].join("\n");
-}
-
-const INSTRUMENTATION_EXTENSIONS = [".ts", ".mts", ".js", ".mjs"];
-
-/**
- * Resolves the optional `agent/instrumentation` module from the agent root
- * directory. Returns the absolute path if found, `undefined` otherwise.
- */
-function resolveInstrumentationModule(agentRoot: string): string | undefined {
-  for (const ext of INSTRUMENTATION_EXTENSIONS) {
-    const candidate = join(agentRoot, `instrumentation${ext}`);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  return undefined;
 }
 
 function stripCompiledModuleMapExports(source: string): string {
@@ -380,19 +418,59 @@ export function createDevelopmentWorkflowWorldPluginSource(input: {
   ].join("\n");
 }
 
+/**
+ * Generates the Nitro plugin that registers the authored instrumentation.
+ *
+ * The single-config layout registers one default export; the provider layout
+ * registers one per file, in slot order, awaiting each `setup` so a provider
+ * cannot miss an event published while it is still starting up.
+ */
 function createInstrumentationPluginSource(input: {
   agentName: string;
-  instrumentationPath: string;
-  registerConfigPath: string;
+  layout: InstrumentationLayout;
 }): string {
+  const agentName = JSON.stringify(input.agentName);
+
+  if (input.layout.kind === "config") {
+    const registerConfigPath = resolvePackageSourceFilePath(
+      "src/harness/instrumentation-config.ts",
+    );
+    return [
+      "// Generated by eve. Do not edit by hand.",
+      `import * as instrumentationModule from ${stringifyEsmImportSpecifier(input.layout.modulePath)};`,
+      `import { registerInstrumentationConfig } from ${stringifyEsmImportSpecifier(registerConfigPath)};`,
+      "",
+      "if (instrumentationModule.default != null) {",
+      `  await registerInstrumentationConfig(instrumentationModule.default, { agentName: ${agentName} });`,
+      "}",
+      "",
+      "// Default export satisfies the Nitro plugin contract so this file",
+      "// can be used directly as a Nitro plugin without a separate wrapper.",
+      "export default function installInstrumentationPlugin() {}",
+      "",
+    ].join("\n");
+  }
+
+  const registerProviderPath = resolvePackageSourceFilePath(
+    "src/harness/instrumentation-providers.ts",
+  );
+  const slots = Object.entries(input.layout.modulePathsBySlot);
+
   return [
     "// Generated by eve. Do not edit by hand.",
-    `import * as instrumentationModule from ${stringifyEsmImportSpecifier(input.instrumentationPath)};`,
-    `import { registerInstrumentationConfig } from ${stringifyEsmImportSpecifier(input.registerConfigPath)};`,
+    ...slots.map(
+      ([slot, modulePath], index) =>
+        `import * as provider${index} from ${stringifyEsmImportSpecifier(modulePath)}; // ${slot}`,
+    ),
+    `import { registerInstrumentationProvider } from ${stringifyEsmImportSpecifier(registerProviderPath)};`,
     "",
-    "if (instrumentationModule.default != null) {",
-    `  registerInstrumentationConfig(instrumentationModule.default, { agentName: ${JSON.stringify(input.agentName)} });`,
-    "}",
+    ...slots.flatMap(([slot], index) => [
+      "await registerInstrumentationProvider({",
+      `  agentName: ${agentName},`,
+      `  slot: ${JSON.stringify(slot)},`,
+      `  value: provider${index}.default,`,
+      "});",
+    ]),
     "",
     "// Default export satisfies the Nitro plugin contract so this file",
     "// can be used directly as a Nitro plugin without a separate wrapper.",

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -257,8 +257,19 @@ function normalizeAgentExperimentalDefinition(
   message: string,
 ): NonNullable<NormalizedAgentDefinition["experimental"]> {
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["subagentPersistentSessions", "workflow"], message);
+  expectOnlyKnownKeys(
+    record,
+    ["instrumentationProviders", "subagentPersistentSessions", "workflow"],
+    message,
+  );
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["experimental"]>> = {};
+
+  if (record.instrumentationProviders !== undefined) {
+    if (typeof record.instrumentationProviders !== "boolean") {
+      throw new Error(`${message} "experimental.instrumentationProviders" must be a boolean.`);
+    }
+    normalizedDefinition.instrumentationProviders = record.instrumentationProviders;
+  }
 
   if (record.subagentPersistentSessions !== undefined) {
     if (typeof record.subagentPersistentSessions !== "boolean") {

--- a/packages/eve/src/internal/instrumentation-layout.integration.test.ts
+++ b/packages/eve/src/internal/instrumentation-layout.integration.test.ts
@@ -1,0 +1,125 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { resolveInstrumentationLayout } from "#internal/instrumentation-layout.js";
+
+let agentRoot: string;
+
+beforeEach(() => {
+  agentRoot = mkdtempSync(join(tmpdir(), "eve-instrumentation-layout-"));
+});
+
+function writeConfig(extension = ".ts"): string {
+  const path = join(agentRoot, `instrumentation${extension}`);
+  writeFileSync(path, "export default {};\n");
+  return path;
+}
+
+function writeProvider(fileName: string): string {
+  const directory = join(agentRoot, "instrumentation");
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, fileName);
+  writeFileSync(path, "export default {};\n");
+  return path;
+}
+
+describe("resolveInstrumentationLayout with providers off", () => {
+  it("returns nothing when the agent authored no instrumentation", () => {
+    expect(resolveInstrumentationLayout({ agentRoot, providersEnabled: false })).toBeUndefined();
+  });
+
+  it("resolves the single config module", () => {
+    const modulePath = writeConfig();
+
+    expect(resolveInstrumentationLayout({ agentRoot, providersEnabled: false })).toEqual({
+      kind: "config",
+      modulePath,
+    });
+  });
+
+  it.each([[".mts"], [".js"], [".mjs"]])("resolves a %s config module", (extension) => {
+    const modulePath = writeConfig(extension);
+
+    expect(resolveInstrumentationLayout({ agentRoot, providersEnabled: false })).toEqual({
+      kind: "config",
+      modulePath,
+    });
+  });
+
+  it("rejects a providers directory, naming the flag", () => {
+    writeProvider("otel.ts");
+
+    expect(() => resolveInstrumentationLayout({ agentRoot, providersEnabled: false })).toThrow(
+      /experimental\.instrumentationProviders/,
+    );
+  });
+});
+
+describe("resolveInstrumentationLayout with providers on", () => {
+  it("returns nothing when the agent authored no instrumentation", () => {
+    expect(resolveInstrumentationLayout({ agentRoot, providersEnabled: true })).toBeUndefined();
+  });
+
+  it("keys each file by the slot its name derives", () => {
+    const otel = writeProvider("otel.ts");
+    const local = writeProvider("local.mts");
+
+    expect(resolveInstrumentationLayout({ agentRoot, providersEnabled: true })).toEqual({
+      kind: "providers",
+      modulePathsBySlot: { local, otel },
+    });
+  });
+
+  it("orders slots independently of directory enumeration", () => {
+    writeProvider("otel.ts");
+    writeProvider("agent-runs.ts");
+    writeProvider("local.ts");
+
+    const layout = resolveInstrumentationLayout({ agentRoot, providersEnabled: true });
+
+    expect(Object.keys(layout?.kind === "providers" ? layout.modulePathsBySlot : {})).toEqual([
+      "agent-runs",
+      "local",
+      "otel",
+    ]);
+  });
+
+  it("ignores files that are not instrumentation modules", () => {
+    writeProvider("otel.ts");
+    writeProvider("README.md");
+
+    const layout = resolveInstrumentationLayout({ agentRoot, providersEnabled: true });
+
+    expect(Object.keys(layout?.kind === "providers" ? layout.modulePathsBySlot : {})).toEqual([
+      "otel",
+    ]);
+  });
+
+  it("rejects two files claiming one slot", () => {
+    writeProvider("otel.ts");
+    writeProvider("otel.js");
+
+    expect(() => resolveInstrumentationLayout({ agentRoot, providersEnabled: true })).toThrow(
+      /Two files declare the "otel" instrumentation provider/,
+    );
+  });
+
+  it("rejects a single config module, naming the flag", () => {
+    writeConfig();
+
+    expect(() => resolveInstrumentationLayout({ agentRoot, providersEnabled: true })).toThrow(
+      /experimental\.instrumentationProviders/,
+    );
+  });
+
+  it("prefers the config error when both layouts are present", () => {
+    writeConfig();
+    writeProvider("otel.ts");
+
+    expect(() => resolveInstrumentationLayout({ agentRoot, providersEnabled: true })).toThrow(
+      /Move it into the "instrumentation\/" directory/,
+    );
+  });
+});

--- a/packages/eve/src/internal/instrumentation-layout.ts
+++ b/packages/eve/src/internal/instrumentation-layout.ts
@@ -1,0 +1,115 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const INSTRUMENTATION_EXTENSIONS = [".ts", ".mts", ".js", ".mjs"] as const;
+
+const INSTRUMENTATION_DIRECTORY = "instrumentation";
+
+const PROVIDERS_FLAG = "experimental.instrumentationProviders";
+
+/**
+ * How instrumentation is authored for one agent.
+ *
+ * `config` is the single `agent/instrumentation.ts` default export. `providers`
+ * is a directory of them, one provider per file, keyed by the slot name the
+ * file derives (`instrumentation/otel.ts` → `otel`). Which one an agent may use
+ * is decided by `experimental.instrumentationProviders`, never by what happens
+ * to be on disk.
+ */
+export type InstrumentationLayout =
+  | { readonly kind: "config"; readonly modulePath: string }
+  | { readonly kind: "providers"; readonly modulePathsBySlot: Readonly<Record<string, string>> };
+
+/**
+ * Resolves the instrumentation layout for one agent root.
+ *
+ * Returns `undefined` when the agent authored no instrumentation. Throws when
+ * the layout on disk is not the one the flag selects: the wrong layout would
+ * otherwise be skipped silently, and telemetry that quietly does nothing is the
+ * failure this whole surface exists to prevent.
+ */
+export function resolveInstrumentationLayout(input: {
+  readonly agentRoot: string;
+  readonly providersEnabled: boolean;
+}): InstrumentationLayout | undefined {
+  const configPath = resolveInstrumentationConfigModule(input.agentRoot);
+  const directoryPath = join(input.agentRoot, INSTRUMENTATION_DIRECTORY);
+  const hasDirectory = existsSync(directoryPath) && statSync(directoryPath).isDirectory();
+
+  if (!input.providersEnabled) {
+    if (hasDirectory) {
+      throw new Error(
+        `Found an "${INSTRUMENTATION_DIRECTORY}/" directory at "${input.agentRoot}", but instrumentation providers are off. Set \`${PROVIDERS_FLAG}: true\` in \`defineAgent\`, or move these files back into a single "${INSTRUMENTATION_DIRECTORY}.ts".`,
+      );
+    }
+
+    return configPath === undefined ? undefined : { kind: "config", modulePath: configPath };
+  }
+
+  if (configPath !== undefined) {
+    throw new Error(
+      `Found "${configPath}", but \`${PROVIDERS_FLAG}\` is on. Move it into the "${INSTRUMENTATION_DIRECTORY}/" directory as one file per provider.`,
+    );
+  }
+
+  if (!hasDirectory) {
+    return undefined;
+  }
+
+  return {
+    kind: "providers",
+    modulePathsBySlot: collectInstrumentationProviderModules(directoryPath),
+  };
+}
+
+/**
+ * Maps each `instrumentation/<slot>.<ext>` file to its absolute path.
+ *
+ * Slots are sorted so the registration order a provider sees does not depend on
+ * how the filesystem happens to enumerate the directory.
+ */
+function collectInstrumentationProviderModules(
+  directoryPath: string,
+): Readonly<Record<string, string>> {
+  const modulePathsBySlot = new Map<string, string>();
+
+  for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+
+    const extension = INSTRUMENTATION_EXTENSIONS.find((candidate) =>
+      entry.name.endsWith(candidate),
+    );
+    if (extension === undefined) continue;
+
+    const slot = entry.name.slice(0, -extension.length);
+    if (slot === "") continue;
+
+    const existing = modulePathsBySlot.get(slot);
+    if (existing !== undefined) {
+      throw new Error(
+        `Two files declare the "${slot}" instrumentation provider in "${directoryPath}". Keep one of them.`,
+      );
+    }
+
+    modulePathsBySlot.set(slot, join(directoryPath, entry.name));
+  }
+
+  return Object.fromEntries(
+    [...modulePathsBySlot].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+/**
+ * Resolves the single `agent/instrumentation` module, ignoring any directory of
+ * the same name.
+ */
+function resolveInstrumentationConfigModule(agentRoot: string): string | undefined {
+  for (const extension of INSTRUMENTATION_EXTENSIONS) {
+    const candidate = join(agentRoot, `${INSTRUMENTATION_DIRECTORY}${extension}`);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/eve/src/internal/materialized-authored-modules.ts
+++ b/packages/eve/src/internal/materialized-authored-modules.ts
@@ -10,16 +10,24 @@ import {
   bundleAuthoredModuleMapForGeneration,
 } from "#internal/authored-module-loader.js";
 import { serializeCompiledManifestForFingerprint } from "#internal/compiled-manifest-fingerprint.js";
+import { resolveInstrumentationLayout } from "#internal/instrumentation-layout.js";
 
 const MATERIALIZED_MODULES_DIRECTORY = "authored-modules";
 const MATERIALIZED_MODULES_INDEX = "authored-modules.json";
-const INSTRUMENTATION_EXTENSIONS = [".ts", ".mts", ".js", ".mjs"] as const;
+
+/**
+ * The materialized instrumentation modules, mirroring the layout they were
+ * authored in. Paths are relative to `.eve/compile`.
+ */
+export type MaterializedInstrumentation =
+  | { readonly kind: "config"; readonly modulePath: string }
+  | { readonly kind: "providers"; readonly modulePathsBySlot: Readonly<Record<string, string>> };
 
 export interface MaterializedAuthoredModuleIndex {
   readonly fingerprint: string;
-  readonly instrumentation?: string;
+  readonly instrumentation?: MaterializedInstrumentation;
   readonly moduleMap: string;
-  readonly version: 2;
+  readonly version: 3;
 }
 
 export async function materializeAuthoredModules(input: {
@@ -54,22 +62,40 @@ export async function materializeAuthoredModules(input: {
   await writeFile(join(modulesRoot, moduleMapFileName), moduleMapCode);
   fingerprint.update("module-map\0").update(moduleMapCode).update("\0");
 
-  const instrumentation = resolveInstrumentationModule(manifest.agentRoot);
-  let instrumentationPath: string | undefined;
-
-  if (instrumentation !== undefined) {
-    const code = await bundleAuthoredModuleForGeneration(instrumentation, {
-      externalDependencies: manifest.config.build?.externalDependencies ?? [],
-    });
+  const layout = resolveInstrumentationLayout({
+    agentRoot: manifest.agentRoot,
+    providersEnabled: manifest.config.experimental?.instrumentationProviders ?? false,
+  });
+  const externalDependencies = manifest.config.build?.externalDependencies ?? [];
+  const materializeInstrumentationModule = async (
+    sourceId: string,
+    sourcePath: string,
+  ): Promise<string> => {
+    const code = await bundleAuthoredModuleForGeneration(sourcePath, { externalDependencies });
     const fileName = createMaterializedModuleFileName(
       ROOT_COMPILED_AGENT_NODE_ID,
-      "instrumentation",
+      `instrumentation:${sourceId}`,
       code,
     );
 
     await writeFile(join(modulesRoot, fileName), code);
-    instrumentationPath = join(MATERIALIZED_MODULES_DIRECTORY, fileName);
-    fingerprint.update("instrumentation\0").update(code).update("\0");
+    fingerprint.update(`instrumentation:${sourceId}\0`).update(code).update("\0");
+    return join(MATERIALIZED_MODULES_DIRECTORY, fileName);
+  };
+
+  let instrumentation: MaterializedInstrumentation | undefined;
+
+  if (layout?.kind === "config") {
+    instrumentation = {
+      kind: "config",
+      modulePath: await materializeInstrumentationModule("config", layout.modulePath),
+    };
+  } else if (layout?.kind === "providers") {
+    const modulePathsBySlot: Record<string, string> = {};
+    for (const [slot, sourcePath] of Object.entries(layout.modulePathsBySlot)) {
+      modulePathsBySlot[slot] = await materializeInstrumentationModule(slot, sourcePath);
+    }
+    instrumentation = { kind: "providers", modulePathsBySlot };
   }
 
   await hashDirectoryIfPresent({
@@ -79,16 +105,16 @@ export async function materializeAuthoredModules(input: {
   });
   const index: {
     fingerprint: string;
-    instrumentation?: string;
+    instrumentation?: MaterializedInstrumentation;
     moduleMap: string;
-    version: 2;
+    version: 3;
   } = {
     fingerprint: fingerprint.digest("hex"),
     moduleMap: moduleMapPath,
-    version: 2,
+    version: 3,
   };
-  if (instrumentationPath !== undefined) {
-    index.instrumentation = instrumentationPath;
+  if (instrumentation !== undefined) {
+    index.instrumentation = instrumentation;
   }
   await writeFile(join(compileRoot, MATERIALIZED_MODULES_INDEX), `${JSON.stringify(index)}\n`);
   return index;
@@ -106,17 +132,37 @@ export async function readMaterializedAuthoredModuleIndex(
     await readFile(indexPath, "utf8"),
   ) as Partial<MaterializedAuthoredModuleIndex>;
   if (
-    parsed.version !== 2 ||
+    parsed.version !== 3 ||
     typeof parsed.fingerprint !== "string" ||
     parsed.fingerprint.length === 0 ||
     typeof parsed.moduleMap !== "string" ||
     parsed.moduleMap.length === 0 ||
-    (parsed.instrumentation !== undefined && typeof parsed.instrumentation !== "string")
+    !isMaterializedInstrumentation(parsed.instrumentation)
   ) {
     throw new Error(`Invalid materialized authored module index at "${indexPath}".`);
   }
 
   return parsed as MaterializedAuthoredModuleIndex;
+}
+
+function isMaterializedInstrumentation(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (typeof value !== "object" || value === null) return false;
+
+  const candidate = value as Partial<MaterializedInstrumentation>;
+  if (candidate.kind === "config") {
+    return typeof (candidate as { modulePath?: unknown }).modulePath === "string";
+  }
+  if (candidate.kind === "providers") {
+    const paths = (candidate as { modulePathsBySlot?: unknown }).modulePathsBySlot;
+    return (
+      typeof paths === "object" &&
+      paths !== null &&
+      Object.values(paths).every((path) => typeof path === "string")
+    );
+  }
+
+  return false;
 }
 
 async function readCompiledManifest(path: string): Promise<CompiledAgentManifest> {
@@ -127,17 +173,6 @@ async function readCompiledManifest(path: string): Promise<CompiledAgentManifest
   }
 
   return manifest;
-}
-
-function resolveInstrumentationModule(agentRoot: string): string | undefined {
-  for (const extension of INSTRUMENTATION_EXTENSIONS) {
-    const candidate = join(agentRoot, `instrumentation${extension}`);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  return undefined;
 }
 
 function createMaterializedModuleFileName(nodeId: string, sourceId: string, code: string): string {

--- a/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/dev-generation-artifacts.scenario.test.ts
@@ -13,6 +13,7 @@ import {
   stageDevelopmentGeneration,
 } from "#internal/nitro/development-generation.js";
 import { createAuthoredSourceRuntimeCompiledArtifactsSource } from "#internal/application/runtime-compiled-artifacts-source.js";
+import type { MaterializedInstrumentation } from "#internal/materialized-authored-modules.js";
 import { useScenarioApp } from "#internal/testing/scenario-app.js";
 
 describe("development generation artifacts", () => {
@@ -454,9 +455,12 @@ describe("development generation artifacts", () => {
         join(first.runtimeAppRoot, ".eve", "compile", "authored-modules.json"),
         "utf8",
       ),
-    ) as { readonly instrumentation?: string };
+    ) as { readonly instrumentation?: MaterializedInstrumentation };
+    if (firstIndex.instrumentation?.kind !== "config") {
+      throw new Error("expected materialized config instrumentation");
+    }
     const materializedInstrumentation = await readFile(
-      join(first.runtimeAppRoot, ".eve", "compile", firstIndex.instrumentation!),
+      join(first.runtimeAppRoot, ".eve", "compile", firstIndex.instrumentation.modulePath),
       "utf8",
     );
 

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -216,6 +216,7 @@ describe("application Nitro creation", () => {
     const { createDevelopmentApplicationNitro } =
       await import("#internal/nitro/host/create-application-nitro.js");
     const preparedHost = createPreparedHost();
+    preparedHost.compiledArtifacts.instrumentationLayout = { kind: "config" };
     preparedHost.compiledArtifacts.instrumentationPluginPath = "/app/instrumentation.mjs";
 
     await createDevelopmentApplicationNitro(preparedHost);
@@ -225,6 +226,32 @@ describe("application Nitro creation", () => {
     expect(plugins).not.toEqual(
       expect.arrayContaining([expect.stringContaining("local-tracing-runtime-plugin.ts")]),
     );
+  });
+
+  it("keeps local tracing beside provider slots unless local is authored", async () => {
+    const { createDevelopmentApplicationNitro } =
+      await import("#internal/nitro/host/create-application-nitro.js");
+
+    for (const [slots, expectsLocal] of [
+      ["rows", true],
+      ["local", false],
+    ] as const) {
+      const nitroStub = createNitroStub();
+      createNitroMock.mockResolvedValueOnce(nitroStub.nitro);
+      const preparedHost = createPreparedHost();
+      preparedHost.compiledArtifacts.instrumentationLayout = {
+        kind: "providers",
+        slots: [slots],
+      };
+      preparedHost.compiledArtifacts.instrumentationPluginPath = "/app/instrumentation.mjs";
+
+      await createDevelopmentApplicationNitro(preparedHost);
+
+      const plugins = createNitroMock.mock.calls.at(-1)?.[0].plugins as string[];
+      expect(plugins.some((plugin) => plugin.includes("local-tracing-runtime-plugin.ts"))).toBe(
+        expectsLocal,
+      );
+    }
   });
 
   it("preserves workflow bundle side effects and skips workflow transform for cached bundles", async () => {

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -519,9 +519,11 @@ function addDynamicCapabilityTransformPlugin(nitro: Nitro): void {
  */
 function addInstrumentationModuleSideEffectsPlugin(
   nitro: Nitro,
-  instrumentationModulePath: string,
+  instrumentationModulePaths: readonly string[],
 ): void {
-  const normalizedInstrumentationModulePath = normalizePath(instrumentationModulePath);
+  const normalizedInstrumentationModulePaths = new Set(
+    instrumentationModulePaths.map(normalizePath),
+  );
 
   nitro.hooks.hook("rollup:before", (_nitro, config) => {
     if (!Array.isArray(config.plugins)) {
@@ -531,7 +533,7 @@ function addInstrumentationModuleSideEffectsPlugin(
     config.plugins.unshift({
       name: "eve:instrumentation-module-side-effects",
       resolveId(source: string) {
-        if (normalizePath(source) !== normalizedInstrumentationModulePath) {
+        if (!normalizedInstrumentationModulePaths.has(normalizePath(source))) {
           return null;
         }
 
@@ -681,10 +683,10 @@ function configureSharedApplicationNitro(
 
   addDynamicCapabilityTransformPlugin(nitro);
 
-  if (preparedHost.compiledArtifacts.instrumentationSourcePath !== undefined) {
+  if (preparedHost.compiledArtifacts.instrumentationSourcePaths !== undefined) {
     addInstrumentationModuleSideEffectsPlugin(
       nitro,
-      preparedHost.compiledArtifacts.instrumentationSourcePath,
+      preparedHost.compiledArtifacts.instrumentationSourcePaths,
     );
   }
 }
@@ -730,7 +732,13 @@ export async function createDevelopmentApplicationNitro(
   const nitroBuildDir = preparedHost.workspace.nitroBuildDir;
   const bundler = createApplicationNitroBundlerConfiguration(preparedHost, undefined);
   const plugins = createApplicationNitroPlugins(preparedHost);
-  if (preparedHost.compiledArtifacts.instrumentationPluginPath === undefined) {
+  const instrumentationLayout = preparedHost.compiledArtifacts.instrumentationLayout;
+  const providersKeepDefaultLocalTracing =
+    instrumentationLayout?.kind === "providers" && !instrumentationLayout.slots.includes("local");
+  if (
+    preparedHost.compiledArtifacts.instrumentationPluginPath === undefined ||
+    providersKeepDefaultLocalTracing
+  ) {
     plugins.unshift(
       resolvePackageSourceFilePath("src/internal/nitro/host/local-tracing-runtime-plugin.ts"),
     );

--- a/packages/eve/src/internal/nitro/host/dev-host-fingerprint.integration.test.ts
+++ b/packages/eve/src/internal/nitro/host/dev-host-fingerprint.integration.test.ts
@@ -20,6 +20,7 @@ afterEach(async () => {
 
 interface HostVariant {
   readonly channels?: CompiledAgentManifest["channels"];
+  readonly instrumentationSlot?: string;
   readonly instrumentationSource?: string;
   readonly schedules?: CompiledAgentManifest["schedules"];
   readonly workflowWorld?: "local" | "vercel";
@@ -55,7 +56,15 @@ async function createHost(variant: HostVariant = {}): Promise<PreparedDevelopmen
     appRoot,
     compiledArtifacts: {
       bootstrapPath: join(appRoot, "bootstrap.mjs"),
-      instrumentationSourcePath,
+      ...(instrumentationSourcePath === undefined
+        ? {}
+        : {
+            instrumentationLayout:
+              variant.instrumentationSlot === undefined
+                ? ({ kind: "config" } as const)
+                : ({ kind: "providers", slots: [variant.instrumentationSlot] } as const),
+            instrumentationSourcePaths: [instrumentationSourcePath],
+          }),
       workflowWorldPluginPath: join(appRoot, "workflow-world.mjs"),
     },
     compileResult: { manifest } as PreparedDevelopmentApplicationHost["compileResult"],
@@ -79,6 +88,18 @@ describe("computeDevelopmentHostFingerprint", () => {
     );
 
     expect(changed).not.toBe(base);
+  });
+
+  it("treats provider slot names as structural", async () => {
+    const source = "export default {}\n";
+    const first = await computeDevelopmentHostFingerprint(
+      await createHost({ instrumentationSlot: "a", instrumentationSource: source }),
+    );
+    const renamed = await computeDevelopmentHostFingerprint(
+      await createHost({ instrumentationSlot: "b", instrumentationSource: source }),
+    );
+
+    expect(renamed).not.toBe(first);
   });
 
   it("treats channel route topology as structural", async () => {

--- a/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
+++ b/packages/eve/src/internal/nitro/host/dev-host-fingerprint.ts
@@ -43,12 +43,21 @@ export async function computeDevelopmentHostFingerprint(
   return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }
 
-async function readInstrumentationSource(
-  host: PreparedDevelopmentApplicationHost,
-): Promise<string | null> {
-  const path = host.compiledArtifacts.instrumentationSourcePath;
-  if (path === undefined) {
+async function readInstrumentationSource(host: PreparedDevelopmentApplicationHost): Promise<{
+  readonly kind: "config" | "providers";
+  readonly modules: readonly { readonly slot: string | null; readonly source: string }[];
+} | null> {
+  const paths = host.compiledArtifacts.instrumentationSourcePaths;
+  const layout = host.compiledArtifacts.instrumentationLayout;
+  if (paths === undefined || layout === undefined) {
     return null;
   }
-  return await readFile(path, "utf8");
+  const sources = await Promise.all(paths.map(async (path) => await readFile(path, "utf8")));
+  return {
+    kind: layout.kind,
+    modules: sources.map((source, index) => ({
+      slot: layout.kind === "providers" ? (layout.slots[index] ?? null) : null,
+      source,
+    })),
+  };
 }

--- a/packages/eve/src/internal/nitro/host/prepare-application-host.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/prepare-application-host.scenario.test.ts
@@ -108,9 +108,9 @@ describe("application host preparation", () => {
       join(firstHostDirectory, "compiled-artifacts-workflow-world.mjs"),
     );
     expect(firstHost.compiledArtifacts.bootstrapPath).not.toContain("/.eve/dev-runtime/snapshots/");
-    expect(firstHost.compiledArtifacts.instrumentationSourcePath).toBe(
+    expect(firstHost.compiledArtifacts.instrumentationSourcePaths).toEqual([
       join(firstHostDirectory, "compiled-artifacts-instrumentation-source.mjs"),
-    );
+    ]);
     expect(await readFile(firstBootstrapPath, "utf8")).not.toContain(
       normalizeEsmImportSpecifier(agentModulePath),
     );

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -165,11 +165,18 @@ function typeOnlyFixtures(): void {
   // @ts-expect-error Instructions identity is path-derived.
   defineInstructions(instructionsWithName);
 
+  defineInstrumentation({
+    isEnabled: true,
+    recordInputs: true,
+  });
+
+  // Unlike the helpers above, `defineInstrumentation` takes a generic union — a
+  // config and a provider overlap on `events` and `setup` — so it cannot use
+  // `ExactDefinition`. Excess keys reach `eve build` instead.
   const instrumentationWithEnabled = {
     isEnabled: true,
     recordInputs: true,
   };
-  // @ts-expect-error Instrumentation has no separate enable toggle.
   defineInstrumentation(instrumentationWithEnabled);
 
   defineInstrumentation({

--- a/packages/eve/src/public/instrumentation/index.ts
+++ b/packages/eve/src/public/instrumentation/index.ts
@@ -1,14 +1,20 @@
-import type { ExactDefinition } from "#public/definitions/exact.js";
-
 /**
- * Instrumentation authoring helpers for `agent/instrumentation.ts`.
+ * Instrumentation authoring helpers for `agent/instrumentation.ts` and, with
+ * `experimental.instrumentationProviders` on, `agent/instrumentation/`.
  */
 
 import type { ModelMessage, SystemModelMessage } from "ai";
 
 import type { SessionAuthContext, SessionParent } from "#channel/types.js";
 import type { InstrumentationChannel } from "#public/channels/index.js";
+import {
+  PROVIDER,
+  type ProviderDefinition,
+  type ProviderSetupContext,
+} from "#public/instrumentation/provider.js";
 import type { JsonObject } from "#shared/json.js";
+
+export * from "#public/instrumentation/provider.js";
 
 // Re-export channel metadata types so existing `eve/instrumentation`
 // imports continue to work. The canonical home is `eve/channels`.
@@ -23,14 +29,13 @@ export {
 
 /**
  * Context passed to the {@link InstrumentationDefinition.setup} callback.
+ *
+ * The same context both layouts receive. Keeping one type is what gives
+ * {@link defineInstrumentation}'s union a contextual signature for `setup`;
+ * two divergent ones would leave every authored `setup(context)` parameter an
+ * implicit `any`.
  */
-export interface InstrumentationSetupContext {
-  /**
-   * The agent name declared by `defineAgent`. Use as the `serviceName` for
-   * `registerOTel` instead of a hard-coded string.
-   */
-  readonly agentName: string;
-}
+export type InstrumentationSetupContext = ProviderSetupContext;
 
 /**
  * User-authored runtime context values attached to AI SDK telemetry spans.
@@ -161,21 +166,39 @@ export interface InstrumentationDefinition {
    */
   readonly traceChannelRequests?: boolean;
   /**
-   * Setup callback invoked at server startup with the resolved agent name.
-   * Use it to call `registerOTel` or other OTel provider setup;
-   * `context.agentName` comes from `defineAgent`.
+   * Setup callback invoked at server startup, before the first request. Use it
+   * to call `registerOTel` or other OTel provider setup; `context.agentName`
+   * comes from `defineAgent`. A returned promise is awaited.
    */
-  readonly setup?: (context: InstrumentationSetupContext) => void;
+  readonly setup?: (context: InstrumentationSetupContext) => void | PromiseLike<void>;
 }
 
 /**
- * Export the result as the default export of `agent/instrumentation.ts`. eve
- * reads these settings at server startup and applies them to every AI SDK
- * model call. The `setup` callback runs later with the resolved agent name,
- * not during `defineInstrumentation` itself.
+ * Declares instrumentation, in either of eve's two layouts.
+ *
+ * Export the result as the default export of `agent/instrumentation.ts`, or —
+ * with `experimental.instrumentationProviders` on — of one file under
+ * `agent/instrumentation/`. The layout decides how eve reads the value; the two
+ * are mutually exclusive builds, so only one can apply. `setup` runs at server
+ * startup, not during this call.
+ *
+ * The parameter is a union because a provider and a legacy config overlap on
+ * `events` and `setup`, so no value-level check separates them. One consequence
+ * is that excess-property checking is weaker here than it was against the
+ * config shape alone, and a misspelled key can reach `eve build` rather than
+ * failing at `tsc`.
  */
-export function defineInstrumentation<T extends InstrumentationDefinition>(
-  definition: ExactDefinition<T, InstrumentationDefinition>,
-): T {
-  return definition;
+export function defineInstrumentation<
+  const TDefinition extends InstrumentationDefinition | ProviderDefinition,
+>(definition: TDefinition): InstrumentationDeclaration<TDefinition> {
+  return { ...definition, [PROVIDER]: true };
 }
+
+/** The branded result of {@link defineInstrumentation}. */
+export type InstrumentationDeclaration<
+  TDefinition extends InstrumentationDefinition | ProviderDefinition =
+    | InstrumentationDefinition
+    | ProviderDefinition,
+> = TDefinition & {
+  readonly [PROVIDER]: true;
+};

--- a/packages/eve/src/public/instrumentation/provider.test.ts
+++ b/packages/eve/src/public/instrumentation/provider.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defineInstrumentation,
+  disableInstrumentation,
+  isInstrumentationDisabled,
+  isInstrumentationProvider,
+} from "#public/instrumentation/index.js";
+
+describe("defineInstrumentation", () => {
+  it("brands a provider-shaped declaration", () => {
+    const provider = defineInstrumentation({
+      events: {
+        "session.started"(event) {
+          void event.sessionId;
+        },
+      },
+    });
+
+    expect(isInstrumentationProvider(provider)).toBe(true);
+  });
+
+  it("brands a legacy config-shaped declaration", () => {
+    const config = defineInstrumentation({ functionId: "support", recordInputs: false });
+
+    expect(isInstrumentationProvider(config)).toBe(true);
+    expect(config.functionId).toBe("support");
+    expect(config).toMatchObject({ functionId: "support", recordInputs: false });
+  });
+
+  it("infers terminal handler events from union-typed discriminants", () => {
+    const provider = defineInstrumentation({
+      events: {
+        "session.completed": (event) => void event.sessionId,
+        "step.attempt.completed": (event) => void event.scope,
+        "turn.failed": (event) => void event.error,
+      },
+    });
+
+    expect(isInstrumentationProvider(provider)).toBe(true);
+  });
+
+  it("preserves the authored fields", () => {
+    const setup = (): void => {};
+    const declaration = defineInstrumentation({ setup });
+
+    expect(declaration).toMatchObject({ setup });
+  });
+});
+
+describe("isInstrumentationProvider", () => {
+  it("rejects a value that never went through defineInstrumentation", () => {
+    expect(isInstrumentationProvider({ events: {} })).toBe(false);
+  });
+
+  it.each([[null], [undefined], ["provider"], [42]])("rejects %p", (value) => {
+    expect(isInstrumentationProvider(value)).toBe(false);
+  });
+});
+
+describe("disableInstrumentation", () => {
+  it("is recognizable as a disabled slot rather than a provider", () => {
+    const disabled = disableInstrumentation();
+
+    expect(isInstrumentationDisabled(disabled)).toBe(true);
+    expect(isInstrumentationProvider(disabled)).toBe(false);
+  });
+
+  it("does not treat a provider as a disabled slot", () => {
+    expect(isInstrumentationDisabled(defineInstrumentation({}))).toBe(false);
+  });
+});

--- a/packages/eve/src/public/instrumentation/provider.ts
+++ b/packages/eve/src/public/instrumentation/provider.ts
@@ -1,0 +1,157 @@
+/**
+ * The provider contract authored under `agent/instrumentation/`.
+ *
+ * Reachable only with `experimental.instrumentationProviders` on. With the flag
+ * off nothing discovers that directory, so these types compile but never run.
+ */
+
+// Type-only, so nothing couples the public entrypoint to the harness at
+// runtime. The event shapes are eve's own vocabulary; deriving the handler map
+// from the union below is what keeps the public contract from drifting away
+// from the bus that feeds it.
+import type { InstrumentationEvent } from "#harness/instrumentation-lifecycle.js";
+
+export type {
+  InstrumentationActionKind,
+  InstrumentationAttemptScope,
+  InstrumentationContentPart,
+  InstrumentationEvent,
+  InstrumentationModelCallCompletedEvent,
+  InstrumentationModelCallFailedEvent,
+  InstrumentationModelCallStartedEvent,
+  InstrumentationModelRef,
+  InstrumentationOperationRef,
+  InstrumentationParentLineage,
+  InstrumentationSessionStartedEvent,
+  InstrumentationSessionTransitionEvent,
+  InstrumentationStepAttemptMetadataEvent,
+  InstrumentationStepAttemptStartedEvent,
+  InstrumentationStepAttemptTerminalEvent,
+  InstrumentationToolCallCompletedEvent,
+  InstrumentationToolCallFailedEvent,
+  InstrumentationToolCallStartedEvent,
+  InstrumentationToolOutput,
+  InstrumentationTraceContext,
+  InstrumentationTurnStartedEvent,
+  InstrumentationTurnTerminalEvent,
+  InstrumentationUsage,
+} from "#harness/instrumentation-lifecycle.js";
+
+/**
+ * Marks a value as having come from `defineInstrumentation` or a built-in
+ * factory.
+ *
+ * It does not say which layout the value belongs to: a provider and a legacy
+ * config both carry `events` and `setup`, so no value-level check separates
+ * them. The layout decides — `agent/instrumentation.ts` is read as a config and
+ * `agent/instrumentation/*.ts` as providers, and the two are mutually exclusive
+ * builds. The brand's job is only to catch a default export that never went
+ * through eve at all.
+ */
+export const PROVIDER = Symbol.for("eve.instrumentation.provider");
+
+/** Marks a slot the author turned off rather than configured. */
+export const DISABLED = Symbol.for("eve.instrumentation.disabled");
+
+/** Where the agent is running when `setup` fires. */
+export type InstrumentationEnvironment = "development" | "preview" | "production";
+
+/**
+ * Passed to {@link InstrumentationProvider.setup} once at server startup,
+ * before any event is published.
+ */
+export interface ProviderSetupContext {
+  /** The agent name declared by `defineAgent`. */
+  readonly agentName: string;
+  readonly environment: InstrumentationEnvironment;
+  /** The eve version running the agent. */
+  readonly frameworkVersion: string;
+}
+
+/**
+ * The second argument to every handler.
+ *
+ * Empty today. It exists now so adding durable per-provider state later is an
+ * additive change rather than a second break in every handler signature.
+ */
+export type ProviderContext = Readonly<Record<never, never>>;
+
+/**
+ * One event handler.
+ *
+ * eve balances every start with exactly one terminal, so a handler that needs
+ * to carry a value from a start to its terminal can key its own map on
+ * `event.id` and delete on the terminal.
+ */
+export type Handler<TEvent> = (event: TEvent, ctx: ProviderContext) => void | PromiseLike<void>;
+
+type EventForType<TEvent, TType> = TEvent extends { readonly type: infer TEventType }
+  ? TType extends TEventType
+    ? TEvent & { readonly type: TType }
+    : never
+  : never;
+
+/**
+ * The events a provider may handle, one optional handler per event type.
+ *
+ * Derived from the event union rather than written out, so a new event reaches
+ * providers the moment the bus can publish it.
+ */
+export type ProviderEvents = {
+  readonly [TType in InstrumentationEvent["type"]]?: Handler<
+    EventForType<InstrumentationEvent, TType>
+  >;
+};
+
+/**
+ * What an author writes for one file under `agent/instrumentation/`.
+ *
+ * Handlers are dispatched in file order and failure-isolated: a handler that
+ * throws is logged and the next provider still runs.
+ */
+export interface ProviderDefinition {
+  readonly events?: ProviderEvents;
+  /** Runs once at server startup, before any event is published. */
+  readonly setup?: (context: ProviderSetupContext) => void | PromiseLike<void>;
+  /** Drains anything buffered. eve calls this before a session goes idle. */
+  readonly flush?: () => void | PromiseLike<void>;
+  /** Releases resources when the process is going away. */
+  readonly shutdown?: () => void | PromiseLike<void>;
+}
+
+/** A {@link ProviderDefinition} that has been through `defineInstrumentation`. */
+export type InstrumentationProvider = ProviderDefinition & {
+  readonly [PROVIDER]: true;
+};
+
+/** A slot the author turned off. eve registers nothing for it. */
+export interface InstrumentationDisabled {
+  readonly [DISABLED]: true;
+}
+
+/**
+ * Turns off the slot the file it is exported from names.
+ *
+ * Export it as the default of `agent/instrumentation/local.ts` to stop eve
+ * spooling local traces, for instance. Omitting the file entirely leaves eve's
+ * default in place, which is why turning one off takes a value.
+ */
+export function disableInstrumentation(): InstrumentationDisabled {
+  return { [DISABLED]: true };
+}
+
+export function isInstrumentationProvider(value: unknown): value is InstrumentationProvider {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<InstrumentationProvider>)[PROVIDER] === true
+  );
+}
+
+export function isInstrumentationDisabled(value: unknown): value is InstrumentationDisabled {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<InstrumentationDisabled>)[DISABLED] === true
+  );
+}

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -227,6 +227,7 @@ function createResolvedAgentConfig(manifest: CompiledAgentNodeManifest): Resolve
 
   if (manifest.config.experimental !== undefined) {
     config.experimental = {
+      instrumentationProviders: manifest.config.experimental.instrumentationProviders,
       subagentPersistentSessions: manifest.config.experimental.subagentPersistentSessions,
       workflow:
         manifest.config.experimental.workflow === undefined

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -197,6 +197,15 @@ export interface AgentLimitsDefinition {
  */
 export interface AgentExperimentalDefinition {
   /**
+   * Reads instrumentation from an `instrumentation/` directory of providers
+   * rather than a single `agent/instrumentation.ts` config object.
+   *
+   * The two layouts are mutually exclusive: with this on, an
+   * `agent/instrumentation.ts` is a build error, and with it off, an
+   * `instrumentation/` directory is.
+   */
+  readonly instrumentationProviders?: boolean;
+  /**
    * Keeps this agent's delegated subagent sessions alive after they answer.
    * The model can pass `agentId` to a subagent tool to continue a previous
    * delegation, and the system prompt documents the `<agents>` listing.

--- a/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
@@ -20,6 +20,10 @@ const createAppRoot = useTemporaryAppRoots();
 describe("writeCompiledArtifactsFiles", () => {
   afterEach(() => {
     delete (globalThis as Record<string, unknown>).__eveInstrumentationLoaded;
+    delete (globalThis as Record<string, unknown>).__eveProviderSetups;
+    delete (globalThis as Record<symbol, unknown>)[
+      Symbol.for("eve.harness-instrumentation-providers")
+    ];
   });
 
   it("installs compile metadata into bundled compiled artifacts", async () => {
@@ -110,6 +114,84 @@ describe("writeCompiledArtifactsFiles", () => {
 
     expect((globalThis as Record<string, unknown>).__eveInstrumentationLoaded).toBe("yes");
     expect(instrumentationPluginModule.default()).toBeUndefined();
+  });
+
+  it("registers one provider per file when the instrumentationProviders flag is on", async () => {
+    const { agentRoot, appRoot } = await createAppRoot("eve-compiled-artifacts-providers-", {
+      packageName: "compiled-artifacts-providers-test-agent",
+    });
+    const outDir = join(appRoot, ".workflow-build");
+    const definePath = resolvePackageSourceFilePath(
+      "src/public/instrumentation/index.ts",
+    ).replaceAll("\\", "/");
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      [
+        "export default {",
+        '  model: "openai/gpt-5.4",',
+        "  experimental: { instrumentationProviders: true },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(join(agentRoot, "instructions.md"), "You are a precise assistant.\n");
+    await mkdir(join(agentRoot, "instrumentation"), { recursive: true });
+    for (const slot of ["local", "otel"]) {
+      await writeFile(
+        join(agentRoot, "instrumentation", `${slot}.ts`),
+        [
+          `import { defineInstrumentation } from ${JSON.stringify(definePath)};`,
+          "",
+          "const container = globalThis as Record<string, unknown>;",
+          "",
+          "export default defineInstrumentation({",
+          "  setup(context) {",
+          "    container.__eveProviderSetups ??= [];",
+          `    (container.__eveProviderSetups as string[]).push(\`${slot}:\${context.agentName}\`);`,
+          "  },",
+          "});",
+          "",
+        ].join("\n"),
+      );
+    }
+
+    const compileResult = await compileAgent({ startPath: appRoot });
+    const generatedArtifacts = await writeCompiledArtifactsFiles({
+      compileResult,
+      defaultWorkflowWorld: "local",
+      outDir,
+    });
+    const instrumentationPluginPath = generatedArtifacts.instrumentationPluginPath;
+
+    if (instrumentationPluginPath === undefined) {
+      throw new Error("Expected instrumentation plugin path to be generated.");
+    }
+
+    expect(generatedArtifacts.instrumentationSourcePaths).toEqual([
+      join(agentRoot, "instrumentation", "local.ts"),
+      join(agentRoot, "instrumentation", "otel.ts"),
+    ]);
+
+    const instrumentationPluginSource = await readFile(instrumentationPluginPath, "utf8");
+
+    expect(instrumentationPluginSource).toContain('slot: "local"');
+    expect(instrumentationPluginSource).toContain('slot: "otel"');
+    expect(instrumentationPluginSource).not.toContain("registerInstrumentationConfig");
+
+    await import(pathToFileURL(instrumentationPluginPath).href);
+
+    // The plugin resolves the registry by absolute path while the assertion
+    // resolves it by package alias, so this also proves the globalThis rooting
+    // survives two module instances.
+    const { getInstrumentationProviders } =
+      await import("../../src/harness/instrumentation-providers.js");
+
+    expect((globalThis as Record<string, unknown>).__eveProviderSetups).toEqual([
+      "local:compiled-artifacts-providers-test-agent",
+      "otel:compiled-artifacts-providers-test-agent",
+    ]);
+    expect(getInstrumentationProviders().map((entry) => entry.slot)).toEqual(["local", "otel"]);
   });
 
   it("surfaces instrumentation import failures when the Nitro plugin module loads", async () => {


### PR DESCRIPTION
### Summary

Related to #1659. Fifth in the instrumentation-provider stack, on top of #1686.

This adds the off-by-default `experimental.instrumentationProviders` flag. With it off, eve continues compiling `agent/instrumentation.ts` and rejects an `agent/instrumentation/` directory. With it on, eve rejects the single config, bundles supported modules under `agent/instrumentation/`, derives deterministic slots from their paths, and rejects duplicate slots or unbranded default exports. `disableInstrumentation()` leaves a claimed slot empty; in development, local tracing remains the default unless the provider layout claims `local`.

The new provider contract exposes typed lifecycle handlers and `setup`/`flush`/`shutdown` hooks. Generated startup awaits each provider's `setup`, but this layer does not yet connect provider handlers to the instrumentation runtime; that follows in #1813.

Both layouts now share `InstrumentationSetupContext`, so existing config authors gain `environment` and `frameworkVersion`, and asynchronous `setup` is awaited. Because `defineInstrumentation` accepts the overlapping config/provider union, its previous excess-property checking is weaker.

### Validation

- `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`
- `pnpm typecheck` - 33/33 projects
- `pnpm test:unit` - 6,070 passed, 1 skipped
- `pnpm test:integration` - 617 passed across 87 files
- `compiled-artifacts-bootstrap` and `prepare-application-host` scenarios - 8 passed
- The flag-on scenario compiles a real agent and imports the generated Nitro plugin, asserting module discovery, slot order, and awaited setup
- E2E and `pnpm dev` with the flag on were not run locally

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
