### PR TITLE
feat(eve): web search - use Exa by default

### DIFF
--- a/.changeset/default-exa-web-search.md
+++ b/.changeset/default-exa-web-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+AI Gateway models now use Exa by default for the built-in `web_search` tool. Agents can continue to select Parallel explicitly with `webSearch({ provider: "parallel" })`.

--- a/docs/concepts/default-harness.md
+++ b/docs/concepts/default-harness.md
@@ -60,7 +60,7 @@ Notes:
 - **`agent`** is available only in the root session. Its child uses the root's instructions, tools, connections, and sandbox, but starts with fresh conversation history and fresh [state](../guides/state). The child receives neither `agent` nor `Workflow`; declared subagents do not receive the built-in `agent` either. See [Subagents](../subagents).
 - **`load_skill`** only pulls instructions into context. It adds no new execution surface, because behavior still comes from the tools the agent already has.
 - **`connection_search`** surfaces a connection's tools by their qualified name (e.g. `linear__list_issues`), which the model can then call directly. It's registered only when the agent has connections.
-- **`web_search`** has no local executor; the provider runs it. AI Gateway models use Parallel by default. To use Exa instead, export `webSearch({ provider: "exa" })` from `agent/tools/web_search.ts`. Direct provider models continue to use their native search implementation. To supply your own implementation, override it with `defineTool()`.
+- **`web_search`** has no local executor; the provider runs it. AI Gateway models use Exa by default. To use Parallel instead, export `webSearch({ provider: "parallel" })` from `agent/tools/web_search.ts`. Direct provider models continue to use their native search implementation. To supply your own implementation, override it with `defineTool()`.
 
 Review these built-in tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 
@@ -88,10 +88,10 @@ Provider-managed web search has a dedicated configuration helper instead of an e
 ```ts title="agent/tools/web_search.ts"
 import { webSearch } from "eve/tools";
 
-export default webSearch({ provider: "exa" });
+export default webSearch({ provider: "parallel" });
 ```
 
-Set `provider` to `"parallel"` or `"exa"`. Without this file, AI Gateway models use Parallel.
+Set `provider` to `"exa"` or `"parallel"`. Without this file, AI Gateway models use Exa.
 
 ## Disable a default
 

--- a/packages/eve/src/harness/provider-tools.test.ts
+++ b/packages/eve/src/harness/provider-tools.test.ts
@@ -87,14 +87,14 @@ describe("resolveWebSearchBackend", () => {
     openaiWebSearch.mockClear();
   });
 
-  it("returns 'parallel' for an OpenAI gateway model by default", () => {
+  it("returns 'exa' for an OpenAI gateway model by default", () => {
     const ref: RuntimeModelReference = { id: "openai/gpt-5.4" };
-    expect(resolveWebSearchBackend(ref)).toBe("parallel");
+    expect(resolveWebSearchBackend(ref)).toBe("exa");
   });
 
-  it("returns the configured Exa provider for a gateway model", () => {
+  it("returns the configured Parallel provider for a gateway model", () => {
     const ref: RuntimeModelReference = { id: "openai/gpt-5.4" };
-    expect(resolveWebSearchBackend(ref, "exa")).toBe("exa");
+    expect(resolveWebSearchBackend(ref, "parallel")).toBe("parallel");
   });
 
   it("returns 'openai' for a BYO OpenAI model", () => {
@@ -110,9 +110,9 @@ describe("resolveWebSearchBackend", () => {
     expect(resolveWebSearchBackend(ref, "exa")).toBe("openai");
   });
 
-  it("returns 'parallel' for an Anthropic gateway model", () => {
+  it("returns 'exa' for an Anthropic gateway model", () => {
     const ref: RuntimeModelReference = { id: "anthropic/claude-opus-4.6" };
-    expect(resolveWebSearchBackend(ref)).toBe("parallel");
+    expect(resolveWebSearchBackend(ref)).toBe("exa");
   });
 
   it("returns 'anthropic' for a BYO Anthropic model", () => {
@@ -141,14 +141,14 @@ describe("resolveWebSearchBackend", () => {
     expect(resolveWebSearchBackend(ref)).toBe("google");
   });
 
-  it("returns 'parallel' for a Google model on AI Gateway", () => {
+  it("returns 'exa' for a Google model on AI Gateway", () => {
     const ref: RuntimeModelReference = { id: "google/gemini-3.1-pro" };
-    expect(resolveWebSearchBackend(ref)).toBe("parallel");
+    expect(resolveWebSearchBackend(ref)).toBe("exa");
   });
 
-  it("returns 'parallel' for any other AI Gateway model", () => {
+  it("returns 'exa' for any other AI Gateway model", () => {
     const ref: RuntimeModelReference = { id: "mistral/mistral-large" };
-    expect(resolveWebSearchBackend(ref)).toBe("parallel");
+    expect(resolveWebSearchBackend(ref)).toBe("exa");
   });
 
   it("returns null for a BYO non-OpenAI/Anthropic/Google model", () => {

--- a/packages/eve/src/harness/provider-tools.ts
+++ b/packages/eve/src/harness/provider-tools.ts
@@ -71,7 +71,7 @@ export function resolveWebSearchOutputSchema(backend: WebSearchBackend): JsonObj
 /**
  * Determines the web search backend for a model reference.
  *
- * - All AI Gateway models: the configured search provider (Parallel by default)
+ * - All AI Gateway models: the configured search provider (Exa by default)
  * - Direct/BYO OpenAI models: native OpenAI search
  * - Direct/BYO Anthropic models: native Anthropic search
  * - Direct/BYO Google models: native Google search grounding
@@ -79,7 +79,7 @@ export function resolveWebSearchOutputSchema(backend: WebSearchBackend): JsonObj
  */
 export function resolveWebSearchBackend(
   modelRef: RuntimeModelReference,
-  gatewayProvider: WebSearchProvider = "parallel",
+  gatewayProvider: WebSearchProvider = "exa",
 ): WebSearchBackend | null {
   if (modelRef.source === undefined) {
     return gatewayProvider;

--- a/packages/eve/src/harness/tools.test.ts
+++ b/packages/eve/src/harness/tools.test.ts
@@ -386,8 +386,8 @@ describe("buildToolSet", () => {
   });
 
   it.each([
-    [{ id: "openai/gpt-5.4" }, WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA],
-    [{ id: "anthropic/claude-opus-4.6" }, WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA],
+    [{ id: "openai/gpt-5.4" }, WEB_SEARCH_EXA_OUTPUT_SCHEMA],
+    [{ id: "anthropic/claude-opus-4.6" }, WEB_SEARCH_EXA_OUTPUT_SCHEMA],
     [
       {
         id: "openai.chat/gpt-5.4",
@@ -424,7 +424,7 @@ describe("buildToolSet", () => {
       },
       WEB_SEARCH_GOOGLE_OUTPUT_SCHEMA,
     ],
-    [{ id: "mistral/mistral-large" }, WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA],
+    [{ id: "mistral/mistral-large" }, WEB_SEARCH_EXA_OUTPUT_SCHEMA],
   ] satisfies Array<readonly [RuntimeModelReference, JsonObject]>)(
     "injects the selected web_search provider output schema",
     async (modelReference, expectedOutputSchema) => {
@@ -448,7 +448,7 @@ describe("buildToolSet", () => {
     },
   );
 
-  it("injects Exa when configured for an AI Gateway model", async () => {
+  it("injects Parallel when configured for an AI Gateway model", async () => {
     const tools: HarnessToolMap = new Map<string, HarnessToolDefinition>([
       [
         "web_search",
@@ -463,10 +463,10 @@ describe("buildToolSet", () => {
     const result = await buildToolSetWithProviderTools({
       modelReference: { id: "openai/gpt-5.4" },
       tools,
-      webSearchProvider: "exa",
+      webSearchProvider: "parallel",
     });
 
-    expect(getOutputJsonSchema(result.web_search)).toEqual(WEB_SEARCH_EXA_OUTPUT_SCHEMA);
+    expect(getOutputJsonSchema(result.web_search)).toEqual(WEB_SEARCH_PARALLEL_OUTPUT_SCHEMA);
   });
 
   it("omits provider-managed web_search when no provider backend is available", async () => {

--- a/packages/eve/src/public/tools/web-search.ts
+++ b/packages/eve/src/public/tools/web-search.ts
@@ -25,7 +25,7 @@ export interface WebSearchToolDefinition {
 /**
  * Configures the framework-provided `web_search` tool.
  *
- * When no configuration file is present, eve uses Parallel for AI Gateway
+ * When no configuration file is present, eve uses Exa for AI Gateway
  * models.
  *
  * @example
@@ -33,7 +33,7 @@ export interface WebSearchToolDefinition {
  * // agent/tools/web_search.ts
  * import { webSearch } from "eve/tools";
  *
- * export default webSearch({ provider: "exa" });
+ * export default webSearch({ provider: "parallel" });
  * ```
  */
 export function webSearch(input: WebSearchToolInput): WebSearchToolDefinition {


### PR DESCRIPTION
### Summary

Closes #1894. AI Gateway models now use Exa by default for the built-in `web_search` tool. Agents can still select Parallel explicitly, and direct-provider models continue to use their native search implementations.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/provider-tools.test.ts src/harness/tools.test.ts` (57/57 passed)
- `pnpm test:unit` (6,206 passed, 1 skipped)
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
