### PR TITLE
fix(docs): disable streaming in Sendblue scaffold

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -650,6 +650,8 @@ export const { bot, channel, send } = chatSdkChannel({
     sendblue: createSendblueAdapter(),
   },
   state: createMemoryState(),
+  // Sendblue's iMessage API does not support editing sent messages.
+  streaming: false,
 });
 
 bot.onNewMention(async (thread: Thread, message: Message) => {

--- a/apps/docs/registry/channels/chat-sdk-sendblue.ts
+++ b/apps/docs/registry/channels/chat-sdk-sendblue.ts
@@ -9,6 +9,8 @@ export const { bot, channel, send } = chatSdkChannel({
     sendblue: createSendblueAdapter(),
   },
   state: createMemoryState(),
+  // Sendblue's iMessage API does not support editing sent messages.
+  streaming: false,
 });
 
 bot.onNewMention(async (thread: Thread, message: Message) => {

--- a/apps/docs/scripts/validate-channel-registry.ts
+++ b/apps/docs/scripts/validate-channel-registry.ts
@@ -162,6 +162,15 @@ for (const [index, item] of items.entries()) {
   }
   await access(join(docsRoot, expectedPath));
 
+  if (entry.slug === "chat-sdk-sendblue") {
+    const source = await readFile(join(docsRoot, expectedPath), "utf8");
+    if (!source.includes("streaming: false")) {
+      throw new Error(
+        `Registry item "${item.name}" must disable streaming because Sendblue does not support message editing.`,
+      );
+    }
+  }
+
   const adapterDependency = adapterDependenciesByCatalogSlug[entry.slug];
   if (entry.slug.startsWith("chat-sdk-") && adapterDependency === undefined) {
     throw new Error(`Registry item "${item.name}" has no adapter dependency mapping.`);


### PR DESCRIPTION
### Summary

Closes #1872. The Sendblue registry scaffold inherited Chat SDK's default streaming behavior, so eve attempted to edit the sent iMessage on `message.completed` and the adapter swallowed a `Sendblue does not support message editing` error. The scaffold now disables streaming so generated Sendblue channels post one response on completion; the quick-start example matches, and registry validation preserves this provider-specific requirement. Existing generated channel files are not rewritten automatically.

### Validation

- `pnpm --filter eve-docs registry:check`
- `pnpm exec oxlint apps/docs/registry/channels/chat-sdk-sendblue.ts apps/docs/lib/integrations/data.ts apps/docs/scripts/validate-channel-registry.ts`
- `git diff --check`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

A changeset is not required because this does not touch the published `eve` package.
