### PR TITLE
fix: avoid re-injecting terminal todo lists

### DIFF
--- a/packages/eve/src/runtime/framework-tools/todo.test.ts
+++ b/packages/eve/src/runtime/framework-tools/todo.test.ts
@@ -161,4 +161,48 @@ describe("getTodoCompactionMessage", () => {
   it("returns undefined when no state has been set", () => {
     expect(callHook(undefined)).toBeUndefined();
   });
+
+  it("returns undefined when every item is completed", () => {
+    expect(
+      callHook({
+        items: [
+          { content: "Fix bug", priority: "high", status: "completed" },
+          { content: "Write tests", priority: "medium", status: "completed" },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when every item is cancelled", () => {
+    expect(
+      callHook({
+        items: [{ content: "Dropped task", priority: "low", status: "cancelled" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a terminal-only list mixing completed and cancelled", () => {
+    expect(
+      callHook({
+        items: [
+          { content: "Fix bug", priority: "high", status: "completed" },
+          { content: "Dropped task", priority: "low", status: "cancelled" },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves the full list while any item is still active", () => {
+    const message = callHook({
+      items: [
+        { content: "Fix bug", priority: "high", status: "completed" },
+        { content: "In flight task", priority: "medium", status: "in_progress" },
+      ],
+    });
+
+    expect(message).toBeDefined();
+    const text = String(message?.content ?? "");
+    expect(text).toContain("[x] [high] Fix bug");
+    expect(text).toContain("[ ] [medium] In flight task");
+  });
 });

--- a/packages/eve/src/runtime/framework-tools/todo.ts
+++ b/packages/eve/src/runtime/framework-tools/todo.ts
@@ -35,6 +35,12 @@ export type TodoToolInput = z.infer<typeof TODO_INPUT_SCHEMA>;
 function formatTodoSummary(state: TodoState): string | undefined {
   if (state.items.length === 0) return undefined;
 
+  // A terminal-only list leaves no active work to resume, so re-injecting it
+  // after compaction would only revive stale completed tasks on the next turn.
+  if (state.items.every((item) => item.status === "completed" || item.status === "cancelled")) {
+    return undefined;
+  }
+
   const lines = state.items.map((item) => {
     const check = item.status === "completed" ? "x" : item.status === "cancelled" ? "-" : " ";
     return `- [${check}] [${item.priority}] ${item.content}`;
@@ -46,7 +52,9 @@ function formatTodoSummary(state: TodoState): string | undefined {
 /**
  * Builds the message that re-injects the current todo list after the harness
  * compacts message history, so the agent keeps its task list across
- * compaction. Returns `undefined` when there is no list to preserve.
+ * compaction. Returns `undefined` when there is no active work to preserve —
+ * the list is empty or every item has a terminal (completed/cancelled)
+ * status.
  */
 export function getTodoCompactionMessage(): ModelMessage | undefined {
   const state = loadContext().get(TodoStateKey);


### PR DESCRIPTION
## Summary

- Stop re-injecting todo state after compaction when every item is terminal (`completed` or `cancelled`).
- Preserve the complete list when any item remains active.
- Add focused coverage for terminal-only and mixed active/terminal lists.

Fixes vercel/eve#1844.

## Verification

local verification not run; relying on upstream CI

The worktree has no installed `node_modules`, so the repository's local test commands cannot run here.
