### PR TITLE
feat(eve): identify local eval provider setup

### DIFF
--- a/.changeset/silver-donkeys-shake.md
+++ b/.changeset/silver-donkeys-shake.md
@@ -1,0 +1,6 @@
+---
+"eve": patch
+---
+
+Expose the local eval run ID to instrumentation provider setup so telemetry can
+be associated with or excluded from synthetic runs.

--- a/packages/eve/src/evals/cli/eval.ts
+++ b/packages/eve/src/evals/cli/eval.ts
@@ -1,8 +1,13 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import { shutdownActiveSandboxHandles } from "#execution/sandbox/active-handles.js";
+import {
+  EVE_EVALUATION_ENV_FLAG,
+  EVE_EVALUATION_RUN_ID_ENV,
+} from "#internal/application/dev-environment.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { createDevelopmentServer, type DevelopmentServer } from "#internal/nitro/host.js";
 import { createEvalClient } from "#evals/cli/eval-client.js";
@@ -141,6 +146,10 @@ export async function runEvalCommand(
         url: options.url,
       });
     } else {
+      // Set before the server boots, because a provider's `setup` reads it
+      // once at startup and never again.
+      process.env[EVE_EVALUATION_ENV_FLAG] = "1";
+      process.env[EVE_EVALUATION_RUN_ID_ENV] = randomUUID();
       devServer = createDevelopmentServer(appRoot, { host: "127.0.0.1", port: 0 });
       const started = await devServer.start();
       client = await createEvalClient({ kind: "local", url: started.url });

--- a/packages/eve/src/harness/instrumentation-providers.test.ts
+++ b/packages/eve/src/harness/instrumentation-providers.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { turnIdempotencyKey } from "#harness/instrumentation-lifecycle.js";
 import {
+  EVE_EVALUATION_ENV_FLAG,
+  EVE_EVALUATION_RUN_ID_ENV,
+} from "#internal/application/dev-environment.js";
+import {
   finalizeInstrumentationProviders,
   getInstrumentationProviders,
   registerInstrumentationProvider,
@@ -59,6 +63,7 @@ describe("registerInstrumentationProvider", () => {
     expect(contexts).toHaveLength(1);
     expect(contexts[0]?.agentName).toBe("weather-agent");
     expect(contexts[0]?.environment).toMatch(/^(development|preview|production)$/);
+    expect(contexts[0]?.evaluation).toBeUndefined();
     expect(contexts[0]?.frameworkVersion).toEqual(expect.any(String));
   });
 
@@ -72,6 +77,23 @@ describe("registerInstrumentationProvider", () => {
     );
 
     expect(contexts[0]?.environment).toBe("preview");
+  });
+
+  it("reports an evaluation server to setup", async () => {
+    vi.stubEnv(EVE_EVALUATION_ENV_FLAG, "1");
+    vi.stubEnv(EVE_EVALUATION_RUN_ID_ENV, "eval-run-1");
+
+    const contexts: ProviderSetupContext[] = [];
+    await register(
+      "otel",
+      defineInstrumentation({
+        setup: (context) => {
+          contexts.push(context);
+        },
+      }),
+    );
+
+    expect(contexts[0]?.evaluation).toEqual({ runId: "eval-run-1" });
   });
 
   it("registers nothing for a disabled slot", async () => {

--- a/packages/eve/src/harness/instrumentation-setup-context.ts
+++ b/packages/eve/src/harness/instrumentation-setup-context.ts
@@ -1,4 +1,7 @@
-import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
+import {
+  isEveDevEnvironment,
+  resolveEveEvaluationRunId,
+} from "#internal/application/dev-environment.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import type { ProviderSetupContext } from "#public/instrumentation/provider.js";
 
@@ -13,9 +16,11 @@ import type { ProviderSetupContext } from "#public/instrumentation/provider.js";
  * @internal — not part of the public API.
  */
 export function createInstrumentationSetupContext(agentName: string): ProviderSetupContext {
+  const evaluationRunId = resolveEveEvaluationRunId();
   return {
     agentName,
     environment: resolveInstrumentationEnvironment(),
+    evaluation: evaluationRunId === undefined ? undefined : { runId: evaluationRunId },
     frameworkVersion: resolveInstalledPackageInfo().version,
   };
 }

--- a/packages/eve/src/internal/application/dev-environment.ts
+++ b/packages/eve/src/internal/application/dev-environment.ts
@@ -5,3 +5,25 @@ export const EVE_DEV_ENV_FLAG = "EVE_DEV";
 export function isEveDevEnvironment(): boolean {
   return process.env[EVE_DEV_ENV_FLAG] === "1";
 }
+
+/** Environment flag set for a server `eve eval` started to run against. */
+export const EVE_EVALUATION_ENV_FLAG = "EVE_EVALUATION";
+
+/** Stable identifier for the local eval run this server was started to serve. */
+export const EVE_EVALUATION_RUN_ID_ENV = "EVE_EVALUATION_RUN_ID";
+
+/**
+ * Reports whether this process exists to serve an eval run.
+ *
+ * False for a server that `eve eval --url` merely points at: that process was
+ * started to serve ordinary traffic and cannot know an eval is among it.
+ */
+export function isEveEvaluationEnvironment(): boolean {
+  return process.env[EVE_EVALUATION_ENV_FLAG] === "1";
+}
+
+export function resolveEveEvaluationRunId(): string | undefined {
+  if (!isEveEvaluationEnvironment()) return undefined;
+  const runId = process.env[EVE_EVALUATION_RUN_ID_ENV];
+  return runId === undefined || runId.length === 0 ? undefined : runId;
+}

--- a/packages/eve/src/public/instrumentation/provider.ts
+++ b/packages/eve/src/public/instrumentation/provider.ts
@@ -69,6 +69,11 @@ export const DISABLED = Symbol.for("eve.instrumentation.disabled");
 /** Where the agent is running when `setup` fires. */
 export type InstrumentationEnvironment = "development" | "preview" | "production";
 
+/** The local eval run this server was started to serve. */
+export interface EvaluationRef {
+  readonly runId: string;
+}
+
 /**
  * Passed to {@link InstrumentationProvider.setup} once at server startup,
  * before any event is published.
@@ -77,6 +82,8 @@ export interface ProviderSetupContext {
   /** The agent name declared by `defineAgent`. */
   readonly agentName: string;
   readonly environment: InstrumentationEnvironment;
+  /** Present only when this server was started for a local `eve eval` run. */
+  readonly evaluation?: EvaluationRef;
   /** The eve version running the agent. */
   readonly frameworkVersion: string;
 }

--- a/packages/eve/test/scenarios/eval-command-environment.scenario.test.ts
+++ b/packages/eve/test/scenarios/eval-command-environment.scenario.test.ts
@@ -44,6 +44,8 @@ const DEVELOPMENT_ENV_KEYS = [
   "EVE_DEV_LOCAL_ONLY",
   "EVE_DEV_SHARED",
   "EVE_DEV_SHELL_ONLY",
+  "EVE_EVALUATION",
+  "EVE_EVALUATION_RUN_ID",
 ] as const;
 
 async function createEnvironmentFixture(): Promise<string> {
@@ -192,6 +194,8 @@ describe("eve eval environment loading", () => {
 
     expect(close).toHaveBeenCalledTimes(1);
     expect(handle.shutdown).toHaveBeenCalledTimes(1);
+    expect(process.env.EVE_EVALUATION).toBe("1");
+    expect(process.env.EVE_EVALUATION_RUN_ID).toMatch(/^[0-9a-f-]{36}$/u);
     expect(exit).toHaveBeenCalledWith(0);
   });
 


### PR DESCRIPTION
### Summary

Related to #1659 and the proposal in #1799. Stacked on #1817 and still gated by `experimental.instrumentationProviders`.

Instrumentation providers could not distinguish a server started for local `eve eval` from an ordinary server. Local eval now creates one run ID for its server and exposes it to provider setup as `evaluation: { runId }`, allowing destinations to associate or exclude synthetic telemetry.

This is setup metadata only: eve does not attach the ID to events or spans. Ordinary servers and evals targeting an existing server with `--url` do not receive it.

### Validation

- Full rebased eve unit suite: 6,164 passed, 1 skipped
- Full eve integration suite: 618 passed
- Focused provider, eval, tracing, and compiled-artifact scenarios: 14 passed
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `pnpm guard:invariants`; docs checks pass
- E2E not run locally; the provider layout remains behind the experimental flag

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
