### PR TITLE
docs(eve): document instrumentation providers

### DIFF
--- a/docs/guides/instrumentation-providers.md
+++ b/docs/guides/instrumentation-providers.md
@@ -70,15 +70,18 @@ Omitting this file is the common case. eve registers the pipeline for whatever d
 `otelIntegration()` is a destination, and there may be as many as there are files. A `traceExporter` is wrapped in eve's batching processor, which is what makes the one-line form enough:
 
 ```ts title="agent/instrumentation/datadog.ts"
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
 import { otelIntegration } from "eve/instrumentation/otel";
 
 export default otelIntegration({
-  traceExporter: new OTLPTraceExporter(),
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+    headers: { "dd-api-key": process.env.DD_API_KEY! },
+  }),
 });
 ```
 
-For Datadog, enable [OTLP ingestion in the Datadog Agent](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest_in_the_agent/) and set `OTEL_EXPORTER_OTLP_ENDPOINT` in the agent application to the local Agent endpoint.
+Set `DATADOG_OTLP_TRACES_ENDPOINT` to your [Datadog OTLP traces intake endpoint](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/traces/) and provide `DD_API_KEY` through the deployment environment.
 
 Pass `spanProcessors` instead when the destination needs its own batching, sampling, or filtering. Both may be given: declared processors come first, and the wrapped exporter is appended after them.
 
@@ -131,11 +134,14 @@ present only for providers that capture content.
 `recordInputs` and `recordOutputs` belong to a destination, not to the process. Content is written onto a span if any destination wants it, and each destination that declined never exports it. A local spool and a hosted backend no longer have to agree:
 
 ```ts title="agent/instrumentation/datadog.ts"
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
 import { otelIntegration } from "eve/instrumentation/otel";
 
 export default otelIntegration({
-  traceExporter: new OTLPTraceExporter(),
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+    headers: { "dd-api-key": process.env.DD_API_KEY! },
+  }),
   recordInputs: false,
   recordOutputs: false,
 });

--- a/docs/guides/instrumentation-providers.md
+++ b/docs/guides/instrumentation-providers.md
@@ -1,0 +1,300 @@
+---
+title: "Instrumentation Providers"
+description: "The experimental agent/instrumentation/ directory: one provider per file, the otel() and otelIntegration() split, per-destination content policy, and the lifecycle events providers handle."
+---
+
+Instrumentation providers replace the single `agent/instrumentation.ts` config object with a directory: `agent/instrumentation/`, one provider per file. A provider handles eve's lifecycle events, declares an OpenTelemetry destination, or both. Adding one destination no longer means taking responsibility for every other.
+
+This is experimental and off by default. Turn it on in `defineAgent`:
+
+```ts title="agent/agent.ts"
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-sonnet-5",
+  experimental: {
+    instrumentationProviders: true,
+  },
+});
+```
+
+The two layouts are mutually exclusive builds. With the flag off, an `instrumentation/` directory is a build error; with it on, a leftover `instrumentation.ts` is a build error. eve never silently picks one — telemetry that quietly does nothing is the failure this surface exists to prevent. For the shipped default layout, see [`instrumentation.ts`](./instrumentation).
+
+## One provider per file
+
+The filename is the slot name: `agent/instrumentation/otel.ts` fills the `otel` slot. Slots register in alphabetical order, so what a provider sees does not depend on how the filesystem enumerates the directory. Two files claiming one slot is an error.
+
+```text
+agent/instrumentation/
+  otel.ts        the process-wide OpenTelemetry settings
+  braintrust.ts  a destination
+  local.ts       eve's local trace spool, reconfigured or turned off
+  audit.ts       a provider that only handles events
+```
+
+Each file default-exports the result of `defineInstrumentation` or one of the built-in factories. A default export that never went through eve throws at server startup rather than being skipped.
+
+```ts title="agent/instrumentation/audit.ts"
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  setup: ({ agentName, evaluation }) => {
+    if (evaluation) return;
+    console.log(`auditing ${agentName}`);
+  },
+  events: {
+    "action.started": (event) => {
+      console.log(event.kind, event.name);
+    },
+  },
+});
+```
+
+## OpenTelemetry, in two halves
+
+OpenTelemetry has one process-wide half and one plural half, and the directory splits them the same way.
+
+`otel()` is the settings a process can only hold one of — a process has one tracer provider, so it has one resource, one sampler, and one propagator set. Declaring it twice is a boot error, which one file per slot makes structurally hard to do.
+
+```ts title="agent/instrumentation/otel.ts"
+import { otel } from "eve/instrumentation/otel";
+
+export default otel({
+  traceChannelRequests: true,
+  resource: { "deployment.environment": process.env.VERCEL_ENV ?? "development" },
+});
+```
+
+Omitting this file is the common case. eve registers the pipeline for whatever destinations are declared beside it; `otel()` only names what those destinations share.
+
+`otelIntegration()` is a destination, and there may be as many as there are files. A `traceExporter` is wrapped in eve's batching processor, which is what makes the one-line form enough:
+
+```ts title="agent/instrumentation/braintrust.ts"
+import { BraintrustExporter } from "@braintrust/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
+
+export default otelIntegration({
+  traceExporter: new BraintrustExporter({ filterAISpans: true }),
+});
+```
+
+Pass `spanProcessors` instead when the destination needs its own batching, sampling, or filtering. Both may be given: declared processors come first, and the wrapped exporter is appended after them.
+
+`otel()` and `otelIntegration()` come from `eve/instrumentation/otel`, a separate entrypoint from `eve/instrumentation`.
+
+## Content is per provider
+
+A provider declares how much of each event it wants. The default is
+`"metadata"`: structure, identity, usage, and timing, but not what the
+conversation said. `"content"` adds the prompt, the response, tool arguments,
+and tool results.
+
+```ts title="agent/instrumentation/audit.ts"
+export default defineInstrumentation({
+  capture: "content",
+  events: {
+    "model.call.completed": (event) => {
+      console.log(event.content);
+    },
+  },
+});
+```
+
+Asking is what makes eve build the projection at all. A directory in which no
+provider asked — and whose destinations all declined — never serializes a
+prompt, so declining is cheaper than filtering as well as safer. Providers that
+did not ask receive the same events with the content fields absent; a
+`capture: "content"` provider beside them changes nothing about what they see.
+
+Structure survives declining. `action.completed` still says whether the tool
+returned or threw, and `model.call.completed` still carries its finish reason
+and token usage — a provider counting failures or cost never has to ask for
+content to get them.
+
+Failure details and opaque provider metadata can contain prompts, tool output,
+search queries, or retrieved text, so metadata providers do not receive them.
+`step.attempt.metadata` keeps only the gateway cost and generation ID by
+default; `capture: "content"` exposes the complete provider payload and failure
+objects.
+
+Content fields are therefore optional on the event types that carry them:
+`input` on `channel.delivery.started`, `model.call.started`, `action.started`,
+and `tool.call.started`; `content` on `model.call.completed`; and the payloads
+inside action and tool-call outputs. Input lifecycle events follow the same
+rule: `request` on `input.requested` and `response` on `input.resolved` are
+present only for providers that capture content.
+
+## Content is per destination
+
+`recordInputs` and `recordOutputs` belong to a destination, not to the process. Content is written onto a span if any destination wants it, and each destination that declined never exports it. A local spool and a hosted backend no longer have to agree:
+
+```ts title="agent/instrumentation/braintrust.ts"
+export default otelIntegration({
+  traceExporter: new BraintrustExporter({ filterAISpans: true }),
+  recordInputs: false,
+  recordOutputs: false,
+});
+```
+
+An agent whose every destination declines still never materializes a prompt — the OpenTelemetry pipeline is itself one provider, and a pipeline whose destinations all declined asks for `"metadata"` like any other. Declining wraps every processor in that file, an author's included: they are this destination, and the point of declining is that nothing under it sees what was said. The wrapper copies the span rather than editing it, because the span it is handed is shared with every other destination in the pipeline.
+
+For sensitive, regulated, or production data, decline content on any destination whose retention path you have not reviewed. You are responsible for ensuring an observability or eval provider is approved for what is exported to it.
+
+## Local traces
+
+`eve dev` records spans to disk — one trace per session window, read with [`/traces`](./dev-tui#inspect-traces) in the dev TUI or [`eve traces`](../reference/cli#eve-traces) in the terminal. Under the provider layout that spool is a destination like any other, and eve fills the `local` slot with it by default. Adding a hosted backend does not switch it off.
+
+Say something about the slot only when you want to change it. `localTraces()` reconfigures it:
+
+```ts title="agent/instrumentation/local.ts"
+import { localTraces } from "eve/instrumentation/otel";
+
+export default localTraces({ recordInputs: false });
+```
+
+`disableInstrumentation()` removes it:
+
+```ts title="agent/instrumentation/local.ts"
+import { disableInstrumentation } from "eve/instrumentation";
+
+export default disableInstrumentation();
+```
+
+Omitting the file leaves eve's default in place, which is why turning one off takes a value rather than an absence. `EVE_TRACES_CONTENT=off` narrows this destination and no other, so declining content locally leaves what a hosted backend receives alone.
+
+The spool is `eve dev` only: it writes under the dev worker's app root, and a deployed process has nowhere to put it.
+
+## Agent Runs
+
+On Vercel production, eve fills the reserved `agent-runs` slot with `agentRuns()` so the same canonical spans reach Agent Runs without an authored destination. Reconfigure it only when you need a narrower content policy:
+
+```ts title="agent/instrumentation/agent-runs.ts"
+import { agentRuns } from "eve/instrumentation/otel";
+
+export default agentRuns({ recordInputs: false });
+```
+
+Export `disableInstrumentation()` from that file to turn Agent Runs off. Omitting the file leaves the production default in place.
+
+## Lifecycle events
+
+A provider's `events` map takes one handler per event type, each called with `(event, ctx)`:
+
+| Event                                                                                                             | Fires when                                                           |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `session.started`, `session.completed`, `session.waiting`, `session.failed`                                       | A session begins, settles, parks for input, or fails                 |
+| `channel.delivery.started`, `channel.delivery.completed`, `channel.delivery.cancelled`, `channel.delivery.failed` | An inbound channel operation begins or reaches a terminal            |
+| `turn.started`, `turn.completed`, `turn.cancelled`, `turn.failed`                                                 | A turn begins or reaches a terminal                                  |
+| `step.attempt.started`, `step.attempt.completed`, `step.attempt.failed`, `step.attempt.metadata`                  | One model-call attempt within a turn                                 |
+| `model.call.started`, `model.call.completed`, `model.call.failed`                                                 | The model call itself                                                |
+| `action.started`, `action.completed`, `action.failed`                                                             | Every eve dispatch: tool call, skill load, subagent, or remote agent |
+| `input.requested`, `input.resolved`                                                                               | One user-input request suspends and later resumes                    |
+| `tool.call.started`, `tool.call.completed`, `tool.call.failed`                                                    | The AI SDK execution boundary for an ordinary tool call              |
+
+An ordinary tool emits both families. `action.*` is eve's durable dispatch
+boundary and covers work that can settle in another worker; `tool.call.*` is the
+model SDK's in-process execution boundary. Handle one unless you intentionally
+want both views.
+
+A channel delivery covers durable inbound processing through the resulting turn
+terminal. Several deliveries can coalesce into one turn while retaining separate
+lifecycle pairs. See [Channel delivery traces](./instrumentation#channel-delivery-traces)
+for content boundaries and OpenTelemetry mapping.
+
+Action terminals carry structural result metadata independently from captured
+content. `acceptedAtMs` records when the parent workflow accepted that action's
+result, even when a parallel batch waits for slower siblings before publication.
+`action.completed` has `outcome: "completed"` and optional normalized subagent
+`usage`. `action.failed` distinguishes `failed`, `rejected`, `cancelled`, and
+`abandoned`; `errorCode` remains visible to metadata providers, while the error
+object follows content capture policy.
+
+OpenTelemetry records these fields on the durable caller-side `agent.action`
+span as `agent.action.outcome`, `agent.action.error.code`, standard `error.type`,
+and the `agent.usage.*` token attributes. Together with `agent.action.call_id`
+and `agent.action.kind`, an exporter can group local and remote subagent outcomes
+without reconstructing the runtime event stream. The span ends at
+`acceptedAtMs`, so its duration does not inherit the slowest sibling's wait.
+
+`input.requested` and `input.resolved` form a durable pair for each request in
+an input batch. They keep the requesting action and original turn scope even
+when the response resumes in another worker. `input.resolved.outcome` is
+`answered`, `approved`, `denied`, `ignored`, or `invalid` for ordinary runtime
+resolutions. The event types also reserve `cancelled` and `failed` for terminal
+runtime outcomes.
+
+OpenTelemetry maps a `tool-approval` input pair to an `agent.approval` span
+under the originating `agent.action`:
+
+```text
+agent.action approval_echo
+  agent.approval
+  ai.toolCall approval_echo
+```
+
+The approval span covers the wait from request to decision. The action covers
+the complete dispatch, and `ai.toolCall` covers execution after approval. A
+denial is recorded as an approval outcome rather than an OpenTelemetry error;
+infrastructure failures still use error status.
+
+Every event carries an `idempotencyKey` naming the operation it is about. A start and its terminal share a key when the terminal arrives. An incomplete model stream can close without one, so live resources need step-attempt cleanup or their own expiry.
+
+eve opens its framework spans before it calls authored handlers, then performs framework cleanup after they finish. Authored handlers for the same event run concurrently and are failure-isolated: one that throws is logged without stopping another provider.
+
+One event publication does not finish until every authored handler settles, fails, or reaches its own timeout. There is no cross-provider completion ordering guarantee, so providers must not coordinate through handler order. A provider sees source publication order only where the runtime itself publishes those events sequentially.
+
+### Carrying a value across a handler pair
+
+`ctx.state` is durable storage scoped to one provider and one operation. Two providers reacting concurrently to the same event cannot see or overwrite each other, and one provider's turns and actions stay separate.
+
+A terminal event names the operation it settles but not what that operation was — `action.completed` carries the output, while `kind` and `name` were on `action.started`. Carrying either across the pair is what state is for:
+
+```ts title="agent/instrumentation/timing.ts"
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  events: {
+    "action.started": (event, ctx) => {
+      ctx.state.set({ name: event.name, startedAt: Date.now() });
+    },
+    "action.completed": (_event, ctx) => {
+      // `get` returns `JsonValue`, which cannot know the shape you wrote.
+      const started = ctx.state.get() as { name: string; startedAt: number } | undefined;
+      if (started === undefined) return;
+      console.log(`${started.name} took ${Date.now() - started.startedAt}ms`);
+    },
+  },
+});
+```
+
+`set` is synchronous because it stages into the durable context eve commits when the step settles, rather than writing to a store of its own. That is also why the value must survive JSON — a value that cannot throws at `set` rather than at the step boundary. Writes after the handler settles or times out are ignored.
+
+State survives a step boundary. An approval-gated tool suspends and resumes in a different process, and values written at `action.started` or `input.requested` are still readable at their terminals there — which a module-level `Map` would not be. eve releases each slot when its terminal arrives.
+
+### Handler timeouts
+
+Each handler has its own timeout. Several authored handlers that hang consume one timeout window because they run concurrently, rather than accumulating one delay per provider. If a `*.started` or `input.requested` handler times out, the operation is durably abandoned for that provider and its later terminal is withheld, even in another worker. Point and terminal handler timeouts do not abandon the operation, and late state writes are ignored.
+
+A Promise deadline cannot interrupt synchronous CPU-bound JavaScript. Handlers must cooperate by yielding to asynchronous work; long synchronous computation blocks both the timeout and the rest of the process.
+
+## Setup, flush, and shutdown
+
+`setup` runs once at server startup in slot order, before any event is published, and eve awaits each setup — a provider cannot miss an event published while it is still starting up.
+
+```ts
+setup: ({ agentName, environment, evaluation, frameworkVersion }) => {
+  console.log(evaluation?.runId);
+};
+```
+
+`evaluation` contains `{ runId }` when the server exists to serve a local `eve eval` run. Eval traffic is synthetic, so providers can associate or exclude it. The field is absent for ordinary servers and for a server that `eve eval --url` merely points at: that process cannot claim one remote caller's run as its own.
+
+`setup` is not where an OpenTelemetry pipeline gets registered. The pipeline is the union of every destination in the directory, so no single file knows enough to build it; a `setup` that reaches for a tracer gets the no-op one. Declare destinations as values and let eve assemble them.
+
+`flush` drains anything buffered, and eve calls it when a step settles — including when a session suspends, which on a serverless host is the last moment a buffered exporter can still reach the network. `shutdown` releases resources when the process is going away.
+
+## What to read next
+
+- [`instrumentation.ts`](./instrumentation): the shipped default layout, workflow run tags, and Agent Runs
+- [Hooks](./hooks): observe the runtime event stream
+- [`agent.ts`](../agent-config): where `experimental` lives

--- a/docs/guides/instrumentation-providers.md
+++ b/docs/guides/instrumentation-providers.md
@@ -27,7 +27,7 @@ The filename is the slot name: `agent/instrumentation/otel.ts` fills the `otel` 
 ```text
 agent/instrumentation/
   otel.ts        the process-wide OpenTelemetry settings
-  braintrust.ts  a destination
+  datadog.ts     a destination
   local.ts       eve's local trace spool, reconfigured or turned off
   audit.ts       a provider that only handles events
 ```
@@ -69,14 +69,16 @@ Omitting this file is the common case. eve registers the pipeline for whatever d
 
 `otelIntegration()` is a destination, and there may be as many as there are files. A `traceExporter` is wrapped in eve's batching processor, which is what makes the one-line form enough:
 
-```ts title="agent/instrumentation/braintrust.ts"
-import { BraintrustExporter } from "@braintrust/otel";
+```ts title="agent/instrumentation/datadog.ts"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { otelIntegration } from "eve/instrumentation/otel";
 
 export default otelIntegration({
-  traceExporter: new BraintrustExporter({ filterAISpans: true }),
+  traceExporter: new OTLPTraceExporter(),
 });
 ```
+
+For Datadog, enable [OTLP ingestion in the Datadog Agent](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest_in_the_agent/) and set `OTEL_EXPORTER_OTLP_ENDPOINT` in the agent application to the local Agent endpoint.
 
 Pass `spanProcessors` instead when the destination needs its own batching, sampling, or filtering. Both may be given: declared processors come first, and the wrapped exporter is appended after them.
 
@@ -128,9 +130,12 @@ present only for providers that capture content.
 
 `recordInputs` and `recordOutputs` belong to a destination, not to the process. Content is written onto a span if any destination wants it, and each destination that declined never exports it. A local spool and a hosted backend no longer have to agree:
 
-```ts title="agent/instrumentation/braintrust.ts"
+```ts title="agent/instrumentation/datadog.ts"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { otelIntegration } from "eve/instrumentation/otel";
+
 export default otelIntegration({
-  traceExporter: new BraintrustExporter({ filterAISpans: true }),
+  traceExporter: new OTLPTraceExporter(),
   recordInputs: false,
   recordOutputs: false,
 });

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -7,6 +7,8 @@ description: "Trace an agent with OpenTelemetry in instrumentation.ts, read the 
 
 If you intend to export telemetry, review the exporter destination, data categories, and required legal approvals before enabling telemetry.
 
+An experimental alternative splits this file into a directory of providers, one per file, so that adding a destination does not mean taking responsibility for every other. See [Instrumentation Providers](./instrumentation-providers).
+
 ## Three observability surfaces
 
 eve observes an agent through three distinct surfaces. They do not all live in this file, and they write to different places:
@@ -182,7 +184,7 @@ Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace p
 - [`/traces`](dev-tui#inspect-traces) in the dev TUI: a live viewer that replays the trace as a conversation.
 - [`eve traces`](../reference/cli#eve-traces): a span tree in the terminal, `eve traces ls` to list. Works after `eve dev` exits.
 
-Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
+Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. Under the experimental [provider layout](./instrumentation-providers#local-traces) the spool is a destination instead, so adding a backend beside it leaves it on. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
 
 ## Debugging
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -24,7 +24,7 @@ The two configurable surfaces send AI SDK spans to your OpenTelemetry backend. W
 ## Define instrumentation
 
 ```ts title="agent/instrumentation.ts"
-import { BraintrustExporter } from "@braintrust/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { defineInstrumentation } from "eve/instrumentation";
 import { registerOTel } from "@vercel/otel";
 
@@ -32,10 +32,7 @@ export default defineInstrumentation({
   setup: ({ agentName }) =>
     registerOTel({
       serviceName: agentName,
-      traceExporter: new BraintrustExporter({
-        parent: `project_name:${agentName}`,
-        filterAISpans: true,
-      }),
+      traceExporter: new OTLPTraceExporter(),
     }),
 });
 ```
@@ -46,7 +43,7 @@ Export the result of `defineInstrumentation` as the default export.
 
 Use the `setup` callback to register your OTel provider (for example `registerOTel` from `@vercel/otel`). The framework invokes it at server startup with the resolved agent name. `context.agentName` is resolved at compile time from your project (the package's `name`, falling back to the app directory name), so you never hard-code a service name.
 
-Any OTel-compatible backend works (Braintrust, PostHog, Raindrop, Arize, Honeycomb, Datadog, Jaeger). Install the exporter package you need and configure it in the callback. The [PostHog AI Observability integration](/integrations/posthog-instrumentation) provides a ready-to-install exporter and optional user identification.
+Any OTel-compatible backend works (Datadog, PostHog, Raindrop, Arize, Honeycomb, Jaeger). Install the exporter package you need and configure it in the callback. For Datadog, enable [OTLP ingestion in the Datadog Agent](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest_in_the_agent/) and set `OTEL_EXPORTER_OTLP_ENDPOINT` in the agent application to the local Agent endpoint. The [PostHog AI Observability integration](/integrations/posthog-instrumentation) provides a ready-to-install exporter and optional user identification.
 
 Three more fields control what the AI SDK records inside those spans (see the AI SDK's [telemetry reference](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)):
 
@@ -173,7 +170,7 @@ Per-turn usage tags are written on each step of a turn, accumulating cumulative 
 
 Tag writes are best-effort: a failure is logged once per process and then swallowed, so a broken tag emit never breaks the agent.
 
-These tags power the **Agent Runs** tab in the Vercel dashboard. When you deploy on Vercel, the platform auto-detects `eve` as the framework and surfaces an Agent Runs view under your project's **Observability** tab, where you can browse sessions and drill into each conversation's trace, with no `instrumentation.ts` required. The tab is currently gated per team. See [Deploy to Vercel](./deployment/vercel#inspect-agent-runs) for enablement. Agent Runs is separate from the OpenTelemetry export above. Use OTel when you want spans in Braintrust, PostHog, Datadog, or another third-party backend.
+These tags power the **Agent Runs** tab in the Vercel dashboard. When you deploy on Vercel, the platform auto-detects `eve` as the framework and surfaces an Agent Runs view under your project's **Observability** tab, where you can browse sessions and drill into each conversation's trace, with no `instrumentation.ts` required. The tab is currently gated per team. See [Deploy to Vercel](./deployment/vercel#inspect-agent-runs) for enablement. Agent Runs is separate from the OpenTelemetry export above. Use OTel when you want spans in Datadog, PostHog, Honeycomb, or another third-party backend.
 
 Note: By default, telemetry records full message history and model outputs You may need to disclose these data flows in your privacy materials if utilized.
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -24,7 +24,7 @@ The two configurable surfaces send AI SDK spans to your OpenTelemetry backend. W
 ## Define instrumentation
 
 ```ts title="agent/instrumentation.ts"
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { BraintrustExporter } from "@braintrust/otel";
 import { defineInstrumentation } from "eve/instrumentation";
 import { registerOTel } from "@vercel/otel";
 
@@ -32,7 +32,10 @@ export default defineInstrumentation({
   setup: ({ agentName }) =>
     registerOTel({
       serviceName: agentName,
-      traceExporter: new OTLPTraceExporter(),
+      traceExporter: new BraintrustExporter({
+        parent: `project_name:${agentName}`,
+        filterAISpans: true,
+      }),
     }),
 });
 ```
@@ -43,7 +46,7 @@ Export the result of `defineInstrumentation` as the default export.
 
 Use the `setup` callback to register your OTel provider (for example `registerOTel` from `@vercel/otel`). The framework invokes it at server startup with the resolved agent name. `context.agentName` is resolved at compile time from your project (the package's `name`, falling back to the app directory name), so you never hard-code a service name.
 
-Any OTel-compatible backend works (Datadog, PostHog, Raindrop, Arize, Honeycomb, Jaeger). Install the exporter package you need and configure it in the callback. For Datadog, enable [OTLP ingestion in the Datadog Agent](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest_in_the_agent/) and set `OTEL_EXPORTER_OTLP_ENDPOINT` in the agent application to the local Agent endpoint. The [PostHog AI Observability integration](/integrations/posthog-instrumentation) provides a ready-to-install exporter and optional user identification.
+Any OTel-compatible backend works (Braintrust, PostHog, Raindrop, Arize, Honeycomb, Datadog, Jaeger). Install the exporter package you need and configure it in the callback. The [PostHog AI Observability integration](/integrations/posthog-instrumentation) provides a ready-to-install exporter and optional user identification.
 
 Three more fields control what the AI SDK records inside those spans (see the AI SDK's [telemetry reference](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)):
 
@@ -170,7 +173,7 @@ Per-turn usage tags are written on each step of a turn, accumulating cumulative 
 
 Tag writes are best-effort: a failure is logged once per process and then swallowed, so a broken tag emit never breaks the agent.
 
-These tags power the **Agent Runs** tab in the Vercel dashboard. When you deploy on Vercel, the platform auto-detects `eve` as the framework and surfaces an Agent Runs view under your project's **Observability** tab, where you can browse sessions and drill into each conversation's trace, with no `instrumentation.ts` required. The tab is currently gated per team. See [Deploy to Vercel](./deployment/vercel#inspect-agent-runs) for enablement. Agent Runs is separate from the OpenTelemetry export above. Use OTel when you want spans in Datadog, PostHog, Honeycomb, or another third-party backend.
+These tags power the **Agent Runs** tab in the Vercel dashboard. When you deploy on Vercel, the platform auto-detects `eve` as the framework and surfaces an Agent Runs view under your project's **Observability** tab, where you can browse sessions and drill into each conversation's trace, with no `instrumentation.ts` required. The tab is currently gated per team. See [Deploy to Vercel](./deployment/vercel#inspect-agent-runs) for enablement. Agent Runs is separate from the OpenTelemetry export above. Use OTel when you want spans in Braintrust, PostHog, Datadog, or another third-party backend.
 
 Note: By default, telemetry records full message history and model outputs You may need to disclose these data flows in your privacy materials if utilized.
 

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -4,6 +4,7 @@
     "deployment",
     "auth-and-route-protection",
     "instrumentation",
+    "instrumentation-providers",
     "hooks",
     "session-context",
     "state",

--- a/docs/guides/remote-agents.md
+++ b/docs/guides/remote-agents.md
@@ -20,14 +20,14 @@ export default defineRemoteAgent({
 
 `defineRemoteAgent` accepts:
 
-| Parameter          | Type                                          | Required | Default           | Description                                                                                                                                              |
-| ------------------ | --------------------------------------------- | -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url`              | `string \| (() => string \| Promise<string>)` | Yes      | n/a               | Base URL of the remote eve deployment to call. A string is baked at compile time; a function is resolved at runtime (see [Runtime URLs](#runtime-urls)). |
-| `description`      | `string`                                      | Yes      | n/a               | Model-visible delegation description.                                                                                                                    |
-| `auth`             | `OutboundAuthFn`                              | No       | none              | Outbound auth hook from `eve/agents/auth`.                                                                                                               |
-| `forwardPrincipal` | `boolean`                                     | No       | `false`           | Forward the dispatching turn's session principal to the remote deployment (see [Forwarding the caller identity](#forwarding-the-caller-identity)).       |
-| `headers`          | `HeadersValue`                                | No       | none              | Static or lazily resolved request headers.                                                                                                               |
-| `path`             | `string`                                      | No       | `/eve/v1/session` | Route appended to `url` for the create-session request.                                                                                                  |
+| Parameter          | Type                                          | Required | Default           | Description                                                                                                                                                                          |
+| ------------------ | --------------------------------------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `url`              | `string \| (() => string \| Promise<string>)` | Yes      | n/a               | Base URL of the remote eve deployment to call. A string is baked at compile time; a function is resolved at runtime (see [Runtime URLs](#runtime-urls)).                             |
+| `description`      | `string`                                      | Yes      | n/a               | Model-visible delegation description.                                                                                                                                                |
+| `auth`             | `OutboundAuthFn`                              | No       | none              | Outbound auth hook from `eve/agents/auth`.                                                                                                                                           |
+| `forwardPrincipal` | `boolean`                                     | No       | `false`           | Forward the dispatching turn's session principal to the remote deployment (see [Forwarding the caller identity](#forwarding-the-caller-identity)).                                   |
+| `headers`          | `HeadersValue`                                | No       | none              | Static or lazily resolved request headers.                                                                                                                                           |
+| `path`             | `string`                                      | No       | `/eve/v1/session` | Route appended to `url` for the create-session request.                                                                                                                              |
 | `outputSchema`     | `StandardSchema \| JSON Schema`               | No       | none              | Structured return type the caller requires. Enforced by the remote agent like any task-mode output schema. Set it on the definition to apply to every call, or override it per call. |
 
 ## Dynamic remote agents
@@ -127,6 +127,14 @@ A local subagent runs inline. A remote one runs in its own deployment, so dispat
 3. When the callback arrives, the parent resumes and surfaces the result.
 
 The parent stream carries the same `subagent.called`, `action.result`, and `subagent.completed` events as local delegation. For a remote call, `subagent.called.data.remote.url` records the target.
+
+The create-session request also carries the caller's durable action context in a
+W3C `traceparent` header. The receiving eve agent records the remote session and
+turn under that caller-side `agent.action`, so both deployments form one trace in
+a shared backend such as Datadog. Receivers on older eve versions ignore the
+header and keep their independent trace; control flow and callbacks are
+unchanged. Continuations stay on the trace chosen when the persistent remote
+session was created.
 
 Cancelling the parent while a remote call is active sends an authenticated `POST /eve/v1/session/:childSessionId/cancel` to the remote and waits for that request to be accepted before the parent settles. eve resolves the remote's `headers` and `auth` again for every cancellation attempt, so rotating credentials work the same way as they do for session creation. Cancellation always uses the standard eve cancel path on `url`, even when `path` customizes only the create-session endpoint. The remote child reports `turn.cancelled` → `session.waiting` on its own stream; an older or unreachable remote is logged but cannot turn the parent's cancellation into a failure.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -292,7 +292,7 @@ Reads the immutable OTLP/JSON segments under `.eve/traces/v1`, so `eve dev` need
 
 Span rows carry inline metrics when the span recorded them — `↑input`/`↓output` token counts, gateway cost, and the tool name for `ai.toolCall` spans — and the header aggregates models, token totals, cost, and error count across the trace's step spans. `--verbose` expands each span under its tree row: status (with the error message on failures), timing, ids, every attribute (prompts, responses, and tool payloads as transcripts or pretty-printed JSON), and every span event with its offset from span start. `--json` prints the same records as JSON, one object per selected trace.
 
-A subagent keeps its own session id but records into the trace its parent had open at dispatch, so delegated work appears under the session that caused it, tagged with `agent.root.session.id`. Either session id resolves to that trace. A remote agent traces under its own deployment and is not recorded here.
+A subagent keeps its own session id but records into the trace its parent had open at dispatch, so delegated work appears under the session that caused it, tagged with `agent.root.session.id`. Either session id resolves to that trace. A remote eve agent joins the same trace in a shared backend through `traceparent`, but its spans remain in the remote deployment's local spool and are not recorded here.
 
 A session long enough to outgrow one trace — far longer than anything you will drive locally — continues into a new one. Each is a session window, numbered from zero on `agent.session.window`; passing a session id shows every window it produced, oldest first, and a trace id shows just that window.
 


### PR DESCRIPTION
### Summary

Related to the instrumentation providers proposal in #1799. The implementation stack has landed; this PR now contains only the public documentation for the experimental `agent/instrumentation/` provider layout.

The guide covers provider discovery, OpenTelemetry destinations, per-provider and per-destination content policy, local traces, Agent Runs, lifecycle events, durable provider state, handler deadlines, and setup/flush/shutdown. It also documents remote trace propagation and links the provider layout from the existing instrumentation and CLI guides.

Docs-only; no changeset required.

### Validation

- `pnpm docs:check`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)