### PR TITLE
docs: swap homepage agent.ts snippet model to xai/grok-4.5

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/architecture.tsx
+++ b/apps/docs/app/[lang]/(home)/components/architecture.tsx
@@ -5,6 +5,7 @@ import {
   IconArrowUpRightSmall,
   IconLinked,
   IconMessage,
+  IconOpenai,
   IconSandbox,
   IconSparkles,
   IconWorkflow,
@@ -32,22 +33,6 @@ interface Backend {
   Logo: LogoComponent;
 }
 
-// Vendored official xAI mark (via models.dev); not available in geistdocs or simple-icons.
-const LogoXai: LogoComponent = ({ size = 16, className }) => (
-  <svg
-    className={className}
-    height={size}
-    viewBox="0 0 40 40"
-    width={size}
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M12.4579 15.6036L26.1529 35H20.0656L6.37059 15.6036H12.4579ZM12.4524 26.3764L15.4974 30.6909L12.4551 35H6.36377L12.4524 26.3764ZM33.6365 7.15727V35H28.647V14.2236L33.6365 7.15727ZM33.6365 5L20.0656 24.2205L17.0206 19.9073L27.5451 5H33.6365Z"
-      fill="currentColor"
-    />
-  </svg>
-);
-
 interface Primitive {
   icon: ReactNode;
   title: string;
@@ -69,7 +54,7 @@ const RUNTIME_ITEMS: Primitive[] = [
     href: "https://ai-sdk.dev/",
     backend: {
       managed: { label: "AI Gateway", Logo: LogoIconVercel },
-      "self-hosted": { label: "Grok 4.5 API", Logo: LogoXai },
+      "self-hosted": { label: "GPT-5.4 API", Logo: IconOpenai },
     },
   },
   {

--- a/apps/docs/app/[lang]/(home)/components/architecture.tsx
+++ b/apps/docs/app/[lang]/(home)/components/architecture.tsx
@@ -5,7 +5,6 @@ import {
   IconArrowUpRightSmall,
   IconLinked,
   IconMessage,
-  IconOpenai,
   IconSandbox,
   IconSparkles,
   IconWorkflow,
@@ -33,6 +32,22 @@ interface Backend {
   Logo: LogoComponent;
 }
 
+// Vendored official xAI mark (via models.dev); not available in geistdocs or simple-icons.
+const LogoXai: LogoComponent = ({ size = 16, className }) => (
+  <svg
+    className={className}
+    height={size}
+    viewBox="0 0 40 40"
+    width={size}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12.4579 15.6036L26.1529 35H20.0656L6.37059 15.6036H12.4579ZM12.4524 26.3764L15.4974 30.6909L12.4551 35H6.36377L12.4524 26.3764ZM33.6365 7.15727V35H28.647V14.2236L33.6365 7.15727ZM33.6365 5L20.0656 24.2205L17.0206 19.9073L27.5451 5H33.6365Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 interface Primitive {
   icon: ReactNode;
   title: string;
@@ -54,7 +69,7 @@ const RUNTIME_ITEMS: Primitive[] = [
     href: "https://ai-sdk.dev/",
     backend: {
       managed: { label: "AI Gateway", Logo: LogoIconVercel },
-      "self-hosted": { label: "GPT-5.4 API", Logo: IconOpenai },
+      "self-hosted": { label: "Grok 4.5 API", Logo: LogoXai },
     },
   },
   {

--- a/apps/docs/app/[lang]/(home)/components/file-tree.tsx
+++ b/apps/docs/app/[lang]/(home)/components/file-tree.tsx
@@ -163,7 +163,7 @@ export default defineMcpClientConnection({
 
 export default defineAgent({
   description: "Investigate questions",
-  model: "openai/gpt-5.4",
+  model: "xai/grok-4.5",
 });`,
   },
   {

--- a/apps/docs/app/[lang]/(home)/components/file-tree.tsx
+++ b/apps/docs/app/[lang]/(home)/components/file-tree.tsx
@@ -58,7 +58,7 @@ city in the world.`,
     code: `import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "openai/gpt-5.4-mini",
+  model: "xai/grok-4.5",
 });`,
   },
   {


### PR DESCRIPTION
### Summary

Updates the models referenced on the eve.dev homepage: both code snippets in the file-tree demo — the `agent.ts` snippet (`openai/gpt-5.4-mini`) and the Sub Agents snippet (`openai/gpt-5.4`) — now read `model: "xai/grok-4.5"`. Copy-only change in `apps/docs/app/[lang]/(home)/components/file-tree.tsx`; no behavior or component logic changes.

`xai/grok-4.5` was verified against the AI Gateway model list, so the snippets reference a real, currently available model ID.

### Validation

- `curl https://ai-gateway.vercel.sh/v1/models` confirms `xai/grok-4.5` is a valid model ID
- No tests or docs checks run — string-literal copy edit only

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

Tests, docs updates, and a changeset are not applicable — docs-site copy change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
