### PR TITLE
feat(eve): bound instrumentation handler deadlines

### DIFF
--- a/.changeset/instrumentation-handler-deadlines.md
+++ b/.changeset/instrumentation-handler-deadlines.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Bound instrumentation handler execution and persist abandonment so one stalled provider cannot block the bus or receive a mismatched terminal later.

--- a/packages/eve/src/harness/instrumentation-lifecycle.test.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   attemptIdempotencyKey,
   createInstrumentationHooks,
@@ -114,5 +115,114 @@ describe("provider state lifecycle", () => {
       });
       expect(instrumentationStateSlot("sink", modelKey).get()).toBeUndefined();
     });
+  });
+});
+
+describe("provider handler deadlines", () => {
+  const key = turnIdempotencyKey("session-1", "turn-1");
+  const started = {
+    idempotencyKey: key,
+    rootSessionId: "session-1",
+    sequence: 0,
+    sessionId: "session-1",
+    turnId: "turn-1",
+    type: "turn.started" as const,
+  };
+  const completed = {
+    idempotencyKey: key,
+    sessionId: "session-1",
+    turnId: "turn-1",
+    type: "turn.completed" as const,
+  };
+  const hang = () => new Promise<void>(() => {});
+
+  it("lets providers behind a hanging handler run", async () => {
+    const after = vi.fn();
+    const hooks = createInstrumentationHooks(
+      [
+        { events: { "turn.started": hang }, name: "hangs" },
+        { events: { "turn.started": after }, name: "after" },
+      ],
+      { handlerTimeoutMs: 1 },
+    );
+    await contextStorage.run(new ContextContainer(), () => hooks.publish(started));
+    expect(after).toHaveBeenCalledOnce();
+  });
+
+  it("persists abandonment across workers and skips the terminal", async () => {
+    const terminal = vi.fn();
+    const context = new ContextContainer();
+    const starts = createInstrumentationHooks(
+      [{ events: { "turn.started": hang }, name: "sink" }],
+      { handlerTimeoutMs: 1 },
+    );
+    await contextStorage.run(context, () => starts.publish(started));
+
+    const restored = await deserializeContext(await serializeContext(context));
+    const terminals = createInstrumentationHooks(
+      [{ events: { "turn.completed": terminal }, name: "sink" }],
+      { handlerTimeoutMs: 1 },
+    );
+    await contextStorage.run(restored, () => terminals.publish(completed));
+    expect(terminal).not.toHaveBeenCalled();
+  });
+
+  it("ignores a timed-out handler's late state write", async () => {
+    let resume!: () => void;
+    const continued = new Promise<void>((resolve) => {
+      resume = resolve;
+    });
+    const hooks = createInstrumentationHooks(
+      [
+        {
+          events: {
+            "turn.started": async (_event, ctx) => {
+              await continued;
+              ctx.state.set("late");
+            },
+          },
+          name: "slow",
+        },
+      ],
+      { handlerTimeoutMs: 1 },
+    );
+    await contextStorage.run(new ContextContainer(), async () => {
+      await hooks.publish(started);
+      await hooks.publish(completed);
+      resume();
+      await continued;
+      await Promise.resolve();
+      expect(instrumentationStateSlot("slow", key).get()).toBeUndefined();
+    });
+  });
+
+  it("does not abandon an operation for a point-event timeout", async () => {
+    const terminal = vi.fn();
+    const hooks = createInstrumentationHooks(
+      [
+        {
+          events: {
+            "step.attempt.completed": terminal,
+            "step.attempt.metadata": hang,
+          },
+          name: "slow-metadata",
+        },
+      ],
+      { handlerTimeoutMs: 1 },
+    );
+    await contextStorage.run(new ContextContainer(), async () => {
+      await hooks.publish({
+        idempotencyKey: attemptIdempotencyKey(scope),
+        providerMetadata: {},
+        scope,
+        type: "step.attempt.metadata",
+      });
+      await hooks.publish({
+        idempotencyKey: attemptIdempotencyKey(scope),
+        scope,
+        type: "step.attempt.completed",
+      });
+    });
+    expect(terminal).toHaveBeenCalledOnce();
   });
 });

--- a/packages/eve/src/harness/instrumentation-lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation-lifecycle.ts
@@ -1,6 +1,8 @@
 import { createLogger, formatError } from "#internal/logging.js";
 import {
+  abandonInstrumentationState,
   instrumentationStateSlot,
+  isInstrumentationStateAbandoned,
   releaseInstrumentationAttemptState,
   releaseInstrumentationState,
   type InstrumentationStateSlot,
@@ -380,12 +382,21 @@ export interface InstrumentationHooks {
 
 const log = createLogger("harness.instrumentation-lifecycle");
 
+const DEFAULT_HANDLER_TIMEOUT_MS = 5_000;
+
+export interface CreateInstrumentationHooksOptions {
+  readonly handlerTimeoutMs?: number;
+}
+
 /** Creates failure-isolated hooks backed by an ordered provider list. */
 export function createInstrumentationHooks(
   providers: readonly InstrumentationProviderInput[],
+  options: CreateInstrumentationHooksOptions = {},
 ): InstrumentationHooks {
+  const handlerTimeoutMs = options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
   const publish = async (event: InstrumentationEvent): Promise<void> => {
     const terminal = isTerminal(event.type);
+    const startedBoundary = event.type.endsWith(".started");
     const attemptTerminal =
       event.type === "step.attempt.completed" || event.type === "step.attempt.failed";
     const attemptId = stateAttemptId(event);
@@ -396,6 +407,10 @@ export function createInstrumentationHooks(
         if (attemptTerminal)
           releaseInstrumentationAttemptState(providerName, event.scope.attemptId);
       };
+      if (isInstrumentationStateAbandoned(providerName, event.idempotencyKey)) {
+        release();
+        continue;
+      }
       const handler = provider.events?.[event.type];
       if (handler === undefined) {
         release();
@@ -403,7 +418,23 @@ export function createInstrumentationHooks(
       }
       const state = instrumentationStateSlot(providerName, event.idempotencyKey, attemptId);
       try {
-        await (handler as InstrumentationEventHandler<InstrumentationEvent>)(event, { state });
+        const settled = await withTimeout(
+          () => (handler as InstrumentationEventHandler<InstrumentationEvent>)(event, { state }),
+          handlerTimeoutMs,
+          () => {
+            state.revoke();
+            if (startedBoundary) {
+              abandonInstrumentationState(providerName, event.idempotencyKey, attemptId);
+            }
+          },
+        );
+        if (!settled && startedBoundary) {
+          log.warn("instrumentation provider timed out", {
+            boundary: event.type,
+            provider: providerName,
+            timeoutMs: handlerTimeoutMs,
+          });
+        }
       } catch (error) {
         log.warn("instrumentation provider failed", {
           boundary: event.type,
@@ -418,6 +449,27 @@ export function createInstrumentationHooks(
   };
 
   return { publish };
+}
+
+async function withTimeout(
+  run: () => void | PromiseLike<void>,
+  timeoutMs: number,
+  onTimeout: () => void,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(run()).then(() => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => {
+          onTimeout();
+          resolve(false);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function stateAttemptId(event: InstrumentationEvent): string | undefined {

--- a/packages/eve/src/harness/instrumentation-state.test.ts
+++ b/packages/eve/src/harness/instrumentation-state.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
+  abandonInstrumentationState,
   instrumentationStateSlot,
+  isInstrumentationStateAbandoned,
   preserveSerializedInstrumentationState,
   releaseInstrumentationAttemptState,
   releaseInstrumentationState,
@@ -71,6 +73,17 @@ describe("instrumentation state", () => {
     ).toEqual({
       authored: "original",
       "eve.harness.instrumentationState": { state: true },
+    });
+  });
+
+  it("persists abandonment across serialization", async () => {
+    const context = new ContextContainer();
+    contextStorage.run(context, () => {
+      abandonInstrumentationState("sink", "model:1", "attempt-1");
+    });
+    const restored = await deserializeContext(await serializeContext(context));
+    contextStorage.run(restored, () => {
+      expect(isInstrumentationStateAbandoned("sink", "model:1")).toBe(true);
     });
   });
 });

--- a/packages/eve/src/harness/instrumentation-state.ts
+++ b/packages/eve/src/harness/instrumentation-state.ts
@@ -3,8 +3,9 @@ import { ContextKey } from "#context/key.js";
 import { type JsonValue, parseJsonValue } from "#shared/json.js";
 
 interface InstrumentationStateRecord {
-  readonly attemptId?: string;
-  readonly value: JsonValue;
+  abandoned?: true;
+  attemptId?: string;
+  value?: JsonValue;
 }
 
 type InstrumentationStateMap = Readonly<Record<string, InstrumentationStateRecord>>;
@@ -58,12 +59,36 @@ export function instrumentationStateSlot(
         return;
       }
       const record: InstrumentationStateRecord = { value: parseJsonValue(value) };
-      if (attemptId !== undefined) {
-        (record as { attemptId?: string }).attemptId = attemptId;
-      }
+      const current = contextStorage.getStore()?.get(InstrumentationStateKey)?.[key];
+      if (current?.abandoned === true) record.abandoned = true;
+      if (attemptId !== undefined) record.attemptId = attemptId;
       writeState((state) => writeSlot(state, key, record));
     },
   };
+}
+
+export function abandonInstrumentationState(
+  provider: string,
+  idempotencyKey: string,
+  attemptId?: string,
+): void {
+  if (contextStorage.getStore() === undefined) return;
+  const key = stateKey(provider, idempotencyKey);
+  writeState((state) => {
+    const current = state[key];
+    const record: InstrumentationStateRecord = { abandoned: true };
+    const owner = attemptId ?? current?.attemptId;
+    if (owner !== undefined) record.attemptId = owner;
+    if (current?.value !== undefined) record.value = current.value;
+    return writeSlot(state, key, record);
+  });
+}
+
+export function isInstrumentationStateAbandoned(provider: string, idempotencyKey: string): boolean {
+  return (
+    contextStorage.getStore()?.get(InstrumentationStateKey)?.[stateKey(provider, idempotencyKey)]
+      ?.abandoned === true
+  );
 }
 
 export function releaseInstrumentationState(provider: string, idempotencyKey: string): void {
@@ -119,11 +144,11 @@ function deserializeState(data: unknown): InstrumentationStateMap {
   for (const [key, value] of Object.entries(data)) {
     if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
     const record = value as Record<string, unknown>;
-    if (record["value"] === undefined) continue;
-    state[key] = {
-      attemptId: typeof record["attemptId"] === "string" ? record["attemptId"] : undefined,
-      value: record["value"] as JsonValue,
-    };
+    const parsed: InstrumentationStateRecord = {};
+    if (record["abandoned"] === true) parsed.abandoned = true;
+    if (typeof record["attemptId"] === "string") parsed.attemptId = record["attemptId"];
+    if (record["value"] !== undefined) parsed.value = record["value"] as JsonValue;
+    if (parsed.abandoned === true || parsed.value !== undefined) state[key] = parsed;
   }
   return state;
 }


### PR DESCRIPTION
### Summary

Related to #1659 and the proposal in #1799. Stacked on #1847 and still gated by `experimental.instrumentationProviders`.

The instrumentation bus awaits providers sequentially, so one hanging handler could block every later provider and the agent turn. Each event handler now has a five-second deadline; dispatch continues after timeout, and a timed-out `*.started` handler leaves a durable abandonment marker so its terminal is skipped even in a replacement worker.

Timeout revokes access to provider state but cannot cancel handler code or its external side effects. Point-event timeouts do not abandon an operation, and provider `flush` and `shutdown` remain outside this deadline.

### Validation

- Full rebased eve unit suite: 6,163 passed, 1 skipped
- Full eve integration suite: 618 passed
- Focused provider, eval, tracing, and compiled-artifact scenarios: 14 passed
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `pnpm guard:invariants`; docs checks pass
- E2E not run locally; the provider layout remains behind the experimental flag

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
