### PR TITLE
test(e2e): cover authorized approval responses

### DIFF
--- a/.changeset/recover-cancelled-approval-settlements.md
+++ b/.changeset/recover-cancelled-approval-settlements.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Recover cancelled responder-authorized approvals after replay so the pending tool call remains cancelled and cannot hang while waiting for a consumed response.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -160,7 +160,7 @@ curl -X POST http://127.0.0.1:2000/eve/v1/session/<sessionId> \
 
 Message sends default to cancellation-backed `"steer"`; if a turn is active, eve buffers the follow-up, cancels that turn, and starts the message under a new turn ID. Channels and TypeScript `Session.send(...)` calls can select `turnPolicy: "queue"` when active work should finish first. Structured `inputResponses` never steer.
 
-If one pending batch is waiting on a human-in-the-loop approval, a matching text reply such as `approve` or `cancel` answers it. Unrelated text starts an ordinary turn immediately without denying the tool call; the approval stays pending and answerable. A later structured `inputResponses` answer keyed by its `requestId` still resumes the original tool call, even after intervening turns.
+If the session is waiting on a human-in-the-loop approval, respond with the channel’s Approve or Cancel controls. Text messages do not decide an approval; unrelated text starts an ordinary turn while the approval stays pending and answerable. A later structured `inputResponses` answer keyed by its `requestId` still resumes the original tool call, even after intervening turns.
 
 With one question-only batch, an exact option match or permitted freeform response answers `ask_question`. Any other follow-up marks the question unanswered and starts the new turn. With several approval or question batches pending, eve does not guess which batch plain text addresses: the message starts an ordinary turn and the batches stay open. Use structured responses to target requests unambiguously.
 

--- a/e2e/fixtures/agent-tools-hitl/agent/channels/eve.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/channels/eve.ts
@@ -1,23 +1,16 @@
-import type { AuthFn } from "eve/channels/auth";
 import { eveChannel } from "eve/channels/eve";
-import type { SessionAuthContext } from "eve/context";
 
-/**
- * Authored eve channel for the interactive-authorization evals. Interactive
- * authorizations are always `principalType: "user"`, and the eval driver is
- * otherwise anonymous (`local-dev` on the local world), which fails principal
- * resolution before a challenge can open. Every caller maps to one fixed end
- * user (fixture-only; do not pattern production channels off this).
- */
-const authenticateDefaultUser: AuthFn<Request> = (): SessionAuthContext => ({
-  attributes: {},
-  authenticator: "e2e-fixture",
-  issuer: "e2e",
-  principalId: "e2e-user",
-  principalType: "user",
-  subject: "e2e-user",
-});
-
+/** Fixture-only authentication for interactive authorization evals. */
 export default eveChannel({
-  auth: [authenticateDefaultUser],
+  auth: (request) => {
+    const principalId = request.headers.get("x-eve-fixture-user") ?? "e2e-approval-responder";
+    return {
+      attributes: { fixture: "authorized-response" },
+      authenticator: "e2e-fixture",
+      issuer: "e2e",
+      principalId,
+      principalType: "user",
+      subject: principalId,
+    };
+  },
 });

--- a/e2e/fixtures/agent-tools-hitl/agent/tools/authorized-gate.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/tools/authorized-gate.ts
@@ -1,0 +1,18 @@
+import { defineTool } from "eve/tools";
+import { always } from "eve/tools/approval";
+import { z } from "zod";
+
+export default defineTool({
+  description: "PROOF-ONLY: executes after an authenticated response policy allows approval.",
+  inputSchema: z.object({ marker: z.string() }),
+  approval: {
+    request: always(),
+    response: ({ response, responder }) =>
+      response.decision === "approve" && responder.principalId === "e2e-approval-responder"
+        ? ({ status: "allowed" } as const)
+        : ({ status: "rejected", reason: "Unexpected eval responder." } as const),
+  },
+  async execute({ marker }) {
+    return { executed: true, marker };
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/agent/tools/oauth-authorized-gate.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/tools/oauth-authorized-gate.ts
@@ -1,0 +1,51 @@
+import {
+  ConnectionAuthorizationRequiredError,
+  defineInteractiveAuthorization,
+} from "eve/connections";
+import { defineTool } from "eve/tools";
+import { always } from "eve/tools/approval";
+import { z } from "zod";
+
+const tokens = new Map<string, string>();
+const fakeOAuth = defineInteractiveAuthorization<{ principalId: string }>({
+  displayName: "Fixture OAuth",
+  async getToken({ principal }) {
+    if (principal.type !== "user") throw new Error("Expected a user principal.");
+    const token = tokens.get(principal.id);
+    if (token === undefined) throw new ConnectionAuthorizationRequiredError("fixture-oauth");
+    return { providerSubject: principal.id, token };
+  },
+  async startAuthorization({ callbackUrl, principal }) {
+    if (principal.type !== "user") throw new Error("Expected a user principal.");
+    const url = new URL(callbackUrl);
+    url.searchParams.set("code", "fake-oauth-code");
+    return {
+      challenge: { instructions: "Complete fixture OAuth.", url: url.href },
+      resume: { principalId: principal.id },
+    };
+  },
+  async completeAuthorization({ callback, resume }) {
+    if (callback.params.code !== "fake-oauth-code" || resume === undefined) {
+      throw new Error("Unexpected fixture OAuth callback.");
+    }
+    tokens.set(resume.principalId, "fake-oauth-token");
+    return { providerSubject: resume.principalId, token: "fake-oauth-token" };
+  },
+});
+
+export default defineTool({
+  description: "PROOF-ONLY: executes after a fake responder OAuth flow.",
+  inputSchema: z.object({ marker: z.string() }),
+  approval: {
+    request: always(),
+    async response({ auth, responder }) {
+      const credential = await auth.getToken(fakeOAuth, { authKey: "fixture-oauth" });
+      return credential.providerSubject === responder.principalId
+        ? { status: "allowed" }
+        : { status: "rejected", reason: "Fixture OAuth identity mismatch." };
+    },
+  },
+  async execute({ marker }) {
+    return { executed: true, marker };
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/agent/tools/responder-gate.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/tools/responder-gate.ts
@@ -1,0 +1,18 @@
+import { defineTool } from "eve/tools";
+import { always } from "eve/tools/approval";
+import { z } from "zod";
+
+export default defineTool({
+  description: "PROOF-ONLY: only the authorized fixture responder may approve.",
+  inputSchema: z.object({ marker: z.string() }),
+  approval: {
+    request: always(),
+    response: ({ responder }) =>
+      responder.principalId === "e2e-approval-responder"
+        ? { status: "allowed" }
+        : { status: "rejected", reason: "This responder is not authorized." },
+  },
+  async execute({ marker }) {
+    return { executed: true, marker };
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response-oauth-cancel.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response-oauth-cancel.eval.ts
@@ -1,0 +1,51 @@
+import { defineEval } from "eve/evals";
+
+const MARKER = "authorized-response-oauth-cancel-P6W2";
+const TOOL_NAME = "oauth-authorized-gate";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "Cancel beats a candidate parked on OAuth and a late callback cannot execute.",
+  async test(t) {
+    const parked = await t.send(`Call the \`${TOOL_NAME}\` tool with marker "${MARKER}".`);
+    const approval = t.requireInputRequest({ display: "confirmation", toolName: TOOL_NAME });
+    const approvalTurn = await t.startRespond(
+      [{ optionId: "approve", requestId: approval.requestId }],
+      { headers: { "x-eve-fixture-user": "oauth-cancel-responder" } },
+    );
+    const required = await approvalTurn.waitForEvent("authorization.required");
+
+    const cancelTurn = await approvalTurn.session.startRespond([
+      { optionId: "cancel", requestId: approval.requestId },
+    ]);
+    await cancelTurn.waitForEvent("approval.settled", {
+      data: { outcome: "cancelled", requestId: approval.requestId },
+    });
+    const cancelled = await cancelTurn.result();
+    cancelled.event("approval.settled", {
+      count: 1,
+      data: { outcome: "cancelled", requestId: approval.requestId },
+    });
+    cancelled.notEvent("action.result", {
+      data: { result: { kind: "tool-result", toolName: TOOL_NAME }, status: "completed" },
+    });
+
+    if (
+      required.type !== "authorization.required" ||
+      required.data.authorization?.url === undefined
+    ) {
+      throw new Error("Expected candidate OAuth URL.");
+    }
+    const callbackUrl = new URL(required.data.authorization.url);
+    const callback = await fetch(callbackUrl);
+    if (!callback.ok)
+      throw new Error(`Late fixture OAuth callback failed (${String(callback.status)}).`);
+
+    const late = await cancelTurn.session.send("Confirm the cancelled action did not execute.");
+    late.notEvent("approval.settled", { data: { outcome: "approved" } });
+    late.notEvent("action.result", {
+      data: { result: { kind: "tool-result", toolName: TOOL_NAME }, status: "completed" },
+    });
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response-oauth-nonblocking.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response-oauth-nonblocking.eval.ts
@@ -1,0 +1,57 @@
+import { defineEval } from "eve/evals";
+
+const MARKER = "authorized-response-oauth-nonblocking-K3T9";
+const TOOL_NAME = "oauth-authorized-gate";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "A message runs while candidate OAuth stays open, then OAuth settles the approval.",
+  async test(t) {
+    const parked = await t.send(`Call the \`${TOOL_NAME}\` tool with marker "${MARKER}".`);
+    const approval = t.requireInputRequest({ display: "confirmation", toolName: TOOL_NAME });
+    const approvalTurn = await t.startRespond(
+      [{ optionId: "approve", requestId: approval.requestId }],
+      { headers: { "x-eve-fixture-user": "oauth-nonblocking-responder" } },
+    );
+    const required = await approvalTurn.waitForEvent("authorization.required");
+
+    const message = await approvalTurn.session.send(
+      "Do not call tools. Reply with exactly CANDIDATE-OAUTH-OPEN-OK.",
+    );
+    message.expectOk();
+    message.messageIncludes("CANDIDATE-OAUTH-OPEN-OK");
+    message.notEvent("approval.settled");
+    message.notEvent("action.result", {
+      data: { result: { kind: "tool-result", toolName: TOOL_NAME }, status: "completed" },
+    });
+
+    if (
+      required.type !== "authorization.required" ||
+      required.data.authorization?.url === undefined
+    ) {
+      throw new Error("Expected candidate OAuth URL.");
+    }
+    const callbackUrl = new URL(required.data.authorization.url);
+    const callbackTurn = t.target.watchTurn(approvalTurn.sessionId, {
+      startIndex: t.state?.streamIndex,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const callback = await fetch(callbackUrl);
+    if (!callback.ok)
+      throw new Error(`Fixture OAuth callback failed (${String(callback.status)}).`);
+    const resumed = await callbackTurn.result();
+    resumed.event("authorization.completed", { count: 1, data: { outcome: "authorized" } });
+    resumed.event("approval.settled", {
+      count: 1,
+      data: { outcome: "approved", requestId: approval.requestId },
+    });
+    resumed.event("action.result", {
+      count: 1,
+      data: {
+        result: { kind: "tool-result", output: new RegExp(MARKER), toolName: TOOL_NAME },
+        status: "completed",
+      },
+    });
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response-oauth.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response-oauth.eval.ts
@@ -1,0 +1,65 @@
+import { defineEval } from "eve/evals";
+
+const MARKER = "authorized-response-oauth-e2e-R8N5";
+const TOOL_NAME = "oauth-authorized-gate";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "Approval response policy parks for fake OAuth, resumes, and settles.",
+  async test(t) {
+    const parked = await t.send(`Call the \`${TOOL_NAME}\` tool with marker "${MARKER}".`);
+    const approval = t.requireInputRequest({ display: "confirmation", toolName: TOOL_NAME });
+    const approvalTurn = await t.startRespond([
+      {
+        optionId: "approve",
+        requestId: approval.requestId,
+      },
+    ]);
+
+    const required = await approvalTurn.waitForEvent("authorization.required");
+    if (
+      required?.type !== "authorization.required" ||
+      required.data.authorization?.url === undefined
+    ) {
+      throw new Error("Expected a fake OAuth authorization URL.");
+    }
+    const callbackUrl = new URL(required.data.authorization.url);
+    if (callbackUrl.origin !== new URL(t.target.url).origin) {
+      throw new Error("Fixture OAuth callback targeted an unexpected origin.");
+    }
+    const callback = await fetch(callbackUrl);
+    if (!callback.ok) {
+      throw new Error(
+        `Fixture OAuth callback failed (${String(callback.status)}): ${await callback.text()}`,
+      );
+    }
+
+    const resumed = await approvalTurn.result();
+    resumed.event("approval.candidate", {
+      data: { outcome: "pending", requestId: approval.requestId },
+      count: 1,
+    });
+    resumed.event("authorization.required", { count: 1 });
+    resumed.expectOk();
+    resumed.event("authorization.completed", {
+      data: { candidateId: required.data.candidateId, outcome: "authorized" },
+      count: 1,
+    });
+    resumed.event("approval.settled", {
+      data: { outcome: "approved", requestId: approval.requestId },
+      count: 1,
+    });
+    resumed.event("action.result", {
+      data: {
+        result: {
+          kind: "tool-result",
+          output: new RegExp(MARKER),
+          toolName: TOOL_NAME,
+        },
+        status: "completed",
+      },
+      count: 1,
+    });
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/authorized-response.eval.ts
@@ -1,0 +1,43 @@
+import { defineEval } from "eve/evals";
+
+const MARKER = "authorized-response-e2e-Q7M4";
+const TOOL_NAME = "authorized-gate";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "Authenticated response policy emits candidate and settlement before execution.",
+  async test(t) {
+    const parked = await t.send(`Call the \`${TOOL_NAME}\` tool with marker "${MARKER}".`);
+    const approval = t.requireInputRequest({ display: "confirmation", toolName: TOOL_NAME });
+    parked.calledTool(TOOL_NAME, { status: "pending", count: 1 });
+
+    const approved = await t.respond([
+      {
+        optionId: "approve",
+        requestId: approval.requestId,
+      },
+    ]);
+
+    approved.expectOk();
+    approved.event("approval.candidate", {
+      data: { outcome: "pending", requestId: approval.requestId },
+      count: 1,
+    });
+    approved.event("approval.settled", {
+      data: { outcome: "approved", requestId: approval.requestId },
+      count: 1,
+    });
+    approved.event("action.result", {
+      data: {
+        result: {
+          kind: "tool-result",
+          output: new RegExp(MARKER),
+          toolName: TOOL_NAME,
+        },
+        status: "completed",
+      },
+      count: 1,
+    });
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/text-approve.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/text-approve.eval.ts
@@ -1,14 +1,39 @@
 import { defineEval } from "eve/evals";
 
+const MARKER = "authorized-response-retry-e2e-N4J8";
+const TOOL_NAME = "responder-gate";
+
 export default defineEval({
   tags: ["real-model"],
-  description: "HITL smoke: approval decisions use structured controls.",
+  description: "A rejected responder leaves the approval open for an authorized retry.",
   async test(t) {
-    const parked = await t.send('Call the guarded-echo tool with note "button-only".');
-    parked.calledTool("guarded-echo", { status: "pending", count: 1 });
-    const request = t.requireInputRequest({ display: "confirmation", toolName: "guarded-echo" });
-    const cancelled = await t.respond([{ optionId: "cancel", requestId: request.requestId }]);
-    cancelled.expectOk();
+    const parked = await t.send(`Call the \`${TOOL_NAME}\` tool with marker "${MARKER}".`);
+    const approval = t.requireInputRequest({ display: "confirmation", toolName: TOOL_NAME });
+    parked.calledTool(TOOL_NAME, { status: "pending", count: 1 });
+
+    const rejectedTurn = await t.startRespond(
+      [{ optionId: "approve", requestId: approval.requestId }],
+      { headers: { "x-eve-fixture-user": "unauthorized-responder" } },
+    );
+    await rejectedTurn.waitForEvent("approval.candidate", {
+      data: { outcome: "rejected", requestId: approval.requestId },
+    });
+
+    const approved = await rejectedTurn.session.respond([
+      { optionId: "approve", requestId: approval.requestId },
+    ]);
+    approved.expectOk();
+    approved.event("approval.settled", {
+      count: 1,
+      data: { outcome: "approved", requestId: approval.requestId },
+    });
+    approved.event("action.result", {
+      count: 1,
+      data: {
+        result: { kind: "tool-result", output: new RegExp(MARKER), toolName: TOOL_NAME },
+        status: "completed",
+      },
+    });
     t.succeeded();
   },
 });

--- a/packages/eve/src/evals/context.ts
+++ b/packages/eve/src/evals/context.ts
@@ -56,6 +56,7 @@ export function createEvalContext(deps: {
     cancel: () => primary().cancel(),
     requireInputRequest: (filter) => primary().requireInputRequest(filter),
     respond: (responses, options) => primary().respond(responses, options),
+    startRespond: (responses, options) => primary().startRespond(responses, options),
     respondAll: (optionId) => primary().respondAll(optionId),
     send: (message, options) => {
       lastPrompt = typeof message === "string" ? message : "";

--- a/packages/eve/src/evals/session.ts
+++ b/packages/eve/src/evals/session.ts
@@ -169,6 +169,14 @@ export class EvalSessionDriver implements EveEvalSession {
     return await (await this.#start({ ...options, inputResponses: responses })).result();
   }
 
+  async startRespond(
+    responses: readonly InputResponse[],
+    options: SendTurnOptions = {},
+  ): Promise<EveEvalLiveTurn> {
+    if (responses.length === 0) throw new Error("startRespond() requires input responses.");
+    return await this.#start({ ...options, inputResponses: responses });
+  }
+
   async respondAll(optionId: string): Promise<EveEvalTurn> {
     const requests = this.#pendingInputRequests;
     if (requests.length === 0) {

--- a/packages/eve/src/evals/types.ts
+++ b/packages/eve/src/evals/types.ts
@@ -303,6 +303,11 @@ export interface EveEvalSessionDriver {
   requireInputRequest(filter?: EveEvalInputRequestMatchOptions): InputRequest;
   /** Resolve specific pending requests and run the resumed turn. */
   respond(responses: readonly InputResponse[], options?: SendTurnOptions): Promise<EveEvalTurn>;
+  /** Start a response turn without waiting for its boundary. */
+  startRespond(
+    responses: readonly InputResponse[],
+    options?: SendTurnOptions,
+  ): Promise<EveEvalLiveTurn>;
   /** Resolve every pending request with the same option id. */
   respondAll(optionId: string): Promise<EveEvalTurn>;
   /** Send one turn through this session. */

--- a/packages/eve/src/harness/approval-delivery-coordinator.test.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.test.ts
@@ -62,4 +62,24 @@ describe("coordinateApprovalDelivery", () => {
       { optionId: "approve", requestId: request.requestId },
     ]);
   });
+
+  it("recovers a cancelled settlement before its synthetic response is consumed", async () => {
+    const parked = parkedSession();
+    const settled = settleDirectApprovalResponse({
+      actor: responder,
+      outcome: "cancelled",
+      requestId: request.requestId,
+      settledAt: 100,
+      state: parked.state,
+    });
+    const result = await coordinateApprovalDelivery({
+      now: 101,
+      session: { ...parked, state: settled.state },
+      tools: new Map(),
+    });
+    expect(result.kind).toBe("continue");
+    expect(result.stepInput?.inputResponses).toEqual([
+      { optionId: "cancel", requestId: request.requestId },
+    ]);
+  });
 });

--- a/packages/eve/src/harness/approval-delivery-coordinator.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.ts
@@ -16,6 +16,7 @@ import {
   settleAllowedCandidate,
   settleDirectApprovalResponse,
   type ActiveApprovalCandidate,
+  type ApprovalSettlementAuditRecord,
 } from "#harness/approval-candidates.js";
 import {
   clearPendingAuthorization,
@@ -118,13 +119,8 @@ export async function coordinateApprovalDelivery(input: {
   const pendingRequestIds = new Set(
     batches.flatMap((batch) => batch.requests.map((request) => request.requestId)),
   );
-  const allowedRequestIds = new Set(
-    audit.settlements
-      .filter(
-        (settlement) =>
-          settlement.outcome === "allowed" && pendingRequestIds.has(settlement.requestId),
-      )
-      .map((settlement) => settlement.requestId),
+  const pendingSettlements = audit.settlements.filter((settlement) =>
+    pendingRequestIds.has(settlement.requestId),
   );
   const settledRequestIds = new Set(audit.settlements.map((settlement) => settlement.requestId));
   const discardedDuplicate = hasResponseForRequest(input.stepInput, settledRequestIds);
@@ -133,7 +129,7 @@ export async function coordinateApprovalDelivery(input: {
     : input.stepInput;
   if (
     discardedDuplicate &&
-    allowedRequestIds.size === 0 &&
+    pendingSettlements.length === 0 &&
     !hasMeaningfulInput(deduplicatedInput)
   ) {
     return deliveryResult(session, deduplicatedInput, "park");
@@ -297,11 +293,11 @@ export async function coordinateApprovalDelivery(input: {
     const settlement = getApprovalAuditState(session.state).settlements.find(
       (entry) => entry.requestId === candidate.requestId,
     );
-    if (settlement?.outcome === "allowed") allowedRequestIds.add(candidate.requestId);
+    if (settlement !== undefined) pendingSettlements.push(settlement);
   }
 
-  const resumedStepInput = appendAllowedResponses(remainingStepInput, allowedRequestIds);
-  if (allowedRequestIds.size > 0) {
+  const resumedStepInput = appendSettledResponses(remainingStepInput, pendingSettlements);
+  if (pendingSettlements.length > 0) {
     return deliveryResult(session, resumedStepInput, "continue");
   }
   return didCommit
@@ -478,16 +474,19 @@ function hasMeaningfulInput(stepInput: StepInput | undefined): boolean {
   );
 }
 
-function appendAllowedResponses(
+function appendSettledResponses(
   stepInput: StepInput | undefined,
-  requestIds: ReadonlySet<string>,
+  settlements: readonly ApprovalSettlementAuditRecord[],
 ): StepInput | undefined {
-  if (requestIds.size === 0) return stepInput;
+  if (settlements.length === 0) return stepInput;
   return {
     ...stepInput,
     inputResponses: [
       ...(stepInput?.inputResponses ?? []),
-      ...[...requestIds].map((requestId) => ({ optionId: "approve", requestId })),
+      ...settlements.map((settlement) => ({
+        optionId: settlement.outcome === "allowed" ? "approve" : "cancel",
+        requestId: settlement.requestId,
+      })),
     ],
   };
 }


### PR DESCRIPTION
## Summary

Adds fixture-owned e2e coverage for the responder-authorized HITL lifecycle introduced by this stack.

The deterministic fixture authenticates the eval driver as a fixed user and defines a tool with explicit request and response policies:

```ts
approval: {
  request: always(),
  response: ({ response, responder }) =>
    response.decision === "approve" && responder.principalId === "e2e-approval-responder"
      ? { status: "allowed" }
      : { status: "rejected", safeReason: "Unexpected eval responder." },
}
```

The eval asserts:

```text
input.requested
→ approval.candidate pending
→ approval.settled approved
→ action.result completed
```

It uses no external OAuth provider or injected credential, so the result is deterministic and self-contained.

This also adds compiler/runtime normalization coverage for the explicit `{ request, response }` approval object; previously only the function shorthand was accepted by runtime normalization even though the public type allowed the object form.

Depends on #1374.

## Validation

- `pnpm --filter agent-tools-hitl typecheck`
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- focused authored-definition unit tests

