### PR TITLE
fix(eve): ignore non-local URLs when discovering framework dev servers

### DIFF
--- a/.changeset/nuxt-dev-server-loopback-url.md
+++ b/.changeset/nuxt-dev-server-loopback-url.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Ignore non-local URLs in eve/nuxt and eve/sveltekit dev-server startup output when discovering the listening address.

--- a/packages/eve/src/public/next/server.ts
+++ b/packages/eve/src/public/next/server.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import { resolvePackageRoot } from "#internal/application/package.js";
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
+import { findLocalServerOrigin } from "#shared/network-address.js";
 
 const EVE_BASE_URL_ENV = "EVE_BASE_URL";
 const DEFAULT_SERVER_READY_TIMEOUT_MS = 180_000;
@@ -16,7 +17,6 @@ const EVE_NEXT_DEV_SERVER_FILE_NAME = "next-dev-server.json";
 const EVE_NEXT_DEV_SERVER_LOCK_FILE_NAME = "next-dev-server.lock";
 const ANSI_ESCAPE = String.fromCharCode(27);
 const ANSI_ESCAPE_PATTERN = new RegExp(`${ANSI_ESCAPE}\\[[0-?]*[ -/]*[@-~]`, "g");
-const SERVER_URL_CANDIDATE_PATTERN = /https?:\/\/[^\s"'<>]+/g;
 const NEXT_PHASE_PRODUCTION_BUILD = "phase-production-build";
 
 interface EveProcessHandle {
@@ -245,44 +245,6 @@ async function acquireEveDevServerLock(
 
 function createEveBinaryPath(): string {
   return join(resolvePackageRoot(), "bin", "eve.js");
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  return (
-    hostname === "localhost" ||
-    hostname === "::1" ||
-    hostname === "[::1]" ||
-    /^127(?:\.\d{1,3}){3}$/.test(hostname)
-  );
-}
-
-function parseLocalServerOrigin(urlText: string): string | undefined {
-  const url = URL.parse(urlText);
-  // Dev-server discovery reads mixed subprocess output. Build metadata and
-  // dependency warnings can print unrelated URLs before eve reports its listener,
-  // but withEve only owns the app-local loopback server it started.
-  if (
-    url === null ||
-    (url.protocol !== "http:" && url.protocol !== "https:") ||
-    !isLoopbackHostname(url.hostname) ||
-    url.port.length === 0
-  ) {
-    return undefined;
-  }
-
-  return url.origin;
-}
-
-function findLocalServerOrigin(output: string): string | undefined {
-  for (const match of output.matchAll(SERVER_URL_CANDIDATE_PATTERN)) {
-    const candidate = match[0];
-    const origin = parseLocalServerOrigin(candidate);
-    if (origin !== undefined) {
-      return origin;
-    }
-  }
-
-  return undefined;
 }
 
 function formatEveDevOutputLine(line: string, logLabel: string | undefined): string | undefined {

--- a/packages/eve/src/public/nuxt/dev-server.integration.test.ts
+++ b/packages/eve/src/public/nuxt/dev-server.integration.test.ts
@@ -1,10 +1,38 @@
+import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
 import { EVE_BASE_URL_ENV, resolveSharedEveDevServer } from "./dev-server.js";
+
+interface MockChildProcess extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  killed: boolean;
+  kill(): void;
+  pid: number;
+}
+
+function createMockChildProcess(): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.pid = 12345;
+  child.kill = () => {
+    child.killed = true;
+    child.emit("exit", null, "SIGTERM");
+  };
+  return child;
+}
 
 async function createTempAppRoot(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "eve-nuxt-dev-server-"));
@@ -19,6 +47,8 @@ async function writeRegistry(appRoot: string, registry: Record<string, unknown>)
 }
 
 afterEach(() => {
+  spawnMock.mockReset();
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   delete process.env[EVE_BASE_URL_ENV];
@@ -45,5 +75,34 @@ describe("resolveSharedEveDevServer", () => {
     expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:49152/eve/v1/health", {
       signal: expect.any(AbortSignal),
     });
+  });
+
+  it("ignores non-server URLs in eve output while waiting for the listening URL", async () => {
+    const appRoot = await createTempAppRoot();
+    const child = createMockChildProcess();
+    const stdoutWrites: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    spawnMock.mockReturnValue(child);
+
+    const handle = resolveSharedEveDevServer(appRoot);
+
+    await vi.waitFor(() => {
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+
+    child.stdout.emit(
+      "data",
+      Buffer.from('dependency metadata: "homepage": "https://rolldown.rs/"\n'),
+    );
+    child.stdout.emit("data", Buffer.from("docs: open http://localhost for details\n"));
+    child.stderr.emit("data", Buffer.from("dev server listening at http://127.0.0.1:33449\n"));
+
+    await expect(handle).resolves.toMatchObject({ origin: "http://127.0.0.1:33449" });
+    expect(process.env[EVE_BASE_URL_ENV]).toBe("http://127.0.0.1:33449");
+    expect(stdoutWrites).toContain('dependency metadata: "homepage": "https://rolldown.rs/"\n');
   });
 });

--- a/packages/eve/src/public/nuxt/dev-server.ts
+++ b/packages/eve/src/public/nuxt/dev-server.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { resolvePackageRoot } from "#internal/application/package.js";
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
+import { findLocalServerOrigin } from "#shared/network-address.js";
 
 import { joinRoutePrefix, normalizeOrigin } from "./routing.js";
 
@@ -16,7 +17,6 @@ const DEV_SERVER_STALE_LOCK_MS = 30_000;
 const EVE_CACHE_DIRECTORY_NAME = ".eve";
 const EVE_NUXT_DEV_SERVER_FILE_NAME = "nuxt-dev-server.json";
 const EVE_NUXT_DEV_SERVER_LOCK_FILE_NAME = "nuxt-dev-server.lock";
-const LOCAL_SERVER_URL_PATTERN = /https?:\/\/(?:\[[^\]\s]+\]|[^\s/:[\]]+)(?::\d+)?/;
 
 export interface EveProcessHandle {
   readonly origin: string;
@@ -211,11 +211,11 @@ function startServerProcess(input: {
     let resolved = false;
     const handleOutput = (chunk: Buffer) => {
       if (resolved) return;
-      const match = LOCAL_SERVER_URL_PATTERN.exec(chunk.toString("utf8"));
-      if (match === null) return;
+      const origin = findLocalServerOrigin(chunk.toString("utf8"));
+      if (origin === undefined) return;
       resolved = true;
       cleanup();
-      resolvePromise({ origin: normalizeOrigin(match[0]), process: child });
+      resolvePromise({ origin, process: child });
     };
 
     child.once("error", handleError);

--- a/packages/eve/src/public/sveltekit/dev-server.ts
+++ b/packages/eve/src/public/sveltekit/dev-server.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { resolvePackageRoot } from "#internal/application/package.js";
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
+import { findLocalServerOrigin } from "#shared/network-address.js";
 
 import { joinRoutePrefix, normalizeOrigin } from "./routing.js";
 
@@ -16,7 +17,6 @@ const DEV_SERVER_STALE_LOCK_MS = 30_000;
 const EVE_CACHE_DIRECTORY_NAME = ".eve";
 const EVE_SVELTEKIT_DEV_SERVER_FILE_NAME = "sveltekit-dev-server.json";
 const EVE_SVELTEKIT_DEV_SERVER_LOCK_FILE_NAME = "sveltekit-dev-server.lock";
-const LOCAL_SERVER_URL_PATTERN = /https?:\/\/(?:\[[^\]\s]+\]|[^\s/:[\]]+)(?::\d+)?/;
 
 export interface EveProcessHandle {
   readonly origin: string;
@@ -211,11 +211,11 @@ function startServerProcess(input: {
     let resolved = false;
     const handleOutput = (chunk: Buffer) => {
       if (resolved) return;
-      const match = LOCAL_SERVER_URL_PATTERN.exec(chunk.toString("utf8"));
-      if (match === null) return;
+      const origin = findLocalServerOrigin(chunk.toString("utf8"));
+      if (origin === undefined) return;
       resolved = true;
       cleanup();
-      resolvePromise({ origin: normalizeOrigin(match[0]), process: child });
+      resolvePromise({ origin, process: child });
     };
 
     child.once("error", handleError);

--- a/packages/eve/src/shared/network-address.test.ts
+++ b/packages/eve/src/shared/network-address.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  findLocalServerOrigin,
   isLoopbackHostname,
   isLoopbackServerUrl,
   isPrivateOrReservedIpAddress,
@@ -48,6 +49,26 @@ describe("isLoopbackServerUrl", () => {
     ]) {
       expect(isLoopbackServerUrl(url), url).toBe(false);
     }
+  });
+});
+
+describe("findLocalServerOrigin", () => {
+  it("returns the first loopback origin with an explicit port", () => {
+    expect(
+      findLocalServerOrigin(
+        'dependency metadata: "homepage": "https://rolldown.rs/"\ndocs: open http://localhost for details\ndev server listening at http://127.0.0.1:33449\n',
+      ),
+    ).toBe("http://127.0.0.1:33449");
+  });
+
+  it("accepts localhost and IPv6 loopback with ports", () => {
+    expect(findLocalServerOrigin("ready at http://localhost:3000")).toBe("http://localhost:3000");
+    expect(findLocalServerOrigin("ready at http://[::1]:8080/")).toBe("http://[::1]:8080");
+  });
+
+  it("ignores wildcard binds and non-loopback hosts", () => {
+    expect(findLocalServerOrigin("listening at http://0.0.0.0:3000")).toBeUndefined();
+    expect(findLocalServerOrigin("see https://example.com/docs")).toBeUndefined();
   });
 });
 

--- a/packages/eve/src/shared/network-address.ts
+++ b/packages/eve/src/shared/network-address.ts
@@ -85,6 +85,31 @@ export function isLoopbackServerUrl(urlText: string): boolean {
   return parsed.success && isLoopbackHostname(new URL(parsed.data).hostname);
 }
 
+const SERVER_URL_CANDIDATE_PATTERN = /https?:\/\/[^\s"'<>]+/g;
+
+/**
+ * Find the first http(s) loopback origin with an explicit port in mixed
+ * subprocess output. Build metadata and dependency warnings can print
+ * unrelated URLs before eve reports its listener.
+ */
+export function findLocalServerOrigin(output: string): string | undefined {
+  for (const match of output.matchAll(SERVER_URL_CANDIDATE_PATTERN)) {
+    const url = URL.parse(match[0]);
+    if (
+      url === null ||
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      !isLoopbackHostname(url.hostname) ||
+      url.port.length === 0
+    ) {
+      continue;
+    }
+
+    return url.origin;
+  }
+
+  return undefined;
+}
+
 /**
  * Whether `host` is an IP literal in a private, link-local, or otherwise
  * reserved range that an outbound framework request must not target — an SSRF


### PR DESCRIPTION
Nuxt and SvelteKit were matching the first http(s) URL in eve startup output, so dependency metadata could be mistaken for the listener. Share Next's loopback-with-port discovery helper across adapters.

### Summary

<!--
Link the issue where this change was discussed (for example, "Closes #123" or
"Related to #123"). Explain the concrete problem and solution, then summarize
meaningful behavior or decisions—not changed files or commits. Call out breaking
changes, preserved behavior, scope boundaries, or stacked PRs when relevant.
-->

### Validation

<!--
List the exact commands you ran and useful manual coverage. Include relevant
results or limitations. Explain when tests are not applicable.
-->

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
