### PR TITLE
feat(eve): propagate authorized approval state through subagents

### DIFF
--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -1,6 +1,6 @@
 import type { UserContent } from "ai";
 
-import type { UnstampedMessageStreamEvent, MessageStreamEvent } from "#protocol/message.js";
+import type { MessageStreamEvent, UnstampedMessageStreamEvent } from "#protocol/message.js";
 import type { CancelTurnResult as ProtocolCancelTurnResult } from "#protocol/cancel-turn.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeSubagentChildResult } from "#runtime/actions/types.js";
@@ -274,10 +274,16 @@ export interface SubagentInputRequestHookPayload {
   readonly subagentName: string;
 }
 
-/** Authorization lifecycle event forwarded from a delegated child. */
+/** Responder-specific lifecycle event forwarded from a delegated child. */
 export type SubagentAuthorizationEvent = Extract<
   UnstampedMessageStreamEvent,
-  { type: "authorization.required" | "authorization.completed" }
+  {
+    type:
+      | "approval.candidate"
+      | "approval.settled"
+      | "authorization.required"
+      | "authorization.completed";
+  }
 >;
 
 /**

--- a/packages/eve/src/execution/subagent-adapter.ts
+++ b/packages/eve/src/execution/subagent-adapter.ts
@@ -24,6 +24,12 @@ const log = createLogger("execution.subagent-adapter");
  */
 export const SUBAGENT_ADAPTER: ChannelAdapter = {
   kind: SUBAGENT_ADAPTER_KIND,
+  async "approval.candidate"(data, ctx) {
+    await forwardSubagentAuthorizationEvent({ data, type: "approval.candidate" }, ctx);
+  },
+  async "approval.settled"(data, ctx) {
+    await forwardSubagentAuthorizationEvent({ data, type: "approval.settled" }, ctx);
+  },
   async "authorization.required"(data, ctx) {
     await forwardSubagentAuthorizationEvent({ data, type: "authorization.required" }, ctx);
   },

--- a/packages/eve/src/execution/subagent-auth-proxy.integration.test.ts
+++ b/packages/eve/src/execution/subagent-auth-proxy.integration.test.ts
@@ -136,6 +136,52 @@ function decodeEvent(chunk: Uint8Array): MessageStreamEvent {
 }
 
 describe("subagent authorization proxy", () => {
+  it("preserves approval candidate and settlement events", async () => {
+    const parentSessionId = "parent-approval-session";
+    const session = createSession(parentSessionId);
+    const { ctx } = buildContext({ adapter: authorizationAdapter, sessionId: parentSessionId });
+    const chunks: Uint8Array[] = [];
+    const parentWritable = createCapturingWritable(chunks);
+    const candidateEvent: SubagentAuthorizationEvent = {
+      data: {
+        candidateId: "candidate-1",
+        outcome: "pending",
+        requestId: "approval-1",
+        responderPrincipalId: "slack:T1:U1",
+        sequence: 0,
+        stepIndex: 1,
+        turnId: "child-turn",
+      },
+      type: "approval.candidate",
+    };
+    const settledEvent: SubagentAuthorizationEvent = {
+      data: {
+        outcome: "approved",
+        requestId: "approval-1",
+        responderPrincipalId: "slack:T1:U1",
+        sequence: 0,
+        stepIndex: 2,
+        turnId: "child-turn",
+      },
+      type: "approval.settled",
+    };
+
+    await emitProxiedSubagentEvent({
+      ctx,
+      durableSession: projectToDurableSession(session),
+      hookPayload: authorizationPayload(candidateEvent),
+      parentWritable,
+    });
+    await emitProxiedSubagentEvent({
+      ctx,
+      durableSession: projectToDurableSession(session),
+      hookPayload: authorizationPayload(settledEvent),
+      parentWritable,
+    });
+
+    expect(decodeEvent(chunks[0]!)).toMatchObject(candidateEvent);
+    expect(decodeEvent(chunks[1]!)).toMatchObject(settledEvent);
+  });
   it("preserves events and parent adapter state across required/completed steps", async () => {
     const parentSessionId = "parent-session";
     const session = createSession(parentSessionId);


### PR DESCRIPTION
## Summary

Extends eve's existing local-subagent HITL proxy so responder-authorized approvals keep the same identity, policy ownership, OAuth lifecycle, and client events across parent/child boundaries.

## Identity flow

The root channel still authenticates the person responding to the approval. Existing delivery routing sends that verified `auth` context to the child session:

```text
root channel click
  → verified responder auth
  → parent requestId → childContinuationToken routing
  → child delivery
  → child session.auth.current
```

The child runs its own currently deployed response authorizer. The parent does not authorize on the child's behalf.

## Upward lifecycle proxy

The subagent adapter now forwards these child events through the existing parent continuation hook:

```ts
"approval.candidate"
"approval.settled"
"authorization.required"
"authorization.completed"
```

The parent channel receives the same event payload it would receive for a root-owned approval, so Slack/client presentation does not need separate child-specific behavior.

```text
child candidate/policy/OAuth
  → subagent adapter
  → parent durable hook
  → root channel event handler
```

## Ownership

The child session remains the canonical owner of:

- the pending approval request;
- active candidates and responder binding;
- the response-authorizer callback;
- OAuth challenge/callback state;
- candidate audit history and terminal settlement;
- eventual tool execution.

The root session owns only routing and user-facing presentation.

### Local and remote agents

Local subagents use eve's capability-protected durable continuation hooks, so verified delivery auth can be forwarded without a new trust protocol.

Remote agents are intentionally unchanged. They continue to require the existing `forwardPrincipal: true` opt-in and receiver-side `trustedForwarders` validation. This PR does not let a remote parent assert approval on behalf of a child.

Depends on #1371.

## Validation

Validated with:

- `pnpm --filter eve typecheck`
- focused subagent adapter, authorization proxy, HITL routing, and turn-workflow tests

