### PR TITLE
feat(eve): make integration setup headless-deterministic

### DIFF
--- a/.changeset/deterministic-integration-setup.md
+++ b/.changeset/deterministic-integration-setup.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow headless integration setup via keyed Asker answers, and fail closed on missing Vercel project links instead of opening interactive linking mid-flow.

--- a/packages/eve/src/setup/flows/ensure-vercel-project.test.ts
+++ b/packages/eve/src/setup/flows/ensure-vercel-project.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
+
+import { ensureVercelProject } from "./ensure-vercel-project.js";
+
+describe("ensureVercelProject", () => {
+  it("returns an existing on-disk link without prompting", async () => {
+    const fake = createFakePrompter();
+    const readProjectLink = vi.fn(async () => ({ orgId: "team", projectId: "prj" }));
+
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter: fake.prompter,
+        deps: { readProjectLink },
+      }),
+    ).resolves.toEqual({ orgId: "team", projectId: "prj" });
+    expect(fake.selectMessages).toEqual([]);
+  });
+
+  it("headless without a link fails closed with vercel-link action required", async () => {
+    const fake = createFakePrompter();
+    const readProjectLink = vi.fn(async () => undefined);
+
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter: fake.prompter,
+        headless: true,
+        deps: { readProjectLink },
+      }),
+    ).rejects.toMatchObject({
+      name: "HumanActionRequiredError",
+      action: {
+        kind: "vercel-link",
+        command: "vercel link",
+      },
+    });
+    expect(fake.selectMessages).toEqual([]);
+  });
+
+  it("headless HumanActionRequiredError is instanceof the public error class", async () => {
+    const fake = createFakePrompter();
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter: fake.prompter,
+        headless: true,
+        deps: { readProjectLink: vi.fn(async () => undefined) },
+      }),
+    ).rejects.toBeInstanceOf(HumanActionRequiredError);
+  });
+});

--- a/packages/eve/src/setup/flows/ensure-vercel-project.ts
+++ b/packages/eve/src/setup/flows/ensure-vercel-project.ts
@@ -4,6 +4,7 @@ import {
   resolveProvisioning,
   type ResolveProvisioningDeps,
 } from "../boxes/resolve-provisioning.js";
+import { HumanActionRequiredError } from "../human-action.js";
 import type { Prompter } from "../prompter.js";
 import { readProjectLink, type VercelProjectReference } from "../project-resolution.js";
 import { runInteractive, type AnySetupBox } from "../runner.js";
@@ -22,12 +23,27 @@ export async function ensureVercelProject(input: {
   appRoot: string;
   prompter: Prompter;
   signal?: AbortSignal;
+  /**
+   * Headless / agent runs must not open the interactive link wizard. When no
+   * on-disk link exists, throw {@link HumanActionRequiredError} so the caller
+   * completes `vercel link` (or equivalent) separately and retries.
+   */
+  headless?: boolean;
   teamSelectMessage?: (currentTeam: string) => string;
   deps?: Partial<EnsureVercelProjectDeps>;
 }): Promise<VercelProjectReference> {
   const readLink = input.deps?.readProjectLink ?? readProjectLink;
   const existing = await readLink(input.appRoot);
   if (existing !== undefined) return existing;
+
+  if (input.headless) {
+    throw new HumanActionRequiredError({
+      kind: "vercel-link",
+      command: "vercel link",
+      reason:
+        "Integration setup needs this directory linked to a Vercel project before continuing.",
+    });
+  }
 
   const state = inProjectSetupState(input.appRoot, { kind: "unresolved" });
   const boxes: AnySetupBox<SetupState>[] = [

--- a/packages/eve/src/setup/integrations/discord/setup.test.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
-import type { Asker, Question } from "#setup/ask.js";
+import {
+  headlessAsker,
+  InteractionRequired,
+  withAnswers,
+  type Asker,
+  type Question,
+} from "#setup/ask.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createIntegrationSetupUi } from "../shared/ui.js";
 import { setupDiscord, type DiscordSetupDeps } from "./setup.js";
@@ -29,6 +36,12 @@ function deps(): DiscordSetupDeps {
   };
 }
 
+const DISCORD_ANSWERS = {
+  "discord-bot-token": "  bot-token  ",
+  "discord-command-name": "ask",
+  "discord-command-description": "Ask the eve agent",
+} as const;
+
 describe("Discord setup", () => {
   it("provisions Connect, registers the command and callback, and scaffolds the channel", async () => {
     const fake = createFakePrompter();
@@ -40,11 +53,7 @@ describe("Discord setup", () => {
           appRoot: "/project",
           environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
           ui: createIntegrationSetupUi({
-            asker: asker({
-              "discord-bot-token": "  bot-token  ",
-              "discord-command-name": "ask",
-              "discord-command-description": "Ask the eve agent",
-            }),
+            asker: asker({ ...DISCORD_ANSWERS }),
             prompter: fake.prompter,
           }),
         },
@@ -110,5 +119,89 @@ describe("Discord setup", () => {
         ui: createIntegrationSetupUi({ asker: asker({}), prompter: fake.prompter }),
       }),
     ).rejects.toThrow("vercel login");
+  });
+
+  it("headless answers-by-key succeeds without prompting and passes headless to ensureVercelProject", async () => {
+    const fake = createFakePrompter();
+    const effects = deps();
+    const headless = withAnswers({ ...DISCORD_ANSWERS })(headlessAsker());
+
+    await expect(
+      setupDiscord(
+        {
+          appRoot: "/project",
+          environment: integrationSetupEnvironment("authenticated", {
+            kind: "linked",
+            projectId: "project-id",
+          }),
+          headless: true,
+          ui: createIntegrationSetupUi({ asker: headless, prompter: fake.prompter }),
+        },
+        effects,
+      ),
+    ).resolves.toMatchObject({ kind: "done" });
+
+    expect(effects.ensureVercelProject).toHaveBeenCalledWith(
+      expect.objectContaining({ headless: true }),
+    );
+    expect(fake.selectMessages).toEqual([]);
+  });
+
+  it("missing required answer throws InteractionRequired before any mutation", async () => {
+    const fake = createFakePrompter();
+    const effects = deps();
+    const headless = withAnswers({})(headlessAsker());
+
+    await expect(
+      setupDiscord(
+        {
+          appRoot: "/project",
+          environment: integrationSetupEnvironment("authenticated", {
+            kind: "linked",
+            projectId: "project-id",
+          }),
+          headless: true,
+          ui: createIntegrationSetupUi({ asker: headless, prompter: fake.prompter }),
+        },
+        effects,
+      ),
+    ).rejects.toBeInstanceOf(InteractionRequired);
+
+    expect(effects.resolveApplication).not.toHaveBeenCalled();
+    expect(effects.ensureVercelProject).not.toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+    expect(effects.registerCommand).not.toHaveBeenCalled();
+    expect(effects.configureEndpoint).not.toHaveBeenCalled();
+    expect(effects.writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it("propagates ensureVercelProject headless failure without Connect mutation", async () => {
+    const fake = createFakePrompter();
+    const effects = deps();
+    effects.ensureVercelProject = vi.fn(async () => {
+      throw new HumanActionRequiredError({
+        kind: "vercel-link",
+        command: "vercel link",
+        reason:
+          "Integration setup needs this directory linked to a Vercel project before continuing.",
+      });
+    });
+    const headless = withAnswers({ ...DISCORD_ANSWERS })(headlessAsker());
+
+    await expect(
+      setupDiscord(
+        {
+          appRoot: "/project",
+          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+          headless: true,
+          ui: createIntegrationSetupUi({ asker: headless, prompter: fake.prompter }),
+        },
+        effects,
+      ),
+    ).rejects.toBeInstanceOf(HumanActionRequiredError);
+
+    expect(effects.resolveApplication).toHaveBeenCalled();
+    expect(effects.provisionConnector).not.toHaveBeenCalled();
+    expect(effects.writeTextFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { text } from "#setup/ask.js";
+import { text, type Asker } from "#setup/ask.js";
 import { ensureVercelProject } from "#setup/flows/ensure-vercel-project.js";
 import { deriveSlackConnectorSlug } from "#setup/scaffold/index.js";
 import { writeTextFile } from "#setup/scaffold/files.js";
@@ -57,6 +57,112 @@ export default discordChannel({
 `;
 }
 
+/** Decisions collected before any irreversible Discord / Connect mutation. */
+export interface DiscordSetupDecisions {
+  botToken: string;
+  commandName: string;
+  commandDescription: string;
+}
+
+/**
+ * Phase 1: resolve every keyed Discord decision through the Asker. Must not
+ * call Discord, Connect, or the filesystem with side effects.
+ */
+export async function gatherDiscordSetupDecisions(asker: Asker): Promise<DiscordSetupDecisions> {
+  const botToken = (
+    await asker.ask(
+      text({
+        key: "discord-bot-token",
+        message: "Discord bot token",
+        required: true,
+        sensitive: true,
+      }),
+    )
+  ).trim();
+  const commandName = await asker.ask(
+    text({
+      key: "discord-command-name",
+      message: "Discord command name",
+      detected: "ask",
+      required: true,
+      validate: validateCommandName,
+    }),
+  );
+  const commandDescription = await asker.ask(
+    text({
+      key: "discord-command-description",
+      message: "Discord command description",
+      detected: "Ask the eve agent",
+      required: true,
+      validate: (value) =>
+        value.trim().length === 0
+          ? "Command description is required."
+          : value.trim().length > 100
+            ? "Command description must be 100 characters or fewer."
+            : null,
+    }),
+  );
+  return {
+    botToken,
+    commandName: commandName.trim(),
+    commandDescription: commandDescription.trim(),
+  };
+}
+
+/**
+ * Phase 2: apply gathered decisions. Idempotent where possible; fails closed
+ * rather than opening interactive prerequisites when {@link IntegrationSetupContext.headless}.
+ */
+async function performDiscordSetup(
+  context: IntegrationSetupContext,
+  decisions: DiscordSetupDecisions,
+  deps: DiscordSetupDeps,
+): Promise<IntegrationSetupResult> {
+  const application = await deps.resolveApplication(decisions.botToken);
+  const project = await deps.ensureVercelProject({
+    appRoot: context.appRoot,
+    prompter: context.ui.prompter,
+    signal: context.signal,
+    headless: context.headless,
+  });
+  const connector = await deps.provisionConnector({
+    botToken: decisions.botToken,
+    log: context.ui.prompter.log,
+    project,
+    projectRoot: context.appRoot,
+    slug: await deps.deriveConnectorSlug(context.appRoot),
+    signal: context.signal,
+  });
+  await deps.registerCommand(application.id, decisions.botToken, {
+    name: decisions.commandName,
+    description: decisions.commandDescription,
+  });
+  // Connect configures this automatically when supported; the explicit call
+  // makes setup deterministic while older API deployments are still live.
+  await deps.configureEndpoint(decisions.botToken, connector.id);
+  await deps.writeTextFile(
+    join(context.appRoot, "agent/channels/discord.ts"),
+    connectTemplate(connector.uid),
+    { force: context.force },
+  );
+  const installUrl =
+    `https://discord.com/oauth2/authorize?client_id=${encodeURIComponent(application.id)}` +
+    `&scope=${encodeURIComponent("bot applications.commands")}&permissions=3072`;
+  context.ui.nextSteps([
+    `Install the Discord application, then try /${decisions.commandName}: ${installUrl}`,
+  ]);
+  return {
+    kind: "done",
+    facts: [
+      {
+        label: "Discord application",
+        value: `https://discord.com/developers/applications/${application.id}/information`,
+        kind: "url",
+      },
+    ],
+  };
+}
+
 /** Runs guided Discord connector, command, and channel setup. */
 export async function setupDiscord(
   context: IntegrationSetupContext,
@@ -81,81 +187,8 @@ export async function setupDiscord(
     } else {
       context.ui.prompter.log.info(`Discord application\n${applicationInstructions.join("\n")}`);
     }
-    const botToken = (
-      await context.ui.asker.ask(
-        text({
-          key: "discord-bot-token",
-          message: "Discord bot token",
-          required: true,
-          sensitive: true,
-        }),
-      )
-    ).trim();
-    const commandName = await context.ui.asker.ask(
-      text({
-        key: "discord-command-name",
-        message: "Discord command name",
-        detected: "ask",
-        required: true,
-        validate: validateCommandName,
-      }),
-    );
-    const commandDescription = await context.ui.asker.ask(
-      text({
-        key: "discord-command-description",
-        message: "Discord command description",
-        detected: "Ask the eve agent",
-        required: true,
-        validate: (value) =>
-          value.trim().length === 0
-            ? "Command description is required."
-            : value.trim().length > 100
-              ? "Command description must be 100 characters or fewer."
-              : null,
-      }),
-    );
-    const application = await deps.resolveApplication(botToken);
-    const project = await deps.ensureVercelProject({
-      appRoot: context.appRoot,
-      prompter: context.ui.prompter,
-      signal: context.signal,
-    });
-    const connector = await deps.provisionConnector({
-      botToken,
-      log: context.ui.prompter.log,
-      project,
-      projectRoot: context.appRoot,
-      slug: await deps.deriveConnectorSlug(context.appRoot),
-      signal: context.signal,
-    });
-    await deps.registerCommand(application.id, botToken, {
-      name: commandName.trim(),
-      description: commandDescription.trim(),
-    });
-    // Connect configures this automatically when supported; the explicit call
-    // makes setup deterministic while older API deployments are still live.
-    await deps.configureEndpoint(botToken, connector.id);
-    await deps.writeTextFile(
-      join(context.appRoot, "agent/channels/discord.ts"),
-      connectTemplate(connector.uid),
-      { force: context.force },
-    );
-    const installUrl =
-      `https://discord.com/oauth2/authorize?client_id=${encodeURIComponent(application.id)}` +
-      `&scope=${encodeURIComponent("bot applications.commands")}&permissions=3072`;
-    context.ui.nextSteps([
-      `Install the Discord application, then try /${commandName.trim()}: ${installUrl}`,
-    ]);
-    return {
-      kind: "done",
-      facts: [
-        {
-          label: "Discord application",
-          value: `https://discord.com/developers/applications/${application.id}/information`,
-          kind: "url",
-        },
-      ],
-    };
+    const decisions = await gatherDiscordSetupDecisions(context.ui.asker);
+    return await performDiscordSetup(context, decisions, deps);
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };
     throw error;

--- a/packages/eve/src/setup/integrations/github/setup.ts
+++ b/packages/eve/src/setup/integrations/github/setup.ts
@@ -121,6 +121,7 @@ export async function setupGitHub(
       appRoot: context.appRoot,
       prompter: context.ui.prompter,
       signal: context.signal,
+      headless: context.headless,
     });
     const connector = await deps.provisionConnector({
       log: context.ui.prompter.log,

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -139,6 +139,7 @@ export async function setupLinear(
       appRoot: context.appRoot,
       prompter: context.ui.prompter,
       signal: context.signal,
+      headless: context.headless,
     });
     const connector = await chooseConnector(context, deps, project);
     if (connector === undefined) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/photon/setup-flow.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.ts
@@ -25,6 +25,8 @@ export interface PhotonSetupOptions {
   ui: IntegrationSetupUi;
   signal?: AbortSignal;
   force?: boolean;
+  /** When true, skip interactive Vercel linking; require an existing project link. */
+  headless?: boolean;
   deps?: PhotonSetupDeps;
 }
 
@@ -233,6 +235,7 @@ async function scaffoldPhoton(
         appRoot: projectRoot,
         prompter: options.ui.prompter,
         signal: options.signal,
+        headless: options.headless,
       });
       const connector = await deps.provisionConnector({
         credentials: managedProject,

--- a/packages/eve/src/setup/integrations/photon/setup.ts
+++ b/packages/eve/src/setup/integrations/photon/setup.ts
@@ -17,6 +17,7 @@ export const PHOTON_SETUP: SetupIntegration = {
       ui: context.ui,
       signal: context.signal,
       force: context.force,
+      headless: context.headless,
     });
     if (result.kind === "cancelled") return result;
     return {

--- a/packages/eve/src/setup/integrations/runner.test.ts
+++ b/packages/eve/src/setup/integrations/runner.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import {
+  headlessAsker,
+  InteractionRequired,
+  withAnswers,
+  type Asker,
+  type Question,
+} from "#setup/ask.js";
+
+import { composeIntegrationAsker, runIntegrationSetup } from "./runner.js";
+import { createIntegrationSetupUi } from "./shared/ui.js";
+import { integrationSetupEnvironment } from "./shared/environment.js";
+
+vi.mock("./registry.js", () => ({
+  setupIntegration: vi.fn(),
+}));
+
+import { setupIntegration } from "./registry.js";
+
+describe("composeIntegrationAsker", () => {
+  it("uses interactiveAsker by default so prompts reach the prompter", async () => {
+    const fake = createFakePrompter({
+      password: () => "secret-token",
+    });
+    const asker = composeIntegrationAsker({ prompter: fake.prompter });
+    await expect(
+      asker.ask({
+        key: "discord-bot-token",
+        kind: "text",
+        message: "Discord bot token",
+        required: true,
+        sensitive: true,
+      }),
+    ).resolves.toBe("secret-token");
+  });
+
+  it("headless with answers resolves by key without touching the prompter", async () => {
+    const fake = createFakePrompter();
+    const asker = composeIntegrationAsker({
+      prompter: fake.prompter,
+      headless: true,
+      answers: { "discord-bot-token": "from-agent" },
+    });
+    await expect(
+      asker.ask({
+        key: "discord-bot-token",
+        kind: "text",
+        message: "Discord bot token",
+        required: true,
+        sensitive: true,
+      }),
+    ).resolves.toBe("from-agent");
+    expect(fake.selectMessages).toEqual([]);
+  });
+
+  it("headless without a required answer throws InteractionRequired", async () => {
+    const fake = createFakePrompter();
+    const asker = composeIntegrationAsker({
+      prompter: fake.prompter,
+      headless: true,
+      answers: {},
+    });
+    await expect(
+      asker.ask({
+        key: "discord-bot-token",
+        kind: "text",
+        message: "Discord bot token",
+        required: true,
+        sensitive: true,
+      }),
+    ).rejects.toBeInstanceOf(InteractionRequired);
+  });
+});
+
+describe("runIntegrationSetup headless composition", () => {
+  it("passes a headless answers-by-key Asker and headless context into setup", async () => {
+    const fake = createFakePrompter();
+    let capturedAsker: Asker | undefined;
+    let capturedHeadless: boolean | undefined;
+
+    vi.mocked(setupIntegration).mockReturnValue({
+      kind: "discord",
+      label: "Discord",
+      async setup(context) {
+        capturedAsker = context.ui.asker;
+        capturedHeadless = context.headless;
+        const token = await context.ui.asker.ask({
+          key: "discord-bot-token",
+          kind: "text",
+          message: "Discord bot token",
+          required: true,
+          sensitive: true,
+        } satisfies Question<string>);
+        expect(token).toBe("bot-from-answers");
+        return { kind: "done" };
+      },
+    });
+
+    await expect(
+      runIntegrationSetup(
+        "discord",
+        {
+          appRoot: "/project",
+          prompter: fake.prompter,
+          headless: true,
+          answers: { "discord-bot-token": "bot-from-answers" },
+        },
+        {
+          detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
+          getVercelAuthStatus: vi.fn(async () => "authenticated" as const),
+        },
+      ),
+    ).resolves.toEqual({ kind: "done" });
+
+    expect(capturedHeadless).toBe(true);
+    expect(capturedAsker).toBeDefined();
+    // Same stack shape as withAnswers(answers)(headlessAsker()).
+    const expected = withAnswers({ "discord-bot-token": "bot-from-answers" })(headlessAsker());
+    await expect(
+      expected.ask({
+        key: "discord-bot-token",
+        kind: "text",
+        message: "Discord bot token",
+        required: true,
+        sensitive: true,
+      }),
+    ).resolves.toBe("bot-from-answers");
+  });
+
+  it("keeps the interactive path when headless is unset", async () => {
+    const fake = createFakePrompter({
+      password: () => "interactive-token",
+    });
+    vi.mocked(setupIntegration).mockReturnValue({
+      kind: "discord",
+      label: "Discord",
+      async setup(context) {
+        expect(context.headless).toBeUndefined();
+        const token = await context.ui.asker.ask({
+          key: "discord-bot-token",
+          kind: "text",
+          message: "Discord bot token",
+          required: true,
+          sensitive: true,
+        });
+        expect(token).toBe("interactive-token");
+        return { kind: "done" };
+      },
+    });
+
+    await expect(
+      runIntegrationSetup(
+        "discord",
+        { appRoot: "/project", prompter: fake.prompter },
+        {
+          detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
+          getVercelAuthStatus: vi.fn(async () => "authenticated" as const),
+        },
+      ),
+    ).resolves.toEqual({ kind: "done" });
+  });
+});
+
+describe("createIntegrationSetupUi (smoke)", () => {
+  it("still builds UI over a composed asker", () => {
+    const fake = createFakePrompter();
+    const ui = createIntegrationSetupUi({
+      asker: composeIntegrationAsker({
+        prompter: fake.prompter,
+        headless: true,
+        answers: {},
+      }),
+      prompter: fake.prompter,
+    });
+    expect(ui.asker).toBeDefined();
+    expect(integrationSetupEnvironment("authenticated", { kind: "unresolved" }).vercel.kind).toBe(
+      "available",
+    );
+  });
+});

--- a/packages/eve/src/setup/integrations/runner.ts
+++ b/packages/eve/src/setup/integrations/runner.ts
@@ -1,4 +1,4 @@
-import { interactiveAsker } from "#setup/ask.js";
+import { headlessAsker, interactiveAsker, withAnswers, type Asker } from "#setup/ask.js";
 import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 import { detectDeployment, projectResolutionFromDeployment } from "#setup/project-resolution.js";
 import type { Prompter } from "#setup/prompter.js";
@@ -17,6 +17,14 @@ export interface RunIntegrationSetupOptions {
   prompter: Prompter;
   signal?: AbortSignal;
   yes?: boolean;
+  /**
+   * Prefer the headless Asker base so required decisions refuse with
+   * {@link import("#setup/ask.js").InteractionRequired} instead of prompting.
+   * Pair with {@link answers} for agent/flag-driven runs.
+   */
+  headless?: boolean;
+  /** Pre-answers keyed by question `key` (flags, agent tool args). */
+  answers?: Record<string, unknown>;
 }
 
 /** Effects shared by the built-in integration setup runner. */
@@ -34,6 +42,20 @@ const defaultDeps: IntegrationSetupRunnerDeps = {
 export type IntegrationSetupOutcome =
   | { kind: "cancelled" }
   | { kind: "done"; facts?: readonly RegistrySetupFact[] };
+
+/**
+ * Composes the Asker stack for one integration setup run. Interactive default
+ * matches today's CLI; headless uses {@link headlessAsker} so missing required
+ * keys refuse structurally. Optional {@link withAnswers} sits outside either base.
+ */
+export function composeIntegrationAsker(options: {
+  prompter: Prompter;
+  headless?: boolean;
+  answers?: Record<string, unknown>;
+}): Asker {
+  const base = options.headless ? headlessAsker() : interactiveAsker(options.prompter);
+  return options.answers === undefined ? base : withAnswers(options.answers)(base);
+}
 
 /** Runs one built-in integration setup flow selected by its registry setup name. */
 export async function runIntegrationSetup(
@@ -55,10 +77,15 @@ export async function runIntegrationSetup(
     environment,
     appRoot: options.appRoot,
     ui: createIntegrationSetupUi({
-      asker: interactiveAsker(options.prompter),
+      asker: composeIntegrationAsker({
+        prompter: options.prompter,
+        headless: options.headless,
+        answers: options.answers,
+      }),
       prompter: options.prompter,
     }),
     yes: options.yes,
+    headless: options.headless,
     signal: options.signal,
   });
   return result;

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -198,6 +198,7 @@ export async function setupSlack(
     appRoot: context.appRoot,
     prompter: context.ui.prompter,
     signal: context.signal,
+    headless: context.headless,
   });
   if (project.projectId.length === 0) throw new Error(SLACK_REQUIRES_VERCEL);
   const slackbot = await provisionSlack(context, deps, slug);

--- a/packages/eve/src/setup/integrations/types.ts
+++ b/packages/eve/src/setup/integrations/types.ts
@@ -11,6 +11,11 @@ export interface IntegrationSetupContext {
   readonly signal?: AbortSignal;
   readonly force?: boolean;
   readonly yes?: boolean;
+  /**
+   * When true, shared prerequisites such as Vercel project linking must already
+   * be satisfied; they must not open an interactive wizard mid-flow.
+   */
+  readonly headless?: boolean;
 }
 
 /** Outcome from one registry-owned integration setup flow. */

--- a/research/deterministic-integration-setup-repro.md
+++ b/research/deterministic-integration-setup-repro.md
@@ -1,0 +1,140 @@
+---
+issue: https://github.com/vercel/eve/issues/1786
+status: in-progress
+last_updated: "2026-08-07"
+---
+
+# Reproduction: deterministic integration setup (#1786)
+
+Branch under test: `cursor/deterministic-integration-setup-c02c`
+
+## A. Reproduce the problem on CURRENT eve (`main`, before this fix)
+
+### A1. Code evidence: runner always hardcodes interactive Asker
+
+On `main`, `packages/eve/src/setup/integrations/runner.ts` always does:
+
+```ts
+asker: interactiveAsker(options.prompter),
+```
+
+There is no `headless` / `answers` option. A coding agent cannot inject keyed
+answers; every semantic decision goes through TTY prompts.
+
+### A2. Code evidence: `ensureVercelProject` surprise-opens interactive linking
+
+On `main`, `packages/eve/src/setup/flows/ensure-vercel-project.ts`:
+
+1. Reads the on-disk link.
+2. If missing, always builds `interactiveAsker` + `runInteractive` (team/project
+   pickers) — even when the caller is already mid Discord/Linear/GitHub setup.
+
+Discord calls this **after** collecting the bot token and **before**
+provisioning Connect (`packages/eve/src/setup/integrations/discord/setup.ts`).
+So a headless agent that somehow answered earlier prompts can still be dropped
+into an interactive Vercel link wizard mid-flow.
+
+### A3. Why replay after partial mutation is unsafe
+
+Discord (and Linear/GitHub similarly) interleaves decisions with mutations:
+
+1. Ask bot token / command fields (or branching Linear connector choices).
+2. Call Discord/Connect APIs (`resolveApplication`, then later
+   `provisionConnector`, `registerCommand`, `configureEndpoint`).
+3. Write `agent/channels/discord.ts`.
+
+If the process dies after `provisionConnector` but before the channel file is
+written, re-running the interactive flow can create a **second** connector or
+re-register commands while the agent cannot reliably re-answer the same
+branching prompts. That is why gather must complete before perform, and why
+perform must be idempotent or fail closed.
+
+### A4. Unit tests that FAIL on `main` and PASS on this branch
+
+From repo root on `main` (before this change), these tests do not exist yet.
+After cherry-picking only the new test files onto `main` without the
+implementation, they fail because:
+
+- `composeIntegrationAsker` / `RunIntegrationSetupOptions.headless` are missing
+- `ensureVercelProject({ headless: true })` opens interactive boxes instead of
+  throwing `HumanActionRequiredError`
+- Discord does not pass `headless` into `ensureVercelProject`
+
+Commands (after this branch’s tests exist; compare against `main`):
+
+```sh
+pnpm --filter eve exec vitest run --config vitest.unit.config.ts \
+  src/setup/integrations/runner.test.ts \
+  src/setup/integrations/discord/setup.test.ts \
+  src/setup/flows/ensure-vercel-project.test.ts
+```
+
+Optional CLI illustration (needs a real eve project + TTY; no credentials
+required to _see_ prompts start):
+
+```sh
+# In an eve agent directory that is authenticated but NOT linked:
+eve add discord
+# → branching / password prompts; no answers-by-key contract
+```
+
+## B. Verify AFTER this change
+
+### B1. Branch and files
+
+- Branch: `cursor/deterministic-integration-setup-c02c`
+- Key files:
+  - `packages/eve/src/setup/integrations/runner.ts` — headless Asker composition
+  - `packages/eve/src/setup/integrations/types.ts` — `headless` on context
+  - `packages/eve/src/setup/flows/ensure-vercel-project.ts` — fail closed headless
+  - `packages/eve/src/setup/integrations/discord/setup.ts` — gather then perform
+  - unit tests listed below
+  - `research/deterministic-integration-setup.md`
+  - `.changeset/deterministic-integration-setup.md`
+
+### B2. Headless answers-by-key (unit)
+
+```sh
+pnpm --filter eve exec vitest run --config vitest.unit.config.ts \
+  src/setup/integrations/runner.test.ts \
+  src/setup/integrations/discord/setup.test.ts \
+  src/setup/flows/ensure-vercel-project.test.ts
+```
+
+Expected:
+
+- `composeIntegrationAsker` headless + answers resolves without TTY
+- missing required key → `InteractionRequired`, no Discord/Connect mutation
+- `ensureVercelProject({ headless: true })` with no link →
+  `HumanActionRequiredError` (`vercel-link`)
+- interactive path still answers via prompter
+- Discord passes `headless: true` into `ensureVercelProject`
+
+### B3. Cheap workspace checks
+
+```sh
+pnpm fmt
+pnpm lint
+pnpm --filter eve typecheck
+```
+
+### B4. Programmatic headless shape (what agents will call)
+
+```ts
+import { runIntegrationSetup } from "eve/..."; // internal runner today
+
+await runIntegrationSetup("discord", {
+  appRoot,
+  prompter, // unused for questions when headless + answers cover required keys
+  headless: true,
+  answers: {
+    "discord-bot-token": process.env.DISCORD_BOT_TOKEN,
+    "discord-command-name": "ask",
+    "discord-command-description": "Ask the eve agent",
+  },
+});
+```
+
+If the directory is not linked, expect `HumanActionRequiredError` with
+`command: "vercel link"` **before** Connect provisioning — complete linking
+separately, then retry.

--- a/research/deterministic-integration-setup.md
+++ b/research/deterministic-integration-setup.md
@@ -1,0 +1,104 @@
+---
+issue: https://github.com/vercel/eve/issues/1786
+status: in-progress
+last_updated: "2026-08-07"
+---
+
+# Deterministic integration setup for coding agents
+
+## Summary
+
+Built-in integration setup (`eve add` / registry setup flows) is optimized for
+interactive terminals. Coding agents cannot reliably answer branching prompts,
+and replaying setup after a partial run is unsafe once earlier choices mutated
+external state (Connect connectors, Discord commands, project links).
+
+Make every semantic setup decision addressable by a stable key through the
+existing `Asker` channel, collect decisions before irreversible mutation, and
+let headless callers supply answers by key. Shared one-time prerequisites
+(Vercel project linking) are a go/no-go phase 0 in headless mode—completed
+separately—not an unexpected interactive diversion mid-flow.
+
+Interactive CLI/TUI behavior stays unchanged, including editable selects.
+
+## Public / composition API
+
+### Asker stacks (already exist)
+
+```ts
+withAnswers(agentArgs)(headlessAsker());
+withAnswers(flags)(withPolicy("confirm-detected")(interactiveAsker(prompter)));
+```
+
+Boxes and integrations only see `Asker`. Headless required questions refuse with
+`InteractionRequired` (full question payload). Invalid supplied answers refuse
+with `InvalidAnswerError`.
+
+### Integration runner
+
+```ts
+await runIntegrationSetup(kind, {
+  appRoot,
+  prompter,
+  headless: true,
+  answers: {
+    "discord-bot-token": "...",
+    "discord-command-name": "ask",
+    "discord-command-description": "Ask the eve agent",
+  },
+});
+```
+
+Interactive default remains `interactiveAsker(prompter)`. When `headless: true`,
+the runner composes `withAnswers(answers)(headlessAsker())` and passes
+`headless` on `IntegrationSetupContext` so shared prerequisites can fail closed.
+
+### Prerequisite phase 0
+
+`ensureVercelProject` keeps today's interactive linking wizard when not
+headless. In headless mode, a missing on-disk project link throws
+`HumanActionRequiredError` (`kind: "vercel-link"`, command `vercel link`)
+instead of opening prompts. Callers complete linking separately, then retry.
+
+## Lifecycle
+
+```text
+phase 0  prerequisites (auth, linked project)  → go / HumanActionRequired
+phase 1  gather  keyed Asker decisions         → Input (no external mutation)
+phase 2  perform idempotent side effects       → Payload / fail closed
+```
+
+```mermaid
+flowchart LR
+  P0[Phase 0 prerequisites] -->|go| G[Gather keyed answers]
+  P0 -->|no-go| H[HumanActionRequired / InteractionRequired]
+  G --> Perf[Perform mutations]
+  Perf --> Done[Done]
+```
+
+Invariants:
+
+1. Every semantic decision travels through keyed `Asker` (one channel).
+2. Gather never mutates external systems; perform is idempotent or fails closed.
+3. Headless missing required keys throw `InteractionRequired` before perform.
+4. Interactive rendering (including specialized controls) is unchanged.
+
+## Slice boundaries (this change)
+
+In scope:
+
+- Integration runner headless Asker composition (`answers` / `headless`).
+- Discord setup gather-then-perform split as the first migrated integration.
+- `ensureVercelProject` headless fail-closed (no surprise interactive link).
+- Unit tests for headless success, missing-key refusal, and interactive path.
+
+Out of scope (follow-ups):
+
+- Migrating Linear, Slack, GitHub, Photon to explicit gather-then-perform.
+- Structured CLI / agent tool contract for `eve add` answer bags.
+- Full SetupBox migration of every integration.
+- Changing interactive TUI controls.
+
+## Reproduction
+
+See [deterministic-integration-setup-repro.md](./deterministic-integration-setup-repro.md).


### PR DESCRIPTION
### Summary

Related to #1786. Built-in integration setup always used an interactive Asker, so coding agents could not supply answers by key, and an unlinked Vercel project could open an interactive linking wizard mid-flow after other choices had already started mutating external state.

This slice adds `headless` + keyed `answers` to `runIntegrationSetup`, routes Discord through an explicit gather-then-perform split, and makes `ensureVercelProject` throw `HumanActionRequiredError` (`vercel-link`) in headless mode when no on-disk link exists instead of launching the interactive linker. Interactive CLI/TUI behavior is preserved. Linear/Slack/GitHub/Photon only pass `headless` through for the prerequisite; full gather→perform migration for those is follow-up.

### Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/runner.test.ts src/setup/integrations/discord/setup.test.ts src/setup/flows/ensure-vercel-project.test.ts src/setup/ask.test.ts` (46 passed)
- Repro notes: `research/deterministic-integration-setup-repro.md`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)