### PR TITLE
feat(eve): make integration setup headless-capable

### DIFF
--- a/packages/eve/src/setup/flows/ensure-vercel-project.test.ts
+++ b/packages/eve/src/setup/flows/ensure-vercel-project.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+
+import { ensureVercelProject } from "./ensure-vercel-project.js";
+
+describe("ensureVercelProject", () => {
+  it("headless returns an existing link without opening a flow", async () => {
+    const readProjectLink = vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" }));
+
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter: createFakePrompter().prompter,
+        headless: true,
+        deps: { readProjectLink },
+      }),
+    ).resolves.toEqual({ orgId: "team-id", projectId: "project-id" });
+    expect(readProjectLink).toHaveBeenCalledTimes(1);
+  });
+
+  it("headless refuses to open the interactive linking flow when nothing is linked", async () => {
+    const readProjectLink = vi.fn(async () => undefined);
+
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter: createFakePrompter().prompter,
+        headless: true,
+        deps: { readProjectLink },
+      }),
+    ).rejects.toThrow("not linked to a Vercel project");
+    // The refusal happens before the interactive boxes run: the link probe is
+    // the only read (the post-flow verification read never happens).
+    expect(readProjectLink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eve/src/setup/flows/ensure-vercel-project.ts
+++ b/packages/eve/src/setup/flows/ensure-vercel-project.ts
@@ -22,12 +22,24 @@ export async function ensureVercelProject(input: {
   appRoot: string;
   prompter: Prompter;
   signal?: AbortSignal;
+  /**
+   * Headless runs never open the interactive linking flow below: an existing
+   * link is returned and a missing link fails, so the caller completes this
+   * shared one-time prerequisite separately.
+   */
+  headless?: boolean;
   teamSelectMessage?: (currentTeam: string) => string;
   deps?: Partial<EnsureVercelProjectDeps>;
 }): Promise<VercelProjectReference> {
   const readLink = input.deps?.readProjectLink ?? readProjectLink;
   const existing = await readLink(input.appRoot);
   if (existing !== undefined) return existing;
+
+  if (input.headless) {
+    throw new Error(
+      "This project is not linked to a Vercel project, and headless setup cannot open the interactive linking flow. Link the project separately, then retry.",
+    );
+  }
 
   const state = inProjectSetupState(input.appRoot, { kind: "unresolved" });
   const boxes: AnySetupBox<SetupState>[] = [

--- a/packages/eve/src/setup/integrations/discord/setup.test.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.test.ts
@@ -66,6 +66,9 @@ describe("Discord setup", () => {
       expect.stringContaining('connectDiscordCredentials("discord/agent")'),
       { force: undefined },
     );
+    expect(effects.ensureVercelProject).toHaveBeenCalledWith(
+      expect.objectContaining({ headless: undefined }),
+    );
   });
 
   it("prefills the command name and description", async () => {
@@ -98,6 +101,33 @@ describe("Discord setup", () => {
           detected: "Ask the eve agent",
         }),
       ]),
+    );
+  });
+
+  it("hands headless runs keyed answers and a headless Vercel-link prerequisite", async () => {
+    const effects = deps();
+
+    await expect(
+      setupDiscord(
+        {
+          appRoot: "/project",
+          environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+          headless: true,
+          ui: createIntegrationSetupUi({
+            asker: asker({
+              "discord-bot-token": "bot-token",
+              "discord-command-name": "ask",
+              "discord-command-description": "Ask the eve agent",
+            }),
+            prompter: createFakePrompter().prompter,
+          }),
+        },
+        effects,
+      ),
+    ).resolves.toMatchObject({ kind: "done" });
+
+    expect(effects.ensureVercelProject).toHaveBeenCalledWith(
+      expect.objectContaining({ headless: true }),
     );
   });
 

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -119,6 +119,9 @@ export async function setupDiscord(
       appRoot: context.appRoot,
       prompter: context.ui.prompter,
       signal: context.signal,
+      // A headless run completes this shared prerequisite separately instead
+      // of falling into its interactive linking flow.
+      headless: context.headless,
     });
     const connector = await deps.provisionConnector({
       botToken,

--- a/packages/eve/src/setup/integrations/runner.ts
+++ b/packages/eve/src/setup/integrations/runner.ts
@@ -1,4 +1,4 @@
-import { interactiveAsker } from "#setup/ask.js";
+import { headlessAsker, interactiveAsker, withAnswers } from "#setup/ask.js";
 import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 import { detectDeployment, projectResolutionFromDeployment } from "#setup/project-resolution.js";
 import type { Prompter } from "#setup/prompter.js";
@@ -17,6 +17,13 @@ export interface RunIntegrationSetupOptions {
   prompter: Prompter;
   signal?: AbortSignal;
   yes?: boolean;
+  /**
+   * Headless runs supply pre-answered questions by stable key. Setting this
+   * makes the run headless: unmatched non-required questions skip, required
+   * ones refuse with InteractionRequired, and the context carries `headless`
+   * so one-time interactive prerequisites stay out of the run.
+   */
+  answers?: Record<string, unknown>;
 }
 
 /** Effects shared by the built-in integration setup runner. */
@@ -51,15 +58,20 @@ export async function runIntegrationSetup(
   const project = projectResolutionFromDeployment(deployment);
   const environment = integrationSetupEnvironment(authStatus, project);
   options.prompter.log.info(describeIntegrationSetupEnvironment(environment));
+  // Headless runs (answers supplied) swap the terminal for the keyed answer
+  // ladder: supplied answers win; the rest skips when non-required and
+  // refuses with InteractionRequired when required.
+  const headless = options.answers !== undefined;
+  const asker = headless
+    ? withAnswers(options.answers ?? {})(headlessAsker())
+    : interactiveAsker(options.prompter);
   const result = await integration.setup({
     environment,
     appRoot: options.appRoot,
-    ui: createIntegrationSetupUi({
-      asker: interactiveAsker(options.prompter),
-      prompter: options.prompter,
-    }),
+    ui: createIntegrationSetupUi({ asker, prompter: options.prompter }),
     yes: options.yes,
     signal: options.signal,
+    headless,
   });
   return result;
 }

--- a/packages/eve/src/setup/integrations/types.ts
+++ b/packages/eve/src/setup/integrations/types.ts
@@ -11,6 +11,12 @@ export interface IntegrationSetupContext {
   readonly signal?: AbortSignal;
   readonly force?: boolean;
   readonly yes?: boolean;
+  /**
+   * True when the caller has no terminal: prompts resolve from keyed answers
+   * or refuse, and one-time interactive prerequisites (Vercel project
+   * linking) are completed separately instead of opening a flow.
+   */
+  readonly headless?: boolean;
 }
 
 /** Outcome from one registry-owned integration setup flow. */


### PR DESCRIPTION
Fixes #1786

## Summary
- route keyed answers through the existing Asker ladder for headless integration setup
- keep interactive behavior unchanged and make Vercel linking an explicit headless prerequisite
- add focused Discord setup coverage

## Verification
local verification not run; relying on upstream CI

The worktree has no installed node_modules, so the repository test and typecheck commands cannot run locally.