### PR TITLE
fix: run sandbox image as workspace owner

### DIFF
--- a/.github/workflows/docker-image-size-analysis.yml
+++ b/.github/workflows/docker-image-size-analysis.yml
@@ -81,6 +81,17 @@ jobs:
           size_bytes="$(docker image inspect eve-docker-size:current --format '{{.Size}}')"
           echo "size_bytes=$size_bytes" >> "$GITHUB_OUTPUT"
 
+      - name: Verify sandbox user workspace and sudo permissions
+        run: |
+          docker run --rm eve-docker-size:current bash -lc '
+            set -euo pipefail
+            test "$(id -un)" = vercel-sandbox
+            test "$(stat -c %U /workspace)" = vercel-sandbox
+            git init --quiet /workspace
+            git -C /workspace remote add origin https://github.com/vercel/eve.git
+            sudo -n true
+          '
+
       - name: Generate Docker image size report
         env:
           BASELINE_LABEL: ${{ steps.baseline.outputs.label }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,4 +84,5 @@ RUN set -eux; \
   printf 'vercel-sandbox ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/vercel-sandbox; \
   chmod 0440 /etc/sudoers.d/vercel-sandbox
 
+USER vercel-sandbox
 WORKDIR /workspace

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -100,7 +100,7 @@ export default defineSandbox({
   revalidationKey: () => "repo-bootstrap-v1",
   async bootstrap({ use }) {
     const sandbox = await use();
-    await sandbox.run({ command: "apt-get install -y jq" });
+    await sandbox.run({ command: "sudo apt-get install -y jq" });
   },
   async onSession({ use }) {
     await use({ networkPolicy: "deny-all" });


### PR DESCRIPTION
### Summary

Closes #1596. The published sandbox image gives `/workspace` to `vercel-sandbox` but currently runs commands as root, causing GitHub channel checkout to fail Git's ownership check. The image now runs as its workspace owner, preserving passwordless `sudo` for privileged setup instead of weakening `safe.directory`; the image analysis job executes the failing Git sequence as a regression test, and the sandbox bootstrap example uses `sudo` accordingly.

Existing durable sandboxes are not rotated, so they retain their current process user and workspace state; the fix applies when a sandbox is provisioned from the updated image. This draft reaches the same core image-user correction as #1692 and adds executable image coverage and the corresponding documentation update.

### Validation

- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check .github/workflows/docker-image-size-analysis.yml docs/sandbox.mdx`
- `git diff --check`
- Docker was unavailable locally; the added CI smoke test builds and runs the candidate image
- Changeset not applicable: this does not modify the published `eve` package

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
