### PR TITLE
Update nuxt dependency version to 4.4.7

### DIFF
--- a/apps/frameworks/nuxt/package.json
+++ b/apps/frameworks/nuxt/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "eve": "workspace:*",
-    "nuxt": "^4.0.0",
+    "nuxt": "^4.4.7",
     "vue": "^3.5.0",
     "zod": "catalog:"
   },


### PR DESCRIPTION
Nuxt versions 4.0.0 before 4.4.7 and 3.x before 3.21.7 fail to validate script-capable URLs in the navigateTo open option, allowing client-side script execution. Attackers can supply javascript: URLs through the open parameter to execute arbitrary scripts in the application's origin when user-controlled input is passed to navigateTo.

### Summary

<!--
A critical Cross-site Scripting (XSS) vulnerability was identified in the dependencies of the Nuxt framework application residing within the eve repository. The project currently references an unsafe version of Nuxt (4.4.6), which exposes the application to remote script execution in users' browser contexts.
-->

