### PR TITLE
docs(eve): document the instrumentation provider layout

### DIFF
--- a/.changeset/quiet-integrations-compose.md
+++ b/.changeset/quiet-integrations-compose.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Telemetry integrations registered with the AI SDK's `registerTelemetry` no longer stop receiving events once eve attaches its own instrumentation bridge to a model call. eve now composes its bridge with every registered integration instead of replacing them.

--- a/.changeset/spool-survives-a-backend.md
+++ b/.changeset/spool-survives-a-backend.md
@@ -1,0 +1,10 @@
+---
+"eve": patch
+---
+
+Keep `eve dev`'s local trace spool on when an agent adds a hosted destination
+under the experimental provider layout. Authoring any file in
+`agent/instrumentation/` used to switch local tracing off, contradicting what
+`localTraces()` and `disableInstrumentation()` promise: eve now fills the
+`local` slot by default, so a file only changes the spool when it says
+something about it.

--- a/docs/guides/instrumentation-providers.md
+++ b/docs/guides/instrumentation-providers.md
@@ -1,0 +1,208 @@
+---
+title: "Instrumentation Providers"
+description: "The experimental agent/instrumentation/ directory: one provider per file, the otel() and otelIntegration() split, per-destination content policy, and the lifecycle events providers handle."
+---
+
+Instrumentation providers replace the single `agent/instrumentation.ts` config object with a directory: `agent/instrumentation/`, one provider per file. A provider handles eve's lifecycle events, declares an OpenTelemetry destination, or both. Adding one destination no longer means taking responsibility for every other.
+
+This is experimental and off by default. Turn it on in `defineAgent`:
+
+```ts title="agent/agent.ts"
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-opus-4.8",
+  experimental: {
+    instrumentationProviders: true,
+  },
+});
+```
+
+The two layouts are mutually exclusive builds. With the flag off, an `instrumentation/` directory is a build error; with it on, a leftover `instrumentation.ts` is a build error. eve never silently picks one — telemetry that quietly does nothing is the failure this surface exists to prevent. For the shipped default layout, see [`instrumentation.ts`](./instrumentation).
+
+## One provider per file
+
+The filename is the slot name: `agent/instrumentation/otel.ts` fills the `otel` slot. Slots register in alphabetical order, so what a provider sees does not depend on how the filesystem enumerates the directory. Two files claiming one slot is an error.
+
+```text
+agent/instrumentation/
+  otel.ts        the process-wide OpenTelemetry settings
+  braintrust.ts  a destination
+  local.ts       eve's local trace spool, reconfigured or turned off
+  audit.ts       a provider that only handles events
+```
+
+Each file default-exports the result of `defineInstrumentation` or one of the built-in factories. A default export that never went through eve throws at server startup rather than being skipped.
+
+```ts title="agent/instrumentation/audit.ts"
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName, evaluation }) => {
+    if (evaluation) return;
+    console.log(`auditing ${agentName}`);
+  },
+  events: {
+    "action.started": (event) => {
+      console.log(event.kind, event.name);
+    },
+  },
+});
+```
+
+## OpenTelemetry, in two halves
+
+OpenTelemetry has one process-wide half and one plural half, and the directory splits them the same way.
+
+`otel()` is the settings a process can only hold one of — a process has one tracer provider, so it has one resource, one sampler, and one propagator set. Declaring it twice is a boot error, which one file per slot makes structurally hard to do.
+
+```ts title="agent/instrumentation/otel.ts"
+import { otel } from "eve/instrumentation/otel";
+
+export default otel({
+  traceChannelRequests: true,
+  resource: { "deployment.environment": process.env.VERCEL_ENV ?? "development" },
+});
+```
+
+Omitting this file is the common case. eve registers the pipeline for whatever destinations are declared beside it; `otel()` only names what those destinations share.
+
+`otelIntegration()` is a destination, and there may be as many as there are files. A `traceExporter` is wrapped in eve's batching processor, which is what makes the one-line form enough:
+
+```ts title="agent/instrumentation/braintrust.ts"
+import { BraintrustExporter } from "@braintrust/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
+
+export default otelIntegration({
+  traceExporter: new BraintrustExporter({ filterAISpans: true }),
+});
+```
+
+Pass `spanProcessors` instead when the destination needs its own batching, sampling, or filtering. Both may be given: declared processors come first, and the wrapped exporter is appended after them.
+
+`otel()` and `otelIntegration()` come from `eve/instrumentation/otel`, a separate entrypoint from `eve/instrumentation`.
+
+## Content is per destination
+
+`recordInputs` and `recordOutputs` belong to a destination, not to the process. Content is written onto a span if any destination wants it, and each destination that declined never exports it. A local spool and a hosted backend no longer have to agree:
+
+```ts title="agent/instrumentation/braintrust.ts"
+export default otelIntegration({
+  traceExporter: new BraintrustExporter({ filterAISpans: true }),
+  recordInputs: false,
+  recordOutputs: false,
+});
+```
+
+An agent whose every destination declines still never materializes a prompt — the union of nothing is nothing. Declining wraps every processor in that file, an author's included: they are this destination, and the point of declining is that nothing under it sees what was said. The wrapper copies the span rather than editing it, because the span it is handed is shared with every other destination in the pipeline.
+
+For sensitive, regulated, or production data, decline content on any destination whose retention path you have not reviewed. You are responsible for ensuring an observability or eval provider is approved for what is exported to it.
+
+## Local traces
+
+`eve dev` records spans to disk — one trace per session, read with [`/traces`](./dev-tui#inspect-traces) in the dev TUI or [`eve traces`](../reference/cli#eve-traces) in the terminal. Under the provider layout that spool is a destination like any other, and eve fills the `local` slot with it by default. Adding a hosted backend does not switch it off.
+
+Say something about the slot only when you want to change it. `localTraces()` reconfigures it:
+
+```ts title="agent/instrumentation/local.ts"
+import { localTraces } from "eve/instrumentation/otel";
+
+export default localTraces({ recordInputs: false });
+```
+
+`disableInstrumentation()` removes it:
+
+```ts title="agent/instrumentation/local.ts"
+import { disableInstrumentation } from "eve/instrumentation";
+
+export default disableInstrumentation();
+```
+
+Omitting the file leaves eve's default in place, which is why turning one off takes a value rather than an absence. `EVE_TRACES_CONTENT=off` narrows this destination and no other, so declining content locally leaves what a hosted backend receives alone.
+
+The spool is `eve dev` only: it writes under the dev worker's app root, and a deployed process has nowhere to put it.
+
+## Agent Runs
+
+On Vercel production, eve fills the reserved `agent-runs` slot with `agentRuns()` so the same canonical spans reach Agent Runs without an authored destination. Reconfigure it only when you need a narrower content policy:
+
+```ts title="agent/instrumentation/agent-runs.ts"
+import { agentRuns } from "eve/instrumentation/otel";
+
+export default agentRuns({ recordInputs: false });
+```
+
+Export `disableInstrumentation()` from that file to turn Agent Runs off. Omitting the file leaves the production default in place.
+
+## Lifecycle events
+
+A provider's `events` map takes one handler per event type, each called with `(event, ctx)`:
+
+| Event                                                                                            | Fires when                                                           |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `session.started`, `session.completed`, `session.waiting`, `session.failed`                      | A session begins, settles, parks for input, or fails                 |
+| `turn.started`, `turn.completed`, `turn.cancelled`, `turn.failed`                                | A turn begins or reaches a terminal                                  |
+| `step.attempt.started`, `step.attempt.completed`, `step.attempt.failed`, `step.attempt.metadata` | One model-call attempt within a turn                                 |
+| `model.call.started`, `model.call.completed`, `model.call.failed`                                | The model call itself                                                |
+| `action.started`, `action.completed`, `action.failed`                                            | Every eve dispatch: tool call, skill load, subagent, or remote agent |
+| `tool.call.started`, `tool.call.completed`, `tool.call.failed`                                   | The AI SDK execution boundary for an ordinary tool call              |
+
+An ordinary tool emits both families. `action.*` is eve's durable dispatch boundary and covers work that can settle in another worker; `tool.call.*` is the model SDK's in-process execution boundary. Handle one unless you intentionally want both views.
+
+Every event carries an `idempotencyKey` naming the operation it is about. A start and its terminal share a key when the terminal arrives. An incomplete model stream can close without one, so live resources need step-attempt cleanup or their own expiry.
+
+Handlers are dispatched in slot order and failure-isolated: one that throws is logged and the next provider still runs.
+
+### Carrying a value across a handler pair
+
+`ctx.state` is durable storage scoped to one provider and one operation. Two providers reacting to the same event cannot see or overwrite each other, and one provider's turns and actions stay separate.
+
+A terminal event names the operation it settles but not what that operation was — `action.completed` carries the output, while `kind` and `name` were on `action.started`. Carrying either across the pair is what state is for:
+
+```ts title="agent/instrumentation/timing.ts"
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  events: {
+    "action.started": (event, ctx) => {
+      ctx.state.set({ name: event.name, startedAt: Date.now() });
+    },
+    "action.completed": (_event, ctx) => {
+      // `get` returns `JsonValue`, which cannot know the shape you wrote.
+      const started = ctx.state.get() as { name: string; startedAt: number } | undefined;
+      if (started === undefined) return;
+      console.log(`${started.name} took ${Date.now() - started.startedAt}ms`);
+    },
+  },
+});
+```
+
+`set` is synchronous because it stages into the durable context eve commits when the step settles, rather than writing to a store of its own. That is also why the value must survive JSON — a value that cannot throws at `set` rather than at the step boundary. Writes after the handler settles or times out are ignored.
+
+State survives a step boundary. An approval-gated tool suspends and resumes in a different process, and a value written at `action.started` is still readable at `action.completed` there — which a module-level `Map` would not be. eve releases the slot when that terminal arrives.
+
+### Handler timeouts
+
+Dispatch is sequential and awaited, so a handler that never settles would stop the bus for everything behind it. When any handler exceeds eve's timeout the bus moves on. If it was a `*.started` handler, the operation is durably abandoned for that provider and its later terminal is withheld, even in another worker. Point and terminal handler timeouts do not abandon the operation, and late state writes are ignored.
+
+## Setup, flush, and shutdown
+
+`setup` runs once at server startup, before any event is published, and eve awaits it — a provider cannot miss an event published while it is still starting up.
+
+```ts
+setup: ({ agentName, environment, evaluation, frameworkVersion }) => {
+  console.log(evaluation?.runId);
+};
+```
+
+`evaluation` contains `{ runId }` when the server exists to serve a local `eve eval` run. Eval traffic is synthetic, so providers can associate or exclude it. The field is absent for ordinary servers and for a server that `eve eval --url` merely points at: that process cannot claim one remote caller's run as its own.
+
+`setup` is not where an OpenTelemetry pipeline gets registered. The pipeline is the union of every destination in the directory, so no single file knows enough to build it; a `setup` that reaches for a tracer gets the no-op one. Declare destinations as values and let eve assemble them.
+
+`flush` drains anything buffered, and eve calls it when a step settles — including when a session suspends, which on a serverless host is the last moment a buffered exporter can still reach the network. `shutdown` releases resources when the process is going away.
+
+## What to read next
+
+- [`instrumentation.ts`](./instrumentation): the shipped default layout, workflow run tags, and Agent Runs
+- [Hooks](./hooks): observe the runtime event stream
+- [`agent.ts`](../agent-config): where `experimental` lives

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -7,6 +7,8 @@ description: "Trace an agent with OpenTelemetry in instrumentation.ts, read the 
 
 If you intend to export telemetry, review the exporter destination, data categories, and required legal approvals before enabling telemetry.
 
+An experimental alternative splits this file into a directory of providers, one per file, so that adding a destination does not mean taking responsibility for every other. See [Instrumentation Providers](./instrumentation-providers).
+
 ## Three observability surfaces
 
 eve observes an agent through three distinct surfaces. They do not all live in this file, and they write to different places:
@@ -160,7 +162,7 @@ Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace p
 - [`/traces`](dev-tui#inspect-traces) in the dev TUI: a live viewer that replays the trace as a conversation.
 - [`eve traces`](../reference/cli#eve-traces): a span tree in the terminal, `eve traces ls` to list. Works after `eve dev` exits.
 
-Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
+Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. Under the experimental [provider layout](./instrumentation-providers#local-traces) the spool is a destination instead, so adding a backend beside it leaves it on. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
 
 ## Debugging
 

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -4,6 +4,7 @@
     "deployment",
     "auth-and-route-protection",
     "instrumentation",
+    "instrumentation-providers",
     "hooks",
     "session-context",
     "state",

--- a/packages/eve/src/harness/ai-sdk-telemetry.test.ts
+++ b/packages/eve/src/harness/ai-sdk-telemetry.test.ts
@@ -1,0 +1,25 @@
+import type { Telemetry } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getRegisteredTelemetryIntegrations } from "#harness/ai-sdk-telemetry.js";
+
+describe("getRegisteredTelemetryIntegrations", () => {
+  const original = globalThis.AI_SDK_TELEMETRY_INTEGRATIONS;
+
+  afterEach(() => {
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = original;
+  });
+
+  it("is empty when nothing has registered", () => {
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;
+    expect(getRegisteredTelemetryIntegrations()).toEqual([]);
+  });
+
+  it("reports the integrations in registration order", () => {
+    const first: Telemetry = { onStart() {} };
+    const second: Telemetry = { onStart() {} };
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [first, second];
+
+    expect(getRegisteredTelemetryIntegrations()).toEqual([first, second]);
+  });
+});

--- a/packages/eve/src/harness/ai-sdk-telemetry.ts
+++ b/packages/eve/src/harness/ai-sdk-telemetry.ts
@@ -16,10 +16,17 @@ export function ensureOtelIntegration(): void {
     return;
   }
   registered = true;
-  registerTelemetry(createOtelIntegration());
+  registerTelemetry(new OpenTelemetry({ runtimeContext: true }));
 }
 
-/** Creates the existing OTel integration for explicit per-call composition. */
-export function createOtelIntegration(): Telemetry {
-  return new OpenTelemetry({ runtimeContext: true });
+/**
+ * Every integration currently registered with the AI SDK — eve's own, plus any
+ * an authored instrumentation module added with `registerTelemetry`.
+ *
+ * A per-call `integrations` list replaces the registered ones rather than
+ * adding to them, so anything that passes integrations per call has to carry
+ * these forward or they stop receiving events.
+ */
+export function getRegisteredTelemetryIntegrations(): readonly Telemetry[] {
+  return globalThis.AI_SDK_TELEMETRY_INTEGRATIONS ?? [];
 }

--- a/packages/eve/src/harness/instrumentation-providers-local.scenario.test.ts
+++ b/packages/eve/src/harness/instrumentation-providers-local.scenario.test.ts
@@ -40,6 +40,6 @@ describe("instrumentation provider local default", () => {
     await runtime.forceFlush();
     await runtime.shutdown();
 
-    expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["local", "backend"]);
+    expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["backend", "local"]);
   });
 });

--- a/packages/eve/src/harness/instrumentation-providers.test.ts
+++ b/packages/eve/src/harness/instrumentation-providers.test.ts
@@ -134,11 +134,11 @@ describe("seedInstrumentationProviders", () => {
     vi.stubEnv(DEVELOPMENT_WORKER_APP_ROOT_ENV, "/tmp/eve-seed-test");
   });
 
-  it("keeps default local traces beside an authored destination", async () => {
+  it("sorts default local traces with authored destinations", async () => {
     seedInstrumentationProviders();
     await register("backend", otelIntegration());
 
-    expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["local", "backend"]);
+    expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["backend", "local"]);
   });
 
   it("seeds Agent Runs only in Vercel production", () => {
@@ -169,6 +169,21 @@ describe("seedInstrumentationProviders", () => {
     await register("agent-runs", authored);
 
     expect(getInstrumentationProviders()).toEqual([{ provider: authored, slot: "agent-runs" }]);
+  });
+
+  it("sorts built-ins, authored slots, and reserved-slot replacements together", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    seedInstrumentationProviders();
+    await register("zeta", defineInstrumentation({}));
+    await register("audit", defineInstrumentation({}));
+    await register("local", localTraces({ recordInputs: false }));
+
+    expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual([
+      "agent-runs",
+      "audit",
+      "local",
+      "zeta",
+    ]);
   });
 });
 

--- a/packages/eve/src/harness/instrumentation-providers.ts
+++ b/packages/eve/src/harness/instrumentation-providers.ts
@@ -91,7 +91,9 @@ export async function registerInstrumentationProvider(input: {
 
 /** Registered providers in slot order. @internal */
 export function getInstrumentationProviders(): readonly RegisteredInstrumentationProvider[] {
-  return [...providerRegistry()].map(([slot, provider]) => ({ provider, slot }));
+  return [...providerRegistry()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([slot, provider]) => ({ provider, slot }));
 }
 
 /**

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -75,18 +75,25 @@ vi.mock("ai", () => ({
   tool: vi.fn((t: unknown) => t),
 }));
 
-const { existingOtelIntegration, mockCreateAiSdkHookBridge } = vi.hoisted(() => ({
-  existingOtelIntegration: { onStart: vi.fn() },
+const {
+  mockCreateAiSdkHookBridge,
+  mockGetRegisteredTelemetryIntegrations,
+  registeredAuthorIntegration,
+  registeredOtelIntegration,
+} = vi.hoisted(() => ({
   mockCreateAiSdkHookBridge: vi.fn((..._args: unknown[]) => ({ onStart: vi.fn() })),
+  mockGetRegisteredTelemetryIntegrations: vi.fn((): unknown[] => []),
+  registeredAuthorIntegration: { onStart: vi.fn() },
+  registeredOtelIntegration: { onStart: vi.fn() },
 }));
 
 vi.mock("./ai-sdk-hook-bridge.js", () => ({
   createAiSdkHookBridge: (...args: unknown[]) => mockCreateAiSdkHookBridge(...args),
 }));
 
-vi.mock("./otel-integration.js", () => ({
-  createOtelIntegration: vi.fn(() => existingOtelIntegration),
+vi.mock("./ai-sdk-telemetry.js", () => ({
   ensureOtelIntegration: vi.fn(),
+  getRegisteredTelemetryIntegrations: () => mockGetRegisteredTelemetryIntegrations(),
 }));
 
 const mockGetInstrumentationConfig = vi.fn().mockReturnValue(undefined);
@@ -132,6 +139,7 @@ afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
   declareTelemetry(undefined);
+  mockGetRegisteredTelemetryIntegrations.mockReturnValue([]);
 });
 
 function createTestSession(overrides?: Partial<HarnessSession>): HarnessSession {
@@ -9683,7 +9691,7 @@ describe("createToolLoopHarness", () => {
       );
     });
 
-    it("composes lifecycle hooks with existing authored OTel", async () => {
+    it("composes the bridge with every registered integration", async () => {
       setupMockAgent({
         finishReason: "stop",
         response: { messages: [{ content: "Hello!", role: "assistant" }] },
@@ -9692,6 +9700,11 @@ describe("createToolLoopHarness", () => {
         toolResults: [],
       });
       declareTelemetry({ recordInputs: true, recordOutputs: false });
+      // An authored module can register its own integration alongside eve's.
+      mockGetRegisteredTelemetryIntegrations.mockReturnValue([
+        registeredOtelIntegration,
+        registeredAuthorIntegration,
+      ]);
       const hooks = createInstrumentationHooks([]);
       const runStep = createToolLoopHarness(
         createTestConfig("conversation", undefined, {
@@ -9713,7 +9726,7 @@ describe("createToolLoopHarness", () => {
         };
       };
       expect(agentCall.telemetry).toMatchObject({
-        integrations: [bridge, existingOtelIntegration],
+        integrations: [bridge, registeredOtelIntegration, registeredAuthorIntegration],
         recordInputs: true,
         recordOutputs: false,
       });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -162,7 +162,10 @@ import {
   hasEmptyDeliverySentinel,
 } from "#shared/empty-delivery.js";
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
-import { createOtelIntegration, ensureOtelIntegration } from "#harness/otel-integration.js";
+import {
+  ensureOtelIntegration,
+  getRegisteredTelemetryIntegrations,
+} from "#harness/ai-sdk-telemetry.js";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
 import {
   applyLastToolCacheBreakpoint,
@@ -281,12 +284,12 @@ function enrichTelemetry(
   return {
     functionId: settings?.functionId ?? agentName,
     includeRuntimeContext,
+    // Passing integrations replaces the registered ones for this call, so the
+    // bridge has to be composed with them rather than handed over on its own.
     integrations:
       bridgeIntegration === undefined
         ? undefined
-        : settings === undefined
-          ? [bridgeIntegration]
-          : [bridgeIntegration, createOtelIntegration()],
+        : [bridgeIntegration, ...getRegisteredTelemetryIntegrations()],
     isEnabled: true,
     recordInputs: settings?.recordInputs ?? true,
     recordOutputs: settings?.recordOutputs ?? true,

--- a/packages/eve/src/public/instrumentation/otel.ts
+++ b/packages/eve/src/public/instrumentation/otel.ts
@@ -31,7 +31,12 @@ export {
 
 export type { SpanExporter, SpanProcessor } from "#compiled/@vercel/otel/index.js";
 
-/** Vercel Agent Runs, enabled by default in production. */
+/**
+ * Vercel Agent Runs, enabled by default in production.
+ *
+ * Export it from `agent/instrumentation/agent-runs.ts` to narrow content, or
+ * export `disableInstrumentation()` from that file to turn it off.
+ */
 export function agentRuns(options: ContentOptions = {}): OtelIntegration {
   return agentRunsIntegration(options);
 }

--- a/packages/eve/src/tracing/local-traces.ts
+++ b/packages/eve/src/tracing/local-traces.ts
@@ -23,7 +23,15 @@ export interface LocalTracesProcessor extends SpanProcessor {
   releaseSession(sessionId: string): Promise<boolean>;
 }
 
-/** Whether a processor still exposes the local spool's session lifecycle. */
+/**
+ * Reports whether a processor tracks which session owns which trace, so eve can
+ * tell it when that session is done.
+ *
+ * Anything standing between eve and the spool has to answer for the spool, so
+ * this is the check a wrapper uses to decide whether it must forward the call.
+ *
+ * @internal
+ */
 export function hasSessionRelease(processor: SpanProcessor): processor is LocalTracesProcessor {
   return typeof (processor as Partial<LocalTracesProcessor>).releaseSession === "function";
 }


### PR DESCRIPTION
### Summary

Related to #1659 and the proposal in #1799. Stacked on #1851 and still gated by `experimental.instrumentationProviders`.

When eve adds its lifecycle bridge to a model call, the AI SDK's per-call integration list replaces globally registered integrations, which could stop authored integrations from receiving callbacks. eve now composes its bridge with every registered AI SDK telemetry integration.

This also publishes the instrumentation-provider guide and makes provider dispatch deterministic by sorting built-in, authored, and reserved-slot replacement providers alphabetically. The guide documents lifecycle boundaries, durable state and deadlines, local eval setup metadata, local traces, Agent Runs, destination policy, and shutdown.

### Validation

- Full rebased eve unit suite: 6,172 passed, 1 skipped
- Provider ordering suite: 19 passed
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `pnpm docs:check`; formatting, lint, and invariants pass
- Full integration suite inherited from #1817: 618 passed

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
