### PR TITLE
feat(eve): redact content per OpenTelemetry destination

### DIFF
--- a/.changeset/otel-destination-redaction.md
+++ b/.changeset/otel-destination-redaction.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+OpenTelemetry destinations can independently decline input or output content. Redaction covers span attributes, exception and custom events, and status messages without mutating spans shared with other destinations; `EVE_TRACES_CONTENT=off` now narrows only local traces.

--- a/packages/eve/src/tracing/content-attributes.test.ts
+++ b/packages/eve/src/tracing/content-attributes.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { withoutDeclinedContent } from "#tracing/content-attributes.js";
+
+const ATTRIBUTES = {
+  "ai.prompt.messages": "what the user said",
+  "ai.response.finish_reason": "stop",
+  "ai.response.text": "what the model said",
+  "gen_ai.request.model": "test-model",
+  "gen_ai.tool.call.arguments": "{}",
+  "gen_ai.tool.call.result": "42",
+  "gen_ai.tool.name": "weather",
+};
+
+describe("withoutDeclinedContent", () => {
+  it("keeps everything when the destination declined nothing", () => {
+    expect(
+      withoutDeclinedContent(ATTRIBUTES, { recordInputs: true, recordOutputs: true }),
+    ).toBeUndefined();
+  });
+
+  it("keeps everything when the span carries none of what was declined", () => {
+    expect(
+      withoutDeclinedContent(
+        { "gen_ai.request.model": "test-model" },
+        { recordInputs: false, recordOutputs: false },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("drops inputs alone", () => {
+    expect(
+      withoutDeclinedContent(ATTRIBUTES, { recordInputs: false, recordOutputs: true }),
+    ).toEqual({
+      "ai.response.finish_reason": "stop",
+      "ai.response.text": "what the model said",
+      "gen_ai.request.model": "test-model",
+      "gen_ai.tool.call.result": "42",
+      "gen_ai.tool.name": "weather",
+    });
+  });
+
+  it("drops outputs alone", () => {
+    expect(
+      withoutDeclinedContent(ATTRIBUTES, { recordInputs: true, recordOutputs: false }),
+    ).toEqual({
+      "ai.prompt.messages": "what the user said",
+      "ai.response.finish_reason": "stop",
+      "gen_ai.request.model": "test-model",
+      "gen_ai.tool.call.arguments": "{}",
+      "gen_ai.tool.name": "weather",
+    });
+  });
+
+  // The prefixes are shared: `ai.response.finish_reason` and `gen_ai.tool.name`
+  // say what happened rather than what was said, so declining content cannot
+  // cost a destination the ability to read its own traces.
+  it("keeps metadata that shares a prefix with content", () => {
+    expect(
+      withoutDeclinedContent(ATTRIBUTES, { recordInputs: false, recordOutputs: false }),
+    ).toEqual({
+      "ai.response.finish_reason": "stop",
+      "gen_ai.request.model": "test-model",
+      "gen_ai.tool.name": "weather",
+    });
+  });
+
+  it("leaves the attributes it was handed alone", () => {
+    const attributes = { ...ATTRIBUTES };
+    withoutDeclinedContent(attributes, { recordInputs: false, recordOutputs: false });
+    expect(attributes).toEqual(ATTRIBUTES);
+  });
+});

--- a/packages/eve/src/tracing/content-attributes.ts
+++ b/packages/eve/src/tracing/content-attributes.ts
@@ -1,0 +1,86 @@
+/**
+ * Which span attributes carry conversation content, and in which direction.
+ *
+ * Two vocabularies land on the same spans: the ones eve sets on its own
+ * `agent.*` spans, and the ones the AI SDK's OpenTelemetry integration sets on
+ * the model-call spans beneath them. A destination that declined content has to
+ * be rid of both, so both are listed here rather than in the module that writes
+ * each.
+ *
+ * Listed by name rather than by prefix because the prefixes are shared with
+ * metadata that must survive: `ai.response.finish_reason` and
+ * `gen_ai.tool.name` say what happened, not what was said. The cost is that a
+ * new content attribute in a dependency is not covered until it is added here.
+ */
+
+/** Prompts, instructions, tool arguments — what went in. */
+const INPUT_CONTENT_ATTRIBUTES: ReadonlySet<string> = new Set([
+  "ai.documents",
+  "ai.prompt",
+  "ai.prompt.messages",
+  "ai.prompt.system",
+  "ai.prompt.toolChoice",
+  "ai.prompt.tools",
+  "ai.value",
+  "ai.values",
+  "gen_ai.input.messages",
+  "gen_ai.system_instructions",
+  "gen_ai.tool.call.arguments",
+  "gen_ai.tool.definitions",
+]);
+
+/**
+ * Responses, reasoning, tool results — what came out.
+ *
+ * `ai.toolCall.args` is here rather than above because the AI SDK gates it on
+ * `recordOutputs`; matching that is what keeps one destination's view coherent.
+ */
+const OUTPUT_CONTENT_ATTRIBUTES: ReadonlySet<string> = new Set([
+  "ai.embedding",
+  "ai.embeddings",
+  "ai.ranking",
+  "ai.response.files",
+  "ai.response.object",
+  "ai.response.reasoning",
+  "ai.response.text",
+  "ai.response.toolCalls",
+  "ai.response.tool_calls",
+  "ai.response.tool_results",
+  "ai.toolCall.args",
+  "ai.toolCall.result",
+  "gen_ai.output.messages",
+  "gen_ai.tool.call.result",
+]);
+
+/** What one destination is willing to receive. */
+export interface ResolvedContentOptions {
+  readonly recordInputs: boolean;
+  readonly recordOutputs: boolean;
+}
+
+function isDeclined(key: string, content: ResolvedContentOptions): boolean {
+  if (!content.recordInputs && INPUT_CONTENT_ATTRIBUTES.has(key)) return true;
+  return !content.recordOutputs && OUTPUT_CONTENT_ATTRIBUTES.has(key);
+}
+
+/**
+ * The attributes with the declined content removed, or `undefined` when there
+ * was none to remove.
+ *
+ * The `undefined` return is what lets the caller forward the original span
+ * untouched in the common case, so a destination that declined a direction the
+ * span never carried costs one pass over its keys and no allocation.
+ */
+export function withoutDeclinedContent(
+  attributes: Readonly<Record<string, unknown>>,
+  content: ResolvedContentOptions,
+): Record<string, unknown> | undefined {
+  const keys = Object.keys(attributes);
+  if (!keys.some((key) => isDeclined(key, content))) return undefined;
+
+  const kept: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (!isDeclined(key, content)) kept[key] = attributes[key];
+  }
+  return kept;
+}

--- a/packages/eve/src/tracing/content-span-processor.test.ts
+++ b/packages/eve/src/tracing/content-span-processor.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BasicTracerProvider,
+  type SpanProcessor as OpenTelemetrySpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+import type { SpanProcessor } from "#compiled/@vercel/otel/index.js";
+
+import { contentFilteringProcessor } from "#tracing/content-span-processor.js";
+
+function recordingProcessor(): SpanProcessor & {
+  readonly ended: unknown[];
+  readonly started: unknown[];
+} {
+  const ended: unknown[] = [];
+  const started: unknown[] = [];
+  return {
+    ended,
+    forceFlush: () => Promise.resolve(),
+    onEnd: (span) => {
+      ended.push(span);
+    },
+    onStart: (span) => {
+      started.push(span);
+    },
+    started,
+    shutdown: () => Promise.resolve(),
+  };
+}
+
+function span(attributes: Record<string, unknown>): unknown {
+  return {
+    attributes,
+    spanContext: () => ({ spanId: "span", traceId: "trace" }),
+  };
+}
+
+describe("contentFilteringProcessor", () => {
+  it("forwards the span untouched when the destination declined nothing", () => {
+    const downstream = recordingProcessor();
+    const original = span({ "ai.prompt.messages": "what the user said" });
+
+    contentFilteringProcessor(downstream, { recordInputs: true, recordOutputs: true }).onEnd(
+      original as never,
+    );
+
+    expect(downstream.ended).toEqual([original]);
+  });
+
+  it("forwards a copy without what the destination declined", () => {
+    const downstream = recordingProcessor();
+
+    contentFilteringProcessor(downstream, { recordInputs: false, recordOutputs: true }).onEnd(
+      span({
+        "ai.prompt.messages": "what the user said",
+        "ai.response.text": "what the model said",
+      }) as never,
+    );
+
+    expect((downstream.ended[0] as { attributes: unknown }).attributes).toEqual({
+      "ai.response.text": "what the model said",
+    });
+  });
+
+  it("leaves the original span's attributes in place for the other destinations", () => {
+    const kept = recordingProcessor();
+    const declined = recordingProcessor();
+    const original = span({ "ai.prompt.messages": "what the user said" });
+
+    contentFilteringProcessor(declined, { recordInputs: false, recordOutputs: false }).onEnd(
+      original as never,
+    );
+    kept.onEnd(original as never);
+
+    expect((declined.ended[0] as { attributes: unknown }).attributes).toEqual({});
+    expect((kept.ended[0] as { attributes: unknown }).attributes).toEqual({
+      "ai.prompt.messages": "what the user said",
+    });
+  });
+
+  it("keeps the rest of the span surface reachable on the copy", () => {
+    const downstream = recordingProcessor();
+
+    contentFilteringProcessor(downstream, { recordInputs: false, recordOutputs: false }).onEnd(
+      span({ "ai.prompt.messages": "what the user said" }) as never,
+    );
+
+    expect((downstream.ended[0] as { spanContext: () => unknown }).spanContext()).toEqual({
+      spanId: "span",
+      traceId: "trace",
+    });
+  });
+
+  it("withholds exception details when outputs are declined", () => {
+    const downstream = recordingProcessor();
+    const original = {
+      ...(span({ "service.name": "weather" }) as object),
+      events: [
+        { attributes: { "exception.message": "private output" }, name: "exception" },
+        { attributes: { detail: "private event data" }, name: "turn.completed" },
+      ],
+      status: { code: 2, message: "private failure detail" },
+    };
+
+    contentFilteringProcessor(downstream, { recordInputs: true, recordOutputs: false }).onEnd(
+      original as never,
+    );
+
+    const visible = downstream.ended[0] as {
+      events: unknown[];
+      status: unknown;
+    };
+    expect(visible.events).toEqual([{ attributes: undefined, name: "turn.completed" }]);
+    expect(visible.status).toEqual({ code: 2 });
+    expect(original.events).toHaveLength(2);
+    expect(original.status).toEqual({ code: 2, message: "private failure detail" });
+  });
+
+  it("redacts initial attributes before onStart without exposing the original", () => {
+    const downstream = recordingProcessor();
+    const original = span({
+      "ai.prompt.messages": "what the user said",
+      "service.name": "weather",
+    });
+
+    contentFilteringProcessor(downstream, { recordInputs: false, recordOutputs: true }).onStart(
+      original as never,
+      undefined as never,
+    );
+
+    expect(downstream.started[0]).not.toBe(original);
+    expect((downstream.started[0] as { attributes: unknown }).attributes).toEqual({
+      "service.name": "weather",
+    });
+    expect((original as { attributes: unknown }).attributes).toHaveProperty(
+      "ai.prompt.messages",
+      "what the user said",
+    );
+  });
+
+  it("reuses and refreshes one facade from onStart through onEnd", () => {
+    const downstream = recordingProcessor();
+    const original = span({
+      "ai.prompt.messages": "what the user said",
+      "service.name": "weather",
+    }) as { attributes: Record<string, unknown> };
+    const processor = contentFilteringProcessor(downstream, {
+      recordInputs: false,
+      recordOutputs: true,
+    });
+
+    processor.onStart(original as never, undefined as never);
+    const retainedAttributes = (downstream.started[0] as { attributes: unknown }).attributes;
+    original.attributes["ai.response.text"] = "what the model said";
+    processor.onEnd(original as never);
+
+    expect(downstream.started[0]).toBe(downstream.ended[0]);
+    expect((downstream.ended[0] as { attributes: unknown }).attributes).toBe(retainedAttributes);
+    expect((downstream.started[0] as { attributes: unknown }).attributes).toEqual({
+      "ai.response.text": "what the model said",
+      "service.name": "weather",
+    });
+  });
+
+  it("keeps SDK methods bound to the original span", () => {
+    let original: {
+      attributes: Record<string, unknown>;
+      fluent(): unknown;
+      setAttribute(key: string, value: unknown): unknown;
+      spanContext(): unknown;
+    };
+    original = {
+      attributes: { "ai.prompt.messages": "what the user said" },
+      fluent() {
+        return this;
+      },
+      setAttribute(key, value) {
+        this.attributes[key] = value;
+        return this;
+      },
+      spanContext() {
+        if (this !== original) throw new Error("wrong span receiver");
+        return { spanId: "span", traceId: "trace" };
+      },
+    };
+    const downstream = recordingProcessor();
+    const processor = contentFilteringProcessor(downstream, {
+      recordInputs: false,
+      recordOutputs: true,
+    });
+
+    processor.onStart(original as never, undefined as never);
+
+    expect((downstream.started[0] as { spanContext(): unknown }).spanContext()).toEqual({
+      spanId: "span",
+      traceId: "trace",
+    });
+    expect((downstream.started[0] as { fluent(): unknown }).fluent()).toBe(downstream.started[0]);
+    expect((downstream.started[0] as { valueOf(): unknown }).valueOf()).toBe(downstream.started[0]);
+    const facade = downstream.started[0] as {
+      attributes: Record<string, unknown>;
+      setAttribute(key: string, value: unknown): unknown;
+    };
+    expect(facade.setAttribute("service.name", "weather")).toBe(facade);
+    expect(facade.attributes["service.name"]).toBe("weather");
+  });
+
+  it("continues refreshing after a processor freezes the facade", () => {
+    const downstream = recordingProcessor();
+    const original = span({ "ai.prompt.messages": "what the user said" }) as {
+      attributes: Record<string, unknown>;
+    };
+    const processor = contentFilteringProcessor(downstream, {
+      recordInputs: false,
+      recordOutputs: true,
+    });
+
+    processor.onStart(original as never, undefined as never);
+    Object.freeze(downstream.started[0]);
+    original.attributes["ai.response.text"] = "what the model said";
+
+    expect(() => processor.onEnd(original as never)).not.toThrow();
+    expect((downstream.ended[0] as { attributes: unknown }).attributes).toEqual({
+      "ai.response.text": "what the model said",
+    });
+  });
+
+  it("facades a real OpenTelemetry span across both callbacks", () => {
+    const downstream = recordingProcessor();
+    const filtering = contentFilteringProcessor(downstream, {
+      recordInputs: false,
+      recordOutputs: true,
+    });
+    const provider = new BasicTracerProvider({
+      spanProcessors: [filtering as OpenTelemetrySpanProcessor],
+    });
+    const span = provider.getTracer("test").startSpan("test", {
+      attributes: { "ai.prompt.messages": "what the user said" },
+    });
+
+    span.setAttribute("ai.response.text", "what the model said");
+    span.end();
+
+    expect(downstream.started[0]).toBe(downstream.ended[0]);
+    expect((downstream.started[0] as { spanContext(): unknown }).spanContext()).toEqual(
+      span.spanContext(),
+    );
+    expect((downstream.ended[0] as { attributes: unknown }).attributes).toEqual({
+      "ai.response.text": "what the model said",
+    });
+  });
+
+  it("preserves local trace session release through the wrapper", async () => {
+    const releaseSession = vi.fn(async () => true);
+    const downstream: SpanProcessor & {
+      releaseSession(sessionId: string): Promise<boolean>;
+    } = { ...recordingProcessor(), releaseSession };
+    const processor = contentFilteringProcessor(downstream, {
+      recordInputs: false,
+      recordOutputs: false,
+    }) as SpanProcessor & { releaseSession(sessionId: string): Promise<boolean> };
+
+    await expect(processor.releaseSession("session-1")).resolves.toBe(true);
+    expect(releaseSession).toHaveBeenCalledExactlyOnceWith("session-1");
+  });
+});

--- a/packages/eve/src/tracing/content-span-processor.ts
+++ b/packages/eve/src/tracing/content-span-processor.ts
@@ -1,0 +1,192 @@
+import type { SpanProcessor } from "#compiled/@vercel/otel/index.js";
+
+import {
+  withoutDeclinedContent,
+  type ResolvedContentOptions,
+} from "#tracing/content-attributes.js";
+import { hasSessionRelease, type LocalTracesProcessor } from "#tracing/local-traces.js";
+
+/**
+ * Puts one destination's content policy in front of it.
+ *
+ * Content is written onto a span if any destination wants it, so the span
+ * reaching a destination that declined still carries it. This cannot strip the
+ * attribute in place: that span object is shared with every other processor in
+ * the pipeline, and editing it would strip the attribute everywhere. So it
+ * gives the destination a facade whose attributes omit what it declined.
+ *
+ * One facade follows the original from start through end. This preserves the
+ * object identity stateful processors key on without ever exposing the original
+ * span or its attribute map. Methods stay bound to the original, so private SDK
+ * state remains reachable without eve knowing that SDK's concrete span shape.
+ *
+ * @internal
+ */
+export function contentFilteringProcessor(
+  downstream: SpanProcessor,
+  content: ResolvedContentOptions,
+): SpanProcessor {
+  if (content.recordInputs && content.recordOutputs) return downstream;
+
+  const facades = new WeakMap<object, SpanFacade>();
+  const filtering: SpanProcessor = {
+    forceFlush: () => downstream.forceFlush(),
+    onEnd: (span) => {
+      if (typeof span !== "object" || span === null) {
+        downstream.onEnd(span);
+        return;
+      }
+
+      const scoped = facadeFor(span, content, facades);
+      scoped.refresh();
+      try {
+        downstream.onEnd(scoped.value);
+      } finally {
+        facades.delete(span);
+      }
+    },
+    onStart: (span, parentContext) => {
+      if (typeof span !== "object" || span === null) {
+        downstream.onStart(span, parentContext);
+        return;
+      }
+      downstream.onStart(facadeFor(span, content, facades).value, parentContext);
+    },
+    shutdown: () => downstream.shutdown(),
+  };
+
+  if (!hasSessionRelease(downstream)) return filtering;
+  const releasing: LocalTracesProcessor = {
+    ...filtering,
+    releaseSession: (sessionId) => downstream.releaseSession(sessionId),
+  };
+  return releasing;
+}
+
+interface SpanFacade {
+  readonly refresh: () => void;
+  readonly value: object;
+}
+
+function facadeFor(
+  span: object,
+  content: ResolvedContentOptions,
+  facades: WeakMap<object, SpanFacade>,
+): SpanFacade {
+  const existing = facades.get(span);
+  if (existing !== undefined) return existing;
+
+  const attributes: Record<string, unknown> = {};
+  const events: unknown[] = [];
+  const status: Record<string, unknown> = {};
+  const target = Object.create(Reflect.getPrototypeOf(span)) as Record<PropertyKey, unknown>;
+  const boundMethods = new Map<PropertyKey, unknown>();
+  const refresh = (): void => {
+    refreshAttributes(attributes, span, content);
+    refreshEvents(events, span, content);
+    refreshStatus(status, span, content);
+  };
+  let value: object;
+  const readOriginal = (property: PropertyKey): unknown => {
+    const original = Reflect.get(span, property, span) as unknown;
+    if (typeof original !== "function" || property === "constructor") return original;
+
+    const bound = boundMethods.get(property);
+    if (bound !== undefined) return bound;
+    const created = (...args: unknown[]) => {
+      const result = Reflect.apply(original, span, args) as unknown;
+      refresh();
+      return result === span ? value : result;
+    };
+    boundMethods.set(property, created);
+    return created;
+  };
+
+  Object.defineProperty(target, "attributes", {
+    configurable: true,
+    enumerable: true,
+    value: attributes,
+  });
+  Object.defineProperty(target, "events", {
+    configurable: true,
+    enumerable: true,
+    value: events,
+  });
+  Object.defineProperty(target, "status", {
+    configurable: true,
+    enumerable: true,
+    value: status,
+  });
+  for (const property of Reflect.ownKeys(span)) {
+    if (property === "attributes" || property === "events" || property === "status") continue;
+    const descriptor = Reflect.getOwnPropertyDescriptor(span, property);
+    Object.defineProperty(target, property, {
+      configurable: true,
+      enumerable: descriptor?.enumerable ?? false,
+      get: () => readOriginal(property),
+    });
+  }
+
+  value = new Proxy(target, {
+    get: (facadeTarget, property, receiver) =>
+      Object.hasOwn(facadeTarget, property)
+        ? Reflect.get(facadeTarget, property, receiver)
+        : readOriginal(property),
+  });
+  const facade = {
+    refresh,
+    value,
+  };
+  facade.refresh();
+  facades.set(span, facade);
+  return facade;
+}
+
+function refreshAttributes(
+  destination: Record<string, unknown>,
+  span: object,
+  content: ResolvedContentOptions,
+): void {
+  for (const key of Object.keys(destination)) delete destination[key];
+
+  const source = (span as { readonly attributes?: unknown }).attributes;
+  if (typeof source !== "object" || source === null) return;
+
+  const kept = withoutDeclinedContent(source as Record<string, unknown>, content);
+  Object.assign(destination, kept ?? source);
+}
+
+function refreshEvents(
+  destination: unknown[],
+  span: object,
+  content: ResolvedContentOptions,
+): void {
+  destination.length = 0;
+  const source = (span as { readonly events?: unknown }).events;
+  if (!Array.isArray(source)) return;
+  if (content.recordOutputs) {
+    destination.push(...source);
+    return;
+  }
+  for (const event of source) {
+    if (typeof event !== "object" || event === null) continue;
+    const record = event as Readonly<Record<string, unknown>>;
+    if (record["name"] === "exception") continue;
+    destination.push({ ...record, attributes: undefined });
+  }
+}
+
+function refreshStatus(
+  destination: Record<string, unknown>,
+  span: object,
+  content: ResolvedContentOptions,
+): void {
+  for (const key of Object.keys(destination)) delete destination[key];
+  const source = (span as { readonly status?: unknown }).status;
+  if (typeof source !== "object" || source === null) return;
+  const record = source as Readonly<Record<string, unknown>>;
+  if (record["code"] !== undefined) destination["code"] = record["code"];
+  if (content.recordOutputs && record["message"] !== undefined) {
+    destination["message"] = record["message"];
+  }
+}

--- a/packages/eve/src/tracing/local-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.ts
@@ -3,7 +3,7 @@ import {
   type InstrumentationRuntime,
 } from "#harness/instrumentation-runtime.js";
 import { installInstrumentationRuntime } from "#tracing/install-instrumentation-runtime.js";
-import { createLocalTracesProcessor } from "#tracing/local-traces.js";
+import { createLocalTracesProcessor, resolveLocalTracesContent } from "#tracing/local-traces.js";
 import { collectOtelPipeline, otel, otelIntegration } from "#tracing/otel-declaration.js";
 
 /** Installs the zero-config local OTel runtime once in an `eve dev` worker. */
@@ -15,24 +15,12 @@ export function installLocalInstrumentationRuntime(input: {
   const existing = getInstrumentationRuntime();
   if (existing !== undefined) return existing;
 
-  // The zero-config default expressed with the same values an authored
-  // `agent/instrumentation/` would declare, so this path exercises them.
   const spool = createLocalTracesProcessor({ appRoot: input.appRoot });
-  const collectedPipeline = collectOtelPipeline([
-    otel(),
-    otelIntegration({ spanProcessors: [spool] }),
-  ]);
-  const captureContent = process.env.EVE_TRACES_CONTENT !== "off";
-  const collected = {
-    ...collectedPipeline,
-    settings: {
-      ...collectedPipeline.settings,
-      recordInputs: captureContent,
-      recordOutputs: captureContent,
-    },
-  };
   return installInstrumentationRuntime({
-    collected,
+    collected: collectOtelPipeline([
+      otel(),
+      otelIntegration({ ...resolveLocalTracesContent(), spanProcessors: [spool] }),
+    ]),
     frameworkVersion: input.frameworkVersion,
     providers: [],
     serviceName: input.serviceName,

--- a/packages/eve/src/tracing/local-traces.test.ts
+++ b/packages/eve/src/tracing/local-traces.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createLocalTracesProcessor } from "#tracing/local-traces.js";
+import { createLocalTracesProcessor, resolveLocalTracesContent } from "#tracing/local-traces.js";
 
 vi.mock("#tracing/local-trace-span-processor.js", () => ({
   LocalTraceSpanProcessor: class {
@@ -59,5 +59,18 @@ describe("createLocalTracesProcessor", () => {
     expect(() => processor.onEnd(agentSpan("session-one", "a".repeat(32)))).not.toThrow();
     await expect(processor.forceFlush()).resolves.toBeUndefined();
     await expect(processor.shutdown()).resolves.toBeUndefined();
+  });
+
+  it("lets the environment override narrow only this destination", () => {
+    vi.stubEnv("EVE_TRACES_CONTENT", "off");
+    expect(resolveLocalTracesContent()).toEqual({ recordInputs: false, recordOutputs: false });
+  });
+
+  it("preserves explicit destination narrowing when content is enabled", () => {
+    vi.stubEnv("EVE_TRACES_CONTENT", "on");
+    expect(resolveLocalTracesContent({ recordInputs: false })).toEqual({
+      recordInputs: false,
+      recordOutputs: true,
+    });
   });
 });

--- a/packages/eve/src/tracing/local-traces.ts
+++ b/packages/eve/src/tracing/local-traces.ts
@@ -80,6 +80,20 @@ export function createLocalTracesProcessor(
   };
 }
 
+/** Intersects the local destination policy with `EVE_TRACES_CONTENT`. */
+export function resolveLocalTracesContent(
+  options: {
+    readonly recordInputs?: boolean;
+    readonly recordOutputs?: boolean;
+  } = {},
+): { readonly recordInputs: boolean; readonly recordOutputs: boolean } {
+  const enabled = process.env.EVE_TRACES_CONTENT !== "off";
+  return {
+    recordInputs: enabled && options.recordInputs !== false,
+    recordOutputs: enabled && options.recordOutputs !== false,
+  };
+}
+
 /** A production-authored `localTraces()` has no local development store. */
 function inertLocalTracesProcessor(): LocalTracesProcessor {
   return {

--- a/packages/eve/src/tracing/otel-declaration.test.ts
+++ b/packages/eve/src/tracing/otel-declaration.test.ts
@@ -56,13 +56,34 @@ describe("otelIntegration", () => {
     expect(integration.spanProcessors).toHaveLength(2);
     expect(integration.spanProcessors[0]).toBe(first);
   });
+
+  it("records everything unless told otherwise", () => {
+    expect(otelIntegration().content).toStrictEqual({ recordInputs: true, recordOutputs: true });
+  });
+
+  it("puts a declined policy in front of every processor", () => {
+    const first = processor();
+    const integration = otelIntegration({ recordOutputs: false, spanProcessors: [first] });
+
+    expect(integration.content).toStrictEqual({ recordInputs: true, recordOutputs: false });
+    expect(integration.spanProcessors[0]).not.toBe(first);
+  });
 });
 
 describe("agentRunsIntegration", () => {
   it("uses Vercel's automatic processor by default", () => {
     const integration = agentRunsIntegration();
 
+    expect(integration.content).toStrictEqual({ recordInputs: true, recordOutputs: true });
     expect(integration.spanProcessors).toStrictEqual(["auto"]);
+  });
+
+  it("wraps the request-context transport when its content policy is narrowed", () => {
+    const integration = agentRunsIntegration({ recordInputs: false });
+
+    expect(integration.content).toStrictEqual({ recordInputs: false, recordOutputs: true });
+    expect(integration.spanProcessors).toHaveLength(1);
+    expect(integration.spanProcessors[0]).not.toBe("auto");
   });
 });
 
@@ -118,6 +139,24 @@ describe("collectOtelPipeline", () => {
       recordOutputs: false,
       traceChannelRequests: true,
     });
+  });
+
+  it("takes content capture as the union across destinations", () => {
+    const collected = collectOtelPipeline([
+      otelIntegration({ recordInputs: false, recordOutputs: false }),
+      otelIntegration({ recordInputs: false, recordOutputs: true }),
+    ]);
+
+    expect(collected.settings).toMatchObject({ recordInputs: false, recordOutputs: true });
+  });
+
+  it("writes nothing when every destination declined", () => {
+    const collected = collectOtelPipeline([
+      otelIntegration({ recordInputs: false, recordOutputs: false }),
+      otelIntegration({ recordInputs: false, recordOutputs: false }),
+    ]);
+
+    expect(collected.settings).toMatchObject({ recordInputs: false, recordOutputs: false });
   });
 
   // A process has one tracer provider, so letting the first declaration win

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -7,6 +7,9 @@ import type {
 } from "#compiled/@vercel/otel/index.js";
 
 import { batchSpanProcessor } from "#tracing/batch-span-processor.js";
+import type { ResolvedContentOptions } from "#tracing/content-attributes.js";
+import { contentFilteringProcessor } from "#tracing/content-span-processor.js";
+import { vercelRuntimeSpanProcessor } from "#tracing/vercel-runtime-span-exporter.js";
 
 /**
  * The process-wide OpenTelemetry settings, declared by `otel()`.
@@ -47,8 +50,16 @@ export interface OtelOptions {
   readonly propagators?: readonly PropagatorOrName[];
 }
 
-/** Where one `otelIntegration()` sends spans. */
-export interface OtelIntegrationOptions {
+/** What one destination records of the conversation itself. */
+export interface ContentOptions {
+  /** Record model prompts and tool call inputs. Defaults to `true`. */
+  readonly recordInputs?: boolean;
+  /** Record model responses and tool call outputs. Defaults to `true`. */
+  readonly recordOutputs?: boolean;
+}
+
+/** Where one `otelIntegration()` sends spans, and what it records. */
+export interface OtelIntegrationOptions extends ContentOptions {
   /** Merged into the pipeline in declaration order. */
   readonly spanProcessors?: readonly SpanProcessor[];
   /** Wrapped in eve's batching processor and appended after `spanProcessors`. */
@@ -70,6 +81,7 @@ export interface OtelDeclaration {
 /** One declared destination. A process may have as many as it has files. */
 export interface OtelIntegration {
   readonly [OTEL_INTEGRATION]: true;
+  readonly content: ResolvedContentOptions;
   readonly spanProcessors: readonly SpanProcessorOrName[];
 }
 
@@ -90,21 +102,39 @@ export function otel(options: OtelOptions = {}): OtelDeclaration {
  * when the destination needs its own batching, sampling, or filtering.
  */
 export function otelIntegration(options: OtelIntegrationOptions = {}): OtelIntegration {
+  const content = resolveContentOptions(options);
   const declared = options.spanProcessors ?? [];
+  const spanProcessors =
+    options.traceExporter === undefined
+      ? declared
+      : [...declared, batchSpanProcessor(options.traceExporter)];
   return {
     [OTEL_INTEGRATION]: true,
+    content,
     spanProcessors:
-      options.traceExporter === undefined
-        ? declared
-        : [...declared, batchSpanProcessor(options.traceExporter)],
+      content.recordInputs && content.recordOutputs
+        ? spanProcessors
+        : spanProcessors.map((processor) => contentFilteringProcessor(processor, content)),
   };
 }
 
-/** Vercel Agent Runs through @vercel/otel's automatic processor. @internal */
-export function agentRunsIntegration(): OtelIntegration {
+/** Vercel Agent Runs through the production request-context transport. @internal */
+export function agentRunsIntegration(options: ContentOptions = {}): OtelIntegration {
+  const content = resolveContentOptions(options);
   return {
     [OTEL_INTEGRATION]: true,
-    spanProcessors: ["auto"],
+    content,
+    spanProcessors:
+      content.recordInputs && content.recordOutputs
+        ? ["auto"]
+        : [contentFilteringProcessor(vercelRuntimeSpanProcessor(), content)],
+  };
+}
+
+export function resolveContentOptions(options: ContentOptions): ResolvedContentOptions {
+  return {
+    recordInputs: options.recordInputs !== false,
+    recordOutputs: options.recordOutputs !== false,
   };
 }
 
@@ -175,8 +205,8 @@ export function collectOtelPipeline(values: readonly unknown[]): CollectedOtel {
   for (const value of values) {
     if (isOtelIntegration(value)) {
       declared = true;
-      recordInputs = true;
-      recordOutputs = true;
+      recordInputs ||= value.content.recordInputs;
+      recordOutputs ||= value.content.recordOutputs;
       spanProcessors.push(...value.spanProcessors);
       continue;
     }


### PR DESCRIPTION
### Summary

Related to the instrumentation providers proposal in #1799. Stacked on #1857.

Adds independent input and output content policies for each OpenTelemetry destination. eve materializes content requested by any destination, then gives narrower processors non-mutating span facades that redact content attributes, exception and custom-event details, and status messages without affecting other destinations. `EVE_TRACES_CONTENT=off` now narrows local traces only.

Provider event capture is deliberately separate and lands in #1864.

### Validation

- Focused unit suite: 55 tests passed
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `node scripts/guard-invariants.mjs`
- Full branch validation: 6,164 unit and 618 integration tests passed

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
