### PR TITLE
test(eve): remove scenario observation races

### DIFF
--- a/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { ROOT_CONTEXT, trace } from "@opentelemetry/api";
+import { ROOT_CONTEXT, trace as runtimeTrace } from "@opentelemetry/api";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -14,6 +15,7 @@ import { installLocalInstrumentationRuntime } from "#tracing/local-instrumentati
 import { LocalTraceSpanProcessor } from "#tracing/local-trace-span-processor.js";
 
 const temporaryDirectories: string[] = [];
+const require = createRequire(import.meta.url);
 
 afterEach(async () => {
   await Promise.all(
@@ -30,6 +32,10 @@ describe("local instrumentation runtime", () => {
       frameworkVersion: "test",
       serviceName: "test-agent",
     });
+    // Resolve the public API outside Vitest's transformed module graph, as an
+    // authored app does when it imports its own @opentelemetry/api dependency.
+    const authoredTrace = (require("@opentelemetry/api") as typeof import("@opentelemetry/api"))
+      .trace;
     const scope: InstrumentationAttemptScope = {
       attemptId: "session-1:turn-1:0:0",
       attemptIndex: 0,
@@ -70,7 +76,8 @@ describe("local instrumentation runtime", () => {
       await bridge.executeLanguageModelCall!({
         callId: "call-1",
         execute: async () => {
-          const span = trace.getTracer("test-user").startSpan("user.model-work");
+          const span = authoredTrace.getTracer("test-user").startSpan("user.model-work");
+          expect(span.isRecording()).toBe(true);
           await Promise.resolve();
           span.end();
         },
@@ -94,7 +101,8 @@ describe("local instrumentation runtime", () => {
       await bridge.executeTool!({
         callId: "call-1",
         execute: async () => {
-          const span = trace.getTracer("test-user").startSpan("user.tool-work");
+          const span = authoredTrace.getTracer("test-user").startSpan("user.tool-work");
+          expect(span.isRecording()).toBe(true);
           await Promise.resolve();
           span.end();
         },
@@ -173,9 +181,9 @@ describe("local instrumentation runtime", () => {
     const secondProcessor = new LocalTraceSpanProcessor(appRoot);
     const firstProvider = new BasicTracerProvider({ spanProcessors: [firstProcessor] });
     const secondProvider = new BasicTracerProvider({ spanProcessors: [secondProcessor] });
-    const parent = trace.setSpan(
+    const parent = runtimeTrace.setSpan(
       ROOT_CONTEXT,
-      trace.wrapSpanContext({
+      runtimeTrace.wrapSpanContext({
         spanId: "b".repeat(16),
         traceFlags: 1,
         traceId: "a".repeat(32),

--- a/packages/eve/test/scenarios/dev-server-workflow-generations.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server-workflow-generations.scenario.test.ts
@@ -39,7 +39,7 @@ const WORKFLOW_GENERATION_DESCRIPTOR: ScenarioAppDescriptor = {
 function createGenerationMarkerToolSource(marker: string, crashOnce: boolean): string {
   const lifecycle = crashOnce
     ? [
-        'import { existsSync, watch, writeFileSync } from "node:fs";',
+        'import { existsSync, renameSync, watch, writeFileSync } from "node:fs";',
         'import { basename, join } from "node:path";',
         "",
         "async function waitForPath(path: string) {",
@@ -67,7 +67,10 @@ function createGenerationMarkerToolSource(marker: string, crashOnce: boolean): s
         '    const restartPath = join(process.cwd(), ".restart-generation-test");',
         '    writeFileSync(startedPath, "ready");',
         "    if (existsSync(restartPath)) {",
-        `      writeFileSync(join(process.cwd(), ".recovered-turn-started"), JSON.stringify({ instrumentation: String(globalThis.__EVE_INSTRUMENTATION_MARKER__ ?? "missing"), marker: ${JSON.stringify(marker)} }));`,
+        '      const recoveredPath = join(process.cwd(), ".recovered-turn-started");',
+        "      const temporaryRecoveredPath = `${recoveredPath}.${process.pid}.tmp`;",
+        `      writeFileSync(temporaryRecoveredPath, JSON.stringify({ instrumentation: String(globalThis.__EVE_INSTRUMENTATION_MARKER__ ?? "missing"), marker: ${JSON.stringify(marker)} }));`,
+        "      renameSync(temporaryRecoveredPath, recoveredPath);",
         "    } else {",
         "      await waitForPath(crashPath);",
         "      if (!existsSync(crashedPath)) {",


### PR DESCRIPTION
## Summary

- resolve the public OpenTelemetry API through native Node resolution in the local trace scenario, then assert authored spans are recording before reading persisted segments
- atomically publish the recovered-workflow JSON marker so its existence proves the payload is complete

## Validation

- `vitest run --config vitest.scenario.config.ts src/tracing/local-instrumentation-runtime.scenario.test.ts`
- `vitest run --config vitest.scenario.config.ts test/scenarios/dev-server-workflow-generations.scenario.test.ts -t "recovers a nonterminal child Workflow on its selected generation after restart"`
- `vitest run --config vitest.scenario.config.ts test/scenarios/dev-server-workflow-generations.scenario.test.ts`
- `oxfmt --check` on changed files
- `oxlint` on changed files
- `git diff --check`

No changeset: test-only change.