### PR TITLE
fix(eve): namespace dynamic-tool step ids by module path

### DIFF
--- a/.changeset/dynamic-tool-module-step-scope.md
+++ b/.changeset/dynamic-tool-module-step-scope.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Namespace dynamic-tool and dynamic-remote-agent step ids by module path so independently transformed files no longer overwrite each other in the global step registry.

--- a/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.test.ts
@@ -65,7 +65,9 @@ export default defineDynamic({
       stepId?: string;
     };
     expect(Object.keys(remote)).not.toContain("__eveResolveRemoteAgentCredentials");
-    expect(credentialsFactory.stepId).toMatch(/^eve:dynamic-remote-agent\/\//);
+    expect(credentialsFactory.stepId).toMatch(
+      /^eve:dynamic-remote-agent\/\/[^/]+\/__eve_dynamic_remote_credentials_/,
+    );
     const key = Symbol.for("@workflow/core//registeredSteps");
     const registry = (globalThis as Record<symbol, Map<string, Function> | undefined>)[key];
     if (registry === undefined) throw new Error("Step registry was not created");

--- a/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.ts
@@ -4,6 +4,7 @@ import {
   type DynamicToolAstNode as AstNode,
   walkNode,
 } from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
+import { moduleStepScope } from "#internal/workflow-bundle/module-step-scope.js";
 
 interface CredentialsFactoryInfo {
   readonly authPropertySource?: string;
@@ -32,9 +33,15 @@ export async function transformDynamicRemoteAgentCredentials(
     return null;
   }
 
-  const ast = (await parseWithNitroRolldownAst(filename, source)) as AstNode;
-  const factories = findCredentialsFactories(source, ast);
-  return factories.length === 0 ? null : applyTransform(source, factories);
+  const previousCounter = transformCounter;
+  transformCounter = 0;
+  try {
+    const ast = (await parseWithNitroRolldownAst(filename, source)) as AstNode;
+    const factories = findCredentialsFactories(source, ast);
+    return factories.length === 0 ? null : applyTransform(source, factories, filename);
+  } finally {
+    transformCounter = previousCounter;
+  }
 }
 
 function findCredentialsFactories(source: string, ast: AstNode): CredentialsFactoryInfo[] {
@@ -77,18 +84,20 @@ function findCredentialsFactories(source: string, ast: AstNode): CredentialsFact
 function applyTransform(
   source: string,
   factories: readonly CredentialsFactoryInfo[],
+  filename: string,
 ): {
   code: string;
 } {
   const replacements: Array<{ start: number; end: number; text: string }> = [];
   const hoistedFunctions: string[] = [];
   const registrations: string[] = [];
+  const stepScope = moduleStepScope(filename);
 
   for (const credentials of factories) {
     const properties = [credentials.authPropertySource, credentials.headersPropertySource].filter(
       (property) => property !== undefined,
     );
-    const stepId = `eve:dynamic-remote-agent//${credentials.hoistedName}`;
+    const stepId = `eve:dynamic-remote-agent//${stepScope}/${credentials.hoistedName}`;
     hoistedFunctions.push(
       `function ${credentials.hoistedName}() {\n` +
         `  return { ${properties.join(", ")} };\n` +

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -184,6 +184,46 @@ export default defineDynamic({
     expect(result).toBe(50);
   });
 
+  it("namespaces step ids by module so sibling files do not overwrite each other", async () => {
+    const sourceFor = (toolName: string) => `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      return {
+        ${toolName}: defineTool({
+          description: "${toolName}",
+          inputSchema: { type: "object" },
+          execute(input) { return "${toolName}:" + input.x; },
+        }),
+      };
+    },
+  },
+});
+`;
+
+    const first = await transformAndEval("tools/search.ts", sourceFor("search"));
+    const second = await transformAndEval("tools/tokenize.ts", sourceFor("tokenize"));
+
+    const searchTools = await first.callHandler();
+    const tokenizeTools = await second.callHandler();
+    const searchStep = (searchTools.search as Record<string, unknown>)
+      .__executeStepFn as Function & {
+      stepId: string;
+    };
+    const tokenizeStep = (tokenizeTools.tokenize as Record<string, unknown>)
+      .__executeStepFn as Function & { stepId: string };
+
+    expect(searchStep.stepId).toMatch(/^eve:dynamic-tool\/\/[^/]+\/__eve_dynamic_exec_/);
+    expect(tokenizeStep.stepId).toMatch(/^eve:dynamic-tool\/\/[^/]+\/__eve_dynamic_exec_/);
+    expect(searchStep.stepId).not.toBe(tokenizeStep.stepId);
+    expect(first.registry.get(searchStep.stepId)).toBe(searchStep);
+    expect(second.registry.get(tokenizeStep.stepId)).toBe(tokenizeStep);
+    expect(first.registry.get(searchStep.stepId)!({}, { x: 1 })).toBe("search:1");
+    expect(second.registry.get(tokenizeStep.stepId)!({}, { x: 2 })).toBe("tokenize:2");
+  });
+
   it("replay path: step function + stored closure vars produce correct result", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -32,6 +32,7 @@ import {
   type DynamicToolAstNode as AstNode,
   walkNode,
 } from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
+import { moduleStepScope } from "#internal/workflow-bundle/module-step-scope.js";
 
 interface HandlerInfo {
   /** The handler function AST node */
@@ -96,14 +97,22 @@ export async function transformDynamicToolExecute(
     return null;
   }
 
-  const ast = await parseSource(filename, source);
-  const handlers = findDynamicToolHandlers(source, ast);
+  // Per-file counters keep `__eve_dynamic_exec_N` stable when other modules
+  // are added or reordered; moduleStepScope disambiguates the shared registry.
+  const previousCounter = transformCounter;
+  transformCounter = 0;
+  try {
+    const ast = await parseSource(filename, source);
+    const handlers = findDynamicToolHandlers(source, ast);
 
-  if (handlers.every((h) => h.executes.length === 0)) {
-    return null;
+    if (handlers.every((h) => h.executes.length === 0)) {
+      return null;
+    }
+
+    return applyTransform(source, handlers, filename);
+  } finally {
+    transformCounter = previousCounter;
   }
-
-  return applyTransform(source, handlers);
 }
 
 // Keep the old export name for backward compatibility with the plugin
@@ -452,11 +461,16 @@ function extractFnBody(source: string, fn: AstNode): string {
 // Transform application
 // ---------------------------------------------------------------------------
 
-function applyTransform(source: string, handlers: HandlerInfo[]): { code: string } {
+function applyTransform(
+  source: string,
+  handlers: HandlerInfo[],
+  filename: string,
+): { code: string } {
   const replacements: Array<{ start: number; end: number; text: string }> = [];
   const hoistedFunctions: string[] = [];
   const registrations: string[] = [];
   const allExecNames: string[] = [];
+  const stepScope = moduleStepScope(filename);
 
   for (const handler of handlers) {
     for (const exec of handler.executes) {
@@ -499,7 +513,7 @@ function applyTransform(source: string, handlers: HandlerInfo[]): { code: string
       const originalParams = exec.params;
       const hoistedParams = originalParams ? `__vars, ${originalParams}` : "__vars";
       const bodyContent = exec.body.slice(1, -1).trim();
-      const stepId = `eve:dynamic-tool//${exec.hoistedName}`;
+      const stepId = `eve:dynamic-tool//${stepScope}/${exec.hoistedName}`;
 
       hoistedFunctions.push(
         `${asyncPrefix}function ${exec.hoistedName}(${hoistedParams}) {\n` +

--- a/packages/eve/src/internal/workflow-bundle/module-step-scope.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/module-step-scope.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { moduleStepScope } from "./module-step-scope.js";
+
+describe("moduleStepScope", () => {
+  it("is stable for the same normalized path", () => {
+    expect(moduleStepScope("agent/tools/search.ts")).toBe(moduleStepScope("agent/tools/search.ts"));
+  });
+
+  it("differs across distinct modules", () => {
+    expect(moduleStepScope("agent/tools/search.ts")).not.toBe(
+      moduleStepScope("agent/tools/tokenize.ts"),
+    );
+  });
+
+  it("strips the cwd prefix for absolute local paths", () => {
+    const absolute = `${process.cwd()}/agent/tools/search.ts`;
+    expect(moduleStepScope(absolute)).toBe(moduleStepScope("agent/tools/search.ts"));
+  });
+
+  it("collapses pnpm nested node_modules paths to the package path", () => {
+    const nested = "/app/node_modules/.pnpm/evlog@1.0.0/node_modules/evlog/dist/tools/search.js";
+    const plain = "/app/node_modules/evlog/dist/tools/search.js";
+    expect(moduleStepScope(nested)).toBe(moduleStepScope(plain));
+  });
+
+  it("keeps distinct packages distinct after pnpm collapsing", () => {
+    expect(moduleStepScope("/app/node_modules/.pnpm/foo@1/node_modules/foo/tools/a.js")).not.toBe(
+      moduleStepScope("/app/node_modules/.pnpm/bar@1/node_modules/bar/tools/a.js"),
+    );
+  });
+});

--- a/packages/eve/src/internal/workflow-bundle/module-step-scope.ts
+++ b/packages/eve/src/internal/workflow-bundle/module-step-scope.ts
@@ -1,0 +1,33 @@
+/**
+ * Normalize a transform filename into a short, stable step-id scope.
+ *
+ * Dynamic-tool step ids live in a process-global registry. Without a
+ * per-module scope, independently transformed files (or pnpm-nested
+ * dependency packages) that both emit `__eve_dynamic_exec_0` overwrite
+ * each other and resume fails with "step function ... is not registered".
+ */
+export function moduleStepScope(filename: string): string {
+  let normalized = String(filename ?? "").replace(/\\/g, "/");
+  const nodeModulesIndex = normalized.indexOf("/node_modules/");
+
+  if (nodeModulesIndex === -1) {
+    const cwd = process.cwd().replace(/\\/g, "/");
+    if (normalized.startsWith(`${cwd}/`)) {
+      normalized = normalized.slice(cwd.length + 1);
+    }
+  } else {
+    // Prefer the package path after the last pnpm nesting level so
+    // `.pnpm/<pkg>@<ver>/node_modules/<pkg>/...` collapses to `<pkg>/...`.
+    normalized = normalized
+      .slice(nodeModulesIndex + "/node_modules/".length)
+      .replace(/^\.pnpm\/[^/]+\/node_modules\//, "");
+  }
+
+  // FNV-1a 32-bit — short, stable across machines once the path is normalized.
+  let hash = 2166136261;
+  for (let i = 0; i < normalized.length; i++) {
+    hash ^= normalized.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}


### PR DESCRIPTION
### Summary

While running an agent with several dynamic-tool modules, resumed sessions started failing with `references step function "..." which is not registered`. Fresh sessions were fine; only resume broke.

The dynamic-tool bundler transform registers each `execute` into a process-global step map under ids like `eve:dynamic-tool//__eve_dynamic_exec_0`. That name is only a per-transform counter, so two independently transformed files (or an app module and one pulled from `node_modules`) can emit the same key. The later registration overwrites the earlier one, and replay looks up an id that no longer points at the original function.

I first worked around this with a local `pnpm` patch on the published `eve` package (`patches/eve@0.30.6.patch`), adding a stable per-module scope into the step id. This PR lands that fix upstream:

- step ids become `eve:dynamic-tool//{moduleScope}/{hoistedName}` (same idea for dynamic remote-agent credentials)
- `moduleScope` is a short hash of a normalized module path (cwd / pnpm `node_modules` stripped so it stays stable across machines)
- the hoist counter resets per file so adding or reordering other modules does not renumber existing ones

Regular `"use step"` functions already use path-qualified ids (`step//{module}//{name}`); dynamic tools were the under-scoped exception.

**Compatibility note:** open sessions that already persisted the old unscoped ids will not resolve those steps after upgrade; new turns and new sessions are fine.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/workflow-bundle/module-step-scope.test.ts src/internal/workflow-bundle/dynamic-tool-transform.test.ts src/internal/workflow-bundle/dynamic-remote-agent-transform.test.ts` (69 passed)

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)