### PR TITLE
feat(eve): harden the instrumentation bus and wire providers to it

### DIFF
--- a/.changeset/instrumentation-provider-runtime.md
+++ b/.changeset/instrumentation-provider-runtime.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Wire authored instrumentation providers into eve's runtime bus and lifecycle-owned flush and shutdown handling.

--- a/packages/eve/src/harness/instrumentation-providers.test.ts
+++ b/packages/eve/src/harness/instrumentation-providers.test.ts
@@ -151,30 +151,58 @@ describe("seedInstrumentationProviders", () => {
 });
 
 describe("finalizeInstrumentationProviders", () => {
+  const turnStarted = {
+    idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+    rootSessionId: "session-1",
+    sequence: 0,
+    sessionId: "session-1",
+    turnId: "turn-1",
+    type: "turn.started",
+  } as const;
+
   beforeEach(() => {
     vi.unstubAllEnvs();
     delete (globalThis as Record<symbol, unknown>)[REGISTRY_GLOBAL_KEY];
     delete (globalThis as Record<symbol, unknown>)[RUNTIME_GLOBAL_KEY];
   });
 
-  it("installs a bus for authored providers without an OpenTelemetry destination", async () => {
+  it("publishes to an authored handler", async () => {
     const started = vi.fn();
     await register("rows", defineInstrumentation({ events: { "turn.started": started } }));
 
     const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
-    await runtime.hooks.publish({
-      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
-      rootSessionId: "session-1",
-      sequence: 0,
-      sessionId: "session-1",
-      turnId: "turn-1",
-      type: "turn.started",
-    });
+    await runtime.hooks.publish(turnStarted);
 
     expect(started).toHaveBeenCalledOnce();
+    expect(started.mock.calls[0]?.[0]).toMatchObject({ turnId: "turn-1" });
   });
 
-  it("drives authored flush and shutdown hooks", async () => {
+  it("still runs execution when no destination was declared", async () => {
+    // A directory with no `otel()` has nothing to hang a span on, so
+    // `runInContext` degrades to running the work directly rather than
+    // going missing.
+    await register("rows", defineInstrumentation({}));
+
+    const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
+    const result = await runtime.runInContext(
+      {
+        idempotencyKey: "tool:session-1:turn-1:0:0:call-1:0",
+        scope: {
+          attemptId: "session-1:turn-1:0:0",
+          attemptIndex: 0,
+          sessionId: "session-1",
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "tool.call",
+      },
+      () => Promise.resolve("ran"),
+    );
+
+    expect(result).toBe("ran");
+  });
+
+  it("drains and releases every provider", async () => {
     const flush = vi.fn();
     const shutdown = vi.fn();
     await register("rows", defineInstrumentation({ flush, shutdown }));

--- a/packages/eve/src/harness/instrumentation-providers.ts
+++ b/packages/eve/src/harness/instrumentation-providers.ts
@@ -95,16 +95,17 @@ export function getInstrumentationProviders(): readonly RegisteredInstrumentatio
 }
 
 /**
- * Builds the process's OpenTelemetry pipeline from the registered providers.
+ * Installs the process instrumentation runtime from the registered providers.
  *
  * Called once by the generated Nitro plugin after every slot has registered,
- * which is also why it cannot happen inside `setup`: the pipeline is the union
- * of every destination declared in the directory, so no single file knows
- * enough to build it. A `setup` that reaches for a tracer therefore gets the
- * no-op one; declare destinations as values and let this assemble them.
+ * which is also why it cannot happen inside `setup`: the OpenTelemetry pipeline
+ * is the union of every destination declared in the directory, so no single
+ * file knows enough to build it. A `setup` that reaches for a tracer therefore
+ * gets the no-op one; declare destinations as values and let this assemble
+ * them.
  *
- * A directory that declared no OpenTelemetry at all leaves the global tracer
- * provider slot alone.
+ * A directory that declared no OpenTelemetry at all still gets a bus. Its
+ * providers see every event; they just have no spans to hang them on.
  *
  * @internal — not part of the public API.
  */
@@ -120,17 +121,29 @@ export function finalizeInstrumentationProviders(input: {
   });
 }
 
-/** Drains and releases the process runtime from Nitro's close hook. */
+/**
+ * Releases every registered provider and OTel processor from Nitro's close
+ * hook, the last point a buffered exporter can still reach the network.
+ */
 export async function shutdownInstrumentationProviders(): Promise<void> {
   await getInstrumentationRuntime()?.shutdown();
 }
 
+/**
+ * Adapts an authored provider onto the internal bus contract.
+ *
+ * The event maps are the same shape — the public one is derived from the
+ * internal union and both handlers take `(event, ctx)` — so only the name has
+ * to be supplied.
+ */
 function toProviderDefinition(
   entry: RegisteredInstrumentationProvider,
 ): InstrumentationProviderDefinition {
   return {
     events: entry.provider.events as InstrumentationProviderDefinition["events"],
     flush: entry.provider.flush,
+    // The file the provider came from, which is the only name an author can
+    // recognize in a log line about it.
     name: entry.slot,
     shutdown: entry.provider.shutdown,
   };

--- a/packages/eve/src/internal/application/compiled-artifacts.ts
+++ b/packages/eve/src/internal/application/compiled-artifacts.ts
@@ -480,6 +480,7 @@ function createInstrumentationPluginSource(input: {
     "// Default export satisfies the Nitro plugin contract so this file",
     "// can be used directly as a Nitro plugin without a separate wrapper.",
     "export default function installInstrumentationPlugin(nitroApp) {",
+    "  // The last point a buffered exporter can still reach the network.",
     "  nitroApp?.hooks?.hook('close', async () => {",
     "    await shutdownInstrumentationProviders();",
     "  });",

--- a/packages/eve/src/tracing/install-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.ts
@@ -19,7 +19,16 @@ import { registerOtelPipeline, type RegisteredOtelPipeline } from "#tracing/otel
 
 const log = createLogger("tracing.install-instrumentation-runtime");
 
-/** Installs the bus and the one OpenTelemetry pipeline collected for this process. */
+/**
+ * Installs the process instrumentation runtime around a collected pipeline.
+ *
+ * Both layouts land here. `eve dev`'s zero-config default and an authored
+ * `agent/instrumentation/` directory differ only in where the declared values
+ * came from, so sharing the install keeps them on one runtime path.
+ *
+ * A directory that declared no OpenTelemetry still gets a bus: its providers
+ * see every event, they just have no spans to hang them on.
+ */
 export function installInstrumentationRuntime(input: {
   readonly collected: CollectedOtel;
   readonly frameworkVersion: string;
@@ -44,6 +53,7 @@ export function installInstrumentationRuntime(input: {
       stateStore: new ContextAgentTraceStateStore(),
       tracer: trace.getTracer("eve.agent", input.frameworkVersion),
     });
+    // First, so the span is open before an authored provider sees the event.
     providers.unshift(agentOtel.hook);
     runInContext = agentOtel.runInContext;
 

--- a/packages/eve/src/tracing/otel-registration.scenario.test.ts
+++ b/packages/eve/src/tracing/otel-registration.scenario.test.ts
@@ -1,6 +1,6 @@
 import { context, propagation, trace, type Context } from "@opentelemetry/api";
 import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { registerOtelPipeline } from "#tracing/otel-registration.js";
 
@@ -40,7 +40,8 @@ describe("registerOtelPipeline", () => {
   it("does not export the private registration span", async () => {
     const exporter = new InMemorySpanExporter();
     const processor = new SimpleSpanProcessor(exporter);
-    registerOtelPipeline({
+    const shutdown = vi.spyOn(processor, "shutdown");
+    const runtime = registerOtelPipeline({
       pipeline: { spanProcessors: [processor] },
       serviceName: "weather",
     });
@@ -49,6 +50,7 @@ describe("registerOtelPipeline", () => {
     await processor.forceFlush();
 
     expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual(["user.work"]);
-    await processor.shutdown();
+    await runtime.shutdown();
+    expect(shutdown).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
### Summary

Related to #1659 and the proposal in #1799. Stacked on #1850 and still gated by `experimental.instrumentationProviders`.

This layer adds the release note and closes coverage and documentation around the authored-provider runtime assembled by the preceding stack; it does not change production behavior. Tests explicitly cover lifecycle event delivery to authored handlers, direct execution without an OpenTelemetry destination, and provider flush and shutdown handling.

Scenario coverage verifies that shutting down eve's registered OpenTelemetry runtime shuts down its collected span processors. Comments clarify the shared runtime path, eve's span-hook ordering, and Nitro close-hook ownership.

### Validation

- Full eve unit suite: 6,162 passed, 1 skipped
- Full eve integration suite: 618 passed
- Focused eval, local tracing, registration, and compiled-artifact scenarios: 14 passed
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `oxlint` on changed sources; `pnpm guard:invariants`
- E2E not run locally

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
