### PR TITLE
fix(setup): show dedicated Photon numbers

### DIFF
--- a/.changeset/fix-photon-dedicated-number.md
+++ b/.changeset/fix-photon-dedicated-number.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Photon setup now shows an existing project's dedicated number when available, rather than its shared fallback number.
+Photon setup now shows an existing project's dedicated number when available, rather than allocating and showing a shared fallback number.

--- a/.changeset/fix-photon-dedicated-number.md
+++ b/.changeset/fix-photon-dedicated-number.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Photon setup now shows an existing project's dedicated number when available, rather than its shared fallback number.

--- a/packages/eve/src/setup/integrations/photon/management.test.ts
+++ b/packages/eve/src/setup/integrations/photon/management.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 
 import {
+  findDedicatedPhotonLine,
   provisionPhotonProject,
   usePhotonProject,
   validatePhotonPhoneNumber,
@@ -30,10 +31,7 @@ describe("Photon management provisioning", () => {
       .mockResolvedValueOnce(response({ id: "project-id" }))
       .mockResolvedValueOnce(response({ projectSecret: "project-secret" }))
       .mockResolvedValueOnce(
-        response({
-          succeed: true,
-          data: { user: { id: "user-id", assignedPhoneNumber: "+15550000000" } },
-        }),
+        response({ succeed: true, data: { assignedPhoneNumber: "+15550000000" } }),
       );
     const onAuthorization = vi.fn();
 
@@ -66,16 +64,11 @@ describe("Photon management provisioning", () => {
     });
   });
 
-  test("uses an existing project without dashboard authorization", async () => {
+  test("uses an existing project's dedicated line without registering the operator", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () =>
       response({
         succeed: true,
-        data: {
-          user: {
-            assignedPhoneNumber: "+15550000000",
-            phoneNumber: "+15551111111",
-          },
-        },
+        data: { line: { phoneNumber: "+15550000000" } },
       }),
     );
 
@@ -89,9 +82,49 @@ describe("Photon management provisioning", () => {
     ).resolves.toMatchObject({
       projectId: "project-id",
       projectSecret: "project-secret",
-      assignedPhoneNumber: "+15551111111",
+      assignedPhoneNumber: "+15550000000",
     });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://spectrum.photon.codes/projects/project-id/lines/route",
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
     expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  test("registers the operator on an existing shared project", async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(response({ message: "No dedicated line" }, 404))
+      .mockResolvedValueOnce(
+        response({ succeed: true, data: { assignedPhoneNumber: "+15550000000" } }),
+      );
+
+    await expect(
+      usePhotonProject({
+        projectId: "project-id",
+        projectSecret: "project-secret",
+        phoneNumber: "+15551234567",
+        deps: { fetch, delay: vi.fn(async () => {}) },
+      }),
+    ).resolves.toMatchObject({ assignedPhoneNumber: "+15550000000" });
+    expect(fetch).toHaveBeenLastCalledWith(
+      "https://spectrum.photon.codes/projects/project-id/users/",
+      expect.objectContaining({
+        body: JSON.stringify({ type: "shared", phoneNumber: "+15551234567" }),
+      }),
+    );
+  });
+
+  test("returns no dedicated line when Photon reports none", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => response({}, 404));
+
+    await expect(
+      findDedicatedPhotonLine({
+        projectId: "project-id",
+        projectSecret: "project-secret",
+        deps: { fetch },
+      }),
+    ).resolves.toBeUndefined();
   });
 
   test.each([

--- a/packages/eve/src/setup/integrations/photon/management.test.ts
+++ b/packages/eve/src/setup/integrations/photon/management.test.ts
@@ -68,7 +68,15 @@ describe("Photon management provisioning", () => {
 
   test("uses an existing project without dashboard authorization", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      response({ succeed: true, data: { user: { assignedPhoneNumber: "+15550000000" } } }),
+      response({
+        succeed: true,
+        data: {
+          user: {
+            assignedPhoneNumber: "+15550000000",
+            phoneNumber: "+15551111111",
+          },
+        },
+      }),
     );
 
     await expect(
@@ -81,7 +89,7 @@ describe("Photon management provisioning", () => {
     ).resolves.toMatchObject({
       projectId: "project-id",
       projectSecret: "project-secret",
-      assignedPhoneNumber: "+15550000000",
+      assignedPhoneNumber: "+15551111111",
     });
     expect(fetch).toHaveBeenCalledOnce();
   });

--- a/packages/eve/src/setup/integrations/photon/management.ts
+++ b/packages/eve/src/setup/integrations/photon/management.ts
@@ -40,20 +40,10 @@ const ErrorResponseSchema = z.object({
   message: z.unknown().optional(),
 });
 const PhoneRegistrationSchema = z.object({
-  assignedPhoneNumber: z.string().optional(),
-  phoneNumber: z.string().optional(),
-  data: z
-    .object({
-      assignedPhoneNumber: z.string().optional(),
-      phoneNumber: z.string().optional(),
-      user: z
-        .object({ assignedPhoneNumber: z.string().optional(), phoneNumber: z.string().optional() })
-        .optional(),
-    })
-    .optional(),
-  user: z
-    .object({ assignedPhoneNumber: z.string().optional(), phoneNumber: z.string().optional() })
-    .optional(),
+  data: z.object({ assignedPhoneNumber: z.string().min(1) }),
+});
+const DedicatedLineSchema = z.object({
+  data: z.object({ line: z.object({ phoneNumber: z.string().min(1) }) }),
 });
 
 interface DeviceCodeResponse {
@@ -88,7 +78,8 @@ export interface ProvisionPhotonProjectOptions {
 export interface UsePhotonProjectOptions {
   projectId: string;
   projectSecret: string;
-  phoneNumber: string;
+  dedicatedLine?: string;
+  phoneNumber?: string;
   deps?: PhotonManagementDeps;
 }
 
@@ -256,16 +247,25 @@ async function registerUser(
     await json(response, "phone registration"),
     "Photon returned an invalid phone registration response.",
   );
-  return (
-    body.data?.user?.phoneNumber ??
-    body.data?.user?.assignedPhoneNumber ??
-    body.data?.phoneNumber ??
-    body.data?.assignedPhoneNumber ??
-    body.user?.phoneNumber ??
-    body.user?.assignedPhoneNumber ??
-    body.phoneNumber ??
-    body.assignedPhoneNumber
+  return body.data.assignedPhoneNumber;
+}
+
+/** Returns the least-loaded dedicated iMessage line, when the project has one. */
+export async function findDedicatedPhotonLine(input: {
+  projectId: string;
+  projectSecret: string;
+  deps?: Pick<PhotonManagementDeps, "fetch">;
+}): Promise<string | undefined> {
+  const response = await (input.deps?.fetch ?? fetch)(
+    `${PHOTON_SPECTRUM_HOST}/projects/${encodeURIComponent(input.projectId)}/lines/route`,
+    { headers: basic(input.projectId, input.projectSecret) },
   );
+  if (response.status === 404) return undefined;
+  return parsePhotonResponse(
+    DedicatedLineSchema,
+    await json(response, "dedicated line lookup"),
+    "Photon returned an invalid dedicated line response.",
+  ).data.line.phoneNumber;
 }
 
 async function deleteProject(
@@ -310,23 +310,38 @@ export async function provisionPhotonProject(
 export async function usePhotonProject(
   options: UsePhotonProjectOptions,
 ): Promise<PhotonManagedProject> {
-  const phoneNumber = options.phoneNumber.trim();
-  const validationError = validatePhotonPhoneNumber(phoneNumber);
-  if (validationError !== null)
-    throw new Error(`Photon phone number is invalid. ${validationError}.`);
   const projectId = options.projectId.trim();
   const projectSecret = options.projectSecret.trim();
   if (!projectId || !projectSecret) {
     throw new Error("Photon project ID and project secret are required.");
   }
+  const dedicatedLine =
+    options.dedicatedLine ??
+    (await findDedicatedPhotonLine({
+      projectId,
+      projectSecret,
+      deps: options.deps,
+    }));
+  if (dedicatedLine !== undefined) {
+    return {
+      projectId,
+      projectSecret,
+      assignedPhoneNumber: dedicatedLine,
+      cleanup: async () => {},
+    };
+  }
+  if (options.phoneNumber === undefined) {
+    throw new Error("Photon phone number is required for projects without a dedicated line.");
+  }
+  const phoneNumber = options.phoneNumber.trim();
+  const validationError = validatePhotonPhoneNumber(phoneNumber);
+  if (validationError !== null)
+    throw new Error(`Photon phone number is invalid. ${validationError}.`);
   const assignedPhoneNumber = await registerUser(
     projectId,
     projectSecret,
     phoneNumber,
     options.deps ?? defaultDeps,
   );
-  const cleanup = async () => {};
-  return assignedPhoneNumber === undefined
-    ? { projectId, projectSecret, cleanup }
-    : { projectId, projectSecret, assignedPhoneNumber, cleanup };
+  return { projectId, projectSecret, assignedPhoneNumber, cleanup: async () => {} };
 }

--- a/packages/eve/src/setup/integrations/photon/management.ts
+++ b/packages/eve/src/setup/integrations/photon/management.ts
@@ -257,14 +257,14 @@ async function registerUser(
     "Photon returned an invalid phone registration response.",
   );
   return (
-    body.data?.user?.assignedPhoneNumber ??
     body.data?.user?.phoneNumber ??
-    body.data?.assignedPhoneNumber ??
+    body.data?.user?.assignedPhoneNumber ??
     body.data?.phoneNumber ??
-    body.user?.assignedPhoneNumber ??
+    body.data?.assignedPhoneNumber ??
     body.user?.phoneNumber ??
-    body.assignedPhoneNumber ??
-    body.phoneNumber
+    body.user?.assignedPhoneNumber ??
+    body.phoneNumber ??
+    body.assignedPhoneNumber
   );
 }
 

--- a/packages/eve/src/setup/integrations/photon/setup-flow.test.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.test.ts
@@ -19,6 +19,7 @@ function deps(): PhotonSetupDeps {
     appendEnv: vi.fn(async () => ({ written: [], skipped: [] })),
     deriveConnectorSlug: vi.fn(async () => "agent" as never),
     ensureVercelProject: vi.fn(async () => ({ orgId: "team-id", projectId: "project-id" })),
+    findDedicatedLine: vi.fn(async () => undefined),
     openUrl: vi.fn(),
     provisionConnector: vi.fn(),
     provisionProject: vi.fn(async () => ({
@@ -79,6 +80,42 @@ describe("Photon setup", () => {
     expect(effects.provisionProject).toHaveBeenCalledWith(
       expect.objectContaining({ projectName: "eve · weather-agent" }),
     );
+  });
+
+  it("uses an existing dedicated project without asking for an operator number", async () => {
+    const answers: ("portable" | "existing")[] = ["portable", "existing"];
+    const fake = createFakePrompter({ single: () => answers.shift() ?? "existing" });
+    const effects = deps();
+    vi.mocked(effects.findDedicatedLine).mockResolvedValue("+15550000000");
+    vi.mocked(effects.useProject).mockResolvedValue({
+      projectId: "project-id",
+      projectSecret: "project-secret",
+      assignedPhoneNumber: "+15550000000",
+      cleanup: vi.fn(async () => {}),
+    });
+
+    await expect(
+      setupPhoton({
+        agentName: "agent",
+        projectPath: "/project",
+        environment: integrationSetupEnvironment("cli-missing", { kind: "unresolved" }),
+        ui: createIntegrationSetupUi({
+          asker: asker({
+            "photon-project-id": "project-id",
+            "photon-project-secret": "project-secret",
+          }),
+          prompter: fake.prompter,
+        }),
+        deps: effects,
+      }),
+    ).resolves.toMatchObject({ kind: "done", assignedPhoneNumber: "+15550000000" });
+
+    expect(effects.useProject).toHaveBeenCalledWith({
+      projectId: "project-id",
+      projectSecret: "project-secret",
+      dedicatedLine: "+15550000000",
+      phoneNumber: undefined,
+    });
   });
 
   it("requires Vercel login when Connect is selected without an authenticated CLI", async () => {

--- a/packages/eve/src/setup/integrations/photon/setup-flow.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.ts
@@ -4,6 +4,7 @@ import { text } from "../../ask.js";
 import { appendEnv } from "../../append-env.js";
 import { provisionPhotonConnector } from "./connect.js";
 import {
+  findDedicatedPhotonLine,
   provisionPhotonProject,
   usePhotonProject,
   validatePhotonPhoneNumber,
@@ -43,6 +44,7 @@ export interface PhotonSetupDeps {
   appendEnv: typeof appendEnv;
   deriveConnectorSlug: typeof deriveSlackConnectorSlug;
   ensureVercelProject: typeof ensureVercelProject;
+  findDedicatedLine: typeof findDedicatedPhotonLine;
   openUrl: typeof openUrl;
   provisionConnector: typeof provisionPhotonConnector;
   provisionProject: typeof provisionPhotonProject;
@@ -54,6 +56,7 @@ const defaultDeps: PhotonSetupDeps = {
   appendEnv,
   deriveConnectorSlug: deriveSlackConnectorSlug,
   ensureVercelProject,
+  findDedicatedLine: findDedicatedPhotonLine,
   openUrl,
   provisionConnector: provisionPhotonConnector,
   provisionProject: provisionPhotonProject,
@@ -183,12 +186,14 @@ async function chooseSetupPlan(
 async function resolvePhotonProject(
   options: PhotonSetupOptions,
   plan: PhotonSetupPlan,
-  phoneNumber: string,
+  phoneNumber: string | undefined,
+  dedicatedLine: string | undefined,
   deps: PhotonSetupDeps,
 ): Promise<PhotonManagedProject> {
   if (plan.photonProject !== "create") {
-    return deps.useProject({ ...plan.photonProject, phoneNumber });
+    return deps.useProject({ ...plan.photonProject, dedicatedLine, phoneNumber });
   }
+  if (phoneNumber === undefined) throw new Error("Photon phone number is required.");
   const spinner = options.ui.prompter.log.spinner?.("Waiting for Photon approval…", {
     kind: "external-action",
     emphasis: "browser",
@@ -214,17 +219,28 @@ async function scaffoldPhoton(
   plan: PhotonSetupPlan,
   deps: PhotonSetupDeps,
 ): Promise<{ assignedPhoneNumber?: string; dashboardUrl: string }> {
-  const phoneNumber = await options.ui.asker.ask(
-    text({
-      key: "photon-phone-number",
-      message: "Your iMessage phone number",
-      placeholder: "+15551234567",
-      required: true,
-      validate: validatePhotonPhoneNumber,
-    }),
-  );
+  const dedicatedLine =
+    plan.photonProject === "create" ? undefined : await deps.findDedicatedLine(plan.photonProject);
+  const phoneNumber =
+    plan.photonProject !== "create" && dedicatedLine !== undefined
+      ? undefined
+      : await options.ui.asker.ask(
+          text({
+            key: "photon-phone-number",
+            message: "Your iMessage phone number",
+            placeholder: "+15551234567",
+            required: true,
+            validate: validatePhotonPhoneNumber,
+          }),
+        );
   const projectRoot = options.projectPath;
-  const managedProject = await resolvePhotonProject(options, plan, phoneNumber, deps);
+  const managedProject = await resolvePhotonProject(
+    options,
+    plan,
+    phoneNumber,
+    dedicatedLine,
+    deps,
+  );
   try {
     const channelPath = join(projectRoot, "agent/channels/photon.ts");
     if (plan.credentials === "vercel-connect") {


### PR DESCRIPTION
### Summary

Photon setup now detects an existing project’s dedicated line before registering the operator. Dedicated projects display Photon’s least-loaded line and skip the shared-user registration; shared projects retain the existing registration flow and show its assigned number.

The Photon response parsing now follows its published Spectrum API schema rather than guessing among undocumented response shapes.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/photon/management.test.ts src/setup/integrations/photon/setup-flow.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm lint`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
