### PR TITLE
feat(eve): persist instrumentation provider state

### DIFF
--- a/.changeset/instrumentation-provider-state.md
+++ b/.changeset/instrumentation-provider-state.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add durable operation-scoped state to instrumentation providers, including provider isolation and automatic terminal cleanup.

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -24,6 +24,7 @@ import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js
 import { runStep } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import { getHarnessEmissionState } from "#harness/emission.js";
+import { preserveSerializedInstrumentationState } from "#harness/instrumentation-state.js";
 import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
 import { readTurnSleepDurationMs } from "#harness/turn-sleep.js";
 import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellation.js";
@@ -452,11 +453,15 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   } catch (error) {
     if (!isTurnCancellation(error)) throw error;
     writer.releaseLock();
+    // Both carve-outs exist because the cancellation epilogue still publishes
+    // `turn.cancelled` downstream, and the open spans and provider state it
+    // needs to close were written by the step being discarded.
+    const interrupted = serializeContext(ctx);
     return {
       action: "cancelled",
-      serializedContext: preserveSerializedAgentTraceState(
-        input.serializedContext,
-        serializeContext(ctx),
+      serializedContext: preserveSerializedInstrumentationState(
+        preserveSerializedAgentTraceState(input.serializedContext, interrupted),
+        interrupted,
       ),
       sessionState: input.sessionState,
     };

--- a/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/harness/ai-sdk-hook-bridge.test.ts
@@ -38,6 +38,7 @@ describe("createAiSdkHookBridge", () => {
             );
           },
         },
+        name,
       };
     };
     const hooks = createInstrumentationHooks([provider("a"), provider("b")]);
@@ -221,6 +222,7 @@ describe("createAiSdkHookBridge", () => {
 
     expect(after).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ error, type: "model.call.failed" }),
+      expect.anything(),
     );
   });
 
@@ -250,8 +252,8 @@ describe("createAiSdkHookBridge", () => {
       scope,
       type: "step.attempt.started",
     };
-    expect(mutator).toHaveBeenCalledExactlyOnceWith(expected);
-    expect(started).toHaveBeenCalledExactlyOnceWith(expected);
+    expect(mutator).toHaveBeenCalledExactlyOnceWith(expected, expect.anything());
+    expect(started).toHaveBeenCalledExactlyOnceWith(expected, expect.anything());
   });
 
   it("projects the model call callbacks onto eve fields only", async () => {
@@ -306,33 +308,39 @@ describe("createAiSdkHookBridge", () => {
       },
     ]);
 
-    expect(before).toHaveBeenCalledExactlyOnceWith({
-      idempotencyKey: `model:${scope.attemptId}:0`,
-      input: { instructions: "be brief", messages: [{ content: "hi", role: "user" }] },
-      model: { modelId: "model", provider: "test" },
-      scope,
-      type: "model.call.started",
-    });
+    expect(before).toHaveBeenCalledExactlyOnceWith(
+      {
+        idempotencyKey: `model:${scope.attemptId}:0`,
+        input: { instructions: "be brief", messages: [{ content: "hi", role: "user" }] },
+        model: { modelId: "model", provider: "test" },
+        scope,
+        type: "model.call.started",
+      },
+      expect.anything(),
+    );
     // An unrecognized part kind is dropped rather than forwarded, so widening
     // InstrumentationContentPart is what makes a new kind reachable.
-    expect(after).toHaveBeenCalledExactlyOnceWith({
-      content: [
-        { text: "thinking", type: "reasoning" },
-        { text: "hello", type: "text" },
-        { input: { a: 1 }, toolName: "search", type: "tool-call" },
-        { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
-        { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
-      ],
-      finishReason: "tool-calls",
-      idempotencyKey: `model:${scope.attemptId}:0`,
-      scope,
-      type: "model.call.completed",
-      usage: {
-        inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
-        inputTokens: 1,
-        outputTokens: 2,
+    expect(after).toHaveBeenCalledExactlyOnceWith(
+      {
+        content: [
+          { text: "thinking", type: "reasoning" },
+          { text: "hello", type: "text" },
+          { input: { a: 1 }, toolName: "search", type: "tool-call" },
+          { input: { a: 1 }, output: "ok", toolName: "search", type: "tool-result" },
+          { error: "boom", input: { a: 2 }, toolName: "search", type: "tool-error" },
+        ],
+        finishReason: "tool-calls",
+        idempotencyKey: `model:${scope.attemptId}:0`,
+        scope,
+        type: "model.call.completed",
+        usage: {
+          inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
+          inputTokens: 1,
+          outputTokens: 2,
+        },
       },
-    });
+      expect.anything(),
+    );
   });
 
   it.each([
@@ -366,21 +374,27 @@ describe("createAiSdkHookBridge", () => {
         { callId: "call-1", toolCall, toolExecutionMs: 1, toolOutput },
       ]);
 
-      expect(before).toHaveBeenCalledExactlyOnceWith({
-        callId: "tool-1",
-        idempotencyKey: `tool:${scope.attemptId}:tool-1:0`,
-        input: { q: "eve" },
-        kind: "tool-call",
-        scope,
-        toolName: "search",
-        type: "tool.call.started",
-      });
-      expect(after).toHaveBeenCalledExactlyOnceWith({
-        idempotencyKey: `tool:${scope.attemptId}:tool-1:0`,
-        output: expected,
-        scope,
-        type: "tool.call.completed",
-      });
+      expect(before).toHaveBeenCalledExactlyOnceWith(
+        {
+          callId: "tool-1",
+          idempotencyKey: `tool:${scope.attemptId}:tool-1:0`,
+          input: { q: "eve" },
+          kind: "tool-call",
+          scope,
+          toolName: "search",
+          type: "tool.call.started",
+        },
+        expect.anything(),
+      );
+      expect(after).toHaveBeenCalledExactlyOnceWith(
+        {
+          idempotencyKey: `tool:${scope.attemptId}:tool-1:0`,
+          output: expected,
+          scope,
+          type: "tool.call.completed",
+        },
+        expect.anything(),
+      );
     },
   );
 
@@ -414,6 +428,7 @@ describe("createAiSdkHookBridge", () => {
           },
           "model.call.started": (event) => void own.set(event.idempotencyKey, `${name}-state`),
         },
+        name,
       };
     };
     const hooks = createInstrumentationHooks([provider("a"), provider("b")]);

--- a/packages/eve/src/harness/instrumentation-lifecycle.test.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import { ContextContainer, contextStorage } from "#context/container.js";
 import {
   attemptIdempotencyKey,
+  createInstrumentationHooks,
   modelCallIdempotencyKey,
   sessionIdempotencyKey,
   toolCallIdempotencyKey,
   turnIdempotencyKey,
   type InstrumentationAttemptScope,
 } from "#harness/instrumentation-lifecycle.js";
+import { instrumentationStateSlot } from "#harness/instrumentation-state.js";
 
 const scope: InstrumentationAttemptScope = {
   attemptId: "session-1:turn-1:0:0",
@@ -36,5 +39,80 @@ describe("instrumentation idempotency keys", () => {
     const retry = { ...scope, attemptId: "session-1:turn-1:0:1", attemptIndex: 1 };
     expect(attemptIdempotencyKey(scope)).not.toBe(attemptIdempotencyKey(retry));
     expect(modelCallIdempotencyKey(scope, 0)).not.toBe(toolCallIdempotencyKey(scope, "call-1", 0));
+  });
+});
+
+describe("provider state lifecycle", () => {
+  const started = {
+    idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+    rootSessionId: "session-1",
+    sequence: 0,
+    sessionId: "session-1",
+    turnId: "turn-1",
+    type: "turn.started" as const,
+  };
+  const completed = {
+    idempotencyKey: started.idempotencyKey,
+    sessionId: "session-1",
+    turnId: "turn-1",
+    type: "turn.completed" as const,
+  };
+
+  it("carries a value from a start to its terminal and releases it", async () => {
+    let observed: unknown;
+    const hooks = createInstrumentationHooks([
+      {
+        events: {
+          "turn.completed": (_event, ctx) => {
+            observed = ctx.state.get();
+          },
+          "turn.started": (_event, ctx) => ctx.state.set({ rowId: "row-1" }),
+        },
+        name: "sink",
+      },
+    ]);
+
+    await contextStorage.run(new ContextContainer(), async () => {
+      await hooks.publish(started);
+      await hooks.publish(completed);
+      expect(instrumentationStateSlot("sink", started.idempotencyKey).get()).toBeUndefined();
+    });
+    expect(observed).toEqual({ rowId: "row-1" });
+  });
+
+  it("releases state when no terminal handler exists", async () => {
+    const hooks = createInstrumentationHooks([
+      { events: { "turn.started": (_event, ctx) => ctx.state.set("open") }, name: "sink" },
+    ]);
+    await contextStorage.run(new ContextContainer(), async () => {
+      await hooks.publish(started);
+      await hooks.publish(completed);
+      expect(instrumentationStateSlot("sink", started.idempotencyKey).get()).toBeUndefined();
+    });
+  });
+
+  it("releases unterminated model state when its attempt ends", async () => {
+    const modelKey = modelCallIdempotencyKey(scope, 0);
+    const hooks = createInstrumentationHooks([
+      {
+        events: { "model.call.started": (_event, ctx) => ctx.state.set("open") },
+        name: "sink",
+      },
+    ]);
+    await contextStorage.run(new ContextContainer(), async () => {
+      await hooks.publish({
+        idempotencyKey: modelKey,
+        input: { messages: [] },
+        model: { modelId: "model", provider: "test" },
+        scope,
+        type: "model.call.started",
+      });
+      await hooks.publish({
+        idempotencyKey: attemptIdempotencyKey(scope),
+        scope,
+        type: "step.attempt.completed",
+      });
+      expect(instrumentationStateSlot("sink", modelKey).get()).toBeUndefined();
+    });
   });
 });

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -1,4 +1,10 @@
 import { createLogger, formatError } from "#internal/logging.js";
+import {
+  instrumentationStateSlot,
+  releaseInstrumentationAttemptState,
+  releaseInstrumentationState,
+  type InstrumentationStateSlot,
+} from "#harness/instrumentation-state.js";
 
 /**
  * Stable eve identity for one actual model attempt.
@@ -285,15 +291,23 @@ export type InstrumentationToolCallTerminalEvent =
   | InstrumentationToolCallCompletedEvent
   | InstrumentationToolCallFailedEvent;
 
+export interface InstrumentationHandlerContext {
+  readonly state: InstrumentationStateSlot;
+}
+
 /**
  * The AI SDK can omit a model terminal when an incomplete stream closes. A
  * provider that correlates starts with terminals must scope that state to the
  * attempt and release anything still open when the step attempt terminates.
  */
-export type InstrumentationEventHandler<TEvent> = (event: TEvent) => void | PromiseLike<void>;
+export type InstrumentationEventHandler<TEvent> = (
+  event: TEvent,
+  ctx: InstrumentationHandlerContext,
+) => void | PromiseLike<void>;
 
 /** Internal provider shape mirrored by the future public hook contract. */
 export interface InstrumentationProviderDefinition {
+  readonly name: string;
   readonly events?: {
     readonly "step.attempt.started"?: InstrumentationEventHandler<InstrumentationStepAttemptStartedEvent>;
     readonly "step.attempt.completed"?: InstrumentationEventHandler<InstrumentationStepAttemptCompletedEvent>;
@@ -315,9 +329,12 @@ export interface InstrumentationProviderDefinition {
     readonly "turn.started"?: InstrumentationEventHandler<InstrumentationTurnStartedEvent>;
   };
   readonly flush?: () => void | PromiseLike<void>;
-  readonly name?: string;
   readonly shutdown?: () => void | PromiseLike<void>;
 }
+
+type InstrumentationProviderInput = Omit<InstrumentationProviderDefinition, "name"> & {
+  readonly name?: string;
+};
 
 /** Events that pair a start with its terminal under one `idempotencyKey`. */
 export type InstrumentationCorrelatedEvent =
@@ -365,22 +382,53 @@ const log = createLogger("harness.instrumentation-lifecycle");
 
 /** Creates failure-isolated hooks backed by an ordered provider list. */
 export function createInstrumentationHooks(
-  providers: readonly InstrumentationProviderDefinition[],
+  providers: readonly InstrumentationProviderInput[],
 ): InstrumentationHooks {
   const publish = async (event: InstrumentationEvent): Promise<void> => {
-    for (const provider of providers) {
+    const terminal = isTerminal(event.type);
+    const attemptTerminal =
+      event.type === "step.attempt.completed" || event.type === "step.attempt.failed";
+    const attemptId = stateAttemptId(event);
+    for (const [providerIndex, provider] of providers.entries()) {
+      const providerName = provider.name ?? `provider-${String(providerIndex)}`;
+      const release = (): void => {
+        if (terminal) releaseInstrumentationState(providerName, event.idempotencyKey);
+        if (attemptTerminal)
+          releaseInstrumentationAttemptState(providerName, event.scope.attemptId);
+      };
       const handler = provider.events?.[event.type];
-      if (handler === undefined) continue;
+      if (handler === undefined) {
+        release();
+        continue;
+      }
+      const state = instrumentationStateSlot(providerName, event.idempotencyKey, attemptId);
       try {
-        await (handler as InstrumentationEventHandler<InstrumentationEvent>)(event);
+        await (handler as InstrumentationEventHandler<InstrumentationEvent>)(event, { state });
       } catch (error) {
         log.warn("instrumentation provider failed", {
           boundary: event.type,
           error: formatError(error),
+          provider: providerName,
         });
+      } finally {
+        state.revoke();
+        release();
       }
     }
   };
 
   return { publish };
+}
+
+function stateAttemptId(event: InstrumentationEvent): string | undefined {
+  if (!("scope" in event)) return undefined;
+  return event.type.startsWith("model.call.") ||
+    event.type.startsWith("tool.call.") ||
+    event.type.startsWith("step.attempt.")
+    ? event.scope.attemptId
+    : undefined;
+}
+
+function isTerminal(type: InstrumentationEvent["type"]): boolean {
+  return type.endsWith(".completed") || type.endsWith(".failed") || type.endsWith(".cancelled");
 }

--- a/packages/eve/src/harness/instrumentation-providers.ts
+++ b/packages/eve/src/harness/instrumentation-providers.ts
@@ -1,7 +1,4 @@
-import type {
-  InstrumentationEvent,
-  InstrumentationProviderDefinition,
-} from "#harness/instrumentation-lifecycle.js";
+import type { InstrumentationProviderDefinition } from "#harness/instrumentation-lifecycle.js";
 import {
   getInstrumentationRuntime,
   type InstrumentationRuntime,
@@ -15,9 +12,7 @@ import { collectOtelPipeline } from "#tracing/otel-declaration.js";
 import {
   isInstrumentationDisabled,
   isInstrumentationProvider,
-  type Handler,
   type InstrumentationProvider,
-  type ProviderContext,
 } from "#public/instrumentation/provider.js";
 
 /**
@@ -130,19 +125,11 @@ export async function shutdownInstrumentationProviders(): Promise<void> {
   await getInstrumentationRuntime()?.shutdown();
 }
 
-const PROVIDER_CONTEXT: ProviderContext = Object.freeze({});
-
 function toProviderDefinition(
   entry: RegisteredInstrumentationProvider,
 ): InstrumentationProviderDefinition {
-  const events: Record<string, (event: never) => void | PromiseLike<void>> = {};
-  for (const [type, handler] of Object.entries(entry.provider.events ?? {})) {
-    if (handler === undefined) continue;
-    const invoke = handler as Handler<InstrumentationEvent>;
-    events[type] = (event: InstrumentationEvent) => invoke(event, PROVIDER_CONTEXT);
-  }
   return {
-    events: events as InstrumentationProviderDefinition["events"],
+    events: entry.provider.events as InstrumentationProviderDefinition["events"],
     flush: entry.provider.flush,
     name: entry.slot,
     shutdown: entry.provider.shutdown,

--- a/packages/eve/src/harness/instrumentation-state.test.ts
+++ b/packages/eve/src/harness/instrumentation-state.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import {
+  instrumentationStateSlot,
+  preserveSerializedInstrumentationState,
+  releaseInstrumentationAttemptState,
+  releaseInstrumentationState,
+} from "#harness/instrumentation-state.js";
+
+describe("instrumentation state", () => {
+  it("survives a serialized step boundary", async () => {
+    const context = new ContextContainer();
+    contextStorage.run(context, () => {
+      instrumentationStateSlot("sink", "model:1", "attempt-1").set({ rowId: "row-1" });
+    });
+    const restored = await deserializeContext(await serializeContext(context));
+    contextStorage.run(restored, () => {
+      expect(instrumentationStateSlot("sink", "model:1").get()).toEqual({ rowId: "row-1" });
+    });
+  });
+
+  it("isolates providers and operations", () => {
+    contextStorage.run(new ContextContainer(), () => {
+      instrumentationStateSlot("a", "turn:1").set("a-1");
+      instrumentationStateSlot("b", "turn:1").set("b-1");
+      instrumentationStateSlot("a", "turn:2").set("a-2");
+      expect(instrumentationStateSlot("a", "turn:1").get()).toBe("a-1");
+      expect(instrumentationStateSlot("b", "turn:1").get()).toBe("b-1");
+      expect(instrumentationStateSlot("a", "turn:2").get()).toBe("a-2");
+    });
+  });
+
+  it("rejects values that cannot survive serialization", () => {
+    contextStorage.run(new ContextContainer(), () => {
+      expect(() => instrumentationStateSlot("sink", "turn:1").set(new Date() as never)).toThrow(
+        TypeError,
+      );
+    });
+  });
+
+  it("revokes late reads and writes", () => {
+    contextStorage.run(new ContextContainer(), () => {
+      const lease = instrumentationStateSlot("sink", "turn:1");
+      lease.set("before");
+      lease.revoke();
+      lease.set("after");
+      expect(lease.get()).toBeUndefined();
+      expect(instrumentationStateSlot("sink", "turn:1").get()).toBe("before");
+    });
+  });
+
+  it("releases exact and attempt-owned state", () => {
+    contextStorage.run(new ContextContainer(), () => {
+      instrumentationStateSlot("sink", "model:1", "attempt-1").set("one");
+      instrumentationStateSlot("sink", "model:2", "attempt-2").set("two");
+      releaseInstrumentationState("sink", "model:2");
+      releaseInstrumentationAttemptState("sink", "attempt-1");
+      expect(instrumentationStateSlot("sink", "model:1").get()).toBeUndefined();
+      expect(instrumentationStateSlot("sink", "model:2").get()).toBeUndefined();
+    });
+  });
+
+  it("preserves state from a discarded step", () => {
+    expect(
+      preserveSerializedInstrumentationState(
+        { authored: "original" },
+        { "eve.harness.instrumentationState": { state: true } },
+      ),
+    ).toEqual({
+      authored: "original",
+      "eve.harness.instrumentationState": { state: true },
+    });
+  });
+});

--- a/packages/eve/src/harness/instrumentation-state.ts
+++ b/packages/eve/src/harness/instrumentation-state.ts
@@ -1,0 +1,129 @@
+import { contextStorage, loadContext } from "#context/container.js";
+import { ContextKey } from "#context/key.js";
+import { type JsonValue, parseJsonValue } from "#shared/json.js";
+
+interface InstrumentationStateRecord {
+  readonly attemptId?: string;
+  readonly value: JsonValue;
+}
+
+type InstrumentationStateMap = Readonly<Record<string, InstrumentationStateRecord>>;
+
+const InstrumentationStateKey = new ContextKey<InstrumentationStateMap>(
+  "eve.harness.instrumentationState",
+  {
+    codec: {
+      deserialize: deserializeState,
+      serialize: (state) => state,
+    },
+  },
+);
+
+/** Keeps provider state from an interrupted step's discarded context changes. */
+export function preserveSerializedInstrumentationState(
+  original: Record<string, unknown>,
+  interrupted: Record<string, unknown>,
+): Record<string, unknown> {
+  const state = interrupted[InstrumentationStateKey.name];
+  return state === undefined ? original : { ...original, [InstrumentationStateKey.name]: state };
+}
+
+export interface InstrumentationStateSlot {
+  get(): JsonValue | undefined;
+  set(value: JsonValue | undefined): void;
+}
+
+export interface InstrumentationStateLease extends InstrumentationStateSlot {
+  revoke(): void;
+}
+
+/** One provider's durable state for one operation. */
+export function instrumentationStateSlot(
+  provider: string,
+  idempotencyKey: string,
+  attemptId?: string,
+): InstrumentationStateLease {
+  const key = stateKey(provider, idempotencyKey);
+  let active = true;
+  return {
+    get: () =>
+      active ? contextStorage.getStore()?.get(InstrumentationStateKey)?.[key]?.value : undefined,
+    revoke: () => {
+      active = false;
+    },
+    set: (value) => {
+      if (!active || contextStorage.getStore() === undefined) return;
+      if (value === undefined) {
+        writeState((state) => writeSlot(state, key, undefined));
+        return;
+      }
+      const record: InstrumentationStateRecord = { value: parseJsonValue(value) };
+      if (attemptId !== undefined) {
+        (record as { attemptId?: string }).attemptId = attemptId;
+      }
+      writeState((state) => writeSlot(state, key, record));
+    },
+  };
+}
+
+export function releaseInstrumentationState(provider: string, idempotencyKey: string): void {
+  const key = stateKey(provider, idempotencyKey);
+  const current = contextStorage.getStore()?.get(InstrumentationStateKey);
+  if (current?.[key] === undefined) return;
+  writeState((state) => writeSlot(state, key, undefined));
+}
+
+/** Releases children whose terminal may be omitted when an attempt ends. */
+export function releaseInstrumentationAttemptState(provider: string, attemptId: string): void {
+  const prefix = `${provider}\0`;
+  const current = contextStorage.getStore()?.get(InstrumentationStateKey);
+  if (current === undefined) return;
+  if (
+    !Object.entries(current).some(
+      ([key, record]) => key.startsWith(prefix) && record.attemptId === attemptId,
+    )
+  ) {
+    return;
+  }
+  writeState((state) => {
+    const next = { ...state };
+    for (const [key, record] of Object.entries(state)) {
+      if (key.startsWith(prefix) && record.attemptId === attemptId) delete next[key];
+    }
+    return next;
+  });
+}
+
+function writeState(update: (state: InstrumentationStateMap) => InstrumentationStateMap): void {
+  loadContext().set(InstrumentationStateKey, (state) => update(state ?? {}));
+}
+
+function writeSlot(
+  state: InstrumentationStateMap,
+  key: string,
+  value: InstrumentationStateRecord | undefined,
+): InstrumentationStateMap {
+  const next = { ...state };
+  if (value === undefined) delete next[key];
+  else next[key] = value;
+  return next;
+}
+
+function stateKey(provider: string, idempotencyKey: string): string {
+  return `${provider}\0${idempotencyKey}`;
+}
+
+function deserializeState(data: unknown): InstrumentationStateMap {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
+  const state: Record<string, InstrumentationStateRecord> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+    const record = value as Record<string, unknown>;
+    if (record["value"] === undefined) continue;
+    state[key] = {
+      attemptId: typeof record["attemptId"] === "string" ? record["attemptId"] : undefined,
+      value: record["value"] as JsonValue,
+    };
+  }
+  return state;
+}

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -9628,6 +9628,7 @@ describe("createToolLoopHarness", () => {
           scope: expect.objectContaining({ attemptIndex: 0 }),
           type: "step.attempt.completed",
         }),
+        expect.anything(),
       );
     });
 
@@ -9709,6 +9710,7 @@ describe("createToolLoopHarness", () => {
           toolName: "delegate",
           type: "tool.call.started",
         }),
+        expect.anything(),
       );
     });
 

--- a/packages/eve/src/public/instrumentation/provider.ts
+++ b/packages/eve/src/public/instrumentation/provider.ts
@@ -10,6 +10,9 @@
 // from the union below is what keeps the public contract from drifting away
 // from the bus that feeds it.
 import type { InstrumentationEvent } from "#harness/instrumentation-lifecycle.js";
+import type { JsonValue } from "#public/types/json.js";
+
+export type { JsonValue } from "#public/types/json.js";
 
 export type {
   InstrumentationActionKind,
@@ -74,20 +77,21 @@ export interface ProviderSetupContext {
   readonly frameworkVersion: string;
 }
 
-/**
- * The second argument to every handler.
- *
- * Empty today. It exists now so adding durable per-provider state later is an
- * additive change rather than a second break in every handler signature.
- */
-export type ProviderContext = Readonly<Record<never, never>>;
+export interface ProviderState {
+  get(): JsonValue | undefined;
+  /** Stages a JSON value; `undefined` releases this operation's slot. */
+  set(value: JsonValue | undefined): void;
+}
+
+export interface ProviderContext {
+  readonly state: ProviderState;
+}
 
 /**
  * One event handler.
  *
- * eve balances every start with exactly one terminal, so a handler that needs
- * to carry a value from a start to its terminal can key its own map on
- * `event.id` and delete on the terminal.
+ * A handler can carry durable JSON state from a start to its terminal through
+ * `ctx.state`. eve scopes and releases that state by provider and operation.
  */
 export type Handler<TEvent> = (event: TEvent, ctx: ProviderContext) => void | PromiseLike<void>;
 

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -516,6 +516,7 @@ export function createAgentOtelInstrumentation(
         "turn.failed": onTurnTerminal,
         "turn.started": onTurnStarted,
       },
+      name: "eve.otel",
     },
     runInContext(operation, execute) {
       const contexts = executionContexts.get(operation.scope);

--- a/packages/eve/src/tracing/install-instrumentation-runtime.test.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.test.ts
@@ -45,7 +45,7 @@ describe("installInstrumentationRuntime", () => {
     const runtime = installInstrumentationRuntime({
       collected: collectOtelPipeline([otelIntegration()]),
       frameworkVersion: "test",
-      providers: [{ flush: providerFlush, shutdown: providerShutdown }],
+      providers: [{ flush: providerFlush, name: "test", shutdown: providerShutdown }],
       serviceName: "weather",
     });
 


### PR DESCRIPTION
### Summary

Related to #1659 and the proposal in #1799. Stacked on #1846 and still gated by `experimental.instrumentationProviders`.

Provider-local maps cannot carry correlation data through serialized workflow steps or replacement workers. Handlers now receive JSON-valued state scoped by provider slot and event idempotency key; starts can pass state to terminals, terminal and attempt cleanup releases it, and cancellation preserves it long enough for the cancellation epilogue to close outstanding operations.

State leases are revoked when a handler returns, preventing late reads or writes. Values are serialized into the durable context, so provider authors remain responsible for keeping them small.

### Validation

- Full rebased eve unit suite: 6,163 passed, 1 skipped
- Full eve integration suite: 618 passed
- Focused provider, eval, tracing, and compiled-artifact scenarios: 14 passed
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `pnpm guard:invariants`; docs checks pass
- E2E not run locally; the provider layout remains behind the experimental flag

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
